### PR TITLE
fix(keeper): unify checkpoint session_id with trace_id

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -193,6 +193,7 @@ let run_turn
     Oas_worker.run_named
       ~cascade_name
       ~goal:user_message
+      ~session_id:meta.trace_id
       ~system_prompt:turn_system_prompt
       ~tools
       ~initial_messages:ctx_work.messages

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -468,6 +468,7 @@ let config_for_label
 let run_named
     ~cascade_name
     ~goal
+    ?session_id
     ?(system_prompt = "")
     ?(tools = [])
     ?(initial_messages = [])
@@ -529,6 +530,7 @@ let run_named
       transport = transport_resolved;
       allowed_paths;
       working_context;
+      session_id;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -40,6 +40,7 @@ val default_model_strings : cascade_name:string -> string list
 val run_named :
   cascade_name:string ->
   goal:string ->
+  ?session_id:string ->
   ?system_prompt:string ->
   ?tools:Oas.Tool.t list ->
   ?initial_messages:Oas.Types.message list ->

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -344,6 +344,7 @@ let planned_worker_to_entry_with_state
     run;
     role;
     get_telemetry = Some (fun () -> !telemetry_ref);
+    extensions = [];
   }
 
 let planned_worker_to_entry


### PR DESCRIPTION
## Summary

- Keeper checkpoint save/load가 서로 다른 파일을 사용하던 버그 수정
- save: 턴별 자동 생성 ID (`oas-<cascade>-<ts>-<hash>.json`)로 저장
- load: `trace_id` (`trace-<ts>-<hex>.json`)로 조회
- 매 턴마다 빈 context에서 시작 → keeper가 이전 대화를 기억 못함

## Fix

`Oas_worker.run_named`에 `?session_id` 파라미터 추가. `keeper_agent_run`에서 `meta.trace_id`를 전달하여 save/load 경로를 일치시킴.

| 파일 | 변경 |
|------|------|
| `lib/oas_worker.mli` | `?session_id:string` 파라미터 추가 |
| `lib/oas_worker.ml` | `?session_id` 수신, config에 전달 |
| `lib/keeper/keeper_agent_run.ml` | `~session_id:meta.trace_id` 전달 |
| `lib/team_session/team_session_oas_bridge.ml` | OAS 0.93.2 `extensions = []` compat |

Layer 2 of 2-layer keeper continuity bug (Layer 1: jeong-sik/oas#467 merged).

Closes #3630

## Test plan

- [x] `test_oas_worker.exe` — 32 tests pass
- [x] `test_keeper_unified.exe` — 28 tests pass
- [x] `test_keeper_memory.exe` — 18 tests pass
- [ ] E2E: keeper 기동 → "나는 Vincent" → checkpoint 확인 → "내 이름?" → 회상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)