### PR TITLE
refactor(oas_worker): consolidate inference defaults to single definition

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -14,6 +14,15 @@
 module Oas = Agent_sdk
 
 (* ================================================================ *)
+(* Inference defaults — single definition point (ADR D2).            *)
+(* Callers override via optional params.                             *)
+(* Cascade config auto-resolution tracked in jeong-sik/me#915.      *)
+(* ================================================================ *)
+
+let default_temperature = 0.7
+let default_max_tokens = 4096
+
+(* ================================================================ *)
 (* Cascade metrics                                                   *)
 (* ================================================================ *)
 
@@ -97,8 +106,8 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
   { name; provider; model_id; system_prompt; tools;
     max_turns = 20;
     max_idle_turns = 3;
-    max_tokens = 4096;
-    temperature = 0.7;
+    max_tokens = default_max_tokens;
+    temperature = default_temperature;
     hooks = None;
     context_reducer = None;
     guardrails = None;
@@ -474,8 +483,8 @@ let run_named
     ?(initial_messages = [])
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
-    ?(temperature = 0.7)
-    ?(max_tokens = 4096)
+    ?(temperature = default_temperature)
+    ?(max_tokens = default_max_tokens)
     ?(accept = fun (_ : Oas_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -554,8 +563,8 @@ let run_model_by_label
     ?(tools = [])
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
-    ?(temperature = 0.7)
-    ?(max_tokens = 4096)
+    ?(temperature = default_temperature)
+    ?(max_tokens = default_max_tokens)
     ?(accept = fun (_ : Oas_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -601,8 +610,8 @@ let run_named_with_masc_tools
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?(max_turns = 20)
-    ?(temperature = 0.7)
-    ?(max_tokens = 4096)
+    ?(temperature = default_temperature)
+    ?(max_tokens = default_max_tokens)
     ?guardrails
     ?hooks
     ?memory
@@ -633,8 +642,8 @@ let run_model_with_masc_tools
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?(max_turns = 20)
-    ?(temperature = 0.7)
-    ?(max_tokens = 4096)
+    ?(temperature = default_temperature)
+    ?(max_tokens = default_max_tokens)
     ?guardrails
     ?hooks
     ?memory

--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -42,8 +42,8 @@ let default ?(repo = default_repo_config ()) () : t =
     cascade_name = "research";
     cascade_defaults = ["llama:auto"];
     timeout_sec = 120;
-    max_tokens = 8192;
-    temperature = 0.7;
+    max_tokens = 8192;  (* research-specific: larger budget for code analysis *)
+    temperature = 0.7;  (* TODO: resolve from cascade config "research" profile *)
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \


### PR DESCRIPTION
## Summary
- oas_worker.ml의 temperature=0.7 + max_tokens=4096 5곳 반복을 default_temperature, default_max_tokens 상수로 통합
- research_config.ml에 cascade config TODO 추가
- auto_recall.ml의 max_tokens=2000은 recall context budget이므로 변경 없음

## Product Impact
inference default 변경 시 1곳만 수정 (기존 5곳). Cascade config auto-resolution은 별도 follow-up.

## Evidence
- dune build: green
- 기존 동작 변경 없음 (값 동일, 참조만 상수화)

## Review Evidence
- GLM-5 (sb glm-text) cross-model review 2026-03-30: 5건 중 해당 1건
  - #3 research_config.ml temperature 미연결: 유효. 별도 sub-library(lib/research/)라 cross-dep보다 TODO 유지가 적절

## ADR
docs/design/adr-masc-oas-boundary-ssot.md D2

Refs jeong-sik/me#915