### PR TITLE
fix(ci): stop triage-required label infinite loop

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -2,7 +2,7 @@ name: Issue Triage
 
 on:
   issues:
-    types: [opened, edited, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened]
 
 permissions:
   contents: read
@@ -134,7 +134,12 @@ jobs:
             const typeMatches = [...nextLabels].filter((name) => name.startsWith("type:"));
             const areaMatches = [...nextLabels].filter((name) => name.startsWith("area:"));
             const targetMatches = [...nextLabels].filter((name) => name.startsWith("target:"));
-            const needsTriage = typeMatches.length !== 1 || areaMatches.length !== 1 || targetMatches.length !== 1;
+
+            // Epics are trackers — they don't need area/target labels
+            const isEpic = typeMatches.includes("type:epic");
+            const needsTriage = isEpic
+              ? false
+              : typeMatches.length !== 1 || areaMatches.length !== 1 || targetMatches.length !== 1;
 
             if (needsTriage) {
               nextLabels.add(process.env.TRIAGE_LABEL);


### PR DESCRIPTION
## Summary
- `unlabeled`/`labeled` 트리거 제거: triage-required 제거 → unlabeled 이벤트 → 재평가 → 재부착 무한 루프 차단
- `type:epic` 면제: Epic은 area/target 라벨 없어도 triage-required 붙지 않음

## 근거
12 라운드 이슈 정리 중 triage-required를 5번 반복 제거해야 했음. 근본 원인은 workflow 트리거 설계.

Closes 없음 (인프라 개선)