### PR TITLE
fix(dashboard): governance ml-auto layout followup from #3843 review

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -206,6 +206,8 @@ describe('Governance surface', () => {
     expect(container.textContent).toContain('85%')
     expect(container.textContent).toContain('recover')
     expect(container.textContent).toContain('masc_operator_confirm')
+    expect(container.textContent).toContain('승인 필요')
+    expect(container.textContent).toContain('zombie agent detected')
 
     const judgeStatus = container.querySelector('[data-testid="judge-status"]')
     expect(judgeStatus).toBeTruthy()

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -90,8 +90,18 @@ function JudgeStatusBar() {
         <span class="font-medium text-text-muted">Judge ${label}</span>
       </span>
       ${judge.model_used ? html`<span class="text-text-dim">${judge.model_used}</span>` : null}
-      ${judge.generated_at ? html`<span class="text-text-dim ml-auto"><${TimeAgo} timestamp=${judge.generated_at} /></span>` : null}
-      ${judge.last_error ? html`<span class="text-bad/80 ml-auto truncate max-w-[300px]">${judge.last_error}</span>` : null}
+      ${judge.generated_at || judge.last_error
+        ? html`
+            <span class="ml-auto flex items-center gap-3 min-w-0">
+              ${judge.generated_at
+                ? html`<span class="text-text-dim"><${TimeAgo} timestamp=${judge.generated_at} /></span>`
+                : null}
+              ${judge.last_error
+                ? html`<span class="text-bad/80 truncate max-w-[300px]">${judge.last_error}</span>`
+                : null}
+            </span>
+          `
+        : null}
     </div>
   `
 }


### PR DESCRIPTION
Followup from #3843 review comments (merged before fix was applied). Groups generated_at + last_error into single ml-auto container and adds badge test assertions.