### PR TITLE
refactor(cdal): content-based eval — proof artifact reading + constraint algebra

### DIFF
--- a/lib/cdal_eval.ml
+++ b/lib/cdal_eval.ml
@@ -1,101 +1,169 @@
-(** Cdal_eval -- Phase 0 structural verdict over CDAL proof bundles.
+(** Cdal_eval — Content-based CDAL proof evaluation.
 
-    @since Phase 0 -- CDAL proof tap *)
+    @since CDAL eval content-based redesign *)
 
 type severity =
   | Ok
   | Warn of string
   | Fail of string
 
-type evidence_check = {
-  has_tool_traces : bool;
-  has_raw_evidence : bool;
-  has_checkpoint : bool;
+type evidence_content = {
+  violations : Violation_record.t list;
+  token_usage : Token_usage_record.t list;
+  tool_trace_count : int;
   completed_normally : bool;
 }
 
-type violation_summary = {
-  violation_ref_count : int;
-  mode_was_downgraded : bool;
-  downgrade_reason : string option;
+type mode_recommendation = {
+  current_mode : Agent_sdk.Execution_mode.t;
+  minimum_required : Agent_sdk.Execution_mode.t;
+  gap : int;
+  offending_tools : string list;
+  violation_kinds : Violation_record.violation_kind list;
 }
 
 type eval_result = {
-  evidence : evidence_check;
-  violations : violation_summary;
+  evidence : evidence_content;
   overall : severity;
+  recommendation : mode_recommendation option;
   run_id : string;
   contract_id : string;
   result_status : Agent_sdk.Cdal_proof.result_status;
   evaluated_at : float;
 }
 
-let string_contains ~needle haystack =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let rec check i =
-      if i > hlen - nlen then false
-      else if String.sub haystack i nlen = needle then true
-      else check (i + 1)
-    in
-    check 0
+(* ================================================================ *)
+(* Constraint algebra                                                *)
+(* ================================================================ *)
 
-let count_violation_refs (refs : Agent_sdk.Cdal_proof.artifact_ref list) : int =
-  List.length
-    (List.filter (fun r -> string_contains ~needle:"mode_violations" r) refs)
+let mode_ordinal = function
+  | Agent_sdk.Execution_mode.Diagnose -> 0
+  | Draft -> 1
+  | Execute -> 2
 
-let make_evidence_check (p : Agent_sdk.Cdal_proof.t) : evidence_check =
-  {
-    has_tool_traces = p.tool_trace_refs <> [];
-    has_raw_evidence = p.raw_evidence_refs <> [];
-    has_checkpoint = p.checkpoint_ref <> None;
-    completed_normally = p.result_status = Completed;
-  }
+let compute_recommendation ~(effective_mode : Agent_sdk.Execution_mode.t)
+    (violations : Violation_record.t list) : mode_recommendation option =
+  match violations with
+  | [] -> None
+  | _ ->
+    let max_required = List.fold_left (fun acc v ->
+      let req = Violation_record.minimum_required_mode v in
+      if mode_ordinal req > mode_ordinal acc then req else acc
+    ) effective_mode violations in
+    let gap = mode_ordinal max_required - mode_ordinal effective_mode in
+    if gap <= 0 then None
+    else
+      let tools = List.sort_uniq String.compare
+        (List.map (fun (v : Violation_record.t) -> v.tool_name) violations) in
+      let kinds = List.sort_uniq compare
+        (List.map (fun (v : Violation_record.t) -> v.violation_kind) violations) in
+      Some {
+        current_mode = effective_mode;
+        minimum_required = max_required;
+        gap;
+        offending_tools = tools;
+        violation_kinds = kinds;
+      }
 
-let make_violation_summary (p : Agent_sdk.Cdal_proof.t) : violation_summary =
-  let downgraded =
-    p.effective_execution_mode <> p.requested_execution_mode
-  in
-  {
-    violation_ref_count = count_violation_refs p.raw_evidence_refs;
-    mode_was_downgraded = downgraded;
-    downgrade_reason =
-      (if downgraded then Some p.mode_decision_source else None);
-  }
+(* ================================================================ *)
+(* Verdict computation                                               *)
+(* ================================================================ *)
 
-let compute_overall ~(evidence : evidence_check)
-    ~(violations : violation_summary)
-    ~(result_status : Agent_sdk.Cdal_proof.result_status) : severity =
+let compute_overall ~(evidence : evidence_content)
+    ~(result_status : Agent_sdk.Cdal_proof.result_status)
+    ~(recommendation : mode_recommendation option) : severity =
   match result_status with
   | Cancelled -> Fail "cancelled by contract"
   | Errored -> Warn "execution error"
   | Timed_out -> Warn "execution timed out"
   | Completed ->
-    if violations.violation_ref_count > 0 then
-      Warn
-        (Printf.sprintf "%d mode violation(s) detected"
-           violations.violation_ref_count)
-    else if
-      (not evidence.has_tool_traces) && (not evidence.has_raw_evidence)
-    then
-      Warn "no evidence produced"
-    else Ok
+    match recommendation with
+    | Some r ->
+      Warn (Printf.sprintf "%d violation(s) from %s; requires %s (current: %s)"
+              (List.length evidence.violations)
+              (String.concat ", " r.offending_tools)
+              (Agent_sdk.Execution_mode.to_string r.minimum_required)
+              (Agent_sdk.Execution_mode.to_string r.current_mode))
+    | None ->
+      if evidence.tool_trace_count = 0 && evidence.violations = [] then
+        Warn "no evidence produced"
+      else Ok
 
-let evaluate (p : Agent_sdk.Cdal_proof.t) : eval_result =
-  let evidence = make_evidence_check p in
-  let violations = make_violation_summary p in
-  let overall = compute_overall ~evidence ~violations ~result_status:p.result_status in
+(* ================================================================ *)
+(* Pure evaluation (no I/O)                                          *)
+(* ================================================================ *)
+
+let evaluate_content ~(violations : Violation_record.t list)
+    ~(token_usage : Token_usage_record.t list) ~(trace_count : int)
+    (p : Agent_sdk.Cdal_proof.t) : eval_result =
+  let evidence = {
+    violations;
+    token_usage;
+    tool_trace_count = trace_count;
+    completed_normally = p.result_status = Completed;
+  } in
+  let recommendation =
+    compute_recommendation ~effective_mode:p.effective_execution_mode violations in
+  let overall = compute_overall ~evidence ~result_status:p.result_status
+      ~recommendation in
   {
     evidence;
-    violations;
     overall;
+    recommendation;
     run_id = p.run_id;
     contract_id = p.contract_id;
     result_status = p.result_status;
     evaluated_at = Unix.gettimeofday ();
   }
+
+(* ================================================================ *)
+(* Artifact-reading evaluation                                       *)
+(* ================================================================ *)
+
+let read_violations (store : Agent_sdk.Proof_store.config)
+    (refs : Agent_sdk.Cdal_proof.artifact_ref list) : Violation_record.t list =
+  List.concat_map (fun ref_ ->
+    match Proof_artifact_reader.read_json store ref_ with
+    | Ok json ->
+      (match Violation_record.of_json_list json with
+       | Ok vs -> vs
+       | Error _ -> [])
+    | Error _ -> []
+  ) (List.filter (fun r ->
+    let len = String.length r in
+    len >= 20 && (
+      let suffix = String.sub r (len - 20) 20 in
+      suffix = "mode_violations.json"
+    )
+  ) refs)
+
+let read_token_usage (store : Agent_sdk.Proof_store.config)
+    (refs : Agent_sdk.Cdal_proof.artifact_ref list) : Token_usage_record.t list =
+  List.concat_map (fun ref_ ->
+    match Proof_artifact_reader.read_json store ref_ with
+    | Ok json ->
+      (match Token_usage_record.of_json_list json with
+       | Ok ts -> ts
+       | Error _ -> [])
+    | Error _ -> []
+  ) (List.filter (fun r ->
+    let len = String.length r in
+    len >= 16 && (
+      let suffix = String.sub r (len - 16) 16 in
+      suffix = "token_usage.json"
+    )
+  ) refs)
+
+let evaluate ~(store : Agent_sdk.Proof_store.config)
+    (p : Agent_sdk.Cdal_proof.t) : eval_result =
+  let violations = read_violations store p.raw_evidence_refs in
+  let token_usage = read_token_usage store p.raw_evidence_refs in
+  let trace_count = List.length p.tool_trace_refs in
+  evaluate_content ~violations ~token_usage ~trace_count p
+
+(* ================================================================ *)
+(* Severity helpers                                                  *)
+(* ================================================================ *)
 
 let is_acceptable (r : eval_result) : bool =
   match r.overall with
@@ -107,45 +175,31 @@ let severity_to_string = function
   | Warn reason -> Printf.sprintf "warn: %s" reason
   | Fail reason -> Printf.sprintf "fail: %s" reason
 
+(* ================================================================ *)
+(* JSON serialization                                                *)
+(* ================================================================ *)
+
 let severity_to_json = function
   | Ok -> `Assoc [("level", `String "ok")]
   | Warn reason -> `Assoc [("level", `String "warn"); ("reason", `String reason)]
   | Fail reason -> `Assoc [("level", `String "fail"); ("reason", `String reason)]
 
-let evidence_check_to_json (e : evidence_check) : Yojson.Safe.t =
+let violation_to_json (v : Violation_record.t) : Yojson.Safe.t =
   `Assoc [
-    ("has_tool_traces", `Bool e.has_tool_traces);
-    ("has_raw_evidence", `Bool e.has_raw_evidence);
-    ("has_checkpoint", `Bool e.has_checkpoint);
-    ("completed_normally", `Bool e.completed_normally);
+    ("tool_name", `String v.tool_name);
+    ("violation_kind", `String (Violation_record.violation_kind_to_string v.violation_kind));
+    ("effective_mode", `String (Agent_sdk.Execution_mode.to_string v.effective_mode));
   ]
 
