### PR TITLE
feat(keeper): effective_allowed_paths guardrail for workspace scope

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -252,7 +252,7 @@ let run_turn
       ?on_event
       ~agent_ref
       ?contract
-      ~allowed_paths:meta.allowed_paths
+      ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
       ~working_context:checkpoint_sidecar
       ~priority:(Option.value priority ~default:Llm_provider.Request_priority.Interactive)
       ~cache_system_prompt:true

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -58,6 +58,23 @@ let resolve_keeper_target_path ~(config : Room.config)
              "path_not_in_allowed_paths: %s (allowed: [%s])"
              raw (String.concat ", " allowed_paths))
 
+(** Compute effective allowed_paths from keeper meta, applying scope-based
+    defaults when the operator has not set an explicit list.
+    - ["*"]          → [] (full access, explicit opt-in)
+    - non-empty list → list as-is (explicit restriction)
+    - [] + workspace → keeper's own dirs (computed default)
+    - [] + otherwise → [] (observe_only blocks writes; local = full access) *)
+let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
+  match meta.allowed_paths with
+  | ["*"] -> []
+  | _ :: _ as explicit -> explicit
+  | [] ->
+    (match String.lowercase_ascii meta.execution_scope with
+     | "workspace" ->
+       [ Printf.sprintf ".masc/keepers/%s/" meta.name;
+         ".masc/traces/" ]
+     | _ -> [])
+
 let truncate_tool_output ?(max_len = 12000) (s : string) : string =
   if String.length s <= max_len then s
   else String.sub s 0 max_len ^ "\n...[truncated]"

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -64,6 +64,12 @@ let resolve_keeper_target_path ~(config : Room.config)
     - non-empty list → list as-is (explicit restriction)
     - [] + workspace → keeper's own dirs (computed default)
     - [] + otherwise → [] (observe_only blocks writes; local = full access) *)
+let sanitize_keeper_name (name : string) : string =
+  String.map (fun c ->
+    if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+       || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
+    then c else '_') name
+
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   match meta.allowed_paths with
   | ["*"] -> []
@@ -71,7 +77,8 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   | [] ->
     (match String.lowercase_ascii meta.execution_scope with
      | "workspace" ->
-       [ Printf.sprintf ".masc/keepers/%s/" meta.name;
+       let safe_name = sanitize_keeper_name meta.name in
+       [ Printf.sprintf ".masc/keepers/%s/" safe_name;
          ".masc/traces/" ]
      | _ -> [])
 

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -14,10 +14,11 @@ let infer_execution_mode (meta : Keeper_types.keeper_meta) : Oas.Execution_mode.
   | _ -> Oas.Execution_mode.Execute
 
 let infer_allowed_mutations (meta : Keeper_types.keeper_meta) : string list =
+  let effective = Keeper_alerting_path.effective_allowed_paths ~meta in
   match String.lowercase_ascii meta.execution_scope with
   | "workspace" | "local" -> ["workspace_only"]
   | _ ->
-    if meta.allowed_paths <> [] then ["workspace_only"]
+    if effective <> [] then ["workspace_only"]
     else []
 
 let of_keeper_meta (meta : Keeper_types.keeper_meta)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -794,7 +794,17 @@ let execute_keeper_tool_call
          key, validate it against effective_allowed_paths before dispatching. *)
       let effective_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
       let path_blocked =
-        if effective_paths = [] then None
+        if effective_paths = [] && meta.execution_scope <> "observe_only" then None
+        else if meta.execution_scope = "observe_only" && effective_paths = [] then
+          (* observe_only with no explicit paths: block write-capable tool args *)
+          let has_path_arg =
+            List.exists (fun key ->
+              match Yojson.Safe.Util.member key args with
+              | `String p when String.trim p <> "" -> true
+              | _ -> false) ["path"; "file_path"; "target_path"]
+          in
+          if has_path_arg then Some "observe_only_scope: write paths blocked"
+          else None
         else
           let candidates =
             List.filter_map (fun key ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -317,7 +317,7 @@ let execute_keeper_tool_call
         Safe_ops.json_int ~default:20000 "max_bytes" args
         |> fun n -> max 512 (min 200000 n)
       in
-      (match resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path:path with
+      (match resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path:path with
       | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
       | Ok target -> (
           match Safe_ops.read_file_safe target with
@@ -346,7 +346,7 @@ let execute_keeper_tool_call
         Safe_ops.json_string ~default:"overwrite" "mode" args
         |> String.lowercase_ascii
       in
-      (match resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path:path with
+      (match resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path:path with
       | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
       | Ok target ->
           (try
@@ -439,7 +439,7 @@ let execute_keeper_tool_call
       let root = project_root_of_config config in
       let read_target () =
         let raw_path = Safe_ops.json_string ~default:"." "path" args in
-        resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path
+        resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path
       in
       let render_process_result ~cmd argv =
         let st, out =
@@ -790,9 +790,29 @@ let execute_keeper_tool_call
             (`Assoc [ ("error", `String "unknown_autoresearch_tool");
                       ("tool", `String name) ]))
   | name when String.starts_with ~prefix:"masc_" name ->
