### PR TITLE
fix(governance): return Result from write functions to prevent partial commits

### DIFF
--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -210,21 +210,32 @@ let load_execution_order base_path case_id =
   | None -> None
   | Some json -> Result.to_option (execution_order_of_yojson json)
 
+(** Wrap write_json so filesystem errors become Result instead of raising.
+    Eio cancellation is re-raised (not a write failure). *)
+let try_write path json =
+  try
+    write_json path json;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Error (Printf.sprintf "write failed: %s: %s" path (Printexc.to_string exn))
+
 let write_petition base_path (petition : petition) =
   ensure_dirs base_path;
-  write_json (petition_path base_path petition.id) (petition_to_yojson petition)
+  try_write (petition_path base_path petition.id) (petition_to_yojson petition)
 
 let write_case base_path (case_ : case_record) =
   ensure_dirs base_path;
-  write_json (case_path base_path case_.id) (case_to_yojson case_)
+  try_write (case_path base_path case_.id) (case_to_yojson case_)
 
 let write_ruling base_path (ruling : ruling) =
   ensure_dirs base_path;
-  write_json (ruling_path base_path ruling.case_id) (ruling_to_yojson ruling)
+  try_write (ruling_path base_path ruling.case_id) (ruling_to_yojson ruling)
 
 let write_execution_order base_path (order : execution_order) =
   ensure_dirs base_path;
-  write_json
+  try_write
     (execution_order_path base_path order.case_id)
     (execution_order_to_yojson order)
 
@@ -485,8 +496,8 @@ let submit_petition base_path ~title ~origin ~subject_type ~risk_class
         origin = if merged then case_.origin else origin;
       }
     in
-    write_petition base_path petition;
-    write_case base_path updated_case;
+    let* () = write_petition base_path petition in
+    let* () = write_case base_path updated_case in
     Ok { petition; case_ = updated_case; merged }
   )
 
@@ -509,7 +520,7 @@ let submit_brief base_path ~case_id ~author ~stance ~summary ~evidence_refs =
       updated_at = now_unix ();
     }
   in
-  write_case base_path updated_case;
+  let* () = write_case base_path updated_case in
   Ok updated_case
 
 let save_ruling base_path (ruling : ruling) =
@@ -523,26 +534,29 @@ let save_ruling base_path (ruling : ruling) =
     | _ -> Pending_ruling
   in
   let updated_case = { case_ with status = next_status; updated_at = now_unix () } in
-  write_case base_path updated_case;
-  write_ruling base_path ruling;
-  (if next_status = Ready_auto_execute then
-     match load_execution_order base_path ruling.case_id with
-     | Some _ -> ()
-     | None ->
-         let now = now_unix () in
-         let order : execution_order = {
-           id = generate_id "order";
-           case_id = ruling.case_id;
-           status = Queued_auto;
-           risk_class = ruling.risk_class;
-           action_request = ruling.recommended_action;
-           created_at = now;
-           updated_at = now;
-           execution_ref = None;
-           result_summary = None;
-           actor = Some ruling.keeper_name;
-         } in
-         write_execution_order base_path order);
+  let* () = write_case base_path updated_case in
+  let* () = write_ruling base_path ruling in
+  let* () =
+    if next_status = Ready_auto_execute then
+      match load_execution_order base_path ruling.case_id with
+      | Some _ -> Ok ()
+      | None ->
+          let now = now_unix () in
+          let order : execution_order = {
+            id = generate_id "order";
+            case_id = ruling.case_id;
+            status = Queued_auto;
+            risk_class = ruling.risk_class;
+            action_request = ruling.recommended_action;
+            created_at = now;
+            updated_at = now;
+            execution_ref = None;
+            result_summary = None;
+            actor = Some ruling.keeper_name;
+          } in
+          write_execution_order base_path order
+    else Ok ()
+  in
   Ok updated_case
 
 let save_execution_order base_path (order : execution_order) =
@@ -555,8 +569,8 @@ let save_execution_order base_path (order : execution_order) =
     | Denied | Blocked_order -> Blocked
   in
   let updated_case = { case_ with status = next_status; updated_at = now_unix () } in
-  write_case base_path updated_case;
-  write_execution_order base_path order;
+  let* () = write_case base_path updated_case in
+  let* () = write_execution_order base_path order in
   Ok updated_case
 
 let update_execution_order base_path (order : execution_order) =
@@ -565,7 +579,7 @@ let update_execution_order base_path (order : execution_order) =
 let set_case_status base_path ~case_id ~status =
   let* case_ = get_case base_path case_id in
   let updated_case = { case_ with status; updated_at = now_unix () } in
-  write_case base_path updated_case;
+  let* () = write_case base_path updated_case in
   Ok updated_case
 
 let latest_generated_at base_path =


### PR DESCRIPTION
## Summary

Convert governance_v2 write functions from `unit` (raises on failure) to `(unit, string) result`. Callers chain with `let*` to abort early on write failure, preventing orphaned petition/case states.

- Add `try_write` wrapper that catches filesystem exceptions (re-raises Eio cancellation)
- `write_petition`, `write_case`, `write_ruling`, `write_execution_order` now return Result
- `submit_petition`, `submit_brief`, `save_ruling`, `save_execution_order`, `set_case_status` all chain writes with `let*`

Follows the `consensus.ml` `persist_session` pattern (line 279-298).

Closes #3969

## Changes

1 file, +44/-30 lines. `lib/council/governance_v2.ml` only.

## Testing

CI build verification. Write-failure tests (chmod trick) recommended as follow-up.