### PR TITLE
chore(config): remove dead config modules, expose missing dashboard settings

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -1,42 +1,5 @@
 open Env_config_core
 
-module Endpoints = struct
-  let masc_host_result () =
-    match Uri.host (Uri.of_string (masc_http_base_url ())) with
-    | Some host -> Ok host
-    | None -> Error "MASC_HTTP_BASE_URL must include a host"
-
-  (** MASC server host *)
-  let masc_host () =
-    match masc_host_result () with
-    | Ok host -> host
-    | Error msg -> failwith msg
-
-  let masc_port_result () =
-    match Uri.port (Uri.of_string (masc_http_base_url ())) with
-    | Some port -> Ok port
-    | None -> (
-        match Uri.scheme (Uri.of_string (masc_http_base_url ())) with
-        | Some "https" -> Ok 443
-        | Some "http" -> Ok 80
-        | _ -> Error "MASC_HTTP_BASE_URL must include a port or scheme")
-
-  (** MASC server port *)
-  let masc_port () =
-    match masc_port_result () with
-    | Ok port -> port
-    | Error msg -> failwith msg
-
-  let masc_sse_url_result () =
-    Result.map (fun base -> Printf.sprintf "%s/sse" base) (masc_http_base_url_result ())
-
-  (** MASC SSE URL (derived) *)
-  let masc_sse_url () =
-    match masc_sse_url_result () with
-    | Ok url -> url
-    | Error msg -> failwith msg
-end
-
 (** {1 Keeper Bootstrap Configuration} *)
 
 module KeeperBootstrap = struct

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -104,46 +104,6 @@ module Orchestrator = struct
     get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED"
 end
 
-(** {1 Team Session Configuration} *)
-
-module TeamSession = struct
-  let model_35b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_35B" |> trim_opt
-
-  let model_27b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_27B" |> trim_opt
-
-  let model_9b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_9B" |> trim_opt
-
-  let router_judge_enabled =
-    get_bool ~default:true "MASC_TEAM_SESSION_ROUTER_JUDGE"
-
-  let router_judge_timeout_sec =
-    max 5 (get_int ~default:15 "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC")
-
-  let router_judge_confidence_threshold =
-    let v = get_float ~default:0.72 "MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD" in
-    Float.max 0.0 (Float.min 1.0 v)
-
-  let router_judge_model_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL" |> trim_opt
-end
-
-(** {1 Mitosis (Cell Division) Configuration} *)
-
-module Mitosis = struct
-  (** Time-based trigger interval (seconds) *)
-  let trigger_interval_seconds =
-    get_float ~default:300.0 "MASC_MITOSIS_INTERVAL_SEC"
-
-  (** Cooldown between consecutive handoffs (seconds).
-      Prevents rapid repeated handoffs when context_ratio fluctuates near threshold. *)
-  let handoff_cooldown_seconds =
-    get_float ~default:60.0 "MASC_MITOSIS_HANDOFF_COOLDOWN_SEC"
-
-end
-
 (** {1 Spawn Configuration} *)
 
 module Spawn = struct
@@ -193,29 +153,6 @@ module Cancellation = struct
     get_float ~default:3600.0 "MASC_CANCELLATION_TOKEN_MAX_AGE_SEC"
 end
 
-(** {1 Neo4j Configuration} *)
-
-module Neo4j = struct
-  (** Bolt connection URI *)
-  let uri =
-    get_string ~default:"bolt://turntable.proxy.rlwy.net:11490" "NEO4J_URI"
-
-  (** HTTP API URI (overrides bolt-to-HTTP conversion when set) *)
-  let http_uri =
-    get_string ~default:"" "NEO4J_HTTP_URI"
-
-  (** Database user *)
-  let user =
-    get_string ~default:"neo4j" "NEO4J_USER"
-
-  (** Require NEO4J_PASSWORD from environment. Returns Error if unset or empty. *)
-  let password_result () : (string, string) result =
-    match Sys.getenv_opt "NEO4J_PASSWORD" with
-    | Some pw when String.trim pw <> "" -> Ok pw
-    | Some _ -> Error "NEO4J_PASSWORD is set but empty"
-    | None -> Error "NEO4J_PASSWORD not set"
-end
-
 (** {1 Voice Bridge Configuration} *)
 
 module Voice = struct
@@ -228,55 +165,12 @@ module Voice = struct
     get_int ~default:8936 "VOICE_MCP_PORT"
 end
 
