### PR TITLE
feat(cdal): labeling protocol v0 freeze + types + CLI + tests

### DIFF
--- a/bin/cdal_label.ml
+++ b/bin/cdal_label.ml
@@ -1,0 +1,162 @@
+(** cdal-label — CDAL labeling protocol v0 CLI.
+
+    Subcommands:
+    - [apply]: read verdict JSON, apply label, write labeled verdict
+    - [metrics]: read labeled verdicts, compute output contract *)
+
+module CT = Masc_mcp.Cdal_types
+module L = Masc_mcp.Labeling
+
+let read_json_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let s = Bytes.create n in
+  really_input ic s 0 n;
+  close_in ic;
+  Yojson.Safe.from_string (Bytes.to_string s)
+
+let write_json_file path json =
+  let oc = open_out path in
+  output_string oc (Yojson.Safe.pretty_to_string json);
+  output_char oc '\n';
+  close_out oc
+
+(* ================================================================ *)
+(* apply subcommand                                                  *)
+(* ================================================================ *)
+
+let apply_cmd verdict_path label_str labeler note output_path =
+  let json = read_json_file verdict_path in
+  match CT.contract_verdict_of_json json with
+  | Error e ->
+    Printf.eprintf "error parsing verdict: %s\n" e;
+    exit 1
+  | Ok verdict -> (
+    match L.label_of_string label_str with
+    | Error e ->
+      Printf.eprintf "error: %s\n" e;
+      exit 1
+    | Ok label ->
+      let now =
+        let t = Unix.gettimeofday () in
+        let tm = Unix.gmtime t in
+        Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+          (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+          tm.tm_hour tm.tm_min tm.tm_sec
+      in
+      let lv : L.labeled_verdict =
+        { verdict; label; labeler; note; labeled_at = now }
+      in
+      let out_json = L.labeled_verdict_to_json lv in
+      (match output_path with
+       | Some path ->
+         write_json_file path out_json;
+         Printf.printf "labeled verdict written to %s\n" path
+       | None ->
+         print_endline (Yojson.Safe.pretty_to_string out_json)))
+
+(* ================================================================ *)
+(* metrics subcommand                                                *)
+(* ================================================================ *)
+
+let collect_labeled_verdicts dir =
+  let entries = Sys.readdir dir in
+  Array.to_list entries
+  |> List.filter (fun f -> Filename.check_suffix f ".json")
+  |> List.sort String.compare
+  |> List.filter_map (fun f ->
+       let path = Filename.concat dir f in
+       let json = read_json_file path in
+       match L.labeled_verdict_of_json json with
+       | Ok lv -> Some lv
+       | Error e ->
+         Printf.eprintf "warning: skipping %s: %s\n" f e;
+         None)
+
+let metrics_cmd input_dir workload_name judge_version label_owner
+    metric_owner total_claims drift_note =
+  let verdicts = collect_labeled_verdicts input_dir in
+  if verdicts = [] then (
+    Printf.eprintf "no labeled verdicts found in %s\n" input_dir;
+    exit 1);
+  let oc =
+    L.build_output_contract ~workload_name
+      ~judge_protocol_version:judge_version ~label_owner ~metric_owner
+      ~total_claims ~drift_note verdicts
+  in
+  print_endline (Yojson.Safe.pretty_to_string (L.output_contract_to_json oc))
+
+(* ================================================================ *)
+(* Cmdliner setup                                                    *)
+(* ================================================================ *)
+
+open Cmdliner
+
+let verdict_path_arg =
+  let doc = "Path to verdict JSON file." in
+  Arg.(required & pos 0 (some file) None & info [] ~docv:"VERDICT" ~doc)
+
+let label_arg =
+  let doc = "Label to apply: supported, unsupported, ambiguous, drift." in
+  Arg.(required & opt (some string) None & info [ "label"; "l" ] ~docv:"LABEL" ~doc)
+
+let labeler_arg =
+  let doc = "Labeler identifier (e.g. human:alice)." in
+  Arg.(required & opt (some string) None & info [ "labeler" ] ~docv:"LABELER" ~doc)
+
+let note_arg =
+  let doc = "Optional labeling note." in
+  Arg.(value & opt (some string) None & info [ "note"; "n" ] ~docv:"NOTE" ~doc)
+
+let output_arg =
+  let doc = "Output file path (stdout if omitted)." in
+  Arg.(value & opt (some string) None & info [ "output"; "o" ] ~docv:"OUTPUT" ~doc)
+
+let apply_term =
+  let doc = "Apply a label to a verdict." in
+  let info = Cmd.info "apply" ~doc in
+  Cmd.v info
+    Term.(const apply_cmd $ verdict_path_arg $ label_arg $ labeler_arg $ note_arg $ output_arg)
+
+let input_dir_arg =
+  let doc = "Directory containing labeled verdict JSON files." in
+  Arg.(required & opt (some dir) None & info [ "input-dir"; "d" ] ~docv:"DIR" ~doc)
+
+let workload_arg =
+  let doc = "Workload name." in
+  Arg.(required & opt (some string) None & info [ "workload"; "w" ] ~docv:"NAME" ~doc)
+
+let judge_version_arg =
+  let doc = "Judge protocol version." in
+  Arg.(value & opt string "v0" & info [ "judge-version" ] ~docv:"VERSION" ~doc)
+
+let label_owner_arg =
+  let doc = "Label owner." in
+  Arg.(required & opt (some string) None & info [ "label-owner" ] ~docv:"OWNER" ~doc)
+
+let metric_owner_arg =
+  let doc = "Metric owner." in
+  Arg.(required & opt (some string) None & info [ "metric-owner" ] ~docv:"OWNER" ~doc)
+
+let total_claims_arg =
+  let doc = "Total material claims count." in
+  Arg.(required & opt (some int) None & info [ "total-claims" ] ~docv:"N" ~doc)
+
+let drift_note_arg =
+  let doc = "Drift note." in
+  Arg.(value & opt string "" & info [ "drift-note" ] ~docv:"NOTE" ~doc)
+
+let metrics_term =
+  let doc = "Compute output contract metrics from labeled verdicts." in
+  let info = Cmd.info "metrics" ~doc in
+  Cmd.v info
+    Term.(
+      const metrics_cmd $ input_dir_arg $ workload_arg $ judge_version_arg
+      $ label_owner_arg $ metric_owner_arg $ total_claims_arg $ drift_note_arg)
+
+let main_cmd =
+  let doc = "CDAL labeling protocol v0 CLI." in
+  let info = Cmd.info "cdal-label" ~version:"v0" ~doc in
+  Cmd.group info [ apply_term; metrics_term ]
+
+let () = exit (Cmd.eval main_cmd)

--- a/bin/dune
+++ b/bin/dune
@@ -28,3 +28,11 @@
  (public_name masc-tui)
  (package masc_mcp)
  (libraries masc_mcp masc_mcp.config unix yojson))
