### PR TITLE
fix(keeper): ADT cohort detection + missing test registrations

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -65,6 +65,7 @@ type registry_entry = {
   last_restart_ts : float;
   crash_log : (float * string) list;
   last_error : string option;
+  last_failure_reason : failure_reason option;
   last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
   board_cursor_ts : float;
@@ -118,6 +119,7 @@ let register ~base_path name meta =
     last_restart_ts = 0.0;
     crash_log = [];
     last_error = None;
+    last_failure_reason = None;
     last_agent_count = 0;
     board_wakeups = Hashtbl.create 8;
     board_cursor_ts = 0.0;
@@ -183,6 +185,9 @@ let record_restart ~base_path name =
 
 let record_error ~base_path name err =
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
+
+let set_failure_reason ~base_path name reason =
+  update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
 
 let is_running ~base_path name =
   match get ~base_path name with

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -49,6 +49,7 @@ type registry_entry = {
   last_restart_ts : float;
   crash_log : (float * string) list;
   last_error : string option;
+  last_failure_reason : failure_reason option;
   last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
   board_cursor_ts : float;
@@ -83,6 +84,9 @@ val record_restart : base_path:string -> string -> unit
 
 (** Record an error message. *)
 val record_error : base_path:string -> string -> string -> unit
+
+(** Set the structured failure reason for cohort detection. *)
+val set_failure_reason : base_path:string -> string -> failure_reason option -> unit
 
 (** Record a crash entry in the crash log (keeps last 5). *)
 val record_crash : base_path:string -> string -> float -> string -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -52,9 +52,10 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            publish_lifecycle "stopped" meta.name "normal exit"
          with
          | Keeper_registry.Keeper_heartbeat_failure info ->
-             (* Phase 2: structured crash — heartbeat failures *)
              let reason =
                Keeper_registry.failure_reason_to_string info.reason in
+             Keeper_registry.set_failure_reason ~base_path meta.name
+               (Some info.reason);
              Keeper_registry.set_state ~base_path meta.name
                Keeper_registry.Crashed;
              Keeper_registry.record_crash ~base_path
@@ -64,10 +65,9 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              publish_lifecycle "crashed" meta.name reason
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-             (* Phase 2: structured crash — generic exception *)
-             let reason =
-               Keeper_registry.failure_reason_to_string
-                 (Keeper_registry.Exception (Printexc.to_string exn)) in
+             let fr = Keeper_registry.Exception (Printexc.to_string exn) in
+             let reason = Keeper_registry.failure_reason_to_string fr in
+             Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
              Keeper_registry.set_state ~base_path meta.name
                Keeper_registry.Crashed;
              Keeper_registry.record_crash ~base_path
@@ -80,10 +80,11 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
         match Eio.Promise.peek reg.done_p with
         | Some _ -> ()  (* Already resolved above *)
         | None ->
-            (* Fallback: fiber terminated without any resolution *)
             let reason =
               Keeper_registry.failure_reason_to_string
                 Keeper_registry.Fiber_unresolved in
+            Keeper_registry.set_failure_reason ~base_path meta.name
+              (Some Keeper_registry.Fiber_unresolved);
             Keeper_registry.record_crash ~base_path
               meta.name (Time_compat.now ()) reason;
             Keeper_registry.record_error ~base_path meta.name reason;
@@ -144,9 +145,16 @@ let reconcile_keepalive_keepers (ctx : _ context) =
                Log.Keeper.info "%s: reconciled durable keeper" meta.name
              end
          | _ -> ())
-(** Phase 2: self-preservation gate.
-    Suppresses restarts when a dominant failure cohort exceeds the
-    ratio threshold AND minimum candidate count. *)
+(** Cohort key from structured failure_reason ADT.
+    Groups failures by variant, ignoring parameters (e.g. failure count). *)
+let cohort_key_of_reason = function
+  | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
+  | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
+  | Some (Keeper_registry.Exception _) -> "exception"
+  | None -> "unknown"
+
+(** Self-preservation gate. Suppresses restarts when a dominant failure
+    cohort exceeds ratio threshold AND minimum candidate count. *)
 let apply_self_preservation ~total_keepers to_restart =
   let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in
   let sp_min = Env_config.KeeperSupervisor.self_preservation_min_candidates in
@@ -156,15 +164,13 @@ let apply_self_preservation ~total_keepers to_restart =
   if ratio > sp_ratio
      && n_candidates >= sp_min
   then begin
-    (* Group by failure reason prefix for cohort detection *)
+    (* Group by failure_reason ADT variant (not string prefix) *)
     let cohorts = Hashtbl.create 4 in
-    List.iter (fun ((_entry : Keeper_registry.registry_entry), msg) ->
-      let key =
-        if String.length msg > 30 then String.sub msg 0 30 else msg in
+    List.iter (fun ((entry : Keeper_registry.registry_entry), _msg) ->
+      let key = cohort_key_of_reason entry.last_failure_reason in
       let prev = try Hashtbl.find cohorts key with Not_found -> [] in
-      Hashtbl.replace cohorts key ((_entry, msg) :: prev)
+      Hashtbl.replace cohorts key ((entry, _msg) :: prev)
     ) to_restart;
-    (* Find dominant cohort *)
     let dominant_key, dominant_entries =
       Hashtbl.fold (fun k v (best_k, best_v) ->
         if List.length v > List.length best_v then (k, v) else (best_k, best_v)
@@ -177,7 +183,6 @@ let apply_self_preservation ~total_keepers to_restart =
       publish_lifecycle "self_preservation" "supervisor"
         (Printf.sprintf "%d/%d suppressed, cohort=%s"
            (List.length dominant_entries) n_total dominant_key);
-      (* Return only non-dominant entries for restart *)
       let dominant_set =
         List.map (fun ((e : Keeper_registry.registry_entry), _) -> e.name)
           dominant_entries in

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -36,3 +36,6 @@ val backoff_delay : int -> float
 
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
+
+val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
+(** Map a structured failure_reason to a cohort key for self-preservation grouping. *)

--- a/test/dune
+++ b/test/dune
@@ -1169,3 +1169,15 @@
  (name test_cdal_friction_projection)
  (modules test_cdal_friction_projection)
  (libraries masc_mcp agent_sdk alcotest yojson unix str))
+
+; Phase 1: Work-as-heartbeat config + freshness logic + percentile
+(test
+ (name test_work_as_heartbeat)
+ (modules test_work_as_heartbeat)
+ (libraries masc_mcp masc_mcp.config alcotest unix))
+
+; Phase 2: Self-preservation, keeper_state, failure_reason, cohort detection
+(test
+ (name test_phase2_self_preservation)
+ (modules test_phase2_self_preservation)
+ (libraries masc_mcp masc_mcp.config alcotest eio eio_main unix))

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -144,6 +144,73 @@ let test_dead_to_running_blocked () =
     check string "still dead" "dead" (R.state_to_string e.state);
     check int "still 0 running" 0 (R.count_running ())
 
+(* ── Fix 1: last_failure_reason stored in registry ────── *)
+
+let test_failure_reason_stored () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  (* Initially None *)
+  (match R.get ~base_path:bp "k1" with
+   | Some e -> check bool "initially None" true (Option.is_none e.last_failure_reason)
+   | None -> fail "expected k1");
+  (* Set a reason *)
+  R.set_failure_reason ~base_path:bp "k1"
+    (Some (R.Heartbeat_consecutive_failures 5));
+  match R.get ~base_path:bp "k1" with
+  | None -> fail "expected k1"
+  | Some e ->
+    check bool "has reason" true (Option.is_some e.last_failure_reason);
+    (match e.last_failure_reason with
+     | Some (R.Heartbeat_consecutive_failures n) ->
+       check int "failure count" 5 n
+     | _ -> fail "expected Heartbeat_consecutive_failures")
+
+let test_failure_reason_cleared_on_reregister () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_failure_reason ~base_path:bp "k1"
+    (Some R.Fiber_unresolved);
+  (* Re-register (simulates restart) clears the reason *)
+  let _e2 = R.register ~base_path:bp "k1" (make_meta "k1") in
+  match R.get ~base_path:bp "k1" with
+  | None -> fail "expected k1"
+  | Some e ->
+    check bool "cleared on re-register" true
+      (Option.is_none e.last_failure_reason)
+
+(* ── Fix 2: Cohort detection uses ADT, not string prefix ── *)
+
+module Sup = Masc_mcp.Keeper_supervisor
+
+let test_cohort_key_heartbeat () =
+  let key = Sup.cohort_key_of_reason
+    (Some (R.Heartbeat_consecutive_failures 3)) in
+  check string "heartbeat cohort" "heartbeat_failures" key
+
+let test_cohort_key_fiber () =
+  let key = Sup.cohort_key_of_reason (Some R.Fiber_unresolved) in
+  check string "fiber cohort" "fiber_unresolved" key
+
+let test_cohort_key_exception () =
+  let key = Sup.cohort_key_of_reason
+    (Some (R.Exception "Sys_error(disk full)")) in
+  check string "exception cohort" "exception" key
+
+let test_cohort_key_none () =
+  let key = Sup.cohort_key_of_reason None in
+  check string "unknown cohort" "unknown" key
+
+(* ── Fix 2: Dead tombstone lifecycle ─────────────────── *)
+
+let test_dead_tombstone_is_registered () =
+  R.clear ();
+  let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
+  R.set_state ~base_path:bp "k1" R.Crashed;
+  R.set_state ~base_path:bp "k1" R.Dead;
+  (* Dead keeper is still registered — reconcile must skip *)
+  check bool "Dead is registered" true (R.is_registered ~base_path:bp "k1");
+  check bool "Dead is not running" false (R.is_running ~base_path:bp "k1")
+
 (* ── Test runner ──────────────────────────────────────── *)
 
 let () =
@@ -174,5 +241,18 @@ let () =
     "state_transitions", [
       eio_test "Running → Crashed → Running" test_state_transition_running_crashed_running;
       eio_test "Dead → Running blocked" test_dead_to_running_blocked;
+    ];
+    "failure_reason_field", [
+      eio_test "stored in registry" test_failure_reason_stored;
+      eio_test "cleared on re-register" test_failure_reason_cleared_on_reregister;
+    ];
+    "cohort_detection", [
+      test_case "heartbeat key" `Quick test_cohort_key_heartbeat;
+      test_case "fiber key" `Quick test_cohort_key_fiber;
+      test_case "exception key" `Quick test_cohort_key_exception;
+      test_case "none key" `Quick test_cohort_key_none;
+    ];
+    "dead_tombstone", [
+      eio_test "Dead is registered but not running" test_dead_tombstone_is_registered;
     ];
   ]


### PR DESCRIPTION
## Summary

Post-merge defect fixes for Adaptive Heartbeat Phase 0/1/2.

### Fix 1: Cohort detection — string prefix → ADT matching
- Added `last_failure_reason : failure_reason option` to `registry_entry`
- `set_failure_reason` called in all 3 catch branches of `launch_supervised_fiber` + finally
- `apply_self_preservation` groups by `cohort_key_of_reason` (ADT variant) instead of 30-char string prefix
- RFC compliance: "string matching이 아닌 ADT matching"

### Fix 2: Missing test registrations
- `test_work_as_heartbeat` (Phase 1): 14 tests, dune entry lost during squash merge
- `test_phase2_self_preservation` (Phase 2): 24 tests, same issue

### New tests (7 cases)
- `failure_reason_field`: stored in registry, cleared on re-register
- `cohort_detection`: heartbeat/fiber/exception/none variant → cohort key mapping
- `dead_tombstone`: Dead is registered but not running

81 tests pass.

## Test plan
- [x] test_phase2_self_preservation: 24/24
- [x] test_keeper_registry: 34/34
- [x] test_keeper_supervisor: 9/9
- [x] test_work_as_heartbeat: 14/14
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)