### PR TITLE
[codex] feat(keeper): add typed social state routing

### DIFF
--- a/config/prompts/keeper.proactive_turn.md
+++ b/config/prompts/keeper.proactive_turn.md
@@ -28,4 +28,13 @@ Guidance:
 - Avoid repeating the previous proactive message verbatim.
 - Do not assume a board action is required.
 - Do NOT output [STATE] blocks on this turn.
-- End your reply with: CHECKIN: <one sentence summary of what you did>
+- Start your reply with:
+  - `SOCIAL_MODEL: bdi_speech_v1`
+  - `BELIEF_SUMMARY: ...`
+  - `ACTIVE_DESIRE: ...` or `none`
+  - `CURRENT_INTENTION: ...` or `none`
+  - `BLOCKER: ...` or `none`
+  - `NEED: ...` or `none`
+  - `SPEECH_ACT: stay_silent|inform|request_help|claim_task|comment_board|post_board|broadcast|defer`
+  - `DELIVERY_SURFACE: silent|visible_reply|board_post|board_comment|task_claim|broadcast`
+- If you choose silence, emit no visible body after the headers.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -16,11 +16,22 @@ Possible actions:
 - Work on active goals (use planning/execution tools)
 - Inspect or use board tools (`keeper_board_list`, `keeper_board_get`, `keeper_board_post`, `keeper_board_comment`, `keeper_board_vote`) when it helps
 - Search knowledge library (keeper_library_search/read) for research references
-- When blocked, emit a short explicit skip reason instead of a silent no-op
+- If you are blocked, set `SPEECH_ACT: request_help` and choose an explicit delivery surface
+- If there is no meaningful outward act, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 
 Board tools are optional. Do not post just to satisfy the loop.
 
 Prefer a single moderate extend_turns request before read/edit/build/verify style work.
 When making claims or decisions, search the library first if relevant documents may exist.
 Do NOT explain your decision-making process at length.
-Act directly and make the trigger visible in your response.
+Start every response with machine-readable headers:
+- `SOCIAL_MODEL: bdi_speech_v1`
+- `BELIEF_SUMMARY: ...`
+- `ACTIVE_DESIRE: ...` or `none`
+- `CURRENT_INTENTION: ...` or `none`
+- `BLOCKER: ...` or `none`
+- `NEED: ...` or `none`
+- `SPEECH_ACT: stay_silent|inform|request_help|claim_task|comment_board|post_board|broadcast|defer`
+- `DELIVERY_SURFACE: silent|visible_reply|board_post|board_comment|task_claim|broadcast`
+
+If `DELIVERY_SURFACE: silent`, emit no visible body after the headers.

