### PR TITLE
fix(governance): extend judge cache TTL to survive slow inference

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -65,7 +65,8 @@ let option_to_yojson f = function Some value -> f value | None -> `Null
 
 let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 
-let cache_ttl_sec () = float_of_int (interval_sec () * 2)
+let cache_ttl_sec () =
+  float_of_int (max (interval_sec () * 4) 600)
 
 let enabled () = Env_config.Dashboard_config.governance_judge_enabled
 


### PR DESCRIPTION
Cherry-picked from orphaned commit on feat/governance-judgment-ux after #3843 merge. Extends judge cache TTL for slow inference scenarios.