### PR TITLE
feat(keeper): persist DM chat history to JSONL

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -199,3 +199,34 @@ export async function streamKeeperMessage(
     reader.releaseLock()
   }
 }
+
+// --- Chat history ---
+
+export interface KeeperChatHistoryMessage {
+  role: string
+  content: string
+  ts: number
+}
+
+export async function fetchKeeperChatHistory(
+  name: string,
+): Promise<KeeperChatHistoryMessage[]> {
+  try {
+    const resp = await fetch(
+      `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
+      { headers: jsonHeaders() },
+    )
+    if (!resp.ok) return []
+    const data: unknown = await resp.json()
+    if (!Array.isArray(data)) return []
+    return data.filter(
+      (m): m is KeeperChatHistoryMessage =>
+        isRecord(m) &&
+        typeof m.role === 'string' &&
+        typeof m.content === 'string' &&
+        typeof m.ts === 'number',
+    )
+  } catch {
+    return []
+  }
+}

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -4,7 +4,11 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { streamKeeperMessage, type KeeperChatStreamEvent } from '../api/keeper'
+import {
+  streamKeeperMessage,
+  fetchKeeperChatHistory,
+  type KeeperChatStreamEvent,
+} from '../api/keeper'
 import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
@@ -119,10 +123,22 @@ async function sendChat(keeperName: string): Promise<void> {
 export function KeeperChatPanel({ name }: { name: string }) {
   useEffect(() => {
     cancelStream()
-    chatMessages.value = []
     chatInput.value = ''
     streamBuffer.value = ''
     chatError.value = ''
+    chatMessages.value = []
+    let stale = false
+    void fetchKeeperChatHistory(name).then((history) => {
+      if (stale) return
+      if (history.length > 0) {
+        chatMessages.value = history.map((m) => ({
+          role: m.role === 'assistant' ? 'assistant' as const : 'user' as const,
+          content: m.content,
+          timestamp: m.ts * 1000,
+        }))
+      }
+    })
+    return () => { stale = true }
   }, [name])
 
   const messages = chatMessages.value

--- a/lib/dune
+++ b/lib/dune
@@ -499,6 +499,7 @@
    keeper_coordination
    keeper_execution
    keeper_keepalive
+   keeper_chat_store
    keeper_recurring
    keeper_registry
    keeper_supervisor

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1,0 +1,105 @@
+(** Keeper_chat_store — JSONL-based persistence for keeper direct messages.
+
+    Each keeper gets a file: [<base_dir>/.masc/keeper_chat/<name>.jsonl]
+    Lines are append-only with timestamps.
+
+    Line format:
+    {v {"role":"user","content":"hello","ts":1774000000.0} v}
+
+    @since 2.145.0 *)
+
+let sanitize_name name =
+  Room_utils_backend_setup.sanitize_namespace_segment name
+
+let chat_dir base_dir =
+  Filename.concat (Filename.concat base_dir ".masc") "keeper_chat"
+
+let chat_path ~base_dir ~keeper_name =
+  Filename.concat (chat_dir base_dir) (sanitize_name keeper_name ^ ".jsonl")
+
+let dir_ensured : (string, bool) Hashtbl.t = Hashtbl.create 4
+
+let ensure_dir_once ~base_dir =
+  let dir = chat_dir base_dir in
+  if not (Hashtbl.mem dir_ensured dir) then begin
+    Fs_compat.mkdir_p dir;
+    Hashtbl.replace dir_ensured dir true
+  end
+
+let encode_line ~role ~content ~ts : string =
+  Yojson.Safe.to_string
+    (`Assoc
+       [
+         ("role", `String role);
+         ("content", `String content);
+         ("ts", `Float ts);
+       ])
+
+let append_pair ~base_dir ~keeper_name
+    ~(user_content : string) ~(assistant_content : string) =
+  try
+    ensure_dir_once ~base_dir;
+    let path = chat_path ~base_dir ~keeper_name in
+    let ts = Time_compat.now () in
+    let user_line = encode_line ~role:"user" ~content:user_content ~ts in
+    let asst_line = encode_line ~role:"assistant" ~content:assistant_content ~ts in
+    Fs_compat.append_file path (user_line ^ "\n" ^ asst_line ^ "\n")
+  with exn ->
+    Log.Keeper.warn "keeper_chat_store: append failed for %s: %s"
+      (sanitize_name keeper_name) (Printexc.to_string exn)
+
+type chat_message = {
+  role : string;
+  content : string;
+  ts : float;
+}
+
+let parse_line (line : string) : chat_message option =
+  try
+    let json = Yojson.Safe.from_string line in
+    let open Yojson.Safe.Util in
+    let role = member "role" json |> to_string_option |> Option.value ~default:"" in
+    let content = member "content" json |> to_string_option |> Option.value ~default:"" in
+    let ts = (try member "ts" json |> to_float with _ -> 0.0) in
+    if role = "" || content = "" then None
+    else Some { role; content; ts }
+  with Yojson.Json_error _ -> None
+
+let max_history = 100
+
+let load ~base_dir ~keeper_name : chat_message list =
+  let path = chat_path ~base_dir ~keeper_name in
+  try
+    let content = Fs_compat.load_file path in
+    let lines = String.split_on_char '\n' content in
+    (* Single pass: keep a running window of last max_history entries *)
+    let q = Queue.create () in
+    List.iter
+      (fun line ->
+        let trimmed = String.trim line in
+        if trimmed <> "" then
+          match parse_line trimmed with
+          | Some msg ->
+              Queue.push msg q;
+              if Queue.length q > max_history then ignore (Queue.pop q)
+          | None -> ())
+      lines;
+    Queue.fold (fun acc msg -> msg :: acc) [] q |> List.rev
+  with
+  | Sys_error _ -> []
+  | exn ->
+      Log.Keeper.warn "keeper_chat_store: load failed for %s: %s"
+        (sanitize_name keeper_name) (Printexc.to_string exn);
+      []
+
+let to_json_array (messages : chat_message list) : Yojson.Safe.t =
+  `List
+    (List.map
+       (fun m ->
+         `Assoc
+           [
+             ("role", `String m.role);
+             ("content", `String m.content);
+             ("ts", `Float m.ts);
+           ])
+       messages)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -510,6 +510,12 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                               ~custom_name:(Some "KEEPER_REPLY_DETAILS")
                               ~custom_value:(Some payload_json) Custom))
                  | None -> ());
