### PR TITLE
chore(release): bump version to 2.170.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## [2.170.0] - 2026-03-30
+
+### Added
+- **Unified session activity trace** — GitHub Agents-style chronological trace view in agent/keeper detail overlays. Merges broadcast, task, and tool call events with expandable details, type filtering, live indicator, and cost summary (#3875).
+
 ## [2.169.0] - 2026-03-30
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.169.0)
+(version 2.170.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Version bump 2.169.0 → 2.170.0
- CHANGELOG entry for #3875 (unified session activity trace view)

## Test plan
- [ ] `dune-project` version matches tag
- [ ] CHANGELOG entry present

🤖 Generated with [Claude Code](https://claude.com/claude-code)