### PR TITLE
perf(dashboard): lightweight paused keepers + cp profiling

### DIFF
--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -2,15 +2,27 @@ include Cp_lifecycle_intents
 open Result_syntax
 
 let snapshot_json ?sessions config =
-  let state = build_snapshot_state ?sessions config in
-  let topology = topology_json_from_state state in
-  let intents = intents_summary_json_from_state state in
-  let operations = list_operations_json_from_state state in
-  let detachments = list_detachments_json_from_state state in
-  let alerts = list_alerts_json_from_state config state in
-  let decisions = list_policy_decisions_json_from_state state in
-  let capacity = capacity_json_from_state state in
-  let traces = list_traces_json config ~limit:10 () in
+  let t0 = Unix.gettimeofday () in
+  let timed label f =
+    let t_start = Unix.gettimeofday () in
+    let result = f () in
+    let elapsed = Unix.gettimeofday () -. t_start in
+    if elapsed > 0.5 then
+      Log.Dashboard.info "[cp_snapshot] %s: %.0fms" label (elapsed *. 1000.0);
+    result
+  in
+  let state = timed "build_state" (fun () -> build_snapshot_state ?sessions config) in
+  let topology = timed "topology" (fun () -> topology_json_from_state state) in
+  let intents = timed "intents" (fun () -> intents_summary_json_from_state state) in
+  let operations = timed "operations" (fun () -> list_operations_json_from_state state) in
+  let detachments = timed "detachments" (fun () -> list_detachments_json_from_state state) in
+  let alerts = timed "alerts" (fun () -> list_alerts_json_from_state config state) in
+  let decisions = timed "decisions" (fun () -> list_policy_decisions_json_from_state state) in
+  let capacity = timed "capacity" (fun () -> capacity_json_from_state state) in
+  let traces = timed "traces" (fun () -> list_traces_json config ~limit:10 ()) in
+  let dt_total = Unix.gettimeofday () -. t0 in
+  if dt_total > 1.0 then
+    Log.Dashboard.warn "[cp_snapshot] total: %.0fms" (dt_total *. 1000.0);
   `Assoc
     [
       ("version", `String "cp-v2");

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -172,7 +172,8 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
   | None, None ->
       (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
 
-let keepers_json ?keeper_names ?(include_recent_activity = true) config =
+let keepers_json ?keeper_names ?(include_recent_activity = true)
+    ?(lightweight = false) config =
   let names = match keeper_names with
     | Some n -> n
     | None -> Keeper_types.keeper_names config
@@ -182,6 +183,22 @@ let keepers_json ?keeper_names ?(include_recent_activity = true) config =
       (fun name ->
         match Keeper_types.read_meta config name with
         | Error _ | Ok None -> None
+        | Ok (Some meta) when lightweight && meta.paused ->
+            Some
+              (`Assoc
+                [
+                  ("runtime_class", `String "keeper");
+                  ("pipeline_stage", `String "paused");
+                  ("name", `String meta.name);
+                  ("agent_name", `String meta.agent_name);
+                  ("status", `String "paused");
+                  ("paused", `Bool true);
+                  ("goal", `String meta.goal);
+                  ("short_goal", `String meta.short_goal);
+                  ("turn_count", `Int meta.usage.total_turns);
+                  ("updated_at", `String meta.updated_at);
+                  ("created_at", `String meta.created_at);
+                ])
         | Ok (Some meta) ->
             let agent_json =
               Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
@@ -582,7 +599,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
              keepers_ref :=
                timed "keepers_json" (fun () ->
                  if initialized && include_keepers then
-                   keepers_json ~keeper_names
+                   keepers_json ~keeper_names ~lightweight:lightweight_summary
                      ~include_recent_activity:(not lightweight_summary) config
                  else empty_section));
            (fun () ->


### PR DESCRIPTION
## Summary

- **B1**: `keepers_json`에서 `lightweight && meta.paused`인 keeper는 minimal stub 반환. agent status, diagnostics, metrics JSONL, tool audit 처리 생략.
- **B2**: `cp_lifecycle.snapshot_json`에 per-operation timing 추가. 500ms+ sub-op 또는 1s+ total 시 `[cp_snapshot]` 로그 출력.

## Background

Dashboard 로그에서 관측된 이상:
- `[mission profile] total=53.8s` (compute만 53.8s)
- `[snapshot_json] total=18.5s` (keepers_json=1.8s, gap=16.7s)
- 23개 keeper 전원 active, 100% proactive self-loop

## Changes

| File | Change |
|------|--------|
| `lib/operator/operator_control_snapshot.ml` | `keepers_json`에 `?lightweight` param 추가, paused keeper 경량 경로 |
| `lib/command_plane/cp_lifecycle.ml` | `snapshot_json` 내 9개 sub-operation에 timed wrapper 추가 |

## Phase A (코드 외, 이미 적용)

- 13개 중복/stale keeper paused (23→10 active)
- env: `MASC_OPERATOR_REFRESH_INTERVAL_S=30`, `MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS=12`

## Test plan

- [x] `dune build` 성공
- [x] `dune runtest` 통과
- [ ] 서버 재시작 후 `[snapshot_json]` 로그에서 keepers_json 시간 감소 확인
- [ ] `[cp_snapshot]` 로그에서 병목 sub-operation 식별
- [ ] 대시보드 UI에서 paused keeper가 "paused" status로 표시되는지 확인

Generated with [Claude Code](https://claude.com/claude-code)