### PR TITLE
fix(keeper): deduplicate user message in checkpoint

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -152,6 +152,10 @@ let run_turn
   in
   (* 6. Append user message and persist *)
   let user_msg = Agent_sdk.Types.user_msg user_message in
+  (* Capture history BEFORE appending the current user_msg.
+     OAS Agent.run appends user_msg from ~goal internally, so passing it
+     in initial_messages would cause duplication. *)
+  let history_messages = ctx_work.messages in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
   let checkpoint_sidecar =
@@ -196,7 +200,7 @@ let run_turn
       ~session_id:meta.trace_id
       ~system_prompt:turn_system_prompt
       ~tools
-      ~initial_messages:ctx_work.messages
+      ~initial_messages:history_messages
       ~hooks
       ~context_reducer:reducer
       ~memory


### PR DESCRIPTION
## Summary

- keeper checkpoint에 user message가 매 턴 2번씩 저장되는 버그 수정
- `keeper_agent_run`이 user_msg를 `ctx_work`에 append한 뒤 `initial_messages`로 전달
- OAS `Agent.run`이 `goal`에서 동일 메시지를 한 번 더 append → 중복
- fix: `initial_messages`에 history만 전달 (user_msg append 전 캡처)

## 근본 원인

```
keeper_agent_run.ml:155  ctx_work = append ctx_work user_msg
keeper_agent_run.ml:199  ~initial_messages:ctx_work.messages  ← user_msg 포함
agent.ml:67              messages = snoc (base_messages agent) user_msg  ← 또 추가
```

Closes #3684

## Test plan

- [x] `test_oas_worker.exe` — 32 tests pass
- [ ] E2E: checkpoint messages에 동일 user message 중복 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)