### PR TITLE
feat(keeper): wire Heartbeat_smart into keepalive loop

### DIFF
--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -61,6 +61,8 @@ let print_summary () =
   Log.Env.info "WorkAsHeartbeat: enabled=%b max_silence=%.0fs"
     Env_config_keeper.WorkAsHeartbeat.enabled
     Env_config_keeper.WorkAsHeartbeat.max_silence_sec;
+  Log.Env.info "SmartHeartbeat: enabled=%b"
+    Env_config_keeper.SmartHeartbeat.enabled;
   Log.Env.info "SelfPreservation: ratio=%.2f min_candidates=%d dead_ttl=%.0fs"
     Env_config_keeper.KeeperSupervisor.self_preservation_ratio
     Env_config_keeper.KeeperSupervisor.self_preservation_min_candidates
@@ -115,6 +117,7 @@ let to_json () : Yojson.Safe.t =
       "alert_slack_enabled", bool_val Env_config_keeper.KeeperAlert.slack_enabled;
       "work_as_heartbeat_enabled", bool_val Env_config_keeper.WorkAsHeartbeat.enabled;
       "work_as_heartbeat_max_silence_sec", float_val Env_config_keeper.WorkAsHeartbeat.max_silence_sec;
+      "smart_heartbeat_enabled", bool_val Env_config_keeper.SmartHeartbeat.enabled;
       "self_preservation_ratio", float_val Env_config_keeper.KeeperSupervisor.self_preservation_ratio;
       "self_preservation_min_candidates", int_val Env_config_keeper.KeeperSupervisor.self_preservation_min_candidates;
       "dead_ttl_sec", float_val Env_config_keeper.KeeperSupervisor.dead_ttl_sec;

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -209,4 +209,14 @@ module WorkAsHeartbeat = struct
     Float.max 30.0 (get_float ~default:120.0 "MASC_KEEPER_MAX_SILENCE_SEC")
 end
 
+(** {1 Smart Heartbeat Configuration (Phase 2)} *)
+
+module SmartHeartbeat = struct
+  (** Master switch for adaptive heartbeat scheduling in the keepalive loop.
+      When true, Heartbeat_smart.should_emit gates presence/snapshot/board/turn
+      blocks, skipping cycles when the keeper is busy or deeply idle. *)
+  let enabled =
+    get_bool ~default:true "MASC_KEEPER_SMART_HEARTBEAT"
+end
+
 (** Print configuration summary for debugging *)

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -97,6 +97,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.162.0" };
 
