### PR TITLE
fix(gc): reap zombie agents on set_room and join

### DIFF
--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -213,6 +213,8 @@ let handle_set_room (ctx : context) : result option =
     else begin
       state.Mcp_server.room_config <- Room.default_config expanded |> Room.config_with_resolved_scope;
       let rc = state.Mcp_server.room_config in
+      (* GC: reap zombie agents when entering a room (uses newly resolved config) *)
+      let _gc = Room.cleanup_zombies rc in
       let status = if Room.is_initialized rc then "ok" else "(not initialized)" in
       let workspace_note =
         if rc.workspace_path <> rc.base_path then
@@ -231,6 +233,8 @@ let handle_join (ctx : context) : result option =
   let mcp_session_id = ctx.mcp_session_id in
   let caps = arg_get_string_list ctx "capabilities" in
   let result = Room.join config ~agent_name ~capabilities:caps () in
+  (* GC: reap zombie agents on join *)
+  let _gc = Room.cleanup_zombies config in
   (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
   let nickname =
     try

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -213,8 +213,11 @@ let handle_set_room (ctx : context) : result option =
     else begin
       state.Mcp_server.room_config <- Room.default_config expanded |> Room.config_with_resolved_scope;
       let rc = state.Mcp_server.room_config in
-      (* GC: reap zombie agents when entering a room (uses newly resolved config) *)
-      let _gc = Room.cleanup_zombies rc in
+      (* GC: reap zombie agents when entering a room (uses newly resolved config).
+         Best-effort: GC failure must not block set_room. *)
+      (try ignore (Room.cleanup_zombies rc)
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+         Log.Gc.warn "set_room GC failed: %s" (Printexc.to_string exn));
       let status = if Room.is_initialized rc then "ok" else "(not initialized)" in
       let workspace_note =
         if rc.workspace_path <> rc.base_path then
@@ -233,8 +236,10 @@ let handle_join (ctx : context) : result option =
   let mcp_session_id = ctx.mcp_session_id in
   let caps = arg_get_string_list ctx "capabilities" in
   let result = Room.join config ~agent_name ~capabilities:caps () in
-  (* GC: reap zombie agents on join *)
-  let _gc = Room.cleanup_zombies config in
+  (* GC: reap zombie agents on join. Best-effort. *)
+  (try ignore (Room.cleanup_zombies config)
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+     Log.Gc.warn "join GC failed: %s" (Printexc.to_string exn));
   (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
   let nickname =
     try


### PR DESCRIPTION
## Summary

- `set_room`/`join` 시 `Room.cleanup_zombies` 1회 자동 호출
- set_room: 새로 resolve된 config 사용 (RFC 주의사항 준수)
- join: Room.join 직후 호출
- 기존 zombie는 명시적 `masc_cleanup_zombies` 또는 orchestrator sweep으로만 제거됐음

RFC Phase 3 구현. Ref #3626.

## Test plan

- [x] `test_oas_worker.exe` — 34 tests pass
- [x] 빌드 성공
- [ ] E2E: set_room 후 stale agent 파일 자동 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)