### PR TITLE
refactor(dashboard): add .mli for repo_synthesis and briefing_json_helpers (#3722)

### DIFF
--- a/lib/dashboard/briefing_json_helpers.mli
+++ b/lib/dashboard/briefing_json_helpers.mli
@@ -1,0 +1,14 @@
+(** Generic JSON extraction and normalization helpers for mission briefing. *)
+
+val compact_text : ?max_len:int -> string -> string
+val member_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t
+val string_field : ?default:string -> string -> Yojson.Safe.t -> string
+val string_json : ?default:string -> ?max_len:int -> Yojson.Safe.t -> Yojson.Safe.t
+val string_list_json : Yojson.Safe.t -> Yojson.Safe.t
+val int_json : ?default:int -> Yojson.Safe.t -> Yojson.Safe.t
+val float_json : ?default:float -> Yojson.Safe.t -> Yojson.Safe.t
+val int_field : ?default:int -> string -> Yojson.Safe.t -> int
+val take : int -> 'a list -> 'a list
+val option_string_json : string option -> Yojson.Safe.t
+val trim_to_option : string option -> string option
+val parse_iso_opt : string option -> float option

--- a/lib/dashboard/dashboard_http_repo_synthesis.mli
+++ b/lib/dashboard/dashboard_http_repo_synthesis.mli
@@ -1,0 +1,7 @@
+(** Dashboard HTTP repo synthesis benchmark endpoints. *)
+
+val repo_synthesis_benchmarks_json :
+  base_path:string -> ?limit:int -> unit -> Yojson.Safe.t
+
+val repo_synthesis_benchmark_detail_json :
+  base_path:string -> run_id:string -> (Yojson.Safe.t, string) result


### PR DESCRIPTION
## Summary
- dashboard_http_repo_synthesis.mli: benchmark endpoints
- briefing_json_helpers.mli: 12 JSON helper functions

dashboard/ .mli coverage: 16% -> 22%. Part of Phase 2 (#3722).

Generated with Claude Code