### PR TITLE
fix(config): remove duplicate WORK_AS_HEARTBEAT feature flag entries

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -127,20 +127,10 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.150.0" };
 
-  { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
-    description = "Treat meaningful work as implicit heartbeat signal";
-    default = true; category = "keeper";
-    lifecycle = Active; since = "2.162.0" };
-
   { env_name = "MASC_KEEPER_DEBUG";
     description = "Keeper debug logging";
     default = false; category = "keeper";
     lifecycle = Active; since = "2.50.0" };
-
-  { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
-    description = "Treat successful keeper work cycles as heartbeat presence proof";
-    default = true; category = "keeper";
-    lifecycle = Active; since = "2.163.0" };
 
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";


### PR DESCRIPTION
## Summary
- remove 2 duplicate `MASC_KEEPER_WORK_AS_HEARTBEAT` entries from `feature_flag_registry`
- keep the original canonical entry at line 95 (`since = 2.162.0`)
- restore this PR head after an unrelated OAS pin commit briefly contaminated the branch

## Product impact
- makes the feature flag registry a single source of truth again
- removes ambiguous duplicate definitions for keeper heartbeat behavior
- avoids future drift when tooling or docs enumerate keeper flags

## Evidence
- `rg -n "MASC_KEEPER_WORK_AS_HEARTBEAT" lib/config/feature_flag_registry.ml` shows 3 entries on `main`
- rebased PR head `a7ee371e5d304e72c49b7a8c4dff21d3f02923e1` leaves exactly 1 entry
- current PR diff is only `lib/config/feature_flag_registry.ml` with 10 deletions

## Review evidence
- GLM-5 via direct `sb glm-text --no-thinking` on the rebased diff (`2026-03-30 KST`): No findings.
- local verification: single remaining entry confirmed via `rg`
- CI rerun is in progress on restored head `a7ee371e5d304e72c49b7a8c4dff21d3f02923e1`

## Linked issue
- Refs #3793

## Test plan
- [x] single entry confirmed via `rg`
- [x] cross-model review completed
- [ ] CI green
