### PR TITLE
Fix mcp tool matrix dispatch and timeout regressions

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -117,6 +117,10 @@ let () =
   register_module_tag ~schemas:Tool_portal.schemas ~tag:Mod_portal;
   register_module_tag ~schemas:Tool_worktree.schemas ~tag:Mod_worktree;
   register_module_tag ~schemas:Tool_auth.schemas ~tag:Mod_auth;
+  register_module_tag ~schemas:Tool_audit.schemas ~tag:Mod_audit;
+  register_module_tag ~schemas:Tool_cost.schemas ~tag:Mod_cost;
+  register_module_tag ~schemas:Tool_encryption.schemas ~tag:Mod_encryption;
+  register_module_tag ~schemas:Tool_schemas_fire_task.schemas ~tag:Mod_fire_task;
   register_module_tag ~schemas:Tool_agent.schemas ~tag:Mod_agent;
   register_module_tag ~schemas:Tool_room.schemas ~tag:Mod_room;
   register_module_tag ~schemas:Tool_agent_timeline.schemas ~tag:Mod_agent_timeline;
@@ -134,6 +138,10 @@ let () =
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_hat.schemas ~tag:Mod_hat;
   register_module_tag ~schemas:Tool_cache.schemas ~tag:Mod_cache;
+  register_module_tag ~schemas:Tool_model_catalog.schemas ~tag:Mod_model_catalog;
+  register_module_tag ~schemas:Tool_rate_limit.schemas ~tag:Mod_rate_limit;
+  register_module_tag ~schemas:Tool_run.schemas ~tag:Mod_run;
+  register_module_tag ~schemas:Tool_tempo.schemas ~tag:Mod_tempo;
   register_module_tag ~schemas:Tool_goals.schemas ~tag:Mod_goals;
   register_module_tag ~schemas:Tool_compact.schemas ~tag:Mod_compact;
   register_module_tag ~schemas:Tool_schemas_inline.schemas ~tag:Mod_inline;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -475,10 +475,26 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_heartbeat.dispatch { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args:arguments
     | Mod_auth ->
         Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments
+    | Mod_audit ->
+        Tool_audit.dispatch { Tool_audit.config } ~name ~args:arguments
+    | Mod_cost ->
+        Tool_cost.dispatch { Tool_cost.agent_name = agent_name } ~name ~args:arguments
+    | Mod_encryption ->
+        Tool_encryption.dispatch { Tool_encryption.state } ~name ~args:arguments
+    | Mod_fire_task ->
+        Tool_fire_task.dispatch { Tool_fire_task.config; agent_name; sw } ~name ~args:arguments
     | Mod_cache ->
         Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments
     | Mod_hat ->
         Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args:arguments
+    | Mod_model_catalog ->
+        Tool_model_catalog.dispatch () ~name ~args:arguments
+    | Mod_rate_limit ->
+        Tool_rate_limit.dispatch { Tool_rate_limit.config; agent_name; registry } ~name ~args:arguments
+    | Mod_run ->
+        Tool_run.dispatch { Tool_run.config } ~name ~args:arguments
+    | Mod_tempo ->
+        Tool_tempo.dispatch { Tool_tempo.config; agent_name } ~name ~args:arguments
     | Mod_goals ->
         Tool_goals.dispatch { Tool_goals.config; agent_name; call_keeper_msg = None } ~name ~args:arguments
     | Mod_compact ->

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -273,58 +273,81 @@ let handle_route _ctx args =
       ]) decision.agents));
   ])
 
-let handle_execute ctx args =
-  let topic = get_string args "topic" "" in
-  if topic = "" then json_err "topic is required"
-  else
-    let system_prompt = Prompt_registry.get_prompt "governance.deliberation" in
-    let agent_name = "council-deliberation" in
-    let memory =
-      Memory_oas_bridge.create_memory_full
-        ~agent_name
-        ~config:(room_config_of_ctx ctx)
-        ()
-    in
-    match Oas_worker.run_named
-      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
-    with
-    | Ok result ->
-      let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
-      json_ok (`Assoc [
-        ("topic", `String topic);
-        ("deliberation", `String (Oas_response.text_of_response result.response));
-        ("turns", `Int result.turns);
-        ("session_id", `String result.session_id);
-        ("runtime", `String "oas");
-      ])
-    | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e)
+let voting_result_of_args args =
+  let raw =
+    get_string args "result" "majority" |> String.trim |> String.lowercase_ascii
+  in
+  match raw with
+  | "" | "majority" -> Ok (Council.Consensus.Majority 3)
+  | "unanimous" ->
+      Ok (Council.Consensus.Unanimous Council.Consensus.Approve)
+  | "deadlock" -> Ok Council.Consensus.Deadlock
+  | "escalate" -> Ok Council.Consensus.Escalate
+  | value ->
+      Error
+        (Printf.sprintf
+           "invalid result %S (expected unanimous, majority, deadlock, or escalate)"
+           value)
 
