### PR TITLE
[codex] restore missing cache and schema registrations (rebased)

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -127,6 +127,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.50.0" };
 
+  { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
+    description = "Treat successful keeper work cycles as heartbeat presence proof";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.163.0" };
+
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
     description = "Load dashboard fixture data for testing";

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -232,6 +232,8 @@ let sweep_and_recover (ctx : _ context) =
     | Keeper_registry.Running | Keeper_registry.Paused
     | Keeper_registry.Stopped | Keeper_registry.Crashed ->
       (match Eio.Promise.peek entry.done_p with
+      | None when entry.state = Keeper_registry.Stopped ->
+          to_unregister := entry :: !to_unregister
       | None -> ()  (* Alive — skip *)
       | Some `Stopped ->
           to_unregister := entry :: !to_unregister

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -475,6 +475,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
+    | Mod_cache ->
+        Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_hat ->
         Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
     | Mod_cache ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -479,8 +479,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_hat ->
         Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
-    | Mod_cache ->
-        Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_goals ->
         Tool_goals.dispatch { Tool_goals.config; agent_name; call_keeper_msg = None } ~name ~args:arguments
     | Mod_compact ->

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -12,10 +12,24 @@ let init config ~agent_name =
   (* Ensure root .masc structure exists even when initializing a non-default room. *)
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
+  let root_keepers_dir = Filename.concat root_dir "keepers" in
+  let root_perpetual_keepers_dir =
+    Filename.concat root_dir "perpetual-keepers"
+  in
+  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
-  List.iter mkdir_p [root_agents_dir; root_tasks_dir; root_messages_dir; rooms_root_dir config];
+  List.iter mkdir_p
+    [
+      root_agents_dir;
+      root_keepers_dir;
+      root_perpetual_keepers_dir;
+      root_perpetual_dir;
+      root_tasks_dir;
+      root_messages_dir;
+      rooms_root_dir config;
+    ];
   if not (path_exists_root config (root_state_path config)) then begin
     let root_state = {
       protocol_version = "0.1.0";

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -367,10 +367,24 @@ let ensure_room_bootstrap config room_id =
   (* 1. Always ensure root infrastructure exists *)
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
+  let root_keepers_dir = Filename.concat root_dir "keepers" in
+  let root_perpetual_keepers_dir =
+    Filename.concat root_dir "perpetual-keepers"
+  in
+  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
-  List.iter mkdir_p [ root_agents_dir; root_tasks_dir; root_messages_dir; rooms_root_dir config ];
+  List.iter mkdir_p
+    [
+      root_agents_dir;
+      root_keepers_dir;
+      root_perpetual_keepers_dir;
+      root_perpetual_dir;
+      root_tasks_dir;
+      root_messages_dir;
+      rooms_root_dir config;
+    ];
   if not (path_exists_root config (root_state_path config)) then
     write_json_root config (root_state_path config)
       (room_state_to_yojson (default_room_state config));

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -17,10 +17,17 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_auth.schemas
   @ Tool_schemas_portal.schemas
   @ Tool_schemas_worktree.schemas
+  @ Tool_audit.schemas
   @ Tool_cache.schemas
+  @ Tool_cost.schemas
+  @ Tool_encryption.schemas
+  @ Tool_schemas_fire_task.schemas
   @ Tool_goals.schemas
+  @ Tool_model_catalog.schemas
+  @ Tool_rate_limit.schemas
   @ Tool_run.schemas
   @ Tool_task.schemas
+  @ Tool_tempo.schemas
   @ Tool_suspend.schemas
   @ Tool_council_oas.schemas
   @ Tool_relay.schemas

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -353,6 +353,9 @@ let all_known_tool_names =
     "masc_voice_session_start";
     "masc_voice_sessions";
     "masc_voice_speak";
+    "masc_walph_control";
+    "masc_walph_natural";
+    "masc_walph_status";
     "masc_webrtc_answer";
     "masc_webrtc_offer";
     "masc_websocket_discovery";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -158,12 +158,6 @@ let all_known_tool_names =
     "masc_governance_report";
     "masc_governance_set";
     "masc_governance_status";
-    "masc_goal_dispatch";
-    "masc_goal_list";
-    "masc_goal_refresh";
-    "masc_goal_review";
-    "masc_goal_snapshot";
-    "masc_goal_upsert";
     "masc_handover_claim";
     "masc_handover_claim_and_spawn";
     "masc_handover_create";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -59,6 +59,9 @@ let all_known_tool_names =
     "masc_auth_refresh";
     "masc_auth_revoke";
     "masc_auth_status";
+    "masc_audit_query";
+    "masc_audit_stats";
+    "masc_audit_trail";
     "masc_autoresearch_cycle";
     "masc_autoresearch_inject";
     "masc_autoresearch_record_finding";
@@ -118,6 +121,8 @@ let all_known_tool_names =
     "masc_convo_list";
     "masc_convo_reply";
     "masc_convo_start";
+    "masc_cost_log";
+    "masc_cost_report";
     "masc_dashboard";
     "masc_deliver";
     "masc_detachment_list";
@@ -130,6 +135,9 @@ let all_known_tool_names =
     "masc_dispatch_tick";
     "masc_episode_flush";
     "masc_episode_list";
+    "masc_encryption_disable";
+    "masc_encryption_enable";
+    "masc_encryption_status";
     "masc_error_add";
     "masc_error_resolve";
     "masc_execute";
@@ -137,6 +145,7 @@ let all_known_tool_names =
     "masc_execution_orders";
     "masc_feature_flags";
     "masc_find_by_capability";
+    "masc_fire_task";
     "masc_gc";
     "masc_get_metrics";
     "masc_goal_dispatch";
@@ -146,8 +155,15 @@ let all_known_tool_names =
     "masc_goal_snapshot";
     "masc_goal_upsert";
     "masc_governance_feed";
+    "masc_governance_report";
     "masc_governance_set";
     "masc_governance_status";
+    "masc_goal_dispatch";
+    "masc_goal_list";
+    "masc_goal_refresh";
+    "masc_goal_review";
+    "masc_goal_snapshot";
+    "masc_goal_upsert";
     "masc_handover_claim";
     "masc_handover_claim_and_spawn";
     "masc_handover_create";
@@ -260,6 +276,8 @@ let all_known_tool_names =
     "masc_portal_send";
     "masc_portal_status";
     "masc_progress";
+    "masc_rate_limit_config";
+    "masc_rate_limit_status";
     "masc_recall_search";
     "masc_register_capabilities";
     "masc_reject";
@@ -294,6 +312,11 @@ let all_known_tool_names =
     "masc_suspend";
     "masc_task_history";
     "masc_tasks";
+    "masc_tempo";
+    "masc_tempo_adjust";
+    "masc_tempo_get";
+    "masc_tempo_reset";
+    "masc_tempo_set";
     "masc_team_session_compare";
     "masc_team_session_events";
     "masc_team_session_finalize";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -346,6 +346,10 @@ let all_known_tool_names =
     "masc_verify_request";
     "masc_verify_status";
     "masc_verify_submit";
+    "masc_vote_cast";
+    "masc_vote_create";
+    "masc_vote_status";
+    "masc_votes";
     "masc_voice_agent";
     "masc_voice_conference_end";
     "masc_voice_conference_start";
@@ -353,9 +357,6 @@ let all_known_tool_names =
     "masc_voice_session_start";
     "masc_voice_sessions";
     "masc_voice_speak";
-    "masc_walph_control";
-    "masc_walph_natural";
-    "masc_walph_status";
     "masc_webrtc_answer";
     "masc_webrtc_offer";
     "masc_websocket_discovery";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -147,6 +147,7 @@ let all_known_tool_names =
     "masc_find_by_capability";
     "masc_fire_task";
     "masc_gc";
+    "masc_generate_key";
     "masc_get_metrics";
     "masc_goal_dispatch";
     "masc_goal_list";
@@ -216,6 +217,7 @@ let all_known_tool_names =
     "masc_mdal_swarm_start";
     "masc_memento_mori";
     "masc_messages";
+    "masc_model_catalog";
     "masc_note_add";
     "masc_observe_alerts";
     "masc_observe_capacity";
@@ -340,10 +342,6 @@ let all_known_tool_names =
     "masc_verify_request";
     "masc_verify_status";
     "masc_verify_submit";
-    "masc_vote_cast";
-    "masc_vote_create";
-    "masc_vote_status";
-    "masc_votes";
     "masc_voice_agent";
     "masc_voice_conference_end";
     "masc_voice_conference_start";

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -221,6 +221,21 @@ let test_keeper_paths_use_cluster_root () =
           Alcotest.(check bool) "keeper dir under cluster root" true
             (String.starts_with ~prefix:expected_root keeper_dir)))
 
+let test_room_init_bootstraps_keeper_runtime_dirs () =
+  with_temp_dir "startup-keeper-dirs" (fun dir ->
+      let config = Room.default_config dir |> Room.config_with_resolved_scope in
+      ignore (Room.init config ~agent_name:None);
+      let root_dir = Room.masc_root_dir config in
+      let legacy_keepers_dir = Filename.concat root_dir "keepers" in
+      let keeper_dir = Filename.concat root_dir "perpetual-keepers" in
+      let perpetual_dir = Filename.concat root_dir "perpetual" in
+      Alcotest.(check bool) "legacy keeper dir exists" true
+        (Sys.file_exists legacy_keepers_dir && Sys.is_directory legacy_keepers_dir);
+      Alcotest.(check bool) "keeper dir exists" true
+        (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir);
+      Alcotest.(check bool) "perpetual dir exists" true
+        (Sys.file_exists perpetual_dir && Sys.is_directory perpetual_dir))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -373,6 +388,8 @@ let () =
             `Quick test_restore_persisted_sessions_uses_scoped_agents_dir;
           Alcotest.test_case "keeper paths use cluster root" `Quick
             test_keeper_paths_use_cluster_root;
+          Alcotest.test_case "room init bootstraps keeper runtime dirs" `Quick
+            test_room_init_bootstraps_keeper_runtime_dirs;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -234,7 +234,10 @@ let () =
                 internal);
           test_case "non-public tool remains in full registry" `Quick
             (fun () ->
-              let all_names = Config.all_tool_names () in
+              let all_names =
+                Config.raw_all_tool_schemas
+                |> List.map (fun (s : Types.tool_schema) -> s.name)
+              in
               (* masc_team_session_step has a schema but is not public *)
               let internal = "masc_team_session_step" in
               check bool (internal ^ " in registry") true


### PR DESCRIPTION
## Summary

- restore omitted schema-owner modules in `Tools.raw_schemas`
- wire `Tool_cache` back into the tag-based MCP dispatch path
- bootstrap keeper runtime directories and recover stopped keepalives
- refresh tool exposure / inventory contracts and rebase the follow-up cleanly on current `main`

## Why

The previous follow-up PR `#3696` was closed on GitHub and then got stuck with stale merge metadata. This replacement branch contains the same logical fixes, rebased onto current `main`, with the rebase conflicts resolved.

## Validation

- GitHub Actions CI on the predecessor branch head `a652af0f8733b994e3bea2aaf4154aabcd5a3574`: `23710072198` passed
- `git diff --check origin/main...HEAD` passed locally
- cross-model review: `GLM-5.1` via `sb glm-text --no-thinking`
- latest incremental review result: `No findings.`

## Supersedes

- supersedes closed PR `#3696`