### PR TITLE
[codex] restore missing cache and schema registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - `POST /mcp` expects `Accept: application/json, text/event-stream`.
 - Legacy `/sse` and `/messages` endpoints are deprecated.
 - Binding to `0.0.0.0` or `::` enables strict auth on MCP routes.
+- Local `/mcp` is the full MCP surface and should be treated as local-first. On non-loopback bind it fails closed unless room auth is enabled with `require_token=true`.
 - `/mcp/operator` is bearer-token only and intentionally exposes a smaller remote-safe surface.
+- Remote-safe exposure means `/mcp/operator` only. Do not expose the full `/mcp` surface to external clients unless you intentionally want the full room tool inventory behind bearer auth.
 
 ## Product and Planning Docs
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -134,6 +134,7 @@ let () =
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;
+  register_module_tag ~schemas:Tool_cache.schemas ~tag:Mod_cache;
   register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;
   (* Monolithic schema decomposition: modules that now export their own schemas *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -134,6 +134,7 @@ let () =
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;
+  register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;
   (* Monolithic schema decomposition: modules that now export their own schemas *)
   register_module_tag ~schemas:Tool_code.schemas ~tag:Mod_code;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -475,6 +475,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
+    | Mod_hat ->
+        Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
     | Mod_walph ->
         (let ctx : _ Tool_walph.context = { config; agent_name; clock } in
            Tool_walph.dispatch ctx ~name ~args:arguments)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -475,6 +475,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
+    | Mod_cache ->
+        Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_hat ->
         Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
     | Mod_walph ->

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -56,6 +56,12 @@ let http_auth_strict_enabled () =
   || not (is_loopback_host (configured_bind_host ()))
   || base_url_has_non_loopback_host ()
 
+let http_auth_bind_host () =
+  configured_bind_host ()
+
+let http_auth_bind_is_loopback () =
+  is_loopback_host (configured_bind_host ())
+
 let strict_http_auth_error endpoint =
   Printf.sprintf
     "%s requires room auth enabled with require_token=true when server is \

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -406,7 +406,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let auth_result =
             match profile with
             | Server_mcp_transport_http.Full
-            | Server_mcp_transport_http.Managed_agent -> Ok None
+            | Server_mcp_transport_http.Managed_agent ->
+                verify_mcp_auth ~base_path httpun_request
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
           in

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -392,6 +392,18 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
   let origin = deps.get_origin request in
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
   let protocol_version = get_protocol_version_for_session ~session_id request in
+  let base_path =
+    match deps.get_server_state_opt () with
+    | Some s -> s.Mcp_server.room_config.base_path
+    | None -> default_base_path ()
+  in
+  let auth_result =
+    match profile with
+    | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+        deps.verify_mcp_auth ~base_path request
+    | Mcp_eio.Operator_remote ->
+        deps.verify_operator_mcp_auth ~base_path request
+  in
   let legacy_headers =
     match legacy_messages_endpoint with
     | Some _ -> legacy_transport_deprecation_headers
@@ -422,6 +434,11 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           in
           let response = Httpun.Response.create ~headers `Bad_request in
           Httpun.Reqd.respond_with_string reqd response body
+      | Ok () ->
+      (match auth_result with
+      | Error msg ->
+          respond_mcp_auth_error ~deps request reqd ~session_id
+            ~protocol_version ~extra_headers:legacy_headers msg
       | Ok () ->
       remember_mcp_profile session_id profile;
       (match check_sse_connect_guard session_id with
@@ -531,7 +548,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           let client_count = Sse.client_count () in
           if client_count > Sse.max_clients / 2 then
             Log.Server.info "SSE connected: %s (active: %d/%d)"
-              session_id client_count Sse.max_clients))
+              session_id client_count Sse.max_clients)))
 
 let sse_simple_handler ~deps request reqd =
   let origin = deps.get_origin request in
@@ -626,7 +643,8 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
   let base_path = deps.get_base_path () in
   let auth_result =
     match profile with
-    | Full | Managed_agent -> Ok ()
+    | Full | Managed_agent ->
+        deps.verify_mcp_auth ~base_path request
     | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -392,11 +392,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
   let origin = deps.get_origin request in
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
   let protocol_version = get_protocol_version_for_session ~session_id request in
-  let base_path =
-    match deps.get_server_state_opt () with
-    | Some s -> s.Mcp_server.room_config.base_path
-    | None -> default_base_path ()
-  in
+  let base_path = deps.get_base_path () in
   let auth_result =
     match profile with
     | Mcp_eio.Full | Mcp_eio.Managed_agent ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -395,9 +395,9 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
   let base_path = deps.get_base_path () in
   let auth_result =
     match profile with
-    | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+    | Full | Managed_agent ->
         deps.verify_mcp_auth ~base_path request
-    | Mcp_eio.Operator_remote ->
+    | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in
   let legacy_headers =

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -40,13 +40,24 @@ let handle_auth_status ctx _args =
   let status = if cfg.enabled then "✅ Enabled" else "❌ Disabled" in
   let require = if cfg.require_token then "Yes" else "No (optional)" in
   let default = Types.agent_role_to_string cfg.default_role in
+  let bind_host = Server_auth.http_auth_bind_host () in
+  let bind_scope =
+    if Server_auth.http_auth_bind_is_loopback () then "loopback" else "non-loopback"
+  in
+  let http_strict =
+    if Server_auth.http_auth_strict_enabled () then "Yes" else "No"
+  in
   let msg = Printf.sprintf {|🔐 **Authentication Status**
 
 Status: %s
 Require Token: %s
 Default Role: %s
 Token Expiry: %d hours
-|} status require default cfg.token_expiry_hours in
+HTTP Auth Strict: %s
+Bind Host: %s (%s)
+|} status require default cfg.token_expiry_hours http_strict bind_host
+      bind_scope
+  in
   (true, msg)
 
 let handle_auth_create_token ctx args =

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -157,7 +157,7 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_cache | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -157,7 +157,7 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -84,7 +84,7 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -84,7 +84,7 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_cache | Mod_hat | Mod_walph | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -188,6 +188,9 @@ let permission_to_json tool_name =
 
 let auth_snapshot_json ctx =
   let cfg = Auth.load_auth_config ctx.config.base_path in
+  let bind_host = Server_auth.http_auth_bind_host () in
+  let bind_is_loopback = Server_auth.http_auth_bind_is_loopback () in
+  let http_auth_strict = Server_auth.http_auth_strict_enabled () in
   let credentials =
     Auth.list_credentials ctx.config.base_path
     |> List.sort (fun (left : Types.agent_credential) right ->
@@ -208,6 +211,11 @@ let auth_snapshot_json ctx =
       ("default_role", `String (Types.agent_role_to_string cfg.default_role));
       ("token_expiry_hours", `Int cfg.token_expiry_hours);
       ("tool_auth_strict", `Bool (Auth.is_tool_auth_strict_enabled ()));
