### PR TITLE
refactor(command_plane): add .mli interfaces (Phase 2, #3722)

### DIFF
--- a/lib/command_plane/cp_cleanup.mli
+++ b/lib/command_plane/cp_cleanup.mli
@@ -1,0 +1,39 @@
+include module type of Cp_io
+
+type cleanup_result = {
+  dead_units_removed : int;
+  orphaned_units_removed : int;
+  operations_archived : int;
+  detachments_removed : int;
+  intents_removed : int;
+}
+
+val empty_result : cleanup_result
+val cleanup_result_to_json : cleanup_result -> Yojson.Safe.t
+
+val cutoff_iso : days:int -> string
+val find_dead_units : days:int -> unit_record list -> unit_record list
+val find_orphaned_units : unit_record list -> unit_record list
+val is_terminal_status : operation_status -> bool
+val find_terminal_operations :
+  days:int -> operation_record list -> operation_record list
+val find_orphaned_detachments :
+  operation_ids:string list -> detachment_record list -> detachment_record list
+val find_dropped_intents : days:int -> intent_record list -> intent_record list
+
+val archive_operations : Room.config -> operation_record list -> unit
+val cleanup_dead_units :
+  Room.config -> days:int -> unit_record list -> unit_record list * int
+val cleanup_orphaned_units :
+  Room.config -> unit_record list -> unit_record list * int
+val archive_terminal_operations :
+  Room.config -> days:int -> operation_record list -> operation_record list * int
+val cleanup_orphaned_detachments :
+  Room.config ->
+  operation_ids:string list ->
+  detachment_record list ->
+  detachment_record list * int
+val cleanup_dropped_intents :
+  Room.config -> days:int -> intent_record list -> intent_record list * int
+val cleanup_cp : Room.config -> cleanup_result
+val cleanup_cp_summary : Room.config -> string

--- a/lib/command_plane/cp_paths.mli
+++ b/lib/command_plane/cp_paths.mli
@@ -1,25 +1,25 @@
 include module type of Cp_types
 
-val control_plane_dir : Room.room_config -> string
-val control_plane_root_dir : Room.room_config -> string
-val legacy_control_plane_root_dir : Room.room_config -> string
-val units_path : Room.room_config -> string
-val operations_path : Room.room_config -> string
-val intents_path : Room.room_config -> string
-val events_path : Room.room_config -> string
-val detachments_path : Room.room_config -> string
-val decisions_path : Room.room_config -> string
-val traces_dir : Room.room_config -> string
-val operator_dir : Room.room_config -> string
-val operator_pending_confirms_path : Room.room_config -> string
-val operator_action_log_path : Room.room_config -> string
-val swarm_path : Room.room_config -> string
-val swarm_live_dirs : Room.room_config -> string list
-val swarm_live_run_dirs : Room.room_config -> string -> string list
-val primary_swarm_live_run_dir : Room.room_config -> string -> string
+val control_plane_dir : Room.config -> string
+val control_plane_root_dir : Room.config -> string
+val legacy_control_plane_root_dir : Room.config -> string
+val units_path : Room.config -> string
+val operations_path : Room.config -> string
+val intents_path : Room.config -> string
+val events_path : Room.config -> string
+val detachments_path : Room.config -> string
+val decisions_path : Room.config -> string
+val traces_dir : Room.config -> string
+val operator_dir : Room.config -> string
+val operator_pending_confirms_path : Room.config -> string
+val operator_action_log_path : Room.config -> string
+val swarm_path : Room.config -> string
+val swarm_live_dirs : Room.config -> string list
+val swarm_live_run_dirs : Room.config -> string -> string list
+val primary_swarm_live_run_dir : Room.config -> string -> string
 val find_swarm_live_artifact_path :
-  Room.room_config -> string -> string -> string option
-val swarm_live_resolution_path : Room.room_config -> string -> string
+  Room.config -> string -> string -> string option
+val swarm_live_resolution_path : Room.config -> string -> string
 val find_swarm_live_artifact_json :
-  Room.room_config -> string -> string -> Yojson.Safe.t option
-val search_stats_path : Room.room_config -> string
+  Room.config -> string -> string -> Yojson.Safe.t option
+val search_stats_path : Room.config -> string

--- a/lib/command_plane/cp_paths.mli
+++ b/lib/command_plane/cp_paths.mli
@@ -1,0 +1,25 @@
+include module type of Cp_types
+
+val control_plane_dir : Room.room_config -> string
+val control_plane_root_dir : Room.room_config -> string
+val legacy_control_plane_root_dir : Room.room_config -> string
+val units_path : Room.room_config -> string
+val operations_path : Room.room_config -> string
+val intents_path : Room.room_config -> string
+val events_path : Room.room_config -> string
+val detachments_path : Room.room_config -> string
+val decisions_path : Room.room_config -> string
+val traces_dir : Room.room_config -> string
+val operator_dir : Room.room_config -> string
+val operator_pending_confirms_path : Room.room_config -> string
+val operator_action_log_path : Room.room_config -> string
+val swarm_path : Room.room_config -> string
+val swarm_live_dirs : Room.room_config -> string list
+val swarm_live_run_dirs : Room.room_config -> string -> string list
+val primary_swarm_live_run_dir : Room.room_config -> string -> string
+val find_swarm_live_artifact_path :
+  Room.room_config -> string -> string -> string option
+val swarm_live_resolution_path : Room.room_config -> string -> string
+val find_swarm_live_artifact_json :
+  Room.room_config -> string -> string -> Yojson.Safe.t option
+val search_stats_path : Room.room_config -> string

--- a/lib/command_plane/cp_snapshot_section_cache.mli
+++ b/lib/command_plane/cp_snapshot_section_cache.mli
@@ -1,0 +1,28 @@
+include module type of Cp_unit
+
+type section_cache = {
+  mutable topo_units_mtime : float;
+  mutable topo_agents_mtime : float;
+  mutable agents : Types.agent list;
+  mutable managed_units : unit_record list;
+  mutable units : unit_record list;
+  mutable source : string;
+  mutable sessions_mtime : float;
+  mutable sessions : Team_session_types.session list;
+  mutable intents_mtime : float;
+  mutable intents : intent_record list;
+  mutable ops_topo_units_mtime : float;
+  mutable ops_topo_agents_mtime : float;
+  mutable ops_sessions_mtime : float;
+  mutable ops_mtime : float;
+  mutable operations : operation_record list;
+  mutable det_mtime : float;
+  mutable det_ops_mtime : float;
+  mutable detachments : detachment_record list;
+  mutable decisions_mtime : float;
+  mutable decisions_operator_mtime : float;
+  mutable decisions : policy_decision_record list;
+}
+
+val create : unit -> section_cache
+val shared_cache : section_cache option ref

--- a/lib/command_plane/cp_types.mli
+++ b/lib/command_plane/cp_types.mli
@@ -1,0 +1,173 @@
+module U = Yojson.Safe.Util
+
+type unit_kind = Company | Platoon | Squad | Agent_unit
+type policy_envelope = {
+  policy_class : string;
+  approval_class : string;
+  tool_allowlist : string list;
+  model_allowlist : string list;
+  requires_human_for : string list;
+  escalation_timeout_sec : int;
+  kill_switch : bool;
+  frozen : bool;
+}
+type budget_envelope = {
+  headcount_cap : int;
+  active_operation_cap : int;
+  max_cost_usd : float;
+  max_tokens : int;
+}
+type unit_record = {
+  unit_id : string;
+  label : string;
+  kind : unit_kind;
+  parent_unit_id : string option;
+  leader_id : string option;
+  roster : string list;
+  capability_profile : string list;
+  policy : policy_envelope;
+  budget : budget_envelope;
+  source : string;
+  created_at : string;
+  updated_at : string;
+}
+type operation_status =
+    Planned
+  | Active
+  | Paused
+  | Completed
+  | Cancelled
+  | Failed
+type chain_record = {
+  kind : string;
+  backend : string;
+  chain_id : string option;
+  goal : string option;
+  run_id : string option;
+  status : string;
+  history_event : Yojson.Safe.t option;
+  mermaid : string option;
+  preview_run : Yojson.Safe.t option;
+  viewer_path : string option;
+  last_sync_at : string option;
+}
+type operation_record = {
+  operation_id : string;
+  objective : string;
+  intent_id : string option;
+  assigned_unit_id : string;
+  policy_class : string;
+  budget_class : string;
+  workload_template : string option;
+  workload_profile : string;
+  stage : string option;
+  artifact_scope : string list;
+  depends_on_operation_ids : string list;
+  search_strategy : string;
+  detachment_session_id : string option;
+  trace_id : string;
+  checkpoint_ref : string option;
+  active_goal_ids : string list;
+  note : string option;
+  created_by : string;
+  source : string;
+  status : operation_status;
+  chain : chain_record option;
+  created_at : string;
+  updated_at : string;
+}
+type intent_state =
+    Adopted
+  | Active_intent
+  | Blocked_intent
+  | Suspended_intent
+  | Handoff_ready
+  | Completed_intent
+  | Dropped_intent
+type intent_focus = {
+  stage : string option;
+  artifact_scope : string list;
+  unit_id : string option;
+  verification_state : string option;
+}
+type intent_record = {
+  intent_id : string;
+  title : string;
+  owner : string;
+  workload_profile : string;
+  success_metric : Yojson.Safe.t option;
+  invariants : string list;
+  artifact_priors : string list;
+  state : intent_state;
+  current_focus : intent_focus;
+  checkpoint_ref : string option;
+  source : string;
+  created_at : string;
+  updated_at : string;
+}
+type event_record = {
+  event_id : string;
+  trace_id : string;
+  event_type : string;
+  operation_id : string option;
+  unit_id : string option;
+  actor : string option;
+  source : string;
+  ts : string;
+  detail : Yojson.Safe.t;
+}
+type detachment_record = {
+  detachment_id : string;
+  operation_id : string;
+  assigned_unit_id : string;
+  leader_id : string option;
+  roster : string list;
+  session_id : string option;
+  checkpoint_ref : string option;
+  runtime_kind : string option;
+  runtime_ref : string option;
+  source : string;
+  status : string;
+  last_event_at : string option;
+  last_progress_at : string option;
+  heartbeat_deadline : string option;
+  created_at : string;
+  updated_at : string;
+}
+type policy_decision_record = {
+  decision_id : string;
+  trace_id : string;
+  requested_action : string;
+  scope_type : string;
+  scope_id : string;
+  operation_id : string option;
+  target_unit_id : string option;
+  requested_by : string;
+  status : string;
+  reason : string option;
+  source : string;
+  detail : Yojson.Safe.t;
+  created_at : string;
+  decided_at : string option;
+  expires_at : string option;
+}
+type operation_status_counts = {
+  planned_count : int;
+  active_count : int;
+  paused_count : int;
+  completed_count : int;
+  failed_count : int;
+  cancelled_count : int;
+}
+type topology_summary = {
+  total_units : int;
+  company_count : int;
+  platoon_count : int;
+  squad_count : int;
+  leaf_agent_unit_count : int;
+  live_agent_count : int;
+  managed_unit_count : int;
+  active_operation_count : int;
+  stale_unit_count : int;
+  operation_status_counts : operation_status_counts;
+}


### PR DESCRIPTION
## Summary
- `cp_types.mli` 추가: command_plane 핵심 타입 정의의 인터페이스 명시
- Phase 2 (.mli 인터페이스 보강) 첫 배치

## Context
- Issue #3722: 642개 .ml 중 471개 (73%) .mli 미보유
- command_plane/은 17개 .ml 중 1개만 .mli 보유 (6%)
- 이 PR로 2개 (cp_types + cp_lifecycle_policy)

## Notes
- `module U = Yojson.Safe.Util` 재노출 유지: downstream include chain (cp_serde 등)이 의존
- 추후 include chain 정리 시 U alias를 각 모듈로 이동하고 .mli에서 제거 가능

## Test plan
- [x] `dune build` 성공
- [ ] CI Build and Test

Generated with Claude Code