### PR TITLE
fix(ci): preserve manually-set area/target labels in issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -107,6 +107,9 @@ jobs:
             const selectedTarget = targetMap[extractHeadingValue(body, "Target lane").toLowerCase()];
             const hasProductGap = headingHasCheckedBox(body, "Product gap");
 
+            const existingAreas = [...labelNames].filter((n) => n.startsWith("area:"));
+            const existingTargets = [...labelNames].filter((n) => n.startsWith("target:"));
+
             const nextLabels = new Set(
               [...labelNames].filter((name) =>
                 !name.startsWith("area:") &&
@@ -116,8 +119,16 @@ jobs:
               )
             );
 
-            if (selectedArea) nextLabels.add(selectedArea);
-            if (selectedTarget) nextLabels.add(selectedTarget);
+            if (selectedArea) {
+              nextLabels.add(selectedArea);
+            } else {
+              existingAreas.forEach((a) => nextLabels.add(a));
+            }
+            if (selectedTarget) {
+              nextLabels.add(selectedTarget);
+            } else {
+              existingTargets.forEach((t) => nextLabels.add(t));
+            }
             if (hasProductGap) nextLabels.add("product-gap");
 
             const typeMatches = [...nextLabels].filter((name) => name.startsWith("type:"));


### PR DESCRIPTION
## Summary
- Triage bot이 수동 추가된 `area:*`/`target:*` 라벨을 무조건 제거하는 버그 수정
- Body heading이 있으면 override, 없으면 기존 수동 라벨 보존
- 이슈 bulk triage (`gh issue edit --add-label`) 작업을 가능하게 함

## Context
26개 이슈를 `target:now/next/later`로 재분류하는 과정에서 발견. `labeled` 이벤트가 bot을 트리거하면 body에 `### Target lane` heading이 없는 이슈에서 수동 라벨이 날아감.

## Test plan
- [ ] 이 PR merge 후 `gh issue edit --add-label "target:now"` 실행 시 라벨 유지 확인
- [ ] Issue template로 생성된 이슈에서 body heading이 라벨을 override하는 기존 동작 유지 확인

Generated with [Claude Code](https://claude.com/claude-code)