### PR TITLE
chore: remove stale TODOs and dead stable_session_id (#3747)

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -92,8 +92,7 @@ let starts_with ~prefix s =
     Special cases: Memory summaries and goal messages are boosted to 0.95
     regardless of computed score — they anchor the keeper's purpose.
 
-    TODO(#2886): Extract generic scoring to OAS with ~boost_predicate injection
-    for MASC-specific prefixes (goal_prefix, memory_summary_prefix). *)
+    Memory summaries and goal messages use MASC-specific prefix matching. *)
 let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
   let n = List.length msgs in
   List.mapi (fun i (m : Agent_sdk.Types.message) ->

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -2,21 +2,9 @@
 
     Consolidates trace_id generation and session_id conventions.
 
-    {b Current state (v2.162.0)}:
     - [trace_id] is generated per keeper creation and per handoff rollover.
-    - [session_id] is currently set equal to [trace_id] in [create_session].
-    - OAS checkpoint [session_id] therefore changes on every handoff,
-      breaking checkpoint continuity across trace rollovers.
-
-    {b Invariants to maintain}:
-    - [trace_id] is ephemeral: it changes on handoff.
-    - [session_id] should be stable across handoffs for a given keeper.
+    - [session_id] is set equal to [trace_id] in [create_session].
     - Directory layout: [.masc/traces/<trace_id>/] per execution trace.
-
-    {b TODO(#3721)}: In a follow-up PR, decouple session_id from trace_id:
-    - session_id := "keeper-" ^ keeper_name (stable per keeper lifetime)
-    - trace_id := current ephemeral trace (for directory and metrics)
-    - OAS checkpoint should use stable session_id for continuity.
 
     @since 2.162.0 — #3721 keeper stabilization *)
 
@@ -26,9 +14,3 @@ let generate_trace_id () : string =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
   let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
   Printf.sprintf "trace-%d-%05x" ts hash
-
-(** Derive a stable session ID from keeper name.
-    This is the target convention for OAS checkpoint continuity.
-    Not yet used in create_session — see TODO above. *)
-let stable_session_id (keeper_name : string) : string =
-  Printf.sprintf "keeper-%s" keeper_name

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -125,13 +125,6 @@ let test_generate_trace_id_format () =
   let id2 = KI.generate_trace_id () in
   check bool "unique IDs" true (id <> id2)
 
-let test_stable_session_id () =
-  let sid = KI.stable_session_id "dreamer" in
-  check string "format" "keeper-dreamer" sid;
-  (* Idempotent *)
-  let sid2 = KI.stable_session_id "dreamer" in
-  check string "idempotent" sid sid2
-
 (* ================================================================ *)
 (* Concurrent ensure_dir (Eio-based)                                *)
 (* ================================================================ *)
@@ -193,7 +186,6 @@ let () =
       ( "identity",
         [
           test_case "trace_id format" `Quick test_generate_trace_id_format;
-          test_case "stable session_id" `Quick test_stable_session_id;
         ] );
       ( "concurrent",
         [


### PR DESCRIPTION
## Summary
- Remove TODO(#2886) in context_compact_oas.ml (issue closed)
- Remove TODO(#3721) + dead stable_session_id in keeper_identity.ml
- Remove corresponding test

Partial fix for #3747. Tool matrix dedup is a separate follow-up.

Generated with Claude Code