### PR TITLE
fix(research): restore single-call append for TSV result logging

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -324,9 +324,8 @@ let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
     entry.metric.files_changed
     (Research_metric.status_to_string entry.metric.status)
     entry.hypothesis.description in
-  try
-    if needs_header then Fs_compat.append_file results_file header;
-    Fs_compat.append_file results_file line
+  let content = if needs_header then header ^ line else line in
+  try Fs_compat.append_file results_file content
   with exn ->
     log_best_effort_failure "log_result" exn
 


### PR DESCRIPTION
## Summary

Combine header + row into one `Fs_compat.append_file` call to prevent:
- Header duplication from concurrent writers
- Partial writes (header-only) on crash/cancel between two calls

Regression from #3952 which split the single write into two `append_file` calls.

Closes #3976

## Changes

1 file, +2/-3 lines. `lib/research/research_loop.ml` only.