### PR TITLE
feat(cdal): wire contract into local/delegate worker execution

### DIFF
--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -18,6 +18,7 @@ let run_worker_oas ~sw ?net ~base_path ~worker_name
     ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id
+    ?contract
     ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
@@ -171,9 +172,9 @@ let run_worker_oas ~sw ?net ~base_path ~worker_name
         let* net = resolve_net ?net () in
         Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~meta ~provider
           ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
-          ?worker_run_id ()
+          ?contract ?worker_run_id ()
 
-let continue_worker ?worker_run_id ~sw ?net ~base_path ~room_config ~worker_name
+let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~worker_name
     ~(team_session_id : string) ~(prompt : string) :
     unit -> (run_result, string) result =
   fun () ->
@@ -304,11 +305,11 @@ let continue_worker ?worker_run_id ~sw ?net ~base_path ~room_config ~worker_name
               in
               let* net = resolve_net ?net () in
               Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~meta ~checkpoint
-                ~prompt ~tools ~raw_trace ?worker_run_id ()))
+                ~prompt ~tools ~raw_trace ?contract ?worker_run_id ()))
 
 let run_worker ~sw ?net ~base_path ~worker_name ~model_label ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ~role
+    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
@@ -320,5 +321,5 @@ let run_worker ~sw ?net ~base_path ~worker_name ~model_label ~team_session_id
   run_worker_oas ~sw ?net ~base_path ~worker_name ~provider ~model_id
     ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ~role
+    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
     ~selection_note ~prompt ~allowed_tools ~timeout_sec

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -83,13 +83,23 @@ let execute_delegate_pipeline
                         | _ -> None)
                       session.planned_workers)
               in
+              let contract =
+                let delivery_contract =
+                  Tool_team_session_step_exec.delivery_contract_for_session
+                    ctx.config session_id
+                in
+                Option.map
+                  (fun dc -> Contract_composer.compose ~delivery_contract:dc
+                    ~tool_names:[])
+                  delivery_contract
+              in
               let run_delegate () =
                 match
                   Worker_runtime.continue_worker ~sw:ctx.sw
                     ~base_path:ctx.config.base_path
                     ~room_config:(Some ctx.config)
                     ~worker_name ~team_session_id:session_id
-                    ~worker_run_id
+                    ~worker_run_id ?contract
                     ~prompt:delegate_prompt ()
                 with
                 | Ok run_result ->
@@ -149,7 +159,7 @@ let execute_delegate_pipeline
                       ?trace_ref:run_result.raw_trace_run
                       ?trace_summary:trace_summary_json
                       ?trace_validation:trace_validation_json
-                      ?proof:None
+                      ?proof:run_result.proof
                       ~trace_capability:
                         (if Option.is_some run_result.raw_trace_run
                          then "raw"

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -301,6 +301,7 @@ let rec run_worker_via_oas
     ~(tools : Oas.Tool.t list)
     ~(raw_trace : Oas.Raw_trace.t)
     ?(gate_config : Eval_gate.gate_config option)
+    ?contract
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
   let session_id = meta.mcp_session_id in
@@ -340,7 +341,7 @@ let rec run_worker_via_oas
         else base_path
       in
       run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ~tool_names_ref agent)
+        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
 
 and resume_worker_via_oas
     ~(sw : Eio.Switch.t)
@@ -351,6 +352,7 @@ and resume_worker_via_oas
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(raw_trace : Oas.Raw_trace.t)
+    ?contract
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
   let worker_name = meta.worker_name in
@@ -407,7 +409,7 @@ and resume_worker_via_oas
         else base_path
       in
       run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ~tool_names_ref agent)
+        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
 
 and run_existing_worker_agent
     ~(sw : Eio.Switch.t)
@@ -417,6 +419,7 @@ and run_existing_worker_agent
     ~(workspace_path : string)
     ~(raw_trace : Oas.Raw_trace.t)
     ?worker_run_id
+    ?contract
     ~(tool_names_ref : string list ref)
     (agent : Oas.Agent.t)
   : (Worker_container_types.run_result, string) result =
@@ -432,7 +435,13 @@ and run_existing_worker_agent
           Log.LocalWorker.warn "agent close failed for %s: %s" worker_name
             (Printexc.to_string exn))
     (fun () ->
-      let result = Oas.Agent.run ~sw agent prompt in
+      let result, proof = match contract with
+        | Some c ->
+          let cr = Oas.Contract_runner.run ~sw ~contract:c agent prompt in
+          (cr.response, Some cr.proof)
+        | None ->
+          (Oas.Agent.run ~sw agent prompt, None)
+      in
       let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
       let checkpoint = Oas.Agent.checkpoint ~session_id agent in
       let tool_names =
@@ -479,7 +488,7 @@ and run_existing_worker_agent
               session_id;
               raw_trace_run;
               api_response = Some response;
-              proof = None;
+              proof;
             }
       | Error err ->
           let detail = Oas.Error.to_string err in


### PR DESCRIPTION
## Summary
- Wire `?contract` through `worker_oas.ml` so local/delegate workers use `Contract_runner.run` when a delivery_contract is present
- Forward `?contract` through `worker_container_runners.ml` (run_worker_oas, continue_worker, run_worker)
- Construct contract from `delivery_contract_for_session` in delegate pipeline (`tool_team_session_step.ml`)
- Delegate snapshot now passes actual `run_result.proof` instead of hardcoded `None`

## Context
PR #3963 wired CDAL contract into the spawn path. This PR completes the remaining gaps:

| Path | Before | After |
|------|--------|-------|
| spawn | contract + proof (PR #3963) | no change |
| delegate | proof = None | contract → Contract_runner → proof |
| local worker | proof = None | contract → Contract_runner → proof |

## Test plan
- [x] `opam exec -- dune build --root .` passes
- [x] `test_dashboard_proof.exe` — 8/8 pass
- [x] `test_persist_worker_run_snapshot.exe` — 3/3 pass
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)