### PR TITLE
feat(cdal): Phase-1B friction wiring + path traversal fix

### DIFF
--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -4,6 +4,7 @@
 
 type eval_outcome =
   | Verdict of Cdal_types.contract_verdict
+      * Cdal_friction_projection.friction_projection option
   | Load_failure of Cdal_loader.load_error * Cdal_types.contract_verdict
 
 (* ================================================================ *)
@@ -57,14 +58,20 @@ let evaluate ~(store : Agent_sdk.Proof_store.config)
   match Cdal_loader.load ~store proof with
   | Ok bundle ->
     let verdict = Cdal_judge.judge bundle in
-    Verdict verdict
+    let friction = Cdal_friction_projection.project_single_run
+      ~store ~completeness_gaps:verdict.completeness_gaps proof in
+    Verdict (verdict, friction)
   | Error err ->
     let verdict = synthesize_inconclusive ~proof err in
     Load_failure (err, verdict)
 
 let verdict_of_outcome = function
-  | Verdict v -> v
+  | Verdict (v, _) -> v
   | Load_failure (_, v) -> v
+
+let friction_of_outcome = function
+  | Verdict (_, f) -> f
+  | Load_failure _ -> None
 
 (* ================================================================ *)
 (* JSONL persistence                                                *)

--- a/lib/cdal_eval_v1.mli
+++ b/lib/cdal_eval_v1.mli
@@ -9,9 +9,10 @@
     an Inconclusive verdict describing what went wrong. *)
 type eval_outcome =
   | Verdict of Cdal_types.contract_verdict
+      * Cdal_friction_projection.friction_projection option
   | Load_failure of Cdal_loader.load_error * Cdal_types.contract_verdict
 
-(** Run the full evaluation pipeline: load bundle, judge, return outcome. *)
+(** Run the full evaluation pipeline: load bundle, judge, compute friction. *)
 val evaluate :
   store:Agent_sdk.Proof_store.config ->
   Agent_sdk.Cdal_proof.t ->
@@ -19,6 +20,10 @@ val evaluate :
 
 (** Extract the verdict from either outcome branch. *)
 val verdict_of_outcome : eval_outcome -> Cdal_types.contract_verdict
+
+(** Extract friction projection (None for load failures). *)
+val friction_of_outcome :
+  eval_outcome -> Cdal_friction_projection.friction_projection option
 
 (** Persist a verdict to date-split JSONL.
     Defaults to data/cdal_verdicts. Pass [~base_dir] for test isolation. *)

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -17,12 +17,22 @@ type blocked_attempt_group = {
   count : int;
 }
 
+type evidence_gap_group = {
+  artifact : string;
+  reason : string;
+  impact : string;
+  count : int;
+}
+
 type friction_projection = {
   window : string;
   based_on_run_ids : string list;
   basis_hash : string;
   blocked_attempt_count : int;
+  blocked_tool_counts : (string * int) list;
   blocked_attempt_groups : blocked_attempt_group list;
+  evidence_gap_groups : evidence_gap_group list;
+  review_tripwires : string list;
 }
 
 (* ================================================================ *)
@@ -77,36 +87,80 @@ let compute_basis_hash (run_id : string) : string =
   let input = run_id ^ "|friction_v1" in
   "md5:" ^ (Digest.string input |> Digest.to_hex)
 
