### PR TITLE
fix(team_session): harden slot-aware capacity runtime guards

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -570,7 +570,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                Tool_improve_loop.maybe_tick_from_keepalive ~config:ctx.config
                  ~agent_name:meta_after_proactive.agent_name
                  ~keeper_name:meta_after_proactive.name
-                 ~sw:ctx.sw ~clock:ctx.clock ~proc_mgr:ctx.proc_mgr ()
+                 ~sw:ctx.sw ~clock:ctx.clock ~proc_mgr:ctx.proc_mgr
+                 ~net:ctx.net ()
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -550,13 +550,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_autoresearch ->
         let start_team_session ~goal ~operation_id ~loop_id:_ ~target_file:_
             ~program_note:_ =
-          match state.Mcp_server.proc_mgr with
-          | None -> Error "process_mgr not available"
-          | Some process_mgr ->
-              let net = match state.Mcp_server.net with
-                | Some n -> n
-                | None -> failwith "net not available for team session"
-              in
+          match state.Mcp_server.proc_mgr, state.Mcp_server.net with
+          | None, _ -> Error "process_mgr not available"
+          | Some _process_mgr, None -> Error "net not available for team session"
+          | Some process_mgr, Some net ->
               let env = object
                 method clock = clock
                 method process_mgr = process_mgr

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -376,15 +376,18 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("reconcile_active_agents", fun () -> reconcile_active_agents_gauge state);
           ( "recover_running_team_sessions",
             fun () ->
-              match state.Mcp_server.proc_mgr with
-              | None ->
+              match state.Mcp_server.proc_mgr, state.Mcp_server.net with
+              | None, _ ->
                   Log.Server.warn
                     "skipping team session recovery: process_mgr not available"
-              | Some process_mgr ->
+              | Some _process_mgr, None ->
+                  Log.Server.warn
+                    "skipping team session recovery: net not available"
+              | Some process_mgr, Some net ->
                   let env = object
                     method clock = clock
                     method process_mgr = process_mgr
-                    method net = match state.Mcp_server.net with Some n -> n | None -> failwith "net not available"
+                    method net = net
                   end in
                   Team_session_engine_eio.recover_running_sessions ~sw ~env
                     ~config:state.Mcp_server.room_config );

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -194,6 +194,17 @@ let run_repair_loop_until_terminal ~sw ~(clock : _ Eio.Time.clock)
       dispatch_supported_tool ~sw ~clock ~config ~name ~args)
     args
 
+let slot_aware_concurrency_cap ~entry_count ~selection_count ~all_discovered
+    ~endpoints_found ~total =
+  if entry_count <= 1 || selection_count <= 0 then
+    entry_count
+  (* Multiple worker selections can legitimately collapse onto one discovered
+     local endpoint, so endpoint coverage is not a 1:1 proxy for slot count. *)
+  else if all_discovered && endpoints_found > 0 && total > 0 then
+    total
+  else
+    entry_count
+
 (* ── Role mapping ──────────────────────────────────────────────── *)
 
 let role_of_worker_class : Team_session_types.worker_class option -> Swarm.Swarm_types.agent_role =
@@ -577,21 +588,27 @@ let session_to_swarm_config
   in
   (* Slot-aware max_concurrent_agents for local-only sessions *)
   let slot_aware_cap =
-    let all_selections =
-      session.planned_workers
-      |> List.map (fun pw ->
-           cascade_of_worker ~session_cascade:session.model_cascade pw)
-      |> List.sort_uniq String.compare
-    in
-    let config_path = Oas_worker.default_config_path () in
-    let cap =
-      Llm_provider.Cascade_config.local_capacity_for_selections
-        ~sw ~net ?config_path all_selections
-    in
-    if cap.all_discovered && cap.endpoints_found > 0 && cap.total > 0
-       && cap.endpoints_found >= List.length all_selections
-    then cap.total
-    else entry_count
+    if entry_count <= 1 then
+      entry_count
+    else
+      let all_selections =
+        session.planned_workers
+        |> List.map (fun pw ->
+             cascade_of_worker ~session_cascade:session.model_cascade pw)
+        |> List.sort_uniq String.compare
+      in
+      match all_selections with
+      | [] -> entry_count
+      | _ ->
+          let config_path = Oas_worker.default_config_path () in
+          let cap =
+            Llm_provider.Cascade_config.local_capacity_for_selections
+              ~sw ~net ?config_path all_selections
+          in
+          slot_aware_concurrency_cap ~entry_count
+            ~selection_count:(List.length all_selections)
+            ~all_discovered:cap.all_discovered
+            ~endpoints_found:cap.endpoints_found ~total:cap.total
   in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -62,6 +62,14 @@ val run_repair_loop_until_terminal :
   Yojson.Safe.t ->
   bool * string
 
+val slot_aware_concurrency_cap :
+  entry_count:int ->
+  selection_count:int ->
+  all_discovered:bool ->
+  endpoints_found:int ->
+  total:int ->
+  int
+
 val role_of_worker_class :
   Team_session_types.worker_class option -> Swarm.Swarm_types.agent_role
 

--- a/lib/tool_improve_loop.ml
+++ b/lib/tool_improve_loop.ml
@@ -197,14 +197,15 @@ let handle_resume (ctx : _ context) args =
 let maybe_tick_from_keepalive ~(config : Room.config) ~(agent_name : string)
     ~(keeper_name : string) ~(sw : Eio.Switch.t)
     ~(clock : _ Eio.Time.clock)
