### PR TITLE
fix(build): repair main after #3640 merge

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.93.0))
+  (agent_sdk (>= 0.93.2))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/dune
+++ b/lib/dune
@@ -161,6 +161,7 @@
    local_runtime_pool
    retrieval_projection
    sdk_tool_contract
+   tool_schema_dsl
    worker_oas
    worker_runtime
    worker_container_types

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -344,7 +344,6 @@ let planned_worker_to_entry_with_state
     run;
     role;
     get_telemetry = Some (fun () -> !telemetry_ref);
-    extensions = [];
   }
 
 let planned_worker_to_entry

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -339,7 +339,13 @@ let planned_worker_to_entry_with_state
              (Oas.Error.InvalidConfig
                 { field = "worker"; detail = Printf.sprintf "%s: %s" name e }))
   in
-  { name; run; role; get_telemetry = Some (fun () -> !telemetry_ref) }
+  {
+    name;
+    run;
+    role;
+    get_telemetry = Some (fun () -> !telemetry_ref);
+    extensions = [];
+  }
 
 let planned_worker_to_entry
     ~(config : Room.config)

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -303,4 +303,3 @@ let string_prop = Tool_schema_dsl.string_prop
 let integer_prop = Tool_schema_dsl.integer_prop
 let boolean_prop = Tool_schema_dsl.boolean_prop
 let string_array_prop = Tool_schema_dsl.string_array_prop
-    ]

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -88,12 +88,7 @@ let register_all () =
     "masc_heartbeat_stop"; "masc_heartbeat_list";
   ];
 
-  (* ── Mod_hat: non-schema tools ──────────────────────────────── *)
-  reg Mod_hat [
-    "masc_hat_wear";
-  ];
-
-  (* Mod_cost and Mod_rate_limit: fully covered by schemas — no entries needed *)
+  (* Mod_hat, Mod_cost, Mod_rate_limit: removed from MCP surface (#3640) *)
 
   (* Mod_suspend: fully covered by schemas — no entries needed *)
 

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.93.0"}
+  "agent_sdk" {>= "0.93.2"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.93.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.93.2"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="67d7e0c43c5ed4382f91c3d457d7a70d104a359c"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.93.0"
+readonly OAS_AGENT_SDK_SHA="7fe0229c4d70fda56be75b065ca391db089b9ae5"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.93.2"


### PR DESCRIPTION
## Summary

- register `tool_schema_dsl` in `lib/dune` so `tool_command_plane_support.ml` builds again after `#3640`
- remove the stray rebase artifact (`]`) left in `tool_command_plane_support.ml`
- drop the stale `Mod_hat` registration that no longer exists on the MCP surface
- align `masc-mcp` with the current OAS swarm record by adding the new `agent_entry.extensions` field during team-session projection
- bump the `agent_sdk` floor/pin to `0.93.2` and `oas@7fe0229` so CI installs the same API shape this branch now uses

## Product impact

- restores `main` to a buildable state after the `#3640` squash merge
- keeps the MASC team-session bridge compatible with the current OAS `Swarm_types.agent_entry` record shape
- removes the local-vs-CI dependency skew that still pinned `agent_sdk` below the required API surface

## Evidence

Root cause:

- `#3640` landed while CI was still pending and left three source-level build breaks on `main`
- after patching those, a fourth compile break surfaced because OAS recently added the required `agent_entry.extensions` field and `team_session_oas_bridge.ml` still constructed the older record shape
- CI was still pinning `agent_sdk` to an older OAS SHA, so the branch needed the OAS floor/pin ratcheted alongside the source fix

Validation:

- `dune build --root .`
- `scripts/check-oas-pin.sh`

## Review evidence

- GLM-5 cross-model review evidence recorded in PR comments
- Result: no high/critical findings blocking merge

## Linked issue

- Closes #3663
- Relates #3640
