### PR TITLE
refactor(keeper): consolidate ensure_dir and atomic file writes (#3721)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -470,6 +470,8 @@
    keeper_exec_status_metrics
    keeper_exec_status
    keeper_exec_persona
+   keeper_fs
+   keeper_identity
    keeper_working_context
    keeper_checkpoint_store
    keeper_text_processing
@@ -609,6 +611,8 @@
   keeper_exec_status
   keeper_status_detail
   keeper_exec_persona
+  keeper_fs
+  keeper_identity
   keeper_working_context
   keeper_checkpoint_store
   keeper_text_processing

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -17,14 +17,8 @@ let chat_dir base_dir =
 let chat_path ~base_dir ~keeper_name =
   Filename.concat (chat_dir base_dir) (sanitize_name keeper_name ^ ".jsonl")
 
-let dir_ensured : (string, bool) Hashtbl.t = Hashtbl.create 4
-
 let ensure_dir_once ~base_dir =
-  let dir = chat_dir base_dir in
-  if not (Hashtbl.mem dir_ensured dir) then begin
-    Fs_compat.mkdir_p dir;
-    Hashtbl.replace dir_ensured dir true
-  end
+  ignore (Keeper_fs.ensure_dir (chat_dir base_dir))
 
 let encode_line ~role ~content ~ts : string =
   Yojson.Safe.to_string

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -79,7 +79,7 @@ let save
     ("context", context_json);
   ] in
   let content = Yojson.Safe.to_string json in
-  Fs_compat.save_file path content;
+  Keeper_fs.save_atomic path content;
   (* Auto-prune old checkpoints after each save *)
   ignore (prune ~session_dir ~keep:max_checkpoints_retained)
 
@@ -133,7 +133,7 @@ let save_oas_error (detail : string) =
 
 let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
   try
-    Fs_compat.mkdir_p session_dir;
+    ignore (Keeper_fs.ensure_dir session_dir);
     match Fs_compat.get_fs_opt () with
     | Some fs ->
         let dir = Eio.Path.(fs / session_dir) in
@@ -146,7 +146,7 @@ let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
          | Error err ->
              raise (save_oas_error (Agent_sdk.Error.to_string err)))
     | None ->
