### PR TITLE
feat(cdal): MASC artifact store backend

### DIFF
--- a/lib/cdal/artifact_store.ml
+++ b/lib/cdal/artifact_store.ml
@@ -1,0 +1,172 @@
+(** Artifact_store — MASC CDAL artifact storage backend.
+
+    Filesystem-first storage for evaluator results, intervention
+    summaries, and acceptance verdicts. *)
+
+module U = Yojson.Safe.Util
+
+type artifact_kind =
+  | Evaluator_result
+  | Intervention_summary
+  | Acceptance_verdict
+  | Evidence_bundle
+
+type artifact_metadata = {
+  artifact_id : string;
+  kind : artifact_kind;
+  producer : string;
+  schema_version : string;
+  created_at_iso : string;
+  owner : string;
+  session_id : string;
+}
+
+type config = {
+  base_dir : string;
+}
+
+let kind_to_string = function
+  | Evaluator_result -> "evaluator_result"
+  | Intervention_summary -> "intervention_summary"
+  | Acceptance_verdict -> "acceptance_verdict"
+  | Evidence_bundle -> "evidence_bundle"
+
+let kind_of_string = function
+  | "evaluator_result" -> Ok Evaluator_result
+  | "intervention_summary" -> Ok Intervention_summary
+  | "acceptance_verdict" -> Ok Acceptance_verdict
+  | "evidence_bundle" -> Ok Evidence_bundle
+  | other -> Error (Printf.sprintf "unknown artifact kind: %s" other)
+
+let default_config ~session_id =
+  let home =
+    try Sys.getenv "HOME" with Not_found -> "/tmp"
+  in
+  { base_dir = Filename.concat home (Printf.sprintf ".masc/sessions/%s/artifacts" session_id) }
+
+(* --- Filesystem helpers --- *)
+
+let kind_dir config kind =
+  Filename.concat config.base_dir (Printf.sprintf "cdal/%s" (kind_to_string kind))
+
+let artifact_path config kind artifact_id =
+  Filename.concat (kind_dir config kind) (artifact_id ^ ".json")
+
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    (try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  end
+
+let init config =
+  List.iter
+    (fun kind -> mkdir_p (kind_dir config kind))
+    [ Evaluator_result; Intervention_summary; Acceptance_verdict; Evidence_bundle ]
+
+(* --- Metadata serialization --- *)
+
+let metadata_to_yojson (m : artifact_metadata) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("artifact_id", `String m.artifact_id);
+      ("kind", `String (kind_to_string m.kind));
+      ("producer", `String m.producer);
+      ("schema_version", `String m.schema_version);
+      ("created_at_iso", `String m.created_at_iso);
+      ("owner", `String m.owner);
+      ("session_id", `String m.session_id);
+    ]
+
+let metadata_of_yojson (json : Yojson.Safe.t) :
+    (artifact_metadata, string) result =
+  try
+    let artifact_id = json |> U.member "artifact_id" |> U.to_string in
+    let kind_str = json |> U.member "kind" |> U.to_string in
+    match kind_of_string kind_str with
+    | Error e -> Error e
+    | Ok kind ->
+        Ok
+          {
+            artifact_id;
+            kind;
+            producer = json |> U.member "producer" |> U.to_string;
+            schema_version = json |> U.member "schema_version" |> U.to_string;
+            created_at_iso = json |> U.member "created_at_iso" |> U.to_string;
+            owner = json |> U.member "owner" |> U.to_string;
+            session_id = json |> U.member "session_id" |> U.to_string;
+          }
+  with
+  | U.Type_error (msg, _) -> Error (Printf.sprintf "metadata parse error: %s" msg)
+  | Not_found -> Error "metadata parse error: missing required field"
+
+(* --- Envelope: metadata + payload --- *)
+
+let envelope_to_json metadata payload =
+  `Assoc
+    [
+      ("_metadata", metadata_to_yojson metadata);
+      ("payload", payload);
+    ]
+
+let envelope_of_json json =
+  try
+    let meta_json = json |> U.member "_metadata" in
+    let payload = json |> U.member "payload" in
+    match metadata_of_yojson meta_json with
+    | Ok metadata -> Ok (metadata, payload)
+    | Error e -> Error e
+  with
+  | U.Type_error (msg, _) -> Error (Printf.sprintf "envelope parse error: %s" msg)
+  | Not_found -> Error "envelope parse error: missing _metadata or payload"
+
+(* --- Store operations --- *)
+
+let write config ~(metadata : artifact_metadata) ~(payload : Yojson.Safe.t) =
+  let dir = kind_dir config metadata.kind in
+  mkdir_p dir;
+  let path = artifact_path config metadata.kind metadata.artifact_id in
+  let envelope = envelope_to_json metadata payload in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.pretty_to_string envelope))
+
+let read config ~kind ~artifact_id =
+  let path = artifact_path config kind artifact_id in
+  if not (Sys.file_exists path) then
+    Error (Printf.sprintf "artifact not found: %s" path)
+  else
+    try
+      let ic = open_in path in
+      let content =
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () ->
+            let n = in_channel_length ic in
+            let buf = Bytes.create n in
+            really_input ic buf 0 n;
+            Bytes.to_string buf)
+      in
+      let json = Yojson.Safe.from_string content in
+      envelope_of_json json
+    with
+    | Yojson.Json_error msg -> Error (Printf.sprintf "json parse error: %s" msg)
+    | Sys_error msg -> Error msg
+
+let list_artifacts config ~kind =
+  let dir = kind_dir config kind in
+  if not (Sys.file_exists dir) then []
+  else
+    let entries = Sys.readdir dir |> Array.to_list in
+    entries
+    |> List.filter (fun name -> Filename.check_suffix name ".json")
+    |> List.filter_map (fun name ->
+           let artifact_id = Filename.chop_suffix name ".json" in
+           match read config ~kind ~artifact_id with
+           | Ok (metadata, _) -> Some metadata
+           | Error _ -> None)
+
+let make_ref ~session_id ~kind ~artifact_id =
+  Printf.sprintf "masc-artifact://%s/%s/%s" session_id (kind_to_string kind)
+    artifact_id