--- a/docs/design/keeper-social-model-inventory.md
+++ b/docs/design/keeper-social-model-inventory.md
@@ -1,0 +1,79 @@
+# Keeper Social Model Inventory
+
+Status: active baseline + research inventory
+
+## Active baseline
+
+### `bdi_speech_v1`
+
+- Role: current keeper social model
+- Fit: best fit for the existing keeper + board + task + status architecture
+- Core idea:
+  - the model explicitly emits a typed social-state header
+  - code validates and routes that act
+  - board/task/broadcast remain the only outward surfaces
+- Why active now:
+  - keeper already has `will / needs / desires`
+  - unified turn already records trigger/affordance/outcome artifacts
+  - this adds explicit expression without replacing the current harness
+
+## Inventory candidates
+
+### `magentic_ledger_v1`
+
+- Role: progress/stall-oriented planning overlay
+- Best use: detect stuck work, stalled loops, replanning triggers
+- Why not default now:
+  - good for task/progress ledgers
+  - weaker as the primary social-expression model
+
+Reference:
+- Magentic-One article
+- https://www.microsoft.com/en-us/research/articles/magentic-one-a-generalist-multi-agent-system-for-solving-complex-tasks/
+
+### `reaction_identity_v2`
+
+- Role: history/emergence-driven keeper identity
+- Best use: diversity, long-horizon persona drift, reaction-history experiments
+- Why not default now:
+  - useful research track
+  - too indirect for immediate blocker/request-help expression
+
+Related local context:
+- `docs/archive/keeper-autonomy-identity-v2/ARCHITECTURE.md`
+- `docs/archive/keeper-autonomy-identity-v2/RESEARCH.md`
+
+### `tom_diversity_v1`
+
+- Role: cross-agent expectation modeling
+- Best use: diversity maintenance, consensus-vs-dissent control
+- Why not default now:
+  - high complexity
+  - requires more state and scaling work than current keeper loop needs
+
+Reference:
+- Jason / BDI ecosystem for explicit agent mental state
+- https://jason-lang.github.io/jason/
+
+### `hitl_intervention_v1`
+
+- Role: approval/handoff/escalation overlay
+- Best use: operator gating, action previews, external approval
+- Why not default now:
+  - complements social routing
+  - does not replace it
+
+References:
+- LangGraph HITL docs
+- https://docs.langchain.com/oss/javascript/deepagents/human-in-the-loop
+- AutoGen intervention + handoff docs
+- https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/cookbook/tool-use-with-intervention.html
+- https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/design-patterns/handoffs.html
+
+## Selection rule
+
+Until multiple implementations are production-ready:
+
+- runtime default stays `bdi_speech_v1`
+- inventory entries are documentation-only
+- unknown runtime values should fail fast or fall back explicitly to `bdi_speech_v1`

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -507,6 +507,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
+              ("social_model", `String m.social_model);
               ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
               ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
               ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);
@@ -519,6 +520,18 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 if String.trim m.runtime.proactive_rt.last_reason = ""
                 then `Null
                 else `String m.runtime.proactive_rt.last_reason);
+              ("last_speech_act",
+                if String.trim m.runtime.last_speech_act = ""
+                then `Null
+                else `String m.runtime.last_speech_act);
+              ("last_blocker",
+                if String.trim m.runtime.last_blocker = ""
+                then `Null
+                else `String m.runtime.last_blocker);
+              ("last_need",
+                if String.trim m.runtime.last_need = ""
+                then `Null
+                else `String m.runtime.last_need);
 	              ("last_proactive_preview",
 	                if String.trim m.runtime.proactive_rt.last_preview = ""
 	                then `Null

--- a/lib/dune
+++ b/lib/dune
@@ -395,6 +395,7 @@
    eval_calibration
    ;; Keeper contract
    keeper_schema
+   keeper_social_model
    keeper_config
    keeper_toml_loader
    keeper_contract

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -1,0 +1,306 @@
+(** Keeper_social_model — keeper-side social routing for unified turns. *)
+
+open Keeper_types
+
+type speech_act =
+  | Stay_silent
+  | Inform
+  | Request_help
+  | Claim_task
+  | Comment_board
+  | Post_board
+  | Broadcast
+  | Defer
+
+type delivery_surface =
+  | Silent
+  | Visible_reply
+  | Board_post
+  | Board_comment
+  | Task_claim_surface
+  | Broadcast_surface
+
+type social_state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+  speech_act : speech_act;
+  delivery_surface : delivery_surface;
+}
+
+let speech_act_to_string = function
+  | Stay_silent -> "stay_silent"
+  | Inform -> "inform"
+  | Request_help -> "request_help"
+  | Claim_task -> "claim_task"
+  | Comment_board -> "comment_board"
+  | Post_board -> "post_board"
+  | Broadcast -> "broadcast"
+  | Defer -> "defer"
+
+let delivery_surface_to_string = function
+  | Silent -> "silent"
+  | Visible_reply -> "visible_reply"
+  | Board_post -> "board_post"
+  | Board_comment -> "board_comment"
+  | Task_claim_surface -> "task_claim"
+  | Broadcast_surface -> "broadcast"
+
+let speech_act_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "stay_silent" -> Some Stay_silent
+  | "inform" -> Some Inform
+  | "request_help" -> Some Request_help
+  | "claim_task" -> Some Claim_task
+  | "comment_board" -> Some Comment_board
+  | "post_board" -> Some Post_board
+  | "broadcast" -> Some Broadcast
+  | "defer" -> Some Defer
+  | _ -> None
+
+let delivery_surface_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "silent" -> Some Silent
+  | "visible_reply" -> Some Visible_reply
+  | "board_post" -> Some Board_post
+  | "board_comment" -> Some Board_comment
+  | "task_claim" -> Some Task_claim_surface
+  | "broadcast" -> Some Broadcast_surface
+  | _ -> None
+
+let parse_header_line line =
+  match String.index_opt line ':' with
+  | None -> None
+  | Some idx ->
+      let key = String.sub line 0 idx |> String.trim in
+      let value =
+        String.sub line (idx + 1) (String.length line - idx - 1) |> String.trim
+      in
+      if key = "" then None else Some (key, value)
+
+let is_social_header_key = function
+  | "SOCIAL_MODEL"
+  | "BELIEF_SUMMARY"
+  | "ACTIVE_DESIRE"
+  | "CURRENT_INTENTION"
+  | "BLOCKER"
+  | "NEED"
+  | "SPEECH_ACT"
+  | "DELIVERY_SURFACE" ->
+      true
+  | _ -> false
+
+let parse_header_block raw =
+  let lines = String.split_on_char '\n' raw in
+  let rec consume acc = function
+    | line :: rest -> (
+        match parse_header_line line with
+        | Some (key, value) when is_social_header_key key ->
+            consume ((key, value) :: acc) rest
+        | _ -> (List.rev acc, line :: rest))
+    | [] -> (List.rev acc, [])
+  in
+  let headers, body_lines = consume [] lines in
+  (headers, String.concat "\n" body_lines |> String.trim)
+
+let header_assoc_opt headers key =
+  headers
+  |> List.find_map (fun (header_key, value) ->
+         if String.equal header_key key then Some value else None)
+
+let nonempty_header_opt headers key =
+  match header_assoc_opt headers key with
+  | Some value -> (
+      match String.lowercase_ascii (String.trim value) with
+      | "" | "none" | "null" -> None
+      | _ -> Some (String.trim value))
+  | None -> None
+
+let belief_summary_of_observation
+    (observation : Keeper_world_observation.world_observation) : string =
+  let beliefs = ref [] in
+  let add value =
+    if String.trim value <> "" then beliefs := value :: !beliefs
+  in
+  if observation.pending_mentions <> [] then
+    add (Printf.sprintf "mentions=%d" (List.length observation.pending_mentions));
+  if observation.pending_board_events <> [] then
+    add
+      (Printf.sprintf "board_events=%d"
+         (List.length observation.pending_board_events));
+  if observation.unclaimed_task_count > 0 then
+    add (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count);
+  if observation.failed_task_count > 0 then
+    add (Printf.sprintf "failed_tasks=%d" observation.failed_task_count);
+  if observation.active_goals <> [] then
+    add (Printf.sprintf "active_goals=%d" (List.length observation.active_goals));
+  if observation.idle_seconds > 0 then
+    add (Printf.sprintf "idle=%ds" observation.idle_seconds);
+  if Option.is_some observation.worktree_change_summary then add "worktree_delta";
+  match List.rev !beliefs with
+  | [] -> "quiet_room"
+  | values -> String.concat "; " values
+
+let protocol_violation_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation) ~(reason : string)
+    =
+  {
+    social_model = meta.social_model;
+    belief_summary = belief_summary_of_observation observation;
+    active_desire = None;
+    current_intention = None;
+    blocker = Some reason;
+    need = None;
+    speech_act = Defer;
+    delivery_surface = Silent;
+  }
+
+let social_state_of_headers ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation) headers
+    ~response_body ~(tools_used : string list) =
+  let _ = response_body in
+  let _ = tools_used in
+  match nonempty_header_opt headers "SPEECH_ACT", header_assoc_opt headers "DELIVERY_SURFACE" with
+  | Some speech_raw, Some delivery_raw -> (
+      match
+        speech_act_of_string speech_raw,
+        delivery_surface_of_string delivery_raw
+      with
+      | Some speech_act, Some delivery_surface ->
+          {
+            social_model =
+              Option.value
+                ~default:meta.social_model
+                (nonempty_header_opt headers "SOCIAL_MODEL");
+            belief_summary =
+              Option.value
+                ~default:(belief_summary_of_observation observation)
+                (nonempty_header_opt headers "BELIEF_SUMMARY");
+            active_desire = nonempty_header_opt headers "ACTIVE_DESIRE";
+            current_intention = nonempty_header_opt headers "CURRENT_INTENTION";
+            blocker = nonempty_header_opt headers "BLOCKER";
+            need = nonempty_header_opt headers "NEED";
+            speech_act;
+            delivery_surface;
+          }
+      | _ ->
+          protocol_violation_state ~meta ~observation
+            ~reason:"invalid social headers")
+  | _ ->
+      protocol_violation_state ~meta ~observation
+        ~reason:"missing social headers"
+
+let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) =
+  match blocker with
+  | None -> false
+  | Some blocker ->
+      String.equal blocker (String.trim meta.runtime.last_blocker)
+      && String.equal meta.runtime.last_speech_act "request_help"
+      && meta.runtime.proactive_rt.last_ts > 0.0
+      && Time_compat.now () -. meta.runtime.proactive_rt.last_ts
+         < float_of_int meta.proactive.cooldown_sec
+
+let request_help_post_body ~(meta : keeper_meta) ~(state : social_state) blocker =
+  String.concat "\n"
+    [
+      Printf.sprintf "keeper `%s` is blocked." meta.name;
+      Printf.sprintf "goal: %s" meta.goal;
+      Printf.sprintf "beliefs: %s" state.belief_summary;
+      (match state.current_intention with
+      | Some value -> "intended action: " ^ value
+      | None -> "intended action: unspecified");
+      "blocker: " ^ blocker;
+      (match state.need with
+      | Some value -> "need: " ^ value
+      | None -> "need: guidance");
+      "retry condition: external capability or operator guidance becomes available";
+    ]
+
+type request_help_delivery =
+  | Request_help_posted
+  | Request_help_deduped
+  | Request_help_failed
+
+let deliver_request_help_post ~(meta : keeper_meta) ~(state : social_state) =
+  match state.blocker with
+  | None -> Request_help_failed
+  | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker) ->
+      Request_help_deduped
+  | Some blocker ->
+      let title = Printf.sprintf "[keeper-blocked] %s needs help" meta.name in
+      let body = request_help_post_body ~meta ~state blocker in
+      let meta_json =
+        Some
+          (`Assoc
+            [
+              ("source", `String "keeper_board_post");
+              ("social_model", `String state.social_model);
+              ("speech_act", `String (speech_act_to_string state.speech_act));
+              ("keeper_name", `String meta.name);
+              ("agent_name", `String meta.agent_name);
+              ("belief_summary", `String state.belief_summary);
+              ("blocker", `String blocker);
+              ( "need",
+                match state.need with
+                | Some value -> `String value
+                | None -> `Null );
+            ])
+      in
+      match
+        Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
+          ~post_kind:Board.Automation_post ?meta_json ~visibility:Board.Internal
+          ~ttl_hours:24 ~hearth:"keepers" ()
+      with
+      | Ok _ -> Request_help_posted
+      | Error _ -> Request_help_failed
+
+let apply_to_result ~(config : Room.config) ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    (result : Keeper_agent_run.run_result) =
+  let _ = config in
+  let headers, response_body = parse_header_block result.response_text in
+  let state =
+    social_state_of_headers ~meta ~observation headers ~response_body
+      ~tools_used:result.tools_used
+  in
+  match state.speech_act, state.delivery_surface with
+  | Request_help, Board_post when result.tools_used = [] ->
+      (match deliver_request_help_post ~meta ~state with
+      | Request_help_posted ->
+          let tools_used =
+            dedupe_keep_order ("keeper_board_post" :: result.tools_used)
+          in
+          ( { result with
+              response_text = "";
+              tools_used;
+              tool_calls_made = List.length tools_used;
+            },
+            state )
+      | Request_help_deduped | Request_help_failed ->
+          ({ result with response_text = "" }, state))
+  | Defer, Silent ->
+      ({ result with response_text = "" }, state)
+  | Stay_silent, Silent when result.tools_used = [] ->
+      ({ result with response_text = "" }, state)
+  | _ ->
+      ({ result with response_text = response_body }, state)
+
+let derive_failure_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(reason : string) =
+  {
+    social_model = meta.social_model;
+    belief_summary = belief_summary_of_observation observation;
+    active_desire = None;
+    current_intention = None;
+    blocker =
+      (match String.trim reason with
+      | "" -> None
+      | value -> Some (short_preview value));
+    need = None;
+    speech_act = Defer;
+    delivery_surface = Silent;
+  }

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -1,0 +1,50 @@
+(** Keeper_social_model — keeper-side social routing for unified turns.
+
+    Converts world observation + raw turn result into a small typed social
+    decision so keepers can stay silent, inform, or ask for help without
+    relying on repetitive free-form fallback text. *)
+
+type speech_act =
+  | Stay_silent
+  | Inform
+  | Request_help
+  | Claim_task
+  | Comment_board
+  | Post_board
+  | Broadcast
+  | Defer
+
+type delivery_surface =
+  | Silent
+  | Visible_reply
+  | Board_post
+  | Board_comment
+  | Task_claim_surface
+  | Broadcast_surface
+
+type social_state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+  speech_act : speech_act;
+  delivery_surface : delivery_surface;
+}
+
+val speech_act_to_string : speech_act -> string
+val delivery_surface_to_string : delivery_surface -> string
+
+val derive_failure_state :
+  meta:Keeper_types.keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  reason:string ->
+  social_state
+
+val apply_to_result :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  Keeper_agent_run.run_result ->
+  Keeper_agent_run.run_result * social_state

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -208,6 +208,19 @@ let handle_keeper_list ctx args : tool_result =
                 if String.trim m.runtime.proactive_rt.last_preview = ""
                 then `Null
                 else `String m.runtime.proactive_rt.last_preview);
