### PR TITLE
[codex] define keeper continuity product contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md) — product promise, GitHub operating model, 6-8 week execution tracks
 - [ROADMAP.md](ROADMAP.md) — current package version, latest release truth, active tracks
 - [docs/PRODUCT-REVIEW.md](docs/PRODUCT-REVIEW.md) — current product posture by promise level
+- [docs/design/keeper-continuity-product-rfc.md](docs/design/keeper-continuity-product-rfc.md) — bounded keeper continuity contract and promise level
+- [docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md](docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md) — release gate, evidence, monitoring, and rollback for keeper continuity
 
 ## Document Map
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -31,6 +31,30 @@ All keepers receive: base + board + fs + shell + library + taskboard + governanc
 Voice tools are added when `policy_voice_enabled = true`.
 `write_done = true` returns empty tool list (session terminated).
 
+## Continuity Contract
+
+Keeper continuity is a bounded advanced capability, not a general memory promise.
+
+What the product should promise:
+
+- `masc_keeper_msg` can continue a same-trace conversation when checkpoint restore is healthy
+- `masc_keeper_status` and `masc_keeper_list(detailed=true)` expose enough continuity state to diagnose restore and handoff behavior
+- validation should rely on OAS checkpoint truth plus live runtime evidence
+
+What the product should not promise:
+
+- long-term or general conversational memory
+- cross-generation recall
+- assistant reply recall outside the active checkpoint window
+- memory bank resurrection as part of keeper continuity
+
+Primary continuity fields:
+
+- `trace_id`
+- `generation`
+- `trace_history_count`
+- `continuity_summary`
+
 ## Triage System
 
 Triage evaluates 9 trigger types on each heartbeat:

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -55,7 +55,7 @@ Primary continuity fields:
 - `trace_history_count`
 - `continuity_summary`
 
-`continuity_summary` is the latest continuity snapshot text. It may be empty or `null` when no continuity snapshot is available yet; a successful validated turn should eventually replace that empty state with a newer snapshot in detailed keeper status.
+`continuity_summary` is the latest continuity snapshot text. It may be empty or `null` before the first continuity snapshot exists. After a harness-validated continuity update, detailed keeper status should expose a non-empty latest snapshot for that keeper.
 
 ## Triage System
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -31,17 +31,17 @@ All keepers receive: base + board + fs + shell + library + taskboard + governanc
 Voice tools are added when `policy_voice_enabled = true`.
 `write_done = true` returns empty tool list (session terminated).
 
-## Continuity Contract
+## Continuity Positioning
 
 Keeper continuity is a bounded advanced capability, not a general memory promise.
 
-What the product should promise:
+If productized, the continuity promise is:
 
 - `masc_keeper_msg` can continue a same-trace conversation when checkpoint restore is healthy
 - `masc_keeper_status` and `masc_keeper_list(detailed=true)` expose enough continuity state to diagnose restore and handoff behavior
 - validation should rely on OAS checkpoint truth plus live runtime evidence
 
-What the product should not promise:
+The product should not promise:
 
 - long-term or general conversational memory
 - cross-generation recall

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -54,6 +54,7 @@ Primary continuity fields:
 - `generation`
 - `trace_history_count`
 - `continuity_summary`
+- `last_continuity_update_ts` (detailed status tie-breaker)
 
 `continuity_summary` is the latest continuity snapshot text. It may be empty or `null` before the first continuity snapshot exists. After a harness-validated continuity update, detailed keeper status should expose a non-empty latest snapshot for that keeper.
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -53,7 +53,7 @@ Primary continuity fields:
 - `trace_id`
 - `generation`
 - `trace_history_count`
-- `continuity_summary`
+- `continuity_summary` (optional before the first continuity snapshot exists)
 
 Supporting diagnostic field:
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -54,9 +54,12 @@ Primary continuity fields:
 - `generation`
 - `trace_history_count`
 - `continuity_summary`
+
+Supporting diagnostic field:
+
 - `last_continuity_update_ts` (detailed status tie-breaker)
 
-`continuity_summary` is the latest continuity snapshot text. It may be empty or `null` before the first continuity snapshot exists. After a harness-validated continuity update, detailed keeper status should expose a non-empty latest snapshot for that keeper.
+`continuity_summary` is the latest continuity snapshot text. It may be empty or `null` before the first continuity snapshot exists. During validation, a harness-validated continuity update should correlate with a non-empty latest snapshot in detailed keeper status.
 
 ## Triage System
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -55,6 +55,8 @@ Primary continuity fields:
 - `trace_history_count`
 - `continuity_summary`
 
