### PR TITLE
fix(keeper): use cluster-scoped path for crash-events persistence

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -254,7 +254,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ) entry.crash_log in
                 let disk_crashes =
                   (try Keeper_crash_persistence.recent_crashes
-                    ~base_path:config.base_path ~name:m.name ~max_entries:20
+                    ~masc_root:(Room.masc_root_dir config) ~name:m.name ~max_entries:20
                   with _ -> []) in
                 let combined_log = match disk_crashes with
                   | [] -> crash_log

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -39,6 +39,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
   let now_ts = Time_compat.now () in
   (* Parallel keeper I/O: each keeper's metadata + metrics reads run concurrently.
      Results are collected into a shared ref array, then filter_map'd. *)
+  let masc_root = Room.masc_root_dir config in
   let results = Array.make (List.length names) None in
   Eio.Fiber.all
     (List.mapi (fun idx name -> fun () ->
@@ -254,7 +255,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ) entry.crash_log in
                 let disk_crashes =
                   (try Keeper_crash_persistence.recent_crashes
-                    ~masc_root:(Room.masc_root_dir config) ~name:m.name ~max_entries:20
+                    ~masc_root ~name:m.name ~max_entries:20
                   with _ -> []) in
                 let combined_log = match disk_crashes with
                   | [] -> crash_log

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -3,17 +3,20 @@
     Architecture:
     - [enqueue_record] pushes to an in-memory Queue (non-yielding).
     - A background drain fiber periodically flushes the queue to
-      Dated_jsonl stores under [.masc/keepers/<name>/crash-events/].
+      Dated_jsonl stores under [masc_root/keepers/<name>/crash-events/].
     - Each keeper gets a cached [Dated_jsonl.t] instance (same pattern
       as [keeper_types_support.ml:metrics_store_cache]).
     - [recent_crashes] reads from disk for dashboard display.
+
+    Callers must pass [Room.masc_root_dir config] as [~masc_root]
+    to ensure cluster-scoped paths.
 
     @since 3.0.0 *)
 
 (* ── types ───────────────────────────────────────────────────── *)
 
 type crash_event = {
-  base_path : string;
+  masc_root : string;
   name : string;
   ts : float;
   reason : string;
@@ -29,10 +32,9 @@ let queue : crash_event Queue.t = Queue.create ()
 let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
 let store_mu = Eio.Mutex.create ()
 
-let crash_store ~base_path name : Dated_jsonl.t =
-  let masc = Filename.concat base_path ".masc" in
+let crash_store ~masc_root name : Dated_jsonl.t =
   let dir = Filename.concat
-    (Filename.concat (Filename.concat masc "keepers") name)
+    (Filename.concat (Filename.concat masc_root "keepers") name)
     "crash-events" in
   Eio_guard.with_mutex store_mu (fun () ->
     match Hashtbl.find_opt store_cache dir with
@@ -44,8 +46,8 @@ let crash_store ~base_path name : Dated_jsonl.t =
 
 (* ── enqueue (non-yielding) ──────────────────────────────────── *)
 
-let enqueue_record ~base_path ~name ~ts ~reason ~restart_count =
-  Queue.push { base_path; name; ts; reason; restart_count } queue
+let enqueue_record ~masc_root ~name ~ts ~reason ~restart_count =
+  Queue.push { masc_root; name; ts; reason; restart_count } queue
 
 (* ── drain fiber ─────────────────────────────────────────────── *)
 
@@ -57,7 +59,7 @@ let drain_batch () =
   List.rev !batch
 
 let write_event (ev : crash_event) =
-  let store = crash_store ~base_path:ev.base_path ev.name in
+  let store = crash_store ~masc_root:ev.masc_root ev.name in
   let json = `Assoc [
     ("ts", `Float ev.ts);
     ("reason", `String ev.reason);
@@ -81,6 +83,6 @@ let start_drain_fiber ~sw ~clock =
 
 (* ── read (I/O, for dashboard) ───────────────────────────────── *)
 
-let recent_crashes ~base_path ~name ~max_entries =
-  let store = crash_store ~base_path name in
+let recent_crashes ~masc_root ~name ~max_entries =
+  let store = crash_store ~masc_root name in
   Dated_jsonl.read_recent store max_entries

--- a/lib/keeper/keeper_crash_persistence.mli
+++ b/lib/keeper/keeper_crash_persistence.mli
@@ -1,15 +1,18 @@
 (** Keeper_crash_persistence -- Durable crash event store.
 
     Non-yielding enqueue + background drain fiber.
-    Dated_jsonl under Room.masc_root_dir/keepers/<name>/crash-events/.
+    Dated_jsonl under [masc_root/keepers/<name>/crash-events/].
+    Callers must pass [Room.masc_root_dir config] as [~masc_root]
+    to ensure cluster-scoped paths.
     Separate from Keeper_registry to preserve its non-yielding contract.
 
     @since 3.0.0 *)
 
 (** Non-yielding: Queue.push only. Safe to call from keeper_registry
-    or keeper_supervisor catch blocks without breaking fiber atomicity. *)
+    or keeper_supervisor catch blocks without breaking fiber atomicity.
+    [~masc_root] must be [Room.masc_root_dir config] (cluster-aware). *)
 val enqueue_record :
-  base_path:string ->
+  masc_root:string ->
   name:string ->
   ts:float ->
   reason:string ->
@@ -21,9 +24,10 @@ val enqueue_record :
 val start_drain_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
 
 (** Read recent crash events from disk. Performs I/O -- call from
-    dashboard handlers, not from keeper_registry context. *)
+    dashboard handlers, not from keeper_registry context.
+    [~masc_root] must be [Room.masc_root_dir config] (cluster-aware). *)
 val recent_crashes :
-  base_path:string ->
+  masc_root:string ->
   name:string ->
   max_entries:int ->
   Yojson.Safe.t list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -56,6 +56,7 @@ let publish_lifecycle event_name keeper_name detail =
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
+  let masc_root = Room.masc_root_dir ctx.config in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =
@@ -87,7 +88,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                meta.name ts reason;
              let rc = match Keeper_registry.get ~base_path meta.name with
                | Some e -> e.restart_count | None -> 0 in
-             Keeper_crash_persistence.enqueue_record ~base_path
+             Keeper_crash_persistence.enqueue_record ~masc_root
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
@@ -104,7 +105,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                meta.name ts reason;
              let rc = match Keeper_registry.get ~base_path meta.name with
                | Some e -> e.restart_count | None -> 0 in
-             Keeper_crash_persistence.enqueue_record ~base_path
+             Keeper_crash_persistence.enqueue_record ~masc_root
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
@@ -122,7 +123,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               meta.name ts reason;
             let rc = match Keeper_registry.get ~base_path meta.name with
               | Some e -> e.restart_count | None -> 0 in
-            Keeper_crash_persistence.enqueue_record ~base_path
+            Keeper_crash_persistence.enqueue_record ~masc_root
               ~name:meta.name ~ts ~reason ~restart_count:rc;
             Keeper_registry.record_error ~base_path meta.name reason;
             Keeper_registry.set_state ~base_path meta.name


### PR DESCRIPTION
## Summary

- `crash_store`가 `base_path`에서 직접 `.masc/keepers/...`를 합성하여 `Room.masc_root_dir`의 cluster-aware 경로를 우회하는 버그 수정
- API: `~base_path` -> `~masc_root`. 호출자가 `Room.masc_root_dir config`을 전달
- 4 files, 26+/19-

## 변경 파일

| 파일 | 변경 |
|------|------|
| `keeper_crash_persistence.ml/mli` | `~base_path` -> `~masc_root`, path 합성에서 `.masc` 제거 |
| `keeper_supervisor.ml` | 3개 enqueue_record 호출에 `Room.masc_root_dir ctx.config` 전달 |
| `dashboard_http_keeper.ml` | recent_crashes 호출에 `Room.masc_root_dir config` 전달 |

## Test plan

- [x] `test_keeper_supervisor.exe` 16/16 green
- [x] `test_runtime_params.exe` 10/10 green
- [ ] CI checks

Closes #3897

Generated with [Claude Code](https://claude.com/claude-code)
