### PR TITLE
fix(cdal): enforce adversarial red-line paths (#3524)

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -49,6 +49,9 @@ let banned_doc_patterns =
 let doc_extensions =
   [ ".md"; ".markdown"; ".mdx"; ".txt"; ".rst"; ".adoc"; ".asciidoc" ]
 
+let data_artifact_extensions =
+  [ ".json"; ".jsonl"; ".yaml"; ".yml"; ".log"; ".txt" ]
+
 let normalize_path path =
   String.map (fun c -> if c = '\\' then '/' else c) path
   |> String.lowercase_ascii
@@ -65,6 +68,12 @@ let contains_substring text pattern =
 
 let has_doc_extension path =
   List.exists (Filename.check_suffix path) doc_extensions
+
+let has_data_artifact_extension path =
+  List.exists (Filename.check_suffix path) data_artifact_extensions
+
+let has_history_artifact_extension path =
+  has_doc_extension path || has_data_artifact_extension path
 
 let split_path_segments path =
   String.split_on_char '/' path
@@ -119,21 +128,23 @@ let classify_path path =
       segments
   in
   let has_room_history =
-    List.exists (contains_substring normalized)
-      [ "room_history"; "room-history"; "roomtaskhistory"; "room_task_history";
-        "room-task-history" ]
+    has_history_artifact_extension lower
+    && List.exists (contains_substring normalized)
+         [ "room_history"; "room-history"; "roomtaskhistory"; "room_task_history";
+           "room-task-history" ]
   in
   let has_task_history =
-    List.exists (contains_substring normalized)
-      [ "task_history"; "task-history"; "taskhistory"; "room/task_history";
-        "room/task-history" ]
+    has_history_artifact_extension lower
+    && List.exists (contains_substring normalized)
+         [ "task_history"; "task-history"; "taskhistory"; "room/task_history";
+           "room/task-history" ]
   in
   let has_governance_history =
     (List.mem "governance" basename_tokens
-     && List.exists (Filename.check_suffix lower)
-          [ ".json"; ".jsonl"; ".yaml"; ".yml"; ".log"; ".txt" ])
-    || List.exists (contains_substring normalized) [ "session_log"; "session-log" ]
-    || (List.mem "retrospective" basename_tokens && has_doc_extension lower)
+     && has_data_artifact_extension lower)
+    || (has_history_artifact_extension lower
+        && List.exists (contains_substring normalized) [ "session_log"; "session-log" ])
+    || (List.mem "retrospective" basename_tokens && has_history_artifact_extension lower)
   in
   if check_patterns banned_readme_patterns then Some Readme
   else if has_room_history then Some Room_history

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -46,39 +46,69 @@ let banned_doc_patterns =
   [ "design"; "architecture"; "adr"; "rfc"; "spec";
     "contributing"; "changelog"; "license" ]
 
+let doc_extensions =
+  [ ".md"; ".markdown"; ".mdx"; ".txt"; ".rst"; ".adoc"; ".asciidoc" ]
+
+let normalize_path path =
+  String.map (fun c -> if c = '\\' then '/' else c) path
+  |> String.lowercase_ascii
+
+let contains_substring text pattern =
+  let pat_len = String.length pattern in
+  let text_len = String.length text in
+  let rec search i =
+    if i + pat_len > text_len then false
+    else if String.sub text i pat_len = pattern then true
+    else search (i + 1)
+  in
+  pat_len > 0 && search 0
+
+let has_doc_extension path =
+  List.exists (Filename.check_suffix path) doc_extensions
+
+let split_path_segments path =
+  String.split_on_char '/' path
+  |> List.filter (fun segment -> segment <> "" && segment <> ".")
+
 let classify_path path =
