### PR TITLE
chore: remove dead code — unused function and disabled test stanzas

### DIFF
--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -106,10 +106,6 @@ let session_id_of_result_json json =
   try Some Yojson.Safe.Util.(json |> member "session_id" |> to_string)
   with Yojson.Safe.Util.Type_error _ -> None
 
-let _bool_option_to_json = function
-  | Some value -> `Bool value
-  | None -> `Null
-
 let string_option_to_json = function
   | Some value -> `String value
   | None -> `Null

--- a/test/dune
+++ b/test/dune
@@ -736,19 +736,6 @@
 
 ; WebRTC contract test removed — modules moved to ocaml-webrtc
 
-; ============================================================
-; Disabled: Lwt-based tests (require cohttp-lwt-unix, ppx_lwt)
-; These modules are not currently in masc_mcp library.
-; ============================================================
-; (test
-;  (name test_voice_bridge)
-;  (modules test_voice_bridge)
-;  (libraries masc_mcp alcotest lwt lwt.unix cohttp-lwt-unix yojson))
-;
-; (test
-;  (name test_webrtc_datachannel)
-;  (modules test_webrtc_datachannel)
-;  (libraries masc_mcp alcotest lwt lwt.unix))
 (executable
  (name test_atomic_simple)
  (modules test_atomic_simple)


### PR DESCRIPTION
## Summary
- Remove `_bool_option_to_json` from `keeper_turn_session.ml` (defined but never called anywhere)
- Remove disabled `test_voice_bridge` and `test_webrtc_datachannel` stanzas from `test/dune` (source files don't exist, Lwt deps removed)

## Context
4-agent parallel scan (modules/functions/tests/dune) found only 2 items of dead code in the 327K LOC codebase. The rest is well-maintained.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)