### PR TITLE
feat(keeper): crash persistence + dashboard diagnostics + params editing

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -250,11 +250,19 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
   })
 }
 
+export interface RuntimeParamMeta {
+  description: string
+  value_type: string
+  min_value?: number
+  max_value?: number
+}
+
 export interface RuntimeParam {
   key: string
   current: unknown
   default: unknown
   has_override: boolean
+  meta?: RuntimeParamMeta | null
 }
 
 export interface RuntimeParamsSurface {
@@ -271,6 +279,14 @@ export interface RuntimeParamsResponse {
 
 export function fetchRuntimeParams(): Promise<RuntimeParamsResponse> {
   return get('/api/v1/governance/params')
+}
+
+export function setRuntimeParam(paramKey: string, value: unknown, reason = ''): Promise<{ ok: boolean; message: string }> {
+  return post('/api/v1/governance/params/set', { param_key: paramKey, value, reason })
+}
+
+export function clearRuntimeParam(paramKey: string): Promise<{ ok: boolean; message: string }> {
+  return post('/api/v1/governance/params/clear', { param_key: paramKey })
 }
 
 export function fetchDashboardMission(): Promise<DashboardMissionResponse> {

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { EmptyState } from './common/empty-state'
 import { LoadingState } from './common/feedback-state'
 import { Card } from './common/card'
@@ -6,6 +7,7 @@ import { TimeAgo } from './common/time-ago'
 import { governanceToneClass } from '../lib/tone'
 import type { GovernanceTimelineEvent } from '../types'
 import type { RuntimeParamsSurface } from '../api'
+import { setRuntimeParam, clearRuntimeParam } from '../api/dashboard'
 import {
   governanceData,
   runtimeLoading,
@@ -16,6 +18,9 @@ import {
   activityKindLabel,
   formatParamValue,
 } from './governance-utils'
+
+const editingParam = signal<string | null>(null)
+const editValue = signal<string>('')
 
 export function ActivityRail() {
   const events = (governanceData.value?.activity ?? []).slice(0, 20)
@@ -121,17 +126,77 @@ export function RuntimeParamsPanel() {
                     </div>
                     <div class="text-[11px] text-text-muted mb-3">${surface.description}</div>
                     <div class="flex flex-col gap-1.5">
-                      ${surfaceParams.map(param => html`
+                      ${surfaceParams.map(param => {
+                        const isEditing = editingParam.value === param.key
+                        const meta = param.meta
+                        return html`
                         <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-white/3 ${param.has_override ? 'border border-warn/20' : ''}">
-                          <span class="text-xs font-mono text-text-muted">${param.key}</span>
-                          <span class="text-xs font-medium text-text-strong">
-                            ${formatParamValue(param.current)}
-                            ${param.has_override
-                              ? html`<span class="ml-1.5 text-[10px] text-warn font-bold">override</span>`
-                              : null}
-                          </span>
+                          <div class="flex flex-col gap-0.5">
+                            <span class="text-xs font-mono text-text-muted">${param.key}</span>
+                            ${meta?.description ? html`<span class="text-[10px] text-text-muted/60">${meta.description}</span>` : null}
+                          </div>
+                          <div class="flex items-center gap-2">
+                            ${isEditing ? html`
+                              <input type="number"
+                                class="w-20 py-0.5 px-2 rounded text-xs font-mono bg-[var(--white-5)] border border-[var(--white-10)] text-text-strong outline-none focus:border-accent/50"
+                                value=${editValue.value}
+                                min=${meta?.min_value ?? ''}
+                                max=${meta?.max_value ?? ''}
+                                onInput=${(e: Event) => { editValue.value = (e.target as HTMLInputElement).value }}
+                                onKeyDown=${(e: KeyboardEvent) => {
+                                  if (e.key === 'Enter') {
+                                    const val = meta?.value_type === 'float' ? parseFloat(editValue.value) : parseInt(editValue.value, 10)
+                                    if (!isNaN(val)) {
+                                      void setRuntimeParam(param.key, val).then(() => {
+                                        editingParam.value = null
+                                      })
+                                    }
+                                  } else if (e.key === 'Escape') {
+                                    editingParam.value = null
+                                  }
+                                }}
+                              />
+                              <button type="button"
+                                class="text-[10px] py-0.5 px-1.5 rounded bg-accent/10 text-accent hover:bg-accent/20 cursor-pointer border-none"
+                                onClick=${() => {
+                                  const val = meta?.value_type === 'float' ? parseFloat(editValue.value) : parseInt(editValue.value, 10)
+                                  if (!isNaN(val)) {
+                                    void setRuntimeParam(param.key, val).then(() => {
+                                      editingParam.value = null
+                                    })
+                                  }
+                                }}
+                              >Apply</button>
+                              <button type="button"
+                                class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
+                                onClick=${() => { editingParam.value = null }}
+                              >Cancel</button>
+                            ` : html`
+                              <span class="text-xs font-medium text-text-strong">
+                                ${formatParamValue(param.current)}
+                              </span>
+                              ${param.has_override ? html`
+                                <span class="text-[10px] text-warn font-bold">override</span>
+                                <button type="button"
+                                  class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
+                                  onClick=${() => {
+                                    void clearRuntimeParam(param.key)
+                                  }}
+                                >Reset</button>
+                              ` : null}
+                              ${surface.risk !== 'high' ? html`
+                                <button type="button"
+                                  class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
+                                  onClick=${() => {
+                                    editingParam.value = param.key
+                                    editValue.value = String(param.current)
+                                  }}
+                                >Edit</button>
+                              ` : null}
+                            `}
+                          </div>
                         </div>
-                      `)}
+                      `})}
                     </div>
                   </div>
                 `

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -149,6 +149,72 @@ function SectionCard({ title, children }: { title: string; children: preact.Comp
   `
 }
 
+// ── Supervisor Diagnostics Panel ────────────────────────
+
+function registryStateBadge(state: string | null) {
+  if (!state) return null
+  const colors: Record<string, { bg: string; text: string }> = {
+    Running: { bg: 'bg-[rgba(34,197,94,0.12)]', text: 'text-[#4ade80]' },
+    Crashed: { bg: 'bg-[rgba(239,68,68,0.15)]', text: 'text-[#ef4444]' },
+    Dead: { bg: 'bg-[rgba(100,116,139,0.15)]', text: 'text-[#94a3b8]' },
+    Stopped: { bg: 'bg-[rgba(234,179,8,0.12)]', text: 'text-[#facc15]' },
+    Paused: { bg: 'bg-[rgba(168,85,247,0.12)]', text: 'text-[#c084fc]' },
+  }
+  const c = colors[state] ?? { bg: 'bg-[rgba(138,163,211,0.1)]', text: 'text-[#86a0cf]' }
+  return html`<span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold ${c.bg} ${c.text}">${state}</span>`
+}
+
+function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
+  const diag = (keeper as any).supervisor_diagnostics
+  if (!diag) return null
+  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since } = diag
+  const budgetPct = max_restarts > 0 ? Math.min(100, (restart_count / max_restarts) * 100) : 0
+  const budgetColor = budgetPct >= 80 ? '#ef4444' : budgetPct >= 50 ? '#f59e0b' : '#4ade80'
+  return html`
+    <${SectionCard} title="Supervisor 진단">
+      <div class="space-y-3">
+        <div class="flex items-center justify-between">
+          <span class="text-xs text-[var(--text-muted)]">Fiber 상태</span>
+          ${registryStateBadge((keeper as any).registry_state)}
+        </div>
+        <div>
+          <div class="flex items-center justify-between mb-1">
+            <span class="text-xs text-[var(--text-muted)]">재시작 예산</span>
+            <span class="text-xs font-mono text-[var(--text-body)]">${restart_count}/${max_restarts}</span>
+          </div>
+          <div class="w-full h-1.5 rounded-full bg-[var(--white-5)] overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-300" style="width: ${budgetPct}%; background: ${budgetColor}"></div>
+          </div>
+        </div>
+        ${last_failure_reason ? html`
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-[var(--text-muted)]">마지막 실패 원인</span>
+            <span class="text-[11px] font-mono text-[#fb7185]">${last_failure_reason}</span>
+          </div>
+        ` : null}
+        ${dead_since ? html`
+          <div class="py-2 px-3 rounded-lg bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] text-xs text-[#fb7185]">
+            Dead since ${new Date(dead_since * 1000).toLocaleString()}. Reboot 필요.
+          </div>
+        ` : null}
+        ${crash_log && crash_log.length > 0 ? html`
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Crash 이력</div>
+            <div class="space-y-1 max-h-32 overflow-y-auto">
+              ${crash_log.slice(0, 10).map((e: any) => html`
+                <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
+                  <span class="font-mono text-[var(--text-muted)]">${new Date((e.ts ?? 0) * 1000).toLocaleTimeString()}</span>
+                  <span class="text-[#fb7185]">${e.reason ?? 'unknown'}</span>
+                </div>
+              `)}
+            </div>
+          </div>
+        ` : null}
+      </div>
+    <//>
+  `
+}
+
 // ── Main Detail Overlay ─────────────────────────────────
 
 export function KeeperDetailOverlay() {
@@ -241,6 +307,9 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Context chart ── */}
         <${ContextChart} keeper=${keeper} />
+
+        ${'' /* ── Supervisor diagnostics ── */}
+        <${SupervisorDiagnosticsPanel} keeper=${keeper} />
 
         ${'' /* ── Latency / Cost / Model charts ── */}
         <${MetricsCharts} keeper=${keeper} />

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -236,10 +236,50 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | _ -> 0
           in
           let keepalive_running = runtime_keepalive_running config m in
+          let registry_entry =
+            Keeper_registry.get ~base_path:config.base_path m.name in
           let registry_state =
-            match Keeper_registry.get ~base_path:config.base_path m.name with
+            match registry_entry with
             | Some entry -> Some (Keeper_registry.state_to_string entry.state)
             | None -> None
+          in
+          let supervisor_diagnostics =
+            let max_restarts =
+              Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
+            match registry_entry with
+            | Some entry ->
+                let crash_log =
+                  List.map (fun (ts, reason) ->
+                    `Assoc [("ts", `Float ts); ("reason", `String reason)]
+                  ) entry.crash_log in
+                let disk_crashes =
+                  (try Keeper_crash_persistence.recent_crashes
+                    ~base_path:config.base_path ~name:m.name ~max_entries:20
+                  with _ -> []) in
+                let combined_log = match disk_crashes with
+                  | [] -> crash_log
+                  | _ -> disk_crashes in
+                `Assoc [
+                  ("restart_count", `Int entry.restart_count);
+                  ("max_restarts", `Int max_restarts);
+                  ("crash_log", `List combined_log);
+                  ("last_failure_reason",
+                    match entry.last_failure_reason with
+                    | Some r -> `String (Keeper_registry.failure_reason_to_string r)
+                    | None -> `Null);
+                  ("dead_since",
+                    match entry.dead_since_ts with
+                    | Some ts -> `Float ts
+                    | None -> `Null);
+                ]
+            | None ->
+                `Assoc [
+                  ("restart_count", `Int 0);
+                  ("max_restarts", `Int max_restarts);
+                  ("crash_log", `List []);
+                  ("last_failure_reason", `Null);
+                  ("dead_since", `Null);
+                ]
           in
 
           let context =
@@ -346,6 +386,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 match registry_state with
                 | Some state -> `String state
                 | None -> `Null);
+              ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));

--- a/lib/dune
+++ b/lib/dune
@@ -490,6 +490,7 @@
    keeper_coordination
    keeper_execution
    keeper_keepalive
+   keeper_crash_persistence
    keeper_chat_store
    keeper_recurring
    keeper_registry

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -140,14 +140,13 @@ let keeper_keepalive_interval_sec =
 let keeper_dead_ttl_sec =
   Runtime_params.register
     ~key:"keeper.dead_ttl_sec"
-    ~default:(fun () ->
-      Float.to_int Env_config_keeper.KeeperSupervisor.dead_ttl_sec)
-    ~validate:(validate_int_range ~min:60 ~max:86400 "keeper_dead_ttl_sec")
-    ~serialize:(fun v -> `Int v)
+    ~default:(fun () -> Env_config_keeper.KeeperSupervisor.dead_ttl_sec)
+    ~validate:(validate_float_range ~min:60.0 ~max:86400.0 "keeper_dead_ttl_sec")
+    ~serialize:(fun v -> `Float v)
     ~meta:{ description = "Dead 상태 유지 시간(초)";
-            value_type = "int";
-            min_value = Some (`Int 60); max_value = Some (`Int 86400) }
-    ~deserialize:deserialize_int
+            value_type = "float";
+            min_value = Some (`Float 60.0); max_value = Some (`Float 86400.0) }
+    ~deserialize:deserialize_float
     ()
 
 (* ── surface catalog ─────────────────────────────────────────── *)

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -1,0 +1,86 @@
+(** Keeper_crash_persistence -- Durable crash event store.
+
+    Architecture:
+    - [enqueue_record] pushes to an in-memory Queue (non-yielding).
+    - A background drain fiber periodically flushes the queue to
+      Dated_jsonl stores under [.masc/keepers/<name>/crash-events/].
+    - Each keeper gets a cached [Dated_jsonl.t] instance (same pattern
+      as [keeper_types_support.ml:metrics_store_cache]).
+    - [recent_crashes] reads from disk for dashboard display.
+
+    @since 3.0.0 *)
+
+(* ── types ───────────────────────────────────────────────────── *)
+
+type crash_event = {
+  base_path : string;
+  name : string;
+  ts : float;
+  reason : string;
+  restart_count : int;
+}
+
+(* ── queue (non-yielding enqueue) ────────────────────────────── *)
+
+let queue : crash_event Queue.t = Queue.create ()
+
+(* ── Dated_jsonl store cache ─────────────────────────────────── *)
+
+let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
+let store_mu = Eio.Mutex.create ()
+
+let crash_store ~base_path name : Dated_jsonl.t =
+  let masc = Filename.concat base_path ".masc" in
+  let dir = Filename.concat
+    (Filename.concat (Filename.concat masc "keepers") name)
+    "crash-events" in
+  Eio_guard.with_mutex store_mu (fun () ->
+    match Hashtbl.find_opt store_cache dir with
+    | Some store -> store
+    | None ->
+        let store = Dated_jsonl.create ~base_dir:dir () in
+        Hashtbl.replace store_cache dir store;
+        store)
+
+(* ── enqueue (non-yielding) ──────────────────────────────────── *)
+
+let enqueue_record ~base_path ~name ~ts ~reason ~restart_count =
+  Queue.push { base_path; name; ts; reason; restart_count } queue
+
+(* ── drain fiber ─────────────────────────────────────────────── *)
+
+let drain_batch () =
+  let batch = ref [] in
+  while not (Queue.is_empty queue) do
+    batch := Queue.pop queue :: !batch
+  done;
+  List.rev !batch
+
+let write_event (ev : crash_event) =
+  let store = crash_store ~base_path:ev.base_path ev.name in
+  let json = `Assoc [
+    ("ts", `Float ev.ts);
+    ("reason", `String ev.reason);
+    ("restart_count", `Int ev.restart_count);
+  ] in
+  Dated_jsonl.append store json
+
+let start_drain_fiber ~sw ~clock =
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    while true do
+      Eio.Time.sleep clock 2.0;
+      let batch = drain_batch () in
+      List.iter (fun ev ->
+        (try write_event ev
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           Log.Keeper.warn "crash persistence write failed for %s: %s"
+             ev.name (Printexc.to_string exn))
+      ) batch
+    done;
+    `Stop_daemon)
+
+(* ── read (I/O, for dashboard) ───────────────────────────────── *)
+
+let recent_crashes ~base_path ~name ~max_entries =
+  let store = crash_store ~base_path name in
+  Dated_jsonl.read_recent store max_entries

--- a/lib/keeper/keeper_crash_persistence.mli
+++ b/lib/keeper/keeper_crash_persistence.mli
@@ -1,0 +1,29 @@
+(** Keeper_crash_persistence -- Durable crash event store.
+
+    Non-yielding enqueue + background drain fiber.
+    Dated_jsonl under Room.masc_root_dir/keepers/<name>/crash-events/.
+    Separate from Keeper_registry to preserve its non-yielding contract.
+
+    @since 3.0.0 *)
+
+(** Non-yielding: Queue.push only. Safe to call from keeper_registry
+    or keeper_supervisor catch blocks without breaking fiber atomicity. *)
+val enqueue_record :
+  base_path:string ->
+  name:string ->
+  ts:float ->
+  reason:string ->
+  restart_count:int ->
+  unit
+
+(** Start background drain fiber. Call once from server bootstrap.
+    Drains the internal queue and writes to Dated_jsonl. *)
+val start_drain_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
+
+(** Read recent crash events from disk. Performs I/O -- call from
+    dashboard handlers, not from keeper_registry context. *)
+val recent_crashes :
+  base_path:string ->
+  name:string ->
+  max_entries:int ->
+  Yojson.Safe.t list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -82,8 +82,13 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                (Some info.reason);
              Keeper_registry.set_state ~base_path meta.name
                Keeper_registry.Crashed;
+             let ts = Time_compat.now () in
              Keeper_registry.record_crash ~base_path
-               meta.name (Time_compat.now ()) reason;
+               meta.name ts reason;
+             let rc = match Keeper_registry.get ~base_path meta.name with
+               | Some e -> e.restart_count | None -> 0 in
+             Keeper_crash_persistence.enqueue_record ~base_path
+               ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
              publish_lifecycle "crashed" meta.name reason
@@ -94,8 +99,13 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
              Keeper_registry.set_state ~base_path meta.name
                Keeper_registry.Crashed;
+             let ts = Time_compat.now () in
              Keeper_registry.record_crash ~base_path
-               meta.name (Time_compat.now ()) reason;
+               meta.name ts reason;
+             let rc = match Keeper_registry.get ~base_path meta.name with
+               | Some e -> e.restart_count | None -> 0 in
+             Keeper_crash_persistence.enqueue_record ~base_path
+               ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
              publish_lifecycle "crashed" meta.name reason))
@@ -107,8 +117,13 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                 Keeper_registry.Fiber_unresolved in
             Keeper_registry.set_failure_reason ~base_path meta.name
               (Some Keeper_registry.Fiber_unresolved);
+            let ts = Time_compat.now () in
             Keeper_registry.record_crash ~base_path
-              meta.name (Time_compat.now ()) reason;
+              meta.name ts reason;
+            let rc = match Keeper_registry.get ~base_path meta.name with
+              | Some e -> e.restart_count | None -> 0 in
+            Keeper_crash_persistence.enqueue_record ~base_path
+              ~name:meta.name ~ts ~reason ~restart_count:rc;
             Keeper_registry.record_error ~base_path meta.name reason;
             Keeper_registry.set_state ~base_path meta.name
               Keeper_registry.Crashed;

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -287,7 +287,7 @@ let apply_self_preservation ~total_keepers to_restart =
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
-  let dead_ttl_sec = Float.of_int (Runtime_params.get Governance_registry.keeper_dead_ttl_sec) in
+  let dead_ttl_sec = Runtime_params.get Governance_registry.keeper_dead_ttl_sec in
   let base_path = ctx.config.base_path in
   (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
      This prevents reconcile from re-launching keepers that sweep is about

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -376,3 +376,104 @@ let add_routes ~sw ~clock router =
                ]))
          )
        ) request reqd)
+
+  (* Governance Runtime Params: set / clear *)
+  |> Http.Router.post "/api/v1/governance/params/set" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_set_param"
+         (fun state _req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             let base_path = state.Mcp_server.room_config.base_path in
+             let actor = agent_from_request request
+               |> Option.value ~default:"dashboard" in
+             let submit_petition _ctx _petition_args =
+               (false, "High-risk parameter changes from dashboard require governance petition via CLI")
+             in
+             let ctx = Tool_council_feed.{ base_path; agent_name = actor;
+               room_config = Some state.Mcp_server.room_config } in
+             let (ok, msg) = Tool_council_feed.handle_set_param
+               ~submit_petition ctx args in
+             let status = if ok then `OK else `Bad_request in
+             respond_json_with_cors ~status request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool ok); ("message", `String msg)
+               ]))
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool false);
+                 ("error", `String (Printexc.to_string exn))
+               ]))
+         )
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/governance/params/clear" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_set_param"
+         (fun state _req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             let param_key = Yojson.Safe.Util.(member "param_key" args
+               |> to_string_option) |> Option.value ~default:"" in
+             let base_path = state.Mcp_server.room_config.base_path in
+             let actor = agent_from_request request
+               |> Option.value ~default:"dashboard" in
+             if param_key = "" then
+               respond_json_with_cors ~status:`Bad_request request reqd
+                 (Yojson.Safe.to_string (`Assoc [
+                   ("ok", `Bool false); ("error", `String "param_key is required")
+                 ]))
+             else begin
+               let risk = Governance_registry.surfaces
+                 |> List.find_opt (fun (s : Governance_registry.surface) ->
+                      List.mem param_key s.param_keys)
+                 |> Option.map (fun (s : Governance_registry.surface) -> s.risk)
+                 |> Option.value ~default:"low" in
+               if risk = "high" then
+                 respond_json_with_cors request reqd
+                   (Yojson.Safe.to_string (`Assoc [
+                     ("ok", `Bool false);
+                     ("error", `String "High-risk param clear requires governance petition. Use masc_set_param tool.");
+                   ]))
+               else begin
+                 let old_value =
+                   match Runtime_params.registry ()
+                     |> List.find_opt (fun (k, _, _, _, _) -> k = param_key) with
+                   | Some (_, current, _, _, _) -> current
+                   | None -> `Null in
+                 match Runtime_params.clear_by_key param_key with
+                 | Error msg ->
+                   respond_json_with_cors ~status:`Bad_request request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool false); ("error", `String msg)
+                     ]))
+                 | Ok () ->
+                   let new_value =
+                     match Runtime_params.registry ()
+                       |> List.find_opt (fun (k, _, _, _, _) -> k = param_key) with
+                     | Some (_, _, default, _, _) -> default
+                     | None -> `Null in
+                   Runtime_params.persist ~base_path;
+                   Runtime_params.record_audit ~base_path
+                     ~key:param_key ~old_value ~new_value ~actor ();
+                   Sse.broadcast
+                     (`Assoc [
+                       ("type", `String "governance_param_changed");
+                       ("param_key", `String param_key);
+                     ]);
+                   respond_json_with_cors request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool true);
+                       ("message", `String (Printf.sprintf "Cleared %s to default" param_key));
+                     ]))
+               end
+             end
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool false);
+                 ("error", `String (Printexc.to_string exn))
+               ]))
+         )
+       ) request reqd)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -157,7 +157,9 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
           if not (Sys.file_exists keepers) then 0
           else
             Array.fold_left (fun acc name ->
-              acc + prune_dir (Filename.concat (Filename.concat keepers name) "metrics")
+              acc
+              + prune_dir (Filename.concat (Filename.concat keepers name) "metrics")
+              + prune_dir (Filename.concat (Filename.concat keepers name) "crash-events")
             ) 0 (Sys.readdir keepers))
      in
      if total > 0 then
