### PR TITLE
feat(keeper): config-driven tool tier for masc_* tool exposure

### DIFF
--- a/config/personas/sangsu/profile.json
+++ b/config/personas/sangsu/profile.json
@@ -73,6 +73,7 @@
       "상수",
       "홍상수"
     ],
+    "tool_tier": "essential",
     "presence_keepalive": true,
     "presence_keepalive_sec": 30,
     "proactive_enabled": true

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -38,6 +38,7 @@ let resolved_keeper_args_to_json
     ~instructions ~soul_profile ~will ~needs ~desires ~policy_voice_enabled
     ~room_scope ~scope_kind ~mention_targets
     ~proactive_enabled ~shards
+    ~tool_tier ~extra_masc_tools
     ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec =
   let base =
     [
@@ -57,6 +58,8 @@ let resolved_keeper_args_to_json
       ("scope_kind", `String scope_kind);
       ("mention_targets", string_list_to_json mention_targets);
       ("proactive_enabled", `Bool proactive_enabled);
+      ("tool_tier", `String tool_tier);
+      ("extra_masc_tools", string_list_to_json extra_masc_tools);
       ("auto_handoff", `Bool auto_handoff);
       ("handoff_threshold", `Float handoff_threshold);
       ("handoff_cooldown_sec", `Int handoff_cooldown_sec);
@@ -200,6 +203,16 @@ let resolved_keeper_args_from_persona args :
               | _ :: _ as xs -> Some xs
               | [] -> defaults.shards
             in
+            let tool_tier =
+              get_string_opt args "tool_tier"
+              |> first_some defaults.tool_tier
+              |> Option.value ~default:"essential"
+            in
+            let extra_masc_tools =
+              match get_string_list args "extra_masc_tools" with
+              | _ :: _ as xs -> xs
+              | [] -> Option.value ~default:[] defaults.extra_masc_tools
+            in
             let auto_handoff = get_bool args "auto_handoff" true in
             let handoff_threshold =
               Safe_ops.json_float_opt "handoff_threshold" args
@@ -218,6 +231,7 @@ let resolved_keeper_args_from_persona args :
                 ~policy_voice_enabled
                 ~room_scope ~scope_kind ~mention_targets
                 ~proactive_enabled ~shards
+                ~tool_tier ~extra_masc_tools
                 ~auto_handoff ~handoff_threshold
                 ~handoff_cooldown_sec
             in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -81,9 +81,11 @@ let keeper_voice_tool_schemas =
 
 (** Curated masc_* bridge for keepers.
     Schema list is injected at server init to avoid cyclic dependency on Tools.
-    Keep raw masc_* passthrough minimal and move keeper-visible workflows into
-    dedicated shards whenever possible. *)
+    Keeper tool access is controlled per-keeper via tool_tier (essential/standard/full)
+    in persona config, using Tool_catalog tier definitions. *)
 
+(** @deprecated Legacy hardcoded list. Tier-based filtering via Tool_catalog
+    replaces this. Kept for test backward-compatibility reference. *)
 let keeper_passthrough_masc_tool_names =
   [
     "masc_status";
@@ -99,16 +101,30 @@ let masc_schemas_ref : Types.tool_schema list ref = ref []
 let inject_masc_schemas (schemas : Types.tool_schema list) =
   masc_schemas_ref :=
     List.filter (fun (s : Types.tool_schema) ->
-      String.starts_with ~prefix:"masc_" s.name
-      && List.mem s.name keeper_passthrough_masc_tool_names)
+      String.starts_with ~prefix:"masc_" s.name)
       schemas
 
-let keeper_masc_tool_names (_meta : keeper_meta) : string list =
+let keeper_masc_tool_names (meta : keeper_meta) : string list =
+  let tier =
+    Tool_catalog.tier_of_string meta.tool_tier
+    |> Option.value ~default:Tool_catalog.Essential
+  in
   !masc_schemas_ref
-  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+  |> List.filter_map (fun (schema : Types.tool_schema) ->
+    if Tool_catalog.is_in_tier tier schema.name
+       || List.mem schema.name meta.extra_masc_tools
+    then Some schema.name
+    else None)
 
-let keeper_masc_tool_schemas (_meta : keeper_meta) : Types.tool_schema list =
+let keeper_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
+  let tier =
+    Tool_catalog.tier_of_string meta.tool_tier
+    |> Option.value ~default:Tool_catalog.Essential
+  in
   !masc_schemas_ref
