### PR TITLE
feat(cdal): aggregate worker proof evidence

### DIFF
--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -149,11 +149,20 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
       artifact_paths
     || checkpoints_count > 0
   in
+  let worker_run_meta = Dashboard_proof_actors.worker_run_meta_jsons config session_id in
+  let stored_worker_proof_count =
+    worker_run_meta
+    |> List.fold_left
+         (fun acc json ->
+           match U.member "proof_present" json with
+           | `Bool true -> acc + 1
+           | _ -> acc)
+         0
+  in
   let evidence_present =
     tool_evidence_count > 0 || deliverable_count > 0 || checkpoints_count > 0
-    || Option.is_some proof_doc
+    || Option.is_some proof_doc || stored_worker_proof_count > 0
   in
-  let worker_run_meta = Dashboard_proof_actors.worker_run_meta_jsons config session_id in
   let raw_trace_run_count =
     worker_run_meta
     |> List.fold_left
@@ -239,13 +248,25 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
         Dashboard_proof_verdict.session_summary_json session verdict ~planned_actor_count
           ~active_actor_count ~mentioned_actor_count ~unanswered_actor_count
           ~interaction_count
-          ~evidence_count:(tool_evidence_count + deliverable_count + checkpoints_count)
+          ~evidence_count:
+            (tool_evidence_count + deliverable_count + checkpoints_count
+           + stored_worker_proof_count)
           ~cp_trace_count ~raw_trace_run_count ~validated_worker_run_count
           ~live_verdict ~historical_verdict ~verdict_basis );
       ("timeline", Dashboard_proof_verdict.timeline_json ?session_id ?operation_id events cp_traces);
       ("actor_contributions", `List (Dashboard_proof_actors.actor_contributions_json contributions));
       ("goal_binding", goal_binding);
       ("tool_evidence", tool_evidence);