+                (* Persist user + assistant messages in a single write *)
+                Keeper_chat_store.append_pair
+                  ~base_dir:state.Mcp_server.room_config.base_path
+                  ~keeper_name:payload.name
+                  ~user_content:payload.message
+                  ~assistant_content:visible_reply;
                 send_keeper_stream_finish writer mutex closed ~thread_id
                   ~run_id ~message_id
               with

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -303,23 +303,36 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
 
-  (* Keeper config — structured read-only config view for a single keeper *)
+  (* Keeper GET sub-routes: /config and /chat/history *)
   |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let req_path = Http.Request.path req in
          let prefix = "/api/v1/keepers/" in
-         let suffix = "/config" in
          let plen = String.length prefix in
-         let slen = String.length suffix in
          let tlen = String.length req_path in
-         if tlen > plen + slen
-            && String.sub req_path 0 plen = prefix
-            && String.sub req_path (tlen - slen) slen = suffix
-         then
-           let name =
-             String.trim
-               (String.sub req_path plen (tlen - plen - slen))
-           in
+         let ends_with suffix =
+           let slen = String.length suffix in
+           tlen > plen + slen
+           && String.sub req_path (tlen - slen) slen = suffix
+         in
+         let extract_name suffix =
+           let slen = String.length suffix in
+           String.trim (String.sub req_path plen (tlen - plen - slen))
+         in
+         if ends_with "/chat/history" then
+           let name = extract_name "/chat/history" in
+           if name = "" then
+             respond_json_with_cors ~status:`Bad_request request reqd
+               {|{"error":"missing keeper name"}|}
+           else
+             let base_dir = state.Mcp_server.room_config.base_path in
+             let messages =
+               Keeper_chat_store.load ~base_dir ~keeper_name:name
+             in
+             respond_json_with_cors ~status:`OK request reqd
+               (Yojson.Safe.to_string (Keeper_chat_store.to_json_array messages))
+         else if ends_with "/config" then
+           let name = extract_name "/config" in
            if String.length name = 0 then
              Http.Response.json ~status:`Bad_request
                {|{"error":"keeper name is required"}|} reqd


### PR DESCRIPTION
## Problem

Keeper 직접 대화(DM) 메시지가 dialog를 닫으면 전부 사라짐.
원인: 클라이언트 Preact signal에만 저장, 서버 저장/로드 경로 부재.

## Solution

3-layer fix:

1. **`lib/keeper/keeper_chat_store.ml`** (신규)
   - `.masc/keeper_chat/<name>.jsonl`에 append-only 저장
   - `load` 함수로 최근 100개 메시지 로드
   - `to_json_array`로 API 응답 직렬화

2. **Server** (`server_routes_http_keeper_stream.ml`)
   - 성공적인 스트림 완료 시 user message + assistant reply를 JSONL에 append
   - GET `/api/v1/keepers/:name/chat/history` 엔드포인트 추가

3. **Dashboard** (`keeper-chat-panel.ts` + `keeper.ts`)
   - dialog open 시 `fetchKeeperChatHistory()` 호출
   - history를 `chatMessages` signal에 복원

## Test plan

- [x] `dune build @check` 통과
- [x] `tsc --noEmit` 통과
- [ ] 수동 테스트: keeper DM 보내기 -> dialog 닫기 -> 다시 열기 -> 이전 대화 표시 확인
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)