+              ("social_model", `String m.social_model);
+              ("last_speech_act",
+                if String.trim m.runtime.last_speech_act = ""
+                then `Null
+                else `String m.runtime.last_speech_act);
+              ("last_blocker",
+                if String.trim m.runtime.last_blocker = ""
+                then `Null
+                else `String m.runtime.last_blocker);
+              ("last_need",
+                if String.trim m.runtime.last_need = ""
+                then `Null
+                else `String m.runtime.last_need);
               ("continuity_summary",
                 if String.trim m.continuity_summary = ""
                 then `Null

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -498,6 +498,21 @@ let handle_keeper_status ctx args : tool_result =
              ("noop_turn_count", `Int m.runtime.noop_turn_count);
              ("tool_action_count", `Int m.runtime.autonomous_action_count);
            ]);
+           ("social", `Assoc [
+             ("model", `String m.social_model);
+             ("last_speech_act",
+               if String.trim m.runtime.last_speech_act = ""
+               then `Null
+               else `String m.runtime.last_speech_act);
+             ("last_blocker",
+               if String.trim m.runtime.last_blocker = ""
+               then `Null
+               else `String m.runtime.last_blocker);
+             ("last_need",
+               if String.trim m.runtime.last_need = ""
+               then `Null
+               else `String m.runtime.last_need);
+           ]);
            ("active_team_session_id",
              match m.active_team_session_id with
              | Some session_id -> `String session_id

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -192,6 +192,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            mid_goal;
            long_goal;
            soul_profile;
+           social_model = default_social_model;
            cascade_name = "keeper_unified";
            will;
            needs;
@@ -275,6 +276,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
              board_reactive_turn_count = 0;
              mention_reactive_turn_count = 0;
              noop_turn_count = 0;
+             last_speech_act = "";
+             last_blocker = "";
+             last_need = "";
            };
          } in
          Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
@@ -329,6 +333,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
              ("voice_enabled", `Bool meta.voice_enabled);
              ("voice_channel", `String meta.voice_channel);
              ("voice_agent_id", `String meta.voice_agent_id);
