### PR TITLE
refactor(keeper): separate system prompt into hard constraints and soft context (P1-1a)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -10,6 +10,17 @@
 
     @since Phase 5 — Keeper Agent.run encapsulation *)
 
+(** Structured prompt result from [build_turn_prompt] callback.
+    [system_prompt] contains hard constraints (identity, policy guards,
+    tool guidance, direct-reply mode) that must stay in the system prompt.
+    [dynamic_context] contains soft context (continuity, skill route,
+    worktree changes, turn instructions) injected via OAS
+    [extra_system_context] — prepended as a User message after reduction. *)
+type turn_prompt = {
+  system_prompt : string;
+  dynamic_context : string;
+}
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result = {
   response_text : string;
@@ -67,7 +78,7 @@ let run_turn
     ~(build_turn_prompt :
         base_system_prompt:string ->
         messages:Agent_sdk.Types.message list ->
-        string)
+        turn_prompt)
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
@@ -144,8 +155,10 @@ let run_turn
     Keeper_exec_context.set_system_prompt base_ctx
       ~system_prompt:base_system_prompt
   in
-  (* 5. Build final turn system prompt via caller callback *)
-  let turn_system_prompt =
+  (* 5. Build final turn system prompt via caller callback.
+     Hard constraints stay in system_prompt; soft context is injected
+     via OAS extra_system_context (prepended as User message after reduction). *)
+  let { system_prompt = turn_system_prompt; dynamic_context } =
     build_turn_prompt
       ~base_system_prompt
       ~messages:ctx_work.messages
@@ -169,10 +182,32 @@ let run_turn
   let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
-  let hooks = Keeper_hooks_oas.make_hooks
+  let base_hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd
     ?trajectory_acc
     () in
+  (* Compose dynamic_context injection via extra_system_context.
+     The before_turn_params hook fires each turn and sets
+     extra_system_context, which OAS prepends as a User message
+     after context reduction (agent_turn.ml:66-75). *)
+  let hooks =
+    if String.trim dynamic_context = "" then base_hooks
+    else
+      let inject_ctx : Agent_sdk.Hooks.hooks = {
+        Agent_sdk.Hooks.empty with
+        before_turn_params = Some (fun event ->
+          match event with
+          | Agent_sdk.Hooks.BeforeTurnParams { current_params; _ } ->
+            let ctx = match current_params.extra_system_context with
+              | None -> dynamic_context
+              | Some existing -> existing ^ "\n\n" ^ dynamic_context
+            in
+            Agent_sdk.Hooks.AdjustParams
+              { current_params with extra_system_context = Some ctx }
+          | _ -> Agent_sdk.Hooks.Continue)
+      } in
+      Agent_sdk.Hooks.compose ~outer:inject_ctx ~inner:base_hooks
+  in
   let base_dir = Filename.concat config.base_path ".masc" in
   let memory =
     Memory_oas_bridge.create_memory_full

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -263,13 +263,13 @@ let resolved_keeper_skill_route
        | None ->
            { route = fallback_route; selection_mode = "agent"; provenance = "fallback" })
 
-let skill_route_system_prompt_agent
-    ~(base_system_prompt : string)
+(** Standalone skill routing context text — without base_system_prompt.
+    Used as soft context injected via [extra_system_context]. *)
+let skill_route_context_text
     ~(fallback_route : keeper_skill_route)
     ~(soul_profile : string) : string =
   Printf.sprintf
-    "%s\n\n\
-     Skill routing policy (agent-selected):\n\
+    "Skill routing policy (agent-selected):\n\
      - Available skills: %s\n\
      - SOUL profile: %s\n\
      - You MUST choose exactly one primary skill from the list above.\n\
@@ -279,7 +279,14 @@ let skill_route_system_prompt_agent
      - If uncertain, default to `%s`.\n\
      - After those lines, answer normally and concretely.\n\
      - Do not fabricate capabilities beyond chosen skills."
-    base_system_prompt
     (String.concat ", " keeper_allowed_skills)
     soul_profile
     fallback_route.primary_skill
+
+let skill_route_system_prompt_agent
+    ~(base_system_prompt : string)
+    ~(fallback_route : keeper_skill_route)
+    ~(soul_profile : string) : string =
+  Printf.sprintf "%s\n\n%s"
+    base_system_prompt
+    (skill_route_context_text ~fallback_route ~soul_profile)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -108,37 +108,62 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 Worktree_live_context.capture_change_block
                   ~base_path:ctx.config.base_path ~actor_key:meta.name
             in
