### PR TITLE
feat(board): SSE notifications for filesystem-first Board operations

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -36,6 +36,12 @@ type keeper_board_signal = {
   hearth : string option;
 }
 
+type board_sse_event =
+  | Post_created of { post_id : string; author : string; title : string; hearth : string option }
+  | Comment_added of { post_id : string; comment_id : string; author : string }
+  | Post_voted of { post_id : string; voter : string; direction : Board.vote_direction }
+  | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
+
 (** Current backend state. Single ref avoids contradictory initialized/backend pairs. *)
 let backend_state : backend_state ref = ref Uninitialized
 
@@ -52,6 +58,17 @@ let emit_keeper_board_signal signal =
   let hook_opt = with_board_ro (fun () -> !keeper_board_signal_hook) in
   match hook_opt with
   | Some hook -> hook signal
+  | None -> ()
+
+let board_sse_hook : (board_sse_event -> unit) option ref = ref None
+
+let set_board_sse_hook hook =
+  with_board_rw (fun () -> board_sse_hook := Some hook)
+
+let emit_board_sse_event event =
+  let hook_opt = with_board_ro (fun () -> !board_sse_hook) in
+  match hook_opt with
+  | Some hook -> (try hook event with _ -> ())
   | None -> ()
 
 let is_initialized () =
@@ -157,15 +174,20 @@ let create_post ~author ~content ?title ?body ?post_kind ?meta_json
            ~visibility ~ttl_hours ?hearth ?thread_id ()
        with
        | Ok post as ok ->
+           let pid = Board.Post_id.to_string post.id in
+           let auth = Board.Agent_id.to_string post.author in
            emit_keeper_board_signal
              {
                kind = Board_post_created;
-               post_id = Board.Post_id.to_string post.id;
-               author = Board.Agent_id.to_string post.author;
+               post_id = pid;
+               author = auth;
                title = post.title;
                content = post.content;
                hearth = post.hearth;
              };
+           emit_board_sse_event
+             (Post_created { post_id = pid; author = auth;
+                             title = post.title; hearth = post.hearth });
            ok
        | Error _ as err -> err)
   | Postgres t ->
@@ -174,15 +196,20 @@ let create_post ~author ~content ?title ?body ?post_kind ?meta_json
            ~visibility ~ttl_hours ?hearth ?thread_id ()
        with
        | Ok post as ok ->
+           let pid = Board.Post_id.to_string post.id in
+           let auth = Board.Agent_id.to_string post.author in
            emit_keeper_board_signal
              {
                kind = Board_post_created;
-               post_id = Board.Post_id.to_string post.id;
-               author = Board.Agent_id.to_string post.author;
+               post_id = pid;
+               author = auth;
                title = post.title;
                content = post.content;
                hearth = post.hearth;
              };
+           emit_board_sse_event
+             (Post_created { post_id = pid; author = auth;
+                             title = post.title; hearth = post.hearth });
            ok
        | Error _ as err -> err)
 
@@ -238,47 +265,69 @@ let add_comment ~post_id ~author ~content ?parent_id
   | Jsonl store ->
       (match Board.add_comment store ~post_id ~author ~content ?parent_id ~ttl_hours () with
        | Ok comment as ok ->
+           let cid = Board.Comment_id.to_string comment.id in
+           let auth = Board.Agent_id.to_string comment.author in
            (match Board.get_post store ~post_id with
             | Ok post ->
                 emit_keeper_board_signal
                   {
                     kind = Board_comment_added;
                     post_id;
-                    author = Board.Agent_id.to_string comment.author;
+                    author = auth;
                     title = post.title;
                     content;
                     hearth = post.hearth;
                   }
             | Error e -> Log.BoardLog.warn "board signal skipped: get_post failed for %s: %s" post_id (Board_types.show_board_error e));
+           emit_board_sse_event
+             (Comment_added { post_id; comment_id = cid; author = auth });
            ok
        | Error _ as err -> err)
   | Postgres t ->
       (match Board_pg.add_comment t ~post_id ~author ~content ?parent_id ~ttl_hours () with
        | Ok comment as ok ->
+           let cid = Board.Comment_id.to_string comment.id in
+           let auth = Board.Agent_id.to_string comment.author in
            (match Board_pg.get_post t ~post_id with
             | Ok post ->
                 emit_keeper_board_signal
                   {
                     kind = Board_comment_added;
                     post_id;
-                    author = Board.Agent_id.to_string comment.author;
+                    author = auth;
                     title = post.title;
                     content;
                     hearth = post.hearth;
                   }
             | Error e -> Log.BoardLog.warn "board signal skipped: pg get_post failed for %s: %s" post_id (Board_types.show_board_error e));
+           emit_board_sse_event
+             (Comment_added { post_id; comment_id = cid; author = auth });
            ok
        | Error _ as err -> err)
 
 let vote ~voter ~post_id ~direction =
