### PR TITLE
test(keeper): property-based invariant tests for config and supervisor

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -101,6 +101,76 @@ let test_should_cleanup_dead_false_when_recent () =
   check bool "ttl not exceeded" false
     (Sup.should_cleanup_dead ~now:200.0 ~dead_ttl_sec:3600.0 entry)
 
+(* ── Property: backoff invariants ───────────────────────── *)
+
+let test_backoff_monotonic_until_cap () =
+  (* backoff(n) <= backoff(n+1) for all n until cap *)
+  let cap = Sup.backoff_delay 20 in  (* at attempt 20, always at cap *)
+  let rec check_mono i prev =
+    if i > 20 then ()
+    else begin
+      let curr = Sup.backoff_delay i in
+      check bool (Printf.sprintf "attempt %d >= prev" i)
+        true (curr >= prev);
+      check bool (Printf.sprintf "attempt %d <= cap" i)
+        true (curr <= cap);
+      check_mono (i + 1) curr
+    end
+  in
+  check_mono 0 0.0
+
+let test_backoff_never_negative () =
+  for i = 0 to 30 do
+    let d = Sup.backoff_delay i in
+    check bool (Printf.sprintf "attempt %d >= 0" i) true (d >= 0.0)
+  done
+
+(* ── Property: keep_last_n invariants ──────────────────── *)
+
+let test_keep_last_n_never_exceeds () =
+  let n = 5 in
+  let result = ref [] in
+  for _i = 0 to 20 do
+    result := Sup.keep_last_n n "x" !result
+  done;
+  check bool "length <= n" true (List.length !result <= n)
+
+(* ── Property: self-preservation subset ────────────────── *)
+
+let bp = "/tmp/test-sp-prop"
+let make_meta name =
+  let json = `Assoc [
+    ("name", `String name);
+    ("agent_name", `String ("agent-" ^ name));
+    ("trace_id", `String ("trace-" ^ name));
+    ("goal", `String "test");
+  ] in
+  match KT.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta: " ^ err)
+
+let test_self_preservation_subset () =
+  Reg.clear ();
+  let names = ["a"; "b"; "c"; "d"; "e"] in
+  let entries = List.map (fun name ->
+    let _reg = Reg.register ~base_path:bp name (make_meta name) in
+    Reg.set_state ~base_path:bp name Reg.Crashed;
+    Reg.set_failure_reason ~base_path:bp name
+      (Some (Reg.Heartbeat_consecutive_failures 3));
+    match Reg.get ~base_path:bp name with
+    | Some e -> (e, "crash") | None -> fail name
+  ) names in
+  let result = Sup.apply_self_preservation ~total_keepers:10 entries in
+  let result_names = List.map (fun ((e : Reg.registry_entry), _) -> e.name) result in
+  let input_names = List.map (fun ((e : Reg.registry_entry), _) -> e.name) entries in
+  List.iter (fun rn ->
+    check bool (Printf.sprintf "%s in input" rn) true (List.mem rn input_names)
+  ) result_names
+
+let test_self_preservation_empty_input () =
+  let result = Sup.apply_self_preservation ~total_keepers:5 [] in
+  check int "empty in = empty out" 0 (List.length result)
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -121,5 +191,16 @@ let () =
       test_case "crash_log empty" `Quick test_crash_log_empty_for_unknown;
       test_case "should cleanup dead when ttl exceeded" `Quick test_should_cleanup_dead_true;
       test_case "should not cleanup dead when recent" `Quick test_should_cleanup_dead_false_when_recent;
+    ];
+    "backoff_properties", [
+      test_case "monotonic until cap" `Quick test_backoff_monotonic_until_cap;
+      test_case "never negative" `Quick test_backoff_never_negative;
+    ];
+    "keep_last_n_properties", [
+      test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;
+    ];
+    "self_preservation_properties", [
+      test_case "output subset of input" `Quick test_self_preservation_subset;
+      test_case "empty input → empty output" `Quick test_self_preservation_empty_input;
     ];
   ]

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -107,6 +107,26 @@ let test_timing_ring_size_range () =
   check bool "ring >= 10" true (v >= 10);
   check bool "ring <= 1000" true (v <= 1000)
 
+(* ── Config invariant properties ───────────────────────── *)
+
+let test_config_invariant_silence_ge_interval () =
+  let silence = Cfg.WorkAsHeartbeat.max_silence_sec in
+  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
+  check bool "max_silence >= interval (invariant)" true (silence >= interval)
+
+let test_config_invariant_sweep_independent () =
+  let sweep = Cfg.KeeperSupervisor.sweep_interval_sec in
+  let backoff_base = Cfg.KeeperSupervisor.backoff_base_s in
+  check bool "sweep > 0" true (sweep > 0.0);
+  check bool "backoff_base > 0" true (backoff_base > 0.0);
+  check bool "backoff_max >= backoff_base" true
+    (Cfg.KeeperSupervisor.backoff_max_s >= backoff_base)
+
+let test_config_invariant_debounce_ge_interval () =
+  let debounce = Cfg.KeeperKeepalive.board_debounce_sec in
+  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
+  check bool "board debounce >= interval" true (debounce >= interval)
+
 (* ── Freshness decision pure logic ──────────────────────── *)
 
 let test_freshness_fresh () =
@@ -225,6 +245,11 @@ let () =
       test_case "exact boundary → stale (strict <)" `Quick test_freshness_exact_boundary;
       test_case "never heartbeated → stale" `Quick test_freshness_never_heartbeated;
       test_case "feature disabled → always stale" `Quick test_freshness_disabled_flag;
+    ];
+    "config_invariants", [
+      test_case "max_silence >= interval" `Quick test_config_invariant_silence_ge_interval;
+      test_case "sweep/backoff coherence" `Quick test_config_invariant_sweep_independent;
+      test_case "debounce >= interval" `Quick test_config_invariant_debounce_ge_interval;
     ];
     "percentile", [
       test_case "empty array" `Quick test_percentile_empty;


### PR DESCRIPTION
## Summary
- 구조적 invariant를 검증하는 property tests 추가
- 기존 단위 테스트 + 시나리오 테스트에 더해 config 일관성까지 검증

## Added Tests

| Group | Tests | Verified Invariant |
|-------|-------|-------------------|
| backoff_properties | 2 | monotonic until cap, never negative (0..30) |
| keep_last_n_properties | 1 | output never exceeds limit (20 iterations) |
| self_preservation_properties | 2 | output subset of input, empty→empty |
| config_invariants | 3 | silence >= interval, backoff coherence, debounce >= interval |

## Test plan
- [x] `test_keeper_supervisor.exe` — 16 tests pass (11→16)
- [x] `test_work_as_heartbeat.exe` — 33 tests pass (30→33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)