### PR TITLE
feat(cdal): JSONL persistence + actionable recommendations

### DIFF
--- a/lib/cdal_eval.ml
+++ b/lib/cdal_eval.ml
@@ -130,8 +130,25 @@ let violation_summary_to_json (v : violation_summary) : Yojson.Safe.t =
      | None -> `Null);
   ]
 
+let recommendation (r : eval_result) : string option =
+  match r.overall with
+  | Ok -> None
+  | Fail "cancelled by contract" ->
+    Some "contract risk_class or requested_execution_mode is incompatible with keeper capabilities; adjust scope_kind in keeper config"
+  | Fail reason -> Some (Printf.sprintf "investigate failure: %s" reason)
+  | Warn reason ->
+    if r.violations.violation_ref_count > 0 then
+      if r.violations.mode_was_downgraded then
+        Some "mode was downgraded and violations detected; widen scope_kind to match actual tool usage or remove mutating tools"
+      else
+        Some "mode violations detected; restrict tools to match execution mode or widen scope_kind"
+    else if not r.evidence.completed_normally then
+      Some "run did not complete normally; check max_turns, timeout, or model availability"
+    else
+      Some (Printf.sprintf "review: %s" reason)
+
 let to_json (r : eval_result) : Yojson.Safe.t =
-  `Assoc [
+  let base = [
     ("run_id", `String r.run_id);
     ("contract_id", `String r.contract_id);
     ("result_status",
@@ -140,4 +157,39 @@ let to_json (r : eval_result) : Yojson.Safe.t =
     ("violations", violation_summary_to_json r.violations);
     ("overall", severity_to_json r.overall);
     ("evaluated_at", `Float r.evaluated_at);
-  ]
+  ] in
+  let extra = match recommendation r with
+    | Some rec_text -> [("recommendation", `String rec_text)]
+    | None -> []
+  in
+  `Assoc (base @ extra)
+
+(* ================================================================ *)
+(* JSONL Persistence                                                 *)
+(* ================================================================ *)
+
+let store_ref : Dated_jsonl.t option ref = ref None
+
+let base_path () =
+  let root = try Sys.getenv "MASC_DATA_DIR"
+    with Not_found ->
+      try Filename.concat (Sys.getenv "ME_ROOT") "data"
+      with Not_found -> "data"
+  in
+  Filename.concat root "cdal_evals"
+
+let get_store () =
+  match !store_ref with
+  | Some s -> s
+  | None ->
+    let s = Dated_jsonl.create ~base_dir:(base_path ()) () in
+    store_ref := Some s;
+    s
+
+let reset_store_for_testing () = store_ref := None
+
+let set_store_for_testing ~base_dir =
+  store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let persist (r : eval_result) : unit =
+  Dated_jsonl.append (get_store ()) (to_json r)

--- a/lib/cdal_eval.mli
+++ b/lib/cdal_eval.mli
@@ -55,3 +55,17 @@ val to_json : eval_result -> Yojson.Safe.t
 
 (** Severity to short string for logging. *)
 val severity_to_string : severity -> string
+
+(** Actionable recommendation based on the eval result.
+    Returns [None] when overall is [Ok]. *)
+val recommendation : eval_result -> string option
+
+(** Persist eval result to date-partitioned JSONL store.
+    Writes to [data/cdal_evals/YYYY-MM/DD.jsonl]. *)
+val persist : eval_result -> unit
+
+(** Reset the store reference.  For testing only. *)
+val reset_store_for_testing : unit -> unit
+
+(** Set a custom store base directory.  For testing only. *)
+val set_store_for_testing : base_dir:string -> unit

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -253,11 +253,14 @@ let run_turn
               (Agent_sdk.Cdal_proof.show_result_status p.result_status)
               (List.length p.raw_evidence_refs);
             let eval = Cdal_eval.evaluate p in
+            Cdal_eval.persist eval;
             Log.Keeper.info "keeper:%s cdal_eval: %s"
               meta.name (Cdal_eval.severity_to_string eval.overall);
-            if not (Cdal_eval.is_acceptable eval) then
-              Log.Keeper.warn "keeper:%s cdal verdict NOT acceptable: %s"
-                meta.name (Cdal_eval.severity_to_string eval.overall)
+            (match Cdal_eval.recommendation eval with
+             | Some rec_text ->
+               Log.Keeper.warn "keeper:%s cdal recommendation: %s"
+                 meta.name rec_text
+             | None -> ())
           | None -> ());
          Ok {
            response_text;

--- a/test/test_cdal_eval.ml
+++ b/test/test_cdal_eval.ml
@@ -175,6 +175,74 @@ let test_json_output () =
   | _ -> Alcotest.fail "expected JSON object"
 
 (* ================================================================ *)
+(* Test: Recommendation for Ok → None                                *)
+(* ================================================================ *)
+
+let test_recommendation_ok () =
+  let proof = make_proof () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Alcotest.(check bool) "no recommendation for Ok"
+    true (Masc_mcp.Cdal_eval.recommendation result = None)
+
+(* ================================================================ *)
+(* Test: Recommendation for violations → actionable text             *)
+(* ================================================================ *)
+
+let test_recommendation_violations () =
+  let proof = make_proof
+    ~raw_evidence_refs:["proof-store://r1/evidence/mode_violations.json"] () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  match Masc_mcp.Cdal_eval.recommendation result with
+  | Some text ->
+    Alcotest.(check bool) "mentions scope_kind or tools"
+      true (String.length text > 10)
+  | None -> Alcotest.fail "expected recommendation for violations"
+
+(* ================================================================ *)
+(* Test: Recommendation for cancelled → mentions scope_kind          *)
+(* ================================================================ *)
+
+let test_recommendation_cancelled () =
+  let proof = make_proof ~result_status:Cancelled () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  match Masc_mcp.Cdal_eval.recommendation result with
+  | Some text ->
+    Alcotest.(check bool) "mentions scope_kind"
+      true (String.length text > 10)
+  | None -> Alcotest.fail "expected recommendation for cancelled"
+
+(* ================================================================ *)
+(* Test: JSON includes recommendation field when not Ok              *)
+(* ================================================================ *)
+
+let test_json_has_recommendation () =
+  let proof = make_proof ~result_status:Errored () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  let json = Masc_mcp.Cdal_eval.to_json result in
+  match json with
+  | `Assoc fields ->
+    Alcotest.(check bool) "has recommendation"
+      true (List.mem_assoc "recommendation" fields)
+  | _ -> Alcotest.fail "expected JSON object"
+
+(* ================================================================ *)
+(* Test: Persist writes to JSONL store                               *)
+(* ================================================================ *)
+
+let test_persist () =
+  Eio_main.run @@ fun _env ->
+  let tmp_dir = Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "cdal_eval_test_%d" (Unix.getpid ())) in
+  Masc_mcp.Cdal_eval.set_store_for_testing ~base_dir:tmp_dir;
+  let proof = make_proof () in
+  let result = Masc_mcp.Cdal_eval.evaluate proof in
+  Masc_mcp.Cdal_eval.persist result;
+  Alcotest.(check bool) "store dir exists"
+    true (Sys.file_exists tmp_dir);
+  Masc_mcp.Cdal_eval.reset_store_for_testing ()
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -190,5 +258,10 @@ let () =
       Alcotest.test_case "mode downgrade" `Quick test_mode_downgrade;
       Alcotest.test_case "checkpoint present" `Quick test_checkpoint_present;
       Alcotest.test_case "json output" `Quick test_json_output;
+      Alcotest.test_case "recommendation ok" `Quick test_recommendation_ok;
+      Alcotest.test_case "recommendation violations" `Quick test_recommendation_violations;
+      Alcotest.test_case "recommendation cancelled" `Quick test_recommendation_cancelled;
+      Alcotest.test_case "json has recommendation" `Quick test_json_has_recommendation;
+      Alcotest.test_case "persist" `Quick test_persist;
     ]);
   ]


### PR DESCRIPTION
## Summary

Phase 0 eval(#3565)에 이어 CDAL 루프 Level 1→2 완성.

- **JSONL persistence**: eval verdict를 `data/cdal_evals/YYYY-MM/DD.jsonl`에 date-partitioned 적재. `Dated_jsonl` 패턴 재사용.
- **Actionable recommendations**: verdict에 operator가 취할 action을 매핑.
  - violations → "restrict tools to match execution mode or widen scope_kind"
  - cancelled → "adjust scope_kind in keeper config"
  - timed_out/errored → "check max_turns, timeout, or model availability"
- Keeper가 recommendation을 warn 레벨로 로그

### 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/cdal_eval.ml` | persist, recommendation, store 추가 (~60 LOC) |
| `lib/cdal_eval.mli` | persist, recommendation, store API 노출 |
| `lib/keeper/keeper_agent_run.ml` | persist 호출 + recommendation 로깅 |
| `test/test_cdal_eval.ml` | 5 new tests (14 total) |

## Test plan

- [x] `dune exec --root . test/test_cdal_eval.exe` — 14/14 통과
- [ ] CI Build and Test green

## Relates

- Phase 0: #3565
- RFC: #3475
- Tracker: #3528