### PR TITLE
chore: remove 4 dead functions with zero callers

### DIFF
--- a/lib/chain/chain_executor_leaf.ml
+++ b/lib/chain/chain_executor_leaf.ml
@@ -231,10 +231,6 @@ let execute_model_node ctx ~clock ~(exec_fn : exec_fn) ~(node : node) (model : n
           Error msg)
   | _ -> Error "execute_model_node called with non-MODEL node"
 
-(** MASC MCP endpoint - configurable via MASC_MCP_URL env var *)
-let _masc_mcp_url () =
-  Env_config.Chain.mcp_url ()
-
 (** Get MASC agent name from env or default *)
 let masc_agent_name () =
   Env_config.Chain.agent_name

--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -157,12 +157,6 @@ let markdown_dir = store.markdown_dir
 (** Make a storage key from id and version *)
 let make_key ~id ~version = Printf.sprintf "%s@%s" id version
 
-(** Parse a storage key back to id and version *)
-let _parse_key key =
-  match String.split_on_char '@' key with
-  | [id; version] -> Some (id, version)
-  | _ -> None
-
 (** Initialize the registry with optional file persistence *)
 let init ?persist_dir () =
   prompts_dir := persist_dir;

--- a/lib/tool_command_plane_chain_query.ml
+++ b/lib/tool_command_plane_chain_query.ml
@@ -480,16 +480,6 @@ let string_member_opt json key =
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
-let _assoc_member_opt json key =
-  match U.member key json with
-  | `Assoc _ as value -> Some value
-  | _ -> None
-
-let _list_member json key =
-  match U.member key json with
-  | `List rows -> rows
-  | _ -> []
-
 let string_json value =
   match value with
   | Some v -> `String v


### PR DESCRIPTION
## Summary
- `_` prefix 함수 4개가 정의만 있고 호출처 0건 — codebase-wide grep으로 검증
- 3개 파일에서 총 20줄 삭제

## 제거 대상
| 함수 | 파일 | 근거 |
|------|------|------|
| `_parse_key` | `prompt_registry.ml` | `make_key`의 역함수, 한번도 호출된 적 없음 |
| `_masc_mcp_url` | `chain_executor_leaf.ml` | `Env_config.Chain.mcp_url()` wrapper, companion `masc_agent_name`만 사용됨 |
| `_assoc_member_opt` | `chain_query.ml` | JSON assoc 추출기, 리팩토링 후 잔재 |
| `_list_member` | `chain_query.ml` | JSON list 추출기, 리팩토링 후 잔재 |

## 유지 대상 (제거하지 않음)
- `_cost_max_session_usd` (governance_registry.ml): `Runtime_params.register` side-effect
- `_arg_get_*` (tool_inline_dispatch.ml): `(* unused but kept for symmetry *)` 주석

## Test plan
- [x] `dune build` 성공
- [ ] CI 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)