### PR TITLE
refactor(autoresearch): require strict JSON codegen output

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -130,7 +130,6 @@ let apply_code_change = Autoresearch_file.apply_code_change
 (* ================================================================ *)
 
 let build_code_change_prompt = Autoresearch_codegen.build_code_change_prompt
-let extract_tag = Autoresearch_codegen.extract_tag
 let parse_model_code_response = Autoresearch_codegen.parse_model_code_response
 let generate_code_change = Autoresearch_codegen.generate_code_change
 

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -1,7 +1,7 @@
 (** Autoresearch_codegen — LLM-based code change generation.
 
-    Builds prompts, parses MODEL responses containing <hypothesis> and
-    <modified_code> XML tags, and invokes the cascade for code generation.
+    Builds prompts, parses MODEL responses as a strict JSON object, and
+    invokes the cascade for code generation.
 
     @since 2.80.0 *)
 
@@ -32,69 +32,70 @@ let build_code_change_prompt ~goal ~baseline ~history ~insights
     "</current_code>";
     "";
     "Modify the code to improve the metric score.";
-    "Reply with exactly:";
-    "1. A <hypothesis> tag containing a one-line description of your change";
-    "2. A <modified_code> tag containing the COMPLETE modified file";
+    "Reply with exactly one valid JSON object and nothing else.";
+    "Do not wrap the JSON in markdown or code fences.";
+    "The JSON object must contain:";
+    "1. \"hypothesis\": a one-line description of your change";
+    "2. \"modified_code\": the COMPLETE modified file";
     "";
     "Example format:";
-    "<hypothesis>Increase batch size from 32 to 64 for better throughput</hypothesis>";
-    "<modified_code>";
-    "... complete file content ...";
-    "</modified_code>";
+    {|{"hypothesis":"Increase batch size from 32 to 64 for better throughput","modified_code":"... complete file content ..."}|};
   ])
 
-(** Extract text between XML-style tags. *)
-let extract_tag ~tag text =
-  let open_tag = Printf.sprintf "<%s>" tag in
-  let close_tag = Printf.sprintf "</%s>" tag in
-  let open_len = String.length open_tag in
-  let close_len = String.length close_tag in
-  let text_len = String.length text in
-  let rec find_start i =
-    if i + open_len > text_len then None
-    else if String.sub text i open_len = open_tag then
-      let content_start = i + open_len in
-      find_end content_start content_start
-    else find_start (i + 1)
-  and find_end content_start j =
-    if j + close_len > text_len then None
-    else if String.sub text j close_len = close_tag then
-      Some (String.sub text content_start (j - content_start))
-    else find_end content_start (j + 1)
+(** Strip leading/trailing whitespace-only lines from generated code. *)
+let normalize_modified_code code =
+  let lines = String.split_on_char '\n' code in
+  let rec drop_blank = function
+    | [] -> []
+    | l :: rest ->
+      if String.trim l = "" then drop_blank rest
+      else l :: rest
   in
-  find_start 0
+  let stripped = drop_blank lines in
+  let stripped = List.rev (drop_blank (List.rev stripped)) in
+  String.concat "\n" stripped
 
-(** Parse MODEL response containing <hypothesis> and <modified_code> tags.
-    Returns Ok (hypothesis, modified_code) or Error reason. *)
+let parse_required_string_field ~field json =
+  match Safe_ops.json_member_opt field json with
+  | None ->
+    Result.error (Printf.sprintf "Missing \"%s\" field in MODEL response" field)
+  | Some (`String value) ->
+    let trimmed = String.trim value in
+    if trimmed = "" then
+      Result.error (Printf.sprintf "Empty \"%s\" field in MODEL response" field)
+    else
+      Result.ok value
+  | Some _ ->
+    Result.error (Printf.sprintf "\"%s\" field must be a string in MODEL response" field)
+
+(** Parse MODEL response containing a strict JSON object with hypothesis and
+    modified_code string fields. Returns Ok (hypothesis, modified_code) or
+    Error reason. *)
 let parse_model_code_response response =
-  if String.trim response = "" then
+  let trimmed_response = String.trim response in
+  if trimmed_response = "" then
     Result.error "MODEL returned empty response"
   else
-    match extract_tag ~tag:"hypothesis" response with
-    | None -> Result.error "Missing <hypothesis> tag in MODEL response"
-    | Some h ->
-      let hypothesis = String.trim h in
-      if hypothesis = "" then Result.error "Empty <hypothesis> tag"
-      else
-        match extract_tag ~tag:"modified_code" response with
-        | None -> Result.error "Missing <modified_code> tag in MODEL response"
-        | Some code ->
-          if String.trim code = "" then Result.error "Empty <modified_code> tag"
+    match
+      Safe_ops.parse_json_safe
+        ~context:"autoresearch_codegen.parse_model_code_response"
+        trimmed_response
+    with
+    | Error err -> Result.error err
+    | Ok (`Assoc _ as json) ->
+      (match parse_required_string_field ~field:"hypothesis" json with
+      | Error _ as e -> e
+      | Ok hypothesis ->
+        match parse_required_string_field ~field:"modified_code" json with
+        | Error _ as e -> e
+        | Ok code ->
+          let normalized_code = normalize_modified_code code in
+          if normalized_code = "" then
+            Result.error "Empty \"modified_code\" field in MODEL response"
           else
-            (* Strip all leading/trailing whitespace-only lines *)
-            let trimmed =
-              let lines = String.split_on_char '\n' code in
-              let rec drop_blank = function
-                | [] -> []
-                | l :: rest ->
-                  if String.trim l = "" then drop_blank rest
-                  else l :: rest
-              in
-              let stripped = drop_blank lines in
-              let stripped = List.rev (drop_blank (List.rev stripped)) in
-              String.concat "\n" stripped
-            in
-            Result.ok (hypothesis, trimmed)
+            Result.ok (String.trim hypothesis, normalized_code))
+    | Ok _ ->
+      Result.error "MODEL response must be a JSON object"
 
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)

