### PR TITLE
[codex] fix keeper direct chat persona drift

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -17,7 +17,7 @@
   "keeper_autonomy_models": ["llama:auto", "glm:auto"],
   "keeper_proactive_models": ["llama:auto", "glm:auto"],
   "keeper_deliberation_models": ["llama:auto", "glm:auto"],
-  "keeper_reply_models": ["llama:auto", "glm:auto"],
+  "keeper_reply_models": ["glm:auto", "llama:auto"],
   "keeper_social_models": ["llama:auto", "glm:auto"],
   "keeper_turn_models": ["llama:auto", "glm:auto"],
   "routing_judge_models": ["llama:auto", "glm:auto"],

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -525,11 +525,16 @@ let keeper_config_json (config : Room.config) (name : string)
       (* bootstrap_runtime is called at server startup — skip here to
          avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
       let active_model = Keeper_exec_status.active_model_of_meta m in
+      let persona_extended =
+        Keeper_types_profile.load_persona_extended m.name
+        |> Option.value ~default:""
+      in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt
           ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
           ~long_goal:m.long_goal ~soul_profile:m.soul_profile ~will:m.will
-          ~needs:m.needs ~desires:m.desires ~instructions:m.instructions ()
+          ~needs:m.needs ~desires:m.desires ~instructions:m.instructions
+          ~persona_extended ()
       in
       let prompt =
         `Assoc [

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -131,6 +131,22 @@ let build_keeper_system_prompt
        </continuity>";
     ]
 
+let append_direct_reply_mode_prompt ~(base_prompt : string) : string =
+  String.concat "\n"
+    [
+      base_prompt;
+      "";
+      "<direct_reply_mode>";
+      "This turn is a direct chat with the user.";
+      "Prioritize the keeper's authored persona, tone, relationship style, and examples over generic autonomous narration.";
+      "Reply as the keeper, not as a neutral assistant, control-plane operator, or world-state summarizer.";
+      "Do not expose hidden world state, board scans, metrics, token budgets, or internal workflow unless the user explicitly asks for them.";
+      "Keep the reply in the user's language and preserve the keeper's natural speech patterns.";
+      "Do not emit SKILL:, SKILL_REASON:, [STATE], or generic world-state summaries.";
+      "If a tool is needed, use it first, then answer in-character with the result.";
+      "</direct_reply_mode>";
+    ]
+
 let append_trait_clause ~(base : string) ~(clause : string) : string =
   let b = String.trim base in
   let c = String.trim clause in

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -20,6 +20,10 @@ val build_keeper_system_prompt :
   unit ->
   string
 
+val append_direct_reply_mode_prompt :
+  base_prompt:string ->
+  string
+
 val append_trait_clause : base:string -> clause:string -> string
 
 val apply_self_model_drift :

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -45,7 +45,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     let turn_instructions = get_string_opt args "turn_instructions" in
     let no_skill_route = get_bool args "no_skill_route" false in
     let no_state_block = get_bool args "no_state_block" false in
-    let _direct_reply = get_bool args "direct_reply" false in
+    let direct_reply = get_bool args "direct_reply" false in
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> (false, "❌ " ^ e)
     | Ok () ->
@@ -78,7 +78,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~trace_id:meta.trace_id
           ~generation:meta.generation
       in
-      let effective_models = effective_model_labels_for_turn meta in
+      let turn_cascade_name = if direct_reply then "keeper_reply" else "keeper_turn" in
+      let effective_models =
+        if direct_reply then
+          Oas_model_resolve.models_of_cascade_name turn_cascade_name
+        else
+          effective_model_labels_for_turn meta
+      in
       Progress.Tracker.step turn_tracker ~message:"Validating API keys" ();
       (match ensure_api_keys_for_labels effective_models with
        | Error e ->
@@ -90,13 +96,17 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
            Oas_model_resolve.resolve_primary_max_context effective_models
          in
             let base_dir = session_base_dir ctx.config in
-            let effective_no_skill_route = no_skill_route in
+            let effective_no_skill_route = no_skill_route || direct_reply in
+            let effective_no_state_block = no_state_block || direct_reply in
             let fallback_skill_route =
               route_keeper_skill ~soul_profile:meta.soul_profile ~message
             in
             let live_worktree_change =
-              Worktree_live_context.capture_change_block
-                ~base_path:ctx.config.base_path ~actor_key:meta.name
+              if direct_reply then
+                None
+              else
+                Worktree_live_context.capture_change_block
+                  ~base_path:ctx.config.base_path ~actor_key:meta.name
             in
             let build_turn_prompt ~base_system_prompt ~messages =
               let continuity_snapshot = latest_state_snapshot_from_messages messages in
@@ -123,10 +133,17 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   ~continuity_summary
               in
               let prompt =
+                if direct_reply then
+                  Keeper_prompt.append_direct_reply_mode_prompt
+                    ~base_prompt:prompt
+                else
+                  prompt
+              in
+              let prompt =
                 let policy_guards = [
                   (effective_no_skill_route,
                    "Output guard: NEVER output lines starting with SKILL: or SKILL_REASON:.");
-                  (no_state_block,
+                  (effective_no_state_block,
                    "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn.");
                 ] in
                 let policy_lines =
@@ -167,7 +184,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~max_context:primary_max_context
                 ~build_turn_prompt
                 ~user_message:message
-                ~cascade_name:"keeper_turn"
+                ~cascade_name:turn_cascade_name
                 ~generation:meta.generation
                 ?on_event
                 ~trajectory_acc

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -138,11 +138,18 @@ let test_keeper_direct_reply_contracts () =
   check bool "operator keeper_message forwards direct reply flag" true
     (file_contains_pattern "lib/operator/operator_control.ml"
        {|("direct_reply", `Bool true)|});