+
+;; CDAL Labeling Protocol v0 CLI
+(executable
+ (name cdal_label)
+ (modules cdal_label)
+ (public_name cdal-label)
+ (package masc_mcp)
+ (libraries masc_mcp cmdliner yojson unix))

--- a/docs/design/contract-driven-agent-loop-labeling-protocol.md
+++ b/docs/design/contract-driven-agent-loop-labeling-protocol.md
@@ -1,6 +1,7 @@
 # Contract-Driven Agent Loop Labeling Protocol
 
-**Status**: Draft
+**Version**: v0
+**Status**: v0-frozen (2026-03-29)
 **Related RFC**: [Contract-Driven Agent Loop RFC](./contract-driven-agent-loop-rfc.md)
 
 이 문서는 `evidence_precision`, `unsupported_claim_penalty`, `false_positive_risk_flag_rate`, `false_negative_escape_rate`를 일관되게 계산하기 위한 최소 labeling / judging 운영 규칙을 정의한다.

--- a/fixtures/cdal/sample_verdict.json
+++ b/fixtures/cdal/sample_verdict.json
@@ -1,0 +1,20 @@
+{
+  "run_id": "test-run-fixture-1",
+  "contract_id": "md5:fixture123",
+  "claim_scope": "phase1_scoped_runtime_audit",
+  "judgment_basis_hash": "sha256:basis",
+  "judgment_hash": "sha256:judgment",
+  "loader_semantics_version": "phase1a_v1",
+  "schema_compat_mode": "proof_bundle_v1",
+  "status": "satisfied",
+  "findings": [],
+  "completeness_gaps": [],
+  "check_results": [
+    {
+      "check_id": "runtime.requested_execution_mode",
+      "status": "satisfied",
+      "findings": [],
+      "completeness_gaps": []
+    }
+  ]
+}

