### PR TITLE
refactor(config): connect hardcoded agent/port values to env config

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -104,6 +104,27 @@ module Orchestrator = struct
     get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED"
 end
 
+(** {1 Relay Configuration} *)
+
+module Relay = struct
+  let target_agent =
+    get_string ~default:"auto" "MASC_RELAY_TARGET_AGENT"
+end
+
+(** {1 MDAL Configuration} *)
+
+module Mdal = struct
+  let default_agent =
+    get_string ~default:"auto" "MASC_MDAL_AGENT"
+end
+
+(** {1 CLI Configuration} *)
+
+module Cli = struct
+  let default_agent =
+    get_string ~default:"auto" "MASC_CLI_AGENT"
+end
+
 (** {1 Spawn Configuration} *)
 
 module Spawn = struct

--- a/lib/mdal.ml
+++ b/lib/mdal.ml
@@ -191,6 +191,8 @@ let current_evidence_status (state : loop_state) =
 (* Built-in Profiles                                                *)
 (* ================================================================ *)
 
+let default_mdal_agent = Env_config_runtime.Mdal.default_agent
+
 let builtin_profile name =
   match name with
   | "ssim" ->
@@ -199,7 +201,7 @@ let builtin_profile name =
       goal = { path = "metric"; condition = Bounded.Gte 0.95 };
       target = "SSIM >= 0.95 (perceptual similarity)";
       reference = None;
-      agent = "claude";
+      agent = default_mdal_agent;
       max_iterations = 20;
       max_time_seconds = Some 3600.0;
       stagnation_threshold = 0.005;
@@ -214,7 +216,7 @@ let builtin_profile name =
       goal = { path = "metric"; condition = Bounded.Gte 80.0 };
       target = "Test coverage >= 80%";
       reference = None;
-      agent = "claude";
+      agent = default_mdal_agent;
       max_iterations = 15;
       max_time_seconds = Some 1800.0;
       stagnation_threshold = 1.0;
@@ -229,7 +231,7 @@ let builtin_profile name =
       goal = { path = "metric"; condition = Bounded.Lte 0.0 };
       target = "Zero lint errors/warnings";
       reference = None;
-      agent = "claude";
+      agent = default_mdal_agent;
       max_iterations = 10;
       max_time_seconds = Some 900.0;
       stagnation_threshold = 1.0;
@@ -244,7 +246,7 @@ let builtin_profile name =
       goal = { path = "metric"; condition = Bounded.Gte 0.9 };
       target = "Code review score >= 0.9";
       reference = None;
-      agent = "claude";
+      agent = default_mdal_agent;
       max_iterations = 5;
       max_time_seconds = Some 1200.0;
       stagnation_threshold = 0.05;
@@ -259,7 +261,7 @@ let builtin_profile name =
       goal = { path = "metric"; condition = Bounded.Gte 0.8 };
       target = "Documentation coverage >= 0.8";
       reference = None;
-      agent = "claude";
+      agent = default_mdal_agent;
       max_iterations = 10;
       max_time_seconds = Some 1200.0;
       stagnation_threshold = 0.05;

--- a/lib/mdal/mdal_worker.ml
+++ b/lib/mdal/mdal_worker.ml
@@ -94,6 +94,9 @@ let resolve_model_label ~(agent : string) ~(worker_model : string option) :
         (* Map bare agent names to canonical provider:model via env config.
            Provider_adapter.default_model_for_family resolves from env vars. *)
         match normalized with
