### PR TITLE
fix(ci): ignore quoted Obj.magic mentions in health ratchet

### DIFF
--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -92,13 +92,13 @@ count_pattern() {
   printf '%s' "${total:-0}"
 }
 
-count_pattern_without_quotes() {
+count_pattern_pcre() {
   local dir="$1"
   local pattern="$2"
   local total
   total="$(
-    rg -n "$pattern" "$dir" -g '*.{ml,mli}' 2>/dev/null \
-      | awk 'index($0, "\"") == 0 {count++} END {print count+0}'
+    rg -n -P "$pattern" "$dir" -g '*.{ml,mli}' 2>/dev/null \
+      | awk 'END {print NR+0}'
   )"
   printf '%s' "${total:-0}"
 }
@@ -200,13 +200,13 @@ lib_failwith="$(count_pattern lib 'failwith')"
 lib_list_hd="$(count_pattern lib 'List\.hd')"
 lib_list_tl="$(count_pattern lib 'List\.tl')"
 lib_option_get="$(count_pattern lib 'Option\.get')"
-lib_obj_magic="$(count_pattern_without_quotes lib 'Obj\.magic([[:space:]]|\()')"
+lib_obj_magic="$(count_pattern_pcre lib '^(?:[^"\n]*"[^"\n]*")*[^"\n]*\bObj\.magic\b')"
 
 test_failwith="$(count_pattern test 'failwith')"
 test_list_hd="$(count_pattern test 'List\.hd')"
 test_list_tl="$(count_pattern test 'List\.tl')"
 test_option_get="$(count_pattern test 'Option\.get')"
-test_obj_magic="$(count_pattern_without_quotes test 'Obj\.magic([[:space:]]|\()')"
+test_obj_magic="$(count_pattern_pcre test '^(?:[^"\n]*"[^"\n]*")*[^"\n]*\bObj\.magic\b')"
 
 ml_line_cap_json="$(mktemp)"
 ml_line_cap_cmd=(

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -92,6 +92,17 @@ count_pattern() {
   printf '%s' "${total:-0}"
 }
 
+count_pattern_without_quotes() {
+  local dir="$1"
+  local pattern="$2"
+  local total
+  total="$(
+    rg -n "$pattern" "$dir" -g '*.{ml,mli}' 2>/dev/null \
+      | awk 'index($0, "\"") == 0 {count++} END {print count+0}'
+  )"
+  printf '%s' "${total:-0}"
+}
+
 extract_baseline_value() {
   local content="$1"
   local key="$2"
@@ -189,13 +200,13 @@ lib_failwith="$(count_pattern lib 'failwith')"
 lib_list_hd="$(count_pattern lib 'List\.hd')"
 lib_list_tl="$(count_pattern lib 'List\.tl')"
 lib_option_get="$(count_pattern lib 'Option\.get')"
-lib_obj_magic="$(count_pattern lib 'Obj\.magic')"
+lib_obj_magic="$(count_pattern_without_quotes lib 'Obj\.magic([[:space:]]|\()')"
 
 test_failwith="$(count_pattern test 'failwith')"
 test_list_hd="$(count_pattern test 'List\.hd')"
 test_list_tl="$(count_pattern test 'List\.tl')"
 test_option_get="$(count_pattern test 'Option\.get')"
-test_obj_magic="$(count_pattern test 'Obj\.magic')"
+test_obj_magic="$(count_pattern_without_quotes test 'Obj\.magic([[:space:]]|\()')"
 
 ml_line_cap_json="$(mktemp)"
 ml_line_cap_cmd=(


### PR DESCRIPTION
## Summary
- make the health ratchet count Obj.magic only when it looks like an actual call
- ignore quoted Obj.magic mentions in prompts, fixtures, and training data
- unblock PRs whose Health check is currently failing on false-positive lib_obj_magic regressions

## Product impact
- promise: CI signal quality
- impact: docs/CI-only PRs no longer fail Health because of string literals such as "Use Obj.magic everywhere"

## Evidence
- bash -n scripts/health_snapshot.sh
- bash scripts/health_snapshot.sh --skip-build --json-out /tmp/health-obj-magic-fix.json --baseline-ref origin/main --fail-on-lib-regression
- result after fix: Unsafe patterns (lib) obj_magic=0, Unsafe patterns (test) obj_magic=0, Ratchet: pass (no lib regressions)

## Review evidence
- reviewer: local merge-gate investigation + direct command verification
- reviewed at: 2026-03-29 Asia/Seoul
- summary: current failures on PRs such as #3609 came from quoted Obj.magic strings in lib/cdal/*, not from real unsafe casts

## Linked issue
- Refs #3609
- Refs #3622
