### PR TITLE
feat(dashboard): add start autoresearch loop from UI

### DIFF
--- a/dashboard/src/api/autoresearch.ts
+++ b/dashboard/src/api/autoresearch.ts
@@ -58,10 +58,23 @@ export interface AutoresearchLoopDetail extends AutoresearchLoopSummary {
 
 export interface AutoresearchLoopActionResponse {
   ok: boolean
-  action?: 'retry' | 'delete'
+  action?: 'retry' | 'delete' | 'start'
   loop_id?: string
   loop?: AutoresearchLoopSummary
   error?: string
+}
+
+export interface StartAutoresearchLoopParams {
+  goal: string
+  metric_fn: string
+  target_file: string
+  workdir?: string
+  max_cycles?: number
+  cycle_timeout_s?: number
+  model_model?: string
+  baseline?: number
+  patience?: number
+  build_verify_fn?: string
 }
 
 export function fetchAutoresearchLoops(): Promise<AutoresearchLoopsResponse> {
@@ -81,4 +94,10 @@ export function retryAutoresearchLoop(loopId: string): Promise<AutoresearchLoopA
 
 export function deleteAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
   return post('/api/v1/autoresearch/loops/delete', { loop_id: loopId })
+}
+
+export function startAutoresearchLoop(
+  params: StartAutoresearchLoopParams,
+): Promise<AutoresearchLoopActionResponse> {
+  return post('/api/v1/autoresearch/loops/start', params)
 }

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -89,7 +89,7 @@ async function loadComponentWithApi(api: {
     ...api,
     retryAutoresearchLoop: api.retryAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'retry' }),
     deleteAutoresearchLoop: api.deleteAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'delete' }),
-    startAutoresearchLoop: vi.fn().mockResolvedValue({ ok: true, action: 'start' }),
+    startAutoresearchLoop: (api as Record<string, unknown>).startAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'start' }),
   }))
   const module = await import('./autoresearch')
   module.resetAutoresearchState()

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -89,6 +89,7 @@ async function loadComponentWithApi(api: {
     ...api,
     retryAutoresearchLoop: api.retryAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'retry' }),
     deleteAutoresearchLoop: api.deleteAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'delete' }),
