### PR TITLE
fix(build): restore extensions field in agent_entry record

### DIFF
--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -344,6 +344,7 @@ let planned_worker_to_entry_with_state
     run;
     role;
     get_telemetry = Some (fun () -> !telemetry_ref);
+    extensions = [];
   }
 
 let planned_worker_to_entry


### PR DESCRIPTION
## Summary

- `Swarm_types.agent_entry`에 `extensions = []` 복원
- #3661에서 로컬 빌드 캐시 기반으로 잘못 제거됨
- CI OAS pin(v0.93.0)에서는 이 필드가 필수

## Why

PR branch CI에서 `Some record fields are undefined: extensions` 에러 발생.
main CI는 OAS 빌드 캐시 덕분에 통과했지만, 새 빌드에서는 실패.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>