### PR TITLE
refactor(keeper): split keeper_meta into domain/policy + agent_runtime_state

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -53,27 +53,27 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             |> Option.value ~default:0.0
           in
           let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-          let last_turn_ago_s = if m.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.usage.last_turn_ts in
+          let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
           let last_handoff_ago_s =
-            if m.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.last_handoff_ts
+            if m.runtime.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.runtime.last_handoff_ts
           in
           let last_compaction_ago_s =
-            if m.compaction.last_ts <= 0.0 then 0.0 else now_ts -. m.compaction.last_ts
+            if m.runtime.compaction_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.compaction_rt.last_ts
           in
           let last_proactive_ago_s =
-            if m.proactive.last_ts <= 0.0 then 0.0 else now_ts -. m.proactive.last_ts
+            if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
           in
           (* C-3 fix: compute last_activity from the most recent activity timestamp
              to avoid showing misleading staleness when agent is actually active *)
           let last_activity_ts =
             List.fold_left max 0.0
-              [ m.usage.last_turn_ts; m.proactive.last_ts; m.last_handoff_ts;
-                m.compaction.last_ts; created_ts ]
+              [ m.runtime.usage.last_turn_ts; m.runtime.proactive_rt.last_ts; m.runtime.last_handoff_ts;
+                m.runtime.compaction_rt.last_ts; created_ts ]
           in
           let last_activity_ago_s =
             if last_activity_ts <= 0.0 then 0.0 else now_ts -. last_activity_ts
           in
-          let trace_history_count = List.length m.trace_history in
+          let trace_history_count = List.length m.runtime.trace_history in
           let active_model = Keeper_exec_status.active_model_of_meta m in
           let next_model_hint = Keeper_exec_status.next_model_hint_of_meta m in
           let cascade_models =
@@ -86,7 +86,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           in
           let primary_model_norm = normalize_model_name primary_model in
           let last_compaction_saved_tokens =
-            max 0 (m.compaction.last_before_tokens - m.compaction.last_after_tokens)
+            max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
           in
 
           let metrics_store = Keeper_types.keeper_metrics_store config m.name in
@@ -146,7 +146,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
 
           let (metrics_series_items, metrics_window_summary, last_handoff_event, last_compaction_event) =
             compute_metrics_window
-              ~parsed_metrics ~generation:m.generation ~compact ~series_points
+              ~parsed_metrics ~generation:m.runtime.generation ~compact ~series_points
               ~metrics_window_max_bytes ~primary_model_norm ~primary_model
           in
           let metrics_series = `List metrics_series_items in
@@ -186,7 +186,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           in
           let history_path =
             Filename.concat
-              (Filename.concat (Keeper_types.session_base_dir config) m.trace_id)
+              (Filename.concat (Keeper_types.session_base_dir config) m.runtime.trace_id)
               "history.jsonl"
           in
           let ( conversation_tail,
@@ -267,7 +267,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
-                         ~trace_id:m.trace_id
+                         ~trace_id:m.runtime.trace_id
                          ~primary_model_max_tokens:primary_max_context
                          ~base_dir
                      in
@@ -349,8 +349,8 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));
-              ("trace_id", `String m.trace_id);
-              ("generation", `Int m.generation);
+              ("trace_id", `String m.runtime.trace_id);
+              ("generation", `Int m.runtime.generation);
               ("created_at", `String m.created_at);
               ("updated_at", `String m.updated_at);
               ("trace_history_count", `Int trace_history_count);
@@ -399,19 +399,19 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("last_proactive_ago_s", `Float last_proactive_ago_s);
               ("last_activity_ago_s", `Float last_activity_ago_s);
               ("handoff_count_total", `Int trace_history_count);
-              ("total_turns", `Int m.usage.total_turns);
-              ("total_input_tokens", `Int m.usage.total_input_tokens);
-              ("total_output_tokens", `Int m.usage.total_output_tokens);
-              ("total_tokens", `Int m.usage.total_tokens);
-              ("total_cost_usd", `Float m.usage.total_cost_usd);
-              ("last_model_used", `String m.usage.last_model_used);
+              ("total_turns", `Int m.runtime.usage.total_turns);
+              ("total_input_tokens", `Int m.runtime.usage.total_input_tokens);
+              ("total_output_tokens", `Int m.runtime.usage.total_output_tokens);
+              ("total_tokens", `Int m.runtime.usage.total_tokens);
+              ("total_cost_usd", `Float m.runtime.usage.total_cost_usd);
+              ("last_model_used", `String m.runtime.usage.last_model_used);
               ("last_usage", `Assoc [
-                ("input_tokens", `Int m.usage.last_input_tokens);
-                ("output_tokens", `Int m.usage.last_output_tokens);
-                ("total_tokens", `Int m.usage.last_total_tokens);
+                ("input_tokens", `Int m.runtime.usage.last_input_tokens);
+                ("output_tokens", `Int m.runtime.usage.last_output_tokens);
+                ("total_tokens", `Int m.runtime.usage.last_total_tokens);
               ]);
-              ("last_latency_ms", `Int m.usage.last_latency_ms);
-              ("compaction_count", `Int m.compaction.count);
+              ("last_latency_ms", `Int m.runtime.usage.last_latency_ms);
+              ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ("compaction_profile", `String m.compaction.profile);
               ("compaction_ratio_gate", `Float compact_ratio_gate);
@@ -420,23 +420,23 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
-              ("proactive_count_total", `Int m.proactive.count_total);
-              ("autonomous_turn_count", `Int m.autonomous_turn_count);
-              ("autonomous_text_turn_count", `Int m.autonomous_text_turn_count);
-              ("autonomous_tool_turn_count", `Int m.autonomous_tool_turn_count);
-              ("board_reactive_turn_count", `Int m.board_reactive_turn_count);
-              ("mention_reactive_turn_count", `Int m.mention_reactive_turn_count);
-              ("noop_turn_count", `Int m.noop_turn_count);
-              ("autonomous_action_count", `Int m.autonomous_action_count);
-              ("last_proactive_ts", `Float m.proactive.last_ts);
+              ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
+              ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
+              ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
+              ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);
+              ("board_reactive_turn_count", `Int m.runtime.board_reactive_turn_count);
+              ("mention_reactive_turn_count", `Int m.runtime.mention_reactive_turn_count);
+              ("noop_turn_count", `Int m.runtime.noop_turn_count);
+              ("autonomous_action_count", `Int m.runtime.autonomous_action_count);
+              ("last_proactive_ts", `Float m.runtime.proactive_rt.last_ts);
               ("last_proactive_reason",
-                if String.trim m.proactive.last_reason = ""
+                if String.trim m.runtime.proactive_rt.last_reason = ""
                 then `Null
-                else `String m.proactive.last_reason);
+                else `String m.runtime.proactive_rt.last_reason);
 	              ("last_proactive_preview",
-	                if String.trim m.proactive.last_preview = ""
+	                if String.trim m.runtime.proactive_rt.last_preview = ""
 	                then `Null
-	                else `String m.proactive.last_preview);
+	                else `String m.runtime.proactive_rt.last_preview);
 	              ("skill_primary",
 	                match last_skill_primary with
 	                | Some s -> `String s
@@ -593,24 +593,24 @@ let keeper_config_json (config : Room.config) (name : string)
       in
       let metrics =
         `Assoc [
-          ("generation", `Int m.generation);
-          ("total_turns", `Int m.usage.total_turns);
-          ("total_input_tokens", `Int m.usage.total_input_tokens);
-          ("total_output_tokens", `Int m.usage.total_output_tokens);
-          ("total_tokens", `Int m.usage.total_tokens);
-          ("total_cost_usd", `Float m.usage.total_cost_usd);
-          ("last_model_used", `String m.usage.last_model_used);
-          ("last_input_tokens", `Int m.usage.last_input_tokens);
-          ("last_output_tokens", `Int m.usage.last_output_tokens);
-          ("last_total_tokens", `Int m.usage.last_total_tokens);
-          ("last_latency_ms", `Int m.usage.last_latency_ms);
+          ("generation", `Int m.runtime.generation);
+          ("total_turns", `Int m.runtime.usage.total_turns);
+          ("total_input_tokens", `Int m.runtime.usage.total_input_tokens);
+          ("total_output_tokens", `Int m.runtime.usage.total_output_tokens);
+          ("total_tokens", `Int m.runtime.usage.total_tokens);
+          ("total_cost_usd", `Float m.runtime.usage.total_cost_usd);
+          ("last_model_used", `String m.runtime.usage.last_model_used);
+          ("last_input_tokens", `Int m.runtime.usage.last_input_tokens);
+          ("last_output_tokens", `Int m.runtime.usage.last_output_tokens);
+          ("last_total_tokens", `Int m.runtime.usage.last_total_tokens);
+          ("last_latency_ms", `Int m.runtime.usage.last_latency_ms);
           ( "last_total_tokens_per_sec",
-            tokens_per_sec_json ~tokens:m.usage.last_total_tokens
-              ~latency_ms:m.usage.last_latency_ms );
+            tokens_per_sec_json ~tokens:m.runtime.usage.last_total_tokens
+              ~latency_ms:m.runtime.usage.last_latency_ms );
           ( "last_output_tokens_per_sec",
-            tokens_per_sec_json ~tokens:m.usage.last_output_tokens
-              ~latency_ms:m.usage.last_latency_ms );
-          ("compaction_count", `Int m.compaction.count);
+            tokens_per_sec_json ~tokens:m.runtime.usage.last_output_tokens
+              ~latency_ms:m.runtime.usage.last_latency_ms );
+          ("compaction_count", `Int m.runtime.compaction_rt.count);
         ]
       in
       let now_ts = Time_compat.now () in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -103,12 +103,12 @@ let run_turn
      exist before any file I/O (checkpoint load, history persist).
      In filesystem fallback mode (PG unavailable), these directories may
      not have been created by keeper_up if it only registered in-memory. *)
-  let session_dir = Filename.concat base_dir meta.trace_id in
+  let session_dir = Filename.concat base_dir meta.runtime.trace_id in
   Keeper_types.mkdir_p session_dir;
   (* 2. Load checkpoint *)
   let (session, ctx_opt) =
     Keeper_exec_context.load_context_from_checkpoint
-      ~trace_id:meta.trace_id
+      ~trace_id:meta.runtime.trace_id
       ~primary_model_max_tokens:max_context
       ~base_dir
   in
@@ -178,7 +178,7 @@ let run_turn
     Memory_oas_bridge.create_memory_full
       ~agent_name
       ~base_dir
-      ~session_id:meta.trace_id
+      ~session_id:meta.runtime.trace_id
       ~config
       ~episode_limit:30
       ~procedure_limit:10
@@ -201,7 +201,7 @@ let run_turn
     Oas_worker.run_named
       ~cascade_name
       ~goal:user_message
-      ~session_id:meta.trace_id
+      ~session_id:meta.runtime.trace_id
       ~system_prompt:turn_system_prompt
       ~tools
       ~initial_messages:history_messages
@@ -229,7 +229,7 @@ let run_turn
               checkpoint on the next turn. oas_worker generates a per-turn
               session_id that differs from trace_id, causing a load miss. *)
            let checkpoint =
-             { checkpoint with Agent_sdk.Checkpoint.session_id = meta.trace_id }
+             { checkpoint with Agent_sdk.Checkpoint.session_id = meta.runtime.trace_id }
            in
            Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
              checkpoint

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -216,7 +216,7 @@ let keeper_alert_text
      - response_alignment: %.2f\n\
      - user: %s\n\
      - reply: %s"
-    meta.name score meta.trace_id meta.generation work_kind
+    meta.name score meta.runtime.trace_id meta.runtime.generation work_kind
     reason_text keyword_text context_ratio goal_alignment response_alignment
     message_preview reply_preview
 
@@ -449,7 +449,7 @@ let maybe_emit_interesting_alert
       }
     else
       let now_ts = Time_compat.now () in
-      let alert_id = Printf.sprintf "%s-%d" meta.trace_id (int_of_float (now_ts *. 1000.0)) in
+      let alert_id = Printf.sprintf "%s-%d" meta.runtime.trace_id (int_of_float (now_ts *. 1000.0)) in
       let alert_text =
         keeper_alert_text
           ~meta
@@ -470,8 +470,8 @@ let maybe_emit_interesting_alert
           ("alert_id", `String alert_id);
           ("name", `String meta.name);
           ("agent_name", `String meta.agent_name);
