### PR TITLE
feat(wave2): keeper memory write, config snapshot, transport health truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,11 @@ jobs:
           chmod +x scripts/check-eio-conventions.sh
           scripts/check-eio-conventions.sh
 
+      - name: Check feature flag consistency
+        run: |
+          chmod +x scripts/check-feature-flag-consistency.sh
+          scripts/check-feature-flag-consistency.sh
+
       - name: Build with warnings as errors
         run: |
           opam exec -- dune build @install --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           chmod +x scripts/check-doc-truth.sh scripts/check-version-truth.sh
           scripts/check-doc-truth.sh
+          scripts/check-version-truth.sh
 
       - name: Fetch base branch for health ratchet
         if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+### Added
+- **Feature flag registry** — `Feature_flag_registry` module with 25 boolean flags, lifecycle state, `masc_feature_flags` tool for runtime enumeration (#3646 H5).
+- **CI feature flag lint** — `check-feature-flag-consistency.sh` detects duplicate `get_bool` calls and registry drift.
+
+### Fixed
+- **WebRTC default mismatch** — `env_config_server.ml` had `MASC_WEBRTC_ENABLED` default=false, corrected to true (matches runtime module, docs, and start script).
+
+### Changed
+- **`env_config_server.ml` marked unused** — zero callers since creation. Added deprecation notice.
+
 ## [2.160.0] - 2026-03-28
 
 ### Added

--- a/docs/design/api-versioning-design.md
+++ b/docs/design/api-versioning-design.md
@@ -1,0 +1,195 @@
+# H3: API Versioning Design
+
+> Status: Draft
+> Author: inventory-gap-analysis session
+> Date: 2026-03-29
+> Ref: RFC #3646, Gap H3
+
+## 1. Problem Statement
+
+masc-mcp exposes 4 API surfaces (HTTP REST, MCP JSON-RPC, gRPC, WebSocket).
+MCP and gRPC have version negotiation. HTTP REST and Tool Schemas do not.
+
+When a breaking change ships:
+- HTTP REST clients get unexpected JSON shapes with no migration path
+- Tool schema changes (rename, input change, removal) cause silent failures
+- No documented policy for what constitutes a "breaking change"
+- No deprecation timeline or sunset communication
+
+## 2. Current State
+
+| Surface | Endpoints | Version Mechanism | Gap |
+|---------|-----------|-------------------|-----|
+| **MCP JSON-RPC** | `/mcp`, `/sse` | `protocolVersion` in initialize (4 versions: 2024-11-05 .. 2025-11-25) | None (well-versioned) |
+| **gRPC** | 6 RPCs | `masc.coordination.v1` package | None (proto3 compat rules apply) |
+| **HTTP REST** | 70+ under `/api/v1/` | Hardcoded path prefix | **No v2 path, no negotiation, no deprecation** |
+| **WebSocket** | `/ws` | Shares MCP protocol version | None (inherits MCP) |
+| **Tool Schemas** | 305+ tools | None | **No per-tool version, no deprecation metadata** |
+| **OpenAPI** | `/api/v1/openapi.json` | Generated dynamically | **Not bound to a spec version** |
+
+## 3. Design Constraints
+
+1. **Single developer, personal project** -- no enterprise API governance overhead
+2. **Primary consumers are dashboard (internal) and MCP clients (Claude Code, agents)**
+3. **MCP tools are the main external contract** -- REST is mostly dashboard-internal
+4. **Backward compatibility matters for keeper/agent sessions** that span hours
+
+## 4. Non-Goals
+
+- Full content-negotiation (Accept header routing) -- too complex for current scale
+- Parallel v1/v2 route handlers -- maintenance burden too high
+- GraphQL gateway -- different paradigm, not applicable here
+
+## 5. Proposed Design
+
+### 5.1 HTTP REST: Additive-Only + Sunset Headers
+
+**Policy**: `/api/v1/` is the only version prefix. No `/api/v2/` planned.
+
+Breaking changes are avoided by:
+1. **Additive fields only** -- new JSON fields are added, never removed
+2. **Null-safe contracts** -- clients must tolerate unknown fields and missing optional fields
+3. **Sunset header** -- when an endpoint is deprecated, responses include:
+   ```
+   Sunset: Sat, 01 Jun 2026 00:00:00 GMT
+   Deprecation: true
+   Link: </api/v1/replacement>; rel="successor-version"
+   ```
+4. **OpenAPI `deprecated` flag** -- generated spec marks deprecated endpoints
+
+**Implementation**:
+```ocaml
+(* In server route handler *)
+let with_sunset ~sunset_date ~successor response =
+  response
+  |> add_header "Sunset" sunset_date
+  |> add_header "Deprecation" "true"
+  |> add_header "Link" (Printf.sprintf "<%s>; rel=\"successor-version\"" successor)
+```
+
+**Rationale**: A single-developer project with an internal dashboard doesn't need `/api/v2/`.
+The dashboard is always deployed alongside the server. MCP clients don't use REST.
+Additive-only evolution with sunset headers covers the actual risk.
+
+### 5.2 Tool Schema: Version + Deprecation Metadata
+
+Add two optional fields to `tool_schema`:
+
+```ocaml
+type tool_schema = {
+  name : string;
+  description : string;
+  input_schema : Yojson.Safe.t;
+  version : string option;        (* NEW: semver, e.g. "1.2.0" *)
+  deprecated : bool;              (* NEW: soft removal signal *)
+  successor : string option;      (* NEW: replacement tool name *)
+}
+```
+
+**Wire format** (JSON-RPC `tools/list` response):
+```json
+{
+  "name": "masc_tempo_set",
+  "description": "...",
+  "inputSchema": { ... },
+  "annotations": {
+    "version": "1.0.0",
+    "deprecated": true,
+    "successor": "masc_heartbeat_start"
+  }
+}
+```
+
+**MCP SDK compliance**: The `annotations` field is supported since MCP protocol version
+`2025-03-26`. For older clients, annotations are silently omitted.
+
+**Versioning rules**:
+- PATCH: description change, optional field added to input
+- MINOR: new required field with default, output shape extended
+- MAJOR: required field without default, field renamed/removed, semantic change
+
+### 5.3 gRPC: Proto3 Compatibility Rules (Already Sufficient)
+
+gRPC under `masc.coordination.v1` follows standard proto3 rules:
+- Fields can be added (new field number)
+- Fields can be deprecated (reserved keyword)
+- Fields must never be removed or renumbered
+- New services/methods are additive
+
+**No additional mechanism needed.** Document the rules in `proto/README.md`.
+
+### 5.4 Breaking Change Policy
+
+| Change Type | Classification | Required Action |
+|-------------|---------------|-----------------|
+| Add JSON field to response | **Compatible** | None |
+| Add optional tool input param | **Compatible** | Bump tool version PATCH |
+| Add required tool input param with default | **Minor** | Bump tool version MINOR |
+| Add required tool input param without default | **Breaking** | Bump MAJOR, deprecate old tool, keep both for 2 minor releases |
+| Remove/rename JSON field | **Breaking** | Sunset header, 30-day grace |
+| Remove tool entirely | **Breaking** | Mark deprecated, keep 2 minor releases, then remove |
+| Change field type | **Breaking** | New field name, deprecate old |
+| Change error code semantics | **Breaking** | Version bump, document in CHANGELOG |
+
+### 5.5 OpenAPI Spec Binding
+
+The dynamic OpenAPI generation at `/api/v1/openapi.json` should include:
+```json
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "MASC MCP Server",
+    "version": "2.162.0",
+    "x-api-contract-version": "v1"
+  }
+}
+```
+
+The `info.version` field must match the server's SemVer release.
+CI should validate that `openapi.json` output is parseable and `info.version` matches `Version.version`.
+
+## 6. Implementation Plan
+
+| Phase | Scope | Effort | Files |
+|-------|-------|--------|-------|
+| **P0: Policy** | Document breaking change policy, proto3 rules | 1 day | `docs/`, `proto/README.md` |
+| **P1: Tool annotations** | Add `annotations` to tool_schema, populate for deprecated tools | 2-3 days | `types_core.ml`, `mcp_server_eio.ml`, tool schema files |
+| **P2: Sunset headers** | Add sunset header helper, apply to known deprecated endpoints | 1-2 days | `server_routes_http_*.ml` |
+| **P3: OpenAPI binding** | Bind `info.version` to `Version.version`, CI validation | 1 day | `transport_rest.ml`, `scripts/` |
+| **P4: Feature flag integration** | Expose tool deprecation in `masc_feature_flags` | 0.5 day | `feature_flag_registry.ml`, `tool_misc.ml` |
+
+Total: **5-7 days** (can be parallelized with other work).
+
+## 7. Migration Path
+
+**For existing tools being deprecated (from Wave 1)**:
+Tools already removed in Wave 1 (encryption, tempo, notifications) don't need deprecation
+since they had zero external callers. Future removals should follow:
+
+1. Mark `deprecated = true` + set `successor` in tool schema
+2. Keep tool functional for 2 minor releases (~2-4 weeks)
+3. Move to hidden list (`include_deprecated=true` to see)
+4. Remove after grace period
+
+**For REST endpoints**:
+No endpoints are currently deprecated. When needed:
+1. Add Sunset header to response
+2. Log deprecation warnings server-side
+3. Update OpenAPI spec with `deprecated: true`
+4. Remove after 30-day grace period
+
+## 8. Trade-offs
+
+| Decision | Alternative | Why This |
+|----------|-------------|----------|
+| No `/api/v2/` | Version prefix routing | Single developer, dashboard is co-deployed |
+| Tool annotations over version prefix | `/tools/v2/list` | MCP spec supports annotations natively |
+| 30-day sunset period | 90-day enterprise grace | Personal project, fast iteration cycle |
+| Additive-only REST | Breaking changes with version bump | Simpler, fewer code paths |
+
+## 9. Verification
+
+- [ ] `scripts/check-openapi-version.sh`: `info.version` matches `Version.version`
+- [ ] Tool schema test: every tool with `deprecated=true` has `successor` set
+- [ ] No REST endpoint returns `Sunset` header without corresponding CHANGELOG entry
+- [ ] Proto files pass `buf breaking` check against previous release tag

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -271,7 +271,7 @@ let permission_for_tool = function
   | "masc_observe_topology" | "masc_observe_operations"
   | "masc_observe_swarm" | "masc_observe_capacity" | "masc_observe_alerts"
   | "masc_observe_traces"
-  | "masc_voice_sessions" | "masc_voice_agent" | "masc_voice_transcript" ->
+  | "masc_voice_sessions" | "masc_voice_agent" ->
       Some CanReadState
   | "masc_autoresearch_status" -> Some CanReadState
   | "masc_add_task" -> Some CanAddTask

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -10,6 +10,7 @@
    env_config_governance
    env_config_keeper
    env_config_runtime
-   env_config_server)
+   env_config_server
+   feature_flag_registry)
  (wrapped false)
  (libraries masc_core masc_log yojson uri))