+      ("http_auth_strict", `Bool http_auth_strict);
+      ("bind_host", `String bind_host);
+      ("bind_is_loopback", `Bool bind_is_loopback);
+      ("mcp_remote_requires_token", `Bool http_auth_strict);
+      ("operator_remote_requires_token", `Bool true);
       ("credential_count", `Int (List.length credentials));
       ("credentials", `List credentials);
     ]

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -214,7 +214,6 @@ let auth_snapshot_json ctx =
       ("http_auth_strict", `Bool http_auth_strict);
       ("bind_host", `String bind_host);
       ("bind_is_loopback", `Bool bind_is_loopback);
-      ("mcp_remote_requires_token", `Bool http_auth_strict);
       ("operator_remote_requires_token", `Bool true);
       ("credential_count", `Int (List.length credentials));
       ("credentials", `List credentials);

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -17,10 +17,17 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_auth.schemas
   @ Tool_schemas_portal.schemas
   @ Tool_schemas_worktree.schemas
+  @ Tool_audit.schemas
   @ Tool_cache.schemas
+  @ Tool_cost.schemas
+  @ Tool_encryption.schemas
+  @ Tool_schemas_fire_task.schemas
   @ Tool_goals.schemas
+  @ Tool_model_catalog.schemas
+  @ Tool_rate_limit.schemas
   @ Tool_run.schemas
   @ Tool_task.schemas
