### PR TITLE
fix(keeper): treat empty allowlist as unrestricted (#4018)

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -93,15 +93,17 @@ let inject_masc_schemas (schemas : Types.tool_schema list) =
       schemas
 
 (** Apply allowlist/denylist filtering to masc_* tool names.
-    - allowlist empty → no masc_* tools (deny-by-default)
-    - allowlist non-empty → only those tools
+    - allowlist empty → all masc_* tools allowed (no restriction)
+    - allowlist non-empty → only listed tools allowed
     - denylist always wins (deny overrides allow) *)
 let filter_by_access ~(allowlist : string list) ~(denylist : string list)
     (name : string) : bool =
-  if allowlist = [] then false
-  else
-    List.mem name allowlist
-    && not (List.mem name denylist)
+  let allowed =
+    match allowlist with
+    | [] -> true
+    | _ -> List.mem name allowlist
+  in
+  allowed && not (List.mem name denylist)
 
 let keeper_masc_tool_names (meta : keeper_meta) : string list =
   !masc_schemas_ref

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -93,7 +93,10 @@ let inject_masc_schemas (schemas : Types.tool_schema list) =
       schemas
 
 (** Apply allowlist/denylist filtering to masc_* tool names.
-    - allowlist empty → all masc_* tools allowed (no restriction)
+    - allowlist empty → all masc_* tools allowed (no restriction).
+      This matches keeper_turn_up_create default (tool_allowlist=[]).
+      TODO: replace string list with [Unrestricted | Restricted of string list]
+      to make empty-vs-unrestricted semantics explicit.
     - allowlist non-empty → only listed tools allowed
     - denylist always wins (deny overrides allow) *)
 let filter_by_access ~(allowlist : string list) ~(denylist : string list)

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -36,15 +36,19 @@ let test_inject_stores_all_masc () =
   Alcotest.(check bool) "no keeper_time_now" false
     (List.mem "keeper_time_now" names)
 
-(** Default: empty allowlist = no masc_* tools (deny-by-default). *)
-let test_default_locked () =
+(** Default: empty allowlist = unrestricted masc_* exposure. *)
+let test_default_unrestricted () =
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "empty allowlist = 0 masc tools" 0 (List.length names)
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "has masc_governance_status" true
+    (List.mem "masc_governance_status" names);
+  Alcotest.(check bool) "has masc_autoresearch_cycle" true
+    (List.mem "masc_autoresearch_cycle" names)
 
-(** Default: allowed_tool_names also blocks shard-sourced masc_* tools. *)
-let test_default_blocks_shard_masc () =
+(** Default: allowed_tool_names also exposes shard-sourced masc_* tools. *)
+let test_default_exposes_shard_masc () =
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let meta = make_meta () in
   let names = KET.keeper_allowed_tool_names meta in
@@ -53,11 +57,11 @@ let test_default_blocks_shard_masc () =
     (List.mem "keeper_time_now" names);
   Alcotest.(check bool) "has keeper_board_post" true
     (List.mem "keeper_board_post" names);
-  (* masc_* should be blocked *)
-  Alcotest.(check bool) "no masc_status" false (List.mem "masc_status" names);
-  Alcotest.(check bool) "no masc_governance_status" false
+  (* masc_* should also be available when no allowlist restriction is set *)
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "has masc_governance_status" true
     (List.mem "masc_governance_status" names);
-  Alcotest.(check bool) "no masc_autoresearch_cycle" false
+  Alcotest.(check bool) "has masc_autoresearch_cycle" true
     (List.mem "masc_autoresearch_cycle" names)
 
 (** Allowlist opens specific tools. *)
@@ -83,6 +87,19 @@ let test_deny_overrides_allow () =
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
   Alcotest.(check bool) "no masc_broadcast (denied)" false
     (List.mem "masc_broadcast" names)
+
+(** Denylist also restricts the unrestricted empty-allowlist path. *)
+let test_denylist_restricts_unrestricted_default () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta = make_meta
+    ~tool_denylist:["masc_status"; "masc_governance_status"] () in
+  let names = KET.keeper_allowed_tool_names meta in
+  Alcotest.(check bool) "no masc_status (denied)" false
+    (List.mem "masc_status" names);
+  Alcotest.(check bool) "no masc_governance_status (denied)" false
+    (List.mem "masc_governance_status" names);
+  Alcotest.(check bool) "other masc tools remain" true
+    (List.mem "masc_autoresearch_cycle" names)
 
 (** Allowlist also gates shard-sourced masc_* in allowed_tool_names. *)
 let test_allowlist_gates_shard_tools () =
@@ -128,12 +145,12 @@ let () =
           Alcotest.test_case "stores all masc_* schemas" `Quick
             test_inject_stores_all_masc;
         ] );
-      ( "deny_by_default",
+      ( "unrestricted_by_default",
         [
-          Alcotest.test_case "empty allowlist = no masc tools" `Quick
-            test_default_locked;
-          Alcotest.test_case "blocks shard-sourced masc_*" `Quick
-            test_default_blocks_shard_masc;
+          Alcotest.test_case "empty allowlist exposes masc tools" `Quick
+            test_default_unrestricted;
+          Alcotest.test_case "exposes shard-sourced masc_*" `Quick
+            test_default_exposes_shard_masc;
         ] );
       ( "allowlist",
         [
@@ -146,6 +163,8 @@ let () =
         [
           Alcotest.test_case "deny overrides allow" `Quick
             test_deny_overrides_allow;
+          Alcotest.test_case "deny restricts unrestricted default" `Quick
+            test_denylist_restricts_unrestricted_default;
         ] );
       ( "dispatch",
         [


### PR DESCRIPTION
## Summary
- `filter_by_access`에서 `tool_allowlist = []`일 때 `masc_*` 도구를 전부 차단하던 해석을 수정합니다.
- 빈 allowlist는 `keeper_turn_up_create` 기본값과 맞춰 `unrestricted`로 취급하고, 비어있지 않을 때만 명시된 `masc_*` 도구로 제한합니다.
- `tool_denylist`는 기존처럼 항상 우선 적용됩니다.

## Product impact
- 신규 keeper가 기본 생성 경로에서 research/autoresearch 및 기타 `masc_*` 브리지 도구를 잃어버리던 회귀를 막습니다.
- `tool_allowlist`를 명시적으로 넣은 keeper는 계속 해당 목록으로 제한되고, `tool_denylist`도 그대로 유효합니다.

## Root Cause
- `#4003`에서 도입된 `filter_by_access`가 빈 allowlist를 `deny-by-default`로 해석했습니다.
- 하지만 keeper 기본 생성 경로는 `tool_allowlist = []`를 사용하므로, 기본 keeper 전체가 의도와 다르게 `masc_*` 도구를 잃었습니다.

## Evidence
- Failing CI on `#4034`: `Build and Test` failed in `test_keeper_masc_bridge` because the suite still expected `empty allowlist = no masc tools`.
- Local verification:
  - `git diff --check`
  - `env -u DUNE_RPC opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4018-ci-regression test/test_keeper_masc_bridge.exe`
  - `./_build/default/test/test_keeper_masc_bridge.exe` -> 9 tests passed

## Review evidence
- Model: direct `GLM-5`
- Reviewed at: 2026-03-31
- Reviewed head: `8d6befdb7`
- Result: `No findings.`

## Linked issue
- Closes #4018
