### PR TITLE
feat(cdal): add CDAL feature flags to registry and gate keeper evaluation

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -184,6 +184,22 @@ let all_flags : flag list = [
     description = "Llama.cpp runtime debug output";
     default = false; category = "runtime";
     lifecycle = Active; since = "2.100.0" };
+
+  (* ── CDAL (Contract-Driven Agent Loop) ───────────────────── *)
+  { env_name = "MASC_CDAL_ENABLED";
+    description = "Contract-driven agent loop: proof capture and verdict evaluation";
+    default = true; category = "runtime";
+    lifecycle = Active; since = "2.162.0" };
+
+  { env_name = "MASC_CDAL_RISK_ENFORCEMENT";
+    description = "Enforce risk_contract constraints (fail on violation)";
+    default = false; category = "runtime";
+    lifecycle = Experimental; since = "2.162.0" };
+
+  { env_name = "MASC_CDAL_PROOF_AGGREGATION";
+    description = "Aggregate proof bundles across multi-turn sessions";
+    default = false; category = "runtime";
+    lifecycle = Experimental; since = "2.162.0" };
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for 25 flags. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -192,7 +192,11 @@ let run_turn
     { strategy = Agent_sdk.Context_reducer.Merge_contiguous };
   ] in
   (* 8. Run Agent *)
-  let contract = Keeper_cdal_contract.of_keeper_meta meta in
+  let contract =
+    if Env_config_core.get_bool ~default:true "MASC_CDAL_ENABLED"
+    then Keeper_cdal_contract.of_keeper_meta meta
+    else None
+  in
   match
     Oas_worker.run_named
       ~cascade_name


### PR DESCRIPTION
## Summary
- Feature flag registry에 CDAL 플래그 3개 추가
  - `MASC_CDAL_ENABLED` (default: true) — CDAL 전체 on/off
  - `MASC_CDAL_RISK_ENFORCEMENT` (default: false, experimental)
  - `MASC_CDAL_PROOF_AGGREGATION` (default: false, experimental)
- `keeper_agent_run.ml`에서 contract 생성을 `MASC_CDAL_ENABLED` 플래그로 gate
  - 플래그 off → contract None → proof 미생성 → verdict 평가 스킵

## Motivation
프로덕션에서 CDAL이 돌아가고 있지만 kilswitch가 없었음. 이 PR은 안전한 rollback 경로를 제공.
Closes #3522

## Test plan
- [x] `test_cdal_eval_v1.exe` 3개 통과
- [x] `test_cdal_judge.exe` 12개 통과
- [x] `test_labeling.exe` 11개 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)