### PR TITLE
feat(cdal): risk-aware supervisor digest — 4 structural risk signals

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -260,6 +260,7 @@
    operator_digest_event
    operator_digest_guidance
    operator_digest_types
+   risk_digest
    operator_digest_session
    operator_control
    operator_control_snapshot

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -72,6 +72,7 @@ type session_digest = {
   attention_items : attention_item list;
   recommended_actions : recommended_action list;
   worker_cards : worker_card list;
+  risk_digest : Yojson.Safe.t;
 }
 
 val stalled_session_threshold_sec : float

--- a/lib/operator/operator_digest_session.ml
+++ b/lib/operator/operator_digest_session.ml
@@ -688,5 +688,6 @@ let build_session_digest ?status_json:cached_status config (session : Team_sessi
     attention_items;
     recommended_actions;
     worker_cards;
+    risk_digest = Risk_digest.(compute ~session ~worker_cards |> to_yojson);
   }
 

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -75,6 +75,7 @@ type session_digest = {
   attention_items : attention_item list;
   recommended_actions : recommended_action list;
   worker_cards : worker_card list;
+  risk_digest : Yojson.Safe.t;
 }
 
 let stalled_session_threshold_sec = 300.0
@@ -394,6 +395,7 @@ let session_card_to_yojson ~actor (digest : session_digest) =
       ("context_pressure_by_lane", digest.context_pressure_by_lane);
       ("intervention_counters", digest.intervention_counters);
       ("local_runtime", digest.local_runtime);
+      ("risk_digest", digest.risk_digest);
       ("attention_count", `Int (List.length digest.attention_items));
       ("top_attention", option_to_json attention_item_to_yojson top_attention);
       ("recommended_action_count", `Int (List.length digest.recommended_actions));

