### PR TITLE
feat(keeper): Phase 1 — work-as-heartbeat for keeper keepalive

### DIFF
--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -57,7 +57,10 @@ let print_summary () =
     Env_config_keeper.KeeperAlert.github_enabled;
   Log.Env.info "KeeperAlert(SlackDM): enabled=%b user_id_set=%b"
     Env_config_keeper.KeeperAlert.slack_dm_enabled
-    (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "")
+    (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "");
+  Log.Env.info "WorkAsHeartbeat: enabled=%b max_silence=%.0fs"
+    Env_config_keeper.WorkAsHeartbeat.enabled
+    Env_config_keeper.WorkAsHeartbeat.max_silence_sec
 
 (** Serialize all known configuration as JSON for dashboard introspection.
     Sensitive values (passwords, tokens, API keys) are masked. *)
@@ -106,6 +109,8 @@ let to_json () : Yojson.Safe.t =
       "alert_enabled", bool_val Env_config_keeper.KeeperAlert.enabled;
       "alert_min_score", float_val Env_config_keeper.KeeperAlert.min_score;
       "alert_slack_enabled", bool_val Env_config_keeper.KeeperAlert.slack_enabled;
+      "work_as_heartbeat_enabled", bool_val Env_config_keeper.WorkAsHeartbeat.enabled;
+      "work_as_heartbeat_max_silence_sec", float_val Env_config_keeper.WorkAsHeartbeat.max_silence_sec;
     ];
     "server", `Assoc [
       "grpc_enabled", bool_val (Env_config_runtime.Transport.grpc_enabled ());

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -181,4 +181,19 @@ module AlertDedup = struct
     Float.max 5.0 (get_float ~default:60.0 "MASC_ALERT_DEDUP_WINDOW_SEC")
 end
 
+(** {1 Work-as-Heartbeat Configuration (Phase 1)} *)
+
+module WorkAsHeartbeat = struct
+  (** Master switch. When true, successful Room.heartbeat_in_room after a
+      unified turn counts as presence proof, allowing the next cycle to skip
+      the full ensure_keeper_room_presence call. *)
+  let enabled =
+    get_bool ~default:true "MASC_KEEPER_WORK_AS_HEARTBEAT"
+
+  (** Maximum seconds since last successful room heartbeat before presence
+      sync is required again. Must be >= keepalive_interval_sec (30). *)
+  let max_silence_sec =
+    Float.max 30.0 (get_float ~default:120.0 "MASC_KEEPER_MAX_SILENCE_SEC")
+end
+
 (** Print configuration summary for debugging *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -163,6 +163,11 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
     { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
       turn_ms = 0.0; recurring_ms = 0.0; improve_ms = 0.0 } in
   let timing_count = ref 0 in
+  (* Phase 1: work-as-heartbeat freshness tracking.
+     Updated ONLY on Room.heartbeat_in_room success after turn. *)
+  let last_successful_heartbeat_ts = ref 0.0 in
+  let work_as_hb = Env_config.WorkAsHeartbeat.enabled in
+  let max_silence = Env_config.WorkAsHeartbeat.max_silence_sec in
   let rec loop () =
     if Atomic.get stop then ()
     else (
@@ -173,28 +178,39 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               | Ok (Some latest) -> latest
               | _ -> m
             in
+            (* Phase 1: skip presence sync when recent room heartbeat proves freshness *)
+            let presence_fresh =
+              work_as_hb
+              && t_presence_start -. !last_successful_heartbeat_ts < max_silence
+            in
             let meta_current =
-              try
-                let synced = ensure_keeper_room_presence ctx.config meta_current in
-                if synced.joined_room_ids = [] then (
+              if presence_fresh then (
+                Log.Keeper.debug "presence sync skipped: fresh heartbeat %.0fs ago"
+                  (t_presence_start -. !last_successful_heartbeat_ts);
+                meta_current)
+              else
+                try
+                  let synced = ensure_keeper_room_presence ctx.config meta_current in
+                  if synced.joined_room_ids = [] then (
+                    incr consecutive_failures;
+                    Log.Keeper.warn "room presence returned empty rooms (%d/%d)"
+                      !consecutive_failures max_consecutive_heartbeat_failures)
+                  else (
+                    consecutive_failures := 0;
+                    last_successful_heartbeat_ts := Time_compat.now ());
+                  (match write_meta ctx.config synced with
+                   | Ok () -> synced
+                   | Error e ->
+                     Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
+                     synced)
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
                   incr consecutive_failures;
-                  Log.Keeper.warn "room presence returned empty rooms (%d/%d)"
-                    !consecutive_failures max_consecutive_heartbeat_failures)
-                else
-                  consecutive_failures := 0;
-                (match write_meta ctx.config synced with
-                 | Ok () -> synced  (* use written value directly, no second read_meta *)
-                 | Error e ->
-                   Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
-                   synced)
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                incr consecutive_failures;
-                Log.Keeper.error "room heartbeat failed (%d/%d): %s"
-                  !consecutive_failures max_consecutive_heartbeat_failures
-                  (Printexc.to_string exn);
-                meta_current
+                  Log.Keeper.error "room heartbeat failed (%d/%d): %s"
+                    !consecutive_failures max_consecutive_heartbeat_failures
+                    (Printexc.to_string exn);
+                  meta_current
             in
             if !consecutive_failures >= max_consecutive_heartbeat_failures then (
               Log.Keeper.error
@@ -427,6 +443,22 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    meta_after_triage)
               else meta_after_triage
             in
+            (* Phase 1: work-as-heartbeat — renew point (b).
+               After turn, call Room.heartbeat_in_room to prove room I/O health.
+               On success: refresh freshness lease + reset consecutive_failures.
+               On failure: leave timestamp unchanged → presence sync resumes next cycle. *)
+            (if work_as_hb && proactive_warmup_elapsed then
+               let hb_ok = List.exists (fun room_id ->
+                 try
+                   ignore
+                     (Room.heartbeat_in_room ctx.config ~room_id
+                        ~agent_name:meta_after_proactive.agent_name);
+                   true
+                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
+               ) meta_after_proactive.joined_room_ids in
+               if hb_ok then (
+                 last_successful_heartbeat_ts := Time_compat.now ();
+                 consecutive_failures := 0));
             let t_turn_end = Time_compat.now () in
             let t_recurring_start = t_turn_end in
             (* Recurring task dispatch (#3190) *)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -33,6 +33,10 @@ val run_heartbeat_loop :
   proactive_warmup_sec:int -> 'a context -> keeper_meta -> bool Atomic.t ->
   wakeup:bool Atomic.t -> unit
 
+(** Compute the p-th percentile of a float array.
+    Returns 0.0 for empty arrays. Used by per-stage profiling. *)
+val percentile : float array -> float -> float
+
 val start_keepalive :
   ?proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
 val stop_keepalive : string -> unit

--- a/test/dune
+++ b/test/dune
@@ -57,7 +57,6 @@
         test_adversarial_eval
         test_labeling
         test_tool_deep_review
-        test_work_as_heartbeat
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -96,7 +95,6 @@
           test_adversarial_eval
           test_labeling
           test_tool_deep_review
-          test_work_as_heartbeat
   )
  (libraries masc_mcp masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.response agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))
@@ -1175,3 +1173,9 @@
  (name test_cdal_friction_projection)
  (modules test_cdal_friction_projection)
  (libraries masc_mcp agent_sdk alcotest yojson unix str))
+
+; Phase 1: Work-as-heartbeat config + freshness logic + percentile
+(test
+ (name test_work_as_heartbeat)
+ (modules test_work_as_heartbeat)
+ (libraries masc_mcp masc_mcp.config alcotest unix))

--- a/test/dune
+++ b/test/dune
@@ -57,6 +57,7 @@
         test_adversarial_eval
         test_labeling
         test_tool_deep_review
+        test_work_as_heartbeat
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -95,6 +96,7 @@
           test_adversarial_eval
           test_labeling
           test_tool_deep_review
+          test_work_as_heartbeat
   )
  (libraries masc_mcp masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.response agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -7,7 +7,8 @@
 
 open Alcotest
 
-module Cfg = Masc_mcp.Env_config
+(* Env_config from masc_mcp.config (unwrapped library) *)
+module Cfg = Env_config
 module KK = Masc_mcp.Keeper_keepalive
 
 (* ── Config default values ──────────────────────────────── *)

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -1,0 +1,137 @@
+(** Test suite for Phase 1: Work-as-heartbeat config defaults,
+    freshness decision logic, and Phase 0 percentile function.
+
+    Note: env_config values are top-level let bindings, evaluated once at
+    program start. Runtime putenv does NOT affect them. Tests verify defaults
+    (no env override in test dune env-vars). *)
+
+open Alcotest
+
+module Cfg = Masc_mcp.Env_config
+module KK = Masc_mcp.Keeper_keepalive
+
+(* ── Config default values ──────────────────────────────── *)
+
+let test_wah_enabled_default () =
+  (* MASC_KEEPER_WORK_AS_HEARTBEAT not set in test env → default true *)
+  check bool "work-as-heartbeat enabled by default"
+    true Cfg.WorkAsHeartbeat.enabled
+
+let test_wah_max_silence_default () =
+  (* MASC_KEEPER_MAX_SILENCE_SEC not set in test env → default 120.0 *)
+  let v = Cfg.WorkAsHeartbeat.max_silence_sec in
+  check (float 0.1) "default max silence 120s" 120.0 v
+
+let test_wah_max_silence_floor_logic () =
+  (* The floor clamp (Float.max 30.0 x) ensures minimum 30s.
+     We verify the invariant: max_silence_sec >= 30.0 always. *)
+  let v = Cfg.WorkAsHeartbeat.max_silence_sec in
+  check bool "max_silence >= 30.0 (keepalive interval)"
+    true (v >= 30.0)
+
+(* ── Freshness decision pure logic ──────────────────────── *)
+
+let test_freshness_fresh () =
+  let now = 100.0 in
+  let last_hb = 50.0 in
+  let max_silence = 120.0 in
+  let fresh = now -. last_hb < max_silence in
+  check bool "50s ago < 120s window → fresh" true fresh
+
+let test_freshness_stale () =
+  let now = 200.0 in
+  let last_hb = 50.0 in
+  let max_silence = 120.0 in
+  let fresh = now -. last_hb < max_silence in
+  check bool "150s ago >= 120s window → stale" false fresh
+
+let test_freshness_exact_boundary () =
+  let now = 170.0 in
+  let last_hb = 50.0 in
+  let max_silence = 120.0 in
+  let fresh = now -. last_hb < max_silence in
+  check bool "exactly 120s → NOT fresh (< is strict)" false fresh
+
+let test_freshness_never_heartbeated () =
+  (* Initial last_hb = 0.0. At unix epoch + 200s:
+     200.0 - 0.0 = 200.0 >= 120.0 → stale.
+     This correctly forces initial presence sync. *)
+  let now = 200.0 in
+  let last_hb = 0.0 in
+  let max_silence = 120.0 in
+  let fresh = now -. last_hb < max_silence in
+  check bool "never heartbeated (0.0) → stale → forces presence sync"
+    false fresh
+
+let test_freshness_disabled_flag () =
+  (* When work_as_hb = false, presence_fresh is always false regardless of timestamp *)
+  let work_as_hb = false in
+  let now = 100.0 in
+  let last_hb = 99.0 in
+  let max_silence = 120.0 in
+  let fresh = work_as_hb && (now -. last_hb < max_silence) in
+  check bool "feature disabled → always stale" false fresh
+
+(* ── Percentile function (Phase 0 profiling) ────────────── *)
+
+let test_percentile_empty () =
+  let arr = [||] in
+  check (float 0.001) "empty → 0.0" 0.0 (KK.percentile arr 0.5)
+
+let test_percentile_single () =
+  let arr = [| 42.0 |] in
+  check (float 0.001) "single → that element" 42.0 (KK.percentile arr 0.5)
+
+let test_percentile_two_elements () =
+  let arr = [| 10.0; 20.0 |] in
+  let p0 = KK.percentile arr 0.0 in
+  let p100 = KK.percentile arr 1.0 in
+  check (float 0.001) "p0 = min" 10.0 p0;
+  check (float 0.001) "p100 = max" 20.0 p100
+
+let test_percentile_sorted () =
+  let arr = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  let p50 = KK.percentile arr 0.5 in
+  (* index = round(4 * 0.5) = round(2.0) = 2 → sorted[2] = 3.0 *)
+  check (float 0.001) "p50 of 1..5 = 3.0" 3.0 p50;
+  let p95 = KK.percentile arr 0.95 in
+  (* index = round(4 * 0.95) = round(3.8) = 4 → sorted[4] = 5.0 *)
+  check (float 0.001) "p95 of 1..5 = 5.0" 5.0 p95
+
+let test_percentile_unsorted () =
+  let arr = [| 5.0; 1.0; 3.0; 2.0; 4.0 |] in
+  let p50 = KK.percentile arr 0.5 in
+  check (float 0.001) "p50 of shuffled 1..5 = 3.0" 3.0 p50
+
+let test_percentile_does_not_mutate () =
+  let arr = [| 5.0; 1.0; 3.0 |] in
+  let _p = KK.percentile arr 0.5 in
+  (* Original array must remain unsorted *)
+  check (float 0.001) "arr[0] unchanged" 5.0 arr.(0);
+  check (float 0.001) "arr[1] unchanged" 1.0 arr.(1)
+
+(* ── Test runner ────────────────────────────────────────── *)
+
+let () =
+  run "work_as_heartbeat" [
+    "config", [
+      test_case "enabled default" `Quick test_wah_enabled_default;
+      test_case "max_silence default" `Quick test_wah_max_silence_default;
+      test_case "max_silence floor invariant" `Quick test_wah_max_silence_floor_logic;
+    ];
+    "freshness_logic", [
+      test_case "within window → fresh" `Quick test_freshness_fresh;
+      test_case "beyond window → stale" `Quick test_freshness_stale;
+      test_case "exact boundary → stale (strict <)" `Quick test_freshness_exact_boundary;
+      test_case "never heartbeated → stale" `Quick test_freshness_never_heartbeated;
+      test_case "feature disabled → always stale" `Quick test_freshness_disabled_flag;
+    ];
+    "percentile", [
+      test_case "empty array" `Quick test_percentile_empty;
+      test_case "single element" `Quick test_percentile_single;
+      test_case "two elements" `Quick test_percentile_two_elements;
+      test_case "sorted input" `Quick test_percentile_sorted;
+      test_case "unsorted input" `Quick test_percentile_unsorted;
+      test_case "does not mutate" `Quick test_percentile_does_not_mutate;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Implements [Heartbeat] Phase 1: Work-as-heartbeat (#3642) from the Adaptive Heartbeat RFC (#3635).

- **Config**: `MASC_KEEPER_WORK_AS_HEARTBEAT` (bool, default true) + `MASC_KEEPER_MAX_SILENCE_SEC` (float, default 120s, floor 30s)
- **Freshness skip**: when `Room.heartbeat_in_room` succeeded within MAX_SILENCE_SEC, skip full `ensure_keeper_room_presence` on next cycle
- **Renew point (b)**: after unified turn, call `Room.heartbeat_in_room` — on success only: update `last_successful_heartbeat_ts` + reset `consecutive_failures`
- **Scope boundary**: freshness (presence skip) and liveness (fiber `done_p`) are independent concerns. Timestamp never overrides supervisor SSOT
- **Percentile**: expose for testing (Phase 0 profiling)
- **Build fix**: add missing `extensions` field in `team_session_oas_bridge.ml`

### Changed files

| File | Change |
|------|--------|
| `lib/config/env_config_keeper.ml` | `WorkAsHeartbeat` module (feature flag + max silence) |
| `lib/config/env_config.ml` | Summary + JSON introspection |
| `lib/keeper/keeper_keepalive.ml` | Local ref, freshness skip, renew point (b) |
| `lib/keeper/keeper_keepalive.mli` | Expose `percentile` |
| `lib/team_session/team_session_oas_bridge.ml` | OAS `extensions` field fix |
| `test/test_work_as_heartbeat.ml` | 14 tests: config + freshness logic + percentile |

### Phase 0 changes (included from parent branch)

| File | Change |
|------|--------|
| `lib/room/resilience.ml` | Config SSOT (hardcoded → env_config) |
| `lib/room/dune` | masc_config dependency |
| `lib/keeper/keeper_keepalive.ml` | Per-stage profiling ring buffer |

Depends on: #3659 (Phase 0)
Closes: #3642

## Test plan

- [x] 14 unit tests pass (config defaults, freshness logic, percentile)
- [ ] Full test suite (`dune runtest`)
- [ ] CI checks green
- [ ] Feature flag `MASC_KEEPER_WORK_AS_HEARTBEAT=false` disables all Phase 1 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>