### PR TITLE
fix(keeper): remove last_triage_triggers duplication, fix #3833 missed file

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -146,7 +146,7 @@ let make_hooks
         in
         let total_tok = input_tok + output_tok in
         Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
-          meta.name turn meta.usage.total_turns model total_tok;
+          meta.name turn meta.runtime.usage.total_turns model total_tok;
         (* Emit per-turn cost event for task attribution.
            cost_usd is 0.0 until OAS cascade provides actual cost
            (see oas#393). Token counts are the primary data for now. *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -211,7 +211,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            updated_at = now_iso ();
            continuity_summary = "";
            active_goal_ids = [];
-           last_triage_triggers = "";
            active_team_session_id = None;
            last_team_session_started_at = "";
            team_session_start_count_total = 0;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -114,7 +114,6 @@ type keeper_meta = {
   active_team_session_id: string option;
   last_team_session_started_at: string;
   team_session_start_count_total: int;
-  last_triage_triggers: string;
   paused: bool;
   current_task_id: string option;
   (** Currently claimed task ID for cost attribution.
@@ -308,7 +307,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("board_reactive_turn_count", `Int rt.board_reactive_turn_count);
       ("mention_reactive_turn_count", `Int rt.mention_reactive_turn_count);
       ("noop_turn_count", `Int rt.noop_turn_count);
-      ("last_triage_triggers", `String m.last_triage_triggers);
       ("paused", `Bool m.paused);
       ("current_task_id",
         (match m.current_task_id with None -> `Null | Some s -> `String s));
@@ -508,9 +506,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let noop_turn_count =
       Safe_ops.json_int ~default:0 "noop_turn_count" json
     in
-    let last_triage_triggers =
-      Safe_ops.json_string ~default:"" "last_triage_triggers" json
-    in
     let paused =
       Safe_ops.json_bool ~default:false "paused" json
     in
@@ -567,7 +562,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           active_team_session_id;
           last_team_session_started_at;
           team_session_start_count_total;
-          last_triage_triggers;
           paused;
           current_task_id;
           runtime = {

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -114,7 +114,6 @@ type keeper_meta = {
   active_team_session_id: string option;
   last_team_session_started_at: string;
   team_session_start_count_total: int;
-  last_triage_triggers: string;
   paused: bool;
   current_task_id: string option;
   (** Currently claimed task ID for cost attribution. *)

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -205,9 +205,9 @@ let test_deliberation_meta_defaults () =
 (* ---------- Keeper meta deliberation fields ---------- *)
 
 let test_keeper_meta_deliberation_fields_roundtrip () =
-  (* deliberation_count/cost/ts removed from keeper_meta (live in
-     deliberation_meta). Verify that old JSON keys are silently ignored
-     and remaining fields parse correctly. *)
+  (* deliberation_count/cost/ts/last_triage_triggers removed from keeper_meta
+     (live in deliberation_meta). Verify that old JSON keys are silently
+     ignored and remaining fields parse correctly. *)
   let json =
     `Assoc
       [
@@ -224,8 +224,7 @@ let test_keeper_meta_deliberation_fields_roundtrip () =
   match Keeper_types.meta_of_json json with
   | Error err -> fail ("meta parse failed: " ^ err)
   | Ok meta ->
-      check string "triage triggers" "direct_mention"
-        meta.last_triage_triggers
+      check string "name preserved" "test-keeper" meta.name
 
 let test_keeper_meta_deliberation_fields_default () =
   let json =
@@ -239,8 +238,7 @@ let test_keeper_meta_deliberation_fields_default () =
   match Keeper_types.meta_of_json json with
   | Error err -> fail ("meta parse failed: " ^ err)
   | Ok meta ->
-      check string "default triage triggers" ""
-        meta.last_triage_triggers
+      check string "name preserved" "test-keeper-2" meta.name
 
 (* ---------- Triage result JSON ---------- *)
 


### PR DESCRIPTION
## Summary

- `keeper_meta.last_triage_triggers` 제거 — `deliberation_meta`가 canonical source
- `keeper_hooks_oas.ml` 누락 수정 — #3833 squash merge 시 빠진 `meta.usage` → `meta.runtime.usage`

## Product impact

Internal cleanup. 사용자 대면 변경 없음.

## Evidence

- `keeper_meta.last_triage_triggers`는 생성 시 `""` 초기화 외에 실제 write가 없는 dead field
- `deliberation_meta.last_triage_triggers`가 실제 triage 결과를 기록하는 canonical source
- `keeper_hooks_oas.ml:149`는 #3833에서 누락되어 main 빌드 브레이크 유발

## Review evidence

- `dune build @all` 통과
- 5개 파일, -16/+6줄

## Linked issue

Closes #3814

## Test plan

- [x] `dune build @all` 통과
- [ ] CI Build and Test pass
- [ ] CI Contract Harness pass