-  let lower = String.lowercase_ascii (Filename.basename path) in
+  let normalized = normalize_path path in
+  let lower = Filename.basename normalized in
+  let segments = split_path_segments normalized in
+  let dir_segments =
+    match List.rev segments with
+    | _basename :: rev_dirs -> List.rev rev_dirs
+    | [] -> []
+  in
   let check_patterns patterns =
     List.exists (fun pat ->
-      String.length lower >= String.length pat &&
-      String.sub lower 0 (String.length pat) = pat) patterns
+      String.starts_with ~prefix:pat lower) patterns
+  in
+  let has_doc_dir =
+    List.exists
+      (fun segment ->
+        List.mem segment [ "docs"; "doc"; "design"; "adr"; "rfcs"; "rfc"; "spec"; "specs" ])
+      dir_segments
+  in
+  let has_room_history =
+    List.exists (contains_substring normalized)
+      [ "room_history"; "room-history"; "roomtaskhistory"; "room_task_history";
+        "room-task-history" ]
+  in
+  let has_task_history =
+    List.exists (contains_substring normalized)
+      [ "task_history"; "task-history"; "taskhistory"; "room/task_history";
+        "room/task-history" ]
+  in
+  let has_governance_history =
+    List.exists (contains_substring normalized)
+      [ "governance"; "session_log"; "session-log"; "retrospective" ]
   in
   if check_patterns banned_readme_patterns then Some Readme
-  else if check_patterns banned_doc_patterns then Some Design_doc
-  else if List.exists (fun pat ->
-    try
-      let pat_len = String.length pat in
-      let lower_len = String.length lower in
-      let rec search i =
-        if i + pat_len > lower_len then false
-        else if String.sub lower i pat_len = pat then true
-        else search (i + 1)
-      in
-      search 0
-    with Invalid_argument _ -> false) [ "room_history"; "task_history" ]
-  then Some Room_history
-  else if List.exists (fun pat ->
-    try
-      let pat_len = String.length pat in
-      let lower_len = String.length lower in
-      let rec search i =
-        if i + pat_len > lower_len then false
-        else if String.sub lower i pat_len = pat then true
-        else search (i + 1)
-      in
-      search 0
-    with Invalid_argument _ -> false) [ "governance"; "session_log"; "retrospective" ]
-  then Some Governance_history
+  else if has_room_history then Some Room_history
+  else if has_task_history then Some Task_history
+  else if has_governance_history then Some Governance_history
+  else if has_doc_dir && has_doc_extension lower then Some Design_doc
+  else if has_doc_extension lower && check_patterns banned_doc_patterns then Some Design_doc
   else None
 
 let validate_inputs inputs =

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -70,6 +70,25 @@ let split_path_segments path =
   String.split_on_char '/' path
   |> List.filter (fun segment -> segment <> "" && segment <> ".")
 
+let tokenize_segment segment =
+  let len = String.length segment in
+  let is_token_char = function
+    | 'a' .. 'z' | '0' .. '9' -> true
+    | _ -> false
+  in
+  let rec collect start idx acc =
+    if idx = len then
+      if start < idx then String.sub segment start (idx - start) :: acc else acc
+    else if is_token_char segment.[idx] then
+      collect start (idx + 1) acc
+    else
+      let acc =
+        if start < idx then String.sub segment start (idx - start) :: acc else acc
+      in
+      collect (idx + 1) (idx + 1) acc
+  in
+  List.rev (collect 0 0 [])
+
 let classify_path path =
   let normalized = normalize_path path in
   let lower = Filename.basename normalized in
@@ -83,11 +102,21 @@ let classify_path path =
     List.exists (fun pat ->
       String.starts_with ~prefix:pat lower) patterns
   in
+  let basename_tokens = tokenize_segment lower in
+  let segment_has_token segment token =
+    List.mem token (tokenize_segment segment)
+  in
   let has_doc_dir =
     List.exists
       (fun segment ->
         List.mem segment [ "docs"; "doc"; "design"; "adr"; "rfcs"; "rfc"; "spec"; "specs" ])
       dir_segments
+  in
+  let has_doc_token =
+    List.exists
+      (fun segment ->
+        List.exists (segment_has_token segment) banned_doc_patterns)
+      segments
   in
   let has_room_history =
     List.exists (contains_substring normalized)
@@ -100,15 +129,17 @@ let classify_path path =
         "room/task-history" ]
   in
   let has_governance_history =
