### PR TITLE
feat(keeper): count unified turn failures toward crash threshold (#3751)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -239,6 +239,12 @@ module KeeperKeepalive = struct
   let max_consecutive_failures =
     max 2 (min 50 (get_int ~default:5 "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES"))
 
+  (** Maximum consecutive unified turn failures before marking keeper as
+      crashed. Covers LLM timeout, rate limit, and other turn errors.
+      Default: 10. Range: [3, 100]. *)
+  let max_consecutive_turn_failures =
+    max 3 (min 100 (get_int ~default:10 "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES"))
+
   (** Board-reactive wakeup debounce in seconds. Prevents rapid repeated
       wakeups from the same board post. Default: 60.0.
       Range: [5, 300]. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -27,12 +27,15 @@ module StringMap = Map.Make (String)
     ADT matching replaces string prefix matching for crash_msg grouping. *)
 type failure_reason =
   | Heartbeat_consecutive_failures of int
+  | Turn_consecutive_failures of int
   | Fiber_unresolved
   | Exception of string
 
 let failure_reason_to_string = function
   | Heartbeat_consecutive_failures n ->
       Printf.sprintf "heartbeat_consecutive_failures(%d)" n
+  | Turn_consecutive_failures n ->
+      Printf.sprintf "turn_consecutive_failures(%d)" n
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
 
@@ -67,6 +70,7 @@ type registry_entry = {
   crash_log : (float * string) list;
   last_error : string option;
   last_failure_reason : failure_reason option;
+  turn_consecutive_failures : int;
   last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
   board_cursor_ts : float;
@@ -122,6 +126,7 @@ let register ~base_path name meta =
     crash_log = [];
     last_error = None;
     last_failure_reason = None;
+    turn_consecutive_failures = 0;
     last_agent_count = 0;
     board_wakeups = Hashtbl.create 8;
     board_cursor_ts = 0.0;
@@ -209,6 +214,19 @@ let record_error ~base_path name err =
 
 let set_failure_reason ~base_path name reason =
   update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
+
+let increment_turn_failures ~base_path name =
+  update_entry ~base_path name (fun e ->
+    { e with turn_consecutive_failures = e.turn_consecutive_failures + 1 })
+
+let reset_turn_failures ~base_path name =
+  update_entry ~base_path name (fun e ->
+    { e with turn_consecutive_failures = 0 })
+
+let get_turn_failures ~base_path name =
+  match get ~base_path name with
+  | Some e -> e.turn_consecutive_failures
+  | None -> 0
 
 let is_running ~base_path name =
   match get ~base_path name with

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -13,6 +13,7 @@ open Keeper_types
 (** Structured failure reason for crash cohort detection. *)
 type failure_reason =
   | Heartbeat_consecutive_failures of int
+  | Turn_consecutive_failures of int
   | Fiber_unresolved
   | Exception of string
 
@@ -51,6 +52,7 @@ type registry_entry = {
   crash_log : (float * string) list;
   last_error : string option;
   last_failure_reason : failure_reason option;
+  turn_consecutive_failures : int;
   last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
   board_cursor_ts : float;
@@ -88,6 +90,15 @@ val record_error : base_path:string -> string -> string -> unit
 
 (** Set the structured failure reason for cohort detection. *)
 val set_failure_reason : base_path:string -> string -> failure_reason option -> unit
+
+(** Increment turn consecutive failure counter. *)
+val increment_turn_failures : base_path:string -> string -> unit
+
+(** Reset turn consecutive failure counter (on success). *)
+val reset_turn_failures : base_path:string -> string -> unit
+
+(** Get current turn consecutive failure count. *)
+val get_turn_failures : base_path:string -> string -> int
 
 (** Record a crash entry in the crash log (keeps last 5). *)
 val record_crash : base_path:string -> string -> float -> string -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -213,6 +213,7 @@ let cleanup_dead_tombstone (ctx : _ context)
     Groups failures by variant, ignoring parameters (e.g. failure count). *)
 let cohort_key_of_reason = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
+  | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "unknown"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -260,6 +260,26 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            | Error msg ->
                Log.Keeper.error
                  "write_meta failed after unified turn failure: %s" msg);
+          let base_path = config.base_path in
+          Keeper_registry.increment_turn_failures ~base_path meta.name;
+          let count = Keeper_registry.get_turn_failures ~base_path meta.name in
+          let threshold =
+            Env_config.KeeperKeepalive.max_consecutive_turn_failures
+          in
+          if count >= threshold then begin
+            Log.Keeper.error
+              "%s: %d consecutive turn failures (threshold=%d), marking crashed"
+              meta.name count threshold;
+            let reason = Keeper_registry.Turn_consecutive_failures count in
+            Keeper_registry.set_failure_reason ~base_path meta.name (Some reason);
+            Keeper_registry.set_state ~base_path meta.name
+              Keeper_registry.Crashed;
+            Keeper_registry.record_crash ~base_path meta.name
+              (Time_compat.now ())
+              (Keeper_registry.failure_reason_to_string reason);
+            Keeper_registry.record_error ~base_path meta.name
+              (Printf.sprintf "turn_consecutive_failures(%d)" count)
+          end;
           Error e
       | Ok result ->
           let used_model_id =
@@ -328,4 +348,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            | Ok () -> ()
            | Error msg ->
                Log.Keeper.error "write_meta failed after unified turn: %s" msg);
+          (* 8. Reset turn failure counter on success *)
+          Keeper_registry.reset_turn_failures ~base_path:config.base_path
+            meta.name;
           Ok updated_meta


### PR DESCRIPTION
## Summary
- Keeper with perpetual LLM turn failures now gets marked as Crashed
- `turn_consecutive_failures` counter in registry: increment on error, reset on success
- Threshold: `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` (default 10, range 3-100)
- New `Turn_consecutive_failures` ADT variant in failure_reason

## Context
Issue #3751: consecutive_failures only tracked heartbeat I/O. LLM timeouts and rate limits were logged but never affected keeper health.

## Deterministic/Non-deterministic boundary
- Counter logic: deterministic (increment/reset/threshold check)
- Turn failure itself: non-deterministic (LLM response, network)
- Threshold value: configurable env var

Fixes #3751.

Generated with Claude Code