### PR TITLE
feat(keeper): crash cohort + health score + allowed_paths dashboard (#3905, #3908, #3876)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -602,6 +602,7 @@ export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
 export type KeeperConfigUpdatePayload = {
   // Scope
   execution_scope?: 'observe_only' | 'workspace' | 'local'
+  allowed_paths?: string[]
   // Prompt fields
   goal?: string
   short_goal?: string

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -72,6 +72,7 @@ type ExecutionScope = 'observe_only' | 'workspace' | 'local'
 
 type RuntimeDraft = {
   execution_scope: ExecutionScope
+  allowed_paths_text: string
   proactive_enabled: boolean
   proactive_idle_sec: number
   proactive_cooldown_sec: number
@@ -90,6 +91,7 @@ const runtimeSaving = signal(false)
 function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     execution_scope: (c.execution_scope as ExecutionScope) ?? 'workspace',
+    allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
     proactive_enabled: c.proactive.enabled,
     proactive_idle_sec: c.proactive.idle_sec,
     proactive_cooldown_sec: c.proactive.cooldown_sec,
@@ -106,6 +108,9 @@ function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
 function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
   const payload: KeeperConfigUpdatePayload = {}
   if (draft.execution_scope !== (orig.execution_scope ?? 'workspace')) payload.execution_scope = draft.execution_scope
+  const newPaths = draft.allowed_paths_text.split('\n').map(s => s.trim()).filter(Boolean)
+  const origPaths = orig.allowed_paths ?? []
+  if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
   if (draft.proactive_enabled !== orig.proactive.enabled) payload.proactive_enabled = draft.proactive_enabled
   if (draft.proactive_idle_sec !== orig.proactive.idle_sec) payload.proactive_idle_sec = draft.proactive_idle_sec
   if (draft.proactive_cooldown_sec !== orig.proactive.cooldown_sec) payload.proactive_cooldown_sec = draft.proactive_cooldown_sec
@@ -599,8 +604,27 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
             <option value="local">local</option>
           </select>
         </div>
+        <div class="py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1">
+            <span class="text-xs text-[var(--text-body)]">allowed_paths</span>
+            <span class="text-[10px] text-[var(--text-muted)]">한 줄에 하나씩. * = 전체 허용</span>
+          </div>
+          <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--card-border)] rounded px-2 py-1.5 text-[var(--text-body)] resize-y"
+            rows=${3}
+            value=${rd.allowed_paths_text}
+            placeholder=".masc/keepers/<name>/"
+            onInput=${(e: Event) => updateRuntimeDraft('allowed_paths_text', (e.target as HTMLTextAreaElement).value)}
+          ></textarea>
+        </div>
+        ${(c.effective_allowed_paths ?? []).length > 0 ? html`
+          <div class="py-1.5 px-3 text-[10px] text-[var(--text-muted)]">
+            effective: ${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'}
+          </div>
+        ` : null}
       ` : html`
         <${ConfigRow} label="execution_scope" value=${c.execution_scope ?? 'workspace'} />
+        <${ConfigRow} label="allowed_paths" value=${(c.allowed_paths ?? []).join(', ') || '(computed default)'} />
+        <${ConfigRow} label="effective_paths" value=${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'} />
       `}
 
       <${SectionHeader} title="프로액티브" />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -164,10 +164,66 @@ function registryStateBadge(state: string | null) {
   return html`<span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold ${c.bg} ${c.text}">${state}</span>`
 }
 
+function CrashCohortBar({ crash_log }: { crash_log: any[] }) {
+  if (!crash_log || crash_log.length === 0) return null
+  const cohorts: Record<string, number> = {}
+  for (const e of crash_log) {
+    const reason = (e.reason ?? 'unknown') as string
+    const key = reason.startsWith('heartbeat') ? 'heartbeat'
+      : reason.startsWith('turn') ? 'turn'
+      : reason.startsWith('fiber') ? 'fiber'
+      : reason.startsWith('exception') ? 'exception'
+      : 'other'
+    cohorts[key] = (cohorts[key] ?? 0) + 1
+  }
+  const total = crash_log.length
+  const colors: Record<string, string> = {
+    heartbeat: '#f59e0b', turn: '#ef4444', fiber: '#8b5cf6',
+    exception: '#ec4899', other: '#6b7280',
+  }
+  return html`
+    <div>
+      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Crash Cohort 분포</div>
+      <div class="flex w-full h-3 rounded-full overflow-hidden bg-[var(--white-5)]">
+        ${Object.entries(cohorts).map(([key, count]) => html`
+          <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${colors[key] ?? '#6b7280'}"
+               title="${key}: ${count}건 (${(count / total * 100).toFixed(0)}%)"
+               class="h-full"></div>
+        `)}
+      </div>
+      <div class="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
+        ${Object.entries(cohorts).map(([key, count]) => html`
+          <span class="text-[10px] text-[var(--text-muted)] flex items-center gap-1">
+            <span class="inline-block w-2 h-2 rounded-full" style="background: ${colors[key] ?? '#6b7280'}"></span>
+            ${key} ${count}
+          </span>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function SpEventsPanel({ sp_events }: { sp_events: any[] }) {
+  if (!sp_events || sp_events.length === 0) return null
+  return html`
+    <div>
+      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Self-Preservation 발동 이력</div>
+      <div class="space-y-1 max-h-28 overflow-y-auto">
+        ${sp_events.slice(0, 10).map((e: any) => html`
+          <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[rgba(139,92,246,0.06)]">
+            <span class="font-mono text-[var(--text-muted)]">${new Date((e.ts ?? 0) * 1000).toLocaleTimeString()}</span>
+            <span class="text-[#8b5cf6]">${e.suppressed_count}/${e.total} suppressed (${e.dominant_cohort})</span>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
 function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
   const diag = (keeper as any).supervisor_diagnostics
   if (!diag) return null
-  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since } = diag
+  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since, sp_events } = diag
   const budgetPct = max_restarts > 0 ? Math.min(100, (restart_count / max_restarts) * 100) : 0
   const budgetColor = budgetPct >= 80 ? '#ef4444' : budgetPct >= 50 ? '#f59e0b' : '#4ade80'
   return html`
@@ -197,6 +253,7 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
             Dead since ${new Date(dead_since * 1000).toLocaleString()}. Reboot 필요.
           </div>
         ` : null}
