### PR TITLE
feat(types): phantom type + GADT PoC for typed state transitions

### DIFF
--- a/lib/types/dune
+++ b/lib/types/dune
@@ -3,6 +3,6 @@
  (name masc_types)
  (public_name masc_mcp.masc_types)
  (wrapped false)
- (modules ids types_core types_auth error types task_stage)
+ (modules ids types_core types_auth error types task_stage typed_state)
  (libraries yojson unix time_compat)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/types/typed_state.ml
+++ b/lib/types/typed_state.ml
@@ -1,0 +1,168 @@
+(** Typed_state — Phantom type + GADT PoC for compile-time state safety.
+
+    Three patterns demonstrated:
+    1. Phantom-typed task status: [active] vs [terminal] at type level
+    2. GADT action state: [preview] vs [confirmed] enforced by constructor
+    3. Rich validation errors: field path + expected/actual + protocol hint
+
+    @since PoC-3 (#3526) *)
+
+(* ──────────────────────────────────────────────────────────
+   1. Phantom-typed task status
+   ────────────────────────────────────────────────────────── *)
+
+type active
+type terminal
+
+(** Internal representation — the phantom parameter is erased at runtime.
+    The .mli hides the constructors, so callers cannot forge a
+    [terminal task_status_t] that is actually active. *)
+type _ task_status_t =
+  | PTodo : active task_status_t
+  | PClaimed : { assignee: string; claimed_at: string } -> active task_status_t
+  | PInProgress : { assignee: string; started_at: string } -> active task_status_t
+  | PDone : { assignee: string; completed_at: string; notes: string option } -> terminal task_status_t
+  | PCancelled : { cancelled_by: string; cancelled_at: string; reason: string option } -> terminal task_status_t
+
+let todo () = PTodo
+
+let claim (type p) (status : p task_status_t) ~agent : active task_status_t =
+  ignore status;
+  let claimed_at = Types_core.now_iso () in
+  PClaimed { assignee = agent; claimed_at }
+
+let start (type p) (status : p task_status_t) : active task_status_t =
+  match status with
+  | PClaimed { assignee; _ } ->
+    let started_at = Types_core.now_iso () in
+    PInProgress { assignee; started_at }
+  | _ ->
+    let started_at = Types_core.now_iso () in
+    PInProgress { assignee = "unknown"; started_at }
+
+let complete (type p) (status : p task_status_t) ~notes : terminal task_status_t =
+  let assignee = match status with
+    | PClaimed { assignee; _ } -> assignee
+    | PInProgress { assignee; _ } -> assignee
+    | _ -> "unknown"
+  in
+  let completed_at = Types_core.now_iso () in
+  PDone { assignee; completed_at; notes }
+
+let cancel (type p) (status : p task_status_t) ~by ~reason : terminal task_status_t =
+  ignore status;
+  let cancelled_at = Types_core.now_iso () in
+  PCancelled { cancelled_by = by; cancelled_at; reason }
+
+(* Wire conversion *)
+
+let to_wire : type p. p task_status_t -> Types_core.task_status = function
+  | PTodo -> Types_core.Todo
+  | PClaimed { assignee; claimed_at } ->
+    Types_core.Claimed { assignee; claimed_at }
+  | PInProgress { assignee; started_at } ->
+    Types_core.InProgress { assignee; started_at }
+  | PDone { assignee; completed_at; notes } ->
+    Types_core.Done { assignee; completed_at; notes }
+  | PCancelled { cancelled_by; cancelled_at; reason } ->
+    Types_core.Cancelled { cancelled_by; cancelled_at; reason }
+
+type any_task_status =
+  | Active of active task_status_t
+  | Terminal of terminal task_status_t
+
+let of_wire : Types_core.task_status -> any_task_status = function
+  | Types_core.Todo -> Active PTodo
+  | Types_core.Claimed { assignee; claimed_at } ->
+    Active (PClaimed { assignee; claimed_at })
+  | Types_core.InProgress { assignee; started_at } ->
+    Active (PInProgress { assignee; started_at })
+  | Types_core.Done { assignee; completed_at; notes } ->
+    Terminal (PDone { assignee; completed_at; notes })
+  | Types_core.Cancelled { cancelled_by; cancelled_at; reason } ->
+    Terminal (PCancelled { cancelled_by; cancelled_at; reason })
+
+let status_name : type p. p task_status_t -> string = function
+  | PTodo -> "todo"
+  | PClaimed _ -> "claimed"
+  | PInProgress _ -> "in_progress"
+  | PDone _ -> "done"
+  | PCancelled _ -> "cancelled"
+
+let is_terminal = function
+  | Active _ -> false
+  | Terminal _ -> true
+
+(* ──────────────────────────────────────────────────────────
+   2. GADT action state
+   ────────────────────────────────────────────────────────── *)
+
+type preview
+type confirmed
+
+type _ action_state =
+  | Preview : {
+      action_type: string;
+      target_type: string;
+      target_id: string;
+      payload: Yojson.Safe.t;
+    } -> preview action_state
+  | Confirmed : {
+      token: string;
+      action_type: string;
+      target_type: string;
+      target_id: string;
+      payload: Yojson.Safe.t;
+    } -> confirmed action_state
+
+let make_preview ~action_type ~target_type ~target_id ~payload =
+  Preview { action_type; target_type; target_id; payload }
+
+let confirm (Preview { action_type; target_type; target_id; payload }) ~token =
+  Confirmed { token; action_type; target_type; target_id; payload }
+
+let action_type_of : type p. p action_state -> string = function
+  | Preview { action_type; _ } -> action_type
+  | Confirmed { action_type; _ } -> action_type
+
+let token_of (Confirmed { token; _ }) = token
+
+(* ──────────────────────────────────────────────────────────
+   3. Rich validation errors
+   ────────────────────────────────────────────────────────── *)
+
+type validation_error = {
+  field_path: string list;
+  expected: string;
+  actual: string;
+  protocol_version: string option;
+  hint: string option;
+}
+
+let field_error ~path ~expected ~actual ?protocol_version ?hint () =
+  { field_path = path; expected; actual; protocol_version; hint }
+
+let validation_error_to_json (e : validation_error) : Yojson.Safe.t =
+  `Assoc ([
+    ("field_path", `List (List.map (fun s -> `String s) e.field_path));
+    ("expected", `String e.expected);
+    ("actual", `String e.actual);
+  ] @ (match e.protocol_version with
+       | Some v -> [("protocol_version", `String v)]
+       | None -> [])
+    @ (match e.hint with
+       | Some h -> [("hint", `String h)]
+       | None -> []))
+
+let validation_error_to_string (e : validation_error) : string =
+  let path = String.concat "." e.field_path in
+  let base = Printf.sprintf "%s: expected %s, got %s" path e.expected e.actual in
+  let proto = match e.protocol_version with
+    | Some v -> Printf.sprintf " (protocol %s)" v
+    | None -> ""
+  in
+  let hint_s = match e.hint with
+    | Some h -> Printf.sprintf " [hint: %s]" h
+    | None -> ""
+  in
+  base ^ proto ^ hint_s

--- a/lib/types/typed_state.mli
+++ b/lib/types/typed_state.mli
@@ -1,0 +1,108 @@
+(** Typed_state — Phantom type + GADT PoC for compile-time state safety.
+
+    Demonstrates three patterns:
+    1. Phantom-typed task status (active vs terminal)
+    2. GADT action state (preview vs confirmed)
+    3. Rich validation errors with field path + context
+
+    Wire compatibility: to_wire/of_wire preserve existing JSON format.
+
+    @since PoC-3 (#3526) *)
+
+(** {1 Phantom-typed task status} *)
+
+(** Phantom types for phase classification. *)
+type active
+type terminal
+
+(** A task status tagged with its phase at the type level.
+    [active task_status_t] can transition; [terminal task_status_t] cannot. *)
+type _ task_status_t
+
+(** {2 Construction (phase-safe)} *)
+
+val todo : unit -> active task_status_t
+val claim : active task_status_t -> agent:string -> active task_status_t
+val start : active task_status_t -> active task_status_t
+val complete : active task_status_t -> notes:string option -> terminal task_status_t
+val cancel : active task_status_t -> by:string -> reason:string option -> terminal task_status_t
+
+(** {2 Wire conversion} *)
+
+(** Erase phase information for serialization. *)
+val to_wire : _ task_status_t -> Types_core.task_status
+
+(** Existential wrapper for deserialized task status. *)
+type any_task_status =
+  | Active of active task_status_t
+  | Terminal of terminal task_status_t
+
+(** Parse wire format into phase-tagged status. *)
+val of_wire : Types_core.task_status -> any_task_status
+
+(** {2 Introspection} *)
+
+val status_name : _ task_status_t -> string
+val is_terminal : any_task_status -> bool
+
+(** {1 GADT action state} *)
+
+(** Phantom types for action lifecycle. *)
+type preview
+type confirmed
+
+(** GADT encoding preview/confirmed distinction. *)
+type _ action_state =
+  | Preview : {
+      action_type: string;
+      target_type: string;
+      target_id: string;
+      payload: Yojson.Safe.t;
+    } -> preview action_state
+  | Confirmed : {
+      token: string;
+      action_type: string;
+      target_type: string;
+      target_id: string;
+      payload: Yojson.Safe.t;
+    } -> confirmed action_state
+
+(** Create a preview action. *)
+val make_preview :
+  action_type:string ->
+  target_type:string ->
+  target_id:string ->
+  payload:Yojson.Safe.t ->
+  preview action_state
+
+(** Confirm a preview action with a token. Only preview -> confirmed. *)
+val confirm : preview action_state -> token:string -> confirmed action_state
+
+(** Extract action type from either phase. *)
+val action_type_of : _ action_state -> string
+
+(** Extract confirmation token (only available on confirmed actions). *)
+val token_of : confirmed action_state -> string
+
+(** {1 Rich validation errors} *)
+
+type validation_error = {
+  field_path: string list;
+  expected: string;
+  actual: string;
+  protocol_version: string option;
+  hint: string option;
+}
+
+val validation_error_to_json : validation_error -> Yojson.Safe.t
+val validation_error_to_string : validation_error -> string
+
+(** Convenience constructors. *)
+val field_error :
+  path:string list ->
+  expected:string ->
+  actual:string ->
+  ?protocol_version:string ->
+  ?hint:string ->
+  unit ->
+  validation_error

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,7 @@
         test_adversarial_eval
         test_labeling
         test_tool_deep_review
+        test_typed_state
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -97,6 +98,7 @@
           test_adversarial_eval
           test_labeling
           test_tool_deep_review
+          test_typed_state
   )
  (libraries masc_mcp masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.response agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt caqti-eio httpun cohttp-eio masc_mcp.mcp_transport_protocol agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))

--- a/test/test_typed_state.ml
+++ b/test/test_typed_state.ml
@@ -1,0 +1,182 @@
+(** test_typed_state — Conformance tests for PoC-3 phantom type + GADT.
+
+    Verifies:
+    - Phantom-typed task status transitions (compile-time + runtime)
+    - Wire roundtrip compatibility (typed <-> wire <-> JSON)
+    - GADT action state (preview -> confirm lifecycle)
+    - Rich validation error formatting *)
+
+open Alcotest
+
+module TS = Typed_state
+
+(* ── Phantom-typed task status ────────────────────────── *)
+
+let test_todo_is_active () =
+  let status = TS.todo () in
+  check string "todo name" "todo" (TS.status_name status);
+  let wire = TS.to_wire status in
+  match wire with
+  | Types_core.Todo -> ()
+  | _ -> fail "expected Todo wire status"
+
+let test_claim_transition () =
+  let t = TS.todo () in
+  let claimed = TS.claim t ~agent:"alice" in
+  check string "claimed name" "claimed" (TS.status_name claimed);
+  match TS.to_wire claimed with
+  | Types_core.Claimed { assignee; _ } ->
+    check string "assignee" "alice" assignee
+  | _ -> fail "expected Claimed wire status"
+
+let test_start_transition () =
+  let t = TS.todo () in
+  let claimed = TS.claim t ~agent:"bob" in
+  let in_progress = TS.start claimed in
+  check string "in_progress name" "in_progress" (TS.status_name in_progress);
+  match TS.to_wire in_progress with
+  | Types_core.InProgress { assignee; _ } ->
+    check string "assignee" "bob" assignee
+  | _ -> fail "expected InProgress wire status"
+
+let test_complete_is_terminal () =
+  let t = TS.todo () in
+  let claimed = TS.claim t ~agent:"charlie" in
+  let done_ = TS.complete claimed ~notes:(Some "finished") in
+  check string "done name" "done" (TS.status_name done_);
+  let any = TS.of_wire (TS.to_wire done_) in
+  check bool "terminal" true (TS.is_terminal any)
+
+let test_cancel_is_terminal () =
+  let t = TS.todo () in
+  let cancelled = TS.cancel t ~by:"dave" ~reason:(Some "no longer needed") in
+  check string "cancelled name" "cancelled" (TS.status_name cancelled);
+  let any = TS.of_wire (TS.to_wire cancelled) in
+  check bool "terminal" true (TS.is_terminal any)
+
+let test_active_is_not_terminal () =
+  let t = TS.todo () in
+  let any = TS.of_wire (TS.to_wire t) in
+  check bool "not terminal" false (TS.is_terminal any)
+
+let test_wire_roundtrip_todo () =
+  let t = TS.todo () in
+  let wire = TS.to_wire t in
+  match TS.of_wire wire with
+  | TS.Active a -> check string "roundtrip name" "todo" (TS.status_name a)
+  | TS.Terminal _ -> fail "todo should be active"
+
+let test_wire_roundtrip_done () =
+  let t = TS.todo () in
+  let claimed = TS.claim t ~agent:"eve" in
+  let done_ = TS.complete claimed ~notes:None in
+  let wire = TS.to_wire done_ in
+  match TS.of_wire wire with
+  | TS.Terminal d -> check string "roundtrip name" "done" (TS.status_name d)
+  | TS.Active _ -> fail "done should be terminal"
+
+let test_wire_json_roundtrip () =
+  let t = TS.todo () in
+  let claimed = TS.claim t ~agent:"frank" in
+  let wire = TS.to_wire claimed in
+  let json = Types_core.task_status_to_yojson wire in
+  match Types_core.task_status_of_yojson json with
+  | Ok wire2 ->
+    (match TS.of_wire wire2 with
+     | TS.Active a -> check string "json roundtrip" "claimed" (TS.status_name a)
+     | TS.Terminal _ -> fail "claimed should be active")
+  | Error e -> fail ("json parse error: " ^ e)
+
+(* ── GADT action state ────────────────────────────────── *)
+
+let test_make_preview () =
+  let p = TS.make_preview
+    ~action_type:"pause_keeper"
+    ~target_type:"keeper"
+    ~target_id:"alice"
+    ~payload:(`Assoc [("reason", `String "maintenance")])
+  in
+  check string "action_type" "pause_keeper" (TS.action_type_of p)
+
+let test_confirm_action () =
+  let p = TS.make_preview
+    ~action_type:"scale_up"
+    ~target_type:"room"
+    ~target_id:"ops"
+    ~payload:`Null
+  in
+  let c = TS.confirm p ~token:"tok-123" in
+  check string "confirmed action_type" "scale_up" (TS.action_type_of c);
+  check string "token" "tok-123" (TS.token_of c)
+
+(* ── Rich validation errors ───────────────────────────── *)
+
+let test_validation_error_to_string () =
+  let e = TS.field_error
+    ~path:["params"; "task_id"]
+    ~expected:"non-empty string"
+    ~actual:"empty string"
+    ~protocol_version:"2025-06-18"
+    ~hint:"task_id is required for task operations"
+    ()
+  in
+  let s = TS.validation_error_to_string e in
+  check bool "contains path" true (String.length s > 0);
+  check bool "has field path" true (Astring.String.is_infix ~affix:"params.task_id" s);
+  check bool "has expected" true (Astring.String.is_infix ~affix:"non-empty string" s);
+  check bool "has actual" true (Astring.String.is_infix ~affix:"empty string" s);
+  check bool "has protocol" true (Astring.String.is_infix ~affix:"2025-06-18" s);
+  check bool "has hint" true (Astring.String.is_infix ~affix:"task_id is required" s)
+
+let test_validation_error_to_json () =
+  let e = TS.field_error
+    ~path:["initialize"; "clientInfo"; "name"]
+    ~expected:"string"
+    ~actual:"null"
+    ()
+  in
+  let json = TS.validation_error_to_json e in
+  let open Yojson.Safe.Util in
+  let path = json |> member "field_path" |> to_list |> List.map to_string in
+  check (list string) "path" ["initialize"; "clientInfo"; "name"] path;
+  check string "expected" "string" (json |> member "expected" |> to_string);
+  check string "actual" "null" (json |> member "actual" |> to_string);
+  check bool "no protocol" true
+    (json |> member "protocol_version" = `Null)
+
+let test_validation_error_minimal () =
+  let e = TS.field_error
+    ~path:["status"]
+    ~expected:"todo|claimed|in_progress|done|cancelled"
+    ~actual:"unknown_state"
+    ()
+  in
+  let s = TS.validation_error_to_string e in
+  check bool "no protocol suffix" false (Astring.String.is_infix ~affix:"(protocol" s);
+  check bool "no hint suffix" false (Astring.String.is_infix ~affix:"[hint:" s)
+
+(* ── Test suite ───────────────────────────────────────── *)
+
+let () =
+  run "typed_state (PoC-3)" [
+    "phantom_task_status", [
+      test_case "todo is active" `Quick test_todo_is_active;
+      test_case "claim transition" `Quick test_claim_transition;
+      test_case "start transition" `Quick test_start_transition;
+      test_case "complete is terminal" `Quick test_complete_is_terminal;
+      test_case "cancel is terminal" `Quick test_cancel_is_terminal;
+      test_case "active is not terminal" `Quick test_active_is_not_terminal;
+      test_case "wire roundtrip todo" `Quick test_wire_roundtrip_todo;
+      test_case "wire roundtrip done" `Quick test_wire_roundtrip_done;
+      test_case "wire+json roundtrip" `Quick test_wire_json_roundtrip;
+    ];
+    "gadt_action_state", [
+      test_case "make preview" `Quick test_make_preview;
+      test_case "confirm action" `Quick test_confirm_action;
+    ];
+    "rich_validation_error", [
+      test_case "to_string full" `Quick test_validation_error_to_string;
+      test_case "to_json" `Quick test_validation_error_to_json;
+      test_case "to_string minimal" `Quick test_validation_error_minimal;
+    ];
+  ]


### PR DESCRIPTION
## Summary

PoC-3 (#3526): MCP SDK 상태 전이를 컴파일타임에 검증하는 3가지 패턴 시연.

- **Phantom-typed task status**: `active task_status_t` / `terminal task_status_t`로 terminal 상태에서 transition 호출을 타입 레벨에서 차단
- **GADT action state**: `preview action_state` → `confirm` → `confirmed action_state`만 허용. `token_of`는 confirmed에서만 호출 가능
- **Rich validation error**: `field_path` + `expected`/`actual` + `protocol_version` + `hint` 구조화

## Product impact

PoC only. 기존 코드 변경 없음. `typed_state.ml/mli` 신규 모듈 + 테스트 추가.

## Evidence

- 14/14 conformance tests pass
- Wire roundtrip 검증: `typed -> wire -> JSON -> wire -> typed`
- `dune build @all` 통과

## Linked issue

Ref #3526

## Key design decisions

| 결정 | 근거 |
|------|------|
| Abstract phantom types (`type active`, `type confirmed`) | .mli에서 타입 구별 보장 |
| Accessor `token_of` 대신 GADT match | OCaml exhaustiveness checker가 abstract phantom types를 보수적으로 처리. accessor가 idiomatic |
| `of_wire` → `any_task_status` existential | 런타임에서 phase를 결정해야 하므로 existential wrapping 필수 |
| Wire format 변경 없음 | `to_wire`/`of_wire`가 기존 `Types_core.task_status`와 양방향 변환 |

## Test plan

- [x] 14 conformance tests pass (phantom + GADT + validation)
- [x] `dune build @all` 통과
- [ ] CI Build and Test pass