### PR TITLE
fix: sync ROADMAP.md version to 2.163.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.162.0
-> Latest release: v2.162.0 (2026-03-29)
+> Current package version: v2.163.0
+> Latest release: v2.163.0 (2026-03-30)
 > Updated: 2026-03-29
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
-> Current package version: v2.162.0
-> Latest release: v2.162.0 (2026-03-29)
-> Updated: 2026-03-29
+> Current package version: v2.163.0
+> Latest release: v2.163.0 (2026-03-30)
+> Updated: 2026-03-30
 
 ## Product Promise
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -3,7 +3,7 @@
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-03-29
-> Snapshot baseline: `dune-project` version `2.162.0`
+> Snapshot baseline: `dune-project` version `2.163.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
 


### PR DESCRIPTION
## Summary
- ROADMAP.md `current_package_version`이 2.162.0으로 남아 있어 Health CI의 `check-version-truth.sh`가 실패
- dune-project (2.163.0)과 일치하도록 수정

## Test plan
- [x] `scripts/check-version-truth.sh` 로컬 통과
- [ ] CI Health job green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)