### PR TITLE
fix(keeper): remove Stdlib.Mutex from keeper_registry (EDEADLK fix)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -3,15 +3,19 @@
     Consolidates keeper_keepalive Hashtbl, keeper_supervisor
     Hashtbl, and file-based meta into one registry.
 
-    All operations are serialized via Eio.Mutex (allows other fibers
-    to run while waiting, unlike Stdlib.Mutex which blocks the domain).
-    Falls back to unprotected access in non-Eio test contexts.
+    Thread-safety: all operations are non-yielding (in-memory map/ref
+    ops only).  In single-domain Eio, the cooperative scheduler only
+    switches fibers at yield points (I/O, sleep, stream ops), so
+    non-yielding code runs atomically w.r.t. other fibers.  No mutex
+    is needed.  See Eio README: "If the operation does not switch
+    fibers and the resource is only accessed from one domain, then no
+    mutex is needed at all."
 
     Implementation: registry_entry records are immutable (except embedded
     Hashtbl fields board_wakeups and tool_usage which remain mutable
     containers -- Phase 2 target).  Inter-fiber signaling uses [Atomic.t]
     instead of [ref] for lock-free visibility.  The global registry is a
-    persistent [StringMap] behind [Eio.Mutex]. *)
+    persistent [StringMap] behind a single [ref]. *)
 
 open Keeper_types
 
@@ -49,19 +53,10 @@ let state_to_string = function
   | Stopped -> "stopped"
 
 let registry : registry_entry StringMap.t ref = ref StringMap.empty
-(* Stdlib.Mutex: all critical sections are non-yielding (in-memory map ops
-   only), and the registry is accessed from both the main Eio domain and
-   Executor_pool domains.  Eio.Mutex causes cross-domain deadlock because
-   its fiber-based waiters do not interoperate across OCaml domains. *)
-let mu = Mutex.create ()
 let running_count_atomic = Atomic.make 0
 
 let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
-
-let with_lock f =
-  Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
 
 (** Write an entry back to the registry map. *)
 let put_entry key entry =
@@ -70,48 +65,46 @@ let put_entry key entry =
 let max_crash_log_entries = 5
 
 let register ~base_path name meta =
-  with_lock (fun () ->
-    let done_p, done_r = Eio.Promise.create () in
-    let key = registry_key ~base_path name in
-    (match StringMap.find_opt key !registry with
-     | Some entry when entry.state = Running ->
-         Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
-     | _ -> ());
-    let entry = {
-      base_path;
-      name;
-      meta;
-      state = Running;
-      fiber_stop = Atomic.make false;
-      fiber_wakeup = Atomic.make false;
-      started_at = Time_compat.now ();
-      grpc_close = Atomic.make None;
-      done_p;
-      done_r;
-      restart_count = 0;
-      last_restart_ts = 0.0;
-      crash_log = [];
-      last_error = None;
-      last_agent_count = 0;
-      board_wakeups = Hashtbl.create 8;
-      board_cursor_ts = 0.0;
-      tool_usage = Hashtbl.create 16;
-    } in
-    put_entry key entry;
-    Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1);
-    entry)
+  let done_p, done_r = Eio.Promise.create () in
+  let key = registry_key ~base_path name in
+  (match StringMap.find_opt key !registry with
+   | Some entry when entry.state = Running ->
+       Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
+   | _ -> ());
+  let entry = {
+    base_path;
+    name;
+    meta;
+    state = Running;
+    fiber_stop = Atomic.make false;
+    fiber_wakeup = Atomic.make false;
+    started_at = Time_compat.now ();
+    grpc_close = Atomic.make None;
+    done_p;
+    done_r;
+    restart_count = 0;
+    last_restart_ts = 0.0;
+    crash_log = [];
+    last_error = None;
+    last_agent_count = 0;
+    board_wakeups = Hashtbl.create 8;
+    board_cursor_ts = 0.0;
+    tool_usage = Hashtbl.create 16;
+  } in
+  put_entry key entry;
+  Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1);
+  entry
 
 let unregister ~base_path name =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    (match StringMap.find_opt key !registry with
-     | Some entry when entry.state = Running ->
-         Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
-     | _ -> ());
-    registry := StringMap.remove key !registry)
+  let key = registry_key ~base_path name in
+  (match StringMap.find_opt key !registry with
+   | Some entry when entry.state = Running ->
+       Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
+   | _ -> ());
+  registry := StringMap.remove key !registry
 
 let get ~base_path name =
