### PR TITLE
fix(keeper): add missing Log.Keeper.warn to keeper_fs operations

### DIFF
--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -18,7 +18,11 @@ let ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 16
 let ensure_dir (path : string) : string =
   Eio_guard.with_mutex dir_mu (fun () ->
     if not (Hashtbl.mem ensured_dirs path) || not (Sys.file_exists path) then begin
-      Fs_compat.mkdir_p path;
+      (try Fs_compat.mkdir_p path
+       with exn ->
+         Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
+           path (Printexc.to_string exn);
+         raise exn);
       Hashtbl.replace ensured_dirs path ()
     end);
   path
@@ -54,8 +58,11 @@ let save_atomic (path : string) (content : string) : unit =
       close_out_noerr oc;
       closed := true
     end;
-    if not !renamed then
-      try Sys.remove tmp_path with Sys_error _ -> ())
+    if not !renamed then begin
+      Log.Keeper.warn "keeper_fs: save_atomic failed path=%s tmp=%s"
+        path tmp_path;
+      try Sys.remove tmp_path with Sys_error _ -> ()
+    end)
     (fun () ->
       output_string oc content;
       close_out oc;


### PR DESCRIPTION
## Summary

- `keeper_fs.ml`의 `ensure_dir`과 `save_atomic`에 실패 로깅 추가
- 디스크 에러, 권한 문제, rename 실패 시 `Log.Keeper.warn`으로 기록
- 기존에는 예외만 전파되고 로그가 없어서 디버깅 불가했음

## 변경

| 함수 | 추가된 로깅 |
|------|------------|
| `ensure_dir` | `mkdir_p` 실패 시 경로와 에러 메시지 기록 |
| `save_atomic` | rename 미완료(실패) 시 경로와 tmp 파일 경로 기록 |

## Test plan

- [x] test_keeper_fs: 10/10 통과
- [x] dune build: 성공

Related to #3721

🤖 Generated with [Claude Code](https://claude.com/claude-code)