-let violation_summary_to_json (v : violation_summary) : Yojson.Safe.t =
+let recommendation_to_json (r : mode_recommendation) : Yojson.Safe.t =
   `Assoc [
-    ("violation_ref_count", `Int v.violation_ref_count);
-    ("mode_was_downgraded", `Bool v.mode_was_downgraded);
-    ("downgrade_reason",
-     match v.downgrade_reason with
-     | Some r -> `String r
-     | None -> `Null);
+    ("current_mode", `String (Agent_sdk.Execution_mode.to_string r.current_mode));
+    ("minimum_required", `String (Agent_sdk.Execution_mode.to_string r.minimum_required));
+    ("gap", `Int r.gap);
+    ("offending_tools", `List (List.map (fun s -> `String s) r.offending_tools));
+    ("violation_kinds", `List (List.map (fun k ->
+       `String (Violation_record.violation_kind_to_string k)) r.violation_kinds));
   ]
-
-let recommendation (r : eval_result) : string option =
-  match r.overall with
-  | Ok -> None
-  | Fail "cancelled by contract" ->
-    Some "contract risk_class or requested_execution_mode is incompatible with keeper capabilities; adjust scope_kind in keeper config"
-  | Fail reason -> Some (Printf.sprintf "investigate failure: %s" reason)
-  | Warn reason ->
-    if r.violations.violation_ref_count > 0 then
-      if r.violations.mode_was_downgraded then
-        Some "mode was downgraded and violations detected; widen scope_kind to match actual tool usage or remove mutating tools"
-      else
-        Some "mode violations detected; restrict tools to match execution mode or widen scope_kind"
-    else if not r.evidence.completed_normally then
-      Some "run did not complete normally; check max_turns, timeout, or model availability"
-    else
-      Some (Printf.sprintf "review: %s" reason)
 
 let to_json (r : eval_result) : Yojson.Safe.t =
   let base = [
@@ -153,19 +207,21 @@ let to_json (r : eval_result) : Yojson.Safe.t =
     ("contract_id", `String r.contract_id);
     ("result_status",
      `String (Agent_sdk.Cdal_proof.show_result_status r.result_status));
-    ("evidence", evidence_check_to_json r.evidence);
-    ("violations", violation_summary_to_json r.violations);
     ("overall", severity_to_json r.overall);
+    ("violations", `List (List.map violation_to_json r.evidence.violations));
+    ("token_usage_total", `Int (Token_usage_record.total_tokens r.evidence.token_usage));
+    ("tool_trace_count", `Int r.evidence.tool_trace_count);
+    ("completed_normally", `Bool r.evidence.completed_normally);
     ("evaluated_at", `Float r.evaluated_at);
   ] in
-  let extra = match recommendation r with
-    | Some rec_text -> [("recommendation", `String rec_text)]
+  let extra = match r.recommendation with
+    | Some rec_ -> [("recommendation", recommendation_to_json rec_)]
     | None -> []
   in
   `Assoc (base @ extra)
 
 (* ================================================================ *)
-(* JSONL Persistence                                                 *)
+(* JSONL persistence                                                 *)
 (* ================================================================ *)
 
 let store_ref : Dated_jsonl.t option ref = ref None

--- a/lib/cdal_eval.mli
+++ b/lib/cdal_eval.mli
@@ -1,13 +1,11 @@
-(** Cdal_eval -- Phase 0 structural verdict over CDAL proof bundles.
+(** Cdal_eval — Content-based CDAL proof evaluation.
 
-    Consumes {!Agent_sdk.Cdal_proof.t} and produces a deterministic verdict.
-    No LLM judge, no golden set, no baseline lock.
+    Reads actual proof artifacts (violations, token usage, tool traces)
+    and derives verdict + recommendation from their content.
+    Recommendation is computed via constraint algebra (inverse of
+    [Mode_enforcer.check_violation]), not hardcoded string mapping.
 
-    Two dimensions:
-    - Evidence presence: did OAS produce expected artifacts?
-    - Violation summary: did Mode_enforcer detect runtime violations?
-
-    @since Phase 0 -- CDAL proof tap *)
+    @since CDAL eval content-based redesign *)
 
 (** Verdict severity. *)
 type severity =
@@ -15,57 +13,57 @@ type severity =
   | Warn of string
   | Fail of string
 
-(** Evidence presence check -- did OAS produce artifacts?
-    This is a crash detector, not a quality signal. *)
-type evidence_check = {
-  has_tool_traces : bool;
-  has_raw_evidence : bool;
-  has_checkpoint : bool;
+(** Evidence actually read from proof artifacts. *)
+type evidence_content = {
+  violations : Violation_record.t list;
+  token_usage : Token_usage_record.t list;
+  tool_trace_count : int;
   completed_normally : bool;
 }
 
-(** Runtime violation summary extracted from proof metadata.
-    Mode_enforcer already collects violations at runtime;
-    this aggregates what was recorded in the proof bundle. *)
-type violation_summary = {
-  violation_ref_count : int;
-  mode_was_downgraded : bool;
-  downgrade_reason : string option;
+(** Structured recommendation derived from constraint algebra.
+    [minimum_required] is computed as [max(minimum_required_mode v)]
+    across all violations. [gap] is the ordinal distance from
+    [current_mode] to [minimum_required]. *)
+type mode_recommendation = {
+  current_mode : Agent_sdk.Execution_mode.t;
+  minimum_required : Agent_sdk.Execution_mode.t;
+  gap : int;
+  offending_tools : string list;
+  violation_kinds : Violation_record.violation_kind list;
 }
 
-(** Phase 0 eval result. *)
+(** Eval result with full evidence content. *)
 type eval_result = {
-  evidence : evidence_check;
-  violations : violation_summary;
+  evidence : evidence_content;
   overall : severity;
+  recommendation : mode_recommendation option;
   run_id : string;
   contract_id : string;
   result_status : Agent_sdk.Cdal_proof.result_status;
   evaluated_at : float;
 }
 
-(** Evaluate a proof bundle. Pure function, no I/O. *)
-val evaluate : Agent_sdk.Cdal_proof.t -> eval_result
+(** Evaluate a proof bundle by reading actual artifacts from the proof store.
+    Gracefully degrades if artifact files are missing. *)
+val evaluate :
+  store:Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.t ->
+  eval_result
 
-(** [is_acceptable r] returns [true] when [r.overall] is [Ok] or [Warn _]. *)
+(** Pure evaluation from pre-loaded content (for testing without I/O). *)
+val evaluate_content :
+  violations:Violation_record.t list ->
+  token_usage:Token_usage_record.t list ->
+  trace_count:int ->
+  Agent_sdk.Cdal_proof.t ->
+  eval_result
+
 val is_acceptable : eval_result -> bool
-
-(** JSON serialization for JSONL persistence. *)
 val to_json : eval_result -> Yojson.Safe.t
-
-(** Severity to short string for logging. *)
 val severity_to_string : severity -> string
 
-(** Actionable recommendation based on the eval result.
-    Returns [None] when overall is [Ok]. *)
-val recommendation : eval_result -> string option
-
-(** Persist eval result to date-partitioned JSONL store.
-    Writes to [data/cdal_evals/YYYY-MM/DD.jsonl]. *)
+(** Persist eval result to date-partitioned JSONL store. *)
 val persist : eval_result -> unit
-
-(** Reset the store reference.  For testing only. *)
 val reset_store_for_testing : unit -> unit
-
-(** Set a custom store base directory.  For testing only. *)
 val set_store_for_testing : base_dir:string -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -466,6 +466,9 @@
    keeper_toml_loader
    keeper_contract
    keeper_cdal_contract
+   proof_artifact_reader
+   violation_record
+   token_usage_record
    cdal_eval
    keeper_deliberation
    keeper_types_profile

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -252,14 +252,19 @@ let run_turn
               (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
               (Agent_sdk.Cdal_proof.show_result_status p.result_status)
               (List.length p.raw_evidence_refs);
-            let eval = Cdal_eval.evaluate p in
+            let store = Agent_sdk.Proof_store.default_config in
+            let eval = Cdal_eval.evaluate ~store p in
             Cdal_eval.persist eval;
             Log.Keeper.info "keeper:%s cdal_eval: %s"
               meta.name (Cdal_eval.severity_to_string eval.overall);
-            (match Cdal_eval.recommendation eval with
-             | Some rec_text ->
-               Log.Keeper.warn "keeper:%s cdal recommendation: %s"
-                 meta.name rec_text
+            (match eval.recommendation with
+             | Some r ->
+               Log.Keeper.warn
+                 "keeper:%s cdal: %d violation(s) from [%s]; mode %s needed (current: %s)"
+                 meta.name (List.length eval.evidence.violations)
+                 (String.concat ", " r.offending_tools)
+                 (Agent_sdk.Execution_mode.to_string r.minimum_required)
+                 (Agent_sdk.Execution_mode.to_string r.current_mode)
              | None -> ())
           | None -> ());
          Ok {

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -1,0 +1,28 @@
+(** Proof_artifact_reader — Dereference proof-store:// artifact refs.
+
+    @since CDAL eval content-based redesign *)
+
+let prefix = "proof-store://"
+let prefix_len = String.length prefix
+
+let resolve_path (config : Agent_sdk.Proof_store.config)
+    (ref_ : Agent_sdk.Cdal_proof.artifact_ref) : (string, string) result =
+  if String.length ref_ > prefix_len
+     && String.sub ref_ 0 prefix_len = prefix then
+    let rel = String.sub ref_ prefix_len (String.length ref_ - prefix_len) in
+    Ok (Filename.concat (Filename.concat config.root "proofs") rel)
+  else
+    Error (Printf.sprintf "invalid artifact ref: %s" ref_)
+
+let read_json (config : Agent_sdk.Proof_store.config)
+    (ref_ : Agent_sdk.Cdal_proof.artifact_ref)
+    : (Yojson.Safe.t, string) result =
+  match resolve_path config ref_ with
+  | Error e -> Error e
+  | Ok path ->
+    if Sys.file_exists path then
+      (try Ok (Yojson.Safe.from_file path)
+       with exn -> Error (Printf.sprintf "JSON parse error in %s: %s"
+                            path (Printexc.to_string exn)))
+    else
+      Error (Printf.sprintf "artifact not found: %s" path)

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -1,0 +1,20 @@
+(** Proof_artifact_reader — Dereference proof-store:// artifact refs.
+
+    Resolves [proof-store://{run_id}/{subpath}] references to filesystem
+    paths under [{config.root}/proofs/] and reads their JSON content.
+
+    @since CDAL eval content-based redesign *)
+
+(** Resolve a proof-store:// artifact_ref to a filesystem path.
+    Returns [Error] if the ref does not have the expected prefix. *)
+val resolve_path :
+  Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.artifact_ref ->
+  (string, string) result
+
+(** Read and parse a JSON artifact from the proof store.
+    Returns [Error] if the file does not exist or is not valid JSON. *)
+val read_json :
+  Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.artifact_ref ->
+  (Yojson.Safe.t, string) result

--- a/lib/token_usage_record.ml
+++ b/lib/token_usage_record.ml
@@ -1,0 +1,46 @@
+(** Token_usage_record — Parse token usage evidence from CDAL proof.
+
+    @since CDAL eval content-based redesign *)
+
+type t = {
+  turn : int;
+  input_tokens : int;
+  output_tokens : int;
+  cost_usd : float option;
+}
+
+let of_json (json : Yojson.Safe.t) : (t, string) result =
+  match json with
+  | `Assoc fields ->
+    let get key = List.assoc_opt key fields in
+    (match get "turn", get "input_tokens", get "output_tokens" with
+     | Some (`Int turn), Some (`Int input_tokens), Some (`Int output_tokens) ->
+       let cost_usd = match get "cost_usd" with
+         | Some (`Float c) -> Some c
+         | Some (`Int c) -> Some (Float.of_int c)
+         | _ -> None
+       in
+       Ok { turn; input_tokens; output_tokens; cost_usd }
+     | _ -> Error "missing required fields in token usage record")
+  | _ -> Error "token usage record must be a JSON object"
+
+let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
+  match json with
+  | `List items ->
+    let rec parse acc = function
+      | [] -> Ok (List.rev acc)
+      | item :: rest ->
+        (match of_json item with
+         | Ok v -> parse (v :: acc) rest
+         | Error e -> Error e)
+    in
+    parse [] items
+  | _ -> Error "expected JSON array of token usage records"
+
+let total_tokens (records : t list) : int =
+  List.fold_left (fun acc r -> acc + r.input_tokens + r.output_tokens) 0 records
+
+let total_cost (records : t list) : float =
+  List.fold_left (fun acc r ->
+    match r.cost_usd with Some c -> acc +. c | None -> acc
+  ) 0.0 records

--- a/lib/token_usage_record.mli
+++ b/lib/token_usage_record.mli
@@ -1,0 +1,19 @@
+(** Token_usage_record — Parse token usage evidence from CDAL proof.
+
+    @since CDAL eval content-based redesign *)
+
+type t = {
+  turn : int;
+  input_tokens : int;
+  output_tokens : int;
+  cost_usd : float option;
+}
+
+(** Parse an array of token usage records from JSON. *)
+val of_json_list : Yojson.Safe.t -> (t list, string) result
+
+(** Total input + output tokens across all turns. *)
+val total_tokens : t list -> int
+
+(** Total cost across all turns (0.0 if no cost data). *)
+val total_cost : t list -> float

--- a/lib/violation_record.ml
+++ b/lib/violation_record.ml
@@ -1,0 +1,76 @@
+(** Violation_record — Typed violation records + constraint algebra.
+
+    @since CDAL eval content-based redesign *)
+
+type violation_kind =
+  | Mutating_in_diagnose
+  | External_in_draft
+  | Scope_violation
+  | Unknown of string
+
+type t = {
+  ts : float;
+  tool_name : string;
+  input_summary : string;
+  effective_mode : Agent_sdk.Execution_mode.t;
+  violation_kind : violation_kind;
+}
+
+let violation_kind_of_string = function
+  | "mutating_in_diagnose" -> Mutating_in_diagnose
+  | "external_in_draft" -> External_in_draft
+  | "scope_violation" -> Scope_violation
+  | s -> Unknown s
+
+let violation_kind_to_string = function
+  | Mutating_in_diagnose -> "mutating_in_diagnose"
+  | External_in_draft -> "external_in_draft"
+  | Scope_violation -> "scope_violation"
+  | Unknown s -> s
+
+let effective_mode_of_string = function
+  | "diagnose" -> Agent_sdk.Execution_mode.Diagnose
+  | "draft" -> Agent_sdk.Execution_mode.Draft
+  | "execute" -> Agent_sdk.Execution_mode.Execute
+  | _ -> Agent_sdk.Execution_mode.Diagnose
+
+let of_json (json : Yojson.Safe.t) : (t, string) result =
+  match json with
+  | `Assoc fields ->
+    let get key = List.assoc_opt key fields in
+    (match get "ts", get "tool_name", get "violation_kind", get "effective_mode" with
+     | Some (`Float ts), Some (`String tool_name),
+       Some (`String vk), Some (`String em) ->
+       let input_summary = match get "input_summary" with
+         | Some (`String s) -> s
+         | _ -> ""
+       in
+       Ok {
+         ts;
+         tool_name;
+         input_summary;
+         effective_mode = effective_mode_of_string em;
+         violation_kind = violation_kind_of_string vk;
+       }
+     | _ -> Error "missing required fields in violation record")
+  | _ -> Error "violation record must be a JSON object"
+
+let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
+  match json with
+  | `List items ->
+    let rec parse acc = function
+      | [] -> Ok (List.rev acc)
+      | item :: rest ->
+        (match of_json item with
+         | Ok v -> parse (v :: acc) rest
+         | Error e -> Error e)
+    in
+    parse [] items
+  | _ -> Error "expected JSON array of violation records"
+
+let minimum_required_mode (v : t) : Agent_sdk.Execution_mode.t =
+  match v.violation_kind with
+  | Mutating_in_diagnose -> Agent_sdk.Execution_mode.Draft
+  | External_in_draft -> Agent_sdk.Execution_mode.Execute
+  | Scope_violation -> Agent_sdk.Execution_mode.Execute
+  | Unknown _ -> v.effective_mode

--- a/lib/violation_record.mli
+++ b/lib/violation_record.mli
@@ -1,0 +1,40 @@
+(** Violation_record — Typed violation records from CDAL proof artifacts.
+
+    Parses the JSON written by OAS [Proof_capture.collect_evidence_refs]
+    into typed OCaml records. Provides constraint algebra for deriving
+    the minimum execution mode that would prevent each violation.
+
+    @since CDAL eval content-based redesign *)
+
+(** Violation kind — mirrors Mode_enforcer's classification. *)
+type violation_kind =
+  | Mutating_in_diagnose  (** workspace mutation attempted in Diagnose mode *)
+  | External_in_draft     (** external effect attempted in Draft mode *)
+  | Scope_violation       (** violated allowed_mutations constraint *)
+  | Unknown of string     (** unrecognized violation_kind from JSON *)
+
+(** A single violation record as written by Proof_capture. *)
+type t = {
+  ts : float;
+  tool_name : string;
+  input_summary : string;
+  effective_mode : Agent_sdk.Execution_mode.t;
+  violation_kind : violation_kind;
+}
+
+(** Parse a single violation from JSON. *)
+val of_json : Yojson.Safe.t -> (t, string) result
+
+(** Parse an array of violations from JSON. *)
+val of_json_list : Yojson.Safe.t -> (t list, string) result
+
+(** The minimum execution mode that would have prevented this violation.
+    This is the inverse of [Mode_enforcer.check_violation]:
+    - [Mutating_in_diagnose] -> [Draft]
+    - [External_in_draft] -> [Execute]
+    - [Scope_violation] -> [Execute]
+    - [Unknown _] -> the violation's [effective_mode] (no change) *)
+val minimum_required_mode : t -> Agent_sdk.Execution_mode.t
+
+(** Violation kind to string for JSON serialization. *)
+val violation_kind_to_string : violation_kind -> string

--- a/test/test_cdal_eval.ml
+++ b/test/test_cdal_eval.ml
@@ -1,7 +1,11 @@
-(** test_cdal_eval — Phase 0 CDAL eval unit tests.
+(** test_cdal_eval — Content-based CDAL eval tests.
 
-    Verifies that Masc_mcp.Cdal_eval.evaluate produces correct verdicts
-    for each result_status, violation state, and evidence state. *)
+    Tests both pure evaluation (evaluate_content) and artifact-reading
+    evaluation (evaluate ~store) with synthetic proof bundles. *)
+
+module CE = Masc_mcp.Cdal_eval
+module VR = Masc_mcp.Violation_record
+module TU = Masc_mcp.Token_usage_record
 
 let make_proof
     ?(run_id = "test-run-001")
@@ -43,204 +47,245 @@ let make_proof
     ended_at = 1001.0;
   }
 
+let make_violation ?(ts = 1000.5) ?(tool_name = "write")
+    ?(input_summary = "{}") ?(effective_mode = Agent_sdk.Execution_mode.Diagnose)
+    ?(violation_kind = VR.Mutating_in_diagnose)
+    () : VR.t =
+  { ts; tool_name; input_summary; effective_mode; violation_kind }
+
 (* ================================================================ *)
-(* Test: Completed run with traces → Ok                              *)
+(* Pure evaluate_content tests                                       *)
 (* ================================================================ *)
 
-let test_completed_with_traces () =
+let test_completed_no_violations () =
   let proof = make_proof () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "has_tool_traces" true result.evidence.has_tool_traces;
-  Alcotest.(check bool) "completed_normally" true result.evidence.completed_normally;
-  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
-  Alcotest.(check string) "overall is ok"
-    "ok" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
-
-(* ================================================================ *)
-(* Test: Cancelled run → Fail                                        *)
-(* ================================================================ *)
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:1 proof in
+  Alcotest.(check string) "ok" "ok" (CE.severity_to_string result.overall);
+  Alcotest.(check bool) "acceptable" true (CE.is_acceptable result);
+  Alcotest.(check bool) "no recommendation" true (result.recommendation = None)
 
 let test_cancelled () =
   let proof = make_proof ~result_status:Cancelled () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "completed_normally" false result.evidence.completed_normally;
-  Alcotest.(check bool) "is_acceptable" false (Masc_mcp.Cdal_eval.is_acceptable result);
-  Alcotest.(check string) "overall is fail"
-    "fail: cancelled by contract" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
-
-(* ================================================================ *)
-(* Test: Errored run → Warn                                          *)
-(* ================================================================ *)
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:0 proof in
+  Alcotest.(check string) "fail" "fail: cancelled by contract"
+    (CE.severity_to_string result.overall);
+  Alcotest.(check bool) "not acceptable" false (CE.is_acceptable result)
 
 let test_errored () =
   let proof = make_proof ~result_status:Errored () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
-  Alcotest.(check string) "overall is warn"
-    "warn: execution error" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
-
-(* ================================================================ *)
-(* Test: Timed out run → Warn                                        *)
-(* ================================================================ *)
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:0 proof in
+  Alcotest.(check string) "warn" "warn: execution error"
+    (CE.severity_to_string result.overall)
 
 let test_timed_out () =
   let proof = make_proof ~result_status:Timed_out () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "is_acceptable" true (Masc_mcp.Cdal_eval.is_acceptable result);
-  Alcotest.(check string) "overall is warn"
-    "warn: execution timed out" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:0 proof in
+  Alcotest.(check string) "warn" "warn: execution timed out"
+    (CE.severity_to_string result.overall)
 
-(* ================================================================ *)
-(* Test: Mode violations detected → Warn                             *)
-(* ================================================================ *)
+let test_mutating_in_diagnose () =
+  let v = make_violation ~tool_name:"fs_edit"
+    ~effective_mode:Diagnose ~violation_kind:Mutating_in_diagnose () in
+  let proof = make_proof ~effective:Diagnose () in
+  let result = CE.evaluate_content ~violations:[v] ~token_usage:[] ~trace_count:1 proof in
+  (match result.recommendation with
+   | Some r ->
+     Alcotest.(check string) "min required = Draft"
+       "draft" (Agent_sdk.Execution_mode.to_string r.minimum_required);
+     Alcotest.(check int) "gap = 1" 1 r.gap;
+     Alcotest.(check (list string)) "offending tools"
+       ["fs_edit"] r.offending_tools
+   | None -> Alcotest.fail "expected recommendation for violation")
 
-let test_violations () =
-  let proof = make_proof
-    ~raw_evidence_refs:[
-      "proof-store://r1/evidence/mode_violations.json";
-      "proof-store://r1/evidence/token_usage.json";
-    ] () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check int) "violation_ref_count" 1 result.violations.violation_ref_count;
-  Alcotest.(check bool) "has_raw_evidence" true result.evidence.has_raw_evidence;
-  Alcotest.(check string) "overall is warn"
-    "warn: 1 mode violation(s) detected"
-    (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+let test_external_in_draft () =
+  let v = make_violation ~tool_name:"mcp__slack_send"
+    ~effective_mode:Draft ~violation_kind:External_in_draft () in
+  let proof = make_proof ~effective:Draft () in
+  let result = CE.evaluate_content ~violations:[v] ~token_usage:[] ~trace_count:1 proof in
+  (match result.recommendation with
+   | Some r ->
+     Alcotest.(check string) "min required = Execute"
+       "execute" (Agent_sdk.Execution_mode.to_string r.minimum_required);
+     Alcotest.(check int) "gap = 1" 1 r.gap
+   | None -> Alcotest.fail "expected recommendation")
 
-(* ================================================================ *)
-(* Test: No evidence at all → Warn                                   *)
-(* ================================================================ *)
+let test_multiple_violations_max_mode () =
+  let v1 = make_violation ~tool_name:"write"
+    ~effective_mode:Diagnose ~violation_kind:Mutating_in_diagnose () in
+  let v2 = make_violation ~tool_name:"bash"
+    ~effective_mode:Diagnose ~violation_kind:External_in_draft () in
+  let proof = make_proof ~effective:Diagnose () in
+  let result = CE.evaluate_content ~violations:[v1; v2] ~token_usage:[] ~trace_count:1 proof in
+  (match result.recommendation with
+   | Some r ->
+     Alcotest.(check string) "max = Execute"
+       "execute" (Agent_sdk.Execution_mode.to_string r.minimum_required);
+     Alcotest.(check int) "gap = 2" 2 r.gap;
+     Alcotest.(check int) "2 offending tools" 2 (List.length r.offending_tools)
+   | None -> Alcotest.fail "expected recommendation")
 
 let test_no_evidence () =
-  let proof = make_proof
-    ~tool_trace_refs:[]
-    ~raw_evidence_refs:[] () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "has_tool_traces" false result.evidence.has_tool_traces;
-  Alcotest.(check bool) "has_raw_evidence" false result.evidence.has_raw_evidence;
-  Alcotest.(check string) "overall is warn"
-    "warn: no evidence produced" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
+  let proof = make_proof ~tool_trace_refs:[] () in
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:0 proof in
+  Alcotest.(check string) "warn" "warn: no evidence produced"
+    (CE.severity_to_string result.overall)
 
-(* ================================================================ *)
-(* Test: Mode downgrade detected                                     *)
-(* ================================================================ *)
-
-let test_mode_downgrade () =
-  let proof = make_proof
-    ~requested:Execute
-    ~effective:Draft
-    ~mode_decision_source:"risk_class_downgrade" () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "mode_was_downgraded" true
-    result.violations.mode_was_downgraded;
-  Alcotest.(check string) "downgrade_reason"
-    "risk_class_downgrade"
-    (Option.get result.violations.downgrade_reason);
-  (* Downgrade alone does not produce a violation ref, so overall is Ok *)
-  Alcotest.(check string) "overall is ok"
-    "ok" (Masc_mcp.Cdal_eval.severity_to_string result.overall)
-
-(* ================================================================ *)
-(* Test: Checkpoint present                                          *)
-(* ================================================================ *)
-
-let test_checkpoint_present () =
-  let proof = make_proof
-    ~checkpoint_ref:(Some "proof-store://r1/checkpoint.json") () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "has_checkpoint" true result.evidence.has_checkpoint
-
-(* ================================================================ *)
-(* Test: JSON round-trip                                             *)
-(* ================================================================ *)
-
-let test_json_output () =
+let test_token_usage_in_evidence () =
+  let usage = [
+    { TU.turn = 0; input_tokens = 100; output_tokens = 50; cost_usd = Some 0.01 };
+    { TU.turn = 1; input_tokens = 200; output_tokens = 100; cost_usd = Some 0.02 };
+  ] in
   let proof = make_proof () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  let json = Masc_mcp.Cdal_eval.to_json result in
-  let json_str = Yojson.Safe.to_string json in
-  (* Verify it is valid JSON with expected fields *)
-  Alcotest.(check bool) "has run_id"
-    true (String.length json_str > 0);
+  let result = CE.evaluate_content ~violations:[] ~token_usage:usage ~trace_count:1 proof in
+  Alcotest.(check int) "total tokens" 450
+    (TU.total_tokens result.evidence.token_usage)
+
+let test_json_has_violations_detail () =
+  let v = make_violation ~tool_name:"bash" ~violation_kind:External_in_draft () in
+  let proof = make_proof ~effective:Draft () in
+  let result = CE.evaluate_content ~violations:[v] ~token_usage:[] ~trace_count:1 proof in
+  let json = CE.to_json result in
   match json with
   | `Assoc fields ->
