### PR TITLE
refactor(cdal): replace manual violation parsing with OAS canonical serializers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.93.2))
+  (agent_sdk (>= 0.94.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/violation_record.ml
+++ b/lib/violation_record.ml
@@ -1,14 +1,19 @@
 (** Violation_record — Typed violation records + constraint algebra.
 
-    @since CDAL eval content-based redesign *)
+    Delegates JSON serialization to Agent_sdk.Mode_enforcer canonical types.
+    MASC consumers use this module for backward-compatible access.
 
-type violation_kind =
+    @since CDAL eval content-based redesign
+    @see Agent_sdk.Mode_enforcer for canonical serializers *)
+
+(** Re-export OAS canonical violation_kind. *)
+type violation_kind = Agent_sdk.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
   | Scope_violation
-  | Unknown of string
 
-type t = {
+(** Re-export OAS canonical violation record. *)
+type t = Agent_sdk.Mode_enforcer.violation = {
   ts : float;
   tool_name : string;
   input_summary : string;
@@ -16,44 +21,13 @@ type t = {
   violation_kind : violation_kind;
 }
 
-let violation_kind_of_string = function
-  | "mutating_in_diagnose" -> Mutating_in_diagnose
-  | "external_in_draft" -> External_in_draft
-  | "scope_violation" -> Scope_violation
-  | s -> Unknown s
+let violation_kind_of_string s =
+  Agent_sdk.Mode_enforcer.violation_kind_of_string s
 
-let violation_kind_to_string = function
-  | Mutating_in_diagnose -> "mutating_in_diagnose"
-  | External_in_draft -> "external_in_draft"
-  | Scope_violation -> "scope_violation"
-  | Unknown s -> s
+let violation_kind_to_string v =
+  Agent_sdk.Mode_enforcer.violation_kind_to_string v
 
-let effective_mode_of_string = function
-  | "diagnose" -> Agent_sdk.Execution_mode.Diagnose
-  | "draft" -> Agent_sdk.Execution_mode.Draft
-  | "execute" -> Agent_sdk.Execution_mode.Execute
-  | _ -> Agent_sdk.Execution_mode.Diagnose
-
-let of_json (json : Yojson.Safe.t) : (t, string) result =
-  match json with
-  | `Assoc fields ->
-    let get key = List.assoc_opt key fields in
-    (match get "ts", get "tool_name", get "violation_kind", get "effective_mode" with
-     | Some (`Float ts), Some (`String tool_name),
-       Some (`String vk), Some (`String em) ->
-       let input_summary = match get "input_summary" with
-         | Some (`String s) -> s
-         | _ -> ""
-       in
-       Ok {
-         ts;
-         tool_name;
-         input_summary;
-         effective_mode = effective_mode_of_string em;
-         violation_kind = violation_kind_of_string vk;
-       }
-     | _ -> Error "missing required fields in violation record")
-  | _ -> Error "violation record must be a JSON object"
+let of_json json = Agent_sdk.Mode_enforcer.violation_of_yojson json
 
 let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
   match json with
@@ -73,4 +47,3 @@ let minimum_required_mode (v : t) : Agent_sdk.Execution_mode.t =
   | Mutating_in_diagnose -> Agent_sdk.Execution_mode.Draft
   | External_in_draft -> Agent_sdk.Execution_mode.Execute
   | Scope_violation -> Agent_sdk.Execution_mode.Execute
-  | Unknown _ -> v.effective_mode

--- a/lib/violation_record.mli
+++ b/lib/violation_record.mli
@@ -1,20 +1,19 @@
 (** Violation_record — Typed violation records from CDAL proof artifacts.
 
-    Parses the JSON written by OAS [Proof_capture.collect_evidence_refs]
-    into typed OCaml records. Provides constraint algebra for deriving
-    the minimum execution mode that would prevent each violation.
+    Re-exports [Agent_sdk.Mode_enforcer] canonical types and provides
+    MASC-specific constraint algebra (minimum_required_mode).
 
-    @since CDAL eval content-based redesign *)
+    @since CDAL eval content-based redesign
+    @see Agent_sdk.Mode_enforcer for canonical serializers *)
 
