### PR TITLE
feat(harness): add observability smoke harness scripts

### DIFF
--- a/scripts/harness/workload/observability_smoke_coding.sh
+++ b/scripts/harness/workload/observability_smoke_coding.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# observability_smoke_coding.sh
+#
+# Verify tool_input_preview redaction and 200 char limit after a coding worker run.
+#
+# Prerequisites:
+#   - MASC server built: dune build --root . bin/main_eio.exe
+#   - jq, curl available
+#
+# Environment variables:
+#   PORT                 - server port (auto-assigned if empty)
+#   BASE_PATH            - room base path (temp dir if empty)
+#   LLAMA_SWARM_MODEL    - model name for llama worker (auto-detected if single)
+#   MCP_URL              - override MCP endpoint (auto-derived from PORT)
+#   SERVER_EXE           - path to compiled server executable
+#   SKIP_SERVER_START    - set to 1 to use an existing server
+#   HTTP_TIMEOUT_SEC     - curl timeout (default: 120)
+#   HEALTH_TIMEOUT_SEC   - server health check timeout (default: 30)
+#
+# Assertions:
+#   - tool_input_preview length <= 200
+#   - tool_output_preview length <= 200
+#   - No raw API key patterns in any preview field
+#
+# Exit codes:
+#   0 - PASS (or graceful skip if server unavailable)
+#   1 - FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
+
+SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
+PORT="${PORT:-}"
+BASE_PATH="${BASE_PATH:-}"
+LOG_FILE="${LOG_FILE:-}"
+MCP_URL="${MCP_URL:-}"
+SKIP_SERVER_START="${SKIP_SERVER_START:-0}"
+HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
+HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
+STOP_WAIT_SEC="${STOP_WAIT_SEC:-60}"
+LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
+MCP_SESSION_ID="obs-smoke-coding"
+AGENT_NAME="obs-smoke-coding"
+TEAM_GOAL="Observability smoke: verify tool preview redaction and length limits"
+TEAM_SESSION_DURATION_SECONDS="${TEAM_SESSION_DURATION_SECONDS:-180}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SERVER_PID=""
+
+# ── prerequisite checks ──
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required"
+  exit 1
+fi
+
+if [ "$SKIP_SERVER_START" != "1" ] && [ ! -x "$SERVER_EXE" ]; then
+  echo "SKIP: server executable not found: $SERVER_EXE"
+  echo "build it first with: dune build --root . bin/main_eio.exe"
+  exit 0
+fi
+
+# ── assertion helpers ──
+
+assert_no_api_key() {
+  local text="$1"
+  if echo "$text" | grep -qE '(sk-[a-zA-Z0-9]{20,}|key-[a-zA-Z0-9]{20,}|AIza[a-zA-Z0-9]{30,})'; then
+    echo "FAIL: found raw API key in preview text"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: no API key patterns found"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_max_length() {
+  local text="$1" max="${2:-200}"
+  local len=${#text}
+  if [ "$len" -gt "$max" ]; then
+    echo "FAIL: length $len exceeds max $max"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: length $len within limit $max"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_not_null() {
+  local field_name="$1" value="$2"
+  if [ -z "$value" ] || [ "$value" = "null" ]; then
+    echo "FAIL: $field_name is null or empty"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: $field_name = $value"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# ── infrastructure ──
+
+if [ -z "$PORT" ]; then
+  PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+fi
+
+if [ -z "$BASE_PATH" ]; then
+  BASE_PATH="$(mktemp -d "${TMPDIR:-/tmp}/masc-obs-smoke-coding.XXXXXX")"
+fi
+
+if [ -z "$LOG_FILE" ]; then
+  LOG_FILE="$(mcp_mktemp_file "masc-obs-smoke-coding")"
+fi
+
+if [ -z "$MCP_URL" ]; then
+  MCP_URL="http://127.0.0.1:${PORT}/mcp"
+fi
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_health() {
+  local deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SEC ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local health_json
+    health_json="$(curl -fsS --http1.1 --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || true)"
+    if [ -n "$health_json" ] && printf '%s' "$health_json" | jq -e '.startup.state_ready == true' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+call_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  mcp_call_tool "$id" "$tool_name" "$args_json" "$MCP_SESSION_ID" "" "$MCP_URL"
+}
+
+extract_tool_result() {
+  mcp_extract_result
+}
+
+require_tool_success() {
+  local payload="$1"
+  local label="${2:-observability_smoke_coding tool}"
+  mcp_require_tool_ok "$payload" "$label"
+}
+
+# ── step 1: start server ──
+
+printf '[1/5] start server\n'
+if [ "$SKIP_SERVER_START" != "1" ]; then
+  env \
+    MASC_AUTONOMY_ENABLED=0 \
+    GRAPHQL_API_KEY= \
+    GRAPHQL_URL=http://127.0.0.1:9/graphql \
+    MASC_POSTGRES_URL= \
+    DATABASE_URL= \
+    SUPABASE_DB_URL= \
+    SB_PG_URL= \
+    MASC_BOARD_BACKEND=jsonl \
+    MASC_GRPC_ENABLED=0 \
+    MASC_WS_ENABLED=0 \
+    MASC_WEBRTC_ENABLED=0 \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$LOG_FILE" 2>&1 &
+  SERVER_PID="$!"
+else
+  printf '  using existing server on port %s\n' "$PORT"
+fi
+
+if ! wait_for_health; then
+  echo "SKIP: server did not become healthy (not running or build missing)"
+  exit 0
+fi
+
+# ── step 2: bootstrap room ──
+
+printf '[2/5] initialize room and join agent\n'
+init_raw="$(call_tool 1 "masc_init" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a}')")"
+require_tool_success "$init_raw"
+
+join_raw="$(call_tool 2 "masc_join" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a,capabilities:["supervisor","operator","team-session"]}')")"
+require_tool_success "$join_raw"
+
+agent_nickname="$(printf '%s' "$join_raw" | mcp_extract_text | sed -n 's/^  Nickname: //p' | head -n1)"
+if [ -z "$agent_nickname" ]; then
+  echo "FAIL: could not parse joined nickname"
+  printf '%s\n' "$join_raw"
+  exit 1
+fi
+
+# detect llama model
+llama_models_raw="$(call_tool 3 "masc_llama_models" '{}')"
+require_tool_success "$llama_models_raw"
+llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
+
+if [ -z "$LLAMA_SWARM_MODEL" ]; then
+  single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
+  if [ -n "$single_model" ]; then
+    LLAMA_SWARM_MODEL="$single_model"
+    printf '  auto-selected: %s\n' "$LLAMA_SWARM_MODEL"
+  else
+    echo "SKIP: LLAMA_SWARM_MODEL not set and multiple models available"
+    exit 0
+  fi
+fi
+
+# ── step 3: start coding session with worker ──
+
+printf '[3/5] start coding team session with worker\n'
+start_raw="$(call_tool 4 "masc_team_session_start" "$(jq -cn \
+  --arg goal "$TEAM_GOAL" \
+  --arg agent "$agent_nickname" \
+  --argjson duration "$TEAM_SESSION_DURATION_SECONDS" \
+  '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:"limited_code_change",fallback_policy:"cascade_then_task",instruction_profile:"strict",min_agents:1,agents:[$agent]}')")"
+require_tool_success "$start_raw"
+
+TEAM_SESSION_ID="$(printf '%s' "$start_raw" | extract_tool_result | jq -r '.session_id // empty')"
+if [ -z "$TEAM_SESSION_ID" ]; then
+  echo "FAIL: missing session_id"
+  printf '%s\n' "$start_raw"
+  exit 1
+fi
+
+# Spawn a coding worker that will exercise tool calls
+MODEL_SELECTION_NOTE="[model-selection] obs-coding selected $LLAMA_SWARM_MODEL"
+spawn_raw="$(call_tool 5 "masc_team_session_step" "$(jq -cn \
+  --arg s "$TEAM_SESSION_ID" \
+  --arg note "$MODEL_SELECTION_NOTE" \
+  '{session_id:$s,wait_mode:"blocking",spawn_batch:[{spawn_role:"coding-obs-worker",worker_class:"executor",worker_size:"lg",spawn_selection_note:$note,spawn_prompt:"Write a minimal Python function that adds two numbers. Use file_write to save it as add.py, then verify with shell_exec. Reply with the result.",spawn_timeout_seconds:120}]}')")"
+require_tool_success "$spawn_raw"
+
+# Wait for session to finish or stop it
+deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
+while :; do
+  status_raw="$(call_tool 6 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
+  require_tool_success "$status_raw"
+  session_status="$(printf '%s' "$status_raw" | extract_tool_result | jq -r '.session.status // empty')"
+  if [ "$session_status" != "running" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    # Force stop
+    call_tool 7 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"obs_coding_timeout",generate_report:true}')" >/dev/null 2>&1 || true
+    sleep 2
+    break
+  fi
+  sleep 2
+done
+
+# ── step 4: query proof endpoint and check tool previews ──
+
+printf '[4/5] query proof endpoint and verify tool preview redaction\n'
+proof_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
+  "http://127.0.0.1:${PORT}/api/v1/dashboard/proof?session_id=${TEAM_SESSION_ID}" 2>/dev/null || true)"
+
+if [ -z "$proof_json" ]; then
+  echo "SKIP: proof endpoint returned empty"
+  exit 0
+fi
+
+# Extract all tool_input_preview values and check lengths
+tool_input_previews="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | .tool_input_preview? // empty | select(. != null and . != "" and type == "string")] | .[]
+' 2>/dev/null || true)"
+
+tool_output_previews="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | .tool_output_preview? // empty | select(. != null and . != "" and type == "string")] | .[]
+' 2>/dev/null || true)"
+
+preview_found=0
+
+if [ -n "$tool_input_previews" ]; then
+  printf '  checking tool_input_preview lengths...\n'
+  while IFS= read -r preview; do
+    [ -z "$preview" ] && continue
+    preview_found=1
+    assert_max_length "$preview" 200
+    assert_no_api_key "$preview"
+  done <<< "$tool_input_previews"
+fi
+
+if [ -n "$tool_output_previews" ]; then
+  printf '  checking tool_output_preview lengths...\n'
+  while IFS= read -r preview; do
+    [ -z "$preview" ] && continue
+    preview_found=1
+    assert_max_length "$preview" 200
+    assert_no_api_key "$preview"
+  done <<< "$tool_output_previews"
+fi
+
+if [ "$preview_found" -eq 0 ]; then
+  echo "WARN: no tool preview fields found in proof data (worker may not have used tools)"
+fi
+
+# Also check output_preview fields (worker run level)
+output_previews="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | .output_preview? // empty | select(. != null and . != "" and type == "string")] | .[]
+' 2>/dev/null || true)"
+
+if [ -n "$output_previews" ]; then
+  printf '  checking output_preview fields...\n'
+  while IFS= read -r preview; do
+    [ -z "$preview" ] && continue
+    assert_no_api_key "$preview"
+  done <<< "$output_previews"
+fi
+
+# ── step 5: cross-check execution endpoint previews ──
+
+printf '[5/5] cross-check execution endpoint\n'
+execution_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
+  "http://127.0.0.1:${PORT}/api/v1/dashboard/execution" 2>/dev/null || true)"
+
+if [ -n "$execution_json" ]; then
+  # Check all text fields for API keys
+  exec_all_strings="$(printf '%s' "$execution_json" | jq -r '
+    [.. | strings | select(length > 20)] | join("\n")
+  ' 2>/dev/null || true)"
+  if [ -n "$exec_all_strings" ]; then
+    assert_no_api_key "$exec_all_strings"
+  fi
+fi
+
+# ── summary ──
+
+printf '\n[summary]\n'
+printf '  session_id: %s\n' "$TEAM_SESSION_ID"
+printf '  llama_model: %s\n' "$LLAMA_SWARM_MODEL"
+printf '  base_path: %s\n' "$BASE_PATH"
+printf '  log_file: %s\n' "$LOG_FILE"
+printf '  previews_checked: %d\n' "$preview_found"
+printf '  pass: %d\n' "$PASS_COUNT"
+printf '  fail: %d\n' "$FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "FAIL: observability smoke coding ($FAIL_COUNT failures)"
+  exit 1
+fi
+
+echo "PASS: observability smoke coding"

