### PR TITLE
fix: replace hardcoded bigmodel.cn fallback URLs with api.z.ai

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -475,7 +475,7 @@ let oas_provider_of_label (label : string) : Oas.Provider.config =
       (Llm_provider.Provider_config.make
          ~kind:Llm_provider.Provider_config.Glm
          ~model_id:label
-         ~base_url:"https://open.bigmodel.cn/api/paas/v4"
+         ~base_url:"https://api.z.ai/api/coding/paas/v4"
          ~request_path:"/chat/completions" ())
 
 (** Resolve provider from a model label string.

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -544,7 +544,7 @@ let run_named
       Llm_provider.Provider_config.make
         ~kind:Llm_provider.Provider_config.Glm
         ~model_id:"auto"
-        ~base_url:"https://open.bigmodel.cn/api/paas/v4"
+        ~base_url:"https://api.z.ai/api/coding/paas/v4"
         ~request_path:"/chat/completions"
         ()
   in


### PR DESCRIPTION
## Summary
`oas_worker.ml`과 `worker_container.ml`의 GLM fallback URL을 `open.bigmodel.cn` -> `api.z.ai`로 정리.
OAS#501에서 provider_registry 기본값을 변경했지만, MASC 자체의 하드코딩된 fallback 2곳이 남아있었음.

## Changed Files
| 파일 | 변경 |
|------|------|
| `lib/oas_worker.ml:547` | bigmodel.cn -> api.z.ai |
| `lib/local/worker_container.ml:478` | bigmodel.cn -> api.z.ai |