+        | "auto" ->
+            (* "auto" defers to cascade: use glm:auto as the cascade entry point *)
+            parse_worker_model "glm:auto"
         | "claude" ->
             (match Provider_adapter.default_model_label_for_family Provider_adapter.Claude_family with
              | Ok label -> parse_worker_model label

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -5,7 +5,7 @@ type config = {
   check_interval_s: float;      (* How often to check (default: 300s = 5min) *)
   min_priority: int;            (* Minimum task priority to trigger (default: 1) *)
   agent_timeout_s: int;         (* Timeout for spawned orchestrator (default: 300) *)
-  orchestrator_agent: string;   (* Which agent to spawn as orchestrator (default: claude) *)
+  orchestrator_agent: string;   (* Which agent to spawn as orchestrator (env: MASC_ORCHESTRATOR_AGENT) *)
   enabled: bool;                (* Is auto-orchestration enabled *)
   port: int;                    (* MASC HTTP port for API calls *)
 }
@@ -14,9 +14,9 @@ let default_config = {
   check_interval_s = 300.0;
   min_priority = 2;
   agent_timeout_s = 300;
-  orchestrator_agent = "claude";
-  enabled = false;  (* Disabled by default - opt-in *)
-  port = 8935;      (* Default MASC HTTP port *)
+  orchestrator_agent = Env_config_runtime.Orchestrator.agent_name;
+  enabled = false;
+  port = Env_config_core.masc_http_port_int ();
 }
 
 (** Load config from environment or use defaults *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -403,7 +403,7 @@ let voice_http_request_for_tts (endpoint : Voice_config.endpoint) ~api_key
           body_json;
         }
 
-let default_cli_agent_name () = "claude"
+let default_cli_agent_name () = Env_config_runtime.Cli.default_agent
 
 let split_csv_nonempty raw =
   raw

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -3,17 +3,17 @@
 (** Relay configuration *)
 type relay_config = {
   threshold: float;          (* Context usage threshold (0.0-1.0), default 0.8 *)
-  target_agent: string;      (* Agent to relay to, default "claude" *)
+  target_agent: string;      (* Agent to relay to; "auto" defers to cascade *)
   compress_ratio: float;     (* Target compression ratio, default 0.1 *)
   include_todos: bool;       (* Include TODO list in handoff *)
   include_pdca: bool;        (* Include PDCA state in handoff *)
   neo4j_episode: bool;       (* Create Neo4j Episode for continuity *)
 }
 
-(** Default relay configuration *)
+(** Default relay configuration — reads from environment *)
 let default_config = {
   threshold = 0.8;
-  target_agent = "claude";
+  target_agent = Env_config_runtime.Relay.target_agent;
   compress_ratio = 0.1;
   include_todos = true;
   include_pdca = true;

--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -20,7 +20,7 @@ let handle_start (ctx : context) args =
             goal;
             target = Safe_ops.json_string ~default:gs "target" args;
             reference = Safe_ops.json_string_opt "reference" args;
-            agent = Safe_ops.json_string ~default:"claude" "agent" args;
+            agent = Safe_ops.json_string ~default:Mdal.default_mdal_agent "agent" args;
             max_iterations = Safe_ops.json_int ~default:20 "max_iterations" args;
             max_time_seconds = Safe_ops.json_float_opt "max_time_seconds" args;
             stagnation_threshold = 0.005;

--- a/test/test_mdal.ml
+++ b/test/test_mdal.ml
@@ -111,7 +111,7 @@ let test_builtin_ssim () =
   Alcotest.(check string) "name" "ssim" p.name;
   Alcotest.(check int) "max_iterations" 20 p.max_iterations;
   Alcotest.(check string) "metric_fn is explicit-only" "" p.metric_fn;
-  Alcotest.(check string) "agent" "claude" p.agent
+  Alcotest.(check string) "agent" "auto" p.agent
 
 let test_builtin_coverage () =
   let p = Mdal.builtin_profile "coverage" in

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -29,7 +29,7 @@ let test_default_config_agent_timeout () =
   check int "agent_timeout" 300 Orchestrator.default_config.agent_timeout_s
 
 let test_default_config_agent () =
-  check string "orchestrator_agent" "claude"
+  check string "orchestrator_agent" (Env_config_runtime.Orchestrator.agent_name)
     Orchestrator.default_config.orchestrator_agent
 
 let test_default_config_enabled () =

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -53,7 +53,7 @@ let test_vertex_base_url () =
     (Adapter.gemini_vertex_openai_base_url ~project:"demo" ~location:"global")
 
 let test_default_cli_agent_name () =
-  check string "default cli agent" "claude"
+  check string "default cli agent" "auto"
     (Adapter.default_cli_agent_name ())
 
 let test_default_local_model_label () =

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -22,7 +22,7 @@ let test_default_config_threshold () =
 
 let test_default_config_target_agent () =
   let c = Relay.default_config in
-  check string "target_agent" "claude" c.target_agent
+  check string "target_agent" "auto" c.target_agent
 
 let test_default_config_compress_ratio () =
   let c = Relay.default_config in

--- a/test/test_tool_mdal.ml
+++ b/test/test_tool_mdal.ml
@@ -158,7 +158,7 @@ let make_legacy_state ?(loop_id = "legacy-mdal-loop")
         goal = { Bounded.path = "metric"; condition = Bounded.Gt 0.6 };
         target = "legacy loop";
         reference = None;
-        agent = "claude";
+        agent = "auto";
         max_iterations = 5;
         max_time_seconds = Some 60.0;
         stagnation_threshold = 0.01;


### PR DESCRIPTION
## Summary

- Relay, MDAL, CLI, Orchestrator의 하드코딩된 "claude" / 8935 값을 env config 모듈 참조로 교체
- 새 env vars: `MASC_RELAY_TARGET_AGENT`, `MASC_MDAL_AGENT`, `MASC_CLI_AGENT` (기본값 "auto")
- "auto"는 cascade selection에 위임하여 model-agnostic 경계를 유지
- mdal_worker에 "auto" → "glm:auto" cascade 진입점 추가

## Motivation

Cross-repo 코드 품질 감사에서 발견된 "config 함수 위장" 패턴 수정 (P1).
Supersedes #3926 (clean rebase after #3863 chain removal merge).

## Files changed (11)
- `lib/config/env_config_runtime.ml` — Relay/Mdal/Cli 모듈 추가
- `lib/relay.ml` — target_agent env var 참조
- `lib/mdal.ml` — builtin profiles env var 참조
- `lib/orchestrator.ml` — default_config env config 참조
- `lib/provider_adapter.ml` — CLI agent env var 참조
- `lib/mdal/mdal_worker.ml` — "auto" agent resolution
- `lib/tool_mdal.ml` — custom profile agent default
- 4 test files updated

## Test plan
- [x] `dune build --root .` 성공
- [x] relay, orchestrator, mdal 테스트 통과 (로컬)
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)