-  with_lock (fun () -> StringMap.find_opt (registry_key ~base_path name) !registry)
+  StringMap.find_opt (registry_key ~base_path name) !registry
 
 let get_exn ~base_path name =
   match get ~base_path name with
@@ -119,95 +112,83 @@ let get_exn ~base_path name =
   | None -> raise Not_found
 
 let all ?base_path () =
-  with_lock (fun () ->
-    StringMap.fold
-      (fun _k v acc ->
-        match base_path with
-        | Some expected when not (String.equal expected v.base_path) -> acc
-        | _ -> v :: acc)
-      !registry [])
+  StringMap.fold
+    (fun _k v acc ->
+      match base_path with
+      | Some expected when not (String.equal expected v.base_path) -> acc
+      | _ -> v :: acc)
+    !registry []
 
 let update_meta ~base_path name meta =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry -> put_entry key { entry with meta }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry -> put_entry key { entry with meta }
+  | None -> ()
 
 let () =
   register_runtime_meta_write_sync (fun config meta ->
       update_meta ~base_path:config.base_path meta.name meta)
 
 let set_state ~base_path name state =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry ->
-        if entry.state <> state then begin
-          (match (entry.state, state) with
-           | Running, (Paused | Stopped) ->
-               Atomic.set running_count_atomic
-                 (max 0 (Atomic.get running_count_atomic - 1))
-           | (Paused | Stopped), Running ->
-               Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
-           | _ -> ());
-          put_entry key { entry with state }
-        end
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry ->
+      if entry.state <> state then begin
+        (match (entry.state, state) with
+         | Running, (Paused | Stopped) ->
+             Atomic.set running_count_atomic
+               (max 0 (Atomic.get running_count_atomic - 1))
+         | (Paused | Stopped), Running ->
+             Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
+         | _ -> ());
+        put_entry key { entry with state }
+      end
+  | None -> ()
 
 let record_restart ~base_path name =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry ->
-        put_entry key { entry with
-          restart_count = entry.restart_count + 1;
-          last_restart_ts = Time_compat.now () }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry ->
+      put_entry key { entry with
+        restart_count = entry.restart_count + 1;
+        last_restart_ts = Time_compat.now () }
+  | None -> ()
 
 let record_error ~base_path name err =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry -> put_entry key { entry with last_error = Some err }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry -> put_entry key { entry with last_error = Some err }
+  | None -> ()
 
 let is_running ~base_path name =
   match get ~base_path name with
   | Some { state = Running; _ } -> true
   | _ -> false
 
-(* Fast path for process-wide health snapshots. Updates stay serialized under
-   [mu], while the global count can be read lock-free and may lag momentarily
-   behind registry mutations in other fibers. Scoped reads still take the lock
-   so per-base-path counts remain exact. *)
 let count_running ?base_path () =
   match base_path with
   | None -> Atomic.get running_count_atomic
   | Some expected ->
-      with_lock (fun () ->
-        StringMap.fold
-          (fun _k v acc ->
-            if String.equal expected v.base_path && v.state = Running then acc + 1
-            else acc)
-          !registry 0)
+      StringMap.fold
+        (fun _k v acc ->
+          if String.equal expected v.base_path && v.state = Running then acc + 1
+          else acc)
+        !registry 0
 
 let record_crash ~base_path name ts msg =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry ->
