### PR TITLE
[codex] group activity timeline by action

### DIFF
--- a/dashboard/src/components/activity-graph-groups.test.ts
+++ b/dashboard/src/components/activity-graph-groups.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildActionTimelineGroups,
+  buildCategoryCounts,
+  buildRawCategoryCounts,
+  categoryForActivityKind,
+} from './activity-graph-groups'
+import type { ActivityGraphTimelineEvent } from '../types'
+
+function makeEvent(
+  seq: number,
+  kind: string,
+  options: {
+    ts?: string
+    actor?: string
+    subjectId?: string | null
+    payload?: Record<string, unknown>
+  } = {},
+): ActivityGraphTimelineEvent {
+  const tsIso = options.ts ?? '2026-03-30T10:00:00Z'
+  return {
+    seq,
+    ts: Date.parse(tsIso),
+    ts_iso: tsIso,
+    kind,
+    actor: options.actor ? { id: options.actor } : {},
+    summary: kind,
+    subject: options.subjectId ? { id: options.subjectId, type: 'entity' } : null,
+    room_id: 'default',
+    tags: [],
+    payload: options.payload ?? {},
+  }
+}
+
+describe('categoryForActivityKind', () => {
+  it('maps known kinds into the action categories', () => {
+    expect(categoryForActivityKind('task.started')).toBe('task')
+    expect(categoryForActivityKind('team.turn')).toBe('session')
+    expect(categoryForActivityKind('message.broadcast')).toBe('message')
+    expect(categoryForActivityKind('board.posted')).toBe('board')
+    expect(categoryForActivityKind('policy.approved')).toBe('governance')
+    expect(categoryForActivityKind('agent.joined')).toBe('lifecycle')
+  })
+
+  it('falls back to other for unknown kinds', () => {
+    expect(categoryForActivityKind('mystery.kind')).toBe('other')
+  })
+})
+
+describe('buildActionTimelineGroups', () => {
+  it('merges task events for the same task within 15 minutes', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'task.created', { subjectId: 'task-1', actor: 'system', payload: { title: 'Fix drift' } }),
+      makeEvent(2, 'task.claimed', { ts: '2026-03-30T10:05:00Z', subjectId: 'task-1', actor: 'claude' }),
+      makeEvent(3, 'task.started', { ts: '2026-03-30T10:10:00Z', subjectId: 'task-1', actor: 'claude' }),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.category).toBe('task')
+    expect(groups[0]!.rawCount).toBe(3)
+    expect(groups[0]!.subjectId).toBe('task-1')
+  })
+
+  it('keeps session groups separate when the operation changes', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'operation.started', { subjectId: 'sess-1', actor: 'team-session' }),
+      makeEvent(2, 'team.turn', { ts: '2026-03-30T10:01:00Z', subjectId: 'sess-1', actor: 'claude' }),
+      makeEvent(3, 'operation.started', { ts: '2026-03-30T10:02:00Z', subjectId: 'sess-2', actor: 'team-session' }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.map(group => group.subjectId)).toEqual(['sess-2', 'sess-1'])
+  })
+
+  it('chains same-actor message events within 60 seconds', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'message.broadcast', { actor: 'claude', payload: { content: 'part 1' } }),
+      makeEvent(2, 'message.mentioned', { ts: '2026-03-30T10:00:30Z', actor: 'claude', subjectId: 'gemini', payload: { content: 'part 2' } }),
+      makeEvent(3, 'message.broadcast', { ts: '2026-03-30T10:01:20Z', actor: 'claude', payload: { content: 'break' } }),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.rawCount).toBe(3)
+  })
+
+  it('groups board events by post within 120 seconds', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'board.posted', { actor: 'claude', subjectId: 'post-1', payload: { content: 'hello' } }),
+      makeEvent(2, 'board.commented', { ts: '2026-03-30T10:01:30Z', actor: 'gemini', subjectId: 'post-1', payload: { content: 'reply' } }),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.category).toBe('board')
+    expect(groups[0]!.rawCount).toBe(2)
+  })
+
+  it('keeps lifecycle events as singletons', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'agent.joined', { actor: 'claude', subjectId: 'claude' }),
+      makeEvent(2, 'agent.left', { ts: '2026-03-30T10:00:10Z', actor: 'claude', subjectId: 'claude' }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.every(group => group.category === 'lifecycle')).toBe(true)
+  })
+})
+
+describe('activity graph category counters', () => {
+  it('builds grouped counts and raw counts without dropping lifecycle noise', () => {
+    const groups = buildActionTimelineGroups([
+      makeEvent(1, 'task.started', { actor: 'claude', subjectId: 'task-7' }),
+      makeEvent(2, 'agent.joined', { ts: '2026-03-30T10:00:05Z', actor: 'claude', subjectId: 'claude' }),
+      makeEvent(3, 'message.broadcast', { ts: '2026-03-30T10:00:10Z', actor: 'claude', payload: { content: 'hello' } }),
+    ])
+    const groupedCounts = buildCategoryCounts(groups)
+    const rawCounts = buildRawCategoryCounts({
+      'task.started': 2,
+      'agent.joined': 1,
+      'message.broadcast': 3,
+      'unknown.kind': 4,
+    })
+
+    expect(groupedCounts.task).toBe(1)
+    expect(groupedCounts.lifecycle).toBe(1)
+    expect(groupedCounts.message).toBe(1)
+    expect(rawCounts.task).toBe(2)
+    expect(rawCounts.lifecycle).toBe(1)
+    expect(rawCounts.message).toBe(3)
+    expect(rawCounts.other).toBe(4)
+  })
+})