-    ~(proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option) () =
+    ~(proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option) () =
   let state = load_state config in
   let now = Time_compat.now () in
   if state.enabled && state.status = Running
      && String.equal state.keeper_name keeper_name
      && tick_due state ~now
   then
-    let ctx = { config; agent_name; sw = Some sw; clock = Some clock; proc_mgr; net = None } in
+    let ctx = { config; agent_name; sw = Some sw; clock = Some clock; proc_mgr; net } in
     let _ok, _body =
       tick_with_driver default_driver ctx
         (`Assoc [ ("execute", `Bool true) ])

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -307,6 +307,48 @@ let test_is_safe_worker_run_id_rejects_dot_segments () =
   Alcotest.(check bool) "slash rejected" false
     (Team_session_oas_bridge.is_safe_worker_run_id "run/123")
 
+let test_slot_aware_cap_reduces_parallelism () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:4
+      ~selection_count:2 ~all_discovered:true ~endpoints_found:2 ~total:2
+  in
+  Alcotest.(check int) "cap reduced to discovered total" 2 cap
+
+let test_slot_aware_cap_keeps_single_entry_sessions_unchanged () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:1
+      ~selection_count:2 ~all_discovered:true ~endpoints_found:1 ~total:1
+  in
+  Alcotest.(check int) "single-entry sessions keep original entry count" 1 cap
+
+let test_slot_aware_cap_accepts_shared_endpoint_selections () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:3
+      ~selection_count:2 ~all_discovered:true ~endpoints_found:1 ~total:1
+  in
+  Alcotest.(check int) "shared endpoint still caps concurrency" 1 cap
+
+let test_slot_aware_cap_accepts_partially_collapsed_endpoint_selections () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:4
+      ~selection_count:3 ~all_discovered:true ~endpoints_found:2 ~total:2
+  in
+  Alcotest.(check int) "partially collapsed shared endpoints still cap concurrency" 2 cap
+
+let test_slot_aware_cap_falls_back_without_full_discovery () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:3
+      ~selection_count:2 ~all_discovered:false ~endpoints_found:1 ~total:1
+  in
+  Alcotest.(check int) "fallback keeps original entry count" 3 cap
+
+let test_slot_aware_cap_falls_back_for_non_positive_selection_count () =
+  let cap =
+    Team_session_oas_bridge.slot_aware_concurrency_cap ~entry_count:3
+      ~selection_count:0 ~all_discovered:true ~endpoints_found:1 ~total:1
+  in
+  Alcotest.(check int) "non-positive selection count keeps original entry count" 3 cap
+
 (* ================================================================ *)
 (* Supported tool runtime tests                                     *)
 (* ================================================================ *)
@@ -456,6 +498,18 @@ let () =
         test_telemetry_of_run_result_carries_trace_ref;
       Alcotest.test_case "worker run id rejects dot segments" `Quick
         test_is_safe_worker_run_id_rejects_dot_segments;
+      Alcotest.test_case "slot-aware cap reduces parallelism" `Quick
+        test_slot_aware_cap_reduces_parallelism;
+      Alcotest.test_case "slot-aware cap keeps single-entry sessions unchanged" `Quick
+        test_slot_aware_cap_keeps_single_entry_sessions_unchanged;
+      Alcotest.test_case "slot-aware cap accepts shared endpoint selections" `Quick
+        test_slot_aware_cap_accepts_shared_endpoint_selections;
+      Alcotest.test_case "slot-aware cap accepts partially collapsed endpoint selections" `Quick
+        test_slot_aware_cap_accepts_partially_collapsed_endpoint_selections;
+      Alcotest.test_case "slot-aware cap falls back without full discovery" `Quick
+        test_slot_aware_cap_falls_back_without_full_discovery;
+      Alcotest.test_case "slot-aware cap falls back for non-positive selection count" `Quick
+        test_slot_aware_cap_falls_back_for_non_positive_selection_count;
     ];
     "supported_tools", [
       Alcotest.test_case "schemas present" `Quick


### PR DESCRIPTION
## Summary
- Pass `net` through keepalive-driven improve-loop team session starts instead of dropping the runtime surface.
- Replace `failwith`-based missing-net paths with structured errors or graceful recovery skips.
- Lock the slot-aware capacity semantics with explicit helper tests, including shared-endpoint and boundary cases.

## Product impact
- Team-session follow-up paths no longer crash when runtime surfaces are partially unavailable.
- Local slot-aware concurrency keeps matching the shared-endpoint capacity model introduced in `#4001`.

## Evidence
- `git diff --check`
- `env -u DUNE_RPC opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/slot-aware-capacity-followup _build/default/test/test_team_session_oas_bridge.exe _build/default/test/test_tool_improve_loop.exe _build/default/test/test_tool_keeper.exe _build/default/test/test_mcp_server_eio_coverage.exe`
- `./_build/default/test/test_team_session_oas_bridge.exe`
- `./_build/default/test/test_tool_improve_loop.exe`

## Review evidence
- 2026-03-30: direct `GLM-5` review on commit `f115a6866`.
- Result: `No findings.`

## Linked issue
- Refs #4001
