### PR TITLE
test(tool_catalog): lock placeholder env toggle semantics

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -45,10 +45,13 @@ let default_metadata =
   }
 
 (* Runtime-readable like MASC_FULL_SURFACE so tests and local admin flows can
-   toggle placeholder exposure without restarting the server. Invalid or blank
-   values fall back to the default-enabled behavior via Env_config_core. *)
+   toggle placeholder exposure without restarting the server. Keep the legacy
+   exact-match semantics for "false"/"0" so existing deployments do not change
+   behavior when they use other spellings. *)
 let placeholder_tools_enabled () =
-  Env_config_core.get_bool ~default:true "MASC_PLACEHOLDER_TOOLS_ENABLED"
+  match Sys.getenv_opt "MASC_PLACEHOLDER_TOOLS_ENABLED" with
+  | Some "false" | Some "0" -> false
+  | _ -> true
 
 let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = false)
     ?(implementation_status = Adapter) reason =

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -44,10 +44,11 @@ let default_metadata =
     idempotent = None;
   }
 
+(* Runtime-readable like MASC_FULL_SURFACE so tests and local admin flows can
+   toggle placeholder exposure without restarting the server. Invalid or blank
+   values fall back to the default-enabled behavior via Env_config_core. *)
 let placeholder_tools_enabled () =
-  match Sys.getenv_opt "MASC_PLACEHOLDER_TOOLS_ENABLED" with
-  | Some "false" | Some "0" -> false
-  | _ -> true
+  Env_config_core.get_bool ~default:true "MASC_PLACEHOLDER_TOOLS_ENABLED"
 
 let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = false)
     ?(implementation_status = Adapter) reason =

--- a/test/test_tool_tier.ml
+++ b/test/test_tool_tier.ml
@@ -2,6 +2,16 @@
 
 module Tool_catalog = Masc_mcp.Tool_catalog
 
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
 let () =
   let open Alcotest in
   run "Tool_tier"
@@ -166,5 +176,27 @@ let () =
                 (List.assoc_opt "visibility" fields = None);
               check bool "lifecycle omitted" true
                 (List.assoc_opt "lifecycle" fields = None));
+        ] );
+      ( "placeholder_tools_enabled",
+        [
+          test_case "blank value falls back to enabled default" `Quick (fun () ->
+              with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" "" (fun () ->
+                  check bool "blank defaults to enabled" true
+                    (Tool_catalog.placeholder_tools_enabled ())));
+          test_case "parses falsey variants" `Quick (fun () ->
+              List.iter
+                (fun raw ->
+                  with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" raw (fun () ->
+                      check bool raw false
+                        (Tool_catalog.placeholder_tools_enabled ())))
+                [ "false"; "FALSE"; " false "; "0"; "no"; "NO" ]);
+          test_case "parses truthy and invalid variants as enabled" `Quick
+            (fun () ->
+              List.iter
+                (fun raw ->
+                  with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" raw (fun () ->
+                      check bool raw true
+                        (Tool_catalog.placeholder_tools_enabled ())))
+                [ "true"; "TRUE"; " true "; "1"; "yes"; "YES"; "bogus" ]);
         ] );
     ]

--- a/test/test_tool_tier.ml
+++ b/test/test_tool_tier.ml
@@ -9,7 +9,10 @@ let with_env key value f =
     ~finally:(fun () ->
       match old with
       | Some prev -> Unix.putenv key prev
-      | None -> Unix.putenv key "")
+      | None ->
+          (* OCaml stdlib has no unsetenv; blank matches the enabled default
+             path we are asserting for placeholder_tools_enabled. *)
+          Unix.putenv key "")
     f
 
 let () =
@@ -179,24 +182,28 @@ let () =
         ] );
       ( "placeholder_tools_enabled",
         [
-          test_case "blank value falls back to enabled default" `Quick (fun () ->
+          test_case "unset and blank values keep enabled default" `Quick
+            (fun () ->
+              check bool "unset defaults to enabled" true
+                (Tool_catalog.placeholder_tools_enabled ());
               with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" "" (fun () ->
                   check bool "blank defaults to enabled" true
                     (Tool_catalog.placeholder_tools_enabled ())));
-          test_case "parses falsey variants" `Quick (fun () ->
+          test_case "only exact false and 0 disable placeholder tools" `Quick
+            (fun () ->
               List.iter
                 (fun raw ->
                   with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" raw (fun () ->
                       check bool raw false
                         (Tool_catalog.placeholder_tools_enabled ())))
-                [ "false"; "FALSE"; " false "; "0"; "no"; "NO" ]);
-          test_case "parses truthy and invalid variants as enabled" `Quick
-            (fun () ->
+                [ "false"; "0" ]);
+          test_case "other spellings stay enabled for backward compatibility"
+            `Quick (fun () ->
               List.iter
                 (fun raw ->
                   with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" raw (fun () ->
                       check bool raw true
                         (Tool_catalog.placeholder_tools_enabled ())))
-                [ "true"; "TRUE"; " true "; "1"; "yes"; "YES"; "bogus" ]);
+                [ "FALSE"; " false "; "no"; "NO"; "true"; "1"; "bogus" ]);
         ] );
     ]


### PR DESCRIPTION
## Summary
- preserve the legacy exact-match disable semantics for `MASC_PLACEHOLDER_TOOLS_ENABLED`
- document that the flag stays runtime-readable while only exact `"false"` / `"0"` disable placeholder tools
- add focused coverage for unset, blank, exact falsey, and compatibility spellings in `test_tool_tier`

## Product impact
- existing deployments keep the current behavior even if they use non-canonical spellings like `FALSE`, `no`, or padded values
- placeholder-tool visibility semantics are now locked by tests instead of relying on implicit behavior only

## Evidence
- local: `dune build --root . test/test_tool_tier.exe`
- local: `_build/default/test/test_tool_tier.exe`

## Review evidence
- direct `sb glm-text` review found two issues on the previous revision (behavioral regression + test helper cleanup); both addressed in commit `84d66f240`
- final no-findings pass pending on the updated head

## Linked issue
- Refs #3989
