### PR TITLE
refactor(dashboard): deduplicate actor reader, remove dead code

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -5,7 +5,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useRef } from 'preact/hooks'
-import { runOperatorAction } from '../api'
+import { currentDashboardActor, runOperatorAction } from '../api'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
@@ -48,18 +48,11 @@ export function closeKeeperDetail() {
 
 // ── Helpers ───────────────────────────────────────────────
 
-function currentOperatorActor(): string {
-  const q = new URLSearchParams(window.location.search)
-  const queryActor = q.get('agent') ?? q.get('agent_name')
-  const storedActor = localStorage.getItem('masc_dashboard_agent_name')
-  const actor = (queryActor ?? storedActor ?? 'dashboard').trim()
-  return actor || 'dashboard'
-}
 
 async function runSocialSweep(): Promise<void> {
   try {
     await runOperatorAction({
-      actor: currentOperatorActor(),
+      actor: currentDashboardActor(),
       action_type: 'social_sweep',
       target_type: 'room',
       payload: {},
@@ -126,7 +119,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
           <div class="flex flex-col gap-3 px-4 pb-4 pt-2">
             <${KeeperDiagnosticSummary} keeper=${keeper} />
             <${KeeperRuntimeActions}
-              actor=${currentOperatorActor()}
+              actor=${currentDashboardActor()}
               keeper=${keeper}
               onSocialSweep=${() => { void runSocialSweep() }}
             />


### PR DESCRIPTION
## Summary
- `currentOperatorActor()` in keeper-detail.ts 제거 — `currentDashboardActor()` (api/core.ts) SSOT로 통합
- 동일 로직 2곳 → 1곳 (query param + localStorage + fallback)

## Test plan
- [x] `tsc --noEmit` — TypeScript 타입 체크 통과
- [x] `vitest run` — 35 files, 121 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)