### PR TITLE
fix: sync opam agent_sdk floor to 0.97.0

### DIFF
--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.96.0"}
+  "agent_sdk" {>= "0.97.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
- `dune-project`의 agent_sdk floor이 0.97.0으로 올랐으나 `masc_mcp.opam`이 0.96.0에 머물러 모든 open PR의 Health CI(OAS pin ratchet)가 실패
- 1줄 수정: `"agent_sdk" {>= "0.96.0"}` → `"agent_sdk" {>= "0.97.0"}`

## Test plan
- [x] `scripts/check-oas-pin.sh` 로컬 통과
- [x] `scripts/check-doc-truth.sh` 로컬 통과
- [ ] CI Health check green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)