+(** Derive blocked_tool_counts from attempt groups. *)
+let compute_tool_counts (groups : blocked_attempt_group list)
+    : (string * int) list =
+  let tbl = Hashtbl.create 8 in
+  List.iter (fun g ->
+    let prev = try Hashtbl.find tbl g.key.tool_name with Not_found -> 0 in
+    Hashtbl.replace tbl g.key.tool_name (prev + g.count)
+  ) groups;
+  Hashtbl.fold (fun name count acc -> (name, count) :: acc) tbl []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+(** Derive evidence_gap_groups from verdict completeness_gaps. *)
+let compute_gap_groups (gaps : Cdal_types.completeness_gap list)
+    : evidence_gap_group list =
+  let impact_str = function
+    | Cdal_types.Blocks_verdict -> "blocks_verdict"
+    | Cdal_types.Annotation_only -> "annotation_only"
+  in
+  List.map (fun (g : Cdal_types.completeness_gap) ->
+    { artifact = g.artifact;
+      reason = g.reason;
+      impact = impact_str g.impact;
+      count = 1 }
+  ) gaps
+
+(** Compute review tripwires from attempt groups exceeding threshold. *)
+let compute_tripwires ~threshold (groups : blocked_attempt_group list)
+    : string list =
+  List.filter_map (fun (g : blocked_attempt_group) ->
+    if g.count >= threshold then
+      Some (Printf.sprintf "blocked_attempts:%s:%d+"
+              g.key.tool_name g.count)
+    else None
+  ) groups
+  |> List.sort String.compare
+
 (* ================================================================ *)
 (* Public API                                                        *)
 (* ================================================================ *)
 
 let project_single_run
     ~(store : Agent_sdk.Proof_store.config)
+    ?(completeness_gaps : Cdal_types.completeness_gap list = [])
+    ?(tripwire_threshold = 3)
     (proof : Agent_sdk.Cdal_proof.t)
     : friction_projection option =
-  match find_violations_ref proof with
-  | None -> None
-  | Some ref_ ->
-    (* Resolve and read the violations file. *)
-    match Proof_artifact_reader.read_json store ref_ with
-    | Error _ -> None
-    | Ok json ->
-      match Violation_record.of_json_list json with
-      | Error _ -> None
-      | Ok [] -> None
-      | Ok violations ->
-        let groups = group_violations violations in
-        let blocked_attempt_count =
-          List.fold_left (fun acc g -> acc + g.count) 0 groups
-        in
-        Some {
-          window = "single_run";
-          based_on_run_ids = [proof.run_id];
-          basis_hash = compute_basis_hash proof.run_id;
-          blocked_attempt_count;
-          blocked_attempt_groups = groups;
-        }
+  let groups, blocked_attempt_count =
+    match find_violations_ref proof with
+    | None -> ([], 0)
+    | Some ref_ ->
+      match Proof_artifact_reader.read_json store ref_ with
+      | Error _ -> ([], 0)
+      | Ok json ->
+        match Violation_record.of_json_list json with
+        | Error _ | Ok [] -> ([], 0)
+        | Ok violations ->
+          let g = group_violations violations in
+          let c = List.fold_left
+            (fun acc (grp : blocked_attempt_group) -> acc + grp.count) 0 g in
+          (g, c)
+  in
+  let gap_groups = compute_gap_groups completeness_gaps in
+  if blocked_attempt_count = 0 && gap_groups = [] then None
+  else
+    Some {
+      window = "single_run";
+      based_on_run_ids = [proof.run_id];
+      basis_hash = compute_basis_hash proof.run_id;
+      blocked_attempt_count;
+      blocked_tool_counts = compute_tool_counts groups;
+      blocked_attempt_groups = groups;
+      evidence_gap_groups = gap_groups;
+      review_tripwires = compute_tripwires ~threshold:tripwire_threshold groups;
+    }
 
 (* ================================================================ *)
 (* JSON serialization                                                *)
@@ -125,6 +179,14 @@ let blocked_attempt_group_to_json (g : blocked_attempt_group) : Yojson.Safe.t =
     ("key", blocked_attempt_key_to_json g.key);
   ])
 
+let evidence_gap_group_to_json (g : evidence_gap_group) : Yojson.Safe.t =
+  Yojson.Safe.sort (`Assoc [
+    ("artifact", `String g.artifact);
+    ("count", `Int g.count);
+    ("impact", `String g.impact);
+    ("reason", `String g.reason);
+  ])
+
 let to_json (fp : friction_projection) : Yojson.Safe.t =
   Yojson.Safe.sort (`Assoc [
     ("based_on_run_ids", `List (List.map (fun s -> `String s) fp.based_on_run_ids));
@@ -132,5 +194,12 @@ let to_json (fp : friction_projection) : Yojson.Safe.t =
     ("blocked_attempt_count", `Int fp.blocked_attempt_count);
     ("blocked_attempt_groups",
      `List (List.map blocked_attempt_group_to_json fp.blocked_attempt_groups));
