### PR TITLE
feat(keeper): harden supervisor ownership and dead tombstones

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -63,6 +63,7 @@ type registry_entry = {
   done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u;
   restart_count : int;
   last_restart_ts : float;
+  dead_since_ts : float option;
   crash_log : (float * string) list;
   last_error : string option;
   last_failure_reason : failure_reason option;
@@ -117,6 +118,7 @@ let register ~base_path name meta =
     done_r;
     restart_count = 0;
     last_restart_ts = 0.0;
+    dead_since_ts = None;
     crash_log = [];
     last_error = None;
     last_failure_reason = None;
@@ -174,9 +176,26 @@ let set_state ~base_path name state =
          | (Paused | Stopped | Crashed), Running ->
              Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
          | _ -> ());
-        put_entry key { entry with state }
+        let dead_since_ts =
+          match state with
+          | Dead -> entry.dead_since_ts
+          | _ -> None
+        in
+        put_entry key { entry with state; dead_since_ts }
       end
   | None -> ()
+
+let mark_dead ~base_path name ~at =
+  update_entry ~base_path name (fun entry ->
+    if entry.state <> Dead then begin
+      (match entry.state with
+       | Running ->
+           Atomic.set running_count_atomic
+             (max 0 (Atomic.get running_count_atomic - 1))
+       | _ -> ());
+      { entry with state = Dead; dead_since_ts = Some at }
+    end else
+      { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
 
 let record_restart ~base_path name =
   update_entry ~base_path name (fun e ->
@@ -228,7 +247,7 @@ let started_at ~base_path name =
 let spawn_slots_available () =
   let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
   max_keepers <= 0
-  || StringMap.cardinal !registry < max_keepers
+  || Atomic.get running_count_atomic < max_keepers
 
 let wakeup ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with
@@ -246,14 +265,16 @@ let fiber_health_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with
   | None -> Fiber_unknown
   | Some entry ->
-      match Eio.Promise.peek entry.done_p with
-      | None -> Fiber_alive
-      | Some `Stopped -> Fiber_unknown
-      | Some (`Crashed _) ->
-          let max_restarts = Env_config.KeeperSupervisor.max_restarts in
-          if entry.restart_count >= max_restarts
-          then Fiber_dead
-          else Fiber_zombie
+      if entry.state = Dead then Fiber_dead
+      else
+        match Eio.Promise.peek entry.done_p with
+        | None -> Fiber_alive
+        | Some `Stopped -> Fiber_unknown
+        | Some (`Crashed _) ->
+            let max_restarts = Env_config.KeeperSupervisor.max_restarts in
+            if entry.restart_count >= max_restarts
+            then Fiber_dead
+            else Fiber_zombie
 
 let crash_log_of ~base_path name =
   match get ~base_path name with
@@ -263,7 +284,14 @@ let crash_log_of ~base_path name =
 let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts
     ~crash_log =
   update_entry ~base_path name (fun e ->
-    { e with restart_count; last_restart_ts; crash_log })
+    {
+      e with
+      restart_count;
+      last_restart_ts;
+      dead_since_ts = None;
+      crash_log;
+      last_failure_reason = None;
+    })
 
 let get_last_agent_count ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -177,8 +177,10 @@ let set_state ~base_path name state =
              Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
          | _ -> ());
         let dead_since_ts =
-          match state with
-          | Dead -> entry.dead_since_ts
+          match entry.state, state with
+          | _, Dead -> entry.dead_since_ts
+          | Dead, Running -> None
+          | Dead, _ -> entry.dead_since_ts
           | _ -> None
         in
         put_entry key { entry with state; dead_since_ts }

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -47,6 +47,7 @@ type registry_entry = {
           Only the fiber owning this keeper should call [Eio.Promise.resolve]. *)
   restart_count : int;
   last_restart_ts : float;
+  dead_since_ts : float option;
   crash_log : (float * string) list;
   last_error : string option;
   last_failure_reason : failure_reason option;