-(** Violation kind — mirrors Mode_enforcer's classification. *)
-type violation_kind =
+(** Violation kind — re-exported from [Agent_sdk.Mode_enforcer.violation_kind]. *)
+type violation_kind = Agent_sdk.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose  (** workspace mutation attempted in Diagnose mode *)
   | External_in_draft     (** external effect attempted in Draft mode *)
   | Scope_violation       (** violated allowed_mutations constraint *)
-  | Unknown of string     (** unrecognized violation_kind from JSON *)
 
-(** A single violation record as written by Proof_capture. *)
-type t = {
+(** A single violation record — re-exported from [Agent_sdk.Mode_enforcer.violation]. *)
+type t = Agent_sdk.Mode_enforcer.violation = {
   ts : float;
   tool_name : string;
   input_summary : string;
@@ -22,19 +21,19 @@ type t = {
   violation_kind : violation_kind;
 }
 
-(** Parse a single violation from JSON. *)
+(** Parse a single violation from JSON.
+    Delegates to [Agent_sdk.Mode_enforcer.violation_of_yojson]. *)
 val of_json : Yojson.Safe.t -> (t, string) result
 
 (** Parse an array of violations from JSON. *)
 val of_json_list : Yojson.Safe.t -> (t list, string) result
 
 (** The minimum execution mode that would have prevented this violation.
-    This is the inverse of [Mode_enforcer.check_violation]:
     - [Mutating_in_diagnose] -> [Draft]
     - [External_in_draft] -> [Execute]
-    - [Scope_violation] -> [Execute]
-    - [Unknown _] -> the violation's [effective_mode] (no change) *)
+    - [Scope_violation] -> [Execute] *)
 val minimum_required_mode : t -> Agent_sdk.Execution_mode.t
 
-(** Violation kind to string for JSON serialization. *)
+(** Violation kind to/from string. Delegates to OAS canonical functions. *)
 val violation_kind_to_string : violation_kind -> string
+val violation_kind_of_string : string -> (violation_kind, string) result

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.93.2"}
+  "agent_sdk" {>= "0.94.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.93.2"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.94.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7fe0229c4d70fda56be75b065ca391db089b9ae5"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.93.2"
+readonly OAS_AGENT_SDK_SHA="db0e930c49b5187a984843cc6dfafe6d0b0e5c28"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.94.0"


### PR DESCRIPTION
## Summary

- `violation_record.ml/mli`에서 수동 JSON 파싱을 제거하고 `Agent_sdk.Mode_enforcer` canonical serializer로 교체
- OAS canonical violation types를 manifest type equation으로 re-export하여 record field / constructor surface를 유지
- `Unknown of string` variant를 제거하고 strict parser semantics를 채택
- merge-ref `Dashboard` CI를 막던 `shutdownKeeper` import drift를 함께 정리

## Product impact

- 사용자 노출 UI 변경은 없음
- CDAL proof artifact parsing이 OAS canonical serializer 기준으로 정렬됨
- unrecognized `violation_kind` / `effective_mode`는 이제 parse `Error`로 surface됨

## Changes

| 파일 | 변경 |
|------|------|
| `lib/violation_record.ml` | 수동 파싱 제거, OAS 위임 |
| `lib/violation_record.mli` | strict parsing 동작과 error propagation expectation 문서화 |
| `dashboard/src/components/keeper-shared.ts` | merge-ref Dashboard typecheck를 깨던 stale import 제거 |
| `dune-project` | `agent_sdk >= 0.94.0` 반영 |
| `masc_mcp.opam` | `agent_sdk >= 0.94.0` 반영 |
| `scripts/oas-agent-sdk-pin.sh` | OAS pin을 `db0e930c49b5187a984843cc6dfafe6d0b0e5c28` / `v0.94.0`으로 갱신 |

## Evidence

- `dashboard`: `pnpm run typecheck`
- `test_cdal_friction_projection.exe` — 11/11 pass
- `test_cdal_eval_v1.exe` — 3/3 pass
- `test_cdal_judge.exe` — 12/12 pass
- `test_cdal_conformance.exe` — 3/3 pass

## Review evidence

- 2026-03-30: GLM-5.1 via `sb glm-text` reviewed the follow-up diff (`keeper-shared.ts`, `violation_record.mli`) -> `No findings.`
- 2026-03-30: GLM-5.1 via `sb glm-text` reviewed the main OAS serializer change; rationale recorded in PR discussion

## Linked issue

- Closes #3664

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
