### PR TITLE
feat(dashboard): add session activity report to agent detail

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.test.ts
+++ b/dashboard/src/components/agent-detail-session-report.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractBroadcasts,
+  extractTaskEvents,
+  groupBroadcastsIntoReports,
+} from './agent-detail-session-report'
+import type { AgentTimelineEvent } from '../api'
+
+function makeEvent(type: string, detail: Record<string, unknown>, ts = '2026-03-30T10:00:00Z'): AgentTimelineEvent {
+  return { type, detail, ts }
+}
+
+describe('extractBroadcasts', () => {
+  it('filters only broadcast events with content > 20 chars', () => {
+    const events: AgentTimelineEvent[] = [
+      makeEvent('broadcast', { content: 'This is a meaningful broadcast message about work done' }),
+      makeEvent('broadcast', { content: 'short' }),
+      makeEvent('task_completed', { title: 'some task' }),
+      makeEvent('broadcast', { content: 12345 }), // non-string content
+      makeEvent('broadcast', { content: 'Another meaningful message about analysis results' }),
+    ]
+    const result = extractBroadcasts(events)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.detail.content).toBe('This is a meaningful broadcast message about work done')
+    expect(result[1]!.detail.content).toBe('Another meaningful message about analysis results')
+  })
+
+  it('returns empty array when no broadcasts exist', () => {
+    const events: AgentTimelineEvent[] = [
+      makeEvent('task_completed', { title: 'task' }),
+      makeEvent('joined', {}),
+    ]
+    expect(extractBroadcasts(events)).toEqual([])
+  })
+
+  it('handles missing content field gracefully', () => {
+    const events: AgentTimelineEvent[] = [
+      makeEvent('broadcast', {}),
+      makeEvent('broadcast', { other: 'field' }),
+    ]
+    expect(extractBroadcasts(events)).toEqual([])
+  })
+})
+
+describe('extractTaskEvents', () => {
+  it('filters events starting with task_', () => {
+    const events: AgentTimelineEvent[] = [
+      makeEvent('task_completed', { title: 'A' }),
+      makeEvent('broadcast', { content: 'msg' }),
+      makeEvent('task_claimed', { title: 'B' }),
+      makeEvent('joined', {}),
+      makeEvent('task_cancelled', { title: 'C' }),
+    ]
+    const result = extractTaskEvents(events)
+    expect(result).toHaveLength(3)
+    expect(result.map(e => e.type)).toEqual(['task_completed', 'task_claimed', 'task_cancelled'])
+  })
+})
+
+describe('groupBroadcastsIntoReports', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupBroadcastsIntoReports([])).toEqual([])
+  })
+
+  it('creates one report per broadcast when gaps > 60s', () => {
+    const broadcasts: AgentTimelineEvent[] = [
+      makeEvent('broadcast', { content: 'First report' }, '2026-03-30T10:00:00Z'),
+      makeEvent('broadcast', { content: 'Second report' }, '2026-03-30T10:02:00Z'),
+      makeEvent('broadcast', { content: 'Third report' }, '2026-03-30T10:05:00Z'),
+    ]
+    const result = groupBroadcastsIntoReports(broadcasts)
+    expect(result).toHaveLength(3)
+    expect(result[0]!.content).toBe('First report')
+    expect(result[1]!.content).toBe('Second report')
+    expect(result[2]!.content).toBe('Third report')
+  })
+
+  it('merges broadcasts within 60 seconds of each other', () => {
+    const broadcasts: AgentTimelineEvent[] = [
+      makeEvent('broadcast', { content: 'Part 1' }, '2026-03-30T10:00:00Z'),
+      makeEvent('broadcast', { content: 'Part 2' }, '2026-03-30T10:00:30Z'),
+      makeEvent('broadcast', { content: 'Part 3' }, '2026-03-30T10:00:50Z'),
+    ]
+    const result = groupBroadcastsIntoReports(broadcasts)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.content).toBe('Part 1\n\n---\n\nPart 2\n\n---\n\nPart 3')
+    expect(result[0]!.ts).toBe('2026-03-30T10:00:00Z')
+  })
+
+  it('correctly handles chain: each <60s from previous but >60s from start', () => {
+    // 0s, 40s, 80s — each is <60s from previous, should all merge
+    const broadcasts: AgentTimelineEvent[] = [
+      makeEvent('broadcast', { content: 'A' }, '2026-03-30T10:00:00Z'),
+      makeEvent('broadcast', { content: 'B' }, '2026-03-30T10:00:40Z'),
+      makeEvent('broadcast', { content: 'C' }, '2026-03-30T10:01:20Z'),
+    ]
+    const result = groupBroadcastsIntoReports(broadcasts)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.content).toContain('A')
+    expect(result[0]!.content).toContain('B')
+    expect(result[0]!.content).toContain('C')
+  })
+
+  it('splits when gap from previous exceeds 60s', () => {
+    const broadcasts: AgentTimelineEvent[] = [
+      makeEvent('broadcast', { content: 'Group1-A' }, '2026-03-30T10:00:00Z'),
+      makeEvent('broadcast', { content: 'Group1-B' }, '2026-03-30T10:00:30Z'),
+      makeEvent('broadcast', { content: 'Group2-A' }, '2026-03-30T10:02:00Z'),
+    ]
+    const result = groupBroadcastsIntoReports(broadcasts)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.content).toContain('Group1-A')
+    expect(result[0]!.content).toContain('Group1-B')
+    expect(result[1]!.content).toBe('Group2-A')
+  })
+})

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -15,51 +15,60 @@ import {
 } from './agent-detail-state'
 import type { AgentTimelineEvent } from '../api'
 
