### PR TITLE
refactor(keeper): extract tool failure threshold to env_config

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -295,4 +295,14 @@ module KeeperProactive = struct
     max 10 (min 1000 (get_int ~default:100 "MASC_KEEPER_STAGE_TIMING_RING_SIZE"))
 end
 
+(** {1 Tool Execution} *)
+
+module KeeperToolExec = struct
+  (** Maximum consecutive failures for the same (tool_name, args_hash)
+      before blocking further attempts. Prevents infinite retry loops.
+      Default: 3. Range: [2, 20]. *)
+  let max_consecutive_tool_failures =
+    max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
+end
+
 (** Print configuration summary for debugging *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -61,7 +61,8 @@ let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
     consecutive failures with the same (tool_name, args_hash) key.
     Resets on success. Prevents infinite retry loops (e.g. keeper
     reading a non-existent file 400+ times). *)
-let max_consecutive_failures = 3
+let max_consecutive_failures =
+  Env_config.KeeperToolExec.max_consecutive_tool_failures
 
 let keeper_tool_result_is_failure (result : string) : bool =
   try


### PR DESCRIPTION
## Summary
- Move hardcoded `max_consecutive_failures = 3` to env_config
- New: `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` [2..20], default 3
- Consistent with existing env_config patterns (#3746)

2 files, +12/-1.

Generated with Claude Code