-            let build_turn_prompt ~base_system_prompt ~messages =
+            let build_turn_prompt ~base_system_prompt ~messages
+                : Keeper_agent_run.turn_prompt =
+              (* === SOFT CONTEXT (injected via extra_system_context) === *)
+              (* 1. Continuity snapshot *)
               let continuity_snapshot = latest_state_snapshot_from_messages messages in
-              let continuity_summary =
-                match continuity_snapshot with
-                | Some s -> keeper_state_snapshot_to_summary_text s
-                | None ->
-                  let trimmed = String.trim meta.continuity_summary in
-                  if trimmed = "" then "No continuity snapshot available." else trimmed
+              let continuity_text =
+                let summary =
+                  match continuity_snapshot with
+                  | Some s -> keeper_state_snapshot_to_summary_text s
+                  | None ->
+                    let trimmed = String.trim meta.continuity_summary in
+                    if trimmed = "" then "" else trimmed
+                in
+                if summary = "" || summary = "No continuity snapshot available."
+                then ""
+                else "Recent continuity snapshot:\n" ^ summary
               in
-              let base_turn_system_prompt =
-                if effective_no_skill_route then
-                  base_system_prompt
+              (* 2. Skill route *)
+              let skill_route_text =
+                if effective_no_skill_route then ""
                 else
-                  skill_route_system_prompt_agent
-                    ~base_system_prompt
+                  skill_route_context_text
                     ~fallback_route:fallback_skill_route
                     ~soul_profile:meta.soul_profile
               in
-              let prompt =
-                append_continuity_context_prompt
-                  ~base_prompt:base_turn_system_prompt
-                  continuity_snapshot
-                  ~continuity_summary
+              (* 3. Worktree changes *)
+              let worktree_text =
+                match live_worktree_change with
+                | Some summary when String.trim summary <> "" -> summary
+                | _ -> ""
               in
+              (* 4. Turn instructions *)
+              let turn_instructions_text =
+                match turn_instructions with
+                | None -> ""
+                | Some ti ->
+                  "--- Turn-specific instructions ---\n" ^ ti
+              in
+              let soft_parts = List.filter
+                (fun s -> String.trim s <> "")
+                [ skill_route_text;
+                  continuity_text;
+                  worktree_text;
+                  turn_instructions_text ]
+              in
+              let dynamic_context = String.concat "\n\n" soft_parts in
+              (* === HARD CONSTRAINTS (stay in system_prompt) === *)
+              (* 1. Direct reply mode *)
               let prompt =
                 if direct_reply then
                   Keeper_prompt.append_direct_reply_mode_prompt
-                    ~base_prompt:prompt
+                    ~base_prompt:base_system_prompt
                 else
-                  prompt
+                  base_system_prompt
               in
+              (* 2. Policy guards + tool-use guidance *)
               let prompt =
                 let policy_guards = [
                   (effective_no_skill_route,
@@ -164,17 +189,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       prompt
                       (String.concat "\n" (policy_lines @ tool_use_lines))
               in
-              let prompt =
-                match live_worktree_change with
-                | Some summary when String.trim summary <> "" ->
-                    Printf.sprintf "%s\n\n%s" prompt summary
-                | _ -> prompt
-              in
-              match turn_instructions with
-              | None -> prompt
-              | Some ti ->
-                  Printf.sprintf "%s\n\n--- Turn-specific instructions ---\n%s"
-                    prompt ti
+              { system_prompt = prompt; dynamic_context }
             in
             Progress.Tracker.step turn_tracker
               ~message:(Printf.sprintf "Executing Agent.run for %s" name) ();

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -239,8 +239,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let max_turns = Keeper_config.keeper_unified_max_turns () in
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)
-      let build_turn_prompt ~base_system_prompt:_ ~messages:_ =
-        system_prompt
+      let build_turn_prompt ~base_system_prompt:_ ~messages:_
+          : Keeper_agent_run.turn_prompt =
+        (* Unified path already places soft context (continuity, worktree)
+           in the user_message via Keeper_unified_prompt.build_prompt.
+           No dynamic_context needed here. *)
+        { system_prompt; dynamic_context = "" }
       in
       (* 5. Run via OAS Agent.run() *)
       let run_result, latency_ms =

--- a/test/dune
+++ b/test/dune
@@ -60,6 +60,7 @@
         test_labeling
         test_tool_deep_review
         test_typed_state
+        test_keeper_turn_prompt
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -101,6 +102,7 @@
           test_labeling
           test_tool_deep_review
           test_typed_state
+          test_keeper_turn_prompt
   )
  (libraries masc_mcp masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.response agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt caqti-eio httpun cohttp-eio masc_mcp.mcp_transport_protocol agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))