+  { env_name = "MASC_KEEPER_SMART_HEARTBEAT";
+    description = "Skip heartbeat cycles when busy (task proves liveness) or extend interval when idle";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.163.0" };
+
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -169,6 +169,10 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let last_successful_heartbeat_ts = ref 0.0 in
   let work_as_hb = Env_config.WorkAsHeartbeat.enabled in
   let max_silence = Env_config.WorkAsHeartbeat.max_silence_sec in
+  (* Phase 2: smart heartbeat — adaptive scheduling via Heartbeat_smart *)
+  let smart_hb_enabled = Env_config.SmartHeartbeat.enabled in
+  let smart_hb_config = Heartbeat_smart.default_config in
+  let last_heartbeat_cycle_ts = ref 0.0 in
   let rec loop () =
     if Atomic.get stop then ()
     else (
@@ -179,6 +183,41 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               | Ok (Some latest) -> latest
               | _ -> m
             in
+            (* Phase 2: smart heartbeat — skip cycle when busy or deeply idle *)
+            let smart_hb_decision =
+              if smart_hb_enabled then
+                let agent_status =
+                  if meta_current.paused then Types.Inactive
+                  else match meta_current.current_task_id with
+                    | Some _ -> Types.Busy
+                    | None -> Types.Active
+                in
+                Heartbeat_smart.should_emit
+                  ~config:smart_hb_config
+                  ~agent_status
+                  ~last_activity:!last_successful_heartbeat_ts
+                  ~last_heartbeat:!last_heartbeat_cycle_ts
+              else
+                Heartbeat_smart.Emit
+            in
+            (match smart_hb_decision with
+             | Heartbeat_smart.Skip_busy ->
+               Log.Keeper.debug "smart heartbeat: skip (busy, task=%s)"
+                 (Option.value ~default:"?" meta_current.current_task_id);
+               let base = Heartbeat_smart.effective_interval
+                 ~config:smart_hb_config
+                 ~last_activity:!last_successful_heartbeat_ts in
+               let jitter = base *. 0.2 *. Random.float 1.0 in
+               interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
+               if Atomic.get stop then () else loop ()
+             | Heartbeat_smart.Skip_idle next_time ->
+               let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
+               Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
+               let jitter = wait *. 0.1 *. Random.float 1.0 in
+               interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (wait +. jitter);
+               if Atomic.get stop then () else loop ()
+             | Heartbeat_smart.Emit ->
+               last_heartbeat_cycle_ts := Time_compat.now ());
             (* Phase 1: skip presence sync when recent room heartbeat proves freshness *)
             let presence_fresh =
               work_as_hb
@@ -493,8 +532,12 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             let t_recurring_end = Time_compat.now () in
             let t_improve_start = t_recurring_end in
             let base =
-              float_of_int
-                keepalive_interval_sec
+              if smart_hb_enabled then
+                Heartbeat_smart.effective_interval
+                  ~config:smart_hb_config
+                  ~last_activity:!last_successful_heartbeat_ts
+              else
+                float_of_int keepalive_interval_sec
             in
             (try
                Tool_improve_loop.maybe_tick_from_keepalive ~config:ctx.config

--- a/test/dune
+++ b/test/dune
@@ -1188,6 +1188,12 @@
  (modules test_heartbeat_integration)
  (libraries masc_mcp masc_mcp.config fs_compat alcotest eio eio_main unix))
 
+; Phase 2: Smart heartbeat keepalive integration — agent_status mapping + decisions
+(test
+ (name test_smart_heartbeat_keepalive)
+ (modules test_smart_heartbeat_keepalive)
+ (libraries masc_mcp masc_mcp.config masc_room masc_types alcotest unix))
+
 ; Keeper_fs: atomic writes, ensure_dir consolidation, concurrent safety (#3721)
 (test
  (name test_keeper_fs)

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -1,0 +1,150 @@
+(** Tests for smart heartbeat integration in keeper_keepalive.
+
+    Verifies that the Heartbeat_smart module decisions correctly map
+    to Types.agent_status based on keeper_meta fields (current_task_id,
+    paused), and that the env-config feature flag controls activation.
+
+    These are unit-level tests of the mapping logic, not full keepalive
+    loop integration tests (which require Eio fibers + Room I/O). *)
+
+open Alcotest
+module HS = Heartbeat_smart
+
+(* ── agent_status derivation from keeper_meta fields ─── *)
+
+(** Derive agent_status from keeper_meta fields, mirroring the logic
+    in keeper_keepalive.ml run_heartbeat_loop. *)
+let derive_agent_status ~paused ~current_task_id =
+  if paused then Types.Inactive
+  else match current_task_id with
+    | Some _ -> Types.Busy
+    | None -> Types.Active
+
+let test_status_busy_when_task_claimed () =
+  let status = derive_agent_status ~paused:false ~current_task_id:(Some "task-42") in
+  check string "busy when task claimed" (Types.show_agent_status Types.Busy)
+    (Types.show_agent_status status)
+
+let test_status_active_when_no_task () =
+  let status = derive_agent_status ~paused:false ~current_task_id:None in
+  check string "active when no task" (Types.show_agent_status Types.Active)
+    (Types.show_agent_status status)
+
+let test_status_inactive_when_paused () =
+  let status = derive_agent_status ~paused:true ~current_task_id:(Some "task-99") in
+  check string "inactive when paused" (Types.show_agent_status Types.Inactive)
+    (Types.show_agent_status status)
+
+let test_status_inactive_when_paused_no_task () =
+  let status = derive_agent_status ~paused:true ~current_task_id:None in
+  check string "inactive when paused, no task" (Types.show_agent_status Types.Inactive)
+    (Types.show_agent_status status)
+
+(* ── Heartbeat_smart decision tests with keeper-derived statuses ─── *)
+
+let test_skip_busy_with_task () =
+  let config = HS.default_config in
+  let now = Unix.gettimeofday () in
+  let decision = HS.should_emit
+    ~config
+    ~agent_status:Types.Busy
+    ~last_activity:now
+    ~last_heartbeat:(now -. 10.0) in
+  check string "skip when busy" "skip:busy"
+    (HS.decision_to_string decision)
+
+let test_emit_when_active_and_interval_elapsed () =
+  let config = HS.default_config in
+  let now = Unix.gettimeofday () in
+  (* last_heartbeat 31s ago, base interval 30s *)
+  let decision = HS.should_emit
+    ~config
+    ~agent_status:Types.Active
+    ~last_activity:now
+    ~last_heartbeat:(now -. 31.0) in
+  check bool "should emit" true (HS.should_emit_now decision)
+
+let test_skip_idle_when_interval_not_elapsed () =
+  let config = HS.default_config in
+  let now = Unix.gettimeofday () in
+  (* last_heartbeat 10s ago, base interval 30s *)
+  let decision = HS.should_emit
+    ~config
+    ~agent_status:Types.Active
+    ~last_activity:now
+    ~last_heartbeat:(now -. 10.0) in
+  check bool "should not emit" false (HS.should_emit_now decision);
+  (match decision with
+   | HS.Skip_idle _ -> ()
+   | _ -> fail "expected Skip_idle decision")
+
+let test_idle_multiplier_extends_interval () =
+  let config = HS.default_config in
+  let now = Unix.gettimeofday () in
+  (* Agent idle for 6 minutes (> 5min threshold) *)
+  let last_activity = now -. 360.0 in
+  let interval = HS.effective_interval ~config ~last_activity in
+  (* Should be base * multiplier = 30 * 3 = 90 *)
+  check (float 0.1) "idle interval is 90s" 90.0 interval
+
+let test_active_uses_base_interval () =
+  let config = HS.default_config in
+  let now = Unix.gettimeofday () in
+  (* Agent active 10s ago (< 5min threshold) *)
+  let last_activity = now -. 10.0 in
+  let interval = HS.effective_interval ~config ~last_activity in
+  check (float 0.1) "active interval is 30s" 30.0 interval
+
+(* ── Feature flag behavior ─── *)
+
+let test_feature_flag_disabled () =
+  (* When smart_hb_enabled=false, decision should always be Emit.
+     This mirrors the logic: if not enabled then Emit. *)
+  let decision = HS.Emit in
+  check bool "emit when disabled" true (HS.should_emit_now decision)
+
+let test_env_config_default_enabled () =
+  (* Verify default value matches expectation *)
+  check bool "smart heartbeat default enabled" true
+    Env_config.SmartHeartbeat.enabled
+
+(* ── decision_to_string coverage ─── *)
+
+let test_decision_to_string_emit () =
+  check string "emit string" "emit" (HS.decision_to_string HS.Emit)
+
+let test_decision_to_string_skip_busy () =
+  check string "skip_busy string" "skip:busy" (HS.decision_to_string HS.Skip_busy)
+
+let test_decision_to_string_skip_idle () =
+  let s = HS.decision_to_string (HS.Skip_idle (Unix.gettimeofday () +. 60.0)) in
+  check bool "starts with skip:idle" true
+    (String.length s > 9 && String.sub s 0 9 = "skip:idle")
+
+(* ── Test runner ─── *)
+
+let () =
+  run "smart_heartbeat_keepalive" [
+    "agent_status_derivation", [
+      test_case "busy when task claimed" `Quick test_status_busy_when_task_claimed;
+      test_case "active when no task" `Quick test_status_active_when_no_task;
+      test_case "inactive when paused" `Quick test_status_inactive_when_paused;
+      test_case "inactive when paused no task" `Quick test_status_inactive_when_paused_no_task;
+    ];
+    "smart_heartbeat_decisions", [
+      test_case "skip busy with task" `Quick test_skip_busy_with_task;
+      test_case "emit when active and interval elapsed" `Quick test_emit_when_active_and_interval_elapsed;
+      test_case "skip idle when interval not elapsed" `Quick test_skip_idle_when_interval_not_elapsed;
+      test_case "idle multiplier extends interval" `Quick test_idle_multiplier_extends_interval;
+      test_case "active uses base interval" `Quick test_active_uses_base_interval;
+    ];
+    "feature_flag", [
+      test_case "disabled means emit" `Quick test_feature_flag_disabled;
+      test_case "default is enabled" `Quick test_env_config_default_enabled;
+    ];
+    "decision_to_string", [
+      test_case "emit" `Quick test_decision_to_string_emit;
+      test_case "skip_busy" `Quick test_decision_to_string_skip_busy;
+      test_case "skip_idle" `Quick test_decision_to_string_skip_idle;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Integrate `Heartbeat_smart.should_emit` into keeper keepalive loop
- Skip entire cycle on `Skip_busy` (task proves liveness)
- Extend sleep interval on `Skip_idle` (3x multiplier when idle >5min)
- Feature flag: `MASC_KEEPER_SMART_HEARTBEAT` (default: true)
- 14 unit tests for status derivation, decisions, feature flag

## Boundary
Pure MASC coordination policy. No OAS/provider knowledge.
Heartbeat_smart module unchanged — only keepalive loop modified.

## Token savings estimate
- Busy periods: ~100% reduction (task ops prove liveness)
- Idle periods: ~66% reduction (3x interval)
- Overall: 60-80% heartbeat token reduction

## Test plan
- [x] 14 unit tests pass (0.002s)
- [x] `dune build` passes
- [ ] CI green