### PR TITLE
feat(cdal): fresh-context adversarial evaluator

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -1,0 +1,293 @@
+(** Adversarial_eval — Fresh-context adversarial evaluator.
+
+    Structural checks only. No LLM inference. *)
+
+type allowed_input =
+  | Diff of string
+  | Changed_file of { path : string; content : string }
+  | Type_signature of { module_name : string; signature : string }
+  | Interface_contract of { path : string; content : string }
+
+type banned_input_kind =
+  | Readme
+  | Design_doc
+  | Room_history
+  | Task_history
+  | Governance_history
+
+type advisory_finding = {
+  finding_id : string;
+  severity : string;
+  category : string;
+  summary : string;
+  location : string option;
+}
+
+type eval_context = {
+  inputs : allowed_input list;
+  session_id : string;
+  evaluator_version : string;
+}
+
+type eval_result = {
+  findings : advisory_finding list;
+  input_count : int;
+  is_advisory : bool;
+}
+
+let evaluator_version = "0.1.0"
+
+(* --- Red line enforcement --- *)
+
+let banned_readme_patterns =
+  [ "readme"; "readme.md"; "readme.txt"; "readme.rst" ]
+
+let banned_doc_patterns =
+  [ "design"; "architecture"; "adr"; "rfc"; "spec";
+    "contributing"; "changelog"; "license" ]
+
+let classify_path path =
+  let lower = String.lowercase_ascii (Filename.basename path) in
+  let check_patterns patterns =
+    List.exists (fun pat ->
+      String.length lower >= String.length pat &&
+      String.sub lower 0 (String.length pat) = pat) patterns
+  in
+  if check_patterns banned_readme_patterns then Some Readme
+  else if check_patterns banned_doc_patterns then Some Design_doc
+  else if List.exists (fun pat ->
+    try
+      let pat_len = String.length pat in
+      let lower_len = String.length lower in
+      let rec search i =
+        if i + pat_len > lower_len then false
+        else if String.sub lower i pat_len = pat then true
+        else search (i + 1)
+      in
+      search 0
+    with Invalid_argument _ -> false) [ "room_history"; "task_history" ]
+  then Some Room_history
+  else if List.exists (fun pat ->
+    try
+      let pat_len = String.length pat in
+      let lower_len = String.length lower in
+      let rec search i =
+        if i + pat_len > lower_len then false
+        else if String.sub lower i pat_len = pat then true
+        else search (i + 1)
+      in
+      search 0
+    with Invalid_argument _ -> false) [ "governance"; "session_log"; "retrospective" ]
+  then Some Governance_history
+  else None
+
+let validate_inputs inputs =
+  let check_path path =
+    match classify_path path with
+    | Some kind -> Error (path, kind)
+    | None -> Ok ()
+  in
+  let rec validate = function
+    | [] -> Ok inputs
+    | input :: rest ->
+        let result = match input with
+          | Diff _ -> Ok ()
+          | Changed_file { path; _ } -> check_path path
+          | Type_signature _ -> Ok ()
+          | Interface_contract { path; _ } -> check_path path
+        in
+        match result with
+        | Error e -> Error e
+        | Ok () -> validate rest
+  in
+  validate inputs
+
+(* --- Context creation --- *)
+
+let create_context ~session_id ~inputs =
+  { inputs; session_id; evaluator_version }
+
+(* --- Structural checks --- *)
+
+let finding_counter = ref 0
+
+let next_finding_id () =
+  incr finding_counter;
+  Printf.sprintf "adv-%04d" !finding_counter
+
+(** Check for large diffs that may indicate scope creep. *)
+let check_diff_size diff =
+  let line_count =
+    String.split_on_char '\n' diff |> List.length
+  in
+  if line_count > 500 then
+    Some
+      {
+        finding_id = next_finding_id ();
+        severity = "warn";
+        category = "scope";
+        summary =
+          Printf.sprintf "Large diff (%d lines) — potential scope creep" line_count;
+        location = None;
+      }
+  else None
+
+(** Check for files without corresponding .mli. *)
+let check_missing_interface inputs =
+  let ml_files =
+    List.filter_map
+      (fun input ->
+        match input with
+        | Changed_file { path; _ } ->
+            if Filename.check_suffix path ".ml" then Some path else None
+        | _ -> None)
+      inputs
+  in
+  let mli_files =
+    List.filter_map
+      (fun input ->
+        match input with
+        | Interface_contract { path; _ } -> Some path
+        | _ -> None)
+      inputs
+  in
+  List.filter_map
+    (fun ml_path ->
+      let mli_path = ml_path ^ "i" in
+      if not (List.mem mli_path mli_files) then
+        Some
+          {
+            finding_id = next_finding_id ();
+            severity = "info";
+            category = "encapsulation";
+            summary =
+              Printf.sprintf "Changed %s has no corresponding .mli in context"
+                (Filename.basename ml_path);
+            location = Some ml_path;
+          }
+      else None)
+    ml_files
+
+(** Check for potentially unsafe patterns in changed files. *)
+let unsafe_patterns =
+  [
+    ("Obj.magic", "type-unsafe cast");
+    ("Stdlib.Mutex", "non-Eio mutex in concurrent code");
+    ("ignore (", "silenced return value");
+    ("assert false", "runtime assertion instead of type safety");
+    ("Sys.command", "shell command execution");
+    ("Unix.execvp", "process execution");
+  ]
+
+let check_unsafe_patterns inputs =
+  List.concat_map
+    (fun input ->
+      match input with
+      | Changed_file { path; content } ->
+          List.filter_map
+            (fun (pattern, description) ->
+              if
+                try
+                  let pat_len = String.length pattern in
+                  let content_len = String.length content in
+                  let rec search i =
+                    if i + pat_len > content_len then false
+                    else if String.sub content i pat_len = pattern then true
+                    else search (i + 1)
+                  in
+                  search 0
+                with Invalid_argument _ -> false
+              then
+                Some
+                  {
+                    finding_id = next_finding_id ();
+                    severity = "warn";
+                    category = "safety";
+                    summary =
+                      Printf.sprintf "Found '%s' (%s) in %s" pattern description
+                        (Filename.basename path);
+                    location = Some path;
+                  }
+              else None)
+            unsafe_patterns
+      | _ -> [])
+    inputs
+
+(** Check for added files without tests. *)
+let check_untested_additions inputs =
+  let changed_paths =
+    List.filter_map
+      (fun input ->
+        match input with
+        | Changed_file { path; _ } -> Some path
+        | _ -> None)
+      inputs
+  in
+  let has_test_file =
+    List.exists
+      (fun path ->
+        let base = Filename.basename path in
+        String.length base > 5 && String.sub base 0 5 = "test_")
+      changed_paths
+  in
+  let lib_files =
+    List.filter
+      (fun path ->
+        let base = Filename.basename path in
+        not (String.length base > 5 && String.sub base 0 5 = "test_"))
+      changed_paths
+  in
+  if List.length lib_files > 0 && not has_test_file then
+    [
+      {
+        finding_id = next_finding_id ();
+        severity = "info";
+        category = "testing";
+        summary =
+          Printf.sprintf "%d changed file(s) with no test file in context"
+            (List.length lib_files);
+        location = None;
+      };
+    ]
+  else []
+
+(* --- Main evaluation --- *)
+
+let evaluate ctx =
+  finding_counter := 0;
+  let diff_findings =
+    List.filter_map
+      (fun input ->
+        match input with Diff content -> check_diff_size content | _ -> None)
+      ctx.inputs
+  in
+  let interface_findings = check_missing_interface ctx.inputs in
+  let unsafe_findings = check_unsafe_patterns ctx.inputs in
+  let test_findings = check_untested_additions ctx.inputs in
+  let findings =
+    diff_findings @ interface_findings @ unsafe_findings @ test_findings
+  in
+  { findings; input_count = List.length ctx.inputs; is_advisory = true }
+
+(* --- JSON serialization --- *)
+
+let finding_to_yojson (f : advisory_finding) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("finding_id", `String f.finding_id);
+      ("severity", `String f.severity);
+      ("category", `String f.category);
+      ("summary", `String f.summary);
+      ( "location",
+        match f.location with Some l -> `String l | None -> `Null );
+    ]
+
+let result_to_yojson (r : eval_result) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("findings", `List (List.map finding_to_yojson r.findings));
+      ("finding_count", `Int (List.length r.findings));
+      ("input_count", `Int r.input_count);
+      ("is_advisory", `Bool r.is_advisory);
+      ("evaluator_version", `String evaluator_version);
+    ]

--- a/lib/cdal/adversarial_eval.mli
+++ b/lib/cdal/adversarial_eval.mli
@@ -1,0 +1,65 @@
+(** Adversarial_eval — Fresh-context adversarial evaluator.
+
+    Layer 3 reviewer that operates with restricted context:
+    only diff, changed files, type signatures, and interface contracts.
+
+    Designed to catch structural defects that domain-aware reviewers miss.
+    Output is advisory only — not a gate.
+
+    Red line: this evaluator never sees README, design docs,
+    room/task history, or governance history. *)
+
+(** Allowed input types — anything not in this type is banned. *)
+type allowed_input =
+  | Diff of string
+  | Changed_file of { path : string; content : string }
+  | Type_signature of { module_name : string; signature : string }
+  | Interface_contract of { path : string; content : string }
+
+(** Banned input classification for red-line enforcement. *)
+type banned_input_kind =
+  | Readme
+  | Design_doc
+  | Room_history
+  | Task_history
+  | Governance_history
+
+(** Advisory finding — not a gate, just a signal. *)
+type advisory_finding = {
+  finding_id : string;
+  severity : string;  (** "info" | "warn" | "error" *)
+  category : string;
+  summary : string;
+  location : string option;  (** file:line if applicable *)
+}
+
+type eval_context = {
+  inputs : allowed_input list;
+  session_id : string;
+  evaluator_version : string;
+}
+
+type eval_result = {
+  findings : advisory_finding list;
+  input_count : int;
+  is_advisory : bool;  (** Always true — not a gate *)
+}
+
+val create_context :
+  session_id:string ->
+  inputs:allowed_input list ->
+  eval_context
+
+val classify_path : string -> banned_input_kind option
+(** Check if a file path is banned. None = allowed. *)
+
+val validate_inputs :
+  allowed_input list ->
+  (allowed_input list, string * banned_input_kind) result
+(** Check that no banned content is present. *)
+
+val evaluate : eval_context -> eval_result
+(** Run adversarial evaluation. Structural checks only. *)
+
+val finding_to_yojson : advisory_finding -> Yojson.Safe.t
+val result_to_yojson : eval_result -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -478,6 +478,7 @@
    cdal_friction_projection
    artifact_store
    golden_set
+   adversarial_eval
    contract_risk
    contract_composer
    keeper_deliberation

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_risk_digest
         test_artifact_store
         test_golden_set
+        test_adversarial_eval
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -91,6 +92,7 @@
           test_risk_digest
           test_artifact_store
           test_golden_set
+          test_adversarial_eval
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -1,0 +1,202 @@
+(** test_adversarial_eval.ml — Tests for fresh-context adversarial evaluator.
+    Includes red-line enforcement tests per RFC #3475. *)
+
+open Masc_mcp
+
+(* --- Red line enforcement tests --- *)
+
+let test_classify_readme () =
+  Alcotest.(check bool) "README.md is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "README.md"));
+  Alcotest.(check bool) "readme.txt is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "readme.txt"))
+
+let test_classify_design_doc () =
+  Alcotest.(check bool) "DESIGN.md is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "DESIGN.md"));
+  Alcotest.(check bool) "architecture.md is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "architecture.md"));
+  Alcotest.(check bool) "ADR-001.md is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "ADR-001.md"))
+
+let test_classify_history () =
+  Alcotest.(check bool) "governance_v2.json is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "governance_v2.json"));
+  Alcotest.(check bool) "session_log.jsonl is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "session_log.jsonl"))
+
+let test_classify_allowed () =
+  Alcotest.(check bool) "module.ml is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "module.ml"));
+  Alcotest.(check bool) "module.mli is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "module.mli"));
+  Alcotest.(check bool) "test_foo.ml is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "test_foo.ml"))
+
+let test_validate_clean_inputs () =
+  let inputs =
+    Adversarial_eval.[
+      Diff "--- a/lib/foo.ml\n+++ b/lib/foo.ml\n@@ ...\n+let x = 1";
+      Changed_file { path = "lib/foo.ml"; content = "let x = 1" };
+      Type_signature { module_name = "Foo"; signature = "val x : int" };
+      Interface_contract { path = "lib/foo.mli"; content = "val x : int" };
+    ]
+  in
+  match Adversarial_eval.validate_inputs inputs with
+  | Ok _ -> ()
+  | Error (path, _) -> Alcotest.fail (Printf.sprintf "unexpected rejection: %s" path)
+
+let test_validate_rejects_readme () =
+  let inputs =
+    Adversarial_eval.[
+      Changed_file { path = "README.md"; content = "# Project" };
+    ]
+  in
+  match Adversarial_eval.validate_inputs inputs with
+  | Error (_, Adversarial_eval.Readme) -> ()
+  | Error (_, _) -> Alcotest.fail "wrong rejection kind"
+  | Ok _ -> Alcotest.fail "should reject README"
+
+let test_validate_rejects_design_doc () =
+  let inputs =
+    Adversarial_eval.[
+      Interface_contract { path = "DESIGN.md"; content = "..." };
+    ]
+  in
+  match Adversarial_eval.validate_inputs inputs with
+  | Error (_, Adversarial_eval.Design_doc) -> ()
+  | Error (_, _) -> Alcotest.fail "wrong rejection kind"
+  | Ok _ -> Alcotest.fail "should reject design doc"
+
+(* --- Structural check tests --- *)
+
+let test_large_diff_warning () =
+  let big_diff = String.concat "\n" (List.init 600 (fun i -> Printf.sprintf "+line %d" i)) in
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[ Diff big_diff ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  Alcotest.(check bool) "has scope warning" true
+    (List.exists
+       (fun (f : Adversarial_eval.advisory_finding) ->
+         String.equal f.category "scope")
+       result.findings)
+
+let test_small_diff_no_warning () =
+  let small_diff = "+let x = 1\n+let y = 2" in
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[ Diff small_diff ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  Alcotest.(check bool) "no scope warning" false
+    (List.exists
+       (fun (f : Adversarial_eval.advisory_finding) ->
+         String.equal f.category "scope")
+       result.findings)
+
+let test_unsafe_pattern_detection () =
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[
+        Changed_file {
+          path = "lib/hack.ml";
+          content = "let x = Obj.magic 42\nlet y = ignore (dangerous_call ())";
+        };
+      ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  let safety_findings =
+    List.filter
+      (fun (f : Adversarial_eval.advisory_finding) ->
+        String.equal f.category "safety")
+      result.findings
+  in
+  Alcotest.(check bool) "found unsafe patterns" true (List.length safety_findings >= 2)
+
+let test_missing_test_warning () =
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[
+        Changed_file { path = "lib/new_module.ml"; content = "let f () = ()" };
+      ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  Alcotest.(check bool) "has testing warning" true
+    (List.exists
+       (fun (f : Adversarial_eval.advisory_finding) ->
+         String.equal f.category "testing")
+       result.findings)
+
+let test_with_test_file_no_warning () =
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[
+        Changed_file { path = "lib/module.ml"; content = "let f () = ()" };
+        Changed_file { path = "test/test_module.ml"; content = "let () = ()" };
+      ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  Alcotest.(check bool) "no testing warning" false
+    (List.exists
+       (fun (f : Adversarial_eval.advisory_finding) ->
+         String.equal f.category "testing")
+       result.findings)
+
+(* --- Advisory flag test --- *)
+
+let test_always_advisory () =
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test" ~inputs:[]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  Alcotest.(check bool) "is advisory" true result.is_advisory
+
+(* --- JSON serialization --- *)
+
+let test_result_to_yojson () =
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:[ Diff "+line 1" ]
+  in
+  let result = Adversarial_eval.evaluate ctx in
+  let json = Adversarial_eval.result_to_yojson result in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "is_advisory in json" true
+    (json |> member "is_advisory" |> to_bool);
+  Alcotest.(check int) "input_count" 1
+    (json |> member "input_count" |> to_int)
+
+(* --- Test suite --- *)
+
+let () =
+  Alcotest.run "adversarial_eval"
+    [
+      ( "red_line",
+        [
+          Alcotest.test_case "classify readme" `Quick test_classify_readme;
+          Alcotest.test_case "classify design doc" `Quick test_classify_design_doc;
+          Alcotest.test_case "classify history" `Quick test_classify_history;
+          Alcotest.test_case "classify allowed" `Quick test_classify_allowed;
+          Alcotest.test_case "validate clean" `Quick test_validate_clean_inputs;
+          Alcotest.test_case "reject readme" `Quick test_validate_rejects_readme;
+          Alcotest.test_case "reject design doc" `Quick test_validate_rejects_design_doc;
+        ] );
+      ( "structural_checks",
+        [
+          Alcotest.test_case "large diff" `Quick test_large_diff_warning;
+          Alcotest.test_case "small diff" `Quick test_small_diff_no_warning;
+          Alcotest.test_case "unsafe patterns" `Quick test_unsafe_pattern_detection;
+          Alcotest.test_case "missing tests" `Quick test_missing_test_warning;
+          Alcotest.test_case "with test file" `Quick test_with_test_file_no_warning;
+        ] );
+      ( "advisory",
+        [
+          Alcotest.test_case "always advisory" `Quick test_always_advisory;
+        ] );
+      ( "serialization",
+        [
+          Alcotest.test_case "result to json" `Quick test_result_to_yojson;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `Adversarial_eval` 모듈: Layer 3 fresh-context adversarial reviewer
- Red-line enforcement: README, design docs, room/task/governance history 접근 차단
- 4가지 structural check: scope creep, missing .mli, unsafe patterns, untested additions
- Advisory only — gate로 승격하지 않음 (RFC #3475 PoC-2 원칙)

## Content restriction (Red line)
| Input type | Allowed |
|------------|---------|
| Diff | O |
| Changed files (.ml, .mli) | O |
| Type signatures | O |
| Interface contracts | O |
| README | X (banned) |
| Design docs | X (banned) |
| Room/task history | X (banned) |
| Governance history | X (banned) |

## Structural checks
- **Scope**: diff > 500 lines → scope creep warning
- **Encapsulation**: .ml without .mli in context
- **Safety**: Obj.magic, Stdlib.Mutex, ignore(), assert false, Sys.command, Unix.execvp
- **Testing**: changed lib files without test files

Closes #3524

## Test plan
- [x] `dune build` green
- [x] 14 tests pass (7 red-line, 5 structural, 1 advisory, 1 json)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)