### PR TITLE
feat(governance): wire high-risk param set/clear to petition pipeline

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -387,8 +387,35 @@ let add_routes ~sw ~clock router =
              let base_path = state.Mcp_server.room_config.base_path in
              let actor = agent_from_request request
                |> Option.value ~default:"dashboard" in
-             let submit_petition _ctx _petition_args =
-               (false, "High-risk parameter changes from dashboard require governance petition via CLI")
+             let submit_petition _ctx petition_args =
+               let open Yojson.Safe.Util in
+               let title = member "title" petition_args |> to_string in
+               let origin = member "origin" petition_args |> to_string in
+               let subject_type = member "subject_type" petition_args |> to_string in
+               let risk_class_str = member "risk_class" petition_args |> to_string in
+               let risk_class = match risk_class_str with
+                 | "high" -> Council.Governance_v2.High
+                 | _ -> Council.Governance_v2.Low in
+               let raw_action = member "requested_action" petition_args in
+               let requested_action = match raw_action with
+                 | `Null -> None
+                 | action ->
+                   Some Council.Governance_v2.{
+                     action_type = member "action_type" action |> to_string_option
+                       |> Option.value ~default:"set_param";
+                     target_type = member "target_type" action |> to_string_option;
+                     target_id = member "target_id" action |> to_string_option;
+                     payload = (match member "payload" action with
+                       | `Null -> None | p -> Some p);
+                   } in
+               let source_refs = member "source_refs" petition_args
+                 |> to_list |> List.map to_string in
+               match Council.Governance_v2.submit_petition base_path
+                 ~title ~origin ~subject_type ~risk_class
+                 ~requested_action ~source_refs ~created_by:actor with
+               | Ok result ->
+                 (true, Printf.sprintf "Governance petition created: %s" result.case_.id)
+               | Error msg -> (false, msg)
              in
              let ctx = Tool_council_feed.{ base_path; agent_name = actor;
                room_config = Some state.Mcp_server.room_config } in
@@ -430,12 +457,35 @@ let add_routes ~sw ~clock router =
                       List.mem param_key s.param_keys)
                  |> Option.map (fun (s : Governance_registry.surface) -> s.risk)
                  |> Option.value ~default:"low" in
-               if risk = "high" then
-                 respond_json_with_cors request reqd
-                   (Yojson.Safe.to_string (`Assoc [
-                     ("ok", `Bool false);
-                     ("error", `String "High-risk param clear requires governance petition. Use masc_set_param tool.");
-                   ]))
+               if risk = "high" then begin
+                 let title = Printf.sprintf "Clear %s to default" param_key in
+                 let requested_action = Some Council.Governance_v2.{
+                   action_type = "clear_param";
+                   target_type = None;
+                   target_id = None;
+                   payload = Some (`Assoc [
+                     ("param_key", `String param_key);
+                     ("clear", `Bool true) ]);
+                 } in
+                 let source_refs = [param_key] in
+                 match Council.Governance_v2.submit_petition base_path
+                   ~title ~origin:"dashboard" ~subject_type:"param_change"
+                   ~risk_class:Council.Governance_v2.High
+                   ~requested_action ~source_refs ~created_by:actor with
+                 | Ok result ->
+                   respond_json_with_cors request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool true);
+                       ("message", `String (Printf.sprintf
+                         "Governance petition created for clear: %s" result.case_.id));
+                     ]))
+                 | Error msg ->
+                   respond_json_with_cors ~status:`Bad_request request reqd
+                     (Yojson.Safe.to_string (`Assoc [
+                       ("ok", `Bool false);
+                       ("error", `String (Printf.sprintf "Petition failed: %s" msg));
+                     ]))
+               end
                else begin
                  let old_value =
                    match Runtime_params.registry ()


### PR DESCRIPTION
## Summary

- High-risk param set: stub `submit_petition` -> 실제 `Governance_v2.submit_petition` 호출
- High-risk param clear: reject -> petition 생성 (`clear_param` action_type)
- Low/medium risk는 기존 동작 유지 (직접 적용)
- JSON petition_args -> typed `action_request` + `risk_class` variant 변환

## 변경

1 file, 58+/8-: `lib/server/server_routes_http_routes_activity.ml`

### set route
- `handle_set_param`의 `submit_petition` 콜백이 JSON을 파싱하여 `Council.Governance_v2.submit_petition` 호출
- `action_request` record 생성: `action_type`, `target_type`, `target_id`, `payload`

### clear route
- High-risk: `clear_param` action_type으로 petition 생성
- 기존 "Use CLI" 에러 대신 governance pipeline 통과

## Test plan

- [x] `test_runtime_params.exe` 20/20 green (high-risk petition test 포함)
- [ ] CI checks
- [ ] E2E: inference.default_model 변경 시도 -> petition 생성 확인

Closes #3898

Generated with [Claude Code](https://claude.com/claude-code)