-          ("trace_id", `String meta.trace_id);
-          ("generation", `Int meta.generation);
+          ("trace_id", `String meta.runtime.trace_id);
+          ("generation", `Int meta.runtime.generation);
           ("score", `Float score);
           ("threshold", `Float threshold);
           ("reasons", `List (List.map (fun s -> `String s) reasons));

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -83,7 +83,7 @@ let context_of_legacy_checkpoint
 
 let checkpoint_model_of_meta (meta : keeper_meta) =
   let candidates =
-    meta.usage.last_model_used
+    meta.runtime.usage.last_model_used
     :: Oas_model_resolve.models_of_cascade_name meta.cascade_name
   in
   List.find_opt (fun value -> String.trim value <> "") candidates
@@ -160,16 +160,16 @@ let maybe_rollover_oas_handoff
   | Some cp ->
       let ctx = context_of_oas_checkpoint cp ~primary_model_max_tokens in
       let current_generation =
-        sidecar_generation cp ~fallback:meta.generation
+        sidecar_generation cp ~fallback:meta.runtime.generation
       in
       let base_meta =
-        if current_generation = meta.generation then meta
-        else { meta with generation = current_generation }
+        if current_generation = meta.runtime.generation then meta
+        else map_runtime (fun rt -> { rt with generation = current_generation }) meta
       in
       let ratio = context_ratio ctx in
       let cooldown_elapsed =
-        base_meta.last_handoff_ts <= 0.0
-        || Time_compat.now () -. base_meta.last_handoff_ts
+        base_meta.runtime.last_handoff_ts <= 0.0
+        || Time_compat.now () -. base_meta.runtime.last_handoff_ts
            >= float_of_int base_meta.handoff_cooldown_sec
       in
       let rollover_base =
@@ -190,7 +190,7 @@ let maybe_rollover_oas_handoff
         rollover_base
       else
         let now_ts = Time_compat.now () in
-        let prev_trace_id = base_meta.trace_id in
+        let prev_trace_id = base_meta.runtime.trace_id in
         let new_trace_id = Keeper_identity.generate_trace_id () in
         let next_generation = current_generation + 1 in
         let new_session =
@@ -204,12 +204,14 @@ let maybe_rollover_oas_handoff
           let updated_meta =
             {
               base_meta with
-              trace_id = new_trace_id;
-              trace_history =
-                dedupe_keep_order (prev_trace_id :: base_meta.trace_history);
-              generation = next_generation;
-              last_handoff_ts = now_ts;
               updated_at = now_iso ();
+              runtime = { base_meta.runtime with
+                trace_id = new_trace_id;
+                trace_history =
+                  dedupe_keep_order (prev_trace_id :: base_meta.runtime.trace_history);
+                generation = next_generation;
+                last_handoff_ts = now_ts;
+              };
             }
           in
           let handoff_json =
@@ -292,7 +294,7 @@ let compact_if_needed
   let token_count = ctx.token_count in
   let ratio_gate, message_gate, token_gate = compaction_policy_of_keeper meta in
   let cooldown = Float.of_int meta.compaction.cooldown_sec in
-  let last_reflection_ts = max meta.last_continuity_update_ts meta.proactive.last_ts in
+  let last_reflection_ts = max meta.runtime.last_continuity_update_ts meta.runtime.proactive_rt.last_ts in
   let reflection_ready =
     last_reflection_ts > 0.0 && now_ts -. last_reflection_ts >= cooldown
   in
@@ -524,7 +526,7 @@ let run_proactive_generation
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
   in
   let max_attempts = Env_config.KeeperProactive.max_attempts in
-  let previous_preview = String.trim meta.proactive.last_preview in
+  let previous_preview = String.trim meta.runtime.proactive_rt.last_preview in
   let similarity_threshold = Keeper_config.keeper_proactive_similarity_threshold () in
   let fallback_skill_route =
     route_keeper_skill ~soul_profile:meta.soul_profile ~message:"proactive idle automation checkin"

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -5,7 +5,7 @@
 open Keeper_types
 
 let active_model_of_meta (m : keeper_meta) : string =
-  if m.usage.last_model_used <> "" then m.usage.last_model_used
+  if m.runtime.usage.last_model_used <> "" then m.runtime.usage.last_model_used
   else
     match Oas_model_resolve.models_of_cascade_name m.cascade_name with
     | model :: _ -> model
@@ -162,7 +162,7 @@ let keeper_reply_snapshot_of_history (history_items : Yojson.Safe.t list) =
 let keeper_error_hint ~agent_status ~meta =
   let agent_error = json_string_opt "error" agent_status in
   let proactive_reason =
-    let reason = String.trim meta.proactive.last_reason in
+    let reason = String.trim meta.runtime.proactive_rt.last_reason in
     if reason = "" then None else Some reason
   in
   let drift_reason = None in

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -207,7 +207,7 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
     || agent_status_text = "offline"
     || agent_status_text = "inactive"
   then Some "agent_missing"
-  else if meta.usage.total_turns = 0 && meta.proactive.count_total = 0 then
+  else if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then
     let keeper_age_s =
       match Resilience.Time.parse_iso8601_opt meta.created_at with
       | Some created_ts when created_ts > 0.0 -> max 0.0 (now_ts -. created_ts)
@@ -228,12 +228,12 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
     | Some _ -> Some "unknown"
     | None ->
         let last_turn_ago_s =
-          if meta.usage.last_turn_ts <= 0.0 then None
-          else Some (max 0.0 (now_ts -. meta.usage.last_turn_ts))
+          if meta.runtime.usage.last_turn_ts <= 0.0 then None
+          else Some (max 0.0 (now_ts -. meta.runtime.usage.last_turn_ts))
         in
         let last_proactive_ago_s =
-          if meta.proactive.last_ts <= 0.0 then None
-          else Some (max 0.0 (now_ts -. meta.proactive.last_ts))
+          if meta.runtime.proactive_rt.last_ts <= 0.0 then None
+          else Some (max 0.0 (now_ts -. meta.runtime.proactive_rt.last_ts))
         in
         if meta.proactive.enabled then
           match last_proactive_ago_s with
@@ -265,8 +265,8 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   let is_zombie = json_bool "is_zombie" agent_status false in
   let stale_threshold_s = 120.0 in
   let last_turn_ago_s =
-    if meta.usage.last_turn_ts <= 0.0 then max_float
-    else max 0.0 (now_ts -. meta.usage.last_turn_ts)
+    if meta.runtime.usage.last_turn_ts <= 0.0 then max_float
+    else max 0.0 (now_ts -. meta.runtime.usage.last_turn_ts)
   in
   if not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive"
   then "offline"
@@ -279,7 +279,7 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
     match quiet_reason with
     | Some "graphql_error" | Some "model_error" -> "degraded"
     | _ ->
-        if meta.usage.total_turns = 0 && meta.proactive.count_total = 0 then "idle"
+        if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then "idle"
         else if last_turn_ago_s > float_of_int (max meta.proactive.idle_sec 900)
         then "idle"
         else "healthy"
@@ -300,9 +300,9 @@ let keeper_next_action_path ~health_state ~quiet_reason =
 
 let keeper_next_eligible_at_s ~meta ~quiet_reason ~now_ts =
   match quiet_reason with
-  | Some "min_gap" when meta.proactive.last_ts > 0.0 ->
+  | Some "min_gap" when meta.runtime.proactive_rt.last_ts > 0.0 ->
       let remaining =
-        float_of_int meta.proactive.cooldown_sec -. (now_ts -. meta.proactive.last_ts)
+        float_of_int meta.proactive.cooldown_sec -. (now_ts -. meta.runtime.proactive_rt.last_ts)
       in
       if remaining > 0.0 then `Float remaining else `Null
   | _ -> `Null
@@ -475,20 +475,20 @@ let derive_pipeline_stage
   else
     let recency_threshold = 30.0 in
     let turn_ago =
-      if meta.usage.last_turn_ts <= 0.0 then Float.infinity
-      else now_ts -. meta.usage.last_turn_ts
+      if meta.runtime.usage.last_turn_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.runtime.usage.last_turn_ts
     in
     let compaction_ago =
-      if meta.compaction.last_ts <= 0.0 then Float.infinity
-      else now_ts -. meta.compaction.last_ts
+      if meta.runtime.compaction_rt.last_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.runtime.compaction_rt.last_ts
     in
     let handoff_ago =
-      if meta.last_handoff_ts <= 0.0 then Float.infinity
-      else now_ts -. meta.last_handoff_ts
+      if meta.runtime.last_handoff_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.runtime.last_handoff_ts
     in
     let proactive_ago =
-      if meta.proactive.last_ts <= 0.0 then Float.infinity
-      else now_ts -. meta.proactive.last_ts
+      if meta.runtime.proactive_rt.last_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.runtime.proactive_rt.last_ts
     in
     (* Pick the most recent activity within the recency window.
        Priority order when multiple are recent: handoff > compacting > proactive > thinking *)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -205,13 +205,13 @@ let execute_keeper_tool_call
         (`Assoc
           [
             ("name", `String meta.name);
-            ("trace_id", `String meta.trace_id);
-            ("generation", `Int meta.generation);
+            ("trace_id", `String meta.runtime.trace_id);
+            ("generation", `Int meta.runtime.generation);
             ("context_ratio", `Float (Keeper_working_context.context_ratio ctx_work));
             ("context_tokens", `Int ctx_work.token_count);
             ("context_max", `Int ctx_work.max_tokens);
             ("message_count", `Int (List.length ctx_work.messages));
-            ("last_model_used", `String meta.usage.last_model_used);
+            ("last_model_used", `String meta.runtime.usage.last_model_used);
             ( "continuity_state",
               match continuity with
               | None -> `Null

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -278,10 +278,10 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  in
                  let base_dir = session_base_dir ctx.config in
                  (* Ensure session directory tree for filesystem fallback (issue #3019) *)
-                 ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.trace_id));
+                 ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));
                  let _session, ctx_opt =
                    load_context_from_checkpoint
-                     ~trace_id:meta_current.trace_id
+                     ~trace_id:meta_current.runtime.trace_id
                      ~primary_model_max_tokens:primary_max_context
                      ~base_dir
                  in