-    Alcotest.(check bool) "has run_id field"
-      true (List.mem_assoc "run_id" fields);
-    Alcotest.(check bool) "has evidence field"
-      true (List.mem_assoc "evidence" fields);
-    Alcotest.(check bool) "has violations field"
+    Alcotest.(check bool) "has violations"
       true (List.mem_assoc "violations" fields);
-    Alcotest.(check bool) "has overall field"
-      true (List.mem_assoc "overall" fields)
+    Alcotest.(check bool) "has recommendation"
+      true (List.mem_assoc "recommendation" fields);
+    (match List.assoc "violations" fields with
+     | `List [_v] -> ()
+     | _ -> Alcotest.fail "expected 1 violation in JSON")
   | _ -> Alcotest.fail "expected JSON object"
 
-(* ================================================================ *)
-(* Test: Recommendation for Ok → None                                *)
-(* ================================================================ *)
-
-let test_recommendation_ok () =
+let test_json_no_recommendation_when_ok () =
   let proof = make_proof () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Alcotest.(check bool) "no recommendation for Ok"
-    true (Masc_mcp.Cdal_eval.recommendation result = None)
-
-(* ================================================================ *)
-(* Test: Recommendation for violations → actionable text             *)
-(* ================================================================ *)
-
-let test_recommendation_violations () =
-  let proof = make_proof
-    ~raw_evidence_refs:["proof-store://r1/evidence/mode_violations.json"] () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  match Masc_mcp.Cdal_eval.recommendation result with
-  | Some text ->
-    Alcotest.(check bool) "mentions scope_kind or tools"
-      true (String.length text > 10)
-  | None -> Alcotest.fail "expected recommendation for violations"
-
-(* ================================================================ *)
-(* Test: Recommendation for cancelled → mentions scope_kind          *)
-(* ================================================================ *)
-
-let test_recommendation_cancelled () =
-  let proof = make_proof ~result_status:Cancelled () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  match Masc_mcp.Cdal_eval.recommendation result with
-  | Some text ->
-    Alcotest.(check bool) "mentions scope_kind"
-      true (String.length text > 10)
-  | None -> Alcotest.fail "expected recommendation for cancelled"
-
-(* ================================================================ *)
-(* Test: JSON includes recommendation field when not Ok              *)
-(* ================================================================ *)
-
-let test_json_has_recommendation () =
-  let proof = make_proof ~result_status:Errored () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  let json = Masc_mcp.Cdal_eval.to_json result in
+  let result = CE.evaluate_content ~violations:[] ~token_usage:[] ~trace_count:1 proof in
+  let json = CE.to_json result in
   match json with
   | `Assoc fields ->
-    Alcotest.(check bool) "has recommendation"
-      true (List.mem_assoc "recommendation" fields)
+    Alcotest.(check bool) "no recommendation"
+      false (List.mem_assoc "recommendation" fields)
   | _ -> Alcotest.fail "expected JSON object"
 
 (* ================================================================ *)
-(* Test: Persist writes to JSONL store                               *)
+(* Integration test: write proof artifacts, then evaluate             *)
 (* ================================================================ *)
 
-let test_persist () =
+let test_integration_read_violations () =
   Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat
     (Filename.get_temp_dir_name ())
-    (Printf.sprintf "cdal_eval_test_%d" (Unix.getpid ())) in
-  Masc_mcp.Cdal_eval.set_store_for_testing ~base_dir:tmp_dir;
-  let proof = make_proof () in
-  let result = Masc_mcp.Cdal_eval.evaluate proof in
-  Masc_mcp.Cdal_eval.persist result;
-  Alcotest.(check bool) "store dir exists"
-    true (Sys.file_exists tmp_dir);
-  Masc_mcp.Cdal_eval.reset_store_for_testing ()
+    (Printf.sprintf "cdal_eval_int_%d" (Unix.getpid ())) in
+  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  let run_id = "int-test-001" in
+  let run_dir = Filename.concat (Filename.concat tmp_dir "proofs") run_id in
+  let () =
+    let rec mkdirp path =
+      if not (Sys.file_exists path) then begin
+        mkdirp (Filename.dirname path);
+        Unix.mkdir path 0o755
+      end
+    in
+    mkdirp (Filename.concat run_dir "tool_traces");
+    mkdirp (Filename.concat run_dir "evidence")
+  in
+  (* Write synthetic violation evidence *)
+  let violation_json = `List [
+    `Assoc [
+      ("ts", `Float 1000.5);
+      ("tool_name", `String "bash");
+      ("input_summary", `String "rm -rf /tmp/x");
+      ("effective_mode", `String "draft");
+      ("violation_kind", `String "external_in_draft");
+    ]
+  ] in
+  Agent_sdk.Proof_store.write_evidence store ~run_id
+    ~ref_id:"mode_violations" violation_json;
+  (* Write synthetic token usage *)
+  let token_json = `List [
+    `Assoc [
+      ("turn", `Int 0);
+      ("input_tokens", `Int 500);
+      ("output_tokens", `Int 100);
+      ("cost_usd", `Float 0.005);
+    ]
+  ] in
+  Agent_sdk.Proof_store.write_evidence store ~run_id
+    ~ref_id:"token_usage" token_json;
+  (* Build proof manifest with refs *)
+  let proof = make_proof ~run_id ~effective:Draft
+    ~raw_evidence_refs:[
+      Agent_sdk.Proof_store.make_ref ~run_id ~subpath:"evidence/mode_violations.json";
+      Agent_sdk.Proof_store.make_ref ~run_id ~subpath:"evidence/token_usage.json";
+    ] () in
+  (* Evaluate with artifact reading *)
+  let result = CE.evaluate ~store proof in
+  Alcotest.(check int) "1 violation read" 1
+    (List.length result.evidence.violations);
+  Alcotest.(check int) "1 token record read" 1
+    (List.length result.evidence.token_usage);
+  (match result.recommendation with
+   | Some r ->
+     Alcotest.(check string) "min = execute"
+       "execute" (Agent_sdk.Execution_mode.to_string r.minimum_required);
+     Alcotest.(check (list string)) "offending = [bash]"
+       ["bash"] r.offending_tools
+   | None -> Alcotest.fail "expected recommendation from read violations");
+  (* Verify JSONL persistence *)
+  let jsonl_dir = Filename.concat tmp_dir "cdal_evals_test" in
+  CE.set_store_for_testing ~base_dir:jsonl_dir;
+  CE.persist result;
+  Alcotest.(check bool) "jsonl dir exists" true (Sys.file_exists jsonl_dir);
+  CE.reset_store_for_testing ()
+
+let test_integration_missing_artifact () =
+  let store : Agent_sdk.Proof_store.config =
+    { root = "/nonexistent/path" } in
+  let proof = make_proof
+    ~raw_evidence_refs:["proof-store://missing/evidence/mode_violations.json"]
+    () in
+  let result = CE.evaluate ~store proof in
+  Alcotest.(check int) "0 violations (graceful)" 0
+    (List.length result.evidence.violations);
+  Alcotest.(check string) "ok (no violations read)" "ok"
+    (CE.severity_to_string result.overall)
+
+(* ================================================================ *)
+(* Violation_record unit tests                                       *)
+(* ================================================================ *)
+
+let test_violation_parse () =
+  let json = `Assoc [
+    ("ts", `Float 1.0);
+    ("tool_name", `String "write");
+    ("input_summary", `String "content");
+    ("effective_mode", `String "diagnose");
+    ("violation_kind", `String "mutating_in_diagnose");
+  ] in
+  match VR.of_json json with
+  | Ok v ->
+    Alcotest.(check string) "tool" "write" v.tool_name;
+    Alcotest.(check string) "kind" "mutating_in_diagnose"
+      (VR.violation_kind_to_string v.violation_kind);
+    Alcotest.(check string) "min mode" "draft"
+      (Agent_sdk.Execution_mode.to_string (VR.minimum_required_mode v))
+  | Error e -> Alcotest.fail e
+
+let test_violation_unknown_kind () =
+  let json = `Assoc [
+    ("ts", `Float 1.0);
+    ("tool_name", `String "x");
+    ("input_summary", `String "");
+    ("effective_mode", `String "execute");
+    ("violation_kind", `String "new_kind_v2");
+  ] in
+  match VR.of_json json with
+  | Ok v ->
+    (match v.violation_kind with
+     | VR.Unknown "new_kind_v2" -> ()
+     | _ -> Alcotest.fail "expected Unknown");
+    Alcotest.(check string) "min mode unchanged" "execute"
+      (Agent_sdk.Execution_mode.to_string (VR.minimum_required_mode v))
+  | Error e -> Alcotest.fail e
 
 (* ================================================================ *)
 (* Runner                                                            *)
@@ -248,20 +293,25 @@ let test_persist () =
 
 let () =
   Alcotest.run "Cdal_eval" [
-    ("evaluate", [
-      Alcotest.test_case "completed with traces" `Quick test_completed_with_traces;
+    ("pure_eval", [
+      Alcotest.test_case "completed no violations" `Quick test_completed_no_violations;
       Alcotest.test_case "cancelled" `Quick test_cancelled;
       Alcotest.test_case "errored" `Quick test_errored;
       Alcotest.test_case "timed out" `Quick test_timed_out;
-      Alcotest.test_case "violations" `Quick test_violations;
+      Alcotest.test_case "mutating in diagnose" `Quick test_mutating_in_diagnose;
+      Alcotest.test_case "external in draft" `Quick test_external_in_draft;
+      Alcotest.test_case "multiple violations max mode" `Quick test_multiple_violations_max_mode;
       Alcotest.test_case "no evidence" `Quick test_no_evidence;
-      Alcotest.test_case "mode downgrade" `Quick test_mode_downgrade;
-      Alcotest.test_case "checkpoint present" `Quick test_checkpoint_present;
-      Alcotest.test_case "json output" `Quick test_json_output;
-      Alcotest.test_case "recommendation ok" `Quick test_recommendation_ok;
-      Alcotest.test_case "recommendation violations" `Quick test_recommendation_violations;
-      Alcotest.test_case "recommendation cancelled" `Quick test_recommendation_cancelled;
-      Alcotest.test_case "json has recommendation" `Quick test_json_has_recommendation;
-      Alcotest.test_case "persist" `Quick test_persist;
+      Alcotest.test_case "token usage" `Quick test_token_usage_in_evidence;
+      Alcotest.test_case "json violations detail" `Quick test_json_has_violations_detail;
+      Alcotest.test_case "json no recommendation when ok" `Quick test_json_no_recommendation_when_ok;
+    ]);
+    ("integration", [
+      Alcotest.test_case "read violations from store" `Quick test_integration_read_violations;
+      Alcotest.test_case "missing artifact graceful" `Quick test_integration_missing_artifact;
+    ]);
+    ("violation_record", [
+      Alcotest.test_case "parse" `Quick test_violation_parse;
+      Alcotest.test_case "unknown kind" `Quick test_violation_unknown_kind;
     ]);
   ]


### PR DESCRIPTION
Content-based CDAL eval. Replaces ref-counting with proof artifact reading + constraint algebra for recommendations. 15 tests. Relates #3475 #3528