### PR TITLE
[codex] prune stale removed-tool references

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -95,7 +95,7 @@ masc_claim_next()
 
 ```bash
 # Add specific tools to the public surface
-MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause
+MASC_PUBLIC_TOOLS_EXTRA=masc_board_search,masc_pause
 
 # Restore the full inventory (debugging)
 MASC_FULL_SURFACE=1

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -79,10 +79,6 @@ let spawned_agent_public_tool_names : string list =
     "masc_poll_events";
     (* masc_vote_create, masc_vote_cast, masc_vote_status removed:
        hidden in Tool_catalog (prefer decision/governance V2 tools) *)
-    "masc_run_init";
-    "masc_run_log";
-    "masc_run_deliverable";
-    "masc_run_get";
     "masc_spawn";
   ]
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -254,7 +254,7 @@ let permission_for_tool = function
   | "masc_transport_status" | "masc_websocket_discovery"
   | "masc_agents" | "masc_portal_status" | "masc_pending_interrupts"
   | "masc_votes" | "masc_vote_status" | "masc_worktree_list"
-  | "masc_cost_report" | "masc_task_history" | "masc_operator_snapshot"
+  | "masc_task_history" | "masc_operator_snapshot"
   | "masc_operator_digest" | "masc_surface_audit"
   | "masc_collaboration_evidence"
   | "masc_persona_list"
@@ -315,7 +315,7 @@ let permission_for_tool = function
   | "masc_vote_create" | "masc_vote_cast" -> Some CanVote
   | "masc_interrupt" | "masc_branch" -> Some CanInterrupt
   | "masc_approve" | "masc_reject" -> Some CanApprove
-  | "masc_cost_log" | "masc_cleanup_zombies" -> Some CanBroadcast (* Worker level *)
+  | "masc_cleanup_zombies" -> Some CanBroadcast (* Worker level *)
   | "masc_board_list" | "masc_board_get" | "masc_board_hearths"
   | "masc_board_search" | "masc_board_profile" | "masc_board_stats" ->
       Some CanReadState

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -25,7 +25,6 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_command_plane.schemas
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
-    @ Tool_compact.schemas
     @ Tool_autoresearch.schemas
     )
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -92,6 +92,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.130.0" };
 
+  { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
+    description = "Count successful room heartbeat after a turn as presence proof";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.162.0" };
+
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/dune
+++ b/lib/dune
@@ -380,6 +380,7 @@
    tool_deep_review
    tool_budget
    tool_catalog
+   tool_schema_dsl
    tool_result
    tool_dispatch
    tool_input_validation

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -126,7 +126,11 @@ let build_https_connector_result () =
             (fun uri
                   (raw : [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t)
                 ->
-              let flow : [> Eio.Flow.two_way_ty | Eio.Resource.close_ty ] Eio.Resource.t = (raw :> _) in
+              let flow =
+                (raw :>
+                  [> Eio.Flow.two_way_ty | Eio.Resource.close_ty ]
+                  Eio.Resource.t)
+              in
               let host =
                 match Uri.host uri with
                 | None -> None

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -32,6 +32,7 @@ let make_closing_client ~sw ~net ~https =
     in
     let sock = Eio.Net.connect ~sw:conn_sw net addr in
     last_sock := Some sock;
+    (* Return type must include `Close for cohttp-eio make_generic. *)
     match Uri.scheme uri with
     | Some "https" -> (
         match https with

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -74,9 +74,9 @@ let read_only_tools =
    "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
    "masc_transport_status"; "masc_websocket_discovery";
    "masc_worktree_list"; "masc_pending_interrupts";
-   "masc_cost_report"; "masc_portal_status";
+   "masc_portal_status";
    "masc_verify_handoff"; "masc_tool_help";
-   "masc_goal_list"; "masc_team_session_status"; "masc_team_session_report";
+   "masc_team_session_status"; "masc_team_session_report";
    "masc_team_session_list"; "masc_team_session_compare";
    "masc_team_session_events"; "masc_team_session_prove";
    "masc_operator_snapshot"; "masc_operator_digest";
@@ -94,7 +94,6 @@ let requires_join_tools = [
   "masc_operator_action"; "masc_operator_confirm";
   "masc_improve_loop_start"; "masc_improve_loop_pause";
   "masc_improve_loop_resume"; "masc_improve_loop_tick";
-  "masc_code_swarm_plan"; "masc_code_swarm_verify"; "masc_code_swarm_merge";
 ]
 
 let () = Tool_dispatch.init_read_only_set read_only_tools

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -339,13 +339,7 @@ let planned_worker_to_entry_with_state
              (Oas.Error.InvalidConfig
                 { field = "worker"; detail = Printf.sprintf "%s: %s" name e }))
   in
