### PR TITLE
fix(governance): wire dashboard to real judge status and surface judgments

### DIFF
--- a/config/prompts/dashboard.governance_judge.md
+++ b/config/prompts/dashboard.governance_judge.md
@@ -9,11 +9,19 @@ Read only the factual snapshot JSON below.
 Do not invent links, evidence, or actions.
 If evidence is insufficient, omit the item from output.
 You are not a heuristic generator. Only produce judgments you can justify directly from the facts.
+
+The facts JSON may contain:
+- "items": governance V2 case bundles (kind="case")
+- "activity": recent governance timeline events
+- "agents": current agent states (name, status, is_zombie, current_task)
+
+Evaluate: agent health (zombie detection, stale tasks), open case status, risk patterns.
+
 Output strict JSON only with this shape:
 {
   "items": [
     {
-      "kind": "debate|consensus",
+      "kind": "case|agent_health|room_state",
       "id": string,
       "summary": string,
       "confidence": number,

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -107,7 +107,7 @@ function normalizeGovernanceGuardrailState(raw: unknown): GovernanceGuardrailSta
   }
 }
 
-function normalizeGovernanceJudgment(raw: unknown): GovernanceJudgment | null {
+export function normalizeGovernanceJudgment(raw: unknown): GovernanceJudgment | null {
   if (!isRecord(raw)) return null
   const summary = asNullableString(raw.summary)
   const targetId = asNullableString(raw.target_id)

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -6,6 +6,7 @@ import {
   normalizeGovernanceDecisionItem,
   normalizeGovernanceTimelineEvent,
   normalizeGovernanceJudgeSummary,
+  normalizeGovernanceJudgment,
   normalizePendingConfirmation,
 } from './board'
 import { get, post, patch, withRetries, ROOM_TRUTH_GET_TIMEOUT_MS } from './core'
@@ -23,6 +24,7 @@ import type {
   DashboardShellResponse,
   BoardSortMode,
   GovernanceDecisionItem,
+  GovernanceJudgment,
   GovernanceTimelineEvent,
   PendingConfirmation,
   CommandPlaneHelpResponse,
@@ -238,6 +240,11 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
             .filter((item): item is GovernanceTimelineEvent => item !== null)
         : [],
       judge: normalizeGovernanceJudgeSummary(raw.judge),
+      judgments: Array.isArray(raw.judgments)
+        ? raw.judgments
+            .map(item => normalizeGovernanceJudgment(item))
+            .filter((item): item is GovernanceJudgment => item !== null)
+        : [],
       pending_actions: pendingActions,
     }
   })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -135,10 +135,11 @@ function GovernanceToolbar() {
 function governanceEmptyMessage(): string {
   const data = governanceData.value
   const allItems = data?.items ?? []
+  const judgments = data?.judgments ?? []
   const lastActivityAge = data?.summary?.last_activity_age_s
 
-  // All items empty (not just filtered) — show guidance
-  if (allItems.length === 0) {
+  // All items and judgments empty — show guidance
+  if (allItems.length === 0 && judgments.length === 0) {
     const ageText = formatAgeSummary(lastActivityAge)
     if (ageText != null) {
       return `거버넌스 사건이 없습니다. 마지막 활동: ${ageText} 전. keeper가 활동 중일 때 자동 생성됩니다.`
@@ -203,6 +204,28 @@ function DecisionInbox() {
   `
 }
 
+function JudgmentsSection() {
+  const judgments = governanceData.value?.judgments ?? []
+  if (judgments.length === 0) return null
+  return html`
+    <${Card} title="AI Judge 판단" class="section mb-5" variant="compact">
+      <div class="flex flex-col gap-2.5">
+        ${judgments.map(j => html`
+          <div class="rounded-lg border border-card-border bg-card/34 p-3.5 text-[13px]">
+            <div class="flex items-center gap-2 mb-1.5">
+              <span class="inline-flex items-center rounded-md border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-[10px] font-bold text-accent">${j.target_kind ?? 'unknown'}</span>
+              <span class="font-medium text-text-strong">${j.target_id ?? ''}</span>
+              ${j.confidence != null ? html`<span class="ml-auto text-[11px] text-text-muted">신뢰도 ${Math.round(j.confidence * 100)}%</span>` : null}
+            </div>
+            <div class="text-text-muted/90 leading-relaxed">${j.summary ?? ''}</div>
+            ${j.generated_at ? html`<div class="mt-1.5 text-[11px] text-text-dim"><${TimeAgo} timestamp=${j.generated_at} /></div>` : null}
+          </div>
+        `)}
+      </div>
+    <//>
+  `
+}
+
 export function Governance() {
   useEffect(() => {
     void refreshGovernance()
@@ -212,6 +235,7 @@ export function Governance() {
     <div class="flex flex-col gap-0.5">
       <${GovernanceSummaryStrip} />
       <${GovernanceToolbar} />
+      <${JudgmentsSection} />
       <div class="governance-layout">
         <${DecisionInbox} />
         <${DecisionDetail} />

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -1,7 +1,7 @@
 import type { Agent, BoardPost } from './core'
 import type { OperatorAttentionItem, OperatorRecommendedAction } from './dashboard-mission'
 import type { CommandPlaneSurface } from './command-plane'
-import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, GovernanceTimelineEvent, GovernanceJudgeSummary, PendingConfirmation, PendingConfirmSummary } from './governance'
+import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, GovernanceTimelineEvent, GovernanceJudgeSummary, GovernanceJudgment, PendingConfirmation, PendingConfirmSummary } from './governance'
 
 // --- Dashboard projection responses ---
 
@@ -279,6 +279,7 @@ export interface DashboardGovernanceResponse {
   items?: GovernanceDecisionItem[]
   activity?: GovernanceTimelineEvent[]
   judge?: GovernanceJudgeSummary
+  judgments?: GovernanceJudgment[]
   pending_actions?: PendingConfirmation[]
 }
 

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -283,17 +283,20 @@ let compare_activity left right =
   Float.compare right_ts left_ts
 
 let judge_runtime_json base_path =
-  let latest_ts = GV2.latest_generated_at base_path in
+  let st = Dashboard_governance_judge.runtime_status base_path in
   `Assoc
     [
-      ("judge_online", `Bool true);
-      ("refreshing", `Bool false);
+      ("judge_online", `Bool st.judge_online);
+      ("refreshing", `Bool st.refreshing);
       ( "generated_at",
-        if latest_ts > 0.0 then `String (iso_of_unix latest_ts) else `Null );
-      ("expires_at", `Null);
-      ("model_used", `String "heuristic:governance_v2");
-      ("keeper_name", `String "governance-judge");
-      ("last_error", `Null);
+        option_to_yojson (fun s -> `String s) st.generated_at );
+      ( "expires_at",
+        option_to_yojson (fun s -> `String s) st.expires_at );
+      ( "model_used",
+        option_to_yojson (fun s -> `String s) st.model_used );
+      ("keeper_name", `String st.keeper_name);
+      ( "last_error",
+        option_to_yojson (fun s -> `String s) st.last_error );
     ]
 
 let factual_snapshot_json ~base_path =
@@ -390,6 +393,9 @@ let dashboard_json ~base_path ~limit ~offset ~status_filter =
          None
   in
   let judge = judge_runtime_json base_path in
+  let judgments =
+    Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit:20
+  in
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
@@ -417,6 +423,7 @@ let dashboard_json ~base_path ~limit ~offset ~status_filter =
       ("items", `List items);
       ("activity", `List activity);
       ("judge", judge);
+      ("judgments", `List judgments);
       ("pending_actions", `List pending_actions);
       ("cases", `List items);
     ]

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -69,7 +69,7 @@ let cache_ttl_sec () = float_of_int (interval_sec () * 2)
 
 let enabled () = Env_config.Dashboard_config.governance_judge_enabled
 
-let keeper_name = "operator-judge"
+let keeper_name = "governance-judge"
 
 let get_state base_path =
   with_outer_rw (fun () ->
@@ -149,6 +149,20 @@ let latest_judgments base_path =
   with_lock st (fun () ->
       if Hashtbl.length st.judgments = 0 then st.judgments <- load_latest_from_disk base_path;
       Hashtbl.to_seq_values st.judgments |> List.of_seq)
+
+let fresh_judgments_json ~base_path ~limit =
+  let now = Unix.gettimeofday () in
+  latest_judgments base_path
+  |> List.filter (fun j ->
+    match j |> member "expires_at" |> to_string_option with
+    | Some iso ->
+      (match Dashboard_utils.parse_iso_opt (Some iso) with
+       | Some ts -> ts > now
+       | None -> false)
+    | None -> false)
+  |> List.sort (fun a b ->
+    Float.compare (judgment_generated_at b) (judgment_generated_at a))
+  |> List.filteri (fun i _ -> i < limit)
 
 let runtime_status base_path =
   let st = get_state base_path in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -158,8 +158,8 @@ let fresh_judgments_json ~base_path ~limit =
     | Some iso ->
       (match Dashboard_utils.parse_iso_opt (Some iso) with
        | Some ts -> ts > now
-       | None -> false)
-    | None -> false)
+       | None -> true)
+    | None -> true)
   |> List.sort (fun a b ->
     Float.compare (judgment_generated_at b) (judgment_generated_at a))
   |> List.filteri (fun i _ -> i < limit)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -138,9 +138,10 @@ let start_keeper_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
     | Ok schemas -> schemas
     | Error _ -> []
   in
-  let judge_dispatch ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
+  let make_judge_dispatch ~actor ~(name : string) ~(args : Yojson.Safe.t)
+      : bool * string =
     let config = state.room_config in
-    let agent_name = "operator-judge" in
+    let agent_name = actor in
     let ctx_room : Tool_room.context = { config; agent_name } in
     let ctx_task : Tool_task.context = { config; agent_name; sw = Some sw } in
     let ctx_agent : Tool_agent.context = { config; agent_name } in
@@ -161,10 +162,12 @@ let start_keeper_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
         Tool_board.handle_tool name args
     | _ -> (false, Printf.sprintf "judge: tool '%s' not allowed" name)
   in
+  let governance_judge_dispatch = make_judge_dispatch ~actor:"governance-judge" in
+  let operator_judge_dispatch = make_judge_dispatch ~actor:"operator-judge" in
   fork_subsystem "governance_judge" (fun () ->
     Dashboard_governance_judge.start ~sw ~clock
       ~base_path:state.room_config.base_path
-      ~masc_tools:judge_masc_tools ~dispatch:judge_dispatch
+      ~masc_tools:judge_masc_tools ~dispatch:governance_judge_dispatch
       ~build_facts:(fun () ->
         Dashboard_governance.factual_snapshot_json
           ~base_path:state.room_config.base_path)
@@ -181,7 +184,7 @@ let start_keeper_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
       }
     in
     Dashboard_operator_judge.start ~sw ~clock ~config:state.room_config
-      ~masc_tools:judge_masc_tools ~dispatch:judge_dispatch
+      ~masc_tools:judge_masc_tools ~dispatch:operator_judge_dispatch
       ~build_facts:(fun () ->
         Operator_control.snapshot_json ~actor:"operator-judge" ~view:"summary"
           ~include_messages:false ~include_keepers:false operator_judge_ctx)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -169,8 +169,11 @@ let start_keeper_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
       ~base_path:state.room_config.base_path
       ~masc_tools:judge_masc_tools ~dispatch:governance_judge_dispatch
       ~build_facts:(fun () ->
-        Dashboard_governance.factual_snapshot_json
-          ~base_path:state.room_config.base_path)
+        let base = Dashboard_governance.factual_snapshot_json
+          ~base_path:state.room_config.base_path in
+        let agents = Room.get_agents_status state.room_config in
+        Operator_control_snapshot.merge_json_objects base
+          (`Assoc [("agents", agents)]))
       ());
   fork_subsystem "operator_judge" (fun () ->
     let operator_judge_ctx : _ Operator_control.context =

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -56,8 +56,14 @@ let test_empty_governance_structure () =
       let activity = json |> member "activity" |> to_list in
       check int "activity empty" 0 (List.length activity);
       let judge = json |> member "judge" in
-      check bool "judge has judge_online bool" true
-        (match judge |> member "judge_online" with `Bool _ -> true | _ -> false);
+      check bool "judge_online is false when no judge started" false
+        (judge |> member "judge_online" |> to_bool);
+      check string "keeper_name is governance-judge" "governance-judge"
+        (judge |> member "keeper_name" |> to_string);
+      check bool "model_used is null when no judge started" true
+        (judge |> member "model_used" = `Null);
+      let judgments = json |> member "judgments" |> to_list in
+      check int "judgments empty" 0 (List.length judgments);
       let pending = json |> member "pending_actions" |> to_list in
       check int "pending_actions empty" 0 (List.length pending))
 


### PR DESCRIPTION
## Summary

- 거버넌스 대시보드가 하드코딩된 `judge_online: true`를 반환하여 실제 judge 상태를 은폐하던 문제 수정
- LLM judge가 생산한 judgments를 대시보드 API에 노출하는 소비 경로 추가
- governance judge와 operator judge의 identity 분리

## Changes

### Backend (OCaml)
- `dashboard_governance.ml`: `judge_runtime_json` → `Dashboard_governance_judge.runtime_status` 실제 값 반영
- `dashboard_governance_judge.ml`: `keeper_name` "operator-judge" → "governance-judge", `fresh_judgments_json` 함수 추가 (expires_at freshness filter + generated_at desc sort + limit cap)
- `server_bootstrap_loops.ml`: `make_judge_dispatch ~actor` 패턴으로 governance/operator judge dispatch 분리
- `dashboard_governance.ml`: `dashboard_json`에 `"judgments"` 키 추가

### Frontend (TypeScript)
- `dashboard-execution.ts`: `DashboardGovernanceResponse`에 `judgments` 필드
- `board.ts`: `normalizeGovernanceJudgment` export
- `dashboard.ts`: `raw.judgments` 파싱
- `governance.ts`: `JudgmentsSection` 컴포넌트, empty state 기준 수정

### Tests
- `test_dashboard_governance.ml`: judge_online=false, keeper_name identity, judgments 키 존재 확인

## Closes

- Closes #3816
- Closes #3817

## Remaining (separate PRs)

- #3818 — 프롬프트 스키마 정렬 + facts 보강 (Phase 3)
- #3819 — Pipeline → V2 자동 petition (Phase 4)

## Test plan

- [x] `dune build --root .` 통과
- [x] `test_dashboard_governance.exe` 2/2 통과
- [x] `test_governance_pipeline.exe` 57/57 통과
- [x] TypeScript `tsc --noEmit` 통과
- [ ] 서버 재시작 후 `/api/v1/dashboard/governance` 에서 `judge.judge_online` 실제 상태 확인
- [ ] `judge.keeper_name == "governance-judge"` 확인