### PR TITLE
feat(dashboard): keeper/agent observability pipeline

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -599,3 +599,42 @@ export function patchKeeperConfig(
     payload,
   )
 }
+
+// --- Keeper trajectory (tool call history) ---
+
+export type TrajectoryGate = {
+  status: 'pass' | 'reject'
+  reason?: string
+}
+
+export type TrajectoryEntry = {
+  ts: number
+  ts_iso: string
+  turn: number
+  round: number
+  tool_name: string
+  args: Record<string, unknown> | string
+  gate: TrajectoryGate
+  result: string | null
+  duration_ms: number
+  error: string | null
+  cost_usd: number
+}
+
+export type TrajectoryResponse = {
+  keeper: string
+  trace_id: string
+  generation: number
+  total_entries: number
+  showing: number
+  entries: TrajectoryEntry[]
+}
+
+export function fetchKeeperTrajectory(
+  name: string,
+  limit?: number,
+): Promise<TrajectoryResponse> {
+  return get<TrajectoryResponse>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${limit != null ? `?limit=${limit}` : ''}`,
+  )
+}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -7,6 +7,17 @@ import { signal } from '@preact/signals'
 import { formatPct } from '../lib/format-number'
 import type { Keeper, KeeperMetricPoint } from '../types'
 
+// ── Context pressure thresholds (shared across KPIs, charts) ─
+const CTX_CRITICAL_PCT = 85
+const CTX_WARN_PCT = 70
+const CTX_COLOR_CRITICAL = '#ef4444'
+const CTX_COLOR_WARN = '#f59e0b'
+const CTX_COLOR_OK = '#22c55e'
+
+function ctxColor(pct: number): string {
+  return pct > CTX_CRITICAL_PCT ? CTX_COLOR_CRITICAL : pct > CTX_WARN_PCT ? CTX_COLOR_WARN : CTX_COLOR_OK
+}
+
 // ── Utility functions ────────────────────────────────────
 
 export function formatTokens(n: number | undefined): string {
@@ -64,7 +75,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
       <div class="text-2xl font-bold ${KPI_VALUE_TONE[tone]} tabular-nums leading-none">${value}</div>
       ${progress != null ? html`
         <div class="w-full h-1 bg-[var(--white-6)] rounded-full overflow-hidden mt-0.5">
-          <div class="h-full rounded-full transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${progress > 85 ? '#ef4444' : progress > 70 ? '#fbbf24' : '#4ade80'}"></div>
+          <div class="h-full rounded-full transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${progress > CTX_CRITICAL_PCT ? CTX_COLOR_CRITICAL : progress > CTX_WARN_PCT ? '#fbbf24' : '#4ade80'}"></div>
         </div>
       ` : null}
       ${hint ? html`<div class="text-[10px] text-[var(--text-dim)] leading-snug">${hint}</div>` : null}
@@ -83,8 +94,8 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       : null
 
   const ctxPct = keeper.context_ratio != null ? Math.round(keeper.context_ratio * 100) : null
-  const ctxTone: KpiTone = ctxPct == null ? 'default' : ctxPct > 85 ? 'bad' : ctxPct > 70 ? 'warn' : ctxPct > 0 ? 'ok' : 'default'
-  const ctxHint = ctxPct != null && ctxPct > 80 ? '한계 접근 중' : undefined
+  const ctxTone: KpiTone = ctxPct == null ? 'default' : ctxPct > CTX_CRITICAL_PCT ? 'bad' : ctxPct > CTX_WARN_PCT ? 'warn' : ctxPct > 0 ? 'ok' : 'default'
+  const ctxHint = ctxPct != null && ctxPct > CTX_WARN_PCT ? '한계 접근 중' : undefined
 
   // Provider-model call statistics from metrics_series
   const modelCounts: Record<string, number> = {}
@@ -170,7 +181,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) {
     const pct = ((keeper.context?.context_ratio ?? 0) * 100)
-    const color = pct > 85 ? '#ef4444' : pct > 70 ? '#f59e0b' : '#22c55e'
+    const color = ctxColor(pct)
     return html`
       <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
@@ -189,14 +200,14 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   })
   const polyline = pts.map(({ x, y }) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')
   const lastRatio = ((series[series.length - 1] as KeeperMetricPoint)?.context_ratio ?? 0) * 100
-  const lineColor = lastRatio > 85 ? '#ef4444' : lastRatio > 70 ? '#f59e0b' : '#22c55e'
+  const lineColor = ctxColor(lastRatio)
 
   return html`
     <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded" style="background:#0b1220;">
         <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
-        <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
-        <line x1="${pad}" y1="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" stroke="#f59e0b" stroke-dasharray="3,3" stroke-width="0.5"/>
+        <line x1="${pad}" y1="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
+        <line x1="${pad}" y1="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="${CTX_COLOR_WARN}" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
           <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
         `)}
