### PR TITLE
fix(keeper): migrate perpetual keeper metadata

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -171,13 +171,9 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
     Moves contents via recursive merge. Conflicting files go to _quarantine/,
     except keeper meta files where a fresher valid legacy record may replace a
     stale or invalid current record. *)
-let keeper_meta_updated_ts path =
-  match Keeper_types.read_meta_file_path path with
-  | Ok (Some meta) ->
-      Some
-        (Resilience.Time.parse_iso8601_opt meta.updated_at
-        |> Option.value ~default:0.0)
-  | Ok None | Error _ -> None
+let keeper_meta_updated_ts (meta : Keeper_types.keeper_meta) =
+  Resilience.Time.parse_iso8601_opt meta.updated_at
+  |> Option.value ~default:0.0
 
 let should_promote_legacy_keeper_meta ~legacy_path ~current_path =
   match
@@ -185,13 +181,7 @@ let should_promote_legacy_keeper_meta ~legacy_path ~current_path =
     Keeper_types.read_meta_file_path current_path
   with
   | Ok (Some _legacy), Ok (Some _current) -> (
-      match
-        keeper_meta_updated_ts legacy_path,
-        keeper_meta_updated_ts current_path
-      with
-      | Some legacy_ts, Some current_ts -> legacy_ts > current_ts
-      | Some _, None -> true
-      | None, Some _ | None, None -> false)
+      keeper_meta_updated_ts _legacy > keeper_meta_updated_ts _current)
   | Ok (Some _), Ok None | Ok (Some _), Error _ -> true
   | _ -> false
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -168,11 +168,38 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    | exn -> Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn))
 
 (** Migrate legacy directory names: perpetual->traces, perpetual-keepers->keepers.
-    Moves contents via recursive merge. Conflicting files go to _quarantine/. *)
+    Moves contents via recursive merge. Conflicting files go to _quarantine/,
+    except keeper meta files where a fresher valid legacy record may replace a
+    stale or invalid current record. *)
+let keeper_meta_updated_ts path =
+  match Keeper_types.read_meta_file_path path with
+  | Ok (Some meta) ->
+      Some
+        (Resilience.Time.parse_iso8601_opt meta.updated_at
+        |> Option.value ~default:0.0)
+  | Ok None | Error _ -> None
+
+let should_promote_legacy_keeper_meta ~legacy_path ~current_path =
+  match
+    Keeper_types.read_meta_file_path legacy_path,
+    Keeper_types.read_meta_file_path current_path
+  with
+  | Ok (Some _legacy), Ok (Some _current) -> (
+      match
+        keeper_meta_updated_ts legacy_path,
+        keeper_meta_updated_ts current_path
+      with
+      | Some legacy_ts, Some current_ts -> legacy_ts > current_ts
+      | Some _, None -> true
+      | None, Some _ | None, None -> false)
+  | Ok (Some _), Ok None | Ok (Some _), Error _ -> true
+  | _ -> false
+
 let migrate_legacy_dirs (state : Mcp_server.server_state) =
   let masc = Room.masc_root_dir state.room_config in
   let quarantine = Filename.concat masc "_quarantine" in
-  let rec migrate_recursive ~old_dir ~new_dir ~rel_path =
+  let rec migrate_recursive ~old_dir ~new_dir ~rel_path
+      ~prefer_root_keeper_meta_conflicts =
     if not (Sys.file_exists old_dir) then ()
     else begin
       Keeper_types.mkdir_p new_dir;
@@ -183,13 +210,27 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
         if Sys.is_directory old_path then begin
           if Sys.file_exists new_path then
             migrate_recursive ~old_dir:old_path ~new_dir:new_path ~rel_path:rel
+              ~prefer_root_keeper_meta_conflicts
           else
             Sys.rename old_path new_path
         end else begin
           if Sys.file_exists new_path then begin
