### PR TITLE
test(keeper): align autoresearch expectations with allowlist gating

### DIFF
--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -19,6 +19,7 @@ let make_meta
     ?(policy_voice_enabled = false)
     ?(soul_profile = "default")
     ?(name = "test-keeper")
+    ?(tool_allowlist = [])
     () : Keeper_types.keeper_meta =
   let json = `Assoc [
     ("name", `String name);
@@ -26,10 +27,22 @@ let make_meta
     ("trace_id", `String "safety-test-trace");
     ("policy_voice_enabled", `Bool policy_voice_enabled);
     ("soul_profile", `String soul_profile);
+    ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
   ] in
   match Keeper_types.meta_of_json json with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
+
+let research_tool_allowlist =
+  [
+    "masc_autoresearch_cycle";
+    "masc_autoresearch_status";
+    "masc_autoresearch_start";
+    "masc_autoresearch_inject";
+    "masc_autoresearch_stop";
+    "masc_research_start";
+    "masc_research_status";
+  ]
 
 (* ================================================================ *)
 (* Group 1: Destructive Pattern Detection (all 19 patterns)          *)
@@ -207,9 +220,11 @@ let test_voice_disabled () =
   check bool "keeper_voice_speak still available" true (List.mem "keeper_voice_speak" tools);
   check bool "keeper_voice_agent still available" true (List.mem "keeper_voice_agent" tools)
 
-let test_all_keepers_have_research_tools () =
-  (* Mode removal: research tools available to all keepers *)
-  let meta = make_meta ~soul_profile:"default" () in
+let test_keeper_with_research_allowlist_has_research_tools () =
+  (* keeper masc_* tools stay deny-by-default; research access requires an allowlist *)
+  let meta =
+    make_meta ~soul_profile:"default" ~tool_allowlist:research_tool_allowlist ()
+  in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let has_any_research = List.exists (fun t ->
     String.length t > 5 &&
@@ -399,7 +414,8 @@ let () =
       test_case "all keepers get full toolset" `Quick test_all_keepers_get_full_toolset;
       test_case "voice enabled" `Quick test_voice_enabled;
       test_case "voice disabled" `Quick test_voice_disabled;
-      test_case "all keepers have research tools" `Quick test_all_keepers_have_research_tools;
+      test_case "keeper with research allowlist has research tools" `Quick
+        test_keeper_with_research_allowlist_has_research_tools;
       test_case "heuristic mode" `Quick test_heuristic_mode_tools;
       test_case "voice plus other tools" `Quick test_voice_plus_other_tools;
       test_case "all keepers have shell and coding" `Quick test_all_keepers_have_shell_and_coding;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -4,11 +4,24 @@ open Agent_sdk
 open Alcotest
 open Masc_mcp
 
-let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
+let research_tool_allowlist =
+  [
+    "masc_autoresearch_cycle";
+    "masc_autoresearch_status";
+    "masc_autoresearch_start";
+    "masc_autoresearch_inject";
+    "masc_autoresearch_stop";
+    "masc_research_start";
+    "masc_research_status";
+  ]
+
+let make_test_meta ?(name = "test-keeper") ?(tool_allowlist = []) ()
+    : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-001");
-             ("allowed_paths", `List [`String "*"])]) with
+             ("allowed_paths", `List [`String "*"]);
+             ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist))]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
 
@@ -240,7 +253,8 @@ let make_research_meta () : Keeper_types.keeper_meta =
     (`Assoc [("name", `String "test-researcher");
              ("agent_name", `String "test-researcher");
              ("trace_id", `String "test-trace-research");
-             ("soul_profile", `String "research")]) with
+             ("soul_profile", `String "research");
+             ("tool_allowlist", `List (List.map (fun s -> `String s) research_tool_allowlist))]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_research_meta failed: %s" e)
 
@@ -254,14 +268,41 @@ let test_research_keeper_has_autoresearch_tools () =
   check bool "has start" true has_start;
   check bool "has status" true has_status
 
-let test_non_research_keeper_has_autoresearch () =
-  (* Mode removal: all keepers get all tools unconditionally *)
-  let meta = make_test_meta () in
+let test_keeper_with_research_allowlist_has_autoresearch () =
+  let meta = make_test_meta ~tool_allowlist:research_tool_allowlist () in
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let has_any = List.exists (fun n ->
     String.length n > 18
     && String.sub n 0 18 = "masc_autoresearch_") allowed in
   check bool "has autoresearch tools" true has_any
+
+let test_non_research_keeper_without_allowlist_blocks_autoresearch () =
+  let meta = make_test_meta () in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let has_autoresearch = List.exists (fun n ->
+    String.length n > 18
+    && String.sub n 0 18 = "masc_autoresearch_") allowed in
+  let has_research = List.exists (fun n ->
+    String.length n > 14
+    && String.sub n 0 14 = "masc_research_") allowed in
+  check bool "autoresearch stays deny-by-default without allowlist" false has_autoresearch;
+  check bool "research loop tools stay deny-by-default without allowlist" false has_research
+
+let test_research_keeper_without_allowlist_blocks_autoresearch () =
+  let meta =
+    match Keeper_types.meta_of_json
+      (`Assoc [("name", `String "test-researcher-no-allowlist");
+               ("agent_name", `String "test-researcher-no-allowlist");
+               ("trace_id", `String "test-trace-research-no-allowlist");
+               ("soul_profile", `String "research")]) with
+    | Ok meta -> meta
+    | Error e -> failwith (Printf.sprintf "research meta without allowlist failed: %s" e)
+  in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let has_any = List.exists (fun n ->
+    String.length n > 18
+    && String.sub n 0 18 = "masc_autoresearch_") allowed in
+  check bool "research profile alone does not bypass allowlist" false has_any
 
 let test_research_model_tools_include_autoresearch () =
   let meta = make_research_meta () in
@@ -351,7 +392,12 @@ let () =
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;
-      test_case "non-research has autoresearch" `Quick test_non_research_keeper_has_autoresearch;
+      test_case "keeper with research allowlist has autoresearch" `Quick
+        test_keeper_with_research_allowlist_has_autoresearch;
+      test_case "non-research without allowlist blocks autoresearch" `Quick
+        test_non_research_keeper_without_allowlist_blocks_autoresearch;
+      test_case "research profile without allowlist blocks autoresearch" `Quick
+        test_research_keeper_without_allowlist_blocks_autoresearch;
       test_case "model tools include autoresearch" `Quick test_research_model_tools_include_autoresearch;
     ];
     "library_tools", [


### PR DESCRIPTION
## Summary
- Align keeper autoresearch expectation tests with the current deny-by-default `masc_*` allowlist policy.
- Add explicit research-tool allowlists where the tests intend to exercise opt-in exposure.
- Add negative coverage proving that both non-research keepers and `soul_profile:"research"` alone still do not bypass the allowlist.

## Product impact
- Restores `Build and Test` stability on `main` for keeper autoresearch expectation suites.
- Unblocks unrelated PRs such as `#4022`, which were failing on a pre-existing `main` regression rather than their own diffs.

## Evidence
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp --build-dir /tmp/masc-main-keeper-safety ./test/test_keeper_safety_gates.exe`
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp --build-dir /tmp/masc-main-keeper-oas ./test/test_keeper_tools_oas.exe`
- `env -u DUNE_RPC opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4033-keeper-autoresearch-test-truth _build/default/test/test_keeper_safety_gates.exe _build/default/test/test_keeper_tools_oas.exe _build/default/test/test_keeper_masc_bridge.exe`
- `./_build/default/test/test_keeper_safety_gates.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_masc_bridge.exe`

## Review evidence
- 2026-03-31: direct `GLM-5` review on commit `d4c5538d6`.
- Result: `No findings.`

## Linked issue
- Closes #4033
- Refs #4022
