### PR TITLE
refactor(core): consolidate 10 duplicate contains_substring into String_util

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -94,7 +94,7 @@ let scan_persisted_loop_ids = Autoresearch_storage.scan_persisted_loop_ids
 (* Re-exports: Metric                                                *)
 (* ================================================================ *)
 
-let contains_substring = Autoresearch_metric.contains_substring
+let contains_substring = String_util.contains_substring
 let validate_metric_fn = Autoresearch_metric.validate_metric_fn
 let measure_metric = Autoresearch_metric.measure_metric
 let measure_metric_with_retry = Autoresearch_metric.measure_metric_with_retry

--- a/lib/autoresearch/autoresearch_metric.ml
+++ b/lib/autoresearch/autoresearch_metric.ml
@@ -5,18 +5,7 @@
 
     @since 2.80.0 *)
 
-(** Check if [needle] is a substring of [haystack]. *)
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  if nlen > hlen then false
-  else
-    let found = ref false in
-    for i = 0 to hlen - nlen do
-      if not !found && String.sub haystack i nlen = needle then
-        found := true
-    done;
-    !found
+let contains_substring = String_util.contains_substring
 
 (** Shell metacharacters that indicate injection risk in metric_fn when they
     appear outside quotes. *)

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -172,17 +172,7 @@ let post_kind_of_string = function
   | "system" -> Some System_post
   | _ -> None
 
-let contains_substring haystack needle =
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      if idx + needle_len > hay_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
+let contains_substring = String_util.contains_substring
 
 (** Take at most [n] elements from a list. *)
 let take n lst =

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -56,15 +56,7 @@ let normalize_path path =
   String.map (fun c -> if c = '\\' then '/' else c) path
   |> String.lowercase_ascii
 
-let contains_substring text pattern =
-  let pat_len = String.length pattern in
-  let text_len = String.length text in
-  let rec search i =
-    if i + pat_len > text_len then false
-    else if String.sub text i pat_len = pattern then true
-    else search (i + 1)
-  in
-  pat_len > 0 && search 0
+let contains_substring = String_util.contains_substring
 
 let has_doc_extension path =
   List.exists (Filename.check_suffix path) doc_extensions

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax executor_pool_ref text_similarity)
+ (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax executor_pool_ref text_similarity string_util)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log))

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -1,0 +1,12 @@
+let contains_substring haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else if needle_len > hay_len then false
+  else
+    let rec loop idx =
+      if idx + needle_len > hay_len then false
+      else if String.sub haystack idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -1,0 +1,6 @@
+(** Shared string utility functions. *)
+
+val contains_substring : string -> string -> bool
+(** [contains_substring haystack needle] returns [true] if [needle]
+    appears anywhere inside [haystack].  Returns [true] when [needle]
+    is empty. *)

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -42,14 +42,7 @@ let ensure_dirs base_path =
   ensure_dir (rulings_dir base_path);
   ensure_dir (execution_orders_dir base_path)
 
-let contains_substring haystack needle =
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= hay_len
-    && ((String.sub haystack idx needle_len = needle) || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
+let contains_substring = String_util.contains_substring
 
 let normalize_text raw =
   raw

--- a/lib/repo_synthesis_benchmark.ml
+++ b/lib/repo_synthesis_benchmark.ml
@@ -72,18 +72,7 @@ type run_record = {
 let bench_root ~base_path =
   Filename.concat base_path ".masc/repo-synthesis-benchmarks"
 
-let contains_substring haystack needle =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else
-    let rec loop idx =
-      if idx + needle_len > haystack_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
+let contains_substring = String_util.contains_substring
 
 let validate_run_id run_id =
   let run_id = String.trim run_id in

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -2,17 +2,7 @@ open Types
 open Room_utils_backend_setup
 open Room_utils_paths_backend
 
-let contains_substring haystack needle =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len > haystack_len then false
-  else
-    let rec check i =
-      if i > haystack_len - needle_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else check (i + 1)
-    in
-    check 0
+let contains_substring = String_util.contains_substring
 
 let validate_agent_name name =
   (* Delegate to Validation module for consistent security checks *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -5,14 +5,7 @@ open Types
 open Server_utils
 
 let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let hay_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > hay_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  needle_len = 0 || loop 0
+  String_util.contains_substring haystack needle
 
 let take n xs =
   let rec loop acc remaining xs =

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -63,17 +63,7 @@ let status_line_is_healthy line =
   | _ -> false
 
 let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > haystack_len then
-      false
-    else if String.sub haystack idx needle_len = needle then
-      true
-    else
-      loop (idx + 1)
-  in
-  needle_len > 0 && loop 0
+  String_util.contains_substring haystack needle
 
 let looks_like_server_command command =
   List.exists

--- a/lib/team_session_types/dune
+++ b/lib/team_session_types/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.team_session_types)
  (modules team_session_types team_session_types_enums)
  (wrapped false)
- (libraries masc_mcp.dashboard_utils masc_types masc_log time_compat eio yojson))
+ (libraries masc_mcp.dashboard_utils masc_types masc_core masc_log time_compat eio yojson))

