### PR TITLE
refactor(http): connect http_server_eio defaults to env config

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -14,9 +14,9 @@ type config = {
 }
 
 let default_config = {
-  port = 8935;
-  host = "127.0.0.1";
-  max_connections = 128;
+  port = Env_config_core.masc_http_port_int ();
+  host = Env_config_core.get_string ~default:"127.0.0.1" "MASC_HTTP_HOST";
+  max_connections = Env_config_core.get_int ~default:128 "MASC_HTTP_MAX_CONNECTIONS";
 }
 
 (** HTTP request handler type *)


### PR DESCRIPTION
## Summary

- `http_server_eio.ml`의 하드코딩된 port/host/max_connections를 env config 참조로 교체
- 새 env vars: `MASC_HTTP_HOST` (default "127.0.0.1"), `MASC_HTTP_MAX_CONNECTIONS` (default 128)
- 기존 `MASC_HTTP_PORT`는 이미 지원됨 — `default_config`에서 직접 참조하도록 연결

## Test plan
- [x] `dune build --root .` 성공
- [x] http_server_eio 34 tests 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)