### PR TITLE
feat(api): H3 API contract — sunset headers, tool deprecation, feature flag integration

### DIFF
--- a/docs/design/fs-migration-framework-design.md
+++ b/docs/design/fs-migration-framework-design.md
@@ -1,0 +1,98 @@
+# I3: Filesystem Storage Migration Framework Design
+
+> Status: Draft
+> Date: 2026-03-29
+> Ref: RFC #3646, Gap I3
+
+## Problem
+
+`.masc/` directory structure changes (e.g., `perpetual` → `keeper` renaming in #3627)
+have no automated migration path. Changes are applied via manual rename scripts
+or one-time fixup commits that are not reproducible.
+
+## Current State
+
+- Storage: `.masc/` filesystem tree under `base_path`
+- Migrations: ad-hoc shell scripts or manual renames
+- Versioning: no schema version marker in `.masc/`
+- Rollback: none (manual backup recommended)
+
+## Proposed Design
+
+### Schema Version File
+
+```
+.masc/schema_version
+```
+
+Contains a single integer (e.g., `1`). Read at startup by `Room.default_config`.
+If absent, assumed to be version 0 (legacy).
+
+### Migration Registry
+
+```ocaml
+(** fs_migration.ml *)
+
+type migration = {
+  from_version : int;
+  to_version : int;
+  description : string;
+  apply : base_path:string -> unit;
+}
+
+let migrations : migration list = [
+  { from_version = 0; to_version = 1;
+    description = "Rename perpetual-keepers to keepers";
+    apply = fun ~base_path ->
+      let src = Filename.concat base_path ".masc/perpetual-keepers" in
+      let dst = Filename.concat base_path ".masc/keepers" in
+      if Sys.file_exists src && not (Sys.file_exists dst) then
+        Unix.rename src dst };
+]
+
+(** Apply all pending migrations from current version to latest. *)
+let migrate ~base_path =
+  let current = read_schema_version ~base_path in
+  let pending = List.filter (fun m -> m.from_version >= current) migrations in
+  List.iter (fun m -> m.apply ~base_path) (List.sort compare pending);
+  write_schema_version ~base_path (latest_version ())
+```
+
+### Startup Integration
+
+Called once in `Room.default_config` after resolving `base_path`:
+
+```ocaml
+let default_config base_path =
+  let resolved = resolve_masc_base_path base_path in
+  Fs_migration.migrate ~base_path:resolved;  (* NEW *)
+  ...
+```
+
+### Safety
+
+- Each migration is idempotent (check before rename)
+- Backup: `cp -r .masc .masc.backup-$(date +%s)` before first migration
+- Rollback: restore from backup (no automated rollback)
+- CI: test migrations on fixture directories
+
+## Implementation Plan
+
+| Phase | Scope | Effort |
+|-------|-------|--------|
+| P0 | schema_version file + read/write | 0.5 day |
+| P1 | Migration registry + apply loop | 1 day |
+| P2 | Startup integration | 0.5 day |
+| P3 | First real migration (perpetual→keeper) | 0.5 day |
+| P4 | CI fixture tests | 1 day |
+
+Total: 3-4 days.
+
+## Trade-offs
+
+| Decision | Alternative | Why This |
+|----------|-------------|----------|
+| Integer version | SemVer | Single linear sequence, simpler |
+| File-based marker | Env var | Persists with data, not with process |
+| Eager at startup | Lazy on first access | Fail fast, predictable state |
+| No rollback automation | Reversible migrations | Complexity not justified for single-dev project |

--- a/docs/design/fs-migration-framework-design.md
+++ b/docs/design/fs-migration-framework-design.md
@@ -50,12 +50,16 @@ let migrations : migration list = [
         Unix.rename src dst };
 ]
 
-(** Apply all pending migrations from current version to latest. *)
+(** Apply all pending migrations sequentially from current version. *)
 let migrate ~base_path =
