### PR TITLE
fix(build): restore OAS 0.93.2 agent_entry extensions

### DIFF
--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -344,6 +344,7 @@ let planned_worker_to_entry_with_state
     run;
     role;
     get_telemetry = Some (fun () -> !telemetry_ref);
+    extensions = [];
   }
 
 let planned_worker_to_entry


### PR DESCRIPTION
## Summary

- restore the missing `extensions = []` field when projecting `Swarm.Swarm_types.agent_entry` values in `team_session_oas_bridge`

## Product impact

- repairs the follow-up main build break introduced after `#3661` bumped the OAS pin to `agent_sdk >= 0.93.2`
- keeps the runtime OAS pin and the MASC-side swarm record construction in sync again

## Evidence

Root cause:

- current `origin/main` pins OAS at `0.93.2`, where `Swarm.Swarm_types.agent_entry` requires an `extensions` field
- `lib/team_session/team_session_oas_bridge.ml` on `main` still constructed the older record shape without that field

Validation:

- pre-fix local repro: `dune build --root .` failed with `Some record fields are undefined: extensions`
- `scripts/check-oas-pin.sh`
- post-fix local full build was started, but this shared workstation currently has many long-lived concurrent `dune build` jobs across other worktrees, so final completion was deferred to CI for this hotfix

## Review evidence

- GLM-5 cross-model review via `sb glm-text --no-thinking`
- Timestamp: `2026-03-29 19:34:17 KST`
- Result: no high/critical findings
- Local fallback review path was unavailable because the local review endpoint on `127.0.0.1:8085` was not running

## Linked issue

- Closes #3663