-  {
-    name;
-    run;
-    role;
-    get_telemetry = Some (fun () -> !telemetry_ref);
-    extensions = [];
-  }
+  { name; run; role; get_telemetry = Some (fun () -> !telemetry_ref); extensions = [] }
 
 let planned_worker_to_entry
     ~(config : Room.config)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -183,7 +183,7 @@ let public_mcp_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 64 in
   List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
   (* MASC_PUBLIC_TOOLS_EXTRA: comma-separated tool names to add at runtime.
-     Example: MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause *)
+     Example: MASC_PUBLIC_TOOLS_EXTRA=masc_board_search,masc_pause *)
   (match Env_config.Tools.public_tools_extra_opt () with
    | Some raw ->
        String.split_on_char ',' raw

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -272,7 +272,7 @@ Pair with masc_collaboration_graph to review the graph before and after consolid
     name = "masc_get_metrics";
     description = "Fetch raw performance metrics for an agent: task completion data, timing, error rates, and collaboration history. \
 Use when investigating agent performance issues or preparing data for masc_metrics_compare. \
-Pair with masc_agent_fitness for computed scores, masc_audit_stats for security-focused metrics.";
+Pair with masc_agent_fitness for computed scores and masc_status for current room context.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -131,7 +131,7 @@ Pair with masc_cancellation to support cooperative abort during tracked operatio
     name = "masc_governance_set";
     description = "Configure governance policies for the room including audit logging, anomaly detection, and agent isolation levels. \
 Use when setting up a new room for production or tightening security after an incident. \
-Pair with masc_governance_report to verify policy effects and masc_governance_status for current state.";
+Pair with masc_governance_status to confirm current state after changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -82,7 +82,8 @@ let register_all () =
     "masc_heartbeat_stop"; "masc_heartbeat_list";
   ];
 
-  (* Mod_hat, Mod_cost, Mod_rate_limit: removed from MCP surface (#3640) *)
+  (* Mod_hat removed from MCP surface (#3640);
+     Mod_cost and Mod_rate_limit are fully covered by schemas. *)
 
   (* Mod_suspend: fully covered by schemas — no entries needed *)
 

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -74,7 +74,7 @@ let test_dashboard_tools_projection () =
       let hidden_tool =
         inventory_rows
         |> List.find_opt (fun row ->
-               row |> member "name" |> to_string = "masc_team_session_step")
+               row |> member "name" |> to_string = "masc_code_search")
       in
       check bool "includes hidden tool" true (Option.is_some hidden_tool);
       match hidden_tool with

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -571,9 +571,9 @@ let test_handle_request_tools_list () =
     true
     (List.mem "masc_board_post" names);
   Alcotest.(check bool)
-    "goal_upsert hidden from public surface"
+    "board_search hidden from public surface"
     false
-    (List.mem "masc_goal_upsert" names);
+    (List.mem "masc_board_search" names);
   Alcotest.(check bool)
     "legacy experiment_start hidden from list"
     false
@@ -1736,7 +1736,6 @@ let test_handle_request_invalid_json () =
   cleanup_dir base_path
 
 (* masc_cache_get structured content test removed: cache tools retired from MCP surface (#3640) *)
-
 let test_handle_request_tools_call_board_post_structured_content () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -287,12 +287,6 @@ let all_known_tool_names =
     "masc_room_strategy_set";
     "masc_route";
     "masc_ruling_status";
-    "masc_run_deliverable";
-    "masc_run_get";
-    "masc_run_init";
-    "masc_run_list";
-    "masc_run_log";
-    "masc_run_plan";
     "masc_runtime_params";
     "masc_runtime_verify";
     "masc_select_agent";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -112,7 +112,6 @@ let all_known_tool_names =
     "masc_code_write";
     "masc_collaboration_evidence";
     "masc_collaboration_graph";
-    "masc_compact_context";
     "masc_config";
     "masc_config_snapshot";
     "masc_consolidate_learning";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -158,6 +158,8 @@ let all_known_tool_names =
     "masc_governance_report";
     "masc_governance_set";
     "masc_governance_status";
+    "masc_hat_status";
+    "masc_hat_wear";
     "masc_handover_claim";
     "masc_handover_claim_and_spawn";
     "masc_handover_create";
@@ -287,6 +289,12 @@ let all_known_tool_names =
     "masc_room_strategy_set";
     "masc_route";
     "masc_ruling_status";
+    "masc_run_deliverable";
+    "masc_run_get";
+    "masc_run_init";
+    "masc_run_list";
+    "masc_run_log";
+    "masc_run_plan";
     "masc_runtime_params";
     "masc_runtime_verify";
     "masc_select_agent";

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -118,7 +118,7 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_a2a_delegate" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits vote_create (hidden)" false
     (List.mem "mcp__masc__masc_vote_create" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains run_deliverable" true
+  Alcotest.(check bool) "omits run_deliverable" false
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains board_post" true
     (List.mem "mcp__masc__masc_board_post" Spawn.masc_mcp_tools);

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -160,7 +160,7 @@ let test_masc_mcp_tools_has_vote_create () =
     (List.mem "mcp__masc__masc_vote_create" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_run_deliverable () =
-  check bool "has run_deliverable" true
+  check bool "omits run_deliverable" false
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_tool_help () =


### PR DESCRIPTION
Rebased onto the latest main and refreshed stale removed-tool expectations.

Local verification:
- `dune build --root . test/test_tool_exposure.exe test/test_mcp_tool_matrix.exe test/test_dashboard_tools.exe`
- `./_build_3712_rebase/default/test/test_tool_exposure.exe`
- `env MASC_OTEL_ENABLED=0 ./_build_3712_rebase/default/test/test_mcp_tool_matrix.exe test inventory`
- `./_build_3712_rebase/default/test/test_dashboard_tools.exe`

Notes:
- Previous PR #3712 was closed unexpectedly, so this reopens the same branch as a fresh draft PR.
- `test_mcp_server_eio.exe` expectation changes were compiled as part of the branch rebase; focused runtime verification above was rerun on the drift-sensitive surfaces.