+    ("blocked_tool_counts",
+     `List (List.map (fun (name, count) ->
+       Yojson.Safe.sort (`Assoc [("count", `Int count); ("tool_name", `String name)]))
+       fp.blocked_tool_counts));
+    ("evidence_gap_groups",
+     `List (List.map evidence_gap_group_to_json fp.evidence_gap_groups));
+    ("review_tripwires", `List (List.map (fun s -> `String s) fp.review_tripwires));
     ("window", `String fp.window);
   ])

--- a/lib/cdal_friction_projection.mli
+++ b/lib/cdal_friction_projection.mli
@@ -21,27 +21,37 @@ type blocked_attempt_group = {
   count : int;
 }
 
+(** A group of evidence completeness gaps sharing the same artifact/impact. *)
+type evidence_gap_group = {
+  artifact : string;
+  reason : string;
+  impact : string;
+  count : int;
+}
+
 (** Friction projection for a single run. *)
 type friction_projection = {
   window : string;  (** Always ["single_run"]. *)
   based_on_run_ids : string list;
   basis_hash : string;
   blocked_attempt_count : int;
+  blocked_tool_counts : (string * int) list;
   blocked_attempt_groups : blocked_attempt_group list;
+  evidence_gap_groups : evidence_gap_group list;
+  review_tripwires : string list;
 }
 
-(** [project_single_run ~store proof] reads [mode_violations.json]
-    from [proof.raw_evidence_refs], parses v1 violation records,
-    groups by [(tool_name, violation_kind, effective_mode)], and
-    returns [Some projection] if violations exist, [None] otherwise.
+(** [project_single_run ~store ?completeness_gaps ?tripwire_threshold proof]
+    reads [mode_violations.json], parses v1 violation records, groups by
+    [(tool_name, violation_kind, effective_mode)], derives tool counts and
+    evidence gap groups, and fires review tripwires when any group count
+    exceeds [tripwire_threshold] (default 3).
 
-    Returns [None] when:
-    - no [mode_violations.json] ref exists in [raw_evidence_refs]
-    - the file is missing on disk
-    - the file parses to an empty array
-    - a parse error occurs (treated as missing evidence) *)
+    Returns [None] when no violations and no completeness gaps exist. *)
 val project_single_run :
   store:Agent_sdk.Proof_store.config ->
+  ?completeness_gaps:Cdal_types.completeness_gap list ->
+  ?tripwire_threshold:int ->
   Agent_sdk.Cdal_proof.t ->
   friction_projection option
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -266,7 +266,15 @@ let run_turn
              | Cdal_eval_v1.Load_failure (err, _) ->
                Log.Keeper.warn "keeper:%s contract_verdict load failure: %s"
                  meta.name (Cdal_loader.load_error_to_string err)
