### PR TITLE
fix(ci): switch Dashboard job from npm to pnpm (#3754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,17 +350,20 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Enable corepack and install pnpm
+        run: corepack enable && corepack prepare pnpm@10.31.0 --activate
+
       - name: Install dashboard dependencies
         working-directory: dashboard
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: TypeScript typecheck
         working-directory: dashboard
-        run: npm run typecheck
+        run: pnpm run typecheck
 
       - name: Run dashboard tests
         working-directory: dashboard
-        run: npm test
+        run: pnpm test
 
   docs:
     name: Documentation


### PR DESCRIPTION
## Summary
- Dashboard CI step fails: `npm error ERESOLVE unable to resolve dependency tree` (vite@undefined)
- Root cause: `package.json` declares `packageManager: pnpm@10.31.0`, only `pnpm-lock.yaml` exists
- Fix: `corepack enable` + `pnpm install --frozen-lockfile`

Fixes #3754.

Generated with Claude Code