### PR TITLE
chore: bump OAS agent_sdk pin to 0.98.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.97.0))
+  (agent_sdk (>= 0.98.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.97.0"}
+  "agent_sdk" {>= "0.98.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.97.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.98.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="f7186dd095d74db708a26bde3549bc97ac1cff4c"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.97.0"
+readonly OAS_AGENT_SDK_SHA="08f54b973c993613cb320682337e9a567477b414"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.98.0"


### PR DESCRIPTION
## Summary
OAS pin 0.97.0 -> 0.98.0. Includes oas#501:
- GLM base URL: `bigmodel.cn` -> `api.z.ai` (cascade fallback 해결)
- GLM auto: `glm-5` -> `glm-5.1` (reasoning + tool calling)

MASC 서버 재시작 후 keeper가 GLM-5.1로 전환되어 tool calling이 가능해짐.

## Test plan
- [ ] CI green
- [ ] 서버 재시작 후 keeper `last_model_used` = `glm-5.1` 확인
- [ ] `autonomous_tool_turn_count > 0` 확인