### PR TITLE
feat(cdal): add protocol_version to labeling output contract

### DIFF
--- a/bin/cdal_label.ml
+++ b/bin/cdal_label.ml
@@ -80,7 +80,7 @@ let metrics_cmd input_dir workload_name judge_version label_owner
     Printf.eprintf "no labeled verdicts found in %s\n" input_dir;
     exit 1);
   let oc =
-    L.build_output_contract ~workload_name
+    L.build_output_contract ~workload_name ~protocol_version:"v0.1"
       ~judge_protocol_version:judge_version ~label_owner ~metric_owner
       ~total_claims ~drift_note verdicts
   in

--- a/lib/cdal/labeling.ml
+++ b/lib/cdal/labeling.ml
@@ -29,6 +29,7 @@ type confusion_summary = {
 
 type output_contract = {
   workload_name : string;
+  protocol_version : string;
   judge_protocol_version : string;
   label_owner : string;
   metric_owner : string;
@@ -85,14 +86,16 @@ let compute_claim_coverage ~labeled ~total =
   if total = 0 then 0.0
   else float_of_int labeled /. float_of_int total
 
-let build_output_contract ~workload_name ~judge_protocol_version
-    ~label_owner ~metric_owner ~total_claims ~drift_note verdicts =
+let build_output_contract ~workload_name ~protocol_version
+    ~judge_protocol_version ~label_owner ~metric_owner ~total_claims
+    ~drift_note verdicts =
   let confusion = compute_confusion verdicts in
   let labeled_non_drift =
     confusion.supported + confusion.unsupported + confusion.ambiguous
   in
   {
     workload_name;
+    protocol_version;
     judge_protocol_version;
     label_owner;
     metric_owner;
@@ -163,6 +166,7 @@ let output_contract_to_json oc =
   `Assoc
     [
       ("workload_name", `String oc.workload_name);
+      ("protocol_version", `String oc.protocol_version);
       ("judge_protocol_version", `String oc.judge_protocol_version);
       ("label_owner", `String oc.label_owner);
       ("metric_owner", `String oc.metric_owner);

--- a/lib/cdal/labeling.mli
+++ b/lib/cdal/labeling.mli
@@ -32,6 +32,7 @@ type confusion_summary = {
 (** Output contract per protocol Section 7. *)
 type output_contract = {
   workload_name : string;
+  protocol_version : string;
   judge_protocol_version : string;
   label_owner : string;
   metric_owner : string;
@@ -60,9 +61,20 @@ val compute_precision_lenient : confusion_summary -> float
 (** [labeled / total]. *)
 val compute_claim_coverage : labeled:int -> total:int -> float
 
-(** Build a complete output contract from labeled verdicts. *)
+(** Build a complete output contract from labeled verdicts.
+
+    @param workload_name Identifier for the workload being evaluated (e.g. "coding_task").
+    @param protocol_version Version of the labeling protocol artifact schema (e.g. "v0.1").
+    @param judge_protocol_version Version of the judge/evaluator protocol (e.g. "phase1a_v1").
+    @param label_owner Person responsible for labeling (e.g. "human:alice").
+    @param metric_owner Person responsible for metrics interpretation.
+    @param total_claims Total material claims to compute claim_coverage against.
+        This is the denominator: [claim_coverage = labeled_non_drift / total_claims].
+    @param drift_note Free-text note about observed drift, or empty string.
+    @param labeled_verdict list The labeled verdicts to aggregate. *)
 val build_output_contract :
   workload_name:string ->
+  protocol_version:string ->
   judge_protocol_version:string ->
   label_owner:string ->
   metric_owner:string ->

--- a/test/test_labeling.ml
+++ b/test/test_labeling.ml
@@ -126,10 +126,12 @@ let test_build_output_contract () =
   in
   let oc =
     L.build_output_contract ~workload_name:"coding_task"
-      ~judge_protocol_version:"v0" ~label_owner:"alice"
-      ~metric_owner:"bob" ~total_claims:10 ~drift_note:"" verdicts
+      ~protocol_version:"v0.1" ~judge_protocol_version:"v0"
+      ~label_owner:"alice" ~metric_owner:"bob" ~total_claims:10
+      ~drift_note:"" verdicts
   in
   check string "workload" "coding_task" oc.workload_name;
+  check string "protocol_version" "v0.1" oc.protocol_version;
   check int "confusion.supported" 3 oc.confusion.supported;
   check int "confusion.unsupported" 1 oc.confusion.unsupported;
   check int "confusion.ambiguous" 1 oc.confusion.ambiguous;
@@ -169,6 +171,7 @@ let test_output_contract_json () =
   let oc : L.output_contract =
     {
       workload_name = "coding_task";
+      protocol_version = "v0.1";
       judge_protocol_version = "v0";
       label_owner = "alice";
       metric_owner = "bob";
@@ -185,6 +188,9 @@ let test_output_contract_json () =
     (match List.assoc_opt "workload_name" fields with
      | Some (`String "coding_task") -> ()
      | _ -> fail "missing workload_name");
+    (match List.assoc_opt "protocol_version" fields with
+     | Some (`String "v0.1") -> ()
+     | _ -> fail "missing or wrong protocol_version");
     (match List.assoc_opt "precision_strict" fields with
      | Some (`Float _) -> ()
      | _ -> fail "missing precision_strict")


### PR DESCRIPTION
## Summary
- `output_contract` 타입에 `protocol_version : string` 필드 추가
- `build_output_contract` 함수에 `~protocol_version` 파라미터 추가
- `.mli`에 `@param` 문서화 (각 파라미터의 의미와 사용법 명시)
- `cdal_label` CLI에서 기본값 `"v0.1"` 사용

## Motivation
Labeling artifact에 프로토콜 버전 정보가 없어 cross-version 비교가 불가능했음.
RFC Section 7의 output contract 사양에 따라 `protocol_version` 추가.
Closes #3628

## Test plan
- [x] `test_labeling.exe` 11개 테스트 통과
- [x] `test_cdal_types.exe` 16개 통과 (회귀 없음)
- [x] `test_cdal_judge.exe` 12개 통과 (회귀 없음)
- [x] `test_cdal_eval_v1.exe` 3개 통과 (회귀 없음)
- [x] `protocol_version` 필드 JSON round-trip 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)