-            let q_path = Filename.concat quarantine rel in
-            Keeper_types.mkdir_p (Filename.dirname q_path);
-            Sys.rename old_path q_path
+            if prefer_root_keeper_meta_conflicts && rel_path = ""
+               && Filename.check_suffix name ".json"
+               && should_promote_legacy_keeper_meta
+                    ~legacy_path:old_path ~current_path:new_path
+            then begin
+              let replaced_q_path =
+                Filename.concat quarantine (Filename.concat "_replaced" rel)
+              in
+              Keeper_types.mkdir_p (Filename.dirname replaced_q_path);
+              Sys.rename new_path replaced_q_path;
+              Sys.rename old_path new_path
+            end else begin
+              let q_path = Filename.concat quarantine rel in
+              Keeper_types.mkdir_p (Filename.dirname q_path);
+              Sys.rename old_path q_path
+            end
           end else
             Sys.rename old_path new_path
         end
@@ -204,7 +245,7 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
   in
   let renames = [
     ("perpetual", "traces");
-    ("keepers", "keepers");
+    ("perpetual-keepers", "keepers");
     ("resident-keepers", "keepers");
   ] in
   (try
@@ -214,6 +255,7 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
       if Sys.file_exists old_dir then begin
         Log.Misc.info "migrate: %s -> %s" old_name new_name;
         migrate_recursive ~old_dir ~new_dir ~rel_path:""
+          ~prefer_root_keeper_meta_conflicts:(String.equal new_name "keepers")
       end
     ) renames
   with

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -45,6 +45,7 @@ val bootstrap_chain_state : Mcp_server.server_state -> unit
 (** {1 Startup Tasks} *)
 
 val warm_tool_registry_from_telemetry : Mcp_server.server_state -> unit
+val migrate_legacy_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -236,6 +236,65 @@ let test_room_init_bootstraps_keeper_runtime_dirs () =
       Alcotest.(check bool) "perpetual dir exists" true
         (Sys.file_exists perpetual_dir && Sys.is_directory perpetual_dir))
 
+let make_keeper_meta_json ?(name = "sangsu")
+    ?(trace_id = "trace-sangsu-live")
+    ?(updated_at = "2026-03-29T10:36:57Z") () =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String trace_id);
+          ("goal", `String ("goal-" ^ name));
+          ("cascade_name", `String "keeper_unified");
+          ("updated_at", `String updated_at);
+          ("last_model_used", `String "llama:auto");
+        ])
+  with
+  | Ok meta -> Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
+  | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+
+let test_migrate_legacy_keeper_dirs_promotes_valid_meta () =
+  with_temp_dir "startup-legacy-keepers" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let keepers_dir = Filename.concat masc_root "keepers" in
+      let legacy_dir = Filename.concat masc_root "perpetual-keepers" in
+      let quarantine_dir =
+        Filename.concat masc_root "_quarantine/_replaced"
+      in
+      Fs_compat.mkdir_p keepers_dir;
+      Fs_compat.mkdir_p legacy_dir;
+      write_file (Filename.concat keepers_dir "sangsu.json")
+        {|{"name":"sangsu","created_at":"2026-03-26T15:53:16Z","updated_at":"2026-03-26T17:44:32Z"}|};
+      write_file (Filename.concat legacy_dir "sangsu.json")
+        (make_keeper_meta_json ());
+      write_file (Filename.concat legacy_dir "other.json")
+        (make_keeper_meta_json ~name:"other" ~trace_id:"trace-other-live" ());
+      Server_runtime_bootstrap.migrate_legacy_dirs state;
+      let read_meta_exn path =
+        match Keeper_types.read_meta_file_path path with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.failf "missing keeper meta at %s" path
+        | Error err -> Alcotest.failf "failed to read keeper meta %s: %s" path err
+      in
+      let sangsu_meta =
+        read_meta_exn (Filename.concat keepers_dir "sangsu.json")
+      in
+      let other_meta =
+        read_meta_exn (Filename.concat keepers_dir "other.json")
+      in
+      Alcotest.(check string) "sangsu trace promoted from perpetual-keepers"
+        "trace-sangsu-live" sangsu_meta.trace_id;
+      Alcotest.(check string) "other keeper migrated from perpetual-keepers"
+        "trace-other-live" other_meta.trace_id;
+      Alcotest.(check bool) "legacy dir removed after merge" false
+        (Sys.file_exists legacy_dir);
+      Alcotest.(check bool) "replaced stale keeper quarantined" true
+        (Sys.file_exists (Filename.concat quarantine_dir "sangsu.json")))
+
+>>>>>>> 0e4314ccf (fix(keeper): migrate perpetual keeper metadata)
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -390,6 +449,9 @@ let () =
             test_keeper_paths_use_cluster_root;
           Alcotest.test_case "room init bootstraps keeper runtime dirs" `Quick
             test_room_init_bootstraps_keeper_runtime_dirs;
+          Alcotest.test_case
+            "legacy keeper migration promotes valid perpetual meta"
+            `Quick test_migrate_legacy_keeper_dirs_promotes_valid_meta;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -294,7 +294,36 @@ let test_migrate_legacy_keeper_dirs_promotes_valid_meta () =
       Alcotest.(check bool) "replaced stale keeper quarantined" true
         (Sys.file_exists (Filename.concat quarantine_dir "sangsu.json")))
 
