### PR TITLE
fix(research): restore atomic result log writes

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -314,21 +314,30 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
 (** Log a result to the TSV file. *)
 let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
   let header = "experiment\tbuild_ok\ttest_pass_rate\tloc_delta\tfiles_changed\tstatus\tdescription\n" in
-  let needs_header = not (Sys.file_exists results_file) ||
-    (try (Unix.stat results_file).Unix.st_size = 0 with _ -> true) in
-  let line = Printf.sprintf "%s\t%d\t%.4f\t%d\t%d\t%s\t%s\n"
-    entry.id
-    (if entry.metric.build_ok then 1 else 0)
-    entry.metric.test_pass_rate
-    entry.metric.loc_delta
-    entry.metric.files_changed
-    (Research_metric.status_to_string entry.metric.status)
-    entry.hypothesis.description in
-  try
-    if needs_header then Fs_compat.append_file results_file header;
-    Fs_compat.append_file results_file line
-  with exn ->
-    log_best_effort_failure "log_result" exn
+  let oc = open_out_gen [ Open_append; Open_creat ] 0o644 results_file in
+  (* Check file size after open to avoid TOCTOU race on needs_header *)
+  let needs_header =
+    try
+      let pos = LargeFile.pos_out oc in
+      pos = Int64.zero
+    with exn ->
+      log_best_effort_failure "results header check" exn;
+      false
+  in
+  (try
+     if needs_header then output_string oc header;
+     Printf.fprintf oc "%s\t%d\t%.4f\t%d\t%d\t%s\t%s\n"
+       entry.id
+       (if entry.metric.build_ok then 1 else 0)
+       entry.metric.test_pass_rate
+       entry.metric.loc_delta
+       entry.metric.files_changed
+       (Research_metric.status_to_string entry.metric.status)
+       entry.hypothesis.description;
+     close_out oc
+   with exn ->
+     close_out_noerr oc;
+     raise exn)
 
 (** Run a single experiment iteration. *)
 let run_experiment ~sw ~net ~clock ~(config : Research_config.t)


### PR DESCRIPTION
## Summary
- restore single-descriptor append semantics for `research_loop.log_result`
- avoid header/data split writes introduced in `#3952`
- keep the fix scoped to the research TSV results path only

## Product impact
- prevents duplicated/interleaved TSV headers under concurrent writers
- prevents header-only partial writes if execution stops between separate appends

## Evidence
- local: `git diff --check`
- local: `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/research-log-atomic-append _build/default/lib/research/research_loop.ml`
- ci: pending after PR open

## Review evidence
- pending: direct GLM-5 review comment after PR creation

## Linked issue
- closes #3976
