### PR TITLE
fix(research): use fstat for log_result header detection

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -316,11 +316,11 @@ let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
   let header = "experiment\tbuild_ok\ttest_pass_rate\tloc_delta\tfiles_changed\tstatus\tdescription\n" in
   try
     let oc = open_out_gen [ Open_append; Open_creat ] 0o644 results_file in
-    (* Check file size after open to avoid TOCTOU race on needs_header *)
+    (* Use fstat on the underlying fd — pos_out returns 0 for append-opened files *)
     let needs_header =
       try
-        let pos = LargeFile.pos_out oc in
-        pos = Int64.zero
+        let fd = Unix.descr_of_out_channel oc in
+        (Unix.LargeFile.fstat fd).st_size = 0L
       with exn ->
         log_best_effort_failure "results header check" exn;
         false

--- a/test/dune
+++ b/test/dune
@@ -1172,3 +1172,9 @@
  (name test_keeper_fs)
  (modules test_keeper_fs)
  (libraries masc_mcp alcotest yojson unix eio eio_main))
+
+; Research log_result: fstat header detection regression (#3993)
+(test
+ (name test_research_log_result)
+ (modules test_research_log_result)
+ (libraries masc_mcp.masc_research alcotest unix))

--- a/test/test_research_log_result.ml
+++ b/test/test_research_log_result.ml
@@ -1,0 +1,86 @@
+(** Test Research_loop.log_result — regression for fstat header detection. *)
+
+open Research_loop
+open Research_metric
+
+let dummy_entry id =
+  { id;
+    hypothesis = {
+      description = "test hypothesis";
+      target_file = "test.ml";
+      rationale = "test";
+      patch = "";
+      old_text = "";
+      new_text = "";
+    };
+    metric = {
+      build_ok = true;
+      test_pass_rate = 1.0;
+      test_total = 1;
+      test_passed = 1;
+      loc_delta = 0;
+      files_changed = 1;
+      build_seconds = 0.1;
+      test_seconds = 0.2;
+      binary_changed = false;
+      status = Keep;
+      error_message = "";
+    };
+  }
+
+let with_tmp_dir f =
+  let dir = Filename.temp_dir "test_research_" "" in
+  Fun.protect ~finally:(fun () ->
+    Array.iter (fun name -> Sys.remove (Filename.concat dir name))
+      (Sys.readdir dir);
+    Unix.rmdir dir) (fun () -> f dir)
+
+(** Repeated log_result should produce exactly one header line. *)
+let test_no_duplicate_header () =
+  with_tmp_dir (fun dir ->
+    let results_file = Filename.concat dir "results.tsv" in
+    let e1 = dummy_entry "exp-001" in
+    let e2 = dummy_entry "exp-002" in
+    log_result ~results_file ~entry:e1;
+    log_result ~results_file ~entry:e2;
+    let ic = open_in results_file in
+    let lines = ref [] in
+    (try while true do lines := input_line ic :: !lines done
+     with End_of_file -> close_in ic);
+    let lines = List.rev !lines in
+    let header_count =
+      List.length (List.filter (fun l -> String.length l > 0 &&
+        String.sub l 0 (min 10 (String.length l)) = "experiment") lines)
+    in
+    Alcotest.(check int) "exactly one header" 1 header_count;
+    Alcotest.(check int) "header + 2 data lines" 3 (List.length lines))
+
+(** First call on a new file creates the header. *)
+let test_new_file_gets_header () =
+  with_tmp_dir (fun dir ->
+    let results_file = Filename.concat dir "results.tsv" in
+    log_result ~results_file ~entry:(dummy_entry "exp-001");
+    let ic = open_in results_file in
+    let first_line = input_line ic in
+    close_in ic;
+    Alcotest.(check bool) "starts with header"
+      true (String.length first_line > 0 &&
+            String.sub first_line 0 10 = "experiment"))
+
+(** Missing parent directory: best-effort, no crash. *)
+let test_missing_dir_no_crash () =
+  let results_file = "/tmp/nonexistent_dir_9999/results.tsv" in
+  (* Should not raise *)
+  log_result ~results_file ~entry:(dummy_entry "exp-001")
+
+let () =
+  Alcotest.run "research_log_result" [
+    "log_result", [
+      Alcotest.test_case "no duplicate header on repeated append" `Quick
+        test_no_duplicate_header;
+      Alcotest.test_case "new file gets header" `Quick
+        test_new_file_gets_header;
+      Alcotest.test_case "missing dir no crash" `Quick
+        test_missing_dir_no_crash;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `LargeFile.pos_out` returns 0 for append-opened files → duplicate TSV headers on repeated `log_result` calls
- Switch to `Unix.LargeFile.fstat` which reports actual file size
- Add 3 regression tests (duplicate header, new file header, missing dir best-effort)

Closes #3993

## Test plan
- [x] `test_research_log_result` — 3/3 green
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>