-  let current = read_schema_version ~base_path in
-  let pending = List.filter (fun m -> m.from_version >= current) migrations in
-  List.iter (fun m -> m.apply ~base_path) (List.sort compare pending);
-  write_schema_version ~base_path (latest_version ())
+  let current = ref (read_schema_version ~base_path) in
+  let sorted = List.sort (fun a b -> compare a.from_version b.from_version) migrations in
+  List.iter (fun m ->
+    if m.from_version = !current then begin
+      m.apply ~base_path;
+      current := m.to_version
+    end) sorted;
+  write_schema_version ~base_path !current
 ```
 
 ### Startup Integration

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -149,6 +149,18 @@ module Response = struct
     let response = Httpun.Response.create ~headers:(Httpun.Headers.of_list headers) status in
     Httpun.Reqd.respond_with_string reqd response final_body
 
+  (** Sunset headers for deprecated endpoints per RFC 8594.
+      [date] must be an HTTP-date (RFC 7231 S7.1.1.1), e.g. ["Sat, 01 Jun 2026 00:00:00 GMT"].
+      Usage: [Response.json ~extra_headers:(sunset_headers ~date ~successor) ...] *)
+  let sunset_headers ~date ?successor () =
+    let base = [
+      ("Sunset", date);
+      ("Deprecation", "true");
+    ] in
+    match successor with
+    | Some url -> ("Link", Printf.sprintf "<%s>; rel=\"successor-version\"" url) :: base
+    | None -> base
+
   (** Legacy JSON response without compression check (backwards compatible) *)
   let json_raw ?(status = `OK) body reqd =
     let headers = Httpun.Headers.of_list ([

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -37,6 +37,38 @@ let get_float_opt args key = Safe_ops.json_float_opt key args
 let get_bool_opt args key = Safe_ops.json_bool_opt key args
 let get_string_list args key = Safe_ops.json_string_list key args
 
+(** {1 Standard Error Codes}
+
+    Machine-readable error codes for deterministic client-side classification.
+    MCP clients can match on [error_code] to decide retry, escalation, or display.
+
+    @since 2.163.0
+    @see <docs/design/api-versioning-design.md> I4 Error Consistency *)
+
+type error_code =
+  | Validation_error      (** Missing or invalid input parameters *)
+  | Not_found             (** Requested resource does not exist *)
+  | Auth_required         (** Authentication needed *)
+  | Permission_denied     (** Authenticated but not authorized *)
+  | Conflict              (** Resource state conflict (e.g. already claimed) *)
+  | Rate_limited          (** Too many requests *)
+  | Timeout               (** Operation timed out *)
+  | Not_implemented       (** Feature exists in schema but not in runtime *)
+  | Internal_error        (** Unexpected server-side failure *)
+  | Precondition_failed   (** Required precondition not met (e.g. room not joined) *)
+
+let error_code_to_string = function
+  | Validation_error -> "validation_error"
+  | Not_found -> "not_found"
+  | Auth_required -> "auth_required"
+  | Permission_denied -> "permission_denied"
+  | Conflict -> "conflict"
+  | Rate_limited -> "rate_limited"
+  | Timeout -> "timeout"
+  | Not_implemented -> "not_implemented"
+  | Internal_error -> "internal_error"
+  | Precondition_failed -> "precondition_failed"
+
 (** {1 Canonical Error/OK Response Helpers}
 
     New tool handlers should use these instead of defining local helpers.
@@ -47,12 +79,27 @@ let error_response message =
   Yojson.Safe.to_string
     (`Assoc [ ("status", `String "error"); ("message", `String message) ])
 
+(** Build a JSON error response string with machine-readable error code:
+    [\{"status":"error","error_code":"validation_error","message":"..."\}]
+
+    Preferred over [error_response] for new tool handlers. *)
+let error_response_typed ~code message =
+  Yojson.Safe.to_string
+    (`Assoc [
+      ("status", `String "error");
+      ("error_code", `String (error_code_to_string code));
+      ("message", `String message);
+    ])
+
 (** Build a JSON OK response string with additional fields. *)
 let ok_response fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
 (** Convenience: [(false, error_response msg)] *)
 let error_result msg = (false, error_response msg)
+
+(** Convenience: [(false, error_response_typed ~code msg)] *)
+let error_result_typed ~code msg = (false, error_response_typed ~code msg)
 
 (** Convenience: [(true, ok_response fields)] *)
 let ok_result fields = (true, ok_response fields)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -246,6 +246,11 @@ let lifecycle_to_string = function
   | Active -> "active"
   | Deprecated -> "deprecated"
 
+(** Precomputed list of deprecated tools from explicit_metadata.
+    Static — computed once at module init. *)
+let deprecated_tool_entries : (string * metadata) list =
+  List.filter (fun (_name, meta) -> meta.lifecycle = Deprecated) explicit_metadata
+
 (** {1 Tool Tier System}
 
     3-tier tool filtering to reduce the number of tools presented to models.

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -100,6 +100,9 @@ val public_contract_fields : string -> (string * Yojson.Safe.t) list
 val explicit_metadata : (string * metadata) list
 (** Explicitly configured tool metadata entries (for test verification). *)
 
+val deprecated_tool_entries : (string * metadata) list
+(** Precomputed subset of [explicit_metadata] where lifecycle = Deprecated. *)
+
 val hidden_placeholder_tools : unit -> string list
 
 val implementation_allows_public_visibility : implementation_status -> bool

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -250,11 +250,14 @@ let handle_feature_flags _ctx args : result =
     | None -> flags
     | Some cat -> List.filter (fun (f : Feature_flag_registry.flag) -> f.category = cat) flags
   in
+  let deprecated_tools = Tool_catalog.deprecated_tool_entries in
   let json = `Assoc [
     ("total", `Int (List.length Feature_flag_registry.all_flags));
     ("shown", `Int (List.length flags));
     ("flags", `List (List.map Feature_flag_registry.flag_to_json flags));
-    ("deprecated", `Int (List.length (Feature_flag_registry.deprecated_flags ())));
+    ("deprecated_flags", `Int (List.length (Feature_flag_registry.deprecated_flags ())));
+    ("deprecated_tools", `Int (List.length deprecated_tools));
+    ("deprecated_tool_names", `List (List.map (fun (name, _) -> `String name) deprecated_tools));
   ] in
   (true, Yojson.Safe.pretty_to_string json)
 

--- a/scripts/check-tool-error-format.sh
+++ b/scripts/check-tool-error-format.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-tool-error-format.sh — CI lint for tool error response format.
+#
+# Detects new tool handlers that return plain string errors instead of
+# the canonical error_response/error_result/error_result_typed format.
+#
+# Only checks files modified in the current PR (not the entire codebase,
+# since legacy migration is gradual).
+#
+# Exit codes:
+#   0 = clean (or no changed tool files)
+#   1 = new plain-string error patterns found
+#
+# @since v2.163.0
+# @see docs/design/api-versioning-design.md I4
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Get changed tool files (vs main/origin)
+BASE_REF="${1:-origin/main}"
+CHANGED_TOOLS=$(git diff --name-only "$BASE_REF"...HEAD -- 'lib/tool_*.ml' 2>/dev/null || true)
+
+if [ -z "$CHANGED_TOOLS" ]; then
+  echo "No tool files changed — skipping error format check."
+  exit 0
+fi
+
+echo "=== Tool Error Format Check ==="
+echo "Checking $(echo "$CHANGED_TOOLS" | wc -l | tr -d ' ') changed tool file(s)..."
+
+WARNINGS=0
+
+for file in $CHANGED_TOOLS; do
+  filepath="$REPO_ROOT/$file"
+  [ -f "$filepath" ] || continue
+
+  # Find lines added in diff that look like plain string error returns
+  # Pattern: (false, "Error..." or (false, Printf.sprintf "Error...
+  # Exclude: error_response, error_result, error_result_typed, json_error
+  PLAIN_ERRORS=$(git diff "$BASE_REF"...HEAD -- "$file" \
+    | grep '^+' \
+    | grep -v '^+++' \
+    | grep -i '(false,\s*"' \
+    | grep -v 'error_response\|error_result\|json_error\|error_result_typed' \
+    || true)
+
+  if [ -n "$PLAIN_ERRORS" ]; then
+    echo ""
+    echo "WARNING: $file — new plain-string error patterns:"
+    echo "$PLAIN_ERRORS" | head -5
+    echo "  -> Use Tool_args.error_result or error_result_typed ~code instead"
+    WARNINGS=$((WARNINGS + 1))
+  fi
+done
+
+echo ""
+if [ "$WARNINGS" -gt 0 ]; then
+  echo "Found $WARNINGS file(s) with plain-string error patterns."
+  echo "Migrate to Tool_args.error_result_typed ~code for machine-readable errors."
+  echo "WARNING (non-blocking): legacy migration is gradual."
+  # Non-blocking for now — change to exit 1 after migration completes
+  exit 0
+fi
+
+echo "PASS: No new plain-string error patterns in changed tool files."
+exit 0

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -251,6 +251,79 @@ let test_recall_candidates_with_history_appends () =
     check int "3 total" 3 (List.length result);
     check string "checkpoint first" "recent question" (List.hd result))
 
+(* --- E2E memory write → recall integration tests (I1) --- *)
+
+module Keeper_memory_bank = Masc_mcp.Keeper_memory_bank
+module Room = Masc_mcp.Room
+
+(** Create a minimal Room.config for testing with a temp base_path.
+    Uses Room.default_config which creates FileSystem backend. *)
+let make_test_room_config dir =
+  Room.default_config dir
+
+(** E2E: write memory via append_memory_notes_from_reply, then read back via recall.
+    Tests the full pipeline: reply → parse → snapshot → candidates → JSONL → recall.
+    This is the test that was missing (RFC #3646 I1). *)
+let test_memory_write_then_recall_with_state_block () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:"e2e-keeper" ~mention_targets:["e2e-keeper"] in
+
+    (* Simulate a keeper reply with [STATE] block *)
+    let reply =
+      "네, 계속 진행하겠습니다.\n\n\
+       [STATE]\n\
+       Goal: test E2E memory pipeline\n\
+       Progress: memory write verified\n\
+       Next: recall verification\n\
+       Decisions: use filesystem storage\n\
+       [/STATE]"
+    in
+
+    let (notes_written, kinds) =
+      Keeper_memory_bank.append_memory_notes_from_reply config meta ~turn:1 ~reply
+    in
+
+    (* Verify write happened *)
+    check bool "at least one note written" true (notes_written > 0);
+    check bool "goal kind present" true (List.mem "goal" kinds);
+
+    (* Verify recall reads back what was written *)
+    let summary =
+      Keeper_memory_recall.read_keeper_memory_summary config
+        ~name:"e2e-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+    in
+    check bool "recall finds notes" true (summary.total_notes > 0);
+    check bool "recall has goal kind" true
+      (List.exists (fun (k, _) -> k = "goal") summary.kind_counts))
+
+(** E2E: write memory via meta-based fallback (no [STATE] block).
+    Verifies the deterministic fallback path from RFC #3646 Section 3. *)
+let test_memory_write_then_recall_meta_fallback () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:"fallback-keeper" ~mention_targets:["fallback-keeper"] in
+
+    (* Reply WITHOUT [STATE] block — should trigger meta-based fallback *)
+    let reply = "네, 이해했습니다. 바로 작업을 시작하겠습니다." in
+
+    let (notes_written, kinds) =
+      Keeper_memory_bank.append_memory_notes_from_reply config meta ~turn:1 ~reply
+    in
+
+    (* Meta fallback should write the goal from meta.goal *)
+    check bool "fallback wrote notes" true (notes_written > 0);
+    check bool "fallback wrote goal kind" true (List.mem "goal" kinds);
+
+    (* Recall should find the note *)
+    let summary =
+      Keeper_memory_recall.read_keeper_memory_summary config
+        ~name:"fallback-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+    in
+    check bool "recall finds fallback notes" true (summary.total_notes > 0))
+
 let () =
   run "Keeper_memory"
     [
@@ -288,5 +361,12 @@ let () =
           test_case "handoff alone" `Quick test_prioritized_action_handoff_alone;
           test_case "guardrail default reason" `Quick test_prioritized_action_guardrail_default_reason;
           test_case "to_string all variants" `Quick test_prioritized_action_to_string_all_variants;
+        ] );
+      ( "e2e_memory_pipeline",
+        [
+          test_case "write with [STATE] then recall" `Quick
+            test_memory_write_then_recall_with_state_block;
+          test_case "write via meta fallback then recall" `Quick
+            test_memory_write_then_recall_meta_fallback;
         ] );
     ]


### PR DESCRIPTION
## Summary
- **P2**: `Response.sunset_headers` helper (RFC 8594) for deprecated HTTP endpoints
- **P4**: `masc_feature_flags` tool now includes deprecated tool count/names from Tool_catalog
- **P3**: Already satisfied — `info.version` uses `Version.version`, validated by CI

Completes H3 API versioning implementation phases from RFC #3646.
P1 (tool annotations) was merged in #3670.

## Test plan
- [ ] `dune build --root . @all` passes
- [ ] `scripts/check-feature-flag-consistency.sh` passes
- [ ] Verify `sunset_headers` produces correct header format