### PR TITLE
fix(server): periodic JSONL prune + expanded cleanup targets

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -237,6 +237,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   | None ->
       Log.BoardListener.info "Skipped (not using PostgreSQL backend)");
   Eio.Fiber.fork ~sw (fun () ->
+      let last_prune = ref (Unix.gettimeofday ()) in
       let rec loop () =
         Eio.Time.sleep clock 60.0;
         (try
@@ -296,7 +297,39 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
           (* A2A: remove event buffers for dead subscriptions *)
           let buf_reaped = A2a_tools.cleanup_orphan_buffers () in
           if buf_reaped > 0 then
-            Log.Server.info "Reaped %d orphan event buffers" buf_reaped
+            Log.Server.info "Reaped %d orphan event buffers" buf_reaped;
+          (* Periodic JSONL prune: every 24h, clean dated JSONL files *)
+          let now = Unix.gettimeofday () in
+          if now -. !last_prune >= 86400.0 then begin
+            last_prune := now;
+            (try
+               let days =
+                 Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
+               in
+               let masc = Room.masc_dir state.room_config in
+               let prune_dir dir =
+                 if Sys.file_exists dir then
+                   Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
+                 else 0
+               in
+               let total =
+                 prune_dir (Filename.concat masc "audit")
+                 + prune_dir (Filename.concat masc "telemetry")
+                 + prune_dir (Filename.concat (Filename.concat masc "governance") "judgments")
+                 + prune_dir (Filename.concat masc "messages")
+                 + prune_dir (Filename.concat masc "events")
+                 + prune_dir (Filename.concat masc "activity-events")
+                 + prune_dir (Filename.concat masc "voice_sessions")
+               in
+               if total > 0 then
+                 Log.Server.info "periodic JSONL prune: deleted %d day-files (retention=%dd)"
+                   total days
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Server.error "periodic JSONL prune failed: %s"
+                 (Printexc.to_string exn))
+          end
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -149,6 +149,10 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        + prune_dir (Filename.concat masc "telemetry")
        + prune_dir (Filename.concat (Filename.concat masc "governance") "judgments")
        + prune_dir tool_metrics_dir
+       + prune_dir (Filename.concat masc "messages")
+       + prune_dir (Filename.concat masc "events")
+       + prune_dir (Filename.concat masc "activity-events")
+       + prune_dir (Filename.concat masc "voice_sessions")
        + (let keepers = Filename.concat masc "perpetual-keepers" in
           if not (Sys.file_exists keepers) then 0
           else


### PR DESCRIPTION
## Summary
- 60초 background loop에 24h 주기 JSONL prune 추가 (기존: 시작 시에만)
- prune 대상 확대: messages/, events/, activity-events/, voice_sessions/
- 기존 `MASC_JSONL_RETENTION_DAYS` (default 30) 재사용

## Problem
filesystem-first 전환 후 JSONL 파일이 무한 성장. 서버 시작 시에만 정리되므로 장기 실행 시 디스크 누적.

## Test plan
- [ ] `dune build` 성공
- [ ] 서버 24h+ 실행 후 `periodic JSONL prune completed` 로그 확인
- [ ] .masc/ 크기가 retention 기간 이후 안정화되는지 확인

Closes #3549

Generated with [Claude Code](https://claude.com/claude-code)