--- a/lib/cdal/labeling.ml
+++ b/lib/cdal/labeling.ml
@@ -1,0 +1,174 @@
+(** Labeling — CDAL labeling protocol v0 types and metrics.
+
+    @since CDAL Labeling Protocol v0 *)
+
+(* ================================================================ *)
+(* Core types                                                        *)
+(* ================================================================ *)
+
+type label =
+  | Supported
+  | Unsupported
+  | Ambiguous
+  | Drift
+
+type labeled_verdict = {
+  verdict : Cdal_types.contract_verdict;
+  label : label;
+  labeler : string;
+  note : string option;
+  labeled_at : string;
+}
+
+type confusion_summary = {
+  supported : int;
+  unsupported : int;
+  ambiguous : int;
+  drift : int;
+}
+
+type output_contract = {
+  workload_name : string;
+  judge_protocol_version : string;
+  label_owner : string;
+  metric_owner : string;
+  confusion : confusion_summary;
+  claim_coverage : float;
+  precision_strict : float;
+  precision_lenient : float;
+  drift_note : string;
+}
+
+(* ================================================================ *)
+(* String conversions                                                *)
+(* ================================================================ *)
+
+let label_to_string = function
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Ambiguous -> "ambiguous"
+  | Drift -> "drift"
+
+let label_of_string = function
+  | "supported" -> Ok Supported
+  | "unsupported" -> Ok Unsupported
+  | "ambiguous" -> Ok Ambiguous
+  | "drift" -> Ok Drift
+  | s -> Error (Printf.sprintf "unknown label: %s" s)
+
+(* ================================================================ *)
+(* Metrics — protocol Section 3                                      *)
+(* ================================================================ *)
+
+let compute_confusion (verdicts : labeled_verdict list) =
+  List.fold_left
+    (fun acc v ->
+      match v.label with
+      | Supported -> { acc with supported = acc.supported + 1 }
+      | Unsupported -> { acc with unsupported = acc.unsupported + 1 }
+      | Ambiguous -> { acc with ambiguous = acc.ambiguous + 1 }
+      | Drift -> { acc with drift = acc.drift + 1 })
+    { supported = 0; unsupported = 0; ambiguous = 0; drift = 0 }
+    verdicts
+
+let compute_precision_strict (c : confusion_summary) =
+  let denom = c.supported + c.unsupported + c.ambiguous in
+  if denom = 0 then 0.0
+  else float_of_int c.supported /. float_of_int denom
+
+let compute_precision_lenient (c : confusion_summary) =
+  let denom = c.supported + c.unsupported in
+  if denom = 0 then 0.0
+  else float_of_int c.supported /. float_of_int denom
+
+let compute_claim_coverage ~labeled ~total =
+  if total = 0 then 0.0
+  else float_of_int labeled /. float_of_int total
+
+let build_output_contract ~workload_name ~judge_protocol_version
+    ~label_owner ~metric_owner ~total_claims ~drift_note verdicts =
+  let confusion = compute_confusion verdicts in
+  let labeled_non_drift =
+    confusion.supported + confusion.unsupported + confusion.ambiguous
+  in
+  {
+    workload_name;
+    judge_protocol_version;
+    label_owner;
+    metric_owner;
+    confusion;
+    claim_coverage =
+      compute_claim_coverage ~labeled:labeled_non_drift ~total:total_claims;
+    precision_strict = compute_precision_strict confusion;
+    precision_lenient = compute_precision_lenient confusion;
+    drift_note;
+  }
+
+(* ================================================================ *)
+(* JSON serialization                                                *)
+(* ================================================================ *)
+
+let label_to_json l = `String (label_to_string l)
+
+let labeled_verdict_to_json v =
+  `Assoc
+    [
+      ("verdict", Cdal_types.contract_verdict_to_json v.verdict);
+      ("label", label_to_json v.label);
+      ("labeler", `String v.labeler);
+      ( "note",
+        match v.note with
+        | Some n -> `String n
+        | None -> `Null );
+      ("labeled_at", `String v.labeled_at);
+    ]
+
+let labeled_verdict_of_json = function
+  | `Assoc fields -> (
+    let open Result in
+    match
+      ( List.assoc_opt "verdict" fields,
+        List.assoc_opt "label" fields,
+        List.assoc_opt "labeler" fields,
+        List.assoc_opt "labeled_at" fields )
+    with
+    | Some verdict_json, Some (`String label_str), Some (`String labeler),
+      Some (`String labeled_at) -> (
+      match
+        ( Cdal_types.contract_verdict_of_json verdict_json,
+          label_of_string label_str )
+      with
+      | Ok verdict, Ok label ->
+        let note =
+          match List.assoc_opt "note" fields with
+          | Some (`String n) -> Some n
+          | _ -> None
+        in
+        Ok { verdict; label; labeler; note; labeled_at }
+      | Error e, _ -> Error (Printf.sprintf "verdict: %s" e)
+      | _, Error e -> Error (Printf.sprintf "label: %s" e))
+    | _ -> Error "missing or invalid fields in labeled_verdict")
+  | _ -> Error "labeled_verdict: expected JSON object"
+
+let confusion_summary_to_json c =
+  `Assoc
+    [
+      ("supported", `Int c.supported);
+      ("unsupported", `Int c.unsupported);
+      ("ambiguous", `Int c.ambiguous);
+      ("drift", `Int c.drift);
+    ]
+
+let output_contract_to_json oc =
+  `Assoc
+    [
+      ("workload_name", `String oc.workload_name);
+      ("judge_protocol_version", `String oc.judge_protocol_version);
+      ("label_owner", `String oc.label_owner);
+      ("metric_owner", `String oc.metric_owner);
+      ("confusion", confusion_summary_to_json oc.confusion);
+      ("claim_coverage", `Float oc.claim_coverage);
+      ("precision_strict", `Float oc.precision_strict);
+      ("precision_lenient", `Float oc.precision_lenient);
+      ("drift_note", `String oc.drift_note);
+    ]

--- a/lib/cdal/labeling.mli
+++ b/lib/cdal/labeling.mli
@@ -1,0 +1,80 @@
+(** Labeling — CDAL labeling protocol v0 types and metrics.
+
+    Implements Section 2 (core labels), Section 3 (precision definitions),
+    and Section 7 (output contract) of the labeling protocol.
+
+    @see docs/design/contract-driven-agent-loop-labeling-protocol.md *)
+
+(** Core label per protocol Section 2. *)
+type label =
+  | Supported
+  | Unsupported
+  | Ambiguous
+  | Drift
+
+(** A human-labeled verdict. *)
+type labeled_verdict = {
+  verdict : Cdal_types.contract_verdict;
+  label : label;
+  labeler : string;
+  note : string option;
+  labeled_at : string;
+}
+
+(** Confusion matrix counts per protocol Section 7. *)
+type confusion_summary = {
+  supported : int;
+  unsupported : int;
+  ambiguous : int;
+  drift : int;
+}
+
+(** Output contract per protocol Section 7. *)
+type output_contract = {
+  workload_name : string;
+  judge_protocol_version : string;
+  label_owner : string;
+  metric_owner : string;
+  confusion : confusion_summary;
+  claim_coverage : float;
+  precision_strict : float;
+  precision_lenient : float;
+  drift_note : string;
+}
+
+(** {2 String conversions} *)
+
+val label_to_string : label -> string
+val label_of_string : string -> (label, string) result
+
+(** {2 Metrics — protocol Section 3} *)
+
+val compute_confusion : labeled_verdict list -> confusion_summary
+
+(** [supported / (supported + unsupported + ambiguous)]. Drift excluded. *)
+val compute_precision_strict : confusion_summary -> float
+
+(** [supported / (supported + unsupported)]. Ambiguous and drift excluded. *)
+val compute_precision_lenient : confusion_summary -> float
+
+(** [labeled / total]. *)
+val compute_claim_coverage : labeled:int -> total:int -> float
+
+(** Build a complete output contract from labeled verdicts. *)
+val build_output_contract :
+  workload_name:string ->
+  judge_protocol_version:string ->
+  label_owner:string ->
+  metric_owner:string ->
+  total_claims:int ->
+  drift_note:string ->
+  labeled_verdict list ->
+  output_contract
+
+(** {2 JSON serialization} *)
+
+val label_to_json : label -> Yojson.Safe.t
+val labeled_verdict_to_json : labeled_verdict -> Yojson.Safe.t
+val labeled_verdict_of_json : Yojson.Safe.t -> (labeled_verdict, string) result
+val confusion_summary_to_json : confusion_summary -> Yojson.Safe.t
+val output_contract_to_json : output_contract -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -475,6 +475,7 @@
    artifact_store
    golden_set
    adversarial_eval
+   labeling
    contract_risk
    contract_composer
    keeper_deliberation

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_artifact_store
         test_golden_set
         test_adversarial_eval
+        test_labeling
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -91,6 +92,7 @@
           test_artifact_store
           test_golden_set
           test_adversarial_eval
+          test_labeling
   )
  (libraries masc_mcp masc_mcp.team_session_types agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_labeling.ml
+++ b/test/test_labeling.ml
@@ -1,0 +1,226 @@
+open Alcotest
+
+module CT = Masc_mcp.Cdal_types
+module L = Masc_mcp.Labeling
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let check_float msg expected actual =
+  let epsilon = 0.001 in
+  if Float.abs (expected -. actual) > epsilon then
+    fail (Printf.sprintf "%s: expected %.4f, got %.4f" msg expected actual)
+
+let dummy_verdict ?(status = CT.Satisfied) () : CT.contract_verdict =
+  {
+    run_id = "test-run-1";
+    contract_id = "test-contract-1";
+    claim_scope = CT.claim_scope_phase1;
+    judgment_basis_hash = "basis-hash";
+    judgment_hash = "judgment-hash";
+    loader_semantics_version = CT.loader_semantics_version_phase1;
+    schema_compat_mode = CT.schema_compat_mode_v1;
+    status;
+    findings = [];
+    completeness_gaps = [];
+    check_results = [];
+  }
+
+let make_lv label : L.labeled_verdict =
+  {
+    verdict = dummy_verdict ();
+    label;
+    labeler = "human:test";
+    note = None;
+    labeled_at = "2026-03-29T00:00:00Z";
+  }
+
+(* ================================================================ *)
+(* label string round-trip                                           *)
+(* ================================================================ *)
+
+let test_label_roundtrip () =
+  let labels = [ L.Supported; L.Unsupported; L.Ambiguous; L.Drift ] in
+  List.iter
+    (fun l ->
+      let s = L.label_to_string l in
+      match L.label_of_string s with
+      | Ok l' ->
+        check string "round-trip" (L.label_to_string l) (L.label_to_string l')
+      | Error e -> fail (Printf.sprintf "label_of_string failed: %s" e))
+    labels
+
+let test_label_of_string_invalid () =
+  match L.label_of_string "garbage" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error for invalid label"
+
+(* ================================================================ *)
+(* confusion summary                                                 *)
+(* ================================================================ *)
+
+let test_compute_confusion () =
+  let verdicts =
+    List.map make_lv
+      [ L.Supported; L.Supported; L.Supported;
+        L.Unsupported; L.Unsupported;
+        L.Ambiguous;
+        L.Drift ]
+  in
+  let c = L.compute_confusion verdicts in
+  check int "supported" 3 c.supported;
+  check int "unsupported" 2 c.unsupported;
+  check int "ambiguous" 1 c.ambiguous;
+  check int "drift" 1 c.drift
+
+let test_compute_confusion_empty () =
+  let c = L.compute_confusion [] in
+  check int "supported" 0 c.supported;
+  check int "unsupported" 0 c.unsupported;
+  check int "ambiguous" 0 c.ambiguous;
+  check int "drift" 0 c.drift
+
+(* ================================================================ *)
+(* precision metrics                                                 *)
+(* ================================================================ *)
+
+let test_precision_strict () =
+  (* 15 / (15 + 3 + 2) = 0.75 *)
+  let c : L.confusion_summary =
+    { supported = 15; unsupported = 3; ambiguous = 2; drift = 1 }
+  in
+  check_float "precision_strict" 0.75 (L.compute_precision_strict c)
+
+let test_precision_lenient () =
+  (* 15 / (15 + 3) = 0.8333... *)
+  let c : L.confusion_summary =
+    { supported = 15; unsupported = 3; ambiguous = 2; drift = 1 }
+  in
+  check_float "precision_lenient" 0.8333 (L.compute_precision_lenient c)
+
+let test_precision_zero_denom () =
+  let c : L.confusion_summary =
+    { supported = 0; unsupported = 0; ambiguous = 0; drift = 5 }
+  in
+  check_float "strict zero" 0.0 (L.compute_precision_strict c);
+  check_float "lenient zero" 0.0 (L.compute_precision_lenient c)
+
+(* ================================================================ *)
+(* claim coverage                                                    *)
+(* ================================================================ *)
+
+let test_claim_coverage () =
+  check_float "normal" 0.8 (L.compute_claim_coverage ~labeled:16 ~total:20);
+  check_float "full" 1.0 (L.compute_claim_coverage ~labeled:20 ~total:20);
+  check_float "zero total" 0.0 (L.compute_claim_coverage ~labeled:0 ~total:0)
+
+(* ================================================================ *)
+(* build_output_contract                                             *)
+(* ================================================================ *)
+
+let test_build_output_contract () =
+  let verdicts =
+    List.map make_lv
+      [ L.Supported; L.Supported; L.Supported; L.Unsupported; L.Ambiguous ]
+  in
+  let oc =
+    L.build_output_contract ~workload_name:"coding_task"
+      ~judge_protocol_version:"v0" ~label_owner:"alice"
+      ~metric_owner:"bob" ~total_claims:10 ~drift_note:"" verdicts
+  in
+  check string "workload" "coding_task" oc.workload_name;
+  check int "confusion.supported" 3 oc.confusion.supported;
+  check int "confusion.unsupported" 1 oc.confusion.unsupported;
+  check int "confusion.ambiguous" 1 oc.confusion.ambiguous;
+  (* precision_strict = 3 / (3 + 1 + 1) = 0.6 *)
+  check_float "precision_strict" 0.6 oc.precision_strict;
+  (* precision_lenient = 3 / (3 + 1) = 0.75 *)
+  check_float "precision_lenient" 0.75 oc.precision_lenient;
+  (* claim_coverage = 5 / 10 = 0.5 (5 non-drift labeled out of 10 total) *)
+  check_float "claim_coverage" 0.5 oc.claim_coverage
+
+(* ================================================================ *)
+(* JSON round-trip                                                   *)
+(* ================================================================ *)
+
+let test_labeled_verdict_json_roundtrip () =
+  let lv : L.labeled_verdict =
+    {
+      verdict = dummy_verdict ();
+      label = L.Supported;
+      labeler = "human:alice";
+      note = Some "looks correct";
+      labeled_at = "2026-03-29T12:00:00Z";
+    }
+  in
+  let json = L.labeled_verdict_to_json lv in
+  match L.labeled_verdict_of_json json with
+  | Error e -> fail (Printf.sprintf "JSON round-trip failed: %s" e)
+  | Ok lv' ->
+    check string "label" "supported" (L.label_to_string lv'.label);
+    check string "labeler" "human:alice" lv'.labeler;
+    check string "note" "looks correct"
+      (Option.value ~default:"NONE" lv'.note);
+    check string "labeled_at" "2026-03-29T12:00:00Z" lv'.labeled_at;
+    check string "run_id" "test-run-1" lv'.verdict.run_id
+
+let test_output_contract_json () =
+  let oc : L.output_contract =
+    {
+      workload_name = "coding_task";
+      judge_protocol_version = "v0";
+      label_owner = "alice";
+      metric_owner = "bob";
+      confusion = { supported = 10; unsupported = 2; ambiguous = 1; drift = 0 };
+      claim_coverage = 0.9;
+      precision_strict = 0.769;
+      precision_lenient = 0.833;
+      drift_note = "";
+    }
+  in
+  let json = L.output_contract_to_json oc in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "workload_name" fields with
+     | Some (`String "coding_task") -> ()
+     | _ -> fail "missing workload_name");
+    (match List.assoc_opt "precision_strict" fields with
+     | Some (`Float _) -> ()
+     | _ -> fail "missing precision_strict")
+  | _ -> fail "expected JSON object"
+
+(* ================================================================ *)
+(* Test runner                                                       *)
+(* ================================================================ *)
+
+let () =
+  run "Labeling"
+    [
+      ( "label",
+        [
+          test_case "roundtrip" `Quick test_label_roundtrip;
+          test_case "invalid" `Quick test_label_of_string_invalid;
+        ] );
+      ( "confusion",
+        [
+          test_case "counts" `Quick test_compute_confusion;
+          test_case "empty" `Quick test_compute_confusion_empty;
+        ] );
+      ( "precision",
+        [
+          test_case "strict" `Quick test_precision_strict;
+          test_case "lenient" `Quick test_precision_lenient;
+          test_case "zero denom" `Quick test_precision_zero_denom;
+        ] );
+      ( "coverage",
+        [ test_case "claim coverage" `Quick test_claim_coverage ] );
+      ( "contract",
+        [ test_case "build" `Quick test_build_output_contract ] );
+      ( "json",
+        [
+          test_case "labeled verdict roundtrip" `Quick
+            test_labeled_verdict_json_roundtrip;
+          test_case "output contract" `Quick test_output_contract_json;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Labeling protocol 문서를 v0로 freeze (2026-03-29)
- `Labeling` 모듈 신규: label types, confusion_summary, precision metrics, JSON 직렬화
- `cdal-label` CLI 신규: `apply` (verdict에 라벨 적용) + `metrics` (output contract 계산)
- 11개 단위 테스트: label 왕복, confusion 계산, precision_strict/lenient, claim_coverage, JSON 왕복
- sample verdict fixture 추가

## Motivation
RFC #3475 Labeling Protocol Section 7의 output contract를 코드로 구현. evaluator 변경 시 golden set 재실행과 precision 추적을 위한 최소 도구.

## Changes
| 파일 | 변경 |
|------|------|
| `docs/design/contract-driven-agent-loop-labeling-protocol.md` | Status: Draft → v0-frozen |
| `lib/cdal/labeling.mli` | 타입 + 메트릭 + JSON 인터페이스 |
| `lib/cdal/labeling.ml` | 구현 (protocol Section 3 정의 준수) |
| `bin/cdal_label.ml` | Cmdliner CLI (apply + metrics) |
| `bin/dune` | cdal-label executable 추가 |
| `lib/dune` | labeling 모듈 등록 |
| `test/dune` | test_labeling 등록 |
| `test/test_labeling.ml` | 11개 테스트 |
| `fixtures/cdal/sample_verdict.json` | smoke test용 fixture |

## Test plan
- [x] `dune build --root .` passes
- [x] 11/11 labeling tests pass
- [x] `cdal-label --help` 정상 출력
- [x] `cdal-label apply` smoke test — verdict JSON 입력 → labeled verdict 출력 확인

Closes #3525

🤖 Generated with [Claude Code](https://claude.com/claude-code)