### PR TITLE
refactor(capability-registry): use Tool_catalog SSOT directly

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -173,16 +173,16 @@ let make_seed ?capability_id ?(risk_class = Safe)
   }
 
 let spawned_agent_public_tool_names : string list =
-  Agent_tool_surfaces.spawned_agent_public_tool_names
+  Tool_catalog.tools_for_surface Tool_catalog.Spawned_agent
 
 let spawned_agent_prefixed_tools : string list =
-  Agent_tool_surfaces.spawned_agent_prefixed_tools
+  prefixed_tool_names (Tool_catalog.tools_for_surface Tool_catalog.Spawned_agent)
 
 let mdal_auditable_tool_names : string list =
-  Agent_tool_surfaces.mdal_auditable_tool_names
+  Tool_catalog.tools_for_surface Tool_catalog.Mdal_auditable
 
 let local_worker_public_tool_names : string list =
-  Agent_tool_surfaces.local_worker_public_tool_names
+  Tool_catalog.tools_for_surface Tool_catalog.Local_worker
 
 let local_worker_internal_schemas : Types.tool_schema list =
   Agent_tool_surfaces.local_worker_internal_schemas


### PR DESCRIPTION
## Summary
- `capability_registry.ml`에서 `Agent_tool_surfaces` 중간 계층 제거
- `spawned_agent`, `mdal_auditable`, `local_worker` tool name 목록을 `Tool_catalog.tools_for_surface`로 직접 파생
- 의존 체인: 3단(registry→surfaces→catalog) → 2단(registry→catalog)
- `local_worker_internal_schemas`는 schema 데이터가 `Agent_tool_surfaces`에만 있으므로 유지

## Context
PR #3998 (SSOT + observability) 후속 작업. Track A4.

## Test plan
- [ ] CI 빌드 통과 (기존 parity test `test_tool_surface_ssot.ml`이 등가성 검증)
- [ ] `dune test` 전체 suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)