### PR TITLE
Add keeper decision logs and tool audit fallback

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -482,18 +482,24 @@ Keeper는 더 이상 `policy_mode`나 `trigger_mode`로 동작하지 않는다.
 
 ### 6.3 Decision Record 학습
 
-Deliberation의 매 결정은 `{keeper_dir}/{name}.decisions.jsonl`에 기록된다.
+Unified keeper의 내부 decision record는 `{keeper_dir}/{name}.decisions.jsonl`에 기록된다.
+
+이 파일은 public surface가 아니라 사람 운영자용 디버깅/학습 artifact다.
 
 각 레코드에는:
-- `id`: 고유 결정 ID (`dec-{timestamp}-{random}`)
-- `triggers`: 트리거 목록
-- `action_chosen`: 선택된 행동
-- `reasoning`: MODEL의 추론
-- `confidence`: 신뢰도 (0.0~1.0)
-- `outcome`: 결과 (`pending`, `success`, `failed`)
-- `feedback_score`: 인간 피드백 (-1.0~1.0)
+- `id`: 고유 결정 ID (`dec-{timestamp_ms}-{hash}`)
+- `trigger_signals`: turn 시점에 관찰된 트리거 후보 (`direct_mention`, `board_activity`, `new_unclaimed_task` 등)
+- `observed_affordances`: 당시 가능한 액션 후보 (`task_claim`, `reply_in_room`, `board_post_or_comment` 등)
+- `selected_mode`: 실제 최종 결과 분류 (`tool_use`, `text_response`, `skip_text`, `noop`, `error`)
+- `tools_used`: 실제 호출된 tool 목록
+- `claim_was_available` / `claim_executed`: task claim 기회와 실행 여부
+- `response_preview`: 최종 응답 미리보기
+- `response_requests_confirmation`: keeper가 사람 확인을 요청했는지 여부
+- `outcome`: `success` 또는 `error`
 
-`masc_keeper_eval` 도구로 결정 이력을 조회하고, `record_feedback`으로 피드백을 기록할 수 있다.
+주의:
+- unified path는 hidden chain-of-thought나 모델 내부 reasoning/confidence를 저장하지 않는다.
+- decision log는 “무엇을 보고 무엇을 했는지”를 관찰 결과 기준으로 남긴다.
 
 ### 6.4 Checkpoint 시스템 (OAS 기반)
 

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -654,7 +654,7 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
   let agent_briefs =
     Dashboard_mission_assembly.build_agent_briefs config sessions attention_queue room_json keeper_items
   in
-  let keeper_briefs = Dashboard_mission_assembly.build_keeper_briefs keeper_items in
+  let keeper_briefs = Dashboard_mission_assembly.build_keeper_briefs config keeper_items in
   let internal_signals = Dashboard_mission_assembly.build_internal_signals incidents recommended_actions in
   {
     generated_at = Types.now_iso ();

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -27,11 +27,26 @@ let keeper_tool_audit_json_fields config keeper agent_name =
     trim_to_option (string_field "tool_audit_at" keeper)
   in
   let file_snapshot =
-    Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
-      ~keeper_name:
-        (match trim_to_option (string_field "name" keeper) with
-         | Some name -> name
-         | None -> agent_name)
+    let keeper_updated_at =
+      trim_to_option (string_field "updated_at" keeper)
+    in
+    match
+      Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
+        ~keeper_name:
+          (match trim_to_option (string_field "name" keeper) with
+           | Some name -> name
+           | None -> agent_name)
+    with
+    | Some snapshot ->
+        Some
+          {
+            snapshot with
+            tool_audit_at =
+              (match snapshot.tool_audit_source, snapshot.tool_audit_at, keeper_updated_at with
+               | Some _, None, Some updated_at -> Some updated_at
+               | _ -> snapshot.tool_audit_at);
+          }
+    | None -> None
   in
   let allowed_tool_names, latest_tool_names, latest_tool_call_count,
       tool_audit_source, tool_audit_at =

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -5,7 +5,7 @@
 
 include Dashboard_mission_agents
 
-let keeper_tool_audit_json_fields keeper agent_name =
+let keeper_tool_audit_json_fields config keeper agent_name =
   let fallback_allowed =
     string_list_of_json (member_assoc "allowed_tool_names" keeper)
   in
@@ -25,6 +25,13 @@ let keeper_tool_audit_json_fields keeper agent_name =
   in
   let fallback_at =
     trim_to_option (string_field "tool_audit_at" keeper)
+  in
+  let file_snapshot =
+    Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
+      ~keeper_name:
+        (match trim_to_option (string_field "name" keeper) with
+         | Some name -> name
+         | None -> agent_name)
   in
   let allowed_tool_names, latest_tool_names, latest_tool_call_count,
       tool_audit_source, tool_audit_at =
@@ -52,18 +59,26 @@ let keeper_tool_audit_json_fields keeper agent_name =
           Some "heartbeat_result",
           Some result.updated_at )
     | None, None ->
