### PR TITLE
feat(tools): add masc_config introspection tool (#3655)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -273,7 +273,7 @@ let permission_for_tool = function
   | "masc_observe_traces"
   | "masc_voice_sessions" | "masc_voice_agent" ->
       Some CanReadState
-  | "masc_autoresearch_status" -> Some CanReadState
+  | "masc_autoresearch_status" | "masc_config" -> Some CanReadState
   | "masc_add_task" -> Some CanAddTask
   | "masc_claim_next" -> Some CanClaimTask
   | "masc_done" | "masc_update_priority" | "masc_transition" | "masc_release" ->

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -117,6 +117,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.150.0" };
 
+  { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
+    description = "Treat meaningful work as implicit heartbeat signal";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.162.0" };
+
   { env_name = "MASC_KEEPER_DEBUG";
     description = "Keeper debug logging";
     default = false; category = "keeper";

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -192,5 +192,5 @@ let to_json_filtered ?cat () =
     `Assoc [
       ("generated_at", `String (Types.now_iso ()));
       ("server", server_meta ());
-      ("categories", `Assoc (if filtered = [] then cats else filtered));
+      ("categories", `Assoc filtered);
     ]

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -59,23 +59,38 @@ let category name entries =
 (* ================================================================ *)
 
 let server_entries = [
-  entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";
-  entry ~default:"filesystem" "MASC_STORAGE_TYPE" "Backend storage type (filesystem|postgres)";
   entry ~default:"8935" "MASC_HTTP_PORT" "HTTP server port";
   entry ~default:"127.0.0.1" "MASC_HOST" "Server bind host";
   entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
   entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
+  entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";
+  entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
+]
+
+let auth_entries = [
   entry ~sensitive:true ~default:"(none)" "MASC_ADMIN_TOKEN" "Admin authentication token";
   entry ~default:"true" "MASC_TOOL_AUTH_STRICT" "Require auth for all tool calls";
+  entry ~default:"false" "MASC_HTTP_AUTH_STRICT" "Require auth for HTTP endpoints";
+]
+
+let runtime_entries = [
   entry ~default:"(auto)" "MASC_LOG_LEVEL" "Log level override";
   entry ~default:"true" "MASC_TELEMETRY_ENABLED" "Enable telemetry collection";
   entry ~default:"false" "MASC_PARSE_WARN" "Enable JSON parse warnings";
   entry ~default:"production" "MASC_GOVERNANCE_LEVEL" "Governance enforcement level";
-  entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
   entry ~default:"(none)" "MASC_AUTO_RESPOND" "Auto-respond mode";
+  entry ~default:"true" "MASC_DISPATCH_V2" "Enable V2 dispatch engine";
+]
+
+let rate_limiting_entries = [
+  entry ~default:"100.0" "MASC_RATE_LIMIT" "Requests per second";
+  entry ~default:"150" "MASC_RATE_BURST" "Burst capacity";
+  entry ~default:"300.0" "MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC" "Stale bucket cleanup interval (seconds)";
+  entry ~default:"3600.0" "MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC" "Max age for rate limit entries (seconds)";
 ]
 
 let storage_entries = [
+  entry ~default:"filesystem" "MASC_STORAGE_TYPE" "Backend storage type (filesystem|postgres)";
   entry ~sensitive:true ~default:"(none)" "MASC_POSTGRES_URL" "PostgreSQL connection URL";
   entry ~default:"10" "MASC_PG_POOL_SIZE" "PostgreSQL connection pool size";
   entry ~default:"1000" "MASC_PUBSUB_MAX_MESSAGES" "Max pubsub messages per batch";
@@ -144,17 +159,38 @@ let server_meta () =
     ("pid", `Int (Unix.getpid ()));
   ]
 
+let all_categories () = [
+  category "server" server_entries;
+  category "auth" auth_entries;
+  category "transport" transport_entries;
+  category "storage" storage_entries;
+  category "runtime" runtime_entries;
+  category "rate_limiting" rate_limiting_entries;
+  category "chain" chain_entries;
+  category "inference" inference_entries;
+  category "keeper" keeper_entries;
+  category "dashboard" dashboard_entries;
+]
+
 let to_json () =
   `Assoc [
     ("generated_at", `String (Types.now_iso ()));
     ("server", server_meta ());
-    ("categories", `Assoc [
-      category "server" server_entries;
-      category "storage" storage_entries;
-      category "transport" transport_entries;
-      category "chain" chain_entries;
-      category "inference" inference_entries;
-      category "keeper" keeper_entries;
-      category "dashboard" dashboard_entries;
-    ]);
+    ("categories", `Assoc (all_categories ()));
   ]
+
+(** Return config JSON filtered to a single category.
+    Returns the full JSON when [cat] is [None]. *)
+let to_json_filtered ?cat () =
+  match cat with
+  | None -> to_json ()
+  | Some name ->
+    let cats = all_categories () in
+    let filtered =
+      List.filter (fun (k, _) -> k = name) cats
+    in
+    `Assoc [
+      ("generated_at", `String (Types.now_iso ()));
+      ("server", server_meta ());
+      ("categories", `Assoc (if filtered = [] then cats else filtered));
+    ]

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -288,6 +288,8 @@ let standard_tools =
     (* Misc *)
     "masc_spawn"; "masc_agents"; "masc_progress";
     "masc_note_add"; "masc_batch_add_tasks";
+    (* Config introspection *)
+    "masc_config";
   ]
 
 (** Pre-built Hashtbl sets for O(1) tier lookups.

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -707,9 +707,15 @@ let handle_keeper_tool_catalog _ctx args =
   in
   (true, Yojson.Safe.pretty_to_string json)
 
+let handle_config _ctx args : result =
+  let cat = get_string_opt args "category" in
+  let json = Env_config_introspect.to_json_filtered ?cat () in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
+  | "masc_config" -> Some (handle_config ctx args)
   | "masc_transport_status" -> Some (handle_transport_status ctx args)
   | "masc_websocket_discovery" -> Some (handle_websocket_discovery ctx args)
   | "masc_webrtc_offer" -> Some (handle_webrtc_offer ctx args)

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -4,6 +4,21 @@ open Types
 
 let schemas : tool_schema list = [
   {
+    name = "masc_config";
+    description = "Return the effective runtime configuration with source attribution (env var or default) for each setting. \
+Sensitive values (tokens, passwords) are masked. Use to inspect or verify the server config without restarting. \
+Pass category to filter results to a single section.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("category", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional category filter: server, auth, transport, storage, runtime, rate_limiting, chain, inference, keeper, dashboard");
+        ]);
+      ]);
+    ];
+  };
+  {
     name = "masc_transport_status";
     description = "Return the active transport surfaces and runtime counters for HTTP, gRPC, WebSocket, and WebRTC. \
 Use when selecting a client transport or debugging whether realtime transports are enabled and reachable.";


### PR DESCRIPTION
## 요약

- `Env_config_introspect` 모듈을 MCP 도구로 노출하여 런타임 설정을 조회할 수 있도록 함
- 기존 `server_entries`를 `server`, `auth`, `runtime`, `rate_limiting`으로 분리하여 카테고리 구조 개선
- `category` 파라미터로 단일 섹션만 필터링 가능

## 변경 사항

| 파일 | 설명 |
|------|------|
| `lib/env_config_introspect.ml` | auth/runtime/rate_limiting 카테고리 분리, `to_json_filtered` 추가 |
| `lib/tool_misc.ml` | `masc_config` 핸들러 및 dispatch 등록 |
| `lib/tool_schemas/tool_schemas_misc.ml` | MCP tool schema 정의 |
| `lib/auth.ml` | `CanReadState` 권한 등록 |
| `lib/tool_catalog.ml` | Standard tier 등록 |

## 설계 결정

- `Env_config_introspect`가 이미 dashboard HTTP endpoint에서 사용 중이므로 재발명하지 않고 그대로 활용
- 민감 값(token, password, URL)은 기존 마스킹 로직 유지
- 각 항목에 `source` 필드(`env` 또는 `default`)로 출처 귀속

## 테스트 계획

- [ ] `dune build --root .` 컴파일 확인 (완료)
- [ ] 서버 기동 후 `masc_config` 호출하여 전체 카테고리 반환 확인
- [ ] `masc_config category=auth` 호출하여 필터링 확인
- [ ] 민감 값 마스킹 확인 (MASC_ADMIN_TOKEN 등)

Closes #3655