+             ("social_model", `String meta.social_model);
              ("proactive_enabled", `Bool meta.proactive.enabled);
              ("proactive_idle_sec", `Int meta.proactive.idle_sec);
              ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -71,6 +71,9 @@ type agent_runtime_state = {
   board_reactive_turn_count: int;
   mention_reactive_turn_count: int;
   noop_turn_count: int;
+  last_speech_act: string;
+  last_blocker: string;
+  last_need: string;
 }
 
 type keeper_meta = {
@@ -82,6 +85,7 @@ type keeper_meta = {
   mid_goal: string;
   long_goal: string;
   soul_profile: string;
+  social_model: string;
   cascade_name: string;
   will: string;
   needs: string;
@@ -124,6 +128,8 @@ type keeper_meta = {
   (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
   runtime: agent_runtime_state;
 }
+
+let default_social_model = "bdi_speech_v1"
 
 (* -- Updater helpers for nested record updates -- *)
 
@@ -240,6 +246,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("mid_goal", `String m.mid_goal);
       ("long_goal", `String m.long_goal);
       ("soul_profile", `String m.soul_profile);
+      ("social_model", `String m.social_model);
       ("cascade_name", `String m.cascade_name);
       ("will", `String m.will);
       ("needs", `String m.needs);
@@ -311,6 +318,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("board_reactive_turn_count", `Int rt.board_reactive_turn_count);
       ("mention_reactive_turn_count", `Int rt.mention_reactive_turn_count);
       ("noop_turn_count", `Int rt.noop_turn_count);
+      ("last_speech_act", `String rt.last_speech_act);
+      ("last_blocker", `String rt.last_blocker);
+      ("last_need", `String rt.last_need);
       ("paused", `Bool m.paused);
       ("current_task_id",
         (match m.current_task_id with None -> `Null | Some s -> `String s));
@@ -341,6 +351,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       Safe_ops.json_string ~default:default_soul_profile "soul_profile" json
       |> canonical_soul_profile
       |> Option.value ~default:default_soul_profile
+    in
+    let social_model =
+      Safe_ops.json_string ~default:default_social_model "social_model" json
     in
     let will =
       Safe_ops.json_string ~default:default_keeper_will "will" json
@@ -512,6 +525,15 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let noop_turn_count =
       Safe_ops.json_int ~default:0 "noop_turn_count" json
     in
+    let last_speech_act =
+      Safe_ops.json_string ~default:"" "last_speech_act" json
+    in
+    let last_blocker =
+      Safe_ops.json_string ~default:"" "last_blocker" json
+    in
+    let last_need =
+      Safe_ops.json_string ~default:"" "last_need" json
+    in
     let paused =
       Safe_ops.json_bool ~default:false "paused" json
     in
@@ -530,6 +552,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           mid_goal;
           long_goal;
           soul_profile;
+          social_model;
           cascade_name;
           will;
           needs;
@@ -613,6 +636,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
             board_reactive_turn_count;
             mention_reactive_turn_count;
             noop_turn_count;
+            last_speech_act;
+            last_blocker;
+            last_need;
           };
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -74,6 +74,9 @@ type agent_runtime_state = {
   board_reactive_turn_count: int;
   mention_reactive_turn_count: int;
   noop_turn_count: int;
+  last_speech_act: string;
+  last_blocker: string;
+  last_need: string;
 }
 
 (** {1 Keeper meta} *)
@@ -86,6 +89,7 @@ type keeper_meta = {
   mid_goal: string;
   long_goal: string;
   soul_profile: string;
+  social_model: string;
   cascade_name: string;
   will: string;
   needs: string;
@@ -121,6 +125,8 @@ type keeper_meta = {
   (** Currently claimed task ID for cost attribution. *)
   runtime: agent_runtime_state;
 }
+
+val default_social_model : string
 
 val now_iso : unit -> string
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -102,7 +102,16 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
      claim one with keeper_task_claim and work on it.\n\
      When you have findings, opinions, or status updates worth sharing, post them to the board \
      using keeper_board_post. When responding to board activity, use keeper_board_comment.\n\
-     Take a concrete step only when it materially helps; otherwise emit `SKIP: <reason>`."
+     Every response must begin with these machine-readable headers exactly once:\n\
+     SOCIAL_MODEL: bdi_speech_v1\n\
+     BELIEF_SUMMARY: <short summary>\n\
+     ACTIVE_DESIRE: <value or none>\n\
+     CURRENT_INTENTION: <value or none>\n\
+     BLOCKER: <value or none>\n\
+     NEED: <value or none>\n\
+     SPEECH_ACT: stay_silent|inform|request_help|claim_task|comment_board|post_board|broadcast|defer\n\
+     DELIVERY_SURFACE: silent|visible_reply|board_post|board_comment|task_claim|broadcast\n\
+     If DELIVERY_SURFACE is silent, emit no visible body after the headers."
   in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -9,6 +9,7 @@
 open Keeper_types
 open Keeper_memory [@@warning "-33"]
 open Keeper_exec_context [@@warning "-33"]
+module Social = Keeper_social_model
 
 let string_contains_substring ~(needle : string) (haystack : string) : bool =
   let needle_len = String.length needle in
@@ -94,6 +95,7 @@ let append_decision_record
     ~(latency_ms : int)
     ~(outcome : string)
     ~(selected_mode : string)
+    ?social_state
     ?(result : Keeper_agent_run.run_result option = None)
     ?error
     () : unit =
@@ -117,6 +119,27 @@ let append_decision_record
     | None -> 0
   in
   let claim_executed = List.mem "keeper_task_claim" tools_used in
+  let social_fields =
+    match social_state with
+    | None -> []
+    | Some state ->
+        let option_field key = function
+          | Some value -> (key, `String value)
+          | None -> (key, `Null)
+        in
+        [
+          ("social_model", `String state.Social.social_model);
+          ("belief_summary", `String state.belief_summary);
+          option_field "active_desire" state.active_desire;
+          option_field "current_intention" state.current_intention;
+          option_field "blocker" state.blocker;
+          option_field "need" state.need;
+          ("speech_act", `String (Social.speech_act_to_string state.speech_act));
+          ( "delivery_surface",
+            `String
+              (Social.delivery_surface_to_string state.delivery_surface) );
+        ]
+  in
   let suffix_seed =
     match response_preview, error with
     | Some preview, _ -> preview
@@ -125,7 +148,7 @@ let append_decision_record
   in
   let json =
     `Assoc
-      [
+      ([
         ("id", `String (decision_id ~meta ~ts:now_ts ~suffix_seed));
         ("ts", `String (now_iso ()));
         ("ts_unix", `Float now_ts);
@@ -183,6 +206,7 @@ let append_decision_record
                 ]
           | _ -> `Null );
       ]
+      @ social_fields)
   in
   try append_jsonl_line (keeper_decision_log_path config meta.name) json
   with
@@ -195,6 +219,7 @@ let append_decision_record
     No action_taken type — we observe what the agent did, not classify it. *)
 let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
+    ?social_state
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let used_model_id =
@@ -225,6 +250,21 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let is_board_reactive = observation.pending_board_events <> [] in
   let is_mention_reactive = observation.pending_mentions <> [] in
   let rt = meta.runtime in
+  let social_state : Social.social_state =
+    Option.value social_state
+      ~default:
+        Social.
+          {
+            social_model = meta.social_model;
+            belief_summary = "not_recorded";
+            active_desire = None;
+            current_intention = None;
+            blocker = None;
+            need = None;
+            speech_act = Social.Inform;
+            delivery_surface = Social.Visible_reply;
+          }
+  in
   {
     meta with
     updated_at = now_iso ();
@@ -281,6 +321,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
         + (if is_autonomous_turn && not has_text && not has_tool_calls then 1 else 0);
       last_autonomous_action_at =
         (if has_tool_calls then now_iso () else rt.last_autonomous_action_at);
+      last_speech_act = Social.speech_act_to_string social_state.speech_act;
+      last_blocker = Option.value ~default:"" social_state.blocker;
+      last_need = Option.value ~default:"" social_state.need;
     };
   }
 