->>>>>>> 0e4314ccf (fix(keeper): migrate perpetual keeper metadata)
+let test_migrate_legacy_keeper_dirs_keeps_fresher_current_meta () =
+  with_temp_dir "startup-legacy-keepers-current-wins" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let keepers_dir = Filename.concat masc_root "keepers" in
+      let legacy_dir = Filename.concat masc_root "perpetual-keepers" in
+      let quarantine_path =
+        Filename.concat masc_root "_quarantine/sangsu.json"
+      in
+      Fs_compat.mkdir_p keepers_dir;
+      Fs_compat.mkdir_p legacy_dir;
+      write_file (Filename.concat keepers_dir "sangsu.json")
+        (make_keeper_meta_json ~updated_at:"2026-03-29T11:36:57Z" ());
+      write_file (Filename.concat legacy_dir "sangsu.json")
+        (make_keeper_meta_json ~updated_at:"2026-03-29T10:36:57Z" ());
+      Server_runtime_bootstrap.migrate_legacy_dirs state;
+      let current_meta =
+        match
+          Keeper_types.read_meta_file_path
+            (Filename.concat keepers_dir "sangsu.json")
+        with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "missing current keeper meta"
+        | Error err -> Alcotest.failf "failed to read current keeper meta: %s" err
+      in
+      Alcotest.(check string) "fresher current meta preserved"
+        "2026-03-29T11:36:57Z" current_meta.updated_at;
+      Alcotest.(check bool) "older legacy keeper quarantined" true
+        (Sys.file_exists quarantine_path))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -452,6 +481,9 @@ let () =
           Alcotest.test_case
             "legacy keeper migration promotes valid perpetual meta"
             `Quick test_migrate_legacy_keeper_dirs_promotes_valid_meta;
+          Alcotest.test_case
+            "legacy keeper migration keeps fresher current meta"
+            `Quick test_migrate_legacy_keeper_dirs_keeps_fresher_current_meta;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick


### PR DESCRIPTION
## Summary

- restore legacy startup migration from `.masc/perpetual-keepers` to canonical `.masc/keepers`
- prefer fresher valid legacy keeper meta when it conflicts with stale or invalid current meta
- add a regression test covering the exact broken live scenario

## Root Cause

`server_runtime_bootstrap` documented `perpetual-keepers -> keepers` migration but the actual rename table omitted that entry and kept a no-op `keepers -> keepers` row instead. On startup, valid keeper metadata under `.masc/perpetual-keepers` was ignored, so live keeper state could collapse to whatever happened to remain under `.masc/keepers`.

## Validation

- `env MASC_OTEL_ENABLED=0 ./_build/default/test/test_server_runtime_bootstrap.exe`
  - migration regression: `OK`
  - existing `main_eio serves health before lazy startup`: `SKIP` in this environment

## Live Recovery Note

- local `8935` was manually recovered before this patch by restoring canonical keeper metadata and re-arming non-paused keepers
- patched `8935` was then restarted from this branch and confirmed healthy