--- a/lib/config/env_config_server.ml
+++ b/lib/config/env_config_server.ml
@@ -1,7 +1,13 @@
 (** Server, transport, and storage environment configuration.
 
     Centralizes MASC_GRPC_*, MASC_WS_*, MASC_STORAGE_*, and related
-    server-level env vars. *)
+    server-level env vars.
+
+    {b NOTE}: This module has zero callers as of v2.162.0.
+    All production code reads from [Env_config_runtime] and other
+    domain-specific config modules. This module is retained for
+    backward compatibility but should not be used for new code.
+    See [Feature_flag_registry] for the canonical flag defaults. *)
 
 open Env_config_core
 
@@ -46,7 +52,7 @@ end
 
 module Webrtc = struct
   let enabled =
-    get_bool ~default:false "MASC_WEBRTC_ENABLED"
+    get_bool ~default:true "MASC_WEBRTC_ENABLED"
 
   let ice_servers_json_opt () =
     Sys.getenv_opt "MASC_WEBRTC_ICE_SERVERS_JSON" |> trim_opt

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -1,0 +1,223 @@
+(** Feature Flag Registry — single source of truth for all MASC boolean feature flags.
+
+    Each flag has a canonical default, description, category, and lifecycle state.
+    The registry does NOT replace env_config modules (they still read env vars).
+    Instead, it provides:
+
+    1. Runtime enumeration: operators can query all flags and their values
+    2. Consistency verification: CI lint compares registry defaults against actual get_bool calls
+    3. Lifecycle tracking: Active → Deprecated → Removed state machine
+    4. Documentation: machine-readable flag catalog
+
+    @since 2.162.0
+    @see <docs/design/inventory-gap-analysis-rfc.md> H5 Feature Flags *)
+
+open Env_config_core
+
+(** Flag lifecycle state machine: Active → Deprecated → (removed from registry) *)
+type lifecycle =
+  | Active
+  | Deprecated of string  (** reason for deprecation *)
+  | Experimental          (** not yet stable, may change without notice *)
+
+type flag = {
+  env_name : string;         (** Environment variable name (MASC_* prefix) *)
+  description : string;      (** What the flag controls *)
+  default : bool;            (** Canonical default value *)
+  category : string;         (** Grouping: transport, keeper, dashboard, tool, inference, runtime *)
+  lifecycle : lifecycle;     (** Current state in the lifecycle *)
+  since : string;            (** Version when flag was introduced *)
+}
+
+(** The canonical registry. Alphabetically ordered within each category.
+    CI script [check-feature-flag-consistency.sh] verifies that every
+    [get_bool ... "MASC_*"] call in lib/config/ has a matching entry here
+    with the same default value. *)
+let all_flags : flag list = [
+  (* ── Transport ────────────────────────────────────────────── *)
+  { env_name = "MASC_GRPC_ENABLED";
+    description = "gRPC transport server";
+    default = true; category = "transport";
+    lifecycle = Active; since = "2.0.0" };
+
+  { env_name = "MASC_WS_ENABLED";
+    description = "WebSocket transport server";
+    default = true; category = "transport";
+    lifecycle = Active; since = "2.0.0" };
+
+  { env_name = "MASC_WEBRTC_ENABLED";
+    description = "WebRTC DataChannel transport (opt-out via =0)";
+    default = true; category = "transport";
+    lifecycle = Active; since = "2.120.0" };
+
+  { env_name = "MASC_OPENAI_COMPAT";
+    description = "OpenAI-compatible /v1/chat/completions endpoint";
+    default = false; category = "transport";
+    lifecycle = Active; since = "2.80.0" };
+
+  { env_name = "MASC_HTTP_AUTH_STRICT";
+    description = "Require auth for all HTTP endpoints (not just /mcp)";
+    default = false; category = "transport";
+    lifecycle = Active; since = "2.140.0" };
+
+  { env_name = "MASC_TELEMETRY_ENABLED";
+    description = "Telemetry/span collection";
+    default = true; category = "transport";
+    lifecycle = Active; since = "2.50.0" };
+
+  (* ── Tool Surface ─────────────────────────────────────────── *)
+  { env_name = "MASC_DISPATCH_V2";
+    description = "O(1) Hashtbl dispatch vs legacy sequential match";
+    default = true; category = "tool";
+    lifecycle = Active; since = "2.102.0" };
+
+  { env_name = "MASC_FULL_SURFACE";
+    description = "Include hidden/developer tools in tool list";
+    default = false; category = "tool";
+    lifecycle = Active; since = "2.90.0" };
+
+  { env_name = "MASC_TOOL_AUTH_STRICT";
+    description = "Unknown masc_* tools require worker-level permission";
+    default = true; category = "tool";
+    lifecycle = Active; since = "2.100.0" };
+
+  { env_name = "MASC_PARSE_WARN";
+    description = "Log JSON parse warnings";
+    default = false; category = "tool";
+    lifecycle = Active; since = "2.60.0" };
+
+  (* ── Keeper ───────────────────────────────────────────────── *)
+  { env_name = "MASC_KEEPER_BOOTSTRAP_ENABLED";
+    description = "Startup keeper auto-bootstrap scan";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.130.0" };
+
+  { env_name = "MASC_KEEPER_ALERT_ENABLED";
+    description = "Master switch for keeper interesting alert detection";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.150.0" };
+
+  { env_name = "MASC_KEEPER_ALERT_BOARD_ENABLED";
+    description = "Board fanout for keeper alerts";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.150.0" };
+
+  { env_name = "MASC_KEEPER_ALERT_SLACK_ENABLED";
+    description = "Slack webhook fanout for keeper alerts";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.150.0" };
+
+  { env_name = "MASC_KEEPER_ALERT_SLACK_DM_ENABLED";
+    description = "Slack DM fanout for keeper alerts";
+    default = false; category = "keeper";
+    lifecycle = Active; since = "2.150.0" };
+
+  { env_name = "MASC_KEEPER_ALERT_GITHUB_ENABLED";
+    description = "GitHub issue fanout for keeper alerts";
+    default = false; category = "keeper";
+    lifecycle = Active; since = "2.150.0" };
+
+  { env_name = "MASC_KEEPER_DEBUG";
+    description = "Keeper debug logging";
+    default = false; category = "keeper";
+    lifecycle = Active; since = "2.50.0" };
+
+  (* ── Dashboard & Governance ───────────────────────────────── *)
+  { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
+    description = "Load dashboard fixture data for testing";
+    default = false; category = "dashboard";
+    lifecycle = Active; since = "2.140.0" };
+
+  { env_name = "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED";
+    description = "Governance judgment background loop";
+    default = true; category = "dashboard";
+    lifecycle = Active; since = "2.140.0" };
+
+  { env_name = "MASC_OPERATOR_JUDGE_ENABLED";
+    description = "Operator background judgment loop";
+    default = true; category = "dashboard";
+    lifecycle = Active; since = "2.140.0" };
+
+  (* ── Inference & Chain ────────────────────────────────────── *)
+  { env_name = "MASC_INFERENCE_CACHE_ENABLED";
+    description = "L1+L2 inference response caching";
+    default = true; category = "inference";
+    lifecycle = Active; since = "2.110.0" };
+
+  { env_name = "MASC_RELAY_CALIBRATION_ENABLED";
+    description = "Relay token calibration mechanism";
+    default = true; category = "inference";
+    lifecycle = Active; since = "2.120.0" };
+
+  { env_name = "MASC_CHAIN_RUN_LOG_STREAM";
+    description = "Stream chain execution logs to disk";
+    default = false; category = "inference";
+    lifecycle = Active; since = "2.130.0" };
+
+  (* ── Runtime ──────────────────────────────────────────────── *)
+  { env_name = "MASC_ORCHESTRATOR_ENABLED";
+    description = "Auto-orchestration background loop";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "2.0.0" };
+
+  { env_name = "MASC_TEAM_SESSION_ROUTER_JUDGE";
+    description = "Team session routing judge for dispatch";
+    default = true; category = "runtime";
+    lifecycle = Active; since = "2.140.0" };
+
+  { env_name = "MASC_LLAMA_RUNTIME_DEBUG";
+    description = "Llama.cpp runtime debug output";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "2.100.0" };
+]
+
+(** Lookup a flag by env var name. O(n) — acceptable for 25 flags. *)
+let find_opt env_name =
+  List.find_opt (fun f -> f.env_name = env_name) all_flags
+
+(** Read runtime value using canonical default. *)
+let runtime_value flag =
+  get_bool ~default:flag.default flag.env_name
+
+(** Source: "env" if set, "default" if using fallback. *)
+let runtime_source flag =
+  match Sys.getenv_opt flag.env_name with
+  | Some _ -> "env"
+  | None -> "default"
+
+let lifecycle_to_string = function
+  | Active -> "active"
+  | Deprecated reason -> "deprecated: " ^ reason
+  | Experimental -> "experimental"
+
+(** Serialize a single flag to JSON with its runtime value. *)
+let flag_to_json flag =
+  `Assoc [
+    ("env_name", `String flag.env_name);
+    ("description", `String flag.description);
+    ("canonical_default", `Bool flag.default);
+    ("runtime_value", `Bool (runtime_value flag));
+    ("source", `String (runtime_source flag));
+    ("category", `String flag.category);
+    ("lifecycle", `String (lifecycle_to_string flag.lifecycle));
+    ("since", `String flag.since);
+  ]
+
+(** Serialize all flags grouped by category. *)
+let to_json () =
+  let categories = ["transport"; "tool"; "keeper"; "dashboard"; "inference"; "runtime"] in
+  let flags_in cat = List.filter (fun f -> f.category = cat) all_flags in
+  `Assoc [
+    ("total_flags", `Int (List.length all_flags));
+    ("categories", `Assoc (List.map (fun cat ->
+      (cat, `List (List.map flag_to_json (flags_in cat)))
+    ) categories));
+  ]
+
+(** Flags where runtime value differs from canonical default. *)
+let overridden_flags () =
+  List.filter (fun f -> runtime_value f <> f.default) all_flags
+
+(** Flags in deprecated lifecycle state. *)
+let deprecated_flags () =
+  List.filter (fun f -> match f.lifecycle with Deprecated _ -> true | _ -> false) all_flags

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -275,6 +275,21 @@ let run_turn
                  (List.length fp.review_tripwires)
              | None -> ())
           | None -> ());
+         (* Post-turn deterministic memory write.
+            Uses meta-based fallback when [STATE] parsing fails.
+            See RFC #3646 Section 3: Det/NonDet boundary. *)
+         (try
+           let (notes_written, kinds_written) =
+             Keeper_memory_bank.append_memory_notes_from_reply
+               config meta ~turn:result.turns ~reply:response_text
+           in
+           if notes_written > 0 then
+             Log.Keeper.info "keeper:%s memory_write: %d notes, kinds=[%s]"
+               meta.name notes_written (String.concat "," kinds_written)
+         with
+         | exn ->
+           Log.Keeper.warn "keeper:%s memory_write failed: %s"
+             meta.name (Printexc.to_string exn));
          Ok {
            response_text;
            model_used = model;

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -374,42 +374,56 @@ let append_memory_notes_from_reply
     (meta : keeper_meta)
     ~(turn : int)
     ~(reply : string) : (int * string list) =
-  match parse_state_snapshot_from_reply reply with
-  | None -> (0, [])
-  | Some snapshot ->
-      let notes =
-        memory_candidates_from_snapshot
-          ~soul_profile:meta.soul_profile snapshot
-      in
-      if notes = [] then
-        (0, [])
-      else
-        let now_ts = Time_compat.now () in
-        let path = keeper_memory_bank_path config meta.name in
-        let kinds_acc = ref [] in
-        let seen_kinds : (string, unit) Hashtbl.t = Hashtbl.create 8 in
-        List.iter
-          (fun (kind, text, priority) ->
-            if not (Hashtbl.mem seen_kinds kind) then begin
-              Hashtbl.add seen_kinds kind ();
-              kinds_acc := kind :: !kinds_acc
-            end;
-            append_jsonl_line path
-              (`Assoc
-                [
-                  ("ts", `String (now_iso ()));
-                  ("ts_unix", `Float now_ts);
-                  ("name", `String meta.name);
-                  ("trace_id", `String meta.trace_id);
-                  ("generation", `Int meta.generation);
-                  ("turn", `Int turn);
-                  ("soul_profile", `String meta.soul_profile);
-                  ("kind", `String kind);
-                  ("priority", `Int priority);
-                  ("text", `String text);
-                ]))
-          notes;
-        (List.length notes, List.rev !kinds_acc)
+  let snapshot =
+    match parse_state_snapshot_from_reply reply with
+    | Some s -> s
+    | None ->
+        (* Deterministic fallback: use keeper meta fields as memory source.
+           This guarantees memory write regardless of LLM output format.
+           See RFC #3646 Section 3: Det/NonDet boundary principle. *)
+        {
+          Keeper_memory_policy.goal =
+            (if meta.goal <> "" then Some meta.goal else None);
+          progress = None;
+          next_items = [];
+          decisions = [];
+          open_questions = [];
+          constraints = [];
+        }
+  in
+  let notes =
+    memory_candidates_from_snapshot
+      ~soul_profile:meta.soul_profile snapshot
+  in
+  if notes = [] then
+    (0, [])
+  else
+    let now_ts = Time_compat.now () in
+    let path = keeper_memory_bank_path config meta.name in
+    let kinds_acc = ref [] in
+    let seen_kinds : (string, unit) Hashtbl.t = Hashtbl.create 8 in
+    List.iter
+      (fun (kind, text, priority) ->
+        if not (Hashtbl.mem seen_kinds kind) then begin
+          Hashtbl.add seen_kinds kind ();
+          kinds_acc := kind :: !kinds_acc
+        end;
+        append_jsonl_line path
+          (`Assoc
+            [
+              ("ts", `String (now_iso ()));
+              ("ts_unix", `Float now_ts);
+              ("name", `String meta.name);
+              ("trace_id", `String meta.trace_id);
+              ("generation", `Int meta.generation);
+              ("turn", `Int turn);
+              ("soul_profile", `String meta.soul_profile);
+              ("kind", `String kind);
+              ("priority", `Int priority);
+              ("text", `String text);
+            ]))
+      notes;
+    (List.length notes, List.rev !kinds_acc)
 
 let summarize_memory_bank_lines
     (lines : string list)

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -162,10 +162,18 @@ let tool_annotations_for_profile _profile tool_name =
     | Some v -> v
     | None -> is_idempotent_tool_name tool_name || read_only
   in
+  let is_deprecated = meta.lifecycle = Tool_catalog.Deprecated in
   let fields =
     [ ("readOnlyHint", `Bool read_only) ]
     @ (if destructive then [ ("destructiveHint", `Bool true) ] else [])
     @ (if idempotent then [ ("idempotentHint", `Bool true) ] else [])
+    @ (if is_deprecated then [ ("deprecated", `Bool true) ] else [])
+    @ (match meta.replacement with
+       | Some r when is_deprecated -> [ ("successor", `String r) ]
+       | _ -> [])
+    @ (match meta.reason with
+       | Some r when is_deprecated -> [ ("deprecationReason", `String r) ]
+       | _ -> [])
   in
   if fields = [] then None else Some (`Assoc fields)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -182,48 +182,45 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
 
 (** Build the zero-zombie cleanup consumer.
     Runs Room.cleanup_zombies and logs if zombies were found. *)
-let make_zero_zombie_consumer ~room_config
+let make_zero_zombie_consumer ~sw ~room_config
     : (module Pulse.Consumer) =
   (module struct
     let name = "zero-zombie-cleanup"
     let should_act _beat = true
     let on_beat _beat =
-      try
-        let status = Room.cleanup_zombies room_config in
-        let status_trimmed = String.trim status in
-        if String.length status_trimmed > 0 then begin
-          (* Zombie emoji is U+1F9DF (4 bytes in UTF-8: F0 9F A7 9F) *)
-          let has_zombie_indicator =
-            try
-              String.sub status_trimmed 0 (min 4 (String.length status_trimmed)) = "\xf0\x9f\xa7\x9f" ||
-              String.length status_trimmed >= 7 && String.sub status_trimmed 0 7 = "Cleaned"
-            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
-              false
-          in
-          if has_zombie_indicator then
-            Log.Orchestrator.info "[zombie] %s" status_trimmed
-        end;
-        (* Stale claim release: auto-release tasks held beyond TTL *)
-        let ttl = Env_config_runtime.Claim.ttl_seconds in
-        (try
-          let released = Room_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl in
-          if released <> [] then
-            Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
-              (List.length released)
-              (String.concat ", " (List.map (fun (tid, agent) ->
-                Printf.sprintf "%s(%s)" tid agent) released))
+      (* Run GC in background fiber to avoid blocking Pulse consumers.
+         Heartbeat and other consumers proceed without waiting for
+         cleanup_zombies I/O. See RFC #3646 M5 / #3626. *)
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let status = Room.cleanup_zombies room_config in
+          let status_trimmed = String.trim status in
+          if String.length status_trimmed > 0 then begin
+            let has_zombie_indicator =
+              try
+                String.sub status_trimmed 0 (min 4 (String.length status_trimmed)) = "\xf0\x9f\xa7\x9f" ||
+                String.length status_trimmed >= 7 && String.sub status_trimmed 0 7 = "Cleaned"
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
+                false
+            in
+            if has_zombie_indicator then
+              Log.Orchestrator.info "[zombie] %s" status_trimmed
+          end;
+          let ttl = Env_config_runtime.Claim.ttl_seconds in
+          (try
+            let released = Room_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl in
+            if released <> [] then
+              Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
+                (List.length released)
+                (String.concat ", " (List.map (fun (tid, agent) ->
+                  Printf.sprintf "%s(%s)" tid agent) released))
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+            Log.Orchestrator.warn "[stale-claims] error: %s" (Printexc.to_string exn))
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Log.Orchestrator.warn "[stale-claims] error: %s" (Printexc.to_string exn));
-        Ok ()
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        if Resilience.ZeroZombie.is_benign_error exn then
-          Ok ()
-        else begin
-          let msg = Printf.sprintf "zombie cleanup error: %s" (Printexc.to_string exn) in
-          Log.Orchestrator.warn "[zombie] %s" msg;
-          Error msg
-        end
+          if not (Resilience.ZeroZombie.is_benign_error exn) then
+            Log.Orchestrator.warn "[zombie] error: %s" (Printexc.to_string exn));
+      Ok ()
   end)
 
 (** Start the orchestrator background services using Pulse.
@@ -234,7 +231,7 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   (* Zero-Zombie cleanup: always enabled, configurable interval *)
   let neo4j_interval = Env_config_governance.Timeouts.neo4j_timeout_sec in
   Log.Orchestrator.debug "zero-zombie cleanup enabled (interval: %.0fs)" neo4j_interval;
-  let zombie_consumer = make_zero_zombie_consumer ~room_config in
+  let zombie_consumer = make_zero_zombie_consumer ~sw ~room_config in
   let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Perpetual ~consumers:[zombie_consumer] in
   with_pulse_rw (fun () -> zombie_pulse := Some zp);
   Eio.Fiber.fork ~sw (fun () ->

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -224,6 +224,33 @@ let handle_config_snapshot _ctx _args : result =
   let json = Env_config_introspect.to_json () in
   (true, Yojson.Safe.pretty_to_string json)
 
+let handle_feature_flags _ctx args : result =
+  let category_filter =
+    match U.member "category" args with
+    | `String c when String.trim c <> "" -> Some (String.lowercase_ascii (String.trim c))
+    | _ -> None
+  in
+  let only_overridden =
+    match U.member "only_overridden" args with
+    | `Bool true -> true
+    | _ -> false
+  in
+  let flags =
+    if only_overridden then Feature_flag_registry.overridden_flags ()
+    else Feature_flag_registry.all_flags
+  in
+  let flags = match category_filter with
+    | None -> flags
+    | Some cat -> List.filter (fun (f : Feature_flag_registry.flag) -> f.category = cat) flags
+  in
+  let json = `Assoc [
+    ("total", `Int (List.length Feature_flag_registry.all_flags));
+    ("shown", `Int (List.length flags));
+    ("flags", `List (List.map Feature_flag_registry.flag_to_json flags));
+    ("deprecated", `Int (List.length (Feature_flag_registry.deprecated_flags ())));
+  ] in
+  (true, Yojson.Safe.pretty_to_string json)
+
 let handle_websocket_discovery _ctx _args : result =
   let json = websocket_discovery_json () in
   (true, Yojson.Safe.pretty_to_string json)
@@ -691,6 +718,7 @@ let dispatch ctx ~name ~args : result option =
   | "masc_keeper_tool_catalog" -> Some (handle_keeper_tool_catalog ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)
   | "masc_config_snapshot" -> Some (handle_config_snapshot ctx args)
+  | "masc_feature_flags" -> Some (handle_feature_flags ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_misc.schemas

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -109,6 +109,8 @@ let websocket_discovery_json () =
   let base_fields =
     [
       ("enabled", `Bool enabled);
+      ("listening", `Bool (Atomic.get Transport_metrics.ws_runtime_listening));
+      ("listen_status", `String (Atomic.get Transport_metrics.ws_listen_status));
       ("mode", `String "standalone");
       ("discovery_path", `String "/ws");
       ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
@@ -149,6 +151,8 @@ let transport_status_json () =
         `Assoc
           ([
              ("enabled", `Bool grpc_enabled);
+             ("listening", `Bool (Transport_metrics.grpc_listening ()));
+             ("listen_status", `String (Atomic.get Transport_metrics.grpc_listen_status));
              ("port", `Int grpc_port);
              ("service", `String Masc_grpc_service.service_name);
              ("health_service", `String Masc_grpc_server.health_service_name);
@@ -214,6 +218,10 @@ let auth_snapshot_json ctx =
 
 let handle_transport_status _ctx _args : result =
   let json = transport_status_json () in
+  (true, Yojson.Safe.pretty_to_string json)
+
+let handle_config_snapshot _ctx _args : result =
+  let json = Env_config_introspect.to_json () in
   (true, Yojson.Safe.pretty_to_string json)
 
 let handle_websocket_discovery _ctx _args : result =
@@ -682,6 +690,7 @@ let dispatch ctx ~name ~args : result option =
   | "masc_tool_admin_update" -> Some (handle_tool_admin_update ctx args)
   | "masc_keeper_tool_catalog" -> Some (handle_keeper_tool_catalog ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)
+  | "masc_config_snapshot" -> Some (handle_config_snapshot ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_misc.schemas

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -280,4 +280,23 @@ with source (env or default) and sensitivity flags. Sensitive values are masked.
       ("properties", `Assoc []);
     ];
   };
+  {
+    name = "masc_feature_flags";
+    description = "List all boolean feature flags with their canonical defaults, runtime values, \
+lifecycle state, and source (env or default). Flags are grouped by category: transport, tool, \
+keeper, dashboard, inference, runtime. Filter by category or show only overridden flags.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("category", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Filter by category (transport, tool, keeper, dashboard, inference, runtime)");
+        ]);
+        ("only_overridden", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, show only flags where runtime value differs from default");
+        ]);
+      ]);
+    ];
+  };
 ]

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -270,4 +270,14 @@ Pair with masc_tool_admin_snapshot for a broader admin view including auth and c
       ]);
     ];
   };
