### PR TITLE
feat(cdal): add phase-1a kernel and use OAS proof_store readers

### DIFF
--- a/lib/cdal_eval.ml
+++ b/lib/cdal_eval.ml
@@ -120,6 +120,12 @@ let evaluate_content ~(violations : Violation_record.t list)
 (* Artifact-reading evaluation                                       *)
 (* ================================================================ *)
 
+let has_exact_subpath (store : Agent_sdk.Proof_store.config) expected
+    (ref_ : Agent_sdk.Cdal_proof.artifact_ref) =
+  match Agent_sdk.Proof_store.resolve_ref store ref_ with
+  | Ok resolved -> String.equal resolved.subpath expected
+  | Error _ -> false
+
 let read_violations (store : Agent_sdk.Proof_store.config)
     (refs : Agent_sdk.Cdal_proof.artifact_ref list) : Violation_record.t list =
   List.concat_map (fun ref_ ->
@@ -129,13 +135,7 @@ let read_violations (store : Agent_sdk.Proof_store.config)
        | Ok vs -> vs
        | Error _ -> [])
     | Error _ -> []
-  ) (List.filter (fun r ->
-    let len = String.length r in
-    len >= 20 && (
-      let suffix = String.sub r (len - 20) 20 in
-      suffix = "mode_violations.json"
-    )
-  ) refs)
+  ) (List.filter (has_exact_subpath store "evidence/mode_violations.json") refs)
 
 let read_token_usage (store : Agent_sdk.Proof_store.config)
     (refs : Agent_sdk.Cdal_proof.artifact_ref list) : Token_usage_record.t list =
@@ -146,13 +146,7 @@ let read_token_usage (store : Agent_sdk.Proof_store.config)
        | Ok ts -> ts
        | Error _ -> [])
     | Error _ -> []
-  ) (List.filter (fun r ->
-    let len = String.length r in
-    len >= 16 && (
-      let suffix = String.sub r (len - 16) 16 in
-      suffix = "token_usage.json"
-    )
-  ) refs)
+  ) (List.filter (has_exact_subpath store "evidence/token_usage.json") refs)
 
 let evaluate ~(store : Agent_sdk.Proof_store.config)
     (p : Agent_sdk.Cdal_proof.t) : eval_result =

--- a/lib/cdal_eval.ml
+++ b/lib/cdal_eval.ml
@@ -120,6 +120,9 @@ let evaluate_content ~(violations : Violation_record.t list)
 (* Artifact-reading evaluation                                       *)
 (* ================================================================ *)
 
+(* OAS resolve_ref preserves the full run-relative subpath such as
+   [evidence/mode_violations.json]. We rely on exact matches here to avoid
+   suffix-based false positives from lookalike artifact names. *)
 let has_exact_subpath (store : Agent_sdk.Proof_store.config) expected
     (ref_ : Agent_sdk.Cdal_proof.artifact_ref) =
   match Agent_sdk.Proof_store.resolve_ref store ref_ with

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -1,0 +1,92 @@
+(** Cdal_eval_v1 -- Phase 1A integration facade.
+
+    @since CDAL Phase 1A *)
+
+type eval_outcome =
+  | Verdict of Cdal_types.contract_verdict
+  | Load_failure of Cdal_loader.load_error * Cdal_types.contract_verdict
+
+(* ================================================================ *)
+(* Inconclusive verdict for load failures                           *)
+(* ================================================================ *)
+
+let load_failure_artifact = function
+  | Cdal_loader.Manifest_not_found _ | Cdal_loader.Manifest_parse_error _ ->
+    "manifest.json"
+  | Cdal_loader.Contract_not_found _ | Cdal_loader.Contract_parse_error _ ->
+    "contract.json"
+  | Cdal_loader.Schema_unsupported _ -> "manifest.json"
+  | Cdal_loader.Ref_resolution_error _ -> "contract.json"
+
+let synthesize_inconclusive ~(proof : Agent_sdk.Cdal_proof.t)
+    (err : Cdal_loader.load_error) : Cdal_types.contract_verdict =
+  let gap : Cdal_types.completeness_gap = {
+    artifact = load_failure_artifact err;
+    reason = Cdal_loader.load_error_to_string err;
+    impact = Blocks_verdict;
+  } in
+  let basis_input =
+    Printf.sprintf "%s|phase1a_v1_load_failure" proof.contract_id in
+  let basis_hash =
+    "md5:" ^ (Digest.string basis_input |> Digest.to_hex) in
+  let verdict_without_hash : Cdal_types.contract_verdict = {
+    run_id = proof.run_id;
+    contract_id = proof.contract_id;
+    claim_scope = Cdal_types.claim_scope_phase1;
+    judgment_basis_hash = basis_hash;
+    judgment_hash = "";
+    status = Inconclusive;
+    findings = [];
+    completeness_gaps = [gap];
+    check_results = [];
+  } in
+  let judgment_hash = Cdal_types.compute_judgment_hash verdict_without_hash in
+  { verdict_without_hash with judgment_hash }
+
+(* ================================================================ *)
+(* Evaluation pipeline                                              *)
+(* ================================================================ *)
+
+let evaluate ~(store : Agent_sdk.Proof_store.config)
+    (proof : Agent_sdk.Cdal_proof.t) : eval_outcome =
+  match Cdal_loader.load ~store proof with
+  | Ok bundle ->
+    let verdict = Cdal_judge.judge bundle in
+    Verdict verdict
+  | Error err ->
+    let verdict = synthesize_inconclusive ~proof err in
+    Load_failure (err, verdict)
+
+let verdict_of_outcome = function
+  | Verdict v -> v
+  | Load_failure (_, v) -> v
+
+(* ================================================================ *)
+(* JSONL persistence                                                *)
+(* ================================================================ *)
+
+let store_ref : Dated_jsonl.t option ref = ref None
+
+let base_path () =
+  let root = try Sys.getenv "MASC_DATA_DIR"
+    with Not_found ->
+      try Filename.concat (Sys.getenv "ME_ROOT") "data"
+      with Not_found -> "data"
+  in
+  Filename.concat root "cdal_verdicts"
+
+let get_store () =
+  match !store_ref with
+  | Some s -> s
+  | None ->
+    let s = Dated_jsonl.create ~base_dir:(base_path ()) () in
+    store_ref := Some s;
+    s
+
+let reset_store_for_testing () = store_ref := None
+
+let set_store_for_testing ~base_dir =
+  store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let persist (verdict : Cdal_types.contract_verdict) : unit =
+  Dated_jsonl.append (get_store ()) (Cdal_types.contract_verdict_to_json verdict)

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -26,7 +26,10 @@ let synthesize_inconclusive ~(proof : Agent_sdk.Cdal_proof.t)
     impact = Blocks_verdict;
   } in
   let basis_input =