-        (* Use per-keeper tool tracking as last-resort fallback *)
-        let tracked = Keeper_tools_oas.tool_usage_for_keeper agent_name in
-        if tracked <> [] then
-          let names = List.map fst tracked in
-          let total = List.fold_left (fun acc (_, e) -> acc + e.Keeper_tools_oas.count) 0 tracked in
-          let latest_at = List.fold_left (fun acc (_, e) ->
-            max acc e.Keeper_tools_oas.last_used_at) 0.0 tracked in
-          let at_str = if latest_at > 0.0
-            then Some (Dashboard_utils.iso_of_unix latest_at) else None in
-          (fallback_allowed, names, Some total, Some "keeper_dispatch", at_str)
-        else
-          (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
+        (match file_snapshot with
+        | Some snapshot ->
+            ( fallback_allowed,
+              snapshot.latest_tool_names,
+              snapshot.latest_tool_call_count,
+              snapshot.tool_audit_source,
+              snapshot.tool_audit_at )
+        | None ->
+            (* Use per-keeper tool tracking as last-resort fallback *)
+            let tracked = Keeper_tools_oas.tool_usage_for_keeper agent_name in
+            if tracked <> [] then
+              let names = List.map fst tracked in
+              let total = List.fold_left (fun acc (_, e) -> acc + e.Keeper_tools_oas.count) 0 tracked in
+              let latest_at = List.fold_left (fun acc (_, e) ->
+                max acc e.Keeper_tools_oas.last_used_at) 0.0 tracked in
+              let at_str = if latest_at > 0.0
+                then Some (Dashboard_utils.iso_of_unix latest_at) else None in
+              (fallback_allowed, names, Some total, Some "keeper_dispatch", at_str)
+            else
+              (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at))
   in
   [
     ("allowed_tool_names", string_list_json allowed_tool_names);
@@ -149,7 +164,7 @@ let action_matches_incident incident action =
       let action_type = string_field "action_type" action in
       List.mem action_type (incident_action_types (string_field "kind" incident))
 
-let build_keeper_briefs (keepers : Yojson.Safe.t list) =
+let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
   keepers
   |> List.filter_map (fun keeper ->
          let name = string_field "name" keeper in
@@ -194,7 +209,7 @@ let build_keeper_briefs (keepers : Yojson.Safe.t list) =
                            | None -> trim_to_option (string_field "goal" keeper)) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
                     ]
-                    @ keeper_tool_audit_json_fields keeper
+                    @ keeper_tool_audit_json_fields config keeper
                         (match trim_to_option (string_field "agent_name" keeper) with
                          | Some agent_name -> agent_name
                          | None -> name));

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -39,6 +39,13 @@ type metrics_summary = {
   last_compaction : Yojson.Safe.t option;
 }
 
+type tool_audit_snapshot = {
+  latest_tool_names : string list;
+  latest_tool_call_count : int option;
+  tool_audit_source : string option;
+  tool_audit_at : string option;
+}
+
 let empty_metrics_summary =
   {
     sample_points = 0;
@@ -76,6 +83,14 @@ let empty_metrics_summary =
     goal_drift_points = 0;
     last_handoff = None;
     last_compaction = None;
+  }
+
+let empty_tool_audit_snapshot =
+  {
+    latest_tool_names = [];
+    latest_tool_call_count = None;
+    tool_audit_source = None;
+    tool_audit_at = None;
   }
 
 let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
@@ -422,3 +437,109 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
         }
       with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> acc)
     empty_metrics_summary lines