-  match backend () with
-  | Jsonl store -> Board.vote store ~voter ~post_id ~direction
-  | Postgres t -> Board_pg.vote_post t ~voter ~post_id ~direction
+  let result = match backend () with
+    | Jsonl store -> Board.vote store ~voter ~post_id ~direction
+    | Postgres t -> Board_pg.vote_post t ~voter ~post_id ~direction
+  in
+  (match result with
+   | Ok _score ->
+       emit_board_sse_event
+         (Post_voted { post_id; voter; direction })
+   | Error _ -> ());
+  result
 
 let vote_comment ~voter ~comment_id ~direction =
-  match backend () with
-  | Jsonl store -> Board.vote_comment store ~voter ~comment_id ~direction
-  | Postgres t -> Board_pg.vote_comment t ~voter ~comment_id ~direction
+  let result = match backend () with
+    | Jsonl store -> Board.vote_comment store ~voter ~comment_id ~direction
+    | Postgres t -> Board_pg.vote_comment t ~voter ~comment_id ~direction
+  in
+  (match result with
+   | Ok _score ->
+       emit_board_sse_event
+         (Comment_voted { comment_id; voter; direction })
+   | Error _ -> ());
+  result
 
 let stats () =
   match backend () with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -73,6 +73,39 @@ let start_keeper_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
       ~config:state.room_config
       signal);
+  Board_dispatch.set_board_sse_hook (fun event ->
+    let params = match event with
+      | Board_dispatch.Post_created { post_id; author; title; hearth } ->
+          let base = [("type", `String "post_created");
+                      ("post_id", `String post_id);
+                      ("author", `String author);
+                      ("title", `String title)] in
+          `Assoc (match hearth with
+                  | Some h -> ("hearth", `String h) :: base
+                  | None -> base)
+      | Board_dispatch.Comment_added { post_id; comment_id; author } ->
+          `Assoc [("type", `String "comment_added");
+                  ("post_id", `String post_id);
+                  ("comment_id", `String comment_id);
+                  ("author", `String author)]
+      | Board_dispatch.Post_voted { post_id; voter; direction } ->
+          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          `Assoc [("type", `String "post_voted");
+                  ("post_id", `String post_id);
+                  ("voter", `String voter);
+                  ("direction", `String dir)]
+      | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
+          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          `Assoc [("type", `String "comment_voted");
+                  ("comment_id", `String comment_id);
+                  ("voter", `String voter);
+                  ("direction", `String dir)]
+    in
+    Sse.broadcast (`Assoc [
+      ("jsonrpc", `String "2.0");
+      ("method", `String "notifications/board");
+      ("params", params)
+    ]));
   (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
      can react to new tasks, mentions, or room activity immediately. *)
   Room_eio.on_broadcast_mention := (fun mention ->


### PR DESCRIPTION
## Summary
- Board 쓰기 연산 (create_post, add_comment, vote, vote_comment)에 SSE 실시간 알림 추가
- `board_sse_hook` 패턴으로 board_dispatch.ml ↔ SSE 모듈 decoupling 유지
- JSONL + PG 양쪽 브랜치 모두에서 emit (기존 Board_listener는 masc_pubsub INSERT 미구현으로 미작동)

## Context
Filesystem-first 전수 점검에서 유일한 결여 기능. PG 없이 100% 기능 지원을 위해 필요.

## Changes
- `lib/board_dispatch.ml`: `board_sse_event` 타입 + hook + emit 호출
- `lib/server/server_bootstrap_loops.ml`: hook 등록 (JSON-RPC envelope + Sse.broadcast)

## Test plan
- [ ] `dune build` clean
- [ ] CI green
- [ ] `curl -N http://localhost:8935/sse` → board post 생성 → SSE에 notifications/board 이벤트 수신

🤖 Generated with [Claude Code](https://claude.com/claude-code)