+        <${CrashCohortBar} crash_log=${crash_log} />
         ${crash_log && crash_log.length > 0 ? html`
           <div>
             <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Crash 이력</div>
@@ -210,6 +267,7 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
             </div>
           </div>
         ` : null}
+        <${SpEventsPanel} sp_events=${sp_events} />
       </div>
     <//>
   `

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -223,12 +223,18 @@ function SpEventsPanel({ sp_events }: { sp_events: any[] }) {
 function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
   const diag = (keeper as any).supervisor_diagnostics
   if (!diag) return null
-  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since, sp_events } = diag
+  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since, sp_events, health_score } = diag
   const budgetPct = max_restarts > 0 ? Math.min(100, (restart_count / max_restarts) * 100) : 0
   const budgetColor = budgetPct >= 80 ? '#ef4444' : budgetPct >= 50 ? '#f59e0b' : '#4ade80'
+  const hs = typeof health_score === 'number' ? health_score : 100
+  const hsColor = hs >= 80 ? '#4ade80' : hs >= 50 ? '#f59e0b' : '#ef4444'
   return html`
     <${SectionCard} title="Supervisor 진단">
       <div class="space-y-3">
+        <div class="flex items-center justify-between">
+          <span class="text-xs text-[var(--text-muted)]">Health Score</span>
+          <span class="text-sm font-bold font-mono" style="color: ${hsColor}">${hs}</span>
+        </div>
         <div class="flex items-center justify-between">
           <span class="text-xs text-[var(--text-muted)]">Fiber 상태</span>
           ${registryStateBadge((keeper as any).registry_state)}

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -43,10 +43,30 @@ export function OpsKeeperColumn() {
   const selectedKeeper = keepers.find(keeper => keeper.name === selectedKeeperName.value) ?? keepers[0] ?? null
   const busy = operatorActionBusy.value
 
+  const statusCounts = keepers.reduce((acc: Record<string, number>, k) => {
+    const s = k.status === 'active' || k.status === 'running' ? 'running'
+      : k.status === 'offline' ? 'offline'
+      : k.status === 'paused' ? 'paused'
+      : k.status === 'crashed' ? 'crashed'
+      : k.status === 'dead' ? 'dead'
+      : 'other'
+    acc[s] = (acc[s] ?? 0) + 1
+    return acc
+  }, {})
+
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel ops-keeper-section">
         <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">키퍼 목록</h3>
+        ${keepers.length > 0 ? html`
+          <div class="flex gap-3 text-[11px] font-mono">
+            ${statusCounts.running ? html`<span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-[var(--ok)]"></span>${statusCounts.running} running</span>` : null}
+            ${statusCounts.paused ? html`<span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-[#f59e0b]"></span>${statusCounts.paused} paused</span>` : null}
+            ${statusCounts.crashed ? html`<span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-[#ef4444]"></span>${statusCounts.crashed} crashed</span>` : null}
+            ${statusCounts.dead ? html`<span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-[#6b7280]"></span>${statusCounts.dead} dead</span>` : null}
+            ${statusCounts.offline ? html`<span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-[var(--text-muted)]"></span>${statusCounts.offline} offline</span>` : null}
+          </div>
+        ` : null}
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">keeper를 선택하면 아래에서 메시지를 보내거나 상세 정보를 볼 수 있습니다.</p>
 
         <div class="flex flex-col gap-2">

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -534,6 +534,8 @@ export interface KeeperConfigMetrics {
 export interface KeeperConfig {
   name: string
   execution_scope: string
+  allowed_paths: string[]
+  effective_allowed_paths: string[]
   prompt: KeeperConfigPrompt
   execution: KeeperConfigExecution
   compaction: KeeperConfigCompaction

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,6 +10,31 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
+(** Compute keeper health score (0-100). Pure function.
+    Inputs: restart_count, max_restarts, recent_crash_count,
+            is_dead, context_ratio (0.0-1.0). *)
+let compute_health_score
+    ~restart_count ~max_restarts ~recent_crash_count
+    ~is_dead ~context_ratio =
+  if is_dead then 0
+  else
+    let budget_penalty =
+      if max_restarts <= 0 then 0.0
+      else
+        let ratio = float_of_int restart_count /. float_of_int max_restarts in
+        Float.min 1.0 ratio *. 40.0
+    in
+    let crash_penalty =
+      Float.min 30.0 (float_of_int recent_crash_count *. 10.0)
+    in
+    let context_penalty =
+      if context_ratio > 0.9 then 20.0
+      else if context_ratio > 0.8 then 10.0
+      else 0.0
+    in
+    let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in
+    Int.max 0 (Int.min 100 (Float.to_int raw))
+
 let prompt_block_json key =
   let resolved = Prompt_registry.resolve_prompt key in
   `Assoc
@@ -265,6 +290,16 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   (try Keeper_crash_persistence.recent_sp_events
                     ~keepers_dir ~max_entries:20
                   with _ -> []) in
+                let ctx_ratio =
+                  match last_metrics with
+                  | Some m -> Safe_ops.json_float "context_ratio" m
+                  | None -> 0.0 in
+                let health_score = compute_health_score
+                  ~restart_count:entry.restart_count
+                  ~max_restarts
+                  ~recent_crash_count:(List.length combined_log)
+                  ~is_dead:(Option.is_some entry.dead_since_ts)
+                  ~context_ratio:ctx_ratio in
                 `Assoc [
                   ("restart_count", `Int entry.restart_count);
                   ("max_restarts", `Int max_restarts);
@@ -278,6 +313,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                     | Some ts -> `Float ts
                     | None -> `Null);
                   ("sp_events", `List sp_events);
+                  ("health_score", `Int health_score);
                 ]
             | None ->
                 `Assoc [
@@ -287,6 +323,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("last_failure_reason", `Null);
                   ("dead_since", `Null);
                   ("sp_events", `List []);
+                  ("health_score", `Int 100);
                 ]
           in
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -735,6 +735,11 @@ let keeper_config_json (config : Room.config) (name : string)
        `Assoc [
          ("name", `String m.name);
          ("execution_scope", `String m.execution_scope);
+         ("allowed_paths",
+           `List (List.map (fun s -> `String s) m.allowed_paths));
+         ("effective_allowed_paths",
+           `List (List.map (fun s -> `String s)
+             (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
          ("pipeline_stage", `String pipeline_stage);
          ("prompt", prompt);
          ("execution", execution);

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -261,6 +261,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 let combined_log = match disk_crashes with
                   | [] -> crash_log
                   | _ -> disk_crashes in
+                let sp_events =
+                  (try Keeper_crash_persistence.recent_sp_events
+                    ~keepers_dir ~max_entries:20
+                  with _ -> []) in
                 `Assoc [
                   ("restart_count", `Int entry.restart_count);
                   ("max_restarts", `Int max_restarts);
@@ -273,6 +277,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                     match entry.dead_since_ts with
                     | Some ts -> `Float ts
                     | None -> `Null);
+                  ("sp_events", `List sp_events);
                 ]
             | None ->
                 `Assoc [
@@ -281,6 +286,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("crash_log", `List []);
                   ("last_failure_reason", `Null);
                   ("dead_since", `Null);
+                  ("sp_events", `List []);
                 ]
           in
 

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -64,6 +64,61 @@ let write_event (ev : crash_event) =
   ] in
   Dated_jsonl.append store json
 
+(* ── self-preservation events ──────────────────────────────── *)
+
+type sp_event = {
+  sp_keepers_dir : string;
+  sp_ts : float;
+  sp_suppressed_count : int;
+  sp_total : int;
+  sp_ratio : float;
+  sp_dominant_cohort : string;
+}
+
+let sp_queue : sp_event Queue.t = Queue.create ()
+
+let sp_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 2
+let sp_store_mu = Eio.Mutex.create ()
+
+let sp_store ~keepers_dir : Dated_jsonl.t =
+  let dir = Filename.concat keepers_dir "_self-preservation" in
+  Eio_guard.with_mutex sp_store_mu (fun () ->
+    match Hashtbl.find_opt sp_store_cache dir with
+    | Some store -> store
+    | None ->
+        let store = Dated_jsonl.create ~base_dir:dir () in
+        Hashtbl.replace sp_store_cache dir store;
+        store)
+
+let enqueue_sp_event ~keepers_dir ~ts ~suppressed_count ~total ~ratio
+    ~dominant_cohort =
+  Queue.push {
+    sp_keepers_dir = keepers_dir; sp_ts = ts;
+    sp_suppressed_count = suppressed_count;
+    sp_total = total; sp_ratio = ratio;
+    sp_dominant_cohort = dominant_cohort;
+  } sp_queue
+
+let drain_sp_batch () =
+  let batch = ref [] in
+  while not (Queue.is_empty sp_queue) do
+    batch := Queue.pop sp_queue :: !batch
+  done;
+  List.rev !batch
+
+let write_sp_event (ev : sp_event) =
+  let store = sp_store ~keepers_dir:ev.sp_keepers_dir in
+  let json = `Assoc [
+    ("ts", `Float ev.sp_ts);
+    ("suppressed_count", `Int ev.sp_suppressed_count);
+    ("total", `Int ev.sp_total);
+    ("ratio", `Float ev.sp_ratio);
+    ("dominant_cohort", `String ev.sp_dominant_cohort);
+  ] in
+  Dated_jsonl.append store json
+
+(* ── drain fiber ─────────────────────────────────────────────── *)
+
 let start_drain_fiber ~sw ~clock =
   Eio.Fiber.fork_daemon ~sw (fun () ->
     while true do
@@ -74,7 +129,14 @@ let start_drain_fiber ~sw ~clock =
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Keeper.warn "crash persistence write failed for %s: %s"
              ev.name (Printexc.to_string exn))
-      ) batch
+      ) batch;
+      let sp_batch = drain_sp_batch () in
+      List.iter (fun ev ->
+        (try write_sp_event ev
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           Log.Keeper.warn "sp persistence write failed: %s"
+             (Printexc.to_string exn))
+      ) sp_batch
     done;
     `Stop_daemon)
 
@@ -82,4 +144,8 @@ let start_drain_fiber ~sw ~clock =
 
 let recent_crashes ~keepers_dir ~name ~max_entries =
   let store = crash_store ~keepers_dir name in
+  Dated_jsonl.read_recent store max_entries
+
+let recent_sp_events ~keepers_dir ~max_entries =
+  let store = sp_store ~keepers_dir in
   Dated_jsonl.read_recent store max_entries

--- a/lib/keeper/keeper_crash_persistence.mli
+++ b/lib/keeper/keeper_crash_persistence.mli
@@ -31,3 +31,19 @@ val recent_crashes :
   name:string ->
   max_entries:int ->
   Yojson.Safe.t list
+
+(** Non-yielding: record a self-preservation suppression event. *)
+val enqueue_sp_event :
+  keepers_dir:string ->
+  ts:float ->
+  suppressed_count:int ->
+  total:int ->
+  ratio:float ->
+  dominant_cohort:string ->
+  unit
+
+(** Read recent self-preservation events from disk. *)
+val recent_sp_events :
+  keepers_dir:string ->
+  max_entries:int ->
+  Yojson.Safe.t list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -247,7 +247,7 @@ let cohort_key_of_reason = function
 
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count. *)
-let apply_self_preservation ~total_keepers to_restart =
+let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
   let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in
   let sp_min = Env_config.KeeperSupervisor.self_preservation_min_candidates in
   let n_candidates = List.length to_restart in
@@ -275,6 +275,13 @@ let apply_self_preservation ~total_keepers to_restart =
       publish_lifecycle "self_preservation" "supervisor"
         (Printf.sprintf "%d/%d suppressed, cohort=%s"
            (List.length dominant_entries) n_total dominant_key);
+      Keeper_crash_persistence.enqueue_sp_event
+        ~keepers_dir
+        ~ts:(Time_compat.now ())
+        ~suppressed_count:(List.length dominant_entries)
+        ~total:n_total
+        ~ratio
+        ~dominant_cohort:dominant_key;
       let dominant_set =
         List.map (fun ((e : Keeper_registry.registry_entry), _) -> e.name)
           dominant_entries in
@@ -342,7 +349,9 @@ let sweep_and_recover (ctx : _ context) =
       e.state = Keeper_registry.Running || e.state = Keeper_registry.Crashed
     ) entries) in
   let restart_list =
-    apply_self_preservation ~total_keepers:active_count !to_restart in
+    let keepers_dir =
+      Filename.concat (Room.masc_root_dir ctx.config) "keepers" in
+    apply_self_preservation ~keepers_dir ~total_keepers:active_count !to_restart in
   (* Restart crashed keepers *)
   List.iter (fun ((old_entry : Keeper_registry.registry_entry), crash_msg) ->
     match read_meta ctx.config old_entry.name with

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -44,6 +44,7 @@ val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)
 
 val apply_self_preservation :
+  keepers_dir:string ->
   total_keepers:int ->
   (Keeper_registry.registry_entry * string) list ->
   (Keeper_registry.registry_entry * string) list

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -187,7 +187,7 @@ let test_self_preservation_suppresses_dominant () =
   (* Only the first 3 are heartbeat failures *)
   let to_restart = List.filteri (fun i _ -> i <> 3) entries in
   (* total=4: all keepers including the running one *)
-  let result = Sup.apply_self_preservation ~total_keepers:4
+  let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:4
     (to_restart @ [List.nth entries 3]) in
   (* Dominant cohort (heartbeat, 3 entries) should be suppressed.
      Only the exception entry (1) should remain. *)
@@ -210,7 +210,7 @@ let test_self_preservation_below_threshold () =
   let entry = match R.get ~base_path:bp "lone" with
     | Some e -> e | None -> fail "missing lone" in
   let to_restart = [(entry, "crash")] in
-  let result = Sup.apply_self_preservation ~total_keepers:10 to_restart in
+  let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:10 to_restart in
   check int "all pass through" 1 (List.length result)
 
 (** min_candidates not met: 1 candidate < 2 minimum.
@@ -225,7 +225,7 @@ let test_self_preservation_min_candidates_not_met () =
     | Some e -> e | None -> fail "missing solo" in
   let to_restart = [(entry, "crash")] in
   (* ratio = 1/1 = 1.0 > 0.3, BUT candidates=1 < min(2) *)
-  let result = Sup.apply_self_preservation ~total_keepers:1 to_restart in
+  let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:1 to_restart in
   check int "passes despite high ratio" 1 (List.length result)
 
 (* ══════════════════════════════════════════════════════════

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -160,7 +160,7 @@ let test_self_preservation_subset () =
     match Reg.get ~base_path:bp name with
     | Some e -> (e, "crash") | None -> fail name
   ) names in
-  let result = Sup.apply_self_preservation ~total_keepers:10 entries in
+  let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:10 entries in
   let result_names = List.map (fun ((e : Reg.registry_entry), _) -> e.name) result in
   let input_names = List.map (fun ((e : Reg.registry_entry), _) -> e.name) entries in
   List.iter (fun rn ->
@@ -168,7 +168,7 @@ let test_self_preservation_subset () =
   ) result_names
 
 let test_self_preservation_empty_input () =
-  let result = Sup.apply_self_preservation ~total_keepers:5 [] in
+  let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:5 [] in
   check int "empty in = empty out" 0 (List.length result)
 
 (* ── Runtime override: fiber_health_of ─────────────────── *)


### PR DESCRIPTION
## Summary
### #3905: Crash cohort + self-preservation
- Self-preservation 이벤트 Dated_jsonl 영속화 (keeper_crash_persistence에 sp_event 저장)
- Dashboard crash cohort 분포 차트 (heartbeat/turn/fiber/exception 비율 stacked bar)
- Self-preservation 발동 이력 패널
- Keeper 목록 상태 요약 strip (Running/Crashed/Dead/Paused/Offline 카운트)

### #3908: Health score
- Health score 산출 순수 함수 (0-100, budget/crash/context 기반 감점)
- Dashboard health score badge (color-coded green/amber/red)

### #3876 Phase 3: allowed_paths dashboard UI
- Backend: allowed_paths + effective_allowed_paths JSON 노출
- Dashboard: textarea 편집기 (한 줄에 하나씩) + effective paths 표시
- KeeperConfig/KeeperConfigUpdatePayload 타입 확장

## Changes
- `keeper_crash_persistence.ml/mli`: sp_event enqueue/drain/read
- `keeper_supervisor.ml/mli`: `~keepers_dir` param + enqueue call
- `dashboard_http_keeper.ml`: compute_health_score + allowed_paths JSON
- `keeper-detail.ts`: CrashCohortBar, SpEventsPanel, health score badge
- `ops-keeper-column.ts`: status summary strip
- `keeper-config-panel.ts`: allowed_paths textarea editor
- `core.ts`, `dashboard.ts`: type extensions

Closes #3905. Closes #3908.

## Test plan
- [x] `dune build` 성공
- [x] `test_keeper_supervisor.exe` 17 tests pass
- [x] `test_heartbeat_integration.exe` 13 tests pass
- [x] Cross-model review (GLM-5.1)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)