### PR TITLE
fix(keeper): unify checkpoint session_id to trace_id on save

### DIFF
--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -199,7 +199,7 @@ type https_connector =
   | Https_connector :
       (Uri.t ->
        [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
-       [> Eio.Flow.two_way_ty ] Eio.Resource.t)
+       [> Eio.Flow.two_way_ty | Eio.Resource.close_ty ] Eio.Resource.t)
       -> https_connector
 
 type eio_context = {

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -126,7 +126,7 @@ let build_https_connector_result () =
             (fun uri
                   (raw : [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t)
                 ->
-              let flow : [> Eio.Flow.two_way_ty ] Eio.Resource.t = (raw :> _) in
+              let flow : [> Eio.Flow.two_way_ty | Eio.Resource.close_ty ] Eio.Resource.t = (raw :> _) in
               let host =
                 match Uri.host uri with
                 | None -> None

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -221,6 +221,12 @@ let run_turn
     (match result.checkpoint with
      | Some checkpoint -> (
          try
+           (* Unify session_id to trace_id so load_oas can find this
+              checkpoint on the next turn. oas_worker generates a per-turn
+              session_id that differs from trace_id, causing a load miss. *)
+           let checkpoint =
+             { checkpoint with Agent_sdk.Checkpoint.session_id = meta.trace_id }
+           in
            Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
              checkpoint
          with

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -37,9 +37,9 @@ let make_closing_client ~sw ~net ~https =
         match https with
         | Some wrap ->
             (wrap uri sock
-              :> [ `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+              :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
         | None -> failwith "HTTPS requested but not enabled")
-    | _ -> (sock :> [ `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    | _ -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
   in
   let client = Cohttp_eio.Client.make_generic connect in
   Eio.Switch.on_release sw (fun () ->


### PR DESCRIPTION
## Summary
- keeper checkpoint 저장 시 session_id를 trace_id로 통일
- oas_worker가 턴별 고유 session_id를 생성하지만, load_oas는 trace_id로 조회하여 매 턴 빈 context에서 시작하는 버그 수정
- 23개 keeper 전부 영향, 37+ 턴 대화 이력 손실 원인

## Root Cause
```
저장: base_dir/trace_id/<oas_worker_generated_session_id>.json
로드: base_dir/trace_id/<trace_id>.json  ← 파일 없음
```

## Fix
`keeper_agent_run.ml`에서 save 직전에 `{ checkpoint with session_id = meta.trace_id }`로 덮어쓰기. OAS/checkpoint_store 내부 변경 없음.

## Test plan
- [ ] keeper 시작 → 2턴 대화 → checkpoint 파일명이 `<trace_id>.json`인지 확인
- [ ] 2턴째에서 이전 대화 내용을 기억하는지 확인
- [ ] 기존 빈 trace-*.json 파일 존재 시 정상 동작 확인

Related: #3626, #3627, #3630, jeong-sik/oas#467, jeong-sik/me#903

🤖 Generated with [Claude Code](https://claude.com/claude-code)