+
+let json_string_list_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `List items ->
+      items
+      |> List.filter_map (function
+             | `String value ->
+                 let trimmed = String.trim value in
+                 if trimmed = "" then None else Some trimmed
+             | _ -> None)
+  | _ -> []
+
+let json_int_opt_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `Int value -> Some value
+  | `Intlit raw -> (try Some (int_of_string raw) with Failure _ -> None)
+  | `Float value -> Some (int_of_float value)
+  | _ -> None
+
+let json_iso_opt json =
+  match Safe_ops.json_string_opt "ts" json with
+  | Some text when String.trim text <> "" -> Some (String.trim text)
+  | _ ->
+      let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
+      if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
+
+let read_recent_metrics_lines config keeper_name =
+  let store = Keeper_types.keeper_metrics_store config keeper_name in
+  let dated = Dated_jsonl.read_recent_lines store 8 in
+  if dated <> [] then dated
+  else
+    let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+    Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
+
+let latest_tool_audit_snapshot_from_decisions config keeper_name =
+  let path = Keeper_types.keeper_decision_log_path config keeper_name in
+  if not (Sys.file_exists path) then None
+  else
+    Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12
+    |> List.rev
+    |> List.find_map (fun line ->
+           try
+             let json = Yojson.Safe.from_string line in
+             let tools = json_string_list_member "tools_used" json in
+             let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+             let tool_call_count =
+               match raw_tool_call_count with
+               | Some _ as value -> value
+               | None -> Some (List.length tools)
+             in
+             let has_decision_shape =
+               Option.is_some (json_iso_opt json)
+               || Option.is_some (Safe_ops.json_string_opt "selected_mode" json)
+               || Option.is_some (Safe_ops.json_string_opt "outcome" json)
+               || tools <> []
+               || Option.is_some raw_tool_call_count
+             in
+             if not has_decision_shape then None
+             else
+               Some
+                 {
+                   latest_tool_names = List.sort_uniq String.compare tools;
+                   latest_tool_call_count = tool_call_count;
+                   tool_audit_source = Some "keeper_decision_log";
+                   tool_audit_at = json_iso_opt json;
+                 }
+           with Yojson.Json_error _ -> None)
+
+let latest_tool_audit_snapshot_from_metrics config keeper_name =
+  read_recent_metrics_lines config keeper_name
+  |> List.rev
+  |> List.find_map (fun line ->
+         try
+           let json = Yojson.Safe.from_string line in
+           let tools =
+             json_string_list_member "tools_used" json
+             |> List.sort_uniq String.compare
+           in
+           let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+           let tool_call_count =
+             match raw_tool_call_count with
+             | Some _ as value -> value
+             | None -> Some (List.length tools)
+           in
+           let has_metric_shape =
+             Option.is_some (json_iso_opt json)
+             || Option.is_some (Safe_ops.json_string_opt "channel" json)
+             || Option.is_some (Safe_ops.json_string_opt "work_kind" json)
+             || tools <> []
+             || Option.is_some raw_tool_call_count
+           in
+           if not has_metric_shape then None
+           else
+             Some
+               {
+                 latest_tool_names = tools;
+                 latest_tool_call_count = tool_call_count;
+                 tool_audit_source = Some "keeper_metrics";
+                 tool_audit_at = json_iso_opt json;
+               }
+         with Yojson.Json_error _ -> None)
+
+let latest_tool_audit_snapshot_from_files config ~keeper_name =
+  match latest_tool_audit_snapshot_from_decisions config keeper_name with
+  | Some _ as snapshot -> snapshot
+  | None -> latest_tool_audit_snapshot_from_metrics config keeper_name

--- a/lib/keeper/keeper_exec_status_metrics.mli
+++ b/lib/keeper/keeper_exec_status_metrics.mli
@@ -1,6 +1,16 @@
 type metrics_summary
 
+type tool_audit_snapshot = {
+  latest_tool_names : string list;
+  latest_tool_call_count : int option;
+  tool_audit_source : string option;
+  tool_audit_at : string option;
+}
+
 val empty_metrics_summary : metrics_summary
 val metrics_summary_to_json : metrics_summary -> Yojson.Safe.t
 val summarize_metrics_lines :
   string list -> default_generation:int -> metrics_summary
+val empty_tool_audit_snapshot : tool_audit_snapshot
+val latest_tool_audit_snapshot_from_files :
+  Room.config -> keeper_name:string -> tool_audit_snapshot option

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -370,6 +370,28 @@ let handle_keeper_status ctx args : tool_result =
           keeper_model_tools |> List.map (fun tool -> tool.Types.name)
         in
         let allowed_tools = keeper_allowed_tool_names m in
+        let tool_audit_snapshot =
+          match latest_tool_audit_snapshot_from_files ctx.config ~keeper_name:m.name with
+          | Some snapshot -> snapshot
+          | None ->
+              let last_autonomous = String.trim m.runtime.last_autonomous_action_at in
+              let has_runtime_activity =
+                last_autonomous <> ""
+                || m.runtime.autonomous_turn_count > 0
+                || m.runtime.autonomous_action_count > 0
+              in
+              {
+                empty_tool_audit_snapshot with
+                latest_tool_call_count =
+                  (if has_runtime_activity then Some 0 else None);
+                tool_audit_source =
+                  (if has_runtime_activity then Some "keeper_runtime_meta" else None);
+                tool_audit_at =
+                  (if last_autonomous <> "" then Some last_autonomous
+                   else if has_runtime_activity then Some m.updated_at
+                   else None);
+              }
+        in
         let blocked_internal_tools =
           all_internal_tools
           |> List.filter (fun name -> not (List.mem name allowed_tools))
@@ -408,6 +430,21 @@ let handle_keeper_status ctx args : tool_result =
            ("trace_history_count", `Int trace_history_count);
            ("handoff_count_total", `Int trace_history_count);
            ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
+           ("allowed_tool_names", string_list_to_json allowed_tools);
+           ("latest_tool_names",
+             string_list_to_json tool_audit_snapshot.latest_tool_names);
+           ("latest_tool_call_count",
+             match tool_audit_snapshot.latest_tool_call_count with
+             | Some value -> `Int value
+             | None -> `Null);
+           ("tool_audit_source",
+             match tool_audit_snapshot.tool_audit_source with
+             | Some value -> `String value
+             | None -> `Null);
+           ("tool_audit_at",
+             match tool_audit_snapshot.tool_audit_at with
+             | Some value -> `String value
+             | None -> `Null);
            ("lifecycle", `Assoc [
              ("created_at", `String m.created_at);
              ("updated_at", `String m.updated_at);
@@ -499,6 +536,7 @@ let handle_keeper_status ctx args : tool_result =
              ("metrics", `String (Dated_jsonl.base_dir metrics_store));
              ("metrics_single_file", `String metrics_path);
              ("memory_bank", `String memory_bank_path);
+             ("decisions", `String (keeper_decision_log_path ctx.config m.name));
              ("policy", `String (keeper_policy_log_path ctx.config m.name));
              ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
              ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -370,11 +370,19 @@ let handle_keeper_status ctx args : tool_result =
           keeper_model_tools |> List.map (fun tool -> tool.Types.name)
         in
         let allowed_tools = keeper_allowed_tool_names m in
+        let last_autonomous = String.trim m.runtime.last_autonomous_action_at in
         let tool_audit_snapshot =
           match latest_tool_audit_snapshot_from_files ctx.config ~keeper_name:m.name with
-          | Some snapshot -> snapshot
+          | Some snapshot ->
+              {
+                snapshot with
+                tool_audit_at =
+                  (match snapshot.tool_audit_source, snapshot.tool_audit_at with
+                   | Some _, None when last_autonomous <> "" -> Some last_autonomous
+                   | Some _, None -> Some m.updated_at
+                   | _ -> snapshot.tool_audit_at);
+              }
           | None ->
-              let last_autonomous = String.trim m.runtime.last_autonomous_action_at in
               let has_runtime_activity =
                 last_autonomous <> ""
                 || m.runtime.autonomous_turn_count > 0

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -60,6 +60,9 @@ let keeper_history_path config trace_id =
 let keeper_policy_log_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".policy.jsonl")
 
+let keeper_decision_log_path config name =
+  Filename.concat (keeper_dir_ config) (name ^ ".decisions.jsonl")
+
 let keeper_feedback_log_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".feedback.jsonl")
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -10,6 +10,187 @@ open Keeper_types
 open Keeper_memory [@@warning "-33"]
 open Keeper_exec_context [@@warning "-33"]
 
+let string_contains_substring ~(needle : string) (haystack : string) : bool =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  if needle_len = 0 then true
+  else if needle_len > hay_len then false
+  else
+    let rec loop i =
+      if i + needle_len > hay_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
+  string_contains_substring
+    ~needle:(String.lowercase_ascii needle)
+    (String.lowercase_ascii haystack)
+
+let decision_channel_of_observation
+    (observation : Keeper_world_observation.world_observation) : string =
+  if observation.pending_mentions <> [] || observation.pending_board_events <> [] then
+    "turn"
+  else
+    "proactive"
+
+let selected_mode_of_result (result : Keeper_agent_run.run_result) : string =
+  let text = String.trim result.response_text in
+  if result.tools_used <> [] then "tool_use"
+  else if text = "" then "noop"
+  else if String.starts_with ~prefix:"SKIP:" text then "skip_text"
+  else "text_response"
+
+let observed_triggers_of_observation
+    (observation : Keeper_world_observation.world_observation) : string list =
+  let triggers = ref [] in
+  let add trigger = triggers := trigger :: !triggers in
+  if observation.pending_mentions <> [] then add "direct_mention";
+  if observation.pending_board_events <> [] then add "board_activity";
+  if observation.unclaimed_task_count > 0 then add "new_unclaimed_task";
+  if observation.failed_task_count > 0 then add "failed_task";
+  if observation.active_goals <> [] && observation.idle_seconds > 0 then
+    add "idle_timeout_candidate";
+  if Option.is_some observation.worktree_change_summary then add "worktree_change";
+  List.rev !triggers
+
+let observed_affordances_of_observation
+    (observation : Keeper_world_observation.world_observation) : string list =
+  let affordances = ref [] in
+  let add affordance = affordances := affordance :: !affordances in
+  if observation.pending_mentions <> [] then add "reply_in_room";
+  if observation.pending_board_events <> [] then add "board_post_or_comment";
+  if observation.unclaimed_task_count > 0 then add "task_claim";
+  if observation.failed_task_count > 0 then add "task_audit";
+  if Option.is_some observation.worktree_change_summary then add "inspect_worktree_delta";
+  List.rev !affordances
+
+let response_requests_confirmation (text : string) : bool =
+  let trimmed = String.trim text in
+  trimmed <> ""
+  && (String.contains trimmed '?'
+      || string_contains_substring_ci ~needle:"would you like" trimmed
+      || string_contains_substring_ci ~needle:"do you want" trimmed
+      || string_contains_substring_ci ~needle:"let me know" trimmed
+      || string_contains_substring_ci ~needle:"어떻게 할까" trimmed
+      || string_contains_substring_ci ~needle:"할까" trimmed)
+
+let decision_id ~(meta : keeper_meta) ~(ts : float) ~(suffix_seed : string) : string =
+  let digest =
+    Digest.to_hex
+      (Digest.string
+         (Printf.sprintf "%s|%s|%.6f|%s"
+            meta.name meta.runtime.trace_id ts suffix_seed))
+  in
+  Printf.sprintf "dec-%Ld-%s"
+    (Int64.of_float (ts *. 1000.0))
+    (String.sub digest 0 8)
+
+let append_decision_record
+    ~(config : Room.config)
+    ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(latency_ms : int)
+    ~(outcome : string)
+    ~(selected_mode : string)
+    ?(result : Keeper_agent_run.run_result option = None)
+    ?error
+    () : unit =
+  let now_ts = Time_compat.now () in
+  let trigger_signals = observed_triggers_of_observation observation in
+  let affordances = observed_affordances_of_observation observation in
+  let tools_used =
+    match result with
+    | Some r -> r.tools_used
+    | None -> []
+  in
+  let response_preview =
+    match result with
+    | Some r when String.trim r.response_text <> "" ->
+        Some (short_preview r.response_text)
+    | _ -> None
+  in
+  let tool_call_count =
+    match result with
+    | Some r -> r.tool_calls_made
+    | None -> 0
+  in
+  let claim_executed = List.mem "keeper_task_claim" tools_used in
+  let suffix_seed =
+    match response_preview, error with
+    | Some preview, _ -> preview
+    | None, Some err -> err
+    | None, None -> selected_mode
+  in
+  let json =
+    `Assoc
+      [
+        ("id", `String (decision_id ~meta ~ts:now_ts ~suffix_seed));
+        ("ts", `String (now_iso ()));
+        ("ts_unix", `Float now_ts);
+        ("audience", `String "internal_human_only");
+        ("trace_id", `String meta.runtime.trace_id);
+        ("generation", `Int meta.runtime.generation);
+        ("keeper_name", `String meta.name);
+        ("agent_name", `String meta.agent_name);
+        ("channel", `String (decision_channel_of_observation observation));
+        ("outcome", `String outcome);
+        ("selected_mode", `String selected_mode);
+        ("selected_mode_source", `String "observed_result");
+        ("latency_ms", `Int latency_ms);
+        ("trigger_signals", `List (List.map (fun s -> `String s) trigger_signals));
+        ("observed_affordances", `List (List.map (fun s -> `String s) affordances));
+        ( "observation",
+          `Assoc
+            [
+              ("pending_mentions", `Int (List.length observation.pending_mentions));
+              ("pending_board_events", `Int (List.length observation.pending_board_events));
+              ("active_goals", `Int (List.length observation.active_goals));
+              ("idle_seconds", `Int observation.idle_seconds);
+              ("context_ratio", `Float observation.context_ratio);
+              ("unclaimed_task_count", `Int observation.unclaimed_task_count);
+              ("failed_task_count", `Int observation.failed_task_count);
+              ("active_agent_count", `Int observation.active_agent_count);
+              ("worktree_change_detected", `Bool (Option.is_some observation.worktree_change_summary));
+            ] );
+        ("tool_call_count", `Int tool_call_count);
+        ("tools_used", `List (List.map (fun s -> `String s) tools_used));
+        ("claim_was_available", `Bool (observation.unclaimed_task_count > 0));
+        ("claim_executed", `Bool claim_executed);
+        ( "response_preview",
+          match response_preview with
+          | Some preview -> `String preview
+          | None -> `Null );
+        ( "response_requests_confirmation",
+          `Bool
+            (match result with
+             | Some r -> response_requests_confirmation r.response_text
+             | None -> false) );
+        ( "error",
+          match error with
+          | Some reason -> `String reason
+          | None -> `Null );
+        ( "cdal_proof",
+          match result with
+          | Some { proof = Some p; _ } ->
+              `Assoc
+                [
+                  ("run_id", `String p.Agent_sdk.Cdal_proof.run_id);
+                  ( "result_status",
+                    Agent_sdk.Cdal_proof.result_status_to_yojson p.result_status );
+                  ("tool_trace_count", `Int (List.length p.tool_trace_refs));
+                ]
+          | _ -> `Null );
+      ]
+  in
+  try append_jsonl_line (keeper_decision_log_path config meta.name) json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.warn "append decision record failed for %s: %s"
+        meta.name (Printexc.to_string exn)
+
 (** Observe tool call history from run_result to update keeper metrics.
     No action_taken type — we observe what the agent did, not classify it. *)
 let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
@@ -265,6 +446,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           let updated_meta =
             update_metrics_from_failure meta ~latency_ms ~reason:e
           in
+          append_decision_record ~config ~meta:updated_meta ~observation
+            ~latency_ms ~outcome:"error" ~selected_mode:"error"
+            ~error:e ();
           (match write_meta config updated_meta with
            | Ok () -> ()
            | Error msg ->
@@ -353,6 +537,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                Log.Keeper.error
                  "write metrics snapshot failed after unified turn: %s"
                  (Printexc.to_string exn));
+          append_decision_record ~config ~meta:updated_meta ~observation
+            ~latency_ms ~outcome:"success"
+            ~selected_mode:(selected_mode_of_result result)
+            ~result:(Some result) ();
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with
            | Ok () -> ()

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -107,14 +107,22 @@ let recent_messages_json config =
 
 let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
   let fallback_allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
   let fallback_snapshot =
     match
       Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
         ~keeper_name:meta.name
     with
-    | Some snapshot -> snapshot
+    | Some snapshot ->
+        {
+          snapshot with
+          tool_audit_at =
+            (match snapshot.tool_audit_source, snapshot.tool_audit_at with
+             | Some _, None when last_autonomous <> "" -> Some last_autonomous
+             | Some _, None -> Some meta.updated_at
+             | _ -> snapshot.tool_audit_at);
+        }
     | None ->
-        let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
         let has_runtime_activity =
           last_autonomous <> ""
           || meta.runtime.autonomous_turn_count > 0

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -105,46 +105,32 @@ let recent_messages_json config =
   |> List.map Types.message_to_yojson
   |> fun rows -> `List rows
 
-let latest_keeper_tools_from_metrics config keeper_name =
-  let store = Keeper_types.keeper_metrics_store config keeper_name in
-  let lines =
-    let dated = Dated_jsonl.read_recent_lines store 8 in
-    if dated <> [] then dated
-    else
-      let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
-      Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
-  in
-  lines
-  |> List.rev
-  |> List.find_map (fun line ->
-         try
-           let json = Yojson.Safe.from_string line in
-           let tools =
-             match Yojson.Safe.Util.member "tools_used" json with
-             | `List items ->
-                 items
-                 |> List.filter_map (function
-                        | `String tool ->
-                            let trimmed = String.trim tool in
-                            if trimmed = "" then None else Some trimmed
-                        | _ -> None)
-             | _ -> []
-           in
-           if tools = [] then None else Some (List.sort_uniq String.compare tools)
-         with Yojson.Json_error _ -> None)
-  |> Option.value ~default:[]
-
 let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
   let fallback_allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  let fallback_latest = latest_keeper_tools_from_metrics config meta.name in
-  let fallback_count = None in
-  let fallback_source =
-    if fallback_latest <> [] then Some "keeper_metrics" else None
-  in
-  let fallback_at =
-    let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
-    if last_autonomous <> "" then Some last_autonomous
-    else Some meta.updated_at
+  let fallback_snapshot =
+    match
+      Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
+        ~keeper_name:meta.name
+    with
+    | Some snapshot -> snapshot
+    | None ->
+        let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
+        let has_runtime_activity =
+          last_autonomous <> ""
+          || meta.runtime.autonomous_turn_count > 0
+          || meta.runtime.autonomous_action_count > 0
+        in
+        {
+          Keeper_exec_status_metrics.empty_tool_audit_snapshot with
+          latest_tool_call_count =
+            (if has_runtime_activity then Some 0 else None);
+          tool_audit_source =
+            (if has_runtime_activity then Some "keeper_runtime_meta" else None);
+          tool_audit_at =
+            (if last_autonomous <> "" then Some last_autonomous
+             else if has_runtime_activity then Some meta.updated_at
+             else None);
+        }
   in
   match A2a_tools.latest_heartbeat_task meta.agent_name,
         A2a_tools.latest_heartbeat_result meta.agent_name with
@@ -170,7 +156,11 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
         Some "heartbeat_result",
         Some result.updated_at )
   | None, None ->
-      (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
+      ( fallback_allowed,
+        fallback_snapshot.latest_tool_names,
+        fallback_snapshot.latest_tool_call_count,
+        fallback_snapshot.tool_audit_source,
+        fallback_snapshot.tool_audit_at )
 
 let keepers_json ?keeper_names ?(include_recent_activity = true)
     ?(lightweight = false) config =

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -624,41 +624,94 @@ let test_dashboard_mission_http_cache_isolation () =
 
 let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
   let keeper_name = "audit-keeper-assembly-fixture" in
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Lib.A2a_tools.emit_heartbeat_task
-    ~agent:keeper_name
-    ~goal:"Mission keeper audit fixture"
-    ~context:"dashboard mission assembly"
-    ~allowed_tools:[ "masc_board_get"; "masc_board_vote" ]
-    ();
-  let briefs =
-    Lib.Dashboard_mission_assembly.build_keeper_briefs
-      [
-        `Assoc
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Room_utils.default_config dir in
+      Lib.A2a_tools.emit_heartbeat_task
+        ~agent:keeper_name
+        ~goal:"Mission keeper audit fixture"
+        ~context:"dashboard mission assembly"
+        ~allowed_tools:[ "masc_board_get"; "masc_board_vote" ]
+        ();
+      let briefs =
+        Lib.Dashboard_mission_assembly.build_keeper_briefs config
           [
-            ("name", `String keeper_name);
-            ("agent_name", `String keeper_name);
-            ("status", `String "offline");
-            ("updated_at", `String (Types.now_iso ()));
-            ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_vote" ]);
-            ("latest_tool_names", `List []);
-            ("latest_tool_call_count", `Null);
-            ("tool_audit_source", `Null);
-            ("tool_audit_at", `Null);
-          ];
-      ]
-  in
-  let open Yojson.Safe.Util in
-  let brief =
-    briefs |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
-  in
-  check bool "heartbeat task allowed tools present" true
-    ((brief |> member "allowed_tool_names" |> to_list) <> []);
-  check string "heartbeat task source wins in keeper brief" "heartbeat_task"
-    (brief |> member "tool_audit_source" |> to_string);
-  check bool "no observed tools without evidence" true
-    ((brief |> member "latest_tool_names" |> to_list) = [])
+            `Assoc
+              [
+                ("name", `String keeper_name);
+                ("agent_name", `String keeper_name);
+                ("status", `String "offline");
+                ("updated_at", `String (Types.now_iso ()));
+                ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_vote" ]);
+                ("latest_tool_names", `List []);
+                ("latest_tool_call_count", `Null);
+                ("tool_audit_source", `Null);
+                ("tool_audit_at", `Null);
+              ];
+          ]
+      in
+      let open Yojson.Safe.Util in
+      let brief =
+        briefs |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+      in
+      check bool "heartbeat task allowed tools present" true
+        ((brief |> member "allowed_tool_names" |> to_list) <> []);
+      check string "heartbeat task source wins in keeper brief" "heartbeat_task"
+        (brief |> member "tool_audit_source" |> to_string);
+      check bool "no observed tools without evidence" true
+        ((brief |> member "latest_tool_names" |> to_list) = []))
+
+let test_dashboard_mission_keeper_tool_audit_uses_decision_log () =
+  let keeper_name = "audit-keeper-decision-fixture" in
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Room_utils.default_config dir in
+      Room_utils.mkdir_p
+        (Filename.dirname (Lib.Keeper_types.keeper_decision_log_path config keeper_name));
+      Fs_compat.append_jsonl
+        (Lib.Keeper_types.keeper_decision_log_path config keeper_name)
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
+            ("selected_mode", `String "text_response");
+            ("tool_call_count", `Int 0);
+            ("tools_used", `List []);
+          ]);
+      let briefs =
+        Lib.Dashboard_mission_assembly.build_keeper_briefs config
+          [
+            `Assoc
+              [
+                ("name", `String keeper_name);
+                ("agent_name", `String keeper_name);
+                ("status", `String "active");
+                ("updated_at", `String (Types.now_iso ()));
+                ("allowed_tool_names", `List [ `String "masc_board_get" ]);
+                ("latest_tool_names", `List []);
+                ("latest_tool_call_count", `Null);
+                ("tool_audit_source", `Null);
+                ("tool_audit_at", `Null);
+              ];
+          ]
+      in
+      let open Yojson.Safe.Util in
+      let brief =
+        briefs |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+      in
+      check string "decision log source present in keeper brief" "keeper_decision_log"
+        (brief |> member "tool_audit_source" |> to_string);
+      check int "decision log zero tool count preserved" 0
+        (brief |> member "latest_tool_call_count" |> to_int);
+      check bool "decision log still reports empty tool list" true
+        ((brief |> member "latest_tool_names" |> to_list) = []))
 
 let () =
   Alcotest.run "Dashboard Mission"
@@ -677,5 +730,7 @@ let () =
             test_dashboard_mission_http_cache_isolation;
           Alcotest.test_case "keeper brief prefers heartbeat task" `Quick
             test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task;
+          Alcotest.test_case "keeper brief uses decision log fallback" `Quick
+            test_dashboard_mission_keeper_tool_audit_uses_decision_log;
         ] );
     ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -95,6 +95,10 @@ let () =
             .test_keeper_config_exposes_live_runtime_and_sources;
           Alcotest.test_case "snapshot keeper tool audit fallback" `Quick
             Test_operator_control_keeper.test_snapshot_keeper_tool_audit_fallback;
+          Alcotest.test_case "snapshot keeper tool audit uses decision log"
+            `Quick
+            Test_operator_control_keeper
+            .test_snapshot_keeper_tool_audit_uses_decision_log;
           Alcotest.test_case "keeper msg auto team session bridge" `Quick
             Test_operator_control_keeper.test_keeper_msg_auto_team_session_bridge;
           Alcotest.test_case "operator keeper_message rejects legacy models"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -382,6 +382,77 @@ let test_snapshot_keeper_tool_audit_fallback () =
       in
       Alcotest.(check bool) "keeper down ok" true ok)
 
+let test_snapshot_keeper_tool_audit_uses_decision_log () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive "audit-keeper-decision";
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
+      in
+      let keeper_name = "audit-keeper-decision" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Expose dashboard decision audit");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Fs_compat.append_jsonl
+        (Keeper_types.keeper_decision_log_path config keeper_name)
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
+            ("selected_mode", `String "text_response");
+            ("tool_call_count", `Int 0);
+            ("tools_used", `List []);
+          ]);
+      let open Yojson.Safe.Util in
+      let rec load_keeper_snapshot attempts_left =
+        let snapshot =
+          Operator_control.snapshot_json ~include_messages:false ~include_sessions:false
+            ~include_keepers:true (operator_ctx env sw config "operator")
+        in
+        match
+          snapshot
+          |> member "keepers" |> member "items" |> to_list
+          |> List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name)
+        with
+        | Some keeper -> keeper
+        | None when attempts_left > 0 ->
+            Unix.sleepf 0.05;
+            load_keeper_snapshot (attempts_left - 1)
+        | None ->
+            Alcotest.failf "keeper %s missing from snapshot: %s" keeper_name
+              (Yojson.Safe.to_string snapshot)
+      in
+      let keeper = load_keeper_snapshot 10 in
+      Alcotest.(check string) "decision log source exposed" "keeper_decision_log"
+        (keeper |> member "tool_audit_source" |> to_string);
+      Alcotest.(check int) "decision log zero tool count exposed" 0
+        (keeper |> member "latest_tool_call_count" |> to_int);
+      Alcotest.(check bool) "decision log names remain empty" true
+        ((keeper |> member "latest_tool_names" |> to_list) = []))
+
 let test_keeper_msg_auto_team_session_bridge () =
   (* This test triggers a real LLM cascade call (keeper_msg -> run_turn).
      It is opt-in because local runtime/model availability is not stable

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -372,8 +372,13 @@ let test_snapshot_keeper_tool_audit_fallback () =
         (keeper |> member "status" |> to_string);
       Alcotest.(check bool) "allowed tool fallback present" true
         ((keeper |> member "allowed_tool_names" |> to_list) <> []);
-      Alcotest.(check bool) "tool audit source omitted without evidence" true
-        (keeper |> member "tool_audit_source" = `Null);
+      Alcotest.(check string) "tool audit source reflects failed turn evidence"
+        "keeper_decision_log"
+        (keeper |> member "tool_audit_source" |> to_string);
+      Alcotest.(check int) "tool audit count exposed as zero" 0
+        (keeper |> member "latest_tool_call_count" |> to_int);
+      Alcotest.(check bool) "tool audit names remain empty" true
+        ((keeper |> member "latest_tool_names" |> to_list) = []);
       Alcotest.(check bool) "diagnostic removed from snapshot" true
         (keeper |> member "diagnostic" = `Null);
       let ok, _ =

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1200,6 +1200,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
       let metrics_store = Masc_mcp.Keeper_types.keeper_metrics_store config meta.name in
       let history_path = Masc_mcp.Keeper_types.keeper_history_path config meta.runtime.trace_id in
       let memory_bank_path = Masc_mcp.Keeper_types.keeper_memory_bank_path config meta.name in
+      let decision_log_path = Masc_mcp.Keeper_types.keeper_decision_log_path config meta.name in
       let turn_json = Yojson.Safe.from_string
           {|{"channel":"turn","generation":0,"trace_id":"trace-1","context_ratio":0.41,"context_tokens":120,"context_max":1024,"message_count":4,"memory_check":{"performed":true,"passed":true,"final_score":0.9},"skill_primary":"masc-heartbeat","skill_secondary":["masc-keeper-autonomy"],"skill_reason":"stateful routing","skill_selection_mode":"agent","skill_provenance":"judgment"}|}
       in
@@ -1254,6 +1255,16 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         Yojson.Safe.Util.(json |> member "metrics_overview" |> member "compaction_events" |> to_int);
       check string "skill route primary" "masc-heartbeat"
         Yojson.Safe.Util.(json |> member "skill_route" |> member "primary" |> to_string);
+      check string "decision log path exposed" decision_log_path
+        Yojson.Safe.Util.(json |> member "storage_paths" |> member "decisions" |> to_string);
+      check string "tool audit source from metrics fallback" "keeper_metrics"
+        Yojson.Safe.Util.(json |> member "tool_audit_source" |> to_string);
+      check int "tool audit count falls back to zero" 0
+        Yojson.Safe.Util.(json |> member "latest_tool_call_count" |> to_int);
+      check bool "tool audit names remain empty without tool use" true
+        (Yojson.Safe.Util.(json |> member "latest_tool_names" |> to_list) = []);
+      check bool "tool audit timestamp exposed" true
+        Yojson.Safe.Util.(json |> member "tool_audit_at" <> `Null);
       let ok, list_body =
         dispatch "masc_keeper_list"
           (`Assoc [ ("detailed", `Bool true); ("limit", `Int 10) ])


### PR DESCRIPTION
## Summary
- add internal human-only `*.decisions.jsonl` records for unified keeper turns
- reuse decision/metrics fallback to populate keeper tool-audit fields instead of leaving them as `not_collected`
- expose the new audit fields through keeper status and add regression coverage for snapshot/mission/detail paths

## Testing
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/unified-keeper-decision-log test`
  - started, but did not complete with observable output in this environment before PR creation
- `DUNE_BUILD_DIR=_build_codex_fix dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/unified-keeper-decision-log`
  - started successfully with the explicit root workaround, but full completion was still pending
- live worktree server smoke on alternate port
  - pending; dashboard SPA build for the worktree server was still in progress
