### PR TITLE
fix(keeper): use runtime usage in OAS hook logging

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -146,7 +146,7 @@ let make_hooks
         in
         let total_tok = input_tok + output_tok in
         Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
-          meta.name turn meta.usage.total_turns model total_tok;
+          meta.name turn meta.runtime.usage.total_turns model total_tok;
         (* Emit per-turn cost event for task attribution.
            cost_usd is 0.0 until OAS cascade provides actual cost
            (see oas#393). Token counts are the primary data for now. *)


### PR DESCRIPTION
## Summary
- stale `meta.usage.total_turns` access를 `meta.runtime.usage.total_turns`로 교체
- fresh worktree 기준 `keeper_hooks_oas` compile blocker 제거

## Product Impact
현재 `main`에서 fresh worktree `dune build --root ...`가 깨지던 상태를 복구한다. unrelated PR 검증이 다시 가능해진다.

## Evidence
- `"/tmp/dbuild build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-hooks-runtime-usage"` exit 0
- compile error source was `lib/keeper/keeper_hooks_oas.ml:149`

## Review Evidence
- GLM-5 cross-model review 2026-03-30: No findings

## Linked Issue
Refs #3846