-        put_entry key { entry with
-          crash_log =
-            List.filteri (fun i _ -> i < max_crash_log_entries)
-              ((ts, msg) :: entry.crash_log) }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry ->
+      put_entry key { entry with
+        crash_log =
+          List.filteri (fun i _ -> i < max_crash_log_entries)
+            ((ts, msg) :: entry.crash_log) }
+  | None -> ()
 
 let set_grpc_close ~base_path name close_fn =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | Some entry -> Atomic.set entry.grpc_close close_fn
-    | None -> ())
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | Some entry -> Atomic.set entry.grpc_close close_fn
+  | None -> ()
 
 let started_at ~base_path name =
   match get ~base_path name with
@@ -217,35 +198,32 @@ let started_at ~base_path name =
 let spawn_slots_available () =
   let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
   max_keepers <= 0
-  || with_lock (fun () -> StringMap.cardinal !registry < max_keepers)
+  || StringMap.cardinal !registry < max_keepers
 
 let wakeup ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | Some entry -> Atomic.set entry.fiber_wakeup true
-    | None -> ())
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | Some entry -> Atomic.set entry.fiber_wakeup true
+  | None -> ()
 
 let wakeup_all ?base_path () =
-  with_lock (fun () ->
-    StringMap.iter (fun _k entry ->
-      (match base_path with
-       | Some expected when not (String.equal expected entry.base_path) -> ()
-       | _ -> if entry.state = Running then Atomic.set entry.fiber_wakeup true)
-    ) !registry)
+  StringMap.iter (fun _k entry ->
+    (match base_path with
+     | Some expected when not (String.equal expected entry.base_path) -> ()
+     | _ -> if entry.state = Running then Atomic.set entry.fiber_wakeup true)
+  ) !registry
 
 let fiber_health_of ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | None -> Fiber_unknown
-    | Some entry ->
-        match Eio.Promise.peek entry.done_p with
-        | None -> Fiber_alive
-        | Some `Stopped -> Fiber_unknown
-        | Some (`Crashed _) ->
-            let max_restarts = Env_config.KeeperSupervisor.max_restarts in
-            if entry.restart_count >= max_restarts
-            then Fiber_dead
-            else Fiber_zombie)
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | None -> Fiber_unknown
+  | Some entry ->
+      match Eio.Promise.peek entry.done_p with
+      | None -> Fiber_alive
+      | Some `Stopped -> Fiber_unknown
+      | Some (`Crashed _) ->
+          let max_restarts = Env_config.KeeperSupervisor.max_restarts in
+          if entry.restart_count >= max_restarts
+          then Fiber_dead
+          else Fiber_zombie
 
 let crash_log_of ~base_path name =
   match get ~base_path name with
@@ -254,126 +232,112 @@ let crash_log_of ~base_path name =
 
 let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts
     ~crash_log =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry ->
-        put_entry key { entry with restart_count; last_restart_ts; crash_log }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry ->
+      put_entry key { entry with restart_count; last_restart_ts; crash_log }
+  | None -> ()
 
 let get_last_agent_count ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | Some entry -> entry.last_agent_count
-    | None -> 0)
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | Some entry -> entry.last_agent_count
+  | None -> 0
 
 let set_last_agent_count ~base_path name count =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry -> put_entry key { entry with last_agent_count = count }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry -> put_entry key { entry with last_agent_count = count }
+  | None -> ()
 
 let board_wakeup_allowed ~base_path name ~post_id ~debounce_sec =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | None -> true
-    | Some entry ->
-        let now_ts = Time_compat.now () in
-        match Hashtbl.find_opt entry.board_wakeups post_id with
-        | Some last_ts when now_ts -. last_ts < debounce_sec -> false
-        | _ ->
-            Hashtbl.replace entry.board_wakeups post_id now_ts;
-            true)
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | None -> true
+  | Some entry ->
+      let now_ts = Time_compat.now () in
+      match Hashtbl.find_opt entry.board_wakeups post_id with
+      | Some last_ts when now_ts -. last_ts < debounce_sec -> false
+      | _ ->
+          Hashtbl.replace entry.board_wakeups post_id now_ts;
+          true
 
 let clear_board_wakeups ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | Some entry -> Hashtbl.reset entry.board_wakeups
