### PR TITLE
refactor(naming): rename perpetual dirs to traces/keepers

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -106,7 +106,7 @@ type event = {
   content: string;
 }
 
-(** Keeper metadata parsed from perpetual-keepers/*.json *)
+(** Keeper metadata parsed from keepers/*.json *)
 type keeper = {
   k_name: string;
   k_goal: string;
@@ -561,7 +561,7 @@ let render_keeper_list (state : state) =
   in
 
   if visible_count = 0 then begin
-    Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/perpetual-keepers/)%s %s%s%s%s\n"
+    Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/keepers/)%s %s%s%s%s\n"
       Ansi.gray Ansi.box_v Ansi.reset
       Ansi.dim Ansi.reset
       (String.make (max 0 (cols - 50)) ' ')
@@ -987,9 +987,9 @@ let render (state : state) =
   | Keeper_logs -> render_keeper_logs state
   | Keeper_message -> render_keeper_message state
 
-(** Load keepers from .masc/perpetual-keepers/ *)
+(** Load keepers from .masc/keepers/ *)
 let load_keepers (base_path : string) : keeper list =
-  let keepers_dir = Filename.concat (Filename.concat base_path ".masc") "perpetual-keepers" in
+  let keepers_dir = Filename.concat (Filename.concat base_path ".masc") "keepers" in
   if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
     Sys.readdir keepers_dir
     |> Array.to_list
@@ -1100,7 +1100,7 @@ let find_metrics_files (base_path : string) (keeper_name : string) : string list
   let metrics_dir = Filename.concat
     (Filename.concat
        (Filename.concat base_path ".masc")
-       "perpetual-keepers")
+       "keepers")
     (Filename.concat keeper_name "metrics") in
   if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
   else begin

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -266,7 +266,7 @@ end
 (** {1 MODEL Generation Defaults} *)
 
 module Inference_defaults = struct
-  (** Default max_tokens for MODEL generation (used by spawn, chain, perpetual, etc.) *)
+  (** Default max_tokens for MODEL generation (used by spawn, chain, keeper, etc.) *)
   let default_max_tokens =
     get_int ~default:4096 "MASC_INFERENCE_DEFAULT_MAX_TOKENS"
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -99,7 +99,7 @@ let run_turn
         ~fallback:(fun () -> 2048)
   in
   (* 1. Ensure session directory tree exists.
-     Both the base perpetual dir AND the trace-specific session dir must
+     Both the base traces dir AND the trace-specific session dir must
      exist before any file I/O (checkpoint load, history persist).
      In filesystem fallback mode (PG unavailable), these directories may
      not have been created by keeper_up if it only registered in-memory. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -273,11 +273,11 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("remove_meta", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "Delete .masc/perpetual-keepers/<name>.json (default: false). Set true only for permanent removal.");
+          ("description", `String "Delete .masc/keepers/<name>.json (default: false). Set true only for permanent removal.");
         ]);
         ("remove_session", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "Delete .masc/perpetual/<trace_id>/ directory (default: false).");
+          ("description", `String "Delete .masc/traces/<trace_id>/ directory (default: false).");
         ]);
       ]);
       ("required", `List [`String "name"]);

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -498,14 +498,14 @@ let list_persona_summaries () : persona_summary list =
       |> List.sort (fun a b -> String.compare a.persona_name b.persona_name)
 
 let keeper_dir (config : Room.config) =
-  let d = Filename.concat (Room.masc_root_dir config) "perpetual-keepers" in
+  let d = Filename.concat (Room.masc_root_dir config) "keepers" in
   ensure_dir d
 
 let keeper_meta_path config name =
   Filename.concat (keeper_dir config) (name ^ ".json")
 
 let session_base_dir (config : Room.config) =
-  let d = Filename.concat (Room.masc_root_dir config) "perpetual" in
+  let d = Filename.concat (Room.masc_root_dir config) "traces" in
   ensure_dir d
 
 let keeper_agent_name name =

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -21,11 +21,11 @@ let ensure_dir_ d =
   d
 
 let keeper_dir_ (config : Room.config) =
-  let d = Filename.concat (Room.masc_root_dir config) "perpetual-keepers" in
+  let d = Filename.concat (Room.masc_root_dir config) "keepers" in
   ensure_dir_ d
 
 let session_base_dir_ (config : Room.config) =
-  let d = Filename.concat (Room.masc_root_dir config) "perpetual" in
+  let d = Filename.concat (Room.masc_root_dir config) "traces" in
   ensure_dir_ d
 
 (** Check API key availability using model label strings.
@@ -37,7 +37,7 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
 let keeper_metrics_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")
 
-(** Date-split metrics store: [.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl].
+(** Date-split metrics store: [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl].
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 let metrics_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
 let metrics_store_mu = Eio.Mutex.create ()

--- a/lib/pulse.mli
+++ b/lib/pulse.mli
@@ -1,7 +1,7 @@
 (** Pulse — the beating heart of any Space.
 
     A Space is an abstracted environment where agents exist and act.
-    Keeper Autonomy (perpetual, no end) and TRPG (bounded, session ends) are both Spaces.
+    Keeper Autonomy (traces, no end) and TRPG (bounded, session ends) are both Spaces.
     The only axis of variation is lifecycle: when does the heart stop?
 
     The Pulse is a tick engine driven by two forces:

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -292,7 +292,7 @@ let gc config ?(days=7) () =
   (* 5. Cleanup orphan keeper sidecar files (.metrics.jsonl/.memory.jsonl without .json)
         and orphan date-split metrics directories (<name>/metrics/ without <name>.json) *)
   let keeper_orphan_count = ref 0 in
-  let pk_dir = Filename.concat (Filename.concat config.base_path ".masc") "perpetual-keepers" in
+  let pk_dir = Filename.concat (Filename.concat config.base_path ".masc") "keepers" in
   if Sys.file_exists pk_dir then begin
     let entries = Sys.readdir pk_dir |> Array.to_list in
     (* Active keepers = those with a .json config file *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -153,7 +153,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        + prune_dir (Filename.concat masc "events")
        + prune_dir (Filename.concat masc "activity-events")
        + prune_dir (Filename.concat masc "voice_sessions")
-       + (let keepers = Filename.concat masc "perpetual-keepers" in
+       + (let keepers = Filename.concat masc "keepers" in
           if not (Sys.file_exists keepers) then 0
           else
             Array.fold_left (fun acc name ->
@@ -167,15 +167,69 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn))
 
+(** Migrate legacy directory names: perpetual->traces, perpetual-keepers->keepers.
+    Moves contents via recursive merge. Conflicting files go to _quarantine/. *)
+let migrate_legacy_dirs (state : Mcp_server.server_state) =
+  let masc = Room.masc_root_dir state.room_config in
+  let quarantine = Filename.concat masc "_quarantine" in
+  let rec migrate_recursive ~old_dir ~new_dir ~rel_path =
+    if not (Sys.file_exists old_dir) then ()
+    else begin
+      Keeper_types.mkdir_p new_dir;
+      Array.iter (fun name ->
+        let old_path = Filename.concat old_dir name in
+        let new_path = Filename.concat new_dir name in
+        let rel = if rel_path = "" then name else Filename.concat rel_path name in
+        if Sys.is_directory old_path then begin
+          if Sys.file_exists new_path then
+            migrate_recursive ~old_dir:old_path ~new_dir:new_path ~rel_path:rel
+          else
+            Sys.rename old_path new_path
+        end else begin
+          if Sys.file_exists new_path then begin
+            let q_path = Filename.concat quarantine rel in
+            Keeper_types.mkdir_p (Filename.dirname q_path);
+            Sys.rename old_path q_path
+          end else
+            Sys.rename old_path new_path
+        end
+      ) (Sys.readdir old_dir);
+      (try
+        if Array.length (Sys.readdir old_dir) = 0 then
+          Sys.rmdir old_dir
+        else
+          Log.Misc.warn "migrate: old dir not empty after migration: %s" old_dir
+      with Sys_error _ -> ())
+    end
+  in
+  let renames = [
+    ("perpetual", "traces");
+    ("keepers", "keepers");
+    ("resident-keepers", "keepers");
+  ] in
+  (try
+    List.iter (fun (old_name, new_name) ->
+      let old_dir = Filename.concat masc old_name in
+      let new_dir = Filename.concat masc new_name in
+      if Sys.file_exists old_dir then begin
+        Log.Misc.info "migrate: %s -> %s" old_name new_name;
+        migrate_recursive ~old_dir ~new_dir ~rel_path:""
+      end
+    ) renames
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Misc.error "legacy dir migration failed: %s" (Printexc.to_string exn))
+
 let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
   (try
-     let perpetual_dir =
-       Filename.concat (Room.masc_root_dir state.room_config) "perpetual"
+     let traces_dir =
+       Filename.concat (Room.masc_root_dir state.room_config) "traces"
      in
-     if Sys.file_exists perpetual_dir then begin
+     if Sys.file_exists traces_dir then begin
        let total = ref 0 in
        Array.iter (fun trace_name ->
-         let trace_dir = Filename.concat perpetual_dir trace_name in
+         let trace_dir = Filename.concat traces_dir trace_name in
          if Sys.is_directory trace_dir then begin
            let files = Sys.readdir trace_dir |> Array.to_list in
            let ckpt_files =
@@ -195,7 +249,7 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
                end
              ) ckpt_files
          end
-       ) (Sys.readdir perpetual_dir);
+       ) (Sys.readdir traces_dir);
        if !total > 0 then
          Log.Misc.info "startup prune: deleted %d old keeper checkpoint files" !total
      end
@@ -305,6 +359,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("chain_bootstrap", fun () -> bootstrap_chain_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
           ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);
+          ("legacy_dir_migration", fun () -> migrate_legacy_dirs state);
           ("jsonl_prune", fun () -> startup_prune_jsonl state);
           ( "keeper_checkpoint_prune",
             fun () -> startup_prune_keeper_checkpoints state );

--- a/lib/tool_housekeep.ml
+++ b/lib/tool_housekeep.ml
@@ -18,7 +18,7 @@ type file_entry = {
 let classify_path path =
   let base = Filename.basename path in
   let dir = Filename.basename (Filename.dirname path) in
-  if Filename.check_suffix base ".json" && dir = "perpetual-keepers" then "keeper_meta"
+  if Filename.check_suffix base ".json" && dir = "keepers" then "keeper_meta"
   else if Filename.check_suffix base ".metrics.jsonl" then "keeper_metrics_single_file"
   else if Filename.check_suffix base ".memory.jsonl" then "keeper_memory"
   else if Filename.check_suffix base ".feedback.jsonl" then "keeper_feedback"
@@ -168,7 +168,7 @@ let handle_housekeep_prune config args =
       else if String.length store_name > 7
               && String.sub store_name 0 7 = "keeper:" then
         let keeper_name = String.sub store_name 7 (String.length store_name - 7) in
-        Filename.concat (Filename.concat base "perpetual-keepers") (keeper_name ^ "/metrics")
+        Filename.concat (Filename.concat base "keepers") (keeper_name ^ "/metrics")
       else ""
     in
     if store_dir = "" then


### PR DESCRIPTION
## Summary

- `.masc/perpetual/` → `.masc/traces/`
- `.masc/perpetual-keepers/` → `.masc/keepers/`
- `.masc/resident-keepers/` → `.masc/keepers/` (merge)
- 10개 소스 파일, 24개소 참조 업데이트
- startup migration: recursive merge + file-level quarantine (자동 삭제 없음)

RFC Phase 4 구현. Ref #3627.

## Migration

서버 시작 시 `migrate_legacy_dirs`가 old→new 디렉토리를 이동:
- 디렉토리: 재귀 merge (같은 이름 → 내부 재귀)
- 파일: 충돌 시 `.masc/_quarantine/`로 이동
- 빈 old 디렉토리 자동 삭제, 비어있지 않으면 warning 로그

## Test plan

- [x] `test_oas_worker.exe` — 34 tests pass
- [x] 빌드 성공
- [ ] E2E: 서버 시작 시 old dir → new dir 자동 migration 확인
- [ ] test 파일의 stale 참조 별도 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)