### PR TITLE
fix(tools): wire missing dispatch + sync contract inventory (#3699)

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -134,6 +134,9 @@ let () =
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
+  register_module_tag ~schemas:Tool_cache.schemas ~tag:Mod_cache;
+  register_module_tag ~schemas:Tool_goals.schemas ~tag:Mod_goals;
+  register_module_tag ~schemas:Tool_compact.schemas ~tag:Mod_compact;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;
   (* Monolithic schema decomposition: modules that now export their own schemas *)
   register_module_tag ~schemas:Tool_code.schemas ~tag:Mod_code;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -477,6 +477,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
     | Mod_hat ->
         Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
+    | Mod_cache ->
+        Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
+    | Mod_goals ->
+        Tool_goals.dispatch { Tool_goals.config; agent_name; call_keeper_msg = None } ~name ~args:arguments
+    | Mod_compact ->
+        Tool_compact.dispatch ~name ~args:arguments
     | Mod_agent ->
         Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:arguments
     | Mod_task ->

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -157,7 +157,8 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_hat | Mod_cache | Mod_goals | Mod_compact
+  | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -84,7 +84,8 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_agent | Mod_task | Mod_room
+  | Mod_auth | Mod_hat | Mod_cache | Mod_goals | Mod_compact
+  | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal
   | Mod_inline

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -82,13 +82,13 @@ let all_known_tool_names =
     "masc_board_vote";
     "masc_bounded_run";
     "masc_branch";
+    "masc_broadcast";
     "masc_cache_clear";
     "masc_cache_delete";
     "masc_cache_get";
     "masc_cache_list";
     "masc_cache_set";
     "masc_cache_stats";
-    "masc_broadcast";
     "masc_cancellation";
     "masc_case_brief_submit";
     "masc_case_status";
@@ -108,10 +108,10 @@ let all_known_tool_names =
     "masc_code_symbols";
     "masc_code_write";
     "masc_collaboration_evidence";
+    "masc_collaboration_graph";
     "masc_compact_context";
     "masc_config";
     "masc_config_snapshot";
-    "masc_collaboration_graph";
     "masc_consolidate_learning";
     "masc_convo_conclude";
     "masc_convo_get";
@@ -135,9 +135,9 @@ let all_known_tool_names =
     "masc_execute";
     "masc_execute_dry_run";
     "masc_execution_orders";
+    "masc_feature_flags";
     "masc_find_by_capability";
     "masc_gc";
-    "masc_feature_flags";
     "masc_get_metrics";
     "masc_goal_dispatch";
     "masc_goal_list";


### PR DESCRIPTION
## Summary
- Wire runtime dispatch for cache (6 tools), goals (6 tools), compact (1 tool) — schemas were exposed but dispatch was missing
- Add 18 tools to contract inventory, remove 1 stale entry (masc_generate_key)
- Hat tools (2) already dispatched, just needed inventory entry
- Config tools (3) already dispatched via Mod_misc, just needed inventory entry

Fixes #3699

## Changes
| File | Change |
|------|--------|
| `lib/tool_dispatch.ml` + `.mli` | Add `Mod_cache`, `Mod_goals`, `Mod_compact` to `module_tag` |
| `lib/mcp_server_eio.ml` | Register schemas for 3 new module tags |
| `lib/mcp_server_eio_execute.ml` | Add dispatch arms for cache/goals/compact |
| `test/test_mcp_tool_matrix_cases.ml` | +18 tools, -1 stale entry |

## Test plan
- [ ] `test_mcp_tool_matrix` passes (inventory matches raw schemas)
- [ ] `test_mcp_server_eio` cache dispatch succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)