### PR TITLE
refactor(config): centralize env vars into typed Env_config sub-modules (#3364)

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -1416,9 +1416,9 @@ let parse_args () =
 
   (* Resolve room *)
   let r = if !room <> "" then !room
-    else match Sys.getenv_opt "MASC_CLUSTER_NAME" with
-      | Some name when String.trim name <> "" -> String.trim name
-      | _ -> Filename.basename base
+    else match Masc_mcp.Env_config_core.cluster_name_opt () with
+      | Some name -> name
+      | None -> Filename.basename base
   in
 
   (base, r, !port, !refresh)

--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -88,7 +88,7 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
 (** {1 Storage (JSONL)} *)
 
 let findings_dir () =
-  let base = match Sys.getenv_opt "ME_ROOT" with
+  let base = match Env_config_core.me_root_opt () with
     | Some r -> r | None -> Sys.getenv "HOME" ^ "/me"
   in
   Filename.concat base ".masc/autoresearch/findings"

--- a/lib/credits_dashboard.ml
+++ b/lib/credits_dashboard.ml
@@ -15,7 +15,7 @@
 
 (** Get ME_ROOT path *)
 let me_root () =
-  match Sys.getenv_opt "ME_ROOT" with
+  match Env_config_core.me_root_opt () with
   | Some path -> path
   | None ->
       let home = Option.value ~default:"/tmp" (Sys.getenv_opt "HOME") in

--- a/lib/dune
+++ b/lib/dune
@@ -532,6 +532,9 @@
    env_config_governance
    env_config_keeper
    env_config_introspect
+   env_config_server
+   env_config_chain
+   env_config_dashboard
    runtime_params
    governance_registry
    governance_pipeline

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -66,7 +66,7 @@ let print_summary () =
 let to_json () : Yojson.Safe.t =
   let mask s =
     if String.length s <= 4 then "***"
-    else String.sub s 0 2 ^ String.make (String.length s - 4) '*' ^ String.sub s (String.length s - 2) 2
+    else String.sub s 0 (min 4 (String.length s)) ^ "***"
   in
   let mask_opt f = match f () with Some v -> `String (mask v) | None -> `Null in
   let str s = `String s in
@@ -145,7 +145,7 @@ let to_json () : Yojson.Safe.t =
     ];
     "external", `Assoc [
       "graphql_url", str (Server.External.graphql_url ());
-      "neo4j_uri", str_opt Server.External.neo4j_uri_opt;
+      "neo4j_uri", mask_opt Server.External.neo4j_uri_opt;
       "neo4j_password", mask_opt Server.External.neo4j_password_opt;
       "gemini_api_key", mask_opt Server.External.gemini_api_key_opt;
       "graphql_api_key", mask_opt Server.External.graphql_api_key_opt;

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -9,6 +9,9 @@ include Env_config_runtime
 include Env_config_governance
 include Env_config_keeper
 
+module Server = Env_config_server
+module Dashboard = Env_config_dashboard
+
 let print_summary () =
   Log.Env.info "Zombie: threshold=%.0fs cleanup_interval=%.0fs"
     Env_config_runtime.Zombie.threshold_seconds
@@ -57,3 +60,94 @@ let print_summary () =
   Log.Env.info "KeeperAlert(SlackDM): enabled=%b user_id_set=%b"
     Env_config_keeper.KeeperAlert.slack_dm_enabled
     (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "")
+
+(** Serialize all known configuration as JSON for dashboard introspection.
+    Sensitive values (passwords, tokens, API keys) are masked. *)
+let to_json () : Yojson.Safe.t =
+  let mask s =
+    if String.length s <= 4 then "***"
+    else String.sub s 0 2 ^ String.make (String.length s - 4) '*' ^ String.sub s (String.length s - 2) 2
+  in
+  let mask_opt f = match f () with Some v -> `String (mask v) | None -> `Null in
+  let str s = `String s in
+  let str_opt f = match f () with Some v -> `String v | None -> `Null in
+  let int_val i = `Int i in
+  let float_val f = `Float f in
+  let bool_val b = `Bool b in
+  `Assoc [
+    "core", `Assoc [
+      "me_root", str_opt me_root_opt;
+      "sb_path", str_opt sb_path_opt;
+      "http_port", str (masc_http_port ());
+      "host", str (masc_host ());
+      "http_base_url", (match masc_http_base_url_result () with Ok u -> str u | Error _ -> `Null);
+      "assets_dir", str_opt assets_dir_opt;
+      "cluster_name", str (cluster_name ());
+    ];
+    "runtime", `Assoc [
+      "zombie_threshold_sec", float_val Env_config_runtime.Zombie.threshold_seconds;
+      "zombie_keeper_threshold_sec", float_val Env_config_runtime.Zombie.keeper_threshold_seconds;
+      "zombie_cleanup_interval_sec", float_val Env_config_runtime.Zombie.cleanup_interval_seconds;
+      "lock_timeout_sec", float_val Env_config_runtime.Lock.timeout_seconds;
+      "session_max_age_sec", float_val Env_config_runtime.Session.max_age_seconds;
+      "tempo_min_sec", float_val Env_config_runtime.Tempo.min_interval_seconds;
+      "tempo_max_sec", float_val Env_config_runtime.Tempo.max_interval_seconds;
+      "tempo_default_sec", float_val Env_config_runtime.Tempo.default_interval_seconds;
+    ];
+    "governance", `Assoc [
+      "inference_timeout_sec", float_val Env_config_governance.Inference.timeout_seconds;
+      "inference_cache_enabled", bool_val Env_config_governance.Inference.cache_enabled;
+      "inference_cache_ttl_sec", int_val Env_config_governance.Inference.cache_ttl_seconds;
+      "autonomy_tick_sec", float_val Env_config_governance.Autonomy.tick_interval_seconds;
+      "autonomy_agents_per_tick", int_val Env_config_governance.Autonomy.agents_per_tick;
+    ];
+    "keeper", `Assoc [
+      "bootstrap_enabled", bool_val Env_config_keeper.KeeperBootstrap.enabled;
+      "bootstrap_stale_turn_sec", float_val Env_config_keeper.KeeperBootstrap.stale_turn_seconds;
+      "bootstrap_max_scan", int_val Env_config_keeper.KeeperBootstrap.max_scan;
+      "alert_enabled", bool_val Env_config_keeper.KeeperAlert.enabled;
+      "alert_min_score", float_val Env_config_keeper.KeeperAlert.min_score;
+      "alert_slack_enabled", bool_val Env_config_keeper.KeeperAlert.slack_enabled;
+    ];
+    "server", `Assoc [
+      "grpc_enabled", bool_val Server.Grpc.enabled;
+      "grpc_port", int_val Server.Grpc.port;
+      "ws_enabled", bool_val Server.Ws.enabled;
+      "ws_port", int_val Server.Ws.port;
+      "h2_mode", str Server.H2.mode;
+      "webrtc_enabled", bool_val Server.Webrtc.enabled;
+      "storage_type", str Server.Storage.storage_type;
+      "pg_pool_size", int_val Server.Storage.pg_pool_size;
+      "telemetry_enabled", bool_val Server.Runtime.telemetry_enabled;
+      "openai_compat", bool_val Server.Runtime.openai_compat;
+      "dispatch_v2", bool_val Server.Runtime.dispatch_v2;
+      "rate_limit", float_val Server.Rate.limit;
+      "rate_burst", int_val Server.Rate.burst;
+      "build_git_commit", str_opt build_git_commit_opt;
+    ];
+    "chain", `Assoc [
+      "max_nodes", int_val Env_config_runtime.Chain.max_nodes;
+      "max_depth", int_val Env_config_runtime.Chain.max_depth;
+      "max_fanout", int_val Env_config_runtime.Chain.max_fanout;
+      "max_concurrency", int_val Env_config_runtime.Chain.max_concurrency;
+      "default_cascade", str_opt Env_config_chain.Model.default_cascade_opt;
+      "default_provider", str_opt Env_config_chain.Model.default_provider_opt;
+      "default_model", str_opt Env_config_chain.Model.default_model_opt;
+      "llama_swarm_model", str_opt Env_config_chain.Model.llama_swarm_model_opt;
+    ];
+    "dashboard", `Assoc [
+      "fixtures_enabled", bool_val Env_config_dashboard.Fixtures.enabled;
+      "governance_judge_enabled", bool_val Env_config_dashboard.GovernanceJudge.enabled;
+      "governance_judge_interval_sec", int_val Env_config_dashboard.GovernanceJudge.interval_sec;
+      "operator_judge_enabled", bool_val Env_config_dashboard.OperatorJudge.enabled;
+      "operator_judge_interval_sec", int_val Env_config_dashboard.OperatorJudge.interval_sec;
+      "relay_calibration_enabled", bool_val Env_config_dashboard.Relay.calibration_enabled;
+    ];
+    "external", `Assoc [
+      "graphql_url", str (Server.External.graphql_url ());
+      "neo4j_uri", str_opt Server.External.neo4j_uri_opt;
+      "neo4j_password", mask_opt Server.External.neo4j_password_opt;
+      "gemini_api_key", mask_opt Server.External.gemini_api_key_opt;
+      "graphql_api_key", mask_opt Server.External.graphql_api_key_opt;
+    ];
+  ]

--- a/lib/env_config.mli
+++ b/lib/env_config.mli
@@ -11,5 +11,11 @@ include module type of Env_config_runtime
 include module type of Env_config_governance
 include module type of Env_config_keeper
 
+module Server = Env_config_server
+module Dashboard = Env_config_dashboard
+
 val print_summary : unit -> unit
 (** Print configuration summary for debugging. *)
+
+val to_json : unit -> Yojson.Safe.t
+(** Serialize all known configuration as JSON for dashboard introspection. *)

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -1,0 +1,144 @@
+(** Chain engine and model selection environment configuration.
+
+    Centralizes MASC_CHAIN_*, MASC_DEFAULT_*, LLAMA_SWARM_MODEL,
+    and related inference routing env vars. *)
+
+open Env_config_core
+
+(** {1 Chain Engine Limits} *)
+
+module Limits = struct
+  let max_nodes =
+    max 1 (get_int ~default:100 "MASC_CHAIN_MAX_NODES")
+
+  let max_depth =
+    max 1 (get_int ~default:20 "MASC_CHAIN_MAX_DEPTH")
+
+  let max_fanout =
+    max 1 (get_int ~default:20 "MASC_CHAIN_MAX_FANOUT")
+
+  let max_concurrency =
+    max 1 (get_int ~default:10 "MASC_CHAIN_MAX_CONCURRENCY")
+end
+
+(** {1 Chain Paths} *)
+
+module Paths = struct
+  let source_base_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_SOURCE_BASE_PATH" |> trim_opt
+
+  let checkpoint_dir_opt () =
+    Sys.getenv_opt "MASC_CHAIN_CHECKPOINT_DIR" |> trim_opt
+
+  let history_file_opt () =
+    match Sys.getenv_opt "MASC_CHAIN_HISTORY_FILE" |> trim_opt with
+    | Some _ as v -> v
+    | None -> Sys.getenv_opt "CHAIN_HISTORY_FILE" |> trim_opt
+
+  let run_store_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_RUN_STORE_PATH" |> trim_opt
+end
+
+(** {1 Run Store} *)
+
+module RunStore = struct
+  let max_history =
+    get_int ~default:50 "MASC_CHAIN_RUN_HISTORY"
+
+  let max_output_chars =
+    get_int ~default:4000 "MASC_CHAIN_OUTPUT_MAX_CHARS"
+
+  let max_preview_chars =
+    get_int ~default:240 "MASC_CHAIN_OUTPUT_PREVIEW_CHARS"
+end
+
+(** {1 Chain Logging} *)
+
+module Log = struct
+  let level =
+    get_string ~default:"info" "MASC_CHAIN_LOG_LEVEL"
+
+  let format =
+    get_string ~default:"text" "MASC_CHAIN_LOG_FORMAT"
+
+  let run_log_enabled =
+    get_bool ~default:false "MASC_CHAIN_RUN_LOG"
+
+  let run_log_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_RUN_LOG_PATH" |> trim_opt
+
+  let run_log_stream =
+    get_bool ~default:false "MASC_CHAIN_RUN_LOG_STREAM"
+end
+
+(** {1 Model Selection & Cascade} *)
+
+module Model = struct
+  let default_cascade_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_CASCADE" |> trim_opt
+
+  let routing_cascade_opt () =
+    Sys.getenv_opt "MASC_ROUTING_CASCADE" |> trim_opt
+
+  let default_provider_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_PROVIDER" |> trim_opt
+
+  let default_model_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_MODEL" |> trim_opt
+
+  let orchestrator_model_opt () =
+    Sys.getenv_opt "MASC_CHAIN_ORCHESTRATOR_MODEL" |> trim_opt
+
+  let llama_swarm_model_opt () =
+    Sys.getenv_opt "LLAMA_SWARM_MODEL" |> trim_opt
+
+  let goal_models_opt () =
+    Sys.getenv_opt "MASC_GOAL_MODELS" |> trim_opt
+
+  let verifier_model_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_VERIFIER_MODEL" |> trim_opt
+
+  let goal_dispatch_runtime =
+    get_string ~default:"task" "MASC_GOAL_DISPATCH_RUNTIME"
+end
+
+(** {1 Local LLM (Llama)} *)
+
+module Llama = struct
+  let runtime_debug =
+    get_bool ~default:false "MASC_LLAMA_RUNTIME_DEBUG"
+
+  let runtime_cooldown_sec =
+    get_float ~default:30.0 "MASC_LLAMA_RUNTIME_COOLDOWN_SEC"
+
+  let swarm_live_script_opt () =
+    Sys.getenv_opt "MASC_SWARM_LIVE_SCRIPT" |> trim_opt
+end
+
+(** {1 Mitosis Thresholds} *)
+
+module Mitosis = struct
+  let prepare_threshold_opt () =
+    Sys.getenv_opt "MASC_MITOSIS_PREPARE_THRESHOLD" |> trim_opt
+
+  let handoff_threshold_opt () =
+    Sys.getenv_opt "MASC_MITOSIS_HANDOFF_THRESHOLD" |> trim_opt
+end
+
+(** {1 Procedural Memory} *)
+
+module Procedural = struct
+  let min_evidence =
+    max 1 (get_int ~default:3 "MASC_PROC_MIN_EVIDENCE")
+
+  let min_confidence =
+    max 0.0 (min 1.0 (get_float ~default:0.7 "MASC_PROC_MIN_CONFIDENCE"))
+end
+
+(** {1 Memory OAS Bridge} *)
+
+module Memory = struct
+  (** Importance scale 1-10 (integer). *)
+  let oas_default_importance =
+    max 1 (min 10 (get_int ~default:5 "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE"))
+end

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -62,9 +62,3 @@ module Relay = struct
     get_bool ~default:true "MASC_RELAY_CALIBRATION_ENABLED"
 end
 
-(** {1 Orchestrator} *)
-
-module Orchestrator = struct
-  let agent_opt () =
-    Sys.getenv_opt "MASC_ORCHESTRATOR_AGENT" |> trim_opt
-end

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -1,0 +1,70 @@
+(** Dashboard and operator environment configuration.
+
+    Centralizes MASC_DASHBOARD_*, MASC_OPERATOR_*, and related
+    operator-facing env vars. *)
+
+open Env_config_core
+
+(** {1 Dashboard Fixtures} *)
+
+module Fixtures = struct
+  let enabled =
+    get_bool ~default:false "MASC_DASHBOARD_FIXTURES_ENABLED"
+
+  let fixture_name_opt () =
+    Sys.getenv_opt "MASC_DASHBOARD_FIXTURE" |> trim_opt
+end
+
+(** {1 Governance Judge} *)
+
+module GovernanceJudge = struct
+  let enabled =
+    get_bool ~default:true "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED"
+
+  let interval_sec =
+    max 15 (get_int ~default:60 "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC")
+end
+
+(** {1 Operator Judge} *)
+
+module OperatorJudge = struct
+  let enabled =
+    get_bool ~default:true "MASC_OPERATOR_JUDGE_ENABLED"
+
+  let interval_sec =
+    max 15 (get_int ~default:60 "MASC_OPERATOR_JUDGE_INTERVAL_SEC")
+
+  let session_ttl_sec =
+    max 30 (get_int ~default:300 "MASC_OPERATOR_JUDGE_SESSION_TTL_SEC")
+
+  let room_ttl_sec =
+    max 15 (get_int ~default:60 "MASC_OPERATOR_JUDGE_ROOM_TTL_SEC")
+end
+
+(** {1 Operator Cache} *)
+
+module OperatorCache = struct
+  let ttl_sec =
+    get_float ~default:30.0 "MASC_OPERATOR_CACHE_TTL"
+end
+
+(** {1 Alert Configuration} *)
+
+module Alert = struct
+  let dedup_window_sec =
+    max 5.0 (get_float ~default:60.0 "MASC_ALERT_DEDUP_WINDOW_SEC")
+end
+
+(** {1 Relay Calibration} *)
+
+module Relay = struct
+  let calibration_enabled =
+    get_bool ~default:true "MASC_RELAY_CALIBRATION_ENABLED"
+end
+
+(** {1 Orchestrator} *)
+
+module Orchestrator = struct
+  let agent_opt () =
+    Sys.getenv_opt "MASC_ORCHESTRATOR_AGENT" |> trim_opt
+end

--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -93,6 +93,41 @@ module Orchestrator = struct
   (** Orchestrator agent name *)
   let agent_name =
     get_string ~default:"orchestrator" "MASC_ORCHESTRATOR_AGENT"
+
+  let min_priority =
+    max 0 (min 10 (get_int ~default:2 "MASC_ORCHESTRATOR_MIN_PRIORITY"))
+
+  let timeout_seconds =
+    max 10 (min 3600 (get_int ~default:300 "MASC_ORCHESTRATOR_TIMEOUT"))
+
+  let enabled =
+    get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED"
+end
+
+(** {1 Team Session Configuration} *)
+
+module TeamSession = struct
+  let model_35b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_35B" |> trim_opt
+
+  let model_27b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_27B" |> trim_opt
+
+  let model_9b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_9B" |> trim_opt
+
+  let router_judge_enabled =
+    get_bool ~default:true "MASC_TEAM_SESSION_ROUTER_JUDGE"
+
+  let router_judge_timeout_sec =
+    max 5 (get_int ~default:15 "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC")
+
+  let router_judge_confidence_threshold =
+    let v = get_float ~default:0.72 "MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD" in
+    Float.max 0.0 (Float.min 1.0 v)
+
+  let router_judge_model_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL" |> trim_opt
 end
 
 (** {1 Mitosis (Cell Division) Configuration} *)

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -43,6 +43,19 @@ end
 module Orchestrator : sig
   val check_interval_seconds : float
   val agent_name : string
+  val min_priority : int
+  val timeout_seconds : int
+  val enabled : bool
+end
+
+module TeamSession : sig
+  val model_35b_opt : unit -> string option
+  val model_27b_opt : unit -> string option
+  val model_9b_opt : unit -> string option
+  val router_judge_enabled : bool
+  val router_judge_timeout_sec : int
+  val router_judge_confidence_threshold : float
+  val router_judge_model_opt : unit -> string option
 end
 
 module Mitosis : sig

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -139,7 +139,7 @@ end
 
 module Rate = struct
   let limit =
-    get_float ~default:60.0 "MASC_RATE_LIMIT"
+    get_float ~default:100.0 "MASC_RATE_LIMIT"
 
   let burst =
     get_int ~default:150 "MASC_RATE_BURST"
@@ -155,7 +155,7 @@ module Agent = struct
     Sys.getenv_opt "MASC_AGENT_NAME" |> trim_opt
 
   let orchestrator_agent =
-    get_string ~default:"claude" "MASC_ORCHESTRATOR_AGENT"
+    get_string ~default:"orchestrator" "MASC_ORCHESTRATOR_AGENT"
 end
 
 (** {1 Config & Personas Directories} *)
@@ -210,7 +210,7 @@ module Misc = struct
     get_int ~default:5 "MASC_CIRCUIT_THRESHOLD"
 
   let circuit_cooldown =
-    get_float ~default:60.0 "MASC_CIRCUIT_COOLDOWN"
+    get_float ~default:300.0 "MASC_CIRCUIT_COOLDOWN"
 
   let pulse_max_consumer_failures =
     get_int ~default:3 "MASC_PULSE_MAX_CONSUMER_FAILURES"

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -1,0 +1,236 @@
+(** Server, transport, and storage environment configuration.
+
+    Centralizes MASC_GRPC_*, MASC_WS_*, MASC_STORAGE_*, and related
+    server-level env vars. *)
+
+open Env_config_core
+
+(** {1 gRPC Transport} *)
+
+module Grpc = struct
+  let enabled =
+    get_bool ~default:true "MASC_GRPC_ENABLED"
+
+  let port =
+    get_int ~default:8936 "MASC_GRPC_PORT"
+
+  let target =
+    get_string ~default:"" "MASC_GRPC_TARGET"
+end
+
+(** {1 WebSocket Transport} *)
+
+module Ws = struct
+  let enabled =
+    get_bool ~default:true "MASC_WS_ENABLED"
+
+  let port =
+    get_int ~default:8937 "MASC_WS_PORT"
+end
+
+(** {1 HTTP/2 Transport} *)
+
+module H2 = struct
+  (** "true"/"1" → h2_only, "false"/"0" → h1_only, "auto"/unset → auto *)
+  let mode =
+    match Sys.getenv_opt "MASC_USE_H2" |> trim_opt with
+    | Some raw -> (
+        match String.lowercase_ascii raw with
+        | "1" | "true" -> "h2_only"
+        | "0" | "false" -> "h1_only"
+        | _ -> "auto")
+    | None -> "auto"
+end
+
+(** {1 WebRTC Transport} *)
+
+module Webrtc = struct
+  let enabled =
+    get_bool ~default:false "MASC_WEBRTC_ENABLED"
+
+  let ice_servers_json_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_SERVERS_JSON" |> trim_opt
+
+  let ice_urls_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_URLS" |> trim_opt
+
+  let ice_username_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_USERNAME" |> trim_opt
+
+  let ice_credential_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_CREDENTIAL" |> trim_opt
+
+  let ice_tls_ca_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_TLS_CA" |> trim_opt
+end
+
+(** {1 Auth & Tools} *)
+
+module Auth = struct
+  let http_auth_strict =
+    get_bool ~default:false "MASC_HTTP_AUTH_STRICT"
+
+  let admin_token_opt () =
+    Sys.getenv_opt "MASC_ADMIN_TOKEN" |> trim_opt
+
+  let tool_auth_strict =
+    get_bool ~default:true "MASC_TOOL_AUTH_STRICT"
+end
+
+module Tools = struct
+  let timeout_default_sec =
+    max 5 (min 600 (get_int ~default:30 "MASC_TOOL_TIMEOUT_DEFAULT_SEC"))
+
+  let readonly_retry_limit =
+    min 5 (max 1 (get_int ~default:2 "MASC_TOOL_READONLY_RETRY_LIMIT"))
+
+  let description_budget =
+    get_int ~default:200 "MASC_TOOL_DESCRIPTION_BUDGET"
+
+  let public_tools_extra =
+    get_string ~default:"" "MASC_PUBLIC_TOOLS_EXTRA"
+
+  let full_surface =
+    get_bool ~default:false "MASC_FULL_SURFACE"
+end
+
+(** {1 Storage Backend} *)
+
+module Storage = struct
+  let storage_type =
+    get_string ~default:"" "MASC_STORAGE_TYPE"
+
+  let pg_pool_size =
+    max 1 (min 50 (get_int ~default:10 "MASC_PG_POOL_SIZE"))
+
+  let base_path_opt () =
+    Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
+
+  let base_path_input_opt () =
+    Sys.getenv_opt "MASC_BASE_PATH_INPUT" |> trim_opt
+end
+
+(** {1 Server Runtime} *)
+
+module Runtime = struct
+  let startup_watchdog_sec =
+    Float.max 30.0 (Float.min 600.0 (get_float ~default:240.0 "MASC_STARTUP_WATCHDOG_SEC"))
+
+  let telemetry_enabled =
+    get_bool ~default:true "MASC_TELEMETRY_ENABLED"
+
+  let openai_compat =
+    get_bool ~default:false "MASC_OPENAI_COMPAT"
+
+  let dispatch_v2 =
+    get_bool ~default:true "MASC_DISPATCH_V2"
+
+  let auto_respond_raw =
+    get_string ~default:"" "MASC_AUTO_RESPOND"
+
+  let parse_warn =
+    get_bool ~default:false "MASC_PARSE_WARN"
+
+  let governance_level =
+    String.lowercase_ascii (get_string ~default:"production" "MASC_GOVERNANCE_LEVEL")
+end
+
+(** {1 Rate Limiting} *)
+
+module Rate = struct
+  let limit =
+    get_float ~default:60.0 "MASC_RATE_LIMIT"
+
+  let burst =
+    get_int ~default:150 "MASC_RATE_BURST"
+end
+
+(** {1 Agent Identity} *)
+
+module Agent = struct
+  let transport =
+    get_string ~default:"http" "MASC_AGENT_TRANSPORT"
+
+  let name_opt () =
+    Sys.getenv_opt "MASC_AGENT_NAME" |> trim_opt
+
+  let orchestrator_agent =
+    get_string ~default:"claude" "MASC_ORCHESTRATOR_AGENT"
+end
+
+(** {1 Config & Personas Directories} *)
+
+module Dirs = struct
+  let config_dir_opt () =
+    Sys.getenv_opt "MASC_CONFIG_DIR" |> trim_opt
+
+  let personas_dir_opt () =
+    Sys.getenv_opt "MASC_PERSONAS_DIR" |> trim_opt
+end
+
+(** {1 External Services} *)
+
+module External = struct
+  let graphql_url () =
+    match Sys.getenv_opt "GRAPHQL_URL" |> trim_opt with
+    | Some url -> url
+    | None ->
+        get_string ~default:"https://second-brain-graphql-production.up.railway.app/graphql"
+          "RAILWAY_GRAPHQL_URL"
+
+  let graphql_api_key_opt () =
+    Sys.getenv_opt "GRAPHQL_API_KEY" |> trim_opt
+
+  let neo4j_uri_opt () =
+    Sys.getenv_opt "NEO4J_URI" |> trim_opt
+
+  let neo4j_http_uri_opt () =
+    Sys.getenv_opt "NEO4J_HTTP_URI" |> trim_opt
+
+  let neo4j_user () =
+    get_string ~default:"neo4j" "NEO4J_USER"
+
+  let neo4j_password_opt () =
+    Sys.getenv_opt "NEO4J_PASSWORD" |> trim_opt
+
+  let gemini_api_key_opt () =
+    Sys.getenv_opt "GEMINI_API_KEY" |> trim_opt
+end
+
+(** {1 Miscellaneous} *)
+
+module Misc = struct
+  let board_backend =
+    get_string ~default:"filesystem" "MASC_BOARD_BACKEND"
+
+  let board_flush_interval_sec =
+    get_float ~default:30.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
+
+  let circuit_threshold =
+    get_int ~default:5 "MASC_CIRCUIT_THRESHOLD"
+
+  let circuit_cooldown =
+    get_float ~default:60.0 "MASC_CIRCUIT_COOLDOWN"
+
+  let pulse_max_consumer_failures =
+    get_int ~default:3 "MASC_PULSE_MAX_CONSUMER_FAILURES"
+
+  let pubsub_max_messages =
+    get_int ~default:1000 "MASC_PUBSUB_MAX_MESSAGES"
+
+  let build_git_commit () =
+    get_string ~default:"unknown" "MASC_BUILD_GIT_COMMIT"
+
+  let mcp_url_opt () =
+    Sys.getenv_opt "MASC_MCP_URL" |> trim_opt
+
+  let oas_sse_drain_interval_sec =
+    Float.min 5.0 (Float.max 0.05 (get_float ~default:0.25 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC"))
+
+  let log_level =
+    get_string ~default:"info" "MASC_LOG_LEVEL"
+
+  let list_page_size =
+    let v = get_int ~default:512 "MASC_LIST_PAGE_SIZE" in
+    max 10 (min 1024 v)
+end

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -21,7 +21,7 @@ let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Filename.concat base_path ".masc"
   | None -> (
-      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      match trim_opt (Env_config_core.me_root_opt ()) with
       | Some root -> Filename.concat root ".masc"
       | None -> ".masc")
 

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -131,7 +131,7 @@ let model_of_discovery_status (status : Discovery_cache.endpoint_info) =
   | [] -> (
       match status.props with
       | Some props -> trim_opt (Some props.model)
-      | None -> trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL"))
+      | None -> trim_opt (Env_config_chain.Model.llama_swarm_model_opt ()))
 
 let max_concurrency_of_discovery_status (status : Discovery_cache.endpoint_info) =
   match status.slots with
@@ -167,7 +167,7 @@ let runtime_of_endpoint_url base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = trim_opt (Env_config_chain.Model.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;
@@ -256,7 +256,7 @@ let default_runtime () =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = trim_opt (Env_config_chain.Model.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT" ~default:default_parallel_hint;
     active_slots = 0;
@@ -274,7 +274,7 @@ let runtime_from_endpoint base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = trim_opt (Env_config_chain.Model.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;
@@ -300,7 +300,7 @@ let current_fingerprint () =
     [
       String.concat "," (Llm_provider.Discovery.endpoints_from_env ());
       Env_config.Llama.server_url;
-      Option.value ~default:"" (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+      Option.value ~default:"" (Env_config_chain.Model.llama_swarm_model_opt ());
       Option.value ~default:""
         (Env_config.Worker.llama_runtime_cooldown_sec_opt ());
       string_of_int

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -16,7 +16,7 @@ let mcp_profile_by_session : (string, Mcp_eio.tool_profile) Hashtbl.t =
 let session_mutex = Eio.Mutex.create ()
 
 let default_base_path () =
-  match Sys.getenv_opt "ME_ROOT" with
+  match Env_config_core.me_root_opt () with
   | Some path -> path
   | None -> Sys.getcwd ()
 

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -234,7 +234,7 @@ let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Filename.concat base_path ".masc"
   | None -> (
-      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      match trim_opt (Env_config_core.me_root_opt ()) with
       | Some root -> Filename.concat root ".masc"
       | None -> ".masc")
 

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -82,7 +82,7 @@ let repo_voice_config_path_opt () =
   Some (Filename.concat root ".masc/voice_config.json")
 
 let me_root_voice_config_path_opt () =
-  trim_opt (Sys.getenv_opt "ME_ROOT")
+  trim_opt (Env_config_core.me_root_opt ())
   |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
 
 let cwd_voice_config_path () =

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -233,8 +233,8 @@ let test_unified_backend () =
 
 (** Test Postgres backend if URL provided (empty string treated as absent) *)
 let test_postgres_backend () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> () (* Skip if no Postgres URL *)
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> () (* Skip if no Postgres URL *)
   | Some url ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
@@ -270,8 +270,8 @@ let test_postgres_backend () =
           Alcotest.(check bool) "pg not exists" false (Backend.Postgres.exists backend key)
 
 let test_postgres_expired_lock_reacquire () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
@@ -296,8 +296,8 @@ let test_postgres_expired_lock_reacquire () =
           | Error _ -> Alcotest.fail "expired postgres lock reacquire failed"
 
 let test_postgres_lock_blocks_other_owner () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
@@ -321,8 +321,8 @@ let test_postgres_lock_blocks_other_owner () =
           | Error _ -> Alcotest.fail "non-expired postgres lock check failed"
 
 let test_postgres_expired_lock_concurrent_reacquire () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
@@ -356,8 +356,8 @@ let test_postgres_expired_lock_concurrent_reacquire () =
             (bool_to_int acquired_a + bool_to_int acquired_b)
 
 let test_postgres_old_owner_cannot_release_reclaimed_lock () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -8,10 +8,7 @@ open Masc_mcp
 let () = Mirage_crypto_rng_unix.use_default ()
 
 (** Check if PG is available (empty string treated as absent) *)
-let pg_url () =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | Some s when String.trim s <> "" -> Some s
-  | _ -> None
+let pg_url () = Masc_mcp.Env_config_core.postgres_url_opt ()
 
 (** Delete all pg-test-* rows from board tables (votes -> comments -> posts).
     Uses a single connection for all three DELETEs.

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -51,8 +51,8 @@ let with_test_env f =
         (fun () -> f ~env ~sw ~config))
 
 let with_pg_test_env f =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       let dir = test_dir () in
       Fun.protect

--- a/test/test_room_messages_pg.ml
+++ b/test/test_room_messages_pg.ml
@@ -28,8 +28,8 @@ let with_env key value f =
     f
 
 let with_pg_test_env f =
-  match Sys.getenv_opt "MASC_POSTGRES_URL" with
-  | None | Some "" -> ()
+  match Masc_mcp.Env_config_core.postgres_url_opt () with
+  | None -> ()
   | Some url ->
       let dir = test_dir () in
       Fun.protect


### PR DESCRIPTION
## Summary
- 3개 새 typed sub-module 추가: `Env_config_server`, `Env_config_chain`, `Env_config_dashboard`
- `Env_config_runtime`에 `Orchestrator`(3 엔트리) + `TeamSession`(7 엔트리) 추가
- `to_json()` dashboard introspection 함수 추가 (#3365)
- 12개 소비자 파일의 `Sys.getenv_opt` 직접 호출을 typed accessor로 교체

## Design decisions
- `module Chain` alias 제거: `Env_config_runtime.Chain`과 이름 충돌. `Env_config_chain`으로 직접 접근
- Sub-library(council, backend, core, room, masc_log)는 마이그레이션 불가 — 역방향 의존 불가
- `MASC_STORAGE_TYPE` 기본값을 `""` (빈 문자열)으로 설정 — PG env var 자동 감지 보존

## Test plan
- [x] `dune build @check` 통과
- [x] Cross-model review (GLM-5) — high/critical 이슈 없음
- [ ] CI green 확인

Closes #3364
Closes #3365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>