### PR TITLE
refactor(backend): filesystem-first conversion — remove PG-first code paths

### DIFF
--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -35,7 +35,6 @@ let run_cmd base_path =
      Keeper_runtime.start_existing_keepalives if needed *)
   Server_bootstrap_pg.init_task_backend ();
   Server_bootstrap_pg.inject_shared_pg_pool ();
-  Server_bootstrap_pg.init_memory_pg_schema ();
   ignore (Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state);
   Fun.protect
     ~finally:(fun () ->

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -1,17 +1,19 @@
 (** Memory_oas_bridge — Connect MASC memory systems to OAS Memory.t 5-tier.
 
     Tier mapping:
-    - {b Long_term} — PostgreSQL via [Memory_pg] when MASC_POSTGRES_URL is set;
-                        no-op stubs otherwise
+    - {b Long_term} — JSONL files under [.masc/memory/<agent>/<session>.jsonl]
     - {b Episodic}  — [seed_episodes] loads recent [Institution_eio] JSONL
                        episodes and [flush_episodes] writes new OAS episodes back
     - {b Procedural} — [seed_procedures_as_oas] loads [Procedural_memory] entries;
                         [flush_procedures] writes back
     - {b Working/Scratchpad} — managed by OAS in-memory; no backend needed
 
+    Filesystem-first policy: Long_term always uses JSONL, regardless of
+    whether a PG pool is available.  PG long_term was removed in 2.140.0.
+
     @since 2.122.0 (long_term only)
     @since 2.124.0 (5-tier: episodic + procedural seeding/flushing)
-    @since 2.130.0 (PostgreSQL long_term_backend via Memory_pg) *)
+    @since 2.140.0 (filesystem-first: JSONL long_term_backend always) *)
 
 (** Default importance for memories stored via OAS Memory.store.
     Configurable via MASC_MEMORY_OAS_DEFAULT_IMPORTANCE. *)
@@ -54,23 +56,17 @@ let resolve_base_dir ?(base_dir : string option) ?(config : Room_utils.config op
 
 (** Create an OAS [long_term_backend].
 
-    If a PG pool is available (via [Board_dispatch.get_pg_pool]),
-    uses [Memory_pg] for persistent storage scoped by [agent_name].
-    Otherwise falls back to session-based JSONL files under
-    [.masc/memory/<agent_name>/<session_id>.jsonl]. *)
+    Always uses session-based JSONL files under
+    [.masc/memory/<agent_name>/<session_id>.jsonl].
+    Filesystem-first: PG pool availability is not checked. *)
 let make_backend ?base_dir ~(agent_name : string) ~(session_id : string) ()
   : Agent_sdk.Memory.long_term_backend =
-  match Board_dispatch.get_pg_pool () with
-  | Some pool -> Memory_pg.make_backend ~pool ~agent_name
-  | None ->
-    let base_dir = resolve_base_dir ?base_dir () in
-    Log.MemoryJsonl.info "Using JSONL fallback for %s (session=%s)"
-      agent_name session_id;
-    Memory_jsonl.make_backend ~base_dir ~agent_name ~session_id
+  let base_dir = resolve_base_dir ?base_dir () in
+  Memory_jsonl.make_backend ~base_dir ~agent_name ~session_id
 
 (** Create an OAS [Memory.t] instance.
 
-    Uses PostgreSQL long_term_backend when available, JSONL fallback otherwise.
+    Uses JSONL long_term_backend (filesystem-first).
     @param session_id Session identifier; defaults to timestamp-based ID. *)
 let create_memory ~(agent_name : string) ?(base_dir : string option)
     ?(session_id : string option)