+`continuity_summary` is the latest continuity snapshot text. It may be empty or `null` when no continuity snapshot is available yet; a successful validated turn should eventually replace that empty state with a newer snapshot in detailed keeper status.
+
 ## Triage System
 
 Triage evaluates 9 trigger types on each heartbeat:

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -33,7 +33,7 @@ It does not certify:
 Keeper continuity is releaseable as an advanced feature only when all of the following are true:
 
 1. OAS checkpoint diagnosis has a closed root cause and an implemented fix
-2. `Keeper_checkpoint_store.load_oas` returns non-empty message state for the validated scenario
+2. the validated scenario includes explicit checkpoint-restore evidence from the OAS load path (for example diagnosis logs, scripted inspection output, or harness-linked artifacts)
 3. `masc_keeper_msg` same-trace continuity succeeds in live runtime
 4. `masc_keeper_status` and `masc_keeper_list(detailed=true)` report continuity fields consistently
 5. rollback instructions are tested and documented
@@ -46,7 +46,7 @@ If any gate is missing, the feature remains internal or validation-only.
 Each release or promotion decision should capture these artifacts:
 
 - validation harness report from `docs/KEEPER-CONTINUITY-VALIDATION.md`
-- checkpoint diagnosis note proving the OAS load path used for truth
+- checkpoint diagnosis note or structured inspection artifact proving the OAS load path used for truth
 - example `masc_keeper_status` output showing `trace_id`, `generation`, `trace_history_count`, and `continuity_summary`
 - operator note or PR evidence linking the implemented fix to the diagnosed root cause
 
@@ -84,6 +84,7 @@ Use the OAS checkpoint load path as the source of truth.
 
 - confirm the validated keeper trace restores from OAS checkpoint state
 - confirm the restored messages match the continuity scenario being tested
+- record this through a diagnosis note, scripted inspection output, or equivalent artifact that can be attached to the PR or release evidence bundle
 - do not rely on raw `<trace_id>.json` filesystem inspection unless the runtime is known to be in the fallback path
 
 ### 3. Read-model validation
@@ -121,10 +122,13 @@ Operator escalation rules:
 
 If continuity regresses after launch:
 
