### PR TITLE
feat(cdal): wire spawn contract and project worker proof metadata

### DIFF
--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -109,7 +109,7 @@ let worker_run_validation_failures json =
 
 let worker_run_summary_json json =
   let summary = U.member "trace_summary" json in
-  `Assoc
+  let base_fields =
     [
       ("worker_run_id", U.member "worker_run_id" json);
       ("cdal_run_id", U.member "cdal_run_id" json);
@@ -153,6 +153,20 @@ let worker_run_summary_json json =
       ("session_conformance", U.member "session_conformance" json);
       ("ts_iso", U.member "ts_iso" json);
     ]
+  in
+  let proof_fields =
+    match U.member "proof_run_id" json with
+    | `String _ ->
+        [
+          ("proof_run_id", U.member "proof_run_id" json);
+          ("proof_status", U.member "proof_status" json);
+          ("proof_risk_class", U.member "proof_risk_class" json);
+          ("proof_execution_mode", U.member "proof_execution_mode" json);
+          ("proof_evidence_count", U.member "proof_evidence_count" json);
+        ]
+    | _ -> []
+  in
+  `Assoc (base_fields @ proof_fields)
 
 let actor_activity_state (acc : actor_acc) =
   if acc.observed_event_count > 0 then

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -18,6 +18,7 @@ type run_result = {
   session_id : string;
   raw_trace_run : Oas.Raw_trace.run_ref option;
   api_response : Oas.Types.api_response option;
+  proof : Oas.Cdal_proof.t option;
 }
 
 type worker_container_state =

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -599,6 +599,7 @@ let run_model_by_label
     ?context_reducer
     ?memory
     ?enable_thinking
+    ?contract
     ?on_event
     ?transport
     ?priority
@@ -626,7 +627,7 @@ let run_model_by_label
             ()
         in
         let config = { config with transport = transport_resolved; priority } in
-        (match run ~sw ~net ~config ?on_event goal with
+        (match run ~sw ~net ~config ?on_event ?contract goal with
         | Ok result when accept result.response -> Ok result
         | Ok _ ->
             Error

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -85,6 +85,7 @@ val run_model_by_label :
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
   ?enable_thinking:bool ->
+  ?contract:Oas.Risk_contract.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?priority:Llm_provider.Request_priority.t ->

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -441,6 +441,22 @@ let generate_proof ?(proof_level = default_proof_level) config
     let spawn_tool_names = collect_spawn_tool_names events in
     let spawn_tool_call_count = sum_spawn_tool_call_count events in
     let write_capable_spawn_count = count_write_capable_spawns events in
+    let projected_worker_proof_count =
+      Team_session_store.list_worker_run_ids config session.session_id
+      |> List.fold_left
+           (fun acc worker_run_id ->
+             let path =
+               Team_session_store.worker_run_meta_path config session.session_id
+                 worker_run_id
+             in
+             match Room_utils.read_json_opt config path with
+             | Some meta -> (
+                 match Yojson.Safe.Util.member "proof_run_id" meta with
+                 | `String _ -> acc + 1
+                 | _ -> acc)
+             | None -> acc)
+           0
+    in
     let min_turn_events = min_turn_events_for_session required_turn_actors in
     let min_communication = min_communication_for_session required_turn_actors in
     let vote_events =
@@ -564,9 +580,10 @@ let generate_proof ?(proof_level = default_proof_level) config
           ("oas_cdal_integration", `Assoc [
             ("contract_wired", `Bool (Option.is_some session.delivery_contract));
             ("proof_schema_version", `Int 1);
-            ("worker_proof_count", `Int (List.length worker_proofs));
+            ("worker_proof_count",
+             `Int (max (List.length worker_proofs) projected_worker_proof_count));
             ("aggregated", `Bool (worker_proofs <> []));
-            ("note", `String "Session proof aggregates worker-level OAS proof refs when present and falls back cleanly for legacy sessions without stored worker proofs.");
+            ("proof_projected", `Bool (projected_worker_proof_count > 0));
           ]);
         ]
     in

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -149,6 +149,7 @@ let execute_delegate_pipeline
                       ?trace_ref:run_result.raw_trace_run
                       ?trace_summary:trace_summary_json
                       ?trace_validation:trace_validation_json
