### PR TITLE
feat(dashboard): fix config PATCH keys and add runtime controls

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -577,17 +577,29 @@ export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
 }
 
 export type KeeperConfigUpdatePayload = {
-  new_goal?: string
-  new_short_goal?: string
-  new_mid_goal?: string
-  new_long_goal?: string
-  new_soul_profile?: string
-  new_will?: string
-  new_needs?: string
-  new_desires?: string
-  new_instructions?: string
-  new_drift_enabled?: boolean
-  new_drift_min_turn_gap?: number
+  // Prompt fields
+  goal?: string
+  short_goal?: string
+  mid_goal?: string
+  long_goal?: string
+  soul_profile?: string
+  will?: string
+  needs?: string
+  desires?: string
+  instructions?: string
+  // Proactive
+  proactive_enabled?: boolean
+  proactive_idle_sec?: number
+  proactive_cooldown_sec?: number
+  // Compaction
+  compaction_ratio_gate?: number
+  compaction_message_gate?: number
+  compaction_token_gate?: number
+  continuity_compaction_cooldown_sec?: number
+  // Handoff
+  auto_handoff?: boolean
+  handoff_threshold?: number
+  handoff_cooldown_sec?: number
 }
 
 export function patchKeeperConfig(

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -10,6 +10,7 @@ import {
   tasks,
 } from '../store'
 import { fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
+import { callMcpTool } from '../api/mcp'
 import { journal } from '../sse'
 import { route, navigate } from '../router'
 import { missionSnapshot } from '../mission-store'
@@ -39,6 +40,17 @@ export const taskHistories = signal<TaskHistoryRow[]>([])
 export const agentTimeline = signal<AgentTimelineResponse | null>(null)
 export const mentionText = signal('')
 export const sendingMention = signal(false)
+
+// Agent fitness
+export type AgentFitness = {
+  completion_rate?: number
+  reliability_score?: number
+  speed_score?: number
+  overall_fitness?: number
+  [key: string]: unknown
+}
+export const agentFitness = signal<AgentFitness | null>(null)
+export const fitnessLoading = signal(false)
 
 // --- Selectors ---
 
@@ -111,6 +123,7 @@ export function closeAgentDetail(): void {
   taskHistories.value = []
   agentTimeline.value = null
   mentionText.value = ''
+  agentFitness.value = null
   if (route.value.tab === 'monitoring' && route.value.params.agent) {
     navigate('monitoring', { section: 'agents' })
   }
@@ -125,12 +138,16 @@ export async function refreshAgentDetail(): Promise<void> {
   roomActivity.value = []
   taskHistories.value = []
   agentTimeline.value = null
+  agentFitness.value = null
 
   try {
-    // Fetch room messages, task histories, and timeline in parallel
-    const [lines, timelineResult] = await Promise.all([
+    // Fetch room messages, task histories, timeline, and fitness in parallel
+    const [lines, timelineResult, fitnessResult] = await Promise.all([
       fetchRoomMessages(80),
       fetchAgentTimeline(agentName, 4, 20).catch(() => null),
+      callMcpTool('masc_agent_fitness', { agent_name: agentName, days: 7 })
+        .then(raw => JSON.parse(raw) as AgentFitness)
+        .catch(() => null),
     ])
 
     roomActivity.value = lines
@@ -138,6 +155,7 @@ export async function refreshAgentDetail(): Promise<void> {
       .slice(0, 20)
 
     agentTimeline.value = timelineResult
+    agentFitness.value = fitnessResult
 
     const ownedTasks = assignedTasks(agentName).slice(0, 6)
     if (ownedTasks.length === 0) return

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -30,6 +30,7 @@ import {
   refreshAgentDetail,
   submitMention,
   setKeeperRedirect,
+  agentFitness,
   type TaskHistoryRow,
 } from './agent-detail-state'
 import { openKeeperDetail } from './keeper-detail'
@@ -204,6 +205,24 @@ export function AgentDetailOverlay() {
           <${AgentJournalStream} agentName=${agentName} />
           <${AgentTimelineSection} />
           <${AgentWorkerBrief} agentName=${agentName} />
+          ${agentFitness.value ? html`
+            <${Card} title="적합도 (7일)">
+              <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                ${[
+                  ['완료율', agentFitness.value.completion_rate],
+                  ['신뢰도', agentFitness.value.reliability_score],
+                  ['속도', agentFitness.value.speed_score],
+                  ['종합', agentFitness.value.overall_fitness],
+                ].map(([label, val]) => html`
+                  <div class="rounded-xl border border-card-border/50 bg-card/30 p-3 text-center">
+                    <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
+                    <div class="text-lg font-bold ${(val as number) >= 0.7 ? 'text-ok' : (val as number) >= 0.4 ? 'text-[#fbbf24]' : 'text-bad'}">${val != null ? ((val as number) * 100).toFixed(0) + '%' : '-'}</div>
+                  </div>
+                `)}
+              </div>
+            <//>
+          ` : null}
+
           <${Card} title="작업 이력">
             ${taskHistories.value.length === 0
               ? html`<${EmptyState} message="작업 이력이 없습니다" compact />`

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -5,7 +5,11 @@ import { SurfaceCard } from '../common/card'
 import { ActionButton } from '../common/button'
 import { TextInput } from '../common/input'
 import { CountBadge } from '../common/badge'
-import { flowState, flowLoading, fetchPauseStatus, pauseRoom, resumeRoom, interruptRoom } from './flow-control-state'
+import {
+  flowState, flowLoading, fetchPauseStatus, pauseRoom, resumeRoom, interruptRoom,
+  roomStrategy, roomStrategyLoading, fetchRoomStrategy,
+  maintenanceResult, maintenanceLoading, runGarbageCollection, cleanupZombies,
+} from './flow-control-state'
 
 const showInterruptConfirm = signal(false)
 const interruptReason = signal('')
@@ -49,6 +53,46 @@ export function FlowControlPanel() {
           </div>
         </div>
       ` : null}
+    <//>
+
+    ${'' /* ── Room Strategy ── */}
+    <${SurfaceCard} variant="compact" class="mb-4">
+      <details>
+        <summary class="cursor-pointer text-[13px] text-[var(--text-strong)] font-medium select-none py-1">룸 전략</summary>
+        <div class="mt-3">
+          ${roomStrategy.value ? html`
+            <div class="flex flex-col gap-1.5 mb-3">
+              ${Object.entries(roomStrategy.value).map(([key, val]) => html`
+                <div key=${key} class="flex items-center justify-between py-1.5 px-3 rounded-lg border border-card-border/50 bg-card/20 text-[12px]">
+                  <span class="font-medium text-text-muted">${key}</span>
+                  <span class="font-semibold text-text-strong font-mono">${String(val)}</span>
+                </div>
+              `)}
+            </div>
+          ` : html`<p class="text-[11px] text-text-dim mb-3">조회되지 않았습니다</p>`}
+          <${ActionButton} variant="ghost" size="sm" disabled=${roomStrategyLoading.value}
+            onClick=${() => void fetchRoomStrategy()}>
+            ${roomStrategyLoading.value ? '...' : '조회'}<//>
+        </div>
+      </details>
+    <//>
+
+    ${'' /* ── Maintenance ── */}
+    <${SurfaceCard} variant="compact">
+      <details>
+        <summary class="cursor-pointer text-[13px] text-[var(--text-strong)] font-medium select-none py-1">유지보수</summary>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value}
+            onClick=${() => { if (confirm('GC를 실행합니까?')) void runGarbageCollection() }}>
+            ${maintenanceLoading.value ? '...' : 'GC 실행'}<//>
+          <${ActionButton} variant="danger" size="md" disabled=${maintenanceLoading.value}
+            onClick=${() => { if (confirm('좀비 에이전트를 정리합니까?')) void cleanupZombies() }}>
+            ${maintenanceLoading.value ? '...' : '좀비 정리'}<//>
+        </div>
+        ${maintenanceResult.value ? html`
+          <pre class="mt-3 p-3 rounded-lg border border-card-border/50 bg-card/30 text-[11px] text-text-body font-mono max-h-[160px] overflow-auto custom-scrollbar whitespace-pre-wrap">${maintenanceResult.value}</pre>
+        ` : null}
+      </details>
     <//>
   `
 }

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -6,6 +6,14 @@ export type FlowState = 'unknown' | 'running' | 'paused'
 export const flowState = signal<FlowState>('unknown')
 export const flowLoading = signal(false)
 
+// Room strategy state
+export const roomStrategy = signal<Record<string, unknown> | null>(null)
+export const roomStrategyLoading = signal(false)
+
+// Maintenance state
+export const maintenanceResult = signal<string | null>(null)
+export const maintenanceLoading = signal(false)
+
 export async function fetchPauseStatus(): Promise<void> {
   try {
     const raw = await callMcpTool('masc_pause_status', {})
@@ -39,4 +47,52 @@ export async function interruptRoom(reason?: string): Promise<void> {
   } catch (err) {
     showToast(`인터럽트 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
   } finally { flowLoading.value = false }
+}
+
+// ── Room Strategy ───────────────────────────────
+
+export async function fetchRoomStrategy(): Promise<void> {
+  roomStrategyLoading.value = true
+  try {
+    const raw = await callMcpTool('masc_room_strategy_get', {})
+    roomStrategy.value = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    roomStrategy.value = null
+    showToast('룸 전략 조회 실패', 'error')
+  } finally { roomStrategyLoading.value = false }
+}
+
+export async function setRoomStrategy(updates: Record<string, unknown>): Promise<void> {
+  roomStrategyLoading.value = true
+  try {
+    await callMcpTool('masc_room_strategy_set', updates)
+    showToast('룸 전략 업데이트 완료', 'success')
+    await fetchRoomStrategy()
+  } catch (err) {
+    showToast(`룸 전략 저장 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
+  } finally { roomStrategyLoading.value = false }
+}
+
+// ── Maintenance ─────────────────────────────────
+
+export async function runGarbageCollection(): Promise<void> {
+  maintenanceLoading.value = true
+  try {
+    const raw = await callMcpTool('masc_gc', {})
+    maintenanceResult.value = raw
+    showToast('GC 완료', 'success')
+  } catch (err) {
+    showToast(`GC 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
+  } finally { maintenanceLoading.value = false }
+}
+
+export async function cleanupZombies(): Promise<void> {
+  maintenanceLoading.value = true
+  try {
+    const raw = await callMcpTool('masc_cleanup_zombies', {})
+    maintenanceResult.value = raw
+    showToast('좀비 정리 완료', 'success')
+  } catch (err) {
+    showToast(`좀비 정리 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
+  } finally { maintenanceLoading.value = false }
 }

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -132,7 +132,7 @@ describe('KeeperConfigPanel', () => {
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('편집 가능 범위')
     expect(container.textContent).toContain('config/cascade.json')
-    expect(container.textContent).toContain('읽기 전용 런타임')
+    expect(container.textContent).toContain('런타임 설정')
     expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')
     expect(container.textContent).toContain('활성 모델')
 

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -8,6 +8,7 @@ import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig } from '../types'
 import { formatTokens } from './keeper-detail-panels'
+import { showToast } from './common/toast'
 
 // ── State ────────────────────────────────────────────────
 
@@ -54,16 +55,69 @@ function initDraftFromConfig(c: KeeperConfig): EditDraft {
 
 function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
   const payload: KeeperConfigUpdatePayload = {}
-  if (draft.goal !== orig.prompt.goal) payload.new_goal = draft.goal
-  if (draft.short_goal !== orig.prompt.short_goal) payload.new_short_goal = draft.short_goal
-  if (draft.mid_goal !== orig.prompt.mid_goal) payload.new_mid_goal = draft.mid_goal
-  if (draft.long_goal !== orig.prompt.long_goal) payload.new_long_goal = draft.long_goal
-  if (draft.soul_profile !== orig.prompt.soul_profile) payload.new_soul_profile = draft.soul_profile
-  if (draft.will !== orig.prompt.will) payload.new_will = draft.will
-  if (draft.needs !== orig.prompt.needs) payload.new_needs = draft.needs
-  if (draft.desires !== orig.prompt.desires) payload.new_desires = draft.desires
-  if (draft.instructions !== orig.prompt.instructions) payload.new_instructions = draft.instructions
+  if (draft.goal !== orig.prompt.goal) payload.goal = draft.goal
+  if (draft.short_goal !== orig.prompt.short_goal) payload.short_goal = draft.short_goal
+  if (draft.mid_goal !== orig.prompt.mid_goal) payload.mid_goal = draft.mid_goal
+  if (draft.long_goal !== orig.prompt.long_goal) payload.long_goal = draft.long_goal
+  if (draft.soul_profile !== orig.prompt.soul_profile) payload.soul_profile = draft.soul_profile
+  if (draft.will !== orig.prompt.will) payload.will = draft.will
+  if (draft.needs !== orig.prompt.needs) payload.needs = draft.needs
+  if (draft.desires !== orig.prompt.desires) payload.desires = draft.desires
+  if (draft.instructions !== orig.prompt.instructions) payload.instructions = draft.instructions
   return payload
+}
+
+// Runtime config draft for proactive/compaction/handoff inline editing
+type RuntimeDraft = {
+  proactive_enabled: boolean
+  proactive_idle_sec: number
+  proactive_cooldown_sec: number
+  compaction_ratio_gate: number
+  compaction_message_gate: number
+  compaction_token_gate: number
+  compaction_cooldown_sec: number
+  auto_handoff: boolean
+  handoff_threshold: number
+  handoff_cooldown_sec: number
+}
+
+const runtimeDraft = signal<RuntimeDraft | null>(null)
+const runtimeSaving = signal(false)
+
+function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
+  return {
+    proactive_enabled: c.proactive.enabled,
+    proactive_idle_sec: c.proactive.idle_sec,
+    proactive_cooldown_sec: c.proactive.cooldown_sec,
+    compaction_ratio_gate: c.compaction.ratio_gate,
+    compaction_message_gate: c.compaction.message_gate,
+    compaction_token_gate: c.compaction.token_gate,
+    compaction_cooldown_sec: c.compaction.cooldown_sec,
+    auto_handoff: c.handoff.auto,
+    handoff_threshold: c.handoff.threshold,
+    handoff_cooldown_sec: c.handoff.cooldown_sec,
+  }
+}
+
+function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
+  const payload: KeeperConfigUpdatePayload = {}
+  if (draft.proactive_enabled !== orig.proactive.enabled) payload.proactive_enabled = draft.proactive_enabled
+  if (draft.proactive_idle_sec !== orig.proactive.idle_sec) payload.proactive_idle_sec = draft.proactive_idle_sec
+  if (draft.proactive_cooldown_sec !== orig.proactive.cooldown_sec) payload.proactive_cooldown_sec = draft.proactive_cooldown_sec
+  if (draft.compaction_ratio_gate !== orig.compaction.ratio_gate) payload.compaction_ratio_gate = draft.compaction_ratio_gate
+  if (draft.compaction_message_gate !== orig.compaction.message_gate) payload.compaction_message_gate = draft.compaction_message_gate
+  if (draft.compaction_token_gate !== orig.compaction.token_gate) payload.compaction_token_gate = draft.compaction_token_gate
+  if (draft.compaction_cooldown_sec !== orig.compaction.cooldown_sec) payload.continuity_compaction_cooldown_sec = draft.compaction_cooldown_sec
+  if (draft.auto_handoff !== orig.handoff.auto) payload.auto_handoff = draft.auto_handoff
+  if (draft.handoff_threshold !== orig.handoff.threshold) payload.handoff_threshold = draft.handoff_threshold
+  if (draft.handoff_cooldown_sec !== orig.handoff.cooldown_sec) payload.handoff_cooldown_sec = draft.handoff_cooldown_sec
+  return payload
+}
+
+function updateRuntimeDraft(field: keyof RuntimeDraft, value: boolean | number) {
+  const d = runtimeDraft.value
+  if (!d) return
+  runtimeDraft.value = { ...d, [field]: value }
 }
 
 export async function loadKeeperConfig(name: string): Promise<void> {
@@ -85,6 +139,8 @@ export function resetKeeperConfig(): void {
   editMode.value = false
   editDraft.value = null
   saveError.value = null
+  runtimeDraft.value = null
+  runtimeSaving.value = false
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -212,6 +268,47 @@ const SOUL_PROFILES = ['balanced', 'safety', 'delivery', 'research', 'relationsh
 
 const fieldStyle = 'w-full bg-card/60 backdrop-blur-md text-text-strong text-[13px] border border-card-border rounded-xl py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
 
+// ── Inline editing components for runtime config ────────
+
+function InlineToggleRow({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <button type="button"
+        class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-pointer ${value ? 'bg-ok/60' : 'bg-white/10'}"
+        onClick=${() => onChange(!value)}
+      >
+        <span class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform ${value ? 'translate-x-[18px]' : 'translate-x-[3px]'}" />
+      </button>
+    </div>
+  `
+}
+
+function InlineNumberRow({ label, value, onChange, min, max, step, suffix }: {
+  label: string; value: number; onChange: (v: number) => void;
+  min?: number; max?: number; step?: number; suffix?: string
+}) {
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <div class="flex items-center gap-1.5">
+        <input type="number"
+          class="w-20 text-right bg-card/60 text-text-strong text-[12px] font-semibold border border-card-border rounded-lg py-1 px-2 focus:outline-none focus:border-accent/50 transition-colors"
+          value=${value}
+          min=${min}
+          max=${max}
+          step=${step}
+          onInput=${(e: Event) => {
+            const v = parseFloat((e.target as HTMLInputElement).value)
+            if (!isNaN(v)) onChange(v)
+          }}
+        />
+        ${suffix ? html`<span class="text-[10px] text-text-dim w-4">${suffix}</span>` : null}
+      </div>
+    </div>
+  `
+}
+
 // ── Edit field components ────────────────────────────────
 
 function updateDraft(field: keyof EditDraft, value: string | boolean | number) {
@@ -278,6 +375,36 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const c = state.config
   const isEditing = editMode.value
   const isSaving = saving.value
+
+  // Initialize runtime draft if not yet set
+  if (!runtimeDraft.value) {
+    runtimeDraft.value = initRuntimeDraftFromConfig(c)
+  }
+  const rd = runtimeDraft.value
+
+  const runtimeHasChanges = rd ? Object.keys(buildRuntimePayload(rd, c)).length > 0 : false
+
+  async function saveRuntimeConfig() {
+    if (!rd) return
+    const payload = buildRuntimePayload(rd, c)
+    if (Object.keys(payload).length === 0) return
+    runtimeSaving.value = true
+    try {
+      const updated = await patchKeeperConfig(keeperName, payload)
+      configState.value = { status: 'loaded', config: updated }
+      runtimeDraft.value = initRuntimeDraftFromConfig(updated)
+      showToast('런타임 설정 저장 완료', 'success')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '저장 실패'
+      showToast(msg, 'error')
+    } finally {
+      runtimeSaving.value = false
+    }
+  }
+
+  function resetRuntimeDraft() {
+    runtimeDraft.value = initRuntimeDraftFromConfig(c)
+  }
 
   function enterEditMode() {
     editDraft.value = initDraftFromConfig(c)
@@ -398,8 +525,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <div class="mt-2">
         <${Callout}
-          title="읽기 전용 런타임"
-          body="아래 값은 현재 서버가 해석한 실행 상태와 소스 경로입니다. 참고용이며, 이 패널에서 직접 변경되지는 않습니다."
+          title="런타임 설정"
+          body="프로액티브, 컴팩션, 핸드오프 섹션은 인라인 편집이 가능합니다. 소스/실행/런타임/조율/드리프트는 읽기 전용입니다."
         />
       </div>
 
@@ -437,18 +564,42 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${SectionHeader} title="컴팩션" />
       <${ConfigRow} label="프로필" value=${c.compaction.profile || '--'} />
-      <${ConfigRow} label="비율 게이트" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
-      <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
-      <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
+      ${rd ? html`
+        <${InlineNumberRow} label="비율 게이트 (%)" value=${Math.round(rd.compaction_ratio_gate * 100)}
+          onChange=${(v: number) => updateRuntimeDraft('compaction_ratio_gate', v / 100)}
+          min=${0} max=${100} step=${5} suffix="%" />
+        <${InlineNumberRow} label="메시지 게이트" value=${rd.compaction_message_gate}
+          onChange=${(v: number) => updateRuntimeDraft('compaction_message_gate', v)}
+          min=${0} max=${500} step=${5} />
+        <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
+        <${InlineNumberRow} label="쿨다운 (초)" value=${rd.compaction_cooldown_sec}
+          onChange=${(v: number) => updateRuntimeDraft('compaction_cooldown_sec', v)}
+          min=${0} max=${3600} step=${30} suffix="s" />
+      ` : html`
+        <${ConfigRow} label="비율 게이트" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
+        <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
+        <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
+        <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
+      `}
 
       <${SectionHeader} title="프로액티브" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">활성</span>
-        <${BoolBadge} value=${c.proactive.enabled} />
-      </div>
-      <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
-      <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
+      ${rd ? html`
+        <${InlineToggleRow} label="활성" value=${rd.proactive_enabled}
+          onChange=${(v: boolean) => updateRuntimeDraft('proactive_enabled', v)} />
+        <${InlineNumberRow} label="유휴 트리거 (초)" value=${rd.proactive_idle_sec}
+          onChange=${(v: number) => updateRuntimeDraft('proactive_idle_sec', v)}
+          min=${10} max=${3600} step=${10} suffix="s" />
+        <${InlineNumberRow} label="쿨다운 (초)" value=${rd.proactive_cooldown_sec}
+          onChange=${(v: number) => updateRuntimeDraft('proactive_cooldown_sec', v)}
+          min=${10} max=${3600} step=${10} suffix="s" />
+      ` : html`
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-muted)]">활성</span>
+          <${BoolBadge} value=${c.proactive.enabled} />
+        </div>
+        <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
+        <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
+      `}
 
       <${SectionHeader} title="런타임" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
@@ -498,12 +649,38 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       </div>
 
       <${SectionHeader} title="핸드오프" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">자동</span>
-        <${BoolBadge} value=${c.handoff.auto} />
-      </div>
-      <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="쿨다운" value=${c.handoff.cooldown_sec + 's'} />
+      ${rd ? html`
+        <${InlineToggleRow} label="자동" value=${rd.auto_handoff}
+          onChange=${(v: boolean) => updateRuntimeDraft('auto_handoff', v)} />
+        <${InlineNumberRow} label="임계값 (%)" value=${Math.round(rd.handoff_threshold * 100)}
+          onChange=${(v: number) => updateRuntimeDraft('handoff_threshold', v / 100)}
+          min=${0} max=${100} step=${5} suffix="%" />
+        <${InlineNumberRow} label="쿨다운 (초)" value=${rd.handoff_cooldown_sec}
+          onChange=${(v: number) => updateRuntimeDraft('handoff_cooldown_sec', v)}
+          min=${0} max=${3600} step=${30} suffix="s" />
+      ` : html`
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-muted)]">자동</span>
+          <${BoolBadge} value=${c.handoff.auto} />
+        </div>
+        <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
+        <${ConfigRow} label="쿨다운" value=${c.handoff.cooldown_sec + 's'} />
+      `}
+
+      ${runtimeHasChanges ? html`
+        <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded-xl border border-accent/30 bg-accent/5">
+          <button type="button"
+            class="${btnBase} bg-[#4ade80] text-[#000]"
+            onClick=${saveRuntimeConfig}
+            disabled=${runtimeSaving.value}
+          >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
+          <button type="button"
+            class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
+            onClick=${resetRuntimeDraft}
+          >초기화</button>
+          <span class="text-[10px] text-accent">변경된 설정이 있습니다</span>
+        </div>
+      ` : null}
 
       <${SectionHeader} title="마지막 호출 성능" />
       <${ConfigRow} label="총 입력 토큰" value=${formatTokens(c.metrics.total_input_tokens)} />

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -172,8 +172,49 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           ? html`<${KpiCard} label="Cost (USD)" value=${latestCost} />`
           : null}
       </div>
+      ${'' /* Autonomy KPIs — activity breakdown */}
+      ${(keeper.autonomous_action_count ?? 0) > 0 || (keeper.board_reactive_turn_count ?? 0) > 0 ? html`
+        <div class="grid grid-cols-4 gap-2">
+          <${KpiCard}
+            label="Auto Actions"
+            value=${keeper.autonomous_action_count ?? '-'}
+            hint="자율 행동 횟수"
+          />
+          <${KpiCard}
+            label="Auto Turns"
+            value=${keeper.autonomous_turn_count ?? '-'}
+            hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : undefined}
+          />
+          <${KpiCard}
+            label="Board React"
+            value=${keeper.board_reactive_turn_count ?? '-'}
+            hint="게시판 반응"
+          />
+          <${KpiCard}
+            label="Noop"
+            value=${keeper.noop_turn_count ?? '-'}
+            hint="비활동 턴"
+          />
+        </div>
+      ` : null}
+      ${'' /* Proactive activity callout */}
+      ${keeper.last_proactive_ago_s != null ? html`
+        <div class="rounded-xl border border-purple-400/20 bg-purple-500/5 p-3 text-[11px]">
+          <span class="font-semibold text-purple-300">Proactive</span>
+          <span class="text-text-muted ml-2">${formatDuration(keeper.last_proactive_ago_s)} 전</span>
+          ${keeper.last_proactive_reason ? html`
+            <span class="text-text-dim ml-2">| ${keeper.last_proactive_reason}</span>
+          ` : null}
+        </div>
+      ` : null}
     </div>
   `
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}초`
+  if (sec < 3600) return `${Math.floor(sec / 60)}분`
+  return `${Math.floor(sec / 3600)}시간 ${Math.floor((sec % 3600) / 60)}분`
 }
 
 // ── Context Chart ────────────────────────────────────────

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useRef } from 'preact/hooks'
 import { currentDashboardActor, runOperatorAction } from '../api'
+import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
@@ -185,15 +186,46 @@ export function KeeperDetailOverlay() {
               ${keeper.koreanName ? html`<span class="text-xs text-[var(--text-muted)]">${keeper.koreanName}</span>` : null}
             </div>
           </div>
-          <button
-            ref=${closeButtonRef}
-            type="button"
-            onClick=${() => closeKeeperDetail()}
-            class="flex items-center justify-center size-8 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
-            aria-label="키퍼 상세 닫기"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
-          </button>
+          <div class="flex items-center gap-2">
+            ${(() => {
+              const isOffline = ['offline', 'inactive', 'dead', 'crashed'].includes(keeper.status)
+              const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(keeper.status)
+              if (isOffline) return html`
+                <button type="button"
+                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[#4ade80] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
+                  onClick=${() => {
+                    void bootKeeper(keeper.name).then(res => {
+                      if (res.ok) {
+                        showToast(keeper.name + ' booted', 'success')
+                        void refreshDashboard({ force: true })
+                      } else showToast(res.error ?? 'Boot 실패', 'error')
+                    }).catch(() => showToast('Boot 실패', 'error'))
+                  }}
+                >Boot</button>`
+              if (isRunning) return html`
+                <button type="button"
+                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+                  onClick=${() => {
+                    if (confirm(keeper.name + ' 키퍼를 종료합니까?')) {
+                      void shutdownKeeper(keeper.name).then(() => {
+                        showToast(keeper.name + ' 종료됨', 'success')
+                        void refreshDashboard({ force: true })
+                      }).catch(() => showToast('종료 실패', 'error'))
+                    }
+                  }}
+                >Shutdown</button>`
+              return null
+            })()}
+            <button
+              ref=${closeButtonRef}
+              type="button"
+              onClick=${() => closeKeeperDetail()}
+              class="flex items-center justify-center size-8 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
+              aria-label="키퍼 상세 닫기"
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
+            </button>
+          </div>
         </div>
 
         ${'' /* ── Body ── */}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -18,7 +18,7 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-runtime'
 import { isVisibleDirectConversationEntry } from '../keeper-state'
-import { bootKeeper } from '../api/keeper'
+import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 import { signal } from '@preact/signals'


### PR DESCRIPTION
## Summary

- **Phase 0 (Bug Fix)**: `KeeperConfigUpdatePayload`가 `new_goal` 등 `new_` 접두사 키를 전송했지만, 백엔드 `Keeper_turn_up_args.parse`는 `goal` (접두사 없음)만 파싱. Prompt 편집이 silent no-op이었던 버그 수정.
- **Phase 1**: Proactive/Compaction/Handoff 설정을 read-only에서 인라인 편집 가능으로 변경. 백엔드 PATCH 엔드포인트는 이미 이 필드들을 지원.
- **Phase 2**: Autonomy 메트릭(auto actions, auto turns, board reactive, noop) KPI 그리드에 표시. Proactive 활동 callout 추가.
- **Phase 3**: 키퍼 상세 헤더에 Boot/Shutdown 버튼 추가. `keeper-shared.ts`의 `shutdownKeeper` import 누락 수정.

## Root Cause Analysis (Phase 0)

```
Dashboard: {"new_goal": "Ship stable keeper ops"} → POST /api/v1/keepers/:name/config
Backend:   get_string_opt args "goal" → safe_member "goal" json → None (key mismatch)
Result:    old value preserved, edit silently ignored
```

`safe_ops.ml:safe_member` does exact key lookup. No `new_` prefix stripping exists.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vite build` succeeds
- [x] `vitest run` — 35 files, 122 tests pass
- [ ] Manual: 대시보드에서 키퍼 goal 편집 → 저장 → config 리로드 → 변경 반영 확인
- [ ] Manual: proactive enabled 토글 → 저장 → meta JSON 확인
- [ ] Manual: 키퍼 상세 헤더 Boot/Shutdown 버튼 동작 확인