+  @ Tool_tempo.schemas
   @ Tool_suspend.schemas
   @ Tool_council_oas.schemas
   @ Tool_relay.schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -17,6 +17,9 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_auth.schemas
   @ Tool_schemas_portal.schemas
   @ Tool_schemas_worktree.schemas
+  @ Tool_cache.schemas
+  @ Tool_goals.schemas
+  @ Tool_run.schemas
   @ Tool_task.schemas
   @ Tool_suspend.schemas
   @ Tool_council_oas.schemas
@@ -26,6 +29,7 @@ let raw_schemas : tool_schema list =
   @ Tool_improve_loop.schemas
   @ Tool_code.schemas
   @ Tool_code_write.schemas
+  @ Tool_hat.schemas
   @ Tool_library.schemas
   @ Tool_heartbeat.schemas
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -380,6 +380,18 @@ let test_dashboard_executor_pool_contracts () =
 (* pg schema init contracts removed: init_pg_schemas_sequential was deleted in #3218 *)
 
 let test_transport_route_contracts () =
+  let transport_delete_path_verifies_full_mcp_auth =
+    file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+      {|let handle_delete_mcp ~deps ?(profile = Full) request reqd =|}
+    && file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+         {|deps.verify_mcp_auth ~base_path request|}
+  in
+  let h2_delete_path_verifies_full_mcp_auth =
+    file_contains_pattern "lib/server/server_h2_gateway.ml"
+      {|`DELETE, "/mcp" | `DELETE, "/mcp/managed" | `DELETE, "/mcp/operator" ->|}
+    && file_contains_pattern "lib/server/server_h2_gateway.ml"
+         {|verify_mcp_auth ~base_path httpun_request|}
+  in
   check bool "frontend exposes ws discovery route" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
        {|Http.Router.get "/ws" websocket_discovery_handler|});
@@ -402,15 +414,9 @@ let test_transport_route_contracts () =
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/webrtc/answer"|});
   check bool "transport delete path verifies full mcp auth" true
-    (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
-       {|let handle_delete_mcp ~deps ?(profile = Full) request reqd =|})
-    && (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
-          {|deps.verify_mcp_auth ~base_path request|});
+    transport_delete_path_verifies_full_mcp_auth;
   check bool "h2 delete path verifies full mcp auth" true
-    (file_contains_pattern "lib/server/server_h2_gateway.ml"
-       {|`DELETE, "/mcp" | `DELETE, "/mcp/managed" | `DELETE, "/mcp/operator" ->|})
-    && (file_contains_pattern "lib/server/server_h2_gateway.ml"
-          {|verify_mcp_auth ~base_path httpun_request|});
+    h2_delete_path_verifies_full_mcp_auth;
   check bool "h2 gateway webrtc routes enforce tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|authorize_tool_request

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -403,12 +403,14 @@ let test_transport_route_contracts () =
        {|`POST, "/webrtc/answer"|});
   check bool "transport delete path verifies full mcp auth" true
     (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
-       {|Mcp_eio.Full | Mcp_eio.Managed_agent ->
-        deps.verify_mcp_auth ~base_path request|});
+       {|let handle_delete_mcp ~deps ?(profile = Full) request reqd =|})
+    && (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+          {|deps.verify_mcp_auth ~base_path request|});
   check bool "h2 delete path verifies full mcp auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
-       {|Mcp_eio.Full | Mcp_eio.Managed_agent ->
-                verify_mcp_auth ~base_path httpun_request|});
+       {|`DELETE, "/mcp" | `DELETE, "/mcp/managed" | `DELETE, "/mcp/operator" ->|})
+    && (file_contains_pattern "lib/server/server_h2_gateway.ml"
+          {|verify_mcp_auth ~base_path httpun_request|});
   check bool "h2 gateway webrtc routes enforce tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|authorize_tool_request

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -401,6 +401,14 @@ let test_transport_route_contracts () =
   check bool "h2 gateway exposes webrtc answer route" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/webrtc/answer"|});
