### PR TITLE
feat(dashboard): Dead ETA prediction (#3908 followup)

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -223,7 +223,7 @@ function SpEventsPanel({ sp_events }: { sp_events: any[] }) {
 function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
   const diag = (keeper as any).supervisor_diagnostics
   if (!diag) return null
-  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since, sp_events, health_score } = diag
+  const { restart_count, max_restarts, crash_log, last_failure_reason, dead_since, sp_events, health_score, dead_eta_sec } = diag
   const budgetPct = max_restarts > 0 ? Math.min(100, (restart_count / max_restarts) * 100) : 0
   const budgetColor = budgetPct >= 80 ? '#ef4444' : budgetPct >= 50 ? '#f59e0b' : '#4ade80'
   const hs = typeof health_score === 'number' ? health_score : 100
@@ -248,6 +248,12 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
             <div class="h-full rounded-full transition-all duration-300" style="width: ${budgetPct}%; background: ${budgetColor}"></div>
           </div>
         </div>
+        ${typeof dead_eta_sec === 'number' && !dead_since ? html`
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-[var(--text-muted)]">Dead 예상</span>
+            <span class="text-[11px] font-mono text-[${budgetPct >= 50 ? '#f59e0b' : 'var(--text-body)'}]">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
+          </div>
+        ` : null}
         ${last_failure_reason ? html`
           <div class="flex items-center justify-between">
             <span class="text-xs text-[var(--text-muted)]">마지막 실패 원인</span>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -248,10 +248,10 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
             <div class="h-full rounded-full transition-all duration-300" style="width: ${budgetPct}%; background: ${budgetColor}"></div>
           </div>
         </div>
-        ${typeof dead_eta_sec === 'number' && !dead_since ? html`
+        ${typeof dead_eta_sec === 'number' && dead_eta_sec > 0 && dead_since == null ? html`
           <div class="flex items-center justify-between">
             <span class="text-xs text-[var(--text-muted)]">Dead 예상</span>
-            <span class="text-[11px] font-mono text-[${budgetPct >= 50 ? '#f59e0b' : 'var(--text-body)'}]">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
+            <span class="text-[11px] font-mono" style="color: ${budgetPct >= 50 ? '#f59e0b' : 'var(--text-body)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
           </div>
         ` : null}
         ${last_failure_reason ? html`

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -35,6 +35,18 @@ let compute_health_score
     let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in
     Int.max 0 (Int.min 100 (Float.to_int raw))
 
+(** Estimate seconds until Dead based on current restart_count and
+    exponential backoff schedule. Returns None if already dead or
+    restart_count >= max_restarts. *)
+let estimate_dead_eta_sec ~restart_count ~max_restarts =
+  if max_restarts <= 0 || restart_count >= max_restarts then None
+  else
+    let total = ref 0.0 in
+    for i = restart_count to max_restarts - 1 do
+      total := !total +. Keeper_supervisor.backoff_delay i
+    done;
+    Some !total
+
 let prompt_block_json key =
   let resolved = Prompt_registry.resolve_prompt key in
   `Assoc
@@ -314,6 +326,11 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                     | None -> `Null);
                   ("sp_events", `List sp_events);
                   ("health_score", `Int health_score);
+                  ("dead_eta_sec",
+                    match estimate_dead_eta_sec
+                      ~restart_count:entry.restart_count ~max_restarts with
+                    | Some eta -> `Float eta
+                    | None -> `Null);
                 ]
             | None ->
                 `Assoc [
@@ -324,6 +341,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("dead_since", `Null);
                   ("sp_events", `List []);
                   ("health_score", `Int 100);
+                  ("dead_eta_sec", `Null);
                 ]
           in
 


### PR DESCRIPTION
## Summary
- `estimate_dead_eta_sec` 순수 함수: 현재 restart_count에서 max_restarts까지 남은 backoff delay 합산
- `dead_eta_sec` 필드를 supervisor_diagnostics JSON에 추가
- Dashboard에 "Dead 예상 Nh 후" 표시 (budget > 50% 시 amber)

## Context
#4015에서 health score 기본 구현 완료. 이 PR은 Dead 상태 예측 시간을 추가하는 후속 작업.

## Test plan
- [x] `dune build` 성공
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)