### PR TITLE
feat(keeper): allowed_paths profile + schema support (#3876 Phase 2)

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -32,6 +32,19 @@ proactive_enabled = true
 presence_keepalive = true
 presence_keepalive_sec = 30
 
+# Execution scope — controls what the keeper can modify.
+#   observe_only = read-only, no file writes (default for new keepers until #3886)
+#   workspace    = write to allowed_paths only (current default)
+#   local        = full filesystem access
+# execution_scope = "workspace"
+
+# Allowed paths — restrict file writes to these path prefixes.
+#   []       + observe_only = no writes (tool-level block)
+#   []       + workspace    = computed default (.masc/keepers/<name>/, .masc/traces/)
+#   ["*"]    = explicit full access (operator opt-in)
+#   ["src/"] = only src/ prefix allowed
+# allowed_paths = ["src/", "lib/"]
+
 # Tool shards — restrict which tool groups are available.
 # Omit or leave empty to grant all default shards (backward compatible).
 # Available: base, board, filesystem, shell, coding, voice, library,

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -32,6 +32,8 @@ Never work outside masc-mcp. Use worktrees. One active lane at a time.
 room_scope = "current"
 scope_kind = "local"
 mention_targets = ["masc-improver", "improver"]
+execution_scope = "workspace"
+allowed_paths = ["*"]
 
 proactive_enabled = true
 presence_keepalive = true

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -60,6 +60,14 @@ let keeper_schemas : tool_schema list = [
         ("auto_handoff", `Assoc [("type", `String "boolean")]);
         ("handoff_threshold", `Assoc [("type", `String "number")]);
         ("handoff_cooldown_sec", `Assoc [("type", `String "integer")]);
+        ("execution_scope", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "observe_only"; `String "workspace"; `String "local"]);
+        ]);
+        ("allowed_paths", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
       ]);
       ("required", `List [`String "persona_name"]);
     ];
@@ -169,6 +177,16 @@ let keeper_schemas : tool_schema list = [
         ("handoff_cooldown_sec", `Assoc [
           ("type", `String "integer");
           ("description", `String "Minimum seconds between handoffs (default: 300).");
+        ]);
+        ("execution_scope", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "observe_only"; `String "workspace"; `String "local"]);
+          ("description", `String "Execution scope: observe_only (read-only), workspace (write to allowed paths), local (full access). Default: workspace.");
+        ]);
+        ("allowed_paths", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Restrict file writes to these path prefixes. Empty list uses computed defaults based on execution_scope. Use [\"*\"] for explicit full access.");
         ]);
       ]);
       ("required", `List [`String "name"]);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -41,7 +41,14 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     |> Option.value ~default:false
   in
   let allowed_paths =
-    Option.value ~default:[] p.allowed_paths_opt
+    match p.allowed_paths_opt with
+    | Some paths -> paths
+    | None -> Option.value ~default:[] p.profile_defaults.allowed_paths
+  in
+  let execution_scope =
+    p.execution_scope_opt
+    |> first_some p.profile_defaults.execution_scope
+    |> Option.value ~default:default_execution_scope
   in
   let voice_enabled =
     Option.value ~default:(default_voice_enabled_for p.name) p.voice_enabled_opt
@@ -201,7 +208,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            desires;
            instructions;
            policy_voice_enabled;
-           execution_scope = default_execution_scope;
+           execution_scope;
            allowed_paths;
            scope_kind;
            tool_tier;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -205,6 +205,8 @@ type keeper_profile_defaults = {
   shards : string list option;
   tool_tier : string option;
   extra_masc_tools : string list option;
+  allowed_paths : string list option;
+  execution_scope : string option;
 }
 
 type persona_summary = {
@@ -235,6 +237,8 @@ let empty_keeper_profile_defaults = {
   shards = None;
   tool_tier = None;
   extra_masc_tools = None;
+  allowed_paths = None;
+  execution_scope = None;
 }
 
 let personas_root_opt () =
@@ -326,6 +330,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
            (match strs "extra_masc_tools" with
             | [] -> None
             | xs -> Some xs);
+         allowed_paths =
+           (match strs "allowed_paths" with
+            | [] -> None
+            | xs -> Some xs);
+         execution_scope = str "execution_scope";
        })
 
 let load_keeper_toml (path : string)
@@ -413,6 +422,11 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   (match Safe_ops.json_string_list "extra_masc_tools" keeper_json with
                    | [] -> None
                    | xs -> Some xs);
+                allowed_paths =
+                  (match Safe_ops.json_string_list "allowed_paths" keeper_json with
+                   | [] -> None
+                   | xs -> Some xs);
+                execution_scope = Safe_ops.json_string_opt "execution_scope" keeper_json;
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 


### PR DESCRIPTION
## Summary
- `keeper_types_profile.ml`에 `allowed_paths: string list option`, `execution_scope: string option` 필드 추가 (TOML + persona JSON 파싱)
- `keeper_turn_up_create.ml`에서 profile fallback 적용 + `execution_scope_opt` create 경로 반영 (기존엔 update에서만 사용됨)
- `keeper_schema.ml`에 `execution_scope` (enum), `allowed_paths` (array) MCP tool schema 노출
- `config/keepers/example.toml` 문서화, `masc-improver.toml`에 `allowed_paths=["*"]` 설정

## Context
Phase 1 (#3913)에서 `effective_allowed_paths` 함수와 enforcement를 구현. 이 PR은 Phase 2로, profile 시스템과 tool schema에서 이 필드들을 설정할 수 있게 한다.

Closes phase 2 of #3876.

## Test plan
- [x] `dune build` 성공
- [x] `test_keeper_allowed_paths.exe` 9개 테스트 통과
- [ ] CI green 확인
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)