-  (* auto_team_session interception removed in #2908; direct_reply
-     is parsed but unused until a replacement path is wired. *)
   check bool "keeper turn parses direct reply flag" true
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
-       "get_bool args \"direct_reply\"")
+       "get_bool args \"direct_reply\"");
+  check bool "keeper turn promotes direct replies to reply cascade" true
+    (file_contains_pattern "lib/keeper/keeper_turn.ml"
+       {|let turn_cascade_name = if direct_reply then "keeper_reply" else "keeper_turn"|});
+  check bool "keeper turn suppresses skill route headers for direct reply" true
+    (file_contains_pattern "lib/keeper/keeper_turn.ml"
+       "let effective_no_skill_route = no_skill_route || direct_reply");
+  check bool "keeper turn applies direct reply persona prompt" true
+    (file_contains_pattern "lib/keeper/keeper_turn.ml"
+       "Keeper_prompt.append_direct_reply_mode_prompt")
 
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -158,6 +158,19 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "provenance" "fallback" resolved.provenance;
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
+let test_direct_reply_mode_prompt_prioritizes_persona () =
+  let prompt =
+    Masc_mcp.Keeper_prompt.append_direct_reply_mode_prompt
+      ~base_prompt:"base prompt"
+  in
+  check bool "keeps base prompt" true (contains_substring prompt "base prompt");
+  check bool "mentions direct chat" true
+    (contains_substring prompt "direct chat with the user");
+  check bool "mentions persona priority" true
+    (contains_substring prompt "Prioritize the keeper's authored persona");
+  check bool "forbids skill headers" true
+    (contains_substring prompt "Do not emit SKILL:")
+
 let keeper_usage ?cost_usd ~input_tokens ~output_tokens () : Agent_sdk.Types.api_usage =
   {
     input_tokens;
@@ -2017,6 +2030,8 @@ let () =
            test_resolved_keeper_skill_route_marks_agent_judgment;
          test_case "resolved skill route falls back when parse missing" `Quick
            test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing;
+         test_case "direct reply prompt prioritizes persona" `Quick
+           test_direct_reply_mode_prompt_prioritizes_persona;
          test_case "keeper merge usage preserves present cost" `Quick
            test_keeper_merge_usage_preserves_present_cost;
          test_case "keeper merge usage sums costs" `Quick


### PR DESCRIPTION
## Summary
- split direct keeper chat from the generic keeper turn path
- prioritize keeper persona for direct replies and suppress SKILL/STATE/live worktree overlays
- route direct replies through the dedicated keeper_reply cascade and improve dashboard prompt preview parity

## Root Cause
The direct_reply flag was parsed but unused, so keeper chat still ran through the normal keeper_turn prompt/cascade stack. Operational overlays were overwhelming authored persona instructions.

## Impact
- direct keeper chats stay in-character more reliably
- dashboard effective prompt preview now includes persona AGENT content
- reply-time model selection is separated from the generic keeper turn path

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-chat-persona-drift test/test_tool_keeper.exe test/test_ci_hardening_source.exe --display short`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_tool_keeper.exe`