@@ -365,7 +408,7 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
   Dated_jsonl.append metrics_store snapshot
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
-    ~(reason : string) : keeper_meta =
+    ~(reason : string) ?social_state () : keeper_meta =
   let now_ts = Time_compat.now () in
   let preview =
     let trimmed = String.trim reason in
@@ -385,6 +428,21 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         last_reason = "unified:error:" ^ String.trim reason;
         last_preview = preview;
       };
+      last_speech_act =
+        (match social_state with
+         | Some (state : Social.social_state) ->
+             Social.speech_act_to_string state.speech_act
+         | None -> meta.runtime.last_speech_act);
+      last_blocker =
+        (match social_state with
+         | Some (state : Social.social_state) ->
+             Option.value ~default:"" state.blocker
+         | None -> short_preview reason);
+      last_need =
+        (match social_state with
+         | Some (state : Social.social_state) ->
+             Option.value ~default:"" state.need
+         | None -> meta.runtime.last_need);
     };
   }
 
@@ -443,11 +501,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       in
       match run_result with
       | Error e ->
+          let social_state =
+            Social.derive_failure_state ~meta ~observation ~reason:e
+          in
           let updated_meta =
             update_metrics_from_failure meta ~latency_ms ~reason:e
+              ~social_state ()
           in
           append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~outcome:"error" ~selected_mode:"error"