+  |> List.filter (fun (schema : Types.tool_schema) ->
+    Tool_catalog.is_in_tier tier schema.name
+    || List.mem schema.name meta.extra_masc_tools)
 
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -19,11 +19,28 @@ let ensure_keeper_meta config name =
       | Some v -> v
       | None -> Keeper_config.default_proactive_enabled
     in
-    if meta.proactive.enabled <> target_proactive then begin
-      Log.Keeper.info "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b for %s"
-        meta.proactive.enabled target_proactive meta.name;
+    let target_tool_tier =
+      Option.value ~default:"essential" defaults.tool_tier
+    in
+    let target_extra_masc_tools =
+      Option.value ~default:[] defaults.extra_masc_tools
+    in
+    let needs_update =
+      meta.proactive.enabled <> target_proactive
+      || meta.tool_tier <> target_tool_tier
+      || meta.extra_masc_tools <> target_extra_masc_tools
+    in
+    if needs_update then begin
+      if meta.proactive.enabled <> target_proactive then
+        Log.Keeper.info "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b for %s"
+          meta.proactive.enabled target_proactive meta.name;
+      if meta.tool_tier <> target_tool_tier then
+        Log.Keeper.info "ensure_keeper_meta: re-syncing tool_tier %s -> %s for %s"
+          meta.tool_tier target_tool_tier meta.name;
       let updated = { meta with
         proactive = { meta.proactive with enabled = target_proactive };
+        tool_tier = target_tool_tier;
+        extra_masc_tools = target_extra_masc_tools;
         updated_at = now_iso ();
       } in
       match write_meta config updated with

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -38,6 +38,8 @@ type parsed_args = {
   will_opt : string option;
   needs_opt : string option;
   desires_opt : string option;
+  tool_tier_opt : string option;
+  extra_masc_tools_in : string list;
   profile_defaults : keeper_profile_defaults;
   instructions_opt : string option;
 }
@@ -125,6 +127,8 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in
     let desires_opt = parse_self_model_opt args "desires" in
+    let tool_tier_opt = get_string_opt args "tool_tier" in
+    let extra_masc_tools_in = get_string_list args "extra_masc_tools" in
     Ok {
       name;
       soul_profile_opt;
@@ -156,6 +160,8 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       will_opt;
       needs_opt;
       desires_opt;
+      tool_tier_opt;
+      extra_masc_tools_in;
       profile_defaults;
       instructions_opt;
     }

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -90,6 +90,16 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       Option.value ~default:default_proactive_cooldown_sec p.proactive_cooldown_sec_opt
       |> normalize_proactive_cooldown_sec
     in
+    let tool_tier =
+      p.tool_tier_opt
+      |> first_some p.profile_defaults.tool_tier
+      |> Option.value ~default:"essential"
+    in
+    let extra_masc_tools =
+      match p.extra_masc_tools_in with
+      | _ :: _ as xs -> xs
+      | [] -> Option.value ~default:[] p.profile_defaults.extra_masc_tools
+    in
     let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
     let handoff_threshold = Option.value ~default:0.85 p.handoff_threshold_opt in
     let handoff_cooldown_sec = Option.value ~default:300 p.handoff_cooldown_sec_opt in
@@ -194,6 +204,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            execution_scope = default_execution_scope;
            allowed_paths;
            scope_kind;
+           tool_tier;
+           extra_masc_tools;
            room_scope;
            voice_enabled;
            voice_channel;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -119,6 +119,18 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     execution_scope =
       Option.value ~default:old.execution_scope p.execution_scope_opt;
     scope_kind;
+    tool_tier =
+      p.tool_tier_opt
+      |> first_some
+           (if String.trim old.tool_tier <> "" then Some old.tool_tier else None)
+      |> first_some p.profile_defaults.tool_tier
+      |> Option.value ~default:"essential";
+    extra_masc_tools =
+      (match p.extra_masc_tools_in with
+       | _ :: _ as xs -> xs
+       | [] ->
+         if old.extra_masc_tools <> [] then old.extra_masc_tools
+         else Option.value ~default:[] p.profile_defaults.extra_masc_tools);
     room_scope;
     voice_enabled =
       Option.value ~default:old.voice_enabled p.voice_enabled_opt;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -92,6 +92,8 @@ type keeper_meta = {
   execution_scope: string;
   allowed_paths: string list;
   scope_kind: string;
+  tool_tier: string;
+  extra_masc_tools: string list;
   room_scope: string;
   mention_targets: string list;
   joined_room_ids: string list;
@@ -247,6 +249,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("execution_scope", `String m.execution_scope);
       ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
       ("scope_kind", `String m.scope_kind);
+      ("tool_tier", `String m.tool_tier);
+      ("extra_masc_tools", `List (List.map (fun s -> `String s) m.extra_masc_tools));
       ("room_scope", `String m.room_scope);
       ("mention_targets", `List (List.map (fun s -> `String s) m.mention_targets));
       ("joined_room_ids", `List (List.map (fun s -> `String s) m.joined_room_ids));
