### PR TITLE
feat(dashboard): SSE 실시간 게시글 삭제 반영

### DIFF
--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -86,6 +86,7 @@ export function classifyJournalKind(entry: JournalEntry): 'board' | 'tasks' | 'k
   switch (entry.eventType) {
     case 'board_post':
     case 'board_comment':
+    case 'board_delete':
       return 'board'
     case 'task_update':
       return 'tasks'

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -157,6 +157,7 @@ export function eventKindLabel(entry: JournalEntry): string {
   if (type === 'task_update') return 'task'
   if (type === 'board_post') return 'post'
   if (type === 'board_comment') return 'comment'
+  if (type === 'board_delete') return 'deleted'
   if (type === 'keeper_heartbeat') return 'heartbeat'
   if (type === 'keeper_handoff') return 'handoff'
   if (type === 'keeper_compaction') return 'compact'

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -117,6 +117,8 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
   'masc/board_comment': { target: 'board' },
+  board_delete:         { target: 'board' },
+  'masc/board_delete':  { target: 'board' },
   // MDAL
   mdal_started:    { target: 'mdal', debounceMs: SSE_MDAL_DEBOUNCE_MS },
   mdal_iteration:  { target: 'mdal', debounceMs: SSE_MDAL_DEBOUNCE_MS },

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -8,6 +8,7 @@ import {
   updateOasKeeperSnapshot,
   oasLastKeeperTick,
   oasTotalEvents,
+  removeBoardPost,
 } from './store'
 import {
   defaultJournalSeverity,
@@ -300,6 +301,23 @@ function handleEvent(event: SSEEvent): void {
           source: event.source,
           narrativeText: formatBoardNarrative('댓글', event.author ?? agent, event.content ?? event.message),
           preview: normalizePreview(event.content ?? event.message),
+          postId: event.post_id,
+        },
+      )
+      break
+    case 'board_delete':
+    case 'masc/board_delete':
+      removeBoardPost(event.post_id)
+      addTypedJournalEntry(
+        agent,
+        `Post deleted: ${event.post_id ?? 'unknown'}`,
+        'board',
+        'board_delete',
+        {
+          author: event.author ?? agent,
+          severity: event.severity,
+          source: event.source,
+          narrativeText: `${actorLabel(agent)}가 게시글을 삭제했습니다`,
           postId: event.post_id,
         },
       )

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -91,6 +91,11 @@ export const boardSortMode = signal<BoardSortMode>('recent')
 export const boardExcludeSystem = signal(true)
 export const boardExcludeAutomation = signal(false)
 
+export function removeBoardPost(postId: string | undefined): void {
+  if (!postId) return
+  boardPosts.value = boardPosts.value.filter(p => p.id !== postId)
+}
+
 // --- Goals state ---
 
 export const goals = signal<Goal[]>([])

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -97,6 +97,7 @@ export type JournalEventType =
   | 'task_update'
   | 'board_post'
   | 'board_comment'
+  | 'board_delete'
   | 'keeper_heartbeat'
   | 'keeper_handoff'
   | 'keeper_compaction'


### PR DESCRIPTION
## Summary
- `masc/board_delete` SSE 이벤트 수신 시 대시보드에서 즉시 게시글 제거
- `removeBoardPost()` 함수로 boardPosts signal에서 optimistic 삭제
- journal에 삭제 이벤트 기록 (board_delete event type)
- 6파일, +28줄 (순수 추가)

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] 수동: 대시보드 열어둔 상태에서 `masc_board_delete` 호출 → 글 즉시 사라짐 확인
- [ ] 수동: journal 타임라인에 삭제 이벤트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)