### PR TITLE
fix(test): unregister keeper before reconcile to match orphan scenario

### DIFF
--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1861,8 +1861,12 @@ let test_keeper_supervisor_recovers_missing_desired_keeper () =
             ])
       in
       check bool "keeper up ok" true ok;
+      (* Simulate an orphaned keeper: stop keepalive and remove registry
+         entry so reconcile sees a durable keeper on disk with no live
+         entry — the real-world scenario this test targets. *)
       Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
-      check bool "keepalive stopped before recovery" false
+      Masc_mcp.Keeper_registry.unregister ~base_path:config.base_path "sangsu";
+      check bool "keepalive stopped and unregistered before recovery" false
         (Masc_mcp.Keeper_registry.is_running ~base_path:config.base_path "sangsu");
       Masc_mcp.Keeper_supervisor.sweep_and_recover keeper_ctx;
       check bool "keepalive recovered by sweep" true


### PR DESCRIPTION
## Summary
- Fixes flaky `keeper supervisor recovers missing desired keeper` test
- Root cause: `stop_keepalive` sets state to Stopped but fiber may not terminate immediately, leaving `done_p` unresolved. Reconcile correctly skips entries with unresolved fibers (sweep owns them).
- Fix: `unregister` the keeper after stopping to simulate the actual orphaned-keeper scenario (durable on disk, no registry entry)

## Test plan
- [x] This PR fixes the test itself
- CI Build and Test should pass (this test was blocking all PRs)