### PR TITLE
fix: address Copilot review findings + keeper_hooks build fix

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -146,7 +146,7 @@ let make_hooks
         in
         let total_tok = input_tok + output_tok in
         Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
-          meta.name turn meta.usage.total_turns model total_tok;
+          meta.name turn meta.runtime.usage.total_turns model total_tok;
         (* Emit per-turn cost event for task attribution.
            cost_usd is 0.0 until OAS cascade provides actual cost
            (see oas#393). Token counts are the primary data for now. *)

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -81,6 +81,9 @@ let get_calibration_info () =
     ("enabled", `Bool (Env_config_core.relay_calibration_enabled ()));
   ]
 
+(** Cached default registry — avoids re-allocation on every resolve call. *)
+let default_registry = Llm_provider.Provider_registry.default ()
+
 (** Resolve max context tokens from OAS Provider_registry / Capabilities (SSOT).
     Resolution order:
     1. Capabilities.for_model_id — per-model override (e.g. "claude-opus-4-6" -> 1M)
@@ -96,9 +99,8 @@ let resolve_max_context model =
   match from_caps with
   | Some n -> n
   | None ->
-    let registry = Llm_provider.Provider_registry.default () in
     (* Layer 2: exact provider name lookup (e.g. "claude" -> 200K) *)
-    (match Llm_provider.Provider_registry.find registry model with
+    (match Llm_provider.Provider_registry.find default_registry model with
      | Some entry -> entry.Llm_provider.Provider_registry.max_context
      | None ->
        (* Layer 3: extract base provider from hyphenated name
@@ -109,7 +111,7 @@ let resolve_max_context model =
          | _ -> ""
        in
        if base <> "" then
-         match Llm_provider.Provider_registry.find registry base with
+         match Llm_provider.Provider_registry.find default_registry base with
          | Some entry -> entry.Llm_provider.Provider_registry.max_context
          | None -> 100_000
        else 100_000)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -83,38 +83,41 @@ let verdict_to_string = function
   | Warn reason -> sprintf "WARN: %s" reason
   | Fail reason -> sprintf "FAIL: %s" reason
 
+(** Check if keyword at position 0..len is followed by a word boundary
+    (end of string, space, colon, dash, or newline). Prevents "PASSING" matching as PASS. *)
+let has_keyword_boundary upper len =
+  String.length upper = len
+  || (let c = upper.[len] in c = ' ' || c = ':' || c = '-' || c = '\n' || c = '\r')
+
+(** Extract reason text after keyword+separator, stripping leading colon/dash. *)
+let extract_reason trimmed keyword_len default_reason =
+  let reason =
+    if String.length trimmed > keyword_len + 1 then
+      String.trim (String.sub trimmed (keyword_len + 1) (String.length trimmed - keyword_len - 1))
+    else default_reason
+  in
+  if String.length reason > 0 && (reason.[0] = ':' || reason.[0] = '-') then
+    String.trim (String.sub reason 1 (String.length reason - 1))
+  else reason
+
 (** Parse "PASS", "WARN: reason", "FAIL: reason" from model output.
-    Returns Error on unrecognized format instead of silent degrade (ADR D3). *)
+    Returns Error on unrecognized format instead of silent degrade (ADR D3).
+    Requires word boundary after keyword to prevent "PASSING"/"WARNING" false matches. *)
 let parse_verdict (text : string) : (verdict, string) result =
   let trimmed = String.trim text in
   let upper = String.uppercase_ascii trimmed in
-  if String.length upper >= 4 && String.sub upper 0 4 = "PASS" then
+  let len = String.length upper in
+  if len >= 4 && String.sub upper 0 4 = "PASS" && has_keyword_boundary upper 4 then
     Ok Pass
-  else if String.length upper >= 4 && String.sub upper 0 4 = "WARN" then
-    let reason = if String.length trimmed > 5 then
-      String.trim (String.sub trimmed 5 (String.length trimmed - 5))
-    else "unspecified concern" in
-    let reason = if String.length reason > 0 &&
-      (reason.[0] = ':' || reason.[0] = '-') then
-      String.trim (String.sub reason 1 (String.length reason - 1))
-    else reason in
-    Ok (Warn reason)
-  else if String.length upper >= 4 && String.sub upper 0 4 = "FAIL" then
-    let reason = if String.length trimmed > 5 then
-      String.trim (String.sub trimmed 5 (String.length trimmed - 5))
-    else "action did not achieve goal" in
-    let reason = if String.length reason > 0 &&
-      (reason.[0] = ':' || reason.[0] = '-') then
-      String.trim (String.sub reason 1 (String.length reason - 1))
-    else reason in
-    Ok (Fail reason)
-  else if String.length trimmed = 0 then
+  else if len >= 4 && String.sub upper 0 4 = "WARN" && has_keyword_boundary upper 4 then
+    Ok (Warn (extract_reason trimmed 4 "unspecified concern"))
+  else if len >= 4 && String.sub upper 0 4 = "FAIL" && has_keyword_boundary upper 4 then
+    Ok (Fail (extract_reason trimmed 4 "action did not achieve goal"))
+  else if len = 0 then
     Error "empty verifier output"
   else
     Error (sprintf "unrecognized verdict format: %s"
-      (if String.length trimmed > 80
-       then String.sub trimmed 0 80 ^ "..."
-       else trimmed))
+      (if len > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
 
 (* ================================================================ *)
 (* Verification Prompt                                              *)


### PR DESCRIPTION
## Summary
- relay.ml: cache Provider_registry.default() at module scope (Copilot #3832 feedback)
- verifier_oas.ml: word-boundary check prevents PASSING/WARNING false match (Copilot #3842 feedback)
- keeper_hooks_oas.ml: fix meta.usage -> meta.runtime.usage (pre-existing main build error)

## Evidence
- dune build: green (fixes main build break)
- test/test_relay_coverage.exe: 72 tests green
- test/test_verifier_oas_bridge.exe: 23 tests green

## Review Evidence
Copilot findings from #3832, #3837, #3842 addressed directly.