+                      ?proof:None
                       ~trace_capability:
                         (if Option.is_some run_result.raw_trace_run
                          then "raw"
@@ -222,6 +223,7 @@ let execute_delegate_pipeline
                         (Worker_runtime
                          .oas_worker_evidence_session_id
                            ~worker_run_id)
+                      ?proof:None
                       ~trace_capability:"summary_only" ();
                     append_delegate_event ~worker_run_id
                       ~worker_name ~delegate_prompt

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,6 +33,47 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
+let proof_result_status_to_string = function
+  | Oas.Cdal_proof.Completed -> "completed"
+  | Oas.Cdal_proof.Errored -> "errored"
+  | Oas.Cdal_proof.Timed_out -> "timed_out"
+  | Oas.Cdal_proof.Cancelled -> "cancelled"
+
+let proof_summary_fields ~(worker_run_id : string)
+    ?(proof : Oas.Cdal_proof.t option) () =
+  let null_fields =
+    [
+      ("proof_run_id", `Null);
+      ("proof_status", `Null);
+      ("proof_risk_class", `Null);
+      ("proof_execution_mode", `Null);
+      ("proof_evidence_count", `Null);
+    ]
+  in
+  match proof with
+  | None -> null_fields
+  | Some proof -> (
+      match Repo_synthesis_benchmark.validate_run_id proof.run_id with
+      | Ok run_id ->
+          [
+            ("proof_run_id", `String run_id);
+            ( "proof_status",
+              `String (proof_result_status_to_string proof.result_status) );
+            ( "proof_risk_class",
+              `String (Oas.Risk_class.to_string proof.risk_class) );
+            ( "proof_execution_mode",
+              `String
+                (Oas.Execution_mode.to_string
+                   proof.effective_execution_mode) );
+            ( "proof_evidence_count",
+              `Int (List.length proof.raw_evidence_refs) );
+          ]
+      | Error msg ->
+          Log.Misc.warn
+            "team_session_step: dropping invalid proof_run_id for worker_run=%s: %s"
+            worker_run_id msg;
+          null_fields)
+
 let delivery_verdict_of_verification ~session_id ~worker_run_id
     ~(contract : Team_session_types.delivery_contract)
     (outcome : Worker_verification.verification_outcome) :
@@ -330,6 +371,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
     ~status
     ~success ?output_preview ?error ?trace_capability ?trace_ref
     ?trace_summary ?trace_validation ?evidence_session_id
+    ?proof
     () =
   let checkpoint_path =
     Team_session_store.worker_container_checkpoint_path env.ctx.config
@@ -415,6 +457,9 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         | _ -> output_preview)
     | None -> output_preview
   in
+  let proof_fields =
+    proof_summary_fields ~worker_run_id ?proof ()
+  in
   if Room_utils.path_exists env.ctx.config checkpoint_path then
     Team_session_store.save_worker_run_checkpoint_text env.ctx.config
       env.session_id worker_run_id
@@ -422,7 +467,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
   Team_session_store.save_worker_run_meta_json env.ctx.config env.session_id
     worker_run_id
     (`Assoc
-      [
+      ([
         ("worker_run_id", `String worker_run_id);
         ("worker_name", `String worker_name);
         ("mode", `String mode);