@@ -100,6 +101,9 @@ val is_running : base_path:string -> string -> bool
 (** Check if a keeper has ANY registry entry (regardless of state).
     Used by reconcile to skip Crashed/Dead keepers. *)
 val is_registered : base_path:string -> string -> bool
+
+(** Mark a keeper as dead tombstone and record the transition timestamp. *)
+val mark_dead : base_path:string -> string -> at:float -> unit
 
 (** Return the started_at timestamp, or None if not registered. *)
 val started_at : base_path:string -> string -> float option

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -95,8 +95,13 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 else (
                   Keeper_supervisor.supervise_keepalive
                     ~proactive_warmup_sec ctx m;
-                  if max_keepers > 0 then remaining_slots := !remaining_slots - 1;
-                  true
+                  let started_now =
+                    Keeper_registry.is_running
+                      ~base_path:ctx.config.base_path m.name
+                  in
+                  if started_now && max_keepers > 0 then
+                    remaining_slots := !remaining_slots - 1;
+                  started_now
                 )
               in
               ( true,

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -25,6 +25,13 @@ let keep_last_n n item lst =
   if List.length full <= n then full
   else List.filteri (fun i _ -> i < n) full
 
+let should_cleanup_dead ~now ~dead_ttl_sec
+    (entry : Keeper_registry.registry_entry) =
+  match entry.state, entry.dead_since_ts with
+  | Keeper_registry.Dead, Some dead_since ->
+      now -. dead_since >= dead_ttl_sec
+  | _ -> false
+
 (* ── Event publishing ────────────────────────────────────── *)
 
 let publish_lifecycle event_name keeper_name detail =
@@ -40,6 +47,13 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+    let resolved = ref false in
+    let resolve_done value =
+      if not !resolved then begin
+        resolved := true;
+        Eio.Promise.resolve reg.done_r value
+      end
+    in
     Fun.protect
       (fun () ->
         (try
@@ -48,7 +62,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            (* Normal exit: stop flag was set *)
            Keeper_registry.set_state ~base_path meta.name
              Keeper_registry.Stopped;
-           Eio.Promise.resolve reg.done_r `Stopped;
+           resolve_done `Stopped;
            publish_lifecycle "stopped" meta.name "normal exit"
          with
          | Keeper_registry.Keeper_heartbeat_failure info ->
@@ -61,7 +75,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              Keeper_registry.record_crash ~base_path
                meta.name (Time_compat.now ()) reason;
              Keeper_registry.record_error ~base_path meta.name reason;
-             Eio.Promise.resolve reg.done_r (`Crashed reason);
+             resolve_done (`Crashed reason);
              publish_lifecycle "crashed" meta.name reason
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -73,13 +87,11 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              Keeper_registry.record_crash ~base_path
                meta.name (Time_compat.now ()) reason;
              Keeper_registry.record_error ~base_path meta.name reason;
-             Eio.Promise.resolve reg.done_r (`Crashed reason);
+             resolve_done (`Crashed reason);
              publish_lifecycle "crashed" meta.name reason))
       ~finally:(fun () ->
         Keeper_registry.cleanup_tracking ~base_path meta.name;
-        match Eio.Promise.peek reg.done_p with
-        | Some _ -> ()  (* Already resolved above *)
-        | None ->
+        if not !resolved then begin
             let reason =
               Keeper_registry.failure_reason_to_string
                 Keeper_registry.Fiber_unresolved in
@@ -90,8 +102,9 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
             Keeper_registry.record_error ~base_path meta.name reason;
             Keeper_registry.set_state ~base_path meta.name
               Keeper_registry.Crashed;
-            Eio.Promise.resolve reg.done_r (`Crashed reason);
-            publish_lifecycle "crashed" meta.name reason))
+            resolve_done (`Crashed reason);
+            publish_lifecycle "crashed" meta.name reason
+        end))
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -158,6 +158,35 @@ let reconcile_keepalive_keepers (ctx : _ context) =
                end
              end
          | _ -> ())