--- a/scripts/harness/workload/observability_smoke_supervisor.sh
+++ b/scripts/harness/workload/observability_smoke_supervisor.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# observability_smoke_supervisor.sh
+#
+# Verify trace_ref and provider_label in proof endpoint after a team-session.
+#
+# Prerequisites:
+#   - MASC server built: dune build --root . bin/main_eio.exe
+#   - jq, curl available
+#
+# Environment variables:
+#   PORT                 - server port (auto-assigned if empty)
+#   BASE_PATH            - room base path (temp dir if empty)
+#   LLAMA_SWARM_MODEL    - model name for llama worker (auto-detected if single)
+#   MCP_URL              - override MCP endpoint (auto-derived from PORT)
+#   SERVER_EXE           - path to compiled server executable
+#   SKIP_SERVER_START    - set to 1 to use an existing server
+#   HTTP_TIMEOUT_SEC     - curl timeout (default: 60)
+#   HEALTH_TIMEOUT_SEC   - server health check timeout (default: 30)
+#
+# Exit codes:
+#   0 - PASS (or graceful skip if server unavailable)
+#   1 - FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
+
+SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
+PORT="${PORT:-}"
+BASE_PATH="${BASE_PATH:-}"
+LOG_FILE="${LOG_FILE:-}"
+MCP_URL="${MCP_URL:-}"
+SKIP_SERVER_START="${SKIP_SERVER_START:-0}"
+HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-60}"
+HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
+STOP_WAIT_SEC="${STOP_WAIT_SEC:-30}"
+LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
+MCP_SESSION_ID="obs-smoke-supervisor"
+AGENT_NAME="obs-smoke-supervisor"
+TEAM_GOAL="Observability smoke: verify trace_ref and provider_label in proof endpoint"
+TEAM_SESSION_DURATION_SECONDS="${TEAM_SESSION_DURATION_SECONDS:-120}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SERVER_PID=""
+
+# ── prerequisite checks ──
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required"
+  exit 1
+fi
+
+if [ "$SKIP_SERVER_START" != "1" ] && [ ! -x "$SERVER_EXE" ]; then
+  echo "SKIP: server executable not found: $SERVER_EXE"
+  echo "build it first with: dune build --root . bin/main_eio.exe"
+  exit 0
+fi
+
+# ── assertion helpers ──
+
+assert_no_api_key() {
+  local text="$1"
+  if echo "$text" | grep -qE '(sk-[a-zA-Z0-9]{20,}|key-[a-zA-Z0-9]{20,}|AIza[a-zA-Z0-9]{30,})'; then
+    echo "FAIL: found raw API key in preview text"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: no API key patterns found"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_not_null() {
+  local field_name="$1" value="$2"
+  if [ -z "$value" ] || [ "$value" = "null" ]; then
+    echo "FAIL: $field_name is null or empty"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: $field_name = $value"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# ── infrastructure ──
+
+if [ -z "$PORT" ]; then
+  PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+fi
+
+if [ -z "$BASE_PATH" ]; then
+  BASE_PATH="$(mktemp -d "${TMPDIR:-/tmp}/masc-obs-smoke-supervisor.XXXXXX")"
+fi
+
+if [ -z "$LOG_FILE" ]; then
+  LOG_FILE="$(mcp_mktemp_file "masc-obs-smoke-supervisor")"
+fi
+
+if [ -z "$MCP_URL" ]; then
+  MCP_URL="http://127.0.0.1:${PORT}/mcp"
+fi
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_health() {
+  local deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SEC ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local health_json
+    health_json="$(curl -fsS --http1.1 --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || true)"
+    if [ -n "$health_json" ] && printf '%s' "$health_json" | jq -e '.startup.state_ready == true' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+call_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  mcp_call_tool "$id" "$tool_name" "$args_json" "$MCP_SESSION_ID" "" "$MCP_URL"
+}
+
+extract_tool_result() {
+  mcp_extract_result
+}
+
+require_tool_success() {
+  local payload="$1"
+  local label="${2:-observability_smoke_supervisor tool}"
+  mcp_require_tool_ok "$payload" "$label"
+}
+
+# ── step 1: start server ──
+
+printf '[1/6] start server\n'
+if [ "$SKIP_SERVER_START" != "1" ]; then
+  env \
+    MASC_AUTONOMY_ENABLED=0 \
+    GRAPHQL_API_KEY= \
+    GRAPHQL_URL=http://127.0.0.1:9/graphql \
+    MASC_POSTGRES_URL= \
+    DATABASE_URL= \
+    SUPABASE_DB_URL= \
+    SB_PG_URL= \
+    MASC_BOARD_BACKEND=jsonl \
+    MASC_GRPC_ENABLED=0 \
+    MASC_WS_ENABLED=0 \
+    MASC_WEBRTC_ENABLED=0 \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$LOG_FILE" 2>&1 &
+  SERVER_PID="$!"
+else
+  printf '  using existing server on port %s\n' "$PORT"
+fi
+
+if ! wait_for_health; then
+  echo "SKIP: server did not become healthy (not running or build missing)"
+  exit 0
+fi
+
+# ── step 2: initialize room and join ──
+
+printf '[2/6] initialize room and join agent\n'
+init_raw="$(call_tool 1 "masc_init" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a}')")"
+require_tool_success "$init_raw"
+
+join_raw="$(call_tool 2 "masc_join" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a,capabilities:["supervisor","operator","team-session"]}')")"
+require_tool_success "$join_raw"
+
+agent_nickname="$(printf '%s' "$join_raw" | mcp_extract_text | sed -n 's/^  Nickname: //p' | head -n1)"
+if [ -z "$agent_nickname" ]; then
+  echo "FAIL: could not parse joined nickname"
+  printf '%s\n' "$join_raw"
+  exit 1
+fi
+
+# ── step 3: detect llama model ──
+
+printf '[3/6] detect llama model\n'
+llama_models_raw="$(call_tool 3 "masc_llama_models" '{}')"
+require_tool_success "$llama_models_raw"
+llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
+
+if [ -z "$LLAMA_SWARM_MODEL" ]; then
+  single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
+  if [ -n "$single_model" ]; then
+    LLAMA_SWARM_MODEL="$single_model"
+    printf '  auto-selected: %s\n' "$LLAMA_SWARM_MODEL"
+  else
+    echo "SKIP: LLAMA_SWARM_MODEL not set and multiple models available"
+    printf '%s\n' "$llama_models_result" | jq -r '.models[]?'
+    exit 0
+  fi
+fi
+
+# ── step 4: start team session with spawn ──
+
+printf '[4/6] start team session and spawn worker\n'
+start_raw="$(call_tool 4 "masc_team_session_start" "$(jq -cn \
+  --arg goal "$TEAM_GOAL" \
+  --arg agent "$agent_nickname" \
+  --argjson duration "$TEAM_SESSION_DURATION_SECONDS" \
+  '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:"limited_code_change",fallback_policy:"cascade_then_task",instruction_profile:"strict",min_agents:1,agents:[$agent]}')")"
+require_tool_success "$start_raw"
+
+TEAM_SESSION_ID="$(printf '%s' "$start_raw" | extract_tool_result | jq -r '.session_id // empty')"
+if [ -z "$TEAM_SESSION_ID" ]; then
+  echo "FAIL: missing session_id"
+  printf '%s\n' "$start_raw"
+  exit 1
+fi
+
+MODEL_SELECTION_NOTE="[model-selection] obs-smoke selected $LLAMA_SWARM_MODEL"
+spawn_raw="$(call_tool 5 "masc_team_session_step" "$(jq -cn \
+  --arg s "$TEAM_SESSION_ID" \
+  --arg model "$LLAMA_SWARM_MODEL" \
+  --arg note "$MODEL_SELECTION_NOTE" \
+  '{session_id:$s,wait_mode:"blocking",spawn_batch:[{spawn_role:"obs-worker",worker_class:"executor",worker_size:"lg",spawn_selection_note:$note,spawn_prompt:"Reply with one line: observability smoke check complete.",spawn_timeout_seconds:90}]}')")"
+require_tool_success "$spawn_raw"
+
+# Wait for session to finish or stop it
+sleep 2
+session_status_raw="$(call_tool 6 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
+require_tool_success "$session_status_raw"
+session_status="$(printf '%s' "$session_status_raw" | extract_tool_result | jq -r '.session.status // empty')"
+
+if [ "$session_status" = "running" ]; then
+  stop_raw="$(call_tool 7 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"obs_smoke_complete",generate_report:true}')")"
+  require_tool_success "$stop_raw"
+
+  deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
+  while :; do
+    status_raw="$(call_tool 8 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
+    require_tool_success "$status_raw"
+    session_status="$(printf '%s' "$status_raw" | extract_tool_result | jq -r '.session.status // empty')"
+    if [ "$session_status" != "running" ]; then
+      break
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "FAIL: team session did not stop in time"
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+# ── step 5: query proof endpoint and assert observability fields ──
+
+printf '[5/6] query proof endpoint and verify observability\n'
+proof_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
+  "http://127.0.0.1:${PORT}/api/v1/dashboard/proof?session_id=${TEAM_SESSION_ID}" 2>/dev/null || true)"
+
+if [ -z "$proof_json" ]; then
+  echo "SKIP: proof endpoint returned empty (endpoint may not exist yet)"
+  exit 0
+fi
+
+# Assert: trace_ref presence in worker run entries
+has_trace_ref="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | .trace_ref? // empty | select(. != null and . != "")] | length > 0
+' 2>/dev/null || echo "false")"
+if [ "$has_trace_ref" = "true" ]; then
+  echo "OK: trace_ref found in proof data"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "WARN: trace_ref not found in proof data (may be summary_only mode)"
+  # Not a hard fail -- trace_ref depends on raw trace capability
+fi
+
+# Assert: provider-related fields exist (provider_name or resolved_model)
+has_provider_info="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | select(.provider_name? != null or .resolved_model? != null or .provider_snapshot? != null)] | length > 0
+' 2>/dev/null || echo "false")"
+assert_not_null "provider_info_in_proof" "$has_provider_info"
+
+# Assert: no raw API key patterns in all preview fields
+all_previews="$(printf '%s' "$proof_json" | jq -r '
+  [.. | objects | (.tool_input_preview? // empty, .tool_output_preview? // empty, .output_preview? // empty) | select(. != null and . != "")] | join("\n")
+' 2>/dev/null || echo "")"
+if [ -n "$all_previews" ]; then
+  assert_no_api_key "$all_previews"
+else
+  echo "OK: no preview fields to check (clean)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+fi
+
+# ── step 6: verify execution endpoint has provider_label ──
+
+printf '[6/6] verify execution endpoint\n'
+execution_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
+  "http://127.0.0.1:${PORT}/api/v1/dashboard/execution" 2>/dev/null || true)"
+
+if [ -n "$execution_json" ]; then
+  # Check for provider/model information in the execution snapshot
+  has_model_info="$(printf '%s' "$execution_json" | jq -r '
+    [.. | objects | select(.last_model_used? != null or .active_model? != null or .resolved_model? != null)] | length > 0
+  ' 2>/dev/null || echo "false")"
+  if [ "$has_model_info" = "true" ]; then
+    echo "OK: model/provider info present in execution snapshot"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "WARN: no model/provider info in execution snapshot (may have no active workers)"
+  fi
+
+  # Assert: no API keys in execution snapshot text fields
+  exec_text_fields="$(printf '%s' "$execution_json" | jq -r '
+    [.. | strings | select(length > 20)] | join("\n")
+  ' 2>/dev/null || echo "")"
+  if [ -n "$exec_text_fields" ]; then
+    assert_no_api_key "$exec_text_fields"
+  fi
+else
+  echo "WARN: execution endpoint returned empty"
+fi
+
+# ── summary ──
+
+printf '\n[summary]\n'
+printf '  session_id: %s\n' "$TEAM_SESSION_ID"
+printf '  llama_model: %s\n' "$LLAMA_SWARM_MODEL"
+printf '  base_path: %s\n' "$BASE_PATH"
+printf '  log_file: %s\n' "$LOG_FILE"
+printf '  pass: %d\n' "$PASS_COUNT"
+printf '  fail: %d\n' "$FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "FAIL: observability smoke supervisor ($FAIL_COUNT failures)"
+  exit 1
+fi
+
+echo "PASS: observability smoke supervisor"

--- a/scripts/harness/workload/observability_smoke_swarm.sh
+++ b/scripts/harness/workload/observability_smoke_swarm.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# observability_smoke_swarm.sh
+#
+# Verify provider_label diversity across multiple keepers with different cascade profiles.
+#
+# Prerequisites:
+#   - MASC server built: dune build --root . bin/main_eio.exe
+#   - jq, curl available
+#
+# Environment variables:
+#   PORT                 - server port (auto-assigned if empty)
+#   BASE_PATH            - room base path (temp dir if empty)
+#   MCP_URL              - override MCP endpoint (auto-derived from PORT)
+#   SERVER_EXE           - path to compiled server executable
+#   SKIP_SERVER_START    - set to 1 to use an existing server
+#   HTTP_TIMEOUT_SEC     - curl timeout (default: 60)
+#   HEALTH_TIMEOUT_SEC   - server health check timeout (default: 30)
+#   KEEPER_A_CASCADE     - cascade name for keeper A (default: keeper_unified)
+#   KEEPER_B_CASCADE     - cascade name for keeper B (default: keeper_reply)
+#
+# Flow:
+#   1. Start 2 keepers with different cascade profiles
+#   2. Send a message to each keeper
+#   3. Query operator snapshot for keeper rows
+#   4. Assert: at least 1 distinct provider_label/active_model among keepers
+#
+# Exit codes:
+#   0 - PASS (or graceful skip if server unavailable)
+#   1 - FAIL
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
+
+SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
+PORT="${PORT:-}"
+BASE_PATH="${BASE_PATH:-}"
+LOG_FILE="${LOG_FILE:-}"
+MCP_URL="${MCP_URL:-}"
+OPERATOR_URL=""
+SKIP_SERVER_START="${SKIP_SERVER_START:-0}"
+HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-60}"
+HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
+KEEPER_A_CASCADE="${KEEPER_A_CASCADE:-keeper_unified}"
+KEEPER_B_CASCADE="${KEEPER_B_CASCADE:-keeper_reply}"
+MCP_SESSION_ID="obs-smoke-swarm"
+AGENT_NAME="obs-smoke-swarm"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
+KEEPER_MSG_TIMEOUT_SEC="${KEEPER_MSG_TIMEOUT_SEC:-90}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SERVER_PID=""
+
+# ── prerequisite checks ──
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required"
+  exit 1
+fi
+
+if [ "$SKIP_SERVER_START" != "1" ] && [ ! -x "$SERVER_EXE" ]; then
+  echo "SKIP: server executable not found: $SERVER_EXE"
+  echo "build it first with: dune build --root . bin/main_eio.exe"
+  exit 0
+fi
+
+# ── assertion helpers ──
+
+assert_no_api_key() {
+  local text="$1"
+  if echo "$text" | grep -qE '(sk-[a-zA-Z0-9]{20,}|key-[a-zA-Z0-9]{20,}|AIza[a-zA-Z0-9]{30,})'; then
+    echo "FAIL: found raw API key in preview text"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: no API key patterns found"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_not_null() {
+  local field_name="$1" value="$2"
+  if [ -z "$value" ] || [ "$value" = "null" ]; then
+    echo "FAIL: $field_name is null or empty"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: $field_name = $value"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_gte() {
+  local field_name="$1" actual="$2" expected="$3"
+  if [ "$actual" -lt "$expected" ]; then
+    echo "FAIL: $field_name = $actual, expected >= $expected"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 1
+  fi
+  echo "OK: $field_name = $actual (>= $expected)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# ── infrastructure ──
+
+if [ -z "$PORT" ]; then
+  PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+fi
+
+if [ -z "$BASE_PATH" ]; then
+  BASE_PATH="$(mktemp -d "${TMPDIR:-/tmp}/masc-obs-smoke-swarm.XXXXXX")"
+fi
+
+if [ -z "$LOG_FILE" ]; then
+  LOG_FILE="$(mcp_mktemp_file "masc-obs-smoke-swarm")"
+fi
+
+if [ -z "$MCP_URL" ]; then
+  MCP_URL="http://127.0.0.1:${PORT}/mcp"
+fi
+OPERATOR_URL="http://127.0.0.1:${PORT}/mcp/operator"
+
+cleanup() {
+  # Stop keepers before killing server
+  if [ -n "$SERVER_PID" ] || [ "$SKIP_SERVER_START" = "1" ]; then
+    call_tool 90 "masc_keeper_down" "$(jq -cn '{name:"obs-keeper-a"}')" >/dev/null 2>&1 || true
+    call_tool 91 "masc_keeper_down" "$(jq -cn '{name:"obs-keeper-b"}')" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_health() {
+  local deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SEC ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local health_json
+    health_json="$(curl -fsS --http1.1 --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || true)"
+    if [ -n "$health_json" ] && printf '%s' "$health_json" | jq -e '.startup.state_ready == true' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+call_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  mcp_call_tool "$id" "$tool_name" "$args_json" "$MCP_SESSION_ID" "" "$MCP_URL"
+}
+
+call_operator_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  mcp_call_tool "$id" "$tool_name" "$args_json" "$MCP_SESSION_ID" "" "$OPERATOR_URL"
+}
+
+extract_tool_result() {
+  mcp_extract_result
+}
+
+require_tool_success() {
+  local payload="$1"
+  local label="${2:-observability_smoke_swarm tool}"
+  mcp_require_tool_ok "$payload" "$label"
+}
+
+# ── step 1: start server ──
+
+printf '[1/5] start server\n'
+if [ "$SKIP_SERVER_START" != "1" ]; then
+  env \
+    MASC_AUTONOMY_ENABLED=0 \
+    GRAPHQL_API_KEY= \
+    GRAPHQL_URL=http://127.0.0.1:9/graphql \
+    MASC_POSTGRES_URL= \
+    DATABASE_URL= \
+    SUPABASE_DB_URL= \
+    SB_PG_URL= \
+    MASC_BOARD_BACKEND=jsonl \
+    MASC_GRPC_ENABLED=0 \
+    MASC_WS_ENABLED=0 \
+    MASC_WEBRTC_ENABLED=0 \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$LOG_FILE" 2>&1 &
+  SERVER_PID="$!"
+else
+  printf '  using existing server on port %s\n' "$PORT"
+fi
+
+if ! wait_for_health; then
+  echo "SKIP: server did not become healthy (not running or build missing)"
+  exit 0
+fi
+
+# ── step 2: bootstrap room ──
+
+printf '[2/5] initialize room and join agent\n'
+init_raw="$(call_tool 1 "masc_init" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a}')")"
+require_tool_success "$init_raw"
+
+join_raw="$(call_tool 2 "masc_join" "$(jq -cn --arg a "$AGENT_NAME" '{agent_name:$a,capabilities:["supervisor","operator"]}')")"
+require_tool_success "$join_raw"
+
+agent_nickname="$(printf '%s' "$join_raw" | mcp_extract_text | sed -n 's/^  Nickname: //p' | head -n1)"
+if [ -z "$agent_nickname" ]; then
+  echo "FAIL: could not parse joined nickname"
+  printf '%s\n' "$join_raw"
+  exit 1
+fi
+
+# ── step 3: start two keepers with different cascades ──
+
+printf '[3/5] start keepers with different cascade profiles\n'
+printf '  keeper-a cascade: %s\n' "$KEEPER_A_CASCADE"
+printf '  keeper-b cascade: %s\n' "$KEEPER_B_CASCADE"
+
+keeper_a_raw="$(call_tool 10 "masc_keeper_up" "$(jq -cn \
+  --arg name "obs-keeper-a" \
+  --arg goal "Observability smoke keeper A" \
+  --arg cascade "$KEEPER_A_CASCADE" \
+  '{name:$name,goal:$goal,cascade_name:$cascade}')")"
+require_tool_success "$keeper_a_raw" "keeper_a_up"
+
+keeper_b_raw="$(call_tool 11 "masc_keeper_up" "$(jq -cn \
+  --arg name "obs-keeper-b" \
+  --arg goal "Observability smoke keeper B" \
+  --arg cascade "$KEEPER_B_CASCADE" \
+  '{name:$name,goal:$goal,cascade_name:$cascade}')")"
+require_tool_success "$keeper_b_raw" "keeper_b_up"
+
+# ── step 4: send a message to each keeper ──
+
+printf '[4/5] send messages to keepers\n'
+# Save original timeout and use keeper-specific timeout
+ORIG_HTTP_TIMEOUT_SEC="$HTTP_TIMEOUT_SEC"
+HTTP_TIMEOUT_SEC="$KEEPER_MSG_TIMEOUT_SEC"
+
+msg_a_raw="$(call_tool 20 "masc_keeper_msg" "$(jq -cn \
+  --arg name "obs-keeper-a" \
+  --arg msg "Reply with one word: ping" \
+  '{name:$name,message:$msg}')")"
+# Keeper msg may fail if LLM is not available -- that is acceptable
+msg_a_ok=0
+if printf '%s' "$msg_a_raw" | jq -e '.result.isError != true' >/dev/null 2>&1; then
+  msg_a_ok=1
+  printf '  keeper-a replied\n'
+else
+  printf '  keeper-a failed to reply (LLM may be unavailable)\n'
+fi
+
+msg_b_raw="$(call_tool 21 "masc_keeper_msg" "$(jq -cn \
+  --arg name "obs-keeper-b" \
+  --arg msg "Reply with one word: pong" \
+  '{name:$name,message:$msg}')")"
+msg_b_ok=0
+if printf '%s' "$msg_b_raw" | jq -e '.result.isError != true' >/dev/null 2>&1; then
+  msg_b_ok=1
+  printf '  keeper-b replied\n'
+else
+  printf '  keeper-b failed to reply (LLM may be unavailable)\n'
+fi
+
+HTTP_TIMEOUT_SEC="$ORIG_HTTP_TIMEOUT_SEC"
+
+# ── step 5: query operator snapshot and verify provider diversity ──
+
+printf '[5/5] query operator snapshot for keeper rows\n'
+snapshot_raw="$(call_operator_tool 30 "masc_operator_snapshot" "$(jq -cn --arg actor "$agent_nickname" '{actor:$actor,view:"full"}')")"
+require_tool_success "$snapshot_raw" "operator_snapshot"
+
+snapshot_result="$(printf '%s' "$snapshot_raw" | extract_tool_result)"
+
+# Extract keeper rows from snapshot
+keeper_rows="$(printf '%s' "$snapshot_result" | jq -c '
+  [(.keepers.items // [])[] | select(.name | startswith("obs-keeper-"))]
+' 2>/dev/null || echo "[]")"
+
+keeper_count="$(printf '%s' "$keeper_rows" | jq 'length')"
+printf '  keeper rows found: %s\n' "$keeper_count"
+
+# Assert: both keepers are visible in the snapshot
+assert_gte "keeper_count_in_snapshot" "$keeper_count" 2
+
+# Extract cascade_name diversity
+cascade_names="$(printf '%s' "$keeper_rows" | jq -r '[.[].cascade_name // empty] | unique | .[]' 2>/dev/null || true)"
+cascade_count="$(printf '%s' "$keeper_rows" | jq '[.[].cascade_name // empty] | unique | length' 2>/dev/null || echo "0")"
+
+printf '  cascade names: %s\n' "$(echo "$cascade_names" | tr '\n' ', ')"
+
+# Assert: at least 1 distinct cascade_name (2 if both are different, which they should be)
+assert_gte "distinct_cascade_names" "$cascade_count" 1
+
+# Extract active_model / last_model_used diversity
+model_labels="$(printf '%s' "$keeper_rows" | jq -r '
+  [.[] | (.active_model // .last_model_used // empty) | select(. != "" and . != null)] | unique | .[]
+' 2>/dev/null || true)"
+model_count="$(printf '%s' "$keeper_rows" | jq '
+  [.[] | (.active_model // .last_model_used // empty) | select(. != "" and . != null)] | unique | length
+' 2>/dev/null || echo "0")"
+
+if [ "$model_count" -gt 0 ]; then
+  printf '  model labels: %s\n' "$(echo "$model_labels" | tr '\n' ', ')"
+  echo "OK: $model_count model label(s) found across keepers"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  # If neither keeper got a turn (no LLM available), model info may be empty
+  if [ "$msg_a_ok" -eq 0 ] && [ "$msg_b_ok" -eq 0 ]; then
+    echo "WARN: no model labels found (both keepers failed to reply -- LLM unavailable)"
+  else
+    echo "WARN: no model labels found in keeper rows"
+  fi
+fi
+
+# Check for API key leakage in snapshot text
+snapshot_strings="$(printf '%s' "$snapshot_result" | jq -r '
+  [.. | strings | select(length > 20)] | join("\n")
+' 2>/dev/null || true)"
+if [ -n "$snapshot_strings" ]; then
+  assert_no_api_key "$snapshot_strings"
+fi
+
+# ── summary ──
+
+printf '\n[summary]\n'
+printf '  base_path: %s\n' "$BASE_PATH"
+printf '  log_file: %s\n' "$LOG_FILE"
+printf '  keeper_a_cascade: %s\n' "$KEEPER_A_CASCADE"
+printf '  keeper_b_cascade: %s\n' "$KEEPER_B_CASCADE"
+printf '  keeper_a_replied: %s\n' "$msg_a_ok"
+printf '  keeper_b_replied: %s\n' "$msg_b_ok"
+printf '  keeper_rows: %s\n' "$keeper_count"
+printf '  distinct_cascades: %s\n' "$cascade_count"
+printf '  distinct_models: %s\n' "$model_count"
+printf '  pass: %d\n' "$PASS_COUNT"
+printf '  fail: %d\n' "$FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "FAIL: observability smoke swarm ($FAIL_COUNT failures)"
+  exit 1
+fi
+
+echo "PASS: observability smoke swarm"


### PR DESCRIPTION
## Summary
- add three live observability smoke harness entrypoints for supervisor, coding, and multi-keeper flows
- harden the new harnesses so missing provider info / missing tool previews no longer pass silently
- align swarm wording and assertions with the fields the operator snapshot actually exposes today (`cascade_name`, `active_model`, `last_model_used`)

## Product impact
- reduces false-positive green runs in live observability smoke coverage
- keeps graceful skip behavior when the server is unavailable, but fails when the target observability evidence is missing after the harness does run

## Evidence
- `git diff --check`
- `bash -n scripts/harness/workload/observability_smoke_supervisor.sh`
- `bash -n scripts/harness/workload/observability_smoke_coding.sh`
- `bash -n scripts/harness/workload/observability_smoke_swarm.sh`

## Review evidence
- GLM-5 incremental diff review: No findings.
- Comment: https://github.com/jeong-sik/masc-mcp/pull/4031#issuecomment-4156167593

## Linked issue
- Refs #3955
- Follow-up to #3998

## Context
- Track C2 live smoke follow-up for tool/provider observability coverage.