-(** {1 Network Utilities} *)
-
-module Network = struct
-  (** Check if a host string refers to the local machine.
-      Covers localhost, 127.0.0.0/8 (any 127.x address), and ::1. *)
-  let is_localhost host =
-    host = "localhost"
-    || host = "::1"
-    || String.length host >= 4 && String.sub host 0 4 = "127."
-end
-
 (** {1 Timeout Defaults} *)
 
 module Timeout = struct
   (** gcloud auth token fetch (used by a2a_tools, model_client, keeper_alerting) *)
   let gcloud_auth_sec =
     get_float ~default:15.0 "MASC_TIMEOUT_GCLOUD_AUTH_SEC"
-
-  (** Anthropic / Claude API request timeout *)
-  let anthropic_api_sec =
-    get_int ~default:120 "MASC_TIMEOUT_ANTHROPIC_SEC"
-
-  (** OpenAI-compatible API request timeout *)
-  let openai_compat_api_sec =
-    get_int ~default:60 "MASC_TIMEOUT_OPENAI_COMPAT_SEC"
-
-  (** Grace period added on top of MODEL timeouts for curl/network overhead *)
-  let model_grace_sec =
-    get_float ~default:5.0 "MASC_TIMEOUT_MODEL_GRACE_SEC"
-
-  (** Keeper status check timeout *)
-  let keeper_status_sec =
-    get_float ~default:5.0 "MASC_TIMEOUT_KEEPER_STATUS_SEC"
-end
-
-(** {1 MODEL Generation Defaults} *)
-
-module Inference_defaults = struct
-  (** Default max_tokens for MODEL generation (used by spawn, chain, keeper, etc.) *)
-  let default_max_tokens =
-    get_int ~default:4096 "MASC_INFERENCE_DEFAULT_MAX_TOKENS"
-
-  (** SSE retry interval in milliseconds (client reconnection hint) *)
-  let sse_retry_ms =
-    get_int ~default:3000 "MASC_SSE_RETRY_MS"
-
-  (** Log output truncation length *)
-  let log_truncation_len =
-    get_int ~default:1500 "MASC_LOG_TRUNCATION_LEN"
 end
 
 (** {1 Control Plane Cleanup Configuration} *)
@@ -449,16 +343,6 @@ end
 module Pulse_config = struct
   (** Max consecutive consumer failures before recovery. Default: 3. *)
   let max_consumer_failures = max 1 (get_int ~default:3 "MASC_PULSE_MAX_CONSUMER_FAILURES")