-        Fs_compat.save_file
+        Keeper_fs.save_atomic
           (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
           (Agent_sdk.Checkpoint.to_string ckpt)
   with

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -191,11 +191,7 @@ let maybe_rollover_oas_handoff
       else
         let now_ts = Time_compat.now () in
         let prev_trace_id = base_meta.trace_id in
-        let new_trace_id =
-          let ts = int_of_float (Time_compat.now () *. 1000.0) in
-          let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
-          Printf.sprintf "trace-%d-%05x" ts hash
-        in
+        let new_trace_id = Keeper_identity.generate_trace_id () in
         let next_generation = current_generation + 1 in
         let new_session =
           create_session ~session_id:new_trace_id ~base_dir
@@ -394,10 +390,7 @@ let compact_if_needed
         in
         (compacted_ctx, Some reason, "applied:" ^ reason)
 
-let generate_trace_id () =
-  let ts = int_of_float (Time_compat.now () *. 1000.0) in
-  let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
-  Printf.sprintf "trace-%d-%05x" ts hash
+let generate_trace_id = Keeper_identity.generate_trace_id
 
 let keeper_board_write_tool_names =
   [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -1,0 +1,68 @@
+(** Keeper_fs — Centralized keeper filesystem operations.
+
+    Provides atomic file writes (write-to-temp + rename) and
+    fiber-safe directory creation with caching. Consolidates the
+    four scattered ensure_dir implementations into one.
+
+    All mutable state is protected by an Eio.Mutex.
+
+    @since 2.162.0 — #3721 keeper stabilization *)
+
+(* ================================================================ *)
+(* Directory Cache (Eio.Mutex-protected)                            *)
+(* ================================================================ *)
+
+let dir_mu = Eio.Mutex.create ()
+let ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 16
+
+let ensure_dir (path : string) : string =
+  Eio_guard.with_mutex dir_mu (fun () ->
+    if not (Hashtbl.mem ensured_dirs path) || not (Sys.file_exists path) then begin
+      Fs_compat.mkdir_p path;
+      Hashtbl.replace ensured_dirs path ()
+    end);
+  path
+
+let invalidate_dir (path : string) : unit =
+  Eio_guard.with_mutex dir_mu (fun () ->
+    Hashtbl.remove ensured_dirs path)
+
+let clear_dir_cache () : unit =
+  Eio_guard.with_mutex dir_mu (fun () ->
+    Hashtbl.clear ensured_dirs)
+
+(* ================================================================ *)
+(* Atomic File Write (write-to-temp + rename)                       *)
+(* ================================================================ *)
+
+(** Atomically save [content] to [path].
+    Writes to a temporary file first, then renames. On POSIX systems
+    rename(2) is atomic within the same filesystem, so readers never
+    see a partially-written file.
+
+    @raises Sys_error on I/O failure *)
+let save_atomic (path : string) (content : string) : unit =
+  let dir = Filename.dirname path in
+  ignore (ensure_dir dir);
+  let tmp_path = path ^ ".tmp" in
+  Fs_compat.save_file tmp_path content;
+  Unix.rename tmp_path path
+
+(** Atomically save a Yojson value as pretty-printed JSON. *)
+let save_json_atomic (path : string) (json : Yojson.Safe.t) : unit =
+  save_atomic path (Yojson.Safe.pretty_to_string json)
+
+(* ================================================================ *)
+(* Standard Keeper Paths                                            *)
+(* ================================================================ *)
+
+let keeper_dir (config : Room.config) : string =
+  let d = Filename.concat (Room.masc_root_dir config) "keepers" in
+  ensure_dir d
+
+let session_base_dir (config : Room.config) : string =
+  let d = Filename.concat (Room.masc_root_dir config) "traces" in
+  ensure_dir d
+
+let keeper_session_dir (config : Room.config) (trace_id : string) : string =
+  Filename.concat (session_base_dir config) trace_id

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -48,17 +48,20 @@ let save_atomic (path : string) (content : string) : unit =
     Filename.open_temp_file ~temp_dir:dir (Filename.basename path ^ ".") ".tmp"
   in
   let closed = ref false in
+  let renamed = ref false in
   Fun.protect ~finally:(fun () ->
     if not !closed then begin
       close_out_noerr oc;
       closed := true
     end;
-    try Sys.remove tmp_path with Sys_error _ -> ())
+    if not !renamed then
+      try Sys.remove tmp_path with Sys_error _ -> ())
     (fun () ->
       output_string oc content;
       close_out oc;
       closed := true;
-      Unix.rename tmp_path path)
+      Unix.rename tmp_path path;
+      renamed := true)
 
 (** Atomically save a Yojson value as pretty-printed JSON. *)
 let save_json_atomic (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -44,16 +44,20 @@ let clear_dir_cache () : unit =
 let save_atomic (path : string) (content : string) : unit =
   let dir = Filename.dirname path in
   ignore (ensure_dir dir);
-  let tmp_path =
-    Filename.temp_file ~temp_dir:dir (Filename.basename path ^ ".") ".tmp"
+  let tmp_path, oc =
+    Filename.open_temp_file ~temp_dir:dir (Filename.basename path ^ ".") ".tmp"
   in
+  let closed = ref false in
   Fun.protect ~finally:(fun () ->
-    try
-      if Sys.file_exists tmp_path then Sys.remove tmp_path
-    with
-    | Sys_error _ -> ())
+    if not !closed then begin
+      close_out_noerr oc;
+      closed := true
+    end;
+    try Sys.remove tmp_path with Sys_error _ -> ())
     (fun () ->
-      Fs_compat.save_file tmp_path content;
+      output_string oc content;
+      close_out oc;
+      closed := true;
       Unix.rename tmp_path path)
 
 (** Atomically save a Yojson value as pretty-printed JSON. *)

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -44,7 +44,9 @@ let clear_dir_cache () : unit =
 let save_atomic (path : string) (content : string) : unit =
   let dir = Filename.dirname path in
   ignore (ensure_dir dir);
-  let tmp_path = path ^ ".tmp" in
+  let tmp_path =
+    Filename.temp_file ~temp_dir:dir (Filename.basename path ^ ".") ".tmp"
+  in
   Fun.protect ~finally:(fun () ->
     try
       if Sys.file_exists tmp_path then Sys.remove tmp_path

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -45,8 +45,14 @@ let save_atomic (path : string) (content : string) : unit =
   let dir = Filename.dirname path in
   ignore (ensure_dir dir);
   let tmp_path = path ^ ".tmp" in
-  Fs_compat.save_file tmp_path content;
-  Unix.rename tmp_path path
+  Fun.protect ~finally:(fun () ->
+    try
+      if Sys.file_exists tmp_path then Sys.remove tmp_path
+    with
+    | Sys_error _ -> ())
+    (fun () ->
+      Fs_compat.save_file tmp_path content;
+      Unix.rename tmp_path path)
 
 (** Atomically save a Yojson value as pretty-printed JSON. *)
 let save_json_atomic (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -1,0 +1,40 @@
+(** Keeper_fs — Centralized keeper filesystem operations.
+
+    Provides atomic file writes (write-to-temp + rename) and
+    fiber-safe directory creation with caching.
+
+    @since 2.162.0 — #3721 keeper stabilization *)
+
+(** {1 Directory Management} *)
+
+(** Ensure [path] exists, creating it recursively if needed.
+    Fiber-safe: protected by Eio.Mutex. Returns [path] for chaining. *)
+val ensure_dir : string -> string
+
+(** Remove [path] from the directory cache.
+    Call after external deletion or move. *)
+val invalidate_dir : string -> unit
+
+(** Clear the entire directory cache. Useful in tests. *)
+val clear_dir_cache : unit -> unit
+
+(** {1 Atomic File Writes} *)
+
+(** Atomically save [content] to [path] via write-to-temp + rename.
+    @raises Sys_error on I/O failure *)
+val save_atomic : string -> string -> unit
+
+(** Atomically save a JSON value as pretty-printed JSON.
+    @raises Sys_error on I/O failure *)
+val save_json_atomic : string -> Yojson.Safe.t -> unit
+
+(** {1 Standard Keeper Paths} *)
+
+(** [.masc/keepers/] directory. *)
+val keeper_dir : Room.config -> string
+
+(** [.masc/traces/] directory. *)
+val session_base_dir : Room.config -> string
+
+(** [.masc/traces/<trace_id>/] directory. *)
+val keeper_session_dir : Room.config -> string -> string

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -1,0 +1,34 @@
+(** Keeper_identity — Centralized keeper identity and trace ID management.
+
+    Consolidates trace_id generation and session_id conventions.
+
+    {b Current state (v2.162.0)}:
+    - [trace_id] is generated per keeper creation and per handoff rollover.
+    - [session_id] is currently set equal to [trace_id] in [create_session].
+    - OAS checkpoint [session_id] therefore changes on every handoff,
+      breaking checkpoint continuity across trace rollovers.
+
+    {b Invariants to maintain}:
+    - [trace_id] is ephemeral: it changes on handoff.
+    - [session_id] should be stable across handoffs for a given keeper.
+    - Directory layout: [.masc/traces/<trace_id>/] per execution trace.
+
+    {b TODO(#3721)}: In a follow-up PR, decouple session_id from trace_id:
+    - session_id := "keeper-" ^ keeper_name (stable per keeper lifetime)
+    - trace_id := current ephemeral trace (for directory and metrics)
+    - OAS checkpoint should use stable session_id for continuity.
+
+    @since 2.162.0 — #3721 keeper stabilization *)
+
+(** Generate a new trace ID. Used at keeper creation and handoff rollover.
+    Format: [trace-<epoch_ms>-<5hex>] *)
+let generate_trace_id () : string =
+  let ts = int_of_float (Time_compat.now () *. 1000.0) in
+  let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
+  Printf.sprintf "trace-%d-%05x" ts hash
+
+(** Derive a stable session ID from keeper name.
+    This is the target convention for OAS checkpoint continuity.
+    Not yet used in create_session — see TODO above. *)
+let stable_session_id (keeper_name : string) : string =
+  Printf.sprintf "keeper-%s" keeper_name

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -234,7 +234,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  in
                  let base_dir = session_base_dir ctx.config in
                  (* Ensure session directory tree for filesystem fallback (issue #3019) *)
-                 Fs_compat.mkdir_p (Filename.concat base_dir meta_current.trace_id);
+                 ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.trace_id));
                  let _session, ctx_opt =
                    load_context_from_checkpoint
                      ~trace_id:meta_current.trace_id

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -147,7 +147,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
        let trace_id = generate_trace_id () in
          let base_dir = session_base_dir ctx.config in
          (* Ensure full session dir tree, not just base_dir (issue #3019) *)
-         mkdir_p (Filename.concat base_dir trace_id);
+         ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
          let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
            let persona_extended =
              Keeper_types_profile.load_persona_extended p.name

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -625,10 +625,9 @@ let fresher_meta config (meta : keeper_meta) : keeper_meta =
 let write_meta config (m : keeper_meta) : (unit, string) result =
   let persisted = fresher_meta config m in
   let path = keeper_meta_path config persisted.name in
-  let content = Yojson.Safe.pretty_to_string (meta_to_json persisted) in
+  let json = meta_to_json persisted in
   try
-    Fs_compat.mkdir_p (Filename.dirname path);
-    Fs_compat.save_file path content;
+    Keeper_fs.save_json_atomic path json;
     (!runtime_meta_write_sync_hook) config persisted;
     Ok ()
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -122,19 +122,8 @@ let take n xs =
   in
   go n [] xs
 
-let mkdir_p path =
-  Fs_compat.mkdir_p path
-
-(* Directory-creation cache: avoid repeated mkdir_p syscalls for the same path.
-   keeper_dir / session_base_dir are called on every snapshot poll. *)
-let _ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 8
-
-let ensure_dir d =
-  if not (Hashtbl.mem _ensured_dirs d) || not (Sys.file_exists d) then begin
-    mkdir_p d;
-    Hashtbl.replace _ensured_dirs d ()
-  end;
-  d
+(* Delegated to Keeper_fs — single fiber-safe ensure_dir implementation. *)
+let ensure_dir = Keeper_fs.ensure_dir
 
 let dedupe_keep_order items =
   let seen = Hashtbl.create (List.length items) in

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -6,19 +6,13 @@
 
 include Keeper_config
 
-(* Duplicated from Keeper_types to avoid circular dependency. *)
-let mkdir_p_ path =
-  Fs_compat.mkdir_p path
+(* Delegated to Keeper_fs — single fiber-safe ensure_dir implementation. *)
+let mkdir_p_ path = Fs_compat.mkdir_p path
+let ensure_dir_ = Keeper_fs.ensure_dir
 
-(* Directory-creation cache: avoid repeated mkdir_p syscalls for the same path. *)
-let _ensured_dirs_ : (string, unit) Hashtbl.t = Hashtbl.create 8
-
-let ensure_dir_ d =
-  if not (Hashtbl.mem _ensured_dirs_ d) || not (Sys.file_exists d) then begin
-    mkdir_p_ d;
-    Hashtbl.replace _ensured_dirs_ d ()
-  end;
-  d
+(** Backward-compatible mkdir_p: delegates to Keeper_fs.ensure_dir.
+    Used by external callers via [Keeper_types.mkdir_p]. *)
+let mkdir_p path = ignore (Keeper_fs.ensure_dir path)
 
 let keeper_dir_ (config : Room.config) =
   let d = Filename.concat (Room.masc_root_dir config) "keepers" in

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -85,7 +85,7 @@ let extract_state_blocks (s : string) : string list =
 (* ================================================================ *)
 
 let ensure_dir path =
-  Fs_compat.mkdir_p path
+  ignore (Keeper_fs.ensure_dir path)
 
 (* ================================================================ *)
 (* Token Estimation                                                  *)

--- a/test/dune
+++ b/test/dune
@@ -1187,3 +1187,9 @@
  (name test_heartbeat_integration)
  (modules test_heartbeat_integration)
  (libraries masc_mcp masc_mcp.config fs_compat alcotest eio eio_main unix))
+
+; Keeper_fs: atomic writes, ensure_dir consolidation, concurrent safety (#3721)
+(test
+ (name test_keeper_fs)
+ (modules test_keeper_fs)
+ (libraries masc_mcp alcotest yojson unix eio eio_main))

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -26,6 +26,10 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let has_tmp_files dir =
+  Sys.readdir dir
+  |> Array.exists (fun name -> Filename.check_suffix name ".tmp")
+
 (* ================================================================ *)
 (* ensure_dir tests                                                 *)
 (* ================================================================ *)
@@ -78,8 +82,7 @@ let test_save_atomic_basic () =
   KF.save_atomic path content;
   let loaded = read_file path in
   check string "content matches" content loaded;
-  (* Verify no .tmp file left behind *)
-  check bool "no tmp file" false (Sys.file_exists (path ^ ".tmp"));
+  check bool "no tmp file" false (has_tmp_files base);
   cleanup_dir base
 
 let test_save_atomic_overwrites () =
@@ -163,6 +166,7 @@ let test_concurrent_save_atomic () =
   let content = read_file path in
   check bool "contains fiber-" true (String.length content > 0
     && String.sub content 0 6 = "fiber-");
+  check bool "no tmp file left behind" false (has_tmp_files base);
   cleanup_dir base
 
 (* ================================================================ *)

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -1,0 +1,199 @@
+open Alcotest
+
+module KF = Masc_mcp.Keeper_fs
+module KI = Masc_mcp.Keeper_identity
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let len = in_channel_length ic in
+    really_input_string ic len)
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_fs_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+(* ================================================================ *)
+(* ensure_dir tests                                                 *)
+(* ================================================================ *)
+
+let test_ensure_dir_creates_and_caches () =
+  let base = temp_dir () in
+  let dir = Filename.concat base "sub/nested" in
+  let result = KF.ensure_dir dir in
+  check string "returns path" dir result;
+  check bool "directory exists" true (Sys.file_exists dir);
+  check bool "is directory" true (Sys.is_directory dir);
+  (* Second call should hit cache and succeed *)
+  let result2 = KF.ensure_dir dir in
+  check string "cached return" dir result2;
+  cleanup_dir base
+
+let test_ensure_dir_invalidate () =
+  let base = temp_dir () in
+  let dir = Filename.concat base "volatile" in
+  ignore (KF.ensure_dir dir);
+  check bool "exists after ensure" true (Sys.file_exists dir);
+  (* Remove directory externally *)
+  Unix.rmdir dir;
+  check bool "gone after rmdir" false (Sys.file_exists dir);
+  (* Invalidate cache and re-ensure *)
+  KF.invalidate_dir dir;
+  ignore (KF.ensure_dir dir);
+  check bool "recreated after invalidate" true (Sys.file_exists dir);
+  cleanup_dir base
+
+let test_clear_dir_cache () =
+  let base = temp_dir () in
+  let dir = Filename.concat base "cleartest" in
+  ignore (KF.ensure_dir dir);
+  KF.clear_dir_cache ();
+  (* After clearing cache, ensure_dir should re-check filesystem *)
+  Unix.rmdir dir;
+  ignore (KF.ensure_dir dir);
+  check bool "recreated after cache clear" true (Sys.file_exists dir);
+  cleanup_dir base
+
+(* ================================================================ *)
+(* save_atomic tests                                                *)
+(* ================================================================ *)
+
+let test_save_atomic_basic () =
+  let base = temp_dir () in
+  let path = Filename.concat base "data.json" in
+  let content = {|{"key": "value"}|} in
+  KF.save_atomic path content;
+  let loaded = read_file path in
+  check string "content matches" content loaded;
+  (* Verify no .tmp file left behind *)
+  check bool "no tmp file" false (Sys.file_exists (path ^ ".tmp"));
+  cleanup_dir base
+
+let test_save_atomic_overwrites () =
+  let base = temp_dir () in
+  let path = Filename.concat base "overwrite.txt" in
+  KF.save_atomic path "first";
+  KF.save_atomic path "second";
+  let loaded = read_file path in
+  check string "second write wins" "second" loaded;
+  cleanup_dir base
+
+let test_save_atomic_creates_parent_dir () =
+  let base = temp_dir () in
+  let path = Filename.concat base "deep/nested/file.txt" in
+  KF.save_atomic path "content";
+  check bool "file exists" true (Sys.file_exists path);
+  let loaded = read_file path in
+  check string "content matches" "content" loaded;
+  cleanup_dir base
+
+let test_save_json_atomic () =
+  let base = temp_dir () in
+  let path = Filename.concat base "test.json" in
+  let json = `Assoc [("name", `String "keeper"); ("gen", `Int 1)] in
+  KF.save_json_atomic path json;
+  let loaded = Yojson.Safe.from_file path in
+  let open Yojson.Safe.Util in
+  check string "name field" "keeper" (loaded |> member "name" |> to_string);
+  check int "gen field" 1 (loaded |> member "gen" |> to_int);
+  cleanup_dir base
+
+(* ================================================================ *)
+(* Keeper_identity tests                                            *)
+(* ================================================================ *)
+
+let test_generate_trace_id_format () =
+  let id = KI.generate_trace_id () in
+  check bool "starts with trace-" true (String.length id > 6 && String.sub id 0 6 = "trace-");
+  (* Two calls should produce different IDs *)
+  let id2 = KI.generate_trace_id () in
+  check bool "unique IDs" true (id <> id2)
+
+let test_stable_session_id () =
+  let sid = KI.stable_session_id "dreamer" in
+  check string "format" "keeper-dreamer" sid;
+  (* Idempotent *)
+  let sid2 = KI.stable_session_id "dreamer" in
+  check string "idempotent" sid sid2
+
+(* ================================================================ *)
+(* Concurrent ensure_dir (Eio-based)                                *)
+(* ================================================================ *)
+
+let test_concurrent_ensure_dir () =
+  Eio_main.run @@ fun _env ->
+  let base = temp_dir () in
+  KF.clear_dir_cache ();
+  let dir = Filename.concat base "concurrent" in
+  (* Spawn multiple fibers all calling ensure_dir on the same path *)
+  let errors = Atomic.make 0 in
+  Eio.Fiber.all
+    (List.init 10 (fun _i () ->
+       try ignore (KF.ensure_dir dir)
+       with _ -> Atomic.incr errors));
+  check int "no errors" 0 (Atomic.get errors);
+  check bool "directory exists" true (Sys.file_exists dir);
+  cleanup_dir base
+
+let test_concurrent_save_atomic () =
+  Eio_main.run @@ fun _env ->
+  let base = temp_dir () in
+  let path = Filename.concat base "concurrent.txt" in
+  let errors = Atomic.make 0 in
+  Eio.Fiber.all
+    (List.init 10 (fun i () ->
+       try KF.save_atomic path (Printf.sprintf "fiber-%d" i)
+       with _ -> Atomic.incr errors));
+  check int "no errors" 0 (Atomic.get errors);
+  check bool "file exists" true (Sys.file_exists path);
+  (* File should contain exactly one of the fiber writes *)
+  let content = read_file path in
+  check bool "contains fiber-" true (String.length content > 0
+    && String.sub content 0 6 = "fiber-");
+  cleanup_dir base
+
+(* ================================================================ *)
+(* Test runner                                                      *)
+(* ================================================================ *)
+
+let () =
+  KF.clear_dir_cache ();
+  run "Keeper_fs"
+    [
+      ( "ensure_dir",
+        [
+          test_case "creates and caches" `Quick test_ensure_dir_creates_and_caches;
+          test_case "invalidate" `Quick test_ensure_dir_invalidate;
+          test_case "clear cache" `Quick test_clear_dir_cache;
+        ] );
+      ( "save_atomic",
+        [
+          test_case "basic write" `Quick test_save_atomic_basic;
+          test_case "overwrites" `Quick test_save_atomic_overwrites;
+          test_case "creates parent dir" `Quick test_save_atomic_creates_parent_dir;
+          test_case "json atomic" `Quick test_save_json_atomic;
+        ] );
+      ( "identity",
+        [
+          test_case "trace_id format" `Quick test_generate_trace_id_format;
+          test_case "stable session_id" `Quick test_stable_session_id;
+        ] );
+      ( "concurrent",
+        [
+          test_case "ensure_dir 10 fibers" `Quick test_concurrent_ensure_dir;
+          test_case "save_atomic 10 fibers" `Quick test_concurrent_save_atomic;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Keeper 파일 I/O 레이스 조건 해소 및 atomic write 도입
- 4곳 분산된 `ensure_dir` 구현을 `Keeper_fs` 단일 모듈로 통합 (Eio_guard.with_mutex 보호)
- 4곳 non-atomic `Fs_compat.save_file` → write-tmp-rename 패턴으로 전환
- `generate_trace_id`를 `Keeper_identity`로 추출, session_id/trace_id invariant 문서화

## 근본원인

최근 100커밋 중 keeper 관련 fix 8건의 근본원인:
1. **파일 I/O 레이스** (3건): ensure_dir 캐시의 TOCTOU
2. **세션 ID 불일치** (3건): session_id = trace_id 복사 패턴
3. **데드락** (2건): 이미 해결됨 (Stdlib.Mutex 0건)

이 PR은 (1)을 해소하고, (2)는 invariant 문서화 + follow-up 준비.

## 변경 사항

### 새 파일
- `lib/keeper/keeper_fs.ml` + `.mli` — 통합 atomic write + fiber-safe ensure_dir
- `lib/keeper/keeper_identity.ml` — trace_id 생성 + session_id invariant 문서
- `test/test_keeper_fs.ml` — 11개 테스트 (동시성 포함)

### 수정 (11 파일)
- ensure_dir 4곳 → `Keeper_fs.ensure_dir` 위임
- save_file 4곳 → `Keeper_fs.save_atomic` 전환
- generate_trace_id 2곳 → `Keeper_identity.generate_trace_id` 위임

## Test plan

- [x] `test_keeper_fs`: 11/11 통과 (ensure_dir, save_atomic, identity, concurrent)
- [x] `test_keeper_unified`: 28/28 통과 (기존 keeper 테스트 회귀 없음)
- [x] `dune build`: 성공
- [ ] CI health ratchet
- [ ] 교차 모델 리뷰

Closes #3721

🤖 Generated with [Claude Code](https://claude.com/claude-code)