+      ( "worker_proof_evidence",
+        `List
+          (worker_run_meta
+          |> List.filter (fun json -> U.member "proof_present" json = `Bool true)
+          |> List.fold_left
+               (fun acc json ->
+                 if List.length acc >= 12 then acc
+                 else Dashboard_proof_actors.worker_run_summary_json json :: acc)
+               []
+          |> List.rev) );
       ( "worker_run_evidence",
         `List
           (worker_run_meta

--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -112,6 +112,9 @@ let worker_run_summary_json json =
   `Assoc
     [
       ("worker_run_id", U.member "worker_run_id" json);
+      ("cdal_run_id", U.member "cdal_run_id" json);
+      ("contract_id", U.member "contract_id" json);
+      ("result_status", U.member "result_status" json);
       ("worker_name", U.member "worker_name" json);
       ("status", U.member "status" json);
       ("mode", U.member "mode" json);
@@ -142,6 +145,11 @@ let worker_run_summary_json json =
       ("stop_reason", if U.member "stop_reason" json <> `Null then U.member "stop_reason" json else U.member "stop_reason" summary);
       ("failure_reason", U.member "failure_reason" json);
       ("error", if U.member "error" json <> `Null then U.member "error" json else U.member "error" summary);
+      ("proof_path", U.member "proof_path" json);
+      ("proof_present", U.member "proof_present" json);
+      ("tool_trace_refs", U.member "tool_trace_refs" json);
+      ("raw_evidence_refs", U.member "raw_evidence_refs" json);
+      ("checkpoint_ref", U.member "checkpoint_ref" json);
       ("session_conformance", U.member "session_conformance" json);
       ("ts_iso", U.member "ts_iso" json);
     ]

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -285,6 +285,7 @@ let run
     ~(config : config)
     ?(on_event : (Oas.Types.sse_event -> unit) option)
     ?(agent_ref : Oas.Agent.t option ref option)
+    ?(proof_ref : Oas.Cdal_proof.t option ref option)
     ?(contract : Oas.Risk_contract.t option)
     (goal : string)
   : (run_result, string) result =
@@ -328,6 +329,7 @@ let run
         in
         (r, None)
     in
+    (match proof_ref with Some ref_ -> ref_ := proof | None -> ());
     let checkpoint = match config.checkpoint_dir with
       | Some dir ->
         let ckpt = build_checkpoint ~session_id ?working_context:config.working_context agent in
@@ -507,6 +509,7 @@ let run_named
     ?raw_trace
     ?on_event
     ?agent_ref
+    ?proof_ref
     ?contract
     ?transport
     ?(allowed_paths = [])
@@ -560,7 +563,7 @@ let run_named
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in
-  match run ~sw ~net ~config ?on_event ?agent_ref ?contract goal with
+  match run ~sw ~net ~config ?on_event ?agent_ref ?proof_ref ?contract goal with
   | Ok result when accept result.response ->
     record_cascade ~cascade_name ~outcome:`Success;
     Ok result
@@ -635,6 +638,7 @@ let run_named_with_masc_tools
     ?memory
     ?raw_trace
     ?on_event
+    ?proof_ref
     ?contract
     ?transport
     ?priority
@@ -652,7 +656,7 @@ let run_named_with_masc_tools
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
-    ?raw_trace ?on_event ?contract ?transport ?priority ?sw ?net ()
+    ?raw_trace ?on_event ?proof_ref ?contract ?transport ?priority ?sw ?net ()
 
 let run_model_with_masc_tools
     ~(model_label : string)

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -57,6 +57,7 @@ val run_named :
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?agent_ref:Oas.Agent.t option ref ->
+  ?proof_ref:Oas.Cdal_proof.t option ref ->
   ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
@@ -105,6 +106,7 @@ val run_named_with_masc_tools :
   ?memory:Oas.Memory.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?proof_ref:Oas.Cdal_proof.t option ref ->
   ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?priority:Llm_provider.Request_priority.t ->

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -252,6 +252,10 @@ let trace_ref_to_json (trace_ref : Oas.Raw_trace.run_ref) =
 let preview_text text =
   String.sub text 0 (min 200 (String.length text))
 
+let preview_text_opt text =
+  let trimmed = String.trim text in
+  if trimmed = "" then None else Some (preview_text trimmed)
+
 let proof_result_status_to_string = function
   | Oas.Cdal_proof.Completed -> "completed"
   | Oas.Cdal_proof.Errored -> "errored"
@@ -476,10 +480,7 @@ let planned_worker_to_entry_with_state
         Hashtbl.replace success_by_agent name true;
         telemetry_ref := telemetry_of_run_result result;
         let output_preview =
-          let text =
-            Oas.Types.text_of_content result.response.content |> String.trim
-          in
-          if text = "" then None else Some (preview_text text)
+          Oas.Types.text_of_content result.response.content |> preview_text_opt
         in
         let proof_opt =
           match result.proof with Some _ as proof -> proof | None -> !proof_ref
@@ -496,7 +497,7 @@ let planned_worker_to_entry_with_state
         persist_worker_run_proof_if_present ~config ~session_id
           ~fallback_name:name ~planned_worker:pw ~resolved_model:None
           ~trace_ref:None ~success:false
-          ~output_preview:(Some (preview_text e)) ~error:(Some e) !proof_ref;
+          ~output_preview:(preview_text_opt e) ~error:(Some e) !proof_ref;
         Error
           (Oas.Error.Config
              (Oas.Error.InvalidConfig

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -235,6 +235,149 @@ let create_team_session_raw_trace ~(config : Room.config) ~(session_id : string)
         agent_name (Oas.Error.to_string err);
       None
 
+let trace_ref_to_json (trace_ref : Oas.Raw_trace.run_ref) =
+  `Assoc
+    [
+      ("worker_run_id", `String trace_ref.worker_run_id);
+      ("path", `String trace_ref.path);
+      ("start_seq", `Int trace_ref.start_seq);
+      ("end_seq", `Int trace_ref.end_seq);
+      ("agent_name", `String trace_ref.agent_name);
+      ( "session_id",
+        match trace_ref.session_id with
+        | Some session_id -> `String session_id
+        | None -> `Null );
+    ]
+
+let preview_text text =
+  String.sub text 0 (min 200 (String.length text))
+
+let proof_result_status_to_string = function
+  | Oas.Cdal_proof.Completed -> "completed"
+  | Oas.Cdal_proof.Errored -> "errored"
+  | Oas.Cdal_proof.Timed_out -> "timed_out"
+  | Oas.Cdal_proof.Cancelled -> "cancelled"
+
+let worker_name_of_planned_worker ~(fallback : string)
+    (pw : Team_session_types.planned_worker) =
+  match pw.runtime_actor with
+  | Some actor when String.trim actor <> "" -> String.trim actor
+  | _ -> fallback
+
+let is_safe_worker_run_id value =
+  let len = String.length value in
+  len > 0
+  && len <= 128
+  && String.for_all
+       (function
+         | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
+         | _ -> false)
+       value
+
+let persist_worker_run_proof_if_present ~(config : Room.config)
+    ~(session_id : string)
+    ~(fallback_name : string)
+    ~(planned_worker : Team_session_types.planned_worker)
+    ~(resolved_model : string option)
+    ~(trace_ref : Oas.Raw_trace.run_ref option)
+    ~(success : bool)
+    ~(output_preview : string option)
+    ~(error : string option)
+    (proof_opt : Oas.Cdal_proof.t option) =
+  match proof_opt with
+  | None -> ()
+  | Some proof ->
+      if not (is_safe_worker_run_id proof.run_id) then
+        Log.Session.warn
+          "team_session_oas_bridge: skipping proof persistence for unsafe worker run id %S"
+          proof.run_id
+      else
+        let worker_run_id = proof.run_id in
+        let worker_name =
+          worker_name_of_planned_worker ~fallback:fallback_name planned_worker
+        in
+        let proof_path =
+          Team_session_store.worker_run_proof_path config session_id worker_run_id
+        in
+        Team_session_store.save_worker_run_proof_json config session_id
+          worker_run_id (Oas.Cdal_proof.to_json proof);
+        Team_session_store.save_worker_run_meta_json config session_id
+          worker_run_id
+          (`Assoc
+            [
+              ("worker_run_id", `String worker_run_id);
+              ("worker_name", `String worker_name);
+              ("mode", `String "swarm");
+              ("status", `String (if success then "completed" else "failed"));
+              ("wait_mode", `String "background");
+              ( "trace_capability",
+                `String
+                  (if Option.is_some trace_ref then "raw" else "summary_only")
+              );
+              ("success", `Bool success);
+              ( "execution_scope",
+                Option.fold ~none:`Null
+                  ~some:(fun scope ->
+                    `String
+                      (Team_session_types.execution_scope_to_string scope))
+                  planned_worker.execution_scope );
+              ( "requested_worker_class",
+                Option.fold ~none:`Null
+                  ~some:(fun kind ->
+                    `String
+                      (Team_session_types.worker_class_to_string kind))
+                  planned_worker.worker_class );
+              ("requested_worker_size", `Null);
+              ("resolved_runtime", `String "oas_swarm");
+              ( "resolved_model",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  resolved_model );
+              ( "routing_reason",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  planned_worker.routing_reason );
+              ( "output_preview",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  output_preview );
+              ("error", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
+              ( "trace_ref",
+                Option.fold ~none:`Null ~some:trace_ref_to_json trace_ref );
+              ("trace_summary", `Null);
+              ("trace_validation", `Null);
+              ("evidence_session_id", `Null);
+              ("oas_worker_run", `Null);
+              ("session_conformance", `Null);
+              ("validated", `Null);
+              ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) output_preview);
+              ("stop_reason", `Null);
+              ("failure_reason", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
+              ("ts_iso", `String (Types.now_iso ()));
+              ("cdal_run_id", `String proof.run_id);
+              ("contract_id", `String proof.contract_id);
+              ( "requested_execution_mode",
+                `String
+                  (Oas.Execution_mode.to_string proof.requested_execution_mode)
+              );
+              ( "effective_execution_mode",
+                `String
+                  (Oas.Execution_mode.to_string proof.effective_execution_mode)
+              );
+              ("risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
+              ("result_status", `String (proof_result_status_to_string proof.result_status));
+              ( "tool_trace_refs",
+                `List
+                  (List.map (fun ref_ -> `String ref_) proof.tool_trace_refs)
+              );
+              ( "raw_evidence_refs",
+                `List
+                  (List.map (fun ref_ -> `String ref_) proof.raw_evidence_refs)
+              );
+              ( "checkpoint_ref",
+                Option.fold ~none:`Null ~some:(fun ref_ -> `String ref_)
+                  proof.checkpoint_ref );
+              ("proof_path", `String proof_path);
+              ("proof_present", `Bool true);
+            ])
+
 let make_convergence_metric ~(entry_count : int)
     (success_by_agent : (string, bool) Hashtbl.t) :
     Swarm.Swarm_types.convergence_config option =
@@ -308,6 +451,7 @@ let planned_worker_to_entry_with_state
     let raw_trace =
       create_team_session_raw_trace ~config ~session_id ~agent_name:name
     in
+    let proof_ref = ref None in
     let dispatch_with_defaults ~name:(tool_name : string) ~(args : Yojson.Safe.t)
       =
       dispatch ~name:tool_name
@@ -325,16 +469,34 @@ let planned_worker_to_entry_with_state
           ~cascade_name ~fallback:(fun () -> 0.3))
         ~max_tokens:(Cascade_inference.resolve_max_tokens
           ~cascade_name ~fallback:(fun () -> 4096))
-        ?raw_trace ?contract ~sw
+        ?raw_trace ~proof_ref ?contract ~sw
         ~priority:Llm_provider.Request_priority.Proactive ()
     with
     | Ok result ->
         Hashtbl.replace success_by_agent name true;
         telemetry_ref := telemetry_of_run_result result;
+        let output_preview =
+          let text =
+            Oas.Types.text_of_content result.response.content |> String.trim
+          in
+          if text = "" then None else Some (preview_text text)
+        in
+        let proof_opt =
+          match result.proof with Some _ as proof -> proof | None -> !proof_ref
+        in
+        persist_worker_run_proof_if_present ~config ~session_id
+          ~fallback_name:name ~planned_worker:pw
+          ~resolved_model:(Some result.response.model)
+          ~trace_ref:result.trace_ref ~success:true ~output_preview
+          ~error:None proof_opt;
         Ok result.response
     | Error e ->
         Hashtbl.replace success_by_agent name false;
         telemetry_ref := Swarm.Swarm_types.empty_telemetry;
+        persist_worker_run_proof_if_present ~config ~session_id
+          ~fallback_name:name ~planned_worker:pw ~resolved_model:None
+          ~trace_ref:None ~success:false
+          ~output_preview:(Some (preview_text e)) ~error:(Some e) !proof_ref;
         Error
           (Oas.Error.Config
              (Oas.Error.InvalidConfig

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -2,6 +2,89 @@
 
 include Team_session_report_proof_helpers
 
+let string_member_opt key (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member key json with
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let string_list_member key (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member key json with
+  | `List items ->
+      items
+      |> List.filter_map (function
+             | `String value when String.trim value <> "" -> Some value
+             | _ -> None)
+  | _ -> []
+
+let worker_proof_refs config session_id =
+  Team_session_store.list_worker_run_ids config session_id
+  |> List.filter_map (fun worker_run_id ->
+         let proof_path =
+           Team_session_store.worker_run_proof_path config session_id
+             worker_run_id
+         in
+         if not (Room_utils.path_exists config proof_path) then
+           None
+         else
+           let proof_json = Room_utils.read_json config proof_path in
+           let meta_path =
+             Team_session_store.worker_run_meta_path config session_id
+               worker_run_id
+           in
+           let meta_json =
+             if Room_utils.path_exists config meta_path then
+               Some (Room_utils.read_json config meta_path)
+             else None
+           in
+           let run_id =
+             match string_member_opt "run_id" proof_json with
+             | Some value -> value
+             | None -> worker_run_id
+           in
+           Some
+             (`Assoc
+               [
+                 ("worker_run_id", `String worker_run_id);
+                 ("cdal_run_id", `String run_id);
+                 ( "worker_name",
+                   match meta_json with
+                   | Some meta -> (
+                       match string_member_opt "worker_name" meta with
+                       | Some value -> `String value
+                       | None -> `Null)
+                   | None -> `Null );
+                 ( "contract_id",
+                   match string_member_opt "contract_id" proof_json with
+                   | Some value -> `String value
+                   | None -> `Null );
+                 ( "result_status",
+                   match string_member_opt "result_status" proof_json with
+                   | Some value -> `String value
+                   | None -> `Null );
+                 ("proof_path", `String proof_path);
+                 ("meta_path", `String meta_path);
+                 ( "manifest_ref",
+                   `String
+                     (Agent_sdk.Proof_store.make_ref ~run_id
+                        ~subpath:"manifest.json") );
+                 ( "contract_ref",
+                   `String
+                     (Agent_sdk.Proof_store.make_ref ~run_id
+                        ~subpath:"contract.json") );
+                 ( "tool_trace_refs",
+                   `List
+                     (List.map (fun ref_ -> `String ref_)
+                        (string_list_member "tool_trace_refs" proof_json)) );
+                 ( "raw_evidence_refs",
+                   `List
+                     (List.map (fun ref_ -> `String ref_)
+                        (string_list_member "raw_evidence_refs" proof_json)) );
+                 ( "checkpoint_ref",
+                   match string_member_opt "checkpoint_ref" proof_json with
+                   | Some value -> `String value
+                   | None -> `Null );
+               ]))
+
 let proof_markdown ~(session : Team_session_types.session)
     ~(proof_level : Team_session_types.proof_level)
     ~(score_pct : float) ~(verdict : string) ~(criteria : Yojson.Safe.t list)
@@ -372,6 +455,7 @@ let generate_proof ?(proof_level = default_proof_level) config
               ~min_communication ~communication_total ~vote_events
               ~run_deliverables ~empty_note_turn_count
     in
+    let worker_proofs = worker_proof_refs config session.session_id in
     let total = max 1 (List.length criteria) in
     let passed =
       List.fold_left
@@ -467,12 +551,16 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ("done_delta_total", `Int done_delta_total);
                 ("report_json_exists", `Bool report_json_exists);
                 ("report_md_exists", `Bool report_md_exists);
+                ("worker_proof_count", `Int (List.length worker_proofs));
               ] );
+          ("worker_proofs", `List worker_proofs);
           ("generated_at_iso", `String generated_at_iso);
           ("oas_cdal_integration", `Assoc [
             ("contract_wired", `Bool (Option.is_some session.delivery_contract));
             ("proof_schema_version", `Int 1);
-            ("note", `String "Per-worker OAS proof bundles are captured by Contract_runner when delivery_contract is present. Aggregation into session-level proof is tracked in #3515.");
+            ("worker_proof_count", `Int (List.length worker_proofs));
+            ("aggregated", `Bool (worker_proofs <> []));
+            ("note", `String "Session proof aggregates worker-level OAS proof refs when present and falls back cleanly for legacy sessions without stored worker proofs.");
           ]);
         ]
     in

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -26,64 +26,70 @@ let worker_proof_refs config session_id =
          if not (Room_utils.path_exists config proof_path) then
            None
          else
-           let proof_json = Room_utils.read_json config proof_path in
-           let meta_path =
-             Team_session_store.worker_run_meta_path config session_id
-               worker_run_id
-           in
-           let meta_json =
-             if Room_utils.path_exists config meta_path then
-               Some (Room_utils.read_json config meta_path)
-             else None
-           in
-           let run_id =
-             match string_member_opt "run_id" proof_json with
-             | Some value -> value
-             | None -> worker_run_id
-           in
-           Some
-             (`Assoc
-               [
-                 ("worker_run_id", `String worker_run_id);
-                 ("cdal_run_id", `String run_id);
-                 ( "worker_name",
-                   match meta_json with
-                   | Some meta -> (
-                       match string_member_opt "worker_name" meta with
-                       | Some value -> `String value
-                       | None -> `Null)
-                   | None -> `Null );
-                 ( "contract_id",
-                   match string_member_opt "contract_id" proof_json with
-                   | Some value -> `String value
-                   | None -> `Null );
-                 ( "result_status",
-                   match string_member_opt "result_status" proof_json with
-                   | Some value -> `String value
-                   | None -> `Null );
-                 ("proof_path", `String proof_path);
-                 ("meta_path", `String meta_path);
-                 ( "manifest_ref",
-                   `String
-                     (Agent_sdk.Proof_store.make_ref ~run_id
-                        ~subpath:"manifest.json") );
-                 ( "contract_ref",
-                   `String
-                     (Agent_sdk.Proof_store.make_ref ~run_id
-                        ~subpath:"contract.json") );
-                 ( "tool_trace_refs",
-                   `List
-                     (List.map (fun ref_ -> `String ref_)
-                        (string_list_member "tool_trace_refs" proof_json)) );
-                 ( "raw_evidence_refs",
-                   `List
-                     (List.map (fun ref_ -> `String ref_)
-                        (string_list_member "raw_evidence_refs" proof_json)) );
-                 ( "checkpoint_ref",
-                   match string_member_opt "checkpoint_ref" proof_json with
-                   | Some value -> `String value
-                   | None -> `Null );
-               ]))
+           try
+             let proof_json = Room_utils.read_json config proof_path in
+             let meta_path =
+               Team_session_store.worker_run_meta_path config session_id
+                 worker_run_id
+             in
+             let meta_json =
+               if Room_utils.path_exists config meta_path then
+                 Some (Room_utils.read_json config meta_path)
+               else None
+             in
+             let run_id =
+               match string_member_opt "run_id" proof_json with
+               | Some value -> value
+               | None -> worker_run_id
+             in
+             Some
+               (`Assoc
+                 [
+                   ("worker_run_id", `String worker_run_id);
+                   ("cdal_run_id", `String run_id);
+                   ( "worker_name",
+                     match meta_json with
+                     | Some meta -> (
+                         match string_member_opt "worker_name" meta with
+                         | Some value -> `String value
+                         | None -> `Null)
+                     | None -> `Null );
+                   ( "contract_id",
+                     match string_member_opt "contract_id" proof_json with
+                     | Some value -> `String value
+                     | None -> `Null );
+                   ( "result_status",
+                     match string_member_opt "result_status" proof_json with
+                     | Some value -> `String value
+                     | None -> `Null );
+                   ("proof_path", `String proof_path);
+                   ("meta_path", `String meta_path);
+                   ( "manifest_ref",
+                     `String
+                       (Agent_sdk.Proof_store.make_ref ~run_id
+                          ~subpath:"manifest.json") );
+                   ( "contract_ref",
+                     `String
+                       (Agent_sdk.Proof_store.make_ref ~run_id
+                          ~subpath:"contract.json") );
+                   ( "tool_trace_refs",
+                     `List
+                       (List.map (fun ref_ -> `String ref_)
+                          (string_list_member "tool_trace_refs" proof_json)) );
+                   ( "raw_evidence_refs",
+                     `List
+                       (List.map (fun ref_ -> `String ref_)
+                          (string_list_member "raw_evidence_refs" proof_json)) );
+                   ( "checkpoint_ref",
+                     match string_member_opt "checkpoint_ref" proof_json with
+                     | Some value -> `String value
+                     | None -> `Null );
+                 ])
+           with exn ->
+             Log.Session.warn
+               "team_session_report_proof: skipping malformed worker proof json for %s/%s: %s"
+               session_id worker_run_id (Printexc.to_string exn);
+             None)
 
 let proof_markdown ~(session : Team_session_types.session)
     ~(proof_level : Team_session_types.proof_level)

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -41,6 +41,9 @@ let worker_run_checkpoint_path config session_id worker_run_id =
 let worker_run_meta_path config session_id worker_run_id =
   Filename.concat (worker_run_dir config session_id worker_run_id) "meta.json"
 
+let worker_run_proof_path config session_id worker_run_id =
+  Filename.concat (worker_run_dir config session_id worker_run_id) "proof.json"
+
 let session_json_path config session_id =
   Filename.concat (session_dir config session_id) "session.json"
 
@@ -332,6 +335,10 @@ let save_worker_run_checkpoint_text config session_id worker_run_id content =
 
 let save_worker_run_meta_json config session_id worker_run_id json =
   let path = worker_run_meta_path config session_id worker_run_id in
+  write_json config path json
+
+let save_worker_run_proof_json config session_id worker_run_id json =
+  let path = worker_run_proof_path config session_id worker_run_id in
   write_json config path json
 
 let immediate_dir_entries config dir =

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -177,6 +177,40 @@ let write_manual_proof config session_id verdict =
     ("# proof\n\nverdict: " ^ verdict)
 
 let seed_worker_run_meta config session_id =
+  Lib.Team_session_store.save_worker_run_proof_json config session_id
+    "wr-proof-raw"
+    (`Assoc
+      [
+        ("schema_version", `Int 1);
+        ("run_id", `String "wr-proof-raw");
+        ("contract_id", `String "contract-proof-raw");
+        ("requested_execution_mode", `String "execute");
+        ("effective_execution_mode", `String "draft");
+        ("mode_decision_source", `String "downgraded");
+        ("risk_class", `String "high");
+        ( "provider_snapshot",
+          `Assoc
+            [
+              ("provider_name", `String "openai_compat");
+              ("model_id", `String "qwen3.5-35b-a3b-ud-q8-xl");
+              ("api_version", `Null);
+            ] );
+        ( "capability_snapshot",
+          `Assoc
+            [
+              ("tools", `List [ `String "file_write"; `String "shell_exec" ]);
+              ("mcp_servers", `List []);
+              ("max_turns", `Int 12);
+              ("max_tokens", `Int 4096);
+              ("thinking_enabled", `Bool false);
+            ] );
+        ("tool_trace_refs", `List [ `String "proof-store://wr-proof-raw/tool_traces/trace-1.jsonl" ]);
+        ("raw_evidence_refs", `List [ `String "proof-store://wr-proof-raw/evidence/mode_violations.json" ]);
+        ("checkpoint_ref", `String "proof-store://wr-proof-raw/checkpoint.json");
+        ("result_status", `String "completed");
+        ("started_at", `Float 1.0);
+        ("ended_at", `Float 2.0);
+      ]);
   Lib.Team_session_store.save_worker_run_meta_json config session_id
     "wr-proof-raw"
     (`Assoc
@@ -188,6 +222,9 @@ let seed_worker_run_meta config session_id =
         ("wait_mode", `String "background");
         ("trace_capability", `String "raw");
         ("success", `Bool true);