--- a/test/dune
+++ b/test/dune
@@ -46,6 +46,7 @@
         test_keeper_bash_safety
         test_worktree_live_context
         test_tool_input_validation
+        test_autoresearch_codegen
         test_autoresearch_oas_primitives
         test_contract_risk
         test_contract_composer
@@ -85,6 +86,7 @@
           test_keeper_bash_safety
           test_worktree_live_context
           test_tool_input_validation
+          test_autoresearch_codegen
           test_autoresearch_oas_primitives
           test_contract_risk
           test_contract_composer

--- a/test/test_autoresearch_codegen.ml
+++ b/test/test_autoresearch_codegen.ml
@@ -1,0 +1,90 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let contains haystack needle =
+  let len_h = String.length haystack
+  and len_n = String.length needle in
+  let rec loop i =
+    if i + len_n > len_h then false
+    else if String.sub haystack i len_n = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let test_prompt_requires_strict_json () =
+  let prompt =
+    Lib.Autoresearch.build_code_change_prompt
+      ~goal:"Improve throughput"
+      ~baseline:1.25
+      ~history:[]
+      ~insights:[]
+      ~file_content:"let batch = 32\n"
+      ~target_file:"main.py"
+  in
+  check bool "mentions valid JSON object" true
+    (contains prompt "Reply with exactly one valid JSON object and nothing else.");
+  check bool "forbids markdown fences" true
+    (contains prompt "Do not wrap the JSON in markdown or code fences.");
+  check bool "includes hypothesis key" true
+    (contains prompt "\"hypothesis\"");
+  check bool "includes modified_code key" true
+    (contains prompt "\"modified_code\"")
+
+let test_parse_model_code_response_accepts_strict_json () =
+  let response =
+    {|{"hypothesis":"Increase batch size","modified_code":"\nlet batch = 64\nlet keep = true\n\n"}|}
+  in
+  match Lib.Autoresearch.parse_model_code_response response with
+  | Ok (hypothesis, code) ->
+    check string "hypothesis" "Increase batch size" hypothesis;
+    check string "normalized code" "let batch = 64\nlet keep = true" code
+  | Error err ->
+    failf "expected strict JSON response to parse, got %s" err
+
+let test_parse_model_code_response_rejects_legacy_xml () =
+  let response =
+    "<hypothesis>Increase batch size</hypothesis>\n<modified_code>let batch = 64</modified_code>"
+  in
+  match Lib.Autoresearch.parse_model_code_response response with
+  | Ok _ -> fail "expected legacy XML response to be rejected"
+  | Error err ->
+    check bool "mentions JSON parse error" true (contains err "JSON parse error")
+
+let test_parse_model_code_response_rejects_fenced_json () =
+  let response =
+    "```json\n{\"hypothesis\":\"Increase batch size\",\"modified_code\":\"let batch = 64\"}\n```"
+  in
+  match Lib.Autoresearch.parse_model_code_response response with
+  | Ok _ -> fail "expected fenced JSON response to be rejected"
+  | Error err ->
+    check bool "mentions JSON parse error" true (contains err "JSON parse error")
+
+let test_parse_model_code_response_rejects_missing_fields () =
+  let response = {|{"hypothesis":"Increase batch size"}|} in
+  match Lib.Autoresearch.parse_model_code_response response with
+  | Ok _ -> fail "expected missing modified_code to be rejected"
+  | Error err ->
+    check bool "mentions missing modified_code" true
+      (contains err "\"modified_code\"")
+
+let () =
+  run "autoresearch_codegen"
+    [
+      ( "prompt",
+        [
+          test_case "requires strict JSON object output" `Quick
+            test_prompt_requires_strict_json;
+        ] );
+      ( "parser",
+        [
+          test_case "accepts strict JSON object" `Quick
+            test_parse_model_code_response_accepts_strict_json;
+          test_case "rejects legacy XML tags" `Quick
+            test_parse_model_code_response_rejects_legacy_xml;
+          test_case "rejects fenced JSON" `Quick
+            test_parse_model_code_response_rejects_fenced_json;
+          test_case "rejects missing fields" `Quick
+            test_parse_model_code_response_rejects_missing_fields;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `autoresearch_codegen` 응답 계약을 XML-style tags에서 strict JSON object로 변경
- fenced JSON / legacy XML / missing field 응답을 hard error로 처리
- focused parser tests 추가

## Product Impact
LLM 출력의 substring/tag heuristic 파싱에 의존하던 경로를 제거한다. `autoresearch` codegen 단계가 JSON object 계약을 어기면 즉시 실패하므로, downstream deterministic file edit에 nondeterministic formatting이 스며들지 않게 된다.

## Evidence
- `"/tmp/dbuild build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/autoresearch-codegen-structured-output test/test_autoresearch_codegen.exe"` exit 0
- `./_build/default/test/test_autoresearch_codegen.exe` exit 0
- 5 tests passed:
  - strict JSON object accepted
  - legacy XML rejected
  - fenced JSON rejected
  - missing fields rejected

## Review Evidence
- GLM-5 cross-model review 2026-03-30: No findings
- Note: prompt exceeded 8k chars, so GLM auto-disabled thinking and completed in no-thinking mode

## Linked Issue
Refs #3846
Refs jeong-sik/me#916
