### PR TITLE
fix(research): use descriptor fstat for header detection

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -316,11 +316,11 @@ let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
   let header = "experiment\tbuild_ok\ttest_pass_rate\tloc_delta\tfiles_changed\tstatus\tdescription\n" in
   try
     let oc = open_out_gen [ Open_append; Open_creat ] 0o644 results_file in
-    (* Check file size after open to avoid TOCTOU race on needs_header *)
+    (* Check the opened descriptor size to avoid a separate pre-open stat. *)
     let needs_header =
       try
-        let pos = LargeFile.pos_out oc in
-        pos = Int64.zero
+        let stat = Unix.LargeFile.fstat (Unix.descr_of_out_channel oc) in
+        stat.Unix.LargeFile.st_size = Int64.zero
       with exn ->
         log_best_effort_failure "results header check" exn;
         false

--- a/test/dune
+++ b/test/dune
@@ -201,6 +201,11 @@
  (libraries masc_mcp alcotest yojson unix masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str eio_main eio mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))
 
 (test
+ (name test_research_loop)
+ (modules test_research_loop)
+ (libraries masc_mcp.masc_research alcotest unix fs_compat))
+
+(test
  (name test_dashboard_harness_health)
  (modules test_dashboard_harness_health)
  (libraries masc_mcp alcotest yojson unix eio eio_main masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))

--- a/test/test_research_loop.ml
+++ b/test/test_research_loop.ml
@@ -1,0 +1,93 @@
+open Alcotest
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_research_loop" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let sample_entry id description : Research_loop.experiment_entry =
+  let hypothesis : Research_loop.hypothesis =
+    {
+      description;
+      target_file = "lib/example.ml";
+      rationale = "test";
+      patch = "";
+      old_text = "";
+      new_text = "";
+    }
+  in
+  let metric : Research_metric.t =
+    {
+      build_ok = true;
+      test_pass_rate = 1.0;
+      test_total = 1;
+      test_passed = 1;
+      loc_delta = 3;
+      files_changed = 1;
+      build_seconds = 0.1;
+      test_seconds = 0.2;
+      binary_changed = true;
+      status = Research_metric.Keep;
+      error_message = "";
+    }
+  in
+  { id; hypothesis; metric }
+
+let read_lines path =
+  let content = Fs_compat.load_file path in
+  String.split_on_char '\n' content
+  |> List.filter (fun line -> line <> "")
+
+let test_log_result_writes_header_once () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let results_file = Filename.concat dir "results.tsv" in
+      Research_loop.log_result
+        ~results_file ~entry:(sample_entry "exp-1" "first");
+      Research_loop.log_result
+        ~results_file ~entry:(sample_entry "exp-2" "second");
+      let lines = read_lines results_file in
+      check int "header + two rows" 3 (List.length lines);
+      check string "header preserved"
+        "experiment\tbuild_ok\ttest_pass_rate\tloc_delta\tfiles_changed\tstatus\tdescription"
+        (List.nth lines 0);
+      check bool "first row contains exp-1" true
+        (String.starts_with ~prefix:"exp-1\t1\t1.0000\t3\t1\tkeep\tfirst" (List.nth lines 1));
+      check bool "second row contains exp-2" true
+        (String.starts_with ~prefix:"exp-2\t1\t1.0000\t3\t1\tkeep\tsecond" (List.nth lines 2)))
+
+let test_log_result_is_best_effort_on_open_failure () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let results_file = Filename.concat dir "missing/results.tsv" in
+      Research_loop.log_result
+        ~results_file ~entry:(sample_entry "exp-fail" "best-effort");
+      check bool "missing dir still absent" false (Sys.file_exists results_file))
+
+let () =
+  run "research_loop"
+    [
+      ( "log_result",
+        [
+          test_case "writes header once across repeated appends" `Quick
+            test_log_result_writes_header_once;
+          test_case "open failure stays best effort" `Quick
+            test_log_result_is_best_effort_on_open_failure;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- replace `LargeFile.pos_out` with descriptor `Unix.LargeFile.fstat` for `research_loop.log_result` header detection
- keep the current best-effort logging behavior from `#3987`
- add regression coverage for repeated append and missing-directory open failure

## Product impact
- prevents duplicated TSV headers on repeated appends when `log_result` writes to an existing results file
- preserves best-effort behavior when the results directory is missing

## Evidence
- local: `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3993-research-log-header-fstat test/test_research_loop.exe`
- local: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3993-research-log-header-fstat/_build/default/test/test_research_loop.exe`
- local repro: `LargeFile.pos_out` returned `0` after append-open on a non-empty file, while `Unix.LargeFile.fstat (Unix.descr_of_out_channel oc).st_size` returned the real size

## Review evidence
- pending: direct `sb glm-text` review on the final diff

## Linked issue
- closes #3993
