### PR TITLE
refactor(tools): remove 24 unused tools from MCP surface

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -24,7 +24,6 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_local_runtime.schemas
     @ Tool_model_catalog.schemas
     @ Tool_command_plane.schemas
-    @ Tool_goals.schemas
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
     @ Tool_compact.schemas

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -135,12 +135,9 @@ let () =
   register_module_tag ~schemas:Tool_control.schemas ~tag:Mod_control;
   register_module_tag ~schemas:Tool_suspend.schemas ~tag:Mod_suspend;
   register_module_tag ~schemas:Tool_council_oas.schemas ~tag:Mod_council;
-  register_module_tag ~schemas:Tool_cost.schemas ~tag:Mod_cost;
-  register_module_tag ~schemas:Tool_rate_limit.schemas ~tag:Mod_rate_limit;
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;
-  register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;
   (* Monolithic schema decomposition: modules that now export their own schemas *)
   register_module_tag ~schemas:Tool_cache.schemas ~tag:Mod_cache;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -140,12 +140,10 @@ let () =
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;
   (* Monolithic schema decomposition: modules that now export their own schemas *)
-  register_module_tag ~schemas:Tool_cache.schemas ~tag:Mod_cache;
   register_module_tag ~schemas:Tool_run.schemas ~tag:Mod_run;
   register_module_tag ~schemas:Tool_code.schemas ~tag:Mod_code;
   register_module_tag ~schemas:Tool_code_write.schemas ~tag:Mod_code_write;
   register_module_tag ~schemas:Tool_library.schemas ~tag:Mod_library;
-  register_module_tag ~schemas:Tool_audit.schemas ~tag:Mod_audit;
   register_module_tag ~schemas:Tool_a2a.schemas ~tag:Mod_a2a;
   register_module_tag ~schemas:Tool_heartbeat.schemas ~tag:Mod_heartbeat;
   register_module_tag ~schemas:Tool_misc.schemas ~tag:Mod_misc;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -131,7 +131,6 @@ let () =
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
   register_module_tag ~schemas:Tool_research.schemas ~tag:Mod_research;
   register_module_tag ~schemas:Tool_model_catalog.schemas ~tag:Mod_model_catalog;
-  register_module_tag ~schemas:Tool_notifications.schemas ~tag:Mod_notifications;
   (* God Schema decomposition: register modules that now own their schemas *)
   register_module_tag ~schemas:Tool_task.schemas ~tag:Mod_task;
   register_module_tag ~schemas:Tool_control.schemas ~tag:Mod_control;
@@ -139,10 +138,8 @@ let () =
   register_module_tag ~schemas:Tool_council_oas.schemas ~tag:Mod_council;
   register_module_tag ~schemas:Tool_cost.schemas ~tag:Mod_cost;
   register_module_tag ~schemas:Tool_rate_limit.schemas ~tag:Mod_rate_limit;
-  register_module_tag ~schemas:Tool_encryption.schemas ~tag:Mod_encryption;
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
-  register_module_tag ~schemas:Tool_tempo.schemas ~tag:Mod_tempo;
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;
   register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -117,14 +117,11 @@ let () =
   register_module_tag ~schemas:Tool_voice.schemas ~tag:Mod_voice;
   register_module_tag ~schemas:Tool_portal.schemas ~tag:Mod_portal;
   register_module_tag ~schemas:Tool_worktree.schemas ~tag:Mod_worktree;
-  register_module_tag ~schemas:Tool_fire_task.schemas ~tag:Mod_fire_task;
-  register_module_tag ~schemas:Tool_code_swarm.schemas ~tag:Mod_code_swarm;
   register_module_tag ~schemas:Tool_auth.schemas ~tag:Mod_auth;
   register_module_tag ~schemas:Tool_agent.schemas ~tag:Mod_agent;
   register_module_tag ~schemas:Tool_room.schemas ~tag:Mod_room;
   register_module_tag ~schemas:Tool_agent_timeline.schemas ~tag:Mod_agent_timeline;
   register_module_tag ~schemas:Tool_keeper.schemas ~tag:Mod_keeper;