-      (* Bridge to main MCP tool dispatch registry.
-         Handlers are closures that already capture their runtime context
-         (sw, clock, net, etc.) from server initialization. *)
+      (* Pre-dispatch path guard: if the tool args contain a path/file_path
+         key, validate it against effective_allowed_paths before dispatching. *)
+      let effective_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
+      let path_blocked =
+        if effective_paths = [] then None
+        else
+          let candidates =
+            List.filter_map (fun key ->
+              match Yojson.Safe.Util.member key args with
+              | `String p when String.trim p <> "" -> Some p
+              | _ -> None)
+              ["path"; "file_path"; "target_path"]
+          in
+          List.find_map (fun raw ->
+            match resolve_keeper_target_path ~config
+                    ~allowed_paths:effective_paths ~raw_path:raw with
+            | Error e -> Some e
+            | Ok _ -> None) candidates
+      in
+      (match path_blocked with
+      | Some err ->
+          Yojson.Safe.to_string (`Assoc [ ("error", `String err) ])
+      | None ->
       let t0 = Time_compat.now () in
       let result = Tool_dispatch.dispatch ~name ~args in
       let duration_ms =
@@ -807,7 +827,7 @@ let execute_keeper_tool_call
                         ("tool", `String name) ])
       in
       !on_keeper_tool_call ~tool_name:name ~success ~duration_ms;
