### PR TITLE
fix(keeper): mkdir_p before write_meta to prevent missing dir error

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -627,6 +627,7 @@ let write_meta config (m : keeper_meta) : (unit, string) result =
   let path = keeper_meta_path config persisted.name in
   let content = Yojson.Safe.pretty_to_string (meta_to_json persisted) in
   try
+    Fs_compat.mkdir_p (Filename.dirname path);
     Fs_compat.save_file path content;
     (!runtime_meta_write_sync_hook) config persisted;
     Ok ()


### PR DESCRIPTION
## Summary

- `write_meta`에서 `Fs_compat.save_file` 전에 `mkdir_p` 명시 호출
- CI Contract Harness에서 서버 startup 없이 `masc_keeper_up` 호출 시 `.masc/keepers/` 미존재로 실패하던 문제 수정
- `ensure_dir` cache 의존성 제거 — 항상 안전하게 디렉토리 생성

Closes #3706

## Test plan

- [x] 빌드 성공
- [ ] CI Contract Harness pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)