+let cleanup_dead_tombstone (ctx : _ context)
+    (entry : Keeper_registry.registry_entry) =
+  match read_meta ctx.config entry.name with
+  | Ok (Some meta) ->
+      let persisted_paused =
+        if meta.paused then true
+        else
+          match write_meta ctx.config { meta with paused = true } with
+          | Ok () -> true
+          | Error err ->
+              Log.Keeper.warn
+                "%s: dead tombstone cleanup paused write failed: %s"
+                entry.name err;
+              false
+      in
+      if persisted_paused then begin
+        Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+        publish_lifecycle "dead_cleaned" entry.name "paused meta persisted";
+        Log.Keeper.info "%s: dead tombstone cleaned up" entry.name
+      end
+  | Ok None ->
+      Log.Keeper.warn
+        "%s: dead tombstone cleanup skipped (meta missing)"
+        entry.name
+  | Error err ->
+      Log.Keeper.warn
+        "%s: dead tombstone cleanup skipped (%s)"
+        entry.name err
+
 (** Cohort key from structured failure_reason ADT.
     Groups failures by variant, ignoring parameters (e.g. failure count). *)
 let cohort_key_of_reason = function
@@ -210,6 +239,7 @@ let apply_self_preservation ~total_keepers to_restart =
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Env_config.KeeperSupervisor.max_restarts in
+  let dead_ttl_sec = Env_config.KeeperSupervisor.dead_ttl_sec in
   let base_path = ctx.config.base_path in
   (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
      This prevents reconcile from re-launching keepers that sweep is about
@@ -217,45 +247,44 @@ let sweep_and_recover (ctx : _ context) =
   let entries = Keeper_registry.all ~base_path () in
   let to_restart = ref [] in
   let to_unregister = ref [] in
+  let to_mark_dead = ref [] in
+  let to_cleanup_dead = ref [] in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     match entry.state with
     | Keeper_registry.Dead ->
-        (* Phase 2: Dead tombstone TTL cleanup *)
-        if now -. entry.last_restart_ts > Env_config.KeeperSupervisor.dead_ttl_sec then begin
-          to_unregister := entry :: !to_unregister;
-          (* Mark meta as paused so reconcile permanently excludes it *)
-          (match read_meta ctx.config entry.name with
-           | Ok (Some meta) ->
-               ignore (write_meta ctx.config { meta with paused = true })
-           | _ -> ())
-        end
+        (match entry.dead_since_ts with
+         | Some dead_since when now -. dead_since >= dead_ttl_sec ->
+             to_cleanup_dead := entry :: !to_cleanup_dead
+         | _ -> ())
+    | Keeper_registry.Stopped ->
+        to_unregister := entry :: !to_unregister
     | Keeper_registry.Running | Keeper_registry.Paused
-    | Keeper_registry.Stopped | Keeper_registry.Crashed ->
+    | Keeper_registry.Crashed ->
       (match Eio.Promise.peek entry.done_p with
       | None -> ()  (* Alive — skip *)
       | Some `Stopped ->
           to_unregister := entry :: !to_unregister
       | Some (`Crashed msg) ->
-          if entry.restart_count >= max_restarts then begin
-            (* Phase 2: Dead tombstone instead of unregister *)
-            Keeper_registry.set_state ~base_path entry.name
-              Keeper_registry.Dead;
-            publish_lifecycle "dead" entry.name
-              (Printf.sprintf "restart budget exhausted (%d), last: %s"
-                 max_restarts msg);
-            Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
-              entry.name max_restarts
-          end else begin
+          if entry.restart_count >= max_restarts then
+            to_mark_dead := (entry, msg) :: !to_mark_dead
+          else begin
             let delay = backoff_delay entry.restart_count in
             if now -. entry.last_restart_ts >= delay then
               to_restart := (entry, msg) :: !to_restart
           end)
   ) entries;