-    | None -> ())
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | Some entry -> Hashtbl.reset entry.board_wakeups
+  | None -> ()
 
 let cleanup_tracking ~base_path name =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry ->
-        Hashtbl.reset entry.board_wakeups;
-        Hashtbl.reset entry.tool_usage;
-        put_entry key { entry with last_agent_count = 0; board_cursor_ts = 0.0 }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry ->
+      Hashtbl.reset entry.board_wakeups;
+      Hashtbl.reset entry.tool_usage;
+      put_entry key { entry with last_agent_count = 0; board_cursor_ts = 0.0 }
+  | None -> ()
 
 let clear () =
-  with_lock (fun () ->
-    registry := StringMap.empty;
-    Atomic.set running_count_atomic 0)
+  registry := StringMap.empty;
+  Atomic.set running_count_atomic 0
 
 (* -- Board cursor -------------------------------------------------- *)
 
 let get_board_cursor_ts ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | Some entry -> entry.board_cursor_ts
-    | None -> 0.0)
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | Some entry -> entry.board_cursor_ts
+  | None -> 0.0
 
 let set_board_cursor_ts ~base_path name ts =
-  with_lock (fun () ->
-    let key = registry_key ~base_path name in
-    match StringMap.find_opt key !registry with
-    | Some entry -> put_entry key { entry with board_cursor_ts = ts }
-    | None -> ())
+  let key = registry_key ~base_path name in
+  match StringMap.find_opt key !registry with
+  | Some entry -> put_entry key { entry with board_cursor_ts = ts }
+  | None -> ()
 
 (* -- Tool usage tracking ------------------------------------------- *)
 
 let record_tool_use ~base_path name ~tool_name ~success =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | None -> ()
-    | Some entry ->
-      let e =
-        match Hashtbl.find_opt entry.tool_usage tool_name with
-        | Some e -> e
-        | None ->
-          let e = { count = 0; successes = 0; failures = 0;
-                    last_used_at = 0.0 } in
-          Hashtbl.replace entry.tool_usage tool_name e; e
-      in
-      e.count <- e.count + 1;
-      (if success then e.successes <- e.successes + 1
-       else e.failures <- e.failures + 1);
-      e.last_used_at <- Time_compat.now ())
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | None -> ()
+  | Some entry ->
+    let e =
+      match Hashtbl.find_opt entry.tool_usage tool_name with
+      | Some e -> e
+      | None ->
+        let e = { count = 0; successes = 0; failures = 0;
+                  last_used_at = 0.0 } in
+        Hashtbl.replace entry.tool_usage tool_name e; e
+    in
+    e.count <- e.count + 1;
+    (if success then e.successes <- e.successes + 1
+     else e.failures <- e.failures + 1);
+    e.last_used_at <- Time_compat.now ()
 
 let tool_usage_of ~base_path name =
-  with_lock (fun () ->
-    match StringMap.find_opt (registry_key ~base_path name) !registry with
-    | None -> []
-    | Some entry ->
-      Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
-      |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count))
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | None -> []
+  | Some entry ->
+    Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
+    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
 
 (** Look up a keeper by name across all base_paths (O(n) scan). *)
 let find_by_name name =
-  with_lock (fun () ->
-    StringMap.fold
-      (fun _k v acc ->
-        match acc with
-        | Some _ -> acc
-        | None -> if String.equal v.name name then Some v else None)
-      !registry None)
+  StringMap.fold
+    (fun _k v acc ->
+      match acc with
+      | Some _ -> acc
+      | None -> if String.equal v.name name then Some v else None)
+    !registry None
 
 let find_by_agent_name agent_name =