@@ -353,6 +355,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Governance_registry.ensure_init ();
       Runtime_params.restore ~base_path;
       Log.Server.info "Runtime_params restored from %s" base_path;
+      Keeper_crash_persistence.start_drain_fiber ~sw ~clock;
       let t2 = Eio.Time.now clock in
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       Server_bootstrap_loops.install_tooling ~governance_level state;


### PR DESCRIPTION
## Summary

Follows #3881 (merged). Adds remaining phases:

- **Crash persistence module** (`keeper_crash_persistence.ml`): Non-yielding enqueue + background drain fiber. Dated_jsonl under `Room.masc_root_dir/keepers/<name>/crash-events/`. Per-keeper store cache (metrics_store_cache pattern). Crash hooks at fiber catch blocks (supervisor.ml:75,87,100).
- **Dashboard supervisor diagnostics**: `supervisor_diagnostics` API field with restart_count, max_restarts, crash_log, last_failure_reason, dead_since. SupervisorDiagnosticsPanel in keeper-detail.ts.
- **HTTP routes for params set/clear**: `POST /api/v1/governance/params/set` reuses `handle_set_param` pipeline. `POST /api/v1/governance/params/clear` with risk gate. High-risk clear rejected from dashboard.
- **Dashboard editing UI**: Inline number input with meta validation, Apply/Reset buttons, risk-based visibility.
- **Review fix**: `dead_ttl_sec` kept as float (removed unnecessary int truncation).

## Test plan

- [x] `dune build` for changed files
- [x] `tsc --noEmit` dashboard type check
- [x] `test_runtime_params.exe` 10/10 pass
- [x] Cross-model review (GLM-5.1)
- [ ] E2E: server restart param persistence
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)