### PR TITLE
fix(keeper): mkdir_p keepers dir before writing meta (#3706)

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -627,6 +627,7 @@ let write_meta config (m : keeper_meta) : (unit, string) result =
   let path = keeper_meta_path config persisted.name in
   let content = Yojson.Safe.pretty_to_string (meta_to_json persisted) in
   try
+    Fs_compat.mkdir_p (Filename.dirname path);
     Fs_compat.save_file path content;
     (!runtime_meta_write_sync_hook) config persisted;
     Ok ()


### PR DESCRIPTION
## Summary
- `write_meta` relied on `ensure_dir`'s Hashtbl cache via `keeper_meta_path`, which fails on Linux CI (`openat2` ENOENT when `.masc/keepers/` doesn't exist)
- Add explicit `Fs_compat.mkdir_p (Filename.dirname path)` before `save_file`, matching the pattern used in 10+ other codebase locations

Fixes #3706

## Test plan
- [ ] Contract Harness CI passes (the failing test)
- [ ] `masc_keeper_up` works in fresh temp dir without pre-existing `.masc/keepers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)