+            ~social_state
             ~error:e ();
           (match write_meta config updated_meta with
            | Ok () -> ()
@@ -476,6 +539,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           end;
           Error e
       | Ok result ->
+          let result, social_state =
+            Social.apply_to_result ~config ~meta ~observation result
+          in
           let used_model_id =
             let strip_latest s =
               if
@@ -521,7 +587,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           (* 6. Observe result and update metrics *)
           let updated_meta =
             update_metrics_from_result rollover.updated_meta ~latency_ms
-              ~observation result
+              ~observation ~social_state result
           in
           (try
              append_metrics_snapshot ~config ~meta:updated_meta ~observation
@@ -540,6 +606,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~outcome:"success"
             ~selected_mode:(selected_mode_of_result result)
+            ~social_state
             ~result:(Some result) ();
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -25,6 +25,7 @@ val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
+  ?social_state:Keeper_social_model.social_state ->
   Keeper_agent_run.run_result ->
   Keeper_types.keeper_meta
 
@@ -32,6 +33,8 @@ val update_metrics_from_failure :
   Keeper_types.keeper_meta ->
   latency_ms:int ->
   reason:string ->
+  ?social_state:Keeper_social_model.social_state ->
+  unit ->
   Keeper_types.keeper_meta
 
 val run_unified_turn :

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -155,6 +155,11 @@ let keeper_list_row_json ~runtime_class config name =
             ("proactive_enabled", `Bool meta.proactive.enabled);
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
+            ("social_model", `String meta.social_model);
+            ( "last_speech_act",
+              if String.trim meta.runtime.last_speech_act = ""
+              then `Null
+              else `String meta.runtime.last_speech_act );
             ("skill_route", keeper_list_skill_route_json config meta);
             ("cascade_name", `String meta.cascade_name);
             ("created_at", `String meta.created_at);

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4,6 +4,7 @@ module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
 module KAR = Masc_mcp.Keeper_agent_run
+module KSM = Masc_mcp.Keeper_social_model
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
 module HK = Masc_mcp.Keeper_hooks_oas
@@ -44,6 +45,16 @@ let cleanup_dir dir =
         Unix.unlink path
   in
   try rm dir with _ -> ()
+
+let contains_substring haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > hay_len then false
+    else if String.sub haystack i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
 
 (* ---------- World Observation type tests ---------- *)
 
@@ -413,6 +424,10 @@ let test_unified_turn_runtime_defaults () =
     check int "unified max_turns default" 20
       (KC.keeper_unified_max_turns ()))))
 
