### PR TITLE
feat(governance): use semantic risk signals

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -33,6 +33,12 @@ let risk_level_to_int = function
   | High -> 2
   | Critical -> 3
 
+let risk_level_of_contract_risk = function
+  | Agent_sdk.Risk_class.Low -> Low
+  | Agent_sdk.Risk_class.Medium -> Medium
+  | Agent_sdk.Risk_class.High -> High
+  | Agent_sdk.Risk_class.Critical -> Critical
+
 (* ── Risk Assessment ────────────────────────────────────────── *)
 
 (** Pattern sets for risk classification.
@@ -72,7 +78,6 @@ let overwrite_sensitive_tools =
     "edit_text_file";
   ]
 
-let destructive_payload_keys = [ "command"; "cmd"; "content"; "new_string" ]
 let empty_overwrite_payload_keys = [ "content"; "new_string" ]
 
 let contains_pattern name patterns =
@@ -125,13 +130,66 @@ let rec collect_string_values ~keys json =
   | `List values -> List.concat_map (collect_string_values ~keys) values
   | _ -> []
 
+let rec collect_all_string_values json =
+  match json with
+  | `Assoc kvs ->
+      List.concat_map (fun (_, value) -> collect_all_string_values value) kvs
+  | `List values -> List.concat_map collect_all_string_values values
+  | `String text -> [ text ]
+  | _ -> []
+
+let rec collect_string_list_values ~keys json =
+  match json with
+  | `Assoc kvs ->
+      List.concat_map
+        (fun (key, value) ->
+          let normalized_key = String.lowercase_ascii (String.trim key) in
+          let direct =
+            if List.mem normalized_key keys then
+              match value with
+              | `List values ->
+                  values
+                  |> List.filter_map (function
+                         | `String text ->
+                             let trimmed = String.trim text in
+                             if trimmed = "" then None else Some trimmed
+                         | _ -> None)
+              | _ -> []
+            else
+              []
+          in
+          direct @ collect_string_list_values ~keys value)
+        kvs
+  | `List values -> List.concat_map (collect_string_list_values ~keys) values
+  | _ -> []
+
 let has_destructive_payload input =
-  collect_string_values ~keys:destructive_payload_keys input
+  collect_all_string_values input
   |> List.exists (fun text -> Eval_gate.detect_destructive text <> None)
 
 let has_empty_overwrite_payload input =
   collect_string_values ~keys:empty_overwrite_payload_keys input
   |> List.exists (fun text -> String.trim text = "")
+
+let tool_names_of_input ~tool_name input =
+  let tool_names =
+    collect_string_list_values ~keys:[ "tool_names" ] input
+    |> List.sort_uniq String.compare
+  in
+  if tool_names = [] then [ tool_name ] else tool_names
+
+let classify_with_contract_risk ~tool_name ~input =
+  match input with
+  | `Assoc _ -> (
+      match Team_session_types.delivery_contract_of_yojson
+              (Yojson.Safe.Util.member "delivery_contract" input) with
+      | Some delivery_contract ->
+          let tool_names = tool_names_of_input ~tool_name input in
+          Some
+            (risk_level_of_contract_risk
+               (Contract_risk.of_delivery_contract ~delivery_contract ~tool_names))
+      | None -> None)
+  | _ -> None
 
 let classify_with_metadata ~tool_name =
   let meta = Tool_catalog.metadata tool_name in
@@ -147,12 +205,15 @@ let classify_with_payload ~tool_name ~input =
   else None
 
 let assess_risk ~tool_name ~input =
-  match classify_with_metadata ~tool_name with
+  match classify_with_payload ~tool_name ~input with
   | Some level -> level
   | None -> (
-      match classify_with_payload ~tool_name ~input with
+      match classify_with_contract_risk ~tool_name ~input with
       | Some level -> level
-      | None ->
+      | None -> (
+          match classify_with_metadata ~tool_name with
+          | Some level -> level
+          | None ->
           (* Check explicit overrides after metadata/payload semantics. *)
           match List.assoc_opt tool_name risk_overrides with
           | Some level -> level
@@ -162,7 +223,7 @@ let assess_risk ~tool_name ~input =
                 | Some action -> classify_name action
                 | None -> Low
               else
-                classify_name tool_name)
+                classify_name tool_name))
 
 (* ── Trace ID generation ────────────────────────────────────── *)
 

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -172,11 +172,9 @@ let has_empty_overwrite_payload input =
   |> List.exists (fun text -> String.trim text = "")
 
 let tool_names_of_input ~tool_name input =
-  let tool_names =
-    collect_string_list_values ~keys:[ "tool_names" ] input
-    |> List.sort_uniq String.compare
-  in
-  if tool_names = [] then [ tool_name ] else tool_names
+  let (_ : string) = tool_name in
+  collect_string_list_values ~keys:[ "tool_names" ] input
+  |> List.sort_uniq String.compare
 
 let classify_with_contract_risk ~tool_name ~input =
   match input with

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -33,6 +33,9 @@ let risk_level_to_int = function
   | High -> 2
   | Critical -> 3
 
+let max_risk_level left right =
+  if risk_level_to_int left >= risk_level_to_int right then left else right
+
 let risk_level_of_contract_risk = function
   | Agent_sdk.Risk_class.Low -> Low
   | Agent_sdk.Risk_class.Medium -> Medium
@@ -202,26 +205,28 @@ let classify_with_payload ~tool_name ~input =
   then Some Critical
   else None
 
+let baseline_risk ~tool_name ~input =
+  match classify_with_metadata ~tool_name with
+  | Some level -> level
+  | None -> (
+      match List.assoc_opt tool_name risk_overrides with
+      | Some level -> level
+      | None ->
+          if String.equal tool_name "masc_transition" then
+            match transition_action input with
+            | Some action -> classify_name action
+            | None -> Low
+          else
+            classify_name tool_name)
+
 let assess_risk ~tool_name ~input =
   match classify_with_payload ~tool_name ~input with
   | Some level -> level
   | None -> (
+      let baseline = baseline_risk ~tool_name ~input in
       match classify_with_contract_risk ~tool_name ~input with
-      | Some level -> level
-      | None -> (
-          match classify_with_metadata ~tool_name with
-          | Some level -> level
-          | None ->
-          (* Check explicit overrides after metadata/payload semantics. *)
-          match List.assoc_opt tool_name risk_overrides with
-          | Some level -> level
-          | None ->
-              if String.equal tool_name "masc_transition" then
-                match transition_action input with
-                | Some action -> classify_name action
-                | None -> Low
-              else
-                classify_name tool_name))
+      | Some level -> max_risk_level baseline level
+      | None -> baseline)
 
 (* ── Trace ID generation ────────────────────────────────────── *)
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -94,6 +94,23 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     idempotent = None;
   }
 
+let with_semantic_flags ?readonly ?destructive ?idempotent meta =
+  {
+    meta with
+    readonly =
+      (match readonly with Some value -> Some value | None -> meta.readonly);
+    destructive =
+      (match destructive with Some value -> Some value | None -> meta.destructive);
+    idempotent =
+      (match idempotent with Some value -> Some value | None -> meta.idempotent);
+  }
+
+let readonly_tool =
+  with_semantic_flags ~readonly:true ~idempotent:true default_metadata
+
+let destructive_tool =
+  with_semantic_flags ~destructive:true default_metadata
+
 let explicit_metadata : (string * metadata) list =
   [
     ( "masc_post_create",
@@ -132,11 +149,60 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_judgment_latest",
       hidden_active
         "Internal operator-judge read path hidden from the default tool list; use for operator judgment experiments and keeper automation." );
-    (* Annotation overrides: correct misclassifications from name-pattern heuristics *)
+    (* Semantic annotations for governance risk classification. *)
+    ("masc_status", readonly_tool);
+    ("masc_tasks", readonly_tool);
+    ("masc_messages", readonly_tool);
+    ("masc_who", readonly_tool);
+    ("masc_agents", readonly_tool);
+    ("masc_dashboard", readonly_tool);
+    ("masc_agent_card", readonly_tool);
+    ("masc_board_list", readonly_tool);
+    ("masc_board_get", readonly_tool);
+    ("masc_tool_help", readonly_tool);
+    ("masc_keeper_list", readonly_tool);
+    ("masc_keeper_status", readonly_tool);
+    ("masc_transport_status", readonly_tool);
+    ("masc_websocket_discovery", readonly_tool);
+    ("masc_plan_get", readonly_tool);
+    ("masc_worktree_list", readonly_tool);
     ( "masc_run_get",
-      { default_metadata with readonly = Some true; idempotent = Some true } );
+      readonly_tool );
+    ("masc_run_list", readonly_tool);
+    ("masc_execute_dry_run", readonly_tool);
+    ( "masc_admin_cleanup",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Administrative cleanup mutates persisted room state and should be treated as destructive.") );
+    ( "masc_admin_reset",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Administrative reset clears room state and should be treated as destructive.") );
+    ( "masc_gc_force",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Forced garbage collection removes persisted artifacts and should be treated as destructive.") );
+    ( "masc_room_delete",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Room deletion removes persisted state and should be treated as destructive.") );
+    ( "masc_room_destroy",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Room destruction removes persisted state and should be treated as destructive.") );
+    ( "masc_force_leave",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Forced membership removal mutates room state and should be treated as destructive.") );
+    ( "masc_force_remove_agent",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Forced agent removal mutates room state and should be treated as destructive.") );
+    ( "masc_operator_action",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Operator actions can execute privileged side effects and should be treated as destructive.") );
+    ( "masc_execute",
+      with_semantic_flags ~destructive:true
+        (hidden_active "Direct execution can apply privileged side effects and should be treated as destructive.") );
+    ("masc_neo4j_query", destructive_tool);
+    ("masc_pg_query", destructive_tool);
+    ("masc_tool_grant", destructive_tool);
+    ("masc_tool_revoke", destructive_tool);
     ( "masc_operation_stop",
-      { default_metadata with destructive = Some true } );
+      destructive_tool );
     ( "masc_operation_pause",
       { default_metadata with destructive = Some false } );
   ]

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -388,6 +388,47 @@ let test_risk_contract_risk_non_object_input_falls_back_to_heuristic () =
   Alcotest.(check string) "non-object input keeps heuristic risk"
     "high" (Gp.risk_level_to_string risk)
 
+let test_risk_contract_risk_does_not_downgrade_heuristic () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_create_room"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("contract_id", `String "contract-risk-004");
+                  ("summary", `String "benign contract");
+                  ("required_artifacts", `List [ `String "report.md" ]);
+                  ("repair_budget", `Int 5);
+                ] );
+          ])
+  in
+  Alcotest.(check string) "contract risk cannot downgrade high heuristic"
+    "high" (Gp.risk_level_to_string risk)
+
+let test_risk_payload_beats_contract_risk () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_team_session_step"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("contract_id", `String "contract-risk-005");
+                  ("summary", `String "medium contract");
+                  ( "required_artifacts",
+                    `List [ `String "report.md"; `String "test.xml" ] );
+                  ("repair_budget", `Int 3);
+                ] );
+            ("tool_names", `List [ `String "keeper_fs_edit" ]);
+            ("note", `String "rm -rf /tmp/demo");
+          ])
+  in
+  Alcotest.(check string) "payload risk beats contract risk"
+    "critical" (Gp.risk_level_to_string risk)
+
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
 let test_development_allows_all () =