-    List.exists (contains_substring normalized)
-      [ "governance"; "session_log"; "session-log"; "retrospective" ]
+    (List.mem "governance" basename_tokens
+     && List.exists (Filename.check_suffix lower)
+          [ ".json"; ".jsonl"; ".yaml"; ".yml"; ".log"; ".txt" ])
+    || List.exists (contains_substring normalized) [ "session_log"; "session-log" ]
+    || (List.mem "retrospective" basename_tokens && has_doc_extension lower)
   in
   if check_patterns banned_readme_patterns then Some Readme
   else if has_room_history then Some Room_history
   else if has_task_history then Some Task_history
   else if has_governance_history then Some Governance_history
-  else if has_doc_dir && has_doc_extension lower then Some Design_doc
-  else if has_doc_extension lower && check_patterns banned_doc_patterns then Some Design_doc
+  else if has_doc_extension lower && (has_doc_dir || has_doc_token) then Some Design_doc
   else None
 
 let validate_inputs inputs =

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -12,6 +12,29 @@
 
 open Printf
 
+let validate_target_files target_files =
+  let inputs =
+    List.map
+      (fun rel_path ->
+        if Filename.check_suffix rel_path ".mli" then
+          Adversarial_eval.Interface_contract { path = rel_path; content = "" }
+        else
+          Adversarial_eval.Changed_file { path = rel_path; content = "" })
+      target_files
+  in
+  match Adversarial_eval.validate_inputs inputs with
+  | Ok _ -> Ok ()
+  | Error (path, kind) ->
+      let kind_str =
+        match kind with
+        | Adversarial_eval.Readme -> "README"
+        | Adversarial_eval.Design_doc -> "design_doc"
+        | Adversarial_eval.Room_history -> "room_history"
+        | Adversarial_eval.Task_history -> "task_history"
+        | Adversarial_eval.Governance_history -> "governance_history"
+      in
+      Error (sprintf "fresh-context input rejected (%s): %s" kind_str path)
+
 (** Read a file's content, returning at most [max_chars] characters.
     Returns [None] on any file error. *)
 let read_file_truncated path ~max_chars =
@@ -26,19 +49,22 @@ let read_file_truncated path ~max_chars =
 (** Build the isolated review prompt. Only file contents and the question
     are included — no external context. *)
 let build_prompt ~target_files ~question ~base_path =
