### PR TITLE
feat(cdal): Phase 0 eval — proof tap with structural verdict

### DIFF
--- a/lib/cdal_eval.ml
+++ b/lib/cdal_eval.ml
@@ -1,0 +1,143 @@
+(** Cdal_eval -- Phase 0 structural verdict over CDAL proof bundles.
+
+    @since Phase 0 -- CDAL proof tap *)
+
+type severity =
+  | Ok
+  | Warn of string
+  | Fail of string
+
+type evidence_check = {
+  has_tool_traces : bool;
+  has_raw_evidence : bool;
+  has_checkpoint : bool;
+  completed_normally : bool;
+}
+
+type violation_summary = {
+  violation_ref_count : int;
+  mode_was_downgraded : bool;
+  downgrade_reason : string option;
+}
+
+type eval_result = {
+  evidence : evidence_check;
+  violations : violation_summary;
+  overall : severity;
+  run_id : string;
+  contract_id : string;
+  result_status : Agent_sdk.Cdal_proof.result_status;
+  evaluated_at : float;
+}
+
+let string_contains ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let rec check i =
+      if i > hlen - nlen then false
+      else if String.sub haystack i nlen = needle then true
+      else check (i + 1)
+    in
+    check 0
+
+let count_violation_refs (refs : Agent_sdk.Cdal_proof.artifact_ref list) : int =
+  List.length
+    (List.filter (fun r -> string_contains ~needle:"mode_violations" r) refs)
+
+let make_evidence_check (p : Agent_sdk.Cdal_proof.t) : evidence_check =
+  {
+    has_tool_traces = p.tool_trace_refs <> [];
+    has_raw_evidence = p.raw_evidence_refs <> [];
+    has_checkpoint = p.checkpoint_ref <> None;
+    completed_normally = p.result_status = Completed;
+  }
+
+let make_violation_summary (p : Agent_sdk.Cdal_proof.t) : violation_summary =
+  let downgraded =
+    p.effective_execution_mode <> p.requested_execution_mode
+  in
+  {
+    violation_ref_count = count_violation_refs p.raw_evidence_refs;
+    mode_was_downgraded = downgraded;
+    downgrade_reason =
+      (if downgraded then Some p.mode_decision_source else None);
+  }
+
+let compute_overall ~(evidence : evidence_check)
+    ~(violations : violation_summary)
+    ~(result_status : Agent_sdk.Cdal_proof.result_status) : severity =
+  match result_status with
+  | Cancelled -> Fail "cancelled by contract"
+  | Errored -> Warn "execution error"
+  | Timed_out -> Warn "execution timed out"
+  | Completed ->
+    if violations.violation_ref_count > 0 then
+      Warn
+        (Printf.sprintf "%d mode violation(s) detected"
+           violations.violation_ref_count)
+    else if
+      (not evidence.has_tool_traces) && (not evidence.has_raw_evidence)
+    then
+      Warn "no evidence produced"
+    else Ok
+
+let evaluate (p : Agent_sdk.Cdal_proof.t) : eval_result =
+  let evidence = make_evidence_check p in
+  let violations = make_violation_summary p in
+  let overall = compute_overall ~evidence ~violations ~result_status:p.result_status in
+  {
+    evidence;
+    violations;
+    overall;
+    run_id = p.run_id;
+    contract_id = p.contract_id;
+    result_status = p.result_status;
+    evaluated_at = Unix.gettimeofday ();
+  }
+
+let is_acceptable (r : eval_result) : bool =
+  match r.overall with
+  | Ok | Warn _ -> true
+  | Fail _ -> false
+
+let severity_to_string = function
+  | Ok -> "ok"
+  | Warn reason -> Printf.sprintf "warn: %s" reason
+  | Fail reason -> Printf.sprintf "fail: %s" reason
+
+let severity_to_json = function
+  | Ok -> `Assoc [("level", `String "ok")]
+  | Warn reason -> `Assoc [("level", `String "warn"); ("reason", `String reason)]
+  | Fail reason -> `Assoc [("level", `String "fail"); ("reason", `String reason)]
+
+let evidence_check_to_json (e : evidence_check) : Yojson.Safe.t =
+  `Assoc [
+    ("has_tool_traces", `Bool e.has_tool_traces);
+    ("has_raw_evidence", `Bool e.has_raw_evidence);
+    ("has_checkpoint", `Bool e.has_checkpoint);
+    ("completed_normally", `Bool e.completed_normally);
+  ]
+
+let violation_summary_to_json (v : violation_summary) : Yojson.Safe.t =
+  `Assoc [
+    ("violation_ref_count", `Int v.violation_ref_count);
+    ("mode_was_downgraded", `Bool v.mode_was_downgraded);
+    ("downgrade_reason",
+     match v.downgrade_reason with
+     | Some r -> `String r
+     | None -> `Null);
+  ]
+
+let to_json (r : eval_result) : Yojson.Safe.t =
+  `Assoc [
+    ("run_id", `String r.run_id);
+    ("contract_id", `String r.contract_id);
+    ("result_status",
+     `String (Agent_sdk.Cdal_proof.show_result_status r.result_status));
+    ("evidence", evidence_check_to_json r.evidence);
+    ("violations", violation_summary_to_json r.violations);
+    ("overall", severity_to_json r.overall);
+    ("evaluated_at", `Float r.evaluated_at);
+  ]

--- a/lib/cdal_eval.mli
+++ b/lib/cdal_eval.mli
@@ -1,0 +1,57 @@
+(** Cdal_eval -- Phase 0 structural verdict over CDAL proof bundles.
+
+    Consumes {!Agent_sdk.Cdal_proof.t} and produces a deterministic verdict.
+    No LLM judge, no golden set, no baseline lock.
+
+    Two dimensions:
+    - Evidence presence: did OAS produce expected artifacts?
+    - Violation summary: did Mode_enforcer detect runtime violations?
+
+    @since Phase 0 -- CDAL proof tap *)
+
+(** Verdict severity. *)
+type severity =
+  | Ok
+  | Warn of string
+  | Fail of string
+
+(** Evidence presence check -- did OAS produce artifacts?
+    This is a crash detector, not a quality signal. *)
+type evidence_check = {
+  has_tool_traces : bool;
+  has_raw_evidence : bool;
+  has_checkpoint : bool;
+  completed_normally : bool;
+}
+
+(** Runtime violation summary extracted from proof metadata.
+    Mode_enforcer already collects violations at runtime;
+    this aggregates what was recorded in the proof bundle. *)
+type violation_summary = {
+  violation_ref_count : int;
+  mode_was_downgraded : bool;
+  downgrade_reason : string option;
+}
+
+(** Phase 0 eval result. *)
+type eval_result = {
+  evidence : evidence_check;
+  violations : violation_summary;
+  overall : severity;
+  run_id : string;
+  contract_id : string;
+  result_status : Agent_sdk.Cdal_proof.result_status;
+  evaluated_at : float;
+}
+
+(** Evaluate a proof bundle. Pure function, no I/O. *)
+val evaluate : Agent_sdk.Cdal_proof.t -> eval_result
+
+(** [is_acceptable r] returns [true] when [r.overall] is [Ok] or [Warn _]. *)
+val is_acceptable : eval_result -> bool
+
+(** JSON serialization for JSONL persistence. *)
+val to_json : eval_result -> Yojson.Safe.t
+
+(** Severity to short string for logging. *)
+val severity_to_string : severity -> string

--- a/lib/dune
+++ b/lib/dune
@@ -466,6 +466,7 @@
    keeper_toml_loader
    keeper_contract
    keeper_cdal_contract
+   cdal_eval
    keeper_deliberation
    keeper_types_profile
    keeper_types_support

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -247,11 +247,17 @@ let run_turn
          ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
          (match result.proof with
           | Some p ->
-            Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s violations=%d"
+            Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
               meta.name p.run_id
               (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
               (Agent_sdk.Cdal_proof.show_result_status p.result_status)
-              (List.length p.raw_evidence_refs)
+              (List.length p.raw_evidence_refs);
+            let eval = Cdal_eval.evaluate p in
+            Log.Keeper.info "keeper:%s cdal_eval: %s"
+              meta.name (Cdal_eval.severity_to_string eval.overall);
+            if not (Cdal_eval.is_acceptable eval) then
+              Log.Keeper.warn "keeper:%s cdal verdict NOT acceptable: %s"
+                meta.name (Cdal_eval.severity_to_string eval.overall)
           | None -> ());
          Ok {
            response_text;

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,7 @@
         test_worktree_live_context
         test_tool_input_validation
         test_autoresearch_oas_primitives
+        test_cdal_eval
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -75,6 +76,7 @@
           test_worktree_live_context
           test_tool_input_validation
           test_autoresearch_oas_primitives
+          test_cdal_eval
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_cdal_eval.ml
+++ b/test/test_cdal_eval.ml
@@ -1,0 +1,194 @@
+(** test_cdal_eval — Phase 0 CDAL eval unit tests.
+
+    Verifies that Masc_mcp.Cdal_eval.evaluate produces correct verdicts
+    for each result_status, violation state, and evidence state. *)
+
+let make_proof
+    ?(run_id = "test-run-001")
+    ?(contract_id = "md5:abc123")
+    ?(requested = Agent_sdk.Execution_mode.Execute)
+    ?(effective = Agent_sdk.Execution_mode.Execute)
+    ?(mode_decision_source = "passthrough")
+    ?(risk_class = Agent_sdk.Risk_class.Low)
+    ?(tool_trace_refs = ["proof-store://test-run-001/tool_traces/trace-0001.jsonl"])
+    ?(raw_evidence_refs = [])
+    ?(checkpoint_ref = None)
+    ?(result_status = Agent_sdk.Cdal_proof.Completed)
+    () : Agent_sdk.Cdal_proof.t =
+  {
+    schema_version = 1;
+    run_id;
+    contract_id;
+    requested_execution_mode = requested;
+    effective_execution_mode = effective;
+    mode_decision_source;
+    risk_class;
+    provider_snapshot = {
+      provider_name = "test";
+      model_id = "test-model";
+      api_version = None;
+    };
+    capability_snapshot = {
+      tools = ["read"; "write"];
+      mcp_servers = [];
+      max_turns = 10;
+      max_tokens = Some 4096;
+      thinking_enabled = None;
+    };
+    tool_trace_refs;
+    raw_evidence_refs;
+    checkpoint_ref;
+    result_status;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  }
+
+(* ================================================================ *)
+(* Test: Completed run with traces → Ok                              *)
+(* ================================================================ *)
+
+let test_completed_with_traces () =
+  let proof = make_proof () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "has_tool_traces" true result.evidence.has_tool_traces;
+  Alcotest.(check bool) "completed_normally" true result.evidence.completed_normally;
+  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
+  Alcotest.(check string) "overall is ok"
+    "ok" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Cancelled run → Fail                                        *)
+(* ================================================================ *)
+
+let test_cancelled () =
+  let proof = make_proof ~result_status:Cancelled () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "completed_normally" false result.evidence.completed_normally;
+  Alcotest.(check bool) "is_acceptable" false (Masc_mcp.Cdal_eval.is_acceptable result);
+  Alcotest.(check string) "overall is fail"
+    "fail: cancelled by contract" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Errored run → Warn                                          *)
+(* ================================================================ *)
+
+let test_errored () =
+  let proof = make_proof ~result_status:Errored () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
+  Alcotest.(check string) "overall is warn"
+    "warn: execution error" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Timed out run → Warn                                        *)
+(* ================================================================ *)
+
+let test_timed_out () =
+  let proof = make_proof ~result_status:Timed_out () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
+  Alcotest.(check string) "overall is warn"
+    "warn: execution timed out" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Mode violations detected → Warn                             *)
+(* ================================================================ *)
+
+let test_violations () =
+  let proof = make_proof
+    ~raw_evidence_refs:[
+      "proof-store://r1/evidence/mode_violations.json";
+      "proof-store://r1/evidence/token_usage.json";
+    ] () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check int) "violation_ref_count" 1 result.violations.violation_ref_count;
+  Alcotest.(check bool) "has_raw_evidence" true result.evidence.has_raw_evidence;
+  Alcotest.(check string) "overall is warn"
+    "warn: 1 mode violation(s) detected"
+    (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: No evidence at all → Warn                                   *)
+(* ================================================================ *)
+
+let test_no_evidence () =
+  let proof = make_proof
+    ~tool_trace_refs:[]
+    ~raw_evidence_refs:[] () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "has_tool_traces" false result.evidence.has_tool_traces;
+  Alcotest.(check bool) "has_raw_evidence" false result.evidence.has_raw_evidence;
+  Alcotest.(check string) "overall is warn"
+    "warn: no evidence produced" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Mode downgrade detected                                     *)
+(* ================================================================ *)
+
+let test_mode_downgrade () =
+  let proof = make_proof
+    ~requested:Execute
+    ~effective:Draft
+    ~mode_decision_source:"risk_class_downgrade" () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "mode_was_downgraded" true
+    result.violations.mode_was_downgraded;
+  Alcotest.(check string) "downgrade_reason"
+    "risk_class_downgrade"
+    (Option.get result.violations.downgrade_reason);
+  (* Downgrade alone does not produce a violation ref, so overall is Ok *)
+  Alcotest.(check string) "overall is ok"
+    "ok" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Test: Checkpoint present                                          *)
+(* ================================================================ *)
+
+let test_checkpoint_present () =
+  let proof = make_proof
+    ~checkpoint_ref:(Some "proof-store://r1/checkpoint.json") () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "has_checkpoint" true result.evidence.has_checkpoint
+
+(* ================================================================ *)
+(* Test: JSON round-trip                                             *)
+(* ================================================================ *)
+
+let test_json_output () =
+  let proof = make_proof () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  let json = Masc_mcp.Cdal_eval.to_json result in
+  let json_str = Yojson.Safe.to_string json in
+  (* Verify it is valid JSON with expected fields *)
+  Alcotest.(check bool) "has run_id"
+    true (String.length json_str > 0);
+  match json with
+  | `Assoc fields ->
+    Alcotest.(check bool) "has run_id field"
+      true (List.mem_assoc "run_id" fields);
+    Alcotest.(check bool) "has evidence field"
+      true (List.mem_assoc "evidence" fields);
+    Alcotest.(check bool) "has violations field"
+      true (List.mem_assoc "violations" fields);
+    Alcotest.(check bool) "has overall field"
+      true (List.mem_assoc "overall" fields)
+  | _ -> Alcotest.fail "expected JSON object"
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Cdal_eval" [
+    ("evaluate", [
+      Alcotest.test_case "completed with traces" `Quick test_completed_with_traces;
+      Alcotest.test_case "cancelled" `Quick test_cancelled;
+      Alcotest.test_case "errored" `Quick test_errored;
+      Alcotest.test_case "timed out" `Quick test_timed_out;
+      Alcotest.test_case "violations" `Quick test_violations;
+      Alcotest.test_case "no evidence" `Quick test_no_evidence;
+      Alcotest.test_case "mode downgrade" `Quick test_mode_downgrade;
+      Alcotest.test_case "checkpoint present" `Quick test_checkpoint_present;
+      Alcotest.test_case "json output" `Quick test_json_output;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

CDAL 루프의 proof→verdict gap을 닫는 Phase 0 구현.

- OAS는 이미 `Cdal_proof.t`를 생산하지만 MASC가 로그만 찍고 버리고 있었음
- `Cdal_eval.evaluate`가 proof를 소비하여 deterministic severity verdict를 생산
- `keeper_agent_run.ml`에 tap으로 삽입 (advisory only, keeper를 멈추지 않음)

### 설계 근거 (3-관점 분석)

RFC #3475의 4-field를 그대로 구현하지 않고 Skeptic 비판을 수용:
- `evidence_gap` → `evidence_check`로 축소 (crash detector로 정직하게 명명)
- `drift_risk` → Phase 0 제외 (baseline 인프라 없음, 노이즈 문제)
- `unsafe_edit_risk` → violation 집계로 대체 (runtime enforcement와 중복 회피)
- `ambiguity` → Phase 0 제외

### 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/cdal_eval.mli` | 타입 계약: severity, evidence_check, violation_summary, eval_result |
| `lib/cdal_eval.ml` | evaluate, is_acceptable, to_json 구현 (~120 LOC) |
| `lib/keeper/keeper_agent_run.ml` | proof tap 삽입 (line 248 이후) |
| `test/test_cdal_eval.ml` | 9 alcotest cases |
| `lib/dune`, `test/dune` | 모듈 등록 |

## Test plan

- [x] `dune exec --root . test/test_cdal_eval.exe` — 9/9 통과
- [ ] CI Build and Test green
- [ ] Keeper 실행 시 cdal_eval 로그 확인

## Relates

- RFC: #3475
- Tracker: #3528