### PR TITLE
refactor(dashboard): simplify observability code

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -76,7 +76,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
       <div class="text-2xl font-bold ${KPI_VALUE_TONE[tone]} tabular-nums leading-none">${value}</div>
       ${progress != null ? html`
         <div class="w-full h-1 bg-[var(--white-6)] rounded-full overflow-hidden mt-0.5">
-          <div class="h-full rounded-full transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${progress > CTX_CRITICAL_PCT ? CTX_COLOR_CRITICAL : progress > CTX_WARN_PCT ? '#fbbf24' : '#4ade80'}"></div>
+          <div class="h-full rounded-full transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${ctxColor(progress)}"></div>
         </div>
       ` : null}
       ${hint ? html`<div class="text-[10px] text-[var(--text-dim)] leading-snug">${hint}</div>` : null}
@@ -254,7 +254,6 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   const lastLatency = latencies[latencies.length - 1] ?? 0
   const totalCost = costs.reduce((a: number, b: number) => a + b, 0)
 
-  // Model switches: detect when model_used changes
   const modelSwitches: { index: number; model: string }[] = []
   for (let i = 1; i < series.length; i++) {
     if ((series[i] as KeeperMetricPoint).model_used !== (series[i - 1] as KeeperMetricPoint).model_used) {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -242,14 +242,18 @@ export function KeeperConversationPanel({
   const [showInternal, setShowInternal] = useState(readKeeperChatInternalVisible())
 
   const toggleMetadata = () => {
-    const next = !showMetadata
-    setShowMetadata(next)
-    writeKeeperChatMetadataVisible(next)
+    setShowMetadata(prev => {
+      const next = !prev
+      writeKeeperChatMetadataVisible(next)
+      return next
+    })
   }
   const toggleInternal = () => {
-    const next = !showInternal
-    setShowInternal(next)
-    writeKeeperChatInternalVisible(next)
+    setShowInternal(prev => {
+      const next = !prev
+      writeKeeperChatInternalVisible(next)
+      return next
+    })
   }
 
   const [historyExpanded, setHistoryExpanded] = useState(false)

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useState } from 'preact/hooks'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -241,13 +241,16 @@ export function KeeperConversationPanel({
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
   const [showInternal, setShowInternal] = useState(readKeeperChatInternalVisible())
 
-  useEffect(() => {
-    writeKeeperChatMetadataVisible(showMetadata)
-  }, [showMetadata])
-
-  useEffect(() => {
-    writeKeeperChatInternalVisible(showInternal)
-  }, [showInternal])
+  const toggleMetadata = () => {
+    const next = !showMetadata
+    setShowMetadata(next)
+    writeKeeperChatMetadataVisible(next)
+  }
+  const toggleInternal = () => {
+    const next = !showInternal
+    setShowInternal(next)
+    writeKeeperChatInternalVisible(next)
+  }
 
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const rawThread = keeperThreads.value[keeperName] ?? []
@@ -295,14 +298,14 @@ export function KeeperConversationPanel({
             <button
               type="button"
               class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
-              onClick=${() => { setShowMetadata(!showMetadata) }}
+              onClick=${toggleMetadata}
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
             <button
               type="button"
               class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[#a78bfa]' : ''}"
-              onClick=${() => { setShowInternal(!showInternal) }}
+              onClick=${toggleInternal}
             >
               ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
             </button>

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -7,7 +7,18 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { fetchKeeperTrajectory } from '../api/dashboard'
 import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
+import { truncate } from '../lib/truncate'
 import { TimeAgo } from './common/time-ago'
+
+// ── Constants ────────────────────────────────────────────
+
+const TRAJECTORY_DEFAULT_LIMIT = 50
+const ARGS_PREVIEW_MAX_CHARS = 80
+const ARGS_VALUE_MAX_CHARS = 30
+const ARGS_MAX_KEYS = 3
+const RESULT_PREVIEW_MAX_CHARS = 80
+const DURATION_FAST_MS = 500
+const DURATION_SLOW_MS = 2000
 
 // ── State (per-keeper to avoid cross-keeper corruption) ──
 
@@ -48,16 +59,6 @@ export function clearTrajectory(keeperName: string): void {
   trajectoryStates.value = next
 }
 
-// ── Display constants ────────────────────────────────────
-
-const TRAJECTORY_DEFAULT_LIMIT = 50
-const ARGS_PREVIEW_MAX_CHARS = 80
-const ARGS_VALUE_MAX_CHARS = 30
-const ARGS_MAX_KEYS = 3
-const RESULT_PREVIEW_MAX_CHARS = 80
-const DURATION_FAST_MS = 500
-const DURATION_SLOW_MS = 2000
-
 // Tool category → icon/color mapping. Order matters: first match wins.
 const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; color: string }> = [
   { match: n => n.includes('bash'),                         icon: '>', color: 'text-[#4ade80]' },
@@ -81,25 +82,23 @@ function durationColor(ms: number): string {
 }
 
 function formatArgs(args: Record<string, unknown> | string): string {
-  if (typeof args === 'string') {
-    return args.length > ARGS_PREVIEW_MAX_CHARS ? args.slice(0, ARGS_PREVIEW_MAX_CHARS) + '...' : args
-  }
+  if (typeof args === 'string') return truncate(args, ARGS_PREVIEW_MAX_CHARS)
   const keys = Object.keys(args)
   if (keys.length === 0) return '{}'
   const preview = keys.slice(0, ARGS_MAX_KEYS).map(k => {
     const v = args[k]
     const vs = typeof v === 'string'
-      ? (v.length > ARGS_VALUE_MAX_CHARS ? v.slice(0, ARGS_VALUE_MAX_CHARS) + '...' : v)
-      : JSON.stringify(v)?.slice(0, ARGS_VALUE_MAX_CHARS) ?? ''
+      ? truncate(v, ARGS_VALUE_MAX_CHARS)
+      : truncate(JSON.stringify(v) ?? '', ARGS_VALUE_MAX_CHARS)
     return `${k}: ${vs}`
   }).join(', ')
   return keys.length > ARGS_MAX_KEYS ? `{${preview}, ...}` : `{${preview}}`
 }
 
 function formatResult(result: string | null, error: string | null): string {
-  if (error) return `err: ${error.slice(0, RESULT_PREVIEW_MAX_CHARS)}`
+  if (error) return `err: ${truncate(error, RESULT_PREVIEW_MAX_CHARS)}`
   if (!result) return '-'
-  return result.length > RESULT_PREVIEW_MAX_CHARS ? result.slice(0, RESULT_PREVIEW_MAX_CHARS) + '...' : result
+  return truncate(result, RESULT_PREVIEW_MAX_CHARS)
 }
 
 // ── Components ───────────────────────────────────────────
@@ -147,7 +146,6 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
   `
 }
 
-// Group entries by turn number
 function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]> {
   const groups = new Map<number, TrajectoryEntry[]>()
   for (const e of entries) {

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -465,27 +465,15 @@ let restore_tool_usage ~base_path name =
            | _ -> []
          in
          List.iter (fun item ->
-           try
-             match item with
-             | `Assoc fields ->
-               let str key = match List.assoc_opt key fields with
-                 | Some (`String s) -> s | _ -> raise Exit in
-               let int key = match List.assoc_opt key fields with
-                 | Some (`Int n) -> n | _ -> raise Exit in
-               let float key = match List.assoc_opt key fields with
-                 | Some (`Float f) -> f
-                 | Some (`Int n) -> Float.of_int n
-                 | _ -> raise Exit in
-               let tool_name = str "tool" in
-               let e = {
-                 count = int "count";
-                 successes = int "successes";
-                 failures = int "failures";
-                 last_used_at = float "last_used_at";
-               } in
-               Hashtbl.replace entry.tool_usage tool_name e
-             | _ -> ()
-           with Exit -> ()
+           let tool_name = Safe_ops.json_string "tool" item in
+           if tool_name <> "" then
+             let e = {
+               count = Safe_ops.json_int "count" item;
+               successes = Safe_ops.json_int "successes" item;
+               failures = Safe_ops.json_int "failures" item;
+               last_used_at = Safe_ops.json_float "last_used_at" item;
+             } in
+             Hashtbl.replace entry.tool_usage tool_name e
          ) tools
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -465,15 +465,23 @@ let restore_tool_usage ~base_path name =
            | _ -> []
          in
          List.iter (fun item ->
-           let tool_name = Safe_ops.json_string "tool" item in
-           if tool_name <> "" then
+           match
+             ( Safe_ops.json_string_opt "tool" item,
+               Safe_ops.json_int_opt "count" item,
+               Safe_ops.json_int_opt "successes" item,
+               Safe_ops.json_int_opt "failures" item,
+               Safe_ops.json_float_opt "last_used_at" item )
+           with
+           | Some tool_name, Some count, Some successes, Some failures, Some last_used_at
+             when tool_name <> "" ->
              let e = {
-               count = Safe_ops.json_int "count" item;
-               successes = Safe_ops.json_int "successes" item;
-               failures = Safe_ops.json_int "failures" item;
-               last_used_at = Safe_ops.json_float "last_used_at" item;
+               count;
+               successes;
+               failures;
+               last_used_at;
              } in
              Hashtbl.replace entry.tool_usage tool_name e
+           | _ -> ()
          ) tools
        with
        | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Summary

#3758 (keeper observability pipeline) 머지 후 `/simplify` 리뷰에서 발견된 코드 품질 이슈 수정.

- KpiCard 색상 상수 통일 (`ctxColor()` 사용)
- `restore_tool_usage` → `Safe_ops` 재사용 (인라인 JSON extractor 제거)
- `formatArgs`/`formatResult` → 기존 `truncate()` 유틸 재사용
- `useEffect` localStorage sync → click handler 직접 호출 (project guideline 준수)
- 상수 선언 위치 수정 (declaration-before-use)
- WHAT 주석 제거, 미사용 import 제거

Net: -12 lines.

## Test plan

- [x] OCaml build 통과
- [x] TypeScript tsc --noEmit 통과
- [x] keeper-shared.test.ts 통과

Generated with [Claude Code](https://claude.com/claude-code)