@@ -373,6 +377,12 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     in
     let scope_kind =
       Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
+    in
+    let tool_tier =
+      Safe_ops.json_string ~default:"essential" "tool_tier" json
+    in
+    let extra_masc_tools =
+      Safe_ops.json_string_list "extra_masc_tools" json
     in
     let room_scope =
       Safe_ops.json_string ~default:"current" "room_scope" json |> canonical_room_scope
@@ -533,6 +543,8 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           execution_scope;
           allowed_paths;
           scope_kind;
+          tool_tier;
+          extra_masc_tools;
           room_scope;
           mention_targets;
           joined_room_ids;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -95,6 +95,8 @@ type keeper_meta = {
   execution_scope: string;
   allowed_paths: string list;
   scope_kind: string;
+  tool_tier: string;
+  extra_masc_tools: string list;
   room_scope: string;
   mention_targets: string list;
   joined_room_ids: string list;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -203,6 +203,8 @@ type keeper_profile_defaults = {
   mention_targets : string list;
   proactive_enabled : bool option;
   shards : string list option;
+  tool_tier : string option;
+  extra_masc_tools : string list option;
 }
 
 type persona_summary = {
@@ -231,6 +233,8 @@ let empty_keeper_profile_defaults = {
   mention_targets = [];
   proactive_enabled = None;
   shards = None;
+  tool_tier = None;
+  extra_masc_tools = None;
 }
 
 let personas_root_opt () =
@@ -317,6 +321,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
            (match strs "shards" with
             | [] -> None
             | xs -> Some xs);
+         tool_tier = str "tool_tier";
+         extra_masc_tools =
+           (match strs "extra_masc_tools" with
+            | [] -> None
+            | xs -> Some xs);
        })
 
 let load_keeper_toml (path : string)
@@ -397,6 +406,11 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
                 shards =
                   (match Safe_ops.json_string_list "shards" keeper_json with
+                   | [] -> None
+                   | xs -> Some xs);
+                tool_tier = Safe_ops.json_string_opt "tool_tier" keeper_json;
+                extra_masc_tools =
+                  (match Safe_ops.json_string_list "extra_masc_tools" keeper_json with
                    | [] -> None
                    | xs -> Some xs);
               }

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -159,9 +159,10 @@ let () =
      registrations so it fills gaps without overwriting correct mappings. *)
   Tool_tag_init.register_all ();
   mark_tag_registry_initialized ();
-  (* Inject masc_* schemas into keeper bridge for profile-based filtering.
-     Must happen after all schemas are assembled. *)
-  Keeper_exec_tools.inject_masc_schemas Tools.all_schemas_extended;
+  (* Inject masc_* schemas into keeper bridge for tier-based filtering.
+     Uses Config.raw_all_tool_schemas which includes Board/MDAL schemas
+     not present in Tools.all_schemas_extended. *)
+  Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
   (* Wire keeper-internal tool call recording to break Config dependency cycle.
      keeper_exec_tools cannot reference Tool_registry directly. *)
   Keeper_exec_tools.on_keeper_tool_call :=

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -1,22 +1,24 @@
-(** Test keeper masc_* tool bridge — verifies schema injection
-    and dispatch passthrough expose only the curated keeper bridge. *)
+(** Test keeper masc_* tool bridge — verifies tier-based schema injection
+    and dispatch passthrough for keeper tool exposure. *)
 
 module KET = Masc_mcp.Keeper_exec_tools
 
-let make_meta () =
+let make_meta ?(tool_tier = "essential") ?(extra_masc_tools = []) () =
   match Masc_mcp.Keeper_types.meta_of_json
     (`Assoc
       [
         ("name", `String "keeper-bridge-test");
         ("agent_name", `String "keeper-bridge-test");
         ("trace_id", `String "keeper-bridge-trace");