@@ -728,6 +769,10 @@ let () =
         test_risk_contract_risk_empty_tool_names_uses_contract_only;
       Alcotest.test_case "contract risk: non-object input falls back" `Quick
         test_risk_contract_risk_non_object_input_falls_back_to_heuristic;
+      Alcotest.test_case "contract risk: does not downgrade heuristic" `Quick
+        test_risk_contract_risk_does_not_downgrade_heuristic;
+      Alcotest.test_case "payload beats contract risk" `Quick
+        test_risk_payload_beats_contract_risk;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
     ];
     "governance_levels", [

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -210,6 +210,16 @@ let test_risk_metadata_destructive_override () =
   Alcotest.(check string) "operation_stop metadata marks destructive"
     "critical" (Gp.risk_level_to_string risk)
 
+let test_risk_metadata_admin_cleanup_override () =
+  let risk = Gp.assess_risk ~tool_name:"masc_admin_cleanup" ~input:no_args in
+  Alcotest.(check string) "admin_cleanup metadata marks destructive"
+    "critical" (Gp.risk_level_to_string risk)
+
+let test_risk_metadata_pg_query_override () =
+  let risk = Gp.assess_risk ~tool_name:"masc_pg_query" ~input:no_args in
+  Alcotest.(check string) "pg_query metadata marks destructive"
+    "critical" (Gp.risk_level_to_string risk)
+
 let test_risk_payload_empty_overwrite () =
   let risk =
     Gp.assess_risk ~tool_name:"masc_code_write"
@@ -237,6 +247,22 @@ let test_risk_payload_destructive_content () =
   Alcotest.(check string) "destructive payload content is critical"
     "critical" (Gp.risk_level_to_string risk)
 
+let test_risk_payload_destructive_nested_string () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_status"
+      ~input:
+        (`Assoc
+          [
+            ( "payload",
+              `Assoc
+                [
+                  ("note", `String "DROP TABLE production_users");
+                ] );
+          ])
+  in
+  Alcotest.(check string) "nested destructive payload is critical"
+    "critical" (Gp.risk_level_to_string risk)
+
 let test_risk_payload_safe_write_remains_high () =
   let risk =
     Gp.assess_risk ~tool_name:"masc_code_write"