-    Printf.sprintf "%s|phase1a_v1_load_failure" proof.contract_id in
+    Printf.sprintf "%s|%s|%s|load_failure"
+      proof.contract_id
+      Cdal_types.loader_semantics_version_phase1
+      Cdal_types.schema_compat_mode_v1 in
   let basis_hash =
     "md5:" ^ (Digest.string basis_input |> Digest.to_hex) in
   let verdict_without_hash : Cdal_types.contract_verdict = {
@@ -35,6 +38,8 @@ let synthesize_inconclusive ~(proof : Agent_sdk.Cdal_proof.t)
     claim_scope = Cdal_types.claim_scope_phase1;
     judgment_basis_hash = basis_hash;
     judgment_hash = "";
+    loader_semantics_version = Cdal_types.loader_semantics_version_phase1;
+    schema_compat_mode = Cdal_types.schema_compat_mode_v1;
     status = Inconclusive;
     findings = [];
     completeness_gaps = [gap];

--- a/lib/cdal_eval_v1.mli
+++ b/lib/cdal_eval_v1.mli
@@ -1,0 +1,32 @@
+(** Cdal_eval_v1 -- Phase 1A integration facade.
+
+    Composes Cdal_loader + Cdal_judge into a single evaluation
+    pipeline, and persists verdicts to date-split JSONL.
+
+    @since CDAL Phase 1A *)
+
+(** Evaluation outcome: either a verdict or a load failure with
+    an Inconclusive verdict describing what went wrong. *)
+type eval_outcome =
+  | Verdict of Cdal_types.contract_verdict
+  | Load_failure of Cdal_loader.load_error * Cdal_types.contract_verdict
+
+(** Run the full evaluation pipeline: load bundle, judge, return outcome. *)
+val evaluate :
+  store:Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.t ->
+  eval_outcome
+
+(** Extract the verdict from either outcome branch. *)
+val verdict_of_outcome : eval_outcome -> Cdal_types.contract_verdict
+
+(** Persist a verdict to date-split JSONL under data/cdal_verdicts. *)
+val persist : Cdal_types.contract_verdict -> unit
+
+(** {2 Testing helpers} *)
+
+(** Reset the internal JSONL store (for test isolation). *)
+val reset_store_for_testing : unit -> unit
+
+(** Override the JSONL store base directory (for test isolation). *)
+val set_store_for_testing : base_dir:string -> unit

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -1,0 +1,157 @@
+(** Cdal_judge -- Phase 1A contract judge with 4 active checks.
+
+    @since CDAL Phase 1A *)
+
+(* ================================================================ *)
+(* Check 1: Execution mode                                          *)
+(* ================================================================ *)
+
+let check_execution_mode (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  let check_id = "runtime.requested_execution_mode" in
+  let proof = b.proof in
+  let contract_mode =
+    b.contract.runtime_constraints.requested_execution_mode in
+  let proof_requested = proof.requested_execution_mode in
+  let proof_effective = proof.effective_execution_mode in
+  (* Propagation: proof.requested must match contract.runtime_constraints.requested *)
+  let propagation_ok =
+    Agent_sdk.Execution_mode.equal proof_requested contract_mode in
+  (* No-upward-escalation: effective <= requested *)
+  let escalation_ok =
+    Agent_sdk.Execution_mode.can_serve
+      ~requested:proof_requested ~effective:proof_effective in
+  if propagation_ok && escalation_ok then
+    { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+  else
+    let findings = ref [] in
+    if not propagation_ok then
+      findings := {
+        Cdal_types.check_id;
+        event_id = None;
+        observed = `String (Agent_sdk.Execution_mode.to_string proof_requested);
+        expected = `String (Agent_sdk.Execution_mode.to_string contract_mode);
+        trace_ref = None;
+      } :: !findings;
+    if not escalation_ok then
+      findings := {
+        Cdal_types.check_id;
+        event_id = Some "escalation";
+        observed = `String (Agent_sdk.Execution_mode.to_string proof_effective);
+        expected = `String
+          (Printf.sprintf "<= %s"
+             (Agent_sdk.Execution_mode.to_string proof_requested));
+        trace_ref = None;
+      } :: !findings;
+    { check_id; status = Violated;
+      findings = List.rev !findings;
+      completeness_gaps = [] }
+
+(* ================================================================ *)
+(* Check 2: Risk class                                              *)
+(* ================================================================ *)
+
+let check_risk_class (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  let check_id = "runtime.risk_class" in
+  let contract_risk = b.contract.runtime_constraints.risk_class in
+  let proof_risk = b.proof.risk_class in
+  if Agent_sdk.Risk_class.equal contract_risk proof_risk then
+    { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+  else
+    { check_id; status = Violated;
+      findings = [{
+        check_id;
+        event_id = None;
+        observed = `String (Agent_sdk.Risk_class.to_string proof_risk);
+        expected = `String (Agent_sdk.Risk_class.to_string contract_risk);
+        trace_ref = None;
+      }];
+      completeness_gaps = [] }
+
+(* ================================================================ *)
+(* Check 3: Contract snapshot                                       *)
+(* ================================================================ *)
+
+let check_contract_snapshot (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  let check_id = "proof.contract_snapshot" in
+  let proof_contract_id = b.proof.contract_id in
+  let recomputed = b.recomputed_contract_id in
+  if String.equal proof_contract_id recomputed then
+    { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+  else
+    { check_id; status = Violated;
+      findings = [{
+        check_id;
+        event_id = None;
+        observed = `String proof_contract_id;
+        expected = `String recomputed;
+        trace_ref = None;
+      }];
+      completeness_gaps = [] }
+
+(* ================================================================ *)
+(* Check 4: Required artifact                                       *)
+(* ================================================================ *)
+
+let check_required_artifact (_b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  (* The loader already verified manifest.json and contract.json exist
+     and are parseable. If the loader succeeded, this check is Satisfied. *)
+  { check_id = "proof.required_artifact";
+    status = Satisfied;
+    findings = [];
+    completeness_gaps = [] }
+
+(* ================================================================ *)
+(* Verdict derivation                                               *)
+(* ================================================================ *)
+
+let derive_status (checks : Cdal_types.check_result list) : Cdal_types.contract_status =
+  let has_violated =
+    List.exists (fun (c : Cdal_types.check_result) ->
+      c.status = Violated) checks in
+  if has_violated then Violated
+  else
+    let has_blocking_inconclusive =
+      List.exists (fun (c : Cdal_types.check_result) ->
+        c.status = Inconclusive &&
+        List.exists (fun (g : Cdal_types.completeness_gap) ->
+          g.impact = Blocks_verdict) c.completeness_gaps
+      ) checks in
+    if has_blocking_inconclusive then Inconclusive
+    else Satisfied
+
+let judgment_basis_hash ~contract_id ~schema_version : string =
+  let input =
+    Printf.sprintf "%s|phase1a_v1|%d" contract_id schema_version in
+  let hash = Digest.string input |> Digest.to_hex in
+  "md5:" ^ hash
+
+let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
+  let checks = [
+    check_execution_mode b;
+    check_risk_class b;
+    check_contract_snapshot b;
+    check_required_artifact b;
+  ] in
+  let status = derive_status checks in
+  let findings =
+    List.concat_map (fun (c : Cdal_types.check_result) -> c.findings) checks in
+  let completeness_gaps =
+    List.concat_map (fun (c : Cdal_types.check_result) ->
+      c.completeness_gaps) checks in
+  let basis_hash =
+    judgment_basis_hash
+      ~contract_id:b.proof.contract_id
+      ~schema_version:b.proof.schema_version in
+  let verdict_without_hash : Cdal_types.contract_verdict = {
+    run_id = b.proof.run_id;
+    contract_id = b.proof.contract_id;
+    claim_scope = Cdal_types.claim_scope_phase1;
+    judgment_basis_hash = basis_hash;
+    judgment_hash = "";
+    status;
+    findings;
+    completeness_gaps;
+    check_results = checks;
+  } in
+  let judgment_hash = Cdal_types.compute_judgment_hash verdict_without_hash in
+  { verdict_without_hash with judgment_hash }

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -119,13 +119,18 @@ let derive_status (checks : Cdal_types.check_result list) : Cdal_types.contract_
     if has_blocking_inconclusive then Inconclusive
     else Satisfied
 
-let judgment_basis_hash ~contract_id ~schema_version : string =
+let canonical_json_string json =
+  json |> Yojson.Safe.sort |> Yojson.Safe.to_string
+
+let judgment_basis_hash (b : Cdal_loader.loaded_bundle) : string =
   let input =
-    Printf.sprintf "%s|%s|%s|manifest.json|contract.json|%d"
-      contract_id
+    Printf.sprintf "%s|%s|%s|%s|%s|%d"
+      b.proof.contract_id
       Cdal_types.loader_semantics_version_phase1
       Cdal_types.schema_compat_mode_v1
-      schema_version in
+      (canonical_json_string b.manifest_json)
+      (canonical_json_string b.contract_json)
+      b.proof.schema_version in
   let hash = Digest.string input |> Digest.to_hex in
   "md5:" ^ hash
 
@@ -142,10 +147,7 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
   let completeness_gaps =
     List.concat_map (fun (c : Cdal_types.check_result) ->
       c.completeness_gaps) checks in
-  let basis_hash =
-    judgment_basis_hash
-      ~contract_id:b.proof.contract_id
-      ~schema_version:b.proof.schema_version in
+  let basis_hash = judgment_basis_hash b in
   let verdict_without_hash : Cdal_types.contract_verdict = {
     run_id = b.proof.run_id;
     contract_id = b.proof.contract_id;

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -25,23 +25,23 @@ let check_execution_mode (b : Cdal_loader.loaded_bundle) : Cdal_types.check_resu
   else
     let findings = ref [] in
     if not propagation_ok then
-      findings := {
-        Cdal_types.check_id;
+      findings := ({ Cdal_types.
+        check_id;
         event_id = None;
         observed = `String (Agent_sdk.Execution_mode.to_string proof_requested);
         expected = `String (Agent_sdk.Execution_mode.to_string contract_mode);
         trace_ref = None;
-      } :: !findings;
+      } : Cdal_types.contract_finding) :: !findings;
     if not escalation_ok then
-      findings := {
-        Cdal_types.check_id;
+      findings := ({ Cdal_types.
+        check_id;
         event_id = Some "escalation";
         observed = `String (Agent_sdk.Execution_mode.to_string proof_effective);
         expected = `String
           (Printf.sprintf "<= %s"
              (Agent_sdk.Execution_mode.to_string proof_requested));
         trace_ref = None;
-      } :: !findings;
+      } : Cdal_types.contract_finding) :: !findings;
     { check_id; status = Violated;
       findings = List.rev !findings;
       completeness_gaps = [] }
@@ -121,7 +121,11 @@ let derive_status (checks : Cdal_types.check_result list) : Cdal_types.contract_
 
 let judgment_basis_hash ~contract_id ~schema_version : string =
   let input =
-    Printf.sprintf "%s|phase1a_v1|%d" contract_id schema_version in
+    Printf.sprintf "%s|%s|%s|manifest.json|contract.json|%d"
+      contract_id
+      Cdal_types.loader_semantics_version_phase1
+      Cdal_types.schema_compat_mode_v1
+      schema_version in
   let hash = Digest.string input |> Digest.to_hex in
   "md5:" ^ hash
 
@@ -148,6 +152,8 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
     claim_scope = Cdal_types.claim_scope_phase1;
     judgment_basis_hash = basis_hash;
     judgment_hash = "";
+    loader_semantics_version = Cdal_types.loader_semantics_version_phase1;
+    schema_compat_mode = Cdal_types.schema_compat_mode_v1;
     status;
     findings;
     completeness_gaps;

--- a/lib/cdal_judge.mli
+++ b/lib/cdal_judge.mli
@@ -1,0 +1,24 @@
+(** Cdal_judge -- Phase 1A contract judge with 4 active checks.
+
+    Evaluates a loaded proof bundle against its contract constraints:
+    execution mode propagation and escalation, risk class match,
+    contract snapshot integrity, and required artifact presence.
+
+    @since CDAL Phase 1A *)
+
+(** Evaluate all 4 checks and derive run-level verdict. *)
+val judge : Cdal_loader.loaded_bundle -> Cdal_types.contract_verdict
+
+(** {2 Individual checks (exposed for testing)} *)
+
+(** Check execution mode propagation and no-upward-escalation. *)
+val check_execution_mode : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check risk class matches contract constraint. *)
+val check_risk_class : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check proof contract_id matches recomputed hash. *)
+val check_contract_snapshot : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check required artifacts are present (always Satisfied post-load). *)
+val check_required_artifact : Cdal_loader.loaded_bundle -> Cdal_types.check_result

--- a/lib/cdal_loader.ml
+++ b/lib/cdal_loader.ml
@@ -1,0 +1,98 @@
+(** Cdal_loader -- Load and validate a CDAL proof bundle from disk.
+
+    @since CDAL Phase 1A *)
+
+type loaded_bundle = {
+  proof : Agent_sdk.Cdal_proof.t;
+  manifest_json : Yojson.Safe.t;
+  contract : Agent_sdk.Risk_contract.t;
+  contract_json : Yojson.Safe.t;
+  recomputed_contract_id : string;
+}
+
+type load_error =
+  | Manifest_not_found of string
+  | Manifest_parse_error of string
+  | Contract_not_found of string
+  | Contract_parse_error of string
+  | Schema_unsupported of int
+  | Ref_resolution_error of string
+
+let load_error_to_string = function
+  | Manifest_not_found path ->
+    Printf.sprintf "manifest not found: %s" path
+  | Manifest_parse_error msg ->
+    Printf.sprintf "manifest parse error: %s" msg
+  | Contract_not_found path ->
+    Printf.sprintf "contract not found: %s" path
+  | Contract_parse_error msg ->
+    Printf.sprintf "contract parse error: %s" msg
+  | Schema_unsupported v ->
+    Printf.sprintf "unsupported schema version: %d (expected %d)"
+      v Agent_sdk.Cdal_proof.schema_version_current
+  | Ref_resolution_error msg ->
+    Printf.sprintf "ref resolution error: %s" msg
+
+(* ================================================================ *)
+(* File I/O helpers                                                  *)
+(* ================================================================ *)
+
+let read_json_file path =
+  if Sys.file_exists path then
+    (try Ok (Yojson.Safe.from_file path)
+     with exn -> Error (Printexc.to_string exn))
+  else
+    Error "not found"
+
+(* ================================================================ *)
+(* Load pipeline                                                     *)
+(* ================================================================ *)
+
+let load ~(store : Agent_sdk.Proof_store.config)
+    (proof : Agent_sdk.Cdal_proof.t)
+    : (loaded_bundle, load_error) result =
+  let ( let* ) = Result.bind in
+  (* 1. Compute manifest path and read *)
+  let manifest_path =
+    Agent_sdk.Proof_store.manifest_path store ~run_id:proof.run_id in
+  let* manifest_json =
+    read_json_file manifest_path
+    |> Result.map_error (fun msg ->
+      if msg = "not found" then Manifest_not_found manifest_path
+      else Manifest_parse_error msg)
+  in
+  (* 2. Check schema version *)
+  let () =
+    ignore manifest_json  (* manifest was already loaded; proof carries version *)
+  in
+  if proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
+    Error (Schema_unsupported proof.schema_version)
+  else
+  (* 3. Compute contract path and read *)
+  let contract_path =
+    Filename.concat
+      (Filename.concat
+         (Filename.concat store.root "proofs")
+         proof.run_id)
+      "contract.json"
+  in
+  let* contract_json =
+    read_json_file contract_path
+    |> Result.map_error (fun msg ->
+      if msg = "not found" then Contract_not_found contract_path
+      else Contract_parse_error msg)
+  in
+  (* 4. Decode contract with Agent_sdk *)
+  let* contract =
+    Agent_sdk.Risk_contract.of_yojson contract_json
+    |> Result.map_error (fun msg -> Contract_parse_error msg)
+  in
+  (* 5. Recompute contract_id *)
+  let recomputed_contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  Ok {
+    proof;
+    manifest_json;
+    contract;
+    contract_json;
+    recomputed_contract_id;
+  }

--- a/lib/cdal_loader.ml
+++ b/lib/cdal_loader.ml
@@ -34,61 +34,37 @@ let load_error_to_string = function
     Printf.sprintf "ref resolution error: %s" msg
 
 (* ================================================================ *)
-(* File I/O helpers                                                  *)
-(* ================================================================ *)
-
-let read_json_file path =
-  if Sys.file_exists path then
-    (try Ok (Yojson.Safe.from_file path)
-     with exn -> Error (Printexc.to_string exn))
-  else
-    Error "not found"
-
-(* ================================================================ *)
 (* Load pipeline                                                     *)
 (* ================================================================ *)
+
+let contract_path_of_run store ~run_id =
+  let ref_ = Agent_sdk.Proof_store.make_ref ~run_id ~subpath:"contract.json" in
+  match Agent_sdk.Proof_store.resolve_ref store ref_ with
+  | Ok resolved -> Ok resolved.path
+  | Error e -> Error (Ref_resolution_error e)
 
 let load ~(store : Agent_sdk.Proof_store.config)
     (proof : Agent_sdk.Cdal_proof.t)
     : (loaded_bundle, load_error) result =
   let ( let* ) = Result.bind in
-  (* 1. Compute manifest path and read *)
   let manifest_path =
     Agent_sdk.Proof_store.manifest_path store ~run_id:proof.run_id in
-  let* manifest_json =
-    read_json_file manifest_path
+  let* contract_path = contract_path_of_run store ~run_id:proof.run_id in
+  let* (manifest_proof, manifest_json) =
+    Agent_sdk.Proof_store.load_manifest store ~run_id:proof.run_id
     |> Result.map_error (fun msg ->
-      if msg = "not found" then Manifest_not_found manifest_path
-      else Manifest_parse_error msg)
+         if Sys.file_exists manifest_path then Manifest_parse_error msg
+         else Manifest_not_found manifest_path)
   in
-  let* manifest_proof =
-    Agent_sdk.Cdal_proof.of_json manifest_json
-    |> Result.map_error (fun msg -> Manifest_parse_error msg)
-  in
-  (* 2. Check schema version from stored manifest *)
   if manifest_proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
     Error (Schema_unsupported manifest_proof.schema_version)
   else
-  (* 3. Compute contract path and read *)
-  let contract_path =
-    Filename.concat
-      (Filename.concat
-         (Filename.concat store.root "proofs")
-         proof.run_id)
-      "contract.json"
-  in
-  let* contract_json =
-    read_json_file contract_path
+  let* (contract, contract_json) =
+    Agent_sdk.Proof_store.load_contract store ~run_id:proof.run_id
     |> Result.map_error (fun msg ->
-      if msg = "not found" then Contract_not_found contract_path
-      else Contract_parse_error msg)
+         if Sys.file_exists contract_path then Contract_parse_error msg
+         else Contract_not_found contract_path)
   in
-  (* 4. Decode contract with Agent_sdk *)
-  let* contract =
-    Agent_sdk.Risk_contract.of_yojson contract_json
-    |> Result.map_error (fun msg -> Contract_parse_error msg)
-  in
-  (* 5. Recompute contract_id *)
   let recomputed_contract_id = Agent_sdk.Risk_contract.contract_id contract in
   Ok {
     proof = manifest_proof;

--- a/lib/cdal_loader.ml
+++ b/lib/cdal_loader.ml
@@ -61,12 +61,13 @@ let load ~(store : Agent_sdk.Proof_store.config)
       if msg = "not found" then Manifest_not_found manifest_path
       else Manifest_parse_error msg)
   in
-  (* 2. Check schema version *)
-  let () =
-    ignore manifest_json  (* manifest was already loaded; proof carries version *)
+  let* manifest_proof =
+    Agent_sdk.Cdal_proof.of_json manifest_json
+    |> Result.map_error (fun msg -> Manifest_parse_error msg)
   in
-  if proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
-    Error (Schema_unsupported proof.schema_version)
+  (* 2. Check schema version from stored manifest *)
+  if manifest_proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
+    Error (Schema_unsupported manifest_proof.schema_version)
   else
   (* 3. Compute contract path and read *)
   let contract_path =
@@ -90,7 +91,7 @@ let load ~(store : Agent_sdk.Proof_store.config)
   (* 5. Recompute contract_id *)
   let recomputed_contract_id = Agent_sdk.Risk_contract.contract_id contract in
   Ok {
-    proof;
+    proof = manifest_proof;
     manifest_json;
     contract;
     contract_json;

--- a/lib/cdal_loader.mli
+++ b/lib/cdal_loader.mli
@@ -1,7 +1,8 @@
 (** Cdal_loader -- Load and validate a CDAL proof bundle from disk.
 
-    Reads manifest.json and contract.json from the proof store,
-    verifies schema version, parses with Agent_sdk decoders,
+    Uses OAS-owned [Agent_sdk.Proof_store] read-side APIs for
+    manifest/contract loading so MASC does not hardcode proof-store layout.
+    The loader verifies schema version, decodes with Agent_sdk types,
     and recomputes the content-addressed contract_id.
 
     @since CDAL Phase 1A *)

--- a/lib/cdal_loader.mli
+++ b/lib/cdal_loader.mli
@@ -6,7 +6,9 @@
 
     @since CDAL Phase 1A *)
 
-(** Successfully loaded and validated bundle. *)
+(** Successfully loaded and validated bundle.
+    [proof] is the decoded manifest proof, which is treated as the
+    stored truth source for phase-1A replay. *)
 type loaded_bundle = {
   proof : Agent_sdk.Cdal_proof.t;
   manifest_json : Yojson.Safe.t;

--- a/lib/cdal_loader.mli
+++ b/lib/cdal_loader.mli
@@ -1,0 +1,41 @@
+(** Cdal_loader -- Load and validate a CDAL proof bundle from disk.
+
+    Reads manifest.json and contract.json from the proof store,
+    verifies schema version, parses with Agent_sdk decoders,
+    and recomputes the content-addressed contract_id.
+
+    @since CDAL Phase 1A *)
+
+(** Successfully loaded and validated bundle. *)
+type loaded_bundle = {
+  proof : Agent_sdk.Cdal_proof.t;
+  manifest_json : Yojson.Safe.t;
+  contract : Agent_sdk.Risk_contract.t;
+  contract_json : Yojson.Safe.t;
+  recomputed_contract_id : string;
+}
+
+(** Load errors with structured context. *)
+type load_error =
+  | Manifest_not_found of string
+  | Manifest_parse_error of string
+  | Contract_not_found of string
+  | Contract_parse_error of string
+  | Schema_unsupported of int
+  | Ref_resolution_error of string
+
+(** Load a proof bundle from the proof store.
+
+    Steps:
+    1. Read and parse manifest.json
+    2. Check schema_version = current
+    3. Read and parse contract.json
+    4. Decode with Agent_sdk types
+    5. Recompute contract_id *)
+val load :
+  store:Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.t ->
+  (loaded_bundle, load_error) result
+
+(** Human-readable error description. *)
+val load_error_to_string : load_error -> string

--- a/lib/cdal_types.ml
+++ b/lib/cdal_types.ml
@@ -42,6 +42,8 @@ type contract_verdict = {
   claim_scope : string;
   judgment_basis_hash : string;
   judgment_hash : string;
+  loader_semantics_version : string;
+  schema_compat_mode : string;
   status : contract_status;
   findings : contract_finding list;
   completeness_gaps : completeness_gap list;
@@ -53,6 +55,8 @@ type contract_verdict = {
 (* ================================================================ *)
 
 let claim_scope_phase1 = "phase1_scoped_runtime_audit"
+let loader_semantics_version_phase1 = "phase1a_v1"
+let schema_compat_mode_v1 = "proof_bundle_v1"
 
 (* ================================================================ *)
 (* String conversions                                                *)
@@ -207,7 +211,9 @@ let contract_verdict_to_json (v : contract_verdict) : Yojson.Safe.t =
     ("findings", `List (List.map contract_finding_to_json v.findings));
     ("judgment_basis_hash", `String v.judgment_basis_hash);
     ("judgment_hash", `String v.judgment_hash);
+    ("loader_semantics_version", `String v.loader_semantics_version);
     ("run_id", `String v.run_id);
+    ("schema_compat_mode", `String v.schema_compat_mode);
     ("status", `String (contract_status_to_string v.status));
   ])
 
@@ -219,6 +225,9 @@ let contract_verdict_of_json = function
     let* claim_scope = string_field "claim_scope" fields in
     let* judgment_basis_hash = string_field "judgment_basis_hash" fields in
     let* judgment_hash = string_field "judgment_hash" fields in
+    let* loader_semantics_version =
+      string_field "loader_semantics_version" fields in
+    let* schema_compat_mode = string_field "schema_compat_mode" fields in
     let* status_str = string_field "status" fields in
     let* status = contract_status_of_string status_str in
     let* findings = list_field "findings" contract_finding_of_json fields in
@@ -229,6 +238,7 @@ let contract_verdict_of_json = function
     Ok {
       run_id; contract_id; claim_scope;
       judgment_basis_hash; judgment_hash;
+      loader_semantics_version; schema_compat_mode;
       status; findings; completeness_gaps; check_results;
     }
   | j -> Error (Printf.sprintf "contract_verdict: expected object, got %s"

--- a/lib/cdal_types.ml
+++ b/lib/cdal_types.ml
@@ -1,0 +1,250 @@
+(** Cdal_types -- Typed CDAL verdict and check-result types.
+
+    @since CDAL Phase 1A *)
+
+(* ================================================================ *)
+(* Core types                                                        *)
+(* ================================================================ *)
+
+type contract_status =
+  | Satisfied
+  | Violated
+  | Inconclusive
+
+type completeness_impact =
+  | Blocks_verdict
+  | Annotation_only
+
+type contract_finding = {
+  check_id : string;
+  event_id : string option;
+  observed : Yojson.Safe.t;
+  expected : Yojson.Safe.t;
+  trace_ref : string option;
+}
+
+type completeness_gap = {
+  artifact : string;
+  reason : string;
+  impact : completeness_impact;
+}
+
+type check_result = {
+  check_id : string;
+  status : contract_status;
+  findings : contract_finding list;
+  completeness_gaps : completeness_gap list;
+}
+
+type contract_verdict = {
+  run_id : string;
+  contract_id : string;
+  claim_scope : string;
+  judgment_basis_hash : string;
+  judgment_hash : string;
+  status : contract_status;
+  findings : contract_finding list;
+  completeness_gaps : completeness_gap list;
+  check_results : check_result list;
+}
+
+(* ================================================================ *)
+(* Constants                                                         *)
+(* ================================================================ *)
+
+let claim_scope_phase1 = "phase1_scoped_runtime_audit"
+
+(* ================================================================ *)
+(* String conversions                                                *)
+(* ================================================================ *)
+
+let contract_status_to_string = function
+  | Satisfied -> "satisfied"
+  | Violated -> "violated"
+  | Inconclusive -> "inconclusive"
+
+let contract_status_of_string = function
+  | "satisfied" -> Ok Satisfied
+  | "violated" -> Ok Violated
+  | "inconclusive" -> Ok Inconclusive
+  | s -> Error (Printf.sprintf "unknown contract_status: %s" s)
+
+let completeness_impact_to_string = function
+  | Blocks_verdict -> "blocks_verdict"
+  | Annotation_only -> "annotation_only"
+
+let completeness_impact_of_string = function
+  | "blocks_verdict" -> Ok Blocks_verdict
+  | "annotation_only" -> Ok Annotation_only
+  | s -> Error (Printf.sprintf "unknown completeness_impact: %s" s)
+
+(* ================================================================ *)
+(* JSON helpers                                                      *)
+(* ================================================================ *)
+
+let string_field key fields =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Ok s
+  | Some j -> Error (Printf.sprintf "%s: expected string, got %s" key
+                       (Yojson.Safe.to_string j))
+  | None -> Error (Printf.sprintf "missing field: %s" key)
+
+let string_option_field key fields =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Ok (Some s)
+  | Some `Null | None -> Ok None
+  | Some j -> Error (Printf.sprintf "%s: expected string or null, got %s" key
+                       (Yojson.Safe.to_string j))
+
+let json_field key fields =
+  match List.assoc_opt key fields with
+  | Some v -> Ok v
+  | None -> Error (Printf.sprintf "missing field: %s" key)
+
+let list_field key of_item fields =
+  match List.assoc_opt key fields with
+  | Some (`List items) ->
+    let rec go acc = function
+      | [] -> Ok (List.rev acc)
+      | x :: rest ->
+        (match of_item x with
+         | Ok v -> go (v :: acc) rest
+         | Error e -> Error (Printf.sprintf "%s[]: %s" key e))
+    in
+    go [] items
+  | Some j -> Error (Printf.sprintf "%s: expected list, got %s" key
+                       (Yojson.Safe.to_string j))
+  | None -> Ok []
+
+let option_to_json f = function
+  | Some v -> f v
+  | None -> `Null
+
+(* ================================================================ *)
+(* contract_finding JSON                                             *)
+(* ================================================================ *)
+
+let contract_finding_to_json (f : contract_finding) : Yojson.Safe.t =
+  Yojson.Safe.sort (`Assoc [
+    ("check_id", `String f.check_id);
+    ("event_id", option_to_json (fun s -> `String s) f.event_id);
+    ("expected", f.expected);
+    ("observed", f.observed);
+    ("trace_ref", option_to_json (fun s -> `String s) f.trace_ref);
+  ])
+
+let contract_finding_of_json = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* check_id = string_field "check_id" fields in
+    let* event_id = string_option_field "event_id" fields in
+    let* observed = json_field "observed" fields in
+    let* expected = json_field "expected" fields in
+    let* trace_ref = string_option_field "trace_ref" fields in
+    Ok { check_id; event_id; observed; expected; trace_ref }
+  | j -> Error (Printf.sprintf "contract_finding: expected object, got %s"
+                  (Yojson.Safe.to_string j))
+
+(* ================================================================ *)
+(* completeness_gap JSON                                             *)
+(* ================================================================ *)
+
+let completeness_gap_to_json (g : completeness_gap) : Yojson.Safe.t =
+  Yojson.Safe.sort (`Assoc [
+    ("artifact", `String g.artifact);
+    ("impact", `String (completeness_impact_to_string g.impact));
+    ("reason", `String g.reason);
+  ])
+
+let completeness_gap_of_json = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* artifact = string_field "artifact" fields in
+    let* reason = string_field "reason" fields in
+    let* impact_str = string_field "impact" fields in
+    let* impact = completeness_impact_of_string impact_str in
+    Ok { artifact; reason; impact }
+  | j -> Error (Printf.sprintf "completeness_gap: expected object, got %s"
+                  (Yojson.Safe.to_string j))
+
+(* ================================================================ *)
+(* check_result JSON                                                 *)
+(* ================================================================ *)
+
+let check_result_to_json (r : check_result) : Yojson.Safe.t =
+  Yojson.Safe.sort (`Assoc [
+    ("check_id", `String r.check_id);
+    ("completeness_gaps",
+     `List (List.map completeness_gap_to_json r.completeness_gaps));
+    ("findings", `List (List.map contract_finding_to_json r.findings));
+    ("status", `String (contract_status_to_string r.status));
+  ])
+
+let check_result_of_json = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* check_id = string_field "check_id" fields in
+    let* status_str = string_field "status" fields in
+    let* status = contract_status_of_string status_str in
+    let* findings = list_field "findings" contract_finding_of_json fields in
+    let* completeness_gaps =
+      list_field "completeness_gaps" completeness_gap_of_json fields in
+    Ok { check_id; status; findings; completeness_gaps }
+  | j -> Error (Printf.sprintf "check_result: expected object, got %s"
+                  (Yojson.Safe.to_string j))
+
+(* ================================================================ *)
+(* contract_verdict JSON                                             *)
+(* ================================================================ *)
+
+let contract_verdict_to_json (v : contract_verdict) : Yojson.Safe.t =
+  Yojson.Safe.sort (`Assoc [
+    ("check_results", `List (List.map check_result_to_json v.check_results));
+    ("claim_scope", `String v.claim_scope);
+    ("completeness_gaps",
+     `List (List.map completeness_gap_to_json v.completeness_gaps));
+    ("contract_id", `String v.contract_id);
+    ("findings", `List (List.map contract_finding_to_json v.findings));
+    ("judgment_basis_hash", `String v.judgment_basis_hash);
+    ("judgment_hash", `String v.judgment_hash);
+    ("run_id", `String v.run_id);
+    ("status", `String (contract_status_to_string v.status));
+  ])
+
+let contract_verdict_of_json = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* run_id = string_field "run_id" fields in
+    let* contract_id = string_field "contract_id" fields in
+    let* claim_scope = string_field "claim_scope" fields in
+    let* judgment_basis_hash = string_field "judgment_basis_hash" fields in
+    let* judgment_hash = string_field "judgment_hash" fields in
+    let* status_str = string_field "status" fields in
+    let* status = contract_status_of_string status_str in
+    let* findings = list_field "findings" contract_finding_of_json fields in
+    let* completeness_gaps =
+      list_field "completeness_gaps" completeness_gap_of_json fields in
+    let* check_results =
+      list_field "check_results" check_result_of_json fields in
+    Ok {
+      run_id; contract_id; claim_scope;
+      judgment_basis_hash; judgment_hash;
+      status; findings; completeness_gaps; check_results;
+    }
+  | j -> Error (Printf.sprintf "contract_verdict: expected object, got %s"
+                  (Yojson.Safe.to_string j))
+
+(* ================================================================ *)
+(* Judgment hash                                                     *)
+(* ================================================================ *)
+
+let compute_judgment_hash (v : contract_verdict) : string =
+  let zeroed = { v with judgment_hash = "" } in
+  let canonical =
+    zeroed
+    |> contract_verdict_to_json
+    |> Yojson.Safe.sort
+    |> Yojson.Safe.to_string
+  in
+  let hash = Digest.string canonical |> Digest.to_hex in
+  "md5:" ^ hash

--- a/lib/cdal_types.mli
+++ b/lib/cdal_types.mli
@@ -49,6 +49,8 @@ type contract_verdict = {
   claim_scope : string;
   judgment_basis_hash : string;
   judgment_hash : string;
+  loader_semantics_version : string;
+  schema_compat_mode : string;
   status : contract_status;
   findings : contract_finding list;
   completeness_gaps : completeness_gap list;
@@ -58,6 +60,8 @@ type contract_verdict = {
 (** {2 Claim scope constant} *)
 
 val claim_scope_phase1 : string
+val loader_semantics_version_phase1 : string
+val schema_compat_mode_v1 : string
 
 (** {2 String conversions} *)
 

--- a/lib/cdal_types.mli
+++ b/lib/cdal_types.mli
@@ -1,0 +1,88 @@
+(** Cdal_types -- Typed CDAL verdict and check-result types.
+
+    Phase 1A foundation: replaces loose JSON with structured OCaml types
+    for contract status, findings, completeness gaps, and verdicts.
+    All types support canonical JSON serialization with sorted keys
+    and content-addressed hashing (judgment_hash).
+
+    @since CDAL Phase 1A *)
+
+(** Contract check status. *)
+type contract_status =
+  | Satisfied
+  | Violated
+  | Inconclusive
+
+(** Whether a completeness gap blocks the verdict or is annotation-only. *)
+type completeness_impact =
+  | Blocks_verdict
+  | Annotation_only
+
+(** A single finding from a contract check. *)
+type contract_finding = {
+  check_id : string;
+  event_id : string option;
+  observed : Yojson.Safe.t;
+  expected : Yojson.Safe.t;
+  trace_ref : string option;
+}
+
+(** A gap in the evidence completeness. *)
+type completeness_gap = {
+  artifact : string;
+  reason : string;
+  impact : completeness_impact;
+}
+
+(** Result of a single contract check. *)
+type check_result = {
+  check_id : string;
+  status : contract_status;
+  findings : contract_finding list;
+  completeness_gaps : completeness_gap list;
+}
+
+(** Full verdict for a contract evaluation run. *)
+type contract_verdict = {
+  run_id : string;
+  contract_id : string;
+  claim_scope : string;
+  judgment_basis_hash : string;
+  judgment_hash : string;
+  status : contract_status;
+  findings : contract_finding list;
+  completeness_gaps : completeness_gap list;
+  check_results : check_result list;
+}
+
+(** {2 Claim scope constant} *)
+
+val claim_scope_phase1 : string
+
+(** {2 String conversions} *)
+
+val contract_status_to_string : contract_status -> string
+val contract_status_of_string : string -> (contract_status, string) result
+val completeness_impact_to_string : completeness_impact -> string
+val completeness_impact_of_string : string -> (completeness_impact, string) result
+
+(** {2 JSON serialization}
+
+    All [to_json] functions produce canonical JSON with sorted keys
+    via [Yojson.Safe.sort]. *)
+
+val contract_finding_to_json : contract_finding -> Yojson.Safe.t
+val contract_finding_of_json : Yojson.Safe.t -> (contract_finding, string) result
+val completeness_gap_to_json : completeness_gap -> Yojson.Safe.t
+val completeness_gap_of_json : Yojson.Safe.t -> (completeness_gap, string) result
+val check_result_to_json : check_result -> Yojson.Safe.t
+val check_result_of_json : Yojson.Safe.t -> (check_result, string) result
+val contract_verdict_to_json : contract_verdict -> Yojson.Safe.t
+val contract_verdict_of_json : Yojson.Safe.t -> (contract_verdict, string) result
+
+(** {2 Hashing}
+
+    [compute_judgment_hash] computes MD5 of the canonical JSON
+    representation with [judgment_hash] set to [""] during computation. *)
+
+val compute_judgment_hash : contract_verdict -> string

--- a/lib/dune
+++ b/lib/dune
@@ -472,6 +472,9 @@
    cdal_eval
    cdal_types
    cdal_loader
+   cdal_judge
+   cdal_eval_v1
+   cdal_friction_projection
    contract_risk
    contract_composer
    keeper_deliberation

--- a/lib/dune
+++ b/lib/dune
@@ -474,7 +474,6 @@
    cdal_loader
    cdal_judge
    cdal_eval_v1
-   cdal_friction_projection
    contract_risk
    contract_composer
    keeper_deliberation

--- a/lib/dune
+++ b/lib/dune
@@ -470,6 +470,8 @@
    violation_record
    token_usage_record
    cdal_eval
+   cdal_types
+   cdal_loader
    contract_risk
    contract_composer
    keeper_deliberation

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -246,26 +246,27 @@ let run_turn
            session assistant_msg;
          ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
          (match result.proof with
-          | Some p ->
+         | Some p ->
             Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
               meta.name p.run_id
               (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
               (Agent_sdk.Cdal_proof.show_result_status p.result_status)
               (List.length p.raw_evidence_refs);
             let store = Agent_sdk.Proof_store.default_config in
-            let eval = Cdal_eval.evaluate ~store p in
-            Cdal_eval.persist eval;
-            Log.Keeper.info "keeper:%s cdal_eval: %s"
-              meta.name (Cdal_eval.severity_to_string eval.overall);
-            (match eval.recommendation with
-             | Some r ->
-               Log.Keeper.warn
-                 "keeper:%s cdal: %d violation(s) from [%s]; mode %s needed (current: %s)"
-                 meta.name (List.length eval.evidence.violations)
-                 (String.concat ", " r.offending_tools)
-                 (Agent_sdk.Execution_mode.to_string r.minimum_required)
-                 (Agent_sdk.Execution_mode.to_string r.current_mode)
-             | None -> ())
+            let outcome = Cdal_eval_v1.evaluate ~store p in
+            let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
+            Cdal_eval_v1.persist verdict;
+            Log.Keeper.info
+              "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+              meta.name
+              (Cdal_types.contract_status_to_string verdict.status)
+              verdict.claim_scope
+              verdict.judgment_hash;
+            (match outcome with
+             | Cdal_eval_v1.Load_failure (err, _) ->
+               Log.Keeper.warn "keeper:%s contract_verdict load failure: %s"
+                 meta.name (Cdal_loader.load_error_to_string err)
+             | Cdal_eval_v1.Verdict _ -> ())
           | None -> ());
          Ok {
            response_text;

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -2,27 +2,13 @@
 
     @since CDAL eval content-based redesign *)
 
-let prefix = "proof-store://"
-let prefix_len = String.length prefix
-
 let resolve_path (config : Agent_sdk.Proof_store.config)
     (ref_ : Agent_sdk.Cdal_proof.artifact_ref) : (string, string) result =
-  if String.length ref_ > prefix_len
-     && String.sub ref_ 0 prefix_len = prefix then
-    let rel = String.sub ref_ prefix_len (String.length ref_ - prefix_len) in
-    Ok (Filename.concat (Filename.concat config.root "proofs") rel)
-  else
-    Error (Printf.sprintf "invalid artifact ref: %s" ref_)
+  match Agent_sdk.Proof_store.resolve_ref config ref_ with
+  | Ok resolved -> Ok resolved.path
+  | Error e -> Error e
 
 let read_json (config : Agent_sdk.Proof_store.config)
     (ref_ : Agent_sdk.Cdal_proof.artifact_ref)
     : (Yojson.Safe.t, string) result =
-  match resolve_path config ref_ with
-  | Error e -> Error e
-  | Ok path ->
-    if Sys.file_exists path then
-      (try Ok (Yojson.Safe.from_file path)
-       with exn -> Error (Printf.sprintf "JSON parse error in %s: %s"
-                            path (Printexc.to_string exn)))
-    else
-      Error (Printf.sprintf "artifact not found: %s" path)
+  Agent_sdk.Proof_store.read_json config ref_

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -1,7 +1,8 @@
 (** Proof_artifact_reader — Dereference proof-store:// artifact refs.
 
-    Resolves [proof-store://{run_id}/{subpath}] references to filesystem
-    paths under [{config.root}/proofs/] and reads their JSON content.
+    Delegates ref resolution and JSON parsing to OAS-owned
+    [Agent_sdk.Proof_store] read-side APIs so MASC does not hardcode
+    proof-store layout.
 
     @since CDAL eval content-based redesign *)
 

--- a/test/dune
+++ b/test/dune
@@ -1157,9 +1157,3 @@
  (name test_cdal_eval_v1)
  (modules test_cdal_eval_v1)
  (libraries masc_mcp agent_sdk alcotest yojson unix))
-
-; CDAL Phase 1A: Friction projection for single-run (#3602)
-(test
- (name test_cdal_friction_projection)
- (modules test_cdal_friction_projection)
- (libraries masc_mcp agent_sdk alcotest yojson unix str))

--- a/test/dune
+++ b/test/dune
@@ -1133,3 +1133,15 @@
  (name test_keeper_recurring)
  (modules test_keeper_recurring)
  (libraries masc_mcp alcotest yojson unix))
+
+; CDAL Phase 1A: Typed verdict and check-result types (#3597)
+(test
+ (name test_cdal_types)
+ (modules test_cdal_types)
+ (libraries masc_mcp alcotest yojson))
+
+; CDAL Phase 1A: Proof bundle loader (#3598)
+(test
+ (name test_cdal_loader)
+ (modules test_cdal_loader)
+ (libraries masc_mcp agent_sdk alcotest yojson unix))

--- a/test/dune
+++ b/test/dune
@@ -1145,3 +1145,21 @@
  (name test_cdal_loader)
  (modules test_cdal_loader)
  (libraries masc_mcp agent_sdk alcotest yojson unix))
+
+; CDAL Phase 1A: Contract judge with 4 active checks (#3600)
+(test
+ (name test_cdal_judge)
+ (modules test_cdal_judge)
+ (libraries masc_mcp agent_sdk alcotest yojson))
+
+; CDAL Phase 1A: Integration facade (#3601)
+(test
+ (name test_cdal_eval_v1)
+ (modules test_cdal_eval_v1)
+ (libraries masc_mcp agent_sdk alcotest yojson unix))
+
+; CDAL Phase 1A: Friction projection for single-run (#3602)
+(test
+ (name test_cdal_friction_projection)
+ (modules test_cdal_friction_projection)
+ (libraries masc_mcp agent_sdk alcotest yojson unix str))

--- a/test/test_cdal_eval.ml
+++ b/test/test_cdal_eval.ml
@@ -177,17 +177,7 @@ let test_integration_read_violations () =
     (Printf.sprintf "cdal_eval_int_%d" (Unix.getpid ())) in
   let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
   let run_id = "int-test-001" in
-  let run_dir = Filename.concat (Filename.concat tmp_dir "proofs") run_id in
-  let () =
-    let rec mkdirp path =
-      if not (Sys.file_exists path) then begin
-        mkdirp (Filename.dirname path);
-        Unix.mkdir path 0o755
-      end
-    in
-    mkdirp (Filename.concat run_dir "tool_traces");
-    mkdirp (Filename.concat run_dir "evidence")
-  in
+  Agent_sdk.Proof_store.init_run store ~run_id;
   (* Write synthetic violation evidence *)
   let violation_json = `List [
     `Assoc [
@@ -249,6 +239,32 @@ let test_integration_missing_artifact () =
   Alcotest.(check string) "ok (no violations read)" "ok"
     (CE.severity_to_string result.overall)
 
+let test_integration_ignores_suffix_lookalike_refs () =
+  Eio_main.run @@ fun _env ->
+  let tmp_dir = Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "cdal_eval_suffix_%d" (Unix.getpid ())) in
+  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  let run_id = "int-test-lookalike-001" in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_evidence store ~run_id
+    ~ref_id:"archive_mode_violations"
+    (`List [`Assoc [
+      ("ts", `Float 1000.5);
+      ("tool_name", `String "bash");
+      ("input_summary", `String "rm -rf /tmp/x");
+      ("effective_mode", `String "draft");
+      ("violation_kind", `String "external_in_draft");
+    ]]);
+  let proof = make_proof ~run_id ~effective:Draft
+    ~raw_evidence_refs:[
+      Agent_sdk.Proof_store.make_ref ~run_id
+        ~subpath:"evidence/archive_mode_violations.json";
+    ] () in
+  let result = CE.evaluate ~store proof in
+  Alcotest.(check int) "lookalike ref ignored" 0
+    (List.length result.evidence.violations)
+
 (* ================================================================ *)
 (* Violation_record unit tests                                       *)
 (* ================================================================ *)
@@ -309,6 +325,8 @@ let () =
     ("integration", [
       Alcotest.test_case "read violations from store" `Quick test_integration_read_violations;
       Alcotest.test_case "missing artifact graceful" `Quick test_integration_missing_artifact;
+      Alcotest.test_case "ignore suffix lookalike refs" `Quick
+        test_integration_ignores_suffix_lookalike_refs;
     ]);
     ("violation_record", [
       Alcotest.test_case "parse" `Quick test_violation_parse;

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -87,6 +87,10 @@ let test_full_pipeline () =
     Alcotest.(check string) "run_id" run_id v.run_id;
     Alcotest.(check string) "claim_scope"
       "phase1_scoped_runtime_audit" v.claim_scope;
+    Alcotest.(check string) "loader_semantics_version"
+      CT.loader_semantics_version_phase1 v.loader_semantics_version;
+    Alcotest.(check string) "schema_compat_mode"
+      CT.schema_compat_mode_v1 v.schema_compat_mode;
     Alcotest.(check int) "4 check results" 4
       (List.length v.check_results)
   | Load_failure (err, _) ->
@@ -107,6 +111,10 @@ let test_load_failure_inconclusive () =
       (CT.contract_status_to_string v.status);
     Alcotest.(check string) "claim_scope"
       "phase1_scoped_runtime_audit" v.claim_scope;
+    Alcotest.(check string) "loader_semantics_version"
+      CT.loader_semantics_version_phase1 v.loader_semantics_version;
+    Alcotest.(check string) "schema_compat_mode"
+      CT.schema_compat_mode_v1 v.schema_compat_mode;
     Alcotest.(check bool) "has completeness_gaps" true
       (List.length v.completeness_gaps > 0);
     let gap = List.hd v.completeness_gaps in

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -1,0 +1,162 @@
+(** test_cdal_eval_v1 -- Unit tests for Cdal_eval_v1 integration facade.
+
+    Tests the full pipeline (load + judge), load failure path,
+    and verdict_of_outcome extraction. *)
+
+module CE = Masc_mcp.Cdal_eval_v1
+module CT = Masc_mcp.Cdal_types
+module CL = Masc_mcp.Cdal_loader
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_proof
+    ?(run_id = "eval-v1-test-001")
+    ?(contract_id = "md5:abc123")
+    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
+    ?(requested = Agent_sdk.Execution_mode.Execute)
+    ?(effective = Agent_sdk.Execution_mode.Execute)
+    () : Agent_sdk.Cdal_proof.t =
+  {
+    schema_version;
+    run_id;
+    contract_id;
+    requested_execution_mode = requested;
+    effective_execution_mode = effective;
+    mode_decision_source = "passthrough";
+    risk_class = Agent_sdk.Risk_class.Low;
+    provider_snapshot = {
+      provider_name = "test";
+      model_id = "test-model";
+      api_version = None;
+    };
+    capability_snapshot = {
+      tools = ["read"; "write"];
+      mcp_servers = [];
+      max_turns = 10;
+      max_tokens = Some 4096;
+      thinking_enabled = None;
+    };
+    tool_trace_refs = [];
+    raw_evidence_refs = [];
+    checkpoint_ref = None;
+    result_status = Completed;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  }
+
+let make_contract () : Agent_sdk.Risk_contract.t =
+  {
+    runtime_constraints = {
+      requested_execution_mode = Execute;
+      risk_class = Low;
+      allowed_mutations = ["keeper_fs_edit"];
+      review_requirement = None;
+    };
+    eval_criteria = `Assoc [
+      ("success_criteria", `List [`String "tests pass"]);
+    ];
+  }
+
+let setup_store () =
+  let tmp_dir = Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "cdal_eval_v1_%d_%d"
+       (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  (store, tmp_dir)
+
+(* ================================================================ *)
+(* test_full_pipeline                                                *)
+(* ================================================================ *)
+
+let test_full_pipeline () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "full-pipeline-001" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CE.evaluate ~store proof with
+  | Verdict v ->
+    Alcotest.(check string) "status" "satisfied"
+      (CT.contract_status_to_string v.status);
+    Alcotest.(check string) "run_id" run_id v.run_id;
+    Alcotest.(check string) "claim_scope"
+      "phase1_scoped_runtime_audit" v.claim_scope;
+    Alcotest.(check int) "4 check results" 4
+      (List.length v.check_results)
+  | Load_failure (err, _) ->
+    Alcotest.fail
+      (Printf.sprintf "expected Verdict, got Load_failure: %s"
+         (CL.load_error_to_string err))
+
+(* ================================================================ *)
+(* test_load_failure_inconclusive                                    *)
+(* ================================================================ *)
+
+let test_load_failure_inconclusive () =
+  let (store, _tmp) = setup_store () in
+  let proof = make_proof ~run_id:"no-manifest-v1" () in
+  match CE.evaluate ~store proof with
+  | Load_failure (Manifest_not_found _, v) ->
+    Alcotest.(check string) "status" "inconclusive"
+      (CT.contract_status_to_string v.status);
+    Alcotest.(check string) "claim_scope"
+      "phase1_scoped_runtime_audit" v.claim_scope;
+    Alcotest.(check bool) "has completeness_gaps" true
+      (List.length v.completeness_gaps > 0);
+    let gap = List.hd v.completeness_gaps in
+    Alcotest.(check string) "gap artifact" "manifest.json" gap.artifact;
+    Alcotest.(check string) "gap impact" "blocks_verdict"
+      (CT.completeness_impact_to_string gap.impact)
+  | Load_failure (err, _) ->
+    Alcotest.fail
+      (Printf.sprintf "expected Manifest_not_found, got: %s"
+         (CL.load_error_to_string err))
+  | Verdict _ ->
+    Alcotest.fail "expected Load_failure, got Verdict"
+
+(* ================================================================ *)
+(* test_verdict_of_outcome                                           *)
+(* ================================================================ *)
+
+let test_verdict_of_outcome () =
+  (* Verdict branch *)
+  let (store1, _) = setup_store () in
+  let run_id = "voo-test-001" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof1 = make_proof ~run_id ~contract_id () in
+  Agent_sdk.Proof_store.init_run store1 ~run_id;
+  Agent_sdk.Proof_store.write_manifest store1 ~run_id proof1;
+  Agent_sdk.Proof_store.write_contract store1 ~run_id contract;
+  let outcome1 = CE.evaluate ~store:store1 proof1 in
+  let v1 = CE.verdict_of_outcome outcome1 in
+  Alcotest.(check string) "verdict branch status" "satisfied"
+    (CT.contract_status_to_string v1.status);
+  (* Load_failure branch *)
+  let (store2, _) = setup_store () in
+  let proof2 = make_proof ~run_id:"voo-missing" () in
+  let outcome2 = CE.evaluate ~store:store2 proof2 in
+  let v2 = CE.verdict_of_outcome outcome2 in
+  Alcotest.(check string) "failure branch status" "inconclusive"
+    (CT.contract_status_to_string v2.status)
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Cdal_eval_v1" [
+    ("pipeline", [
+      Alcotest.test_case "full pipeline" `Quick test_full_pipeline;
+      Alcotest.test_case "load failure inconclusive" `Quick
+        test_load_failure_inconclusive;
+      Alcotest.test_case "verdict_of_outcome" `Quick
+        test_verdict_of_outcome;
+    ]);
+  ]

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -222,6 +222,14 @@ let test_claim_scope_always_set () =
   Alcotest.(check string) "claim_scope violated"
     "phase1_scoped_runtime_audit" verdict_bad.claim_scope
 
+let test_loader_metadata_set () =
+  let bundle = make_bundle () in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string) "loader semantics version"
+    CT.loader_semantics_version_phase1 verdict.loader_semantics_version;
+  Alcotest.(check string) "schema compat mode"
+    CT.schema_compat_mode_v1 verdict.schema_compat_mode
+
 (* ================================================================ *)
 (* test_replay_determinism                                           *)
 (* ================================================================ *)
@@ -279,6 +287,8 @@ let () =
         test_verdict_priority_inconclusive;
       Alcotest.test_case "claim scope always set" `Quick
         test_claim_scope_always_set;
+      Alcotest.test_case "loader metadata set" `Quick
+        test_loader_metadata_set;
       Alcotest.test_case "replay determinism" `Quick
         test_replay_determinism;
       Alcotest.test_case "findings populated" `Quick

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -1,0 +1,287 @@
+(** test_cdal_judge -- Unit tests for Cdal_judge module.
+
+    Tests 4 active checks and run-level verdict derivation
+    with determinism and findings population verification. *)
+
+module CJ = Masc_mcp.Cdal_judge
+module CT = Masc_mcp.Cdal_types
+module CL = Masc_mcp.Cdal_loader
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_proof
+    ?(run_id = "judge-test-001")
+    ?(contract_id = "md5:abc123")
+    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
+    ?(requested = Agent_sdk.Execution_mode.Execute)
+    ?(effective = Agent_sdk.Execution_mode.Execute)
+    ?(risk_class = Agent_sdk.Risk_class.Low)
+    () : Agent_sdk.Cdal_proof.t =
+  {
+    schema_version;
+    run_id;
+    contract_id;
+    requested_execution_mode = requested;
+    effective_execution_mode = effective;
+    mode_decision_source = "passthrough";
+    risk_class;
+    provider_snapshot = {
+      provider_name = "test";
+      model_id = "test-model";
+      api_version = None;
+    };
+    capability_snapshot = {
+      tools = ["read"; "write"];
+      mcp_servers = [];
+      max_turns = 10;
+      max_tokens = Some 4096;
+      thinking_enabled = None;
+    };
+    tool_trace_refs = [];
+    raw_evidence_refs = [];
+    checkpoint_ref = None;
+    result_status = Completed;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  }
+
+let make_contract
+    ?(requested = Agent_sdk.Execution_mode.Execute)
+    ?(risk_class = Agent_sdk.Risk_class.Low)
+    () : Agent_sdk.Risk_contract.t =
+  {
+    runtime_constraints = {
+      requested_execution_mode = requested;
+      risk_class;
+      allowed_mutations = ["keeper_fs_edit"];
+      review_requirement = None;
+    };
+    eval_criteria = `Assoc [
+      ("success_criteria", `List [`String "tests pass"]);
+    ];
+  }
+
+let make_bundle
+    ?(run_id = "judge-test-001")
+    ?(proof_requested = Agent_sdk.Execution_mode.Execute)
+    ?(proof_effective = Agent_sdk.Execution_mode.Execute)
+    ?(proof_risk = Agent_sdk.Risk_class.Low)
+    ?(contract_requested = Agent_sdk.Execution_mode.Execute)
+    ?(contract_risk = Agent_sdk.Risk_class.Low)
+    ?(contract_id_match = true)
+    () : CL.loaded_bundle =
+  let contract = make_contract ~requested:contract_requested
+      ~risk_class:contract_risk () in
+  let recomputed_contract_id =
+    Agent_sdk.Risk_contract.contract_id contract in
+  let proof_contract_id =
+    if contract_id_match then recomputed_contract_id
+    else "md5:mismatched_hash" in
+  let proof = make_proof ~run_id ~contract_id:proof_contract_id
+      ~requested:proof_requested ~effective:proof_effective
+      ~risk_class:proof_risk () in
+  {
+    proof;
+    manifest_json = `Assoc [];
+    contract;
+    contract_json = `Assoc [];
+    recomputed_contract_id;
+  }
+
+(* ================================================================ *)
+(* test_all_satisfied                                                *)
+(* ================================================================ *)
+
+let test_all_satisfied () =
+  let bundle = make_bundle () in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string) "status" "satisfied"
+    (CT.contract_status_to_string verdict.status);
+  Alcotest.(check int) "no findings" 0 (List.length verdict.findings);
+  Alcotest.(check int) "4 check results" 4
+    (List.length verdict.check_results);
+  List.iter (fun (cr : CT.check_result) ->
+    Alcotest.(check string) (cr.check_id ^ " satisfied") "satisfied"
+      (CT.contract_status_to_string cr.status)
+  ) verdict.check_results
+
+(* ================================================================ *)
+(* test_mode_propagation_violated                                    *)
+(* ================================================================ *)
+
+let test_mode_propagation_violated () =
+  (* proof requests Draft but contract requires Execute *)
+  let bundle = make_bundle
+      ~proof_requested:Agent_sdk.Execution_mode.Draft
+      ~proof_effective:Agent_sdk.Execution_mode.Draft
+      ~contract_requested:Agent_sdk.Execution_mode.Execute () in
+  let cr = CJ.check_execution_mode bundle in
+  Alcotest.(check string) "status" "violated"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check bool) "has findings" true
+    (List.length cr.findings > 0)
+
+(* ================================================================ *)
+(* test_mode_escalation_violated                                     *)
+(* ================================================================ *)
+
+let test_mode_escalation_violated () =
+  (* effective Execute > requested Draft *)
+  let bundle = make_bundle
+      ~proof_requested:Agent_sdk.Execution_mode.Draft
+      ~proof_effective:Agent_sdk.Execution_mode.Execute
+      ~contract_requested:Agent_sdk.Execution_mode.Draft () in
+  let cr = CJ.check_execution_mode bundle in
+  Alcotest.(check string) "status" "violated"
+    (CT.contract_status_to_string cr.status);
+  let has_escalation =
+    List.exists (fun (f : CT.contract_finding) ->
+      f.event_id = Some "escalation") cr.findings in
+  Alcotest.(check bool) "has escalation finding" true has_escalation
+
+(* ================================================================ *)
+(* test_risk_class_violated                                          *)
+(* ================================================================ *)
+
+let test_risk_class_violated () =
+  let bundle = make_bundle
+      ~proof_risk:Agent_sdk.Risk_class.High
+      ~contract_risk:Agent_sdk.Risk_class.Low () in
+  let cr = CJ.check_risk_class bundle in
+  Alcotest.(check string) "status" "violated"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 finding" 1 (List.length cr.findings)
+
+(* ================================================================ *)
+(* test_contract_snapshot_violated                                   *)
+(* ================================================================ *)
+
+let test_contract_snapshot_violated () =
+  let bundle = make_bundle ~contract_id_match:false () in
+  let cr = CJ.check_contract_snapshot bundle in
+  Alcotest.(check string) "status" "violated"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 finding" 1 (List.length cr.findings)
+
+(* ================================================================ *)
+(* test_required_artifact_satisfied                                  *)
+(* ================================================================ *)
+
+let test_required_artifact_satisfied () =
+  let bundle = make_bundle () in
+  let cr = CJ.check_required_artifact bundle in
+  Alcotest.(check string) "status" "satisfied"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "no findings" 0 (List.length cr.findings)
+
+(* ================================================================ *)
+(* test_verdict_priority_violated_wins                               *)
+(* ================================================================ *)
+
+let test_verdict_priority_violated_wins () =
+  (* One violated check (risk mismatch) + others satisfied *)
+  let bundle = make_bundle
+      ~proof_risk:Agent_sdk.Risk_class.Medium
+      ~contract_risk:Agent_sdk.Risk_class.Low () in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string) "status" "violated"
+    (CT.contract_status_to_string verdict.status)
+
+(* ================================================================ *)
+(* test_verdict_priority_inconclusive                                *)
+(* ================================================================ *)
+
+let test_verdict_priority_inconclusive () =
+  (* No direct way to trigger Inconclusive from the 4 checks since
+     they only produce Satisfied or Violated. This test verifies the
+     verdict derivation logic by examining a verdict that is Satisfied
+     when all checks pass, confirming the "else" branch works. *)
+  let bundle = make_bundle () in
+  let verdict = CJ.judge bundle in
+  (* All satisfied means final is Satisfied (not Inconclusive) *)
+  Alcotest.(check string) "status satisfied when no violations"
+    "satisfied" (CT.contract_status_to_string verdict.status)
+
+(* ================================================================ *)
+(* test_claim_scope_always_set                                       *)
+(* ================================================================ *)
+
+let test_claim_scope_always_set () =
+  (* Satisfied case *)
+  let bundle_ok = make_bundle () in
+  let verdict_ok = CJ.judge bundle_ok in
+  Alcotest.(check string) "claim_scope ok"
+    "phase1_scoped_runtime_audit" verdict_ok.claim_scope;
+  (* Violated case *)
+  let bundle_bad = make_bundle
+      ~proof_risk:Agent_sdk.Risk_class.High
+      ~contract_risk:Agent_sdk.Risk_class.Low () in
+  let verdict_bad = CJ.judge bundle_bad in
+  Alcotest.(check string) "claim_scope violated"
+    "phase1_scoped_runtime_audit" verdict_bad.claim_scope
+
+(* ================================================================ *)
+(* test_replay_determinism                                           *)
+(* ================================================================ *)
+
+let test_replay_determinism () =
+  let bundle = make_bundle () in
+  let v1 = CJ.judge bundle in
+  let v2 = CJ.judge bundle in
+  Alcotest.(check string) "judgment_hash deterministic"
+    v1.judgment_hash v2.judgment_hash;
+  Alcotest.(check string) "judgment_basis_hash deterministic"
+    v1.judgment_basis_hash v2.judgment_basis_hash
+
+(* ================================================================ *)
+(* test_findings_populated                                           *)
+(* ================================================================ *)
+
+let test_findings_populated () =
+  let bundle = make_bundle
+      ~proof_risk:Agent_sdk.Risk_class.Critical
+      ~contract_risk:Agent_sdk.Risk_class.Low () in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string) "violated" "violated"
+    (CT.contract_status_to_string verdict.status);
+  Alcotest.(check bool) "has findings" true
+    (List.length verdict.findings > 0);
+  (* Verify finding has expected structure *)
+  let f = List.hd verdict.findings in
+  Alcotest.(check string) "finding check_id" "runtime.risk_class"
+    f.check_id
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Cdal_judge" [
+    ("checks", [
+      Alcotest.test_case "all satisfied" `Quick test_all_satisfied;
+      Alcotest.test_case "mode propagation violated" `Quick
+        test_mode_propagation_violated;
+      Alcotest.test_case "mode escalation violated" `Quick
+        test_mode_escalation_violated;
+      Alcotest.test_case "risk class violated" `Quick
+        test_risk_class_violated;
+      Alcotest.test_case "contract snapshot violated" `Quick
+        test_contract_snapshot_violated;
+      Alcotest.test_case "required artifact satisfied" `Quick
+        test_required_artifact_satisfied;
+    ]);
+    ("verdict", [
+      Alcotest.test_case "violated wins" `Quick
+        test_verdict_priority_violated_wins;
+      Alcotest.test_case "inconclusive path" `Quick
+        test_verdict_priority_inconclusive;
+      Alcotest.test_case "claim scope always set" `Quick
+        test_claim_scope_always_set;
+      Alcotest.test_case "replay determinism" `Quick
+        test_replay_determinism;
+      Alcotest.test_case "findings populated" `Quick
+        test_findings_populated;
+    ]);
+  ]

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -1,0 +1,267 @@
+(** test_cdal_loader -- Unit tests for Cdal_loader module.
+
+    Tests bundle loading from proof store with valid/invalid
+    manifests, contracts, schema versions, and contract_id
+    roundtrip verification. *)
+
+module CL = Masc_mcp.Cdal_loader
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_proof
+    ?(run_id = "loader-test-001")
+    ?(contract_id = "md5:abc123")
+    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
+    ?(requested = Agent_sdk.Execution_mode.Execute)
+    ?(effective = Agent_sdk.Execution_mode.Execute)
+    () : Agent_sdk.Cdal_proof.t =
+  {
+    schema_version;
+    run_id;
+    contract_id;
+    requested_execution_mode = requested;
+    effective_execution_mode = effective;
+    mode_decision_source = "passthrough";
+    risk_class = Agent_sdk.Risk_class.Low;
+    provider_snapshot = {
+      provider_name = "test";
+      model_id = "test-model";
+      api_version = None;
+    };
+    capability_snapshot = {
+      tools = ["read"; "write"];
+      mcp_servers = [];
+      max_turns = 10;
+      max_tokens = Some 4096;
+      thinking_enabled = None;
+    };
+    tool_trace_refs = [];
+    raw_evidence_refs = [];
+    checkpoint_ref = None;
+    result_status = Completed;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  }
+
+let make_contract () : Agent_sdk.Risk_contract.t =
+  {
+    runtime_constraints = {
+      requested_execution_mode = Execute;
+      risk_class = Low;
+      allowed_mutations = ["keeper_fs_edit"];
+      review_requirement = None;
+    };
+    eval_criteria = `Assoc [
+      ("success_criteria", `List [`String "tests pass"]);
+      ("required_evidence", `List [`String "src/main.ml"]);
+    ];
+  }
+
+let setup_store () =
+  let tmp_dir = Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "cdal_loader_%d_%d"
+       (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  (store, tmp_dir)
+
+let mkdirp path =
+  let rec go p =
+    if not (Sys.file_exists p) then begin
+      go (Filename.dirname p);
+      Unix.mkdir p 0o755
+    end
+  in
+  go path
+
+(* ================================================================ *)
+(* test_load_valid_bundle                                            *)
+(* ================================================================ *)
+
+let test_load_valid_bundle () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "valid-bundle-001" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id () in
+  (* Write manifest and contract to disk *)
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CL.load ~store proof with
+  | Ok bundle ->
+    Alcotest.(check string) "run_id" run_id bundle.proof.run_id;
+    Alcotest.(check string) "recomputed contract_id"
+      contract_id bundle.recomputed_contract_id;
+    Alcotest.(check string) "contract mode" "execute"
+      (Agent_sdk.Execution_mode.to_string
+         bundle.contract.runtime_constraints.requested_execution_mode)
+  | Error e -> Alcotest.fail (CL.load_error_to_string e)
+
+(* ================================================================ *)
+(* test_missing_manifest                                             *)
+(* ================================================================ *)
+
+let test_missing_manifest () =
+  let (store, _tmp) = setup_store () in
+  let proof = make_proof ~run_id:"no-manifest" () in
+  match CL.load ~store proof with
+  | Error (Manifest_not_found _) -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "expected Manifest_not_found, got: %s"
+                     (CL.load_error_to_string e))
+  | Ok _ -> Alcotest.fail "expected error for missing manifest"
+
+(* ================================================================ *)
+(* test_malformed_manifest                                           *)
+(* ================================================================ *)
+
+let test_malformed_manifest () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "bad-manifest" in
+  let run_dir = Filename.concat
+    (Filename.concat store.root "proofs") run_id in
+  mkdirp run_dir;
+  let manifest_path = Filename.concat run_dir "manifest.json" in
+  let oc = open_out manifest_path in
+  output_string oc "{invalid json!!!";
+  close_out oc;
+  let proof = make_proof ~run_id () in
+  match CL.load ~store proof with
+  | Error (Manifest_parse_error _) -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "expected Manifest_parse_error, got: %s"
+                     (CL.load_error_to_string e))
+  | Ok _ -> Alcotest.fail "expected error for malformed manifest"
+
+(* ================================================================ *)
+(* test_missing_contract                                             *)
+(* ================================================================ *)
+
+let test_missing_contract () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "no-contract" in
+  let proof = make_proof ~run_id () in
+  (* Write manifest but not contract *)
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  match CL.load ~store proof with
+  | Error (Contract_not_found _) -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "expected Contract_not_found, got: %s"
+                     (CL.load_error_to_string e))
+  | Ok _ -> Alcotest.fail "expected error for missing contract"
+
+(* ================================================================ *)
+(* test_malformed_contract                                           *)
+(* ================================================================ *)
+
+let test_malformed_contract () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "bad-contract" in
+  let proof = make_proof ~run_id () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  (* Write invalid contract JSON *)
+  let contract_path = Filename.concat
+    (Filename.concat
+       (Filename.concat store.root "proofs") run_id)
+    "contract.json" in
+  let oc = open_out contract_path in
+  output_string oc "{not valid contract json}}}";
+  close_out oc;
+  match CL.load ~store proof with
+  | Error (Contract_parse_error _) -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "expected Contract_parse_error, got: %s"
+                     (CL.load_error_to_string e))
+  | Ok _ -> Alcotest.fail "expected error for malformed contract"
+
+(* ================================================================ *)
+(* test_schema_unsupported                                           *)
+(* ================================================================ *)
+
+let test_schema_unsupported () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "bad-schema" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  (* Create proof with wrong schema version *)
+  let proof = make_proof ~run_id ~contract_id ~schema_version:99 () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  (* Write manifest with correct schema for file, but proof object has v99 *)
+  let correct_proof = { proof with schema_version = 1 } in
+  Agent_sdk.Proof_store.write_manifest store ~run_id correct_proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CL.load ~store proof with
+  | Error (Schema_unsupported 99) -> ()
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "expected Schema_unsupported 99, got: %s"
+                     (CL.load_error_to_string e))
+  | Ok _ -> Alcotest.fail "expected error for unsupported schema"
+
+(* ================================================================ *)
+(* test_contract_id_roundtrip                                        *)
+(* ================================================================ *)
+
+let test_contract_id_roundtrip () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "roundtrip-001" in
+  let contract = make_contract () in
+  let original_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id:original_id () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CL.load ~store proof with
+  | Ok bundle ->
+    Alcotest.(check string) "recomputed matches original"
+      original_id bundle.recomputed_contract_id;
+    (* Also verify the recomputed ID matches what contract_id produces *)
+    let recomputed_again =
+      Agent_sdk.Risk_contract.contract_id bundle.contract in
+    Alcotest.(check string) "recomputed from loaded contract"
+      original_id recomputed_again
+  | Error e -> Alcotest.fail (CL.load_error_to_string e)
+
+(* ================================================================ *)
+(* test_load_error_to_string coverage                                *)
+(* ================================================================ *)
+
+let test_load_error_to_string () =
+  let cases = [
+    (CL.Manifest_not_found "/a/b", "manifest not found: /a/b");
+    (CL.Manifest_parse_error "bad", "manifest parse error: bad");
+    (CL.Contract_not_found "/c/d", "contract not found: /c/d");
+    (CL.Contract_parse_error "bad", "contract parse error: bad");
+    (CL.Schema_unsupported 99,
+     Printf.sprintf "unsupported schema version: 99 (expected %d)"
+       Agent_sdk.Cdal_proof.schema_version_current);
+    (CL.Ref_resolution_error "ref", "ref resolution error: ref");
+  ] in
+  List.iter (fun (err, expected) ->
+    Alcotest.(check string) "error string" expected
+      (CL.load_error_to_string err)
+  ) cases
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Cdal_loader" [
+    ("load", [
+      Alcotest.test_case "valid bundle" `Quick test_load_valid_bundle;
+      Alcotest.test_case "missing manifest" `Quick test_missing_manifest;
+      Alcotest.test_case "malformed manifest" `Quick test_malformed_manifest;
+      Alcotest.test_case "missing contract" `Quick test_missing_contract;
+      Alcotest.test_case "malformed contract" `Quick test_malformed_contract;
+      Alcotest.test_case "schema unsupported" `Quick test_schema_unsupported;
+      Alcotest.test_case "contract_id roundtrip" `Quick test_contract_id_roundtrip;
+    ]);
+    ("error_string", [
+      Alcotest.test_case "all variants" `Quick test_load_error_to_string;
+    ]);
+  ]

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -188,12 +188,10 @@ let test_schema_unsupported () =
   let run_id = "bad-schema" in
   let contract = make_contract () in
   let contract_id = Agent_sdk.Risk_contract.contract_id contract in
-  (* Create proof with wrong schema version *)
+  (* Create manifest proof with wrong schema version *)
   let proof = make_proof ~run_id ~contract_id ~schema_version:99 () in
   Agent_sdk.Proof_store.init_run store ~run_id;
-  (* Write manifest with correct schema for file, but proof object has v99 *)
-  let correct_proof = { proof with schema_version = 1 } in
-  Agent_sdk.Proof_store.write_manifest store ~run_id correct_proof;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
   Agent_sdk.Proof_store.write_contract store ~run_id contract;
   match CL.load ~store proof with
   | Error (Schema_unsupported 99) -> ()
@@ -224,6 +222,36 @@ let test_contract_id_roundtrip () =
       Agent_sdk.Risk_contract.contract_id bundle.contract in
     Alcotest.(check string) "recomputed from loaded contract"
       original_id recomputed_again
+  | Error e -> Alcotest.fail (CL.load_error_to_string e)
+
+(* ================================================================ *)
+(* test_manifest_is_truth_source                                     *)
+(* ================================================================ *)
+
+let test_manifest_is_truth_source () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "manifest-truth-001" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let manifest_proof =
+    make_proof ~run_id ~contract_id
+      ~requested:Agent_sdk.Execution_mode.Execute
+      ~effective:Agent_sdk.Execution_mode.Draft () in
+  let input_proof =
+    make_proof ~run_id ~contract_id
+      ~requested:Agent_sdk.Execution_mode.Diagnose
+      ~effective:Agent_sdk.Execution_mode.Diagnose () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id manifest_proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CL.load ~store input_proof with
+  | Ok bundle ->
+    Alcotest.(check string) "requested from manifest"
+      "execute"
+      (Agent_sdk.Execution_mode.to_string bundle.proof.requested_execution_mode);
+    Alcotest.(check string) "effective from manifest"
+      "draft"
+      (Agent_sdk.Execution_mode.to_string bundle.proof.effective_execution_mode)
   | Error e -> Alcotest.fail (CL.load_error_to_string e)
 
 (* ================================================================ *)
@@ -260,6 +288,7 @@ let () =
       Alcotest.test_case "malformed contract" `Quick test_malformed_contract;
       Alcotest.test_case "schema unsupported" `Quick test_schema_unsupported;
       Alcotest.test_case "contract_id roundtrip" `Quick test_contract_id_roundtrip;
+      Alcotest.test_case "manifest is truth source" `Quick test_manifest_is_truth_source;
     ]);
     ("error_string", [
       Alcotest.test_case "all variants" `Quick test_load_error_to_string;

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -165,10 +165,13 @@ let test_malformed_contract () =
   Agent_sdk.Proof_store.init_run store ~run_id;
   Agent_sdk.Proof_store.write_manifest store ~run_id proof;
   (* Write invalid contract JSON *)
-  let contract_path = Filename.concat
-    (Filename.concat
-       (Filename.concat store.root "proofs") run_id)
-    "contract.json" in
+  let contract_ref =
+    Agent_sdk.Proof_store.make_ref ~run_id ~subpath:"contract.json" in
+  let contract_path =
+    match Agent_sdk.Proof_store.resolve_ref store contract_ref with
+    | Ok resolved -> resolved.path
+    | Error e -> Alcotest.fail e
+  in
   let oc = open_out contract_path in
   output_string oc "{not valid contract json}}}";
   close_out oc;

--- a/test/test_cdal_types.ml
+++ b/test/test_cdal_types.ml
@@ -29,12 +29,15 @@ let make_verdict ?(run_id = "test-run-001")
     ?(claim_scope = CT.claim_scope_phase1)
     ?(judgment_basis_hash = "md5:basis-hash")
     ?(judgment_hash = "")
+    ?(loader_semantics_version = CT.loader_semantics_version_phase1)
+    ?(schema_compat_mode = CT.schema_compat_mode_v1)
     ?(status = CT.Satisfied)
     ?(findings = []) ?(completeness_gaps = [])
     ?(check_results = [])
     () : CT.contract_verdict =
   { run_id; contract_id; claim_scope; judgment_basis_hash;
-    judgment_hash; status; findings; completeness_gaps; check_results }
+    judgment_hash; loader_semantics_version; schema_compat_mode;
+    status; findings; completeness_gaps; check_results }
 
 (* ================================================================ *)
 (* contract_finding roundtrip                                        *)
@@ -129,6 +132,10 @@ let test_verdict_json_roundtrip () =
       v.judgment_basis_hash v2.judgment_basis_hash;
     Alcotest.(check string) "judgment_hash"
       v.judgment_hash v2.judgment_hash;
+    Alcotest.(check string) "loader_semantics_version"
+      v.loader_semantics_version v2.loader_semantics_version;
+    Alcotest.(check string) "schema_compat_mode"
+      v.schema_compat_mode v2.schema_compat_mode;
     Alcotest.(check string) "status"
       (CT.contract_status_to_string v.status)
       (CT.contract_status_to_string v2.status);

--- a/test/test_cdal_types.ml
+++ b/test/test_cdal_types.ml
@@ -1,0 +1,269 @@
+(** test_cdal_types -- Unit tests for Cdal_types module.
+
+    Verifies JSON roundtrip, judgment hash determinism,
+    and canonical JSON key ordering. *)
+
+module CT = Masc_mcp.Cdal_types
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_finding ?(check_id = "chk-001") ?(event_id = Some "evt-001")
+    ?(observed = `String "draft") ?(expected = `String "execute")
+    ?(trace_ref = Some "proof-store://run-1/trace-001")
+    () : CT.contract_finding =
+  { check_id; event_id; observed; expected; trace_ref }
+
+let make_gap ?(artifact = "contract.json") ?(reason = "missing field")
+    ?(impact = CT.Annotation_only) () : CT.completeness_gap =
+  { artifact; reason; impact }
+
+let make_check_result ?(check_id = "mode_escalation")
+    ?(status = CT.Satisfied) ?(findings = []) ?(completeness_gaps = [])
+    () : CT.check_result =
+  { check_id; status; findings; completeness_gaps }
+
+let make_verdict ?(run_id = "test-run-001")
+    ?(contract_id = "md5:abc123")
+    ?(claim_scope = CT.claim_scope_phase1)
+    ?(judgment_basis_hash = "md5:basis-hash")
+    ?(judgment_hash = "")
+    ?(status = CT.Satisfied)
+    ?(findings = []) ?(completeness_gaps = [])
+    ?(check_results = [])
+    () : CT.contract_verdict =
+  { run_id; contract_id; claim_scope; judgment_basis_hash;
+    judgment_hash; status; findings; completeness_gaps; check_results }
+
+(* ================================================================ *)
+(* contract_finding roundtrip                                        *)
+(* ================================================================ *)
+
+let test_finding_json_roundtrip () =
+  let f = make_finding () in
+  let json = CT.contract_finding_to_json f in
+  match CT.contract_finding_of_json json with
+  | Ok f2 ->
+    Alcotest.(check string) "check_id" f.check_id f2.check_id;
+    Alcotest.(check (option string)) "event_id" f.event_id f2.event_id;
+    Alcotest.(check (option string)) "trace_ref" f.trace_ref f2.trace_ref;
+    Alcotest.(check string) "observed"
+      (Yojson.Safe.to_string f.observed)
+      (Yojson.Safe.to_string f2.observed);
+    Alcotest.(check string) "expected"
+      (Yojson.Safe.to_string f.expected)
+      (Yojson.Safe.to_string f2.expected)
+  | Error e -> Alcotest.fail e
+
+let test_finding_none_fields () =
+  let f = make_finding ~event_id:None ~trace_ref:None () in
+  let json = CT.contract_finding_to_json f in
+  match CT.contract_finding_of_json json with
+  | Ok f2 ->
+    Alcotest.(check (option string)) "event_id None" None f2.event_id;
+    Alcotest.(check (option string)) "trace_ref None" None f2.trace_ref
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* completeness_gap roundtrip                                        *)
+(* ================================================================ *)
+
+let test_gap_json_roundtrip () =
+  let g = make_gap () in
+  let json = CT.completeness_gap_to_json g in
+  match CT.completeness_gap_of_json json with
+  | Ok g2 ->
+    Alcotest.(check string) "artifact" g.artifact g2.artifact;
+    Alcotest.(check string) "reason" g.reason g2.reason;
+    Alcotest.(check string) "impact"
+      (CT.completeness_impact_to_string g.impact)
+      (CT.completeness_impact_to_string g2.impact)
+  | Error e -> Alcotest.fail e
+
+let test_gap_blocks_verdict () =
+  let g = make_gap ~impact:Blocks_verdict () in
+  let json = CT.completeness_gap_to_json g in
+  match CT.completeness_gap_of_json json with
+  | Ok g2 ->
+    Alcotest.(check string) "impact" "blocks_verdict"
+      (CT.completeness_impact_to_string g2.impact)
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* check_result roundtrip                                            *)
+(* ================================================================ *)
+
+let test_check_result_json_roundtrip () =
+  let f = make_finding () in
+  let g = make_gap ~impact:Blocks_verdict () in
+  let cr = make_check_result ~status:Violated
+    ~findings:[f] ~completeness_gaps:[g] () in
+  let json = CT.check_result_to_json cr in
+  match CT.check_result_of_json json with
+  | Ok cr2 ->
+    Alcotest.(check string) "check_id" cr.check_id cr2.check_id;
+    Alcotest.(check string) "status" "violated"
+      (CT.contract_status_to_string cr2.status);
+    Alcotest.(check int) "findings count" 1 (List.length cr2.findings);
+    Alcotest.(check int) "gaps count" 1 (List.length cr2.completeness_gaps)
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* contract_verdict roundtrip                                        *)
+(* ================================================================ *)
+
+let test_verdict_json_roundtrip () =
+  let f = make_finding () in
+  let g = make_gap () in
+  let cr = make_check_result ~findings:[f] ~completeness_gaps:[g] () in
+  let v = make_verdict ~findings:[f] ~completeness_gaps:[g]
+    ~check_results:[cr] () in
+  let json = CT.contract_verdict_to_json v in
+  match CT.contract_verdict_of_json json with
+  | Ok v2 ->
+    Alcotest.(check string) "run_id" v.run_id v2.run_id;
+    Alcotest.(check string) "contract_id" v.contract_id v2.contract_id;
+    Alcotest.(check string) "claim_scope" v.claim_scope v2.claim_scope;
+    Alcotest.(check string) "basis_hash"
+      v.judgment_basis_hash v2.judgment_basis_hash;
+    Alcotest.(check string) "judgment_hash"
+      v.judgment_hash v2.judgment_hash;
+    Alcotest.(check string) "status"
+      (CT.contract_status_to_string v.status)
+      (CT.contract_status_to_string v2.status);
+    Alcotest.(check int) "findings" 1 (List.length v2.findings);
+    Alcotest.(check int) "gaps" 1 (List.length v2.completeness_gaps);
+    Alcotest.(check int) "check_results" 1 (List.length v2.check_results)
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* judgment hash                                                     *)
+(* ================================================================ *)
+
+let test_judgment_hash_determinism () =
+  let v = make_verdict () in
+  let h1 = CT.compute_judgment_hash v in
+  let h2 = CT.compute_judgment_hash v in
+  Alcotest.(check string) "same hash" h1 h2;
+  (* Verify it starts with md5: prefix *)
+  Alcotest.(check bool) "md5 prefix"
+    true (String.length h1 > 4 && String.sub h1 0 4 = "md5:")
+
+let test_judgment_hash_changes_with_content () =
+  let v1 = make_verdict ~status:Satisfied () in
+  let v2 = make_verdict ~status:Violated () in
+  let h1 = CT.compute_judgment_hash v1 in
+  let h2 = CT.compute_judgment_hash v2 in
+  Alcotest.(check bool) "different hash for different status"
+    true (h1 <> h2)
+
+let test_judgment_hash_ignores_existing_hash () =
+  let v1 = make_verdict ~judgment_hash:"old-hash-1" () in
+  let v2 = make_verdict ~judgment_hash:"old-hash-2" () in
+  let h1 = CT.compute_judgment_hash v1 in
+  let h2 = CT.compute_judgment_hash v2 in
+  Alcotest.(check string) "existing hash ignored" h1 h2
+
+(* ================================================================ *)
+(* canonical JSON sorted keys                                        *)
+(* ================================================================ *)
+
+let extract_keys = function
+  | `Assoc fields -> List.map fst fields
+  | _ -> []
+
+let test_canonical_json_sorted () =
+  let v = make_verdict () in
+  let json = CT.contract_verdict_to_json v in
+  let keys = extract_keys json in
+  let sorted = List.sort String.compare keys in
+  Alcotest.(check (list string)) "top-level keys sorted" sorted keys
+
+let test_finding_keys_sorted () =
+  let f = make_finding () in
+  let json = CT.contract_finding_to_json f in
+  let keys = extract_keys json in
+  let sorted = List.sort String.compare keys in
+  Alcotest.(check (list string)) "finding keys sorted" sorted keys
+
+let test_gap_keys_sorted () =
+  let g = make_gap () in
+  let json = CT.completeness_gap_to_json g in
+  let keys = extract_keys json in
+  let sorted = List.sort String.compare keys in
+  Alcotest.(check (list string)) "gap keys sorted" sorted keys
+
+(* ================================================================ *)
+(* String conversion helpers                                         *)
+(* ================================================================ *)
+
+let test_contract_status_roundtrip () =
+  let statuses = [CT.Satisfied; Violated; Inconclusive] in
+  List.iter (fun s ->
+    let str = CT.contract_status_to_string s in
+    match CT.contract_status_of_string str with
+    | Ok s2 ->
+      Alcotest.(check string) "status roundtrip"
+        (CT.contract_status_to_string s)
+        (CT.contract_status_to_string s2)
+    | Error e -> Alcotest.fail e
+  ) statuses
+
+let test_completeness_impact_roundtrip () =
+  let impacts = [CT.Blocks_verdict; Annotation_only] in
+  List.iter (fun i ->
+    let str = CT.completeness_impact_to_string i in
+    match CT.completeness_impact_of_string str with
+    | Ok i2 ->
+      Alcotest.(check string) "impact roundtrip"
+        (CT.completeness_impact_to_string i)
+        (CT.completeness_impact_to_string i2)
+    | Error e -> Alcotest.fail e
+  ) impacts
+
+let test_invalid_status_string () =
+  match CT.contract_status_of_string "bogus" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for invalid status"
+
+let test_invalid_impact_string () =
+  match CT.completeness_impact_of_string "bogus" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for invalid impact"
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Cdal_types" [
+    ("finding", [
+      Alcotest.test_case "json roundtrip" `Quick test_finding_json_roundtrip;
+      Alcotest.test_case "none fields" `Quick test_finding_none_fields;
+      Alcotest.test_case "keys sorted" `Quick test_finding_keys_sorted;
+    ]);
+    ("completeness_gap", [
+      Alcotest.test_case "json roundtrip" `Quick test_gap_json_roundtrip;
+      Alcotest.test_case "blocks_verdict" `Quick test_gap_blocks_verdict;
+      Alcotest.test_case "keys sorted" `Quick test_gap_keys_sorted;
+    ]);
+    ("check_result", [
+      Alcotest.test_case "json roundtrip" `Quick test_check_result_json_roundtrip;
+    ]);
+    ("contract_verdict", [
+      Alcotest.test_case "json roundtrip" `Quick test_verdict_json_roundtrip;
+      Alcotest.test_case "canonical json sorted" `Quick test_canonical_json_sorted;
+    ]);
+    ("judgment_hash", [
+      Alcotest.test_case "determinism" `Quick test_judgment_hash_determinism;
+      Alcotest.test_case "changes with content" `Quick test_judgment_hash_changes_with_content;
+      Alcotest.test_case "ignores existing hash" `Quick test_judgment_hash_ignores_existing_hash;
+    ]);
+    ("string_conversions", [
+      Alcotest.test_case "contract_status roundtrip" `Quick test_contract_status_roundtrip;
+      Alcotest.test_case "completeness_impact roundtrip" `Quick test_completeness_impact_roundtrip;
+      Alcotest.test_case "invalid status" `Quick test_invalid_status_string;
+      Alcotest.test_case "invalid impact" `Quick test_invalid_impact_string;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- add the Phase-1A CDAL kernel surface already staged on this branch: typed verdicts, loader, judge, eval facade, and keeper wiring
- switch CDAL loader and proof artifact reads to OAS `Proof_store` read-side APIs
- stop legacy `cdal_eval` from classifying artifacts by suffix matching
- remove dangling friction test/module registrations from this kernel-only branch and add exact-subpath regression coverage

## Product impact
- none/internal

## Evidence
- `env DUNE_CACHE=disabled opam exec -- dune build --root . lib/cdal_loader.ml lib/proof_artifact_reader.ml lib/cdal_eval.ml lib/keeper/keeper_agent_run.ml test/test_cdal_types.exe test/test_cdal_loader.exe test/test_cdal_judge.exe test/test_cdal_eval_v1.exe test/test_cdal_eval.exe`
- `env DUNE_CACHE=disabled opam exec -- _build/default/test/test_cdal_types.exe`
- `env DUNE_CACHE=disabled opam exec -- _build/default/test/test_cdal_loader.exe`
- `env DUNE_CACHE=disabled opam exec -- _build/default/test/test_cdal_judge.exe`
- `env DUNE_CACHE=disabled opam exec -- _build/default/test/test_cdal_eval_v1.exe`
- `env DUNE_CACHE=disabled opam exec -- _build/default/test/test_cdal_eval.exe`

## Review evidence
- pending cross-model review

## Linked issue
- Relates #3588
- Relates #3595