### PR TITLE
feat(keeper): wire turn failure counter into keepalive loop

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -109,6 +109,9 @@ let wakeup_relevant_keeper_for_board_signal
 let max_consecutive_heartbeat_failures =
   Env_config.KeeperKeepalive.max_consecutive_failures
 
+let max_consecutive_turn_failures =
+  Env_config.KeeperKeepalive.max_consecutive_turn_failures
+
 (* Per-stage timing accumulator for Phase 0 profiling.
    In-memory ring of last 100 cycles. Flushed as aggregate at snapshot cadence.
    No additional file I/O — appended to existing snapshot JSON. *)
@@ -160,6 +163,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let snapshot_interval_sec = Env_config.KeeperRuntime.snapshot_sec in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
+  let consecutive_turn_failures = ref 0 in
   (* Phase 0: per-stage timing ring buffer *)
   let timing_ring = Array.make stage_timing_ring_size
     { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
@@ -477,21 +481,33 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                          ~generation:meta_after_triage.generation
                      with
                      | Error e ->
-                         Log.Keeper.error "unified turn failed: %s" e;
+                         incr consecutive_turn_failures;
+                         Log.Keeper.error "unified turn failed (%d/%d): %s"
+                           !consecutive_turn_failures max_consecutive_turn_failures e;
                          (match read_meta ctx.config meta_after_triage.name with
                           | Ok (Some latest) -> latest
                           | _ -> meta_after_triage)
-                     | Ok updated -> updated
+                     | Ok updated ->
+                         consecutive_turn_failures := 0;
+                         updated
                    else
                      meta_after_triage
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn ->
-                   Log.Keeper.error "unified turn exception: %s"
+                   incr consecutive_turn_failures;
+                   Log.Keeper.error "unified turn exception (%d/%d): %s"
+                     !consecutive_turn_failures max_consecutive_turn_failures
                      (Printexc.to_string exn);
                    meta_after_triage)
               else meta_after_triage
             in
+            (* Turn failure threshold check — separate from heartbeat I/O *)
+            if !consecutive_turn_failures >= max_consecutive_turn_failures then
+              raise (Keeper_registry.Keeper_heartbeat_failure {
+                reason = Keeper_registry.Turn_consecutive_failures !consecutive_turn_failures;
+                keeper_name = m.name;
+              });
             (* Phase 1: work-as-heartbeat — renew point (b).
                After turn, call Room.heartbeat_in_room to prove room I/O health.
                On success: refresh freshness lease + reset consecutive_failures.

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -327,6 +327,39 @@ let test_restart_state_preservation () =
     check string "state running after restart" "running"
       (R.state_to_string e.state)
 
+(* ══════════════════════════════════════════════════════════
+   7. Turn failure → Crashed with Turn_consecutive_failures reason
+   ══════════════════════════════════════════════════════════ *)
+
+(** Simulate the turn failure crash path: supervisor catch sets
+    Turn_consecutive_failures as failure_reason, state = Crashed. *)
+let test_crash_turn_failures () =
+  R.clear ();
+  let meta = make_meta "turn-crash" in
+  let reg = R.register ~base_path:bp "turn-crash" meta in
+  let reason = R.Turn_consecutive_failures 10 in
+  let reason_str = R.failure_reason_to_string reason in
+  R.set_failure_reason ~base_path:bp "turn-crash" (Some reason);
+  R.set_state ~base_path:bp "turn-crash" R.Crashed;
+  R.record_crash ~base_path:bp "turn-crash" 2000.0 reason_str;
+  R.record_error ~base_path:bp "turn-crash" reason_str;
+  Eio.Promise.resolve reg.done_r (`Crashed reason_str);
+  match R.get ~base_path:bp "turn-crash" with
+  | None -> fail "expected turn-crash"
+  | Some e ->
+    check string "state crashed" "crashed" (R.state_to_string e.state);
+    (match e.last_failure_reason with
+     | Some (R.Turn_consecutive_failures n) ->
+       check int "turn failure count" 10 n
+     | _ -> fail "expected Turn_consecutive_failures");
+    check bool "crash log" true (List.length e.crash_log > 0)
+
+(** Turn failures produce a distinct cohort key for self-preservation. *)
+let test_cohort_key_turn_failures () =
+  let key = Sup.cohort_key_of_reason
+    (Some (R.Turn_consecutive_failures 10)) in
+  check string "turn failure cohort" "turn_failures" key
+
 (* ── Test runner ──────────────────────────────────────────── *)
 
 let () =
@@ -351,5 +384,9 @@ let () =
     ];
     "restart_flow", [
       eio_test "state preservation across restart" test_restart_state_preservation;
+    ];
+    "turn_failure", [
+      eio_test "turn crash flow" test_crash_turn_failures;
+      test_case "cohort key" `Quick test_cohort_key_turn_failures;
     ];
   ]


### PR DESCRIPTION
## Summary
#3751 구현. Turn_consecutive_failures ADT + config는 존재했지만 keepalive loop에 연결되지 않았다. 이제 unified turn Error/exception이 별도 카운터로 추적되고, threshold 도달 시 Keeper_heartbeat_failure raise → supervisor crash→restart 경로를 탄다.

## Changes
- `consecutive_turn_failures` ref 추가 (keepalive loop 내)
- unified turn Error: 카운터 증가 + 로그에 진행도 표시
- unified turn Ok: 카운터 리셋
- unified turn exception: 카운터 증가
- threshold 체크: `>= max_consecutive_turn_failures` → raise

## Config
`MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` (default: 10, range: 3-100)

## Test plan
- [x] `test_heartbeat_integration.exe` — 13 tests pass (11→13)
- [x] `dune build` passes

Closes #3751

🤖 Generated with [Claude Code](https://claude.com/claude-code)