### PR TITLE
chore(deps): ratchet OAS pin to 0.98.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.97.0))
+  (agent_sdk (>= 0.98.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.97.0"}
+  "agent_sdk" {>= "0.98.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.97.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.98.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="f7186dd095d74db708a26bde3549bc97ac1cff4c"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.97.0"
+readonly OAS_AGENT_SDK_SHA="08f54b973c993613cb320682337e9a567477b414"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.98.0"


### PR DESCRIPTION
## Summary
- ratchet the OAS pin script to `main@08f54b973c993613cb320682337e9a567477b414`
- raise the `agent_sdk` minimum version floor to `0.98.0`
- keep `dune-project` and `masc_mcp.opam` aligned with the OAS pin SSOT

## Verification
- ./scripts/check-oas-pin.sh
- dune build --root . --build-dir /tmp/masc-pin-oas-0980-build masc_mcp.opam