+let test_meta_defaults_social_model () =
+  check string "default social model" "bdi_speech_v1"
+    minimal_meta.social_model
+
 (* ---------- Metrics observation tests ---------- *)
 
 let make_run_result ~text ~tools ~model ~input_tok ~output_tok
@@ -475,10 +490,36 @@ let test_metrics_noop_response () =
     updated.runtime.autonomous_action_count;
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
 
+let test_metrics_persist_social_state_fields () =
+  let result =
+    make_run_result
+      ~text:
+        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:50 ~output_tok:10
+  in
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let routed, social_state =
+        KSM.apply_to_result ~config ~meta:minimal_meta
+          ~observation:base_observation result
+      in
+      let updated =
+        UT.update_metrics_from_result minimal_meta ~latency_ms:100
+          ~observation:base_observation ~social_state routed
+      in
+      check string "speech act tracked" "stay_silent"
+        updated.runtime.last_speech_act;
+      check string "no blocker tracked" "" updated.runtime.last_blocker;
+      check string "no need tracked" "" updated.runtime.last_need)
+
 let test_metrics_failure_response () =
   let reason = "Agent run failed: Max turns exceeded (turn 10, limit 10)" in
   let updated =
-    UT.update_metrics_from_failure minimal_meta ~latency_ms:250 ~reason
+    UT.update_metrics_from_failure minimal_meta ~latency_ms:250 ~reason ()
   in
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
   check int "latency recorded" 250 updated.runtime.usage.last_latency_ms;
@@ -525,6 +566,17 @@ let test_prompt_includes_board_activity_section () =
        try ignore (Str.search_forward (Str.regexp_string "Please take a look.") user 0); true
        with Not_found -> false
      in found)
+
+let test_prompt_prefers_silence_guidance () =
+  let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
+  check bool "mentions speech act header" true
+    (let found =
+       try
+         ignore (Str.search_forward (Str.regexp_string "SPEECH_ACT:") sys 0);
+         true
+       with Not_found -> false
+     in
+     found)
 
 let test_metrics_mixed_response () =
   let result =
@@ -588,6 +640,97 @@ let test_normalize_response_text_empty_without_tools_errors () =
          in
          found)
 