+        ("tool_tier", `String tool_tier);
+        ("extra_masc_tools", `List (List.map (fun s -> `String s) extra_masc_tools));
       ])
   with
   | Ok meta -> meta
   | Error e -> failwith e
 
-(** Verify inject_masc_schemas filters to the curated keeper allowlist. *)
-let test_inject_filters_allowlist () =
+(** Verify inject_masc_schemas stores all masc_* schemas (no name-based filter). *)
+let test_inject_stores_all_masc () =
   let schemas : Types.tool_schema list =
     [
       { name = "masc_status"; description = ""; input_schema = `Assoc [] };
@@ -26,14 +28,61 @@ let test_inject_filters_allowlist () =
     ]
   in
   KET.inject_masc_schemas schemas;
-  let meta = make_meta () in
+  (* inject stores all 3 masc_* tools, not the keeper_* one *)
+  let meta = make_meta ~tool_tier:"full" () in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "2 curated masc tools" 2 (List.length names);
+  Alcotest.(check int) "3 masc tools stored" 3 (List.length names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "has masc_broadcast" true (List.mem "masc_broadcast" names);
   Alcotest.(check bool) "has masc_messages" true (List.mem "masc_messages" names);
-  Alcotest.(check bool) "no masc_broadcast" false (List.mem "masc_broadcast" names);
   Alcotest.(check bool) "no keeper_time_now" false
     (List.mem "keeper_time_now" names)
+
+(** Verify Essential tier includes expected tools and excludes non-essential. *)
+let test_essential_tier_filters () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta = make_meta ~tool_tier:"essential" () in
+  let names = KET.keeper_masc_tool_names meta in
+  (* Essential tier should include core coordination tools *)
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "has masc_join" true (List.mem "masc_join" names);
+  Alcotest.(check bool) "has masc_broadcast" true (List.mem "masc_broadcast" names);
+  Alcotest.(check bool) "has masc_claim_next" true (List.mem "masc_claim_next" names);
+  Alcotest.(check bool) "has masc_transition" true (List.mem "masc_transition" names);
+  Alcotest.(check bool) "has masc_heartbeat" true (List.mem "masc_heartbeat" names);
+  (* Board tools should NOT be in Essential *)
+  Alcotest.(check bool) "no masc_board_post" false (List.mem "masc_board_post" names)
+
+(** Verify Standard tier includes board tools. *)
+let test_standard_tier_includes_board () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta = make_meta ~tool_tier:"standard" () in
+  let names = KET.keeper_masc_tool_names meta in
+  Alcotest.(check bool) "has masc_board_post" true (List.mem "masc_board_post" names);
+  Alcotest.(check bool) "has masc_team_session_start" true
+    (List.mem "masc_team_session_start" names);
+  (* Essential tools should also be present in Standard *)
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names)
+
+(** Verify extra_masc_tools adds tools beyond the tier. *)
+let test_extra_tools_override () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta = make_meta ~tool_tier:"essential" ~extra_masc_tools:["masc_board_post"] () in
+  let names = KET.keeper_masc_tool_names meta in
+  (* masc_board_post is NOT in Essential but IS in extra_masc_tools *)
+  Alcotest.(check bool) "extra: has masc_board_post" true
+    (List.mem "masc_board_post" names);
+  (* Normal essential tools still present *)
+  Alcotest.(check bool) "extra: has masc_status" true (List.mem "masc_status" names)
+
+(** Verify Full tier returns all stored schemas. *)
+let test_full_tier_includes_all () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta_full = make_meta ~tool_tier:"full" () in
+  let meta_essential = make_meta ~tool_tier:"essential" () in
+  let full_count = List.length (KET.keeper_masc_tool_names meta_full) in
+  let essential_count = List.length (KET.keeper_masc_tool_names meta_essential) in
+  Alcotest.(check bool) "full > essential" true (full_count > essential_count)
 
 (** Verify dispatch passthrough returns None for unregistered tools. *)
 let test_dispatch_unregistered () =
@@ -42,20 +91,9 @@ let test_dispatch_unregistered () =
   in
   Alcotest.(check bool) "unregistered returns None" true (result = None)
 
-(** Verify real schemas injection matches the curated keeper allowlist. *)
-let test_inject_real_schemas_match_curated_names () =
-  KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
-  let meta = make_meta () in
-  let names = KET.keeper_masc_tool_names meta in
-  let expected =
-    List.sort String.compare KET.keeper_passthrough_masc_tool_names
-  in
-  let actual = List.sort String.compare names in
-  Alcotest.(check (list string)) "curated passthrough names" expected actual
-
 (** Verify schemas and names are consistent. *)
 let test_schemas_match_names () =
-  KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
   let schemas = KET.keeper_masc_tool_schemas meta in
@@ -69,7 +107,7 @@ let test_schemas_match_names () =
 
 (** Verify all bridged tools still have masc_ prefix. *)
 let test_all_have_prefix () =
-  KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
   List.iter
@@ -78,25 +116,34 @@ let test_all_have_prefix () =
         (String.starts_with ~prefix:"masc_" name))
     names
 