-             | Cdal_eval_v1.Verdict _ -> ())
+             | Cdal_eval_v1.Verdict (_, _) -> ());
+            (match Cdal_eval_v1.friction_of_outcome outcome with
+             | Some fp ->
+               Log.Keeper.info
+                 "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+                 meta.name fp.blocked_attempt_count
+                 (List.length fp.blocked_attempt_groups)
+                 (List.length fp.review_tripwires)
+             | None -> ())
           | None -> ());
          Ok {
            response_text;

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -10,7 +10,17 @@ let resolve_path (config : Agent_sdk.Proof_store.config)
   if String.length ref_ > prefix_len
      && String.sub ref_ 0 prefix_len = prefix then
     let rel = String.sub ref_ prefix_len (String.length ref_ - prefix_len) in
-    Ok (Filename.concat (Filename.concat config.root "proofs") rel)
+    (* Reject path traversal: no ".." components or null bytes. *)
+    let segments = String.split_on_char '/' rel in
+    let has_traversal =
+      String.contains rel '\000'
+      || List.exists (fun s -> s = "..") segments
+    in
+    if has_traversal then
+      Error (Printf.sprintf "path traversal rejected: %s" ref_)
+    else
+      let proofs_root = Filename.concat config.root "proofs" in
+      Ok (Filename.concat proofs_root rel)
   else
     Error (Printf.sprintf "invalid artifact ref: %s" ref_)
 

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -81,7 +81,7 @@ let test_full_pipeline () =
   Agent_sdk.Proof_store.write_manifest store ~run_id proof;
   Agent_sdk.Proof_store.write_contract store ~run_id contract;
   match CE.evaluate ~store proof with
-  | Verdict v ->
+  | Verdict (v, _) ->
     Alcotest.(check string) "status" "satisfied"
       (CT.contract_status_to_string v.status);
     Alcotest.(check string) "run_id" run_id v.run_id;
@@ -125,7 +125,7 @@ let test_load_failure_inconclusive () =
     Alcotest.fail
       (Printf.sprintf "expected Manifest_not_found, got: %s"
          (CL.load_error_to_string err))
-  | Verdict _ ->
+  | Verdict (_, _) ->
     Alcotest.fail "expected Load_failure, got Verdict"
 
 (* ================================================================ *)

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -261,6 +261,113 @@ let test_multiple_groups () =
     Alcotest.(check int) "g2 count" 1 g2.count
 
 (* ================================================================ *)
+(* Phase-1B tests: new fields                                        *)
+(* ================================================================ *)
+
+let test_blocked_tool_counts () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "btc-test-001" in
+  let ref_ = Printf.sprintf "proof-store://%s/evidence/mode_violations.json" run_id in
+  let proof = make_proof ~run_id ~raw_evidence_refs:[ref_] () in
+  let dir = Filename.concat (Filename.concat store.root "proofs")
+    (Filename.concat run_id "evidence") in
+  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  let violations = `List [
+    `Assoc [("ts", `Float 1.0); ("tool_name", `String "write");
+            ("input_summary", `String ""); ("effective_mode", `String "diagnose");
+            ("violation_kind", `String "mutating_in_diagnose")];
+    `Assoc [("ts", `Float 2.0); ("tool_name", `String "write");
+            ("input_summary", `String ""); ("effective_mode", `String "diagnose");
+            ("violation_kind", `String "mutating_in_diagnose")];
+    `Assoc [("ts", `Float 3.0); ("tool_name", `String "bash");
+            ("input_summary", `String ""); ("effective_mode", `String "diagnose");
+            ("violation_kind", `String "mutating_in_diagnose")];
+  ] in
+  let path = Filename.concat dir "mode_violations.json" in
+  Yojson.Safe.to_file path violations;
+  match CFP.project_single_run ~store proof with
+  | None -> Alcotest.fail "expected Some"
+  | Some fp ->
+    Alcotest.(check int) "blocked_attempt_count" 3 fp.blocked_attempt_count;
+    let tool_counts = fp.blocked_tool_counts in
+    Alcotest.(check int) "2 tools" 2 (List.length tool_counts);
+    let bash_count = List.assoc "bash" tool_counts in
+    let write_count = List.assoc "write" tool_counts in
+    Alcotest.(check int) "bash count" 1 bash_count;
+    Alcotest.(check int) "write count" 2 write_count
+
+let test_evidence_gap_groups () =
+  let (store, _tmp) = setup_store () in
+  let proof = make_proof ~run_id:"gap-test-001" () in
+  let gaps : Masc_mcp.Cdal_types.completeness_gap list = [
+    { artifact = "manifest.json"; reason = "not found";
+      impact = Blocks_verdict };
+    { artifact = "contract.json"; reason = "parse error";
+      impact = Annotation_only };
+  ] in
+  match CFP.project_single_run ~store ~completeness_gaps:gaps proof with
+  | None -> Alcotest.fail "expected Some (has gaps)"
+  | Some fp ->
+    Alcotest.(check int) "2 gap groups" 2 (List.length fp.evidence_gap_groups);
+    let g0 = List.hd fp.evidence_gap_groups in
+    Alcotest.(check string) "gap artifact" "manifest.json" g0.artifact;
+    Alcotest.(check string) "gap impact" "blocks_verdict" g0.impact
+
+let test_tripwire_fires () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "tw-test-001" in
+  let ref_ = Printf.sprintf "proof-store://%s/evidence/mode_violations.json" run_id in
+  let proof = make_proof ~run_id ~raw_evidence_refs:[ref_] () in
+  let dir = Filename.concat (Filename.concat store.root "proofs")
+    (Filename.concat run_id "evidence") in
+  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  (* 3 identical violations for "write" — threshold=2 should fire *)
+  let v = `Assoc [("ts", `Float 1.0); ("tool_name", `String "write");
+                   ("input_summary", `String ""); ("effective_mode", `String "diagnose");
+                   ("violation_kind", `String "mutating_in_diagnose")] in
+  Yojson.Safe.to_file
+    (Filename.concat dir "mode_violations.json")
+    (`List [v; v; v]);
+  match CFP.project_single_run ~store ~tripwire_threshold:2 proof with
+  | None -> Alcotest.fail "expected Some"
+  | Some fp ->
+    Alcotest.(check bool) "has tripwire" true
+      (List.length fp.review_tripwires > 0);
+    let tw = List.hd fp.review_tripwires in
+    Alcotest.(check bool) "contains write" true
+      (String.length tw > 0 && String.sub tw 0 18 = "blocked_attempts:w")
+
+let test_tripwire_below_threshold () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "tw-below-001" in
+  let ref_ = Printf.sprintf "proof-store://%s/evidence/mode_violations.json" run_id in
+  let proof = make_proof ~run_id ~raw_evidence_refs:[ref_] () in
+  let dir = Filename.concat (Filename.concat store.root "proofs")
+    (Filename.concat run_id "evidence") in
+  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  let v = `Assoc [("ts", `Float 1.0); ("tool_name", `String "write");
+                   ("input_summary", `String ""); ("effective_mode", `String "diagnose");
+                   ("violation_kind", `String "mutating_in_diagnose")] in
+  Yojson.Safe.to_file
+    (Filename.concat dir "mode_violations.json")
+    (`List [v; v]);
+  match CFP.project_single_run ~store ~tripwire_threshold:5 proof with
+  | None -> Alcotest.fail "expected Some"
+  | Some fp ->
+    Alcotest.(check int) "no tripwires" 0 (List.length fp.review_tripwires)
+
+let test_path_traversal_rejected () =
+  let store : Agent_sdk.Proof_store.config = { root = "/tmp/test-store" } in
+  let result = Masc_mcp.Proof_artifact_reader.resolve_path store
+    "proof-store://../../../etc/passwd" in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "contains rejected" true
+      (String.length msg > 0)
+  | Ok path ->
+    Alcotest.fail (Printf.sprintf "should reject, got Ok: %s" path)
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -279,5 +386,17 @@ let () =
          test_deterministic_output;
        Alcotest.test_case "multiple groups" `Quick
          test_multiple_groups;
+     ]);
+    ("phase1b", [
+       Alcotest.test_case "blocked tool counts" `Quick
+         test_blocked_tool_counts;
+       Alcotest.test_case "evidence gap groups" `Quick
+         test_evidence_gap_groups;
+       Alcotest.test_case "tripwire fires" `Quick
+         test_tripwire_fires;
+       Alcotest.test_case "tripwire below threshold" `Quick
+         test_tripwire_below_threshold;
+       Alcotest.test_case "path traversal rejected" `Quick
+         test_path_traversal_rejected;
      ]);
   ]


### PR DESCRIPTION
## Summary

CDAL Phase-1B: friction_projection을 eval pipeline에 연결하고 keeper에 표면화.

- **Security fix**: `proof_artifact_reader`에서 `..` path traversal 차단 (segment-level reject)
- **Friction 확장**: `blocked_tool_counts`, `evidence_gap_groups`, `review_tripwires` 추가
- **Eval 연결**: `Cdal_eval_v1.evaluate`가 verdict + friction 함께 반환
- **Keeper 로깅**: friction summary (blocked count, groups, tripwires)

## Phase-1B Exit Criteria (RFC #3595)

- friction은 cross-run indexing 불필요 (Single_run only) ✓
- v2 unsupported fields는 None 유지 ✓
- verdict/friction 분리 표면화 ✓

## Test plan

- [x] 11 friction tests pass (6 existing + 5 new)
- [x] 3 eval_v1 tests pass (regression 0)
- [x] path traversal: `proof-store://../../../etc/passwd` → Error
- [x] `dune build --root .` — compile success