-let handle_execute_dry_run ctx args =
+let handle_execute _ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
-    let system_prompt = Prompt_registry.get_prompt "governance.dry_run" in
-    let agent_name = "council-dry-run" in
-    let memory =
-      Memory_oas_bridge.create_memory_full
-        ~agent_name
-        ~config:(room_config_of_ctx ctx)
-        ()
-    in
-    match Oas_worker.run_named
-      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
-    with
+    match voting_result_of_args args with
+    | Error msg -> json_err msg
     | Ok result ->
-      let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
-      json_ok (`Assoc [
-        ("topic", `String topic);
-        ("analysis", `String (Oas_response.text_of_response result.response));
-        ("turns", `Int result.turns);
-        ("session_id", `String result.session_id);
-        ("dry_run", `Bool true);
-        ("runtime", `String "oas");
-      ])
-    | Error e -> json_err (Printf.sprintf "Dry-run analysis failed: %s" e)
+        let preview = Council.ExecutorApi.dry_run ~topic ~result in
+        let outcome = Council.ExecutorApi.execute ~topic ~result in
+        let matched = Option.is_some outcome in
+        let executed =
+          match outcome with
+          | Some exec -> exec.success
+          | None -> false
+        in
+        let output =
+          match outcome with
+          | Some exec when String.trim exec.output <> "" -> exec.output
+          | _ -> preview
+        in
+        let stdout =
+          match outcome with
+          | Some exec when String.trim exec.stdout <> "" -> `String exec.stdout
+          | _ -> `Null
+        in
+        let stderr =
+          match outcome with
+          | Some exec when String.trim exec.stderr <> "" -> `String exec.stderr
+          | _ -> `Null
+        in
+        json_ok
+          (`Assoc
+            [
+              ("topic", `String topic);
+              ("matched", `Bool matched);
+              ("executed", `Bool executed);
+              ("preview", `String preview);
+              ("output", `String output);
+              ("stdout", stdout);
+              ("stderr", stderr);
+              ("runtime", `String "executor");
+            ])
+
+let handle_execute_dry_run _ctx args =
+  let topic = get_string args "topic" "" in
+  if topic = "" then json_err "topic is required"
+  else
+    match voting_result_of_args args with
+    | Error msg -> json_err msg
+    | Ok result ->
+        let analysis = Council.ExecutorApi.dry_run ~topic ~result in
+        json_ok
+          (`Assoc
+            [
+              ("topic", `String topic);
+              ("analysis", `String analysis);
+              ("dry_run", `Bool true);
+              ("runtime", `String "executor");
+            ])
 
 (* ================================================================ *)
 (* Schemas — reuse from legacy Tool_council                          *)

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -157,7 +157,9 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_cache | Mod_goals | Mod_compact
+  | Mod_auth | Mod_audit | Mod_cost | Mod_encryption | Mod_fire_task
+  | Mod_hat | Mod_cache | Mod_model_catalog | Mod_rate_limit | Mod_run
+  | Mod_tempo | Mod_goals | Mod_compact
   | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -84,7 +84,9 @@ type module_tag =
   | Mod_code | Mod_code_write
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_heartbeat
-  | Mod_auth | Mod_hat | Mod_cache | Mod_goals | Mod_compact
+  | Mod_auth | Mod_audit | Mod_cost | Mod_encryption | Mod_fire_task
+  | Mod_hat | Mod_cache | Mod_model_catalog | Mod_rate_limit | Mod_run
+  | Mod_tempo | Mod_goals | Mod_compact
   | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_mdal

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -107,8 +107,8 @@ let handle_runtime_bench _ctx args : result =
     | `Intlit value -> (
         match parse_int_opt value with
         | Some parsed -> max 3 (min 120 parsed)
-        | None -> 20)
-    | _ -> 20
+        | None -> 8)
+    | _ -> 8
   in
   let prompt =
     match member "prompt" args with

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -246,6 +246,25 @@ let model_label_for_pool ~model_id runtime_pool =
         Printf.sprintf "custom:%s@%s" model_id base_url
   | None -> Printf.sprintf "llama:%s" model_id
 