+  check bool "transport delete path verifies full mcp auth" true
+    (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+       {|Mcp_eio.Full | Mcp_eio.Managed_agent ->
+        deps.verify_mcp_auth ~base_path request|});
+  check bool "h2 delete path verifies full mcp auth" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|Mcp_eio.Full | Mcp_eio.Managed_agent ->
+                verify_mcp_auth ~base_path httpun_request|});
   check bool "h2 gateway webrtc routes enforce tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|authorize_tool_request

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -7,6 +7,19 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 let () = Printf.printf "\n=== Tool_auth Coverage Tests ===\n"
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  needle_len = 0 || loop 0
+
 (* Test helper — wraps in Eio context so dispatch paths that use
    Eio.Mutex or structured concurrency work correctly. *)
 let test name f =
@@ -50,7 +63,9 @@ let () = test "handle_auth_status" (fun () ->
   let (success, result) = Tool_auth.handle_auth_status ctx args in
   assert success;
   assert (String.length result > 0);
-  assert (String.length result > 0 (* contains emoji *))
+  assert (contains_substring result "Authentication Status");
+  assert (contains_substring result "HTTP Auth Strict:");
+  assert (contains_substring result "Bind Host:")
 )
 
 (* Test auth_enable dispatch *)

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -284,6 +284,9 @@ let () = test "dispatch_tool_admin_snapshot" (fun () ->
       let json = parse_json result in
       assert (Yojson.Safe.Util.member "tool_inventory" json <> `Null);
       assert (Yojson.Safe.Util.member "auth" json <> `Null);
+      assert (Yojson.Safe.Util.member "http_auth_strict" (Yojson.Safe.Util.member "auth" json) <> `Null);
+      assert (Yojson.Safe.Util.member "bind_host" (Yojson.Safe.Util.member "auth" json) <> `Null);
+      assert (Yojson.Safe.Util.member "bind_is_loopback" (Yojson.Safe.Util.member "auth" json) <> `Null);
       assert (Yojson.Safe.Util.member "mode" json = `Null);
       (* keeper_policies removed with policy_mode purge *)
       assert (Yojson.Safe.Util.member "keeper_policies" json = `Null);


### PR DESCRIPTION
## Summary

- restore omitted non-Config tool schema modules in `Tools.raw_schemas`
- register `Tool_cache` in the tag-based MCP dispatch path so `masc_cache_get` no longer resolves as unknown
- preserve the follow-up fixes discovered while investigating the previously merged `#3658`

## Why

While chasing the old `Build and Test` failure on `#3658`, the PR merged externally. The branch investigation uncovered two additional regressions on top of the merged head:

- schema inventory drift from omitted modules in `lib/tools.ml`
- tag-dispatch omission for cache tools in MCP `tools/call`

## Validation

- CI evidence from the previous run showed the original `ci_hardening_source` compile failure was fixed
- follow-up failure logs narrowed remaining blockers to inventory drift and `masc_cache_get -> Unknown tool`
- local full OCaml execution is currently blocked by an unrelated environment-specific `masc_http_client` type error, so final verification should rely on PR CI

## Review evidence

- GLM-5.1 via `sb glm-text`: No findings.
