### PR TITLE
fix(keeper): dynamic max_silence_sec floor from keepalive interval

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -194,6 +194,10 @@ module AlertDedup = struct
     Float.max 5.0 (get_float ~default:60.0 "MASC_ALERT_DEDUP_WINDOW_SEC")
 end
 
+(** Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. *)
+let keepalive_interval_sec_ =
+  max 5 (min 300 (get_int ~default:30 "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC"))
+
 (** {1 Work-as-Heartbeat Configuration (Phase 1)} *)
 
 module WorkAsHeartbeat = struct
@@ -204,9 +208,10 @@ module WorkAsHeartbeat = struct
     get_bool ~default:true "MASC_KEEPER_WORK_AS_HEARTBEAT"
 
   (** Maximum seconds since last successful room heartbeat before presence
-      sync is required again. Must be >= keepalive_interval_sec (30). *)
+      sync is required again. Floor = keepalive interval (dynamic). *)
   let max_silence_sec =
-    Float.max 30.0 (get_float ~default:120.0 "MASC_KEEPER_MAX_SILENCE_SEC")
+    let floor = Float.of_int keepalive_interval_sec_ in
+    Float.max floor (get_float ~default:120.0 "MASC_KEEPER_MAX_SILENCE_SEC")
 end
 
 (** {1 Smart Heartbeat Configuration (Phase 2)} *)
@@ -226,8 +231,7 @@ module KeeperKeepalive = struct
       Range: [5, 300]. This is the foundational timing constant — every
       keeper cycle (presence, snapshot, board scan, turn, recurring) runs
       at this cadence. *)
-  let interval_sec =
-    max 5 (min 300 (get_int ~default:30 "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC"))
+  let interval_sec = keepalive_interval_sec_
 
   (** Maximum consecutive heartbeat failures before raising
       Keeper_heartbeat_failure (structured crash). Default: 5.

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -24,11 +24,12 @@ let test_wah_max_silence_default () =
   check (float 0.1) "default max silence 120s" 120.0 v
 
 let test_wah_max_silence_floor_logic () =
-  (* The floor clamp (Float.max 30.0 x) ensures minimum 30s.
-     We verify the invariant: max_silence_sec >= 30.0 always. *)
+  (* The floor clamp uses keepalive interval dynamically.
+     We verify: max_silence_sec >= keepalive_interval_sec always. *)
   let v = Cfg.WorkAsHeartbeat.max_silence_sec in
-  check bool "max_silence >= 30.0 (keepalive interval)"
-    true (v >= 30.0)
+  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
+  check bool "max_silence >= keepalive interval"
+    true (v >= interval)
 
 (* ── KeeperKeepalive config defaults ───────────────────── *)
 


### PR DESCRIPTION
## Summary
WorkAsHeartbeat.max_silence_sec의 floor가 30.0으로 하드코딩되어 있었다. #3746에서 keepalive_interval_sec를 env_config로 추출하면서, interval을 60으로 설정하면 floor(30) < interval(60)이 되어 work-as-heartbeat 최적화가 무효화되는 버그 발생.

## Fix
- `keepalive_interval_sec_`를 top-level에서 먼저 읽어 `WorkAsHeartbeat`과 `KeeperKeepalive` 양쪽에서 참조
- `max_silence_sec` floor를 `Float.of_int keepalive_interval_sec_`로 동적 바인딩

## Test plan
- [x] `test_work_as_heartbeat.exe` — 30 tests pass
- [x] floor invariant 테스트를 동적 참조로 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)