### PR TITLE
feat(governance): semantic risk classification with metadata + contract_risk

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -72,7 +72,9 @@ let overwrite_sensitive_tools =
     "edit_text_file";
   ]
 
-let destructive_payload_keys = [ "command"; "cmd"; "content"; "new_string" ]
+let destructive_payload_keys =
+  [ "command"; "cmd"; "content"; "new_string"; "body"; "script";
+    "shell"; "bash"; "query"; "message"; "text"; "code" ]
 let empty_overwrite_payload_keys = [ "content"; "new_string" ]
 
 let contains_pattern name patterns =
@@ -133,12 +135,24 @@ let has_empty_overwrite_payload input =
   collect_string_values ~keys:empty_overwrite_payload_keys input
   |> List.exists (fun text -> String.trim text = "")
 
+(** Metadata-based classification.
+    Returns a (level, is_definitive) pair:
+    - destructive=true or readonly=true are definitive (skip payload check)
+    - destructive=false is a hint (payload can still escalate) *)
 let classify_with_metadata ~tool_name =
   let meta = Tool_catalog.metadata tool_name in
   match (meta.Tool_catalog.destructive, meta.Tool_catalog.readonly) with
-  | Some true, _ -> Some Critical
-  | _, Some true -> Some Low
+  | Some true, _ -> Some (Critical, true)
+  | _, Some true -> Some (Low, true)
+  | Some false, _ -> Some (Medium, false)  (* hint: payload can override *)
   | _ -> None
+
+(** Semantic classification using Contract_risk tool lists.
+    Maps external_effect → High, workspace_mutating → Medium. *)
+let classify_with_contract_risk ~tool_name =
+  if List.mem tool_name Contract_risk.external_effect_tools then Some High
+  else if List.mem tool_name Contract_risk.workspace_mutating_tools then Some Medium
+  else None
 
 let classify_with_payload ~tool_name ~input =
   if has_destructive_payload input then Some Critical
@@ -146,23 +160,37 @@ let classify_with_payload ~tool_name ~input =
   then Some Critical
   else None
 
+(** Risk assessment cascade (most specific → least specific):
+    1. Tool_catalog metadata annotations (definitive: destructive/readonly)
+    2. Payload content inspection (destructive patterns, empty overwrites)
+    3. Tool_catalog metadata hint (non-definitive: destructive=false → Medium)
+    4. Contract_risk tool lists (external_effect, workspace_mutating)
+    5. Explicit per-tool overrides (false positive corrections)
+    6. Substring pattern matching on tool name (fallback) *)
 let assess_risk ~tool_name ~input =
   match classify_with_metadata ~tool_name with
-  | Some level -> level
-  | None -> (
+  | Some (level, true) -> level  (* definitive metadata: destructive=true or readonly=true *)
+  | definitive_or_hint -> (
+      (* Payload can escalate even when metadata says destructive=false *)
       match classify_with_payload ~tool_name ~input with
       | Some level -> level
-      | None ->
-          (* Check explicit overrides after metadata/payload semantics. *)
-          match List.assoc_opt tool_name risk_overrides with
-          | Some level -> level
-          | None ->
-              if String.equal tool_name "masc_transition" then
-                match transition_action input with
-                | Some action -> classify_name action
-                | None -> Low
-              else
-                classify_name tool_name)
+      | None -> (
+          (* Non-definitive metadata hint: destructive=false → Medium *)
+          match definitive_or_hint with
+          | Some (level, false) -> level
+          | _ -> (
+              match classify_with_contract_risk ~tool_name with
+              | Some level -> level
+              | None ->
+                  match List.assoc_opt tool_name risk_overrides with
+                  | Some level -> level
+                  | None ->
+                      if String.equal tool_name "masc_transition" then
+                        match transition_action input with
+                        | Some action -> classify_name action
+                        | None -> Low
+                      else
+                        classify_name tool_name)))
 
 (* ── Trace ID generation ────────────────────────────────────── *)
 

--- a/lib/team_session/contract_risk.mli
+++ b/lib/team_session/contract_risk.mli
@@ -13,6 +13,12 @@ type risk_axes = {
   recovery_cost : recovery_cost;
 }
 