+    startAutoresearchLoop: vi.fn().mockResolvedValue({ ok: true, action: 'start' }),
   }))
   const module = await import('./autoresearch')
   module.resetAutoresearchState()

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -6,6 +6,8 @@ import { signal, computed } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
+import { DialogOverlay } from './common/dialog'
+import { TextInput, TextArea } from './common/input'
 import { formatElapsedCompact } from '../lib/format-time'
 import { navigate } from '../router'
 import {
@@ -13,10 +15,12 @@ import {
   fetchAutoresearchLoops,
   fetchAutoresearchLoopDetail,
   retryAutoresearchLoop,
+  startAutoresearchLoop,
   type AutoresearchLoopsResponse,
   type AutoresearchLoopDetail,
   type AutoresearchLoopSummary,
   type AutoresearchCycleRecord,
+  type StartAutoresearchLoopParams,
 } from '../api'
 
 // --- State ---
@@ -36,6 +40,22 @@ let loopsRequest: Promise<void> | null = null
 let pendingRefreshDetail = false
 let detailRequestSeq = 0
 
+// --- Start form state ---
+const showStartForm = signal(false)
+const startFormBusy = signal(false)
+const startFormError = signal<string | null>(null)
+const formGoal = signal('')
+const formMetricFn = signal('')
+const formTargetFile = signal('')
+const formShowAdvanced = signal(false)
+const formWorkdir = signal('')
+const formMaxCycles = signal('100')
+const formCycleTimeoutS = signal('300')
+const formModelModel = signal('glm')
+const formBaseline = signal('')
+const formPatience = signal('')
+const formBuildVerifyFn = signal('')
+
 export function resetAutoresearchState(): void {
   loopsData.value = null
   loopsLoading.value = false
@@ -49,6 +69,10 @@ export function resetAutoresearchState(): void {
   loopsRequest = null
   pendingRefreshDetail = false
   detailRequestSeq = 0
+  showStartForm.value = false
+  startFormBusy.value = false
+  startFormError.value = null
+  resetStartFormFields()
 }
 
 const selectedLoop = computed<AutoresearchLoopSummary | null>(() => {
@@ -375,6 +399,226 @@ function WarningsList({ warnings }: { warnings: string[] }) {
   `
 }
 
+function resetStartFormFields() {
+  formGoal.value = ''
+  formMetricFn.value = ''
+  formTargetFile.value = ''
+  formShowAdvanced.value = false
+  formWorkdir.value = ''
+  formMaxCycles.value = '100'
+  formCycleTimeoutS.value = '300'
+  formModelModel.value = 'glm'
+  formBaseline.value = ''
+  formPatience.value = ''
+  formBuildVerifyFn.value = ''
+}
+
+function closeStartForm() {
+  showStartForm.value = false
+  startFormError.value = null
+}
+
+async function handleStartSubmit() {
+  const goal = formGoal.value.trim()
+  const metric_fn = formMetricFn.value.trim()
+  const target_file = formTargetFile.value.trim()
+  if (!goal || !metric_fn || !target_file) return
+
+  startFormBusy.value = true
+  startFormError.value = null
+  try {
+    const params: StartAutoresearchLoopParams = { goal, metric_fn, target_file }
+    const workdir = formWorkdir.value.trim()
+    if (workdir) params.workdir = workdir
+    const maxCycles = parseInt(formMaxCycles.value, 10)
+    if (Number.isFinite(maxCycles) && maxCycles > 0) params.max_cycles = maxCycles
+    const cycleTimeout = parseFloat(formCycleTimeoutS.value)
+    if (Number.isFinite(cycleTimeout) && cycleTimeout > 0) params.cycle_timeout_s = cycleTimeout
+    const modelModel = formModelModel.value.trim()
+    if (modelModel) params.model_model = modelModel
+    const baseline = parseFloat(formBaseline.value)
+    if (Number.isFinite(baseline)) params.baseline = baseline
+    const patience = parseInt(formPatience.value, 10)
+    if (Number.isFinite(patience) && patience > 0) params.patience = patience
+    const buildVerifyFn = formBuildVerifyFn.value.trim()
+    if (buildVerifyFn) params.build_verify_fn = buildVerifyFn
+
+    const result = await startAutoresearchLoop(params)
+    if (!result.ok) {
+      startFormError.value = result.error ?? '알 수 없는 오류가 발생했습니다.'
+      return
+    }
+    closeStartForm()
+    resetStartFormFields()
+    await refreshAutoresearchSurface()
+  } catch (err) {
+    startFormError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    startFormBusy.value = false
+  }
+}
+
+function inputHandler(sig: { value: string }) {
+  return (e: Event) => { sig.value = (e.target as HTMLInputElement).value }
+}
+
+function StartFormButton({ class: cx }: { class?: string }) {
+  return html`
+    <button type="button"
+      class=${cx ?? 'px-3 py-1.5 rounded-lg text-xs font-medium border border-accent/50 text-accent hover:bg-accent/10 transition-colors'}
+      onClick=${() => { showStartForm.value = true }}
+    >
+      새 루프 시작
+    </button>
+  `
+}
+
+function StartAutoresearchForm() {
+  const canSubmit = formGoal.value.trim() && formMetricFn.value.trim() && formTargetFile.value.trim() && !startFormBusy.value
+
+  return html`
+    <${DialogOverlay}
+      labelledBy="start-autoresearch-title"
+      onClose=${closeStartForm}
+      overlayClass="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      panelClass="w-full max-w-lg mx-4 rounded-xl border border-card-border bg-[var(--card-bg)] shadow-2xl p-6"
+    >
+      <h2 id="start-autoresearch-title" class="text-sm font-semibold text-[var(--text-strong)] mb-4">
+        새 오토리서치 루프
+      </h2>
+
+      <div class="flex flex-col gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">목표 *</span>
+          <${TextArea}
+            value=${formGoal.value}
+            placeholder="최적화 목표 (예: Reduce inference latency by optimizing hot path)"
+            rows=${2}
+            onInput=${inputHandler(formGoal)}
+          />
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">메트릭 명령어 *</span>
+          <${TextInput}
+            value=${formMetricFn.value}
+            placeholder="마지막 줄에 float를 출력하는 명령어 (예: python eval.py --metric accuracy)"
+            onInput=${inputHandler(formMetricFn)}
+          />
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">대상 파일 *</span>
+          <${TextInput}
+            value=${formTargetFile.value}
+            placeholder="수정할 파일 경로 (예: lib/optimizer.ml)"
+            onInput=${inputHandler(formTargetFile)}
+          />
+        </label>
+
+        <button type="button"
+          class="self-start text-[11px] text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
+          onClick=${() => { formShowAdvanced.value = !formShowAdvanced.value }}
+        >
+          ${formShowAdvanced.value ? '고급 설정 접기 \u25B2' : '고급 설정 \u25BC'}
+        </button>
+
+        ${formShowAdvanced.value ? html`
+          <div class="grid grid-cols-2 gap-3 border-t border-card-border pt-3">
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">작업 디렉토리</span>
+              <${TextInput}
+                value=${formWorkdir.value}
+                placeholder="기본: 프로젝트 루트"
+                onInput=${inputHandler(formWorkdir)}
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">모델</span>
+              <${TextInput}
+                value=${formModelModel.value}
+                placeholder="glm"
+                onInput=${inputHandler(formModelModel)}
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">최대 사이클</span>
+              <${TextInput}
+                type="number"
+                value=${formMaxCycles.value}
+                placeholder="100"
+                onInput=${inputHandler(formMaxCycles)}
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">사이클 타임아웃 (초)</span>
+              <${TextInput}
+                type="number"
+                value=${formCycleTimeoutS.value}
+                placeholder="300"
+                onInput=${inputHandler(formCycleTimeoutS)}
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">기준선 (baseline)</span>
+              <${TextInput}
+                type="number"
+                value=${formBaseline.value}
+                placeholder="자동 측정 (빈칸)"
+                onInput=${inputHandler(formBaseline)}
+              />
+            </label>
+            <label class="flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">인내 (patience)</span>
+              <${TextInput}
+                type="number"
+                value=${formPatience.value}
+                placeholder="기본값 사용"
+                onInput=${inputHandler(formPatience)}
+              />
+            </label>
+            <label class="col-span-2 flex flex-col gap-1">
+              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">빌드 검증 명령어</span>
+              <${TextInput}
+                value=${formBuildVerifyFn.value}
+                placeholder="선택 (예: dune build)"
+                onInput=${inputHandler(formBuildVerifyFn)}
+              />
+            </label>
+          </div>
+        ` : null}
+
+        ${startFormError.value ? html`
+          <div class="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs">
+            ${startFormError.value}
+          </div>
+        ` : null}
+
+        <div class="flex items-center justify-end gap-2 mt-2">
+          <button type="button"
+            class="px-3 py-1.5 rounded-lg text-xs font-medium border border-card-border text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
+            onClick=${closeStartForm}
+            disabled=${startFormBusy.value}
+          >
+            취소
+          </button>
+          <button type="button"
+            class="px-4 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
+              canSubmit
+                ? 'border-accent/60 bg-accent/15 text-accent hover:bg-accent/25'
+                : 'border-card-border bg-card/60 text-[var(--text-muted)] cursor-not-allowed opacity-50'
+            }"
+            disabled=${!canSubmit}
+            onClick=${() => { void handleStartSubmit() }}
+          >
+            ${startFormBusy.value ? '시작 중...' : '시작'}
+          </button>
+        </div>
+      </div>
+    <//>
+  `
+}
+
 function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
   const linkedAt = loop.linked_at != null ? formatTimestamp(loop.linked_at) : '미연결'
 
@@ -574,7 +818,16 @@ export function Autoresearch() {
   const loops = loopsData.value?.loops ?? []
 
   if (loops.length === 0) {
-    return html`<${EmptyState} message="실행된 오토리서치 루프가 없습니다." icon="🔬" />`
+    return html`
+      <div class="flex flex-col gap-4">
+        <${EmptyState}
+          message="실행된 오토리서치 루프가 없습니다."
+          icon="🔬"
+          action=${html`<${StartFormButton} />`}
+        />
+        ${showStartForm.value ? html`<${StartAutoresearchForm} />` : null}
+      </div>
+    `
   }
 
   return html`
@@ -585,16 +838,22 @@ export function Autoresearch() {
         <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">
           전체 ${loops.length}개 루프
         </div>
-        <button type="button"
-          class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
-          onClick=${() => { void refreshAutoresearchSurface() }}
-        >
-          새로고침
-        </button>
+        <div class="flex items-center gap-2">
+          <${StartFormButton}
+            class="px-2.5 py-1 rounded text-[11px] text-accent border border-accent/40 hover:bg-accent/10 transition-colors"
+          />
+          <button type="button"
+            class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
+            onClick=${() => { void refreshAutoresearchSurface() }}
+          >
+            새로고침
+          </button>
+        </div>
       </div>
 
       <${LoopSelector} />
       <${LoopDetailView} />
+      ${showStartForm.value ? html`<${StartAutoresearchForm} />` : null}
     </div>
   `
 }

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -473,8 +473,11 @@ function StartFormButton({ class: cx }: { class?: string }) {
   `
 }
 
+const canSubmit = computed(() =>
+  formGoal.value.trim() !== '' && formMetricFn.value.trim() !== '' && formTargetFile.value.trim() !== '' && !startFormBusy.value
+)
+
 function StartAutoresearchForm() {
-  const canSubmit = formGoal.value.trim() && formMetricFn.value.trim() && formTargetFile.value.trim() && !startFormBusy.value
 
   return html`
     <${DialogOverlay}
@@ -604,11 +607,11 @@ function StartAutoresearchForm() {
           </button>
           <button type="button"
             class="px-4 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
-              canSubmit
+              canSubmit.value
                 ? 'border-accent/60 bg-accent/15 text-accent hover:bg-accent/25'
                 : 'border-card-border bg-card/60 text-[var(--text-muted)] cursor-not-allowed opacity-50'
             }"
-            disabled=${!canSubmit}
+            disabled=${!canSubmit.value}
             onClick=${() => { void handleStartSubmit() }}
           >
             ${startFormBusy.value ? '시작 중...' : '시작'}

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -533,3 +533,34 @@ let delete_loop_json ~(base_path : string) ~(loop_id : string) :
                 ("action", `String "delete");
                 ("loop_id", `String loop_id);
               ])
+
+let start_loop_json ~(base_path : string) ~(args : Yojson.Safe.t) :
+    (Yojson.Safe.t, string) result =
+  let ctx : Tool_autoresearch.context =
+    {
+      base_path;
+      agent_name = None;
+      start_operation = None;
+      start_team_session = None;
+      config = None;
+      sw = None;
+      clock = None;
+    }
+  in
+  let result = Tool_autoresearch.handle_start ctx args in
+  match result with
+  | `Assoc fields when List.mem_assoc "error" fields ->
+      let error_msg =
+        match List.assoc "error" fields with
+        | `String msg -> msg
+        | _ -> "unknown error"
+      in
+      Error error_msg
+  | json ->
+      Ok
+        (`Assoc
+          [
+            ("ok", `Bool true);
+            ("action", `String "start");
+            ("loop", json);
+          ])

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -638,6 +638,30 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
 
+  |> Http.Router.post "/api/v1/autoresearch/loops/start" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_autoresearch_start" (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             let base_path = state.Mcp_server.room_config.base_path in
+             (match
+               Dashboard_http_autoresearch.start_loop_json ~base_path ~args
+             with
+             | Ok result ->
+                 Http.Response.json ~compress:true ~request:req
+                   (Yojson.Safe.to_string result) reqd
+             | Error message ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                      (String.escaped message))
+                   reqd)
+           with Yojson.Json_error _ ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               {|{"ok":false,"error":"invalid JSON body"}|}
+               reqd
+         )
+       ) request reqd)
+
   |> Http.Router.post "/api/v1/autoresearch/loops/delete" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_autoresearch_stop" (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -652,8 +652,8 @@ let add_routes ~sw ~clock router =
                    (Yojson.Safe.to_string result) reqd
              | Error message ->
                  Http.Response.json ~status:`Bad_request ~request:req
-                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
-                      (String.escaped message))
+                   (Yojson.Safe.to_string
+                      (`Assoc [("ok", `Bool false); ("error", `String message)]))
                    reqd)
            with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req


