### PR TITLE
feat(keeper): surface allowed tool count in status detail (#3942)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -176,6 +176,8 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const skillRouteLabel =
     keeper.skill_primary
     ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
+  const allowedToolCountLabel =
+    allowedTools.length > 0 ? String(allowedTools.length) : allowlistFallback
   const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
 
   return html`
@@ -186,6 +188,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <${SignalRow} label="현재 태스크" value=${currentTaskLabel} />
       <${SignalRow} label="스킬 경로" value=${skillRouteLabel} />
       <${SignalRow} label="컨텍스트 출처" value=${keeper.context_source ?? keeper.context?.source ?? '-'} />
+      <${SignalRow} label="허용 도구 수" value=${allowedToolCountLabel} />
 
       <div class="flex justify-end mt-1">
         <button type="button"

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -160,8 +160,17 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
       @ Tool_code_write.schemas
       @ (keeper_masc_tool_schemas meta)
     in
-    all_schemas
-    |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+    let result =
+      all_schemas
+      |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+    in
+    let count = List.length result in
+    if count > 100 then
+      Log.Keeper.warn
+        "tool budget exceeded: %d schemas in LLM context (~%dKB estimated). \
+         Consider restricting tool tier."
+        count (count * 470 / 1024);
+    result
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -370,6 +370,9 @@ let handle_keeper_status ctx args : tool_result =
           keeper_model_tools |> List.map (fun tool -> tool.Types.name)
         in
         let allowed_tools = keeper_allowed_tool_names m in
+        let allowed_tool_preview =
+          allowed_tools |> List.filteri (fun idx _ -> idx < 10)
+        in
         let last_autonomous = String.trim m.runtime.last_autonomous_action_at in
         let tool_audit_snapshot =
           match latest_tool_audit_snapshot_from_files ctx.config ~keeper_name:m.name with
@@ -438,7 +441,9 @@ let handle_keeper_status ctx args : tool_result =
            ("trace_history_count", `Int trace_history_count);
            ("handoff_count_total", `Int trace_history_count);
            ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
+           ("allowed_tool_count", `Int (List.length allowed_tools));
            ("allowed_tool_names", string_list_to_json allowed_tools);
+           ("allowed_tool_preview", string_list_to_json allowed_tool_preview);
            ("latest_tool_names",
              string_list_to_json tool_audit_snapshot.latest_tool_names);
            ("latest_tool_call_count",

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1268,6 +1268,17 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         Yojson.Safe.Util.(json |> member "latest_tool_call_count" |> to_int);
       check bool "tool audit names remain empty without tool use" true
         (Yojson.Safe.Util.(json |> member "latest_tool_names" |> to_list) = []);
+      let allowed_tool_names =
+        Yojson.Safe.Util.(
+          json |> member "allowed_tool_names" |> to_list |> List.map to_string)
+      in
+      check int "allowed tool count mirrors allowed names"
+        (List.length allowed_tool_names)
+        Yojson.Safe.Util.(json |> member "allowed_tool_count" |> to_int);
+      check (list string) "allowed tool preview uses first 10 names"
+        (allowed_tool_names |> List.filteri (fun idx _ -> idx < 10))
+        Yojson.Safe.Util.(
+          json |> member "allowed_tool_preview" |> to_list |> List.map to_string);
       check bool "tool audit timestamp exposed" true
         Yojson.Safe.Util.(json |> member "tool_audit_at" <> `Null);
       let ok, list_body =


### PR DESCRIPTION
## Summary

- expose `allowed_tool_count` and `allowed_tool_preview` in `masc_keeper_status`
- show the current allowed tool count in the dashboard keeper runtime panel
- keep the existing schema-budget warning from #3968 and complete the remaining dashboard/status surfacing work

Fixes #3942.

## Why This PR Exists

PR #3968 merged at `a356612df` before follow-up commit `e352309fe` was included. This PR carries only the missing follow-up patch.

## Changes

- `lib/keeper/keeper_status_detail.ml`: include allowed tool count + preview in status payloads
- `dashboard/src/components/keeper-detail-runtime.ts`: render the current allowed tool count
- `test/test_tool_keeper.ml`: assert count/preview status fields stay aligned

## Testing

- `pnpm --dir dashboard typecheck`
- `env -u DUNE_RPC dune clean --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn`
- `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn test/test_tool_keeper.exe`
- `env -u DUNE_RPC dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3942-tool-budget-warn ./test/test_tool_keeper.exe`

## Review Evidence

- `2026-03-30 21:15 KST` direct `sb glm-text` review attempt timed out against ZAI (`curl: (28) Operation timed out after 120004 milliseconds`)
- `2026-03-30 21:17 KST` `sb glm-cascade --simple` fallback failed because no MCP session was initialized
- `2026-03-30 21:20 KST` local `llama-server` fallback on `127.0.0.1:8085` was unavailable during `scripts/review/local-review.sh`
- No external cross-model findings were obtained because reviewer infrastructure was unavailable; local verification above passed
