### PR TITLE
[codex] pin MCP SDK to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **MCP SDK pin** — `scripts/opam-pin-external-deps.sh` now pins `mcp_protocol` to `jeong-sik/mcp-protocol-sdk#v1.2.0` instead of floating on `#main`.
+
 ## [2.159.0] - 2026-03-28
 
 ### Added

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -2,12 +2,14 @@
 # Pin private/external opam dependencies that are not published on opam-repository.
 #
 # NOTE: Most first-party packages here intentionally float on #main. OAS does
-# not float at install time, but it is ratcheted to the current upstream main
-# commit in one shared place so CI/runtime stay reproducible while still
-# consuming the latest required OAS feature set. Set AGENT_SDK_PIN_URL to a
-# local checkout/worktree path when validating unreleased OAS changes locally.
-# If you need reproducible builds for the remaining dependencies, pin them to
-# specific commit SHAs instead:
+# not float at install time, and mcp_protocol is pinned to the current released
+# single-package line so local setup does not drift across packaging changes.
+# OAS itself is ratcheted to the current upstream main commit in one shared
+# place so CI/runtime stay reproducible while still consuming the latest
+# required OAS feature set. Set AGENT_SDK_PIN_URL to a local checkout/worktree
+# path when validating unreleased OAS changes locally. If you need reproducible
+# builds for the remaining dependencies, pin them to specific commit SHAs
+# instead:
 #   opam pin add <pkg> <url>#<commit-sha> -n -y
 set -euo pipefail
 
@@ -38,8 +40,8 @@ if $include_compact_protocol; then
 fi
 
 # mcp_protocol_eio and mcp_protocol_http merged into mcp_protocol
-# as sub-libraries (mcp-protocol-sdk#60). Single pin covers all.
-opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
+# as sub-libraries (mcp-protocol-sdk#60). Pin the released single-package line.
+opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.2.0 -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## What changed
- Pinned `mcp_protocol` in `scripts/opam-pin-external-deps.sh` to `jeong-sik/mcp-protocol-sdk#v1.2.0`.
- Updated the script comment so it no longer implies that `mcp_protocol` intentionally floats on `#main`.
- Added an `Unreleased` changelog entry for the pin change.

## Why
- `mcp-protocol-sdk` now has a stable single-package release line, and downstream local setup should not drift with every upstream `main` change.
- `masc-mcp` already depends on `mcp_protocol >= 1.2.0`, so pinning the setup script to `v1.2.0` makes contributor installs line up with the current dependency floor.

## Impact
- Local contributor setup becomes reproducible across packaging/layout changes in `mcp-protocol-sdk`.
- `agent_sdk` ratcheting remains unchanged and still follows the separate OAS pin flow.

## Validation
- `bash -n scripts/opam-pin-external-deps.sh`
- Confirmed `scripts/opam-pin-external-deps.sh` now references `mcp-protocol-sdk.git#v1.2.0` and no longer references `#main`.
- Scoped diff only touches `scripts/opam-pin-external-deps.sh` and `CHANGELOG.md`.