@@ -341,9 +341,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                            ("channel", `String "heartbeat");
                            ("name", `String meta_current.name);
                            ("agent_name", `String meta_current.agent_name);
-                           ("trace_id", `String meta_current.trace_id);
-                           ("generation", `Int meta_current.generation);
-                           ("model_used", `String meta_current.usage.last_model_used);
+                           ("trace_id", `String meta_current.runtime.trace_id);
+                           ("generation", `Int meta_current.runtime.generation);
+                           ("model_used", `String meta_current.runtime.usage.last_model_used);
                            ( "usage",
                              `Assoc
                                [
@@ -401,7 +401,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                             [
                               ("type", `String "keeper_heartbeat");
                               ("name", `String meta_current.name);
-                              ("generation", `Int meta_current.generation);
+                              ("generation", `Int meta_current.runtime.generation);
                               ( "context_ratio",
                                 `Float (Keeper_exec_context.context_ratio c) );
                               ("ts_unix", `Float now_ts);
@@ -416,7 +416,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                       | Some bus ->
                           Oas_events.publish_keeper_snapshot bus
                             ~keeper_name:meta_current.name
-                            ~generation:meta_current.generation
+                            ~generation:meta_current.runtime.generation
                             ~context_ratio:(Keeper_exec_context.context_ratio c)
                             ~message_count:(List.length c.messages)
                       | None -> ());
@@ -477,7 +477,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                        Keeper_unified_turn.run_unified_turn
                          ~config:ctx.config ~meta:meta_after_triage
                          ~observation:obs
-                         ~generation:meta_after_triage.generation
+                         ~generation:meta_after_triage.runtime.generation
                      with
                      | Error e ->
                          Log.Keeper.error "unified turn failed: %s" e;

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -414,8 +414,8 @@ let append_memory_notes_from_reply
               ("ts", `String (now_iso ()));
               ("ts_unix", `Float now_ts);
               ("name", `String meta.name);
-              ("trace_id", `String meta.trace_id);
-              ("generation", `Int meta.generation);
+              ("trace_id", `String meta.runtime.trace_id);
+              ("generation", `Int meta.runtime.generation);
               ("turn", `Int turn);
               ("soul_profile", `String meta.soul_profile);
               ("kind", `String kind);

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -175,7 +175,7 @@ let keeper_policy_observation_of_room_message
     if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
   in
   let last_turn_ago_s =
-    if meta.usage.last_turn_ts <= 0.0 then 0.0 else max 0.0 (now_ts -. meta.usage.last_turn_ts)
+    if meta.runtime.usage.last_turn_ts <= 0.0 then 0.0 else max 0.0 (now_ts -. meta.runtime.usage.last_turn_ts)
   in
   {
     source_kind = "room_message";
@@ -185,7 +185,7 @@ let keeper_policy_observation_of_room_message
     direct_mention = Mention.any_mentioned ~targets:mention_targets msg.content;
     has_question = observation_has_question msg.content;
     message_chars = String.length msg.content;
-    total_turns = meta.usage.total_turns;
+    total_turns = meta.runtime.usage.total_turns;
     active_goal_count = List.length meta.active_goal_ids;
     joined_room_count = List.length meta.joined_room_ids;
     room_scope = Keeper_contract.room_scope_of_string meta.room_scope;

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -173,8 +173,8 @@ let proactive_prompt_for_keeper
     |> Option.value ~default:default_soul_profile
   in
   let last_preview =
-    if String.trim meta.proactive.last_preview = "" then "none"
-    else meta.proactive.last_preview
+    if String.trim meta.runtime.proactive_rt.last_preview = "" then "none"
+    else meta.runtime.proactive_rt.last_preview
   in
   let continuity_snapshot =
     match snapshot with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -83,8 +83,8 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
               else
               let stale_now =
                 stale_turn_sec > 0.0
-                && (m.usage.last_turn_ts <= 0.0
-                    || now_ts -. m.usage.last_turn_ts >= stale_turn_sec)
+                && (m.runtime.usage.last_turn_ts <= 0.0
+                    || now_ts -. m.runtime.usage.last_turn_ts >= stale_turn_sec)
               in
               let already_running =
                 Keeper_registry.is_running ~base_path:ctx.config.base_path m.name

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -48,15 +48,15 @@ let handle_keeper_list ctx args : tool_result =
               Resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
             in
             let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-            let last_turn_ago_s = if m.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.usage.last_turn_ts in
+            let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
             let last_proactive_ago_s =
-              if m.proactive.last_ts <= 0.0 then 0.0 else now_ts -. m.proactive.last_ts
+              if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
             in
             let active_model = active_model_of_meta m in
             let next_model_hint = next_model_hint_of_meta m in
-            let trace_history_count = List.length m.trace_history in
+            let trace_history_count = List.length m.runtime.trace_history in
             let last_compaction_saved_tokens =
-              max 0 (m.compaction.last_before_tokens - m.compaction.last_after_tokens)
+              max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
             in
             let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
               compaction_policy_of_keeper m
@@ -74,7 +74,7 @@ let handle_keeper_list ctx args : tool_result =
 	              | [] -> None
 	            in
 	            let metrics_overview =
-	              summarize_metrics_lines metrics_window_lines ~default_generation:m.generation
+	              summarize_metrics_lines metrics_window_lines ~default_generation:m.runtime.generation
 	            in
 	            let last_skill_metrics =
 	              let rec find_latest = function
@@ -105,7 +105,7 @@ let handle_keeper_list ctx args : tool_result =
             let continuity_reflection_hold_s =
               let cooldown = Float.of_int m.compaction.cooldown_sec in
               let last_reflection_ts =
-                max m.last_continuity_update_ts m.proactive.last_ts
+                max m.runtime.last_continuity_update_ts m.runtime.proactive_rt.last_ts
               in
               if cooldown <= 0.0 then
                 0.0
@@ -162,8 +162,8 @@ let handle_keeper_list ctx args : tool_result =
 	            Some (`Assoc [
               ("name", `String m.name);
               ("agent_name", `String m.agent_name);
-              ("trace_id", `String m.trace_id);
-              ("generation", `Int m.generation);
+              ("trace_id", `String m.runtime.trace_id);
+              ("generation", `Int m.runtime.generation);
               ("goal", `String m.goal);
               ("short_goal", `String m.short_goal);
               ("mid_goal", `String m.mid_goal);
@@ -185,7 +185,7 @@ let handle_keeper_list ctx args : tool_result =
               ("last_proactive_ago_s", `Float last_proactive_ago_s);
               ("trace_history_count", `Int trace_history_count);
               ("handoff_count_total", `Int trace_history_count);
-              ("compaction_count", `Int m.compaction.count);
+              ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ("compaction_profile", `String m.compaction.profile);
               ("compaction_ratio_gate", `Float compact_ratio_gate);
@@ -194,34 +194,34 @@ let handle_keeper_list ctx args : tool_result =
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
-              ("proactive_count_total", `Int m.proactive.count_total);
-              ("last_compaction_check_ts", `Float m.compaction.last_check_ts);
+              ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
+              ("last_compaction_check_ts", `Float m.runtime.compaction_rt.last_check_ts);
               ("last_compaction_decision",
-                if String.trim m.compaction.last_decision = "" then `Null
-                else `String m.compaction.last_decision);
-              ("last_proactive_ts", `Float m.proactive.last_ts);
+                if String.trim m.runtime.compaction_rt.last_decision = "" then `Null
+                else `String m.runtime.compaction_rt.last_decision);
+              ("last_proactive_ts", `Float m.runtime.proactive_rt.last_ts);
               ("last_proactive_reason",
-                if String.trim m.proactive.last_reason = ""
+                if String.trim m.runtime.proactive_rt.last_reason = ""
                 then `Null
-                else `String m.proactive.last_reason);
+                else `String m.runtime.proactive_rt.last_reason);
               ("last_proactive_preview",
-                if String.trim m.proactive.last_preview = ""
+                if String.trim m.runtime.proactive_rt.last_preview = ""
                 then `Null
-                else `String m.proactive.last_preview);
+                else `String m.runtime.proactive_rt.last_preview);
               ("continuity_summary",
                 if String.trim m.continuity_summary = ""
                 then `Null
                 else `String m.continuity_summary);
               ("continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec);
               ("continuity_reflection_hold_s", `Float continuity_reflection_hold_s);
-              ("last_continuity_update_ts", `Float m.last_continuity_update_ts);
-              ("autonomous_turn_count", `Int m.autonomous_turn_count);
-              ("autonomous_text_turn_count", `Int m.autonomous_text_turn_count);
-              ("autonomous_tool_turn_count", `Int m.autonomous_tool_turn_count);
-              ("board_reactive_turn_count", `Int m.board_reactive_turn_count);
-              ("mention_reactive_turn_count", `Int m.mention_reactive_turn_count);
-              ("noop_turn_count", `Int m.noop_turn_count);
-              ("autonomous_action_count", `Int m.autonomous_action_count);
+              ("last_continuity_update_ts", `Float m.runtime.last_continuity_update_ts);
+              ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
+              ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
+              ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);
+              ("board_reactive_turn_count", `Int m.runtime.board_reactive_turn_count);
+              ("mention_reactive_turn_count", `Int m.runtime.mention_reactive_turn_count);
+              ("noop_turn_count", `Int m.runtime.noop_turn_count);
+              ("autonomous_action_count", `Int m.runtime.autonomous_action_count);
               ("active_team_session_id",
                 match m.active_team_session_id with
                 | Some session_id -> `String session_id
@@ -254,8 +254,8 @@ let handle_keeper_list ctx args : tool_result =
                 ("policy", `String (keeper_policy_log_path ctx.config m.name));
                 ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
                 ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
-                ("session_dir", `String (keeper_session_dir ctx.config m.trace_id));
-                ("history", `String (keeper_history_path ctx.config m.trace_id));
+                ("session_dir", `String (keeper_session_dir ctx.config m.runtime.trace_id));
+                ("history", `String (keeper_history_path ctx.config m.runtime.trace_id));
               ]);
             ])
         ) keeper_names
@@ -278,7 +278,7 @@ let handle_keeper_trajectory ctx args : tool_result =
       let limit = get_int args "limit" 20 in
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let entries =
-        Trajectory.read_entries ~masc_root ~keeper_name:m.name ~trace_id:m.trace_id
+        Trajectory.read_entries ~masc_root ~keeper_name:m.name ~trace_id:m.runtime.trace_id
       in
       let total = List.length entries in
       (* Take the last N entries (most recent) *)
@@ -289,13 +289,13 @@ let handle_keeper_trajectory ctx args : tool_result =
           List.filteri (fun i _e -> i >= drop) entries
       in
       if recent = [] then
-        (true, Printf.sprintf "Keeper %s (trace: %s) has no trajectory entries." name m.trace_id)
+        (true, Printf.sprintf "Keeper %s (trace: %s) has no trajectory entries." name m.runtime.trace_id)
       else
         let json_list = List.map Trajectory.entry_to_json recent in
         let json = `Assoc [
           ("keeper", `String name);
-          ("trace_id", `String m.trace_id);
-          ("generation", `Int m.generation);
+          ("trace_id", `String m.runtime.trace_id);
+          ("generation", `Int m.runtime.generation);
           ("total_entries", `Int total);
           ("showing", `Int (List.length recent));
           ("entries", `List json_list);
@@ -314,7 +314,7 @@ let handle_keeper_eval ctx args : tool_result =
       let scenario_file = get_string_opt args "scenario_file" in
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let entries =
-        Trajectory.read_entries ~masc_root ~keeper_name:m.name ~trace_id:m.trace_id
+        Trajectory.read_entries ~masc_root ~keeper_name:m.name ~trace_id:m.runtime.trace_id
       in
       if entries = [] then
         (true, Printf.sprintf "Keeper %s has no trajectory data to evaluate." name)
@@ -352,15 +352,15 @@ let handle_keeper_eval ctx args : tool_result =
         in
         let json = `Assoc [
           ("keeper", `String name);
-          ("trace_id", `String m.trace_id);
-          ("generation", `Int m.generation);
-          ("total_turns", `Int m.usage.total_turns);
-          ("total_input_tokens", `Int m.usage.total_input_tokens);
-          ("total_output_tokens", `Int m.usage.total_output_tokens);
+          ("trace_id", `String m.runtime.trace_id);
+          ("generation", `Int m.runtime.generation);
+          ("total_turns", `Int m.runtime.usage.total_turns);
+          ("total_input_tokens", `Int m.runtime.usage.total_input_tokens);
+          ("total_output_tokens", `Int m.runtime.usage.total_output_tokens);
           ("total_tool_calls", `Int total);
           ("unique_tools", `Int (List.length unique_tools));
           ("tool_distribution", `List tool_stats);
           ("scenario_file", scenario_info);
-          ("autonomous_action_count", `Int m.autonomous_action_count);
+          ("autonomous_action_count", `Int m.runtime.autonomous_action_count);
         ] in
         (true, Yojson.Safe.pretty_to_string json)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -43,7 +43,7 @@ let handle_keeper_status ctx args : tool_result =
            if include_context then
              let (_session, ctx_opt) =
                load_context_from_checkpoint
-                 ~trace_id:m.trace_id
+                 ~trace_id:m.runtime.trace_id
                  ~primary_model_max_tokens:primary_max_context
                  ~base_dir
              in
@@ -77,17 +77,17 @@ let handle_keeper_status ctx args : tool_result =
            Resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
          in
          let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-         let last_turn_ago_s = if m.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.usage.last_turn_ts in
-         let last_handoff_ago_s = if m.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.last_handoff_ts in
-         let last_compaction_ago_s = if m.compaction.last_ts <= 0.0 then 0.0 else now_ts -. m.compaction.last_ts in
+         let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
+         let last_handoff_ago_s = if m.runtime.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.runtime.last_handoff_ts in
+         let last_compaction_ago_s = if m.runtime.compaction_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.compaction_rt.last_ts in
          let last_proactive_ago_s =
-           if m.proactive.last_ts <= 0.0 then 0.0 else now_ts -. m.proactive.last_ts
+           if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
          in
-         let trace_history_count = List.length m.trace_history in
+         let trace_history_count = List.length m.runtime.trace_history in
          let active_model = active_model_of_meta m in
          let next_model_hint = next_model_hint_of_meta m in
          let last_compaction_saved_tokens =
-           max 0 (m.compaction.last_before_tokens - m.compaction.last_after_tokens)
+           max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
          in
          let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
            compaction_policy_of_keeper m
@@ -114,8 +114,8 @@ let handle_keeper_status ctx args : tool_result =
          let metrics_store = keeper_metrics_store ctx.config m.name in
          let metrics_path = keeper_metrics_path ctx.config m.name in
          let memory_bank_path = keeper_memory_bank_path ctx.config m.name in
-         let session_dir = keeper_session_dir ctx.config m.trace_id in
-         let history_path = keeper_history_path ctx.config m.trace_id in
+         let session_dir = keeper_session_dir ctx.config m.runtime.trace_id in
+         let history_path = keeper_history_path ctx.config m.runtime.trace_id in
 
          let metrics_tail =
            let lines =
@@ -144,7 +144,7 @@ let handle_keeper_status ctx args : tool_result =
            if include_metrics_overview then
              summarize_metrics_lines
                metrics_window_lines
-               ~default_generation:m.generation
+               ~default_generation:m.runtime.generation
            else
              empty_metrics_summary
          in
@@ -336,7 +336,7 @@ let handle_keeper_status ctx args : tool_result =
                            ("ts_unix", `Float ts_unix);
                            ("age_s", match age_s with Some v -> `Float v | None -> `Null);
                            ("trace_id", `String (Safe_ops.json_string ~default:"" "trace_id" j));
-                           ("generation", `Int (Safe_ops.json_int ~default:m.generation "generation" j));
+                           ("generation", `Int (Safe_ops.json_int ~default:m.runtime.generation "generation" j));
                            ("context_ratio", `Float (Safe_ops.json_float ~default:0.0 "context_ratio" j));
                            ("context_before_tokens", `Int before_tokens);
                            ("context_after_tokens", `Int after_tokens);
@@ -417,17 +417,17 @@ let handle_keeper_status ctx args : tool_result =
              ("enabled", `Bool m.proactive.enabled);
              ("idle_sec", `Int m.proactive.idle_sec);
              ("cooldown_sec", `Int m.proactive.cooldown_sec);
-             ("count_total", `Int m.proactive.count_total);
-             ("last_ts", `Float m.proactive.last_ts);
+             ("count_total", `Int m.runtime.proactive_rt.count_total);
+             ("last_ts", `Float m.runtime.proactive_rt.last_ts);
              ("last_ago_s", `Float last_proactive_ago_s);
              ("last_reason",
-               if String.trim m.proactive.last_reason = ""
+               if String.trim m.runtime.proactive_rt.last_reason = ""
                then `Null
-               else `String m.proactive.last_reason);
+               else `String m.runtime.proactive_rt.last_reason);
              ("last_preview",
-               if String.trim m.proactive.last_preview = ""
+               if String.trim m.runtime.proactive_rt.last_preview = ""
                then `Null
-               else `String m.proactive.last_preview);
+               else `String m.runtime.proactive_rt.last_preview);
            ]);
            ("drift", drift_surface_json ());
            ("policy", `Assoc [
@@ -440,13 +440,13 @@ let handle_keeper_status ctx args : tool_result =
            ("auto_team_session", auto_team_session_surface_json ());
            ("auto_team_session_enabled", `Bool false);
            ("autonomy", `Assoc [
-             ("turn_count", `Int m.autonomous_turn_count);
-             ("tool_turn_count", `Int m.autonomous_tool_turn_count);
-             ("text_turn_count", `Int m.autonomous_text_turn_count);
-             ("board_reactive_turn_count", `Int m.board_reactive_turn_count);
-             ("mention_reactive_turn_count", `Int m.mention_reactive_turn_count);
-             ("noop_turn_count", `Int m.noop_turn_count);
-             ("tool_action_count", `Int m.autonomous_action_count);
+             ("turn_count", `Int m.runtime.autonomous_turn_count);
+             ("tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);
+             ("text_turn_count", `Int m.runtime.autonomous_text_turn_count);
+             ("board_reactive_turn_count", `Int m.runtime.board_reactive_turn_count);
+             ("mention_reactive_turn_count", `Int m.runtime.mention_reactive_turn_count);
+             ("noop_turn_count", `Int m.runtime.noop_turn_count);
+             ("tool_action_count", `Int m.runtime.autonomous_action_count);
            ]);
            ("active_team_session_id",
              match m.active_team_session_id with

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -148,7 +148,7 @@ let proactive_fallback_reply ~(meta : keeper_meta) ~(idle_seconds : int) : strin
     |]
   in
   let idx =
