### PR TITLE
refactor(config): remove Chain config module and relocate fields (#3935)

### DIFF
--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -156,15 +156,11 @@ let to_json () : Yojson.Safe.t =
       "rate_burst", int_val Env_config_runtime.Rate_bucket.burst;
       "build_git_commit", str_opt build_git_commit_opt;
     ];
-    "chain", `Assoc [
-      "max_nodes", int_val Env_config_runtime.Chain.max_nodes;
-      "max_depth", int_val Env_config_runtime.Chain.max_depth;
-      "max_fanout", int_val Env_config_runtime.Chain.max_fanout;
-      "max_concurrency", int_val Env_config_runtime.Chain.max_concurrency;
+    "model_defaults", `Assoc [
       "default_cascade", str_opt Env_config_governance.Model_defaults.default_cascade_opt;
       "default_provider", str_opt Env_config_governance.Model_defaults.default_provider_opt;
       "default_model", str_opt Env_config_governance.Model_defaults.default_model_opt;
-      "llama_swarm_model", str_opt Env_config_runtime.Chain.llama_swarm_model_opt;
+      "llama_swarm_model", str_opt Env_config_runtime.Local_runtime.llama_swarm_model_opt;
     ];
     "dashboard", `Assoc [
       "fixtures_enabled", bool_val (Env_config_governance.Dashboard_config.fixtures_enabled ());

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -139,6 +139,17 @@ module Local_runtime = struct
       Callers may request less, but never more than this cap. *)
   let max_tokens =
     get_int ~default:32768 "MASC_LLAMA_MAX_TOKENS"
+
+  (** Llama swarm model override (formerly in Chain module). *)
+  let llama_swarm_model_opt () =
+    Sys.getenv_opt "LLAMA_SWARM_MODEL" |> trim_opt
+
+  (** MASC MCP endpoint URL (formerly in Chain module).
+      Defaults to {base_url}/mcp. *)
+  let mcp_url () =
+    match Sys.getenv_opt "MASC_MCP_URL" |> trim_opt with
+    | Some url -> url
+    | None -> Env_config_core.masc_http_base_url () ^ "/mcp"
 end
 
 (** Backward-compatible alias so existing [Env_config.Llama] references
@@ -188,77 +199,6 @@ module Message = struct
       Oldest messages (by filename sort) are deleted when count exceeds this. *)
   let max_count =
     get_int ~default:200 "MASC_MESSAGE_MAX_COUNT"
-end
-
-(** {1 Chain Executor Configuration} *)
-
-module Chain = struct
-  (** Model used for evaluator/judge calls in chain execution. *)
-  let judge_model =
-    get_string ~default:"gemini" "MASC_CHAIN_JUDGE_MODEL"
-
-  (** Security limits for chain execution. *)
-  let max_depth = max 1 (get_int ~default:20 "MASC_CHAIN_MAX_DEPTH")
-  let max_concurrency = max 1 (get_int ~default:10 "MASC_CHAIN_MAX_CONCURRENCY")
-  let max_nodes = max 1 (get_int ~default:100 "MASC_CHAIN_MAX_NODES")
-  let max_fanout = max 1 (get_int ~default:20 "MASC_CHAIN_MAX_FANOUT")
-
-  (** Chain log level (e.g. "debug", "info"). *)
-  let log_level_opt () =
-    Sys.getenv_opt "MASC_CHAIN_LOG_LEVEL" |> trim_opt
-
-  (** Chain log format: "text" or "json". Default: "text". *)
-  let log_format () =
-    match Sys.getenv_opt "MASC_CHAIN_LOG_FORMAT" |> trim_opt with
-    | Some "json" -> "json"
-    | _ -> "text"
-
-  (** Source base path for chain file resolution. *)
-  let source_base_path_opt () =
-    Sys.getenv_opt "MASC_CHAIN_SOURCE_BASE_PATH" |> trim_opt
-
-  (** Orchestrator model for chain design. Default: "gemini:pro". *)
-  let orchestrator_model () =
-    Sys.getenv_opt "MASC_CHAIN_ORCHESTRATOR_MODEL" |> trim_opt
-    |> Option.value ~default:"gemini:pro"
-
-  (** History file path. Canonical env var; CHAIN_HISTORY_FILE as fallback. *)
-  let history_file_opt () =
-    match Sys.getenv_opt "MASC_CHAIN_HISTORY_FILE" |> trim_opt with
-    | Some _ as v -> v
-    | None -> Sys.getenv_opt "CHAIN_HISTORY_FILE" |> trim_opt
-
-  (** Run store path for chain execution logs. *)
-  let run_store_path_opt () =
-    Sys.getenv_opt "MASC_CHAIN_RUN_STORE_PATH" |> trim_opt
-
-  (** Whether chain run logging is enabled. Default: true. *)
-  let run_log_enabled () =
-    match Sys.getenv_opt "MASC_CHAIN_RUN_LOG" |> trim_opt with
-    | Some "0" | Some "false" | Some "no" -> false
-    | _ -> true
-
-  (** Chain run log file path override. *)
-  let run_log_path_opt () =
-    Sys.getenv_opt "MASC_CHAIN_RUN_LOG_PATH" |> trim_opt
-
-  (** Checkpoint directory for chain execution. *)
-  let checkpoint_dir_opt () =
-    Sys.getenv_opt "MASC_CHAIN_CHECKPOINT_DIR" |> trim_opt
-
-  (** MASC MCP endpoint URL. Defaults to {base_url}/mcp. *)
-  let mcp_url () =
-    match Sys.getenv_opt "MASC_MCP_URL" |> trim_opt with
-    | Some url -> url
-    | None -> Env_config_core.masc_http_base_url () ^ "/mcp"
-
-  (** Agent name for chain execution. Default: "local-worker". *)
-  let agent_name =
-    get_string ~default:"local-worker" "MASC_AGENT_NAME"
-
-  (** Llama swarm model override. *)
-  let llama_swarm_model_opt () =
-    Sys.getenv_opt "LLAMA_SWARM_MODEL" |> trim_opt
 end
 
 (** {1 Transport Configuration} *)

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -109,13 +109,6 @@ let transport_entries = [
   entry ~default:"false" "MASC_OPENAI_COMPAT" "Enable OpenAI-compatible endpoint";
 ]
 
-let chain_entries = [
-  entry ~default:"gemini" "MASC_CHAIN_JUDGE_MODEL" "Chain evaluator/judge model";
-  entry ~default:"20" "MASC_CHAIN_MAX_DEPTH" "Chain max execution depth";
-  entry ~default:"10" "MASC_CHAIN_MAX_CONCURRENCY" "Chain max concurrent nodes";
-  entry ~default:"(derived)" "MASC_MCP_URL" "MCP endpoint URL for chain";
-]
-
 let inference_entries = [
   entry ~default:"30" "MASC_INFERENCE_TIMEOUT_SEC" "Inference call timeout (seconds)";
   entry ~default:"true" "MASC_INFERENCE_CACHE_ENABLED" "Enable inference result cache";
@@ -216,7 +209,6 @@ let all_categories () = [
   category "storage" storage_entries;
   category "runtime" runtime_entries;
   category "rate_limiting" rate_limiting_entries;
-  category "chain" chain_entries;
   category "inference" inference_entries;
   category "keeper" keeper_entries;
   category "keeper_execution" keeper_execution_entries;

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -3,7 +3,7 @@
     Runtime-specific settings: zombies, locks, sessions, tempo, decisions,
     cache, orchestrator, spawn, local runtime, federation,
     cancellation, neo4j, voice, custom model, network, timeouts,
-    inference defaults, control plane cleanup, message GC, chain. *)
+    inference defaults, control plane cleanup, message GC. *)
 
 module Zombie : sig
   val threshold_seconds : float
@@ -68,12 +68,16 @@ module Local_runtime : sig
   val server_url : string
   val default_model : string
   val max_tokens : int
+  val llama_swarm_model_opt : unit -> string option
+  val mcp_url : unit -> string
 end
 
 module Llama : sig
   val server_url : string
   val default_model : string
   val max_tokens : int
+  val llama_swarm_model_opt : unit -> string option
+  val mcp_url : unit -> string
 end
 
 module Cancellation : sig
@@ -116,26 +120,6 @@ end
 
 module Message : sig
   val max_count : int
-end
-
-module Chain : sig
-  val judge_model : string
-  val max_depth : int
-  val max_concurrency : int
-  val max_nodes : int
-  val max_fanout : int
-  val log_level_opt : unit -> string option
-  val log_format : unit -> string
-  val source_base_path_opt : unit -> string option
-  val orchestrator_model : unit -> string
-  val history_file_opt : unit -> string option
-  val run_store_path_opt : unit -> string option
-  val run_log_enabled : unit -> bool
-  val run_log_path_opt : unit -> string option
-  val checkpoint_dir_opt : unit -> string option
-  val mcp_url : unit -> string
-  val agent_name : string
-  val llama_swarm_model_opt : unit -> string option
 end
 
 module Transport : sig

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -131,7 +131,7 @@ let model_of_discovery_status (status : Discovery_cache.endpoint_info) =
   | [] -> (
       match status.props with
       | Some props -> trim_opt (Some props.model)
-      | None -> trim_opt (Env_config.Chain.llama_swarm_model_opt ()))
+      | None -> trim_opt (Env_config.Local_runtime.llama_swarm_model_opt ()))
 
 let max_concurrency_of_discovery_status (status : Discovery_cache.endpoint_info) =
   match status.slots with
@@ -167,7 +167,7 @@ let runtime_of_endpoint_url base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Env_config.Chain.llama_swarm_model_opt ());
+    model = trim_opt (Env_config.Local_runtime.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;
@@ -256,7 +256,7 @@ let default_runtime () =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Env_config.Chain.llama_swarm_model_opt ());
+    model = trim_opt (Env_config.Local_runtime.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT" ~default:default_parallel_hint;
     active_slots = 0;
@@ -274,7 +274,7 @@ let runtime_from_endpoint base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Env_config.Chain.llama_swarm_model_opt ());
+    model = trim_opt (Env_config.Local_runtime.llama_swarm_model_opt ());
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;
@@ -300,7 +300,7 @@ let current_fingerprint () =
     [
       String.concat "," (Llm_provider.Discovery.endpoints_from_env ());
       Env_config.Llama.server_url;
-      Option.value ~default:"" (Env_config.Chain.llama_swarm_model_opt ());
+      Option.value ~default:"" (Env_config.Local_runtime.llama_swarm_model_opt ());
       Option.value ~default:""
         (Env_config.Worker.llama_runtime_cooldown_sec_opt ());
       string_of_int


### PR DESCRIPTION
## Summary
- `Env_config_runtime.Chain` 모듈 제거 (max_nodes/depth/fanout/concurrency)
- `llama_swarm_model`을 `Local_runtime`으로 이동
- JSON 섹션명 `chain` -> `model_defaults`

-116줄. Closes #3935

## Product impact
- retired chain config surface를 제거하고 남아 있는 local runtime 기본값만 `model_defaults`로 노출합니다.
- `llama_swarm_model`은 계속 제공되지만 진입점이 `Env_config.Local_runtime`로 이동합니다.

## Evidence
- GitHub Actions required checks green: Build and Test, Contract Harness, Health, Lint, Dashboard.
- repo scan 기준 `Env_config.Chain.*` 직접 사용처는 없습니다.

## Review evidence
- 2026-03-30 19:50:37 KST: `sb glm-text` correctness review. Findings were limited to intentional surface changes (`Env_config.Chain.*` removal, `chain` -> `model_defaults`). Follow-up repo scan confirmed no in-repo callers/readers.

## Linked issue
- Closes #3935