+(** Tools with irreversible external side effects (git push, bash, broadcast). *)
+val external_effect_tools : string list
+
+(** Tools that mutate workspace files but have no external effect. *)
+val workspace_mutating_tools : string list
+
 val assess :
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -132,12 +132,79 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_judgment_latest",
       hidden_active
         "Internal operator-judge read path hidden from the default tool list; use for operator judgment experiments and keeper automation." );
-    (* Annotation overrides: correct misclassifications from name-pattern heuristics *)
+    (* ── Annotation overrides ─────────────────────────────────── *)
+    (* Correct misclassifications from name-pattern heuristics.
+       Categories aligned with Contract_risk axis model:
+       - destructive=true  → external effect or irreversible mutation
+       - destructive=false → safe despite pattern match on name
+       - readonly=true     → read-only, no side effects *)
+
+    (* Read-only / idempotent tools *)
     ( "masc_run_get",
       { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_status",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_who",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_messages",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_poll_events",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_relay_status",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_read",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_fs_read",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_memory_search",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_library_search",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_library_read",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_time_now",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_context_status",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "keeper_shell_readonly",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+
+    (* External-effect tools: irreversible side effects outside workspace *)
+    ( "keeper_bash",
+      { default_metadata with destructive = Some true } );
+    ( "keeper_github",
+      { default_metadata with destructive = Some true } );
+    ( "masc_broadcast",
+      { default_metadata with destructive = Some false } );
+    ( "masc_spawn",
+      { default_metadata with destructive = Some true } );
+    ( "masc_execute",
+      { default_metadata with destructive = Some true } );
     ( "masc_operation_stop",
       { default_metadata with destructive = Some true } );
+
+    (* Workspace-mutating tools: reversible file mutations *)
+    ( "keeper_fs_edit",
+      { default_metadata with destructive = Some false } );
+    ( "keeper_edit",
+      { default_metadata with destructive = Some false } );
+    ( "keeper_write",
+      { default_metadata with destructive = Some false } );
+    ( "masc_code_write",
+      { default_metadata with destructive = Some false } );
+    ( "masc_code_edit",
+      { default_metadata with destructive = Some false } );
+
+    (* Safe despite pattern-match false positives *)
     ( "masc_operation_pause",
+      { default_metadata with destructive = Some false } );
+    ( "masc_set_room",
+      { default_metadata with destructive = Some false } );
+    ( "masc_join",
+      { default_metadata with destructive = Some false } );
+    ( "masc_leave",
+      { default_metadata with destructive = Some false } );
+    ( "masc_start",
       { default_metadata with destructive = Some false } );
   ]
 

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -237,7 +237,9 @@ let test_risk_payload_destructive_content () =
   Alcotest.(check string) "destructive payload content is critical"
     "critical" (Gp.risk_level_to_string risk)
 
-let test_risk_payload_safe_write_remains_high () =
+(* masc_code_write has metadata destructive=false → medium for safe payloads.
+   Destructive payloads still escalate to critical via payload inspection. *)
+let test_risk_payload_safe_write_remains_medium () =
   let risk =
     Gp.assess_risk ~tool_name:"masc_code_write"
       ~input:
@@ -247,8 +249,8 @@ let test_risk_payload_safe_write_remains_high () =
             ("content", `String "let answer = 42\n");
           ])
   in
-  Alcotest.(check string) "safe write payload remains high"
-    "high" (Gp.risk_level_to_string risk)
+  Alcotest.(check string) "safe write payload is medium (metadata annotated)"
+    "medium" (Gp.risk_level_to_string risk)
 
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
@@ -524,6 +526,52 @@ let test_case_insensitive_matching () =
   Alcotest.(check string) "uppercase delete is critical"
     "critical" (Gp.risk_level_to_string risk)
 
+(* ── Semantic risk classification tests ────────────────────── *)
+
+let test_metadata_readonly_is_low () =
+  let risk = Gp.assess_risk ~tool_name:"keeper_read" ~input:`Null in
+  Alcotest.(check string) "readonly metadata → low"
+    "low" (Gp.risk_level_to_string risk)
+
+let test_metadata_readonly_fs_read () =
+  let risk = Gp.assess_risk ~tool_name:"keeper_fs_read" ~input:`Null in
+  Alcotest.(check string) "fs_read readonly → low"
+    "low" (Gp.risk_level_to_string risk)
+
+let test_metadata_destructive_bash () =
+  let risk = Gp.assess_risk ~tool_name:"keeper_bash" ~input:`Null in
+  Alcotest.(check string) "keeper_bash destructive → critical"
+    "critical" (Gp.risk_level_to_string risk)
+
+let test_metadata_nondestruct_edit () =
+  let risk = Gp.assess_risk ~tool_name:"keeper_fs_edit" ~input:`Null in
+  Alcotest.(check string) "fs_edit non-destructive → medium"
+    "medium" (Gp.risk_level_to_string risk)
+
+let test_contract_risk_external_effect () =
+  let risk = Gp.assess_risk ~tool_name:"masc_execute" ~input:`Null in
+  Alcotest.(check string) "masc_execute destructive → critical"
+    "critical" (Gp.risk_level_to_string risk)
+
+let test_contract_risk_workspace_mutating () =
+  let risk = Gp.assess_risk ~tool_name:"create_text_file" ~input:`Null in
+  Alcotest.(check string) "create_text_file workspace-mutating → medium"
+    "medium" (Gp.risk_level_to_string risk)
+
+let test_metadata_overrides_name_pattern () =
+  (* masc_join has "join" pattern → medium, and metadata destructive=false → medium.
+     But masc_start has "start" pattern → medium, and metadata destructive=false → medium.
+     keeper_shell_readonly has no pattern match but readonly=true → low *)
+  let risk = Gp.assess_risk ~tool_name:"keeper_shell_readonly" ~input:`Null in
+  Alcotest.(check string) "readonly override → low"
+    "low" (Gp.risk_level_to_string risk)
+
+let test_payload_expanded_keys () =
+  let input = `Assoc [("script", `String "rm -rf /")] in
+  let risk = Gp.assess_risk ~tool_name:"masc_some_tool" ~input in
+  Alcotest.(check string) "destructive in script key → critical"
+    "critical" (Gp.risk_level_to_string risk)
+
 (* ── Runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -570,9 +618,27 @@ let () =
         test_risk_payload_empty_overwrite;
       Alcotest.test_case "payload: destructive content" `Quick
         test_risk_payload_destructive_content;
-      Alcotest.test_case "payload: safe write remains high" `Quick
-        test_risk_payload_safe_write_remains_high;
+      Alcotest.test_case "payload: safe write is medium (metadata)" `Quick
+        test_risk_payload_safe_write_remains_medium;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
+    ];
+    "semantic_classification", [
+      Alcotest.test_case "metadata: readonly → low" `Quick
+        test_metadata_readonly_is_low;
+      Alcotest.test_case "metadata: fs_read readonly → low" `Quick
+        test_metadata_readonly_fs_read;
+      Alcotest.test_case "metadata: bash destructive → critical" `Quick
+        test_metadata_destructive_bash;
+      Alcotest.test_case "metadata: fs_edit non-destructive → medium" `Quick
+        test_metadata_nondestruct_edit;
+      Alcotest.test_case "contract_risk: external_effect → critical" `Quick
+        test_contract_risk_external_effect;
+      Alcotest.test_case "contract_risk: workspace_mutating → medium" `Quick
+        test_contract_risk_workspace_mutating;
+      Alcotest.test_case "metadata overrides name pattern" `Quick
+        test_metadata_overrides_name_pattern;
+      Alcotest.test_case "payload: expanded keys (script)" `Quick
+        test_payload_expanded_keys;
     ];
     "governance_levels", [
       Alcotest.test_case "development allows all" `Quick


### PR DESCRIPTION
## Summary
- Upgrade risk assessment from substring matching to 6-layer cascade
- 30+ tools annotated with `destructive`/`readonly` metadata in Tool_catalog
- Contract_risk tool lists integrated as classification layer
- Payload inspection expanded to 12 string field keys (was 4)
- Metadata `destructive=false` is a non-definitive hint: payload can still escalate

## Changes
- `lib/tool_catalog.ml` — 30+ metadata annotations
- `lib/governance_pipeline.ml` — 6-layer assess_risk cascade + contract_risk integration
- `lib/team_session/contract_risk.mli` — expose tool lists
- `test/test_governance_pipeline.ml` — 8 new semantic classification tests

Closes #3970

## Test plan
- [x] `test_governance_pipeline` — 69/69 green (8 new)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>