-    abs (Hashtbl.hash (meta.name, meta.proactive.count_total, idle_seconds))
+    abs (Hashtbl.hash (meta.name, meta.runtime.proactive_rt.count_total, idle_seconds))
     mod Array.length templates
   in
   templates.(idx)

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -148,7 +148,7 @@ let proactive_fallback_reply ~(meta : keeper_meta) ~(idle_seconds : int) : strin
     |]
   in
   let idx =
-    abs (Hashtbl.hash (meta.name, meta.runtime.proactive_rt.count_total, idle_seconds))
+    (Hashtbl.hash (meta.name, meta.runtime.proactive_rt.count_total, idle_seconds) land max_int)
     mod Array.length templates
   in
   templates.(idx)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -75,8 +75,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
         Trajectory.create_accumulator
           ~masc_root
           ~keeper_name:meta.name
-          ~trace_id:meta.trace_id
-          ~generation:meta.generation
+          ~trace_id:meta.runtime.trace_id
+          ~generation:meta.runtime.generation
       in
       let turn_cascade_name = if direct_reply then "keeper_reply" else "keeper_turn" in
       let effective_models =
@@ -185,7 +185,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~build_turn_prompt
                 ~user_message:message
                 ~cascade_name:turn_cascade_name
-                ~generation:meta.generation
+                ~generation:meta.runtime.generation
                 ?on_event
                 ~trajectory_acc
                 ()

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -65,8 +65,8 @@ let handle_keeper_down ctx args : tool_result =
               Sys.remove path
           end
         in
-        if validate_name m.trace_id then (
-          let dir = Filename.concat (session_base_dir ctx.config) m.trace_id in
+        if validate_name m.runtime.trace_id then (
+          let dir = Filename.concat (session_base_dir ctx.config) m.runtime.trace_id in
           try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.Keeper.error "session dir cleanup failed: %s"
               (Printexc.to_string exn)));

--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -16,7 +16,7 @@ let write_meta_logged config (meta : keeper_meta) =
       Log.Keeper.error "write_meta failed: %s" msg
 
 let _keeper_team_session_model (meta : keeper_meta) =