@@ -207,6 +218,94 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
       </svg>
       <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${lastRatio.toFixed(1)}%</span>
     </div>`
+}
+
+// ── Metrics Charts (Latency + Cost + Model) ─────────────
+
+const SPARKLINE_W = 200
+const SPARKLINE_H = 40
+const SPARKLINE_PAD = 2
+const MODEL_NAME_MAX_LEN = 20
+
+function miniSparkline(
+  data: number[],
+  maxOverride?: number,
+): string {
+  const W = SPARKLINE_W, H = SPARKLINE_H, pad = SPARKLINE_PAD
+  const n = data.length
+  if (n < 2) return ''
+  const maxVal = maxOverride ?? Math.max(...data, 1)
+  return data.map((v, i) => {
+    const x = pad + (i / (n - 1)) * (W - 2 * pad)
+    const y = H - pad - (v / maxVal) * (H - 2 * pad)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }).join(' ')
+}
+
+export function MetricsCharts({ keeper }: { keeper: Keeper }) {
+  const series = keeper.metrics_series ?? []
+  if (series.length < 2) return null
+
+  const latencies = series.map((p: KeeperMetricPoint) => p.latency_ms ?? 0)
+  const costs = series.map((p: KeeperMetricPoint) => p.cost_usd ?? 0)
+  const W = SPARKLINE_W, H = SPARKLINE_H
+
+  const lastLatency = latencies[latencies.length - 1] ?? 0
+  const totalCost = costs.reduce((a: number, b: number) => a + b, 0)
+
+  // Model switches: detect when model_used changes
+  const modelSwitches: { index: number; model: string }[] = []
+  for (let i = 1; i < series.length; i++) {
+    if ((series[i] as KeeperMetricPoint).model_used !== (series[i - 1] as KeeperMetricPoint).model_used) {
+      modelSwitches.push({ index: i, model: (series[i] as KeeperMetricPoint).model_used })
+    }
+  }
+
+  const latencyLine = miniSparkline(latencies)
+  const costLine = miniSparkline(costs)
+
+  return html`
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
+      ${'' /* Latency */}
+      <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Latency</span>
+          <span class="text-xs font-mono tabular-nums text-[#9ad9ff]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+        </div>
+        <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
+          ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="#9ad9ff" stroke-width="1.5"/>` : null}
+        </svg>
+      </div>
+
+      ${'' /* Cost */}
+      <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Cost</span>
+          <span class="text-xs font-mono tabular-nums text-[#a78bfa]">$${totalCost.toFixed(4)}</span>
+        </div>
+        <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
+          ${costLine ? html`<polyline points="${costLine}" fill="none" stroke="#a78bfa" stroke-width="1.5"/>` : null}
+        </svg>
+      </div>
+
+      ${'' /* Model timeline */}
+      ${modelSwitches.length > 0 ? html`
+        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Model Switches</span>
+            <span class="text-[10px] text-[var(--text-dim)]">${modelSwitches.length} switch${modelSwitches.length > 1 ? 'es' : ''}</span>
+          </div>
+          <div class="flex flex-wrap gap-1.5">
+            ${modelSwitches.map(s => html`
+              <span class="text-[10px] px-2 py-0.5 rounded-full bg-[rgba(250,204,21,0.08)] text-[#facc15] border border-[rgba(250,204,21,0.15)] font-mono">
+                T${s.index} -> ${s.model.length > MODEL_NAME_MAX_LEN ? s.model.slice(0, MODEL_NAME_MAX_LEN) + '...' : s.model}
+              </span>
+            `)}
+          </div>
+        </div>
+      ` : null}
+    </div>
+  `
 }
 
 // ── Raw Data (Debug) ─────────────────────────────────────

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -20,6 +20,7 @@ import {
   ContextChart,
   EquipmentList,
   KpiGrid,
+  MetricsCharts,
   RawDataDebug,
   RelationshipList,
   TraitsList,
@@ -30,6 +31,7 @@ import {
 } from './keeper-detail-runtime'
 import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
 import { PipelineStageBar } from './keeper-pipeline-stage'
+import { KeeperTrajectoryTimeline } from './keeper-trajectory-timeline'
 import { DialogOverlay } from './common/dialog'
 
 // ── Global overlay state ──────────────────────────────────
@@ -213,6 +215,9 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Context chart ── */}
         <${ContextChart} keeper=${keeper} />
 
+        ${'' /* ── Latency / Cost / Model charts ── */}
+        <${MetricsCharts} keeper=${keeper} />
+
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
 
