### PR TITLE
docs: remove stale walph reference from room.mli

### DIFF
--- a/lib/room.mli
+++ b/lib/room.mli
@@ -1,8 +1,8 @@
 (** MASC Room - Core coordination hub.
 
     This module ties together all Room sub-modules (utils, state, lifecycle,
-    init, status, task, walph, query, agent, portal, worktree, gc, vote,
-    tempo, multi). *)
+    init, status, task, query, agent, portal, worktree, gc, vote, tempo,
+    multi). *)
 
 (** {1 Included sub-modules} *)
 


### PR DESCRIPTION
## Summary
- Walph module was retired in #3705 but room.mli docstring still referenced it
- Single line docstring update

## Test plan
- [x] No code change, docstring only