### PR TITLE
feat(logging): enable MCP logging and add keeper lifecycle logging

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -103,10 +103,12 @@ let update_entry ~base_path name f =
 let max_crash_log_entries = 5
 
 let register ~base_path name meta =
+  Log.Keeper.info "registry: registering keeper name=%s base_path=%s" name base_path;
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key !registry with
    | Some entry when entry.state = Running ->
+       Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
        Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
    | _ -> ());
   let entry = {
@@ -134,18 +136,31 @@ let register ~base_path name meta =
   } in
   put_entry key entry;
   Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1);
+  Log.Keeper.debug "registry: keeper registered name=%s running_count=%d"
+    name (Atomic.get running_count_atomic);
   entry
 
 let unregister ~base_path name =
+  Log.Keeper.info "registry: unregistering keeper name=%s base_path=%s" name base_path;
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key !registry with
    | Some entry when entry.state = Running ->
-       Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
-   | _ -> ());
+       Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1));
+       Log.Keeper.debug "registry: unregistered running keeper name=%s running_count=%d"
+         name (Atomic.get running_count_atomic)
+   | Some entry ->
+       Log.Keeper.debug "registry: unregistered non-running keeper name=%s state=%s"
+         name (state_to_string entry.state)
+   | None ->
+       Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name);
   registry := StringMap.remove key !registry
 
 let get ~base_path name =
-  StringMap.find_opt (registry_key ~base_path name) !registry
+  let result = StringMap.find_opt (registry_key ~base_path name) !registry in
+  (match result with
+   | None -> Log.Keeper.debug "registry: lookup miss name=%s base_path=%s" name base_path
+   | Some _ -> ());
+  result
 
 let get_exn ~base_path name =
   match get ~base_path name with
@@ -172,8 +187,12 @@ let set_state ~base_path name state =
   match StringMap.find_opt key !registry with
   | Some entry ->
       (* Dead is terminal — only unregister can remove a Dead entry *)
-      if entry.state = Dead && state <> Dead then ()
+      if entry.state = Dead && state <> Dead then
+        Log.Keeper.warn "registry: attempted state change on Dead keeper name=%s new_state=%s"
+          name (state_to_string state)
       else if entry.state <> state then begin