--- a/test/test_keeper_turn_prompt.ml
+++ b/test/test_keeper_turn_prompt.ml
@@ -1,0 +1,160 @@
+(** Tests for P1-1a: keeper turn prompt hard/soft separation.
+
+    Verifies that:
+    1. [turn_prompt] type correctly separates hard constraints from soft context
+    2. [skill_route_context_text] produces standalone text without base prompt
+    3. [skill_route_system_prompt_agent] composes base + context_text
+    4. Hard constraints (policy guards, tool guidance, direct reply) stay in system_prompt
+    5. Soft context (skill route, continuity, worktree, turn instructions) goes to dynamic_context *)
+
+open Alcotest
+
+module KAR = Masc_mcp.Keeper_agent_run
+module KSR = Masc_mcp.Keeper_skill_routing
+module KP = Masc_mcp.Keeper_prompt
+
+(* ── turn_prompt type ───────────────────────────────────── *)
+
+let test_turn_prompt_empty_dynamic () =
+  let tp : KAR.turn_prompt =
+    { system_prompt = "You are a keeper.";
+      dynamic_context = "" }
+  in
+  check string "system_prompt preserved"
+    "You are a keeper." tp.system_prompt;
+  check string "dynamic_context empty" "" tp.dynamic_context
+
+let test_turn_prompt_with_dynamic () =
+  let tp : KAR.turn_prompt =
+    { system_prompt = "You are a keeper.";
+      dynamic_context = "Recent continuity snapshot:\nGoal: deploy v2" }
+  in
+  check string "system_prompt unchanged"
+    "You are a keeper." tp.system_prompt;
+  check bool "dynamic_context non-empty" true
+    (String.trim tp.dynamic_context <> "")
+
+(* ── skill_route_context_text ───────────────────────────── *)
+
+let test_skill_route_context_text_standalone () =
+  let route : KSR.keeper_skill_route =
+    { primary_skill = "general_chat"; secondary_skills = []; reason = "" }
+  in
+  let text = KSR.skill_route_context_text
+    ~fallback_route:route ~soul_profile:"delivery" in
+  (* Must NOT contain a base system prompt prefix *)
+  check bool "starts with Skill routing"
+    true (String.length text > 0
+          && String.sub text 0 (min 14 (String.length text)) = "Skill routing ");
+  (* Must contain the fallback skill *)
+  check bool "contains fallback skill" true
+    (let re = Str.regexp_string "general_chat" in
+     try ignore (Str.search_forward re text 0); true with Not_found -> false);
+  (* Must contain soul_profile *)
+  check bool "contains soul_profile" true
+    (let re = Str.regexp_string "delivery" in
+     try ignore (Str.search_forward re text 0); true with Not_found -> false)
+
+let test_skill_route_system_prompt_uses_context_text () =
+  let route : KSR.keeper_skill_route =
+    { primary_skill = "code_review"; secondary_skills = []; reason = "" }
+  in
+  let base = "Base prompt here." in
+  let combined = KSR.skill_route_system_prompt_agent
+    ~base_system_prompt:base
+    ~fallback_route:route
+    ~soul_profile:"research" in
+  let standalone = KSR.skill_route_context_text
+    ~fallback_route:route
+    ~soul_profile:"research" in
+  (* Combined should be base + separator + standalone *)
+  let expected = Printf.sprintf "%s\n\n%s" base standalone in
+  check string "system_prompt_agent = base + context_text"
+    expected combined
+
+(* ── hard constraint: direct_reply_mode ─────────────────── *)
+
+let test_direct_reply_stays_in_system () =
+  let base = "Identity prompt." in
+  let with_dr = KP.append_direct_reply_mode_prompt ~base_prompt:base in
+  check bool "contains direct_reply_mode tag" true
+    (let re = Str.regexp_string "<direct_reply_mode>" in
+     try ignore (Str.search_forward re with_dr 0); true with Not_found -> false);
+  check bool "starts with base prompt" true
+    (String.length with_dr >= String.length base
+     && String.sub with_dr 0 (String.length base) = base)
+
+(* ── separation contract ────────────────────────────────── *)
+
+let test_separation_contract () =
+  (* Simulate what build_turn_prompt does: hard in system_prompt, soft in dynamic *)
+  let base = "You are keeper-test." in
+  let hard_system =
+    Printf.sprintf "%s\n\n%s"
+      (KP.append_direct_reply_mode_prompt ~base_prompt:base)
+      "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn."
+  in
+  let route : KSR.keeper_skill_route =
+    { primary_skill = "general_chat"; secondary_skills = []; reason = "" }
+  in
+  let soft_parts = [
+    KSR.skill_route_context_text ~fallback_route:route ~soul_profile:"delivery";
+    "Recent continuity snapshot:\nGoal: deploy v2";
+  ] in
+  let dynamic = String.concat "\n\n" soft_parts in
+  let tp : KAR.turn_prompt =
+    { system_prompt = hard_system; dynamic_context = dynamic }
+  in
+  (* Hard constraints in system_prompt *)
+  check bool "system has direct_reply" true
+    (let re = Str.regexp_string "<direct_reply_mode>" in
+     try ignore (Str.search_forward re tp.system_prompt 0); true
+     with Not_found -> false);
+  check bool "system has output guard" true
+    (let re = Str.regexp_string "Output guard:" in
+     try ignore (Str.search_forward re tp.system_prompt 0); true
+     with Not_found -> false);
+  (* Soft context NOT in system_prompt *)
+  check bool "system has no Skill routing" true
+    (let re = Str.regexp_string "Skill routing policy" in
+     (try ignore (Str.search_forward re tp.system_prompt 0); false
+      with Not_found -> true));
+  check bool "system has no continuity" true
+    (let re = Str.regexp_string "continuity snapshot" in
+     (try ignore (Str.search_forward re tp.system_prompt 0); false
+      with Not_found -> true));
+  (* Soft context in dynamic_context *)
+  check bool "dynamic has Skill routing" true
+    (let re = Str.regexp_string "Skill routing policy" in
+     try ignore (Str.search_forward re tp.dynamic_context 0); true
+     with Not_found -> false);
+  check bool "dynamic has continuity" true
+    (let re = Str.regexp_string "continuity snapshot" in
+     try ignore (Str.search_forward re tp.dynamic_context 0); true
+     with Not_found -> false)
+
+(* ── test suite ─────────────────────────────────────────── *)
+
+let () =
+  run "keeper_turn_prompt"
+    [
+      ( "turn_prompt_type",
+        [
+          test_case "empty dynamic_context" `Quick test_turn_prompt_empty_dynamic;
+          test_case "with dynamic_context" `Quick test_turn_prompt_with_dynamic;
+        ] );
+      ( "skill_route_context_text",
+        [
+          test_case "standalone text" `Quick test_skill_route_context_text_standalone;
+          test_case "system_prompt_agent = base + context_text" `Quick
+            test_skill_route_system_prompt_uses_context_text;
+        ] );
+      ( "hard_constraints",
+        [
+          test_case "direct_reply in system" `Quick test_direct_reply_stays_in_system;
+        ] );
+      ( "separation_contract",
+        [
+          test_case "hard in system, soft in dynamic" `Quick test_separation_contract;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **P1-1a (Delta-Context Architecture Phase 1)**: keeper system prompt의 8개 동적 레이어를 hard constraint와 soft context로 분리
- Hard constraints (identity, policy guards, tool guidance, direct-reply mode)는 system_prompt에 유지
- Soft context (continuity, skill route, worktree, turn instructions)는 OAS `extra_system_context`로 이동 — reducer 적용 후 User message로 prepend
- system prompt prefix가 턴 간에 안정되어 프로바이더 캐시 효율이 자연스럽게 개선 (MASC는 model-agnostic, 캐시는 OAS provider layer의 부산물)

### 변경 파일
| 파일 | 변경 |
|------|------|
| `keeper_agent_run.ml` | `turn_prompt` 타입, callback 시그니처, `before_turn_params` hook compose |
| `keeper_turn.ml` | `build_turn_prompt` hard/soft 분리 |
| `keeper_unified_turn.ml` | callback 반환 타입 맞춤 (`dynamic_context = ""`) |
| `keeper_skill_routing.ml` | `skill_route_context_text` standalone 함수 추가 |
| `test_keeper_turn_prompt.ml` | 6개 테스트 (타입, standalone, 분리 계약) |

### Classification
| Layer | Category | Destination |
|-------|----------|-------------|
| persona/goal/instructions | Static | system_prompt |
| policy_guards | Hard | system_prompt |
| tool_use_guidance | Hard | system_prompt |
| direct_reply_mode | Hard | system_prompt |
| continuity_snapshot | Soft | extra_system_context |
| skill_route | Soft | extra_system_context |
| worktree_context | Soft | extra_system_context |
| turn_instructions | Soft | extra_system_context |

## Test plan
- [x] `test_keeper_turn_prompt` 6/6 passed
- [x] `test_keeper_unified` 30/30 passed (no regression)
- [x] `test_keeper_memory` 20/20 passed
- [x] `test_keeper_registry` 37/37 passed
- [ ] CI checks
- [ ] Cross-model review (GLM-5.1 or equivalent)

Refs: #3827, oas#484

🤖 Generated with [Claude Code](https://claude.com/claude-code)