-  match String.trim meta.usage.last_model_used with
+  match String.trim meta.runtime.usage.last_model_used with
   | value when value <> "" -> value
   | _ ->
       (match Oas_model_resolve.models_of_cascade_name meta.cascade_name with

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -171,8 +171,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
          let meta = {
            name = p.name;
            agent_name = keeper_agent_name p.name;
-           trace_id;
-           trace_history = [];
            goal;
            short_goal;
            mid_goal;
@@ -194,15 +192,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            mention_targets;
            joined_room_ids = [];
            last_seen_seq_by_room = [];
-           generation = 0;
            proactive = {
              enabled = proactive_enabled;
              idle_sec = proactive_idle_sec;
              cooldown_sec = proactive_cooldown_sec;
-             count_total = 0;
-             last_ts = 0.0;
-             last_reason = "";
-             last_preview = "";
            };
            compaction = {
              profile = compaction_profile;
@@ -210,49 +203,62 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
              message_gate = compaction_message_gate;
              token_gate = compaction_token_gate;
              cooldown_sec = continuity_compaction_cooldown_sec;
-             count = 0;
-             last_ts = 0.0;
-             last_before_tokens = 0;
-             last_after_tokens = 0;
-             last_check_ts = now_ts;
-             last_decision = "initialized";
            };
            auto_handoff;
            handoff_threshold;
            handoff_cooldown_sec;
-           last_handoff_ts = 0.0;
            created_at = now_iso ();
            updated_at = now_iso ();
-           usage = {
-             total_turns = 0;
-             total_input_tokens = 0;
-             total_output_tokens = 0;
-             total_tokens = 0;
-             total_cost_usd = 0.0;
-             last_turn_ts = 0.0;
-             last_model_used = "";
-             last_input_tokens = 0;
-             last_output_tokens = 0;
-             last_total_tokens = 0;
-             last_latency_ms = 0;
+           continuity_summary = "";
+           active_goal_ids = [];
+           last_triage_triggers = "";
+           active_team_session_id = None;
+           last_team_session_started_at = "";
+           team_session_start_count_total = 0;
+           paused = false;
+           current_task_id = None;
+           runtime = {
+             usage = {
+               total_turns = 0;
+               total_input_tokens = 0;
+               total_output_tokens = 0;
+               total_tokens = 0;
+               total_cost_usd = 0.0;
+               last_turn_ts = 0.0;
+               last_model_used = "";
+               last_input_tokens = 0;
+               last_output_tokens = 0;
+               last_total_tokens = 0;
+               last_latency_ms = 0;
+             };
+             compaction_rt = {
+               count = 0;
+               last_ts = 0.0;
+               last_before_tokens = 0;
+               last_after_tokens = 0;
+               last_check_ts = now_ts;
+               last_decision = "initialized";
+             };
+             proactive_rt = {
+               count_total = 0;
+               last_ts = 0.0;
+               last_reason = "";
+               last_preview = "";
+             };
+             generation = 0;
+             trace_id;
+             trace_history = [];
+             last_handoff_ts = 0.0;
+             last_continuity_update_ts = now_ts;
+             last_autonomous_action_at = "";
+             autonomous_action_count = 0;
+             autonomous_turn_count = 0;
+             autonomous_text_turn_count = 0;
+             autonomous_tool_turn_count = 0;
+             board_reactive_turn_count = 0;
+             mention_reactive_turn_count = 0;
+             noop_turn_count = 0;
            };
-            last_continuity_update_ts = now_ts;
-            continuity_summary = "";
-            active_goal_ids = [];
-            last_autonomous_action_at = "";
-            autonomous_action_count = 0;
-            autonomous_turn_count = 0;
-            autonomous_text_turn_count = 0;
-            autonomous_tool_turn_count = 0;
-            board_reactive_turn_count = 0;
-            mention_reactive_turn_count = 0;
-            noop_turn_count = 0;
-            last_triage_triggers = "";
-            active_team_session_id = None;
-            last_team_session_started_at = "";
-            team_session_start_count_total = 0;
-            paused = false;
-            current_task_id = None;
          } in
          Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
          (try
@@ -284,8 +290,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            let json = `Assoc [
              ("name", `String meta.name);
              ("agent_name", `String meta.agent_name);
-             ("trace_id", `String meta.trace_id);
-             ("generation", `Int meta.generation);
+             ("trace_id", `String meta.runtime.trace_id);
+             ("generation", `Int meta.runtime.generation);
              ("goal", `String meta.goal);
              ("short_goal", `String meta.short_goal);
              ("mid_goal", `String meta.mid_goal);

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -127,7 +127,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     voice_agent_id =
       Option.value ~default:old.voice_agent_id p.voice_agent_id_opt;
     mention_targets;
-    proactive = { old.proactive with
+    proactive = {
       enabled =
         Option.value
           ~default:old.proactive.enabled
@@ -139,7 +139,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
         Option.value ~default:old.proactive.cooldown_sec p.proactive_cooldown_sec_opt
         |> normalize_proactive_cooldown_sec;
     };
-    compaction = { old.compaction with
+    compaction = {
       profile = compaction_profile;
       ratio_gate = compaction_ratio_gate;
       message_gate = compaction_message_gate;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -6,18 +6,38 @@
 include Keeper_types_profile
 
 
-type compaction_state = {
+(* -- Policy types (remain in keeper_meta top-level) -- *)
+
+type compaction_policy = {
   profile: string;
   ratio_gate: float;
   message_gate: int;
   token_gate: int;
   cooldown_sec: int;
+}
+
+type proactive_policy = {
+  enabled: bool;
+  idle_sec: int;
+  cooldown_sec: int;
+}
+
+(* -- Runtime types (moved into agent_runtime_state) -- *)
+
+type compaction_runtime = {
   count: int;
   last_ts: float;
   last_before_tokens: int;
   last_after_tokens: int;
   last_check_ts: float;
   last_decision: string;
+}
+
+type proactive_runtime = {
+  count_total: int;
+  last_ts: float;
+  last_reason: string;
+  last_preview: string;
 }
 
 type usage_metrics = {
@@ -34,21 +54,29 @@ type usage_metrics = {
   last_latency_ms: int;
 }
 
-type proactive_config = {
-  enabled: bool;
-  idle_sec: int;
-  cooldown_sec: int;
-  count_total: int;
-  last_ts: float;
-  last_reason: string;
-  last_preview: string;
+type agent_runtime_state = {
+  usage: usage_metrics;
+  compaction_rt: compaction_runtime;
+  proactive_rt: proactive_runtime;
+  generation: int;
+  trace_id: string;
+  trace_history: string list;
+  last_handoff_ts: float;
+  last_continuity_update_ts: float;
+  last_autonomous_action_at: string;
+  autonomous_action_count: int;
+  autonomous_turn_count: int;
+  autonomous_text_turn_count: int;
+  autonomous_tool_turn_count: int;
+  board_reactive_turn_count: int;
+  mention_reactive_turn_count: int;
+  noop_turn_count: int;
 }
 
 type keeper_meta = {
+  (* -- Identity & profile -- *)
   name: string;
   agent_name: string;
-  trace_id: string;
-  trace_history: string list;
   goal: string;
   short_goal: string;
   mid_goal: string;
@@ -59,6 +87,7 @@ type keeper_meta = {
   needs: string;
   desires: string;
   instructions: string;
+  (* -- Policy -- *)
   policy_voice_enabled: bool;
   execution_scope: string;
   allowed_paths: string list;
@@ -67,41 +96,47 @@ type keeper_meta = {
   mention_targets: string list;
   joined_room_ids: string list;
   last_seen_seq_by_room: (string * int) list;
-  generation: int;
-  proactive: proactive_config;
-  compaction: compaction_state;
+  proactive: proactive_policy;
+  compaction: compaction_policy;
   auto_handoff: bool;
   handoff_threshold: float;
   handoff_cooldown_sec: int;
+  (* -- Voice -- *)
   voice_enabled: bool;
   voice_channel: string;
   voice_agent_id: string;
-  last_handoff_ts: float;
+  (* -- Lifecycle -- *)
   created_at: string;
   updated_at: string;
-  usage: usage_metrics;
-
-  last_continuity_update_ts: float;
+  (* -- Operational control (top-level, not runtime) -- *)
   continuity_summary: string;
   active_goal_ids: string list;
   active_team_session_id: string option;
   last_team_session_started_at: string;
   team_session_start_count_total: int;
-  last_autonomous_action_at: string;
-  autonomous_action_count: int;
-  autonomous_turn_count: int;
-  autonomous_text_turn_count: int;
-  autonomous_tool_turn_count: int;
-  board_reactive_turn_count: int;
-  mention_reactive_turn_count: int;
-  noop_turn_count: int;
   last_triage_triggers: string;
   paused: bool;
   current_task_id: string option;
   (** Currently claimed task ID for cost attribution.
       Set when keeper claims a task; cleared on masc_done.
       Propagated to trajectory accumulator for per-task cost tracking. *)
+  (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
+  runtime: agent_runtime_state;
 }
+
+(* -- Updater helpers for nested record updates -- *)
+
+let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta) : keeper_meta =
+  { m with runtime = f m.runtime }
+
+let map_usage (f : usage_metrics -> usage_metrics) (m : keeper_meta) : keeper_meta =
+  { m with runtime = { m.runtime with usage = f m.runtime.usage } }
+
+let map_compaction_rt (f : compaction_runtime -> compaction_runtime) (m : keeper_meta) : keeper_meta =
+  { m with runtime = { m.runtime with compaction_rt = f m.runtime.compaction_rt } }
+
+let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_meta) : keeper_meta =
+  { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
 
 let now_iso () = Types.now_iso ()
 
@@ -192,12 +227,13 @@ let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) :
   | _ -> (json, false)
 
 let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
+  let rt = m.runtime in
   `Assoc
     [
       ("name", `String m.name);
       ("agent_name", `String m.agent_name);
-      ("trace_id", `String m.trace_id);
-      ("trace_history", `List (List.map (fun s -> `String s) m.trace_history));
+      ("trace_id", `String rt.trace_id);
+      ("trace_history", `List (List.map (fun s -> `String s) rt.trace_history));
       ("goal", `String m.goal);
       ("short_goal", `String m.short_goal);
       ("mid_goal", `String m.mid_goal);
@@ -216,7 +252,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("mention_targets", `List (List.map (fun s -> `String s) m.mention_targets));
       ("joined_room_ids", `List (List.map (fun s -> `String s) m.joined_room_ids));
       ("last_seen_seq_by_room", room_seq_map_to_json m.last_seen_seq_by_room);
-      ("generation", `Int m.generation);
+      ("generation", `Int rt.generation);
       ("proactive_enabled", `Bool m.proactive.enabled);
       ("proactive_idle_sec", `Int m.proactive.idle_sec);
       ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
@@ -231,31 +267,31 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("voice_enabled", `Bool m.voice_enabled);
       ("voice_channel", `String m.voice_channel);
       ("voice_agent_id", `String m.voice_agent_id);
-      ("last_handoff_ts", `Float m.last_handoff_ts);
+      ("last_handoff_ts", `Float rt.last_handoff_ts);
       ("created_at", `String m.created_at);
       ("updated_at", `String m.updated_at);
-      ("total_turns", `Int m.usage.total_turns);
-      ("total_input_tokens", `Int m.usage.total_input_tokens);
-      ("total_output_tokens", `Int m.usage.total_output_tokens);
-      ("total_tokens", `Int m.usage.total_tokens);
-      ("total_cost_usd", `Float m.usage.total_cost_usd);
-      ("last_turn_ts", `Float m.usage.last_turn_ts);
-      ("last_model_used", `String m.usage.last_model_used);
-      ("last_input_tokens", `Int m.usage.last_input_tokens);
-      ("last_output_tokens", `Int m.usage.last_output_tokens);
-      ("last_total_tokens", `Int m.usage.last_total_tokens);
-      ("last_latency_ms", `Int m.usage.last_latency_ms);
-      ("compaction_count", `Int m.compaction.count);
-      ("last_compaction_ts", `Float m.compaction.last_ts);
-      ("last_compaction_before_tokens", `Int m.compaction.last_before_tokens);
-      ("last_compaction_after_tokens", `Int m.compaction.last_after_tokens);
-      ("proactive_count_total", `Int m.proactive.count_total);
-      ("last_proactive_ts", `Float m.proactive.last_ts);
-      ("last_proactive_reason", `String m.proactive.last_reason);
-      ("last_proactive_preview", `String m.proactive.last_preview);
-      ("last_compaction_check_ts", `Float m.compaction.last_check_ts);
-      ("last_compaction_decision", `String m.compaction.last_decision);
-      ("last_continuity_update_ts", `Float m.last_continuity_update_ts);
+      ("total_turns", `Int rt.usage.total_turns);
+      ("total_input_tokens", `Int rt.usage.total_input_tokens);
+      ("total_output_tokens", `Int rt.usage.total_output_tokens);
+      ("total_tokens", `Int rt.usage.total_tokens);
+      ("total_cost_usd", `Float rt.usage.total_cost_usd);
+      ("last_turn_ts", `Float rt.usage.last_turn_ts);
+      ("last_model_used", `String rt.usage.last_model_used);
+      ("last_input_tokens", `Int rt.usage.last_input_tokens);
+      ("last_output_tokens", `Int rt.usage.last_output_tokens);
+      ("last_total_tokens", `Int rt.usage.last_total_tokens);
+      ("last_latency_ms", `Int rt.usage.last_latency_ms);
+      ("compaction_count", `Int rt.compaction_rt.count);
+      ("last_compaction_ts", `Float rt.compaction_rt.last_ts);
+      ("last_compaction_before_tokens", `Int rt.compaction_rt.last_before_tokens);
+      ("last_compaction_after_tokens", `Int rt.compaction_rt.last_after_tokens);
+      ("proactive_count_total", `Int rt.proactive_rt.count_total);
+      ("last_proactive_ts", `Float rt.proactive_rt.last_ts);
+      ("last_proactive_reason", `String rt.proactive_rt.last_reason);
+      ("last_proactive_preview", `String rt.proactive_rt.last_preview);
+      ("last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts);
+      ("last_compaction_decision", `String rt.compaction_rt.last_decision);
+      ("last_continuity_update_ts", `Float rt.last_continuity_update_ts);
       ("continuity_summary", `String m.continuity_summary);
       ("active_goal_ids", `List (List.map (fun s -> `String s) m.active_goal_ids));
       ( "active_team_session_id",
@@ -264,14 +300,14 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
         | None -> `Null );
       ("last_team_session_started_at", `String m.last_team_session_started_at);
       ("team_session_start_count_total", `Int m.team_session_start_count_total);
-      ("last_autonomous_action_at", `String m.last_autonomous_action_at);
-      ("autonomous_action_count", `Int m.autonomous_action_count);
-      ("autonomous_turn_count", `Int m.autonomous_turn_count);
-      ("autonomous_text_turn_count", `Int m.autonomous_text_turn_count);
-      ("autonomous_tool_turn_count", `Int m.autonomous_tool_turn_count);
-      ("board_reactive_turn_count", `Int m.board_reactive_turn_count);
-      ("mention_reactive_turn_count", `Int m.mention_reactive_turn_count);
-      ("noop_turn_count", `Int m.noop_turn_count);
+      ("last_autonomous_action_at", `String rt.last_autonomous_action_at);
+      ("autonomous_action_count", `Int rt.autonomous_action_count);
+      ("autonomous_turn_count", `Int rt.autonomous_turn_count);
+      ("autonomous_text_turn_count", `Int rt.autonomous_text_turn_count);
+      ("autonomous_tool_turn_count", `Int rt.autonomous_tool_turn_count);
+      ("board_reactive_turn_count", `Int rt.board_reactive_turn_count);
+      ("mention_reactive_turn_count", `Int rt.mention_reactive_turn_count);
+      ("noop_turn_count", `Int rt.noop_turn_count);
       ("last_triage_triggers", `String m.last_triage_triggers);
       ("paused", `Bool m.paused);
       ("current_task_id",
@@ -488,8 +524,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
         {
           name;
           agent_name = if agent_name = "" then keeper_agent_name name else agent_name;
-          trace_id;
-          trace_history;
           goal;
           short_goal;
           mid_goal;
@@ -508,15 +542,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           mention_targets;
           joined_room_ids;
           last_seen_seq_by_room;
-          generation;
           proactive = {
             enabled = proactive_enabled;
             idle_sec = proactive_idle_sec;
             cooldown_sec = proactive_cooldown_sec;
-            count_total = proactive_count_total;
-            last_ts = last_proactive_ts;
-            last_reason = last_proactive_reason;
-            last_preview = last_proactive_preview;
           };
           compaction = {
             profile = compaction_profile;
@@ -524,12 +553,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
             message_gate = compaction_message_gate;
             token_gate = compaction_token_gate;
             cooldown_sec = continuity_compaction_cooldown_sec;
-            count = compaction_count;
-            last_ts = last_compaction_ts;
-            last_before_tokens = last_compaction_before_tokens;
-            last_after_tokens = last_compaction_after_tokens;
-            last_check_ts = last_compaction_check_ts;
-            last_decision = last_compaction_decision;
           };
           auto_handoff;
           handoff_threshold;
@@ -537,39 +560,58 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           voice_enabled;
           voice_channel;
           voice_agent_id;
-          last_handoff_ts;
           created_at = if created_at = "" then now_iso () else created_at;
           updated_at = if updated_at = "" then now_iso () else updated_at;
-          usage = {
-            total_turns;
-            total_input_tokens;
-            total_output_tokens;
-            total_tokens;
-            total_cost_usd;
-            last_turn_ts;
-            last_model_used;
-            last_input_tokens;
-            last_output_tokens;
-            last_total_tokens;
-            last_latency_ms;
-          };
-          last_continuity_update_ts;
           continuity_summary;
           active_goal_ids;
           active_team_session_id;
           last_team_session_started_at;
           team_session_start_count_total;
-          last_autonomous_action_at;
-          autonomous_action_count;
-          autonomous_turn_count;
-          autonomous_text_turn_count;
-          autonomous_tool_turn_count;
-          board_reactive_turn_count;
-          mention_reactive_turn_count;
-          noop_turn_count;
           last_triage_triggers;
           paused;
           current_task_id;
+          runtime = {
+            usage = {
+              total_turns;
+              total_input_tokens;
+              total_output_tokens;
+              total_tokens;
+              total_cost_usd;
+              last_turn_ts;
+              last_model_used;
+              last_input_tokens;
+              last_output_tokens;
+              last_total_tokens;
+              last_latency_ms;
+            };
+            compaction_rt = {
+              count = compaction_count;
+              last_ts = last_compaction_ts;
+              last_before_tokens = last_compaction_before_tokens;
+              last_after_tokens = last_compaction_after_tokens;
+              last_check_ts = last_compaction_check_ts;
+              last_decision = last_compaction_decision;
+            };
+            proactive_rt = {
+              count_total = proactive_count_total;
+              last_ts = last_proactive_ts;
+              last_reason = last_proactive_reason;
+              last_preview = last_proactive_preview;
+            };
+            generation;
+            trace_id;
+            trace_history;
+            last_handoff_ts;
+            last_continuity_update_ts;
+            last_autonomous_action_at;
+            autonomous_action_count;
+            autonomous_turn_count;
+            autonomous_text_turn_count;
+            autonomous_tool_turn_count;
+            board_reactive_turn_count;
+            mention_reactive_turn_count;
+            noop_turn_count;
+          };
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -7,14 +7,25 @@
 
 include module type of Keeper_types_profile
 
-(** {1 Compaction state} *)
+(** {1 Policy types (remain in keeper_meta top-level)} *)
 
-type compaction_state = {
+type compaction_policy = {
   profile: string;
   ratio_gate: float;
   message_gate: int;
   token_gate: int;
   cooldown_sec: int;
+}
+
+type proactive_policy = {
+  enabled: bool;
+  idle_sec: int;
+  cooldown_sec: int;
+}
+
+(** {1 Runtime types (embedded in agent_runtime_state)} *)
+
+type compaction_runtime = {
   count: int;
   last_ts: float;
   last_before_tokens: int;
@@ -23,7 +34,12 @@ type compaction_state = {
   last_decision: string;
 }
 
-(** {1 Usage metrics} *)
+type proactive_runtime = {
+  count_total: int;
+  last_ts: float;
+  last_reason: string;
+  last_preview: string;
+}
 
 type usage_metrics = {
   total_turns: int;
@@ -39,16 +55,25 @@ type usage_metrics = {
   last_latency_ms: int;
 }
 
-(** {1 Proactive config} *)
+(** {1 Agent runtime state} *)
 
-type proactive_config = {
-  enabled: bool;
-  idle_sec: int;
-  cooldown_sec: int;
-  count_total: int;
-  last_ts: float;
-  last_reason: string;
-  last_preview: string;
+type agent_runtime_state = {
+  usage: usage_metrics;
+  compaction_rt: compaction_runtime;
+  proactive_rt: proactive_runtime;
+  generation: int;
+  trace_id: string;
+  trace_history: string list;
+  last_handoff_ts: float;
+  last_continuity_update_ts: float;
+  last_autonomous_action_at: string;
+  autonomous_action_count: int;
+  autonomous_turn_count: int;
+  autonomous_text_turn_count: int;
+  autonomous_tool_turn_count: int;
+  board_reactive_turn_count: int;
+  mention_reactive_turn_count: int;
+  noop_turn_count: int;
 }
 
 (** {1 Keeper meta} *)
@@ -56,8 +81,6 @@ type proactive_config = {
 type keeper_meta = {
   name: string;
   agent_name: string;
-  trace_id: string;
-  trace_history: string list;
   goal: string;
   short_goal: string;
   mid_goal: string;
@@ -76,40 +99,36 @@ type keeper_meta = {
   mention_targets: string list;
   joined_room_ids: string list;
   last_seen_seq_by_room: (string * int) list;
-  generation: int;
-  proactive: proactive_config;
-  compaction: compaction_state;
+  proactive: proactive_policy;
+  compaction: compaction_policy;
   auto_handoff: bool;
   handoff_threshold: float;
   handoff_cooldown_sec: int;
   voice_enabled: bool;
   voice_channel: string;
   voice_agent_id: string;
-  last_handoff_ts: float;
   created_at: string;
   updated_at: string;
-  usage: usage_metrics;
-  last_continuity_update_ts: float;
   continuity_summary: string;
   active_goal_ids: string list;
   active_team_session_id: string option;
   last_team_session_started_at: string;
   team_session_start_count_total: int;
-  last_autonomous_action_at: string;
-  autonomous_action_count: int;
-  autonomous_turn_count: int;
-  autonomous_text_turn_count: int;
-  autonomous_tool_turn_count: int;
-  board_reactive_turn_count: int;
-  mention_reactive_turn_count: int;
-  noop_turn_count: int;
   last_triage_triggers: string;
   paused: bool;
   current_task_id: string option;
   (** Currently claimed task ID for cost attribution. *)
+  runtime: agent_runtime_state;
 }
 
 val now_iso : unit -> string
+
+(** {1 Updater helpers for nested record updates} *)
+
+val map_runtime : (agent_runtime_state -> agent_runtime_state) -> keeper_meta -> keeper_meta
+val map_usage : (usage_metrics -> usage_metrics) -> keeper_meta -> keeper_meta
+val map_compaction_rt : (compaction_runtime -> compaction_runtime) -> keeper_meta -> keeper_meta
+val map_proactive_rt : (proactive_runtime -> proactive_runtime) -> keeper_meta -> keeper_meta
 
 (** {1 Legacy model arg rejection} *)
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -43,61 +43,64 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let is_autonomous_turn = true in
   let is_board_reactive = observation.pending_board_events <> [] in
   let is_mention_reactive = observation.pending_mentions <> [] in
+  let rt = meta.runtime in
   {
     meta with
     updated_at = now_iso ();
-    usage = {
-      total_turns = meta.usage.total_turns + 1;
-      total_input_tokens = meta.usage.total_input_tokens + result.usage.input_tokens;
-      total_output_tokens = meta.usage.total_output_tokens + result.usage.output_tokens;
-      total_tokens =
-        meta.usage.total_tokens + Keeper_exec_context.total_tokens result.usage;
-      total_cost_usd = meta.usage.total_cost_usd +. turn_cost;
-      last_turn_ts = now_ts;
-      last_model_used = result.model_used;
-      last_input_tokens = result.usage.input_tokens;
-      last_output_tokens = result.usage.output_tokens;
-      last_total_tokens = Keeper_exec_context.total_tokens result.usage;
-      last_latency_ms = latency_ms;
+    runtime = { rt with
+      usage = {
+        total_turns = rt.usage.total_turns + 1;
+        total_input_tokens = rt.usage.total_input_tokens + result.usage.input_tokens;
+        total_output_tokens = rt.usage.total_output_tokens + result.usage.output_tokens;
+        total_tokens =
+          rt.usage.total_tokens + Keeper_exec_context.total_tokens result.usage;
+        total_cost_usd = rt.usage.total_cost_usd +. turn_cost;
+        last_turn_ts = now_ts;
+        last_model_used = result.model_used;
+        last_input_tokens = result.usage.input_tokens;
+        last_output_tokens = result.usage.output_tokens;
+        last_total_tokens = Keeper_exec_context.total_tokens result.usage;
+        last_latency_ms = latency_ms;
+      };
+      (* Proactive count: any turn that produced text or tools *)
+      proactive_rt = {
+        count_total =
+          rt.proactive_rt.count_total + (if has_text || has_tool_calls then 1 else 0);
+        last_ts =
+          (if has_text || has_tool_calls then now_ts else rt.proactive_rt.last_ts);
+        last_reason =
+          (if has_tool_calls then
+             Printf.sprintf "unified:tools=[%s]"
+               (String.concat "," result.tools_used)
+           else if has_text then "unified:text_response"
+           else rt.proactive_rt.last_reason);
+        last_preview =
+          (if has_text then short_preview result.response_text
+           else if has_tool_calls then
+             Printf.sprintf "(tools: %s)" (String.concat ", " result.tools_used)
+           else rt.proactive_rt.last_preview);
+      };
+      (* Autonomous action tracking from tool calls *)
+      autonomous_action_count =
+        rt.autonomous_action_count + List.length result.tools_used;
+      autonomous_turn_count =
+        rt.autonomous_turn_count + (if is_autonomous_turn then 1 else 0);
+      autonomous_text_turn_count =
+        rt.autonomous_text_turn_count
+        + (if is_autonomous_turn && has_text && not has_tool_calls then 1 else 0);
+      autonomous_tool_turn_count =
+        rt.autonomous_tool_turn_count
+        + (if is_autonomous_turn && has_tool_calls then 1 else 0);
+      board_reactive_turn_count =
+        rt.board_reactive_turn_count + (if is_board_reactive then 1 else 0);
+      mention_reactive_turn_count =
+        rt.mention_reactive_turn_count + (if is_mention_reactive then 1 else 0);
+      noop_turn_count =
+        rt.noop_turn_count
+        + (if is_autonomous_turn && not has_text && not has_tool_calls then 1 else 0);
+      last_autonomous_action_at =
+        (if has_tool_calls then now_iso () else rt.last_autonomous_action_at);
     };
-    (* Proactive count: any turn that produced text or tools *)
-    proactive = { meta.proactive with
-      count_total =
-        meta.proactive.count_total + (if has_text || has_tool_calls then 1 else 0);
-      last_ts =
-        (if has_text || has_tool_calls then now_ts else meta.proactive.last_ts);
-      last_reason =
-        (if has_tool_calls then
-           Printf.sprintf "unified:tools=[%s]"
-             (String.concat "," result.tools_used)
-         else if has_text then "unified:text_response"
-         else meta.proactive.last_reason);
-      last_preview =
-        (if has_text then short_preview result.response_text
-         else if has_tool_calls then
-           Printf.sprintf "(tools: %s)" (String.concat ", " result.tools_used)
-         else meta.proactive.last_preview);
-    };
-    (* Autonomous action tracking from tool calls *)
-    autonomous_action_count =
-      meta.autonomous_action_count + List.length result.tools_used;
-    autonomous_turn_count =
-      meta.autonomous_turn_count + (if is_autonomous_turn then 1 else 0);
-    autonomous_text_turn_count =
-      meta.autonomous_text_turn_count
-      + (if is_autonomous_turn && has_text && not has_tool_calls then 1 else 0);
-    autonomous_tool_turn_count =
-      meta.autonomous_tool_turn_count
-      + (if is_autonomous_turn && has_tool_calls then 1 else 0);
-    board_reactive_turn_count =
-      meta.board_reactive_turn_count + (if is_board_reactive then 1 else 0);
-    mention_reactive_turn_count =
-      meta.mention_reactive_turn_count + (if is_mention_reactive then 1 else 0);
-    noop_turn_count =
-      meta.noop_turn_count
-      + (if is_autonomous_turn && not has_text && not has_tool_calls then 1 else 0);
-    last_autonomous_action_at =
-      (if has_tool_calls then now_iso () else meta.last_autonomous_action_at);
   }
 
 let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
@@ -129,8 +132,8 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("channel", `String channel);
         ("name", `String meta.name);
         ("agent_name", `String meta.agent_name);
-        ("trace_id", `String meta.trace_id);
-        ("generation", `Int meta.generation);
+        ("trace_id", `String meta.runtime.trace_id);
+        ("generation", `Int meta.runtime.generation);
         ("model_used", `String result.model_used);
         ( "usage",
           `Assoc
@@ -191,14 +194,16 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   {
     meta with
     updated_at = now_iso ();
-    usage = { meta.usage with
-      total_turns = meta.usage.total_turns + 1;
-      last_turn_ts = now_ts;
-      last_latency_ms = latency_ms;
-    };
-    proactive = { meta.proactive with
-      last_reason = "unified:error:" ^ String.trim reason;
-      last_preview = preview;
+    runtime = { meta.runtime with
+      usage = { meta.runtime.usage with
+        total_turns = meta.runtime.usage.total_turns + 1;
+        last_turn_ts = now_ts;
+        last_latency_ms = latency_ms;
+      };
+      proactive_rt = { meta.runtime.proactive_rt with
+        last_reason = "unified:error:" ^ String.trim reason;
+        last_preview = preview;
+      };
     };
   }
 
@@ -219,7 +224,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       in
       let base_dir = session_base_dir config in
       (* Ensure session dir tree for filesystem fallback (issue #3019) *)
-      Keeper_types.mkdir_p (Filename.concat base_dir meta.trace_id);
+      Keeper_types.mkdir_p (Filename.concat base_dir meta.runtime.trace_id);
       (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
       let temperature =
         Cascade_inference.resolve_temperature

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -106,7 +106,7 @@ let compute_idle_seconds ~(meta : keeper_meta) : int =
     |> Option.value ~default:0.0
   in
   let activity_ts =
-    let base = max meta.usage.last_turn_ts meta.proactive.last_ts in
+    let base = max meta.runtime.usage.last_turn_ts meta.runtime.proactive_rt.last_ts in
     if base > 0.0 then base else created_ts
   in
   if activity_ts <= 0.0 then 0
@@ -157,7 +157,7 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
-      load_context_from_checkpoint ~trace_id:meta.trace_id
+      load_context_from_checkpoint ~trace_id:meta.runtime.trace_id
         ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
@@ -177,7 +177,7 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
-      load_context_from_checkpoint ~trace_id:meta.trace_id
+      load_context_from_checkpoint ~trace_id:meta.runtime.trace_id
         ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
@@ -346,8 +346,8 @@ let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observati
     (* Zero-heuristic scheduling: periodic turns use cooldown only.
        Idle/goal/task scoring stays in the raw world state and is left to the model. *)
     let since_last_proactive =
-      if meta.proactive.last_ts <= 0.0 then max_int
-      else int_of_float (max 0.0 (Time_compat.now () -. meta.proactive.last_ts))
+      if meta.runtime.proactive_rt.last_ts <= 0.0 then max_int
+      else int_of_float (max 0.0 (Time_compat.now () -. meta.runtime.proactive_rt.last_ts))
     in
     meta.proactive.enabled
     && since_last_proactive >= meta.proactive.cooldown_sec

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -3,7 +3,7 @@ include Operator_pending_confirm
 include Operator_digest
 
 let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
-  let input_tokens = meta.usage.last_input_tokens in
+  let input_tokens = meta.runtime.usage.last_input_tokens in
   if input_tokens = 0 then None
   else
     let active_model = Keeper_exec_status.active_model_of_meta meta in
@@ -142,7 +142,7 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
     if fallback_latest <> [] then Some "keeper_metrics" else None
   in
   let fallback_at =
-    let last_autonomous = String.trim meta.last_autonomous_action_at in
+    let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
     if last_autonomous <> "" then Some last_autonomous
     else Some meta.updated_at
   in
@@ -195,7 +195,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = true)
                   ("paused", `Bool true);
                   ("goal", `String meta.goal);
                   ("short_goal", `String meta.short_goal);
-                  ("turn_count", `Int meta.usage.total_turns);
+                  ("turn_count", `Int meta.runtime.usage.total_turns);
                   ("updated_at", `String meta.updated_at);
                   ("created_at", `String meta.created_at);
                 ])
@@ -241,21 +241,21 @@ let keepers_json ?keeper_names ?(include_recent_activity = true)
                   ("pipeline_stage", `String pipeline_stage);
                   ("name", `String meta.name);
                   ("agent_name", `String meta.agent_name);
-                  ("trace_id", `String meta.trace_id);
+                  ("trace_id", `String meta.runtime.trace_id);
                   ("goal", `String meta.goal);
                   ("short_goal", `String meta.short_goal);
                   ("mid_goal", `String meta.mid_goal);
                   ("long_goal", `String meta.long_goal);
                   ("status", `String agent_status);
                   ("agent", agent_json);
-                  ("generation", `Int meta.generation);
-                  ("turn_count", `Int meta.usage.total_turns);
+                  ("generation", `Int meta.runtime.generation);
+                  ("turn_count", `Int meta.runtime.usage.total_turns);
                   ("context_ratio",
                     (match compute_context_ratio meta with
                      | Some r -> `Float r
                      | None -> `Null));
-                  ("context_tokens", `Int meta.usage.last_total_tokens);
-                  ("last_model_used", `String meta.usage.last_model_used);
+                  ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
+                  ("last_model_used", `String meta.runtime.usage.last_model_used);
                   ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
                   ("keepalive_running", `Bool keepalive_running);
                   ( "next_model_hint",
@@ -265,9 +265,9 @@ let keepers_json ?keeper_names ?(include_recent_activity = true)
                     `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids)
                   );
                   ( "last_autonomous_action_at",
-                    if String.trim meta.last_autonomous_action_at = "" then `Null
-                    else `String meta.last_autonomous_action_at );
-                  ("autonomous_action_count", `Int meta.autonomous_action_count);
+                    if String.trim meta.runtime.last_autonomous_action_at = "" then `Null
+                    else `String meta.runtime.last_autonomous_action_at );
+                  ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
                   ("allowed_tool_names", `List (List.map (fun value -> `String value) allowed_tool_names));
                   ("latest_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
                   ("recent_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
@@ -320,26 +320,26 @@ let persistent_agents_json ?keeper_names config =
                   ("runtime_class", `String "keeper");
                   ("name", `String meta.name);
                   ("agent_name", `String meta.agent_name);
-                  ("trace_id", `String meta.trace_id);
+                  ("trace_id", `String meta.runtime.trace_id);
                   ("goal", `String meta.goal);
                   ("short_goal", `String meta.short_goal);
                   ("mid_goal", `String meta.mid_goal);
                   ("long_goal", `String meta.long_goal);
                   ("status", `String agent_status);
-                  ("generation", `Int meta.generation);
-                  ("turn_count", `Int meta.usage.total_turns);
+                  ("generation", `Int meta.runtime.generation);
+                  ("turn_count", `Int meta.runtime.usage.total_turns);
                   ("context_ratio",
                     (match compute_context_ratio meta with
                      | Some r -> `Float r
                      | None -> `Null));
-                  ("context_tokens", `Int meta.usage.last_total_tokens);
-                  ("last_model_used", `String meta.usage.last_model_used);
+                  ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
+                  ("last_model_used", `String meta.runtime.usage.last_model_used);
                   ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
                   ("next_model_hint", string_option_to_json (Keeper_exec_status.next_model_hint_of_meta meta));
                   ("active_goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
                   ("last_autonomous_action_at",
-                    if String.trim meta.last_autonomous_action_at = "" then `Null else `String meta.last_autonomous_action_at);
-                  ("autonomous_action_count", `Int meta.autonomous_action_count);
+                    if String.trim meta.runtime.last_autonomous_action_at = "" then `Null else `String meta.runtime.last_autonomous_action_at);
+                  ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
                   ("updated_at", `String meta.updated_at);
                   ("created_at", `String meta.created_at);
                 ]))

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -290,7 +290,7 @@ let room_state_json config =
       ]
 
 let keeper_context_ratio (meta : Keeper_types.keeper_meta) =
-  let input_tokens = meta.usage.last_input_tokens in
+  let input_tokens = meta.runtime.usage.last_input_tokens in
   if input_tokens = 0 then None
   else
     let active_model = Keeper_exec_status.active_model_of_meta meta in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -377,7 +377,7 @@ let add_routes ~sw ~clock router =
                 let masc_root = Filename.concat config.base_path ".masc" in
                 let entries =
                   Trajectory.read_entries ~masc_root ~keeper_name:m.name
-                    ~trace_id:m.trace_id
+                    ~trace_id:m.runtime.trace_id
                 in
                 let total = List.length entries in
                 let recent =
@@ -388,8 +388,8 @@ let add_routes ~sw ~clock router =
                 in
                 let json = `Assoc [
                   ("keeper", `String name);
-                  ("trace_id", `String m.trace_id);
-                  ("generation", `Int m.generation);
+                  ("trace_id", `String m.runtime.trace_id);
+                  ("generation", `Int m.runtime.generation);
                   ("total_entries", `Int total);
                   ("showing", `Int (List.length recent));
                   ("entries", `List (List.map (Trajectory.entry_to_json ~result_max_len:2000) recent));

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -73,7 +73,7 @@ let keeper_brief_meta_json (meta : keeper_meta) =
     [
       ("name", `String meta.name);
       ("goal", `String meta.goal);
-      ("trace_id", `String meta.trace_id);
+      ("trace_id", `String meta.runtime.trace_id);
       ("created_at", `String meta.created_at);
       ("updated_at", `String meta.updated_at);
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -196,7 +196,13 @@ let test_scheduled_turn_uses_cooldown_only () =
         { minimal_meta.proactive with
           enabled = true;
           cooldown_sec = 60;
-          last_ts = Time_compat.now () -. 120.0;
+        };
+      runtime =
+        { minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 120.0;
+            };
         };
     }
   in
@@ -211,7 +217,13 @@ let test_scheduled_turn_respects_cooldown () =
         { minimal_meta.proactive with
           enabled = true;
           cooldown_sec = 300;
-          last_ts = Time_compat.now () -. 30.0;
+        };
+      runtime =
+        { minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 30.0;
+            };
         };
     }
   in
@@ -425,13 +437,13 @@ let test_metrics_text_response () =
     UT.update_metrics_from_result minimal_meta ~latency_ms:200
       ~observation:base_observation result
   in
-  check int "total_turns +1" (minimal_meta.usage.total_turns + 1) updated.usage.total_turns;
+  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
   check int "proactive_count +1"
-    (minimal_meta.proactive.count_total + 1) updated.proactive.count_total;
-  check int "no autonomous action" minimal_meta.autonomous_action_count
-    updated.autonomous_action_count;
-  check int "input tokens" (minimal_meta.usage.total_input_tokens + 100) updated.usage.total_input_tokens;
-  check int "output tokens" (minimal_meta.usage.total_output_tokens + 50) updated.usage.total_output_tokens
+    (minimal_meta.runtime.proactive_rt.count_total + 1) updated.runtime.proactive_rt.count_total;
+  check int "no autonomous action" minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check int "input tokens" (minimal_meta.runtime.usage.total_input_tokens + 100) updated.runtime.usage.total_input_tokens;
+  check int "output tokens" (minimal_meta.runtime.usage.total_output_tokens + 50) updated.runtime.usage.total_output_tokens
 
 let test_metrics_tool_response () =
   let result =
@@ -442,11 +454,11 @@ let test_metrics_tool_response () =
     UT.update_metrics_from_result minimal_meta ~latency_ms:500
       ~observation:base_observation result
   in
-  check int "proactive_count +1" (minimal_meta.proactive.count_total + 1)
-    updated.proactive.count_total;
-  check int "autonomous_action +2" (minimal_meta.autonomous_action_count + 2)
-    updated.autonomous_action_count;
-  check int "latency_ms" 500 updated.usage.last_latency_ms
+  check int "proactive_count +1" (minimal_meta.runtime.proactive_rt.count_total + 1)
+    updated.runtime.proactive_rt.count_total;
+  check int "autonomous_action +2" (minimal_meta.runtime.autonomous_action_count + 2)
+    updated.runtime.autonomous_action_count;
+  check int "latency_ms" 500 updated.runtime.usage.last_latency_ms
 
 let test_metrics_noop_response () =
   let result =
@@ -457,29 +469,29 @@ let test_metrics_noop_response () =
     UT.update_metrics_from_result minimal_meta ~latency_ms:100
       ~observation:base_observation result
   in
-  check int "proactive_count unchanged" minimal_meta.proactive.count_total
-    updated.proactive.count_total;
-  check int "autonomous unchanged" minimal_meta.autonomous_action_count
-    updated.autonomous_action_count;
-  check int "total_turns +1" (minimal_meta.usage.total_turns + 1) updated.usage.total_turns
+  check int "proactive_count unchanged" minimal_meta.runtime.proactive_rt.count_total
+    updated.runtime.proactive_rt.count_total;
+  check int "autonomous unchanged" minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
 
 let test_metrics_failure_response () =
   let reason = "Agent run failed: Max turns exceeded (turn 10, limit 10)" in
   let updated =
     UT.update_metrics_from_failure minimal_meta ~latency_ms:250 ~reason
   in
-  check int "total_turns +1" (minimal_meta.usage.total_turns + 1) updated.usage.total_turns;
-  check int "latency recorded" 250 updated.usage.last_latency_ms;
-  check bool "last_turn_ts updated" true (updated.usage.last_turn_ts > 0.0);
-  check int "proactive count unchanged" minimal_meta.proactive.count_total
-    updated.proactive.count_total;
+  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
+  check int "latency recorded" 250 updated.runtime.usage.last_latency_ms;
+  check bool "last_turn_ts updated" true (updated.runtime.usage.last_turn_ts > 0.0);
+  check int "proactive count unchanged" minimal_meta.runtime.proactive_rt.count_total
+    updated.runtime.proactive_rt.count_total;
   check bool "failure reason tagged" true
     (let found =
        try
          ignore
            (Str.search_forward
               (Str.regexp_string "unified:error:")
-              updated.proactive.last_reason 0);
+              updated.runtime.proactive_rt.last_reason 0);
          true
        with Not_found -> false
      in
@@ -490,7 +502,7 @@ let test_metrics_failure_response () =
          ignore
            (Str.search_forward
               (Str.regexp_string "Max turns exceeded")
-              updated.proactive.last_preview 0);
+              updated.runtime.proactive_rt.last_preview 0);
          true
        with Not_found -> false
      in
@@ -523,13 +535,13 @@ let test_metrics_mixed_response () =
     UT.update_metrics_from_result minimal_meta ~latency_ms:300
       ~observation:base_observation result
   in
-  check int "proactive +1" (minimal_meta.proactive.count_total + 1)
-    updated.proactive.count_total;
-  check int "autonomous +1" (minimal_meta.autonomous_action_count + 1)
-    updated.autonomous_action_count;
+  check int "proactive +1" (minimal_meta.runtime.proactive_rt.count_total + 1)
+    updated.runtime.proactive_rt.count_total;
+  check int "autonomous +1" (minimal_meta.runtime.autonomous_action_count + 1)
+    updated.runtime.autonomous_action_count;
   check bool "proactive reason has unified" true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "unified:tools=") updated.proactive.last_reason 0); true
+       try ignore (Str.search_forward (Str.regexp_string "unified:tools=") updated.runtime.proactive_rt.last_reason 0); true
        with Not_found -> false
      in found)
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -651,7 +651,7 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         }
       in
       let session =
-        Keeper_exec_context.create_session ~session_id:meta.trace_id ~base_dir
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
       in
       let ctx =
         Keeper_exec_context.create ~system_prompt:"rollover" ~max_tokens:100
@@ -664,7 +664,7 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
-          ~ctx ~generation:meta.generation
+          ~ctx ~generation:meta.runtime.generation
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -673,21 +673,21 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
           ~checkpoint:(Some checkpoint)
       in
       Alcotest.(check int) "generation incremented" 1
-        rollover.updated_meta.generation;
+        rollover.updated_meta.runtime.generation;
       Alcotest.(check bool) "trace rotated" true
-        (rollover.updated_meta.trace_id <> meta.trace_id);
+        (rollover.updated_meta.runtime.trace_id <> meta.runtime.trace_id);
       Alcotest.(check bool) "trace history contains previous trace" true
-        (List.mem meta.trace_id rollover.updated_meta.trace_history);
+        (List.mem meta.runtime.trace_id rollover.updated_meta.runtime.trace_history);
       Alcotest.(check bool) "handoff json present" true
         (Option.is_some rollover.handoff_json);
       let new_session =
         Keeper_exec_context.create_session
-          ~session_id:rollover.updated_meta.trace_id
+          ~session_id:rollover.updated_meta.runtime.trace_id
           ~base_dir
       in
       match
         Keeper_checkpoint_store.load_oas ~session_dir:new_session.session_dir
-          ~session_id:rollover.updated_meta.trace_id
+          ~session_id:rollover.updated_meta.runtime.trace_id
       with
       | Some loaded ->
           let generation =
@@ -714,7 +714,7 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
         }
       in
       let session =
-        Keeper_exec_context.create_session ~session_id:meta.trace_id ~base_dir
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
       in
       let ctx =
         Keeper_exec_context.create ~system_prompt:"stable" ~max_tokens:100
@@ -727,7 +727,7 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
         Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
-          ~ctx ~generation:meta.generation
+          ~ctx ~generation:meta.runtime.generation
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -735,10 +735,10 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
           ~primary_model_max_tokens:100
           ~checkpoint:(Some checkpoint)
       in
-      Alcotest.(check string) "trace unchanged" meta.trace_id
-        rollover.updated_meta.trace_id;
-      Alcotest.(check int) "generation unchanged" meta.generation
-        rollover.updated_meta.generation;
+      Alcotest.(check string) "trace unchanged" meta.runtime.trace_id
+        rollover.updated_meta.runtime.trace_id;
+      Alcotest.(check int) "generation unchanged" meta.runtime.generation
+        rollover.updated_meta.runtime.generation;
       Alcotest.(check bool) "handoff json absent" false
         (Option.is_some rollover.handoff_json))
 

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -228,18 +228,21 @@ proactive_enabled = true
           meta with
           room_scope = "current";
           proactive = { meta.proactive with enabled = false };
-          usage =
-            {
-              meta.usage with
-              total_input_tokens = 1200;
-              total_output_tokens = 800;
-              total_tokens = 2000;
-              total_cost_usd = 0.042;
-              last_model_used = "glm:auto";
-              last_input_tokens = 120;
-              last_output_tokens = 80;
-              last_total_tokens = 200;
-              last_latency_ms = 4000;
+          runtime =
+            { meta.runtime with
+              usage =
+                {
+                  meta.runtime.usage with
+                  total_input_tokens = 1200;
+                  total_output_tokens = 800;
+                  total_tokens = 2000;
+                  total_cost_usd = 0.042;
+                  last_model_used = "glm:auto";
+                  last_input_tokens = 120;
+                  last_output_tokens = 80;
+                  last_total_tokens = 200;
+                  last_latency_ms = 4000;
+                };
             };
           paused = true;
           updated_at = Types.now_iso ();

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -286,9 +286,9 @@ let test_migrate_legacy_keeper_dirs_promotes_valid_meta () =
         read_meta_exn (Filename.concat keepers_dir "other.json")
       in
       Alcotest.(check string) "sangsu trace promoted from perpetual-keepers"
-        "trace-sangsu-live" sangsu_meta.trace_id;
+        "trace-sangsu-live" sangsu_meta.runtime.trace_id;
       Alcotest.(check string) "other keeper migrated from perpetual-keepers"
-        "trace-other-live" other_meta.trace_id;
+        "trace-other-live" other_meta.runtime.trace_id;
       Alcotest.(check bool) "legacy dir removed after merge" false
         (Sys.file_exists legacy_dir);
       Alcotest.(check bool) "replaced stale keeper quarantined" true

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1198,7 +1198,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         | Error e -> fail e
       in
       let metrics_store = Masc_mcp.Keeper_types.keeper_metrics_store config meta.name in
-      let history_path = Masc_mcp.Keeper_types.keeper_history_path config meta.trace_id in
+      let history_path = Masc_mcp.Keeper_types.keeper_history_path config meta.runtime.trace_id in
       let memory_bank_path = Masc_mcp.Keeper_types.keeper_memory_bank_path config meta.name in
       let turn_json = Yojson.Safe.from_string
           {|{"channel":"turn","generation":0,"trace_id":"trace-1","context_ratio":0.41,"context_tokens":120,"context_max":1024,"message_count":4,"memory_check":{"performed":true,"passed":true,"final_score":0.9},"skill_primary":"masc-heartbeat","skill_secondary":["masc-keeper-autonomy"],"skill_reason":"stateful routing","skill_selection_mode":"agent","skill_provenance":"judgment"}|}
@@ -1817,7 +1817,7 @@ let test_keeper_bootstrap_marks_stale_explicit_keeper () =
         {
           meta with
           proactive = { meta.proactive with enabled = false };
-          usage = { meta.usage with last_turn_ts = 0.0 };
+          runtime = { meta.runtime with usage = { meta.runtime.usage with last_turn_ts = 0.0 } };
         }
       in
       (match Masc_mcp.Keeper_types.write_meta config stale_meta with


### PR DESCRIPTION
## Summary

- **keeper_meta god record(83필드) 분리**: `agent_runtime_state` 타입을 신설하여 32개 runtime 필드를 `keeper_meta.runtime`으로 이동
- **proactive/compaction 타입 분리**: `proactive_config` → `proactive_policy` + `proactive_runtime`, `compaction_state` → `compaction_policy` + `compaction_runtime`
- **Flat JSON 직렬화 유지**: 외부 API/persisted JSON 키 변경 없이 내부 OCaml 타입만 구조화 (backward compatible)
- **Updater helpers 4개 추가**: `map_runtime`, `map_usage`, `map_compaction_rt`, `map_proactive_rt`로 nested update 간소화

## Scope

32개 파일, ~1100 line diff. 프로덕션 코드 27개 + 테스트 5개.

Phase 1: internal shape cleanup only — external surface (flat JSON, status API)는 변경 없음.

## Product impact

Internal refactoring only. 사용자 대면 변경 없음. keeper JSON 직렬화 포맷 backward compatible.

## Evidence

- `dune build @all`: 7 wave compiler-driven migration, 전체 통과
- CI: Build and Test, Lint, Health, Contract Harness, Dashboard 전체 green
- GLM-5.1 cross-model review: false positives 확인, 실질 이슈 없음

## Review evidence

- Copilot: 32/32 files reviewed, 1 comment (abs min_int edge case → fixed with `land max_int`)
- GLM-5.1: core diff review 수행. `meta_of_json` 누락 지적은 truncated diff artifact. policy/runtime 분류는 Plan 문서에 근거.

## Linked issue

Closes #3813
Follow-up: #3814 (`last_triage_triggers` 중복 정리)

## Test plan

- [x] `dune build @all` 전체 빌드 통과 (0 errors)
- [x] CI Build and Test pass
- [x] CI Contract Harness pass
- [x] CI Lint pass
- [x] CI Health pass
- [x] GLM cross-model review