### PR TITLE
fix(auth): detect tunnel-through-loopback bypass (#3654)

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -43,13 +43,23 @@ let is_unspecified_host host =
   | Ok ip -> ipaddr_is_unspecified ip
   | Error _ -> false
 
+let base_url_has_non_loopback_host () =
+  match Env_config_core.masc_http_base_url_result () with
+  | Error _ -> false
+  | Ok url -> (
+      match Uri.host (Uri.of_string url) with
+      | None -> false
+      | Some host -> not (is_loopback_host host))
+
 let http_auth_strict_enabled () =
   env_flag_enabled "MASC_HTTP_AUTH_STRICT"
   || not (is_loopback_host (configured_bind_host ()))
+  || base_url_has_non_loopback_host ()
 
 let strict_http_auth_error endpoint =
   Printf.sprintf
-    "%s requires room auth enabled with require_token=true when server is bound to a non-loopback host."
+    "%s requires room auth enabled with require_token=true when server is \
+     bound to a non-loopback host or MASC_HTTP_BASE_URL points to a public address."
     endpoint
 
 let ensure_strict_http_token_auth ~endpoint auth_config =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -45,10 +45,10 @@ let is_unspecified_host host =
 
 let base_url_has_non_loopback_host () =
   match Env_config_core.masc_http_base_url_result () with
-  | Error _ -> false
+  | Error _ -> false  (* no base URL configured — defer to bind-host check *)
   | Ok url -> (
       match Uri.host (Uri.of_string url) with
-      | None -> false
+      | None -> true  (* fail-closed: unparseable host → treat as non-local *)
       | Some host -> not (is_loopback_host host))
 
 let http_auth_strict_enabled () =

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -544,6 +544,61 @@ let test_permission_for_tool_keeper_create_from_persona () =
 
 (* keeper policy auth tests removed — policy tools no longer registered in Auth *)
 
+(* ============================================================
+   Tunnel-through-loopback auth tests (#3654)
+   ============================================================ *)
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect ~finally:(fun () ->
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> (try Unix.putenv name "" with _ -> ())
+  ) f
+
+let clear_env name f =
+  let prev = Sys.getenv_opt name in
+  (try Unix.putenv name "" with _ -> ());
+  Fun.protect ~finally:(fun () ->
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> ()
+  ) f
+
+let test_base_url_non_loopback_enables_strict () =
+  let module SA = Masc_mcp.Server_auth in
+  with_env "MASC_HTTP_BASE_URL" "https://masc.crying.pictures" (fun () ->
+    with_env "MASC_HOST" "127.0.0.1" (fun () ->
+      clear_env "MASC_HTTP_AUTH_STRICT" (fun () ->
+        check bool "tunnel base URL forces strict auth" true
+          (SA.http_auth_strict_enabled ()))))
+
+let test_base_url_localhost_no_strict () =
+  let module SA = Masc_mcp.Server_auth in
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" (fun () ->
+    with_env "MASC_HOST" "127.0.0.1" (fun () ->
+      clear_env "MASC_HTTP_AUTH_STRICT" (fun () ->
+        check bool "localhost base URL no forced strict" false
+          (SA.http_auth_strict_enabled ()))))
+
+let test_base_url_unset_loopback_no_strict () =
+  let module SA = Masc_mcp.Server_auth in
+  clear_env "MASC_HTTP_BASE_URL" (fun () ->
+    with_env "MASC_HOST" "127.0.0.1" (fun () ->
+      with_env "MASC_HTTP_PORT" "8935" (fun () ->
+        clear_env "MASC_HTTP_AUTH_STRICT" (fun () ->
+          check bool "no base URL + loopback = no strict" false
+            (SA.http_auth_strict_enabled ())))))
+
+let test_env_flag_overrides_all () =
+  let module SA = Masc_mcp.Server_auth in
+  with_env "MASC_HTTP_AUTH_STRICT" "true" (fun () ->
+    with_env "MASC_HOST" "127.0.0.1" (fun () ->
+      clear_env "MASC_HTTP_BASE_URL" (fun () ->
+        check bool "env flag forces strict regardless" true
+          (SA.http_auth_strict_enabled ()))))
+
 let test_permission_for_tool_unknown () =
   match Auth.permission_for_tool "unknown_tool_xyz" with
   | None -> ()
@@ -679,5 +734,15 @@ let () =
         test_same_origin_allows_explicit_default_port_https;
       test_case "same-origin allows explicit default port http" `Quick
         test_same_origin_allows_explicit_default_port_http;
+    ];
+    "tunnel_auth (#3654)", [
+      test_case "non-loopback base URL enables strict" `Quick
+        test_base_url_non_loopback_enables_strict;
+      test_case "localhost base URL no strict" `Quick
+        test_base_url_localhost_no_strict;
+      test_case "unset base URL + loopback no strict" `Quick
+        test_base_url_unset_loopback_no_strict;
+      test_case "env flag overrides all" `Quick
+        test_env_flag_overrides_all;
     ];
   ]


### PR DESCRIPTION
## Summary

- `MASC_HTTP_BASE_URL`이 non-loopback host를 가리키면 strict auth를 강제한다
- Cloudflare tunnel(`masc.crying.pictures`) 경유 시 bind address가 127.0.0.1이어도 auth를 요구
- 기존 동작(loopback-only, env flag)과 완전 호환

## 변경 내용

**`server_auth.ml`**: `base_url_has_non_loopback_host()` 추가. `http_auth_strict_enabled()`에 OR 조건으로 연결.

**`test_auth_coverage.ml`**: tunnel bypass 시나리오 4개 테스트 추가.

## 빌드 상태

- `server_auth.ml` 단독 컴파일 성공
- 테스트 exe 링킹은 main의 기존 빌드 에러(`Tool_schema_dsl`, `tool_tag_init.ml`)로 차단됨 (이 PR과 무관)

## Test plan

- [ ] CI에서 기존 빌드 에러 해소 후 tunnel_auth 테스트 4개 통과 확인
- [ ] `MASC_HTTP_BASE_URL=https://masc.crying.pictures`로 서버 시작 시 auth 없이 /mcp 접근 차단 확인

Closes #3654