@@ -451,7 +496,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         ("stop_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.stop_reason) oas_worker);
         ("failure_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.failure_reason) oas_worker);
         ("ts_iso", `String (Types.now_iso ()));
-      ])
+      ] @ proof_fields))
 
 let release_prepared_runtime (prepared : prepared_spawn) ~success
     ?error ?latency_ms () =

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -79,30 +79,45 @@ let execute_spawn_pipeline
                    Some (`Assoc [ ("error", `String msg) ])
                | Ok () ->
                    let execute_spawn index prepared =
-                     (* Phase C-3a: Route spawn through OAS Agent.run via Oas_worker.
-                        This replaces the old Spawn.spawn subprocess call, giving us
-                        trace data, tool_names, and tool_call_count for free. *)
-                     let start_time = Time_compat.now () in
-                     let max_turns =
-                       match prepared.spec.max_turns with
-                       | Some n -> n | None -> 10
-                     in
-                     let oas_result =
-                       Oas_worker.run_model_by_label
-                         ~model_label:prepared.runtime_model_label
-                         ~goal:prepared.spec.spawn_prompt
-                         ~system_prompt:(Printf.sprintf
-                           "You are agent '%s'. Execute the task and return a clear result."
+                   (* Phase C-3a: Route spawn through OAS Agent.run via Oas_worker.
+                       This replaces the old Spawn.spawn subprocess call, giving us
+                       trace data, tool_names, and tool_call_count for free. *)
+                    let start_time = Time_compat.now () in
+                    let max_turns =
+                      match prepared.spec.max_turns with
+                      | Some n -> n | None -> 10
+                    in
+                    let delivery_contract =
+                      Tool_team_session_step_exec.delivery_contract_for_session
+                        ctx.config session_id
+                    in
+                    let contract =
+                      Option.map
+                        (fun delivery_contract ->
+                          (* Spawn workers currently run without an attached
+                             MASC tool surface, so the composed contract uses
+                             the current runtime tool list: [] *)
+                          Contract_composer.compose ~delivery_contract
+                            ~tool_names:[])
+                        delivery_contract
+                    in
+                    let oas_result =
+                      Oas_worker.run_model_by_label
+                        ~model_label:prepared.runtime_model_label
+                        ~goal:prepared.spec.spawn_prompt
+                        ~system_prompt:(Printf.sprintf
+                          "You are agent '%s'. Execute the task and return a clear result."
                            prepared.spec.spawn_agent)
-                         ~max_turns
-                         ~temperature:(Safe_ops.get_env_float_logged
-                           "MASC_SPAWN_TEMPERATURE" ~default:0.3)
-                         ~max_tokens:(Safe_ops.get_env_int_logged
-                           "MASC_SPAWN_MAX_TOKENS" ~default:4096)
-                         ~priority:Llm_provider.Request_priority.Interactive
-                         ~sw:ctx.sw
-                         ()
-                     in
+                        ~max_turns
+                        ~temperature:(Safe_ops.get_env_float_logged
+                          "MASC_SPAWN_TEMPERATURE" ~default:0.3)
+                        ~max_tokens:(Safe_ops.get_env_int_logged
+                          "MASC_SPAWN_MAX_TOKENS" ~default:4096)
+                        ~priority:Llm_provider.Request_priority.Interactive
+                        ?contract
+                        ~sw:ctx.sw
+                        ()
+                    in
                      let elapsed_ms =
                        int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
                      in
@@ -175,6 +190,11 @@ let execute_spawn_pipeline
                      let output_preview =
                        deps.truncate_for_event spawn_result.output
                      in
+                     let proof =
+                       match oas_result with
+                       | Ok result -> result.proof
+                       | Error _ -> None
+                     in
                      let verification_outcome =
                        match oas_result with
                        | Ok result ->
@@ -195,6 +215,7 @@ let execute_spawn_pipeline
                                session_id = result.session_id;
                                raw_trace_run = oas_trace_ref;
                                api_response = Some result.response;
+                               proof = result.proof;
                              }
                            in
                            let goal =
@@ -207,10 +228,7 @@ let execute_spawn_pipeline
                            in
                            Some
                              (Worker_verification.verify_worker_result
-                                ?delivery_contract:
-                                  (Tool_team_session_step_exec
-                                   .delivery_contract_for_session
-                                     ctx.config session_id)
+                                ?delivery_contract
                                 ~goal run_result)
                        | Error _ -> None
                      in
@@ -263,6 +281,7 @@ let execute_spawn_pipeline
                        ?trace_ref:oas_trace_ref
                        ?trace_summary:trace_summary_json
                        ?trace_validation:trace_validation_json
+                       ?proof
                          ~trace_capability:"raw"
                        ();
                      append_spawn_event

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -479,6 +479,7 @@ and run_existing_worker_agent
               session_id;
               raw_trace_run;
               api_response = Some response;
+              proof = None;
             }
       | Error err ->
           let detail = Oas.Error.to_string err in

--- a/test/dune
+++ b/test/dune
@@ -173,6 +173,11 @@
  (modules test_dashboard_proof)
  (libraries masc_mcp masc_mcp.team_session_types alcotest eio eio_main yojson unix masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))
 
+(test
+ (name test_persist_worker_run_snapshot)
+ (modules test_persist_worker_run_snapshot)
+ (libraries masc_mcp masc_mcp.team_session_types alcotest eio eio_main yojson unix masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))
+
 ; Dashboard cache deadlock regression + stampede tests (requires Eio)
 (test
  (name test_dashboard_cache)

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -231,6 +231,11 @@ let seed_worker_run_meta config session_id =
         ("resolved_runtime", `String "llama-8085");
         ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
         ("routing_reason", `String "explicit_task_profile");
+        ("proof_run_id", `String "proof-run-123");
+        ("proof_status", `String "completed");
+        ("proof_risk_class", `String "medium");
+        ("proof_execution_mode", `String "execute");
+        ("proof_evidence_count", `Int 2);
         ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
         ("tool_call_count", `Int 2);
         ("output_preview", `String "Patched calc.py and verification passed.");
@@ -355,8 +360,42 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "resolved_model" |> U.to_string);
       check string "worker result_status" "completed"
         (worker |> U.member "result_status" |> U.to_string);
+      check string "worker proof run id" "proof-run-123"
+        (worker |> U.member "proof_run_id" |> U.to_string);
+      check string "worker proof status" "completed"
+        (worker |> U.member "proof_status" |> U.to_string);
+      check string "worker proof risk class" "medium"
+        (worker |> U.member "proof_risk_class" |> U.to_string);
+      check string "worker proof execution mode" "execute"
+        (worker |> U.member "proof_execution_mode" |> U.to_string);
+      check int "worker proof evidence count" 2
+        (worker |> U.member "proof_evidence_count" |> U.to_int);
       check string "worker final text" "Patched calc.py and verification passed."
         (worker |> U.member "final_text" |> U.to_string))
+
+let test_team_session_proof_projects_worker_proof_metadata () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      let session_id = "ts-proof-worker-projection" in
+      let session = sample_session (Unix.gettimeofday ()) session_id in
+      seed_session_artifacts ~session:(Some session) config session_id;
+      seed_worker_run_meta config session_id;
+      match Lib.Team_session_report.generate_proof config session with
+      | Error msg -> fail msg
+      | Ok (proof_json, _) ->
+          let integration =
+            proof_json |> U.member "oas_cdal_integration"
+          in
+          check int "worker_proof_count" 1
+            (integration |> U.member "worker_proof_count" |> U.to_int);
+          check bool "proof_projected" true
+            (integration |> U.member "proof_projected" |> U.to_bool))
 
 let test_timeline_json_orders_command_plane_events_by_timestamp () =
   let dir = test_dir () in
@@ -579,6 +618,8 @@ let () =
           test_case "builds collaboration proof projection" `Quick test_dashboard_proof_projection;
           test_case "exposes validated worker run evidence" `Quick
             test_dashboard_proof_exposes_validated_worker_run_evidence;
+          test_case "projects worker proof metadata into session proof" `Quick
+            test_team_session_proof_projects_worker_proof_metadata;
           test_case "orders merged timeline chronologically" `Quick
             test_timeline_json_orders_command_plane_events_by_timestamp;
           test_case "prefers actual activity over stronger persisted proof" `Quick

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -1,0 +1,229 @@
+module Lib = Masc_mcp
+module U = Yojson.Safe.Util
+module Oas = Agent_sdk
+
+open Alcotest
+
+let test_counter = ref 0
+
+let temp_dir prefix =
+  incr test_counter;
+  let dir =
+    Filename.temp_file (Printf.sprintf "%s_%d_" prefix !test_counter) ""
+  in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
+  {
+    schema_version = Oas.Cdal_proof.schema_version_current;
+    run_id;
+    contract_id = "dc-proof";
+    requested_execution_mode = Oas.Execution_mode.Execute;
+    effective_execution_mode = Oas.Execution_mode.Execute;
+    mode_decision_source = "test";
+    risk_class = Oas.Risk_class.Medium;
+    provider_snapshot =
+      {
+        Oas.Cdal_proof.provider_name = "glm";
+        model_id = "glm-5";
+        api_version = None;
+      };
+    capability_snapshot =
+      {
+        Oas.Cdal_proof.tools = [];
+        mcp_servers = [];
+        max_turns = 10;
+        max_tokens = Some 4096;
+        thinking_enabled = None;
+      };
+    tool_trace_refs = [ "proof-store://proof-run-123/tool-trace-1" ];
+    raw_evidence_refs =
+      [
+        "proof-store://proof-run-123/evidence-1";
+        "proof-store://proof-run-123/evidence-2";
+      ];
+    checkpoint_ref = Some "proof-store://proof-run-123/checkpoint";
+    result_status = Oas.Cdal_proof.Completed;
+    started_at = 1000.0;
+    ended_at = 1001.0;
+  }
+
+let with_snapshot_env f =
+  let dir = temp_dir "persist_worker_run_snapshot" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "snapshot-tester"));
+      let ctx : _ Lib.Tool_team_session_step_exec.context =
+        {
+          config;
+          agent_name = "snapshot-tester";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = None;
+        }
+      in
+      let deps : Lib.Tool_team_session_step_exec.step_deps =
+        {
+          json_error = (fun msg -> msg);
+          json_ok = (fun _ -> "{}");
+          get_valid_session_id = (fun _ -> Error "unused");
+          ensure_session_access = (fun _ _ -> Error "unused");
+          parse_step_spawn_specs = (fun _ -> Error "unused");
+          annotate_control_hierarchy_for_session = (fun _ specs -> specs);
+          parse_turn_kind = (fun _ -> Error "unused");
+          parse_turn_kind_opt = (fun _ -> Ok None);
+          parse_wait_mode = (fun _ -> Team_session_types.Wait_blocking);
+          int_opt_to_json =
+            (function Some n -> `Int n | None -> `Null);
+          float_opt_to_json =
+            (function Some n -> `Float n | None -> `Null);
+          truncate_for_event = (fun ?max_len:_ text -> text);
+          make_worker_run_id = (fun () -> "unused-run-id");
+          derived_local_runtime_actor =
+            (fun ~session_id:_ ~prompt:_ -> "unused-worker");
+          is_local_spawn_agent = (fun _ -> false);
+          effective_execution_scope_of_spec = (fun _ -> None);
+          worker_size_of_spec = (fun _ -> None);
+          inferred_controller_level_of_spec = (fun _ -> None);
+          planned_worker_of_spec =
+            (fun ?runtime_actor:_ _ ->
+              failwith "planned_worker_of_spec unused");
+          register_planned_workers = (fun _ _ _ -> Ok ());
+          ensure_session_actor = (fun _ _ _ -> Ok ());
+          record_session_turn_json =
+            (fun ~config:_ ~session_id:_ ~actor:_ ~turn_kind:_
+                 ~message:_ ~target_agent:_ ~task_title:_ ~task_description:_
+                 ~task_priority:_ -> Error "unused");
+          resolve_target_worker_name = (fun _ _ _ -> None);
+          session_has_turn_for_actor = (fun _ _ _ -> false);
+          auto_note_message_of_spawn_output = (fun _ -> None);
+          reconcile_failed_spawn_actor =
+            (fun _ _ _ -> Error "unused");
+          extract_vote_id = (fun _ -> None);
+          oas_worker_evidence_payload =
+            (fun ~config:_ ~evidence_session_id:_ -> None);
+          oas_trace_capability_to_string =
+            (fun _ -> "summary_only");
+          oas_worker_status_to_json = (fun _ -> `String "completed");
+          worker_run_status_to_json =
+            (function
+             | `Accepted -> `String "accepted"
+             | `Ready -> `String "ready"
+             | `Running -> `String "running"
+             | `Completed -> `String "completed"
+             | `Failed -> `String "failed");
+          raw_trace_run_ref_to_json = (fun _ -> `String "trace-ref");
+          raw_trace_session_payloads =
+            (fun ~config:_ ~fallback_session_id:_ _ -> None);
+        }
+      in
+      let step_env : _ Lib.Tool_team_session_step_exec.step_env =
+        {
+          deps;
+          ctx;
+          session_id = "ts-proof-snapshot";
+          actor = "snapshot-tester";
+          wait_mode = Team_session_types.Wait_blocking;
+        }
+      in
+      f config step_env)
+
+let read_worker_meta config worker_run_id =
+  Lib.Team_session_store.worker_run_meta_path config "ts-proof-snapshot"
+    worker_run_id
+  |> Room_utils.read_json config
+
+let persist_snapshot ?proof step_env =
+  Lib.Tool_team_session_step_exec.persist_worker_run_snapshot step_env
+    ~worker_run_id:"wr-proof-snapshot"
+    ~worker_name:"worker-proof"
+    ~mode:"spawn"
+    ~wait_mode:Team_session_types.Wait_blocking
+    ~status:`Completed
+    ~resolved_runtime:"llama-8085"
+    ~resolved_model:"glm-5"
+    ~success:true
+    ~output_preview:"ok"
+    ~trace_capability:"summary_only"
+    ?proof
+    ()
+
+let test_persist_worker_run_snapshot_with_proof () =
+  with_snapshot_env @@ fun config step_env ->
+  let proof = sample_proof ~run_id:"proof-run-123" in
+  persist_snapshot ~proof step_env;
+  let json = read_worker_meta config "wr-proof-snapshot" in
+  check string "proof run id" "proof-run-123"
+    (json |> U.member "proof_run_id" |> U.to_string);
+  check string "proof status" "completed"
+    (json |> U.member "proof_status" |> U.to_string);
+  check string "proof risk class" "medium"
+    (json |> U.member "proof_risk_class" |> U.to_string);
+  check string "proof execution mode" "execute"
+    (json |> U.member "proof_execution_mode" |> U.to_string);
+  check int "proof evidence count" 2
+    (json |> U.member "proof_evidence_count" |> U.to_int)
+
+let test_persist_worker_run_snapshot_without_proof () =
+  with_snapshot_env @@ fun config step_env ->
+  persist_snapshot step_env;
+  let json = read_worker_meta config "wr-proof-snapshot" in
+  check bool "proof_run_id null" true
+    (json |> U.member "proof_run_id" = `Null);
+  check bool "proof_status null" true
+    (json |> U.member "proof_status" = `Null);
+  check bool "proof_risk_class null" true
+    (json |> U.member "proof_risk_class" = `Null);
+  check bool "proof_execution_mode null" true
+    (json |> U.member "proof_execution_mode" = `Null);
+  check bool "proof_evidence_count null" true
+    (json |> U.member "proof_evidence_count" = `Null)
+
+let test_persist_worker_run_snapshot_rejects_invalid_run_id () =
+  with_snapshot_env @@ fun config step_env ->
+  let proof = sample_proof ~run_id:"../escape" in
+  persist_snapshot ~proof step_env;
+  let json = read_worker_meta config "wr-proof-snapshot" in
+  check bool "invalid proof_run_id dropped" true
+    (json |> U.member "proof_run_id" = `Null);
+  check bool "invalid proof_status dropped" true
+    (json |> U.member "proof_status" = `Null);
+  check bool "invalid proof_risk_class dropped" true
+    (json |> U.member "proof_risk_class" = `Null);
+  check bool "invalid proof_execution_mode dropped" true
+    (json |> U.member "proof_execution_mode" = `Null);
+  check bool "invalid proof_evidence_count dropped" true
+    (json |> U.member "proof_evidence_count" = `Null)
+
+let () =
+  Alcotest.run "persist_worker_run_snapshot"
+    [
+      ( "snapshot",
+        [
+          test_case "with proof" `Quick
+            test_persist_worker_run_snapshot_with_proof;
+          test_case "without proof" `Quick
+            test_persist_worker_run_snapshot_without_proof;
+          test_case "invalid run id" `Quick
+            test_persist_worker_run_snapshot_rejects_invalid_run_id;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Wire spawn-time CDAL contract forwarding into `Oas_worker.run_model_by_label`, persist spawn proof summary into worker-run `meta.json`, and project that proof metadata into session/dashboard read-models.

Scope of this PR:
- spawn path only is proof-capable after contract wiring
- delegate/local worker paths remain `proof = None`
- dashboard extends existing worker evidence surfaces with persisted proof metadata
- session proof surfaces projected worker proof presence through `oas_cdal_integration`

This reintroduces part of the abandoned CDAL proof-spine work from PR #3773 in a fresh, narrower slice.

## Product impact

- Promise affected: `delivery swarm`
- User-visible change: worker-run proof metadata becomes visible through existing dashboard/session evidence surfaces when spawn runs carry a CDAL contract.

## Evidence

- `opam exec -- dune build --root . @install`
- targeted test follow-up is still pending because concurrent `dune` activity in this repo kept test target builds queued during this session

## Review evidence

- Pending draft PR review via `sb glm-text` (GLM-5)
- Review summary will be added after PR creation and before merge

## Linked issue

- Closes #
- Relates #3528
