### PR TITLE
feat(board): 라벨 수정 + masc_board_delete 도구 추가

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -189,6 +189,15 @@ function authorAvatar(name: string): string {
   return avatars[Math.abs(hash) % avatars.length] ?? '🤖'
 }
 
+function kindLabel(kind: string): string {
+  switch (kind) {
+    case 'human': return '사람'
+    case 'automation': return '자동화'
+    case 'system': return '시스템'
+    default: return kind
+  }
+}
+
 function kindBadgeColor(kind: string): string {
   switch (kind) {
     case 'human': return 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)]'
@@ -200,7 +209,7 @@ function kindBadgeColor(kind: string): string {
 
 function visibilityLabel(vis: string): string | null {
   switch (vis) {
-    case 'internal': return '내부(에이전트 전용)'
+    case 'internal': return '내부'
     case 'unlisted': return '비공개'
     case 'direct': return 'DM'
     case 'public': return null
@@ -567,7 +576,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <span class="text-[11px] text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
-          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(kind)}">${kind === 'human' ? '사람' : kind}</span>
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(kind)}">${kindLabel(kind)}</span>
           ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -322,7 +322,7 @@ let permission_for_tool = function
       Some CanReadState
   | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
   | "masc_board_comment_vote" -> Some CanBroadcast
-  | "masc_board_reclassify" -> Some CanAdmin
+  | "masc_board_reclassify" | "masc_board_delete" -> Some CanAdmin
   (* Auth tools - special handling *)
   | "masc_auth_enable" | "masc_auth_disable"
   | "masc_auth_revoke" -> Some CanInit  (* Admin only *)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -108,8 +108,10 @@ let resolve_board_post_kind ~author ~(meta_json : Yojson.Safe.t option)
   | _, Some Board.Human_post
   | _, None when author <> "anonymous" ->
       Ok Board.Human_post
-  | _, Some (Board.Automation_post | Board.System_post) ->
-      Error "masc_board_post only accepts human posts on the public/dashboard surface"
+  | _, Some Board.Automation_post ->
+      Ok Board.Automation_post
+  | _, Some Board.System_post ->
+      Error "system posts are reserved for internal surfaces (keeper, operator)"
   | _ ->
       Ok Board.Human_post
 
@@ -661,6 +663,27 @@ let tool_migrate : Types.tool_schema = {
   ];
 }
 