-end
-
-(** {1 Circuit Breaker Configuration} *)
-
-module Circuit = struct
-  (** Failure count threshold before opening circuit. Default: 5. *)
-  let failure_threshold = get_int ~default:5 "MASC_CIRCUIT_THRESHOLD"
-
-  (** Cooldown period after circuit opens (seconds). Default: 300. *)
-  let cooldown_sec = get_float ~default:300.0 "MASC_CIRCUIT_COOLDOWN"
 end
 
 (** {1 Tool Surface Configuration} *)

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -132,6 +132,56 @@ let keeper_entries = [
   entry ~default:"300" "MASC_KEEPER_SNAPSHOT_SEC" "Keeper keepalive snapshot interval";
   entry ~default:"false" "MASC_KEEPER_DEBUG" "Enable keeper debug logging";
   entry ~default:"0.10" "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" "Daily deliberation budget (USD)";
+  entry ~default:"5" "MASC_KEEPER_SUPERVISOR_MAX_RESTARTS" "Supervisor max restart attempts";
+  entry ~default:"10.0" "MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S" "Supervisor backoff base delay (seconds)";
+  entry ~default:"300.0" "MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S" "Supervisor backoff max delay (seconds)";
+  entry ~default:"0.3" "MASC_KEEPER_SELF_PRESERVATION_RATIO" "Self-preservation eviction ratio";
+  entry ~default:"5" "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES" "Max heartbeat failures before crash";
+  entry ~default:"10" "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES" "Max turn failures before crash";
+]
+
+let keeper_execution_entries = [
+  entry ~default:"0.5" "MASC_KEEPER_COMPACT_RATIO" "Context compaction trigger ratio";
+  entry ~default:"240" "MASC_KEEPER_COMPACT_MAX_MESSAGES" "Max messages before compaction";
+  entry ~default:"0" "MASC_KEEPER_COMPACT_MAX_TOKENS" "Max tokens before compaction (0=disabled)";
+  entry ~default:"0.10" "MASC_KEEPER_COST_GATE_USD" "Per-turn cost gate (USD)";
+  entry ~default:"0.50" "MASC_KEEPER_TOOL_COST_MAX_USD" "Max tool call cost (USD)";
+  entry ~default:"0.4" "MASC_KEEPER_UNIFIED_TEMP" "Unified turn temperature";
+  entry ~default:"2048" "MASC_KEEPER_UNIFIED_MAX_TOKENS" "Unified turn max output tokens";
+  entry ~default:"20" "MASC_KEEPER_UNIFIED_MAX_TURNS" "Unified turn max tool loops";
+  entry ~default:"3" "MASC_KEEPER_MAX_TOOL_ROUNDS" "Max tool loop rounds per turn";
+  entry ~default:"4000" "MASC_KEEPER_AUTONOMOUS_MAX_TOKENS" "Autonomous execution max tokens";
+  entry ~default:"0.55" "MASC_KEEPER_PROACTIVE_TEMP_LOW" "Proactive temperature (low urgency)";
+  entry ~default:"0.75" "MASC_KEEPER_PROACTIVE_TEMP_MID" "Proactive temperature (mid urgency)";
+  entry ~default:"0.9" "MASC_KEEPER_PROACTIVE_TEMP_HIGH" "Proactive temperature (high urgency)";
+  entry ~default:"0.72" "MASC_KEEPER_PROACTIVE_SIMILARITY" "Proactive similarity threshold";
+]
+
+let keeper_guardrail_entries = [
+  entry ~default:"0.86" "MASC_KEEPER_RULE_REFLECT_REPETITION" "Reflection repetition threshold";
+  entry ~default:"0.06" "MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX" "Plan goal alignment max";
+  entry ~default:"0.10" "MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX" "Plan response alignment max";
+  entry ~default:"0.90" "MASC_KEEPER_RULE_GUARDRAIL_REPETITION" "Guardrail repetition threshold";
+  entry ~default:"0.04" "MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX" "Guardrail goal alignment max";
+  entry ~default:"0.08" "MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX" "Guardrail response alignment max";
+  entry ~default:"0.70" "MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN" "Guardrail context minimum";
+]
+
+let autonomy_entries = [
+  entry ~default:"3" "MASC_AUTONOMY_QUIET_START" "Quiet hours start (0-23)";
+  entry ~default:"7" "MASC_AUTONOMY_QUIET_END" "Quiet hours end (0-23)";
+  entry ~default:"12" "MASC_AUTONOMY_MAX_STARVATION_TICKS" "Max agent starvation ticks";
+  entry ~default:"0.7" "MASC_AUTONOMY_THOMPSON_WEIGHT" "Thompson sampling weight";
+  entry ~default:"0.95" "MASC_AUTONOMY_VOTE_DECAY_FACTOR" "Vote decay factor";
+]
+
+let level2_entries = [
+  entry ~default:"0.85" "MASC_DRIFT_THRESHOLD" "Drift detection threshold";
+  entry ~default:"0.4" "MASC_DRIFT_JACCARD_WEIGHT" "Drift Jaccard weight";
+  entry ~default:"0.6" "MASC_DRIFT_COSINE_WEIGHT" "Drift cosine weight";
+  entry ~default:"0.075" "MASC_HEBBIAN_RATE" "Hebbian learning rate";
+  entry ~default:"0.01" "MASC_HEBBIAN_DECAY" "Hebbian decay rate";
+  entry ~default:"100" "MASC_LOCK_WARN_MS" "Lock contention warning threshold (ms)";
 ]
 
 let dashboard_entries = [
@@ -169,6 +219,10 @@ let all_categories () = [
   category "chain" chain_entries;
   category "inference" inference_entries;
   category "keeper" keeper_entries;
+  category "keeper_execution" keeper_execution_entries;
+  category "keeper_guardrails" keeper_guardrail_entries;
+  category "autonomy" autonomy_entries;
+  category "level2" level2_entries;
   category "dashboard" dashboard_entries;
 ]
 

--- a/lib/level2_config.ml
+++ b/lib/level2_config.ml
@@ -3,8 +3,6 @@
     MAGI Recommendation: Externalize hardcoded constants for runtime tuning.
 
     Environment variables:
-    - MASC_METRICS_CACHE_TTL: Metrics cache TTL in seconds (default: 300)
-    - MASC_TOKEN_CACHE_SIZE: Max token cache entries (default: 1000)
     - MASC_DRIFT_THRESHOLD: Drift detection threshold (default: 0.85)
     - MASC_LOCK_WARN_MS: Lock contention warning threshold in ms (default: 100)
     - MASC_HEBBIAN_RATE: Symmetric Hebbian learning rate (default: 0.075)
@@ -15,21 +13,6 @@ let get_env_float name default =
   match Sys.getenv_opt name with
   | Some s -> Safe_ops.float_of_string_with_default ~default s
   | None -> default
-
-let get_env_int name default =
-  match Sys.getenv_opt name with
-  | Some s -> Safe_ops.int_of_string_with_default ~default s
-  | None -> default
-
-(** Metrics cache configuration *)
-module Metrics_cache = struct
-  let ttl_seconds () = get_env_float "MASC_METRICS_CACHE_TTL" 300.0
-end
-
-(** Token cache configuration *)
-module Token_cache = struct
-  let max_size () = get_env_int "MASC_TOKEN_CACHE_SIZE" 1000
-end
 
 (** Drift guard configuration *)
 module Drift_guard = struct
@@ -56,28 +39,18 @@ module Hebbian = struct
   let max_weight () = get_env_float "MASC_HEBBIAN_MAX_WEIGHT" 1.0
 end
 
-(** Fitness configuration *)
-module Fitness = struct
-  let recency_halflife_days () = get_env_float "MASC_FITNESS_HALFLIFE" 7.0
-end
-
 (** Get all config as JSON for debugging *)
 let to_json () : Yojson.Safe.t =
   `Assoc [
-    ("metrics_cache_ttl", `Float (Metrics_cache.ttl_seconds ()));
-    ("token_cache_max_size", `Int (Token_cache.max_size ()));
     ("drift_threshold", `Float (Drift_guard.default_threshold ()));
     ("lock_warn_ms", `Float (Lock.warn_threshold_ms ()));
     ("hebbian_rate", `Float (Hebbian.learning_rate ()));
     ("hebbian_decay", `Float (Hebbian.decay_rate ()));
-    ("fitness_halflife_days", `Float (Fitness.recency_halflife_days ()));
   ]
 
 (** Print config to stderr for debugging *)
 let print_config () =
   Log.Level2.info "Configuration:";