-  register_module_tag ~schemas:Tool_compact.schemas ~tag:Mod_compact;
   register_module_tag ~schemas:Tool_mdal.schemas ~tag:Mod_mdal;
   register_module_tag ~schemas:Tool_improve_loop.schemas ~tag:Mod_improve_loop;
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -119,7 +119,6 @@ let () =
   register_module_tag ~schemas:Tool_worktree.schemas ~tag:Mod_worktree;
   register_module_tag ~schemas:Tool_fire_task.schemas ~tag:Mod_fire_task;
   register_module_tag ~schemas:Tool_code_swarm.schemas ~tag:Mod_code_swarm;
-  register_module_tag ~schemas:Tool_goals.schemas ~tag:Mod_goals;
   register_module_tag ~schemas:Tool_auth.schemas ~tag:Mod_auth;
   register_module_tag ~schemas:Tool_agent.schemas ~tag:Mod_agent;
   register_module_tag ~schemas:Tool_room.schemas ~tag:Mod_room;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -442,8 +442,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_voice.dispatch { agent_name; sw; clock; net = state.Mcp_server.net } ~name ~args:arguments
     | Mod_cache ->
         Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
-    | Mod_tempo ->
-        Tool_tempo.dispatch { Tool_tempo.config; agent_name } ~name ~args:arguments
     | Mod_portal ->
         Tool_portal.dispatch { Tool_portal.config; agent_name } ~name ~args:arguments
     | Mod_worktree ->
@@ -493,8 +491,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_goals.dispatch ctx ~name ~args:arguments
     | Mod_heartbeat ->
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
-    | Mod_encryption ->
-        Tool_encryption.dispatch { Tool_encryption.state } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
     | Mod_hat ->
@@ -591,9 +587,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_shard ->
         let (ok, json) = Tool_shard.execute name arguments in
         Some (ok, Yojson.Safe.to_string json)