-let test_allowed_tools_use_curated_bridge () =
-  KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
+(** Verify allowed tools include essential masc_* tools by default. *)
+let test_allowed_tools_include_essential () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let meta = make_meta () in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check bool) "has masc_messages" true (List.mem "masc_messages" names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
-  Alcotest.(check bool) "omits masc_join" false (List.mem "masc_join" names);
-  Alcotest.(check bool) "omits masc_broadcast" false
-    (List.mem "masc_broadcast" names)
+  Alcotest.(check bool) "has masc_join" true (List.mem "masc_join" names);
+  Alcotest.(check bool) "has masc_broadcast" true (List.mem "masc_broadcast" names)
 
 let () =
   Alcotest.run "Keeper masc bridge"
     [
       ( "injection",
         [
-          Alcotest.test_case "filters to curated allowlist" `Quick
-            test_inject_filters_allowlist;
-          Alcotest.test_case "real schemas match curated list" `Quick
-            test_inject_real_schemas_match_curated_names;
+          Alcotest.test_case "stores all masc_* schemas" `Quick
+            test_inject_stores_all_masc;
+          Alcotest.test_case "essential tier filters correctly" `Quick
+            test_essential_tier_filters;
+        ] );
+      ( "tiers",
+        [
+          Alcotest.test_case "standard includes board" `Quick
+            test_standard_tier_includes_board;
+          Alcotest.test_case "extra_tools override" `Quick
+            test_extra_tools_override;
+          Alcotest.test_case "full includes all" `Quick
+            test_full_tier_includes_all;
         ] );
       ( "dispatch",
         [
@@ -107,7 +154,7 @@ let () =
         [
           Alcotest.test_case "schemas match names" `Quick test_schemas_match_names;
           Alcotest.test_case "all have masc_ prefix" `Quick test_all_have_prefix;
-          Alcotest.test_case "allowed tools use curated bridge" `Quick
-            test_allowed_tools_use_curated_bridge;
+          Alcotest.test_case "allowed tools include essential" `Quick
+            test_allowed_tools_include_essential;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Keeper의 `masc_*` 도구 접근을 하드코딩 6개 → 설정 기반 tier 시스템으로 전환
- 기존 `Tool_catalog`의 Essential(21개)/Standard(~55개)/Full(~200개) tier를 재활용
- `tool_tier` 설정을 persona `profile.json` 또는 `keeper_up` args로 per-keeper 제어
- Default: `essential` — `masc_join`, `masc_broadcast`, `masc_claim_next`, `masc_transition` 등 핵심 coordination 도구 포함
- `extra_masc_tools`로 tier 외 특정 도구 추가 가능

### 변경 내용

| 항목 | Before | After |
|------|--------|-------|
| masc_* passthrough | 6개 하드코딩 | tier 기반 (Essential=21, Standard=~55, Full=all) |
| 설정 방법 | 코드 수정 필요 | `profile.json`에 `"tool_tier": "standard"` |
| Schema 소스 | `Tools.all_schemas_extended` (Board 누락) | `Config.raw_all_tool_schemas` (전체 포함) |

### 발견된 기존 버그

`Tools.all_schemas_extended`에 `Tool_Board.tools`와 `Tool_mdal.schemas`가 누락. `Config.raw_all_tool_schemas`로 교체하여 해결.

## Test plan

- [x] `test_keeper_masc_bridge` 9/9 pass (tier 필터링, extra_tools, full tier)
- [x] `test_tool_keeper` 43/43 pass (기존 keeper 도구 동작)
- [x] `test_tools_coverage` 83/83 pass (전체 도구 커버리지)
- [ ] 실제 keeper 기동 후 tool_tier 반영 확인
- [ ] GLM-5 tool calling 동작 확인 (#3941)

## Related

- Epic #3890 (Tool Surface Contract Redesign)
- #3941 GLM-5 tool calling 호환성 검증
- #3942 Full tier token budget 경고
- #3943 레거시 passthrough 리스트 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)