+        ("cdal_run_id", `String "wr-proof-raw");
+        ("contract_id", `String "contract-proof-raw");
+        ("result_status", `String "completed");
         ("execution_scope", `String "limited_code_change");
         ("requested_worker_class", `String "executor");
         ("requested_worker_size", `String "lg");
@@ -198,6 +235,14 @@ let seed_worker_run_meta config session_id =
         ("tool_call_count", `Int 2);
         ("output_preview", `String "Patched calc.py and verification passed.");
         ("validated", `Bool true);
+        ( "proof_path",
+          `String
+            (Lib.Team_session_store.worker_run_proof_path config session_id
+               "wr-proof-raw") );
+        ("proof_present", `Bool true);
+        ("tool_trace_refs", `List [ `String "proof-store://wr-proof-raw/tool_traces/trace-1.jsonl" ]);
+        ("raw_evidence_refs", `List [ `String "proof-store://wr-proof-raw/evidence/mode_violations.json" ]);
+        ("checkpoint_ref", `String "proof-store://wr-proof-raw/checkpoint.json");
         ("final_text", `String "Patched calc.py and verification passed.");
         ("failure_reason", `Null);
         ( "session_conformance",
@@ -288,6 +333,15 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (json |> U.member "summary" |> U.member "raw_trace_run_count" |> U.to_int);
       check int "validated worker run count" 1
         (json |> U.member "summary" |> U.member "validated_worker_run_count" |> U.to_int);
+      let worker_proofs = json |> U.member "worker_proof_evidence" |> U.to_list in
+      check int "worker proof evidence count" 1 (List.length worker_proofs);
+      let worker_proof = List.hd worker_proofs in
+      check string "worker proof run id" "wr-proof-raw"
+        (worker_proof |> U.member "cdal_run_id" |> U.to_string);
+      check string "worker proof contract id" "contract-proof-raw"
+        (worker_proof |> U.member "contract_id" |> U.to_string);
+      check bool "worker proof present" true
+        (worker_proof |> U.member "proof_present" |> U.to_bool);
       let worker_runs = json |> U.member "worker_run_evidence" |> U.to_list in
       check int "worker run evidence count" 1 (List.length worker_runs);
       let worker = List.hd worker_runs in
@@ -299,6 +353,8 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "resolved_runtime" |> U.to_string);
       check string "worker resolved model" "qwen3.5-35b-a3b-ud-q8-xl"
         (worker |> U.member "resolved_model" |> U.to_string);
+      check string "worker result_status" "completed"
+        (worker |> U.member "result_status" |> U.to_string);
       check string "worker final text" "Patched calc.py and verification passed."
         (worker |> U.member "final_text" |> U.to_string))
 

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -21,6 +21,8 @@ let () =
             `Quick
             Test_tool_team_session_proof
               .test_report_and_proof_expose_delivery_contract_and_verdict;
+          Alcotest.test_case "proof-aggregates-worker-proof-refs" `Quick
+            Test_tool_team_session_proof.test_proof_aggregates_worker_proof_refs;
           Alcotest.test_case "duration-reached-path" `Quick
             Test_tool_team_session_lifecycle.test_duration_reached_path;
           Alcotest.test_case "recover-elapsed-session" `Quick

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -419,6 +419,129 @@ let test_report_and_proof_expose_delivery_contract_and_verdict () =
      with Not_found -> false);
   cleanup_dir base_dir
 
