### PR TITLE
feat(keeper): Phase 2 — self-preservation + structured crash + Dead tombstone

### DIFF
--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -60,7 +60,11 @@ let print_summary () =
     (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "");
   Log.Env.info "WorkAsHeartbeat: enabled=%b max_silence=%.0fs"
     Env_config_keeper.WorkAsHeartbeat.enabled
-    Env_config_keeper.WorkAsHeartbeat.max_silence_sec
+    Env_config_keeper.WorkAsHeartbeat.max_silence_sec;
+  Log.Env.info "SelfPreservation: ratio=%.2f min_candidates=%d dead_ttl=%.0fs"
+    Env_config_keeper.KeeperSupervisor.self_preservation_ratio
+    Env_config_keeper.KeeperSupervisor.self_preservation_min_candidates
+    Env_config_keeper.KeeperSupervisor.dead_ttl_sec
 
 (** Serialize all known configuration as JSON for dashboard introspection.
     Sensitive values (passwords, tokens, API keys) are masked. *)
@@ -111,6 +115,9 @@ let to_json () : Yojson.Safe.t =
       "alert_slack_enabled", bool_val Env_config_keeper.KeeperAlert.slack_enabled;
       "work_as_heartbeat_enabled", bool_val Env_config_keeper.WorkAsHeartbeat.enabled;
       "work_as_heartbeat_max_silence_sec", float_val Env_config_keeper.WorkAsHeartbeat.max_silence_sec;
