### PR TITLE
analysis(lib): Phase 0 dependency graph for monolith decomposition

### DIFF
--- a/reports/lib-decomposition-phase0.md
+++ b/reports/lib-decomposition-phase0.md
@@ -1,0 +1,112 @@
+# lib/ Monolith Decomposition — Phase 0 Analysis
+
+Date: 2026-03-29
+Issue: #3593
+
+## Current State
+
+| Metric | Value |
+|--------|-------|
+| Sub-libraries extracted | 19 |
+| Monolith modules remaining | 586 (in lib/dune) |
+| Total dependency edges | 1,961 |
+| Avg dependencies per module | 3.35 |
+| Leaf modules (0 internal deps) | 170 |
+| Root modules (nothing depends on them) | 109 |
+
+## Critical Finding: 115-Module Cycle
+
+The monolith contains 3 strongly connected components (cycles):
+
+| SCC | Size | Composition |
+|-----|------|-------------|
+| SCC-1 | 115 modules | Tool_* (49), Keeper_* (17), + 49 others |
+| SCC-2 | 2 modules | Keeper_toml_loader <-> Keeper_types_profile |
+| SCC-3 | 2 modules | Drift_guard <-> Level2_config |
+
+**SCC-1 is the primary obstacle to decomposition.** 20% of all modules are locked in a single cycle. The cycle is driven by:
+- Tool modules calling Keeper for context
+- Keeper calling Tool dispatch for execution
+- Both depending on Room, Mcp_server, and Config
+
+## Hub Modules (Dependency Bottlenecks)
+
+These modules have the highest in-degree (most depended-upon):
+
+| Module | Dependents | Role |
+|--------|------------|------|
+| Room | 139 | Central state container |
+| Tool_args | 59 | Tool argument types |
+| Keeper_types | 44 | Keeper type definitions |
+| Mcp_server | 41 | MCP protocol server |
+| Team_session_store | 38 | Session persistence |
+| Sse | 30 | Server-sent events |
+| Chain_types | 25 | Chain type definitions |
+
+Room (139 dependents = 24% of all modules) is the gravity well.
+
+## Extraction Candidates (by coupling ratio)
+
+High coupling ratio = internal edges dominate over external deps = easier to extract.
+
+| Prefix Group | Modules | Coupling | Ext Deps | Status |
+|-------------|---------|----------|----------|--------|
+| activity_graph | 4 | 1.000 | 0 | Ready |
+| prompt_registry | 3 | 1.000 | 0 | Ready |
+| swarm_status | 8 | 0.889 | 2 | Ready |
+| tool_schemas | 18 | 0.875 | 1 | Ready |
+| server_mcp | 10 | 0.667 | 8 | Medium |
+| tool_command | 9 | 0.630 | 10 | Medium |
+| dashboard_proof | 5 | 0.556 | 4 | Medium |
+| tool_improve | 6 | 0.500 | 5 | Medium |
+| masc_grpc | 5 | 0.429 | 4 | Medium |
+| team_session | 13 | 0.415 | 24 | Hard (high ext deps) |
+
+## vs. Issue #3593 Proposed Plan
+
+| Phase | Issue Proposal | Analysis Verdict |
+|-------|---------------|-----------------|
+| Phase 1: masc_chain (47 files) | Lowest coupling | chain_* prefix not in top extraction candidates — Chain_types has 25 dependents, may be harder than expected |
+| Phase 2: masc_command_plane (18 files) | cp_* prefix clear | Not enough cp_* in analysis. May have been renamed. Needs validation |
+| Phase 3: masc_team_session (17 files) | OAS-heavy | team_session: coupling 0.415, 24 ext deps. Medium-hard |
+| Phase 4: masc_dashboard (43 files) | server/keeper cross-ref | dashboard_* scattered. dashboard_proof (5) is extractable |
+| Phase 5: masc_server (54 files) | Highest global deps | Mcp_server_eio_execute has 60 deps. Hardest extraction |
+| Phase 6: masc_keeper (71 files) | Deferred | 17 keeper modules in SCC-1. Requires breaking Tool<->Keeper cycle first |
+
+## Recommended Extraction Order (Data-Driven)
+
+**Principle**: Extract leaf clusters first (high coupling, low external deps), then progressively tackle hub modules.
+
+### Batch 1: Low-risk extractions (no SCC involvement)
+1. **activity_graph** (4 modules, coupling 1.0) — zero external deps
+2. **prompt_registry** (3 modules, coupling 1.0) — zero external deps
+3. **swarm_status** (8 modules, coupling 0.889) — 2 external deps
+4. **tool_schemas** (18 modules, coupling 0.875) — 1 external dep
+
+**Total**: 33 modules extracted with minimal risk.
+
+### Batch 2: Medium-risk extractions
+5. **server_mcp** (10 modules, coupling 0.667)
+6. **tool_command** (9 modules, coupling 0.630)
+7. **dashboard_proof** (5 modules, coupling 0.556)
+8. **masc_grpc** (5 modules, coupling 0.429)
+
+### Batch 3: SCC-breaking (requires interface redesign)
+9. Break Tool <-> Keeper cycle by introducing interface modules
+10. Extract keeper_* as sub-library
+11. Extract remaining tool_* modules
+12. Extract server_* modules
+
+## SCC-2 and SCC-3 (Quick Fixes)
+
+- **SCC-2**: Keeper_toml_loader <-> Keeper_types_profile — likely a type definition cycle. Fix by merging or splitting the shared type.
+- **SCC-3**: Drift_guard <-> Level2_config — similar pattern.
+
+These should be fixed before Batch 2.
+
+## Next Steps
+
+1. Fix SCC-2 and SCC-3 (trivial cycles) in a quick PR
+2. Extract Batch 1 (33 modules, 4 sub-libraries) — 1-2 sessions
+3. Re-run analysis to validate reduced SCC-1 size
+4. Plan Batch 2 based on updated graph

