### PR TITLE
fix(release): remove committed roadmap conflict markers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,7 @@
 # masc-mcp Roadmap
 
-<<<<<<< HEAD
 > Current package version: v2.177.0
 > Latest release: v2.177.0 (2026-03-30)
-||||||| parent of e452ff3e6 (chore(release): bump version to 2.176.0)
-> Current package version: v2.177.0
-> Latest release: v2.177.0 (2026-03-30)
-=======
-> Current package version: v2.177.0
-> Latest release: v2.177.0 (2026-03-30)
->>>>>>> e452ff3e6 (chore(release): bump version to 2.176.0)
 > Updated: 2026-03-30
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.


### PR DESCRIPTION
## Summary
- remove committed merge-conflict markers from `ROADMAP.md`
- keep roadmap release truth readable for the already-landed `v2.177.0`

## Verification
- `./scripts/check-version-truth.sh`
- `bash ./scripts/check-doc-truth.sh`