### PR TITLE
refactor(relay): delegate model context to OAS Provider_registry

### DIFF
--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -81,9 +81,42 @@ let get_calibration_info () =
     ("enabled", `Bool (Env_config_core.relay_calibration_enabled ()));
   ]
 
-(** Estimate context usage based on heuristics *)
+(** Resolve max context tokens from OAS Provider_registry / Capabilities (SSOT).
+    Resolution order:
+    1. Capabilities.for_model_id — per-model override (e.g. "claude-opus-4-6" -> 1M)
+    2. Provider_registry.find — provider-level default (e.g. "claude" -> 200K)
+    3. 100_000 conservative fallback *)
+let resolve_max_context model =
+  (* Layer 1: per-model capabilities (e.g. "claude-opus-4-6" -> 1M) *)
+  let from_caps =
+    match Llm_provider.Capabilities.for_model_id model with
+    | Some caps -> caps.Llm_provider.Capabilities.max_context_tokens
+    | None -> None
+  in
+  match from_caps with
+  | Some n -> n
+  | None ->
+    let registry = Llm_provider.Provider_registry.default () in
+    (* Layer 2: exact provider name lookup (e.g. "claude" -> 200K) *)
+    (match Llm_provider.Provider_registry.find registry model with
+     | Some entry -> entry.Llm_provider.Provider_registry.max_context
+     | None ->
+       (* Layer 3: extract base provider from hyphenated name
+          e.g. "claude-opus" -> "claude", "gpt-4o" -> registry lookup "gpt" *)
+       let base =
+         match String.index_opt model '-' with
+         | Some idx when idx > 0 -> String.sub model 0 idx
+         | _ -> ""
+       in
+       if base <> "" then
+         match Llm_provider.Provider_registry.find registry base with
+         | Some entry -> entry.Llm_provider.Provider_registry.max_context
+         | None -> 100_000
+       else 100_000)
+
+(** Estimate context usage.
+    Token-per-message estimates are rough heuristics, corrected by calibration. *)
 let estimate_context ~messages ~tool_calls ~model =
-  (* Rough token estimates per message type *)
   let tokens_per_user_msg = 150 in
   let tokens_per_assistant_msg = 500 in
   let tokens_per_tool_call = 200 in
@@ -95,14 +128,7 @@ let estimate_context ~messages ~tool_calls ~model =
   let factor = calibration.correction_factor in
   let estimated = int_of_float (float_of_int estimated_raw *. factor) in
 
-  (* Model-specific max context *)
-  let max_tokens = match model with
-    | "claude" | "claude-sonnet" -> 200000
-    | "claude-opus" -> 200000
-    | "gemini" -> 1000000
-    | "codex" | "gpt" -> 128000
-    | _ -> 100000  (* conservative default *)
-  in
+  let max_tokens = resolve_max_context model in
 
   {
     estimated_tokens = estimated;

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -68,12 +68,15 @@ let test_estimate_context_gemini () =
   check int "max tokens gemini" 1000000 m.max_tokens
 
 let test_estimate_context_codex () =
+  (* "codex" not in OAS Provider_registry; conservative fallback.
+     TODO: register "openai" provider in OAS to cover codex/gpt. *)
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"codex" in
-  check int "max tokens codex" 128000 m.max_tokens
+  check int "max tokens codex" 100000 m.max_tokens
 
 let test_estimate_context_gpt () =
+  (* "gpt" not in OAS Provider_registry; same as codex. *)
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"gpt" in
-  check int "max tokens gpt" 128000 m.max_tokens
+  check int "max tokens gpt" 100000 m.max_tokens
 
 let test_estimate_context_claude_opus () =
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"claude-opus" in


### PR DESCRIPTION
## Summary
- relay.ml의 hardcoded model->context_size match를 OAS Provider_registry + Capabilities 3-layer resolution으로 대체
- codex/gpt는 OAS registry 미등록 상태로 100K fallback (별도 추적)
- 72 relay tests green

## Product Impact
relay 판단이 OAS의 최신 모델 데이터를 자동 반영. 모델 추가/변경 시 MASC 코드 수정 불필요.

## Evidence
- dune build: green
- test/test_relay_coverage.exe: 72 tests, 0 failures
- claude-opus, claude-sonnet: Layer 3 hyphen-split -> "claude" -> 200K (기존 동일)
- codex/gpt: 128K -> 100K (OAS registry 미등록. TODO: OAS에 openai provider 등록)

## Review Evidence
- GLM-5 (sb glm-text) cross-model review 2026-03-30: 5건 중 해당 2건
  - #1 hyphen-split 우려: Layer 1 Capabilities.for_model_id가 먼저 해결하므로 실제 위험 낮음
  - #2 test mock 부재: 유효 P2. 현재 integration test로 동작 확인됨

## ADR
docs/design/adr-masc-oas-boundary-ssot.md D1

Refs jeong-sik/me#915