### PR TITLE
fix(keeper): use cluster-scoped root for crash-events (#3897)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -252,9 +252,11 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   List.map (fun (ts, reason) ->
                     `Assoc [("ts", `Float ts); ("reason", `String reason)]
                   ) entry.crash_log in
+                let keepers_dir =
+                  Filename.concat (Room.masc_root_dir config) "keepers" in
                 let disk_crashes =
                   (try Keeper_crash_persistence.recent_crashes
-                    ~base_path:config.base_path ~name:m.name ~max_entries:20
+                    ~keepers_dir ~name:m.name ~max_entries:20
                   with _ -> []) in
                 let combined_log = match disk_crashes with
                   | [] -> crash_log

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -3,7 +3,7 @@
     Architecture:
     - [enqueue_record] pushes to an in-memory Queue (non-yielding).
     - A background drain fiber periodically flushes the queue to
-      Dated_jsonl stores under [.masc/keepers/<name>/crash-events/].
+      Dated_jsonl stores under [<keepers_dir>/<name>/crash-events/].
     - Each keeper gets a cached [Dated_jsonl.t] instance (same pattern
       as [keeper_types_support.ml:metrics_store_cache]).
     - [recent_crashes] reads from disk for dashboard display.
@@ -13,7 +13,7 @@
 (* ── types ───────────────────────────────────────────────────── *)
 
 type crash_event = {
-  base_path : string;
+  keepers_dir : string;
   name : string;
   ts : float;
   reason : string;
@@ -29,10 +29,9 @@ let queue : crash_event Queue.t = Queue.create ()
 let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
 let store_mu = Eio.Mutex.create ()
 
-let crash_store ~base_path name : Dated_jsonl.t =
-  let masc = Filename.concat base_path ".masc" in
+let crash_store ~keepers_dir name : Dated_jsonl.t =
   let dir = Filename.concat
-    (Filename.concat (Filename.concat masc "keepers") name)
+    (Filename.concat keepers_dir name)
     "crash-events" in
   Eio_guard.with_mutex store_mu (fun () ->
     match Hashtbl.find_opt store_cache dir with
@@ -44,8 +43,8 @@ let crash_store ~base_path name : Dated_jsonl.t =
 
 (* ── enqueue (non-yielding) ──────────────────────────────────── *)
 
-let enqueue_record ~base_path ~name ~ts ~reason ~restart_count =
-  Queue.push { base_path; name; ts; reason; restart_count } queue
+let enqueue_record ~keepers_dir ~name ~ts ~reason ~restart_count =
+  Queue.push { keepers_dir; name; ts; reason; restart_count } queue
 
 (* ── drain fiber ─────────────────────────────────────────────── *)
 
@@ -57,7 +56,7 @@ let drain_batch () =
   List.rev !batch
 
 let write_event (ev : crash_event) =
-  let store = crash_store ~base_path:ev.base_path ev.name in
+  let store = crash_store ~keepers_dir:ev.keepers_dir ev.name in
   let json = `Assoc [
     ("ts", `Float ev.ts);
     ("reason", `String ev.reason);
@@ -81,6 +80,6 @@ let start_drain_fiber ~sw ~clock =
 
 (* ── read (I/O, for dashboard) ───────────────────────────────── *)
 
-let recent_crashes ~base_path ~name ~max_entries =
-  let store = crash_store ~base_path name in
+let recent_crashes ~keepers_dir ~name ~max_entries =
+  let store = crash_store ~keepers_dir name in
   Dated_jsonl.read_recent store max_entries

--- a/lib/keeper/keeper_crash_persistence.mli
+++ b/lib/keeper/keeper_crash_persistence.mli
@@ -1,15 +1,18 @@
 (** Keeper_crash_persistence -- Durable crash event store.
 
     Non-yielding enqueue + background drain fiber.
-    Dated_jsonl under Room.masc_root_dir/keepers/<name>/crash-events/.
+    Dated_jsonl under [keepers_dir]/<name>/crash-events/.
+    Callers must pass the cluster-scoped keepers directory
+    (e.g. [Filename.concat (Room.masc_root_dir config) "keepers"]).
     Separate from Keeper_registry to preserve its non-yielding contract.
 
     @since 3.0.0 *)
 
 (** Non-yielding: Queue.push only. Safe to call from keeper_registry
-    or keeper_supervisor catch blocks without breaking fiber atomicity. *)
+    or keeper_supervisor catch blocks without breaking fiber atomicity.
+    [keepers_dir] is the cluster-scoped keepers root directory. *)
 val enqueue_record :
-  base_path:string ->
+  keepers_dir:string ->
   name:string ->
   ts:float ->
   reason:string ->
@@ -21,9 +24,10 @@ val enqueue_record :
 val start_drain_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
 
 (** Read recent crash events from disk. Performs I/O -- call from
-    dashboard handlers, not from keeper_registry context. *)
+    dashboard handlers, not from keeper_registry context.
+    [keepers_dir] is the cluster-scoped keepers root directory. *)
 val recent_crashes :
