### PR TITLE
fix(council): replace silent placeholder stubs with explicit errors

### DIFF
--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -49,21 +49,21 @@ let default_mappings : action_mapping list = [
   (* PR merge pattern - PCRE syntax *)
   {
     pattern = "merge pr #?([0-9]+)";
-    action = GitHubAction (MergePR 0);  (* 0 = placeholder, extracted from match *)
+    action = GitHubAction (MergePR 0);  (* placeholder: actual PR# extracted at execution time *)
     requires_unanimous = false;
     min_threshold = 0.6;
   };
   (* PR close pattern *)
   {
     pattern = "close pr #?([0-9]+)";
-    action = GitHubAction (ClosePR 0);
+    action = GitHubAction (ClosePR 0);  (* placeholder: actual PR# extracted at execution time *)
     requires_unanimous = false;
     min_threshold = 0.5;
   };
   (* Deploy pattern *)
   {
     pattern = "deploy (v?[0-9.]+)";
-    action = ExecCommand ["echo"; "Deploy placeholder"];
+    action = ExecCommand ["echo"; "Deploy placeholder"];  (* stub: blocked at execution time *)
     requires_unanimous = true;
     min_threshold = 1.0;
   };
@@ -264,15 +264,33 @@ let execute_decision ~topic ~result : exec_result option =
       let action = match mapping.action with
         | GitHubAction (MergePR _) ->
           (match extract_number topic with
-           | Some n -> GitHubAction (MergePR n)
-           | None -> mapping.action)
+           | Some n -> Ok (GitHubAction (MergePR n))
+           | None ->
+             Error (Printf.sprintf
+               "Council: cannot extract PR number from topic %S — \
+                MergePR requires a valid PR number" topic))
         | GitHubAction (ClosePR _) ->
           (match extract_number topic with
-           | Some n -> GitHubAction (ClosePR n)
-           | None -> mapping.action)
-        | other -> other
+           | Some n -> Ok (GitHubAction (ClosePR n))
+           | None ->
+             Error (Printf.sprintf
+               "Council: cannot extract PR number from topic %S — \
+                ClosePR requires a valid PR number" topic))
+        | ExecCommand ["echo"; "Deploy placeholder"] ->
+          Error (Printf.sprintf
+            "Council: deploy action not implemented for topic %S — \
+             requires deployment pipeline integration" topic)
+        | other -> Ok other
       in
-      Some (execute_action action)
+      (match action with
+       | Ok a -> Some (execute_action a)
+       | Error msg ->
+         Log.Misc.error "Executor: %s" msg;
+         Some { success = false;
+                stdout = "";
+                stderr = msg;
+                output = msg;
+                timestamp = Time_compat.now () })
     end else begin
       Log.Misc.info "Executor: threshold not met for: %s" topic;
       None

--- a/test/test_council.ml
+++ b/test/test_council.ml
@@ -484,12 +484,61 @@ let test_executor_github_argv_create_issue () =
     argv
     ["gh"; "issue"; "create"; "--title"; title; "--body"; body]
 
+let contains_substring s sub =
+  let slen = String.length s and sublen = String.length sub in
+  if sublen > slen then false
+  else
+    let rec loop i =
+      if i > slen - sublen then false
+      else if String.sub s i sublen = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_executor_merge_with_valid_pr () =
+  (* Topic with valid PR number should match and extract the number *)
+  match Executor.find_action "Merge PR #42" with
+  | None -> fail "should match merge PR pattern"
+  | Some mapping ->
+    (* The template uses MergePR 0 as placeholder *)
+    (match mapping.Executor.action with
+     | Executor.GitHubAction (Executor.MergePR 0) -> ()
+     | _ -> fail "expected MergePR 0 placeholder in template");
+    (* extract_number should find 42 from the topic *)
+    (match Executor.extract_number "Merge PR #42" with
+     | Some 42 -> ()
+     | Some n -> fail (Printf.sprintf "expected 42, got %d" n)
+     | None -> fail "should extract 42")
+
+let test_executor_deploy_errors () =
+  (* Deploy stub should error, not pretend to succeed *)
+  let result = Consensus.Unanimous Consensus.Approve in
+  match Executor.execute_decision ~topic:"deploy v2.0" ~result with
+  | None -> fail "should return Some (error result), not None"
+  | Some r ->
+    check bool "not successful" (not r.Executor.success) true;
+    check bool "mentions deploy"
+      (contains_substring r.output "deploy") true
+
+let test_executor_deploy_not_silent () =
+  (* Verify the deploy mapping still exists but is explicitly blocked *)
+  match Executor.find_action "deploy v1.0" with
+  | None -> fail "deploy pattern should still match"
+  | Some mapping ->
+    (* The template has the echo placeholder *)
+    (match mapping.Executor.action with
+     | Executor.ExecCommand ["echo"; "Deploy placeholder"] -> ()
+     | _ -> fail "expected deploy echo placeholder in template")
+
 let executor_tests = [
   "find action PR", `Quick, test_executor_find_action_pr;
   "no action for random", `Quick, test_executor_find_action_none;
   "dry run approve", `Quick, test_executor_dry_run_approve;
   "dry run reject", `Quick, test_executor_dry_run_reject;
   "github argv create issue", `Quick, test_executor_github_argv_create_issue;
+  "merge with valid PR extracts number", `Quick, test_executor_merge_with_valid_pr;
+  "deploy stub errors", `Quick, test_executor_deploy_errors;
+  "deploy pattern exists but blocked", `Quick, test_executor_deploy_not_silent;
 ]
 
 (* ============================================================


### PR DESCRIPTION
## Summary

- Council executor의 placeholder PR#0과 deploy echo stub을 명시적 에러로 교체
- `execute_decision`의 action 해석이 `(action_kind, string) result`를 반환하도록 변경
- deploy stub이 실제 production path에서 silent success를 만들고 있었음 확인 (exit 0)
- 테스트 3건 추가

## Motivation

Governance 결정이 실행 불가능할 때 성공을 위장하는 "Silent No-Op" 패턴:
- `MergePR 0` / `ClosePR 0` — PR #0으로 실행 시도
- `echo "Deploy placeholder"` — exit 0으로 성공 보고

## Test plan
- [x] `dune build` 성공
- [x] executor 8 tests 통과 (기존 5 + 신규 3)
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-repo audit: `~/me/planning/claude-plans/luminous-sleeping-moon.md` (P0-M6/M7)