### PR TITLE
fix(spawn): handle partial write when piping stdin to child process

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -280,10 +280,13 @@ let fork_with_cwd ~cmd_array ~stdin_content ~working_dir ~config_working_dir =
         in
         Unix.close stdout_write;
         Unix.close stdin_read;
-        let _ =
-          Unix.write_substring stdin_write stdin_content 0
-            (String.length stdin_content)
+        let rec write_all off len =
+          if len > 0 then begin
+            let written = Unix.write_substring stdin_write stdin_content off len in
+            write_all (off + written) (len - written)
+          end
         in
+        write_all 0 (String.length stdin_content);
         Unix.close stdin_write;
         (pid, stdout_read)))
 


### PR DESCRIPTION
## Summary
- `fork_with_cwd`에서 `Unix.write_substring`의 반환값을 `let _ =`로 버림
- pipe 버퍼(macOS 64KB) 초과하는 프롬프트를 stdin으로 보낼 때 **데이터 잘림 발생 가능**
- write loop으로 교체하여 모든 바이트가 전송될 때까지 재시도

## 재현 조건
- `stdin_content`가 64KB 초과 (긴 프롬프트, 컨텍스트 포함)
- 자식 프로세스가 아직 stdin을 읽기 시작하지 않은 경우

## 변경
```diff
-let _ =
-  Unix.write_substring stdin_write stdin_content 0
-    (String.length stdin_content)
+let rec write_all off len =
+  if len > 0 then begin
+    let written = Unix.write_substring stdin_write stdin_content off len in
+    write_all (off + written) (len - written)
+  end
 in
+write_all 0 (String.length stdin_content);
```

## Test plan
- [x] `dune build` 성공
- [ ] CI 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)