@@ -267,6 +272,12 @@ export function KeeperDetailOverlay() {
               <//>
             `
             : null}
+
+          <div class="md:col-span-2">
+            <${SectionCard} title="도구 호출 궤적">
+              <${KeeperTrajectoryTimeline} keeperName=${keeper.name} />
+            <//>
+          </div>
 
           <${SectionCard} title="품질 시그널">
             <${RuntimeSignals} keeper=${keeper} />

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -109,7 +109,7 @@ describe('KeeperConversationPanel', () => {
     expect(container.textContent).toContain('직접 대화')
     expect(container.textContent).toContain('@sangsu')
     expect(container.textContent).toContain('메타데이터 표시')
-    expect(container.textContent).toContain('1개의 내부 이력이 가독성을 위해 숨겨져 있습니다')
+    expect(container.textContent).toContain('내부 메시지가 숨겨져 있습니다')
     expect(container.textContent).not.toContain('Conversation Lane')
     expect(container.textContent).not.toContain('Visible thread')
     expect(container.textContent).not.toContain('Hidden internal')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -22,11 +22,11 @@ import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 
 const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
+const KEEPER_CHAT_INTERNAL_VISIBLE_KEY = 'masc_keeper_chat_internal_visible'
 
 function readKeeperChatMetadataVisible(): boolean {
   try {
     const stored = localStorage.getItem(KEEPER_CHAT_METADATA_VISIBLE_KEY)
-    // Default to hidden so the direct lane reads like chat first.
     return stored === null ? false : stored === 'true'
   } catch {
     return false
@@ -36,9 +36,22 @@ function readKeeperChatMetadataVisible(): boolean {
 function writeKeeperChatMetadataVisible(value: boolean): void {
   try {
     localStorage.setItem(KEEPER_CHAT_METADATA_VISIBLE_KEY, value ? 'true' : 'false')
+  } catch {}
+}
+
+function readKeeperChatInternalVisible(): boolean {
+  try {
+    const stored = localStorage.getItem(KEEPER_CHAT_INTERNAL_VISIBLE_KEY)
+    return stored === null ? false : stored === 'true'
   } catch {
-    // Ignore persistence failures.
+    return false
   }
+}
+
+function writeKeeperChatInternalVisible(value: boolean): void {
+  try {
+    localStorage.setItem(KEEPER_CHAT_INTERNAL_VISIBLE_KEY, value ? 'true' : 'false')
+  } catch {}
 }
 
 function quietReasonLabel(reason?: string | null): string {
@@ -221,17 +234,20 @@ export function KeeperConversationPanel({
 }) {
   const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
+  const [showInternal, setShowInternal] = useState(readKeeperChatInternalVisible())
 
   useEffect(() => {
     writeKeeperChatMetadataVisible(showMetadata)
   }, [showMetadata])
 
+  useEffect(() => {
+    writeKeeperChatInternalVisible(showInternal)
+  }, [showInternal])
+
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const rawThread = keeperThreads.value[keeperName] ?? []
-  const thread = rawThread.filter(isVisibleDirectConversationEntry)
-  const hiddenHistoryCount = rawThread.filter(
-    entry => entry.delivery === 'history' && !isVisibleDirectConversationEntry(entry),
-  ).length
+  const thread = showInternal ? rawThread : rawThread.filter(isVisibleDirectConversationEntry)
+  const hiddenCount = rawThread.length - thread.length
   const sending = keeperSending.value[keeperName] ?? false
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
@@ -278,6 +294,13 @@ export function KeeperConversationPanel({
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
+            <button
+              type="button"
+              class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[#a78bfa]' : ''}"
+              onClick=${() => { setShowInternal(!showInternal) }}
+            >
+              ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
+            </button>
             ${!historyExpanded
               ? html`
                   <button
@@ -306,10 +329,10 @@ export function KeeperConversationPanel({
           />
         </div>
 
-        ${hiddenHistoryCount > 0
+        ${!showInternal && hiddenCount > 0
           ? html`
               <div class="mx-4 mb-4 rounded-[16px] border border-[rgba(245,158,11,0.16)] bg-[rgba(245,158,11,0.06)] px-3 py-2 text-[11px] leading-[1.55] text-[#f4d79e]">
-                이 대화에서 ${hiddenHistoryCount}개의 내부 이력이 가독성을 위해 숨겨져 있습니다.
+                ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
               </div>
             `
           : null}

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -1,0 +1,197 @@
+// Keeper trajectory timeline — shows per-turn tool call history
+// with args summary, result preview, gate decisions, and duration.
+// Fetches from /api/v1/keepers/:name/trajectory on mount + SSE refresh.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { fetchKeeperTrajectory } from '../api/dashboard'
+import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
+import { TimeAgo } from './common/time-ago'
+
+// ── State ────────────────────────────────────────────────
+
+const trajectoryData = signal<TrajectoryResponse | null>(null)
+const trajectoryLoading = signal(false)
+const trajectoryError = signal<string | null>(null)
+
+export async function loadTrajectory(keeperName: string): Promise<void> {
+  trajectoryLoading.value = true
+  trajectoryError.value = null
+  try {
+    trajectoryData.value = await fetchKeeperTrajectory(keeperName, TRAJECTORY_DEFAULT_LIMIT)
+  } catch (err) {
+    trajectoryError.value = err instanceof Error ? err.message : 'fetch failed'
+    trajectoryData.value = null
+  } finally {
+    trajectoryLoading.value = false
+  }
+}
+
+export function clearTrajectory(): void {
+  trajectoryData.value = null
+  trajectoryError.value = null
+}
+
+// ── Display constants ────────────────────────────────────
+
+const TRAJECTORY_DEFAULT_LIMIT = 50
+const ARGS_PREVIEW_MAX_CHARS = 80
+const ARGS_VALUE_MAX_CHARS = 30
+const ARGS_MAX_KEYS = 3
+const RESULT_PREVIEW_MAX_CHARS = 80
+const DURATION_FAST_MS = 500
+const DURATION_SLOW_MS = 2000
+
+// Tool category → icon/color mapping. Order matters: first match wins.
+const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; color: string }> = [
+  { match: n => n.includes('bash'),                         icon: '>', color: 'text-[#4ade80]' },
+  { match: n => n.includes('edit') || n.includes('fs'),     icon: 'E', color: 'text-[#fbbf24]' },
+  { match: n => n.includes('board') || n.includes('social'),icon: 'B', color: 'text-[#a78bfa]' },
+  { match: n => n.includes('github'),                       icon: 'G', color: 'text-[#9ad9ff]' },
+  { match: n => n.includes('search') || n.includes('read'), icon: 'R', color: 'text-[#60a5fa]' },
+]
+const DEFAULT_TOOL_STYLE = { icon: 'T', color: 'text-[#94a3b8]' }
+
+// ── Helpers ──────────────────────────────────────────────
+
+function toolCategory(name: string): { icon: string; color: string } {
+  return TOOL_CATEGORIES.find(c => c.match(name)) ?? DEFAULT_TOOL_STYLE
+}
+
+function durationColor(ms: number): string {
+  if (ms < DURATION_FAST_MS) return 'text-[#4ade80]'
+  if (ms < DURATION_SLOW_MS) return 'text-[#fbbf24]'
+  return 'text-[#ef4444]'
+}
+
+function formatArgs(args: Record<string, unknown> | string): string {
+  if (typeof args === 'string') {
+    return args.length > ARGS_PREVIEW_MAX_CHARS ? args.slice(0, ARGS_PREVIEW_MAX_CHARS) + '...' : args
+  }
+  const keys = Object.keys(args)
+  if (keys.length === 0) return '{}'
+  const preview = keys.slice(0, ARGS_MAX_KEYS).map(k => {
+    const v = args[k]
+    const vs = typeof v === 'string'
+      ? (v.length > ARGS_VALUE_MAX_CHARS ? v.slice(0, ARGS_VALUE_MAX_CHARS) + '...' : v)
+      : JSON.stringify(v)?.slice(0, ARGS_VALUE_MAX_CHARS) ?? ''
+    return `${k}: ${vs}`
+  }).join(', ')
+  return keys.length > ARGS_MAX_KEYS ? `{${preview}, ...}` : `{${preview}}`
+}
+
+function formatResult(result: string | null, error: string | null): string {
+  if (error) return `err: ${error.slice(0, RESULT_PREVIEW_MAX_CHARS)}`
+  if (!result) return '-'
+  return result.length > RESULT_PREVIEW_MAX_CHARS ? result.slice(0, RESULT_PREVIEW_MAX_CHARS) + '...' : result
+}
+
+// ── Components ───────────────────────────────────────────
+
+function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
+  const gateRejected = entry.gate.status === 'reject'
+  const cat = toolCategory(entry.tool_name)
+  return html`
+    <div class="group flex items-start gap-3 py-2.5 px-3 rounded-lg hover:bg-[var(--white-3)] transition-colors ${gateRejected ? 'opacity-50' : ''}">
+      ${'' /* Tool icon */}
+      <div class="flex-shrink-0 mt-0.5 size-7 rounded-md bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[11px] font-mono font-bold ${cat.color}">
+        ${cat.icon}
+      </div>
+
+      ${'' /* Content */}
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-xs font-mono font-medium ${cat.color}">${entry.tool_name}</span>
+          <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}R${entry.round}</span>
+          ${gateRejected
+            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">거부: ${entry.gate.reason ?? ''}</span>`
+            : null}
+          ${entry.error
+            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">오류</span>`
+            : null}
+        </div>
+
+        ${'' /* Args */}
+        <div class="mt-1 text-[11px] text-[var(--text-muted)] font-mono truncate max-w-full" title=${typeof entry.args === 'string' ? entry.args : JSON.stringify(entry.args)}>
+          ${formatArgs(entry.args)}
+        </div>
+
+        ${'' /* Result preview (on hover/expand) */}
+        <div class="mt-0.5 text-[11px] text-[var(--text-dim)] font-mono truncate max-w-full hidden group-hover:block">
+          ${formatResult(entry.result, entry.error)}
+        </div>
+      </div>
+
+      ${'' /* Duration + timestamp */}
+      <div class="flex-shrink-0 flex flex-col items-end gap-0.5">
+        <span class="text-[11px] font-mono ${durationColor(entry.duration_ms)}">${entry.duration_ms}ms</span>
+        <${TimeAgo} timestamp=${entry.ts} class="text-[10px] text-[var(--text-dim)]" />
+      </div>
+    </div>
+  `
+}
+
+// Group entries by turn number
+function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]> {
+  const groups = new Map<number, TrajectoryEntry[]>()
+  for (const e of entries) {
+    const existing = groups.get(e.turn)
+    if (existing) {
+      existing.push(e)
+    } else {
+      groups.set(e.turn, [e])
+    }
+  }
+  return groups
+}
+
+export function KeeperTrajectoryTimeline({ keeperName }: { keeperName: string }) {
+  useEffect(() => {
+    void loadTrajectory(keeperName)
+    return () => clearTrajectory()
+  }, [keeperName])
+
+  if (trajectoryLoading.value) {
+    return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">궤적 로딩 중...</div>`
+  }
+
+  if (trajectoryError.value) {
+    return html`<div class="text-xs text-[#ef4444] py-4 text-center">${trajectoryError.value}</div>`
+  }
+
+  const data = trajectoryData.value
+  if (!data || data.entries.length === 0) {
+    return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">이 세션에 기록된 도구 호출이 없습니다.</div>`
+  }
+
+  const turnGroups = groupByTurn(data.entries)
+  const turns = Array.from(turnGroups.entries()).sort(([a], [b]) => b - a)
+
+  return html`
+    <div class="flex flex-col gap-1">
+      ${'' /* Header */}
+      <div class="flex items-center justify-between mb-2">
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] font-mono text-[var(--text-dim)]">trace: ${data.trace_id.slice(0, 8)}</span>
+          <span class="text-[10px] text-[var(--text-dim)]">gen ${data.generation}</span>
+        </div>
+        <span class="text-[10px] text-[var(--text-dim)]">
+          ${data.showing}/${data.total_entries} entries
+        </span>
+      </div>
+
+      ${'' /* Turn groups */}
+      ${turns.map(([turnNum, entries]) => html`
+        <div class="mb-2">
+          <div class="flex items-center gap-2 mb-1">
+            <div class="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-wider">Turn ${turnNum}</div>
+            <div class="flex-1 h-px bg-[var(--border-slate-12)]"></div>
+            <div class="text-[10px] text-[var(--text-dim)]">${entries.length} call${entries.length > 1 ? 's' : ''}</div>
+          </div>
+          ${entries.map((e: TrajectoryEntry) => html`<${TrajectoryEntryRow} entry=${e} />`)}
+        </div>
+      `)}
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -9,28 +9,43 @@ import { fetchKeeperTrajectory } from '../api/dashboard'
 import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
 import { TimeAgo } from './common/time-ago'
 
-// ── State ────────────────────────────────────────────────
+// ── State (per-keeper to avoid cross-keeper corruption) ──
 
-const trajectoryData = signal<TrajectoryResponse | null>(null)
-const trajectoryLoading = signal(false)
-const trajectoryError = signal<string | null>(null)
+type TrajectoryState = {
+  data: TrajectoryResponse | null
+  loading: boolean
+  error: string | null
+}
+
+const trajectoryStates = signal<Record<string, TrajectoryState>>({})
+
+function getState(name: string): TrajectoryState {
+  return trajectoryStates.value[name] ?? { data: null, loading: false, error: null }
+}
+
+function setState(name: string, patch: Partial<TrajectoryState>): void {
+  const prev = getState(name)
+  trajectoryStates.value = { ...trajectoryStates.value, [name]: { ...prev, ...patch } }
+}
 
 export async function loadTrajectory(keeperName: string): Promise<void> {
-  trajectoryLoading.value = true
-  trajectoryError.value = null
+  setState(keeperName, { loading: true, error: null })
   try {
-    trajectoryData.value = await fetchKeeperTrajectory(keeperName, TRAJECTORY_DEFAULT_LIMIT)
+    const data = await fetchKeeperTrajectory(keeperName, TRAJECTORY_DEFAULT_LIMIT)
+    setState(keeperName, { data, loading: false })
   } catch (err) {
-    trajectoryError.value = err instanceof Error ? err.message : 'fetch failed'
-    trajectoryData.value = null
-  } finally {
-    trajectoryLoading.value = false
+    setState(keeperName, {
+      data: null,
+      loading: false,
+      error: err instanceof Error ? err.message : 'fetch failed',
+    })
   }
 }
 
-export function clearTrajectory(): void {
-  trajectoryData.value = null
-  trajectoryError.value = null
+export function clearTrajectory(keeperName: string): void {
+  const next = { ...trajectoryStates.value }
+  delete next[keeperName]
+  trajectoryStates.value = next
 }
 
 // ── Display constants ────────────────────────────────────
@@ -149,18 +164,20 @@ function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]>
 export function KeeperTrajectoryTimeline({ keeperName }: { keeperName: string }) {
   useEffect(() => {
     void loadTrajectory(keeperName)
-    return () => clearTrajectory()
+    return () => clearTrajectory(keeperName)
   }, [keeperName])
 
-  if (trajectoryLoading.value) {
+  const state = getState(keeperName)
+
+  if (state.loading) {
     return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">궤적 로딩 중...</div>`
   }
 
