### PR TITLE
refactor(server): add .mli interfaces for 4 server modules (#3722)

### DIFF
--- a/lib/server/server_bootstrap_pg.mli
+++ b/lib/server/server_bootstrap_pg.mli
@@ -1,0 +1,6 @@
+(** Backend initialization functions.
+    Initializes PG task backend when available, otherwise JSONL fallback. *)
+
+val init_task_backend : unit -> unit
+val inject_shared_pg_pool : unit -> unit
+val init_pg_schemas_sequential : unit -> unit

--- a/lib/server/server_h2_gateway_helpers.mli
+++ b/lib/server/server_h2_gateway_helpers.mli
@@ -1,0 +1,29 @@
+(** H2 gateway response helpers. *)
+
+val h2_respond_json :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  H2.Reqd.t -> string -> unit
+
+val h2_respond_text :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  H2.Reqd.t -> string -> unit
+
+val h2_respond_html :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  H2.Reqd.t -> string -> unit
+
+val h2_respond_bytes :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  content_type:string ->
+  H2.Reqd.t -> string -> unit
+
+val h2_respond_empty :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  H2.Reqd.t -> unit
+
+val h2_read_body : H2.Reqd.t -> (string -> unit) -> unit

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -1,0 +1,29 @@
+type tool_profile =
+  | Full
+  | Managed_agent
+  | Operator_remote
+
+type runtime = {
+  base_path : string;
+  sw : Eio.Switch.t;
+  clock : float Eio.Time.clock_ty Eio.Resource.t;
+  handle_request :
+    ?profile:tool_profile ->
+    ?mcp_session_id:string ->
+    ?auth_token:string ->
+    string ->
+    Yojson.Safe.t;
+  clear_resource_subscriptions_for_session : string -> unit;
+}
+
+type deps = {
+  get_origin : Httpun.Request.t -> string;
+  cors_headers : string -> (string * string) list;
+  auth_token_from_request : Httpun.Request.t -> string option;
+  is_ready : unit -> bool;
+  get_runtime_result : unit -> (runtime, string) result;
+  get_base_path : unit -> string;
+  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_operator_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
+}

--- a/lib/server/server_voice_config.mli
+++ b/lib/server/server_voice_config.mli
@@ -1,0 +1,1 @@
+val voice_config_payload : unit -> [> `OK | `Error ] * Yojson.Safe.t


### PR DESCRIPTION
## Summary
4 new .mli files for server/ modules:
- server_voice_config: voice config payload
- server_mcp_transport_http_types: tool_profile, runtime, deps types
- server_bootstrap_pg: PG backend init
- server_h2_gateway_helpers: H2 response helpers

server/ .mli coverage: 12% -> 21%.

Part of Phase 2 (#3722).

Generated with Claude Code