-      msg
+      msg)
   | other ->
       Yojson.Safe.to_string
         (`Assoc [ ("error", `String "unknown_tool"); ("tool", `String other) ])

--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,7 @@
         test_keeper_deliberation
         test_keeper_registry
         test_keeper_supervisor
+        test_keeper_allowed_paths
         test_metrics_rotation
         test_tool_tier
         test_tool_budget
@@ -77,6 +78,7 @@
           test_keeper_deliberation
           test_keeper_registry
           test_keeper_supervisor
+          test_keeper_allowed_paths
           test_metrics_rotation
           test_tool_tier
           test_tool_budget

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -1,0 +1,119 @@
+(** Test suite for Keeper_alerting_path.effective_allowed_paths.
+    Verifies computed defaults, sentinel handling, and scope-based behavior. *)
+
+open Alcotest
+module KAP = Masc_mcp.Keeper_alerting_path
+module KT = Masc_mcp.Keeper_types
+
+let make_meta ?(execution_scope = "observe_only") ?(allowed_paths = [])
+    ~name () =
+  let json = `Assoc [
+    ("name", `String name);
+    ("agent_name", `String ("agent-" ^ name));
+    ("trace_id", `String ("trace-" ^ name));
+    ("goal", `String "test");
+    ("execution_scope", `String execution_scope);
+    ("allowed_paths", `List (List.map (fun s -> `String s) allowed_paths));
+  ] in
+  match KT.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta: " ^ err)
+
+(* ── observe_only scope ── *)
+
+let test_observe_only_empty_paths () =
+  let meta = make_meta ~execution_scope:"observe_only" ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "observe_only + [] = []" [] effective
+
+let test_observe_only_explicit_paths () =
+  let meta = make_meta ~execution_scope:"observe_only"
+      ~allowed_paths:["src/"; "lib/"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "observe_only + explicit = explicit"
+    ["src/"; "lib/"] effective
+
+(* ── workspace scope ── *)
+
+let test_workspace_empty_paths_computed_default () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~name:"sangsu" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "workspace + [] = computed default"
+    [".masc/keepers/sangsu/"; ".masc/traces/"] effective
+
+let test_workspace_explicit_paths () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["src/"; "docs/"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "workspace + explicit = explicit"
+    ["src/"; "docs/"] effective
+
+let test_workspace_star_sentinel () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["*"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "workspace + [*] = [] (full access)" [] effective
+
+(* ── local scope ── *)
+
+let test_local_empty_paths () =
+  let meta = make_meta ~execution_scope:"local" ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "local + [] = []" [] effective
+
+(* ── sentinel handling ── *)
+
+let test_star_sentinel_any_scope () =
+  let scopes = ["observe_only"; "workspace"; "local"; "unknown"] in
+  List.iter (fun scope ->
+    let meta = make_meta ~execution_scope:scope ~allowed_paths:["*"] ~name:"t" () in
+    let effective = KAP.effective_allowed_paths ~meta in
+    check (list string) (scope ^ " + [*] = []") [] effective
+  ) scopes
+
+let test_explicit_paths_any_scope () =
+  let paths = ["lib/keeper/"; "test/"] in
+  let scopes = ["observe_only"; "workspace"; "local"] in
+  List.iter (fun scope ->
+    let meta = make_meta ~execution_scope:scope ~allowed_paths:paths ~name:"t" () in
+    let effective = KAP.effective_allowed_paths ~meta in
+    check (list string) (scope ^ " + explicit = explicit") paths effective
+  ) scopes
+
+(* ── keeper name in computed default ── *)
+
+let test_computed_default_uses_keeper_name () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~name:"cdal-formalist" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "name embedded in path"
+    [".masc/keepers/cdal-formalist/"; ".masc/traces/"] effective
+
+(* ── Runner ── *)
+
+let () =
+  run "keeper_allowed_paths"
+    [
+      ( "effective_allowed_paths",
+        [
+          test_case "observe_only + [] = []" `Quick
+            test_observe_only_empty_paths;
+          test_case "observe_only + explicit = explicit" `Quick
+            test_observe_only_explicit_paths;
+          test_case "workspace + [] = computed default" `Quick
+            test_workspace_empty_paths_computed_default;
+          test_case "workspace + explicit = explicit" `Quick
+            test_workspace_explicit_paths;
+          test_case "workspace + [*] = full access" `Quick
+            test_workspace_star_sentinel;
+          test_case "local + [] = []" `Quick
+            test_local_empty_paths;
+          test_case "[*] sentinel any scope" `Quick
+            test_star_sentinel_any_scope;
+          test_case "explicit paths any scope" `Quick
+            test_explicit_paths_any_scope;
+          test_case "keeper name in computed default" `Quick
+            test_computed_default_uses_keeper_name;
+        ] );
+    ]

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -7,7 +7,8 @@ open Masc_mcp
 let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
-             ("trace_id", `String "test-trace-001")]) with
+             ("trace_id", `String "test-trace-001");
+             ("allowed_paths", `List [`String "*"])]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
 


### PR DESCRIPTION
## Summary
- `effective_allowed_paths` 함수 도입: `execution_scope`에 따라 `allowed_paths = []`의 의미를 분기
- `workspace` scope + `allowed_paths = []` → keeper 자기 디렉토리만 허용 (`.masc/keepers/<name>/`, `.masc/traces/`)
- `["*"]` sentinel으로 명시적 전체 허용 (operator opt-in)
- `masc_*` passthrough에 pre-dispatch path guard 추가 (path/file_path/target_path 키 검증)

## Enforcement Points (4곳)
| 위치 | 변경 |
|------|------|
| `keeper_exec_tools.ml` (fs_read/fs_edit/shell) | `meta.allowed_paths` → `effective_allowed_paths ~meta` |
| `keeper_exec_tools.ml` (masc_* passthrough) | path 키 추출 + resolve_keeper_target_path guard |
| `keeper_agent_run.ml` | OAS Builder allowed_paths |
| `keeper_cdal_contract.ml` | mutation inference |

## Test plan
- [x] `test_keeper_allowed_paths.exe` 9/9 통과
- [x] `test_keeper_supervisor.exe` 16/16 regression 없음
- [x] `dune build --root .` 성공
- [ ] CI green

## 후속 작업 (별도 PR)
- Phase 2: Profile/Schema에 allowed_paths 지원
- Phase 3: Dashboard UI에 allowed_paths 편집기

Closes #3876

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>