### PR TITLE
fix(command-plane): preserve legacy chain checkpoint compatibility (#3957)

### DIFF
--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -205,6 +205,11 @@ let dashboard_projection_json ?sessions config =
 let operation_status_json config ?operation_id () =
   list_operations_json ?operation_id config
 
+let legacy_chain_run_id json =
+  match U.member "chain" json with
+  | `Assoc _ as chain_json -> get_string_opt chain_json "run_id"
+  | _ -> None
+
 let company_scope_id_for units source_unit_id target_unit_id =
   option_first_some
     (Option.bind target_unit_id (fun unit_id -> company_ancestor_id units unit_id))
@@ -532,7 +537,10 @@ let start_operation config ~(actor : string) json =
               ~depends_on_operation_ids
         | _ -> Ok ()
       in
-      let checkpoint_ref = get_string_opt json "checkpoint_ref" in
+      let checkpoint_ref =
+        option_first_some (get_string_opt json "checkpoint_ref")
+          (legacy_chain_run_id json)
+      in
       let operation =
         {
           operation_id = next_operation_id ();

--- a/lib/command_plane/cp_serde.ml
+++ b/lib/command_plane/cp_serde.ml
@@ -90,6 +90,11 @@ let get_string_list json key =
       |> dedup_strings
   | _ -> []
 
+let legacy_chain_run_id json =
+  match U.member "chain" json with
+  | `Assoc _ as chain_json -> get_string_opt chain_json "run_id"
+  | _ -> None
+
 let operation_workload_profile (operation : operation_record) =
   Cp_search_fabric.normalized_workload_profile operation.workload_profile
 
@@ -422,12 +427,14 @@ let operation_to_json (operation : operation_record) =
       ("created_by", `String operation.created_by);
       ("source", `String operation.source);
       ("status", `String (string_of_operation_status operation.status));
+      ("chain", `Null);
       ("created_at", `String operation.created_at);
       ("updated_at", `String operation.updated_at);
     ]
 
-(* operation_of_json tolerates a "chain" key in stored JSON for backwards
-   compatibility but does not parse it — chain_record was removed in #3936. *)
+(* operation_of_json tolerates a legacy "chain" key in stored JSON for
+   backwards compatibility and keeps chain.run_id as a checkpoint_ref
+   fallback without reintroducing chain_record. *)
 let operation_of_json json =
   match Option.bind (get_string_opt json "status") operation_status_of_string with
   | None -> None
@@ -459,7 +466,9 @@ let operation_of_json json =
             search_strategy = get_string_default json "search_strategy" "best_first_v1";
             detachment_session_id = get_string_opt json "detachment_session_id";
             trace_id;
-            checkpoint_ref = get_string_opt json "checkpoint_ref";
+            checkpoint_ref =
+              option_or_else (get_string_opt json "checkpoint_ref") (fun () ->
+                  legacy_chain_run_id json);
             active_goal_ids = get_string_list json "active_goal_ids";
             note = get_string_opt json "note";
             created_by;

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -18,6 +18,18 @@ let () =
             `Quick
             Test_command_plane_v2_scheduler_core_a.test_workload_template_rejects_mismatched_workload_profile;
           Alcotest.test_case
+            "start operation uses legacy chain run_id as checkpoint_ref"
+            `Quick
+            Test_command_plane_v2_scheduler_core_a.test_start_operation_uses_legacy_chain_run_id_as_checkpoint_ref;
+          Alcotest.test_case
+            "operation json preserves chain null for wire compat"
+            `Quick
+            Test_command_plane_v2_scheduler_core_a.test_operation_json_preserves_chain_null_for_wire_compat;
+          Alcotest.test_case
+            "operation of json uses legacy chain run_id as checkpoint_ref"
+            `Quick
+            Test_command_plane_v2_scheduler_core_a.test_operation_of_json_uses_legacy_chain_run_id_as_checkpoint_ref;
+          Alcotest.test_case
             "coding verify and review require expected dependencies"
             `Quick
             Test_command_plane_v2_scheduler_core_a.test_coding_verify_and_review_require_expected_dependencies;

--- a/test/test_command_plane_v2_scheduler_core_a.ml
+++ b/test/test_command_plane_v2_scheduler_core_a.ml
@@ -139,6 +139,77 @@ let test_workload_template_rejects_mismatched_workload_profile () =
             message
       | Ok _ -> Alcotest.fail "expected workload_template mismatch to fail")
 
+let test_start_operation_uses_legacy_chain_run_id_as_checkpoint_ref () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      with_eio_test base_dir @@ fun config ->
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Resume legacy chain checkpoint");
+              ("chain", `Assoc [ ("run_id", `String "legacy-run-123") ]);
+            ])
+      in
+      Alcotest.(check (option string)) "legacy chain run_id promoted"
+        (Some "legacy-run-123") operation.checkpoint_ref)
+
+let test_operation_json_preserves_chain_null_for_wire_compat () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      with_eio_test base_dir @@ fun config ->
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Serialize command plane operation");
+            ])
+      in
+      let fields =
+        match Command_plane_v2.operation_to_json operation with
+        | `Assoc fields -> fields
+        | _ -> Alcotest.fail "expected operation JSON object"
+      in
+      let chain_field = List.assoc_opt "chain" fields in
+      Alcotest.(check bool) "chain key present" true (Option.is_some chain_field);
+      Alcotest.(check bool) "chain key is null" true
+        (match chain_field with
+        | Some `Null -> true
+        | _ -> false))
+
+let test_operation_of_json_uses_legacy_chain_run_id_as_checkpoint_ref () =
+  let legacy_json =
+    `Assoc
+      [
+        ("operation_id", `String "op-legacy-chain");
+        ("objective", `String "Load legacy chain snapshot");
+        ("assigned_unit_id", `String "company-main");
+        ("trace_id", `String "trace-legacy-chain");
+        ("created_by", `String "owner");
+        ("status", `String "active");
+        ("chain", `Assoc [ ("run_id", `String "legacy-run-456") ]);
+      ]
+  in
+  match Command_plane_v2.operation_of_json legacy_json with
+  | Some operation ->
+      Alcotest.(check (option string)) "legacy stored chain run_id promoted"
+        (Some "legacy-run-456") operation.checkpoint_ref
+  | None -> Alcotest.fail "expected legacy operation JSON to load"
+
 let test_coding_verify_and_review_require_expected_dependencies () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -417,4 +488,3 @@ let test_intent_forecast_resolves_dependencies_against_all_operations () =
        |> Yojson.Safe.Util.to_list
        |> List.exists (fun value ->
               String.equal (Yojson.Safe.Util.to_string value) "verification_gap")))
-


### PR DESCRIPTION
## Summary
- restore legacy `chain.run_id` -> `checkpoint_ref` fallback in command-plane lifecycle/serde paths
- preserve `"chain": null` in serialized operation JSON for wire compatibility
- add regression coverage for legacy payload parsing and stored JSON loading

## Product impact
- keeps checkpoint linkage intact for legacy command-plane payloads after #3945
- avoids a wire-shape regression for readers that still expect the `chain` key

## Evidence
- Local (identical patch before cherry-pick): `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3936-cp-chain-record-codex @check`
- Latest `main` follow-up branch re-runs the same `@check`; draft PR opened while that verification/CI propagates.

## Review evidence
- 2026-03-30 19:50:37 KST: direct `sb glm-text` correctness review on the compatibility patch -> `No findings.`
- Copilot review concerns from merged PR #3945 were addressed directly by this follow-up.

## Linked issue
- Closes #3957