-  (* Clean up stopped entries + expired Dead tombstones *)
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name
   ) !to_unregister;
-  (* Phase 2: self-preservation gate before restart *)
+  List.iter (fun ((entry : Keeper_registry.registry_entry), msg) ->
+    Keeper_registry.mark_dead ~base_path entry.name ~at:now;
+    publish_lifecycle "dead" entry.name
+      (Printf.sprintf "restart budget exhausted (%d), last: %s"
+         max_restarts msg);
+    Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
+      entry.name max_restarts
+  ) !to_mark_dead;
+  List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
   let active_count =
     List.length (List.filter (fun (e : Keeper_registry.registry_entry) ->
       e.state = Keeper_registry.Running || e.state = Keeper_registry.Crashed

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -37,5 +37,8 @@ val backoff_delay : int -> float
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
 
+val should_cleanup_dead : now:float -> dead_ttl_sec:float -> Keeper_registry.registry_entry -> bool
+(** True when a dead tombstone has exceeded the configured TTL. *)
+
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)

--- a/lib/room/dune
+++ b/lib/room/dune
@@ -28,8 +28,8 @@
   mention
   resilience
   heartbeat
-  heartbeat_smart
-  nickname)
+ heartbeat_smart
+ nickname)
  (libraries
   masc_types
   masc_core

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -67,6 +67,20 @@ let test_set_state () =
   | None -> fail "expected k4"
   | Some e -> check string "state" "paused" (R.state_to_string e.state)
 
+let test_extended_states () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "k4x" (make_meta "k4x") in
+  R.set_state ~base_path:bp "k4x" R.Crashed;
+  (match R.get ~base_path:bp "k4x" with
+   | None -> fail "expected k4x"
+   | Some e -> check string "crashed string" "crashed" (R.state_to_string e.state));
+  R.mark_dead ~base_path:bp "k4x" ~at:123.0;
+  match R.get ~base_path:bp "k4x" with
+  | None -> fail "expected k4x"
+  | Some e ->
+      check string "dead string" "dead" (R.state_to_string e.state);
+      check (option (float 0.01)) "dead_since set" (Some 123.0) e.dead_since_ts
+
 let test_count_running () =
   R.clear ();
   let _e1 = R.register ~base_path:bp "r1" (make_meta "r1") in
@@ -104,6 +118,17 @@ let test_record_restart () =
   | Some e ->
       check int "restart count" 2 e.restart_count;
       check bool "last_restart_ts set" true (e.last_restart_ts > 0.0)
+
+let test_is_registered () =
+  R.clear ();
+  check bool "not registered before" false
+    (R.is_registered ~base_path:bp "k5x");
+  let _entry = R.register ~base_path:bp "k5x" (make_meta "k5x") in
+  check bool "registered after add" true
+    (R.is_registered ~base_path:bp "k5x");
+  R.unregister ~base_path:bp "k5x";
+  check bool "not registered after remove" false
+    (R.is_registered ~base_path:bp "k5x")
 
 let test_record_error () =
   R.clear ();
@@ -233,6 +258,14 @@ let test_fiber_health_crashed () =
   | Keeper_types.Fiber_zombie -> ()
   | _ -> fail "expected Fiber_zombie for crashed"
 
+let test_fiber_health_dead_state () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "fh4" (make_meta "fh4") in
+  R.mark_dead ~base_path:bp "fh4" ~at:42.0;
+  match R.fiber_health_of ~base_path:bp "fh4" with
+  | Keeper_types.Fiber_dead -> ()
+  | _ -> fail "expected Fiber_dead for dead state"
+
 let test_shared_refs () =
   R.clear ();
   let entry = R.register ~base_path:bp "ref1" (make_meta "ref1") in
@@ -348,9 +381,11 @@ let () =
           eio_test "all" test_all;
           eio_test "update meta" test_update_meta;
           eio_test "set state" test_set_state;
+          eio_test "extended states" test_extended_states;
           eio_test "count running" test_count_running;
           eio_test "count running atomic transitions" test_count_running_atomic_transitions;
           eio_test "record restart" test_record_restart;
+          eio_test "is_registered" test_is_registered;
           eio_test "record error" test_record_error;
           eio_test "get_exn not found" test_get_exn_not_found;
           eio_test "noop on missing keys" test_noop_on_missing;
@@ -367,6 +402,7 @@ let () =
           eio_test "fiber_health unknown" test_fiber_health_unknown;
           eio_test "fiber_health stopped" test_fiber_health_stopped;
           eio_test "fiber_health crashed" test_fiber_health_crashed;
+          eio_test "fiber_health dead state" test_fiber_health_dead_state;
           eio_test "shared refs" test_shared_refs;
           eio_test "spawn slots" test_spawn_slots;
         ] );

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -65,6 +65,42 @@ let test_crash_log_empty_for_unknown () =
   check int "empty crash log" 0
     (List.length (Reg.crash_log_of ~base_path:"/tmp" "nonexistent"))
 
