### PR TITLE
feat(governance): auto-create V2 petitions from pipeline High/Critical events

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -164,6 +164,37 @@ let audit_decision (config : Room.config) (decision : governance_decision) =
     ~confirmation_state:action_str
     ()
 
+(* ── Auto-Petition for High/Critical Risk ──────────────────── *)
+
+let maybe_create_petition ~config ~(decision : governance_decision) =
+  if risk_level_to_int decision.risk >= risk_level_to_int High then begin
+    let module GV2 = Council.Governance_v2 in
+    let gv2_risk = if decision.risk = Critical then GV2.High else GV2.Low in
+    let action : GV2.action_request = {
+      action_type = "review_tool_usage";
+      target_type = Some "tool";
+      target_id = Some decision.tool_name;
+      payload = Some (`Assoc [
+        ("risk_level", `String (risk_level_to_string decision.risk));
+        ("trace_id", `String decision.trace_id);
+      ]);
+    } in
+    match GV2.submit_petition config.Room.base_path
+      ~title:(Printf.sprintf "High-risk tool: %s" decision.tool_name)
+      ~origin:"governance-pipeline"
+      ~subject_type:"tool_call"
+      ~risk_class:gv2_risk
+      ~requested_action:(Some action)
+      ~source_refs:[decision.trace_id]
+      ~created_by:"governance-pipeline"
+    with
+    | Ok result ->
+      Log.Governance.info "auto-petition created: case=%s tool=%s"
+        result.case_.id decision.tool_name
+    | Error msg ->
+      Log.Governance.warn "auto-petition failed: %s" msg
+  end
+
 (* ── Pre-Hook Construction ──────────────────────────────────── *)
 
 let make_pre_hook ~config ~governance_level =
@@ -175,6 +206,7 @@ let make_pre_hook ~config ~governance_level =
     match decision.action with
     | `Allow -> None  (* proceed to handler *)
     | `Require_confirm reason ->
+        maybe_create_petition ~config ~decision;
         Log.Governance.info "[%s] tool=%s risk=%s -> require_confirm (trace=%s)"
           governance_level name (risk_level_to_string decision.risk) decision.trace_id;
         let response = `Assoc [
@@ -192,6 +224,7 @@ let make_pre_hook ~config ~governance_level =
           duration_ms = 0.0;
         }
     | `Deny reason ->
+        maybe_create_petition ~config ~decision;
         Log.Governance.warn "[%s] tool=%s risk=%s -> deny (trace=%s)"
           governance_level name (risk_level_to_string decision.risk) decision.trace_id;
         let response = `Assoc [

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -169,7 +169,7 @@ let audit_decision (config : Room.config) (decision : governance_decision) =
 let maybe_create_petition ~config ~(decision : governance_decision) =
   if risk_level_to_int decision.risk >= risk_level_to_int High then begin
     let module GV2 = Council.Governance_v2 in
-    let gv2_risk = if decision.risk = Critical then GV2.High else GV2.Low in
+    let gv2_risk = GV2.High in
     let action : GV2.action_request = {
       action_type = "review_tool_usage";
       target_type = Some "tool";


### PR DESCRIPTION
## Summary

- High/Critical risk 도구 호출이 governance pipeline에 의해 차단될 때 V2 petition을 자동 생성
- `governance_pipeline.ml`에 `maybe_create_petition` 함수 추가
- `Council.Governance_v2.submit_petition`을 실제 `action_request` 타입으로 호출
- GV2 deduplication (normalized_key)으로 중복 petition 방지

## Changes

1 file: `lib/governance_pipeline.ml` (+33 lines)

## Closes

- Closes #3819

## Test plan

- [x] `test_governance_pipeline.exe` 57/57 통과
- [x] `dune build` 통과
- [ ] production/enterprise 모드에서 High-risk 도구 호출 시 `.masc/governance_v2/petitions/` 파일 생성 확인
- [ ] 대시보드 governance 탭에 case 표시 확인