### PR TITLE
[codex] Fix dashboard asset lookup and startup tmpfile handling

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -17,6 +17,7 @@ let assets_root () =
     let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
     Filename.concat root "assets"
   in
+  (* MASC_BASE_PATH is the runtime data root for .masc, not a dashboard asset root. *)
   let candidates =
     List.fold_right
       (fun path acc ->

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -12,18 +12,6 @@ let assets_root () =
   let is_dir path =
     Sys.file_exists path && Sys.is_directory path
   in
-  let nonempty_env name =
-    match Sys.getenv_opt name with
-    | Some value ->
-        let trimmed = String.trim value in
-        if String.equal trimmed "" then None else Some trimmed
-    | None -> None
-  in
-  let base_path_assets name =
-    match nonempty_env name with
-    | Some path -> Some (Filename.concat path "assets")
-    | None -> None
-  in
   let exe_dir = Filename.dirname Sys.executable_name in
   let inferred_repo_assets =
     let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
@@ -36,7 +24,6 @@ let assets_root () =
         | Some value -> value :: acc
         | None -> acc)
       [
-        base_path_assets "MASC_BASE_PATH";
         Some inferred_repo_assets;
         Some (Filename.concat exe_dir "assets");
         Some (Filename.concat (Sys.getcwd ()) "assets");

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -58,11 +58,19 @@ if needs_rebuild; then
   echo "[dashboard] Sources changed, rebuilding SPA..." >&2
   temp_root="${TMPDIR:-/tmp}"
   temp_root="${temp_root%/}"
-  log_file="$(mktemp "$temp_root/masc-dashboard-build.XXXXXX")"
+  if [ ! -d "$temp_root" ] || [ ! -w "$temp_root" ]; then
+    temp_root="/tmp"
+  fi
+  if ! log_file="$(TMPDIR="$temp_root" mktemp "$temp_root/masc-dashboard-build.XXXXXX" 2>/dev/null)"; then
+    echo "[dashboard] Unable to create temp log file; falling back to stderr-less logging." >&2
+    log_file="/dev/null"
+  fi
   if [ -d "$DASHBOARD_DIR/node_modules" ]; then
     if (cd "$DASHBOARD_DIR" && "${dashboard_pm[@]}" run build >"$log_file" 2>&1); then
       tail -n 3 "$log_file" >&2 || true
-      rm -f "$log_file"
+      if [ "$log_file" != "/dev/null" ]; then
+        rm -f "$log_file"
+      fi
       touch "$STAMP"
       echo "[dashboard] Build complete." >&2
       exit 0
@@ -72,12 +80,16 @@ if needs_rebuild; then
 
   if ! (cd "$DASHBOARD_DIR" && "${dashboard_pm[@]}" install --frozen-lockfile --prefer-offline >"$log_file" 2>&1 && "${dashboard_pm[@]}" run build >>"$log_file" 2>&1); then
     tail -n 20 "$log_file" >&2 || true
-    rm -f "$log_file"
+    if [ "$log_file" != "/dev/null" ]; then
+      rm -f "$log_file"
+    fi
     echo "[dashboard] Build failed (non-fatal)." >&2
     exit 0
   fi
   tail -n 6 "$log_file" >&2 || true
-  rm -f "$log_file"
+  if [ "$log_file" != "/dev/null" ]; then
+    rm -f "$log_file"
+  fi
   touch "$STAMP"
   echo "[dashboard] Build complete." >&2
 else

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -56,7 +56,7 @@ needs_rebuild() {
 
 if needs_rebuild; then
   echo "[dashboard] Sources changed, rebuilding SPA..." >&2
-  log_file="$(mktemp /tmp/masc-dashboard-build.XXXXXX.log)"
+  log_file="$(mktemp -t masc-dashboard-build)"
   if [ -d "$DASHBOARD_DIR/node_modules" ]; then
     if (cd "$DASHBOARD_DIR" && "${dashboard_pm[@]}" run build >"$log_file" 2>&1); then
       tail -n 3 "$log_file" >&2 || true

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -56,7 +56,9 @@ needs_rebuild() {
 
 if needs_rebuild; then
   echo "[dashboard] Sources changed, rebuilding SPA..." >&2
-  log_file="$(mktemp -t masc-dashboard-build)"
+  temp_root="${TMPDIR:-/tmp}"
+  temp_root="${temp_root%/}"
+  log_file="$(mktemp "$temp_root/masc-dashboard-build.XXXXXX")"
   if [ -d "$DASHBOARD_DIR/node_modules" ]; then
     if (cd "$DASHBOARD_DIR" && "${dashboard_pm[@]}" run build >"$log_file" 2>&1); then
       tail -n 3 "$log_file" >&2 || true

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -87,13 +87,21 @@ build_dashboard_spa() {
     fi
     dashboard_pm_label="${dashboard_pm[*]}"
 
-    # macOS mktemp requires the template to end with Xs; a ".log" suffix
-    # makes it treat the literal path as fixed and fail with EEXIST.
-    log_file="$(mktemp "${TMPDIR:-/tmp}/masc-dashboard-build.XXXXXX")"
+    local temp_root="${TMPDIR:-/tmp}"
+    temp_root="${temp_root%/}"
+    if [ ! -d "$temp_root" ] || [ ! -w "$temp_root" ]; then
+        temp_root="/tmp"
+    fi
+    if ! log_file="$(TMPDIR="$temp_root" mktemp "$temp_root/masc-dashboard-build.XXXXXX" 2>/dev/null)"; then
+        echo "[dashboard] Unable to create temp log file; falling back to stderr-less logging." >&2
+        log_file="/dev/null"
+    fi
     if [ -d "$dashboard_dir/node_modules" ]; then
         if (cd "$dashboard_dir" && "${dashboard_pm[@]}" run build >"$log_file" 2>&1); then
             tail -n 3 "$log_file" >&2 || true
-            rm -f "$log_file"
+            if [ "$log_file" != "/dev/null" ]; then
+                rm -f "$log_file"
+            fi
             return 0
         fi
         echo "[dashboard] Existing deps build failed, retrying after ${dashboard_pm_label} install..." >&2
@@ -101,12 +109,16 @@ build_dashboard_spa() {
 
     if (cd "$dashboard_dir" && "${dashboard_pm[@]}" install --frozen-lockfile --prefer-offline >"$log_file" 2>&1 && "${dashboard_pm[@]}" run build >>"$log_file" 2>&1); then
         tail -n 6 "$log_file" >&2 || true
-        rm -f "$log_file"
+        if [ "$log_file" != "/dev/null" ]; then
+            rm -f "$log_file"
+        fi
         return 0
     fi
 
     tail -n 20 "$log_file" >&2 || true
-    rm -f "$log_file"
+    if [ "$log_file" != "/dev/null" ]; then
+        rm -f "$log_file"
+    fi
     echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
 }
 

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -14,8 +14,8 @@ module Web_dashboard = Masc_mcp.Web_dashboard
    so assets_root() can't find assets/dashboard/index.html.
    Resolve it from the executable path: _build/default/test/foo.exe → 3 dirs up. *)
 let has_repo_root root =
-  let web_index = Filename.concat (Filename.concat root "web") "index.html" in
-  Sys.file_exists web_index
+  Sys.file_exists (Filename.concat root "dune-project")
+  && Sys.file_exists (Filename.concat (Filename.concat root "dashboard") "package.json")
 
 let rec ascend_repo_root dir =
   if has_repo_root dir then Some dir
@@ -233,11 +233,11 @@ let test_html_ignores_invalid_explicit_assets_dir () =
         ]
         (fun () ->
           let html = Web_dashboard.html () in
-          check bool "falls back to base_path assets" true
+          check bool "does not fall back to base_path assets" false
             (contains_substr "dashboard-from-base-path" html)))
     ~finally:(fun () -> cleanup_temp_dashboard_root base_root)
 
-let test_html_uses_base_path_assets () =
+let test_html_ignores_base_path_assets () =
   let base_root = make_temp_dashboard_root "base" "dashboard-from-base-path" in
   Fun.protect
     (fun () ->
@@ -248,7 +248,7 @@ let test_html_uses_base_path_assets () =
         ]
         (fun () ->
           let html = Web_dashboard.html () in
-          check bool "uses base_path assets" true
+          check bool "ignores base_path assets" false
             (contains_substr "dashboard-from-base-path" html)))
     ~finally:(fun () ->
       cleanup_temp_dashboard_root base_root)
