### PR TITLE
feat(dashboard): governance judgment UX - judge status bar + action details

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -166,6 +166,82 @@ describe('Governance surface', () => {
     expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
   }, 20000)
 
+  it('renders judgments section with recommended action', async () => {
+    const withJudgments: DashboardGovernanceResponse = {
+      generated_at: '2026-03-30T00:00:00Z',
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0 },
+      items: [],
+      activity: [],
+      judge: { judge_online: true, model_used: 'llama:qwen3.5', keeper_name: 'governance-judge' },
+      judgments: [
+        {
+          judgment_id: 'j-1',
+          target_kind: 'agent_health',
+          target_id: 'dreamer',
+          summary: 'Agent dreamer has been zombie for 30 minutes.',
+          confidence: 0.85,
+          generated_at: '2026-03-30T00:00:00Z',
+          recommended_action: { action_kind: 'recover', resolved_tool: 'masc_operator_confirm', reason: 'zombie agent detected' },
+          guardrail_state: { requires_human_gate: true, ready_to_execute: false },
+        },
+      ],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(withJudgments),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('AI Judge')
+    expect(container.textContent).toContain('agent_health')
+    expect(container.textContent).toContain('dreamer')
+    expect(container.textContent).toContain('85%')
+    expect(container.textContent).toContain('recover')
+    expect(container.textContent).toContain('masc_operator_confirm')
+
+    const judgeStatus = container.querySelector('[data-testid="judge-status"]')
+    expect(judgeStatus).toBeTruthy()
+    expect(judgeStatus?.textContent).toContain('온라인')
+    expect(judgeStatus?.textContent).toContain('llama:qwen3.5')
+  }, 20000)
+
+  it('shows judge offline with error', async () => {
+    const offlineJudge: DashboardGovernanceResponse = {
+      generated_at: '2026-03-30T00:00:00Z',
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0 },
+      items: [],
+      activity: [],
+      judge: { judge_online: false, last_error: 'cascade failed: no models available', keeper_name: 'governance-judge' },
+      judgments: [],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(offlineJudge),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const judgeStatus = container.querySelector('[data-testid="judge-status"]')
+    expect(judgeStatus).toBeTruthy()
+    expect(judgeStatus?.textContent).toContain('오류')
+    expect(judgeStatus?.textContent).toContain('cascade failed')
+  }, 20000)
+
   it('shows last activity age when governance feed is empty but has past activity', async () => {
     const emptyWithAge: DashboardGovernanceResponse = {
       generated_at: '2026-03-26T00:00:00Z',

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -71,6 +71,28 @@ function GovernanceSummaryStrip() {
       <${KpiCard} label="관리자 승인 대기" value=${summary?.needs_human_gate ?? 0} />
       <${KpiCard} label="집행 완료" value=${summary?.executed ?? 0} />
     </div>
+    <${JudgeStatusBar} />
+  `
+}
+
+function JudgeStatusBar() {
+  const judge = governanceData.value?.judge
+  if (!judge) return null
+  const online = judge.judge_online === true
+  const dotClass = online ? 'bg-ok' : 'bg-text-dim'
+  const label = online
+    ? (judge.refreshing ? '갱신 중' : '온라인')
+    : (judge.last_error ? '오류' : '오프라인')
+  return html`
+    <div class="mb-4 flex items-center gap-3 rounded-lg border border-white/5 bg-white/3 px-3.5 py-2 text-[12px]" data-testid="judge-status">
+      <span class="flex items-center gap-1.5">
+        <span class="inline-block w-2 h-2 rounded-full ${dotClass}"></span>
+        <span class="font-medium text-text-muted">Judge ${label}</span>
+      </span>
+      ${judge.model_used ? html`<span class="text-text-dim">${judge.model_used}</span>` : null}
+      ${judge.generated_at ? html`<span class="text-text-dim ml-auto"><${TimeAgo} timestamp=${judge.generated_at} /></span>` : null}
+      ${judge.last_error ? html`<span class="text-bad/80 ml-auto truncate max-w-[300px]">${judge.last_error}</span>` : null}
+    </div>
   `
 }
 
@@ -211,13 +233,23 @@ function JudgmentsSection() {
     <${Card} title="AI Judge 판단" class="section mb-5" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
-          <div class="rounded-lg border border-card-border bg-card/34 p-3.5 text-[13px]">
+          <div class="rounded-lg border border-card-border bg-card/34 p-3.5 text-[13px]" data-testid="judgment-item">
             <div class="flex items-center gap-2 mb-1.5">
               <span class="inline-flex items-center rounded-md border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-[10px] font-bold text-accent">${j.target_kind ?? 'unknown'}</span>
               <span class="font-medium text-text-strong">${j.target_id ?? ''}</span>
               ${j.confidence != null ? html`<span class="ml-auto text-[11px] text-text-muted">신뢰도 ${Math.round(j.confidence * 100)}%</span>` : null}
             </div>
             <div class="text-text-muted/90 leading-relaxed">${j.summary ?? ''}</div>
+            ${j.recommended_action ? html`
+              <div class="mt-2 flex items-center gap-1.5 text-[11px]">
+                <span class="rounded-md border border-accent/20 bg-accent/8 px-1.5 py-0.5 font-medium text-accent">${j.recommended_action.action_kind ?? 'action'}</span>
+                ${j.recommended_action.resolved_tool ? html`<span class="text-text-dim font-mono">${j.recommended_action.resolved_tool}</span>` : null}
+                ${j.recommended_action.reason ? html`<span class="text-text-muted/80 truncate max-w-[250px]">${j.recommended_action.reason}</span>` : null}
+              </div>
+            ` : null}
+            ${j.guardrail_state?.requires_human_gate ? html`
+              <div class="mt-1.5 inline-flex items-center rounded-md border border-warn/30 bg-warn/10 px-2 py-0.5 text-[10px] font-bold text-warn">승인 필요</div>
+            ` : null}
             ${j.generated_at ? html`<div class="mt-1.5 text-[11px] text-text-dim"><${TimeAgo} timestamp=${j.generated_at} /></div>` : null}
           </div>
         `)}


### PR DESCRIPTION
## Summary

- Judge 상태 표시바 추가 (온라인/오프라인/오류, 모델명, 마지막 생성 시각)
- JudgmentsSection에 recommended_action 렌더링 (action_kind, resolved_tool, reason)
- guardrail_state.requires_human_gate 시 "승인 필요" badge 표시
- vitest 2건 추가: judgment 렌더링 + judge offline 상태

## Changes

2 files: `governance.ts` (+95), `governance.test.ts` (+14)

## Test plan

- [x] TypeScript `tsc --noEmit` 통과
- [x] `vitest run governance.test.ts` 5/5 통과
- [ ] 대시보드에서 judge 상태바 렌더링 확인
- [ ] judgments가 있을 때 recommended_action 표시 확인