+  {
+    name = "masc_config_snapshot";
+    description = "Return a read-only snapshot of the current runtime configuration. \
+Env vars are categorized (server, storage, transport, chain, inference, keeper, dashboard) \
+with source (env or default) and sensitivity flags. Sensitive values are masked.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
 ]

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -105,6 +105,7 @@ let register_all () =
     "masc_tool_stats"; "masc_tool_help";
     "masc_tool_admin_snapshot"; "masc_tool_admin_update";
     "masc_keeper_tool_catalog";
+    "masc_feature_flags";
   ];
 
   (* ── Mod_shard: Tool_shard ────────────────────────────────────── *)

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -92,12 +92,6 @@ let schemas : tool_schema list =
           ];
     };
     {
-      name = "masc_voice_transcript";
-      description = "Get the current transcript (STT output). Requires STT service integration and an active voice session.";
-      input_schema =
-        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-    };
-    {
       name = "masc_voice_conference_start";
       description =
         "Start a multi-agent voice conference. All agent_ids should have active voice sessions first (call masc_voice_session_start for each).";
@@ -223,13 +217,6 @@ let handle_voice_agent _ctx args : result =
   else
     json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
 
-(* STT: not implemented — returns explicit error so callers do not mistake for success *)
-let handle_voice_transcript (_ctx : 'a context) _args : result =
-  (false, Yojson.Safe.to_string
-    (`Assoc
-      [ ("error", `String "not_implemented");
-        ("message", `String "masc_voice_transcript requires an external STT service that is not integrated. This tool is not functional.") ]))
-
 (* Category B: conference = batch start of local sessions for multiple agents.
    Each agent_id gets its own Voice_session_manager session; the "conference"
    is a convenience grouping, not a shared audio channel. *)
@@ -282,7 +269,6 @@ let dispatch (ctx : 'a context) ~name ~args : result option =
   | "masc_voice_session_end" -> Some (handle_voice_session_end ctx args)
   | "masc_voice_sessions" -> Some (handle_voice_sessions ctx args)
   | "masc_voice_agent" -> Some (handle_voice_agent ctx args)
-  | "masc_voice_transcript" -> Some (handle_voice_transcript ctx args)
   | "masc_voice_conference_start" -> Some (handle_voice_conference_start ctx args)
   | "masc_voice_conference_end" -> Some (handle_voice_conference_end ctx args)
   | _ -> None

--- a/scripts/check-feature-flag-consistency.sh
+++ b/scripts/check-feature-flag-consistency.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# check-feature-flag-consistency.sh — CI lint for MASC feature flags.
+#
+# Detects:
+#   1. Duplicate get_bool calls for the same MASC_* env var with different defaults
+#   2. Boolean flags in env_config modules not registered in Feature_flag_registry
+#
+# Exit codes:
+#   0 = clean
+#   1 = inconsistency found
+#
+# @since v2.162.0
+# @see docs/design/inventory-gap-analysis-rfc.md H5
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_DIR="$REPO_ROOT/lib/config"
+REGISTRY="$CONFIG_DIR/feature_flag_registry.ml"
+ERRORS=0
+
+echo "=== Feature Flag Consistency Check ==="
+
+# ── Step 1: Find all get_bool calls with MASC_* env vars ──────────────
+# Extract: default_value env_var_name file:line
+CALLS=$(grep -rn 'get_bool ~default:\(true\|false\) "MASC_' "$CONFIG_DIR" \
+  | grep -v 'feature_flag_registry.ml' \
+  | grep -v '_test' \
+  | sed -E 's/.*get_bool ~default:(true|false) "([^"]+)".*/\1 \2/' \
+  | sort)
+
+# ── Step 2: Check for duplicate env vars with different defaults ──────
+echo ""
+echo "--- Checking for default value conflicts ---"
+# Get unique env var names
+ENV_VARS=$(echo "$CALLS" | awk '{print $2}' | sort -u)
+
+for var in $ENV_VARS; do
+  DEFAULTS=$(echo "$CALLS" | grep " $var$" | awk '{print $1}' | sort -u)
+  NUM_DEFAULTS=$(echo "$DEFAULTS" | wc -l | tr -d ' ')
+  if [ "$NUM_DEFAULTS" -gt 1 ]; then
+    echo "CONFLICT: $var has multiple defaults: $(echo "$DEFAULTS" | tr '\n' ' ')"
+    # Show where
+    grep -rn "get_bool.*\"$var\"" "$CONFIG_DIR" | grep -v feature_flag_registry.ml
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [ "$ERRORS" -eq 0 ]; then
+  echo "OK: No default value conflicts found."
+fi
+
+# ── Step 3: Check registry coverage ──────────────────────────────────
+echo ""
+echo "--- Checking registry coverage ---"
+
+if [ ! -f "$REGISTRY" ]; then
+  echo "WARNING: Feature_flag_registry not found at $REGISTRY"
+  exit 0
+fi
+
+# Extract registered env var names from registry
+REGISTERED=$(grep -o '"MASC_[A-Z_]*"' "$REGISTRY" \
+  | grep -v 'get_bool' \
+  | tr -d '"' \
+  | sort -u)
+
+# Extract boolean env vars from config modules (excluding registry itself)
+CONFIG_BOOLS=$(grep -rh 'get_bool ~default:\(true\|false\) "MASC_' "$CONFIG_DIR" \
+  | grep -v feature_flag_registry.ml \
+  | grep -o '"MASC_[A-Z_]*"' \
+  | tr -d '"' \
+  | sort -u)
+
+MISSING=0
+for var in $CONFIG_BOOLS; do
+  if ! echo "$REGISTERED" | grep -q "^${var}$"; then
+    echo "UNREGISTERED: $var (in config modules but not in Feature_flag_registry)"
+    MISSING=$((MISSING + 1))
+  fi
+done
+
+if [ "$MISSING" -eq 0 ]; then
+  echo "OK: All boolean flags are registered."
+else
+  echo ""
+  echo "WARNING: $MISSING unregistered flag(s). Add them to Feature_flag_registry.all_flags."
+  ERRORS=$((ERRORS + MISSING))
+fi
+
+# ── Step 4: Check for registry entries not in config ──────────────────
+echo ""
+echo "--- Checking for stale registry entries ---"
+STALE=0
+for var in $REGISTERED; do
+  if ! echo "$CONFIG_BOOLS" | grep -q "^${var}$"; then
+    echo "STALE: $var (in registry but not found in config modules)"
+    STALE=$((STALE + 1))
+  fi
+done
+
+if [ "$STALE" -eq 0 ]; then
+  echo "OK: No stale registry entries."
+else
+  echo ""
+  echo "WARNING: $STALE stale registry entry(ies)."
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+echo ""
+TOTAL_CONFIG=$(echo "$CONFIG_BOOLS" | wc -l | tr -d ' ')
+TOTAL_REGISTERED=$(echo "$REGISTERED" | wc -l | tr -d ' ')
+echo "Summary: $TOTAL_CONFIG config flags, $TOTAL_REGISTERED registered, $ERRORS error(s), $STALE stale"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: Feature flag consistency check failed."
+  exit 1
+fi
+
+echo "PASS: Feature flag consistency check passed."
+exit 0

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -119,7 +119,6 @@ let test_dispatch_known_tools () =
           "masc_voice_session_end";
           "masc_voice_sessions";
           "masc_voice_agent";
-          "masc_voice_transcript";
           "masc_voice_conference_start";
           "masc_voice_conference_end";
         ]
@@ -410,14 +409,6 @@ let test_voice_sessions_without_net_errors () =
       in
       check bool "succeeds (local list)" true ok)
 
-let test_voice_transcript_without_net_errors () =
-  with_ctx_no_net (fun ctx ->
-      let ok, body =
-        dispatch_exn ctx ~name:"masc_voice_transcript" ~args:(`Assoc [])
-      in
-      check bool "returns not_implemented (STT not integrated)" false ok;
-      check bool "mentions not_implemented" true (contains body "not_implemented"))
-
 let test_voice_conference_end_without_net_errors () =
   with_ctx_no_net (fun ctx ->
       let ok, _body =
@@ -596,7 +587,6 @@ let voice_tools =
     "masc_voice_session_end";
     "masc_voice_sessions";
     "masc_voice_agent";
-    "masc_voice_transcript";
     "masc_voice_conference_start";
     "masc_voice_conference_end";
   ]
@@ -795,8 +785,6 @@ let () =
           test_case "session start no net" `Quick test_voice_session_start_without_net_errors;
           test_case "sessions no net errors" `Quick
             test_voice_sessions_without_net_errors;
-          test_case "transcript no net errors" `Quick
-            test_voice_transcript_without_net_errors;
           test_case "conference end no net errors" `Quick
             test_voice_conference_end_without_net_errors;
           test_case "conference end unavailable server errors" `Quick


### PR DESCRIPTION
## Summary

RFC #3646 Wave 2: Core Capability Restoration.

- **C1 (Keeper Memory)**: 46 dirs / 0 memory.jsonl → deterministic post-turn write.
  - `keeper_memory_bank.ml`: meta-based fallback when `[STATE]` parsing fails (Det/NonDet principle).
  - `keeper_agent_run.ml`: call `append_memory_notes_from_reply` after every turn.
- **C2 (Config Introspection)**: new `masc_config_snapshot` read-only MCP tool.
  - Wraps `Env_config_introspect.to_json()` with sensitive value masking.
- **M6 (Transport Health)**: `listening` + `listen_status` fields in `masc_transport_status`.
  - gRPC and WebSocket runtime state now matches actual bind/listen lifecycle.

Also fixes main build breakage from #3640:
- `lib/dune`: missing `tool_schema_dsl` module
- `tool_command_plane_support.ml`: stray `]`
- `tool_tag_init.ml`: removed `Mod_hat` reference
- `team_session_oas_bridge.ml`: missing `extensions` field

## Key Design Decision

C1 does NOT depend on LLM output format. The `[STATE]` block parser is tried opportunistically, but on failure the keeper's meta fields (goal, soul_profile) provide a deterministic memory source. See RFC #3646 Section 3.

## Related Issues

- #3630 (keeper memory never written)
- #3364, #3365, #3363 (config introspection)
- #3408 (transport health truth)
- #3640 (base build breakage)

## Test plan

- [x] `dune build` succeeds
- [ ] `dune runtest` passes
- [ ] keeper turn produces memory.jsonl entries
- [ ] `masc_config_snapshot` returns masked config JSON
- [ ] `masc_transport_status` includes `listening` and `listen_status` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)