### PR TITLE
fix(verifier): eliminate silent degrade on unrecognized verdict format

### DIFF
--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -343,7 +343,10 @@ let verify_worker ~pattern (worker : worker_plan) diff =
           ~goal:prompt ~max_turns:1
           ~temperature:0.0 ~max_tokens:200 ()
       with
-      | Ok result -> Verifier_oas.parse_verdict (Oas_response.text_of_response result.Oas_worker.response)
+      | Ok result ->
+        (match Verifier_oas.parse_verdict (Oas_response.text_of_response result.Oas_worker.response) with
+         | Ok v -> v
+         | Error parse_err -> Verifier_oas.Warn ("verdict_parse_failed: " ^ parse_err))
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in
     let our_verdict =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -83,22 +83,22 @@ let verdict_to_string = function
   | Warn reason -> sprintf "WARN: %s" reason
   | Fail reason -> sprintf "FAIL: %s" reason
 
-(** Parse "PASS", "WARN: reason", "FAIL: reason" from model output. *)
-let parse_verdict (text : string) : verdict =
+(** Parse "PASS", "WARN: reason", "FAIL: reason" from model output.
+    Returns Error on unrecognized format instead of silent degrade (ADR D3). *)
+let parse_verdict (text : string) : (verdict, string) result =
   let trimmed = String.trim text in
   let upper = String.uppercase_ascii trimmed in
   if String.length upper >= 4 && String.sub upper 0 4 = "PASS" then
-    Pass
+    Ok Pass
   else if String.length upper >= 4 && String.sub upper 0 4 = "WARN" then
     let reason = if String.length trimmed > 5 then
       String.trim (String.sub trimmed 5 (String.length trimmed - 5))
     else "unspecified concern" in
-    (* Strip leading colon/dash *)
     let reason = if String.length reason > 0 &&
       (reason.[0] = ':' || reason.[0] = '-') then
       String.trim (String.sub reason 1 (String.length reason - 1))
     else reason in
-    Warn reason
+    Ok (Warn reason)
   else if String.length upper >= 4 && String.sub upper 0 4 = "FAIL" then
     let reason = if String.length trimmed > 5 then
       String.trim (String.sub trimmed 5 (String.length trimmed - 5))
@@ -107,11 +107,14 @@ let parse_verdict (text : string) : verdict =
       (reason.[0] = ':' || reason.[0] = '-') then
       String.trim (String.sub reason 1 (String.length reason - 1))
     else reason in
-    Fail reason
+    Ok (Fail reason)
+  else if String.length trimmed = 0 then
+    Error "empty verifier output"
   else