@@ -249,6 +275,34 @@ let test_risk_payload_safe_write_remains_high () =
   in
   Alcotest.(check string) "safe write payload remains high"
     "high" (Gp.risk_level_to_string risk)
+
+let test_risk_contract_risk_from_delivery_contract () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_team_session_step"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("contract_id", `String "contract-risk-001");
+                  ("summary", `String "high risk execution");
+                  ( "required_artifacts",
+                    `List
+                      [
+                        `String "a";
+                        `String "b";
+                        `String "c";
+                        `String "d";
+                        `String "e";
+                      ] );
+                  ("repair_budget", `Int 0);
+                ] );
+            ("tool_names", `List [ `String "keeper_bash"; `String "keeper_github" ]);
+          ])
+  in
+  Alcotest.(check string) "delivery contract drives critical risk"
+    "critical" (Gp.risk_level_to_string risk)
 
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
@@ -566,12 +620,20 @@ let () =
         test_risk_precedence_critical_over_high;
       Alcotest.test_case "metadata: destructive override" `Quick
         test_risk_metadata_destructive_override;
+      Alcotest.test_case "metadata: admin cleanup override" `Quick
+        test_risk_metadata_admin_cleanup_override;
+      Alcotest.test_case "metadata: pg query override" `Quick
+        test_risk_metadata_pg_query_override;
       Alcotest.test_case "payload: empty overwrite" `Quick
         test_risk_payload_empty_overwrite;
       Alcotest.test_case "payload: destructive content" `Quick
         test_risk_payload_destructive_content;
+      Alcotest.test_case "payload: destructive nested string" `Quick
+        test_risk_payload_destructive_nested_string;
       Alcotest.test_case "payload: safe write remains high" `Quick
         test_risk_payload_safe_write_remains_high;
+      Alcotest.test_case "contract risk: delivery contract" `Quick
+        test_risk_contract_risk_from_delivery_contract;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
     ];
     "governance_levels", [

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -276,6 +276,22 @@ let test_risk_payload_safe_write_remains_high () =
   Alcotest.(check string) "safe write payload remains high"
     "high" (Gp.risk_level_to_string risk)
 
+let test_risk_payload_safe_nested_string_remains_low () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_status"
+      ~input:
+        (`Assoc
+          [
+            ( "payload",
+              `Assoc
+                [
+                  ("note", `String "temporary scratch directory");
+                ] );
+          ])
+  in
+  Alcotest.(check string) "safe nested payload stays low"
+    "low" (Gp.risk_level_to_string risk)
+
 let test_risk_contract_risk_from_delivery_contract () =
   let risk =
     Gp.assess_risk ~tool_name:"masc_team_session_step"