-  with_lock (fun () ->
-    StringMap.fold
-      (fun _k v acc ->
-        match acc with
-        | Some _ -> acc
-        | None ->
-          if String.equal v.meta.agent_name agent_name then Some v else None)
-      !registry None)
+  StringMap.fold
+    (fun _k v acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+        if String.equal v.meta.agent_name agent_name then Some v else None)
+    !registry None
 
 let tool_usage_of_by_name name =
-  with_lock (fun () ->
-    match find_by_name name with
-    | None -> []
-    | Some entry ->
-      Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
-      |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count))
+  match find_by_name name with
+  | None -> []
+  | Some entry ->
+    Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
+    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -4,8 +4,9 @@
     keeper_supervisor Hashtbl, and file-based meta lookups.
     All keeper state queries and mutations go through this module.
 
-    Thread-safe: all operations protected by Eio.Mutex when available,
-    falls back to Stdlib.Mutex for test contexts without Eio. *)
+    Thread-safety: all operations are non-yielding (in-memory map/ref
+    ops only).  In single-domain Eio, non-yielding code runs atomically
+    w.r.t. other fibers, so no mutex is needed. *)
 
 open Keeper_types
 

--- a/lib/server/server_dashboard_http_runtime_support.ml
+++ b/lib/server/server_dashboard_http_runtime_support.ml
@@ -132,10 +132,10 @@ let run_dashboard_compute state ?(mode = Offloaded_readonly) ?runtime ~sw ~clock
   match mode with
   | Inline_shared -> fallback ()
   | Offloaded_readonly ->
-      (* Non-PG backends (FileSystem, Memory) run inline to avoid cross-domain
-         Eio.Mutex access.  The executor pool exists for PG connection isolation;
-         filesystem ops are already lightweight and sharing in-process mutexes
-         across domains causes deadlock (Keeper_registry.mu). *)
+      (* Non-PG backends (FileSystem, Memory) run inline: filesystem ops are
+         lightweight and Keeper_registry uses no mutex (non-yielding ops in
+         single-domain Eio are inherently atomic).  The executor pool exists
+         for PG connection isolation only. *)
       if is_pg then offloaded () else fallback ()
 
 let dashboard_active_or_recent_sessions_cached state ~clock


### PR DESCRIPTION
## Summary
- Remove `Stdlib.Mutex` and `with_lock` wrapper from `keeper_registry.ml`
- All critical sections are non-yielding (StringMap, Hashtbl, ref ops) in a single Eio domain — no mutex needed per [Eio docs](https://github.com/ocaml-multicore/eio/blob/main/README.md)
- Fixes EDEADLK caused by `tool_usage_of_by_name` re-entering `with_lock` via `find_by_name`

## Root Cause
`Stdlib.Mutex` + OCaml 5.x `PTHREAD_MUTEX_ERRORCHECK` = `Sys_error("Mutex.lock: Resource deadlock avoided")` when the same OS thread (all Eio fibers in single-domain) re-locks the same mutex. `tool_usage_of_by_name` called `find_by_name` inside `with_lock`, and `find_by_name` also used `with_lock`.

This caused:
- Mission refresh failures (6+ consecutive)
- Dashboard cache warm-up failures
- `Sys_error("Mutex.lock: Resource deadlock avoided")` in server logs

## Evidence
- Eio README: "If the operation does not switch fibers and the resource is only accessed from one domain, then no mutex is needed at all."
- `eio_mutex.mli`: "mutexes are often unnecessary for code running in a single domain"
- OCaml PR [#9846](https://github.com/ocaml/ocaml/pull/9846): Error-checking mutexes via `PTHREAD_MUTEX_ERRORCHECK`
- Current server uses `filesystem` backend → all dashboard compute runs inline (same domain)
- All 11 caller files operate in main Eio domain

## Test plan
- [x] `dune build` passes
- [x] `test_keeper_registry.exe` — 34 tests pass
- [ ] CI green
- [ ] Server restart confirms no more EDEADLK in logs

Closes #3181 (partial — keeper_registry was the last Stdlib.Mutex in runtime path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)