-  let file_sections =
-    List.filter_map (fun rel_path ->
-      let full_path = Filename.concat base_path rel_path in
-      match read_file_truncated full_path ~max_chars:3000 with
-      | Some content -> Some (sprintf "=== %s ===\n%s" rel_path content)
-      | None -> None
-    ) target_files
-  in
-  if file_sections = [] then
-    Error "No readable target files found"
-  else
-    let files_str = String.concat "\n\n" file_sections in
-    Ok (sprintf
+  match validate_target_files target_files with
+  | Error _ as e -> e
+  | Ok () ->
+      let file_sections =
+        List.filter_map (fun rel_path ->
+          let full_path = Filename.concat base_path rel_path in
+          match read_file_truncated full_path ~max_chars:3000 with
+          | Some content -> Some (sprintf "=== %s ===\n%s" rel_path content)
+          | None -> None
+        ) target_files
+      in
+      if file_sections = [] then
+        Error "No readable target files found"
+      else
+        let files_str = String.concat "\n\n" file_sections in
+        Ok (sprintf
 {|You are an adversarial code reviewer. Your job is to find bugs, edge cases,
 and potential issues that a domain-aware reviewer might miss.
 

--- a/test/dune
+++ b/test/dune
@@ -56,6 +56,7 @@
         test_golden_set
         test_adversarial_eval
         test_labeling
+        test_tool_deep_review
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -93,6 +94,7 @@
           test_golden_set
           test_adversarial_eval
           test_labeling
+          test_tool_deep_review
   )
  (libraries masc_mcp masc_mcp.team_session_types agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -17,13 +17,23 @@ let test_classify_design_doc () =
   Alcotest.(check bool) "architecture.md is banned" true
     (Option.is_some (Adversarial_eval.classify_path "architecture.md"));
   Alcotest.(check bool) "ADR-001.md is banned" true
-    (Option.is_some (Adversarial_eval.classify_path "ADR-001.md"))
+    (Option.is_some (Adversarial_eval.classify_path "ADR-001.md"));
+  Alcotest.(check bool) "docs/design/... is banned" true
+    (Option.is_some
+       (Adversarial_eval.classify_path
+          "docs/design/contract-driven-agent-loop-rfc.md"));
+  Alcotest.(check bool) "docs/spec/... is banned" true
+    (Option.is_some
+       (Adversarial_eval.classify_path "docs/spec/13-oas-integration.md"))
 
 let test_classify_history () =
   Alcotest.(check bool) "governance_v2.json is banned" true
     (Option.is_some (Adversarial_eval.classify_path "governance_v2.json"));
   Alcotest.(check bool) "session_log.jsonl is banned" true
-    (Option.is_some (Adversarial_eval.classify_path "session_log.jsonl"))
+    (Option.is_some (Adversarial_eval.classify_path "session_log.jsonl"));
+  Alcotest.(check bool) "room-task-history path is banned" true
+    (Option.is_some
+       (Adversarial_eval.classify_path "memory/room-task-history.jsonl"))
 
 let test_classify_allowed () =
   Alcotest.(check bool) "module.ml is allowed" true
@@ -31,7 +41,9 @@ let test_classify_allowed () =
   Alcotest.(check bool) "module.mli is allowed" true
     (Option.is_none (Adversarial_eval.classify_path "module.mli"));
   Alcotest.(check bool) "test_foo.ml is allowed" true
-    (Option.is_none (Adversarial_eval.classify_path "test_foo.ml"))
+    (Option.is_none (Adversarial_eval.classify_path "test_foo.ml"));
+  Alcotest.(check bool) "spec_decoder.ml is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "lib/spec_decoder.ml"))
 
 let test_validate_clean_inputs () =
   let inputs =
@@ -60,13 +72,29 @@ let test_validate_rejects_readme () =
 let test_validate_rejects_design_doc () =
   let inputs =
     Adversarial_eval.[
-      Interface_contract { path = "DESIGN.md"; content = "..." };
+      Interface_contract
+        {
+          path = "docs/design/contract-driven-agent-loop-rfc.md";
+          content = "...";
+        };
     ]
   in
   match Adversarial_eval.validate_inputs inputs with
   | Error (_, Adversarial_eval.Design_doc) -> ()
   | Error (_, _) -> Alcotest.fail "wrong rejection kind"
   | Ok _ -> Alcotest.fail "should reject design doc"
+
+let test_validate_rejects_room_history_path () =
+  let inputs =
+    Adversarial_eval.[
+      Changed_file
+        { path = "memory/room-task-history.jsonl"; content = "{}\n" };
+    ]
+  in
+  match Adversarial_eval.validate_inputs inputs with
+  | Error (_, Adversarial_eval.Room_history) -> ()
+  | Error (_, _) -> Alcotest.fail "wrong rejection kind"
+  | Ok _ -> Alcotest.fail "should reject room history"
 
 (* --- Structural check tests --- *)
 
@@ -182,6 +210,8 @@ let () =
           Alcotest.test_case "validate clean" `Quick test_validate_clean_inputs;
           Alcotest.test_case "reject readme" `Quick test_validate_rejects_readme;
           Alcotest.test_case "reject design doc" `Quick test_validate_rejects_design_doc;
+          Alcotest.test_case "reject room history path" `Quick
+            test_validate_rejects_room_history_path;
         ] );
       ( "structural_checks",
         [

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -37,6 +37,8 @@ let test_classify_history () =
     (Option.is_some (Adversarial_eval.classify_path "governance_v2.json"));
   Alcotest.(check bool) "session_log.jsonl is banned" true
     (Option.is_some (Adversarial_eval.classify_path "session_log.jsonl"));
+  Alcotest.(check bool) "retrospective.json is banned" true
+    (Option.is_some (Adversarial_eval.classify_path "retrospective.json"));
   Alcotest.(check bool) "room-task-history path is banned" true
     (Option.is_some
        (Adversarial_eval.classify_path "memory/room-task-history.jsonl"))
@@ -51,7 +53,9 @@ let test_classify_allowed () =
   Alcotest.(check bool) "spec_decoder.ml is allowed" true
     (Option.is_none (Adversarial_eval.classify_path "lib/spec_decoder.ml"));
   Alcotest.(check bool) "governance source file is allowed" true
-    (Option.is_none (Adversarial_eval.classify_path "lib/governance_pipeline.ml"))
+    (Option.is_none (Adversarial_eval.classify_path "lib/governance_pipeline.ml"));
+  Alcotest.(check bool) "room history source file is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "lib/room_history_parser.ml"))
 
 let test_validate_clean_inputs () =
   let inputs =

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -24,7 +24,13 @@ let test_classify_design_doc () =
           "docs/design/contract-driven-agent-loop-rfc.md"));
   Alcotest.(check bool) "docs/spec/... is banned" true
     (Option.is_some
-       (Adversarial_eval.classify_path "docs/spec/13-oas-integration.md"))
+       (Adversarial_eval.classify_path "docs/spec/13-oas-integration.md"));
+  Alcotest.(check bool) "rfc doc outside docs/ is banned" true
+    (Option.is_some
+       (Adversarial_eval.classify_path "tmp/contract-driven-agent-loop-rfc.md"));
+  Alcotest.(check bool) "architecture doc outside docs/ is banned" true
+    (Option.is_some
+       (Adversarial_eval.classify_path "notes/system-architecture.md"))
 
 let test_classify_history () =
   Alcotest.(check bool) "governance_v2.json is banned" true