-// ── Helpers ──────────────────────────────────────
+// ── Helpers (exported for testing) ───────────────
+
+/** Safely read a string field from evt.detail (typed as Record<string, unknown>) */
+function detailStr(detail: Record<string, unknown>, key: string): string {
+  const val = detail[key]
+  return typeof val === 'string' ? val : ''
+}
 
 /** Extract broadcast events with meaningful content from timeline */
-function extractBroadcasts(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
+export function extractBroadcasts(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
   return events
     .filter(evt => evt.type === 'broadcast')
     .filter(evt => {
-      const content = (evt.detail as Record<string, string>).content ?? ''
+      const content = detailStr(evt.detail, 'content')
       // Skip trivial heartbeat-like messages
       return content.length > 20
     })
 }
 
 /** Extract task-related events from timeline */
-function extractTaskEvents(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
+export function extractTaskEvents(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
   return events.filter(evt => evt.type.startsWith('task_'))
 }
 
-/** Group consecutive broadcasts that are part of the same report */
-function groupBroadcastsIntoReports(
+/** Group consecutive broadcasts that are part of the same report.
+ *  Broadcasts within 60 seconds of each other (compared to the previous event,
+ *  not the group start) are merged into one report card. */
+export function groupBroadcastsIntoReports(
   broadcasts: AgentTimelineEvent[],
 ): { ts: string; content: string }[] {
   if (broadcasts.length === 0) return []
 
-  // Each broadcast with substantial content is shown as its own report card.
-  // Broadcasts within 60 seconds of each other are merged into one report.
   const reports: { ts: string; parts: string[] }[] = []
   let current: { ts: string; parts: string[] } | null = null
+  let prevTs: string | null = null
 
   for (const evt of broadcasts) {
-    const content = (evt.detail as Record<string, string>).content ?? ''
+    const content = detailStr(evt.detail, 'content')
     const ts = evt.ts
 
-    if (current) {
-      const prevTime = new Date(current.ts).getTime()
+    if (current && prevTs) {
+      const prevTime = new Date(prevTs).getTime()
       const curTime = new Date(ts).getTime()
-      const gapSec = Math.abs(curTime - prevTime) / 1000
-      if (gapSec < 60) {
+      const gapSec = (curTime - prevTime) / 1000
+      if (gapSec >= 0 && gapSec < 60) {
         current.parts.push(content)
+        prevTs = ts
         continue
       }
     }
 
     current = { ts, parts: [content] }
     reports.push(current)
+    prevTs = ts
   }
 
   return reports.map(r => ({
@@ -148,8 +157,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
       <div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-2">태스크 이력</div>
       <div class="flex flex-col gap-1">
         ${events.map((evt, idx) => {
-          const detail = evt.detail as Record<string, string>
-          const title = detail.title ?? detail.task_id ?? ''
+          const title = detailStr(evt.detail, 'title') || detailStr(evt.detail, 'task_id')
           const icon = taskEventIcon(evt.type)
           const color = taskEventColor(evt.type)
           return html`
@@ -213,7 +221,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
   if (reports.length === 0 && taskEvents.length === 0) return null
 
   return html`
-    <${Card} title="세션 활동 리포트">
+    <${Card} title="세션 활동 리포트" class="mb-5">
       <${SessionMeta} agentName=${agentName} />
 
       ${summary ? html`
@@ -239,7 +247,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
       ${reports.length > 0 ? html`
         <div class="flex flex-col gap-3">
           ${reports.map((report, idx) => html`
-            <${BroadcastReport} key=${idx} report=${report} index=${idx} />
+            <${BroadcastReport} key=${report.ts} report=${report} index=${idx} />
           `)}
         </div>
       ` : null}

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -1,0 +1,250 @@
+// Agent session report — GitHub Agents–style activity view
+// Renders broadcast messages as full markdown cards, shows task summary, agent meta info
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { Card } from './common/card'
+import { TimeAgo } from './common/time-ago'
+import { Markdown } from './common/markdown'
+import {
+  agentTimeline,
+  selectedAgent,
+  missionAgentBrief,
+  continuityBriefForAgent,
+  keeperForAgent,
+} from './agent-detail-state'
+import type { AgentTimelineEvent } from '../api'
+
+// ── Helpers ──────────────────────────────────────
+
+/** Extract broadcast events with meaningful content from timeline */
+function extractBroadcasts(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
+  return events
+    .filter(evt => evt.type === 'broadcast')
+    .filter(evt => {
+      const content = (evt.detail as Record<string, string>).content ?? ''
+      // Skip trivial heartbeat-like messages
+      return content.length > 20
+    })
+}
+
+/** Extract task-related events from timeline */
+function extractTaskEvents(events: AgentTimelineEvent[]): AgentTimelineEvent[] {
+  return events.filter(evt => evt.type.startsWith('task_'))
+}
+
+/** Group consecutive broadcasts that are part of the same report */
+function groupBroadcastsIntoReports(
+  broadcasts: AgentTimelineEvent[],
+): { ts: string; content: string }[] {
+  if (broadcasts.length === 0) return []
+
+  // Each broadcast with substantial content is shown as its own report card.
+  // Broadcasts within 60 seconds of each other are merged into one report.
+  const reports: { ts: string; parts: string[] }[] = []
+  let current: { ts: string; parts: string[] } | null = null
+
+  for (const evt of broadcasts) {
+    const content = (evt.detail as Record<string, string>).content ?? ''
+    const ts = evt.ts
+
+    if (current) {
+      const prevTime = new Date(current.ts).getTime()
+      const curTime = new Date(ts).getTime()
+      const gapSec = Math.abs(curTime - prevTime) / 1000
+      if (gapSec < 60) {
+        current.parts.push(content)
+        continue
+      }
+    }
+
+    current = { ts, parts: [content] }
+    reports.push(current)
+  }
+
+  return reports.map(r => ({
+    ts: r.ts,
+    content: r.parts.join('\n\n---\n\n'),
+  }))
+}
+
+function taskEventIcon(type: string): string {
+  switch (type) {
+    case 'task_completed': return 'done'
+    case 'task_claimed': return 'claim'
+    case 'task_started': return 'start'
+    case 'task_cancelled': return 'cancel'
+    default: return type.replace('task_', '')
+  }
+}
+
+function taskEventColor(type: string): string {
+  switch (type) {
+    case 'task_completed': return 'text-ok'
+    case 'task_cancelled': return 'text-bad'
+    default: return 'text-accent'
+  }
+}
+
+// ── Components ───────────────────────────────────
+
+function SessionMeta({ agentName }: { agentName: string }) {
+  const agent = selectedAgent()
+  const brief = missionAgentBrief(agentName)
+  const continuity = continuityBriefForAgent(agentName)
+  const keeper = keeperForAgent(agentName)
+  const timeline = agentTimeline.value
+
+  const meta: { label: string; value: string }[] = []
+
+  if (brief?.where) {
+    meta.push({ label: '위치', value: brief.where })
+  }
+
+  if (brief?.related_session_id) {
+    meta.push({ label: '세션', value: brief.related_session_id })
+  }
+
+  if (agent?.model) {
+    meta.push({ label: '모델', value: agent.model })
+  }
+
+  if (timeline?.summary?.active_duration_minutes) {
+    const mins = Math.round(timeline.summary.active_duration_minutes)
+    meta.push({ label: '활동 시간', value: `${mins}분` })
+  }
+
+  if (keeper?.name) {
+    meta.push({ label: '키퍼', value: keeper.name })
+  }
+
+  if (brief?.current_work) {
+    meta.push({ label: '현재 작업', value: brief.current_work })
+  }
+
+  if (continuity?.continuity_summary) {
+    meta.push({ label: '연속성', value: continuity.continuity_summary })
+  }
+
+  if (meta.length === 0) return null
+
+  return html`
+    <div class="flex flex-wrap gap-2 mb-4">
+      ${meta.map(m => html`
+        <span key=${m.label} class="inline-flex items-center gap-1.5 text-[11px] font-medium py-1 px-2.5 bg-white/5 border border-white/10 rounded-lg text-text-muted">
+          <span class="text-text-dim">${m.label}</span>
+          <span class="text-text-strong font-mono text-[10px]">${m.value}</span>
+        </span>
+      `)}
+    </div>
+  `
+}
+
+function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
+  if (events.length === 0) return null
+
+  return html`
+    <div class="mt-4">
+      <div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-2">태스크 이력</div>
+      <div class="flex flex-col gap-1">
+        ${events.map((evt, idx) => {
+          const detail = evt.detail as Record<string, string>
+          const title = detail.title ?? detail.task_id ?? ''
+          const icon = taskEventIcon(evt.type)
+          const color = taskEventColor(evt.type)
+          return html`
+            <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded-lg hover:bg-white/3 transition-colors">
+              <span class="text-[10px] font-bold uppercase tracking-wider ${color} bg-white/5 px-2 py-0.5 rounded">${icon}</span>
+              <span class="text-[12px] text-text-body flex-1 truncate">${title}</span>
+              ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}
+
+function BroadcastReport({ report, index }: { report: { ts: string; content: string }; index: number }) {
+  const [expanded, setExpanded] = useState(index === 0) // first one expanded by default
+
+  // For long reports, show a preview when collapsed
+  const isLong = report.content.length > 400
+  const preview = isLong && !expanded
+    ? report.content.slice(0, 300) + '...'
+    : report.content
+
+  return html`
+    <div class="border border-card-border/60 rounded-xl bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
+      <div
+        class="flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-card-border/40 cursor-pointer select-none"
+        onClick=${() => setExpanded(!expanded)}
+      >
+        <div class="flex items-center gap-2">
+          <span class="size-2 rounded-full ${index === 0 ? 'bg-accent' : 'bg-white/20'}"></span>
+          <${TimeAgo} timestamp=${report.ts} />
+        </div>
+        ${isLong ? html`
+          <span class="text-[10px] text-text-dim font-medium">
+            ${expanded ? '접기' : '펼치기'}
+          </span>
+        ` : null}
+      </div>
+      <div class="px-4 py-3 text-[13px] leading-relaxed">
+        <${Markdown} text=${expanded || !isLong ? report.content : preview} />
+      </div>
+    </div>
+  `
+}
+
+// ── Main Export ───────────────────────────────────
+
+export function AgentSessionReport({ agentName }: { agentName: string }) {
+  const timeline = agentTimeline.value
+  if (!timeline) return null
+
+  const events = timeline.events ?? []
+  const broadcasts = extractBroadcasts(events)
+  const taskEvents = extractTaskEvents(events)
+  const reports = groupBroadcastsIntoReports(broadcasts)
+  const summary = timeline.summary
+
+  // Don't show this section if there's no meaningful content
+  if (reports.length === 0 && taskEvents.length === 0) return null
+
+  return html`
+    <${Card} title="세션 활동 리포트">
+      <${SessionMeta} agentName=${agentName} />
+
+      ${summary ? html`
+        <div class="flex gap-3 flex-wrap mb-4">
+          ${summary.tasks_completed > 0 ? html`
+            <div class="flex items-center gap-1.5 text-[12px] font-medium text-ok bg-ok/10 border border-ok/20 px-3 py-1.5 rounded-lg">
+              <span class="font-bold">${summary.tasks_completed}</span> 완료
+            </div>
+          ` : null}
+          ${summary.tasks_claimed > 0 ? html`
+            <div class="flex items-center gap-1.5 text-[12px] font-medium text-accent bg-accent/10 border border-accent/20 px-3 py-1.5 rounded-lg">
+              <span class="font-bold">${summary.tasks_claimed}</span> 수임
+            </div>
+          ` : null}
+          ${summary.messages_sent > 0 ? html`
+            <div class="flex items-center gap-1.5 text-[12px] font-medium text-text-muted bg-white/5 border border-white/10 px-3 py-1.5 rounded-lg">
+              <span class="font-bold">${summary.messages_sent}</span> 메시지
+            </div>
+          ` : null}
+        </div>
+      ` : null}
+
+      ${reports.length > 0 ? html`
+        <div class="flex flex-col gap-3">
+          ${reports.map((report, idx) => html`
+            <${BroadcastReport} key=${idx} report=${report} index=${idx} />
+          `)}
+        </div>
+      ` : null}
+
+      <${TaskEventTimeline} events=${taskEvents} />
+    <//>
+  `
+}

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -144,7 +144,7 @@ export async function refreshAgentDetail(): Promise<void> {
     // Fetch room messages, task histories, timeline, and fitness in parallel
     const [lines, timelineResult, fitnessResult] = await Promise.all([
       fetchRoomMessages(80),
-      fetchAgentTimeline(agentName, 4, 20).catch(() => null),
+      fetchAgentTimeline(agentName, 24, 50).catch(() => null),
       callMcpTool('masc_agent_fitness', { agent_name: agentName, days: 7 })
         .then(raw => JSON.parse(raw) as AgentFitness)
         .catch(() => null),

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -190,7 +190,7 @@ export function AgentDetailOverlay() {
 
         <${AgentSessionReport} agentName=${agentName} />
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5 mt-5">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -11,6 +11,7 @@ import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { keeperIdentityHint } from './common/keeper-identity'
 import { AgentJournalStream } from './agent-detail-journal'
+import { AgentSessionReport } from './agent-detail-session-report'
 import { AgentTimelineSection } from './agent-detail-timeline'
 import { AgentWorkerBrief } from './agent-detail-worker'
 import {
@@ -187,7 +188,9 @@ export function AgentDetailOverlay() {
 
         ${detailError.value ? html`<div class="p-4 mb-4 text-bad border border-bad/30 rounded-xl bg-bad/10 shadow-sm font-medium text-sm">${detailError.value}</div>` : null}
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5">
+        <${AgentSessionReport} agentName=${agentName} />
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5 mt-5">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`


### PR DESCRIPTION
## Summary
- Agent detail overlay에 **세션 활동 리포트** 추가 (GitHub Agents 스타일)
- 에이전트의 broadcast 메시지를 마크다운으로 풀 렌더링
- 60초 이내 연속 broadcast는 하나의 리포트 카드로 병합
- task 이벤트를 컬러 배지 타임라인으로 표시
- 세션 메타 정보 (위치, 세션 ID, 모델, 활동 시간, 키퍼, 현재 작업) 표시
- 타임라인 fetch 범위를 4h/20건에서 24h/50건으로 확대

## 변경 파일
- `dashboard/src/components/agent-detail-session-report.ts` (신규, 250줄)
- `dashboard/src/components/agent-detail-state.ts` (1줄 수정)
- `dashboard/src/components/agent-detail.ts` (3줄 수정)

## 동기
에이전트가 세션에서 수행한 작업의 가시성이 0이었음. broadcast 메시지에 에이전트 활동 보고가 담겨있지만, 기존 UI는 이를 80자로 잘라서 1줄로만 보여줌. 이제 기존 Markdown 렌더러를 활용해 풀 마크다운(heading, list, code, mermaid)으로 렌더링.

## Test plan
- [ ] 활성 에이전트의 상세 패널에서 "세션 활동 리포트" 카드가 표시되는지 확인
- [ ] broadcast가 없는 에이전트에서는 리포트 카드가 숨겨지는지 확인
- [ ] 긴 broadcast 메시지의 접기/펼치기가 동작하는지 확인
- [ ] 타입 체크 + Vite 빌드 통과 확인 (완료)

Generated with [Claude Code](https://claude.com/claude-code)