### PR TITLE
feat(keeper): add cache_system_prompt surface and provider prefix cache metrics (P1-1b)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.96.0))
+  (agent_sdk (>= 0.97.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -255,6 +255,7 @@ let run_turn
       ~allowed_paths:meta.allowed_paths
       ~working_context:checkpoint_sidecar
       ~priority:(Option.value priority ~default:Llm_provider.Request_priority.Interactive)
+      ~cache_system_prompt:true
       ()
   with
   | Error e -> Error e

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -145,6 +145,21 @@ let make_hooks
           | None -> (0, 0)
         in
         let total_tok = input_tok + output_tok in
+        (* Provider prefix cache token tracking (Anthropic).
+           Non-Anthropic providers report 0 for these fields. *)
+        (match response.usage with
+         | Some u ->
+           let cc = u.cache_creation_input_tokens in
+           let cr = u.cache_read_input_tokens in
+           if cc > 0 then
+             Prometheus.inc_counter
+               "masc_provider_prefix_cache_creation_tokens_total"
+               ~delta:(Float.of_int cc) ();
+           if cr > 0 then
+             Prometheus.inc_counter
+               "masc_provider_prefix_cache_read_tokens_total"
+               ~delta:(Float.of_int cr) ()
+         | None -> ());
         Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
           meta.name turn meta.runtime.usage.total_turns model total_tok;
         (* Emit per-turn cost event for task attribution.

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -101,6 +101,7 @@ type config = {
   allowed_paths : string list;
   working_context : Yojson.Safe.t option;
   priority : Llm_provider.Request_priority.t option;
+  cache_system_prompt : bool;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -124,6 +125,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     allowed_paths = [];
     working_context = None;
     priority = None;
+    cache_system_prompt = false;
   }
 
 (* ================================================================ *)
@@ -264,6 +266,11 @@ let build
   let builder = match config.priority with
     | Some p -> Oas.Builder.with_priority p builder
     | None -> builder
+  in
+  let builder =
+    if config.cache_system_prompt then
+      Oas.Builder.with_cache_system_prompt true builder
+    else builder
   in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string
@@ -504,6 +511,7 @@ let run_named
     ?transport
     ?(allowed_paths = [])
     ?working_context
+    ?(cache_system_prompt = false)
     ?sw
     ?net
     ()
@@ -548,6 +556,7 @@ let run_named
       working_context;
       session_id;
       priority;
+      cache_system_prompt;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -61,6 +61,7 @@ val run_named :
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
   ?working_context:Yojson.Safe.t ->
+  ?cache_system_prompt:bool ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -149,6 +149,10 @@ let init () =
   add "masc_inference_cache_writes_total" "Total inference cache writes" Counter;
   add "masc_inference_cache_bypass_total" "Total inference cache bypass decisions" Counter;
   add "masc_inference_cache_errors_total" "Total inference cache errors" Counter;
+  add "masc_provider_prefix_cache_creation_tokens_total"
+    "Total provider prefix cache creation tokens (Anthropic)" Counter;
+  add "masc_provider_prefix_cache_read_tokens_total"
+    "Total provider prefix cache read tokens (Anthropic)" Counter;
   register_histogram ~name:"masc_tool_call_duration_seconds"
     ~help:"Tool call latency in seconds" ()
 

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.96.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.97.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7a5db7af0d3da6c4f54a6bc3211da7ce89d58de2"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.96.0"
+readonly OAS_AGENT_SDK_SHA="f7186dd095d74db708a26bde3549bc97ac1cff4c"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.97.0"


### PR DESCRIPTION
## Summary

- **P1-1b (Delta-Context Architecture Phase 1)**: MASC side of cache plumbing
- `oas_worker.ml`: `?cache_system_prompt` parameter + `Builder.with_cache_system_prompt` wiring
- `keeper_agent_run.ml`: keeper path opts in with `~cache_system_prompt:true`
- `prometheus.ml`: provider prefix cache counters (creation/read tokens)
- `keeper_hooks_oas.ml`: `after_turn` reads `cache_{creation,read}_input_tokens` from usage

### OAS dependency
- oas#494: `api.ml` metrics fallback (sync + stream)
- This PR is independent — MASC changes work with or without oas#494

### 2-layer cache distinction (plan requirement)
| Layer | Prometheus counter | Data source |
|-------|-------------------|-------------|
| Response cache (OAS) | `masc_inference_cache_*` (existing) | `Metrics.t` callback |
| Provider prefix cache | `masc_provider_prefix_cache_*` (new) | `usage.cache_{creation,read}_input_tokens` |

## Test plan
- [x] `test_keeper_unified` 30/30 passed
- [x] `test_keeper_turn_prompt` 6/6 passed
- [x] `dune build` clean
- [ ] CI checks

Refs: #3825, oas#484

🤖 Generated with [Claude Code](https://claude.com/claude-code)