--- a/lib/cdal/artifact_store.mli
+++ b/lib/cdal/artifact_store.mli
@@ -1,0 +1,53 @@
+(** Artifact_store — MASC CDAL artifact storage backend.
+
+    Stores evaluator results, intervention summaries, and acceptance
+    verdicts with stable metadata. Compatible with OAS Proof_store
+    namespace for cross-system artifact joins.
+
+    URI scheme: [masc-artifact://{session_id}/{artifact_type}/{artifact_id}]
+    Filesystem layout: [{base_dir}/cdal/{artifact_type}/{artifact_id}.json] *)
+
+type artifact_kind =
+  | Evaluator_result
+  | Intervention_summary
+  | Acceptance_verdict
+  | Evidence_bundle
+
+type artifact_metadata = {
+  artifact_id : string;
+  kind : artifact_kind;
+  producer : string;
+  schema_version : string;
+  created_at_iso : string;
+  owner : string;
+  session_id : string;
+}
+
+type config = {
+  base_dir : string;
+}
+
+val default_config : session_id:string -> config
+(** Default config using session artifacts_dir convention. *)
+
+val init : config -> unit
+(** Create directory structure for the artifact store. *)
+
+val write : config -> metadata:artifact_metadata -> payload:Yojson.Safe.t -> unit
+(** Write an artifact with metadata envelope. *)
+
+val read : config -> kind:artifact_kind -> artifact_id:string ->
+  (artifact_metadata * Yojson.Safe.t, string) result
+(** Read an artifact by kind and id. Returns metadata + payload. *)
+
+val list_artifacts : config -> kind:artifact_kind -> artifact_metadata list
+(** List all artifacts of a given kind. *)
+
+val make_ref : session_id:string -> kind:artifact_kind -> artifact_id:string -> string
+(** Construct a [masc-artifact://] URI reference. *)
+
+val kind_to_string : artifact_kind -> string
+val kind_of_string : string -> (artifact_kind, string) result
+
+val metadata_to_yojson : artifact_metadata -> Yojson.Safe.t
+val metadata_of_yojson : Yojson.Safe.t -> (artifact_metadata, string) result

--- a/lib/dune
+++ b/lib/dune
@@ -476,6 +476,7 @@
    cdal_judge
    cdal_eval_v1
    cdal_friction_projection
+   artifact_store
    contract_risk
    contract_composer
    keeper_deliberation

--- a/test/dune
+++ b/test/dune
@@ -53,6 +53,7 @@
         test_cdal_conformance
         test_task_stage
         test_risk_digest
+        test_artifact_store
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -87,6 +88,7 @@
           test_cdal_conformance
           test_task_stage
           test_risk_digest
+          test_artifact_store
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_artifact_store.ml
+++ b/test/test_artifact_store.ml
@@ -1,0 +1,156 @@
+(** test_artifact_store.ml — Tests for MASC CDAL artifact store. *)
+
+open Masc_mcp
+
+let test_dir = ref ""
+
+let setup () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-artifact-test-%d" (Unix.getpid ())) in
+  test_dir := dir;
+  let config : Artifact_store.config = { base_dir = dir } in
+  Artifact_store.init config;
+  config
+
+let cleanup () =
+  if !test_dir <> "" && Sys.file_exists !test_dir then
+    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote !test_dir)))
+
+let make_metadata ?(artifact_id = "test-001") ?(kind = Artifact_store.Evaluator_result)
+    ?(producer = "test-agent") () : Artifact_store.artifact_metadata =
+  {
+    artifact_id;
+    kind;
+    producer;
+    schema_version = "1.0.0";
+    created_at_iso = "2026-03-29T00:00:00Z";
+    owner = "tester";
+    session_id = "sess-001";
+  }
+
+(* --- Kind conversion tests --- *)
+
+let test_kind_roundtrip () =
+  let kinds =
+    Artifact_store.[
+      Evaluator_result; Intervention_summary;
+      Acceptance_verdict; Evidence_bundle;
+    ]
+  in
+  List.iter
+    (fun kind ->
+      let str = Artifact_store.kind_to_string kind in
+      match Artifact_store.kind_of_string str with
+      | Ok k ->
+          Alcotest.(check string) "roundtrip"
+            (Artifact_store.kind_to_string kind)
+            (Artifact_store.kind_to_string k)
+      | Error e -> Alcotest.fail e)
+    kinds
+
+let test_kind_invalid () =
+  match Artifact_store.kind_of_string "nonexistent" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on invalid kind"
+
+(* --- Write + Read tests --- *)
+
+let test_write_read () =
+  let config = setup () in
+  let metadata = make_metadata () in
+  let payload = `Assoc [ ("score", `Float 0.95); ("passed", `Bool true) ] in
+  Artifact_store.write config ~metadata ~payload;
+  match Artifact_store.read config ~kind:Artifact_store.Evaluator_result ~artifact_id:"test-001" with
+  | Ok (meta, pay) ->
+      Alcotest.(check string) "artifact_id" "test-001" meta.artifact_id;
+      Alcotest.(check string) "producer" "test-agent" meta.producer;
+      let score =
+        pay |> Yojson.Safe.Util.member "score" |> Yojson.Safe.Util.to_float
+      in
+      Alcotest.(check (float 0.01)) "score" 0.95 score;
+      cleanup ()
+  | Error e ->
+      cleanup ();
+      Alcotest.fail e
+
+let test_read_not_found () =
+  let config = setup () in
+  (match Artifact_store.read config ~kind:Artifact_store.Evaluator_result ~artifact_id:"nonexistent" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on missing artifact");
+  cleanup ()
+
+(* --- List artifacts test --- *)
+
+let test_list_artifacts () =
+  let config = setup () in
+  let m1 = make_metadata ~artifact_id:"eval-001" () in
+  let m2 = make_metadata ~artifact_id:"eval-002" () in
+  Artifact_store.write config ~metadata:m1 ~payload:(`Assoc []);
+  Artifact_store.write config ~metadata:m2 ~payload:(`Assoc []);
+  let listed = Artifact_store.list_artifacts config ~kind:Artifact_store.Evaluator_result in
+  Alcotest.(check int) "2 artifacts" 2 (List.length listed);
+  cleanup ()
+
+(* --- Make ref test --- *)
+
+let test_make_ref () =
+  let ref_uri =
+    Artifact_store.make_ref ~session_id:"sess-001"
+      ~kind:Artifact_store.Evaluator_result ~artifact_id:"eval-001"
+  in
+  Alcotest.(check string) "uri format"
+    "masc-artifact://sess-001/evaluator_result/eval-001" ref_uri
+
+(* --- Metadata serialization test --- *)
+
+let test_metadata_roundtrip () =
+  let metadata = make_metadata () in
+  let json = Artifact_store.metadata_to_yojson metadata in
+  match Artifact_store.metadata_of_yojson json with
+  | Ok m ->
+      Alcotest.(check string) "id" metadata.artifact_id m.artifact_id;
+      Alcotest.(check string) "producer" metadata.producer m.producer;
+      Alcotest.(check string) "schema" metadata.schema_version m.schema_version
+  | Error e -> Alcotest.fail e
+
+(* --- Multiple kinds test --- *)
+
+let test_multiple_kinds () =
+  let config = setup () in
+  let m_eval = make_metadata ~artifact_id:"eval-1" ~kind:Artifact_store.Evaluator_result () in
+  let m_verdict = make_metadata ~artifact_id:"verdict-1" ~kind:Artifact_store.Acceptance_verdict () in
+  Artifact_store.write config ~metadata:m_eval ~payload:(`Assoc [ ("type", `String "eval") ]);
+  Artifact_store.write config ~metadata:m_verdict ~payload:(`Assoc [ ("type", `String "verdict") ]);
+  let evals = Artifact_store.list_artifacts config ~kind:Artifact_store.Evaluator_result in
+  let verdicts = Artifact_store.list_artifacts config ~kind:Artifact_store.Acceptance_verdict in
+  Alcotest.(check int) "1 eval" 1 (List.length evals);
+  Alcotest.(check int) "1 verdict" 1 (List.length verdicts);
+  cleanup ()
+
+(* --- Test suite --- *)
+
+let () =
+  Alcotest.run "artifact_store"
+    [
+      ( "kind",
+        [
+          Alcotest.test_case "roundtrip" `Quick test_kind_roundtrip;
+          Alcotest.test_case "invalid" `Quick test_kind_invalid;
+        ] );
+      ( "store",
+        [
+          Alcotest.test_case "write and read" `Quick test_write_read;
+          Alcotest.test_case "read not found" `Quick test_read_not_found;
+          Alcotest.test_case "list artifacts" `Quick test_list_artifacts;
+          Alcotest.test_case "multiple kinds" `Quick test_multiple_kinds;
+        ] );
+      ( "ref",
+        [
+          Alcotest.test_case "make ref" `Quick test_make_ref;
+        ] );
+      ( "metadata",
+        [
+          Alcotest.test_case "roundtrip" `Quick test_metadata_roundtrip;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `Artifact_store` 모듈 신규: filesystem-first CDAL artifact 저장소
- 4가지 artifact kind: evaluator_result, intervention_summary, acceptance_verdict, evidence_bundle
- OAS `Proof_store`와 namespace 호환: `masc-artifact://` URI scheme
- Metadata envelope: artifact_id, producer, schema_version, created_at_iso, owner, session_id

## Changes
| 파일 | 변경 |
|------|------|
| `lib/cdal/artifact_store.ml` + `.mli` | 신규 — store backend |
| `test/test_artifact_store.ml` | 8 tests |

## Design
- Filesystem layout: `{base_dir}/cdal/{kind}/{artifact_id}.json`
- JSON envelope: `_metadata` + `payload` 분리
- URI reference: `masc-artifact://{session_id}/{kind}/{artifact_id}`
- OAS proof와 join 가능: 같은 session artifacts_dir 내에 OAS proofs/ + MASC cdal/ 공존

Closes #3520

## Test plan
- [x] `dune build` green
- [x] 8 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)