--- a/reports/lib-dependency-graph.json
+++ b/reports/lib-dependency-graph.json
@@ -1,0 +1,3851 @@
+{
+  "stats": {
+    "total_modules": 586,
+    "total_edges": 1961,
+    "avg_out_degree": 3.35,
+    "leaf_count": 170,
+    "root_count": 109
+  },
+  "top_imported": [
+    [
+      "Room",
+      139
+    ],
+    [
+      "Tool_args",
+      59
+    ],
+    [
+      "Keeper_types",
+      44
+    ],
+    [
+      "Mcp_server",
+      41
+    ],
+    [
+      "Team_session_store",
+      38
+    ],
+    [
+      "Sse",
+      30
+    ],
+    [
+      "Chain_types",
+      25
+    ],
+    [
+      "Keeper",
+      24
+    ],
+    [
+      "Response",
+      23
+    ],
+    [
+      "Session",
+      21
+    ],
+    [
+      "Board",
+      21
+    ],
+    [
+      "Oas_worker",
+      20
+    ],
+    [
+      "Board_dispatch",
+      20
+    ],
+    [
+      "Command_plane_v2",
+      20
+    ],
+    [
+      "Tool_dispatch",
+      16
+    ],
+    [
+      "Keeper_memory",
+      16
+    ],
+    [
+      "Server_auth",
+      16
+    ],
+    [
+      "Transport",
+      16
+    ],
+    [
+      "Config",
+      15
+    ],
+    [
+      "Oas_response",
+      15
+    ]
+  ],
+  "top_importers": [
+    [
+      "Mcp_server_eio_execute",
+      60
+    ],
+    [
+      "Mcp_server_eio",
+      57
+    ],
+    [
+      "Server_bootstrap_loops",
+      46
+    ],
+    [
+      "Tools",
+      41
+    ],
+    [
+      "Server_runtime_bootstrap",
+      34
+    ],
+    [
+      "Server_routes_http_routes_dashboard",
+      28
+    ],
+    [
+      "Server_h2_gateway",
+      24
+    ],
+    [
+      "Server_dashboard_http",
+      23
+    ],
+    [
+      "Tool_inline_dispatch",
+      21
+    ],
+    [
+      "Keeper_exec_context",
+      21
+    ],
+    [
+      "Tool_misc",
+      20
+    ],
+    [
+      "Keeper_exec_tools",
+      19
+    ],
+    [
+      "Keeper_agent_run",
+      19
+    ],
+    [
+      "Config",
+      18
+    ],
+    [
+      "Server_routes_http_runtime",
+      18
+    ],
+    [
+      "Keeper_keepalive",
+      18
+    ],
+    [
+      "Server_dashboard_http_core",
+      17
+    ],
+    [
+      "Server_routes_http_routes_activity",
+      17
+    ],
+    [
+      "Team_session_oas_bridge",
+      16
+    ],
+    [
+      "Keeper_turn",
+      16
+    ]
+  ],
+  "cycles": [
+    [
+      "A2a_tools",
+      "Agent_card",
+      "Agent_tool_surfaces",
+      "Anti_rationalization",
+      "Autoresearch",
+      "Autoresearch_codegen",
+      "Bounded",
+      "Capability_registry",
+      "Cascade_inference",
+      "Chain_native_eio",
+      "Config",
+      "Context_compact_oas",
+      "Dashboard_harness_health",
+      "Dashboard_operator_judge",
+      "Eval_calibration",
+      "Handover_eio",
+      "Keeper_agent_run",
+      "Keeper_alerting",
+      "Keeper_config",
+      "Keeper_coordination",
+      "Keeper_exec_context",
+      "Keeper_exec_persona",
+      "Keeper_exec_tools",
+      "Keeper_execution",
+      "Keeper_keepalive",
+      "Keeper_prompt",
+      "Keeper_runtime",
+      "Keeper_supervisor",
+      "Keeper_tools_oas",
+      "Keeper_unified_prompt",
+      "Keeper_unified_turn",
+      "Keeper_voice_local",
+      "Keeper_world_observation",
+      "Masc_grpc_client",
+      "Masc_grpc_server",
+      "Masc_grpc_service",
+      "Masc_grpc_transport",
+      "Mcp_server",
+      "Mcp_server_eio_tool_profile",
+      "Mdal",
+      "Mdal_swarm",
+      "Mdal_worker",
+      "Mitosis",
+      "Oas_events",
+      "Oas_worker",
+      "Operator_control",
+      "Operator_pending_confirm",
+      "Orchestrator",
+      "Server_mcp_transport_ws",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Spawn",
+      "Sse",
+      "Swarm_goal_loop",
+      "Team_session_engine_eio",
+      "Team_session_oas_bridge",
+      "Team_session_swarm_runner",
+      "Tool_args",
+      "Tool_audit",
+      "Tool_autoresearch",
+      "Tool_autoresearch_broadcast",
+      "Tool_autoresearch_cycle",
+      "Tool_autoresearch_registry",
+      "Tool_autoresearch_repo_synthesis",
+      "Tool_board",
+      "Tool_budget",
+      "Tool_cache",
+      "Tool_catalog",
+      "Tool_code",
+      "Tool_code_write",
+      "Tool_command_plane",
+      "Tool_command_plane_chain_common",
+      "Tool_command_plane_chain_launch",
+      "Tool_command_plane_chain_query",
+      "Tool_command_plane_dispatch",
+      "Tool_command_plane_mutations",
+      "Tool_command_plane_schemas_01",
+      "Tool_command_plane_schemas_02",
+      "Tool_command_plane_support",
+      "Tool_compact",
+      "Tool_cost",
+      "Tool_council_oas",
+      "Tool_dispatch",
+      "Tool_encryption",
+      "Tool_goals",
+      "Tool_handover",
+      "Tool_hat",
+      "Tool_heartbeat",
+      "Tool_help_registry",
+      "Tool_improve_loop",
+      "Tool_keeper",
+      "Tool_mdal",
+      "Tool_metrics",
+      "Tool_operator",
+      "Tool_permissions",
+      "Tool_relay",
+      "Tool_research",
+      "Tool_room",
+      "Tool_run",
+      "Tool_shard",
+      "Tool_suspend",
+      "Tool_task",
+      "Tool_tempo",
+      "Tool_voice",
+      "Tool_walph",
+      "Tool_worktree",
+      "Tools",
+      "Transport",
+      "Transport_metrics",
+      "Verifier_oas",
+      "Voice_bridge",
+      "Voice_session_manager",
+      "Worker_container",
+      "Worker_container_types",
+      "Worker_oas"
+    ],
+    [
+      "Keeper_toml_loader",
+      "Keeper_types_profile"
+    ],
+    [
+      "Drift_guard",
+      "Level2_config"
+    ]
+  ],
+  "clusters": [
+    {
+      "prefix": "activity_graph",
+      "module_count": 4,
+      "members": [
+        "Activity_graph",
+        "Activity_graph_reducer",
+        "Activity_graph_registry",
+        "Activity_graph_types"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 0,
+      "coupling_ratio": 1.0
+    },
+    {
+      "prefix": "prompt_registry",
+      "module_count": 3,
+      "members": [
+        "Prompt_registry",
+        "Prompt_registry_store",
+        "Prompt_registry_types"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 0,
+      "coupling_ratio": 1.0
+    },
+    {
+      "prefix": "swarm_status",
+      "module_count": 8,
+      "members": [
+        "Swarm_status",
+        "Swarm_status_build",
+        "Swarm_status_classify",
+        "Swarm_status_inputs",
+        "Swarm_status_json",
+        "Swarm_status_lanes",
+        "Swarm_status_parse",
+        "Swarm_status_types"
+      ],
+      "internal_edges": 16,
+      "external_dep_count": 2,
+      "coupling_ratio": 0.889
+    },
+    {
+      "prefix": "tool_schemas",
+      "module_count": 18,
+      "members": [
+        "Tool_schemas_a2a",
+        "Tool_schemas_agent",
+        "Tool_schemas_auth",
+        "Tool_schemas_control",
+        "Tool_schemas_fire_task",
+        "Tool_schemas_inline",
+        "Tool_schemas_inline_convo",
+        "Tool_schemas_inline_episodes",
+        "Tool_schemas_inline_infra",
+        "Tool_schemas_inline_room",
+        "Tool_schemas_inline_verify",
+        "Tool_schemas_misc",
+        "Tool_schemas_plan",
+        "Tool_schemas_portal",
+        "Tool_schemas_room",
+        "Tool_schemas_room_core",
+        "Tool_schemas_room_extra",
+        "Tool_schemas_worktree"
+      ],
+      "internal_edges": 7,
+      "external_dep_count": 1,
+      "coupling_ratio": 0.875
+    },
+    {
+      "prefix": "server_mcp",
+      "module_count": 10,
+      "members": [
+        "Server_mcp_transport_http",
+        "Server_mcp_transport_http_agui",
+        "Server_mcp_transport_http_conn",
+        "Server_mcp_transport_http_headers",
+        "Server_mcp_transport_http_protocol",
+        "Server_mcp_transport_http_respond",
+        "Server_mcp_transport_http_session",
+        "Server_mcp_transport_http_sse",
+        "Server_mcp_transport_http_types",
+        "Server_mcp_transport_ws"
+      ],
+      "internal_edges": 16,
+      "external_dep_count": 8,
+      "coupling_ratio": 0.667
+    },
+    {
+      "prefix": "tool_command",
+      "module_count": 9,
+      "members": [
+        "Tool_command_plane",
+        "Tool_command_plane_chain_common",
+        "Tool_command_plane_chain_launch",
+        "Tool_command_plane_chain_query",
+        "Tool_command_plane_dispatch",
+        "Tool_command_plane_mutations",
+        "Tool_command_plane_schemas_01",
+        "Tool_command_plane_schemas_02",
+        "Tool_command_plane_support"
+      ],
+      "internal_edges": 17,
+      "external_dep_count": 10,
+      "coupling_ratio": 0.63
+    },
+    {
+      "prefix": "dashboard_proof",
+      "module_count": 5,
+      "members": [
+        "Dashboard_proof",
+        "Dashboard_proof_actors",
+        "Dashboard_proof_events",
+        "Dashboard_proof_helpers",
+        "Dashboard_proof_verdict"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 4,
+      "coupling_ratio": 0.556
+    },
+    {
+      "prefix": "tool_improve",
+      "module_count": 6,
+      "members": [
+        "Tool_improve_loop",
+        "Tool_improve_loop_executor",
+        "Tool_improve_loop_gh",
+        "Tool_improve_loop_planner",
+        "Tool_improve_loop_schemas",
+        "Tool_improve_loop_types"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 5,
+      "coupling_ratio": 0.5
+    },
+    {
+      "prefix": "masc_grpc",
+      "module_count": 5,
+      "members": [
+        "Masc_grpc_client",
+        "Masc_grpc_server",
+        "Masc_grpc_service",
+        "Masc_grpc_transport",
+        "Masc_grpc_types"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 4,
+      "coupling_ratio": 0.429
+    },
+    {
+      "prefix": "team_session",
+      "module_count": 13,
+      "members": [
+        "Team_session_engine_eio",
+        "Team_session_engine_helpers",
+        "Team_session_engine_policy",
+        "Team_session_engine_status",
+        "Team_session_oas_bridge",
+        "Team_session_plan",
+        "Team_session_report",
+        "Team_session_report_core",
+        "Team_session_report_proof",
+        "Team_session_report_proof_helpers",
+        "Team_session_store",
+        "Team_session_swarm_callbacks",
+        "Team_session_swarm_runner"
+      ],
+      "internal_edges": 17,
+      "external_dep_count": 24,
+      "coupling_ratio": 0.415
+    },
+    {
+      "prefix": "tool_local",
+      "module_count": 6,
+      "members": [
+        "Tool_local_runtime",
+        "Tool_local_runtime_bench",
+        "Tool_local_runtime_core",
+        "Tool_local_runtime_http",
+        "Tool_local_runtime_status",
+        "Tool_local_runtime_verify"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.333
+    },
+    {
+      "prefix": "tool_autoresearch",
+      "module_count": 6,
+      "members": [
+        "Tool_autoresearch",
+        "Tool_autoresearch_broadcast",
+        "Tool_autoresearch_cycle",
+        "Tool_autoresearch_registry",
+        "Tool_autoresearch_repo_synthesis",
+        "Tool_autoresearch_schemas"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.312
+    },
+    {
+      "prefix": "tool_team",
+      "module_count": 10,
+      "members": [
+        "Tool_team_session",
+        "Tool_team_session_handlers",
+        "Tool_team_session_routing",
+        "Tool_team_session_routing_workers",
+        "Tool_team_session_schemas",
+        "Tool_team_session_step",
+        "Tool_team_session_step_exec",
+        "Tool_team_session_step_spawn",
+        "Tool_team_session_step_types",
+        "Tool_team_session_support"
+      ],
+      "internal_edges": 7,
+      "external_dep_count": 16,
+      "coupling_ratio": 0.304
+    },
+    {
+      "prefix": "keeper_turn",
+      "module_count": 8,
+      "members": [
+        "Keeper_turn",
+        "Keeper_turn_lifecycle",
+        "Keeper_turn_session",
+        "Keeper_turn_setup",
+        "Keeper_turn_up",
+        "Keeper_turn_up_args",
+        "Keeper_turn_up_create",
+        "Keeper_turn_up_update"
+      ],
+      "internal_edges": 9,
+      "external_dep_count": 21,
+      "coupling_ratio": 0.3
+    },
+    {
+      "prefix": "server_command",
+      "module_count": 5,
+      "members": [
+        "Server_command_plane_http",
+        "Server_command_plane_http_help",
+        "Server_command_plane_http_mutations",
+        "Server_command_plane_http_stream",
+        "Server_command_plane_http_support"
+      ],
+      "internal_edges": 6,
+      "external_dep_count": 14,
+      "coupling_ratio": 0.3
+    },
+    {
+      "prefix": "tool_code",
+      "module_count": 3,
+      "members": [
+        "Tool_code",
+        "Tool_code_swarm",
+        "Tool_code_write"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 3,
+      "coupling_ratio": 0.25
+    },
+    {
+      "prefix": "operator_digest",
+      "module_count": 5,
+      "members": [
+        "Operator_digest",
+        "Operator_digest_event",
+        "Operator_digest_guidance",
+        "Operator_digest_session",
+        "Operator_digest_types"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 10,
+      "coupling_ratio": 0.231
+    },
+    {
+      "prefix": "server_routes",
+      "module_count": 12,
+      "members": [
+        "Server_routes_http",
+        "Server_routes_http_common",
+        "Server_routes_http_keeper_stream",
+        "Server_routes_http_pages",
+        "Server_routes_http_routes_activity",
+        "Server_routes_http_routes_command_plane_read",
+        "Server_routes_http_routes_command_plane_write",
+        "Server_routes_http_routes_dashboard",
+        "Server_routes_http_routes_frontend",
+        "Server_routes_http_routes_provider_runs",
+        "Server_routes_http_routes_room",
+        "Server_routes_http_runtime"
+      ],
+      "internal_edges": 18,
+      "external_dep_count": 65,
+      "coupling_ratio": 0.217
+    },
+    {
+      "prefix": "tool_council",
+      "module_count": 5,
+      "members": [
+        "Tool_council_feed",
+        "Tool_council_helpers",
+        "Tool_council_internal_schemas",
+        "Tool_council_json",
+        "Tool_council_oas"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.214
+    },
+    {
+      "prefix": "tool_inline",
+      "module_count": 6,
+      "members": [
+        "Tool_inline_dispatch",
+        "Tool_inline_dispatch_comm",
+        "Tool_inline_dispatch_episode",
+        "Tool_inline_dispatch_extra",
+        "Tool_inline_dispatch_room",
+        "Tool_inline_dispatch_types"
+      ],
+      "internal_edges": 7,
+      "external_dep_count": 29,
+      "coupling_ratio": 0.194
+    },
+    {
+      "prefix": "dashboard_mission",
+      "module_count": 4,
+      "members": [
+        "Dashboard_mission",
+        "Dashboard_mission_agents",
+        "Dashboard_mission_assembly",
+        "Dashboard_mission_briefing"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 13,
+      "coupling_ratio": 0.188
+    },
+    {
+      "prefix": "chain_executor",
+      "module_count": 7,
+      "members": [
+        "Chain_executor_complex",
+        "Chain_executor_eio",
+        "Chain_executor_helpers",
+        "Chain_executor_leaf",
+        "Chain_executor_resilience",
+        "Chain_executor_retry",
+        "Chain_executor_search"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 24,
+      "coupling_ratio": 0.172
+    },
+    {
+      "prefix": "mcp_server",
+      "module_count": 10,
+      "members": [
+        "Mcp_server",
+        "Mcp_server_eio",
+        "Mcp_server_eio_call_tool",
+        "Mcp_server_eio_execute",
+        "Mcp_server_eio_governance",
+        "Mcp_server_eio_helpers",
+        "Mcp_server_eio_protocol",
+        "Mcp_server_eio_resource",
+        "Mcp_server_eio_tool_profile",
+        "Mcp_server_eio_types"
+      ],
+      "internal_edges": 17,
+      "external_dep_count": 85,
+      "coupling_ratio": 0.167
+    },
+    {
+      "prefix": "cp_snapshot",
+      "module_count": 4,
+      "members": [
+        "Cp_snapshot",
+        "Cp_snapshot_core",
+        "Cp_snapshot_section_cache",
+        "Cp_snapshot_summaries"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 5,
+      "coupling_ratio": 0.167
+    },
+    {
+      "prefix": "server_h2",
+      "module_count": 4,
+      "members": [
+        "Server_h2_gateway",
+        "Server_h2_gateway_helpers",
+        "Server_h2_gateway_routes_cp",
+        "Server_h2_gateway_routes_extra"
+      ],
+      "internal_edges": 4,
+      "external_dep_count": 27,
+      "coupling_ratio": 0.129
+    },
+    {
+      "prefix": "keeper_status",
+      "module_count": 3,
+      "members": [
+        "Keeper_status",
+        "Keeper_status_bridge",
+        "Keeper_status_detail"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 14,
+      "coupling_ratio": 0.125
+    },
+    {
+      "prefix": "dashboard_http",
+      "module_count": 8,
+      "members": [
+        "Dashboard_http_autoresearch",
+        "Dashboard_http_helpers",
+        "Dashboard_http_keeper",
+        "Dashboard_http_keeper_detail",
+        "Dashboard_http_keeper_metrics",
+        "Dashboard_http_mdal",
+        "Dashboard_http_monitoring",
+        "Dashboard_http_repo_synthesis"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 24,
+      "coupling_ratio": 0.111
+    },
+    {
+      "prefix": "keeper_exec",
+      "module_count": 5,
+      "members": [
+        "Keeper_exec_context",
+        "Keeper_exec_persona",
+        "Keeper_exec_status",
+        "Keeper_exec_status_metrics",
+        "Keeper_exec_tools"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 34,
+      "coupling_ratio": 0.081
+    },
+    {
+      "prefix": "server_dashboard",
+      "module_count": 4,
+      "members": [
+        "Server_dashboard_http",
+        "Server_dashboard_http_cache",
+        "Server_dashboard_http_core",
+        "Server_dashboard_http_runtime_support"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 30,
+      "coupling_ratio": 0.032
+    },
+    {
+      "prefix": "dashboard_execution",
+      "module_count": 5,
+      "members": [
+        "Dashboard_execution",
+        "Dashboard_execution_builders",
+        "Dashboard_execution_fixture",
+        "Dashboard_execution_helpers",
+        "Dashboard_execution_sessions"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 10,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "chain_parser",
+      "module_count": 5,
+      "members": [
+        "Chain_parser",
+        "Chain_parser_helpers",
+        "Chain_parser_parse",
+        "Chain_parser_serialize",
+        "Chain_parser_validate"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 2,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "cp_lifecycle",
+      "module_count": 4,
+      "members": [
+        "Cp_lifecycle",
+        "Cp_lifecycle_intents",
+        "Cp_lifecycle_policy",
+        "Cp_lifecycle_search"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 2,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "chain_mermaid",
+      "module_count": 4,
+      "members": [
+        "Chain_mermaid_graph",
+        "Chain_mermaid_node_content",
+        "Chain_mermaid_parse",
+        "Chain_mermaid_parser"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 3,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "keeper_memory",
+      "module_count": 4,
+      "members": [
+        "Keeper_memory",
+        "Keeper_memory_bank",
+        "Keeper_memory_policy",
+        "Keeper_memory_recall"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 4,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "server_bootstrap",
+      "module_count": 3,
+      "members": [
+        "Server_bootstrap_http",
+        "Server_bootstrap_loops",
+        "Server_bootstrap_pg"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 51,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "worker_container",
+      "module_count": 3,
+      "members": [
+        "Worker_container",
+        "Worker_container_runners",
+        "Worker_container_types"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "operator_control",
+      "module_count": 3,
+      "members": [
+        "Operator_control",
+        "Operator_control_action",
+        "Operator_control_snapshot"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 21,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "tool_mdal",
+      "module_count": 3,
+      "members": [
+        "Tool_mdal",
+        "Tool_mdal_handlers",
+        "Tool_mdal_schemas"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 9,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "keeper_types",
+      "module_count": 3,
+      "members": [
+        "Keeper_types",
+        "Keeper_types_profile",
+        "Keeper_types_support"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 7,
+      "coupling_ratio": 0.0
+    }
+  ],
+  "graph": {
+    "A2a_types": [],
+    "A2a_tools": [
+      "A2a_types",
+      "Agent_card",
+      "Room",
+      "Sse"
+    ],
+    "Ag_ui": [],
+    "Agent_card": [
+      "Config",
+      "Masc_grpc_server",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Version"
+    ],
+    "Agent_economy": [],
+    "Agent_health": [],
+    "Agent_identity": [],
+    "Agent_tool_surfaces": [
+      "Sdk_tool_contract",
+      "Tool_board",
+      "Tool_permissions"
+    ],
+    "Agent_registry_eio": [
+      "Agent_identity",
+      "Session"
+    ],
+    "Anti_rationalization": [
+      "Oas_response",
+      "Oas_worker"
+    ],
+    "Auto_recall": [
+      "Cache_eio",
+      "Retrieval_projection",
+      "Room"
+    ],
+    "Auto_responder": [
+      "Code",
+      "Oas_response",
+      "Oas_worker",
+      "Provider_adapter"
+    ],
+    "Auth": [],
+    "Board": [],
+    "Board_core": [
+      "Agent_economy",
+      "Board",
+      "Board_dispatch"
+    ],
+    "Board_votes": [
+      "Agent_economy",
+      "Thompson_sampling"
+    ],
+    "Board_pg": [
+      "Board",
+      "Thompson_sampling"
+    ],
+    "Board_pg_queries": [
+      "Board",
+      "Board_core"
+    ],
+    "Board_dispatch": [
+      "Board",
+      "Board_pg"
+    ],
+    "Board_listener": [
+      "Sse"
+    ],
+    "Capability_registry": [
+      "Agent_tool_surfaces",
+      "Mcp_server_eio_tool_profile",
+      "Tool_catalog",
+      "Tool_dispatch",
+      "Tool_help_registry",
+      "Tool_shard"
+    ],
+    "Bounded": [
+      "Spawn"
+    ],
+    "Cache_eio": [],
+    "Cascade_inference": [
+      "Oas_worker"
+    ],
+    "Cancellation": [],
+    "Command_plane_v2": [
+      "Cp_cleanup"
+    ],
+    "Command_plane_orchestra": [
+      "Command_plane_v2",
+      "Operator_control",
+      "Room",
+      "Swarm_status",
+      "Team_session_engine_eio",
+      "Team_session_store"
+    ],
+    "Cp_types": [],
+    "Cp_paths": [
+      "Room"
+    ],
+    "Cp_serde": [
+      "Cp_search_fabric",
+      "Room"
+    ],
+    "Cp_io": [
+      "Cp_search_fabric"
+    ],
+    "Cp_unit": [
+      "Cp_cleanup",
+      "Room"
+    ],
+    "Cp_unit_projection": [
+      "Team_session_store"
+    ],
+    "Cp_snapshot": [],
+    "Cp_snapshot_section_cache": [],
+    "Cp_snapshot_core": [
+      "Cp_cleanup",
+      "Cp_snapshot_section_cache",
+      "Room",
+      "Team_session_store"
+    ],
+    "Cp_snapshot_summaries": [
+      "Cp_microarch_summary",
+      "Cp_search_fabric",
+      "Team_session_store"
+    ],
+    "Cp_cleanup": [],
+    "Cp_lifecycle": [
+      "Cp_search_fabric"
+    ],
+    "Cp_lifecycle_search": [
+      "Cp_search_fabric",
+      "Team_session_store"
+    ],
+    "Cp_lifecycle_intents": [
+      "Cp_search_fabric"
+    ],
+    "Cp_lifecycle_policy": [
+      "Cp_search_fabric"
+    ],
+    "Config": [
+      "Capability_registry",
+      "Tool_autoresearch",
+      "Tool_board",
+      "Tool_catalog",
+      "Tool_command_plane",
+      "Tool_compact",
+      "Tool_goals",
+      "Tool_keeper",
+      "Tool_local_runtime",
+      "Tool_mdal",
+      "Tool_model_catalog",
+      "Tool_operator",
+      "Tool_schemas_a2a",
+      "Tool_schemas_control",
+      "Tool_schemas_misc",
+      "Tool_team_session",
+      "Tool_voice",
+      "Tools"
+    ],
+    "Config_dir_resolver": [],
+    "Dashboard": [
+      "Dashboard_attention",
+      "Dashboard_labels",
+      "Room",
+      "Swarm_status",
+      "Tempo"
+    ],
+    "Dashboard_labels": [],
+    "Dashboard_agent_relations": [
+      "Graphql_client"
+    ],
+    "Dashboard_attention": [
+      "Dashboard_labels"
+    ],
+    "Dashboard_cache": [
+      "Dashboard"
+    ],
+    "Dashboard_tool_host_events": [
+      "Audit_log",
+      "Telemetry_eio"
+    ],
+    "Dashboard_collaboration_evidence": [
+      "Activity_graph",
+      "Dashboard_proof",
+      "Room",
+      "Team_session_store"
+    ],
+    "Dashboard_governance": [],
+    "Dashboard_governance_judge": [
+      "Oas_response",
+      "Oas_worker",
+      "Prompt_registry"
+    ],
+    "Dashboard_operator_judge": [
+      "Oas_response",
+      "Oas_worker",
+      "Operator_approval",
+      "Operator_judgment",
+      "Prompt_registry",
+      "Room"
+    ],
+    "Dashboard_surface_readiness": [],
+    "Dashboard_execution": [
+      "Command_plane_v2",
+      "Dashboard",
+      "Dashboard_http_helpers",
+      "Operator_control",
+      "Room",
+      "Team_session_store",
+      "Tempo",
+      "Version"
+    ],
+    "Dashboard_execution_helpers": [
+      "A2a_tools",
+      "Dashboard",
+      "Graphql_client"
+    ],
+    "Dashboard_execution_fixture": [
+      "Version"
+    ],
+    "Dashboard_execution_sessions": [],
+    "Dashboard_execution_builders": [],
+    "Dashboard_mission_agents": [
+      "Room"
+    ],
+    "Dashboard_mission_assembly": [
+      "A2a_tools",
+      "Dashboard_mission_agents",
+      "Keeper_tools_oas"
+    ],
+    "Dashboard_mission": [
+      "Command_plane_v2",
+      "Dashboard_cache",
+      "Dashboard_http_helpers",
+      "Dashboard_mission_assembly",
+      "Operator_control",
+      "Room",
+      "Swarm_status",
+      "Team_session_store"
+    ],
+    "Dashboard_proof": [
+      "Dashboard_proof_actors",
+      "Dashboard_proof_events",
+      "Dashboard_proof_verdict",
+      "Team_session_report_proof",
+      "Team_session_store"
+    ],
+    "Dashboard_proof_events": [],
+    "Dashboard_proof_actors": [
+      "Dashboard_proof_events",
+      "Team_session_store"
+    ],
+    "Dashboard_proof_verdict": [
+      "Cp_snapshot",
+      "Dashboard_proof_events",
+      "Room"
+    ],
+    "Dashboard_proof_helpers": [],
+    "Briefing_json_helpers": [],
+    "Briefing_compactors": [
+      "Briefing_json_helpers"
+    ],
+    "Briefing_gaps": [
+      "Briefing_json_helpers"
+    ],
+    "Briefing_sections": [
+      "Briefing_gaps",
+      "Briefing_json_helpers"
+    ],
+    "Dashboard_mission_briefing": [
+      "Briefing_compactors",
+      "Briefing_gaps",
+      "Briefing_json_helpers",
+      "Briefing_sections",
+      "Dashboard_mission",
+      "Operator_control",
+      "Room"
+    ],
+    "Drift_guard": [
+      "Level2_config",
+      "Room"
+    ],
+    "Server_utils": [
+      "Board",
+      "Board_dispatch"
+    ],
+    "Server_auth": [
+      "A2a_tools",
+      "Agent_card",
+      "Auth",
+      "Config",
+      "Http_server_eio",
+      "Mcp_server",
+      "Response",
+      "Server_utils"
+    ],
+    "Server_voice_config": [
+      "Voice_bridge"
+    ],
+    "Dashboard_http_helpers": [
+      "Dashboard"
+    ],
+    "Dashboard_http_monitoring": [
+      "Board",
+      "Board_dispatch",
+      "Dashboard",
+      "Dashboard_governance",
+      "Dashboard_http_helpers",
+      "Room",
+      "Tool_audit"
+    ],
+    "Dashboard_http_keeper_metrics": [
+      "Dashboard_execution_helpers",
+      "Keeper_execution",
+      "Keeper_memory",
+      "Keeper_types"
+    ],
+    "Dashboard_http_keeper_detail": [
+      "Dashboard_http_helpers"
+    ],
+    "Dashboard_http_keeper": [
+      "Dashboard_http_helpers",
+      "Keeper_exec_context",
+      "Keeper_exec_status",
+      "Keeper_execution",
+      "Keeper_memory",
+      "Keeper_prompt",
+      "Keeper_registry",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Prompt_registry",
+      "Room"
+    ],
+    "Dashboard_http_mdal": [
+      "Mdal",
+      "Mdal_store",
+      "Room",
+      "Server_utils",
+      "Tool_mdal"
+    ],
+    "Dashboard_http_autoresearch": [
+      "Autoresearch",
+      "Tool_autoresearch_registry"
+    ],
+    "Dashboard_harness_health": [
+      "Eval_calibration"
+    ],
+    "Dashboard_http_repo_synthesis": [
+      "Repo_synthesis_benchmark"
+    ],
+    "Dashboard_provider_runs": [
+      "Cascade_inference",
+      "Oas_worker",
+      "Provider_adapter",
+      "Tool_local_runtime_core"
+    ],
+    "Proactive_refresh": [
+      "Dashboard"
+    ],
+    "Server_dashboard_http_runtime_support": [
+      "Dashboard",
+      "Room"
+    ],
+    "Server_dashboard_http": [
+      "Board",
+      "Board_dispatch",
+      "Build_identity",
+      "Config_dir_resolver",
+      "Dashboard",
+      "Dashboard_cache",
+      "Dashboard_execution",
+      "Dashboard_governance",
+      "Goal_store",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Mcp_server",
+      "Operator_control",
+      "Proactive_refresh",
+      "Prompt_registry",
+      "Room",
+      "Server_command_plane_http",
+      "Server_utils",
+      "Sse",
+      "Team_session_store",
+      "Tool_misc",
+      "Tool_unified",
+      "Transport_metrics"
+    ],
+    "Server_dashboard_http_cache": [
+      "Dashboard_cache"
+    ],
+    "Server_dashboard_http_core": [
+      "Build_identity",
+      "Dashboard",
+      "Dashboard_cache",
+      "Dashboard_execution_helpers",
+      "Dashboard_mission",
+      "Dashboard_mission_briefing",
+      "Dashboard_proof",
+      "Mcp_server",
+      "Operator_control",
+      "Proactive_refresh",
+      "Room",
+      "Server_auth",
+      "Server_command_plane_http_support",
+      "Server_dashboard_http_runtime_support",
+      "Server_utils",
+      "Team_session_store",
+      "Tempo"
+    ],
+    "Server_routes_http": [
+      "Server_routes_http_routes_activity",
+      "Server_routes_http_routes_command_plane_read",
+      "Server_routes_http_routes_command_plane_write",
+      "Server_routes_http_routes_dashboard",
+      "Server_routes_http_routes_frontend",
+      "Server_routes_http_routes_provider_runs",
+      "Server_routes_http_routes_room"
+    ],
+    "Server_routes_http_common": [
+      "Mcp_server",
+      "Mcp_transport_protocol",
+      "Server_auth",
+      "Server_command_plane_http",
+      "Server_dashboard_http",
+      "Server_mcp_transport_http",
+      "Server_utils"
+    ],
+    "Server_routes_http_pages": [
+      "Graphql_api",
+      "Response",
+      "Server_auth",
+      "Web_dashboard"
+    ],
+    "Server_routes_http_runtime": [
+      "Board",
+      "Board_dispatch",
+      "Build_identity",
+      "Dashboard_governance",
+      "Keeper_registry",
+      "Masc_grpc_server",
+      "Masc_grpc_service",
+      "Response",
+      "Server_auth",
+      "Server_mcp_transport_ws",
+      "Server_routes_http_common",
+      "Server_startup_state",
+      "Server_utils",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Sse",
+      "Subsystem_health",
+      "Transport_metrics"
+    ],
+    "Server_routes_http_keeper_stream": [
+      "Ag_ui",
+      "Audit_log",
+      "Keeper",
+      "Keeper_alerting",
+      "Keeper_chat_store",
+      "Keeper_config",
+      "Keeper_execution",
+      "Mcp_server",
+      "Response",
+      "Server_auth",
+      "Telemetry_eio",
+      "Tool_keeper",
+      "Tool_registry"
+    ],
+    "Server_routes_http_routes_frontend": [
+      "Credits_dashboard",
+      "Prometheus",
+      "Response",
+      "Server_auth",
+      "Server_routes_http_common",
+      "Server_routes_http_pages",
+      "Server_routes_http_runtime",
+      "Server_utils",
+      "Server_webrtc_transport",
+      "Sse",
+      "Transport",
+      "Web_dashboard"
+    ],
+    "Server_routes_http_routes_room": [
+      "Dashboard_execution_helpers",
+      "Mcp_server",
+      "Response",
+      "Room",
+      "Server_auth",
+      "Server_routes_http_common",
+      "Server_utils",
+      "Tempo"
+    ],
+    "Server_routes_http_routes_dashboard": [
+      "Board_dispatch",
+      "Dashboard_agent_relations",
+      "Dashboard_collaboration_evidence",
+      "Dashboard_harness_health",
+      "Dashboard_http_autoresearch",
+      "Dashboard_http_keeper",
+      "Dashboard_http_repo_synthesis",
+      "Dashboard_surface_readiness",
+      "Dashboard_tool_host_events",
+      "Env_config_introspect",
+      "Goal_store",
+      "Keeper_chat_store",
+      "Keeper_turn_up_args",
+      "Keeper_turn_up_update",
+      "Keeper_types",
+      "Mcp_server",
+      "Response",
+      "Room",
+      "Server_auth",
+      "Server_dashboard_http",
+      "Server_routes_http_common",
+      "Server_routes_http_keeper_stream",
+      "Server_utils",
+      "Task_dispatch",
+      "Telemetry_eio",
+      "Tool_agent_timeline",
+      "Tool_keeper",
+      "Tool_unified"
+    ],
+    "Server_routes_http_routes_command_plane_read": [
+      "Response",
+      "Server_auth",
+      "Server_routes_http_common",
+      "Server_utils"
+    ],
+    "Server_routes_http_routes_command_plane_write": [
+      "Response",
+      "Server_auth",
+      "Server_dashboard_http",
+      "Server_routes_http_common"
+    ],
+    "Server_routes_http_routes_provider_runs": [
+      "Dashboard_provider_runs",
+      "Mcp_server",
+      "Response",
+      "Server_auth",
+      "Server_utils"
+    ],
+    "Server_routes_http_routes_activity": [
+      "Activity_feed",
+      "Activity_graph",
+      "Agent_reputation",
+      "Board",
+      "Board_dispatch",
+      "Mcp_server",
+      "Mention_inbox",
+      "Prompt_registry",
+      "Response",
+      "Server_activity_http",
+      "Server_auth",
+      "Server_mcp_transport_http",
+      "Server_routes_http_common",
+      "Server_routes_http_runtime",
+      "Server_utils",
+      "Tool_board",
+      "Tool_council_feed"
+    ],
+    "Server_h2_gateway": [
+      "Credits_dashboard",
+      "Dashboard_http_autoresearch",
+      "Dashboard_http_repo_synthesis",
+      "Env_config_introspect",
+      "Graphql_api",
+      "Mcp_server",
+      "Mcp_session",
+      "Prometheus",
+      "Response",
+      "Room",
+      "Server_auth",
+      "Server_dashboard_http",
+      "Server_h2_gateway_routes_cp",
+      "Server_h2_gateway_routes_extra",
+      "Server_mcp_transport_http",
+      "Server_routes_http",
+      "Server_routes_http_runtime",
+      "Server_startup_state",
+      "Server_utils",
+      "Server_webrtc_transport",
+      "Sse",
+      "Tempo",
+      "Transport",
+      "Transport_metrics"
+    ],
+    "Server_h2_gateway_helpers": [
+      "Response"
+    ],
+    "Server_h2_gateway_routes_extra": [
+      "Board",
+      "Board_dispatch",
+      "Http_server_eio",
+      "Mcp_server",
+      "Response",
+      "Server_h2_gateway_helpers",
+      "Server_routes_http",
+      "Server_utils",
+      "Server_voice_config",
+      "Web_dashboard"
+    ],
+    "Server_h2_gateway_routes_cp": [
+      "Mcp_server",
+      "Server_auth",
+      "Server_dashboard_http",
+      "Server_h2_gateway_helpers",
+      "Server_routes_http"
+    ],
+    "Server_bootstrap_http": [
+      "Http_protocol_detect",
+      "Masc_grpc_server",
+      "Server_auth",
+      "Server_webrtc_transport",
+      "Server_ws_standalone"
+    ],
+    "Server_bootstrap_pg": [
+      "Board_dispatch",
+      "Task_dispatch"
+    ],
+    "Server_bootstrap_loops": [
+      "A2a_tools",
+      "Agent_identity",
+      "Agent_registry_eio",
+      "Agent_tool_surfaces",
+      "Board",
+      "Board_dispatch",
+      "Board_listener",
+      "Cache_eio",
+      "Dashboard",
+      "Dashboard_governance",
+      "Dashboard_governance_judge",
+      "Dashboard_operator_judge",
+      "Governance_pipeline",
+      "Keeper",
+      "Keeper_keepalive",
+      "Keeper_runtime",
+      "Keeper_types",
+      "Mcp_server",
+      "Metrics_store_eio",
+      "Oas_sse_bridge",
+      "Operator_control",
+      "Orchestrator",
+      "Otel_chain_subscriber",
+      "Otel_dispatch_hook",
+      "Otel_spans",
+      "Progress",
+      "Rate_limit",
+      "Room",
+      "Server_dashboard_http",
+      "Server_mcp_transport_http",
+      "Server_mcp_transport_http_session",
+      "Server_mcp_transport_http_sse",
+      "Server_routes_http_common",
+      "Server_webrtc_transport",
+      "Session",
+      "Shutdown",
+      "Shutdown_hooks",
+      "Sse",
+      "Subsystem_health",
+      "Tool_agent",
+      "Tool_board",
+      "Tool_dispatch",
+      "Tool_metrics_persist",
+      "Tool_permissions",
+      "Tool_room",
+      "Tool_task"
+    ],
+    "Server_runtime_bootstrap": [
+      "Chain_native_eio",
+      "Config_dir_resolver",
+      "Dashboard",
+      "Discovery_cache",
+      "Keeper_keepalive",
+      "Masc_eio_env",
+      "Masc_grpc_client",
+      "Masc_grpc_server",
+      "Masc_grpc_transport",
+      "Mcp_server",
+      "Mcp_server_eio_execute",
+      "Prometheus",
+      "Prompt_defaults",
+      "Prompt_registry",
+      "Room",
+      "Server_auth",
+      "Server_bootstrap_http",
+      "Server_bootstrap_loops",
+      "Server_bootstrap_pg",
+      "Server_command_plane_http_support",
+      "Server_dashboard_http",
+      "Server_mcp_transport_ws",
+      "Server_routes_http",
+      "Server_startup_state",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Session",
+      "Sse",
+      "Team_session_engine_eio",
+      "Telemetry_eio",
+      "Tool_command_plane",
+      "Tool_metrics_persist",
+      "Tool_registry",
+      "Transport"
+    ],
+    "Server_startup_state": [
+      "Transport"
+    ],
+    "Server_startup_takeover": [],
+    "Server_command_plane_http": [
+      "Server_command_plane_http_help",
+      "Server_command_plane_http_mutations",
+      "Server_command_plane_http_stream",
+      "Server_command_plane_http_support"
+    ],
+    "Server_command_plane_http_support": [
+      "Command_plane_orchestra",
+      "Command_plane_v2",
+      "Dashboard_http_helpers",
+      "Mcp_server",
+      "Operator_control",
+      "Proactive_refresh",
+      "Room",
+      "Swarm_status",
+      "Tool_command_plane"
+    ],
+    "Server_command_plane_http_stream": [
+      "Chain_native_eio",
+      "Chain_telemetry",
+      "Response",
+      "Server_command_plane_http_support",
+      "Sse",
+      "Transport"
+    ],
+    "Server_command_plane_http_mutations": [
+      "Command_plane_v2",
+      "Mcp_server",
+      "Server_command_plane_http_support"
+    ],
+    "Server_command_plane_http_help": [],
+    "Server_activity_http": [
+      "Activity_graph",
+      "Mcp_server",
+      "Mcp_session",
+      "Response"
+    ],
+    "Server_mcp_transport_http": [
+      "Mcp_server",
+      "Mcp_session",
+      "Response",
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_sse",
+      "Sse"
+    ],
+    "Server_mcp_transport_http_conn": [
+      "Server_mcp_transport_http_sse",
+      "Sse"
+    ],
+    "Server_mcp_transport_http_respond": [
+      "Response",
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_protocol"
+    ],
+    "Server_mcp_transport_http_agui": [
+      "Ag_ui",
+      "Mcp_session",
+      "Response",
+      "Server_mcp_transport_http_conn",
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_protocol",
+      "Server_mcp_transport_http_respond",
+      "Sse",
+      "Transport"
+    ],
+    "Server_mcp_transport_http_protocol": [
+      "Mcp_server",
+      "Mcp_transport_protocol",
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_session",
+      "Server_mcp_transport_http_types"
+    ],
+    "Server_mcp_transport_http_types": [
+      "Mcp_server"
+    ],
+    "Server_mcp_transport_http_session": [
+      "Mcp_server"
+    ],
+    "Server_mcp_transport_http_headers": [
+      "Mcp_transport_protocol",
+      "Server_mcp_transport_http_session",
+      "Server_mcp_transport_http_types",
+      "Sse"
+    ],
+    "Server_mcp_transport_http_sse": [
+      "Response",
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_types",
+      "Sse"
+    ],
+    "Server_mcp_transport_ws": [
+      "Sse",
+      "Transport",
+      "Transport_metrics"
+    ],
+    "Server_ws_standalone": [
+      "Server_mcp_transport_ws",
+      "Sse",
+      "Transport",
+      "Transport_metrics"
+    ],
+    "Server_webrtc_transport": [
+      "Transport"
+    ],
+    "Server_openai_compat": [
+      "Keeper_turn",
+      "Keeper_types",
+      "Oas_response",
+      "Oas_worker",
+      "Transport"
+    ],
+    "Web_dashboard": [],
+    "Credits_dashboard": [],
+    "Cp_microarch_summary": [],
+    "Cp_search_fabric": [],
+    "Repo_synthesis_benchmark": [],
+    "Inference_utils": [
+      "Oas_response"
+    ],
+    "WebRTC": [],
+    "Modules": [],
+    "Removed": [],
+    "\u2014": [],
+    "Use": [],
+    "Ocaml-webrtc": [],
+    "Library": [],
+    "Directly": [],
+    "Encryption": [],
+    "Gcm_compat": [],
+    "Graphql_client": [
+      "Code",
+      "Graphql_endpoint"
+    ],
+    "Graphql_endpoint": [],
+    "Graphql_api": [
+      "Room"
+    ],
+    "Activity_graph": [],
+    "Activity_graph_types": [],
+    "Activity_graph_registry": [
+      "Activity_graph_types"
+    ],
+    "Activity_graph_reducer": [
+      "Activity_graph_types"
+    ],
+    "Handover_eio": [
+      "Spawn"
+    ],
+    "Hat": [],
+    "Hebbian_eio": [
+      "Level2_config"
+    ],
+    "Http_server_eio": [
+      "Discovery_cache",
+      "Prometheus",
+      "Response",
+      "Streamable_http",
+      "Version"
+    ],
+    "Http_server_h2": [
+      "Response"
+    ],
+    "Http_protocol_detect": [],
+    "Institution_eio": [
+      "Level4_config"
+    ],
+    "Level2_config": [
+      "Drift_guard"
+    ],
+    "Level4_config": [],
+    "Local_runtime_pool": [
+      "Discovery_cache"
+    ],
+    "Retrieval_projection": [],
+    "Sdk_tool_contract": [],
+    "Worker_oas": [
+      "Agent",
+      "Eval_gate",
+      "Orchestrator",
+      "Verifier_oas",
+      "Worker_container",
+      "Worker_container_types"
+    ],
+    "Worker_runtime": [],
+    "Worker_container_types": [
+      "Agent_tool_surfaces",
+      "Auth",
+      "Code"
+    ],
+    "Worker_container": [
+      "Agent",
+      "Room",
+      "Team_session_store",
+      "Telemetry_eio",
+      "Worker_dev_tools",
+      "Worker_oas"
+    ],
+    "Worker_container_runners": [
+      "Agent_tool_surfaces",
+      "Prompt_composer",
+      "Team_context",
+      "Worker_oas"
+    ],
+    "Worker_dev_tools": [
+      "Worker_tool_input"
+    ],
+    "Worker_tool_input": [],
+    "Worker_verification": [
+      "Verifier_oas",
+      "Worker_container_types"
+    ],
+    "Safe_parse": [],
+    "Prompt_registry_types": [],
+    "Prompt_registry_store": [
+      "Prompt_registry_types"
+    ],
+    "Prompt_registry": [
+      "Prompt_registry_store"
+    ],
+    "Prompt_defaults": [
+      "Config_dir_resolver",
+      "Prompt_registry"
+    ],
+    "Prompt_composer": [
+      "Team_context"
+    ],
+    "Chain_types": [
+      "Chain_category"
+    ],
+    "Chain_trace_types": [
+      "Chain_types"
+    ],
+    "Chain_category": [],
+    "Chain_stats": [
+      "Chain_category",
+      "Chain_telemetry"
+    ],
+    "Chain_utils": [
+      "Safe_parse"
+    ],
+    "Chain_conversation": [
+      "Chain_utils"
+    ],
+    "Chain_iteration": [
+      "Chain_utils"
+    ],
+    "Chain_composer": [
+      "Chain_evaluator",
+      "Chain_types"
+    ],
+    "Chain_evaluator": [],
+    "Chain_parser": [],
+    "Chain_parser_helpers": [
+      "Chain_types"
+    ],
+    "Chain_parser_parse": [
+      "Chain_types",
+      "Prompt_registry"
+    ],
+    "Chain_parser_validate": [
+      "Chain_types"
+    ],
+    "Chain_parser_serialize": [
+      "Chain_types"
+    ],
+    "Chain_mermaid_parse": [
+      "Chain_types",
+      "Safe_parse"
+    ],
+    "Chain_mermaid_node_content": [
+      "Chain_types",
+      "Safe_parse"
+    ],
+    "Chain_mermaid_graph": [
+      "Chain_parser",
+      "Chain_types"
+    ],
+    "Chain_mermaid_parser": [
+      "Chain_parser",
+      "Chain_types"
+    ],
+    "Chain_compiler": [
+      "Chain_parser",
+      "Chain_types"
+    ],
+    "Chain_registry": [
+      "Chain_parser",
+      "Chain_types"
+    ],
+    "Chain_telemetry": [
+      "Chain_category"
+    ],
+    "Chain_error": [],
+    "Chain_log": [],
+    "Chain_retry": [
+      "Chain_error",
+      "Chain_log"
+    ],
+    "Chain_executor_retry": [
+      "Chain_error",
+      "Chain_log",
+      "Chain_retry"
+    ],
+    "Chain_adapter_eio": [
+      "Chain_types",
+      "Retrieval_projection"
+    ],
+    "Checkpoint_store": [
+      "Chain_category",
+      "Chain_types"
+    ],
+    "Run_log_eio": [
+      "Safe_parse",
+      "Sse"
+    ],
+    "Chain_spawn_registry": [],
+    "Chain_executor_helpers": [
+      "Chain_category",
+      "Chain_conversation",
+      "Chain_iteration",
+      "Chain_parser",
+      "Chain_telemetry",
+      "Chain_trace_types",
+      "Chain_types",
+      "Chain_utils",
+      "Checkpoint_store",
+      "Oas_response",
+      "Oas_worker",
+      "Run_log_eio"
+    ],
+    "Chain_executor_leaf": [
+      "Chain_adapter_eio",
+      "Chain_category",
+      "Chain_executor_eio",
+      "Chain_types",
+      "Chain_utils",
+      "Prompt_registry",
+      "Run_log_eio"
+    ],
+    "Chain_executor_complex": [
+      "Chain_stats",
+      "Chain_types"
+    ],
+    "Chain_executor_search": [
+      "Chain_executor_resilience",
+      "Chain_types",
+      "Safe_parse"
+    ],
+    "Chain_executor_resilience": [
+      "Chain_compiler",
+      "Chain_parser",
+      "Chain_spawn_registry",
+      "Chain_types"
+    ],
+    "Chain_executor_eio": [
+      "Chain_compiler",
+      "Chain_executor_complex",
+      "Chain_executor_resilience",
+      "Chain_executor_search",
+      "Chain_mermaid_parser",
+      "Chain_registry",
+      "Chain_run_store",
+      "Chain_types"
+    ],
+    "Chain_orchestrator_eio": [
+      "Chain_compiler",
+      "Chain_composer",
+      "Chain_error",
+      "Chain_evaluator",
+      "Chain_executor_eio",
+      "Chain_executor_retry",
+      "Chain_log",
+      "Chain_mermaid_parser",
+      "Chain_parser",
+      "Chain_retry",
+      "Chain_types",
+      "Provider_adapter"
+    ],
+    "Chain_run_store": [
+      "Chain_mermaid_parser",
+      "Chain_types",
+      "Safe_parse"
+    ],
+    "Chain_native_eio": [
+      "Chain_category",
+      "Chain_compiler",
+      "Chain_executor_eio",
+      "Chain_mermaid_parser",
+      "Chain_orchestrator_eio",
+      "Chain_registry",
+      "Chain_run_store",
+      "Chain_telemetry",
+      "Chain_types",
+      "Mcp_server",
+      "Oas_response",
+      "Oas_worker",
+      "Prompt_registry",
+      "Provider_adapter",
+      "Room"
+    ],
+    "Oas_response": [],
+    "Thompson_sampling": [
+      "Agent_health",
+      "Post_verifier"
+    ],
+    "Memory_pg": [],
+    "Memory_jsonl": [],
+    "Memory_oas_bridge": [
+      "Agent",
+      "Institution_eio",
+      "Memory_jsonl",
+      "Procedural_memory"
+    ],
+    "Relation_materializer": [
+      "Graphql_client"
+    ],
+    "Prometheus": [],
+    "Rate_limit": [],
+    "Mdal": [
+      "Bounded"
+    ],
+    "Mdal_swarm": [
+      "Swarm_goal_loop"
+    ],
+    "Mdal_worker": [
+      "Agent_tool_surfaces",
+      "Mdal",
+      "Provider_adapter",
+      "Room",
+      "Worker_runtime"
+    ],
+    "Mcp_transport_protocol": [],
+    "Mcp_prompt_surface": [
+      "Cp_snapshot",
+      "Dashboard_proof",
+      "Mcp_server",
+      "Tool_help_registry"
+    ],
+    "Mcp_sdk_adapter_masc": [
+      "Config",
+      "Mcp_prompt_surface",
+      "Mcp_server",
+      "Mcp_server_eio_resource",
+      "Mcp_server_eio_types",
+      "Sse",
+      "Tool_help_registry",
+      "Version"
+    ],
+    "Mcp_server": [
+      "Board_dispatch",
+      "Encryption",
+      "Mitosis",
+      "Room",
+      "Session",
+      "Subscriptions",
+      "Version"
+    ],
+    "Mcp_server_eio": [
+      "Chain_native_eio",
+      "Keeper_exec_tools",
+      "Mcp_server",
+      "Mcp_server_eio_call_tool",
+      "Mcp_server_eio_governance",
+      "Mcp_server_eio_protocol",
+      "Mcp_server_eio_resource",
+      "Mcp_server_eio_types",
+      "Tool_a2a",
+      "Tool_agent",
+      "Tool_agent_timeline",
+      "Tool_audit",
+      "Tool_auth",
+      "Tool_autoresearch",
+      "Tool_cache",
+      "Tool_code",
+      "Tool_code_swarm",
+      "Tool_code_write",
+      "Tool_command_plane",
+      "Tool_compact",
+      "Tool_control",
+      "Tool_cost",
+      "Tool_council_oas",
+      "Tool_dispatch",
+      "Tool_encryption",
+      "Tool_fire_task",
+      "Tool_goals",
+      "Tool_handover",
+      "Tool_hat",
+      "Tool_heartbeat",
+      "Tool_improve_loop",
+      "Tool_input_validation",
+      "Tool_keeper",
+      "Tool_library",
+      "Tool_local_runtime",
+      "Tool_mdal",
+      "Tool_misc",
+      "Tool_model_catalog",
+      "Tool_notifications",
+      "Tool_operator",
+      "Tool_plan",
+      "Tool_portal",
+      "Tool_rate_limit",
+      "Tool_relay",
+      "Tool_research",
+      "Tool_room",
+      "Tool_run",
+      "Tool_schemas_inline",
+      "Tool_suspend",
+      "Tool_tag_init",
+      "Tool_task",
+      "Tool_team_session",
+      "Tool_tempo",
+      "Tool_voice",
+      "Tool_walph",
+      "Tool_worktree",
+      "Tools"
+    ],
+    "Mcp_server_eio_types": [],
+    "Mcp_server_eio_governance": [
+      "Room"
+    ],
+    "Mcp_server_eio_helpers": [
+      "Session"
+    ],
+    "Mcp_server_eio_resource": [
+      "Config",
+      "Institution_eio",
+      "Mcp_server",
+      "Room",
+      "Session",
+      "Tool_help_registry"
+    ],
+    "Mcp_server_eio_execute": [
+      "Agent_identity",
+      "Agent_registry_eio",
+      "Auth",
+      "Mcp_server",
+      "Mcp_server_eio_governance",
+      "Mcp_server_eio_helpers",
+      "Operator_approval",
+      "Prometheus",
+      "Room",
+      "Session",
+      "Team_session_engine_eio",
+      "Tool_a2a",
+      "Tool_agent",
+      "Tool_agent_timeline",
+      "Tool_audit",
+      "Tool_auth",
+      "Tool_autoresearch",
+      "Tool_cache",
+      "Tool_catalog",
+      "Tool_code",
+      "Tool_code_swarm",
+      "Tool_code_write",
+      "Tool_command_plane",
+      "Tool_compact",
+      "Tool_control",
+      "Tool_cost",
+      "Tool_council_oas",
+      "Tool_dispatch",
+      "Tool_encryption",
+      "Tool_fire_task",
+      "Tool_goals",
+      "Tool_handover",
+      "Tool_hat",
+      "Tool_heartbeat",
+      "Tool_improve_loop",
+      "Tool_inline_dispatch",
+      "Tool_keeper",
+      "Tool_library",
+      "Tool_local_runtime",
+      "Tool_mdal",
+      "Tool_misc",
+      "Tool_model_catalog",
+      "Tool_notifications",
+      "Tool_operator",
+      "Tool_plan",
+      "Tool_portal",
+      "Tool_rate_limit",
+      "Tool_relay",
+      "Tool_research",
+      "Tool_result",
+      "Tool_room",
+      "Tool_run",
+      "Tool_shard",
+      "Tool_suspend",
+      "Tool_task",
+      "Tool_team_session",
+      "Tool_tempo",
+      "Tool_voice",
+      "Tool_walph",
+      "Tool_worktree"
+    ],
+    "Mcp_server_eio_call_tool": [
+      "Agent_identity",
+      "Agent_registry_eio",
+      "Audit_log",
+      "Masc_error_recovery",
+      "Mcp_server",
+      "Mcp_server_eio_types",
+      "Otel_spans",
+      "Prometheus",
+      "Sdk_tool_contract",
+      "Telemetry_eio",
+      "Tool_dispatch",
+      "Tool_registry",
+      "Tool_result",
+      "Tools",
+      "Workflow_guide"
+    ],
+    "Masc_error_recovery": [],
+    "Mcp_server_eio_tool_profile": [
+      "Agent_tool_surfaces",
+      "Config",
+      "Mcp_server",
+      "Mcp_server_eio_types",
+      "Sdk_tool_contract",
+      "Telemetry_eio",
+      "Tool_budget",
+      "Tool_catalog",
+      "Tool_dispatch",
+      "Tool_metrics",
+      "Tool_operator",
+      "Tools"
+    ],
+    "Mcp_server_eio_protocol": [
+      "Agent_card",
+      "Config",
+      "Mcp_prompt_surface",
+      "Mcp_sdk_adapter_masc",
+      "Mcp_server",
+      "Mcp_server_eio_call_tool",
+      "Mcp_server_eio_types",
+      "Room",
+      "Sse",
+      "Telemetry_eio",
+      "Tool_catalog",
+      "Tool_dispatch",
+      "Tool_help_registry",
+      "Version"
+    ],
+    "Mcp_session": [],
+    "Metrics_store_eio": [],
+    "Handoff_quality": [],
+    "Adaptive_thresholds": [
+      "Handoff_quality"
+    ],
+    "Mdal_store": [
+      "Bounded",
+      "Mdal"
+    ],
+    "Verification": [
+      "Agent"
+    ],
+    "Mitosis": [
+      "Dashboard_harness_health",
+      "Harness",
+      "Mitosis_dna",
+      "Spawn",
+      "Sse"
+    ],
+    "Mitosis_defaults": [
+      "Spawn"
+    ],
+    "Mitosis_dna": [],
+    "Operator_approval": [],
+    "Operator_pending_confirm": [
+      "Dashboard_operator_judge",
+      "Operator_approval",
+      "Room"
+    ],
+    "Operator_digest": [
+      "Command_plane_v2",
+      "Operator_digest_guidance",
+      "Operator_pending_confirm",
+      "Room",
+      "Swarm_status",
+      "Team_session_store"
+    ],
+    "Operator_digest_event": [],
+    "Operator_digest_guidance": [
+      "Operator_digest_types",
+      "Operator_judgment"
+    ],
+    "Operator_digest_types": [
+      "Operator_approval",
+      "Operator_pending_confirm",
+      "Tool_local_runtime"
+    ],
+    "Risk_digest": [
+      "Operator_digest_types"
+    ],
+    "Operator_digest_session": [
+      "Operator_digest_event",
+      "Operator_pending_confirm",
+      "Risk_digest",
+      "Team_session_engine_eio",
+      "Team_session_store"
+    ],
+    "Operator_control": [
+      "Audit_log",
+      "Keeper_exec_status",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Room",
+      "Team_session_engine_eio",
+      "Team_session_store",
+      "Tool_args",
+      "Tool_keeper",
+      "Tool_team_session"
+    ],
+    "Operator_control_snapshot": [
+      "A2a_tools",
+      "Command_plane_v2",
+      "Dashboard",
+      "Keeper_exec_status",
+      "Keeper_exec_tools",
+      "Keeper_memory",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Room",
+      "Swarm_status",
+      "Team_session_engine_eio",
+      "Team_session_store",
+      "Tempo"
+    ],
+    "Operator_control_action": [
+      "Auth",
+      "Operator_approval",
+      "Operator_judgment",
+      "Tool_args"
+    ],
+    "Operator_judgment": [
+      "Room"
+    ],
+    "Notify": [],
+    "Orchestrator": [
+      "Agent",
+      "Pulse",
+      "Room",
+      "Spawn"
+    ],
+    "Otel_chain_subscriber": [
+      "Chain_telemetry",
+      "Otel_config"
+    ],
+    "Otel_config": [],
+    "Otel_dispatch_hook": [
+      "Otel_config",
+      "Prometheus",
+      "Tool_dispatch",
+      "Tool_result"
+    ],
+    "Otel_spans": [
+      "Config",
+      "Otel_config"
+    ],
+    "Planning_eio": [
+      "Room"
+    ],
+    "Post_verifier": [],
+    "Provider_adapter": [
+      "Voice_config"
+    ],
+    "Progress": [],
+    "Pulse": [],
+    "Relay": [],
+    "Goal_store": [
+      "Room"
+    ],
+    "Goal_guard": [],
+    "Goal_orchestrator": [
+      "Goal_store",
+      "Room"
+    ],
+    "Goal_scheduler": [
+      "Goal_store",
+      "Room"
+    ],
+    "Swarm_goal_loop": [
+      "Bounded",
+      "Goal_orchestrator",
+      "Room",
+      "Swarm_checkpoint"
+    ],
+    "Response": [],
+    "Room": [
+      "Activity_graph",
+      "Agent_economy",
+      "Audit_log",
+      "Board",
+      "Board_dispatch",
+      "Prometheus",
+      "Relation_materializer",
+      "Subscriptions",
+      "Telemetry_eio"
+    ],
+    "Run_eio": [],
+    "Team_context": [
+      "Context",
+      "Room",
+      "Team_session_store"
+    ],
+    "Team_session_store": [
+      "Activity_graph",
+      "Session"
+    ],
+    "Team_session_report": [],
+    "Team_session_report_core": [
+      "Prometheus",
+      "Room",
+      "Team_session_store"
+    ],
+    "Team_session_report_proof_helpers": [],
+    "Team_session_report_proof": [
+      "Room",
+      "Team_session_store"
+    ],
+    "Team_session_engine_helpers": [
+      "Command_plane_v2",
+      "Room",
+      "Team_session_store"
+    ],
+    "Team_session_engine_status": [
+      "Prometheus",
+      "Room",
+      "Session",
+      "Team_session_plan",
+      "Team_session_report",
+      "Team_session_store",
+      "Tool_local_runtime"
+    ],
+    "Team_session_engine_policy": [
+      "Board",
+      "Board_dispatch",
+      "Room",
+      "Team_session_store"
+    ],
+    "Team_session_engine_eio": [
+      "Command_plane_v2",
+      "Operator_pending_confirm",
+      "Progress",
+      "Room",
+      "Session",
+      "Supervisor",
+      "Team_session_oas_bridge",
+      "Team_session_report",
+      "Team_session_store",
+      "Team_session_swarm_runner"
+    ],
+    "Team_session_oas_bridge": [
+      "Agent_tool_surfaces",
+      "Cascade_inference",
+      "Contract_composer",
+      "Oas_worker",
+      "Room",
+      "Session",
+      "Team_context",
+      "Team_session_store",
+      "Tool_board",
+      "Tool_code",
+      "Tool_heartbeat",
+      "Tool_room",
+      "Tool_run",
+      "Tool_task",
+      "Tool_worktree",
+      "Worker_container"
+    ],
+    "Team_session_swarm_callbacks": [
+      "Room",
+      "Team_session_engine_policy",
+      "Team_session_store"
+    ],
+    "Team_session_swarm_runner": [
+      "Room",
+      "Team_session_oas_bridge",
+      "Team_session_store",
+      "Team_session_swarm_callbacks"
+    ],
+    "Sctp/sctp_eio/sctp_transport": [],
+    "In": [],
+    "Sdp": [],
+    "Session": [],
+    "Shutdown_hooks": [
+      "Sse"
+    ],
+    "Spawn": [
+      "Agent_tool_surfaces",
+      "Provider_adapter"
+    ],
+    "Sse": [
+      "Transport_metrics"
+    ],
+    "Streamable_http": [
+      "Session"
+    ],
+    "Subsystem_health": [],
+    "Subscriptions": [
+      "Session"
+    ],
+    "Swarm_status": [],
+    "Swarm_status_types": [],
+    "Swarm_status_json": [
+      "Command_plane_v2",
+      "Swarm_status_types"
+    ],
+    "Swarm_status_parse": [
+      "Command_plane_v2",
+      "Swarm_status_json",
+      "Swarm_status_types"
+    ],
+    "Swarm_status_classify": [
+      "Command_plane_v2",
+      "Swarm_status_json",
+      "Swarm_status_types"
+    ],
+    "Swarm_status_inputs": [
+      "Command_plane_v2",
+      "Swarm_status_json",
+      "Swarm_status_parse",
+      "Swarm_status_types",
+      "Team_session_store"
+    ],
+    "Swarm_status_lanes": [
+      "Swarm_status_classify",
+      "Swarm_status_json",
+      "Swarm_status_types"
+    ],
+    "Swarm_status_build": [
+      "Command_plane_v2",
+      "Swarm_status_classify",
+      "Swarm_status_inputs",
+      "Swarm_status_json",
+      "Swarm_status_lanes",
+      "Swarm_status_types"
+    ],
+    "Swarm_checkpoint": [
+      "Room"
+    ],
+    "Telemetry_eio": [],
+    "Tempo": [
+      "Room"
+    ],
+    "Tools": [
+      "Tool_audit",
+      "Tool_autoresearch",
+      "Tool_cache",
+      "Tool_code",
+      "Tool_code_write",
+      "Tool_command_plane",
+      "Tool_compact",
+      "Tool_cost",
+      "Tool_council_oas",
+      "Tool_encryption",
+      "Tool_goals",
+      "Tool_handover",
+      "Tool_hat",
+      "Tool_heartbeat",
+      "Tool_improve_loop",
+      "Tool_keeper",
+      "Tool_library",
+      "Tool_local_runtime",
+      "Tool_operator",
+      "Tool_rate_limit",
+      "Tool_relay",
+      "Tool_run",
+      "Tool_schemas_a2a",
+      "Tool_schemas_agent",
+      "Tool_schemas_auth",
+      "Tool_schemas_control",
+      "Tool_schemas_fire_task",
+      "Tool_schemas_inline",
+      "Tool_schemas_misc",
+      "Tool_schemas_plan",
+      "Tool_schemas_portal",
+      "Tool_schemas_room_core",
+      "Tool_schemas_room_extra",
+      "Tool_schemas_worktree",
+      "Tool_shard",
+      "Tool_suspend",
+      "Tool_task",
+      "Tool_team_session",
+      "Tool_tempo",
+      "Tool_voice",
+      "Tool_walph"
+    ],
+    "Tool_args": [
+      "Tool_command_plane_support",
+      "Tool_goals"
+    ],
+    "Tool_schemas_plan": [],
+    "Tool_schemas_portal": [],
+    "Tool_schemas_worktree": [],
+    "Tool_schemas_fire_task": [],
+    "Task_sandbox": [],
+    "Tool_fire_task": [
+      "Room",
+      "Spawn",
+      "Task_sandbox",
+      "Tool_args",
+      "Tool_schemas_fire_task"
+    ],
+    "Tool_schemas_auth": [],
+    "Tool_schemas_agent": [],
+    "Tool_schemas_room": [
+      "Tool_schemas_room_core",
+      "Tool_schemas_room_extra"
+    ],
+    "Tool_schemas_control": [],
+    "Tool_schemas_a2a": [],
+    "Tool_schemas_misc": [
+      "WebRTC"
+    ],
+    "Tool_improve_loop_schemas": [],
+    "Tool_improve_loop_types": [
+      "Room"
+    ],
+    "Tool_improve_loop_gh": [
+      "Tool_command_plane_support",
+      "Tool_improve_loop_types"
+    ],
+    "Tool_improve_loop_planner": [
+      "Autoresearch",
+      "Room",
+      "Tool_improve_loop_types"
+    ],
+    "Tool_improve_loop_executor": [
+      "Tool_improve_loop_planner",
+      "Tool_improve_loop_types",
+      "Tool_team_session"
+    ],
+    "Tool_plan": [
+      "Planning_eio",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_plan"
+    ],
+    "Tool_run": [
+      "Room",
+      "Run_eio",
+      "Tool_args"
+    ],
+    "Tool_bridge": [],
+    "Tool_cache": [
+      "Cache_eio",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_tempo": [
+      "Room",
+      "Tempo",
+      "Tool_args"
+    ],
+    "Mitosis_helpers": [
+      "Mitosis",
+      "Mitosis_spawn",
+      "Provider_adapter",
+      "Room",
+      "Spawn",
+      "Tool_args",
+      "Verifier_oas"
+    ],
+    "Mitosis_spawn": [
+      "Mitosis",
+      "Provider_adapter",
+      "Spawn"
+    ],
+    "Tool_portal": [
+      "Notify",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_portal"
+    ],
+    "Tool_worktree": [
+      "Room",
+      "Tool_args",
+      "Tool_schemas_worktree"
+    ],
+    "Tool_a2a": [
+      "A2a_tools",
+      "Config",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_a2a"
+    ],
+    "Tool_handover": [
+      "Handover_eio",
+      "Room",
+      "Spawn",
+      "Tool_args"
+    ],
+    "Tool_relay": [
+      "Mcp_server",
+      "Mitosis",
+      "Relay",
+      "Room",
+      "Spawn",
+      "Tool_args"
+    ],
+    "Worktree_live_context": [],
+    "Tool_goals": [
+      "Goal_guard",
+      "Goal_orchestrator",
+      "Goal_scheduler",
+      "Goal_store",
+      "Provider_adapter",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_operator": [
+      "Dashboard_collaboration_evidence",
+      "Dashboard_surface_readiness",
+      "Operator_control",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_team_session_support": [
+      "Room",
+      "Session",
+      "Team_session_engine_eio",
+      "Team_session_store",
+      "Tool_args",
+      "Tool_team_session_step"
+    ],
+    "Tool_team_session_handlers": [
+      "Team_session_engine_eio",
+      "Tool_args",
+      "Tool_team_session_step",
+      "Tool_team_session_support"
+    ],
+    "Tool_team_session": [],
+    "Tool_team_session_routing": [
+      "Local_runtime_pool",
+      "Oas_response",
+      "Oas_worker",
+      "Tool_team_session_step"
+    ],
+    "Tool_team_session_routing_workers": [
+      "Team_session_store",
+      "Tool_args"
+    ],
+    "Tool_team_session_step": [
+      "Room",
+      "Run_eio",
+      "Spawn",
+      "Team_session_store",
+      "Tool_args",
+      "Tool_team_session_step_exec",
+      "Tool_team_session_step_spawn",
+      "Worker_runtime",
+      "Worker_verification"
+    ],
+    "Tool_team_session_step_spawn": [
+      "Oas_worker",
+      "Spawn",
+      "Team_context",
+      "Team_session_store",
+      "Tool_team_session_step_exec",
+      "Worker_container_types",
+      "Worker_verification"
+    ],
+    "Tool_team_session_step_exec": [
+      "Local_runtime_pool",
+      "Oas_model_resolve",
+      "Room",
+      "Team_session_store",
+      "Verifier_oas",
+      "Worker_verification"
+    ],
+    "Tool_team_session_step_types": [
+      "Local_runtime_pool",
+      "Room"
+    ],
+    "Team_session_plan": [],
+    "Tool_team_session_schemas": [],
+    "Tool_heartbeat": [
+      "Keeper",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_encryption": [
+      "Encryption",
+      "Mcp_server",
+      "Tool_args"
+    ],
+    "Tool_auth": [
+      "Auth",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_auth"
+    ],
+    "Tool_hat": [
+      "Hat",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_housekeep": [],
+    "Tool_audit": [
+      "Audit_log",
+      "Metrics_store_eio",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_rate_limit": [
+      "Auth",
+      "Room",
+      "Session"
+    ],
+    "Tool_cost": [
+      "Tool_args"
+    ],
+    "Tool_walph": [
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_agent": [
+      "Agent_card",
+      "Config",
+      "Dashboard_agent_relations",
+      "Hebbian_eio",
+      "Metrics_store_eio",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_agent"
+    ],
+    "Tool_task": [
+      "A2a_tools",
+      "Anti_rationalization",
+      "Audit_log",
+      "Auth",
+      "Eval_calibration",
+      "Harness",
+      "Mcp_server",
+      "Metrics_store_eio",
+      "Planning_eio",
+      "Prometheus",
+      "Room",
+      "Sse",
+      "Subscriptions",
+      "Thompson_sampling",
+      "Tool_args"
+    ],
+    "Task_dispatch": [
+      "Room"
+    ],
+    "Tool_room": [
+      "Planning_eio",
+      "Room",
+      "Tool_args",
+      "Tool_schemas_room",
+      "Workflow_guide"
+    ],
+    "Workflow_guide": [],
+    "Tool_control": [
+      "Room",
+      "Tool_args",
+      "Tool_schemas_control"
+    ],
+    "Tool_improve_loop": [
+      "Room",
+      "Tool_args",
+      "Tool_improve_loop_schemas"
+    ],
+    "Tool_verification": [
+      "Tool_args",
+      "Verification"
+    ],
+    "Tool_misc": [
+      "Auth",
+      "Capability_registry",
+      "Command_plane_v2",
+      "Config",
+      "Cp_lifecycle",
+      "Dashboard",
+      "Drift_guard",
+      "Level2_config",
+      "Masc_grpc_server",
+      "Masc_grpc_service",
+      "Room",
+      "Server_mcp_transport_ws",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Tool_args",
+      "Tool_catalog",
+      "Tool_deep_review",
+      "Tool_help_registry",
+      "Tool_registry",
+      "Tool_schemas_misc"
+    ],
+    "Tool_agent_timeline": [
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_local_runtime": [
+      "Tool_local_runtime_bench",
+      "Tool_local_runtime_status",
+      "Tool_local_runtime_verify"
+    ],
+    "Tool_local_runtime_core": [
+      "Room"
+    ],
+    "Tool_local_runtime_http": [],
+    "Tool_local_runtime_verify": [
+      "Discovery_cache",
+      "Inference_utils",
+      "Local_runtime_pool",
+      "Masc_eio_env"
+    ],
+    "Tool_local_runtime_bench": [
+      "Inference_utils",
+      "Local_runtime_pool",
+      "Masc_eio_env",
+      "Oas_model_resolve"
+    ],
+    "Tool_local_runtime_status": [
+      "Inference_utils",
+      "Local_runtime_pool"
+    ],
+    "Tool_model_catalog": [
+      "Inference_utils"
+    ],
+    "Tool_board": [
+      "Board",
+      "Board_dispatch",
+      "Board_pg",
+      "Tool_args"
+    ],
+    "Tool_command_plane": [
+      "Mcp_server",
+      "Room",
+      "Tool_command_plane_chain_query",
+      "Tool_command_plane_dispatch",
+      "Tool_command_plane_schemas_01",
+      "Tool_command_plane_schemas_02",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_support": [
+      "Command_plane_v2",
+      "Cp_paths",
+      "Mcp_server",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_command_plane_chain_common": [
+      "Chain_mermaid_parser",
+      "Chain_native_eio",
+      "Chain_run_store",
+      "Chain_types",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_chain_launch": [
+      "Chain_mermaid_parser",
+      "Chain_native_eio",
+      "Chain_types",
+      "Command_plane_v2",
+      "Tool_command_plane_chain_common",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_chain_query": [
+      "Chain_native_eio",
+      "Command_plane_v2",
+      "Cp_paths",
+      "Cp_snapshot_summaries",
+      "Room",
+      "Tool_command_plane_chain_common",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_mutations": [
+      "Command_plane_v2",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_dispatch": [
+      "Tool_command_plane_chain_launch",
+      "Tool_command_plane_chain_query",
+      "Tool_command_plane_mutations",
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_schemas_01": [
+      "Tool_command_plane_support"
+    ],
+    "Tool_command_plane_schemas_02": [
+      "Tool_command_plane_support"
+    ],
+    "Tool_mdal": [
+      "Board",
+      "Board_dispatch",
+      "Bounded",
+      "Mdal",
+      "Mdal_swarm",
+      "Mdal_worker",
+      "Sse"
+    ],
+    "Tool_mdal_schemas": [
+      "Mdal",
+      "Mdal_swarm",
+      "Mdal_worker",
+      "Room"
+    ],
+    "Tool_mdal_handlers": [
+      "Board",
+      "Board_dispatch",
+      "Mdal",
+      "Mdal_store",
+      "Mdal_swarm",
+      "Mdal_worker",
+      "Room",
+      "Sse"
+    ],
+    "Tool_library": [],
+    "Tool_deep_review": [
+      "Oas_response",
+      "Oas_worker",
+      "Room"
+    ],
+    "Tool_budget": [
+      "Tool_catalog",
+      "Tools"
+    ],
+    "Tool_catalog": [
+      "Tool_dispatch",
+      "Tools"
+    ],
+    "Tool_result": [],
+    "Tool_dispatch": [
+      "Tool_result",
+      "Tools"
+    ],
+    "Tool_input_validation": [
+      "Tool_dispatch",
+      "Tool_result"
+    ],
+    "Tool_tag_init": [
+      "Tool_dispatch"
+    ],
+    "Tool_permissions": [
+      "Tool_dispatch",
+      "Tool_result"
+    ],
+    "Tool_metrics": [
+      "Tool_dispatch",
+      "Tool_result"
+    ],
+    "Tool_metrics_persist": [
+      "Shutdown",
+      "Tool_metrics",
+      "Tool_result"
+    ],
+    "Tool_inline_dispatch_types": [
+      "Mcp_server",
+      "Mcp_server_eio_governance",
+      "Room",
+      "Session"
+    ],
+    "Tool_inline_dispatch_room": [
+      "Institution_eio",
+      "Mcp_server",
+      "Planning_eio",
+      "Room",
+      "Session",
+      "Tool_inline_dispatch_types"
+    ],
+    "Tool_inline_dispatch_comm": [
+      "A2a_tools",
+      "Audit_log",
+      "Auto_responder",
+      "Bounded",
+      "Mcp_server",
+      "Notify",
+      "Room",
+      "Session",
+      "Spawn",
+      "Subscriptions",
+      "Team_session_engine_eio",
+      "Tool_args",
+      "Tool_inline_dispatch_types"
+    ],
+    "Tool_inline_dispatch": [
+      "Cancellation",
+      "Config",
+      "Mcp_server",
+      "Mcp_server_eio_governance",
+      "Mcp_session",
+      "Mitosis",
+      "Notify",
+      "Progress",
+      "Provider_adapter",
+      "Room",
+      "Session",
+      "Spawn",
+      "Subscriptions",
+      "Tool_args",
+      "Tool_catalog",
+      "Tool_inline_dispatch_comm",
+      "Tool_inline_dispatch_episode",
+      "Tool_inline_dispatch_extra",
+      "Tool_inline_dispatch_room",
+      "Tool_inline_dispatch_types",
+      "Tool_verification"
+    ],
+    "Tool_inline_dispatch_episode": [
+      "Mcp_server"
+    ],
+    "Tool_inline_dispatch_extra": [
+      "A2a_tools",
+      "Activity_graph",
+      "Audit_log",
+      "Auto_recall",
+      "Auto_responder",
+      "Board",
+      "Board_dispatch",
+      "Mcp_server",
+      "Metrics_store_eio",
+      "Mitosis",
+      "Notify",
+      "Room",
+      "Spawn",
+      "Tool_board"
+    ],
+    "Tool_unified": [
+      "Config",
+      "Oas_worker",
+      "Tool_catalog",
+      "Tool_dispatch",
+      "Tool_metrics",
+      "Tool_registry"
+    ],
+    "Tool_help_registry": [
+      "Tool_catalog",
+      "Workflow_guide"
+    ],
+    "Tool_registry": [
+      "Config",
+      "Telemetry_eio"
+    ],
+    "Tool_council_feed": [
+      "Board",
+      "Board_dispatch",
+      "Governance_registry",
+      "Room",
+      "Runtime_params",
+      "Sse",
+      "Tool_args",
+      "Tool_council_helpers",
+      "Tool_council_json"
+    ],
+    "Tool_council_helpers": [
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_council_internal_schemas": [],
+    "Tool_council_json": [],
+    "Tool_code": [
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_code_write": [
+      "Room",
+      "Tool_args",
+      "Tool_code"
+    ],
+    "Code_swarm_plan": [
+      "Oas_response",
+      "Oas_worker",
+      "Verifier_oas"
+    ],
+    "Tool_code_swarm": [
+      "Code_swarm_plan",
+      "Room",
+      "Tool_args"
+    ],
+    "Tool_suspend": [
+      "Audit_log",
+      "Room",
+      "Session",
+      "Telemetry_eio",
+      "Tool_args"
+    ],
+    "Tool_notifications": [
+      "Session",
+      "Tool_args"
+    ],
+    "Tool_voice": [
+      "Keeper_voice_local",
+      "Tool_args",
+      "Voice_bridge",
+      "Voice_session_manager"
+    ],
+    "Mention_inbox": [
+      "Room"
+    ],
+    "Agent_reputation": [
+      "Mention_inbox",
+      "Room"
+    ],
+    "Activity_feed": [
+      "Mention_inbox",
+      "Room"
+    ],
+    "Transport": [
+      "Config",
+      "Masc_grpc_server",
+      "Sdk_tool_contract",
+      "Server_webrtc_transport",
+      "Server_ws_standalone",
+      "Tool_catalog",
+      "Tool_help_registry",
+      "Version"
+    ],
+    "Transport_metrics": [
+      "Prometheus",
+      "Room",
+      "Server_webrtc_transport",
+      "Transport"
+    ],
+    "GRPC": [],
+    "Coordination": [],
+    "Masc_grpc_types": [],
+    "Masc_grpc_service": [
+      "Room",
+      "Sse",
+      "Transport",
+      "Transport_metrics"
+    ],
+    "Masc_grpc_server": [
+      "Masc_grpc_service",
+      "Transport",
+      "Transport_metrics"
+    ],
+    "Masc_grpc_client": [
+      "Masc_grpc_server",
+      "Masc_grpc_service",
+      "Transport"
+    ],
+    "Masc_grpc_transport": [
+      "Transport"
+    ],
+    "Shutdown": [],
+    "Supervisor": [],
+    "Audit_log": [],
+    "Build_identity": [
+      "Version"
+    ],
+    "Voice_config": [],
+    "Voice_bridge": [
+      "Code",
+      "Provider_adapter",
+      "Response",
+      "Transport",
+      "Voice_config"
+    ],
+    "Voice_bridge_core": [
+      "Provider_adapter",
+      "Voice_config"
+    ],
+    "Voice_session_manager": [
+      "Voice_bridge"
+    ],
+    "Version": [],
+    "Webrtc_bindings/common/datachannel": [],
+    "Keeper": [],
+    "Agent": [],
+    "Harness": [],
+    "+": [],
+    "Eval": [],
+    "Gates": [],
+    "Scenarios": [],
+    "Trajectory": [
+      "Keeper"
+    ],
+    "Eval_gate": [
+      "Trajectory"
+    ],
+    "Eval_harness": [
+      "Trajectory"
+    ],
+    "Eval_calibration": [
+      "Anti_rationalization",
+      "Harness"
+    ],
+    "Contract": [],
+    "Keeper_schema": [],
+    "Keeper_config": [
+      "Tool_args"
+    ],
+    "Keeper_toml_loader": [
+      "Keeper_types_profile"
+    ],
+    "Keeper_contract": [],
+    "Keeper_cdal_contract": [
+      "Keeper_types"
+    ],
+    "Proof_artifact_reader": [],
+    "Violation_record": [],
+    "Token_usage_record": [],
+    "Cdal_types": [],
+    "Cdal_loader": [],
+    "Cdal_judge": [
+      "Cdal_loader",
+      "Cdal_types"
+    ],
+    "Cdal_eval_v1": [
+      "Cdal_judge",
+      "Cdal_loader",
+      "Cdal_types"
+    ],
+    "Cdal_friction_projection": [
+      "Proof_artifact_reader",
+      "Violation_record"
+    ],
+    "Artifact_store": [],
+    "Golden_set": [],
+    "Adversarial_eval": [],
+    "Contract_risk": [],
+    "Contract_composer": [
+      "Contract_risk"
+    ],
+    "Keeper_deliberation": [
+      "Prompt_registry"
+    ],
+    "Keeper_types_profile": [
+      "Config_dir_resolver",
+      "Keeper",
+      "Keeper_schema",
+      "Keeper_toml_loader",
+      "Room",
+      "Voice_config"
+    ],
+    "Keeper_types_support": [
+      "Oas_model_resolve",
+      "Room"
+    ],
+    "Keeper_types": [
+      "Keeper",
+      "Room"
+    ],
+    "Keeper_memory": [],
+    "Keeper_memory_policy": [
+      "Keeper_contract",
+      "Keeper_deliberation",
+      "Keeper_types"
+    ],
+    "Keeper_memory_bank": [
+      "Keeper_types",
+      "Room"
+    ],
+    "Keeper_memory_recall": [
+      "Keeper_types",
+      "Room"
+    ],
+    "Keeper_skill_routing": [
+      "Keeper_memory",
+      "Keeper_types"
+    ],
+    "Keeper_alerting": [
+      "Keeper",
+      "Keeper_memory",
+      "Keeper_types",
+      "Tool_board",
+      "Tool_shard"
+    ],
+    "Keeper_alerting_path": [
+      "Keeper_working_context",
+      "Room"
+    ],
+    "Keeper_exec_tools": [
+      "Agent",
+      "Keeper",
+      "Keeper_alerting",
+      "Keeper_memory",
+      "Keeper_types",
+      "Keeper_voice_local",
+      "Keeper_working_context",
+      "Room",
+      "Tool_autoresearch",
+      "Tool_board",
+      "Tool_code_write",
+      "Tool_dispatch",
+      "Tool_library",
+      "Tool_research",
+      "Tool_shard",
+      "Tools",
+      "Voice_bridge",
+      "Voice_session_manager",
+      "Worker_dev_tools"
+    ],
+    "Keeper_voice_local": [
+      "Voice_session_manager"
+    ],
+    "Keeper_exec_status_metrics": [],
+    "Keeper_exec_status": [
+      "Keeper_exec_status_metrics",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Room"
+    ],
+    "Keeper_exec_persona": [
+      "Keeper_memory",
+      "Keeper_types",
+      "Tool_args"
+    ],
+    "Keeper_working_context": [
+      "Context",
+      "Inference_utils"
+    ],
+    "Keeper_checkpoint_store": [
+      "Checkpoint_store",
+      "Inference_utils",
+      "Keeper",
+      "Keeper_working_context"
+    ],
+    "Keeper_text_processing": [
+      "Keeper_memory_policy",
+      "Keeper_skill_routing",
+      "Keeper_types"
+    ],
+    "Keeper_exec_context": [
+      "Cascade_inference",
+      "Context",
+      "Context_compact_oas",
+      "Dashboard_harness_health",
+      "Harness",
+      "Inference_utils",
+      "Keeper",
+      "Keeper_alerting",
+      "Keeper_checkpoint_store",
+      "Keeper_config",
+      "Keeper_contract",
+      "Keeper_exec_status",
+      "Keeper_exec_tools",
+      "Keeper_memory",
+      "Keeper_prompt",
+      "Keeper_tools_oas",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Oas_worker",
+      "Room",
+      "Sse"
+    ],
+    "Keeper_tools_oas": [
+      "Agent",
+      "Keeper",
+      "Keeper_exec_tools",
+      "Keeper_registry",
+      "Keeper_types",
+      "Keeper_working_context",
+      "Room",
+      "Tool_bridge",
+      "Worktree_live_context"
+    ],
+    "Keeper_hooks_oas": [
+      "Agent",
+      "Eval_gate",
+      "Keeper",
+      "Keeper_types",
+      "Keeper_working_context",
+      "Room",
+      "Trajectory"
+    ],
+    "Keeper_extend_turns": [
+      "Agent"
+    ],
+    "Keeper_agent_run": [
+      "Agent",
+      "Cascade_inference",
+      "Cdal_eval_v1",
+      "Cdal_loader",
+      "Cdal_types",
+      "Keeper",
+      "Keeper_cdal_contract",
+      "Keeper_checkpoint_store",
+      "Keeper_exec_context",
+      "Keeper_extend_turns",
+      "Keeper_hooks_oas",
+      "Keeper_prompt",
+      "Keeper_tools_oas",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Memory_oas_bridge",
+      "Oas_worker",
+      "Room",
+      "Trajectory"
+    ],
+    "Keeper_world_observation": [
+      "Agent_economy",
+      "Board",
+      "Board_dispatch",
+      "Keeper",
+      "Keeper_config",
+      "Keeper_exec_context",
+      "Keeper_memory",
+      "Keeper_registry",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Room",
+      "Worktree_live_context"
+    ],
+    "Keeper_unified_prompt": [
+      "Agent_economy",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prompt_registry"
+    ],
+    "Keeper_unified_turn": [
+      "Agent",
+      "Cascade_inference",
+      "Keeper",
+      "Keeper_agent_run",
+      "Keeper_config",
+      "Keeper_coordination",
+      "Keeper_exec_context",
+      "Keeper_memory",
+      "Keeper_types",
+      "Keeper_unified_prompt",
+      "Keeper_world_observation",
+      "Oas_model_resolve",
+      "Room"
+    ],
+    "Keeper_prompt": [
+      "Board",
+      "Cascade_inference",
+      "Keeper_config",
+      "Keeper_memory",
+      "Keeper_skill_routing",
+      "Keeper_types",
+      "Prompt_registry"
+    ],
+    "Keeper_coordination": [
+      "Keeper_contract",
+      "Keeper_exec_context",
+      "Keeper_types",
+      "Room"
+    ],
+    "Keeper_execution": [
+      "Keeper_exec_context"
+    ],
+    "Keeper_keepalive": [
+      "Board_dispatch",
+      "Keeper",
+      "Keeper_exec_context",
+      "Keeper_execution",
+      "Keeper_memory",
+      "Keeper_recurring",
+      "Keeper_registry",
+      "Keeper_types",
+      "Keeper_unified_turn",
+      "Keeper_world_observation",
+      "Masc_grpc_client",
+      "Masc_grpc_transport",
+      "Masc_grpc_types",
+      "Oas_events",
+      "Oas_model_resolve",
+      "Room",
+      "Sse",
+      "Tool_improve_loop"
+    ],
+    "Keeper_chat_store": [
+      "Keeper"
+    ],
+    "Keeper_recurring": [],
+    "Keeper_registry": [
+      "Keeper_types"
+    ],
+    "Keeper_supervisor": [
+      "Agent",
+      "Keeper",
+      "Keeper_execution",
+      "Keeper_keepalive",
+      "Keeper_registry",
+      "Keeper_types",
+      "Oas_events",
+      "Room"
+    ],
+    "Keeper_runtime": [
+      "Keeper",
+      "Keeper_config",
+      "Keeper_keepalive",
+      "Keeper_registry",
+      "Keeper_supervisor",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Pulse"
+    ],
+    "Keeper_turn_session": [
+      "Agent",
+      "Keeper",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Team_session_store",
+      "Tool_team_session"
+    ],
+    "Keeper_turn_setup": [
+      "Keeper_types"
+    ],
+    "Keeper_turn_up_args": [
+      "Keeper",
+      "Keeper_types",
+      "Tool_args"
+    ],
+    "Keeper_turn_up_create": [
+      "Keeper_exec_context",
+      "Keeper_execution",
+      "Keeper_keepalive",
+      "Keeper_registry",
+      "Keeper_turn_up_args",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Oas_model_resolve",
+      "Progress"
+    ],
+    "Keeper_turn_up_update": [
+      "Keeper_keepalive",
+      "Keeper_turn_up_args",
+      "Keeper_types"
+    ],
+    "Keeper_turn_up": [
+      "Keeper_turn_up_args",
+      "Keeper_turn_up_create",
+      "Keeper_turn_up_update",
+      "Keeper_types"
+    ],
+    "Keeper_turn_lifecycle": [
+      "Keeper",
+      "Keeper_keepalive",
+      "Keeper_registry",
+      "Keeper_turn_session",
+      "Keeper_types",
+      "Operator_pending_confirm",
+      "Team_session_engine_eio",
+      "Tool_args"
+    ],
+    "Keeper_turn": [
+      "Agent",
+      "Keeper_agent_run",
+      "Keeper_alerting",
+      "Keeper_exec_tools",
+      "Keeper_execution",
+      "Keeper_keepalive",
+      "Keeper_memory",
+      "Keeper_turn_lifecycle",
+      "Keeper_turn_setup",
+      "Keeper_turn_up",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Progress",
+      "Tool_args",
+      "Trajectory",
+      "Worktree_live_context"
+    ],
+    "Keeper_status_detail": [
+      "Keeper_alerting",
+      "Keeper_exec_context",
+      "Keeper_exec_status",
+      "Keeper_exec_status_metrics",
+      "Keeper_exec_tools",
+      "Keeper_execution",
+      "Keeper_memory",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Oas_model_resolve",
+      "Tool_args"
+    ],
+    "Keeper_status": [
+      "Eval_harness",
+      "Keeper_alerting",
+      "Keeper_exec_status",
+      "Keeper_exec_status_metrics",
+      "Keeper_execution",
+      "Keeper_memory",
+      "Keeper_status_detail",
+      "Keeper_types",
+      "Tool_args",
+      "Trajectory"
+    ],
+    "Keeper_status_bridge": [
+      "Keeper_exec_status",
+      "Keeper_registry",
+      "Keeper_types",
+      "Team_session_store"
+    ],
+    "Keeper_persona": [
+      "Keeper_exec_persona",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Tool_args"
+    ],
+    "Context": [],
+    "Management": [],
+    "By": [],
+    "Agents": [],
+    "Masc_eio_env": [],
+    "Discovery_cache": [],
+    "Oas_model_resolve": [
+      "Config_dir_resolver",
+      "Provider_adapter"
+    ],
+    "Context_compact_oas": [
+      "Keeper_working_context",
+      "Keeper_world_observation"
+    ],
+    "Verifier_oas": [
+      "Eval_gate",
+      "Oas_response",
+      "Oas_worker"
+    ],
+    "Procedural_memory": [],
+    "Oas_events": [
+      "Context_compact_oas",
+      "Eval_calibration",
+      "Mitosis"
+    ],
+    "Oas_worker": [
+      "Agent",
+      "Config_dir_resolver",
+      "Masc_grpc_transport",
+      "Oas_model_resolve",
+      "Oas_response",
+      "Provider_adapter",
+      "Tool_bridge"
+    ],
+    "Tool_council_oas": [
+      "Memory_oas_bridge",
+      "Oas_response",
+      "Oas_worker",
+      "Prompt_registry",
+      "Room",
+      "Tool_args",
+      "Tool_council_internal_schemas"
+    ],
+    "Oas_sse_bridge": [
+      "Sse"
+    ],
+    "Env_config_introspect": [
+      "Server_startup_state",
+      "Version"
+    ],
+    "Runtime_params": [
+      "Config"
+    ],
+    "Governance_registry": [
+      "Eval_gate",
+      "Runtime_params"
+    ],
+    "Governance_pipeline": [
+      "Audit_log",
+      "Operator_pending_confirm",
+      "Otel_spans",
+      "Room",
+      "Tool_dispatch",
+      "Tool_result"
+    ],
+    "Tool_compact": [
+      "Context_compact_oas",
+      "Keeper_exec_context"
+    ],
+    "Tool_shard": [
+      "Board",
+      "Tool_autoresearch_schemas",
+      "Tool_code",
+      "Tool_council_internal_schemas",
+      "Tool_schemas_worktree"
+    ],
+    "Tool_keeper": [
+      "Keeper",
+      "Keeper_exec_persona",
+      "Keeper_exec_status",
+      "Keeper_memory",
+      "Keeper_recurring",
+      "Keeper_runtime",
+      "Keeper_status_bridge",
+      "Keeper_types",
+      "Room",
+      "Tool_args",
+      "Tool_housekeep"
+    ],
+    "Autoresearch": [
+      "Autoresearch_codegen"
+    ],
+    "Karpathy-inspired": [],
+    "Autonomous": [],
+    "Experiment": [],
+    "Loop": [],
+    "Autoresearch_codegen": [
+      "Cascade_inference",
+      "Oas_response",
+      "Oas_worker"
+    ],
+    "Autoresearch_knowledge": [
+      "Graphql_client",
+      "Keeper"
+    ],
+    "Tool_autoresearch_schemas": [],
+    "Tool_autoresearch_registry": [
+      "Autoresearch"
+    ],
+    "Tool_autoresearch_broadcast": [
+      "Autoresearch",
+      "Sse"
+    ],
+    "Tool_autoresearch_repo_synthesis": [
+      "Command_plane_v2",
+      "Repo_synthesis_benchmark",
+      "Room",
+      "Team_session_store",
+      "Tool_args"
+    ],
+    "Tool_autoresearch_cycle": [
+      "Autoresearch",
+      "Autoresearch_knowledge",
+      "Memory_oas_bridge",
+      "Procedural_memory",
+      "Room",
+      "Team_session_store",
+      "Tool_args",
+      "Tool_autoresearch_broadcast",
+      "Tool_autoresearch_registry",
+      "Tool_autoresearch_repo_synthesis"
+    ],
+    "Tool_autoresearch": [
+      "Autoresearch",
+      "Autoresearch_knowledge",
+      "Progress",
+      "Room",
+      "Team_session_store",
+      "Tool_args",
+      "Tool_autoresearch_cycle",
+      "Tool_autoresearch_schemas"
+    ],
+    "Code": [],
+    "Research": [],
+    "Tool_research": [
+      "Cascade_inference"
+    ],
+    "Adapter": [],
+    "Logic": [],
+    "Masc_research": [],
+    "Godsplit-phase1:": [],
+    "Type/schema": [],
+    "Sub-modules": [],
+    "Tool_schemas_room_core": [],
+    "Tool_schemas_room_extra": [],
+    "Tool_schemas_inline_room": [],
+    "Tool_schemas_inline_verify": [],
+    "Tool_schemas_inline_infra": [],
+    "Tool_schemas_inline_episodes": [],
+    "Tool_schemas_inline_convo": [],
+    "Tool_schemas_inline": [
+      "Tool_schemas_inline_convo",
+      "Tool_schemas_inline_episodes",
+      "Tool_schemas_inline_infra",
+      "Tool_schemas_inline_room",
+      "Tool_schemas_inline_verify"
+    ]
+  }
+}

--- a/scripts/analyze_lib_deps.py
+++ b/scripts/analyze_lib_deps.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Analyze module dependencies in lib/ monolith for sub-library extraction.
+
+Phase 0 of #3593: dependency graph analysis.
+
+Usage:
+    python3 scripts/analyze_lib_deps.py [--json] [--cycles] [--clusters]
+"""
+
+import os
+import re
+import sys
+import json
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = ROOT / "lib"
+
+# Sub-library directories (already extracted, skip these)
+SUB_LIBRARY_DIRS: set[str] = set()
+
+
+def discover_sub_libraries() -> None:
+    """Find directories with their own dune library stanza."""
+    for child in LIB_DIR.iterdir():
+        if child.is_dir():
+            dune_file = child / "dune"
+            if dune_file.exists():
+                content = dune_file.read_text()
+                if "(library" in content:
+                    SUB_LIBRARY_DIRS.add(child.name)
+
+
+def get_monolith_modules() -> dict[str, Path]:
+    """Parse lib/dune to get explicit module list."""
+    dune_path = LIB_DIR / "dune"
+    content = dune_path.read_text()
+
+    # Extract modules from (modules ...) stanza
+    modules: dict[str, Path] = {}
+    in_modules = False
+    paren_depth = 0
+
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if "(modules" in stripped:
+            in_modules = True
+            paren_depth = 1
+            # Extract any modules on same line after (modules
+            after = stripped.split("(modules")[1]
+            for word in after.split():
+                w = word.strip(")")
+                if w and not w.startswith("("):
+                    modules[w] = _find_ml_file(w)
+            continue
+
+        if in_modules:
+            paren_depth += stripped.count("(") - stripped.count(")")
+            if paren_depth <= 0:
+                in_modules = False
+                continue
+            for word in stripped.split():
+                w = word.strip(")")
+                if w and not w.startswith(";") and not w.startswith("("):
+                    modules[w] = _find_ml_file(w)
+
+    return modules
+
+
+def _find_ml_file(module_name: str) -> Path:
+    """Find .ml file for a module name, searching lib/ and subdirs."""
+    # Direct in lib/
+    direct = LIB_DIR / f"{module_name}.ml"
+    if direct.exists():
+        return direct
+
+    # Search subdirectories (non-sub-library ones only)
+    for child in LIB_DIR.iterdir():
+        if child.is_dir() and child.name not in SUB_LIBRARY_DIRS:
+            candidate = child / f"{module_name}.ml"
+            if candidate.exists():
+                return candidate
+
+    return direct  # fallback even if missing
+
+
+def extract_module_refs(filepath: Path) -> set[str]:
+    """Extract module references from an OCaml source file."""
+    if not filepath.exists():
+        return set()
+
+    content = filepath.read_text(errors="replace")
+    refs: set[str] = set()
+
+    # Pattern 1: open Module
+    for m in re.finditer(r"\bopen\s+([A-Z][A-Za-z0-9_]*)", content):
+        refs.add(m.group(1))
+
+    # Pattern 2: Module.something (but not inside strings/comments)
+    # Simple heuristic: skip lines starting with (* or inside strings
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("(*") or stripped.startswith("\""):
+            continue
+        for m in re.finditer(r"\b([A-Z][A-Za-z0-9_]*)\.(?![A-Z])", line):
+            refs.add(m.group(1))
+
+    # Pattern 3: Module.Constructor or Module.Type (Module.CapitalWord)
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("(*"):
+            continue
+        for m in re.finditer(r"\b([A-Z][A-Za-z0-9_]*)\.[A-Z]", line):
+            refs.add(m.group(1))
+
+    return refs
+
+
+def module_name_of_file(name: str) -> str:
+    """Convert file-level module name to OCaml module name."""
+    # OCaml module names are capitalized
+    return name[0].upper() + name[1:]
+
+
+def build_dependency_graph(
+    modules: dict[str, Path],
+) -> dict[str, set[str]]:
+    """Build adjacency list of module dependencies."""
+    # Map: OCaml module name -> file-level name
+    ocaml_to_file: dict[str, str] = {}
+    for name in modules:
+        ocaml_name = module_name_of_file(name)
+        ocaml_to_file[ocaml_name] = name
+
+    valid_modules = set(ocaml_to_file.keys())
+    graph: dict[str, set[str]] = defaultdict(set)
+
+    for name, filepath in modules.items():
+        ocaml_name = module_name_of_file(name)
+        refs = extract_module_refs(filepath)
+        # Filter to internal monolith modules only
+        internal_refs = refs & valid_modules
+        internal_refs.discard(ocaml_name)  # no self-ref
+        graph[ocaml_name] = internal_refs
+
+    return dict(graph)
+
+
+def find_cycles(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Find all strongly connected components with size > 1 (cycles)."""
+    # Tarjan's SCC algorithm
+    index_counter = [0]
+    stack: list[str] = []
+    lowlink: dict[str, int] = {}
+    index: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    sccs: list[list[str]] = []
+
+    def strongconnect(v: str) -> None:
+        index[v] = index_counter[0]
+        lowlink[v] = index_counter[0]
+        index_counter[0] += 1
+        stack.append(v)
+        on_stack[v] = True
+
+        for w in graph.get(v, set()):
+            if w not in index:
+                strongconnect(w)
+                lowlink[v] = min(lowlink[v], lowlink[w])
+            elif on_stack.get(w, False):
+                lowlink[v] = min(lowlink[v], index[w])
+
+        if lowlink[v] == index[v]:
+            scc: list[str] = []
+            while True:
+                w = stack.pop()
+                on_stack[w] = False
+                scc.append(w)
+                if w == v:
+                    break
+            if len(scc) > 1:
+                sccs.append(sorted(scc))
+
+    # Increase recursion limit for large graphs
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, len(graph) * 2 + 100))
+
+    for v in sorted(graph.keys()):
+        if v not in index:
+            strongconnect(v)
+
+    sys.setrecursionlimit(old_limit)
+    return sorted(sccs, key=lambda x: -len(x))
+
+
+def compute_stats(
+    graph: dict[str, set[str]],
+) -> dict[str, object]:
+    """Compute dependency statistics."""
+    in_degree: dict[str, int] = defaultdict(int)
+    out_degree: dict[str, int] = {}
+
+    for node, deps in graph.items():
+        out_degree[node] = len(deps)
+        for dep in deps:
+            in_degree[dep] += 1
+
+    # Top importers (most dependencies)
+    top_out = sorted(out_degree.items(), key=lambda x: -x[1])[:20]
+
+    # Top imported (most dependents)
+    top_in = sorted(in_degree.items(), key=lambda x: -x[1])[:20]
+
+    # Leaf modules (no internal deps)
+    leaves = [n for n, d in out_degree.items() if d == 0]
+
+    # Root modules (nothing depends on them)
+    all_nodes = set(graph.keys())
+    depended_on = set()
+    for deps in graph.values():
+        depended_on |= deps
+    roots = sorted(all_nodes - depended_on)
+
+    return {
+        "total_modules": len(graph),
+        "total_edges": sum(out_degree.values()),
+        "avg_out_degree": round(sum(out_degree.values()) / max(len(graph), 1), 2),
+        "top_importers": top_out,
+        "top_imported": top_in,
+        "leaf_count": len(leaves),
+        "root_count": len(roots),
+        "roots_sample": roots[:20],
+    }
+
+
+def identify_clusters(
+    graph: dict[str, set[str]],
+    modules: dict[str, Path],
+) -> list[dict[str, object]]:
+    """Identify potential sub-library extraction candidates by prefix."""
+    prefix_groups: dict[str, list[str]] = defaultdict(list)
+
+    for name in modules:
+        ocaml_name = module_name_of_file(name)
+        # Group by common prefixes
+        parts = name.split("_")
+        if len(parts) >= 2:
+            prefix = parts[0] + "_" + parts[1]
+            prefix_groups[prefix].append(ocaml_name)
+
+    # Filter to groups with 3+ modules
+    candidates = []
+    for prefix, members in sorted(prefix_groups.items(), key=lambda x: -len(x[1])):
+        if len(members) < 3:
+            continue
+
+        # Count internal vs external deps
+        member_set = set(members)
+        internal_edges = 0
+        external_deps: set[str] = set()
+        for m in members:
+            for dep in graph.get(m, set()):
+                if dep in member_set:
+                    internal_edges += 1
+                else:
+                    external_deps.add(dep)
+
+        candidates.append({
+            "prefix": prefix,
+            "module_count": len(members),
+            "members": sorted(members),
+            "internal_edges": internal_edges,
+            "external_dep_count": len(external_deps),
+            "coupling_ratio": round(
+                internal_edges / max(internal_edges + len(external_deps), 1), 3
+            ),
+        })
+
+    return sorted(candidates, key=lambda x: (-x["coupling_ratio"], -x["module_count"]))
+
+
+def main() -> None:
+    args = set(sys.argv[1:])
+
+    discover_sub_libraries()
+    print(f"Sub-libraries already extracted: {len(SUB_LIBRARY_DIRS)}")
+    print(f"  {', '.join(sorted(SUB_LIBRARY_DIRS))}")
+    print()
+
+    modules = get_monolith_modules()
+    print(f"Monolith modules in lib/dune: {len(modules)}")
+
+    missing = [n for n, p in modules.items() if not p.exists()]
+    if missing:
+        print(f"  Missing .ml files: {len(missing)}")
+
+    print()
+
+    graph = build_dependency_graph(modules)
+    stats = compute_stats(graph)
+
+    print(f"=== Dependency Statistics ===")
+    print(f"Total modules: {stats['total_modules']}")
+    print(f"Total edges: {stats['total_edges']}")
+    print(f"Avg out-degree: {stats['avg_out_degree']}")
+    print(f"Leaf modules (no internal deps): {stats['leaf_count']}")
+    print(f"Root modules (nothing depends on them): {stats['root_count']}")
+    print()
+
+    print(f"=== Top 20 Most-Imported Modules ===")
+    for name, count in stats["top_imported"]:
+        print(f"  {name}: {count} dependents")
+    print()
+
+    print(f"=== Top 20 Heaviest Importers ===")
+    for name, count in stats["top_importers"]:
+        print(f"  {name}: {count} dependencies")
+    print()
+
+    if "--cycles" in args or "--json" not in args:
+        cycles = find_cycles(graph)
+        print(f"=== Circular Dependencies ===")
+        print(f"Strongly connected components (cycles): {len(cycles)}")
+        for i, scc in enumerate(cycles[:10]):
+            print(f"  SCC {i+1} ({len(scc)} modules): {', '.join(scc[:8])}{'...' if len(scc) > 8 else ''}")
+        print()
+
+    if "--clusters" in args or "--json" not in args:
+        clusters = identify_clusters(graph, modules)
+        print(f"=== Extraction Candidates (prefix-based, 3+ modules) ===")
+        for c in clusters[:15]:
+            print(
+                f"  {c['prefix']}: {c['module_count']} modules, "
+                f"coupling={c['coupling_ratio']}, "
+                f"ext_deps={c['external_dep_count']}"
+            )
+        print()
+
+    if "--json" in args:
+        output = {
+            "stats": {
+                "total_modules": stats["total_modules"],
+                "total_edges": stats["total_edges"],
+                "avg_out_degree": stats["avg_out_degree"],
+                "leaf_count": stats["leaf_count"],
+                "root_count": stats["root_count"],
+            },
+            "top_imported": stats["top_imported"],
+            "top_importers": stats["top_importers"],
+            "cycles": find_cycles(graph),
+            "clusters": identify_clusters(graph, modules),
+            "graph": {k: sorted(v) for k, v in graph.items()},
+        }
+        json_path = ROOT / "reports" / "lib-dependency-graph.json"
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(output, indent=2))
+        print(f"Full graph written to {json_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- lib/ monolith 의존성 그래프 자동 분석 스크립트 + 결과 리포트
- 586 모듈, 1,961 에지, 115-모듈 순환 의존(SCC-1) 발견
- 데이터 기반 추출 우선순위 도출

## Key Findings
- **SCC-1 (115 modules)**: Tool_* 49개 + Keeper_* 17개가 순환의 핵심. Room(139 dependents)이 허브
- **즉시 추출 가능**: activity_graph(4), prompt_registry(3), swarm_status(8), tool_schemas(18) — 총 33 모듈, coupling >= 0.875
- **SCC-2, SCC-3**: 각 2 모듈 사소한 순환 — 빠른 수정 가능
- 이슈 원래 Phase 1(chain) 제안 대비, 데이터 기반 Batch 1이 더 안전

## Files
| 파일 | 용도 |
|------|------|
| `scripts/analyze_lib_deps.py` | 의존성 분석 스크립트 (재실행 가능) |
| `reports/lib-dependency-graph.json` | 전체 그래프 + 통계 (JSON) |
| `reports/lib-decomposition-phase0.md` | 분석 결과 + 추출 계획 |

## Usage
```bash
python3 scripts/analyze_lib_deps.py           # 요약 출력
python3 scripts/analyze_lib_deps.py --json    # JSON 리포트 생성
```

Part of #3593

🤖 Generated with [Claude Code](https://claude.com/claude-code)