+let handle_delete args =
+  let post_id = get_string args "post_id" "" in
+  if String.trim post_id = "" then
+    (false, "post_id is required")
+  else
+    match Board_dispatch.delete_post ~post_id with
+    | Ok () -> (true, Printf.sprintf "Deleted post %s" post_id)
+    | Error e -> (false, Printf.sprintf "Delete failed: %s" (board_error_to_string e))
+
+let tool_delete : Types.tool_schema = {
+  name = "masc_board_delete";
+  description = "Delete a board post and its associated comments and votes. Use for cleanup of stale, test, or expired posts.";
+  input_schema = `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc [
+      ("post_id", `Assoc [("type", `String "string"); ("description", `String "ID of the post to delete")]);
+    ]);
+    ("required", `List [`String "post_id"]);
+  ];
+}
+
 let tool_reclassify : Types.tool_schema = {
   name = "masc_board_reclassify";
   description = "Backfill legacy board rows that predate explicit post_kind contracts. Hidden admin tool for safe dry-run migration only.";
@@ -685,6 +708,7 @@ let tools = [
   tool_comment_vote;
   tool_profile;
   tool_hearth_list;
+  tool_delete;
   tool_migrate;
   tool_reclassify;
 ]
@@ -702,6 +726,7 @@ let handle_tool name args =
   | "masc_board_comment_vote" -> handle_comment_vote args
   | "masc_board_profile" -> handle_profile args
   | "masc_board_hearths" -> handle_hearth_list args
+  | "masc_board_delete" -> handle_delete args
   | "masc_board_migrate" -> handle_migrate args
   | "masc_board_reclassify" -> handle_reclassify args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -165,7 +165,7 @@ let public_mcp_tools =
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
     (* Board — async agent communication *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
-    "masc_board_comment"; "masc_board_vote";
+    "masc_board_comment"; "masc_board_vote"; "masc_board_delete";
     (* Agent discovery *)
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Transport *)
@@ -270,7 +270,7 @@ let standard_tools =
     "masc_board_post"; "masc_board_get"; "masc_board_list";
     "masc_board_vote"; "masc_board_comment"; "masc_board_comment_vote";
     "masc_board_search"; "masc_board_stats"; "masc_board_profile";
-    "masc_board_hearths";
+    "masc_board_hearths"; "masc_board_delete";
     (* Team Session *)
     "masc_team_session_start"; "masc_team_session_step";
     "masc_team_session_status"; "masc_team_session_stop";

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -301,7 +301,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("timestamp", `String (Types.now_iso ()));
         ] in
         Mcp_server.sse_broadcast state notification;
-        emit_activity config ~kind:"board.deleted" ~actor:"operator"
+        emit_activity config ~kind:"board.deleted" ~actor:agent_name
           ~subject:(Activity_graph.entity ~kind:"post" post_id)
           ~tags:[ "board"; "board.deleted" ]
           ~payload:(`Assoc [ ("post_id", `String post_id) ])

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -291,6 +291,24 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       end;
       Some result
 
+  | "masc_board_delete" ->
+      let (success, _message) as result = Tool_board.handle_tool name arguments in
+      if success then begin
+        let post_id = Safe_ops.json_string ~default:"unknown" "post_id" arguments in
+        let notification = `Assoc [
+          ("type", `String "masc/board_delete");
+          ("post_id", `String post_id);
+          ("timestamp", `String (Types.now_iso ()));
+        ] in
+        Mcp_server.sse_broadcast state notification;
+        emit_activity config ~kind:"board.deleted" ~actor:"operator"
+          ~subject:(Activity_graph.entity ~kind:"post" post_id)
+          ~tags:[ "board"; "board.deleted" ]
+          ~payload:(`Assoc [ ("post_id", `String post_id) ])
+          ()
+      end;
+      Some result
+
   | "masc_board_list" | "masc_board_get"
   | "masc_board_stats"
   | "masc_board_search" | "masc_board_profile"

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -30,6 +30,7 @@ let register_all () =
     "masc_board_vote"; "masc_board_stats";
     "masc_board_search"; "masc_board_comment_vote";
     "masc_board_profile"; "masc_board_hearths"; "masc_board_migrate";
+    "masc_board_delete";
     "masc_board_reclassify";
     (* conversations *)
     "masc_convo_start"; "masc_convo_reply"; "masc_convo_conclude";

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -255,6 +255,11 @@ let test_permission_for_tool_board_reclassify () =
   | Some Types.CanAdmin -> ()
   | _ -> fail "expected CanAdmin"
 
+let test_permission_for_tool_board_delete () =
+  match Auth.permission_for_tool "masc_board_delete" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
 let test_permission_for_tool_portal_open () =
   match Auth.permission_for_tool "masc_portal_open" with
   | Some Types.CanOpenPortal -> ()
@@ -666,6 +671,7 @@ let () =
       test_case "board_list" `Quick test_permission_for_tool_board_list;
       test_case "board_post" `Quick test_permission_for_tool_board_post;
       test_case "board_reclassify" `Quick test_permission_for_tool_board_reclassify;
+      test_case "board_delete" `Quick test_permission_for_tool_board_delete;
       test_case "portal_open" `Quick test_permission_for_tool_portal_open;
       test_case "portal_send" `Quick test_permission_for_tool_portal_send;
       test_case "worktree_create" `Quick test_permission_for_tool_worktree_create;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -70,6 +70,7 @@ let all_known_tool_names =
     "masc_batch_add_tasks";
     "masc_board_comment";
     "masc_board_comment_vote";
+    "masc_board_delete";
     "masc_board_get";
     "masc_board_hearths";
     "masc_board_list";
@@ -809,7 +810,7 @@ let prepare_for_name fixture name =
     ignore (ensure_task fixture);
   if List.mem name [ "masc_plan_get"; "masc_plan_update"; "masc_plan_get_task"; "masc_plan_clear_task" ] then
     ensure_plan_initialized fixture;
-  if List.mem name [ "masc_board_get"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote" ] then
+  if List.mem name [ "masc_board_get"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote"; "masc_board_delete" ] then
     ignore (ensure_board_post fixture);
   if List.mem name [ "masc_verify_submit"; "masc_verify_status"; "masc_verify_auto"; "masc_verify_pending" ] then
     ignore (ensure_verification_request fixture);

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -212,11 +212,11 @@ let test_post_create_structured_payload () =
   Alcotest.(check bool) "state_block absent after strip" true
     (Yojson.Safe.Util.(json |> member "meta" |> member "state_block") = `Null)
 
-let test_post_create_rejects_non_human_kind () =
+let test_post_create_accepts_automation_rejects_system () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let ok, body = dispatch "masc_board_post"
+  let ok_auto, _body_auto = dispatch "masc_board_post"
     (make_args
        [
          ("content", `String "automation attempt");
@@ -224,9 +224,18 @@ let test_post_create_rejects_non_human_kind () =
          ("post_kind", `String "automation");
        ])
   in
-  Alcotest.(check bool) "public automation rejected" false ok;
-  Alcotest.(check bool) "error mentions human-only surface" true
-    (contains_substring body "human posts")
+  Alcotest.(check bool) "automation accepted" true ok_auto;
+  let ok_sys, body_sys = dispatch "masc_board_post"
+    (make_args
+       [
+         ("content", `String "system attempt");
+         ("author", `String "tester");
+         ("post_kind", `String "system");
+       ])
+  in
+  Alcotest.(check bool) "system rejected" false ok_sys;
+  Alcotest.(check bool) "error mentions reserved" true
+    (contains_substring body_sys "reserved")
 
 let test_post_create_empty_content () =
   Eio_main.run @@ fun env ->
@@ -540,7 +549,7 @@ let test_tools_count () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "12 tool schemas" 12 (List.length Tool_board.tools)
+  Alcotest.(check int) "13 tool schemas" 13 (List.length Tool_board.tools)
 
 let test_tools_names_unique () =
   Eio_main.run @@ fun env ->
@@ -584,8 +593,8 @@ let () =
           Alcotest.test_case "create success" `Quick test_post_create_success;
           Alcotest.test_case "create structured payload" `Quick
             test_post_create_structured_payload;
-          Alcotest.test_case "reject non-human kind" `Quick
-            test_post_create_rejects_non_human_kind;
+          Alcotest.test_case "accept automation reject system" `Quick
+            test_post_create_accepts_automation_rejects_system;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;
           Alcotest.test_case "create empty title rejected" `Quick
             test_post_create_empty_title_rejected;

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -196,6 +196,16 @@ let test_no_duplicate_schemas () =
            (List.length dups)
            (String.concat "\n  " dups))
 
+let test_board_delete_tag_registered () =
+  ignore (Masc_mcp.Mcp_server_eio.create_state ~test_mode:true ~base_path:"/tmp/masc-pr3991-tag-reg" ());
+  ignore (Masc_mcp.Tool_dispatch.tag_registry_count ());
+  match Masc_mcp.Tool_dispatch.lookup_tag "masc_board_delete" with
+  | Some Masc_mcp.Tool_dispatch.Mod_inline -> ()
+  | Some _ ->
+      Alcotest.fail "masc_board_delete should route through Mod_inline"
+  | None ->
+      Alcotest.fail "masc_board_delete missing from tag registry"
+
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -215,5 +225,7 @@ let () =
             test_docs_do_not_reintroduce_removed_mode_surface;
           Alcotest.test_case "no duplicate tool schemas" `Quick
             test_no_duplicate_schemas;
+          Alcotest.test_case "board delete tag registered" `Quick
+            test_board_delete_tag_registered;
         ] );
     ]


### PR DESCRIPTION
## Summary
- 게시판 visibility 라벨 "내부(에이전트 전용)" → "내부" 수정 (internal = 인스턴스 범위, 에이전트 전용 아님)
- post_kind 배지 한국어화: automation → 자동화, system → 시스템
- `masc_board_post`에서 `Automation_post` 명시 요청 허용 (System_post만 차단)
- `masc_board_delete` MCP tool 추가 (SSE broadcast + activity emit 포함)
- public_mcp_tools, standard_tools에 등록

## Test plan
- [x] `dune build` 성공
- [x] `dune runtest` 성공
- [x] `tsc --noEmit` 성공
- [x] `memory.test.ts` 5건 전부 통과
- [ ] 수동: 대시보드에서 라벨 "내부", "자동화", "시스템" 표시 확인
- [ ] 수동: MCP로 `masc_board_delete` 호출하여 글 삭제 확인
- [ ] 수동: `masc_board_post`에 `post_kind: automation` 지정 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)