### PR TITLE
fix(governance): wire dashboard param set/clear to petition path

### DIFF
--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -8,11 +8,13 @@ import { governanceToneClass } from '../lib/tone'
 import type { GovernanceTimelineEvent } from '../types'
 import type { RuntimeParamsSurface } from '../api'
 import { setRuntimeParam, clearRuntimeParam } from '../api/dashboard'
+import { showToast } from './common/toast'
 import {
   governanceData,
   runtimeLoading,
   runtimeParams,
   runtimeSurfaces,
+  loadRuntimeParams,
 } from './governance-store'
 import {
   activityKindLabel,
@@ -147,8 +149,11 @@ export function RuntimeParamsPanel() {
                                   if (e.key === 'Enter') {
                                     const val = meta?.value_type === 'float' ? parseFloat(editValue.value) : parseInt(editValue.value, 10)
                                     if (!isNaN(val)) {
-                                      void setRuntimeParam(param.key, val).then(() => {
+                                      void setRuntimeParam(param.key, val).then((res) => {
                                         editingParam.value = null
+                                        const isPetition = res.message?.includes('petition')
+                                        showToast(res.message ?? 'Parameter updated', isPetition ? 'warning' : 'success')
+                                        void loadRuntimeParams()
                                       })
                                     }
                                   } else if (e.key === 'Escape') {
@@ -161,12 +166,15 @@ export function RuntimeParamsPanel() {
                                 onClick=${() => {
                                   const val = meta?.value_type === 'float' ? parseFloat(editValue.value) : parseInt(editValue.value, 10)
                                   if (!isNaN(val)) {
-                                    void setRuntimeParam(param.key, val).then(() => {
+                                    void setRuntimeParam(param.key, val).then((res) => {
                                       editingParam.value = null
+                                      const isPetition = res.message?.includes('petition')
+                                      showToast(res.message ?? 'Parameter updated', isPetition ? 'warning' : 'success')
+                                      void loadRuntimeParams()
                                     })
                                   }
                                 }}
-                              >Apply</button>
+                              >${surface.risk === 'high' ? 'Petition' : 'Apply'}</button>
                               <button type="button"
                                 class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
                                 onClick=${() => { editingParam.value = null }}
@@ -180,19 +188,21 @@ export function RuntimeParamsPanel() {
                                 <button type="button"
                                   class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
                                   onClick=${() => {
-                                    void clearRuntimeParam(param.key)
+                                    void clearRuntimeParam(param.key).then((res) => {
+                                      const isPetition = res.message?.includes('petition')
+                                      showToast(res.message ?? 'Parameter reset', isPetition ? 'warning' : 'success')
+                                      void loadRuntimeParams()
+                                    })
                                   }}
-                                >Reset</button>
+                                >${surface.risk === 'high' ? 'Petition Reset' : 'Reset'}</button>
                               ` : null}
-                              ${surface.risk !== 'high' ? html`
-                                <button type="button"
-                                  class="text-[10px] py-0.5 px-1.5 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none"
-                                  onClick=${() => {
-                                    editingParam.value = param.key
-                                    editValue.value = String(param.current)
-                                  }}
-                                >Edit</button>
-                              ` : null}
+                              <button type="button"
+                                class="text-[10px] py-0.5 px-1.5 rounded ${surface.risk === 'high' ? 'bg-warn/10 text-warn hover:bg-warn/20' : 'bg-white/5 text-text-muted hover:bg-white/10'} cursor-pointer border-none"
+                                onClick=${() => {
+                                  editingParam.value = param.key
+                                  editValue.value = String(param.current)
+                                }}
+                              >${surface.risk === 'high' ? 'Edit (petition)' : 'Edit'}</button>
                             `}
                           </div>
                         </div>

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -387,8 +387,34 @@ let add_routes ~sw ~clock router =
              let base_path = state.Mcp_server.room_config.base_path in
              let actor = agent_from_request request
                |> Option.value ~default:"dashboard" in
-             let submit_petition _ctx _petition_args =
-               (false, "High-risk parameter changes from dashboard require governance petition via CLI")
+             let module GV2 = Council.Governance_v2 in
+             let submit_petition ctx petition_args =
+               let open Yojson.Safe.Util in
+               let title = member "title" petition_args |> to_string_option
+                 |> Option.value ~default:"Dashboard param change" in
+               let subject_type = member "subject_type" petition_args |> to_string_option
+                 |> Option.value ~default:"param_change" in
+               let ra_json = member "requested_action" petition_args in
+               let requested_action = match ra_json with
+                 | `Null -> None
+                 | ra ->
+                   let at = member "action_type" ra |> to_string_option
+                     |> Option.value ~default:"set_param" in
+                   let payload = match member "payload" ra with
+                     | `Null -> None | p -> Some p in
+                   Some ({ action_type = at; target_type = Some "param";
+                           target_id = None; payload } : GV2.action_request)
+               in
+               let source_refs = match member "source_refs" petition_args with
+                 | `List items -> List.filter_map to_string_option items
+                 | _ -> [] in
+               match GV2.submit_petition ctx.Tool_council_feed.base_path
+                 ~title ~origin:"dashboard" ~subject_type
+                 ~risk_class:GV2.High
+                 ~requested_action ~source_refs ~created_by:actor with
+               | Ok result ->
+                 (true, Printf.sprintf "Petition created: case %s" result.case_.id)
+               | Error msg -> (false, msg)
              in
              let ctx = Tool_council_feed.{ base_path; agent_name = actor;
                room_config = Some state.Mcp_server.room_config } in
@@ -430,12 +456,36 @@ let add_routes ~sw ~clock router =
                       List.mem param_key s.param_keys)
                  |> Option.map (fun (s : Governance_registry.surface) -> s.risk)
                  |> Option.value ~default:"low" in
-               if risk = "high" then
-                 respond_json_with_cors request reqd
-                   (Yojson.Safe.to_string (`Assoc [
-                     ("ok", `Bool false);
-                     ("error", `String "High-risk param clear requires governance petition. Use masc_set_param tool.");
-                   ]))
+               if risk = "high" then begin
+                 let module GV2 = Council.Governance_v2 in
+                 let title = Printf.sprintf "Clear %s to default" param_key in
+                 let requested_action = Some ({
+                   action_type = "clear_param";
+                   target_type = Some "param";
+                   target_id = None;
+                   payload = Some (`Assoc [("param_key", `String param_key)]);
+                 } : GV2.action_request) in
+                 let source_refs = [param_key] in
+                 match GV2.submit_petition base_path
+                   ~title ~origin:"dashboard" ~subject_type:"param_change"
+                   ~risk_class:GV2.High ~requested_action ~source_refs
+                   ~created_by:actor with
+                 | Ok result ->
+                   respond_json_with_cors request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool true);
+                       ("message", `String (Printf.sprintf
+                         "High-risk param. Governance petition created: case %s"
+                         result.case_.id));
+                     ]))
+                 | Error msg ->
+                   respond_json_with_cors ~status:`Bad_request request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool false);
+                       ("error", `String (Printf.sprintf
+                         "Failed to create governance petition: %s" msg));
+                     ]))
+               end
                else begin
                  let old_value =
                    match Runtime_params.registry ()

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.96.0"}
+  "agent_sdk" {>= "0.97.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
- Dashboard HTTP routes의 `set`/`clear` 고위험 파라미터 변경 시 `GV2.submit_petition`을 호출하여 거버넌스 petition 생성
- 기존: stub 콜백이 항상 실패 (set) / 에러 반환 (clear)
- 변경: CLI/tool 경로와 동일한 거버넌스 파이프라인 적용
- Dashboard UI: 고위험 파라미터에 "Petition" 버튼 텍스트, toast 알림, mutation 후 params 리로드

Closes #3898

## Test plan
- [ ] `dune build` 통과 (완료)
- [ ] `dune runtest` 통과 (실행 중)
- [ ] Dashboard에서 `inference.default_model` (high-risk) 변경 시도 → petition 생성 확인
- [ ] Dashboard에서 `message.max_count` (low-risk) 변경 → 직접 적용 확인
- [ ] Dashboard에서 high-risk param clear 시도 → petition 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)