### PR TITLE
fix(cdal): harden worker proof path handling

### DIFF
--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -145,7 +145,6 @@ let worker_run_summary_json json =
       ("stop_reason", if U.member "stop_reason" json <> `Null then U.member "stop_reason" json else U.member "stop_reason" summary);
       ("failure_reason", U.member "failure_reason" json);
       ("error", if U.member "error" json <> `Null then U.member "error" json else U.member "error" summary);
-      ("proof_path", U.member "proof_path" json);
       ("proof_present", U.member "proof_present" json);
       ("tool_trace_refs", U.member "tool_trace_refs" json);
       ("raw_evidence_refs", U.member "raw_evidence_refs" json);

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -327,6 +327,7 @@ let is_safe_worker_run_id value =
   let len = String.length value in
   len > 0
   && len <= 128
+  && value <> "." && value <> ".."
   && String.for_all
        (function
          | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -75,6 +75,8 @@ val cascade_of_worker :
 val telemetry_of_run_result :
   Oas_worker.run_result -> Swarm.Swarm_types.agent_telemetry
 
+val is_safe_worker_run_id : string -> bool
+
 val planned_worker_to_entry :
   config:Room.config ->
   session_id:string ->

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -62,8 +62,6 @@ let worker_proof_refs config session_id =
                      match string_member_opt "result_status" proof_json with
                      | Some value -> `String value
                      | None -> `Null );
-                   ("proof_path", `String proof_path);
-                   ("meta_path", `String meta_path);
                    ( "manifest_ref",
                      `String
                        (Agent_sdk.Proof_store.make_ref ~run_id
@@ -85,11 +83,18 @@ let worker_proof_refs config session_id =
                      | Some value -> `String value
                      | None -> `Null );
                  ])
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              Log.Session.warn
                "team_session_report_proof: skipping malformed worker proof json for %s/%s: %s"
                session_id worker_run_id (Printexc.to_string exn);
              None)
+  |> List.sort (fun a b ->
+         let id_of json =
+           Yojson.Safe.Util.(member "worker_run_id" json |> to_string)
+         in
+         String.compare (id_of a) (id_of b))
 
 let proof_markdown ~(session : Team_session_types.session)
     ~(proof_level : Team_session_types.proof_level)

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -371,7 +371,13 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
       check int "worker proof evidence count" 2
         (worker |> U.member "proof_evidence_count" |> U.to_int);
       check string "worker final text" "Patched calc.py and verification passed."
-        (worker |> U.member "final_text" |> U.to_string))
+        (worker |> U.member "final_text" |> U.to_string);
+      check bool "worker proof path hidden" true
+        (worker |> U.member "proof_path" = `Null);
+      check bool "worker proof evidence path hidden" true
+        ((worker_proof |> U.member "proof_path") = `Null);
+      check bool "worker proof evidence meta path hidden" true
+        ((worker_proof |> U.member "meta_path") = `Null))
 
 let test_team_session_proof_projects_worker_proof_metadata () =
   let dir = test_dir () in

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -295,6 +295,16 @@ let test_telemetry_of_run_result_carries_trace_ref () =
         actual.agent_name
   | None -> Alcotest.fail "expected trace_ref in telemetry"
 
+let test_is_safe_worker_run_id_rejects_dot_segments () =
+  Alcotest.(check bool) "plain run id accepted" true
+    (Team_session_oas_bridge.is_safe_worker_run_id "run-123");
+  Alcotest.(check bool) "dot rejected" false
+    (Team_session_oas_bridge.is_safe_worker_run_id ".");
+  Alcotest.(check bool) "dot-dot rejected" false
+    (Team_session_oas_bridge.is_safe_worker_run_id "..");
+  Alcotest.(check bool) "slash rejected" false
+    (Team_session_oas_bridge.is_safe_worker_run_id "run/123")
+
 (* ================================================================ *)
 (* Supported tool runtime tests                                     *)
 (* ================================================================ *)
@@ -442,6 +452,8 @@ let () =
         test_session_to_swarm_config_health_contract;
       Alcotest.test_case "telemetry carries trace_ref" `Quick
         test_telemetry_of_run_result_carries_trace_ref;
+      Alcotest.test_case "worker run id rejects dot segments" `Quick
+        test_is_safe_worker_run_id_rejects_dot_segments;
     ];
     "supported_tools", [
       Alcotest.test_case "schemas present" `Quick

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -537,6 +537,10 @@ let test_proof_aggregates_worker_proof_refs () =
     Yojson.Safe.Util.(worker_proof |> member "cdal_run_id" |> to_string);
   Alcotest.(check string) "worker proof contract id" "contract-proof-aggregate"
     Yojson.Safe.Util.(worker_proof |> member "contract_id" |> to_string);
+  Alcotest.(check bool) "worker proof hides proof path" true
+    (Yojson.Safe.Util.(worker_proof |> member "proof_path") = `Null);
+  Alcotest.(check bool) "worker proof hides meta path" true
+    (Yojson.Safe.Util.(worker_proof |> member "meta_path") = `Null);
   Alcotest.(check string) "worker proof manifest ref"
     "proof-store://wr-proof-aggregate/manifest.json"
     Yojson.Safe.Util.(worker_proof |> member "manifest_ref" |> to_string);


### PR DESCRIPTION
Follow-up salvage from stale codex/cdal-contract-bridge after #3927.

What changed
- reject worker run IDs "." and ".." in team-session proof persistence
- stop exposing proof_path and meta_path through proof and dashboard JSON projections
- re-raise Eio.Cancel.Cancelled while loading worker proof refs instead of swallowing it
- add focused regression assertions in bridge, dashboard, and proof tests

Verification
- git diff --check
- shared-build smoke: ./_build/default/test/test_team_session_oas_bridge.exe
- shared-build smoke: ./_build/default/test/test_dashboard_proof.exe

Notes
- worktree-scoped dune verification was attempted with a separate build dir, but this repo dune/test target resolution is inconsistent across shared checkout vs worktree roots, so final exhaustive validation is deferred to CI.