### PR TITLE
refactor(board): extract remove_from_list_index to flatten 3-level nesting

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -21,6 +21,16 @@ let create_store () = {
   last_flush = Time_compat.now ();
 }
 
+(** Remove [value] from the string list stored at [key] in [tbl].
+    Removes the key entirely when the list becomes empty. *)
+let remove_from_list_index tbl key value =
+  match Hashtbl.find_opt tbl key with
+  | None -> ()
+  | Some ids ->
+    match List.filter (fun id -> not (String.equal id value)) ids with
+    | [] -> Hashtbl.remove tbl key
+    | filtered -> Hashtbl.replace tbl key filtered
+
 (** Invalidate caches that depend on post data *)
 let invalidate_post_caches store =
   store.karma_cache <- None;
@@ -67,13 +77,8 @@ let sweep store =
     List.iter (fun cid ->
       (match Hashtbl.find_opt store.comments cid with
        | Some c ->
-           let post_key = Post_id.to_string c.post_id in
-           (match Hashtbl.find_opt store.comments_by_post post_key with
-            | Some ids ->
-                (match List.filter (fun id -> not (String.equal id cid)) ids with
-                 | [] -> Hashtbl.remove store.comments_by_post post_key
-                 | filtered -> Hashtbl.replace store.comments_by_post post_key filtered)
-            | None -> ())
+           remove_from_list_index store.comments_by_post
+             (Post_id.to_string c.post_id) cid
        | None -> ());
       Hashtbl.remove store.comments cid
     ) expired_comments;


### PR DESCRIPTION
## Summary
- `board_core.ml`의 comment sweep 루프에서 3중 중첩 match를 `remove_from_list_index` 헬퍼로 추출
- "Hashtbl에서 리스트 값의 한 원소 제거" 패턴을 재사용 가능한 함수로 분리

## Before (10줄, 3-level nesting)
```ocaml
match Hashtbl.find_opt store.comments cid with
| Some c ->
    (match Hashtbl.find_opt store.comments_by_post post_key with
     | Some ids ->
         (match List.filter (...) ids with
          | [] -> Hashtbl.remove ...
          | filtered -> Hashtbl.replace ...)
     | None -> ())
| None -> ()
```

## After (4줄, 1-level nesting)
```ocaml
match Hashtbl.find_opt store.comments cid with
| Some c ->
    remove_from_list_index store.comments_by_post
      (Post_id.to_string c.post_id) cid
| None -> ()
```

## Test plan
- [x] `dune build` 성공
- [ ] CI 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)