--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -1,0 +1,328 @@
+import type {
+  ActivityCategory,
+  ActivityGraphKindCounts,
+  ActivityGraphTimelineEvent,
+  ActionTimelineGroup,
+} from '../types'
+
+export type ActionTimelineFilter = 'all' | Exclude<ActivityCategory, 'lifecycle' | 'other'> | 'other'
+
+const TASK_GAP_MS = 15 * 60 * 1000
+const SESSION_GAP_MS = 5 * 60 * 1000
+const MESSAGE_GAP_MS = 60 * 1000
+const BOARD_GAP_MS = 120 * 1000
+const GOVERNANCE_GAP_MS = 10 * 60 * 1000
+
+type MutableGroup = {
+  category: ActivityCategory
+  rawEvents: ActivityGraphTimelineEvent[]
+  latestTsMs: number
+}
+
+export function categoryForActivityKind(kind: string): ActivityCategory {
+  if (kind.startsWith('task.')) return 'task'
+  if (
+    kind.startsWith('operation.')
+    || kind.startsWith('team.turn')
+    || kind.startsWith('keeper.autonomy_')
+  ) return 'session'
+  if (kind.startsWith('message.')) return 'message'
+  if (kind.startsWith('board.')) return 'board'
+  if (kind.startsWith('decision.') || kind.startsWith('policy.')) return 'governance'
+  if (
+    kind === 'agent.joined'
+    || kind === 'agent.left'
+    || kind === 'agent.spawned'
+    || kind === 'agent.retired'
+    || kind === 'agent.compacted'
+    || kind === 'agent.handoff'
+    || kind === 'keeper.guardrail'
+    || kind === 'keeper.compaction'
+  ) return 'lifecycle'
+  return 'other'
+}
+
+export function categoryLabel(category: ActivityCategory): string {
+  switch (category) {
+    case 'task': return 'Task'
+    case 'session': return 'Session'
+    case 'message': return 'Message'
+    case 'board': return 'Board'
+    case 'governance': return 'Governance'
+    case 'lifecycle': return 'Lifecycle'
+    default: return 'Other'
+  }
+}
+
+export function eventKindLabel(kind: string): string {
+  switch (kind) {
+    case 'agent.joined': return '입장'
+    case 'agent.left': return '퇴장'
+    case 'agent.spawned': return '스폰'
+    case 'agent.retired': return '은퇴'
+    case 'agent.compacted': return '컴팩트'
+    case 'agent.handoff': return '핸드오프'
+    case 'message.broadcast': return '브로드캐스트'
+    case 'message.mentioned': return '멘션'
+    case 'task.created': return '생성'
+    case 'task.claimed': return '점유'
+    case 'task.started': return '시작'
+    case 'task.done': return '완료'
+    case 'task.released': return '반환'
+    case 'task.cancelled': return '취소'
+    case 'board.posted': return '게시'
+    case 'board.commented': return '댓글'
+    case 'board.voted': return '투표'
+    case 'operation.started': return '세션 시작'
+    case 'operation.resumed': return '세션 재개'
+    case 'operation.paused': return '세션 일시중지'
+    case 'operation.stopped': return '세션 중단'
+    case 'operation.finalized': return '세션 종료'
+    case 'team.turn': return '팀 턴'
+    case 'team.turn_failed': return '팀 턴 실패'
+    case 'decision.opened': return '결정 시작'
+    case 'decision.voted': return '결정 투표'
+    case 'decision.resolved': return '결정 완료'
+    case 'policy.approved': return '정책 승인'
+    case 'policy.denied': return '정책 거절'
+    case 'keeper.autonomy_started': return '자율 시작'
+    case 'keeper.autonomy_completed': return '자율 완료'
+    case 'keeper.compaction': return '컴팩션'
+    case 'keeper.guardrail': return '가드레일'
+    default: return kind
+  }
+}
+
+function eventActor(event: ActivityGraphTimelineEvent): string {
+  const actor = event.actor as Record<string, unknown>
+  if (typeof actor?.id === 'string' && actor.id.trim() !== '') return actor.id
+  const payload = event.payload as Record<string, unknown>
+  for (const key of ['agent', 'author', 'from', 'created_by', 'actor']) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim() !== '') return value
+  }
+  return ''
+}
+
+function eventSubjectId(event: ActivityGraphTimelineEvent): string | null {
+  if (event.subject?.id && typeof event.subject.id === 'string' && event.subject.id.trim() !== '') {
+    return event.subject.id
+  }
+  const payload = event.payload as Record<string, unknown>
+  for (const key of ['task_id', 'session_id', 'operation_id', 'post_id', 'target_id']) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim() !== '') return value
+  }
+  return null
+}
+
+function eventTsMs(event: ActivityGraphTimelineEvent): number {
+  const parsed = Date.parse(event.ts_iso)
+  return Number.isNaN(parsed) ? event.ts : parsed
+}
+
+function payloadString(event: ActivityGraphTimelineEvent, keys: string[]): string {
+  const payload = event.payload as Record<string, unknown>
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  }
+  return ''
+}
+
+export function eventDetail(event: ActivityGraphTimelineEvent, max = 120): string {
+  const text = payloadString(event, ['message', 'content', 'task_title', 'title', 'reason'])
+  const base = text || eventSubjectId(event) || event.kind
+  return base.length > max ? `${base.slice(0, max - 3)}...` : base
+}
+
+function eventPreview(event: ActivityGraphTimelineEvent, max = 72): string {
+  return eventDetail(event, max)
+}
+
+function groupGapMs(category: ActivityCategory): number | null {
+  switch (category) {
+    case 'task': return TASK_GAP_MS
+    case 'session': return SESSION_GAP_MS
+    case 'message': return MESSAGE_GAP_MS
+    case 'board': return BOARD_GAP_MS
+    case 'governance': return GOVERNANCE_GAP_MS
+    default: return null
+  }
+}
+
+function canMergeGroup(group: MutableGroup, event: ActivityGraphTimelineEvent): boolean {
+  const category = categoryForActivityKind(event.kind)
+  if (group.category !== category) return false
+
+  const gapMs = groupGapMs(category)
+  if (gapMs == null) return false
+  if (eventTsMs(event) - group.latestTsMs > gapMs) return false
+
+  const first = group.rawEvents[0]
+  if (!first) return false
+
+  if (category === 'task' || category === 'session' || category === 'board') {
+    return eventSubjectId(first) !== null && eventSubjectId(first) === eventSubjectId(event)
+  }
+
+  if (category === 'message') {
+    return eventActor(first) !== '' && eventActor(first) === eventActor(event)
+  }
+
+  if (category === 'governance') {
+    const firstSubject = eventSubjectId(first)
+    const nextSubject = eventSubjectId(event)
+    if (firstSubject && nextSubject) return firstSubject === nextSubject
+    return eventActor(first) !== '' && eventActor(first) === eventActor(event)
+  }
+
+  return false
+}
+
+function sequenceSummary(events: ActivityGraphTimelineEvent[]): string {
+  const labels: string[] = []
+  for (const event of events) {
+    const label = eventKindLabel(event.kind)
+    if (labels[labels.length - 1] !== label) labels.push(label)
+  }
+  return labels.join(' -> ')
+}
+
+function groupActor(events: ActivityGraphTimelineEvent[]): string {
+  const actors = [...new Set(events.map(eventActor).filter(Boolean))]
+  if (actors.length === 0) return ''
+  if (actors.length === 1) return actors[0]!
+  return `${actors[0]} +${actors.length - 1}`
+}
+
+function groupSubjectId(events: ActivityGraphTimelineEvent[]): string | null {
+  for (const event of events) {
+    const subjectId = eventSubjectId(event)
+    if (subjectId) return subjectId
+  }
+  return null
+}
+
+function groupTitle(category: ActivityCategory, events: ActivityGraphTimelineEvent[]): string {
+  const subjectId = groupSubjectId(events)
+  const actor = groupActor(events)
+  const latest = events[events.length - 1]
+  if (!latest) return 'Activity'
+
+  switch (category) {
+    case 'task':
+      return payloadString(latest, ['task_title', 'title']) || subjectId || 'Task activity'
+    case 'session':
+      return subjectId || payloadString(latest, ['session_id', 'operation_id']) || 'Session activity'
+    case 'message':
+      return actor ? `${actor} message burst` : 'Message burst'
+    case 'board':
+      return payloadString(latest, ['title']) || subjectId || 'Board activity'
+    case 'governance':
+      return subjectId || 'Governance activity'
+    case 'lifecycle':
+      return actor || eventKindLabel(latest.kind)
+    default:
+      return subjectId || eventKindLabel(latest.kind)
+  }
+}
+
+function groupSummary(category: ActivityCategory, events: ActivityGraphTimelineEvent[]): string {
+  const latest = events[events.length - 1]
+  if (!latest) return ''
+
+  switch (category) {
+    case 'message':
+      return `${events.length} message events · ${eventPreview(latest)}`
+    case 'board':
+      return `${events.length} board events · ${eventPreview(latest)}`
+    case 'lifecycle':
+      return eventDetail(latest)
+    default: {
+      const sequence = sequenceSummary(events)
+      return events.length > 1 ? `${sequence} · ${events.length} events` : sequence
+    }
+  }
+}
+
+function groupId(category: ActivityCategory, events: ActivityGraphTimelineEvent[]): string {
+  const first = events[0]
+  const latest = events[events.length - 1]
+  const subjectId = groupSubjectId(events) ?? 'none'
+  const actor = groupActor(events) || 'system'
+  const firstSeq = first?.seq ?? 0
+  const latestSeq = latest?.seq ?? firstSeq
+  return `${category}:${actor}:${subjectId}:${firstSeq}:${latestSeq}`
+}
+
+export function buildActionTimelineGroups(events: ActivityGraphTimelineEvent[]): ActionTimelineGroup[] {
+  const sorted = [...events].sort((a, b) => {
+    const delta = eventTsMs(a) - eventTsMs(b)
+    return delta !== 0 ? delta : a.seq - b.seq
+  })
+
+  const groups: MutableGroup[] = []
+  for (const event of sorted) {
+    const category = categoryForActivityKind(event.kind)
+    const current = groups[groups.length - 1]
+    if (current && canMergeGroup(current, event)) {
+      current.rawEvents.push(event)
+      current.latestTsMs = eventTsMs(event)
+      continue
+    }
+    groups.push({
+      category,
+      rawEvents: [event],
+      latestTsMs: eventTsMs(event),
+    })
+  }
+
+  return groups
+    .map(group => {
+      const latest = group.rawEvents[group.rawEvents.length - 1]!
+      const uniqueKinds = [...new Set(group.rawEvents.map(event => event.kind))]
+      return {
+        id: groupId(group.category, group.rawEvents),
+        category: group.category,
+        actor: groupActor(group.rawEvents),
+        subjectId: groupSubjectId(group.rawEvents),
+        title: groupTitle(group.category, group.rawEvents),
+        summary: groupSummary(group.category, group.rawEvents),
+        latestTs: latest.ts_iso,
+        latestTsMs: group.latestTsMs,
+        rawCount: group.rawEvents.length,
+        kinds: uniqueKinds,
+        rawEvents: group.rawEvents,
+      }
+    })
+    .sort((a, b) => b.latestTsMs - a.latestTsMs)
+}
+
+export function emptyCategoryCounts(): Record<ActivityCategory, number> {
+  return {
+    task: 0,
+    session: 0,
+    message: 0,
+    board: 0,
+    governance: 0,
+    lifecycle: 0,
+    other: 0,
+  }
+}
+
+export function buildCategoryCounts(groups: ActionTimelineGroup[]): Record<ActivityCategory, number> {
+  const counts = emptyCategoryCounts()
+  for (const group of groups) {
+    counts[group.category] += 1
+  }
+  return counts
+}
+
+export function buildRawCategoryCounts(kindCounts: ActivityGraphKindCounts): Record<ActivityCategory, number> {
+  const counts = emptyCategoryCounts()
+  for (const [kind, value] of Object.entries(kindCounts)) {
+    counts[categoryForActivityKind(kind)] += value
+  }
+  return counts
+}

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -6,20 +6,33 @@ import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
+import { FilterChips } from './common/filter-chips'
 import { TimeAgo } from './common/time-ago'
 import { Sparkline } from './common/sparkline'
 import { GraphView } from './activity-graph-view'
 import { ActivitySwimlane } from './activity-swimlane'
 import { ActivityHeatmap } from './activity-heatmap'
 import { CollapsibleSection } from './common/collapsible'