--- a/lib/operator/risk_digest.ml
+++ b/lib/operator/risk_digest.ml
@@ -1,0 +1,243 @@
+(** Risk_digest — Structural risk signals for supervisor digest.
+
+    All computations are deterministic structural checks.
+    No LLM judge or probabilistic inference. *)
+
+type evidence_gap = {
+  required_count : int;
+  present_count : int;
+  missing : string list;
+}
+
+type drift_signal =
+  | Model_tier_inconsistency of { expected : string; actual : string list }
+  | Cascade_length_change of { original : int; current : int }
+
+type unsafe_edit_signal =
+  | Destructive_tool of string
+  | Zero_repair_budget
+  | High_risk_class
+
+type t = {
+  evidence_gap : evidence_gap;
+  drift_risk : drift_signal list;
+  unsafe_edit_risk : unsafe_edit_signal list;
+  ambiguity : string option;
+}
+
+(* --- Evidence gap computation --- *)
+
+let compute_evidence_gap (session : Team_session_types.session) : evidence_gap =
+  match session.delivery_contract with
+  | None ->
+      { required_count = 0; present_count = 0; missing = [] }
+  | Some dc ->
+      let required = dc.required_artifacts in
+      let present = dc.evidence_refs in
+      let required_count = List.length required in
+      let present_set =
+        List.fold_left
+          (fun acc ref_str -> List.cons (String.lowercase_ascii ref_str) acc)
+          [] present
+      in
+      let missing =
+        List.filter
+          (fun artifact ->
+            not
+              (List.exists
+                 (fun ref_str ->
+                   String.equal (String.lowercase_ascii artifact) ref_str)
+                 present_set))
+          required
+      in
+      let present_count = required_count - List.length missing in
+      { required_count; present_count; missing }
+
+(* --- Drift risk computation --- *)
+
+(** Check if worker model_tier values are consistent with the session cascade. *)
+let compute_drift_risk (session : Team_session_types.session)
+    (worker_cards : Operator_digest_types.worker_card list) : drift_signal list =
+  let signals = ref [] in
+  (* Check model_tier consistency across active workers *)
+  let active_tiers =
+    List.filter_map
+      (fun (card : Operator_digest_types.worker_card) ->
+        if String.equal card.status "running" || String.equal card.status "idle"
+        then card.model_tier
+        else None)
+      worker_cards
+  in
+  let unique_tiers =
+    List.sort_uniq String.compare active_tiers
+  in
+  (match session.model_cascade with
+  | first_model :: _ when List.length unique_tiers > 1 ->
+      signals :=
+        Model_tier_inconsistency
+          { expected = first_model; actual = unique_tiers }
+        :: !signals
+  | _ -> ());
+  (* Check cascade length change vs planned workers *)
+  let original_cascade_len = List.length session.model_cascade in
+  let active_cascade_models =
+    List.sort_uniq String.compare active_tiers |> List.length
+  in
+  if
+    original_cascade_len > 0
+    && active_cascade_models > 0
+    && active_cascade_models > original_cascade_len
+  then
+    signals :=
+      Cascade_length_change
+        { original = original_cascade_len; current = active_cascade_models }
+      :: !signals;
+  List.rev !signals
+
+(* --- Unsafe edit risk computation --- *)
+
+(** Known destructive tool name patterns. *)
+let destructive_patterns =
+  [
+    "git_push"; "git_reset"; "rm_"; "delete_"; "drop_"; "truncate_";
+    "force_"; "destroy_"; "remove_file"; "remove_dir";
+  ]
+
+let is_destructive_tool_name name =
+  let lower = String.lowercase_ascii name in
+  List.exists
+    (fun pattern -> try String.sub lower 0 (String.length pattern) = pattern with Invalid_argument _ -> false)
+    destructive_patterns
+  || List.exists
+       (fun pattern ->
+         try
+           let pat_len = String.length pattern in
+           let name_len = String.length lower in
+           let rec check i =
+             if i + pat_len > name_len then false
+             else if String.sub lower i pat_len = pattern then true
+             else check (i + 1)
+           in
+           check 0
+         with Invalid_argument _ -> false)
+       destructive_patterns
+
+let compute_unsafe_edit_risk (session : Team_session_types.session)
+    (worker_cards : Operator_digest_types.worker_card list) : unsafe_edit_signal list =
+  let signals = ref [] in
+  (* Check repair_budget = 0 *)
+  (match session.delivery_contract with
+  | Some dc when dc.repair_budget = 0 ->
+      signals := Zero_repair_budget :: !signals
+  | _ -> ());
+  (* Check for high risk_level in worker cards *)
+  List.iter
+    (fun (card : Operator_digest_types.worker_card) ->
+      match card.risk_level with
+      | Some level
+        when String.equal (String.lowercase_ascii level) "high"
+             || String.equal (String.lowercase_ascii level) "critical" ->
+          if not (List.mem High_risk_class !signals) then
+            signals := High_risk_class :: !signals
+      | _ -> ())
+    worker_cards;
+  (* Check for destructive tool patterns via worker spawn_agent names.
+     Full tool_names are only available from spawn events, not planned_worker.
+     We use spawn_agent as a heuristic — agents with destructive names
+     are likely to have destructive tools. *)
+  List.iter
+    (fun (pw : Team_session_types.planned_worker) ->
+      if is_destructive_tool_name pw.spawn_agent then
+        signals := Destructive_tool pw.spawn_agent :: !signals)
+    session.planned_workers;
+  List.rev !signals
+
+(* --- Ambiguity computation --- *)
+
+let compute_ambiguity (session : Team_session_types.session) : string option =
+  let goal_len = String.length (String.trim session.goal) in
+  if goal_len < 10 then Some "Goal is very short — may lack specificity"
+  else if
+    Option.is_none session.delivery_contract
+    && List.length session.planned_workers > 2
+  then
+    Some
+      "Multi-worker session without delivery_contract — acceptance criteria \
+       undefined"
+  else None
+
+(* --- Main computation --- *)
+
+let compute ~(session : Team_session_types.session)
+    ~(worker_cards : Operator_digest_types.worker_card list) : t =
+  {
+    evidence_gap = compute_evidence_gap session;
+    drift_risk = compute_drift_risk session worker_cards;
+    unsafe_edit_risk = compute_unsafe_edit_risk session worker_cards;
+    ambiguity = compute_ambiguity session;
+  }
+
+(* --- JSON serialization --- *)
+
+let evidence_gap_to_yojson (eg : evidence_gap) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("required_count", `Int eg.required_count);
+      ("present_count", `Int eg.present_count);
+      ("missing", `List (List.map (fun s -> `String s) eg.missing));
+      ( "gap_ratio",
+        `Float
+          (if eg.required_count = 0 then 0.0
+           else
+             float_of_int (eg.required_count - eg.present_count)
+             /. float_of_int eg.required_count) );
+    ]
+
+let drift_signal_to_yojson (signal : drift_signal) : Yojson.Safe.t =
+  match signal with
+  | Model_tier_inconsistency { expected; actual } ->
+      `Assoc
+        [
+          ("type", `String "model_tier_inconsistency");
+          ("expected", `String expected);
+          ("actual", `List (List.map (fun s -> `String s) actual));
+        ]
+  | Cascade_length_change { original; current } ->
+      `Assoc
+        [
+          ("type", `String "cascade_length_change");
+          ("original", `Int original);
+          ("current", `Int current);
+        ]
+
+let unsafe_edit_signal_to_yojson (signal : unsafe_edit_signal) : Yojson.Safe.t =
+  match signal with
+  | Destructive_tool name ->
+      `Assoc
+        [
+          ("type", `String "destructive_tool");
+          ("tool_name", `String name);
+        ]
+  | Zero_repair_budget ->
+      `Assoc [ ("type", `String "zero_repair_budget") ]
+  | High_risk_class ->
+      `Assoc [ ("type", `String "high_risk_class") ]
+
+let to_yojson (t : t) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("evidence_gap", evidence_gap_to_yojson t.evidence_gap);
+      ("drift_risk", `List (List.map drift_signal_to_yojson t.drift_risk));
+      ( "unsafe_edit_risk",
+        `List (List.map unsafe_edit_signal_to_yojson t.unsafe_edit_risk) );
+      ( "ambiguity",
+        match t.ambiguity with
+        | Some msg -> `String msg
+        | None -> `Null );
+      ("signal_count",
+        `Int
+          (List.length t.drift_risk
+           + List.length t.unsafe_edit_risk
+           + (if t.evidence_gap.missing <> [] then 1 else 0)
+           + (if Option.is_some t.ambiguity then 1 else 0)));
+    ]

--- a/lib/operator/risk_digest.mli
+++ b/lib/operator/risk_digest.mli
@@ -1,0 +1,39 @@
+(** Risk_digest — Structural risk signals for supervisor digest.
+
+    Computes 4 risk fields from session state using deterministic
+    structural signals only (no LLM judge). Per RFC #3475 PoC-2:
+    "1st PoC gates close only on deterministic structural signal." *)
+
+type evidence_gap = {
+  required_count : int;
+  present_count : int;
+  missing : string list;
+}
+(** Compares delivery_contract.required_artifacts against evidence_refs. *)
+
+type drift_signal =
+  | Model_tier_inconsistency of { expected : string; actual : string list }
+  | Cascade_length_change of { original : int; current : int }
+(** Structural drift signals from session metadata. *)
+
+type unsafe_edit_signal =
+  | Destructive_tool of string
+  | Zero_repair_budget
+  | High_risk_class
+(** Structural signals indicating unsafe edit potential. *)
+
+type t = {
+  evidence_gap : evidence_gap;
+  drift_risk : drift_signal list;
+  unsafe_edit_risk : unsafe_edit_signal list;
+  ambiguity : string option;
+}
+
+val compute :
+  session:Team_session_types.session ->
+  worker_cards:Operator_digest_types.worker_card list ->
+  t
+(** Compute risk digest from session state and worker cards. *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Serialize risk digest to JSON. *)

--- a/test/dune
+++ b/test/dune
@@ -52,6 +52,7 @@
         test_contract_composer
         test_cdal_conformance
         test_task_stage
+        test_risk_digest
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -85,6 +86,7 @@
           test_contract_composer
           test_cdal_conformance
           test_task_stage
+          test_risk_digest
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_risk_digest.ml
+++ b/test/test_risk_digest.ml
@@ -1,0 +1,311 @@
+(** test_risk_digest.ml — Tests for Risk_digest structural risk signals. *)
+
+open Masc_mcp
+
+(* --- Test helpers --- *)
+
+let make_delivery_contract
+    ?(required_artifacts = []) ?(evidence_refs = [])
+    ?(repair_budget = 3) () : Team_session_types.delivery_contract =
+  {
+    contract_id = "test-contract";
+    summary = "test contract";
+    acceptance_checks = [ "check_1" ];
+    required_artifacts;
+    repair_budget;
+    generator_roles = [ "coder" ];
+    evaluator_role = Some "reviewer";
+    evaluator_cascade = "default";
+    evidence_refs;
+    updated_by = "test";
+    updated_at_iso = "2026-03-29T00:00:00Z";
+  }
+
+let make_session
+    ?(goal = "Implement feature X with proper testing")
+    ?delivery_contract
+    ?(planned_workers = [])
+    ?(model_cascade = [ "opus" ]) () : Team_session_types.session =
+  {
+    session_id = "test-session";
+    goal;
+    created_by = "tester";
+    origin_kind = Team_session_types.Origin_human;
+    room_id = "test-room";
+    operation_id = None;
+    status = Team_session_types.Running;
+    duration_seconds = 3600;
+    execution_scope = Team_session_types.Autonomous;
+    checkpoint_interval_sec = 300;
+    min_agents = 1;
+    scale_profile = Team_session_types.Scale_local64;
+    control_profile = Team_session_types.Control_flat;
+    orchestration_mode = Team_session_types.Auto;
+    communication_mode = Team_session_types.Comm_broadcast;
+    model_cascade;
+    fallback_policy = Team_session_types.Fallback_cascade_then_task;
+    instruction_profile = Team_session_types.Profile_standard;
+    alert_channel = Team_session_types.Alert_broadcast;
+    auto_resume = false;
+    report_formats = [];
+    turn_count = 0;
+    agent_names = [];
+    planned_workers;
+    broadcast_count = 0;
+    portal_count = 0;
+    cascade_attempted = 0;
+    cascade_success = 0;
+    cascade_failed = 0;
+    fallback_task_created = 0;
+    min_agents_violation_streak = 0;
+    policy_violations = [];
+    baseline_done_counts = [];
+    final_done_delta_total = None;
+    final_done_delta_by_agent = None;
+    started_at = 1711670400.0;
+    planned_end_at = 1711674000.0;
+    stopped_at = None;
+    last_checkpoint_at = None;
+    last_event_at = None;
+    last_turn_at = None;
+    stop_reason = None;
+    generated_report = false;
+    delivery_contract;
+    latest_delivery_verdict = None;
+    artifacts_dir = "/tmp/test-artifacts";
+    created_at_iso = "2026-03-29T00:00:00Z";
+    updated_at_iso = "2026-03-29T00:00:00Z";
+  }
+
+let make_worker_card
+    ?(status = "running") ?(model_tier = None) ?(risk_level = None) () :
+    Operator_digest_types.worker_card =
+  {
+    actor = Some "worker-1";
+    spawn_agent = Some "coder";
+    spawn_role = Some "coder";
+    spawn_model = None;
+    execution_scope = None;
+    worker_class = None;
+    parent_actor = None;
+    capsule_mode = None;
+    runtime_pool = None;
+    lane_id = None;
+    controller_level = None;
+    control_domain = None;
+    supervisor_actor = None;
+    model_tier;
+    task_profile = None;
+    risk_level;
+    routing_confidence = None;
+    routing_reason = None;
+    status;
+    turn_count = 5;
+    empty_note_turn_count = 0;
+    has_turn = true;
+    last_turn_age_sec = Some 10;
+    evidence_source = "session_events";
+    last_turn_ts_iso = Some "2026-03-29T00:01:00Z";
+  }
+
+(* --- Evidence gap tests --- *)
+
+let test_evidence_gap_no_contract () =
+  let session = make_session () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check int) "required 0" 0 result.evidence_gap.required_count;
+  Alcotest.(check int) "present 0" 0 result.evidence_gap.present_count;
+  Alcotest.(check int) "missing 0" 0 (List.length result.evidence_gap.missing)
+
+let test_evidence_gap_all_present () =
+  let dc =
+    make_delivery_contract
+      ~required_artifacts:[ "report.md"; "test_results.xml" ]
+      ~evidence_refs:[ "report.md"; "test_results.xml" ] ()
+  in
+  let session = make_session ~delivery_contract:dc () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check int) "required 2" 2 result.evidence_gap.required_count;
+  Alcotest.(check int) "present 2" 2 result.evidence_gap.present_count;
+  Alcotest.(check int) "missing 0" 0 (List.length result.evidence_gap.missing)
+
+let test_evidence_gap_partial () =
+  let dc =
+    make_delivery_contract
+      ~required_artifacts:[ "report.md"; "test_results.xml"; "coverage.json" ]
+      ~evidence_refs:[ "report.md" ] ()
+  in
+  let session = make_session ~delivery_contract:dc () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check int) "required 3" 3 result.evidence_gap.required_count;
+  Alcotest.(check int) "present 1" 1 result.evidence_gap.present_count;
+  Alcotest.(check int) "missing 2" 2 (List.length result.evidence_gap.missing);
+  Alcotest.(check bool) "missing test_results"
+    true
+    (List.mem "test_results.xml" result.evidence_gap.missing);
+  Alcotest.(check bool) "missing coverage"
+    true
+    (List.mem "coverage.json" result.evidence_gap.missing)
+
+(* --- Drift risk tests --- *)
+
+let test_drift_no_workers () =
+  let session = make_session () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check int) "no drift signals" 0 (List.length result.drift_risk)
+
+let test_drift_consistent_tiers () =
+  let cards =
+    [
+      make_worker_card ~model_tier:(Some "opus") ();
+      make_worker_card ~model_tier:(Some "opus") ();
+    ]
+  in
+  let session = make_session ~model_cascade:[ "opus" ] () in
+  let result = Risk_digest.compute ~session ~worker_cards:cards in
+  Alcotest.(check int) "no drift" 0 (List.length result.drift_risk)
+
+let test_drift_inconsistent_tiers () =
+  let cards =
+    [
+      make_worker_card ~model_tier:(Some "opus") ();
+      make_worker_card ~model_tier:(Some "sonnet") ();
+    ]
+  in
+  let session = make_session ~model_cascade:[ "opus" ] () in
+  let result = Risk_digest.compute ~session ~worker_cards:cards in
+  Alcotest.(check bool) "has drift signal" true (List.length result.drift_risk > 0);
+  match result.drift_risk with
+  | Risk_digest.Model_tier_inconsistency { expected; actual } :: _ ->
+      Alcotest.(check string) "expected opus" "opus" expected;
+      Alcotest.(check int) "2 unique tiers" 2 (List.length actual)
+  | _ -> Alcotest.fail "expected Model_tier_inconsistency"
+
+(* --- Unsafe edit risk tests --- *)
+
+let test_unsafe_edit_no_risk () =
+  let session = make_session () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check int) "no unsafe signals" 0 (List.length result.unsafe_edit_risk)
+
+let test_unsafe_edit_zero_repair () =
+  let dc = make_delivery_contract ~repair_budget:0 () in
+  let session = make_session ~delivery_contract:dc () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check bool) "has zero_repair_budget" true
+    (List.exists
+       (fun s -> match s with Risk_digest.Zero_repair_budget -> true | _ -> false)
+       result.unsafe_edit_risk)
+
+let test_unsafe_edit_high_risk_worker () =
+  let cards = [ make_worker_card ~risk_level:(Some "high") () ] in
+  let session = make_session () in
+  let result = Risk_digest.compute ~session ~worker_cards:cards in
+  Alcotest.(check bool) "has high_risk_class" true
+    (List.exists
+       (fun s -> match s with Risk_digest.High_risk_class -> true | _ -> false)
+       result.unsafe_edit_risk)
+
+(* --- Ambiguity tests --- *)
+
+let test_ambiguity_short_goal () =
+  let session = make_session ~goal:"fix" () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check bool) "has ambiguity" true (Option.is_some result.ambiguity)
+
+let test_ambiguity_no_contract_multi_worker () =
+  let pw : Team_session_types.planned_worker =
+    {
+      spawn_agent = "coder";
+      runtime_actor = None;
+      spawn_role = None;
+      spawn_model = None;
+      execution_scope = None;
+      thinking_enabled = None;
+      thinking_budget = None;
+      max_turns = None;
+      timeout_seconds = None;
+      worker_class = None;
+      parent_actor = None;
+      capsule_mode = None;
+      runtime_pool = None;
+      lane_id = None;
+      controller_level = None;
+      control_domain = None;
+      supervisor_actor = None;
+      model_tier = None;
+      task_profile = None;
+      risk_level = None;
+      routing_confidence = None;
+      routing_reason = None;
+      routing_escalated = false;
+    }
+  in
+  let session = make_session ~planned_workers:[ pw; pw; pw ] () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check bool) "has ambiguity" true (Option.is_some result.ambiguity)
+
+let test_ambiguity_clear_session () =
+  let dc = make_delivery_contract () in
+  let session = make_session ~delivery_contract:dc () in
+  let result = Risk_digest.compute ~session ~worker_cards:[] in
+  Alcotest.(check bool) "no ambiguity" true (Option.is_none result.ambiguity)
+
+(* --- JSON serialization test --- *)
+
+let test_to_yojson () =
+  let dc =
+    make_delivery_contract
+      ~required_artifacts:[ "report.md" ]
+      ~evidence_refs:[] ~repair_budget:0 ()
+  in
+  let session = make_session ~delivery_contract:dc () in
+  let cards = [ make_worker_card ~risk_level:(Some "critical") () ] in
+  let result = Risk_digest.compute ~session ~worker_cards:cards in
+  let json = Risk_digest.to_yojson result in
+  let open Yojson.Safe.Util in
+  let eg = json |> member "evidence_gap" in
+  Alcotest.(check int) "required 1" 1 (eg |> member "required_count" |> to_int);
+  let signal_count = json |> member "signal_count" |> to_int in
+  Alcotest.(check bool) "signal_count > 0" true (signal_count > 0);
+  let unsafe = json |> member "unsafe_edit_risk" |> to_list in
+  Alcotest.(check bool) "unsafe not empty" true (List.length unsafe > 0)
+
+(* --- Test suite --- *)
+
+let () =
+  Alcotest.run "risk_digest"
+    [
+      ( "evidence_gap",
+        [
+          Alcotest.test_case "no contract" `Quick test_evidence_gap_no_contract;
+          Alcotest.test_case "all present" `Quick test_evidence_gap_all_present;
+          Alcotest.test_case "partial" `Quick test_evidence_gap_partial;
+        ] );
+      ( "drift_risk",
+        [
+          Alcotest.test_case "no workers" `Quick test_drift_no_workers;
+          Alcotest.test_case "consistent tiers" `Quick test_drift_consistent_tiers;
+          Alcotest.test_case "inconsistent tiers" `Quick
+            test_drift_inconsistent_tiers;
+        ] );
+      ( "unsafe_edit_risk",
+        [
+          Alcotest.test_case "no risk" `Quick test_unsafe_edit_no_risk;
+          Alcotest.test_case "zero repair budget" `Quick
+            test_unsafe_edit_zero_repair;
+          Alcotest.test_case "high risk worker" `Quick
+            test_unsafe_edit_high_risk_worker;
+        ] );
+      ( "ambiguity",
+        [
+          Alcotest.test_case "short goal" `Quick test_ambiguity_short_goal;
+          Alcotest.test_case "no contract multi worker" `Quick
+            test_ambiguity_no_contract_multi_worker;
+          Alcotest.test_case "clear session" `Quick test_ambiguity_clear_session;
+        ] );
+      ( "serialization",
+        [
+          Alcotest.test_case "to_yojson" `Quick test_to_yojson;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `Risk_digest` 모듈 신규: `evidence_gap`, `drift_risk`, `unsafe_edit_risk`, `ambiguity` 4개 structural risk field
- `session_digest`에 `risk_digest` JSON 필드 추가 — dashboard/operator에서 즉시 소비 가능
- RFC #3475 PoC-2 원칙 준수: deterministic structural signal만 사용, LLM judge 미사용

## Changes
| 파일 | 변경 |
|------|------|
| `lib/operator/risk_digest.ml` + `.mli` | 신규 — 4-axis risk computation |
| `lib/operator/operator_digest_types.ml` | `session_digest`에 `risk_digest` 필드 추가 |
| `lib/operator/operator_digest.mli` | interface 동기화 |
| `lib/operator/operator_digest_session.ml` | `build_session_digest`에서 Risk_digest.compute 호출 |
| `test/test_risk_digest.ml` | 13 tests (evidence, drift, unsafe, ambiguity, json) |

## Risk signals
- **evidence_gap**: `delivery_contract.required_artifacts` vs `evidence_refs` 비교
- **drift_risk**: worker model_tier 일관성 + cascade 길이 변동 탐지
- **unsafe_edit_risk**: zero repair_budget, high risk_class worker, destructive agent names
- **ambiguity**: 짧은 goal, contract 없는 multi-worker 세션

Closes #3518

## Test plan
- [x] `dune build` green
- [x] 13 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)