### PR TITLE
fix(h2): use json_rpc_error helper for proper message escaping

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -324,7 +324,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                     remember_mcp_profile session_id profile;
                     (match auth_result with
                      | Error msg ->
-                         let body = Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg in
+                         let body = json_rpc_error (-32001) msg in
                          h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
                      | Ok _cred_opt ->
                          h2_read_body h2_reqd (fun body_str ->
@@ -413,9 +413,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           (match auth_result with
            | Error msg ->
-               let body =
-                 Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg
-               in
+               let body = json_rpc_error (-32001) msg in
                h2_respond_json h2_reqd body ~status:`Unauthorized
                  ~extra_headers:(("www-authenticate", "Bearer") :: cors)
            | Ok _ ->
@@ -423,18 +421,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                 | Some session_id -> (
                     match validate_mcp_session_delete_profile ~profile session_id with
                     | Error msg ->
-                        let body =
-                          Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32600,"message":"%s"}}|} msg
-                        in
+                        let body = json_rpc_error (-32600) msg in
                         h2_respond_json h2_reqd body ~status:`Conflict
                           ~extra_headers:cors
                     | Ok () ->
                         (match Server_mcp_transport_http.validate_protocol_version_continuity
                                  ~session_id httpun_request with
                          | Error msg ->
-                             let body =
-                               Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32600,"message":"%s"}}|} msg
-                             in
+                             let body = json_rpc_error (-32600) msg in
                              h2_respond_json h2_reqd body ~status:`Bad_request
                                ~extra_headers:(cors @ mcp_headers session_id (get_protocol_version httpun_request))
                          | Ok () ->


### PR DESCRIPTION
## Summary
- H2 gateway에서 JSON-RPC 에러 응답 4곳이 raw `Printf.sprintf`로 JSON을 직접 구성
- `String.escaped` 없이 `msg`를 직접 삽입하여, 에러 메시지에 `"` 또는 `\`가 포함되면 malformed JSON 발생
- 같은 코드베이스에 이미 존재하는 `json_rpc_error` 헬퍼(`server_routes_http_runtime.ml:24`)로 교체
- 이 헬퍼는 `String.escaped`를 적용하여 안전

## Before (이스케이프 누락)
```ocaml
Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg
```

## After (String.escaped 적용)
```ocaml
json_rpc_error (-32001) msg
```

## Test plan
- [x] `dune build` 성공
- [ ] CI 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)