### PR TITLE
feat(keeper): Phase 0 — config SSOT + per-stage keepalive profiling

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -107,15 +107,67 @@ let wakeup_relevant_keeper_for_board_signal
 
 let max_consecutive_heartbeat_failures = 5
 
+(* Per-stage timing accumulator for Phase 0 profiling.
+   In-memory ring of last 100 cycles. Flushed as aggregate at snapshot cadence.
+   No additional file I/O — appended to existing snapshot JSON. *)
+type stage_timing = {
+  presence_ms : float;
+  snapshot_ms : float;
+  board_ms : float;
+  turn_ms : float;
+  recurring_ms : float;
+  improve_ms : float;
+}
+
+let stage_timing_ring_size = 100
+
+let percentile arr p =
+  let n = Array.length arr in
+  if n = 0 then 0.0
+  else
+    let sorted = Array.copy arr in
+    Array.sort Float.compare sorted;
+    let idx = Float.to_int (Float.round (float_of_int (n - 1) *. p)) in
+    sorted.(min idx (n - 1))
+
+let stage_timing_to_json ~ring ~count =
+  let n = min count stage_timing_ring_size in
+  if n = 0 then `Null
+  else
+    let extract field =
+      let arr = Array.init n (fun i -> field ring.(i)) in
+      `Assoc [
+        ("p50", `Float (percentile arr 0.5));
+        ("p95", `Float (percentile arr 0.95));
+        ("max", `Float (percentile arr 1.0));
+        ("samples", `Int n);
+      ]
+    in
+    `Assoc [
+      ("presence", extract (fun t -> t.presence_ms));
+      ("snapshot", extract (fun t -> t.snapshot_ms));
+      ("board", extract (fun t -> t.board_ms));
+      ("turn", extract (fun t -> t.turn_ms));
+      ("recurring", extract (fun t -> t.recurring_ms));
+      ("improve", extract (fun t -> t.improve_ms));
+    ]
+
 let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
     (m : keeper_meta) (stop : bool Atomic.t) ~(wakeup : bool Atomic.t) : unit =
   let keepalive_started_ts = Time_compat.now () in
   let snapshot_interval_sec = Env_config.KeeperRuntime.snapshot_sec in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
+  (* Phase 0: per-stage timing ring buffer *)
+  let timing_ring = Array.make stage_timing_ring_size
+    { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
+      turn_ms = 0.0; recurring_ms = 0.0; improve_ms = 0.0 } in
+  let timing_count = ref 0 in
   let rec loop () =
     if Atomic.get stop then ()
     else (
+            (* Phase 0: timing markers *)
+            let t_presence_start = Time_compat.now () in
             let meta_current =
               match read_meta ctx.config m.name with
               | Ok (Some latest) -> latest
@@ -149,7 +201,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                 "keeper %s: %d consecutive heartbeat failures, stopping keepalive"
                 m.name max_consecutive_heartbeat_failures;
               Atomic.set stop true);
-            let now_ts = Time_compat.now () in
+            let t_presence_end = Time_compat.now () in
+            let now_ts = t_presence_end in
+            let t_snapshot_start = now_ts in
             if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
             then (
               (try
@@ -274,6 +328,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                              | Some reason -> `String reason
                              | None -> `Null );
                            ("handoff", `Assoc [ ("performed", `Bool false) ]);
+                           ("stage_timing",
+                             stage_timing_to_json ~ring:timing_ring ~count:!timing_count);
                          ]
                      in
                      Dated_jsonl.append metrics_store snapshot;
@@ -308,6 +364,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  Log.Keeper.error "heartbeat snapshot write failed: %s"
                    (Printexc.to_string exn));
               last_snapshot_ts := now_ts);
+            let t_snapshot_end = Time_compat.now () in
+            let t_board_start = t_snapshot_end in
             let pending_board_events, meta_after_triage =
               let pending_board_events =
                 (try
@@ -327,6 +385,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               in
               (pending_board_events, meta_current)
             in
+            let t_board_end = Time_compat.now () in
+            let t_turn_start = t_board_end in
             let proactive_warmup_elapsed =
               proactive_warmup_sec <= 0
               || now_ts -. keepalive_started_ts
@@ -367,6 +427,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    meta_after_triage)
               else meta_after_triage
             in
+            let t_turn_end = Time_compat.now () in
+            let t_recurring_start = t_turn_end in
             (* Recurring task dispatch (#3190) *)
             let _recurring_dispatched =
               try
@@ -394,6 +456,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                   (Printexc.to_string exn);
                 0
             in
+            let t_recurring_end = Time_compat.now () in
+            let t_improve_start = t_recurring_end in
             let base =
               float_of_int
                 keepalive_interval_sec
@@ -408,6 +472,18 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
              | exn ->
                Log.Keeper.warn "improve loop keepalive tick skipped: %s"
                  (Printexc.to_string exn));
+            let t_improve_end = Time_compat.now () in
+            (* Phase 0: push stage timing to ring buffer *)
+            let timing = {
+              presence_ms = (t_presence_end -. t_presence_start) *. 1000.0;
+              snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0;
+              board_ms = (t_board_end -. t_board_start) *. 1000.0;
+              turn_ms = (t_turn_end -. t_turn_start) *. 1000.0;
+              recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0;
+              improve_ms = (t_improve_end -. t_improve_start) *. 1000.0;
+            } in
+            timing_ring.(!timing_count mod stage_timing_ring_size) <- timing;
+            incr timing_count;
             let jitter = base *. 0.2 *. Random.float 1.0 in  (* intentional: jitter *)
             interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
             if Atomic.get stop then ()

--- a/lib/room/dune
+++ b/lib/room/dune
@@ -34,6 +34,7 @@
  (libraries
   masc_types
   masc_core
+  masc_config
   masc_log
   masc_backend
   masc_eio_context

--- a/lib/room/resilience.ml
+++ b/lib/room/resilience.ml
@@ -1,8 +1,8 @@
 (** MASC Resilience - Single Source of Truth for Failure Handling *)
 
-(** Default zombie threshold in seconds (300s = 5 minutes).
-    Override via MASC_ZOMBIE_THRESHOLD_SEC env var at the caller level. *)
-let default_zombie_threshold = 300.0
+(** Default zombie threshold in seconds.
+    Reads MASC_ZOMBIE_THRESHOLD_SEC (default 300s = 5 minutes). *)
+let default_zombie_threshold = Env_config_runtime.Zombie.threshold_seconds
 
 (** Default inactivity warning threshold in seconds (2 minutes) *)
 let default_warning_threshold = 120.0
@@ -57,7 +57,7 @@ module Zombie = struct
   let is_zombie_for_agent ~agent_name last_seen_iso =
     let threshold =
       if is_keeper_name agent_name
-      then 3600.0  (* keeper threshold — override via MASC_KEEPER_ZOMBIE_THRESHOLD_SEC *)
+      then Env_config_runtime.Zombie.keeper_threshold_seconds
       else default_zombie_threshold
     in
     is_zombie ~threshold last_seen_iso

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -344,6 +344,7 @@ let planned_worker_to_entry_with_state
     run;
     role;
     get_telemetry = Some (fun () -> !telemetry_ref);
+    extensions = [];
   }
 
 let planned_worker_to_entry


### PR DESCRIPTION
## Summary
- resilience.ml: hardcoded zombie thresholds -> Env_config_runtime.Zombie (SSOT)
- keeper_keepalive.ml: in-memory ring buffer profiling for 6 loop stages
- Aggregate (p50/p95/max) flushed at snapshot cadence, no extra I/O

Closes #3641
Part of #3635 (Adaptive Heartbeat RFC)

## Test plan
- [ ] Build passes (dune build)
- [ ] Existing tests pass (dune runtest)
- [ ] Verify stage_timing field appears in keeper snapshot JSONL after 1 snapshot cycle
- [ ] Verify MASC_ZOMBIE_THRESHOLD_SEC env var override works

Generated with [Claude Code](https://claude.com/claude-code)