+let test_should_cleanup_dead_true () =
+  Reg.clear ();
+  let _entry = Reg.register ~base_path:"/tmp" "dead1"
+      (let json = `Assoc [
+        ("name", `String "dead1");
+        ("agent_name", `String "agent-dead1");
+        ("trace_id", `String "trace-dead1");
+        ("goal", `String "goal");
+      ] in
+      match KT.meta_of_json json with
+      | Ok meta -> meta
+      | Error err -> fail err)
+  in
+  Reg.mark_dead ~base_path:"/tmp" "dead1" ~at:10.0;
+  let entry = Option.get (Reg.get ~base_path:"/tmp" "dead1") in
+  check bool "ttl exceeded" true
+    (Sup.should_cleanup_dead ~now:4000.0 ~dead_ttl_sec:3600.0 entry)
+
+let test_should_cleanup_dead_false_when_recent () =
+  Reg.clear ();
+  let _entry = Reg.register ~base_path:"/tmp" "dead2"
+      (let json = `Assoc [
+        ("name", `String "dead2");
+        ("agent_name", `String "agent-dead2");
+        ("trace_id", `String "trace-dead2");
+        ("goal", `String "goal");
+      ] in
+      match KT.meta_of_json json with
+      | Ok meta -> meta
+      | Error err -> fail err)
+  in
+  Reg.mark_dead ~base_path:"/tmp" "dead2" ~at:100.0;
+  let entry = Option.get (Reg.get ~base_path:"/tmp" "dead2") in
+  check bool "ttl not exceeded" false
+    (Sup.should_cleanup_dead ~now:200.0 ~dead_ttl_sec:3600.0 entry)
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -83,5 +119,7 @@ let () =
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;
       test_case "registry count zero" `Quick test_registry_count_initially_zero;
       test_case "crash_log empty" `Quick test_crash_log_empty_for_unknown;
+      test_case "should cleanup dead when ttl exceeded" `Quick test_should_cleanup_dead_true;
+      test_case "should not cleanup dead when recent" `Quick test_should_cleanup_dead_false_when_recent;
     ];
   ]

--- a/test/test_resilience_coverage.ml
+++ b/test/test_resilience_coverage.ml
@@ -21,6 +21,11 @@ module Resilience = Resilience
 let test_default_zombie_threshold_positive () =
   check bool "positive" true (Resilience.default_zombie_threshold > 0.0)
 
+let test_default_zombie_threshold_matches_env_config () =
+  check (float 0.01) "matches env config"
+    Env_config_runtime.Zombie.threshold_seconds
+    Resilience.default_zombie_threshold
+
 let test_default_zombie_threshold_reasonable () =
   (* Should be between 30 seconds and 24 hours *)
   check bool "reasonable" true