@@ -302,8 +302,8 @@ let () =
     ];
     "fallback", [
       test_case "missing asset dir" `Quick test_fallback_on_missing_asset;
-      test_case "invalid explicit assets dir falls back" `Quick test_html_ignores_invalid_explicit_assets_dir;
-      test_case "base_path assets" `Quick test_html_uses_base_path_assets;
+      test_case "invalid explicit assets dir ignores base path" `Quick test_html_ignores_invalid_explicit_assets_dir;
+      test_case "base_path assets ignored" `Quick test_html_ignores_base_path_assets;
     ];
     "asset_path_safety", [
       test_case "accept normal" `Quick test_safe_asset_relative_path_accepts_normal;

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -16,6 +16,7 @@ module Web_dashboard = Masc_mcp.Web_dashboard
 let has_repo_root root =
   Sys.file_exists (Filename.concat root "dune-project")
   && Sys.file_exists (Filename.concat (Filename.concat root "dashboard") "package.json")
+  && Sys.file_exists (Filename.concat (Filename.concat root "lib") "web_dashboard.ml")
 
 let rec ascend_repo_root dir =
   if has_repo_root dir then Some dir


### PR DESCRIPTION
## Summary
- stop dashboard asset lookup from treating `MASC_BASE_PATH/assets` as a static bundle root
- make dashboard build helper temp files portable across BSD/GNU `mktemp`
- tighten dashboard coverage tests around repo-root detection and base-path behavior

## Product impact
- `/dashboard` serves the built SPA again even when `MASC_BASE_PATH` points at the shared `.masc` runtime root
- `start-masc-mcp.sh` and `scripts/build-dashboard-if-needed.sh` no longer fail during temp log creation on macOS or GNU environments

## Evidence
- `bash -n start-masc-mcp.sh scripts/build-dashboard-if-needed.sh`
- `temp_root="${TMPDIR:-/tmp}"; temp_root="${temp_root%/}"; mktemp "$temp_root/masc-dashboard-build.XXXXXX"`
- `dune runtest --root . test/test_web_dashboard_coverage.exe`

## Review evidence
- direct `sb glm-text` review on head `dc0f0370c` returned `No findings.`
- PR comment: https://github.com/jeong-sik/masc-mcp/pull/3896#issuecomment-4153114871

## Linked issue
- Refs #3901