+      "self_preservation_ratio", float_val Env_config_keeper.KeeperSupervisor.self_preservation_ratio;
+      "self_preservation_min_candidates", int_val Env_config_keeper.KeeperSupervisor.self_preservation_min_candidates;
+      "dead_ttl_sec", float_val Env_config_keeper.KeeperSupervisor.dead_ttl_sec;
     ];
     "server", `Assoc [
       "grpc_enabled", bool_val (Env_config_runtime.Transport.grpc_enabled ());

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -151,6 +151,19 @@ module KeeperSupervisor = struct
   (** Interval between supervisor sweep runs (seconds) *)
   let sweep_interval_sec =
     get_float ~default:30.0 "MASC_KEEPER_SUPERVISOR_SWEEP_SEC"
+
+  (** Self-preservation: ratio of crashed keepers to trigger suppression *)
+  let self_preservation_ratio =
+    Float.min 1.0 (Float.max 0.0
+      (get_float ~default:0.3 "MASC_KEEPER_SELF_PRESERVATION_RATIO"))
+
+  (** Self-preservation: minimum crashed candidates to trigger *)
+  let self_preservation_min_candidates =
+    max 1 (get_int ~default:2 "MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES")
+
+  (** Dead tombstone TTL: seconds before Dead entries are cleaned up *)
+  let dead_ttl_sec =
+    Float.max 60.0 (get_float ~default:3600.0 "MASC_KEEPER_DEAD_TTL_SEC")
 end
 
 (** {1 Keeper Runtime Configuration} *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -212,11 +212,12 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                     (Printexc.to_string exn);
                   meta_current
             in
-            if !consecutive_failures >= max_consecutive_heartbeat_failures then (
-              Log.Keeper.error
-                "keeper %s: %d consecutive heartbeat failures, stopping keepalive"
-                m.name max_consecutive_heartbeat_failures;
-              Atomic.set stop true);
+            (* Phase 2: structured exception instead of silent stop *)
+            if !consecutive_failures >= max_consecutive_heartbeat_failures then
+              raise (Keeper_registry.Keeper_heartbeat_failure {
+                reason = Keeper_registry.Heartbeat_consecutive_failures !consecutive_failures;
+                keeper_name = m.name;
+              });
             let t_presence_end = Time_compat.now () in
             let now_ts = t_presence_end in
             let t_snapshot_start = now_ts in

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -23,10 +23,32 @@ open Keeper_types
 
 module StringMap = Map.Make (String)
 
+(** Structured failure reason for cohort detection in self-preservation.
+    ADT matching replaces string prefix matching for crash_msg grouping. *)
+type failure_reason =
+  | Heartbeat_consecutive_failures of int
+  | Fiber_unresolved
+  | Exception of string
+
+let failure_reason_to_string = function
+  | Heartbeat_consecutive_failures n ->
+      Printf.sprintf "heartbeat_consecutive_failures(%d)" n
+  | Fiber_unresolved -> "fiber_unresolved"
+  | Exception s -> Printf.sprintf "exception(%s)" s
+
+(** Structured exception raised by keeper_keepalive when consecutive
+    heartbeat failures exceed the threshold. *)
+exception Keeper_heartbeat_failure of {
+  reason : failure_reason;
+  keeper_name : string;
+}
+
 type keeper_state =
   | Running
   | Paused
   | Stopped
+  | Crashed  (** Error exit, restart candidate (backoff applies) *)
+  | Dead     (** Restart budget exhausted, tombstone — no re-launch *)
 
 type registry_entry = {
   base_path : string;
@@ -53,6 +75,8 @@ let state_to_string = function
   | Running -> "running"
   | Paused -> "paused"
   | Stopped -> "stopped"
+  | Crashed -> "crashed"
+  | Dead -> "dead"
 
 let registry : registry_entry StringMap.t ref = ref StringMap.empty
 let running_count_atomic = Atomic.make 0
@@ -140,10 +164,10 @@ let set_state ~base_path name state =
   | Some entry ->
       if entry.state <> state then begin
         (match (entry.state, state) with
-         | Running, (Paused | Stopped) ->
+         | Running, (Paused | Stopped | Crashed | Dead) ->
              Atomic.set running_count_atomic
                (max 0 (Atomic.get running_count_atomic - 1))
-         | (Paused | Stopped), Running ->
+         | (Paused | Stopped | Crashed | Dead), Running ->
              Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
          | _ -> ());
         put_entry key { entry with state }
@@ -162,6 +186,11 @@ let is_running ~base_path name =
   match get ~base_path name with
   | Some { state = Running; _ } -> true
   | _ -> false
+
+(** True if the keeper has ANY registry entry (regardless of state).
+    Used by reconcile to avoid re-launching Crashed/Dead keepers. *)
+let is_registered ~base_path name =
+  Option.is_some (get ~base_path name)
 
 let count_running ?base_path () =
   match base_path with

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -162,12 +162,14 @@ let set_state ~base_path name state =
   let key = registry_key ~base_path name in
   match StringMap.find_opt key !registry with
   | Some entry ->
-      if entry.state <> state then begin
+      (* Dead is terminal — only unregister can remove a Dead entry *)
+      if entry.state = Dead && state <> Dead then ()
+      else if entry.state <> state then begin
         (match (entry.state, state) with
          | Running, (Paused | Stopped | Crashed | Dead) ->
              Atomic.set running_count_atomic
                (max 0 (Atomic.get running_count_atomic - 1))
-         | (Paused | Stopped | Crashed | Dead), Running ->
+         | (Paused | Stopped | Crashed), Running ->
              Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
          | _ -> ());
         put_entry key { entry with state }

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -10,10 +10,27 @@
 
 open Keeper_types
 
+(** Structured failure reason for crash cohort detection. *)
+type failure_reason =
+  | Heartbeat_consecutive_failures of int
+  | Fiber_unresolved
+  | Exception of string
+
+val failure_reason_to_string : failure_reason -> string
+
+(** Raised by keeper_keepalive when consecutive heartbeat failures
+    exceed the threshold. Caught by launch_supervised_fiber. *)
+exception Keeper_heartbeat_failure of {
+  reason : failure_reason;
+  keeper_name : string;
+}
+
 type keeper_state =
   | Running
   | Paused
   | Stopped
+  | Crashed
+  | Dead
 
 type registry_entry = {
   base_path : string;
@@ -75,6 +92,10 @@ val set_grpc_close : base_path:string -> string -> (unit -> unit) option -> unit
 
 (** Check if a keeper is in Running state. *)
 val is_running : base_path:string -> string -> bool
+
+(** Check if a keeper has ANY registry entry (regardless of state).
+    Used by reconcile to skip Crashed/Dead keepers. *)
+val is_registered : base_path:string -> string -> bool
 
 (** Return the started_at timestamp, or None if not registered. *)
 val started_at : base_path:string -> string -> float option

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -38,29 +38,59 @@ let publish_lifecycle event_name keeper_name detail =
 
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
+  let base_path = ctx.config.base_path in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     Fun.protect
       (fun () ->
-        Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
-          ctx meta reg.fiber_stop ~wakeup:reg.fiber_wakeup;
-        Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
-          Keeper_registry.Stopped;
-        Eio.Promise.resolve reg.done_r `Stopped;
-        publish_lifecycle "stopped" meta.name "normal exit")
+        (try
+           Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
+             ctx meta reg.fiber_stop ~wakeup:reg.fiber_wakeup;
+           (* Normal exit: stop flag was set *)
+           Keeper_registry.set_state ~base_path meta.name
+             Keeper_registry.Stopped;
+           Eio.Promise.resolve reg.done_r `Stopped;
+           publish_lifecycle "stopped" meta.name "normal exit"
+         with
+         | Keeper_registry.Keeper_heartbeat_failure info ->
+             (* Phase 2: structured crash — heartbeat failures *)
+             let reason =
+               Keeper_registry.failure_reason_to_string info.reason in
+             Keeper_registry.set_state ~base_path meta.name
+               Keeper_registry.Crashed;
+             Keeper_registry.record_crash ~base_path
+               meta.name (Time_compat.now ()) reason;
+             Keeper_registry.record_error ~base_path meta.name reason;
+             Eio.Promise.resolve reg.done_r (`Crashed reason);
+             publish_lifecycle "crashed" meta.name reason
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             (* Phase 2: structured crash — generic exception *)
+             let reason =
+               Keeper_registry.failure_reason_to_string
+                 (Keeper_registry.Exception (Printexc.to_string exn)) in
+             Keeper_registry.set_state ~base_path meta.name
+               Keeper_registry.Crashed;
+             Keeper_registry.record_crash ~base_path
+               meta.name (Time_compat.now ()) reason;
+             Keeper_registry.record_error ~base_path meta.name reason;
+             Eio.Promise.resolve reg.done_r (`Crashed reason);
+             publish_lifecycle "crashed" meta.name reason))
       ~finally:(fun () ->
-        Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path meta.name;
+        Keeper_registry.cleanup_tracking ~base_path meta.name;
         match Eio.Promise.peek reg.done_p with
-        | Some _ -> ()  (* Already resolved in the normal path *)
+        | Some _ -> ()  (* Already resolved above *)
         | None ->
-            let msg = "fiber terminated without resolution" in
-            Keeper_registry.record_crash ~base_path:ctx.config.base_path
-              meta.name (Time_compat.now ()) msg;
-            Keeper_registry.record_error ~base_path:ctx.config.base_path
-              meta.name msg;
-            Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
-              Keeper_registry.Stopped;
-            Eio.Promise.resolve reg.done_r (`Crashed msg);
-            publish_lifecycle "crashed" meta.name msg))
+            (* Fallback: fiber terminated without any resolution *)
+            let reason =
+              Keeper_registry.failure_reason_to_string
+                Keeper_registry.Fiber_unresolved in
+            Keeper_registry.record_crash ~base_path
+              meta.name (Time_compat.now ()) reason;
+            Keeper_registry.record_error ~base_path meta.name reason;
+            Keeper_registry.set_state ~base_path meta.name
+              Keeper_registry.Crashed;
+            Eio.Promise.resolve reg.done_r (`Crashed reason);
+            publish_lifecycle "crashed" meta.name reason))
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (meta : keeper_meta) =
@@ -97,6 +127,9 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
 
 (* ── Sweep and recover ───────────────────────────────────── *)
 
+(** Phase 2: reconcile only orphaned durable keepers (no registry entry).
+    is_registered checks entry existence regardless of state, so Crashed/Dead
+    keepers are excluded from reconcile. *)
 let reconcile_keepalive_keepers (ctx : _ context) =
   let base_path = ctx.config.base_path in
   Keeper_types.keepalive_keeper_names ctx.config
@@ -104,55 +137,125 @@ let reconcile_keepalive_keepers (ctx : _ context) =
          match read_meta ctx.config name with
          | Ok (Some meta)
            when not meta.paused
-                && not (Keeper_registry.is_running ~base_path meta.name) ->
+                && not (Keeper_registry.is_registered ~base_path meta.name) ->
              supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
              if Keeper_registry.is_running ~base_path meta.name then begin
                publish_lifecycle "reconciled" meta.name "durable keeper";
                Log.Keeper.info "%s: reconciled durable keeper" meta.name
              end
          | _ -> ())
+(** Phase 2: self-preservation gate.
+    Suppresses restarts when a dominant failure cohort exceeds the
+    ratio threshold AND minimum candidate count. *)
+let self_preservation_ratio = 0.3
+let self_preservation_min_candidates = 2
+
+let apply_self_preservation ~total_keepers to_restart =
+  let n_candidates = List.length to_restart in
+  let n_total = max 1 total_keepers in
+  let ratio = float_of_int n_candidates /. float_of_int n_total in
+  if ratio > self_preservation_ratio
+     && n_candidates >= self_preservation_min_candidates
+  then begin
+    (* Group by failure reason prefix for cohort detection *)
+    let cohorts = Hashtbl.create 4 in
+    List.iter (fun ((_entry : Keeper_registry.registry_entry), msg) ->
+      let key =
+        if String.length msg > 30 then String.sub msg 0 30 else msg in
+      let prev = try Hashtbl.find cohorts key with Not_found -> [] in
+      Hashtbl.replace cohorts key ((_entry, msg) :: prev)
+    ) to_restart;
+    (* Find dominant cohort *)
+    let dominant_key, dominant_entries =
+      Hashtbl.fold (fun k v (best_k, best_v) ->
+        if List.length v > List.length best_v then (k, v) else (best_k, best_v)
+      ) cohorts ("", [])
+    in
+    if List.length dominant_entries >= self_preservation_min_candidates then begin
+      Log.Keeper.warn
+        "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s)"
+        (List.length dominant_entries) n_total ratio dominant_key;
+      publish_lifecycle "self_preservation" "supervisor"
+        (Printf.sprintf "%d/%d suppressed, cohort=%s"
+           (List.length dominant_entries) n_total dominant_key);
+      (* Return only non-dominant entries for restart *)
+      let dominant_set =
+        List.map (fun ((e : Keeper_registry.registry_entry), _) -> e.name)
+          dominant_entries in
+      List.filter (fun ((e : Keeper_registry.registry_entry), _) ->
+        not (List.mem e.name dominant_set)
+      ) to_restart
+    end else
+      to_restart
+  end else
+    to_restart
+
+(** Dead entry TTL: entries in Dead state older than this are cleaned up. *)
+let dead_ttl_sec = 3600.0
+
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Env_config.KeeperSupervisor.max_restarts in
   let base_path = ctx.config.base_path in
-  reconcile_keepalive_keepers ctx;
+  (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
+     This prevents reconcile from re-launching keepers that sweep is about
+     to process (defense-in-depth alongside is_registered check). *)
   let entries = Keeper_registry.all ~base_path () in
   let to_restart = ref [] in
   let to_unregister = ref [] in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    match Eio.Promise.peek entry.done_p with
-    | None -> ()  (* Alive — skip *)
-    | Some `Stopped ->
-        to_unregister := entry :: !to_unregister
-    | Some (`Crashed msg) ->
-        if entry.restart_count >= max_restarts then begin
+    match entry.state with
+    | Keeper_registry.Dead ->
+        (* Phase 2: Dead tombstone TTL cleanup *)
+        if now -. entry.last_restart_ts > dead_ttl_sec then begin
           to_unregister := entry :: !to_unregister;
-          publish_lifecycle "dead" entry.name
-            (Printf.sprintf "restart budget exhausted (%d), last: %s"
-               max_restarts msg);
-          Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
-            entry.name max_restarts
-        end else begin
-          let delay = backoff_delay entry.restart_count in
-          if now -. entry.last_restart_ts >= delay then
-            to_restart := (entry, msg) :: !to_restart
+          (* Mark meta as paused so reconcile permanently excludes it *)
+          (match read_meta ctx.config entry.name with
+           | Ok (Some meta) ->
+               ignore (write_meta ctx.config { meta with paused = true })
+           | _ -> ())
         end
+    | _ ->
+      match Eio.Promise.peek entry.done_p with
+      | None -> ()  (* Alive — skip *)
+      | Some `Stopped ->
+          to_unregister := entry :: !to_unregister
+      | Some (`Crashed msg) ->
+          if entry.restart_count >= max_restarts then begin
+            (* Phase 2: Dead tombstone instead of unregister *)
+            Keeper_registry.set_state ~base_path entry.name
+              Keeper_registry.Dead;
+            publish_lifecycle "dead" entry.name
+              (Printf.sprintf "restart budget exhausted (%d), last: %s"
+                 max_restarts msg);
+            Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
+              entry.name max_restarts
+          end else begin
+            let delay = backoff_delay entry.restart_count in
+            if now -. entry.last_restart_ts >= delay then
+              to_restart := (entry, msg) :: !to_restart
+          end
   ) entries;
-  (* Clean up stopped/dead entries *)
+  (* Clean up stopped entries + expired Dead tombstones *)
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name
   ) !to_unregister;
-  (* Restart zombies *)
+  (* Phase 2: self-preservation gate before restart *)
+  let active_count =
+    List.length (List.filter (fun (e : Keeper_registry.registry_entry) ->
+      e.state = Keeper_registry.Running || e.state = Keeper_registry.Crashed
+    ) entries) in
+  let restart_list =
+    apply_self_preservation ~total_keepers:active_count !to_restart in
+  (* Restart crashed keepers *)
   List.iter (fun ((old_entry : Keeper_registry.registry_entry), crash_msg) ->
     match read_meta ctx.config old_entry.name with
     | Ok (Some meta) ->
         let attempt = old_entry.restart_count + 1 in
         let old_crash_log = old_entry.crash_log in
-        (* Re-register — fresh refs for the new fiber *)
         let reg =
           Keeper_registry.register ~base_path old_entry.name meta
         in
-        (* Carry over supervisor history from previous entry *)
         Keeper_registry.restore_supervisor_state ~base_path old_entry.name
           ~restart_count:attempt ~last_restart_ts:now
           ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
@@ -165,5 +268,6 @@ let sweep_and_recover (ctx : _ context) =
         Log.Keeper.error "%s: cannot read meta for restart, removing"
           old_entry.name;
         Keeper_registry.unregister ~base_path old_entry.name
-  ) !to_restart;
+  ) restart_list;
+  (* Phase 2: reconcile LAST — only orphaned durable keepers *)
   reconcile_keepalive_keepers ctx

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -147,15 +147,14 @@ let reconcile_keepalive_keepers (ctx : _ context) =
 (** Phase 2: self-preservation gate.
     Suppresses restarts when a dominant failure cohort exceeds the
     ratio threshold AND minimum candidate count. *)
-let self_preservation_ratio = 0.3
-let self_preservation_min_candidates = 2
-
 let apply_self_preservation ~total_keepers to_restart =
+  let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in
+  let sp_min = Env_config.KeeperSupervisor.self_preservation_min_candidates in
   let n_candidates = List.length to_restart in
   let n_total = max 1 total_keepers in
   let ratio = float_of_int n_candidates /. float_of_int n_total in
-  if ratio > self_preservation_ratio
-     && n_candidates >= self_preservation_min_candidates
+  if ratio > sp_ratio
+     && n_candidates >= sp_min
   then begin
     (* Group by failure reason prefix for cohort detection *)
     let cohorts = Hashtbl.create 4 in
@@ -171,7 +170,7 @@ let apply_self_preservation ~total_keepers to_restart =
         if List.length v > List.length best_v then (k, v) else (best_k, best_v)
       ) cohorts ("", [])
     in
-    if List.length dominant_entries >= self_preservation_min_candidates then begin
+    if List.length dominant_entries >= sp_min then begin
       Log.Keeper.warn
         "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s)"
         (List.length dominant_entries) n_total ratio dominant_key;
@@ -190,9 +189,6 @@ let apply_self_preservation ~total_keepers to_restart =
   end else
     to_restart
 
-(** Dead entry TTL: entries in Dead state older than this are cleaned up. *)
-let dead_ttl_sec = 3600.0
-
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Env_config.KeeperSupervisor.max_restarts in
@@ -207,7 +203,7 @@ let sweep_and_recover (ctx : _ context) =
     match entry.state with
     | Keeper_registry.Dead ->
         (* Phase 2: Dead tombstone TTL cleanup *)
-        if now -. entry.last_restart_ts > dead_ttl_sec then begin
+        if now -. entry.last_restart_ts > Env_config.KeeperSupervisor.dead_ttl_sec then begin
           to_unregister := entry :: !to_unregister;
           (* Mark meta as paused so reconcile permanently excludes it *)
           (match read_meta ctx.config entry.name with

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -211,8 +211,9 @@ let sweep_and_recover (ctx : _ context) =
                ignore (write_meta ctx.config { meta with paused = true })
            | _ -> ())
         end
-    | _ ->
-      match Eio.Promise.peek entry.done_p with
+    | Keeper_registry.Running | Keeper_registry.Paused
+    | Keeper_registry.Stopped | Keeper_registry.Crashed ->
+      (match Eio.Promise.peek entry.done_p with
       | None -> ()  (* Alive — skip *)
       | Some `Stopped ->
           to_unregister := entry :: !to_unregister
@@ -230,7 +231,7 @@ let sweep_and_recover (ctx : _ context) =
             let delay = backoff_delay entry.restart_count in
             if now -. entry.last_restart_ts >= delay then
               to_restart := (entry, msg) :: !to_restart
-          end
+          end)
   ) entries;
   (* Clean up stopped entries + expired Dead tombstones *)
   List.iter (fun (entry : Keeper_registry.registry_entry) ->

--- a/test/dune
+++ b/test/dune
@@ -1179,3 +1179,9 @@
  (name test_work_as_heartbeat)
  (modules test_work_as_heartbeat)
  (libraries masc_mcp masc_mcp.config alcotest unix))
+
+; Phase 2: Self-preservation, keeper_state extensions, failure_reason
+(test
+ (name test_phase2_self_preservation)
+ (modules test_phase2_self_preservation)
+ (libraries masc_mcp masc_mcp.config alcotest eio eio_main unix))

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -1,0 +1,162 @@
+(** Test suite for Phase 2: keeper_state extensions, failure_reason ADT,
+    is_registered, self-preservation config, and state transition invariants. *)
+
+open Alcotest
+
+module R = Masc_mcp.Keeper_registry
+module KT = Masc_mcp.Keeper_types
+module Cfg = Env_config
+
+let bp = "/tmp/test-phase2"
+
+let make_meta name =
+  let json = `Assoc [
+    ("name", `String name);
+    ("agent_name", `String ("agent-" ^ name));
+    ("trace_id", `String ("trace-test-" ^ name));
+    ("goal", `String "test goal");
+  ] in
+  match KT.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+let eio_test name fn =
+  test_case name `Quick (fun () -> Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env); fn ())
+
+(* ── keeper_state: Crashed + Dead ─────────────────────── *)
+
+let test_state_to_string_crashed () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Crashed;
+  match R.get ~base_path:bp "k1" with
+  | None -> fail "expected k1"
+  | Some e ->
+    check string "state is crashed" "crashed" (R.state_to_string e.state)
+
+let test_state_to_string_dead () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Dead;
+  match R.get ~base_path:bp "k1" with
+  | None -> fail "expected k1"
+  | Some e ->
+    check string "state is dead" "dead" (R.state_to_string e.state)
+
+let test_running_count_crashed () =
+  R.clear ();
+  let _e1 = R.register ~base_path:bp "a" (make_meta "a") in
+  let _e2 = R.register ~base_path:bp "b" (make_meta "b") in
+  check int "2 running" 2 (R.count_running ());
+  R.set_state ~base_path:bp "a" R.Crashed;
+  check int "1 running after crash" 1 (R.count_running ());
+  R.set_state ~base_path:bp "b" R.Dead;
+  check int "0 running after dead" 0 (R.count_running ())
+
+(* ── is_registered ────────────────────────────────────── *)
+
+let test_is_registered_running () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  check bool "running → registered" true (R.is_registered ~base_path:bp "k1")
+
+let test_is_registered_crashed () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Crashed;
+  check bool "crashed → still registered" true (R.is_registered ~base_path:bp "k1")
+
+let test_is_registered_dead () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Dead;
+  check bool "dead → still registered" true (R.is_registered ~base_path:bp "k1")
+
+let test_is_registered_unregistered () =
+  R.clear ();
+  check bool "absent → not registered" false (R.is_registered ~base_path:bp "k1")
+
+let test_is_registered_after_unregister () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.unregister ~base_path:bp "k1";
+  check bool "unregistered → not registered" false (R.is_registered ~base_path:bp "k1")
+
+(* ── failure_reason ADT ───────────────────────────────── *)
+
+let test_failure_reason_heartbeat () =
+  let s = R.failure_reason_to_string (R.Heartbeat_consecutive_failures 5) in
+  check string "heartbeat reason" "heartbeat_consecutive_failures(5)" s
+
+let test_failure_reason_fiber () =
+  let s = R.failure_reason_to_string R.Fiber_unresolved in
+  check string "fiber reason" "fiber_unresolved" s
+
+let test_failure_reason_exception () =
+  let s = R.failure_reason_to_string (R.Exception "Sys_error(disk full)") in
+  check string "exception reason" "exception(Sys_error(disk full))" s
+
+(* ── Config defaults ──────────────────────────────────── *)
+
+let test_self_preservation_ratio_default () =
+  let v = Cfg.KeeperSupervisor.self_preservation_ratio in
+  check (float 0.01) "default ratio 0.3" 0.3 v
+
+let test_self_preservation_min_candidates_default () =
+  let v = Cfg.KeeperSupervisor.self_preservation_min_candidates in
+  check int "default min candidates 2" 2 v
+
+let test_dead_ttl_default () =
+  let v = Cfg.KeeperSupervisor.dead_ttl_sec in
+  check (float 0.1) "default dead TTL 3600s" 3600.0 v
+
+let test_dead_ttl_floor () =
+  let v = Cfg.KeeperSupervisor.dead_ttl_sec in
+  check bool "dead TTL >= 60s" true (v >= 60.0)
+
+(* ── State transition: Running → Crashed → Running ───── *)
+
+let test_state_transition_running_crashed_running () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  check int "1 running" 1 (R.count_running ());
+  R.set_state ~base_path:bp "k1" R.Crashed;
+  check int "0 running" 0 (R.count_running ());
+  check bool "is_running false" false (R.is_running ~base_path:bp "k1");
+  check bool "is_registered true" true (R.is_registered ~base_path:bp "k1");
+  (* Simulate restart: re-register *)
+  let _e2 = R.register ~base_path:bp "k1" (make_meta "k1") in
+  check int "1 running again" 1 (R.count_running ())
+
+(* ── Test runner ──────────────────────────────────────── *)
+
+let () =
+  run "phase2_self_preservation" [
+    "keeper_state", [
+      eio_test "crashed state" test_state_to_string_crashed;
+      eio_test "dead state" test_state_to_string_dead;
+      eio_test "running count with crashed/dead" test_running_count_crashed;
+    ];
+    "is_registered", [
+      eio_test "running" test_is_registered_running;
+      eio_test "crashed" test_is_registered_crashed;
+      eio_test "dead" test_is_registered_dead;
+      eio_test "absent" test_is_registered_unregistered;
+      eio_test "after unregister" test_is_registered_after_unregister;
+    ];
+    "failure_reason", [
+      test_case "heartbeat" `Quick test_failure_reason_heartbeat;
+      test_case "fiber_unresolved" `Quick test_failure_reason_fiber;
+      test_case "exception" `Quick test_failure_reason_exception;
+    ];
+    "config", [
+      test_case "ratio default" `Quick test_self_preservation_ratio_default;
+      test_case "min candidates default" `Quick test_self_preservation_min_candidates_default;
+      test_case "dead TTL default" `Quick test_dead_ttl_default;
+      test_case "dead TTL floor" `Quick test_dead_ttl_floor;
+    ];
+    "state_transitions", [
+      eio_test "Running → Crashed → Running" test_state_transition_running_crashed_running;
+    ];
+  ]

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -129,6 +129,21 @@ let test_state_transition_running_crashed_running () =
   let _e2 = R.register ~base_path:bp "k1" (make_meta "k1") in
   check int "1 running again" 1 (R.count_running ())
 
+(* ── Dead is terminal: set_state Dead → Running is no-op ── *)
+
+let test_dead_to_running_blocked () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Dead;
+  check int "0 running" 0 (R.count_running ());
+  (* Attempt to transition Dead → Running via set_state *)
+  R.set_state ~base_path:bp "k1" R.Running;
+  match R.get ~base_path:bp "k1" with
+  | None -> fail "expected k1"
+  | Some e ->
+    check string "still dead" "dead" (R.state_to_string e.state);
+    check int "still 0 running" 0 (R.count_running ())
+
 (* ── Test runner ──────────────────────────────────────── *)
 
 let () =
@@ -158,5 +173,6 @@ let () =
     ];
     "state_transitions", [
       eio_test "Running → Crashed → Running" test_state_transition_running_crashed_running;
+      eio_test "Dead → Running blocked" test_dead_to_running_blocked;
     ];
   ]


### PR DESCRIPTION
## Summary

Implements [Heartbeat] Phase 2: Restart Resilience (#3643) from the Adaptive Heartbeat RFC (#3635).

### keeper_registry changes
- `keeper_state`: `Running | Paused | Stopped | Crashed | Dead`
- `failure_reason` ADT: `Heartbeat_consecutive_failures | Fiber_unresolved | Exception`
- `Keeper_heartbeat_failure` structured exception
- `is_registered`: true if any entry exists (state-independent)

### keeper_keepalive changes
- Self-stop (`Atomic.set stop true`) replaced with `raise Keeper_heartbeat_failure`

### keeper_supervisor changes
- `launch_supervised_fiber`: 3-tier structured catch (heartbeat failure, generic exception, fiber-unresolved)
- `reconcile`: `is_running` → `is_registered` (Crashed/Dead excluded from re-launch)
- `sweep_and_recover`: restart/unregister FIRST, reconcile LAST
- Dead tombstone: exhausted keepers stay in registry with `Dead` state
- Dead TTL cleanup: 3600s → unregister + meta `paused=true` for permanent exclusion
- Self-preservation gate: `ratio > 0.3 AND candidates >= 2 AND dominant cohort`

### Invariants
- `Crashed` entries: owned by backoff path, reconcile skips via `is_registered`
- `Dead` entries: permanent tombstone, reconcile skips, TTL cleanup after 1h
- `Stopped` → unregister → `is_registered = false` → reconcile can re-launch (normal)

Depends on: #3671 (Phase 1), #3659 (Phase 0)
Closes: #3643

## Test plan

- [x] keeper_registry: 34 tests pass (state transitions, Crashed/Dead variants)
- [x] keeper_supervisor: 9 tests pass (backoff, keep_last_n, fiber health)
- [x] work_as_heartbeat: 14 tests pass (Phase 1 config + freshness)
- [ ] CI checks
- [ ] Integration test: Crashed → backoff → restart → Dead flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>