-1. downgrade public wording from advanced feature to validation-only or internal
-2. disable any newly promoted docs claims before attempting broader fixes
-3. preserve checkpoint artifacts and validation evidence for diagnosis
-4. prefer forward-fix with explicit evidence; do not widen the promise while diagnosis is open
+1. downgrade public wording from advanced feature to validation-only or internal in `README.md`, `docs/PRODUCT-OPERATING-PLAN.md`, and continuity-specific docs
+2. if the release bundles runtime continuity code changes, either revert the offending continuity change or hold the release while keeping the downgraded wording in place
+3. rerun the keeper continuity validation harness against the last known-good build or commit and store the result with the incident evidence
+4. preserve checkpoint artifacts and validation evidence for diagnosis
+5. prefer forward-fix with explicit evidence; do not widen the promise while diagnosis is open
+
+Current default: there is no dedicated runtime feature flag for keeper continuity. Rollback is therefore a combination of product-promise rollback plus code revert or release hold when implementation changes are bundled.
 
 If filesystem naming or migration work is bundled with continuity changes:
 

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -1,0 +1,168 @@
+# Keeper Continuity Production Runbook
+
+**Status**: Draft, production prerequisite
+**Date**: 2026-03-29
+**Scope**: Release gate, evidence, monitoring, and rollback for keeper continuity
+**One sentence**: Treat keeper continuity as production-ready only when checkpoint truth, live validation, diagnostics, and rollback are all in place.
+
+## Related Documents
+
+- `./KEEPER-CONTINUITY-VALIDATION.md`
+- `./design/keeper-continuity-product-rfc.md`
+- `./design/keeper-continuity-diagnosis-rfc.md`
+- `./design/error-handling-and-operations-spec.md`
+- `./PRODUCT-OPERATING-PLAN.md`
+
+## Product Scope
+
+This runbook applies to the advanced keeper feature defined as:
+
+- same-trace checkpoint-backed continuity for `masc_keeper_msg`
+- restart/restore continuity within the same active trace
+- diagnostic truth through keeper read surfaces
+
+It does not certify:
+
+- general memory
+- cross-generation recall
+- long-term assistant reply recall
+- memory bank resurrection
+
+## Release Gate
+
+Keeper continuity is releaseable as an advanced feature only when all of the following are true:
+
+1. OAS checkpoint diagnosis has a closed root cause and an implemented fix
+2. `Keeper_checkpoint_store.load_oas` returns non-empty message state for the validated scenario
+3. `masc_keeper_msg` same-trace continuity succeeds in live runtime
+4. `masc_keeper_status` and `masc_keeper_list(detailed=true)` report continuity fields consistently
+5. rollback instructions are tested and documented
+6. docs use bounded continuity language consistently
+
+If any gate is missing, the feature remains internal or validation-only.
+
+## Required Evidence
+
+Each release or promotion decision should capture these artifacts:
+
+- validation harness report from `docs/KEEPER-CONTINUITY-VALIDATION.md`
+- checkpoint diagnosis note proving the OAS load path used for truth
+- example `masc_keeper_status` output showing `trace_id`, `generation`, `trace_history_count`, and `continuity_summary`
+- operator note or PR evidence linking the implemented fix to the diagnosed root cause
+
+Preferred evidence bundle:
+
+- harness summary
+- checkpoint inspection result
+- keeper status snapshot
+- rollback note
+
+## Validation Flow
+
+### 1. Live continuity validation
+
+Run the existing harness in isolated mode:
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc-mcp
+KEEPER_MODELS="default" \
+scripts/harness_keeper_continuity_validation.sh
+```
+
+Minimum acceptable result for release:
+
+- `PASS` for same-trace continuity
+- no contradictory keeper status signals during the run
+
+The existing harness `PASS` bar is intentionally stricter than the base product contract. It also expects compaction and handoff evidence, which makes it suitable as a production-readiness gate rather than only a minimal feature check.
+
+`PARTIAL` is not production-ready for feature promotion. It is evidence for debugging only.
+
+### 2. Checkpoint truth validation
+
+Use the OAS checkpoint load path as the source of truth.
+
+- confirm the validated keeper trace restores from OAS checkpoint state
+- confirm the restored messages match the continuity scenario being tested
+- do not rely on raw `<trace_id>.json` filesystem inspection unless the runtime is known to be in the fallback path
+
+### 3. Read-model validation
+
+Verify continuity-related read surfaces are coherent:
+
+- `masc_keeper_status`
+- `masc_keeper_list(detailed=true)`
+- continuity harness artifacts
+
+The read surfaces must agree on:
+
+- active `trace_id`
+- `generation`
+- whether handoff occurred
+- whether continuity summary moved forward after the validated turn
+
+## Monitoring And Alerts
+
+At minimum, monitor:
+
+- checkpoint save success rate
+- checkpoint load failure rate
+- empty-message checkpoint restore rate
+- keeper continuity validation pass rate
+- keeper resume/restart failure rate
+
+Operator escalation rules:
+
+- any sustained checkpoint load failure blocks keeper continuity promotion
+- any empty-message restore regression pages or creates a release blocker
+- any mismatch between live keeper state and read surfaces blocks promotion until resolved
+
+## Rollback And Containment
+
+If continuity regresses after launch:
+
+1. downgrade public wording from advanced feature to validation-only or internal
+2. disable any newly promoted docs claims before attempting broader fixes
+3. preserve checkpoint artifacts and validation evidence for diagnosis
+4. prefer forward-fix with explicit evidence; do not widen the promise while diagnosis is open
+
+If filesystem naming or migration work is bundled with continuity changes:
+
+- quarantine on conflict
+- no automatic data deletion
+- continuity rollback takes precedence over cleanup completion
+
+## Documentation Truth Checklist
+
+Before merge or release note publication, ensure these are aligned:
+
+- `README.md`
+- `docs/PRODUCT-OPERATING-PLAN.md`
+- `docs/PRODUCT-REVIEW.md`
+- `docs/KEEPER-CAPABILITY-MATRIX.md`
+- `docs/design/keeper-continuity-product-rfc.md`
+- `docs/KEEPER-CONTINUITY-VALIDATION.md`
+
+Required wording pattern:
+
+- advanced keeper feature
+- bounded continuity
+- same-trace checkpoint-backed restore
+- diagnosable via keeper status / validation
+
+Forbidden wording pattern:
+
+- general memory
+- resurrected memory system
+- remembers everything
+
+## Exit Criteria
+
+Keeper continuity is production-ready only when:
+
+- diagnosis is closed
+- validation is passing on live runtime
+- read surfaces are truthful
+- monitoring exists
+- rollback is documented
+- docs do not over-promise beyond bounded continuity

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -43,6 +43,12 @@ Keeper continuity is releaseable as an advanced feature only when all of the fol
 
 If any gate is missing, the feature remains internal or validation-only.
 
+For this runbook, `diagnosis closed` means all of the following:
+
+- one root-cause bucket from the diagnosis RFC (`H1`-`H4`) is selected
+- the selected fix path is implemented or explicitly marked as no-code with rationale
+- the validating artifact is attached in PR or release evidence
+
 ## Required Evidence
 
 Each release or promotion decision should capture these artifacts:
@@ -125,6 +131,8 @@ Operator escalation rules:
 - any mismatch between live keeper state and read surfaces blocks promotion until resolved
 
 If these metrics are not yet exported in the current telemetry stack, keeper continuity remains blocked from production promotion until equivalent dashboards or reports are defined.
+
+`Equivalent dashboards or reports` means one reproducible command, dashboard, or generated artifact per required metric, referenced from the PR or release evidence so another operator can re-run the same check.
 
 ## Rollback And Containment
 

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -104,7 +104,9 @@ The read surfaces must agree on:
 - active `trace_id`
 - `generation`
 - whether handoff occurred
-- whether `continuity_summary` is no longer empty/stale for the validated turn, with `last_continuity_update_ts` from detailed status used as the tie-breaker when needed
+- whether `continuity_summary` reflects the latest harness-validated continuity update, with `last_continuity_update_ts` from detailed status used as the tie-breaker when needed
+
+For timing-sensitive interpretation, the harness result (`PASS` / `PARTIAL` / `FAIL`) remains authoritative. Read-model checks are used to confirm consistency, not to redefine the harness outcome.
 
 ## Monitoring And Alerts
 
@@ -121,6 +123,8 @@ Operator escalation rules:
 - any sustained checkpoint load failure blocks keeper continuity promotion
 - any empty-message restore regression pages or creates a release blocker
 - any mismatch between live keeper state and read surfaces blocks promotion until resolved
+
+If these metrics are not yet exported in the current telemetry stack, keeper continuity remains blocked from production promotion until equivalent dashboards or reports are defined.
 
 ## Rollback And Containment
 

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -88,6 +88,8 @@ Compaction and handoff are therefore treated here as resilience evidence for rel
 
 `PARTIAL` is not production-ready for feature promotion. It is evidence for debugging only.
 
+If pre-release validation returns `PARTIAL`, the release gate remains blocked and the result should be escalated back into diagnosis rather than accepted as launch evidence.
+
 ### 2. Checkpoint truth validation
 
 Use the OAS checkpoint load path as the source of truth.

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -28,6 +28,8 @@ It does not certify:
 - long-term assistant reply recall
 - memory bank resurrection
 
+This document is a future-state release gate. The current product posture can still be `Not done for product promise` while diagnosis or hardening remains open.
+
 ## Release Gate
 
 Keeper continuity is releaseable as an advanced feature only when all of the following are true:
@@ -76,6 +78,8 @@ Minimum acceptable result for release:
 
 The existing harness `PASS` bar is intentionally stricter than the base product contract. It also expects compaction and handoff evidence, which makes it suitable as a production-readiness gate rather than only a minimal feature check.
 
+Compaction and handoff are therefore treated here as resilience evidence for release promotion, not as the minimum user-facing continuity contract.
+
 `PARTIAL` is not production-ready for feature promotion. It is evidence for debugging only.
 
 ### 2. Checkpoint truth validation
@@ -100,7 +104,7 @@ The read surfaces must agree on:
 - active `trace_id`
 - `generation`
 - whether handoff occurred
-- whether continuity summary moved forward after the validated turn
+- whether `continuity_summary` is no longer empty/stale for the validated turn, with `last_continuity_update_ts` from detailed status used as the tie-breaker when needed
 
 ## Monitoring And Alerts
 
@@ -109,8 +113,8 @@ At minimum, monitor:
 - checkpoint save success rate
 - checkpoint load failure rate
 - empty-message checkpoint restore rate
-- keeper continuity validation pass rate
-- keeper resume/restart failure rate
+- keeper continuity validation pass rate from scheduled harness runs or pre-release validation runs
+- keeper resume/restart failure rate from keeper status/metrics telemetry
 
 Operator escalation rules:
 

--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -88,7 +88,7 @@ Compaction and handoff are therefore treated here as resilience evidence for rel
 
 `PARTIAL` is not production-ready for feature promotion. It is evidence for debugging only.
 
-If pre-release validation returns `PARTIAL`, the release gate remains blocked and the result should be escalated back into diagnosis rather than accepted as launch evidence.
+If pre-release validation returns `PARTIAL`, the release gate remains blocked and the result should be escalated back into diagnosis rather than accepted as launch evidence. Reuse one of the existing diagnosis buckets (`H1`-`H4`) when it fits; otherwise open a follow-up diagnosis work item with the harness artifacts attached.
 
 ### 2. Checkpoint truth validation
 
@@ -123,7 +123,7 @@ At minimum, monitor:
 - checkpoint save success rate
 - checkpoint load failure rate
 - empty-message checkpoint restore rate
-- keeper continuity validation pass rate from scheduled harness runs or pre-release validation runs
+- keeper continuity validation pass rate from periodic or pre-release validation runs
 - keeper resume/restart failure rate from keeper status/metrics telemetry
 
 Operator escalation rules:

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -28,6 +28,7 @@ The front-door promise is level 1. Levels 2-4 are real, but they are not the fir
 | Room and task hygiene | Done | Front door | `docs/spec/C-implementation-status.md`, `README.md` | docs were too spread out | keep as default entry path |
 | Worktree and collision control | Done | Front door | README, room/tool coverage, live usage | onboarding clarity | keep in front-door docs |
 | Team Session + Supervisor | Working | Advanced | `docs/SWARM-DELIVERY-RUNBOOK.md`, `docs/SUPERVISOR-MODE.md` | still not the safest starting path | present as advanced flow |
+| Keeper continuity | Not done for product promise | Advanced | `docs/design/keeper-continuity-product-rfc.md`, `docs/KEEPER-CONTINUITY-VALIDATION.md` | checkpoint truth and bounded contract are not productized yet | ship as bounded same-trace continuity with explicit runbook |
 | Dashboard core read models | Working | Supporting | `docs/qa/REQUIREMENTS-REVERSE-ENGINEERED.md` | transport truth and config visibility gaps | harden read truth and config introspection |
 | Remote-safe operator | Working | Supporting | `docs/REMOTE-MCP-OPERATOR.md` | auth and release posture still need tightening | keep surface reduced and explicit |
 | Multi-transport matrix | Working but not front-door | Experimental | implementation status appendix, live transport issues | reachable state and reported state can diverge | fix health truth before promotion |
@@ -147,6 +148,7 @@ Research next:
 
 - non-local auth defaults and REST contract versioning
 - delivery-swarm readiness and verifier budget reliability
+- bounded keeper continuity contract and release evidence
 - read-only diagnosis bundles for operator workflows
 
 Keep visible, but defer:

--- a/docs/PRODUCT-REVIEW.md
+++ b/docs/PRODUCT-REVIEW.md
@@ -8,6 +8,8 @@
 
 The main problem is no longer “there is no product here.” The main problem is that the explanation layers, release truth, and hardening priorities were wider than the front-door promise.
 
+Keeper continuity now fits the same pattern: it is real enough to design and validate, but it should stay a bounded advanced feature until checkpoint truth and readiness evidence are closed.
+
 ## Product Posture by Promise Level
 
 ### 1. Repo coordination
@@ -82,12 +84,14 @@ These matter after the repo-coordination front door is clean.
 - auth hardening for non-local operation
 - REST API contract versioning and error-shape discipline
 - delivery-swarm ergonomics for delegation, verification, and operator diagnosis
+- bounded keeper continuity contract plus checkpoint/readiness evidence
 - richer config and runtime visibility for operators
 
 ## Judgment
 
 - **Repo-local multi-agent coordination**: ready to describe and use
 - **Supervised delivery swarm**: real and worth documenting, but not the first promise
+- **Keeper continuity**: should be described as checkpoint-backed same-trace continuity, not as general memory
 - **Remote or ops-grade product story**: still incomplete and should remain explicit about its gaps
 
 The next useful re-evaluation gate is:

--- a/docs/design/keeper-continuity-diagnosis-rfc.md
+++ b/docs/design/keeper-continuity-diagnosis-rfc.md
@@ -15,6 +15,8 @@
 - `../spec/13-oas-integration.md`
 - `../ADR-001-MITOSIS-VS-COMPACTION.md`
 - `../KEEPER-CONTINUITY-VALIDATION.md`
+- `./keeper-continuity-product-rfc.md`
+- `../KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md`
 - `config/prompts/keeper.constitution.md`
 
 ## Revision History

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -1,0 +1,119 @@
+# Keeper Continuity Product RFC
+
+**Status**: Draft
+**Date**: 2026-03-29
+**Promise level**: Advanced keeper feature
+**Scope**: Product contract for bounded keeper continuity
+**One sentence**: Productize keeper continuity as same-trace checkpoint continuity plus diagnosability, not as general memory.
+
+## Related Documents
+
+- `./keeper-continuity-diagnosis-rfc.md`
+- `../KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md`
+- `../KEEPER-CONTINUITY-VALIDATION.md`
+- `../PRODUCT-OPERATING-PLAN.md`
+- `../PRODUCT-REVIEW.md`
+- `../spec/05-keeper-agent.md`
+
+## Summary
+
+`masc-mcp` should describe keeper continuity as a bounded advanced feature.
+
+The product promise is:
+
+- a keeper can continue a same-trace conversation through OAS checkpoint-backed context restore
+- continuity failures are diagnosable through keeper read surfaces and operator validation
+- this is an advanced keeper capability, not the front-door product promise
+
+The product must not describe this feature as long-term memory, general memory, or cross-generation recall.
+
+## Product Contract
+
+### Included behavior
+
+- `masc_keeper_msg` preserves same-trace conversation continuity when checkpoint save/load/restore is healthy
+- keeper restart or restore within the same trace preserves conversation continuity to the current checkpoint ceiling
+- operators can diagnose continuity state through `masc_keeper_status`, `masc_keeper_list(detailed=true)`, and the keeper continuity validation harness
+- continuity state is explained with checkpoint/read-model language, not raw filesystem assumptions
+
+### Excluded behavior
+
+- general conversational memory
+- long-tail recall beyond the current checkpoint contract
+- cross-generation or cross-trace recall
+- assistant reply recall outside the active checkpoint window
+- memory bank resurrection as part of the continuity promise
+
+## Public Surface
+
+This contract is anchored to existing keeper surfaces.
+
+### Write surface
+
+- `masc_keeper_msg`
+  - primary user-facing continuity surface
+  - success means the keeper can continue the same trace coherently after prior turns and restore events
+
+### Read surfaces
+
+- `masc_keeper_status`
+  - primary diagnostic surface
+  - continuity-related fields must remain trustworthy: `trace_id`, `generation`, `trace_history_count`, `continuity_summary`
+- `masc_keeper_list(detailed=true)`
+  - lightweight fleet view for continuity and handoff state
+- `docs/KEEPER-CONTINUITY-VALIDATION.md`
+  - operator validation harness and evidence format
+
+### Non-API implementation details
+
+- raw checkpoint file paths are not part of the product contract
+- `Keeper_checkpoint_store.load_oas` is the continuity source of truth for diagnosis
+- fallback legacy checkpoint artifacts may exist, but they must not shape the user-facing promise
+
+## Product Positioning
+
+### Promise level
+
+- Keep keeper continuity in the advanced layer of the product
+- Do not promote it to the front-door repo-coordination promise in README or release framing
+
+### Language rules
+
+Use:
+
+- `keeper continuity`
+- `same-trace continuity`
+- `checkpoint-backed restore`
+- `diagnosable continuity`
+
+Avoid:
+
+- `memory resurrection`
+- `general memory`
+- `the keeper remembers everything`
+
+## Readiness Conditions For Product Language
+
+The feature may be described as a productized advanced capability only when all of the following are true:
+
+- OAS checkpoint diagnosis has identified and closed the root cause of the current continuity regression
+- same-trace continuity passes the validation harness on live runtime
+- keeper read surfaces report continuity state truthfully enough for diagnosis
+- the production runbook defines evidence, monitoring, and rollback
+- docs use the bounded continuity wording consistently across README, product plan, keeper docs, and runbooks
+
+## Follow-On Work
+
+Out of scope for this RFC, but explicitly related:
+
+- history recall for current-trace user messages beyond the keep-last checkpoint window
+- recall observability (`evaluate_memory_recall`, `memory_eval_to_json`, `memory_check`)
+- naming cleanup for `perpetual` / `perpetual-keepers`
+- filesystem cleanup backlog discovered during diagnosis
+
+Any future expansion from bounded continuity to broader recall must ship in a separate RFC with an explicit contract for:
+
+- recall target (`user`, `assistant`, or both)
+- recall span (`same trace`, `trace history`, or broader)
+- prompt budget and ranking policy
+- observability and failure handling

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -64,6 +64,8 @@ This contract is anchored to existing keeper surfaces.
 - `docs/KEEPER-CONTINUITY-VALIDATION.md`
   - operator validation harness and evidence format
 
+Current implementation already emits the continuity fields above on keeper status surfaces. This RFC is narrowing the product promise around those existing fields rather than inventing a new API.
+
 ### Non-API implementation details
 
 - raw checkpoint file paths are not part of the product contract
@@ -101,6 +103,8 @@ The feature may be described as a productized advanced capability only when all 
 - keeper read surfaces report continuity state truthfully enough for diagnosis
 - the production runbook defines evidence, monitoring, and rollback
 - docs use the bounded continuity wording consistently across README, product plan, keeper docs, and runbooks
+
+Until then, the product posture remains `Not done for product promise` even though the design docs themselves are in `Draft`.
 
 ## Follow-On Work
 

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -100,7 +100,7 @@ Avoid:
 
 The feature may be described as a productized advanced capability only when all of the following are true:
 
-- OAS checkpoint diagnosis has identified and closed the root cause of the current continuity regression
+- OAS checkpoint diagnosis has identified and closed the root cause of the current continuity regression, as defined in the production runbook
 - same-trace continuity passes the validation harness on live runtime
 - keeper read surfaces report continuity state truthfully enough for diagnosis
 - the production runbook defines evidence, monitoring, and rollback

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -106,6 +106,8 @@ The feature may be described as a productized advanced capability only when all 
 
 Until then, the product posture remains `Not done for product promise` even though the design docs themselves are in `Draft`.
 
+The current production promotion bar is intentionally stricter than the base user-facing contract. The existing validation harness also uses compaction and handoff evidence as resilience signals before promotion.
+
 ## Follow-On Work
 
 Out of scope for this RFC, but explicitly related:

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -71,7 +71,7 @@ Current implementation already emits the continuity fields above on keeper statu
 ### Non-API implementation details
 
 - raw checkpoint file paths are not part of the product contract
-- `Keeper_checkpoint_store.load_oas` is the continuity source of truth for diagnosis
+- the OAS checkpoint load path is the continuity source of truth for diagnosis
 - fallback legacy checkpoint artifacts may exist, but they must not shape the user-facing promise
 
 ## Product Positioning

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -58,7 +58,9 @@ This contract is anchored to existing keeper surfaces.
 
 - `masc_keeper_status`
   - primary diagnostic surface
-  - continuity-related fields must remain trustworthy: `trace_id`, `generation`, `trace_history_count`, `continuity_summary`
+  - guaranteed continuity-related fields must remain trustworthy: `trace_id`, `generation`, `trace_history_count`
+  - `continuity_summary` is expected after a validated continuity update and may be empty before the first snapshot exists
+  - `last_continuity_update_ts` is a detailed-status supporting field for operator tie-breaks, not part of the minimal product contract
 - `masc_keeper_list(detailed=true)`
   - lightweight fleet view for continuity and handoff state
 - `docs/KEEPER-CONTINUITY-VALIDATION.md`


### PR DESCRIPTION
## Summary
- add a product RFC that defines keeper continuity as bounded same-trace continuity, not general memory
- add a production runbook for continuity release gates, evidence, monitoring, and rollback
- align the README, product plan, product review, capability matrix, and diagnosis RFC with the new continuity contract

## Product impact
- Promise affected: delivery swarm
- keeper continuity is documented as an advanced feature with explicit scope limits and production prerequisites
- front-door repo coordination promise remains unchanged

## Evidence
- `git diff --check`
- documentation-only change; no code paths changed

## Review evidence
- 2026-03-29T09:24:50Z — cross-model review via direct `sb glm-text` (default model order starts with `glm-5`)
- reviewer findings were limited to documentation consistency and readiness wording; they were patched in follow-up commits on this PR branch
- no high or critical findings remain after the follow-up clarifications

## Linked issue
- Related to #3630
- Related to #3627