-    | Mod_notifications ->
-        Tool_notifications.dispatch state.Mcp_server.session_registry
-          ~agent_name ~name arguments
     | Mod_inline ->
         let inline_ctx : Tool_inline_dispatch.context = {
           config; agent_name; registry; state; sw; clock; arguments;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -481,14 +481,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_relay ->
         Tool_relay.dispatch { Tool_relay.config; agent_name; sw;
           proc_mgr = state.Mcp_server.proc_mgr } ~name ~args:arguments
-    | Mod_goals ->
-        let keeper_ctx = make_keeper_ctx () in
-        let ctx : Tool_goals.context = { config; agent_name;
-          call_keeper_msg = Some (fun keeper_args ->
-            match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args:keeper_args with
-            | Some result -> result
-            | None -> (false, "masc_keeper_msg dispatch unavailable")) } in
-        Tool_goals.dispatch ctx ~name ~args:arguments
     | Mod_heartbeat ->
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -440,8 +440,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_team_session.dispatch ctx ~name ~args:arguments
     | Mod_voice ->
         Tool_voice.dispatch { agent_name; sw; clock; net = state.Mcp_server.net } ~name ~args:arguments
-    | Mod_cache ->
-        Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_portal ->
         Tool_portal.dispatch { Tool_portal.config; agent_name } ~name ~args:arguments
     | Mod_worktree ->
@@ -485,8 +483,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
-    | Mod_audit ->
-        Tool_audit.dispatch { Tool_audit.config } ~name ~args:arguments
     | Mod_walph ->
         (let ctx : _ Tool_walph.context = { config; agent_name; clock } in
            Tool_walph.dispatch ctx ~name ~args:arguments)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -444,10 +444,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_portal.dispatch { Tool_portal.config; agent_name } ~name ~args:arguments
     | Mod_worktree ->
         Tool_worktree.dispatch { Tool_worktree.config; agent_name } ~name ~args:arguments
-    | Mod_fire_task ->
-        Tool_fire_task.dispatch { Tool_fire_task.config; agent_name; sw } ~name ~args:arguments
-    | Mod_code_swarm ->
-        Tool_code_swarm.dispatch { Tool_code_swarm.config; agent_name } ~name ~args:arguments
     | Mod_code ->
         Tool_code.dispatch { Tool_code.config; agent_name } ~name ~args:arguments
     | Mod_code_write ->
@@ -515,8 +511,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_library.dispatch { Tool_library.agent_name } ~name ~args:arguments
     | Mod_keeper ->
         Tool_keeper.dispatch (make_keeper_ctx ()) ~name ~args:arguments
-    | Mod_compact ->
-        Tool_compact.dispatch ~name ~args:arguments
     | Mod_mdal ->
         let ctx : Tool_mdal.context = { agent_name; config = Some config;
           sw = Some sw; proc_mgr = state.Mcp_server.proc_mgr;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -485,14 +485,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
-    | Mod_hat ->
-        Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
     | Mod_audit ->
         Tool_audit.dispatch { Tool_audit.config } ~name ~args:arguments
-    | Mod_rate_limit ->
-        Tool_rate_limit.dispatch { Tool_rate_limit.config; agent_name; registry } ~name ~args:arguments
-    | Mod_cost ->
-        Tool_cost.dispatch { Tool_cost.agent_name } ~name ~args:arguments
     | Mod_walph ->
         (let ctx : _ Tool_walph.context = { config; agent_name; clock } in
            Tool_walph.dispatch ctx ~name ~args:arguments)

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -15,21 +15,8 @@ let assoc_field name value = (name, value)
 
 let json_string value = `String value
 
-let string_prop description =
-  `Assoc
-    [
-      assoc_field "type" (`String "string");
-      assoc_field "description" (`String description);
-    ]
-
-let object_schema ?(required = []) properties =
-  let required_json = `List (List.map (fun name -> `String name) required) in
-  `Assoc
-    [
-      assoc_field "type" (`String "object");
-      assoc_field "properties" (`Assoc properties);
-      assoc_field "required" required_json;
-    ]
+let string_prop = Tool_schema_dsl.string_prop
+let object_schema = Tool_schema_dsl.object_schema
 
 let task_item_schema =
   object_schema ~required:[ "title"; "description" ]

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -298,43 +298,9 @@ let handle_unit_define (ctx : (_, _) context) args : result =
 let handle_unit_list (ctx : (_, _) context) : result =
   (true, Yojson.Safe.to_string (Command_plane_v2.list_units_json ctx.config))
 
-let object_schema ?(required = []) properties =
-  `Assoc
-    [
-      ("type", `String "object");
-      ("properties", `Assoc properties);
-      ("required", `List (List.map (fun key -> `String key) required));
-    ]
-
-let string_prop description =
-  `Assoc [ ("type", `String "string"); ("description", `String description) ]
-
-let integer_prop ?default description =
-  `Assoc
-    ([
-       ("type", `String "integer");
-       ("description", `String description);
-     ]
-    @
-    match default with
-    | Some value -> [ ("default", `Int value) ]
-    | None -> [])
-
-let boolean_prop ?default description =
-  `Assoc
-    ([
-       ("type", `String "boolean");
-       ("description", `String description);
-     ]
-    @
-    match default with
-    | Some value -> [ ("default", `Bool value) ]
-    | None -> [])
-
-let string_array_prop description =
-  `Assoc
-    [
-      ("type", `String "array");
-      ("description", `String description);
-      ("items", `Assoc [ ("type", `String "string") ]);
+let object_schema = Tool_schema_dsl.object_schema
+let string_prop = Tool_schema_dsl.string_prop
+let integer_prop = Tool_schema_dsl.integer_prop
+let boolean_prop = Tool_schema_dsl.boolean_prop
+let string_array_prop = Tool_schema_dsl.string_array_prop
     ]

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -153,7 +153,7 @@ let is_join_required name = with_dispatch_ro (fun () -> Hashtbl.mem requires_joi
 type module_tag =
   | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
   | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
-  | Mod_tempo | Mod_portal | Mod_worktree
+  | Mod_portal | Mod_worktree
   | Mod_code_swarm | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -152,22 +152,20 @@ let is_join_required name = with_dispatch_ro (fun () -> Hashtbl.mem requires_joi
 
 type module_tag =
   | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
-  | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
+  | Mod_local_runtime | Mod_team_session | Mod_voice
   | Mod_portal | Mod_worktree
-  | Mod_code_swarm | Mod_code | Mod_code_write
+  | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
-  | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
-  | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit
-  | Mod_cost | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_relay | Mod_heartbeat
+  | Mod_auth | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
-  | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
-  | Mod_notifications | Mod_inline
+  | Mod_library | Mod_keeper | Mod_mdal
+  | Mod_inline
   | Mod_improve_loop
   | Mod_autoresearch
   | Mod_research
   | Mod_model_catalog
   | Mod_shard
-  | Mod_fire_task
 
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
 let tag_registry_initialized = ref false

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -79,22 +79,20 @@ val is_join_required : string -> bool
 
 type module_tag =
   | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
-  | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
-  | Mod_tempo | Mod_portal | Mod_worktree
-  | Mod_code_swarm | Mod_code | Mod_code_write
+  | Mod_local_runtime | Mod_team_session | Mod_voice
+  | Mod_portal | Mod_worktree
+  | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
-  | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
-  | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit
-  | Mod_cost | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_relay | Mod_heartbeat
+  | Mod_auth | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
-  | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
-  | Mod_notifications | Mod_inline
+  | Mod_library | Mod_keeper | Mod_mdal
+  | Mod_inline
   | Mod_improve_loop
   | Mod_autoresearch
   | Mod_research
   | Mod_model_catalog
   | Mod_shard
-  | Mod_fire_task
 
 val register_module_tag : schemas:Types.tool_schema list -> tag:module_tag -> unit
 (** Register tool names from a schema list with a module tag. *)

--- a/lib/tool_schema_dsl.ml
+++ b/lib/tool_schema_dsl.ml
@@ -1,0 +1,42 @@
+(** Tool_schema_dsl — shared JSON Schema builder helpers for MCP tool definitions.
+
+    Reduces per-property boilerplate from ~5 lines of raw Yojson.Safe.t
+    to 1 line. Consolidated from duplicate definitions in
+    Tool_command_plane_support and Sdk_tool_contract. *)
+
+let string_prop description =
+  `Assoc [ ("type", `String "string"); ("description", `String description) ]
+
+let integer_prop ?default description =
+  `Assoc
+    ([ ("type", `String "integer"); ("description", `String description) ]
+    @ (match default with Some v -> [ ("default", `Int v) ] | None -> []))
+
+let boolean_prop ?default description =
+  `Assoc
+    ([ ("type", `String "boolean"); ("description", `String description) ]
+    @ (match default with Some v -> [ ("default", `Bool v) ] | None -> []))
+
+let string_array_prop description =
+  `Assoc
+    [
+      ("type", `String "array");
+      ("description", `String description);
+      ("items", `Assoc [ ("type", `String "string") ]);
+    ]
+
+let enum_prop ~values description =
+  `Assoc
+    [
+      ("type", `String "string");
+      ("description", `String description);
+      ("enum", `List (List.map (fun v -> `String v) values));
+    ]
+
+let object_schema ?(required = []) properties =
+  `Assoc
+    [
+      ("type", `String "object");
+      ("properties", `Assoc properties);
+      ("required", `List (List.map (fun k -> `String k) required));
+    ]

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -47,12 +47,6 @@ let register_all () =
     "masc_run_deliverable"; "masc_run_get"; "masc_run_list";
   ];
 
-  (* ── Mod_cache: Tool_cache ────────────────────────────────────── *)
-  reg Mod_cache [
-    "masc_cache_set"; "masc_cache_get"; "masc_cache_delete";
-    "masc_cache_list"; "masc_cache_clear"; "masc_cache_stats";
-  ];
-
   (* ── Mod_code: Tool_code ──────────────────────────────────────── *)
   reg Mod_code [
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
@@ -97,12 +91,6 @@ let register_all () =
   (* ── Mod_hat: non-schema tools ──────────────────────────────── *)
   reg Mod_hat [
     "masc_hat_wear";
-  ];
-
-  (* ── Mod_audit: Tool_audit ────────────────────────────────────── *)
-  reg Mod_audit [
-    "masc_audit_query"; "masc_audit_stats"; "masc_governance_report";
-    "masc_audit_trail";
   ];
 
   (* Mod_cost and Mod_rate_limit: fully covered by schemas — no entries needed *)

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -53,12 +53,6 @@ let register_all () =
     "masc_cache_list"; "masc_cache_clear"; "masc_cache_stats";
   ];
 
-  (* ── Mod_tempo: non-schema tools ────────────────────────────── *)
-  reg Mod_tempo [
-    "masc_tempo_get"; "masc_tempo_set"; "masc_tempo_adjust";
-    "masc_tempo";
-  ];
-
   (* ── Mod_code: Tool_code ──────────────────────────────────────── *)
   reg Mod_code [
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
@@ -98,11 +92,6 @@ let register_all () =
   reg Mod_heartbeat [
     "masc_heartbeat"; "masc_heartbeat_start";
     "masc_heartbeat_stop"; "masc_heartbeat_list";
-  ];
-
-  (* ── Mod_encryption: non-schema tools ───────────────────────── *)
-  reg Mod_encryption [
-    "masc_generate_key";
   ];
 
   (* ── Mod_hat: non-schema tools ──────────────────────────────── *)

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -25,12 +25,10 @@ let raw_schemas : tool_schema list =
   @ Tool_handover.schemas
   @ Tool_walph.schemas
   @ Tool_improve_loop.schemas
-  @ Tool_cache.schemas
   @ Tool_run.schemas
   @ Tool_code.schemas
   @ Tool_code_write.schemas
   @ Tool_library.schemas
-  @ Tool_audit.schemas
   @ Tool_heartbeat.schemas
 
 let all_schemas : tool_schema list = raw_schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -20,13 +20,10 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_fire_task.schemas
   @ Tool_task.schemas
   @ Tool_suspend.schemas
-  @ Tool_cost.schemas
-  @ Tool_rate_limit.schemas
   @ Tool_council_oas.schemas
   @ Tool_relay.schemas
   @ Tool_handover.schemas
   @ Tool_walph.schemas
-  @ Tool_hat.schemas
   @ Tool_improve_loop.schemas
   @ Tool_cache.schemas
   @ Tool_run.schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -22,11 +22,9 @@ let raw_schemas : tool_schema list =
   @ Tool_suspend.schemas
   @ Tool_cost.schemas
   @ Tool_rate_limit.schemas
-  @ Tool_encryption.schemas
   @ Tool_council_oas.schemas
   @ Tool_relay.schemas
   @ Tool_handover.schemas
-  @ Tool_tempo.schemas
   @ Tool_walph.schemas
   @ Tool_hat.schemas
   @ Tool_improve_loop.schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -45,7 +45,7 @@ let all_schemas_extended =
   @ Tool_schemas_a2a.schemas
   @ Tool_schemas_misc.schemas
   @ Tool_keeper.schemas
-  @ Tool_operator.schemas @ Tool_local_runtime.schemas @ Tool_command_plane.schemas @ Tool_goals.schemas
+  @ Tool_operator.schemas @ Tool_local_runtime.schemas @ Tool_command_plane.schemas
   @ Tool_team_session.schemas @ Tool_voice.schemas @ Tool_shard.schemas
   @ Tool_autoresearch.schemas
   @ Tool_compact.schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -17,7 +17,6 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_auth.schemas
   @ Tool_schemas_portal.schemas
   @ Tool_schemas_worktree.schemas
-  @ Tool_schemas_fire_task.schemas
   @ Tool_task.schemas
   @ Tool_suspend.schemas
   @ Tool_council_oas.schemas
@@ -43,7 +42,6 @@ let all_schemas_extended =
   @ Tool_operator.schemas @ Tool_local_runtime.schemas @ Tool_command_plane.schemas
   @ Tool_team_session.schemas @ Tool_voice.schemas @ Tool_shard.schemas
   @ Tool_autoresearch.schemas
-  @ Tool_compact.schemas
 
 (** Get tool by name *)
 let find_tool name =

--- a/test/test_tool_budget.ml
+++ b/test/test_tool_budget.ml
@@ -113,4 +113,39 @@ let () =
               check bool "no budget" true
                 (Tool_budget.default_budget () = None));
         ] );
+      ( "p3_budget_audit",
+        [
+          test_case "no single tool description exceeds 500 tokens" `Quick (fun () ->
+              let max_per_tool = 500 in
+              let schemas = Masc_mcp.Config.raw_all_tool_schemas in
+              let violations =
+                List.filter_map
+                  (fun (s : Types.tool_schema) ->
+                    let tokens = Tool_budget.estimate_tokens s.description in
+                    if tokens > max_per_tool then
+                      Some (Printf.sprintf "%s: %d tokens" s.name tokens)
+                    else None)
+                  schemas
+              in
+              if violations <> [] then
+                Alcotest.fail
+                  (Printf.sprintf "P3 violation: %d tools exceed %d tokens:\n%s"
+                     (List.length violations) max_per_tool
+                     (String.concat "\n" violations)));
+          test_case "public MCP surface total under 15K tokens" `Quick (fun () ->
+              let max_total = 15000 in
+              let schemas =
+                Masc_mcp.Config.visible_tool_schemas () in
+              let total =
+                List.fold_left
+                  (fun acc (s : Types.tool_schema) ->
+                    acc + Tool_budget.estimate_tokens s.description)
+                  0 schemas
+              in
+              if total > max_total then
+                Alcotest.fail
+                  (Printf.sprintf
+                     "P3 violation: public surface total = %d tokens (limit %d)"
+                     total max_total));
+        ] );
     ]


### PR DESCRIPTION
## Summary

MCP tool surface 정리 + schema 인프라 개선.

- 39개 미사용 tool의 schema/dispatch 등록 제거 (handler 보존)
- `Tool_schema_dsl.ml` 신규 모듈로 중복 schema 헬퍼 통합
- P3 budget CI 테스트 추가 (500tok/tool, 15K total 자동 검증)

## 제거 기준

tool name 문자열이 handler 자기 파일에서만 참조 (refs=1-2):
- user-facing 문서 (CLAUDE.md, Quick-Start, workflow_guide) 언급 없음
- keeper persona 큐레이션 없음
- 다른 tool 모듈에서 내부 호출 없음

## 제거 도구 (39개)

| 도메인 | 도구 | 수 |
|--------|------|---|
| tempo | masc_tempo, _adjust, _get, _reset, _set | 5 |
| encryption | masc_encryption_enable/disable/status, masc_generate_key | 4 |
| notification | masc_notification_count, _check/_consume_notifications | 3 |
| goals | masc_goal_upsert/list/dispatch/refresh/review/snapshot | 6 |
| hat | masc_hat_wear/status | 2 |
| rate_limit | masc_rate_limit_config/status | 2 |
| cost | masc_cost_log/report | 2 |
| audit | masc_audit_query/stats/trail, masc_governance_report | 4 |
| cache | masc_cache_get/set/delete/list/clear/stats | 6 |
| fire_task | masc_fire_task | 1 |
| code_swarm | masc_code_swarm_plan/verify/merge | 3 |
| compact | masc_compact_context | 1 |

## Schema DSL

`Tool_schema_dsl.ml` — `string_prop`, `integer_prop`, `boolean_prop`, `string_array_prop`, `enum_prop`, `object_schema`.

```ocaml
(* Before: 5 lines per property *)
("agent_name", `Assoc [("type", `String "string"); ("description", `String "...")])

(* After: 1 line *)
("agent_name", string_prop "Your agent name")
```

## P3 Budget Test

`test_tool_budget.ml`에 2개 assertion 추가:
- 단일 tool description > 500 tokens → 실패
- Public MCP surface 전체 > 15K tokens → 실패

## Test plan

- [x] `dune build` 성공
- [x] `test_tool_budget` 10/10 통과 (P3 포함)
- [x] 기존 테스트 영향 없음 (포트 충돌 1건은 환경 이슈)
- [ ] `MASC_FULL_SURFACE=1` 서버 기동 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)