### PR TITLE
fix(keeper): timing ring overflow + RFC state machine

### DIFF
--- a/docs/design/adaptive-heartbeat-scheduling-rfc.md
+++ b/docs/design/adaptive-heartbeat-scheduling-rfc.md
@@ -487,6 +487,52 @@ Phase 3 착수 조건:
 1. Phase 1에서 presence skip이 downstream consumer(dashboard, SSE)가 기대하는 `last_seen` 갱신을 누락시킬 수 있음. Step 1.2에서 turn 완료 시 `Room.heartbeat_in_room`을 명시적으로 호출하여 방지.
 2. Phase 1에서 `last_successful_heartbeat_ts`가 supervisor의 `done_p` SSOT를 침범하지 않도록 scope를 엄격히 분리. freshness(presence skip)와 liveness(fiber death)는 독립 관심사.
 
+## 5.1 Keeper State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running : register()
+
+    Running --> Stopped : normal exit (stop flag)
+    Running --> Crashed : Keeper_heartbeat_failure
+    Running --> Crashed : generic exception
+    Running --> Crashed : fiber_unresolved (finally)
+    Running --> Paused : pause (future)
+
+    Paused --> Running : resume (future)
+
+    Crashed --> Running : sweep restart (within budget)
+    Crashed --> Dead : sweep (budget exhausted)
+
+    Dead --> [*] : unregister (after TTL)
+
+    Stopped --> [*] : sweep unregister
+
+    note right of Running
+        sweep: skip (fiber alive)
+        reconcile: skip (sweep-owned)
+    end note
+
+    note right of Crashed
+        sweep: restart candidate
+        reconcile: skip (sweep-owned)
+        self-preservation gate applies
+    end note
+
+    note right of Dead
+        sweep: TTL cleanup only
+        reconcile: skip (sweep-owned)
+        set_state to non-Dead: blocked
+    end note
+
+    note right of Stopped
+        done_p resolved: reconcile-eligible
+        done_p unresolved: sweep will handle
+    end note
+```
+
+**Owner 구분**: sweep_and_recover가 Running/Paused/Crashed/Dead를 관리. reconcile_keepalive_keepers는 orphaned(registry에 없음) 또는 Stopped+resolved 상태만 재시작.
+
 ## 6. Implementation Checklist
 
 - [x] Phase 0.1: Per-stage timer 계측 (keeper_keepalive.ml) — #3659

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -162,7 +162,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let timing_ring = Array.make stage_timing_ring_size
     { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
       turn_ms = 0.0; recurring_ms = 0.0; improve_ms = 0.0 } in
-  let timing_count = ref 0 in
+  let timing_cursor = ref 0 in
+  let timing_filled = ref 0 in
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Room.heartbeat_in_room success after turn. *)
   let last_successful_heartbeat_ts = ref 0.0 in
@@ -346,7 +347,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                              | None -> `Null );
                            ("handoff", `Assoc [ ("performed", `Bool false) ]);
                            ("stage_timing",
-                             stage_timing_to_json ~ring:timing_ring ~count:!timing_count);
+                             stage_timing_to_json ~ring:timing_ring ~count:!timing_filled);
                          ]
                      in
                      Dated_jsonl.append metrics_store snapshot;
@@ -515,8 +516,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0;
               improve_ms = (t_improve_end -. t_improve_start) *. 1000.0;
             } in
-            timing_ring.(!timing_count mod stage_timing_ring_size) <- timing;
-            incr timing_count;
+            timing_ring.(!timing_cursor) <- timing;
+            timing_cursor := (!timing_cursor + 1) mod stage_timing_ring_size;
+            if !timing_filled < stage_timing_ring_size then incr timing_filled;
             let jitter = base *. 0.2 *. Random.float 1.0 in  (* intentional: jitter *)
             interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
             if Atomic.get stop then ()


### PR DESCRIPTION
## Summary
- Replace unbounded `timing_count` with cursor/filled split to prevent 63-bit overflow
- Add Mermaid state machine diagram to RFC documenting keeper state transitions

## Changes

### 1. timing_count overflow fix (`keeper_keepalive.ml`)
Before: `timing_count` incremented forever via `incr`. On 63-bit OCaml int overflow, `mod ring_size` produces negative index -> Array crash.

After:
- `timing_cursor`: wraps at `ring_size` via `mod` (write position)
- `timing_filled`: saturates at `ring_size` (read count for percentile)

No overflow possible regardless of keeper uptime.

### 2. RFC state machine diagram (`adaptive-heartbeat-scheduling-rfc.md`)
Mermaid `stateDiagram-v2` in Section 5.1 documenting:
- All keeper_state transitions (Running/Paused/Stopped/Crashed/Dead)
- sweep vs reconcile ownership per state
- Dead terminal invariant
- Stopped resolved/unresolved distinction

## Test plan
- [x] `dune build` passes
- [x] `test_work_as_heartbeat.exe` — 14 tests pass
- [x] `test_heartbeat_integration.exe` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)