+        Log.Keeper.info "registry: state transition name=%s old=%s new=%s"
+          name (state_to_string entry.state) (state_to_string state);
         (match (entry.state, state) with
          | Running, (Paused | Stopped | Crashed | Dead) ->
              Atomic.set running_count_atomic
@@ -190,9 +209,11 @@ let set_state ~base_path name state =
         in
         put_entry key { entry with state; dead_since_ts }
       end
-  | None -> ()
+  | None ->
+      Log.Keeper.warn "registry: set_state on non-existent keeper name=%s" name
 
 let mark_dead ~base_path name ~at =
+  Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
   update_entry ~base_path name (fun entry ->
     if entry.state <> Dead then begin
       (match entry.state with
@@ -205,11 +226,13 @@ let mark_dead ~base_path name ~at =
       { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
 
 let record_restart ~base_path name =
+  Log.Keeper.warn "registry: recording restart name=%s" name;
   update_entry ~base_path name (fun e ->
     { e with restart_count = e.restart_count + 1;
              last_restart_ts = Time_compat.now () })
 
 let record_error ~base_path name err =
+  Log.Keeper.error "registry: recording error name=%s error=%s" name err;
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
 
 let set_failure_reason ~base_path name reason =
@@ -249,6 +272,7 @@ let count_running ?base_path () =
         !registry 0
 
 let record_crash ~base_path name ts msg =
+  Log.Keeper.error "registry: recording crash name=%s msg=%s" name msg;
   update_entry ~base_path name (fun e ->
     { e with crash_log =
         List.filteri (fun i _ -> i < max_crash_log_entries)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -10,6 +10,7 @@ open Keeper_execution
 open Keeper_turn_up_args
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
+  Log.Keeper.info "create_keeper: starting for name=%s" p.name;
   let task_id = Printf.sprintf "keeper_create_%s" p.name in
   let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
   Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
@@ -59,16 +60,21 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in
-  if goal = "" then
+  if goal = "" then begin
+    Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     (false, "goal is required when creating a keeper")
+  end
   else
     let max_active_keepers = Env_config.KeeperBootstrap.max_active_keepers in
     let active_keepers = Keeper_registry.count_running () in
-    if max_active_keepers > 0 && active_keepers >= max_active_keepers then
+    if max_active_keepers > 0 && active_keepers >= max_active_keepers then begin
+      Log.Keeper.warn "create_keeper failed: max active keepers reached (%d/%d) for name=%s"
+        active_keepers max_active_keepers p.name;
       (false,
         Printf.sprintf
           "keeper max active reached (%d/%d). Stop/remove a keeper or set MASC_KEEPER_MAX_ACTIVE_KEEPERS."
           active_keepers max_active_keepers)
+    end
     else
     let proactive_enabled =
       Option.value
@@ -139,9 +145,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let cascade_models = Oas_model_resolve.models_of_cascade_name "keeper_unified" in
     (match ensure_api_keys_for_labels cascade_models with
      | Error e ->
+       Log.Keeper.error "create_keeper failed: API key validation error for name=%s: %s" p.name e;
        Progress.stop_tracking task_id;
        (false, e)
      | Ok () ->
+       Log.Keeper.debug "create_keeper: API keys validated for name=%s cascade=%s"
+         p.name "keeper_unified";
        Progress.Tracker.step tracker ~message:"Initializing session directory" ();
        let primary_max_context = Oas_model_resolve.resolve_primary_max_context cascade_models in
        let trace_id = generate_trace_id () in
@@ -275,17 +284,24 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
          Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
          match write_meta ctx.config meta with
          | Error e ->
+           Log.Keeper.error "create_keeper failed: write_meta error for name=%s: %s" p.name e;
            Progress.stop_tracking task_id;
            (false, e)
          | Ok () ->
+           Log.Keeper.debug "create_keeper: metadata written for name=%s trace_id=%s"
+             p.name meta.runtime.trace_id;
            Progress.Tracker.step tracker ~message:"Starting keepalive loop" ();
+           Log.Keeper.info "create_keeper: starting keepalive for name=%s" p.name;
            start_keepalive ctx meta;
            (* Apply per-persona shard configuration if present *)
            (match p.profile_defaults.shards with
             | Some (_ :: _ as shard_names) ->
+                Log.Keeper.debug "create_keeper: applying shard config for name=%s shards=%d"
+                  p.name (List.length shard_names);
                 Tool_shard.set_agent_shards p.name shard_names
             | Some [] | None -> ());
            Progress.Tracker.complete tracker ~message:"Keeper created" ();
+           Log.Keeper.info "create_keeper: completed for name=%s trace_id=%s" p.name meta.runtime.trace_id;
            let json = `Assoc [
              ("name", `String meta.name);
              ("agent_name", `String meta.agent_name);

--- a/lib/mcp_sdk_adapter_masc.ml
+++ b/lib/mcp_sdk_adapter_masc.ml
@@ -15,23 +15,6 @@ let sdk_owned_methods =
 let handles_method method_ =
   List.mem method_ sdk_owned_methods
 
-let strip_logging_capability = function
-  | `Assoc fields as json -> (
-      match List.assoc_opt "result" fields with
-      | Some (`Assoc result_fields) -> (
-          match List.assoc_opt "capabilities" result_fields with
-          | Some (`Assoc caps) ->
-              let caps = List.remove_assoc "logging" caps in
-              let result_fields =
-                ("capabilities", `Assoc caps)
-                :: List.remove_assoc "capabilities" result_fields
-              in
-              `Assoc
-                (("result", `Assoc result_fields) :: List.remove_assoc "result" fields)
-          | _ -> json)
-      | _ -> json)
-  | json -> json
-
 let instructions_for_profile = function
   | Full -> TP.default_instructions
   | Managed_agent -> TP.managed_agent_instructions
@@ -59,7 +42,15 @@ let make_context ?mcp_session_id () : Handler.context =
     | None -> ());
     Ok ()
   in
-  let send_log _level _message = Ok () in
+  let send_log (level : MP.Logging.log_level) message =
+    let params =
+      `Assoc [
+        ("level", `String (MP.Logging.log_level_to_string level));
+        ("data", `String message);
+      ]
+    in
+    send_notification ~method_:"notifications/message" ~params:(Some params)
+  in
   let send_progress ~token ~progress ~message ~total =
     let params =
       MP.Mcp_result.progress_to_yojson


### PR DESCRIPTION
## Summary

- **MCP logging 활성화**: `send_log`가 실제로 `notifications/message`를 전송하도록 변경. 기존에는 no-op이었음
- **keeper_registry 구조화 로깅**: register/unregister/state transition/crash/error에 20+ Log 포인트 추가
- **keeper 생성 로깅**: create_keeper 라이프사이클 주요 단계별 로깅

## Product impact

관측성 개선. keeper 디버깅 시 registry 상태 변화를 추적 가능.

## Evidence

- Cherry-pick from #3836 + #3833 호환성 수정 (`meta.runtime.trace_id`, `Logging.log_level` 타입)
- `dune build @all` 통과

## Linked issue

Supersedes #3836

## Test plan

- [x] `dune build @all` 통과
- [ ] CI Build and Test pass