### PR TITLE
refactor(keeper): remove unused default_daily_budget_usd

### DIFF
--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -306,8 +306,6 @@ let deterministic_baseline_action (obs : world_observation) : deliberation_actio
 
 (* ---------- Budget check ---------- *)
 
-let default_daily_budget_usd = 0.10
-
 (** Read the daily budget from env, returning the default if absent or invalid. *)
 let daily_budget_usd_from_env () : float =
   Env_config.KeeperRuntime.deliberation_daily_budget_usd ()

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -95,11 +95,8 @@ val deterministic_baseline_action : world_observation -> deliberation_action
 
 (** {1 Phase 2: MODEL-Driven Deliberation} *)
 
-(** Default daily budget in USD for deliberation MODEL calls. *)
-val default_daily_budget_usd : float
-
 (** Read the daily budget from [MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD]
-    env var, returning [default_daily_budget_usd] if absent or invalid. *)
+    env var (default: 0.10). *)
 val daily_budget_usd_from_env : unit -> float
 
 (** Check whether the keeper has remaining budget for deliberation.

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -523,7 +523,8 @@ let test_budget_check_zero_cost () =
     (D.deliberation_budget_check ~daily_budget_usd:0.10 ~cost_today_usd:0.0)
 
 let test_default_daily_budget () =
-  check (float 0.001) "default budget" 0.10 D.default_daily_budget_usd
+  (* default is 0.10 in env_config_keeper.ml KeeperRuntime *)
+  check (float 0.001) "default budget" 0.10 (D.daily_budget_usd_from_env ())
 
 let test_daily_budget_from_env_default () =
   (* Unset the env var to get default *)
@@ -539,7 +540,7 @@ let test_daily_budget_from_env_default () =
    | Some v -> Unix.putenv "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" v
    | None -> ());
   (* Empty string causes Failure in float_of_string, so default applies *)
-  check (float 0.001) "env default budget" D.default_daily_budget_usd budget
+  check (float 0.001) "env default budget" 0.10 budget
 
 let test_daily_budget_from_env_custom () =
   let saved = Sys.getenv_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" in


### PR DESCRIPTION
## Summary
env_config로 이전된 후 사용되지 않는 `default_daily_budget_usd` 상수 제거.
테스트는 `daily_budget_usd_from_env()` 또는 리터럴 `0.10`으로 업데이트.

## Test plan
- [x] `test_keeper_deliberation.exe` — 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)