### PR TITLE
chore: read placeholder_tools_enabled from env var

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -44,7 +44,10 @@ let default_metadata =
     idempotent = None;
   }
 
-let placeholder_tools_enabled () = true
+let placeholder_tools_enabled () =
+  match Sys.getenv_opt "MASC_PLACEHOLDER_TOOLS_ENABLED" with
+  | Some "false" | Some "0" -> false
+  | _ -> true
 
 let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = false)
     ?(implementation_status = Adapter) reason =


### PR DESCRIPTION
## Summary

Read `MASC_PLACEHOLDER_TOOLS_ENABLED` env var instead of hardcoded `true`. Default true for backward compat. Set to `false` or `0` to disable placeholder tools at runtime.

Closes #3989

## Changes

1 file, +4/-1 lines. `lib/tool_catalog.ml` only.