### PR TITLE
fix(backend): filesystem fallback for key_index exists check

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -249,13 +249,25 @@ module FileSystem = struct
        | _ -> ())
     end
 
-  (** Check if key exists (in-memory index lookup, O(1)) *)
+  (** Check if key exists (in-memory index first, filesystem fallback) *)
   let exists t key =
     match validate_key key with
     | Error _ -> false
     | Ok _ ->
       ensure_key_index t;
-      Hashtbl.mem t.key_index key
+      if Hashtbl.mem t.key_index key then true
+      else
+        (* Fallback: file may have been written outside the backend
+           (e.g. Fs_compat.append_jsonl, raw write_text_file in tests).
+           Check the actual filesystem and update the index on hit. *)
+        match key_to_path t key with
+        | Error _ -> false
+        | Ok path ->
+            (try
+               ignore (Eio.Path.load path : string);
+               Hashtbl.replace t.key_index key ();
+               true
+             with _ -> false)
 
   let list_keys t ~prefix =
     ensure_key_index t;


### PR DESCRIPTION
## Summary
- `FileSystem.exists` now falls back to actual filesystem when key is not in the in-memory index
- Fixes 2 test failures on main caused by #3570 (key_index introduction):
  - `room_state / heartbeat repairs legacy agent last_seen`
  - `projection / orders merged timeline chronologically`

## Root cause
The key_index only tracks files written through the backend API. Files created by:
- `Fs_compat.append_jsonl` (CP events JSONL)
- Raw `write_text_file` (legacy agent repair tests)

were invisible to `path_exists`, making `heartbeat` return "Agent not found" and CP event reads return empty lists.

## Test plan
- [x] `test_room_state_recovery` 5/5 pass (was 4/5)
- [x] `test_dashboard_proof` 7/7 pass (was 6/7)
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)