-    (* If model doesn't follow format, treat as warning *)
-    if String.length trimmed > 0 then Warn trimmed
-    else Warn "empty verifier output"
+    Error (sprintf "unrecognized verdict format: %s"
+      (if String.length trimmed > 80
+       then String.sub trimmed 0 80 ^ "..."
+       else trimmed))
 
 (* ================================================================ *)
 (* Verification Prompt                                              *)
@@ -163,7 +166,13 @@ let verify (req : verification_request) : (verdict, string) result =
         ()
     with
     | Ok result ->
-      Ok (parse_verdict (Oas_response.text_of_response result.response))
+      let text = Oas_response.text_of_response result.response in
+      (match parse_verdict text with
+       | Ok verdict -> Ok verdict
+       | Error parse_err ->
+         Log.Verifier.warn "Verdict parse failed (%s); raw=%s"
+           parse_err (String.sub text 0 (min 80 (String.length text)));
+         Error (sprintf "verdict parse: %s" parse_err))
     | Error message ->
       Error message
 

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -178,41 +178,43 @@ let test_write_tools_are_not_readonly () =
 
 let test_parse_verdict_pass () =
   Alcotest.(check bool) "PASS" true
-    (Verifier_oas.parse_verdict "PASS" = Pass)
+    (Verifier_oas.parse_verdict "PASS" = Ok Pass)
 
 let test_parse_verdict_pass_with_trailing () =
   Alcotest.(check bool) "PASS with trailing" true
-    (Verifier_oas.parse_verdict "PASS - looks good" = Pass)
+    (Verifier_oas.parse_verdict "PASS - looks good" = Ok Pass)
 
 let test_parse_verdict_warn () =
   match Verifier_oas.parse_verdict "WARN: minor issue" with
-  | Warn reason ->
+  | Ok (Warn reason) ->
     Alcotest.(check bool) "reason preserved" true
       (String.length reason > 0)
-  | _ -> Alcotest.fail "expected Warn"
+  | _ -> Alcotest.fail "expected Ok (Warn _)"
 
 let test_parse_verdict_fail () =
   match Verifier_oas.parse_verdict "FAIL: critical error" with
-  | Fail reason ->
+  | Ok (Fail reason) ->
     Alcotest.(check bool) "reason preserved" true
       (String.length reason > 0)
-  | _ -> Alcotest.fail "expected Fail"
+  | _ -> Alcotest.fail "expected Ok (Fail _)"
 
 let test_parse_verdict_case_insensitive () =
   Alcotest.(check bool) "pass lowercase" true
-    (Verifier_oas.parse_verdict "pass" = Pass)
+    (Verifier_oas.parse_verdict "pass" = Ok Pass)
 
-let test_parse_verdict_unknown_defaults_to_warn () =
+let test_parse_verdict_unknown_returns_error () =
   match Verifier_oas.parse_verdict "something unexpected" with
-  | Warn _ -> ()
-  | _ -> Alcotest.fail "unknown text should default to Warn"
+  | Error msg ->
+    Alcotest.(check bool) "error mentions format" true
+      (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "unknown text should return Error"
 
-let test_parse_verdict_empty_defaults_to_warn () =
+let test_parse_verdict_empty_returns_error () =
   match Verifier_oas.parse_verdict "" with
-  | Warn reason ->
-    Alcotest.(check string) "empty output reason"
-      "empty verifier output" reason
-  | _ -> Alcotest.fail "empty text should default to Warn"
+  | Error msg ->
+    Alcotest.(check string) "empty output error"
+      "empty verifier output" msg
+  | Ok _ -> Alcotest.fail "empty text should return Error"
 
 (* ================================================================ *)
 (* should_skip (verify fast path)                                    *)
@@ -335,10 +337,10 @@ let () =
       Alcotest.test_case "FAIL" `Quick test_parse_verdict_fail;
       Alcotest.test_case "case insensitive" `Quick
         test_parse_verdict_case_insensitive;
-      Alcotest.test_case "unknown -> Warn" `Quick
-        test_parse_verdict_unknown_defaults_to_warn;
-      Alcotest.test_case "empty -> Warn" `Quick
-        test_parse_verdict_empty_defaults_to_warn;
+      Alcotest.test_case "unknown -> Error" `Quick
+        test_parse_verdict_unknown_returns_error;
+      Alcotest.test_case "empty -> Error" `Quick
+        test_parse_verdict_empty_returns_error;
     ]);
     ("verify_skip", [
       Alcotest.test_case "read-only skips" `Quick test_verify_skips_readonly;


### PR DESCRIPTION
## Summary
- parse_verdict를 (verdict, string) result로 변경
- 인식 불가 LLM 출력 -> Error (기존: silent Warn degrade)
- verify에서 parse 실패 시 Error 전파 + 로그
- code_swarm_plan.ml caller 업데이트
- 23 tests green

## Product Impact
LLM이 예상 포맷을 따르지 않았을 때 시스템이 그걸 모르고 지나가는 상황을 제거.

## Evidence
- dune build: green
- test/test_verifier_oas_bridge.exe: 23 tests, 0 failures
- unknown format: Error 반환 확인
- empty output: Error 반환 확인

## Review Evidence
- GLM-5 (sb glm-text) cross-model review 2026-03-30: 5건 중 해당 2건
  - #4 code_swarm_plan Error->Warn: 의식적 선택. "verdict_parse_failed:" prefix로 원인 추적 가능. 완전한 Error 전파는 code_swarm 전체 리팩터 필요하여 별도 추적
  - #5 String.sub 80 allocation 우려: max_tokens=200으로 입력 자체 bounded. 비유효

## ADR
docs/design/adr-masc-oas-boundary-ssot.md D3

Refs jeong-sik/me#916 (1/6)