--- a/lib/team_session_types/team_session_types.ml
+++ b/lib/team_session_types/team_session_types.ml
@@ -5,16 +5,7 @@ include Team_session_types_enums
 open Yojson.Safe.Util
 let dedup_strings = Dashboard_utils.dedup_strings
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > text_len then false
-    else if String.sub text idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+let contains_substring = String_util.contains_substring
 
 let system_session_creator_prefixes =
   [ "keeper"; "dashboard"; "operator"; "system";

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -54,23 +54,7 @@ let split_ws text =
   |> List.map String.trim
   |> List.filter (fun item -> item <> "")
 
-let string_contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  if needle_len = 0 then
-    true
-  else if needle_len > text_len then
-    false
-  else
-    let rec loop idx =
-      if idx + needle_len > text_len then
-        false
-      else if String.sub text idx needle_len = needle then
-        true
-      else
-        loop (idx + 1)
-    in
-    loop 0
+let string_contains_substring = String_util.contains_substring
 
 let parse_pid_and_command line =
   let trimmed = String.trim line in

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -31,15 +31,7 @@ let repo_root_for ~base_path =
 
 let current_status_lines ~repo_root =
   let contains_substring text ~substring =
-    let text_len = String.length text in
-    let substring_len = String.length substring in
-    let rec loop idx =
-      if substring_len = 0 then true
-      else if idx > text_len - substring_len then false
-      else if String.sub text idx substring_len = substring then true
-      else loop (idx + 1)
-    in
-    loop 0
+    String_util.contains_substring text substring
   in
   run_git_capture_lines ~workdir:repo_root [ "status"; "--porcelain" ]
   |> Option.value ~default:[]


### PR DESCRIPTION
## Summary
- `contains_substring` 함수가 10개 파일에 독립적으로 구현되어 있었음 (동일한 O(n*m) substring 검색)
- `lib/core/string_util.ml` (`masc_core` 라이브러리)에 canonical 구현을 만들고 나머지를 위임으로 교체
- Net: **-121줄 삭제**, +14줄 추가 (+ 새 파일 2개)

## 변경 파일 (16개)
| 파일 | 변경 |
|------|------|
| `lib/core/string_util.ml` + `.mli` | 새 canonical 구현 |
| `lib/core/dune` | `string_util` 모듈 등록 |
| `lib/team_session_types/dune` | `masc_core` 의존성 추가 |
| 나머지 12개 `.ml` 파일 | 로컬 정의 → `String_util.contains_substring` 위임 |

## 기존 구현 차이점
- 대부분: `haystack needle` (positional)
- `server_dashboard_http`, `server_startup_takeover`: `~needle haystack` (labeled) → 1줄 wrapper 유지
- `worktree_live_context`: local `let` → 1줄 wrapper 유지
- `adversarial_eval`, `server_startup_takeover`: empty needle에 `false` 반환 → canonical `true`로 통일 (호출부에서 empty needle이 전달되는 경우 없음)

## Test plan
- [x] `dune build` 성공 (16개 파일 타입 검증 완료)
- [ ] CI 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)