-  Log.Level2.info "  MASC_METRICS_CACHE_TTL=%.0f" (Metrics_cache.ttl_seconds ());
-  Log.Level2.info "  MASC_TOKEN_CACHE_SIZE=%d" (Token_cache.max_size ());
   Log.Level2.info "  MASC_DRIFT_THRESHOLD=%.2f" (Drift_guard.default_threshold ());
   Log.Level2.info "  MASC_LOCK_WARN_MS=%.0f" (Lock.warn_threshold_ms ());
   Log.Level2.info "  MASC_HEBBIAN_RATE=%.3f" (Hebbian.learning_rate ())

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -2,7 +2,7 @@
 
     Tests for MASC Environment Configuration:
     - get_string, get_int, get_float, get_bool: env var readers
-    - Zombie, Lock, Session, Tempo, Orchestrator, Mitosis, Cancellation modules
+    - Zombie, Lock, Session, Tempo, Orchestrator, Cancellation modules
 *)
 
 open Alcotest
@@ -134,16 +134,6 @@ let test_cluster_name_opt_trims_empty () =
     check string "cluster_name empty -> default" "default"
       (Env_config.cluster_name ()))
 
-let test_endpoints_result_helpers () =
-  with_env "MASC_HTTP_BASE_URL" "https://masc.example.test" (fun () ->
-    check (result string string) "masc_host_result"
-      (Ok "masc.example.test") (Env_config.Endpoints.masc_host_result ());
-    check (result int string) "masc_port_result"
-      (Ok 443) (Env_config.Endpoints.masc_port_result ());
-    check (result string string) "masc_sse_url_result"
-      (Ok "https://masc.example.test/sse")
-      (Env_config.Endpoints.masc_sse_url_result ()))
-
 (* ============================================================
    print_summary Tests
    ============================================================ *)
@@ -221,13 +211,6 @@ let test_orchestrator_interval_positive () =
 
 let test_orchestrator_agent_name_nonempty () =
   check bool "agent name nonempty" true (String.length Env_config.Orchestrator.agent_name > 0)