@@ -126,6 +131,16 @@ let test_zombie_custom_threshold () =
   check bool "zombie with threshold" true
     (Resilience.Zombie.is_zombie ~threshold:1.0 old_ts)
 
+let test_keeper_zombie_threshold_matches_env_config () =
+  let old_ts = "2020-01-01T00:00:00Z" in
+  let expected =
+    Resilience.Zombie.is_zombie
+      ~threshold:Env_config_runtime.Zombie.keeper_threshold_seconds
+      old_ts
+  in
+  check bool "keeper threshold uses env config" expected
+    (Resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-demo-agent" old_ts)
+
 (* ============================================================
    ZeroZombie.global_stats Tests
    ============================================================ *)
@@ -151,6 +166,7 @@ let () =
   run "Resilience Coverage" [
     "constants", [
       test_case "zombie threshold positive" `Quick test_default_zombie_threshold_positive;
+      test_case "zombie threshold matches env config" `Quick test_default_zombie_threshold_matches_env_config;
       test_case "zombie threshold reasonable" `Quick test_default_zombie_threshold_reasonable;
       test_case "warning threshold positive" `Quick test_default_warning_threshold_positive;
       test_case "warning < zombie" `Quick test_default_warning_less_than_zombie;
@@ -179,6 +195,7 @@ let () =
       test_case "old agent" `Quick test_zombie_old_agent;
       test_case "invalid timestamp" `Quick test_zombie_invalid_timestamp;
       test_case "custom threshold" `Quick test_zombie_custom_threshold;
+      test_case "keeper threshold matches env config" `Quick test_keeper_zombie_threshold_matches_env_config;
     ];
     "global_stats", [
       test_case "total_cleanups" `Quick test_global_stats_total_cleanups;

--- a/test/test_resilience_coverage.ml
+++ b/test/test_resilience_coverage.ml
@@ -23,7 +23,7 @@ let test_default_zombie_threshold_positive () =
 
 let test_default_zombie_threshold_matches_env_config () =
   check (float 0.01) "matches env config"
-    Env_config_runtime.Zombie.threshold_seconds
+    Env_config.Zombie.threshold_seconds
     Resilience.default_zombie_threshold
 
 let test_default_zombie_threshold_reasonable () =
@@ -135,7 +135,7 @@ let test_keeper_zombie_threshold_matches_env_config () =
   let old_ts = "2020-01-01T00:00:00Z" in
   let expected =
     Resilience.Zombie.is_zombie
-      ~threshold:Env_config_runtime.Zombie.keeper_threshold_seconds
+      ~threshold:Env_config.Zombie.keeper_threshold_seconds
       old_ts
   in
   check bool "keeper threshold uses env config" expected


### PR DESCRIPTION
## Summary
- align keeper supervisor ownership with the adaptive-heartbeat PR-1 slice
- add `Crashed` / `Dead` registry states, `is_registered`, and dead tombstone TTL config
- stop reconcile from relaunching registered keepers and require paused-meta persistence before dead cleanup unregister
- wire resilience zombie thresholds to the existing env-config SSOT

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature/adaptive-heartbeat-pr1-ownership _build/default/lib/config/env_config_keeper.ml _build/default/lib/room/resilience.ml _build/default/lib/keeper/keeper_registry.ml _build/default/lib/keeper/keeper_keepalive.ml _build/default/lib/keeper/keeper_supervisor.ml _build/default/test/test_keeper_registry.ml _build/default/test/test_keeper_supervisor.ml _build/default/test/test_resilience_coverage.ml`
- `git diff --check`

## Notes
- full test executable / full repo build is currently blocked by unrelated baseline compile issues in this checkout: `Tool_schema_dsl` unbound and `Mod_hat` constructor mismatch
- included one tiny build-unblock cleanup in `lib/tool_command_plane_support.ml` (stray bracket) so touched-module validation could proceed
- follow-up PRs still needed for work-as-heartbeat/status surface and safety harness slices