### PR TITLE
fix(keeper): reconcile Stopped keepers + stale ensure_dir cache

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -128,21 +128,34 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
 
 (* ── Sweep and recover ───────────────────────────────────── *)
 
-(** Phase 2: reconcile only orphaned durable keepers (no registry entry).
-    is_registered checks entry existence regardless of state, so Crashed/Dead
-    keepers are excluded from reconcile. *)
+(** Reconcile only orphaned or cleanly stopped durable keepers.
+    Running/Paused/Crashed/Dead entries are actively managed by sweep
+    and must NOT be re-launched by reconcile. Stopped entries with
+    unresolved fibers (done_p = None) are also skipped — sweep will
+    handle them once the fiber terminates. *)
 let reconcile_keepalive_keepers (ctx : _ context) =
   let base_path = ctx.config.base_path in
   Keeper_types.keepalive_keeper_names ctx.config
   |> List.iter (fun name ->
          match read_meta ctx.config name with
-         | Ok (Some meta)
-           when not meta.paused
-                && not (Keeper_registry.is_registered ~base_path meta.name) ->
-             supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
-             if Keeper_registry.is_running ~base_path meta.name then begin
-               publish_lifecycle "reconciled" meta.name "durable keeper";
-               Log.Keeper.info "%s: reconciled durable keeper" meta.name
+         | Ok (Some meta) when not meta.paused ->
+             let dominated_by_sweep =
+               match Keeper_registry.get ~base_path meta.name with
+               | None -> false  (* no entry = orphaned, reconcile OK *)
+               | Some e ->
+                 match e.state with
+                 | Keeper_registry.Running | Keeper_registry.Paused -> true
+                 | Keeper_registry.Crashed | Keeper_registry.Dead -> true
+                 | Keeper_registry.Stopped ->
+                     (* Stopped with unresolved fiber → sweep will clean up *)
+                     Eio.Promise.peek e.done_p = None
+             in
+             if not dominated_by_sweep then begin
+               supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
+               if Keeper_registry.is_running ~base_path meta.name then begin
+                 publish_lifecycle "reconciled" meta.name "durable keeper";
+                 Log.Keeper.info "%s: reconciled durable keeper" meta.name
+               end
              end
          | _ -> ())
 (** Cohort key from structured failure_reason ADT.

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -130,7 +130,7 @@ let mkdir_p path =
 let _ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 8
 
 let ensure_dir d =
-  if not (Hashtbl.mem _ensured_dirs d) then begin
+  if not (Hashtbl.mem _ensured_dirs d) || not (Sys.file_exists d) then begin
     mkdir_p d;
     Hashtbl.replace _ensured_dirs d ()
   end;

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -14,7 +14,7 @@ let mkdir_p_ path =
 let _ensured_dirs_ : (string, unit) Hashtbl.t = Hashtbl.create 8
 
 let ensure_dir_ d =
-  if not (Hashtbl.mem _ensured_dirs_ d) then begin
+  if not (Hashtbl.mem _ensured_dirs_ d) || not (Sys.file_exists d) then begin
     mkdir_p_ d;
     Hashtbl.replace _ensured_dirs_ d ()
   end;


### PR DESCRIPTION
## Summary

Fixes 3 post-merge issues from Adaptive Heartbeat Phase 2.

### #3709: reconcile skips Stopped keepers
Phase 2 changed reconcile from `is_running` to `is_registered`. Stopped entries are still registered → reconcile skip → keeper not re-launched after `stop_keepalive`.

Fix: explicit state-based check. Running/Paused/Crashed/Dead = sweep-owned. Stopped with resolved `done_p` = reconcile-eligible (orphaned).

### #3706 + #3710: stale ensure_dir cache
Process-global Hashtbl caches `mkdir_p` results. Contract harness deletes and recreates temp dirs within the same process → cache stale → `Not_found` on file write.

Fix: `Sys.file_exists` re-check before trusting cache.

## Test plan
- [x] 34 registry + 9 supervisor + 24 phase2 = 67 tests pass
- [ ] CI checks

Closes #3706, #3709, #3710.