+let ensure_runtime_reachable ?runtime_pool ~timeout_sec () =
+  let base_url = runtime_base_url_for_pool runtime_pool |> String.trim in
+  let health_url = base_url ^ "/health" in
+  let probe_timeout = max 1 (min 2 timeout_sec) in
+  match http_get_text_with_status ~timeout_sec:probe_timeout health_url with
+  | Ok (Some 200, _) -> Ok ()
+  | Ok (status, _) ->
+      let status_text =
+        match status with
+        | Some code -> string_of_int code
+        | None -> "no-status"
+      in
+      Error
+        (Printf.sprintf
+           "runtime unavailable: provider health check returned %s for %s"
+           status_text health_url)
+  | Error err ->
+      Error (Printf.sprintf "runtime unavailable: %s" err)
+
 let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec ()
     =
   match Masc_eio_env.get_opt () with
@@ -306,74 +325,77 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
 
 let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     ~timeout_sec () =
-  let total = parallelism * rounds in
-  let results = Array.make total None in
-  let runtime_breakdown = Hashtbl.create 8 in
-  for round_idx = 0 to rounds - 1 do
-    let offset = round_idx * parallelism in
-    Eio.Fiber.all
-      (List.init parallelism (fun fiber_idx ->
-           fun () ->
-             let resolved_model_id =
-               match model_id with
-               | Some model when String.trim model <> "" -> model
-               | _ -> default_local_model_id ()
-             in
-             let sample, runtime_id =
-               oas_completion_at ?runtime_pool ~model_id:resolved_model_id
-                 ~prompt ~max_tokens ~timeout_sec ()
-             in
-             update_runtime_breakdown runtime_breakdown ~runtime_id ~sample;
-             results.(offset + fiber_idx) <- Some sample))
-  done;
-  let samples = results |> Array.to_list |> List.filter_map (fun item -> item) in
-  let success_count =
-    List.fold_left
-      (fun acc (sample : bench_sample) ->
-        if sample.success then acc + 1 else acc)
-      0 samples
-  in
-  let failure_count = List.length samples - success_count in
-  let latencies =
-    samples
-    |> List.filter_map (fun (sample : bench_sample) ->
-           if sample.success then Some sample.latency_ms else None)
-  in
-  let errors =
-    samples
-    |> List.filter_map (fun (sample : bench_sample) -> sample.error)
-    |> List.sort_uniq String.compare
-  in
-  Local_runtime_pool.record_measured_ceiling success_count;
-  let runtime_breakdown =
-    runtime_breakdown |> per_runtime_breakdown_to_yojson
-    |> List.map finalize_runtime_breakdown
-  in
-  Ok
-    (`Assoc
-      [
-        ("server_url", `String Env_config.Llama.server_url);
-        ("source", `String "oas_complete");
-        ("model_id", string_opt_to_json model_id);
-        ("runtime_pool", string_opt_to_json runtime_pool);
-        ("parallelism", `Int parallelism);
-        ("rounds", `Int rounds);
-        ("total_requests", `Int (List.length samples));
-        ("success_count", `Int success_count);
-        ("failure_count", `Int failure_count);
-        ( "success_rate",
-          `Float
-            (if samples = [] then 0.0
-             else
-               float_of_int success_count
-               /. float_of_int (List.length samples)) );
-        ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
-        ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
-        ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
-        ("configured_max_concurrent_models", `Int Inference_utils.max_concurrent_models);
-        ("configured_capacity", `Int (Local_runtime_pool.configured_capacity ()));
-        ("measured_ceiling", int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
-        ("per_runtime_breakdown", `List runtime_breakdown);
-        ( "errors",
-          `List (errors |> List.map (fun message -> `String message)) );
-      ])
+  match ensure_runtime_reachable ?runtime_pool ~timeout_sec () with
+  | Error _ as err -> err
+  | Ok () ->
+      let total = parallelism * rounds in
+      let results = Array.make total None in
+      let runtime_breakdown = Hashtbl.create 8 in
+      for round_idx = 0 to rounds - 1 do
+        let offset = round_idx * parallelism in
+        Eio.Fiber.all
+          (List.init parallelism (fun fiber_idx ->
+               fun () ->
+                 let resolved_model_id =
+                   match model_id with
+                   | Some model when String.trim model <> "" -> model
+                   | _ -> default_local_model_id ()
+                 in
+                 let sample, runtime_id =
+                   oas_completion_at ?runtime_pool ~model_id:resolved_model_id
+                     ~prompt ~max_tokens ~timeout_sec ()
+                 in
+                 update_runtime_breakdown runtime_breakdown ~runtime_id ~sample;
+                 results.(offset + fiber_idx) <- Some sample))
+      done;
+      let samples = results |> Array.to_list |> List.filter_map (fun item -> item) in
+      let success_count =
+        List.fold_left
+          (fun acc (sample : bench_sample) ->
+            if sample.success then acc + 1 else acc)
+          0 samples
+      in
+      let failure_count = List.length samples - success_count in
+      let latencies =
+        samples
+        |> List.filter_map (fun (sample : bench_sample) ->
+               if sample.success then Some sample.latency_ms else None)
+      in
+      let errors =
+        samples
+        |> List.filter_map (fun (sample : bench_sample) -> sample.error)
+        |> List.sort_uniq String.compare
+      in
+      Local_runtime_pool.record_measured_ceiling success_count;
+      let runtime_breakdown =
+        runtime_breakdown |> per_runtime_breakdown_to_yojson
+        |> List.map finalize_runtime_breakdown
+      in
+      Ok
+        (`Assoc
+          [
+            ("server_url", `String Env_config.Llama.server_url);
+            ("source", `String "oas_complete");
+            ("model_id", string_opt_to_json model_id);
+            ("runtime_pool", string_opt_to_json runtime_pool);
+            ("parallelism", `Int parallelism);
+            ("rounds", `Int rounds);
+            ("total_requests", `Int (List.length samples));
+            ("success_count", `Int success_count);
+            ("failure_count", `Int failure_count);
+            ( "success_rate",
+              `Float
+                (if samples = [] then 0.0
+                 else
+                   float_of_int success_count
+                   /. float_of_int (List.length samples)) );
+            ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
+            ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
+            ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
+            ("configured_max_concurrent_models", `Int Inference_utils.max_concurrent_models);
+            ("configured_capacity", `Int (Local_runtime_pool.configured_capacity ()));
+            ("measured_ceiling", int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
+            ("per_runtime_breakdown", `List runtime_breakdown);
+            ( "errors",
+              `List (errors |> List.map (fun message -> `String message)) );
+          ])

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -152,6 +152,8 @@ let all_known_tool_names =
     "masc_handover_create";
     "masc_handover_get";
     "masc_handover_list";
+    "masc_hat_status";
+    "masc_hat_wear";
     "masc_heartbeat";
     "masc_heartbeat_list";
     "masc_heartbeat_result";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -152,8 +152,6 @@ let all_known_tool_names =
     "masc_handover_create";
     "masc_handover_get";
     "masc_handover_list";
-    "masc_hat_status";
-    "masc_hat_wear";
     "masc_heartbeat";
     "masc_heartbeat_list";
     "masc_heartbeat_result";


### PR DESCRIPTION
## Summary
- register missing MCP runtime/tag-dispatch wiring for tool families that were present in schema inventory but unreachable at runtime
- switch governance execute and dry-run handlers to deterministic executor paths and tighten local runtime bench timeout behavior for matrix stability
- remove duplicate tool inventory entries and revalidate targeted and full mcp tool matrix coverage

## Verification
- targeted unknown-tool subset passed
- targeted execute/dry-run/local-runtime subset passed
- previous timeout bucket subset passed
- full `mcp_tool_matrix` passed with `328 tools registered` in `580.094s`