-
-(* ============================================================
-   Mitosis Module Tests
-   ============================================================ *)
-
-let test_mitosis_interval_positive () =
-  check bool "interval positive" true (Env_config.Mitosis.trigger_interval_seconds > 0.0)
 
 (* ============================================================
    Cancellation Module Tests
@@ -376,7 +359,6 @@ let () =
       test_case "masc_host reads primary env" `Quick test_masc_host_prefers_primary_over_deprecated;
       test_case "assets dir reads primary env" `Quick test_assets_dir_prefers_primary_over_deprecated;
       test_case "cluster_name_opt trims empty" `Quick test_cluster_name_opt_trims_empty;
-      test_case "endpoint result helpers" `Quick test_endpoints_result_helpers;
     ];
     "print_summary", [
       test_case "no error" `Quick test_print_summary_no_error;
@@ -405,9 +387,6 @@ let () =
     "orchestrator", [
       test_case "interval positive" `Quick test_orchestrator_interval_positive;
       test_case "agent name nonempty" `Quick test_orchestrator_agent_name_nonempty;
-    ];
-    "mitosis", [
-      test_case "interval positive" `Quick test_mitosis_interval_positive;
     ];
     "cancellation", [
       test_case "max age positive" `Quick test_cancellation_token_max_age_positive;

--- a/test/test_level2_config_coverage.ml
+++ b/test/test_level2_config_coverage.ml
@@ -1,32 +1,13 @@
 (** Level2_config Module Coverage Tests
 
     Tests for MASC Level 2 Configuration - Externalized Constants:
-    - get_env_float, get_env_int: environment variable readers
-    - Metrics_cache, Token_cache, Drift_guard, Lock, Hebbian, Fitness modules
+    - Drift_guard, Lock, Hebbian modules
     - to_json: configuration serialization
 *)
 
 open Alcotest
 
 module Level2_config = Masc_mcp.Level2_config
-
-(* ============================================================
-   Metrics_cache Tests
-   ============================================================ *)
-
-let test_metrics_cache_ttl_default () =
-  (* Default is 300.0 *)
-  let ttl = Level2_config.Metrics_cache.ttl_seconds () in
-  check bool "positive ttl" true (ttl > 0.0)
-
-(* ============================================================
-   Token_cache Tests
-   ============================================================ *)
-
-let test_token_cache_max_size_default () =
-  (* Default is 1000 *)
-  let size = Level2_config.Token_cache.max_size () in
-  check bool "positive size" true (size > 0)
 
 (* ============================================================
    Drift_guard Tests
@@ -76,14 +57,6 @@ let test_hebbian_min_less_than_max () =
   check bool "min < max" true (min_w < max_w)
 
 (* ============================================================
-   Fitness Tests
-   ============================================================ *)
-
-let test_fitness_halflife () =
-  let halflife = Level2_config.Fitness.recency_halflife_days () in
-  check bool "positive halflife" true (halflife > 0.0)
-
-(* ============================================================
    to_json Tests
    ============================================================ *)
 
@@ -91,20 +64,6 @@ let test_to_json_returns_assoc () =
   let json = Level2_config.to_json () in
   match json with
   | `Assoc _ -> ()
-  | _ -> fail "expected Assoc"
-
-let test_to_json_has_metrics_ttl () =
-  let json = Level2_config.to_json () in
-  match json with
-  | `Assoc fields ->
-    check bool "has metrics_cache_ttl" true (List.mem_assoc "metrics_cache_ttl" fields)
-  | _ -> fail "expected Assoc"
-
-let test_to_json_has_token_cache () =
-  let json = Level2_config.to_json () in
-  match json with
-  | `Assoc fields ->
-    check bool "has token_cache_max_size" true (List.mem_assoc "token_cache_max_size" fields)
   | _ -> fail "expected Assoc"
 
 let test_to_json_has_drift_threshold () =
@@ -147,19 +106,11 @@ let test_to_json_has_hebbian_decay () =
     check bool "has hebbian_decay" true (List.mem_assoc "hebbian_decay" fields)
   | _ -> fail "expected Assoc"
 
-let test_to_json_has_fitness_halflife () =
-  let json = Level2_config.to_json () in
-  match json with
-  | `Assoc fields ->
-    check bool "has fitness_halflife_days" true (List.mem_assoc "fitness_halflife_days" fields)
-  | _ -> fail "expected Assoc"
-
 (* ============================================================
    print_config Tests
    ============================================================ *)
 
 let test_print_config_no_error () =
-  (* Should not throw, just prints to stderr *)
   Level2_config.print_config ();
   ()
 
@@ -169,12 +120,6 @@ let test_print_config_no_error () =
 
 let () =
   run "Level2_config Coverage" [
-    "metrics_cache", [
-      test_case "ttl default" `Quick test_metrics_cache_ttl_default;
-    ];
-    "token_cache", [
-      test_case "max size default" `Quick test_token_cache_max_size_default;
-    ];
     "drift_guard", [
       test_case "threshold default" `Quick test_drift_guard_threshold_default;
       test_case "weights" `Quick test_drift_guard_weights;
@@ -189,18 +134,12 @@ let () =
       test_case "max weight" `Quick test_hebbian_max_weight;
       test_case "min < max" `Quick test_hebbian_min_less_than_max;
     ];
-    "fitness", [
-      test_case "halflife" `Quick test_fitness_halflife;
-    ];
     "to_json", [
       test_case "returns assoc" `Quick test_to_json_returns_assoc;
-      test_case "has metrics ttl" `Quick test_to_json_has_metrics_ttl;
-      test_case "has token cache" `Quick test_to_json_has_token_cache;
       test_case "has drift threshold" `Quick test_to_json_has_drift_threshold;
       test_case "has lock warn" `Quick test_to_json_has_lock_warn;
       test_case "has hebbian rate" `Quick test_to_json_has_hebbian_rate;
       test_case "has hebbian decay" `Quick test_to_json_has_hebbian_decay;
-      test_case "has fitness halflife" `Quick test_to_json_has_fitness_halflife;
       test_case "values positive" `Quick test_to_json_values_positive;
     ];
     "print_config", [

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -230,10 +230,6 @@ let test_env_orchestrator_agent_name () =
   let name = Env_config.Orchestrator.agent_name in
   check bool "non-empty name" true (String.length name > 0)
 
-let test_env_mitosis_interval () =
-  let interval = Env_config.Mitosis.trigger_interval_seconds in
-  check bool "positive interval" true (interval > 0.0)
-
 let test_env_cancellation_max_age () =
   let max_age = Env_config.Cancellation.token_max_age_seconds in
   check bool "positive max_age" true (max_age > 0.0)
@@ -324,9 +320,6 @@ let () =
     "env_config.orchestrator", [
       test_case "interval" `Quick test_env_orchestrator_interval;
       test_case "agent_name" `Quick test_env_orchestrator_agent_name;
-    ];
-    "env_config.mitosis", [
-      test_case "interval" `Quick test_env_mitosis_interval;
     ];
     "env_config.cancellation", [
       test_case "max_age" `Quick test_env_cancellation_max_age;


### PR DESCRIPTION
## Summary
- Dead config 모듈 11개 제거 (-271줄): TeamSession, Mitosis(env_config), Neo4j wrapper, Network, Inference_defaults, Circuit wrapper, Timeout 4필드, Endpoints, Level2 Metrics_cache/Token_cache/Fitness
- 대시보드 설정 노출 38개 추가 (+56줄): keeper_execution(14), keeper_guardrails(7), autonomy(5), level2(6), keeper 확장(6)
- env 변수 자체가 직접 읽히는 경우(circuit_breaker.ml, thread_persist.ml)는 영향 없음. 래퍼 모듈만 제거

## Evidence
- 각 dead 모듈을 `rg 'Env_config\.(모듈명)' lib/ --include='*.ml'`로 검증: 0건
- Neo4j/Circuit env vars는 `Sys.getenv_opt`로 직접 사용됨 (래퍼 미경유) — 동작 무변경
- Default 값은 기존 코드 그대로 노출 (신규 값 없음)

## Review evidence
- GLM-5.1 교차 리뷰 완료: 4개 이슈 제기 → 전부 컨텍스트 부족 오탐 (CI green이 증거)
- Copilot: "reviewed 7 out of 7 changed files, generated no comments"

## Linked issue
Refs: dashboard config introspection 갭 및 config drift 정리

## Test plan
- [x] `dune build` 컴파일 성공
- [x] CI Build and Test pass (9m27s)
- [x] CI Contract Harness pass (5m57s)
- [x] CI Health pass (5m38s)
- [x] CI Lint pass (5m40s)
- [x] CI Dashboard pass (30s)
- [x] `test_env_config_coverage.exe` 56개 테스트 통과
- [x] `test_level2_config_coverage.exe` 15개 테스트 통과
- [x] 잔여 dead 참조 grep 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)