@@ -43,7 +49,9 @@ let test_classify_allowed () =
   Alcotest.(check bool) "test_foo.ml is allowed" true
     (Option.is_none (Adversarial_eval.classify_path "test_foo.ml"));
   Alcotest.(check bool) "spec_decoder.ml is allowed" true
-    (Option.is_none (Adversarial_eval.classify_path "lib/spec_decoder.ml"))
+    (Option.is_none (Adversarial_eval.classify_path "lib/spec_decoder.ml"));
+  Alcotest.(check bool) "governance source file is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "lib/governance_pipeline.ml"))
 
 let test_validate_clean_inputs () =
   let inputs =

--- a/test/test_tool_deep_review.ml
+++ b/test/test_tool_deep_review.ml
@@ -1,0 +1,84 @@
+open Alcotest
+
+module TDR = Masc_mcp.Tool_deep_review
+
+let rec mkdir_p path =
+  if path = "" || path = "." || Sys.file_exists path then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755)
+
+let with_temp_dir f =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "tool_deep_review_%d_%f" (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  mkdir_p base;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" base)))
+    (fun () -> f base)
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let test_build_prompt_accepts_code_files () =
+  with_temp_dir (fun base ->
+      let file = Filename.concat base "lib/foo.ml" in
+      write_file file "let answer = 42\n";
+      match
+        TDR.build_prompt
+          ~target_files:[ "lib/foo.ml" ]
+          ~question:"Is this safe?"
+          ~base_path:base
+      with
+      | Ok prompt ->
+          check bool "contains file section" true
+            (String.contains prompt '=')
+      | Error e -> failf "expected Ok, got Error: %s" e)
+
+let test_build_prompt_rejects_design_docs_by_full_path () =
+  with_temp_dir (fun base ->
+      let file = Filename.concat base "docs/design/contract-driven-agent-loop-rfc.md" in
+      write_file file "# RFC\n";
+      match
+        TDR.build_prompt
+          ~target_files:[ "docs/design/contract-driven-agent-loop-rfc.md" ]
+          ~question:"Find bugs"
+          ~base_path:base
+      with
+      | Error msg ->
+          check bool "mentions rejected" true
+            (String.length msg > 0)
+      | Ok _ -> fail "expected design doc to be rejected")
+
+let test_build_prompt_rejects_room_task_history_paths () =
+  with_temp_dir (fun base ->
+      let file = Filename.concat base "memory/room-task-history.jsonl" in
+      write_file file "{}\n";
+      match
+        TDR.build_prompt
+          ~target_files:[ "memory/room-task-history.jsonl" ]
+          ~question:"Find issues"
+          ~base_path:base
+      with
+      | Error msg ->
+          check bool "mentions rejected" true
+            (String.length msg > 0)
+      | Ok _ -> fail "expected room/task history to be rejected")
+
+let () =
+  run "tool_deep_review"
+    [
+      ( "build_prompt",
+        [
+          test_case "accept code files" `Quick test_build_prompt_accepts_code_files;
+          test_case "reject design docs by full path" `Quick
+            test_build_prompt_rejects_design_docs_by_full_path;
+          test_case "reject room/task history" `Quick
+            test_build_prompt_rejects_room_task_history_paths;
+        ] );
+    ]

--- a/test/test_tool_deep_review.ml
+++ b/test/test_tool_deep_review.ml
@@ -2,6 +2,16 @@ open Alcotest
 
 module TDR = Masc_mcp.Tool_deep_review
 
+let contains_substring text pattern =
+  let pat_len = String.length pattern in
+  let text_len = String.length text in
+  let rec loop i =
+    if i + pat_len > text_len then false
+    else if String.sub text i pat_len = pattern then true
+    else loop (i + 1)
+  in
+  pat_len > 0 && loop 0
+
 let rec mkdir_p path =
   if path = "" || path = "." || Sys.file_exists path then ()
   else (
@@ -36,8 +46,23 @@ let test_build_prompt_accepts_code_files () =
           ~base_path:base
       with
       | Ok prompt ->
-          check bool "contains file section" true
-            (String.contains prompt '=')
+          check bool "contains file path" true
+            (contains_substring prompt "lib/foo.ml")
+      | Error e -> failf "expected Ok, got Error: %s" e)
+
+let test_build_prompt_accepts_governance_source_files () =
+  with_temp_dir (fun base ->
+      let file = Filename.concat base "lib/governance_pipeline.ml" in
+      write_file file "let governance_level = \"development\"\n";
+      match
+        TDR.build_prompt
+          ~target_files:[ "lib/governance_pipeline.ml" ]
+          ~question:"Find correctness issues"
+          ~base_path:base
+      with
+      | Ok prompt ->
+          check bool "contains governance source path" true
+            (contains_substring prompt "lib/governance_pipeline.ml")
       | Error e -> failf "expected Ok, got Error: %s" e)
 
 let test_build_prompt_rejects_design_docs_by_full_path () =
@@ -54,6 +79,21 @@ let test_build_prompt_rejects_design_docs_by_full_path () =
           check bool "mentions rejected" true
             (String.length msg > 0)
       | Ok _ -> fail "expected design doc to be rejected")
+
+let test_build_prompt_rejects_rfc_docs_outside_docs_dir () =
+  with_temp_dir (fun base ->
+      let file = Filename.concat base "tmp/contract-driven-agent-loop-rfc.md" in
+      write_file file "# RFC\n";
+      match
+        TDR.build_prompt
+          ~target_files:[ "tmp/contract-driven-agent-loop-rfc.md" ]
+          ~question:"Find bugs"
+          ~base_path:base
+      with
+      | Error msg ->
+          check bool "mentions rejected" true
+            (String.length msg > 0)
+      | Ok _ -> fail "expected RFC doc to be rejected")
 
 let test_build_prompt_rejects_room_task_history_paths () =
   with_temp_dir (fun base ->
@@ -76,8 +116,12 @@ let () =
       ( "build_prompt",
         [
           test_case "accept code files" `Quick test_build_prompt_accepts_code_files;
+          test_case "accept governance source files" `Quick
+            test_build_prompt_accepts_governance_source_files;
           test_case "reject design docs by full path" `Quick
             test_build_prompt_rejects_design_docs_by_full_path;
+          test_case "reject rfc docs outside docs dir" `Quick
+            test_build_prompt_rejects_rfc_docs_outside_docs_dir;
           test_case "reject room/task history" `Quick
             test_build_prompt_rejects_room_task_history_paths;
         ] );


### PR DESCRIPTION
## Summary
- enforce adversarial red-line checks against normalized full paths instead of basenames
- block design/spec/history/governance/session-log style inputs before deep review prompt construction
- add regression tests for real path shapes and deep-review prompt rejection

## Root cause
`Adversarial_eval.classify_path` only inspected `Filename.basename`, so `docs/design/...` and similar disallowed paths could bypass the red line. The module also was not wired into the deep review prompt builder, so the restriction was not enforced on a live path.

## Impact
`masc_deep_review` now rejects banned prompt inputs early while continuing to accept normal code targets.

## Validation
- `_build/default/test/test_adversarial_eval.exe`
- `dune build --root . test/test_room.exe`