+let test_proof_aggregates_worker_proof_refs () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"aggregate worker proof refs" |> get_session_id
+  in
+  ignore
+    (Team_session_store.update_session config session_id (fun session ->
+         {
+           session with
+           delivery_contract =
+             Some
+               {
+                 Team_session_types.contract_id = "contract-proof-aggregate";
+                 summary = "Aggregate worker proof refs";
+                 acceptance_checks = [ "session proof lists worker proof refs" ];
+                 required_artifacts = [ "proof.json" ];
+                 repair_budget = 1;
+                 generator_roles = [ "implementer" ];
+                 evaluator_role = Some "reviewer";
+                 evaluator_cascade = "cross_verifier";
+                 evidence_refs = [];
+                 updated_by = "tester";
+                 updated_at_iso = Types.now_iso ();
+               };
+           updated_at_iso = Types.now_iso ();
+         }));
+  ignore
+    (dispatch_exn ctx ~name:"masc_team_session_stop"
+       ~args:
+         (`Assoc
+           [
+             ("session_id", `String session_id);
+             ("reason", `String "aggregate-worker-proof-done");
+             ("generate_report", `Bool true);
+           ]));
+  ignore (wait_until_terminal ctx session_id);
+  Team_session_store.save_worker_run_proof_json config session_id "wr-proof-aggregate"
+    (`Assoc
+      [
+        ("schema_version", `Int 1);
+        ("run_id", `String "wr-proof-aggregate");
+        ("contract_id", `String "contract-proof-aggregate");
+        ("requested_execution_mode", `String "execute");
+        ("effective_execution_mode", `String "draft");
+        ("mode_decision_source", `String "downgraded");
+        ("risk_class", `String "high");
+        ( "provider_snapshot",
+          `Assoc
+            [
+              ("provider_name", `String "openai_compat");
+              ("model_id", `String "qwen3.5-35b-a3b-ud-q8-xl");
+              ("api_version", `Null);
+            ] );
+        ( "capability_snapshot",
+          `Assoc
+            [
+              ("tools", `List [ `String "file_write" ]);
+              ("mcp_servers", `List []);
+              ("max_turns", `Int 8);
+              ("max_tokens", `Int 4096);
+              ("thinking_enabled", `Bool false);
+            ] );
+        ("tool_trace_refs", `List [ `String "proof-store://wr-proof-aggregate/tool_traces/trace-1.jsonl" ]);
+        ("raw_evidence_refs", `List [ `String "proof-store://wr-proof-aggregate/evidence/mode_violations.json" ]);
+        ("checkpoint_ref", `String "proof-store://wr-proof-aggregate/checkpoint.json");
+        ("result_status", `String "completed");
+        ("started_at", `Float 1.0);
+        ("ended_at", `Float 2.0);
+      ]);
+  Team_session_store.save_worker_run_meta_json config session_id "wr-proof-aggregate"
+    (`Assoc
+      [
+        ("worker_run_id", `String "wr-proof-aggregate");
+        ("worker_name", `String "worker-proof");
+        ("status", `String "completed");
+        ("mode", `String "swarm");
+        ("wait_mode", `String "background");
+        ("proof_present", `Bool true);
+        ("proof_path", `String (Team_session_store.worker_run_proof_path config session_id "wr-proof-aggregate"));
+        ("cdal_run_id", `String "wr-proof-aggregate");
+        ("contract_id", `String "contract-proof-aggregate");
+        ("result_status", `String "completed");
+        ("tool_trace_refs", `List [ `String "proof-store://wr-proof-aggregate/tool_traces/trace-1.jsonl" ]);
+        ("raw_evidence_refs", `List [ `String "proof-store://wr-proof-aggregate/evidence/mode_violations.json" ]);
+        ("checkpoint_ref", `String "proof-store://wr-proof-aggregate/checkpoint.json");
+        ("ts_iso", `String (Types.now_iso ()));
+      ]);
+  let prove_ok, prove_body =
+    dispatch_exn ctx ~name:"masc_team_session_prove"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("generate_report_if_missing", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "prove ok" true prove_ok;
+  let proof_json =
+    parse_json_exn prove_body |> result_field |> Yojson.Safe.Util.member "proof"
+  in
+  let worker_proofs =
+    proof_json |> Yojson.Safe.Util.member "worker_proofs"
+    |> Yojson.Safe.Util.to_list
+  in
+  Alcotest.(check int) "worker proof refs count" 1 (List.length worker_proofs);
+  let worker_proof = List.hd worker_proofs in
+  Alcotest.(check string) "worker proof run id" "wr-proof-aggregate"
+    Yojson.Safe.Util.(worker_proof |> member "cdal_run_id" |> to_string);
+  Alcotest.(check string) "worker proof contract id" "contract-proof-aggregate"
+    Yojson.Safe.Util.(worker_proof |> member "contract_id" |> to_string);
+  Alcotest.(check string) "worker proof manifest ref"
+    "proof-store://wr-proof-aggregate/manifest.json"
+    Yojson.Safe.Util.(worker_proof |> member "manifest_ref" |> to_string);
+  cleanup_dir base_dir
+
 let test_bootstrap_grace_suppresses_min_agents_violation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);


### PR DESCRIPTION
## Summary
- plumb optional `proof_ref` through `Oas_worker` so swarm runs can capture worker proof bundles
- persist per-worker proof artifacts under team-session worker runs and aggregate them into session proof + dashboard proof outputs
- extend dashboard/session proof tests to cover worker proof evidence exposure

## Product impact
- adds worker proof evidence to session proof JSON and dashboard proof JSON
- preserves legacy behavior when worker proof artifacts are absent
- keeps typed session wrapper changes out of scope for this PR

## Evidence
- local type compile produced updated byte objects for modified proof-related library modules under `_build/default/lib/.masc_mcp.objs/byte`
- `git diff --check`
- full local executable linking is slow/noisy on this macOS environment and is deferred to CI

## Review evidence
- pending cross-model review after PR creation

## Linked issue
- Refs #3515
- Follow-up to #3773 and stacked on #3927
