### PR TITLE
fix stale keeper dir cache after base reset

### DIFF
--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1947,6 +1947,54 @@ let test_legacy_presence_keepalive_false_migrates_to_paused () =
       check bool "paused persisted after scrub" true
         Yojson.Safe.Util.(scrubbed_json |> member "paused" = `Bool true))
 
+let test_keeper_up_recreates_cached_keeper_dir_after_base_reset () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "public-sweep-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Fs_compat.clear_fs ();
+      Masc_mcp.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc_mcp.Keeper_registry.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let keeper_up goal =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String keeper_name);
+              ("goal", `String goal);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      let ok, first_body = keeper_up "Populate cached keeper directory path" in
+      if not ok then fail first_body;
+      check bool "first keeper up ok" true ok;
+      Masc_mcp.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc_mcp.Keeper_registry.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      rm_rf base_dir;
+      Unix.mkdir base_dir 0o755;
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let ok, second_body = keeper_up "Recreate cached keeper directory after reset" in
+      if not ok then fail second_body;
+      check bool "second keeper up ok after base reset" true ok;
+      check bool "keeper meta recreated" true
+        (Sys.file_exists (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)))
+
 let () =
   run "Tool_keeper" [
     ("read_file_tail_lines", [
@@ -2026,6 +2074,8 @@ let () =
            test_keeper_supervisor_recovers_missing_desired_keeper;
          test_case "legacy presence_keepalive false migrates to paused" `Quick
            test_legacy_presence_keepalive_false_migrates_to_paused;
+         test_case "keeper up recreates cached keeper dir after base reset (issue #3710)" `Quick
+           test_keeper_up_recreates_cached_keeper_dir_after_base_reset;
          test_case "session dir mkdir_p creates full tree from scratch (issue #3019)" `Quick
            test_session_dir_mkdir_p_creates_full_tree;
        ]);


### PR DESCRIPTION
## Summary
- fix keeper directory caches so cached paths are re-created if the underlying directory tree was deleted and recreated in the same process
- cover the regression with a keeper-up test that deletes the base dir, re-inits the room, and reuses the same cached path

## Product impact
- fixes `masc_keeper_up` failing with `Not_found` on `.masc/keepers/<name>.json` after temp-room/base-dir reset flows
- keeps directory-path caches fast on the hot path while making them safe for temp/harness lifecycles

## Evidence
- `dune build --root . test/test_tool_keeper.exe`
- `./_build/default/test/test_tool_keeper.exe test 'read_file_tail_lines' 39`
- `./_build/default/test/test_tool_keeper.exe` still has pre-existing failures in `keeper bootstrap marks stale keeper` and `keeper supervisor recovers missing desired keeper` due keepalive spawn-slot behavior; the new regression case passes

## Review evidence
- GLM-5 via `sb glm-text`
- 2026-03-29 KST
- Result: `No findings.`

## Linked issue
- closes #3710