@@ -427,7 +423,7 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
 (** Create an OAS [Memory.t] with all 5 tiers populated.
 
     Seeds:
-    - Long_term: PostgreSQL via [Memory_pg] when available, no-op stubs otherwise
+    - Long_term: JSONL files (filesystem-first, PG not used)
     - Episodic: recent institution episodes from JSONL
     - Procedural: top [procedure_limit] crystallized procedures
     - Working/Scratchpad: empty (managed by OAS at runtime)

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -55,13 +55,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
 
   (* Dedup: if agent already joined, update last_seen and return early *)
   let agent_file_dedup = Filename.concat (agents_dir config) (safe_filename nickname ^ ".json") in
-  let already_joined =
-    if is_pg_backend config then
-      let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
-      backend_exists config ~key:agent_key || Sys.file_exists agent_file_dedup
-    else
-      Sys.file_exists agent_file_dedup
-  in
+  let already_joined = Sys.file_exists agent_file_dedup in
   if already_joined then begin
     (match read_agent_with_repair config agent_file_dedup with
      | Ok existing_agent ->
@@ -296,38 +290,15 @@ let leave config ~agent_name =
 
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
   let in_fs = Sys.file_exists agent_file in
-  (* For PostgreSQL backend: also check masc_kv for HTTP state persistence *)
-  let in_backend =
-    if is_pg_backend config then
-      let agent_key = Printf.sprintf "agents:%s" (safe_filename actual_name) in
-      backend_exists config ~key:agent_key
-    else
-      false
-  in
-  if in_fs || in_backend then begin
+  if in_fs then begin
     (* Mark agent as Inactive instead of deleting, so re-join can restore identity.
        This prevents orphan state when the same agent_type re-joins later. *)
-    (if in_fs then
-      match read_agent_with_repair config agent_file with
-      | Ok existing_agent ->
-        let updated = { existing_agent with status = Inactive; last_seen = now_iso () } in
-        write_json config agent_file (agent_to_yojson updated)
-      | Error e ->
-          Log.Room.warn "agent leave: invalid agent JSON for %s: %s" actual_name e);
-    if is_pg_backend config then begin
-      let agent_key = Printf.sprintf "agents:%s" (safe_filename actual_name) in
-      (* Update backend entry to Inactive as well *)
-      (if in_fs then
-        let updated_json = read_json config agent_file in
-        (match backend_set config ~key:agent_key
-                  ~value:(Yojson.Safe.to_string updated_json) with
-         | Ok () -> ()
-         | Error e -> Log.Room.warn "leave backend_set failed for %s: %s" agent_key (Backend_types.show_error e))
-      else
-        (match backend_delete config ~key:agent_key with
-         | Ok _ -> ()
-         | Error e -> Log.Room.warn "leave backend_delete failed for %s: %s" agent_key (Backend_types.show_error e)))
-    end;
+    (match read_agent_with_repair config agent_file with
+     | Ok existing_agent ->
+       let updated = { existing_agent with status = Inactive; last_seen = now_iso () } in
+       write_json config agent_file (agent_to_yojson updated)
+     | Error e ->
+         Log.Room.warn "agent leave: invalid agent JSON for %s: %s" actual_name e);
 
     (* Capture active agents before removal for relationship materialization *)
     let peers_before_leave = (read_state config).active_agents in

--- a/lib/server/server_bootstrap_pg.ml
+++ b/lib/server/server_bootstrap_pg.ml
@@ -1,8 +1,8 @@
 (** Server_bootstrap_pg — Backend initialization functions.
 
-    Filesystem-first: PG schemas are only initialized when
-    MASC_STORAGE_TYPE=postgres is explicitly configured.
-    Memory_pg schema init removed (memory_oas_bridge uses JSONL). *)
+    Task and Board PG backends are initialized when [Board_dispatch]
+    reports an active PG pool (i.e. MASC_STORAGE_TYPE=postgres).
+    Memory_pg schema init removed: memory_oas_bridge always uses JSONL. *)
 
 let init_task_backend () =
   match Board_dispatch.get_pg_pool () with

--- a/lib/server/server_bootstrap_pg.ml
+++ b/lib/server/server_bootstrap_pg.ml
@@ -1,16 +1,17 @@
-(** Server_bootstrap_pg — PG/database initialization functions.
+(** Server_bootstrap_pg — Backend initialization functions.
 
-    Extracted from Server_runtime_bootstrap to isolate database
-    schema bootstrap steps into a focused module. *)
+    Filesystem-first: PG schemas are only initialized when
+    MASC_STORAGE_TYPE=postgres is explicitly configured.
+    Memory_pg schema init removed (memory_oas_bridge uses JSONL). *)
 
 let init_task_backend () =
   match Board_dispatch.get_pg_pool () with
   | Some pool -> (
       match Task_dispatch.init_pg pool with
       | Ok () ->
-          Log.Task.info "PostgreSQL backend initialized"
+          Log.Task.info "PostgreSQL task backend initialized"
       | Error e ->
-          Log.Task.error "PG init failed: %s, using JSONL"
+          Log.Task.error "PG task init failed: %s, using JSONL"
             (Types.show_masc_error e))
   | None -> Task_dispatch.init_jsonl ()
 
@@ -19,21 +20,10 @@ let inject_shared_pg_pool () =
   | Some _ ->
       Log.Server.info "PG shared pool available"
   | None ->
-      Log.Server.info "No PG pool available"
+      Log.Server.info "No PG pool; filesystem-first mode"
 
-let init_memory_pg_schema () =
-  match Board_dispatch.get_pg_pool () with
-  | Some pool -> (
-      match Memory_pg.ensure_schema pool with
-      | Ok () -> ()
-      | Error msg ->
-          Log.MemoryPg.error "Schema init failed: %s (long_term_backend will use no-op)" msg)
-  | None ->
-      Log.MemoryPg.info "No PG pool available; long_term_backend will use JSONL fallback"
-
-(** Run PG schema/bootstrap steps in a fixed order.
-    These steps share the same PG pool and some of them mutate startup state,
-    so deterministic sequencing is preferred over parallel fan-out. *)
+(** Run backend bootstrap steps in a fixed order.
+    Memory_pg schema init removed: long_term_backend always uses JSONL. *)
 let init_pg_schemas_sequential () =
   let errors = ref [] in
   let run_step label f =
@@ -45,9 +35,8 @@ let init_pg_schemas_sequential () =
   in
   run_step "task_backend" init_task_backend;
   run_step "shared_pg_pool" inject_shared_pg_pool;
-  run_step "memory_pg_schema" init_memory_pg_schema;
   match List.rev !errors with
   | [] -> ()
   | errs ->
-      Log.Server.warn "PG schema init completed with errors: %s"
+      Log.Server.warn "Backend init completed with errors: %s"
         (String.concat "; " errs)

--- a/lib/swarm/swarm_checkpoint.ml
+++ b/lib/swarm/swarm_checkpoint.ml
@@ -137,43 +137,19 @@ let save config =
   let json = swarm_snapshot_to_yojson snapshot in
   let path = checkpoint_path config in
   Room_utils.write_json_local path json;
-  (* Dual persistence: also write to PostgreSQL backend if available *)
-  if Room_utils.is_pg_backend config then begin
-    let json_str = Yojson.Safe.to_string json in
-    (match Room_utils.backend_set config ~key:"swarm:checkpoint" ~value:json_str with
-     | Ok () -> ()
-     | Error e -> Log.Misc.warn "swarm checkpoint backend_set failed: %s" (Backend_types.show_error e))
-  end;
   Ok snapshot
 
 let restore config : (swarm_snapshot, string) result =
-  (* Try PostgreSQL first for distributed environments *)
-  let pg_snapshot =
-    if Room_utils.is_pg_backend config then
-      match Room_utils.backend_get config ~key:"swarm:checkpoint" with
-      | Ok (Some json_str) ->
-          (try
-             let json = Yojson.Safe.from_string json_str in
-             (match swarm_snapshot_of_yojson json with
-              | Ok snap -> Some snap
-              | Error _ -> None)
-           with Yojson.Json_error _ -> None)
-      | Ok None | Error _ -> None
-    else None
-  in
-  match pg_snapshot with
-  | Some snap -> Ok snap
-  | None ->
-      let path = checkpoint_path config in
-      if not (Sys.file_exists path) then
-        Error "No swarm checkpoint found"
-      else
-        match Safe_ops.read_json_file_safe path with
-        | Ok json ->
-            (match swarm_snapshot_of_yojson json with
-             | Ok snap -> Ok snap
-             | Error e -> Error (Printf.sprintf "Checkpoint parse error: %s" e))
-        | Error e -> Error (Printf.sprintf "Checkpoint read error: %s" e)
+  let path = checkpoint_path config in
+  if not (Sys.file_exists path) then
+    Error "No swarm checkpoint found"
+  else
+    match Safe_ops.read_json_file_safe path with
+    | Ok json ->
+        (match swarm_snapshot_of_yojson json with
+         | Ok snap -> Ok snap
+         | Error e -> Error (Printf.sprintf "Checkpoint parse error: %s" e))
+    | Error e -> Error (Printf.sprintf "Checkpoint read error: %s" e)
 
 (* ================================================================ *)
 (* Periodic save daemon (Eio fiber)                                 *)


### PR DESCRIPTION
## Summary
- **memory_oas_bridge**: JSONL long_term_backend only, `Memory_pg` preference removed
- **swarm_checkpoint**: PG dual-write (save) and PG-first read (restore) removed — filesystem only
- **room_lifecycle**: PG backend checks in join/leave removed — filesystem agent files only
- **server_bootstrap_pg**: `init_memory_pg_schema` removed (dead code since bridge no longer uses Memory_pg)
- **main_stdio_eio**: removed `init_memory_pg_schema` call

## Context
Filesystem-first policy (#3549, #3550 이후 후속). PG는 `MASC_STORAGE_TYPE=postgres` 명시 설정 시에만 Board/Task에서 사용.
Memory, Swarm, Agent lifecycle은 PG 가용 여부와 무관하게 항상 filesystem 경로 사용.

## Changes
5 files, -109 lines, +40 lines. Net -69 lines of PG-specific branching removed.

## Test plan
- [ ] `dune build` (local: passed, warnings-as-errors clean)
- [ ] CI green
- [ ] Server starts with `MASC_STORAGE_TYPE` unset (filesystem default)
- [ ] Keeper join/leave works (filesystem agent dedup)
- [ ] Swarm checkpoint save/restore (filesystem only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)