### PR TITLE
fix: extend bump-version.sh to cover all doc-truth targets

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -72,6 +72,27 @@ else
   echo "  CHANGELOG already has $NEW_VERSION entry"
 fi
 
+# 5) ROADMAP.md — current package version + latest release
+sedi -E "s/^> Current package version: v[^ ]*/> Current package version: v$NEW_VERSION/" \
+  "$ROOT_DIR/ROADMAP.md"
+sedi -E "s/^> Latest release: v[^ ]*/> Latest release: v$NEW_VERSION/" \
+  "$ROOT_DIR/ROADMAP.md"
+echo "  ROADMAP.md updated"
+
+# 6) docs/PRODUCT-OPERATING-PLAN.md — current package version + latest release
+sedi -E "s/^> Current package version: v[^ ]*/> Current package version: v$NEW_VERSION/" \
+  "$ROOT_DIR/docs/PRODUCT-OPERATING-PLAN.md"
+sedi -E "s/^> Latest release: v[^ ]*/> Latest release: v$NEW_VERSION/" \
+  "$ROOT_DIR/docs/PRODUCT-OPERATING-PLAN.md"
+echo "  PRODUCT-OPERATING-PLAN.md updated"
+
+# 7) docs/spec/SPEC-INDEX.md — snapshot baseline + release baseline table
+sedi -E "s/version \`[0-9]+\.[0-9]+\.[0-9]+\`/version \`$NEW_VERSION\`/" \
+  "$ROOT_DIR/docs/spec/SPEC-INDEX.md"
+sedi -E "s/Release baseline \| [0-9]+\.[0-9]+\.[0-9]+/Release baseline | $NEW_VERSION/" \
+  "$ROOT_DIR/docs/spec/SPEC-INDEX.md"
+echo "  SPEC-INDEX.md updated"
+
 echo ""
 echo "Release version layers:"
 echo "  1) release SemVer: $NEW_VERSION"
@@ -80,5 +101,5 @@ echo "  3) artifact schema: report/proof JSON schema_version"
 echo ""
 echo "Next:"
 echo "  dune build --root ."
-echo "  git add dune-project README.md CHANGELOG.md masc_mcp.opam"
+echo "  git add dune-project README.md CHANGELOG.md masc_mcp.opam ROADMAP.md docs/PRODUCT-OPERATING-PLAN.md docs/spec/SPEC-INDEX.md"
 echo "  git commit -m \"chore(release): bump version to $NEW_VERSION\""


### PR DESCRIPTION
## Summary
- `bump-version.sh`가 7개 검증 대상 중 4개만 업데이트하여 매 bump마다 CI Health check가 실패하는 구조적 문제 해결
- ROADMAP.md, PRODUCT-OPERATING-PLAN.md, SPEC-INDEX.md 업데이트 추가
- git add 안내도 7개 파일로 업데이트

## Test plan
- [x] `bump-version.sh 2.164.0` idempotent 실행 확인
- [x] `check-doc-truth.sh` 로컬 통과
- [ ] CI 전체 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)