-  if (trajectoryError.value) {
-    return html`<div class="text-xs text-[#ef4444] py-4 text-center">${trajectoryError.value}</div>`
+  if (state.error) {
+    return html`<div class="text-xs text-[#ef4444] py-4 text-center">${state.error}</div>`
   }
 
-  const data = trajectoryData.value
+  const data = state.data
   if (!data || data.entries.length === 0) {
     return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">이 세션에 기록된 도구 호출이 없습니다.</div>`
   }

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -213,13 +213,17 @@ function handleKeeperLifecycle(event: { type: string; name?: string }): void {
   // All keeper lifecycle events trigger operator refresh
   scheduleRefresh('operator', () => _refreshOperatorFn?.(), SSE_KEEPER_OPERATOR_DEBOUNCE_MS)
 
-  // keeper_turn_complete: re-hydrate active keeper's conversation thread
+  // keeper_turn_complete: re-hydrate active keeper's conversation + trajectory
   if (event.type === 'keeper_turn_complete') {
     const keeperName = event.name ?? ''
     const viewing = activeKeeperName.value
     if (keeperName && keeperName === viewing) {
       scheduleRefresh(`keeper_thread_${keeperName}`, () => {
         void hydrateKeeperStatus(keeperName, true)
+      }, SSE_KEEPER_THREAD_DEBOUNCE_MS)
+      scheduleRefresh(`keeper_trajectory_${keeperName}`, async () => {
+        const { loadTrajectory } = await import('./components/keeper-trajectory-timeline')
+        void loadTrajectory(keeperName)
       }, SSE_KEEPER_THREAD_DEBOUNCE_MS)
     }
   }

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -129,7 +129,7 @@ let make_hooks
   ignore config;
   ignore session;
   ignore ctx_ref;
-  ignore generation;
+  let sse_turn_complete = "keeper_turn_complete" in
   let board_write_tools =
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
   in
@@ -157,6 +157,20 @@ let make_hooks
              ~model ~input_tokens:input_tok ~output_tokens:output_tok
              ~cost_usd:0.0
          | None -> ());
+        (try
+           Sse.broadcast
+             (`Assoc
+               [
+                 ("type", `String sse_turn_complete);
+                 ("name", `String meta.name);
+                 ("generation", `Int generation);
+                 ("turn", `Int turn);
+                 ("model_used", `String model);
+                 ("input_tokens", `Int input_tok);
+                 ("output_tokens", `Int output_tok);
+                 ("ts_unix", `Float (Unix.gettimeofday ()));
+               ])
+         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -375,7 +375,13 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                             ~generation:meta_current.generation
                             ~context_ratio:(Keeper_exec_context.context_ratio c)
                             ~message_count:(List.length c.messages)
-                      | None -> ()))
+                      | None -> ());
+                     (* Flush tool usage stats to disk for persistence *)
+                     (try
+                        Keeper_registry.flush_tool_usage
+                          ~base_path:ctx.config.base_path
+                          meta_current.name
+                      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()))
                with
                | Eio.Cancel.Cancelled _ as e -> raise e
                | exn ->
@@ -671,6 +677,8 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
   else (
     (* Register in Keeper_registry first — single source of truth. *)
     let reg = Keeper_registry.register ~base_path:ctx.config.base_path m.name m in
+    (* Restore persisted tool usage stats from previous session *)
+    Keeper_registry.restore_tool_usage ~base_path:ctx.config.base_path m.name;
     let stop = reg.fiber_stop in
     let wakeup = reg.fiber_wakeup in
     (* Start optional gRPC heartbeat fiber *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -395,3 +395,60 @@ let tool_usage_of_by_name name =
   | Some entry ->
     Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
     |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+
+(* -- Tool usage persistence ---------------------------------------- *)
+
+let tool_usage_path ~base_path name =
+  let dir = Filename.concat (Filename.concat base_path ".masc") "keepers" in
+  Filename.concat dir (name ^ ".tool_usage.json")
+
+let flush_tool_usage ~base_path name =
+  match StringMap.find_opt (registry_key ~base_path name) !registry with
+  | None -> ()
+  | Some entry ->
+    let items =
+      Hashtbl.fold (fun tool_name (e : tool_call_entry) acc ->
+        `Assoc [
+          ("tool", `String tool_name);
+          ("count", `Int e.count);
+          ("successes", `Int e.successes);
+          ("failures", `Int e.failures);
+          ("last_used_at", `Float e.last_used_at);
+        ] :: acc
+      ) entry.tool_usage []
+    in
+    let json = `Assoc [
+      ("keeper", `String name);
+      ("flushed_at", `Float (Time_compat.now ()));
+      ("tools", `List items);
+    ] in
+    let path = tool_usage_path ~base_path name in
+    (try
+       Fs_compat.mkdir_p (Filename.dirname path);
+       Fs_compat.save_file path (Yojson.Safe.to_string json ^ "\n")
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+       Log.Keeper.error "flush_tool_usage %s: %s" name (Printexc.to_string exn))
+
+let restore_tool_usage ~base_path name =
+  let path = tool_usage_path ~base_path name in
+  if not (Sys.file_exists path) then ()
+  else
+    match StringMap.find_opt (registry_key ~base_path name) !registry with
+    | None -> ()
+    | Some entry ->
+      (try
+         let content = Fs_compat.load_file path in
+         let json = Yojson.Safe.from_string content in
+         let open Yojson.Safe.Util in
+         let tools = json |> member "tools" |> to_list in
+         List.iter (fun item ->
+           let tool_name = item |> member "tool" |> to_string in
+           let e = {
+             count = item |> member "count" |> to_int;
+             successes = item |> member "successes" |> to_int;
+             failures = item |> member "failures" |> to_int;
+             last_used_at = item |> member "last_used_at" |> to_float;
+           } in
+           Hashtbl.replace entry.tool_usage tool_name e
+         ) tools
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -439,16 +439,37 @@ let restore_tool_usage ~base_path name =
       (try
          let content = Fs_compat.load_file path in
          let json = Yojson.Safe.from_string content in
-         let open Yojson.Safe.Util in
-         let tools = json |> member "tools" |> to_list in
+         let tools = match json with
+           | `Assoc fields ->
+             (match List.assoc_opt "tools" fields with
+              | Some (`List items) -> items
+              | _ -> [])
+           | _ -> []
+         in
          List.iter (fun item ->
-           let tool_name = item |> member "tool" |> to_string in
-           let e = {
-             count = item |> member "count" |> to_int;
-             successes = item |> member "successes" |> to_int;
-             failures = item |> member "failures" |> to_int;
-             last_used_at = item |> member "last_used_at" |> to_float;
-           } in
-           Hashtbl.replace entry.tool_usage tool_name e
+           try
+             match item with
+             | `Assoc fields ->
+               let str key = match List.assoc_opt key fields with
+                 | Some (`String s) -> s | _ -> raise Exit in
+               let int key = match List.assoc_opt key fields with
+                 | Some (`Int n) -> n | _ -> raise Exit in
+               let float key = match List.assoc_opt key fields with
+                 | Some (`Float f) -> f
+                 | Some (`Int n) -> Float.of_int n
+                 | _ -> raise Exit in
+               let tool_name = str "tool" in
+               let e = {
+                 count = int "count";
+                 successes = int "successes";
+                 failures = int "failures";
+                 last_used_at = float "last_used_at";
+               } in
+               Hashtbl.replace entry.tool_usage tool_name e
+             | _ -> ()
+           with Exit -> ()
          ) tools
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Keeper.warn "restore_tool_usage %s: %s" name (Printexc.to_string exn))

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -399,8 +399,8 @@ let tool_usage_of_by_name name =
 (* -- Tool usage persistence ---------------------------------------- *)
 
 let tool_usage_path ~base_path name =
-  let dir = Filename.concat (Filename.concat base_path ".masc") "keepers" in
-  Filename.concat dir (name ^ ".tool_usage.json")
+  let dir = Filename.concat (Filename.concat base_path ".masc") "keepers/tool_usage" in
+  Filename.concat dir (name ^ ".json")
 
 let flush_tool_usage ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -176,3 +176,9 @@ val find_by_agent_name : string -> registry_entry option
 (** Get tool usage by keeper name (scans all base_paths). *)
 val tool_usage_of_by_name : string ->
   (string * Keeper_types.tool_call_entry) list
+
+(** Flush in-memory tool usage stats to disk for persistence across restarts. *)
+val flush_tool_usage : base_path:string -> string -> unit
+
+(** Restore tool usage stats from disk after keeper re-registration. *)
+val restore_tool_usage : base_path:string -> string -> unit

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -346,6 +346,50 @@ let add_routes ~sw ~clock router =
              in
              Http.Response.json ~status ~compress:true ~request:req
                (Yojson.Safe.to_string json) reqd
+         else if ends_with "/trajectory" then
+           let name = extract_name "/trajectory" in
+           if String.length name = 0 then
+             Http.Response.json ~status:`Bad_request
+               {|{"error":"keeper name is required"}|} reqd
+           else
+             let config = state.Mcp_server.room_config in
+             (match Keeper_types.read_meta config name with
+              | Error e ->
+                Http.Response.json ~status:`Internal_server_error
+                  (Printf.sprintf {|{"error":"%s"}|} (String.escaped e)) reqd
+              | Ok None ->
+                Http.Response.json ~status:`Not_found
+                  (Printf.sprintf {|{"error":"keeper %S not found"}|} name) reqd
+              | Ok (Some m) ->
+                let trajectory_default_limit = 50 in
+                let trajectory_max_limit = 500 in
+                let limit =
+                  Server_utils.int_query_param req "limit"
+                    ~default:trajectory_default_limit
+                  |> max 1 |> min trajectory_max_limit
+                in
+                let masc_root = Filename.concat config.base_path ".masc" in
+                let entries =
+                  Trajectory.read_entries ~masc_root ~keeper_name:m.name
+                    ~trace_id:m.trace_id
+                in
+                let total = List.length entries in
+                let recent =
+                  if total <= limit then entries
+                  else
+                    let drop = total - limit in
+                    List.filteri (fun i _e -> i >= drop) entries
+                in
+                let json = `Assoc [
+                  ("keeper", `String name);
+                  ("trace_id", `String m.trace_id);
+                  ("generation", `Int m.generation);
+                  ("total_entries", `Int total);
+                  ("showing", `Int (List.length recent));
+                  ("entries", `List (List.map (Trajectory.entry_to_json ~result_max_len:2000) recent));
+                ] in
+                Http.Response.json ~compress:true ~request:req
+                  (Yojson.Safe.to_string json) reqd)
          else
            Http.Response.json ~status:`Not_found
              {|{"error":"not found"}|} reqd

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -101,7 +101,10 @@ let outcome_to_string = function
   | CostExceeded -> "cost_exceeded"
   | Gated reason -> Printf.sprintf "gated: %s" reason
 
-let entry_to_json (e : tool_call_entry) : Yojson.Safe.t =
+(** Default truncation limit for result text in JSONL persistence. *)
+let default_result_truncation = 500
+
+let entry_to_json ?(result_max_len = default_result_truncation) (e : tool_call_entry) : Yojson.Safe.t =
   `Assoc [
     ("ts", `Float e.ts);
     ("ts_iso", `String e.ts_iso);
@@ -114,8 +117,9 @@ let entry_to_json (e : tool_call_entry) : Yojson.Safe.t =
       (match e.result with
        | None -> `Null
        | Some r ->
-           let trunc = if String.length r > 500 then String.sub r 0 500 ^ "..." else r in
-           `String trunc));
+           if result_max_len > 0 && String.length r > result_max_len then
+             `String (String.sub r 0 result_max_len ^ "...")
+           else `String r));
     ("duration_ms", `Int e.duration_ms);
     ("error", (match e.error with None -> `Null | Some e -> `String e));
     ("cost_usd", `Float e.cost_usd);

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -55,7 +55,8 @@ val tool_cost_estimate : string -> float
 val gate_decision_to_json : gate_decision -> Yojson.Safe.t
 val outcome_to_json : trajectory_outcome -> Yojson.Safe.t
 val outcome_to_string : trajectory_outcome -> string
-val entry_to_json : tool_call_entry -> Yojson.Safe.t
+val default_result_truncation : int
+val entry_to_json : ?result_max_len:int -> tool_call_entry -> Yojson.Safe.t
 val trajectory_to_json : trajectory -> Yojson.Safe.t
 
 (** {1 Persistence} *)


### PR DESCRIPTION
## Summary

- keeper_turn_complete SSE 이벤트 실제 발화 연결 (backend → dashboard 실시간)
- /api/v1/keepers/:name/trajectory REST endpoint 추가 (tool call 상세 조회)
- Turn Timeline 컴포넌트: 턴별 tool call 시각화 (args, result, gate, duration)
- Latency/Cost/Model 시계열 차트 (기존 metrics_series 데이터 활용)
- tool_usage registry 디스크 persistence (heartbeat flush + startup restore)
- 내부 메시지 표시 토글 (conversation panel 디버깅용)
- context pressure threshold 상수 추출 (85/70 → named constants)
- 프론트엔드 매직넘버 → 명명 상수로 추출

### 해결된 관찰성 격차

| 격차 | 해결 |
|------|------|
| tool args/results 미노출 | trajectory timeline에서 확인 가능 |
| keeper_turn_complete SSE dead code | backend에서 실제 발화 |
| latency/cost 시계열 없음 | MetricsCharts 차트 |
| model 전환 타임라인 없음 | model switch chip |
| tool_usage 재시작 소멸 | heartbeat flush + restore |
| 내부 메시지 숨김 고정 | 토글로 전환 가능 |

## Test plan

- [x] OCaml build: `dune build` 통과
- [x] TypeScript: `tsc --noEmit` 통과
- [x] Dashboard tests: 35 files, 121 tests 전체 통과
- [ ] Keeper 기동 후 dashboard에서 trajectory timeline 렌더링 확인
- [ ] SSE keeper_turn_complete 이벤트 수신 → trajectory 자동 갱신 확인
- [ ] "내부 메시지 표시" 토글 동작 확인
- [ ] 서버 재시작 후 tool_usage 복구 확인

Generated with [Claude Code](https://claude.com/claude-code)