### PR DESCRIPTION
## Summary
- Dashboard autoresearch 탭에 "새 루프 시작" 버튼과 폼 다이얼로그를 추가
- Backend: `POST /api/v1/autoresearch/loops/start` endpoint (기존 `Tool_autoresearch.handle_start` 재사용, 로직 중복 0)
- Frontend: `DialogOverlay` + `TextInput`/`TextArea` 기존 컴포넌트 활용, 필수 3필드 + 고급 설정 접기/펼치기

## Changes
| Layer | File | Description |
|-------|------|-------------|
| Backend | `lib/dashboard/dashboard_http_autoresearch.ml` | `start_loop_json` thin wrapper |
| Route | `lib/server/server_routes_http_routes_dashboard.ml` | POST start route 등록 |
| API | `dashboard/src/api/autoresearch.ts` | `startAutoresearchLoop()` + params type |
| UI | `dashboard/src/components/autoresearch.ts` | Start form dialog + buttons |
| Test | `dashboard/src/components/autoresearch.test.ts` | mock 업데이트 |

## Test plan
- [x] `dune build` — OCaml 컴파일 통과
- [x] `vitest run autoresearch.test.ts` — 기존 8개 테스트 통과
- [ ] Dashboard UI에서 빈 상태 → "새 루프 시작" 버튼 클릭 → 폼 표시 확인
- [ ] 필수 필드 미입력 시 "시작" 버튼 비활성화 확인
- [ ] `curl -X POST localhost:8935/api/v1/autoresearch/loops/start -d '{"goal":"test","metric_fn":"echo 1.0","target_file":"README.md"}'` 테스트
- [ ] 생성된 loop이 목록에 나타나고 선택 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)