+import {
+  buildActionTimelineGroups,
+  buildCategoryCounts,
+  buildRawCategoryCounts,
+  categoryLabel,
+  eventDetail,
+  eventKindLabel as activityEventKindLabel,
+  type ActionTimelineFilter,
+} from './activity-graph-groups'
 import { fetchActivityGraph } from '../api'
 import { registerActivityRefresh } from '../sse-store'
-import type { ActivityGraphResponse, ActivityGraphNode, ActivityGraphTimelineEvent } from '../types'
+import type { ActivityGraphResponse, ActivityGraphNode, ActionTimelineGroup } from '../types'
 
 const graphData = signal<ActivityGraphResponse | null>(null)
 const graphError = signal<string | null>(null)
 const graphLoading = signal(false)
 export const selectedTimeRange = signal<string>('all')
+const actionFilter = signal<ActionTimelineFilter>('all')
+const showLifecycle = signal(false)
+const expandedActionGroups = signal<Set<string>>(new Set())
 
 const TIME_RANGES: Array<{ value: string; label: string }> = [
   { value: '1h', label: '1시간' },
@@ -74,49 +87,6 @@ function kindLabel(kind: string): string {
   }
 }
 
-function eventKindLabel(kind: string): string {
-  switch (kind) {
-    case 'agent.joined': return '입장'
-    case 'agent.left': return '퇴장'
-    case 'message.broadcast': return '브로드캐스트'
-    case 'message.mentioned': return '멘션'
-    case 'task.created': return '작업 생성'
-    case 'task.claimed': return '작업 점유'
-    case 'task.started': return '작업 시작'
-    case 'task.done': return '작업 완료'
-    case 'task.released': return '작업 반환'
-    case 'task.cancelled': return '작업 취소'
-    case 'board.posted': return '게시'
-    case 'board.commented': return '댓글'
-    case 'board.voted': return '투표'
-    case 'operation.started': return '세션 시작'
-    case 'operation.resumed': return '세션 재개'
-    case 'operation.finalized': return '세션 종료'
-    case 'team.turn': return '팀 턴'
-    case 'team.turn_failed': return '팀 턴 실패'
-    default: return kind
-  }
-}
-
-function eventActor(event: ActivityGraphTimelineEvent): string {
-  const actor = event.actor as Record<string, unknown>
-  if (actor?.id) return actor.id as string
-  const payload = event.payload as Record<string, unknown>
-  return (payload.agent as string) ?? (payload.author as string) ?? (payload.from as string) ?? ''
-}
-
-function eventSummary(event: ActivityGraphTimelineEvent): string {
-  const payload = event.payload as Record<string, unknown>
-  const message = (payload.message as string) ?? (payload.content as string) ?? ''
-  if (message) return message.length > 80 ? `${message.slice(0, 77)}...` : message
-  const taskTitle = payload.task_title as string | undefined
-  if (taskTitle) return taskTitle
-  const reason = payload.reason as string | undefined
-  if (reason) return reason
-  if (event.subject?.id) return `-> ${event.subject.id}`
-  return event.kind
-}
-
 function StatsRow({ data }: { data: ActivityGraphResponse }) {
   const s = data.stats
   const h = data.stats_history ?? []
@@ -146,34 +116,146 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
   `
 }
 
-function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
-  if (events.length === 0) {
-    return html`<${EmptyState} message="최근 실행 이벤트가 없습니다." compact />`
+function actionCategoryClass(group: ActionTimelineGroup): string {
+  switch (group.category) {
+    case 'task':
+      return 'border-[#fbbf24]/35 bg-[#fbbf24]/10 text-[#fcd34d]'
+    case 'session':
+      return 'border-[#4ade80]/35 bg-[#4ade80]/10 text-[#86efac]'
+    case 'message':
+      return 'border-[#22d3ee]/35 bg-[#22d3ee]/10 text-[#67e8f9]'
+    case 'board':
+      return 'border-[#c084fc]/35 bg-[#c084fc]/10 text-[#d8b4fe]'
+    case 'governance':
+      return 'border-[#fb7185]/35 bg-[#fb7185]/10 text-[#fda4af]'
+    case 'lifecycle':
+      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
+    default:
+      return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-muted)]'
   }
+}
+
+function toggleExpandedGroup(id: string): void {
+  const next = new Set(expandedActionGroups.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expandedActionGroups.value = next
+}
+
+function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
+  const groups = buildActionTimelineGroups(data.timeline)
+  const visibleBaseGroups = showLifecycle.value
+    ? groups
+    : groups.filter(group => group.category !== 'lifecycle')
+  const baseCounts = buildCategoryCounts(visibleBaseGroups)
+  const rawCounts = buildRawCategoryCounts(data.kind_counts)
+  const lifecycleHiddenCount = showLifecycle.value ? 0 : rawCounts.lifecycle
+  const filter = actionFilter.value
+  const filteredGroups = visibleBaseGroups.filter(group =>
+    filter === 'all' ? true : group.category === filter,
+  )
+  const chips = [
+    { key: 'all', label: 'All', count: visibleBaseGroups.length },
+    { key: 'task', label: 'Task', count: baseCounts.task },
+    { key: 'session', label: 'Session', count: baseCounts.session },
+    { key: 'message', label: 'Message', count: baseCounts.message },
+    { key: 'board', label: 'Board', count: baseCounts.board },
+    { key: 'governance', label: 'Governance', count: baseCounts.governance },
+    ...(baseCounts.other > 0 || filter === 'other'
+      ? [{ key: 'other' as const, label: 'Other', count: baseCounts.other }]
+      : []),
+  ]
+
+  if (groups.length === 0) {
+    return html`<${EmptyState} message="액션 단위로 묶을 실행 이벤트가 없습니다." compact />`
+  }
+
   return html`
     <div class="flex flex-col gap-3">
-      ${events.map(event => {
-        const actor = eventActor(event)
-        return html`
-          <div class="monitor-row rounded-xl p-4 ok" key=${event.seq}>
-            <div class="monitor-row rounded-xl-header">
-              <div class="min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
-                  <span class="monitor-title">${actor || '(unknown)'}</span>
-                  <span class="monitor-sub">${eventKindLabel(event.kind)}</span>
-                </div>
-                <div class="monitor-note">${eventSummary(event)}</div>
-              </div>
-              <span class="monitor-pill ok inline-flex items-center rounded-full px-2 py-[3px] text-[11px] uppercase tracking-[0.06em]">${eventKindLabel(event.kind)}</span>
-            </div>
-            <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[13px]">
-              <span>${event.room_id}</span>
-              ${event.ts_iso ? html`<span><${TimeAgo} timestamp=${event.ts_iso} /></span>` : null}
-              ${event.tags.length > 0 ? html`<span>${event.tags.join(', ')}</span>` : null}
-            </div>
+      <div class="flex flex-col gap-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]/50 p-4">
+        <div class="flex flex-col gap-1">
+          <div class="text-[14px] font-semibold text-[var(--text-strong)]">라이브 패널은 원본 스트림, 여기서는 최근 실행을 액션 단위로 묶어 봅니다.</div>
+          <div class="text-[12px] text-[var(--text-muted)]">
+            액션 ${filteredGroups.length}개 · 원본 타임라인 ${data.timeline.length}건 · 분석 범위 ${data.stats.event_count ?? data.timeline.length}건
+            ${lifecycleHiddenCount > 0 ? ` · lifecycle ${lifecycleHiddenCount}건 숨김` : ''}
           </div>
-        `
-      })}
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <${FilterChips} chips=${chips} active=${actionFilter} tone="accent" />
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-[11px] transition-all duration-150 ${showLifecycle.value
+              ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
+              : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'}"
+            onClick=${() => { showLifecycle.value = !showLifecycle.value }}
+          >
+            Lifecycle ${showLifecycle.value ? '표시 중' : '숨김'}
+            <span class="rounded-md bg-[var(--white-6)] px-1.5 py-0.5 text-[10px]">${rawCounts.lifecycle}</span>
+          </button>
+        </div>
+      </div>
+
+      ${filteredGroups.length === 0
+        ? html`<${EmptyState} message="선택한 필터에 맞는 액션 그룹이 없습니다." compact />`
+        : filteredGroups.map(group => {
+            const expanded = expandedActionGroups.value.has(group.id)
+            return html`
+              <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                  <div class="min-w-0 flex-1">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${actionCategoryClass(group)}">
+                        ${categoryLabel(group.category)}
+                      </span>
+                      ${group.actor ? html`<span class="text-[11px] font-medium text-[var(--text-body)]">${group.actor}</span>` : null}
+                      ${group.subjectId ? html`<span class="text-[11px] text-[var(--text-muted)] font-mono">${group.subjectId}</span>` : null}
+                    </div>
+                    <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">${group.title}</div>
+                    <div class="mt-1 text-[13px] leading-[1.6] text-[var(--text-body)]">${group.summary}</div>
+                  </div>
+                  <div class="flex shrink-0 flex-col items-end gap-2 text-[11px] text-[var(--text-muted)]">
+                    <span>${group.rawCount} events</span>
+                    <${TimeAgo} timestamp=${group.latestTs} />
+                  </div>
+                </div>
+                <div class="mt-3 flex flex-wrap gap-1.5">
+                  ${group.kinds.slice(0, 4).map(kind => html`
+                    <span class="inline-flex items-center rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]" key=${kind}>
+                      ${activityEventKindLabel(kind)}
+                    </span>
+                  `)}
+                </div>
+                <div class="mt-3 flex items-center justify-between gap-3 border-t border-[var(--white-6)] pt-3">
+                  <span class="text-[11px] text-[var(--text-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
+                  <button
+                    type="button"
+                    class="rounded-lg border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
+                    onClick=${() => toggleExpandedGroup(group.id)}
+                  >
+                    ${expanded ? '원본 접기' : '원본 보기'}
+                  </button>
+                </div>
+                ${expanded ? html`
+                  <div class="mt-3 flex flex-col gap-2 rounded-xl border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
+                    ${group.rawEvents.map(event => html`
+                      <div class="flex items-start gap-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)] px-3 py-2" key=${event.seq}>
+                        <span class="inline-flex min-w-[72px] items-center rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                          ${activityEventKindLabel(event.kind)}
+                        </span>
+                        <div class="min-w-0 flex-1">
+                          <div class="text-[12px] text-[var(--text-body)]">${eventDetail(event, 160)}</div>
+                          <div class="mt-1 text-[11px] text-[var(--text-muted)]">${event.room_id}</div>
+                        </div>
+                        <span class="shrink-0 text-[11px] text-[var(--text-muted)]">
+                          <${TimeAgo} timestamp=${event.ts_iso} />
+                        </span>
+                      </div>
+                    `)}
+                  </div>
+                ` : null}
+              </div>
+            `
+          })}
     </div>
   `
 }
@@ -261,8 +343,10 @@ export { loadGraph as refreshActivityGraph }
 
 export function ActivityGraphSurface() {
   useEffect(() => {
-    loadGraph()
-    registerActivityRefresh(loadGraph)
+    void loadGraph()
+    return registerActivityRefresh(() => {
+      void loadGraph()
+    })
   }, [])
 
   const data = graphData.value
@@ -292,13 +376,15 @@ export function ActivityGraphSurface() {
     return html`<${EmptyActivityGraph} />`
   }
 
+  const since = selectedTimeRange.value !== 'all' ? selectedTimeRange.value : undefined
+
   return html`
     <div class="flex flex-col gap-5">
 
       <${Card} title="활동 그래프" class="section mb-4" testId="activity_graph.graph">
         <div class="mb-4">
           <h2 class="monitor-headline">실행 이벤트 관계 그래프</h2>
-          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. 노드 크기는 의미적 중요도를 반영합니다. 노드를 클릭하면 상세 정보를 확인할 수 있습니다.</p>
+          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. Live 패널은 원본 스트림이고, 이 영역은 필터링된 이력과 분석에 집중합니다.</p>
         </div>
         <${TimeRangeSelector} />
         <${StatsRow} data=${data} />
@@ -312,7 +398,7 @@ export function ActivityGraphSurface() {
       <//>
 
       <${CollapsibleSection} title="에이전트 타임라인" open=${true}>
-        <${ActivitySwimlane} />
+        <${ActivitySwimlane} since=${since} />
       <//>
 
       <div class="grid grid-cols-[minmax(0,1.08fr)_minmax(0,0.96fr)_minmax(0,0.88fr)] gap-4">
@@ -332,12 +418,12 @@ export function ActivityGraphSurface() {
           <${KindBreakdown} nodes=${data.nodes} />
         <//>
 
-        <${Card} title="최근 실행 이벤트" class="section mb-4" testId="activity_graph.timeline">
+        <${Card} title="액션 타임라인" class="section mb-4" testId="activity_graph.timeline">
           <div class="mb-4">
             <h2 class="monitor-headline">타임라인</h2>
-            <p class="monitor-subheadline">가장 최근의 실행 이벤트를 시간순으로 보여줍니다.</p>
+            <p class="monitor-subheadline">최근 실행을 액션 단위로 묶고, 필요할 때만 원본 이벤트를 펼쳐 봅니다.</p>
           </div>
-          <${ActivityFeed} events=${[...data.timeline].reverse().slice(0, 30)} />
+          <${ActionTimeline} data=${data} />
         <//>
       </div>
 

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -1,12 +1,12 @@
 // Activity heatmap — Canvas 2D day-of-week x hour-of-day density grid.
-// Derives a 7x24 matrix from ActivityGraphResponse.timeline events.
+// Uses server-projected density from the full filtered event set.
 
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { HEATMAP_COLORS } from '../config/constants'
-import type { ActivityGraphResponse, ActivityGraphTimelineEvent } from '../types'
+import type { ActivityGraphResponse } from '../types'
 
 const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'] as const
 const HOUR_LABELS = [0, 3, 6, 9, 12, 15, 18, 21] as const
@@ -33,36 +33,6 @@ interface TooltipInfo {
 
 interface HeatmapProps {
   data: ActivityGraphResponse
-}
-
-/** Map JS getDay() (0=Sun) to our 0=Mon index. */
-function jsDateToDayIndex(date: Date): number {
-  const d = date.getDay()
-  return d === 0 ? 6 : d - 1
-}
-
-function buildMatrix(timeline: ActivityGraphTimelineEvent[]): number[][] {
-  const matrix: number[][] = Array.from({ length: 7 }, () =>
-    Array.from({ length: 24 }, () => 0),
-  )
-  for (const event of timeline) {
-    const date = new Date(event.ts_iso)
-    if (isNaN(date.getTime())) continue
-    const day = jsDateToDayIndex(date)
-    const hour = date.getHours()
-    matrix[day]![hour]! += 1
-  }
-  return matrix
-}
-
-function matrixMax(matrix: number[][]): number {
-  let max = 0
-  for (const row of matrix) {
-    for (const val of row) {
-      if (val > max) max = val
-    }
-  }
-  return max
 }
 
 function intensityColor(count: number, max: number): string {
@@ -194,8 +164,9 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<TooltipInfo | null>(null)
 
-  const matrix = buildMatrix(data.timeline)
-  const max = matrixMax(matrix)
+  const matrix = data.heatmap.matrix
+  const max = data.heatmap.max
+  const total = data.heatmap.total
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -273,7 +244,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
     }
   }, [data, matrix, max])
 
-  if (data.timeline.length === 0) {
+  if (total === 0) {
     return html`
       <${Card} title="활동 히트맵" testId="activity_heatmap">
         <${EmptyState}>히트맵을 표시할 이벤트가 없습니다.<//>
@@ -284,7 +255,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
   return html`
     <${Card} title="활동 히트맵" testId="activity_heatmap">
       <div class="mb-2">
-        <p class="text-[13px] text-[var(--text-muted)]">요일별, 시간대별 활동 밀도를 보여줍니다.</p>
+        <p class="text-[13px] text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
       <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded-xl p-3">
         <canvas ref=${canvasRef} class="block" />

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { fetchSwimlane } from '../api'
+import { registerActivityRefresh } from '../sse-store'
 import type { SwimlaneResponse, AgentSpan } from '../types'
 import { selectedNodeId, highlightedAgentId } from './activity-graph-view'
 import { formatDurationMs } from '../lib/format-time'
@@ -32,12 +33,12 @@ function spanColor(kind: string): string {
   }
 }
 
-async function loadSwimlane() {
+async function loadSwimlane(since?: string) {
   if (swimlaneLoading.value) return
   swimlaneLoading.value = true
   swimlaneError.value = null
   try {
-    swimlaneData.value = await fetchSwimlane()
+    swimlaneData.value = await fetchSwimlane(since)
   } catch (err) {
     swimlaneError.value = err instanceof Error ? err.message : String(err)
   } finally {
@@ -210,12 +211,17 @@ function hitTestSpan(
   return null
 }
 
-export function ActivitySwimlane() {
+export function ActivitySwimlane({ since }: { since?: string }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<TooltipInfo | null>(null)
 
-  useEffect(() => { loadSwimlane() }, [])
+  useEffect(() => {
+    void loadSwimlane(since)
+    return registerActivityRefresh(() => {
+      void loadSwimlane(since)
+    })
+  }, [since])
 
   const data = swimlaneData.value
   const loading = swimlaneLoading.value

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -64,9 +64,12 @@ export function registerMissionRefresh(fn: () => void): void {
   _refreshMissionFn = fn
 }
 
-let _refreshActivityFn: (() => void) | null = null
-export function registerActivityRefresh(fn: () => void): void {
-  _refreshActivityFn = fn
+const _refreshActivityFns = new Set<() => void>()
+export function registerActivityRefresh(fn: () => void): () => void {
+  _refreshActivityFns.add(fn)
+  return () => {
+    _refreshActivityFns.delete(fn)
+  }
 }
 
 // --- Debounced scheduling ---
@@ -136,7 +139,9 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   board:     refreshBoard,
   mdal:      refreshMdal,
   operator:  () => _refreshOperatorFn?.(),
-  activity:  () => _refreshActivityFn?.(),
+  activity:  () => {
+    for (const fn of _refreshActivityFns) fn()
+  },
 }
 
 // --- Named handlers for complex events ---

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -189,10 +189,45 @@ export interface ActivityGraphStats {
   [key: string]: number
 }
 
+export interface ActivityGraphHeatmap {
+  matrix: number[][]
+  max: number
+  total: number
+}
+
+export interface ActivityGraphKindCounts {
+  [kind: string]: number
+}
+
+export type ActivityCategory =
+  | 'task'
+  | 'session'
+  | 'message'
+  | 'board'
+  | 'governance'
+  | 'lifecycle'
+  | 'other'
+
+export interface ActionTimelineGroup {
+  id: string
+  category: ActivityCategory
+  actor: string
+  subjectId: string | null
+  title: string
+  summary: string
+  latestTs: string
+  latestTsMs: number
+  rawCount: number
+  kinds: string[]
+  rawEvents: ActivityGraphTimelineEvent[]
+}
+
 export interface ActivityGraphResponse {
   nodes: ActivityGraphNode[]
   edges: ActivityGraphEdge[]
   stats: ActivityGraphStats
+  kind_counts: ActivityGraphKindCounts
+  heatmap: ActivityGraphHeatmap
   timeline: ActivityGraphTimelineEvent[]
   generated_at: string
   window: { limit: number; room_id: string | null; kinds: string[] }

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -201,6 +201,48 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
     | Some ms -> List.filter (fun e -> e.ts_ms >= ms) events
     | None -> events
   in
+  let kind_counts_json =
+    let counts = Hashtbl.create 16 in
+    List.iter
+      (fun (e : event) ->
+        let prev = Option.value (Hashtbl.find_opt counts e.kind) ~default:0 in
+        Hashtbl.replace counts e.kind (prev + 1))
+      events;
+    `Assoc
+      (Hashtbl.fold
+         (fun kind count acc -> (kind, `Int count) :: acc)
+         counts []
+      |> List.sort (fun (a, _) (b, _) -> String.compare a b))
+  in
+  let heatmap_json =
+    let matrix = Array.init 7 (fun _ -> Array.make 24 0) in
+    let max_count = ref 0 in
+    List.iter
+      (fun (e : event) ->
+        let tm = Unix.localtime (float_of_int e.ts_ms /. 1000.0) in
+        let day = if tm.tm_wday = 0 then 6 else tm.tm_wday - 1 in
+        let hour = tm.tm_hour in
+        let next_count = matrix.(day).(hour) + 1 in
+        matrix.(day).(hour) <- next_count;
+        if next_count > !max_count then max_count := next_count)
+      events;
+    let matrix_json =
+      `List
+        (Array.to_list
+           (Array.map
+              (fun row ->
+                `List
+                  (Array.to_list
+                     (Array.map (fun count -> `Int count) row)))
+              matrix))
+    in
+    `Assoc
+      [
+        ("matrix", matrix_json);
+        ("max", `Int !max_count);
+        ("total", `Int (List.length events));
+      ]
+  in
   let nodes = Hashtbl.create 64 in
   let edges = Hashtbl.create 96 in
   List.iter (reduce_event ~nodes ~edges) events;
@@ -333,6 +375,8 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
             ("active_agents", `Int active_agents);
           ] );
       ("stats_history", `List stats_history);
+      ("kind_counts", kind_counts_json);
+      ("heatmap", heatmap_json);
       ("nodes", `List nodes_json);
       ("edges", `List edges_json);
       ("timeline", `List (List.map event_to_yojson timeline));

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -52,9 +52,10 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/activity/swimlane" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let room_id = query_param req "room_id" in
-         let limit = int_query_param req "limit" ~default:500 |> clamp ~min_v:1 ~max_v:2000 in
-         let json = Activity_graph.agent_spans_json state.Mcp_server.room_config ?room_id ~limit () in
+         let json =
+           Server_activity_http.swimlane_http_json
+             ~deps:(activity_http_deps ~sw ~clock) ~state req
+         in
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/governance/cases" (fun request reqd ->

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -192,6 +192,84 @@ let test_graph_json_tracks_runtime_activity_kinds () =
       check bool "board vote edge captured" true
         (has_edge "votes_on"))
 
+let test_graph_json_reports_kind_counts_and_heatmap_totals () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_config (fun config ->
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"message.broadcast"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~tags:[ "message"; "broadcast" ]
+           ~payload:(`Assoc [ ("content", `String "hello") ])
+           ());
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"message.broadcast"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~tags:[ "message"; "broadcast" ]
+           ~payload:(`Assoc [ ("content", `String "world") ])
+           ());
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"task.started"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-900")
+           ~tags:[ "task"; "task.started" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-900") ])
+           ());
+      let json =
+        Activity_graph.graph_json config ~room_id:"default" ~limit:20
+          ~timeline_limit:10 ()
+      in
+      let open Yojson.Safe.Util in
+      let kind_counts = json |> member "kind_counts" in
+      let heatmap = json |> member "heatmap" in
+      let matrix = heatmap |> member "matrix" |> to_list in
+      check int "message.broadcast count" 2
+        (kind_counts |> member "message.broadcast" |> to_int);
+      check int "task.started count" 1
+        (kind_counts |> member "task.started" |> to_int);
+      check int "heatmap total matches filtered events" 3
+        (heatmap |> member "total" |> to_int);
+      check int "heatmap rows" 7 (List.length matrix);
+      check bool "heatmap rows expose 24 hours" true
+        (List.for_all (fun row -> List.length (to_list row) = 24) matrix))
+
+let test_agent_spans_json_honors_since_ms () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_config (fun config ->
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"task.started"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-old")
+           ~tags:[ "task"; "task.started" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-old") ])
+           ());
+      ignore (Unix.select [] [] [] 0.02);
+      let cutoff_ms = int_of_float (Time_compat.now () *. 1000.0) in
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"task.started"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-new")
+           ~tags:[ "task"; "task.started" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-new") ])
+           ());
+      ignore
+        (Activity_graph.emit config ~room_id:"default" ~kind:"task.done"
+           ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-new")
+           ~tags:[ "task"; "task.done" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-new") ])
+           ());
+      let json =
+        Activity_graph.agent_spans_json config ~room_id:"default"
+          ~since_ms:cutoff_ms ~limit:20 ()
+      in
+      let open Yojson.Safe.Util in
+      let spans = json |> member "spans" |> to_list in
+      check int "only recent span remains" 1 (List.length spans);
+      check string "recent span label kept" "task-new"
+        (List.hd spans |> member "label" |> to_string))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -206,5 +284,9 @@ let () =
             test_graph_json_summarizes_relationships;
           test_case "graph summary tracks runtime activity kinds" `Quick
             test_graph_json_tracks_runtime_activity_kinds;
+          test_case "graph summary exposes kind counts and full heatmap totals"
+            `Quick test_graph_json_reports_kind_counts_and_heatmap_totals;
+          test_case "agent spans honor since filter" `Quick
+            test_agent_spans_json_honors_since_ms;
         ] );
     ]


### PR DESCRIPTION
## Summary
- regroup the Activity Graph timeline into action cards with category filters and raw-event expansion
- align the swimlane with the selected time range and shared activity refresh path
- expose server-side heatmap density and kind counts so the heatmap reflects the full filtered window instead of the truncated timeline

## Why
The Activity tab had three overlapping views of the same runtime activity with inconsistent granularity. The graph timeline was effectively a raw log even though the Live panel already serves that role, which made the dashboard hard to read.

## Impact
- Activity Graph now acts as summarized history/analysis instead of a second raw stream
- lifecycle noise is hidden by default but can be toggled back on
- heatmap and swimlane now follow the same time-range semantics as the graph

## Root Cause
The frontend rendered the graph timeline directly from recent raw events, the heatmap was derived from only the truncated timeline slice, and the swimlane route bypassed the shared `since` parser entirely.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `./node_modules/.bin/vitest run src/components/activity-graph-groups.test.ts`
- `_build/default/test/test_activity_graph.exe`