-  base_path:string ->
+  keepers_dir:string ->
   name:string ->
   max_entries:int ->
   Yojson.Safe.t list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -56,6 +56,8 @@ let publish_lifecycle event_name keeper_name detail =
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
+  let keepers_dir =
+    Filename.concat (Room.masc_root_dir ctx.config) "keepers" in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =
@@ -87,7 +89,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                meta.name ts reason;
              let rc = match Keeper_registry.get ~base_path meta.name with
                | Some e -> e.restart_count | None -> 0 in
-             Keeper_crash_persistence.enqueue_record ~base_path
+             Keeper_crash_persistence.enqueue_record ~keepers_dir
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
@@ -104,7 +106,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                meta.name ts reason;
              let rc = match Keeper_registry.get ~base_path meta.name with
                | Some e -> e.restart_count | None -> 0 in
-             Keeper_crash_persistence.enqueue_record ~base_path
+             Keeper_crash_persistence.enqueue_record ~keepers_dir
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              resolve_done (`Crashed reason);
@@ -122,7 +124,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               meta.name ts reason;
             let rc = match Keeper_registry.get ~base_path meta.name with
               | Some e -> e.restart_count | None -> 0 in
-            Keeper_crash_persistence.enqueue_record ~base_path
+            Keeper_crash_persistence.enqueue_record ~keepers_dir
               ~name:meta.name ~ts ~reason ~restart_count:rc;
             Keeper_registry.record_error ~base_path meta.name reason;
             Keeper_registry.set_state ~base_path meta.name

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -420,17 +420,18 @@ let () =
     let clock = Eio.Stdenv.clock env in
     Eio.Switch.run @@ fun sw ->
     Keeper_crash_persistence.start_drain_fiber ~sw ~clock;
+    let keepers_dir = Filename.concat tmp_dir "keepers" in
     Keeper_crash_persistence.enqueue_record
-      ~base_path:tmp_dir ~name:"test-keeper"
+      ~keepers_dir ~name:"test-keeper"
       ~ts:1000.0 ~reason:"heartbeat_failures" ~restart_count:1;
     Keeper_crash_persistence.enqueue_record
-      ~base_path:tmp_dir ~name:"test-keeper"
+      ~keepers_dir ~name:"test-keeper"
       ~ts:1010.0 ~reason:"exception" ~restart_count:2;
     (* Wait for drain fiber to flush (drain interval = 2s) *)
     Eio.Time.sleep clock 3.0;
     let crashes =
       Keeper_crash_persistence.recent_crashes
-        ~base_path:tmp_dir ~name:"test-keeper" ~max_entries:10
+        ~keepers_dir ~name:"test-keeper" ~max_entries:10
     in
     Alcotest.(check bool) "has crash events" true (List.length crashes >= 2);
     (match crashes with


### PR DESCRIPTION
## Summary
- crash_store/enqueue_record/recent_crashes가 `base_path/.masc/keepers/` 대신 `Room.masc_root_dir`에서 파생한 `keepers_dir`을 사용하도록 변경
- 다른 keeper runtime artifact(metrics, checkpoints)와 경로 일관성 확보

Closes #3897