### PR TITLE
feat(keeper): warn when tool schema count exceeds budget threshold

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -160,8 +160,17 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
       @ Tool_code_write.schemas
       @ (keeper_masc_tool_schemas meta)
     in
-    all_schemas
-    |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+    let result =
+      all_schemas
+      |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+    in
+    let count = List.length result in
+    if count > 100 then
+      Log.Keeper.warn
+        "tool budget exceeded: %d schemas in LLM context (~%dKB estimated). \
+         Consider restricting tool tier."
+        count (count * 470 / 1024);
+    result
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in


### PR DESCRIPTION
## Summary

- Add `Log.Keeper.warn` when the keeper tool schema set exceeds the 100-schema budget threshold
- Expose `allowed_tool_count` and `allowed_tool_preview` in `masc_keeper_status`
- Show the current allowed tool count in the dashboard keeper runtime panel

Fixes #3942.

## Changes

- `lib/keeper/keeper_exec_tools.ml`: warn when the runtime tool schema set exceeds the budget threshold
- `lib/keeper/keeper_status_detail.ml`: include allowed tool count + preview in status payloads
- `dashboard/src/components/keeper-detail-runtime.ts`: render the current allowed tool count
- `test/test_tool_keeper.ml`: assert count/preview status fields stay aligned

## Testing

- `pnpm --dir dashboard typecheck`
- `env -u DUNE_RPC dune clean --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn`
- `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn test/test_tool_keeper.exe`
- `env -u DUNE_RPC dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn ./test/test_tool_keeper.exe`

## Review Evidence

- `2026-03-30 21:15 KST` direct `sb glm-text` review attempt timed out against ZAI (`curl: (28) Operation timed out after 120004 milliseconds`)
- `2026-03-30 21:17 KST` `sb glm-cascade --simple` fallback failed because no MCP session was initialized
- `2026-03-30 21:20 KST` local `llama-server` fallback on `127.0.0.1:8085` was unavailable during `scripts/review/local-review.sh`
- No external cross-model findings were obtained because reviewer infrastructure was unavailable; local verification above passed