+let test_social_model_silences_skip_only_turn () =
+  let result =
+    make_run_result
+      ~text:
+        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5
+  in
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let routed, state =
+        KSM.apply_to_result ~config ~meta:minimal_meta
+          ~observation:base_observation result
+      in
+      check string "speech act" "stay_silent"
+        (KSM.speech_act_to_string state.speech_act);
+      check string "delivery surface" "silent"
+        (KSM.delivery_surface_to_string state.delivery_surface);
+      check string "visible response suppressed" "" routed.response_text;
+      check (list string) "no synthetic tools" [] routed.tools_used)
+
+let test_social_model_requires_explicit_headers () =
+  let result =
+    make_run_result ~text:"I think I should ask for help." ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5
+  in
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let routed, state =
+        KSM.apply_to_result ~config ~meta:minimal_meta
+          ~observation:base_observation result
+      in
+      check string "speech act" "defer"
+        (KSM.speech_act_to_string state.speech_act);
+      check string "delivery surface" "silent"
+        (KSM.delivery_surface_to_string state.delivery_surface);
+      check (option string) "blocker notes protocol violation"
+        (Some "missing social headers") state.blocker;
+      check string "visible response suppressed" "" routed.response_text;
+      check (list string) "no synthetic tools" [] routed.tools_used)
+
+let test_social_model_routes_blocker_to_board_post () =
+  let result =
+    make_run_result
+      ~text:
+        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: seek_help\nCURRENT_INTENTION: recover_tool_route\nBLOCKER: tool route unavailable\nNEED: tool route or operator guidance\nSPEECH_ACT: request_help\nDELIVERY_SURFACE: board_post"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:30 ~output_tok:10
+  in
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
+      let routed, state =
+        KSM.apply_to_result ~config ~meta:minimal_meta
+          ~observation:base_observation result
+      in
+      let posts =
+        Masc_mcp.Board_dispatch.list_posts
+          ~sort_by:Masc_mcp.Board_dispatch.Recent ~limit:10 ()
+      in
+      check string "speech act" "request_help"
+        (KSM.speech_act_to_string state.speech_act);
+      check string "delivery surface" "board_post"
+        (KSM.delivery_surface_to_string state.delivery_surface);
+      check string "response suppressed after routing" "" routed.response_text;
+      check bool "synthetic board tool recorded" true
+        (List.mem "keeper_board_post" routed.tools_used);
+      check int "one board post created" 1 (List.length posts);
+      match posts with
+      | [ post ] ->
+          check string "post author" minimal_meta.name
+            (Masc_mcp.Board.Agent_id.to_string post.author);
+          check bool "post body mentions blocker" true
+            (contains_substring post.body "blocked")
+      | _ -> fail "expected one request-help board post")
+
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -625,9 +768,13 @@ let () =
           test_case "hustle economy" `Quick test_prompt_hustle_economy;
           test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
           test_case "room state section" `Quick test_prompt_room_state_section;
+          test_case "prefers silence guidance" `Quick
+            test_prompt_prefers_silence_guidance;
         ] );
       ( "config",
         [
+          test_case "default social model" `Quick
+            test_meta_defaults_social_model;
           test_case "unified runtime defaults" `Quick
             test_unified_turn_runtime_defaults;
         ] );
@@ -636,6 +783,8 @@ let () =
           test_case "text response" `Quick test_metrics_text_response;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
+          test_case "social fields" `Quick
+            test_metrics_persist_social_state_fields;
           test_case "failure response" `Quick test_metrics_failure_response;
           test_case "mixed response" `Quick test_metrics_mixed_response;
           test_case "normalize passthrough" `Quick
@@ -644,5 +793,11 @@ let () =
             test_normalize_response_text_tool_only_synthesizes;
           test_case "normalize empty without tools errors" `Quick
             test_normalize_response_text_empty_without_tools_errors;
+          test_case "social model silences skip-only turn" `Quick
+            test_social_model_silences_skip_only_turn;
+          test_case "social model requires explicit headers" `Quick
+            test_social_model_requires_explicit_headers;
+          test_case "social model routes blocker to board post" `Quick
+            test_social_model_routes_blocker_to_board_post;
         ] );
     ]

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1713,7 +1713,11 @@ let test_keeper_up_persists_allowed_paths_to_status_policy () =
         Yojson.Safe.Util.(
           status_json |> member "policy" |> member "allowed_paths" |> to_list |> filter_string)
       in
-      check (list string) "allowed_paths roundtrip" allowed_paths persisted)
+      check (list string) "allowed_paths roundtrip" allowed_paths persisted;
+      check string "social model surfaced" "bdi_speech_v1"
+        Yojson.Safe.Util.(status_json |> member "social" |> member "model" |> to_string);
+      check bool "last speech act null by default" true
+        Yojson.Safe.Util.(status_json |> member "social" |> member "last_speech_act" = `Null))
 (* test_keeper_policy_set_accepts_explicit_event_v1: removed — keeper policy_mode system removed *)
 
 (* Issue #3019: session dir must be created from scratch in filesystem fallback.


### PR DESCRIPTION
## What changed

- added `keeper_social_model` as the typed social routing layer for keeper turns
- required explicit social headers in unified/proactive prompts instead of heuristic fallback text inference
- threaded social state through keeper metrics, decision logs, status/detail/dashboard surfaces, and keeper tool status output
- documented alternative social-model candidates in a keeper social model inventory doc

## Why

- keeper social expression should come from explicit model output, not runtime heuristics
- blocked or no-op turns now resolve to structured routing (`request_help`, `stay_silent`, `defer`) instead of repeated free-form skip text

## Impact

- keepers can surface typed social state and remain silent when the protocol says to
- status/detail surfaces now expose `social_model`, `last_speech_act`, `last_blocker`, and `last_need`
- tests cover protocol-required headers, silent/defer behavior, and request-help board routing

## Validation

- `git diff --check`
- `env DUNE_CACHE=disabled opam exec -- dune exec --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/keeper-social-model-v1 --build-dir _build_codex_social ./test/test_keeper_unified.exe`
- `env DUNE_CACHE=disabled opam exec -- dune exec --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/keeper-social-model-v1 --build-dir _build_codex_social ./test/test_tool_keeper.exe`