@@ -303,6 +319,45 @@ let test_risk_contract_risk_from_delivery_contract () =
   in
   Alcotest.(check string) "delivery contract drives critical risk"
     "critical" (Gp.risk_level_to_string risk)
+
+let test_risk_contract_risk_medium_delivery_contract () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_team_session_step"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("contract_id", `String "contract-risk-002");
+                  ("summary", `String "medium risk execution");
+                  ( "required_artifacts",
+                    `List [ `String "report.md"; `String "test.xml" ] );
+                  ("repair_budget", `Int 3);
+                ] );
+            ("tool_names", `List [ `String "keeper_fs_edit" ]);
+          ])
+  in
+  Alcotest.(check string) "delivery contract drives medium risk"
+    "medium" (Gp.risk_level_to_string risk)
+
+let test_risk_invalid_delivery_contract_falls_back_to_heuristic () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_create_room"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("summary", `String "missing contract id");
+                  ("repair_budget", `Int 0);
+                ] );
+            ("tool_names", `List [ `Int 1 ]);
+          ])
+  in
+  Alcotest.(check string) "invalid contract falls back to heuristic"
+    "high" (Gp.risk_level_to_string risk)
 
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
@@ -632,8 +687,14 @@ let () =
         test_risk_payload_destructive_nested_string;
       Alcotest.test_case "payload: safe write remains high" `Quick
         test_risk_payload_safe_write_remains_high;
+      Alcotest.test_case "payload: safe nested string remains low" `Quick
+        test_risk_payload_safe_nested_string_remains_low;
       Alcotest.test_case "contract risk: delivery contract" `Quick
         test_risk_contract_risk_from_delivery_contract;
+      Alcotest.test_case "contract risk: medium delivery contract" `Quick
+        test_risk_contract_risk_medium_delivery_contract;
+      Alcotest.test_case "contract risk: invalid contract falls back" `Quick
+        test_risk_invalid_delivery_contract_falls_back_to_heuristic;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
     ];
     "governance_levels", [

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -359,6 +359,35 @@ let test_risk_invalid_delivery_contract_falls_back_to_heuristic () =
   Alcotest.(check string) "invalid contract falls back to heuristic"
     "high" (Gp.risk_level_to_string risk)
 
+let test_risk_contract_risk_empty_tool_names_uses_contract_only () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_team_session_step"
+      ~input:
+        (`Assoc
+          [
+            ( "delivery_contract",
+              `Assoc
+                [
+                  ("contract_id", `String "contract-risk-003");
+                  ("summary", `String "medium risk without explicit tools");
+                  ( "required_artifacts",
+                    `List [ `String "report.md"; `String "test.xml" ] );
+                  ("repair_budget", `Int 3);
+                ] );
+            ("tool_names", `List []);
+          ])
+  in
+  Alcotest.(check string) "empty tool_names keeps contract-derived medium risk"
+    "medium" (Gp.risk_level_to_string risk)
+
+let test_risk_contract_risk_non_object_input_falls_back_to_heuristic () =
+  let risk =
+    Gp.assess_risk ~tool_name:"masc_create_room"
+      ~input:(`List [ `String "delivery_contract"; `String "ignored" ])
+  in
+  Alcotest.(check string) "non-object input keeps heuristic risk"
+    "high" (Gp.risk_level_to_string risk)
+
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
 let test_development_allows_all () =
@@ -695,6 +724,10 @@ let () =
         test_risk_contract_risk_medium_delivery_contract;
       Alcotest.test_case "contract risk: invalid contract falls back" `Quick
         test_risk_invalid_delivery_contract_falls_back_to_heuristic;
+      Alcotest.test_case "contract risk: empty tool_names uses contract only" `Quick
+        test_risk_contract_risk_empty_tool_names_uses_contract_only;
+      Alcotest.test_case "contract risk: non-object input falls back" `Quick
+        test_risk_contract_risk_non_object_input_falls_back_to_heuristic;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
     ];
     "governance_levels", [


### PR DESCRIPTION
## Summary
- inspect all string-valued JSON fields for destructive payload patterns instead of only a small key allowlist
- derive governance risk from `delivery_contract` + `tool_names` via `Contract_risk` before falling back to name heuristics
- expand `Tool_catalog` semantic metadata for high-impact destructive tools and common readonly/idempotent surfaces
- add governance pipeline regression tests for metadata overrides, nested payload inspection, and contract-risk escalation

## Product impact
- reduces false-low classifications for privileged tools such as `masc_pg_query` and `masc_admin_cleanup`
- escalates team-session style requests by actual contract/tool semantics instead of just the outer tool name
- catches destructive commands hidden in nested payload strings before governance approval policy runs

## Evidence
- local: `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3970-governance-risk test/test_governance_pipeline.exe`
- local: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3970-governance-risk/_build/default/test/test_governance_pipeline.exe`
- result: `Governance_pipeline` 65/65 tests passing after rebase on current `origin/main`

## Review evidence
- pending: direct `sb glm-text` review on the final diff

## Linked issue
- closes #3970
