### PR TITLE
feat(keeper): turn counter dedup + goal-aware turn intent

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -163,7 +163,6 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let snapshot_interval_sec = Env_config.KeeperRuntime.snapshot_sec in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
-  let consecutive_turn_failures = ref 0 in
   (* Phase 0: per-stage timing ring buffer *)
   let timing_ring = Array.make stage_timing_ring_size
     { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
@@ -481,31 +480,29 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                          ~generation:meta_after_triage.generation
                      with
                      | Error e ->
-                         incr consecutive_turn_failures;
-                         Log.Keeper.error "unified turn failed (%d/%d): %s"
-                           !consecutive_turn_failures max_consecutive_turn_failures e;
+                         Log.Keeper.error "unified turn failed: %s" e;
                          (match read_meta ctx.config meta_after_triage.name with
                           | Ok (Some latest) -> latest
                           | _ -> meta_after_triage)
-                     | Ok updated ->
-                         consecutive_turn_failures := 0;
-                         updated
+                     | Ok updated -> updated
                    else
                      meta_after_triage
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn ->
-                   incr consecutive_turn_failures;
-                   Log.Keeper.error "unified turn exception (%d/%d): %s"
-                     !consecutive_turn_failures max_consecutive_turn_failures
+                   Log.Keeper.error "unified turn exception: %s"
                      (Printexc.to_string exn);
                    meta_after_triage)
               else meta_after_triage
             in
-            (* Turn failure threshold check — separate from heartbeat I/O *)
-            if !consecutive_turn_failures >= max_consecutive_turn_failures then
+            (* Turn failure threshold: registry tracks count (via unified_turn),
+               keepalive raises to terminate the fiber for supervisor restart. *)
+            let turn_fail_count =
+              Keeper_registry.get_turn_failures
+                ~base_path:ctx.config.base_path m.name in
+            if turn_fail_count >= max_consecutive_turn_failures then
               raise (Keeper_registry.Keeper_heartbeat_failure {
-                reason = Keeper_registry.Turn_consecutive_failures !consecutive_turn_failures;
+                reason = Keeper_registry.Turn_consecutive_failures turn_fail_count;
                 keeper_name = m.name;
               });
             (* Phase 1: work-as-heartbeat — renew point (b).


### PR DESCRIPTION
## Summary
1. **Turn failure counter 중복 제거**: keepalive local ref 제거, registry SSOT 사용
2. **Goal-aware turn intent**: goal이 있는 keeper는 "SKIP only when no progress possible", goal 없으면 기존 conservative SKIP

## Why keepers weren't acting
Turn intent 프롬프트가 모든 keeper에게 동일하게 "SKIP unless materially helps"를 지시.
Goal이 있어도 LLM이 이 지시를 따라 대부분 SKIP을 출력했다.

## Changes
### Counter dedup
- `consecutive_turn_failures` local ref 제거
- `Keeper_registry.get_turn_failures`로 SSOT 읽기
- Threshold raise만 keepalive에 유지

### Goal-aware intent
- `meta.goal != ""` or `meta.short_goal != ""` → action-biased prompt
- Goal 없으면 기존 conservative prompt 유지

## Test plan
- [x] `test_heartbeat_integration.exe` — 13 tests pass
- [x] `test_work_as_heartbeat.exe` — 33 tests pass
- [x] `dune build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)