### PR TITLE
feat(council): replace keyword heuristics with capability-aware routing

### DIFF
--- a/lib/council/council.ml
+++ b/lib/council/council.ml
@@ -113,6 +113,10 @@ module RouterApi = struct
   let route ?(max_agents=3) ?(input_tokens=1000) ?(output_tokens=500) query =
     Router.route ~max_agents ~input_tokens ~output_tokens query
 
+  (** Extract multi-dimensional requirements from query text *)
+  let extract_requirements query =
+    Router.extract_requirements query
+
   (** Classify a query into heuristic categories with confidence *)
   let classify query =
     Router.classify_query query

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -1,10 +1,11 @@
-(** Heuristic query router with sparse tier selection.
+(** Capability-aware query router with sparse tier selection.
 
-    This module uses deterministic keyword/length heuristics to classify a
-    query and then picks 2-3 agents from a static pool. It is not an
-    LLM-routed MoE system. *)
+    This module classifies queries using structural pattern analysis
+    (not keyword matching) and scores agents by multi-dimensional
+    capability dot product. It picks 2-3 agents from a static pool.
+    It is not an LLM-routed MoE system. *)
 
-(** Query classification categories *)
+(** Query classification categories (preserved for backward compat) *)
 type query_class =
   | Code         (** Programming, debugging, implementation *)
   | Analysis     (** Data analysis, reasoning, evaluation *)
@@ -23,12 +24,33 @@ type model_tier =
   | Giant  (** Highest-cost tier *)
 [@@deriving show, eq]
 
+(** Multi-dimensional query requirements extracted from text.
+    Each dimension is 0.0-1.0, computed from structural patterns. *)
+type query_requirements = {
+  reasoning_depth : float;
+  code_ability : float;
+  creativity : float;
+  factual_precision : float;
+  speed_priority : float;
+}
+[@@deriving show]
+
+(** Agent capability scores (0.0-1.0 per dimension) *)
+type agent_capabilities = {
+  reasoning_score : float;
+  code_score : float;
+  creativity_score : float;
+  factual_score : float;
+  speed_score : float;
+}
+[@@deriving show]
+
 (** Agent specification *)
 type agent_spec = {
   name : string;
   model : string;
   tier : model_tier;
-  strengths : query_class list;
+  capabilities : agent_capabilities;
   cost_per_1k : float;  (** Cost per 1K tokens in USD *)
 }
 [@@deriving show]
@@ -38,11 +60,16 @@ type route_decision = {
   agents : agent_spec list;
   reason : string;
   estimated_cost : float;
-  complexity_score : float;  (** Heuristic 0.0-1.0 score *)
+  complexity_score : float;
+  requirements : query_requirements;
+  match_scores : (string * float) list;
 }
 [@@deriving show]
 
-(** Default agent pool - configurable *)
+(* ================================================================
+   Default agent pool
+   ================================================================ *)
+
 let default_tiny_model_opt () =
   let split_csv_nonempty raw =
     raw
@@ -77,146 +104,208 @@ let default_agents : agent_spec list =
     match default_tiny_model_opt () with
     | Some model ->
         [ { name = "default-tiny"; model; tier = Tiny;
-            strengths = [Factual; Conversation; Code; Analysis; Creative];
+            capabilities = { reasoning_score = 0.3; code_score = 0.4;
+                             creativity_score = 0.3; factual_score = 0.5;
+                             speed_score = 1.0 };
             cost_per_1k = 0.0 } ]
     | None -> []
   in
-  (* NOTE: model IDs here are defaults for the council sub-library which cannot
-     access Env_config_governance. Update these when model generations change. *)
   tiny_agents @ [
     { name = "sonnet"; model = "claude-sonnet-4-6"; tier = Medium;
-      strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
+      capabilities = { reasoning_score = 0.7; code_score = 0.8;
+                       creativity_score = 0.7; factual_score = 0.7;
+                       speed_score = 0.6 };
+      cost_per_1k = 0.003 };
     { name = "gpt-4o-mini"; model = "gpt-4.1-mini"; tier = Medium;
-      strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
+      capabilities = { reasoning_score = 0.4; code_score = 0.5;
+                       creativity_score = 0.4; factual_score = 0.6;
+                       speed_score = 0.8 };
+      cost_per_1k = 0.00015 };
     { name = "opus"; model = "claude-opus-4-6"; tier = Large;
-      strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
+      capabilities = { reasoning_score = 0.95; code_score = 0.9;
+                       creativity_score = 0.9; factual_score = 0.9;
+                       speed_score = 0.3 };
+      cost_per_1k = 0.015 };
     { name = "gpt-4o"; model = "gpt-4.1"; tier = Large;
-      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
+      capabilities = { reasoning_score = 0.7; code_score = 0.75;
+                       creativity_score = 0.6; factual_score = 0.75;
+                       speed_score = 0.5 };
+      cost_per_1k = 0.005 };
     { name = "o1"; model = "o1"; tier = Giant;
-      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };
+      capabilities = { reasoning_score = 1.0; code_score = 0.8;
+                       creativity_score = 0.5; factual_score = 0.8;
+                       speed_score = 0.1 };
+      cost_per_1k = 0.015 };
   ]
 
-(** Feature extraction from query text *)
-module Features = struct
-  let code_indicators = [
-    "code"; "function"; "implement"; "debug"; "error"; "compile";
-    "syntax"; "bug"; "class"; "method"; "variable"; "type";
-    "ocaml"; "python"; "typescript"; "rust"; "javascript";
+(* ================================================================
+   Pattern-based query requirement extraction
+   ================================================================ *)
+
+module Patterns = struct
+  (** Compiled regex + weight pairs. Compiled once at module init. *)
+
+  let compile pat = Re.compile (Re.Pcre.re ~flags:[`CASELESS] pat)
+
+  let reasoning_patterns = [
+    (* Causal / why questions *)
+    (compile {|why\s+(?:does|is|do|are|would|can't|cannot)|}, 0.4);
+    (compile {|how\s+(?:would|should|can|do)\s+(?:you|we|I)|}, 0.3);
+    (* Design / tradeoff analysis *)
+    (compile {|trade.?offs?|implications|consequences|pros?\s+and\s+cons?|}, 0.4);
+    (compile {|compare\s+.*(?:and|vs\.?|versus)|}, 0.3);
+    (* Multi-step reasoning markers *)
+    (compile {|step.by.step|walk.*through|break.*down|}, 0.3);
+    (* Domain complexity markers -- short queries still score high *)
+    (compile {|concurren|mutex|deadlock|race\s+condition|}, 0.4);
+    (compile {|distribut|byzantin|consensus|replicat|}, 0.4);
+    (compile {|architect|system\s+design|design\s+pattern|}, 0.3);
+    (compile {|proof|theorem|induction|invariant|formal\s+verif|}, 0.5);
+    (compile {|optimi[sz]|complex|NP.hard|algorithm|}, 0.25);
+    (* Multi-constraint detection *)
+    (compile {|\b(?:but|however|while|although|constraint|trade)\b|}, 0.15);
   ]
 
-  let analysis_indicators = [
-    "analyze"; "compare"; "evaluate"; "assess"; "review";
-    "why"; "how"; "explain"; "understand"; "reason";
+  let code_patterns = [
+    (* Language names *)
+    (compile {|\b(?:ocaml|haskell|rust|python|typescript|javascript|java|go|c\+\+|kotlin|swift|elixir|clojure)\b|}, 0.4);
+    (* Code fences *)
+    (compile {|```|}, 0.5);
+    (* Code artifacts in text *)
+    (compile {|\b(?:def |fn |let |class |struct |interface |module )|}, 0.5);
+    (* Implementation keywords *)
+    (compile {|\b(?:implement|refactor|debug|compile|lint|test\s+case|unit\s+test)\b|}, 0.3);
+    (compile {|\b(?:function|method|variable|API|endpoint|middleware)\b|}, 0.2);
+    (compile {|\b(?:bug|error|stack\s+trace|exception|segfault)\b|}, 0.3);
   ]
 
-  let creative_indicators = [
-    "write"; "create"; "imagine"; "story"; "poem"; "design";
-    "brainstorm"; "idea"; "suggest"; "generate";
+  let creativity_patterns = [
+    (compile {|\b(?:write|create|compose|draft)\b.*(?:story|poem|essay|article|song)|}, 0.5);
+    (compile {|\b(?:imagine|brainstorm|ideate|invent)\b|}, 0.4);
+    (compile {|\b(?:creative|fiction|narrative|metaphor)\b|}, 0.3);
+    (compile {|\b(?:generate|suggest|propose)\b.*(?:idea|concept|name|title)|}, 0.3);
   ]
 
-  let complex_indicators = [
-    "step by step"; "multi"; "complex"; "detailed"; "thorough";
-    "plan"; "architecture"; "system"; "design pattern";
+  let factual_patterns = [
+    (compile {|\b(?:what\s+is|what\s+are|define|definition\s+of)\b|}, 0.4);
+    (compile {|\b(?:when\s+was|who\s+(?:is|was|invented)|where\s+(?:is|was))\b|}, 0.4);
+    (compile {|\b(?:list|enumerate|name\s+(?:the|all))\b|}, 0.3);
+    (compile {|\b(?:fact|lookup|reference|specification)\b|}, 0.2);
   ]
 
-  let contains_any words text =
-    let lower = String.lowercase_ascii text in
-    List.exists (fun w ->
-      let pattern = String.lowercase_ascii w in
-      let re = Re.str pattern |> Re.compile in
-      Re.execp re lower
-    ) words
+  let speed_patterns = [
+    (compile {|\b(?:quick|fast|brief|short|one.?liner|tldr|tl;dr)\b|}, 0.4);
+    (compile {|\b(?:just|simply|only)\b|}, 0.15);
+  ]
 
-  let count_matches words text =
-    let lower = String.lowercase_ascii text in
-    List.fold_left (fun acc w ->
-      let pattern = String.lowercase_ascii w in
-      let re = Re.str pattern |> Re.compile in
-      if Re.execp re lower then acc + 1 else acc
-    ) 0 words
+  (** Sum matched pattern weights, capped at 1.0 *)
+  let score_patterns patterns text =
+    let total = List.fold_left (fun acc (re, weight) ->
+      if Re.execp re text then acc +. weight else acc
+    ) 0.0 patterns in
+    Float.min 1.0 total
 end
 
-(** Classify a query into heuristic categories with confidence scores. *)
-let classify_query (query : string) : (query_class * float) list =
-  let len = String.length query in
-  let scores = [
-    (Code, float_of_int (Features.count_matches Features.code_indicators query) *. 0.3);
-    (Analysis, float_of_int (Features.count_matches Features.analysis_indicators query) *. 0.25);
-    (Creative, float_of_int (Features.count_matches Features.creative_indicators query) *. 0.25);
-    (Complex, float_of_int (Features.count_matches Features.complex_indicators query) *. 0.4);
-    (Factual, if len < 50 then 0.3 else 0.1);
-    (Conversation, if len < 100 && not (Features.contains_any Features.code_indicators query) 
-                   then 0.2 else 0.05);
+(** Extract multi-dimensional requirements from query text. *)
+let extract_requirements (query : string) : query_requirements =
+  let text = String.lowercase_ascii query in
+  {
+    reasoning_depth = Patterns.score_patterns Patterns.reasoning_patterns text;
+    code_ability = Patterns.score_patterns Patterns.code_patterns text;
+    creativity = Patterns.score_patterns Patterns.creativity_patterns text;
+    factual_precision = Patterns.score_patterns Patterns.factual_patterns text;
+    speed_priority = Patterns.score_patterns Patterns.speed_patterns text;
+  }
+
+(* ================================================================
+   Backward-compatible derived functions
+   ================================================================ *)
+
+(** Derive query_class from requirements (backward compat) *)
+let classify_from_requirements (r : query_requirements) : (query_class * float) list =
+  let raw = [
+    (Code, r.code_ability);
+    (Analysis, (r.reasoning_depth +. r.factual_precision) /. 2.0);
+    (Creative, r.creativity);
+    (Factual, r.factual_precision);
+    (Conversation, r.speed_priority *. Float.max 0.0 (1.0 -. r.reasoning_depth));
+    (Complex, r.reasoning_depth);
   ] in
-  (* Normalize and sort by score descending *)
-  let total = List.fold_left (fun acc (_, s) -> acc +. s) 0.0 scores in
-  let normalized = 
-    if total > 0.0 
-    then List.map (fun (c, s) -> (c, s /. total)) scores
-    else scores 
+  let total = List.fold_left (fun acc (_, s) -> acc +. s) 0.0 raw in
+  let normalized =
+    if total > 0.0
+    then List.map (fun (c, s) -> (c, s /. total)) raw
+    else raw
   in
   List.sort (fun (_, a) (_, b) -> compare b a) normalized
 
-(** Calculate a heuristic complexity score (0.0-1.0). *)
+(** Classify a query into heuristic categories with confidence scores.
+    Backward-compatible wrapper. *)
+let classify_query (query : string) : (query_class * float) list =
+  classify_from_requirements (extract_requirements query)
+
+(** Calculate a heuristic complexity score (0.0-1.0).
+    Derived from requirements instead of text length. *)
 let calculate_complexity (query : string) : float =
-  let len = String.length query in
-  let has_complex = Features.contains_any Features.complex_indicators query in
-  let question_count = 
-    List.length (String.split_on_char '?' query) - 1 in
-  let base = 
-    if len > 500 then 0.6
-    else if len > 200 then 0.4
-    else if len > 100 then 0.2
-    else 0.1
+  let r = extract_requirements query in
+  let weighted =
+    (r.reasoning_depth *. 0.4)
+    +. (r.code_ability *. 0.2)
+    +. ((1.0 -. r.speed_priority) *. 0.2)
+    +. (r.creativity *. 0.1)
+    +. (r.factual_precision *. 0.1)
   in
-  let complexity_bonus = if has_complex then 0.3 else 0.0 in
-  let question_bonus = Float.min 0.2 (float_of_int question_count *. 0.1) in
-  Float.min 1.0 (base +. complexity_bonus +. question_bonus)
+  (* Ensure "hello" stays < 0.3: zero requirements → base 0.2 from (1-0)*0.2 *)
+  Float.min 1.0 weighted
 
-(** Select agents using deterministic sparse tier selection.
+(* ================================================================
+   Capability-aware scoring
+   ================================================================ *)
 
-    Strategy:
-    - Default to 2 agents
-    - Expand to 3 agents for higher heuristic complexity *)
-let select_agents 
-    ?(agents = default_agents) 
-    ?(max_agents = 3) 
+(** Tier cost penalty -- higher tiers are penalized more *)
+let tier_cost_penalty = function
+  | Tiny -> 0.0
+  | Small -> 0.1
+  | Medium -> 0.3
+  | Large -> 0.6
+  | Giant -> 0.9
+
+(** Score an agent against query requirements.
+    Returns capability match (dot product) minus cost penalty.
+    Cost penalty decreases as complexity increases. *)
+let score_agent ~(requirements : query_requirements) ~(complexity : float)
+    (agent : agent_spec) : float =
+  let c = agent.capabilities in
+  let r = requirements in
+  let match_score =
+    (r.reasoning_depth *. c.reasoning_score)
+    +. (r.code_ability *. c.code_score)
+    +. (r.creativity *. c.creativity_score)
+    +. (r.factual_precision *. c.factual_score)
+    +. (r.speed_priority *. c.speed_score)
+  in
+  (* Cost penalty decreases with complexity -- same logic as before *)
+  let cost_sensitivity = 1.0 -. (complexity *. 0.7) in
+  let penalty = tier_cost_penalty agent.tier *. cost_sensitivity in
+  match_score -. penalty
+
+(* ================================================================
+   Agent selection and routing
+   ================================================================ *)
+
+(** Select agents using capability-aware sparse tier selection.
+    2 agents normally, 3 for high complexity. *)
+let select_agents
+    ?(agents = default_agents)
+    ?(max_agents = 3)
     (query : string) : agent_spec list =
-  let classifications = classify_query query in
+  let requirements = extract_requirements query in
   let complexity = calculate_complexity query in
-  
-  (* Get top 2 query classes *)
-  let top_classes = 
-    classifications 
-    |> List.filter (fun (_, score) -> score > 0.1)
-    |> List.map fst
-    |> (fun l -> match l with a :: b :: _ -> [a; b] | _ -> l)
-  in
-  
-  (* Score each agent by strength match *)
-  let score_agent (agent : agent_spec) : float =
-    let strength_score = 
-      List.fold_left (fun acc cls ->
-        if List.mem cls agent.strengths then acc +. 1.0 else acc
-      ) 0.0 top_classes
-    in
-    (* Prefer cheaper models unless complexity is high *)
-    let tier_penalty = match agent.tier with
-      | Tiny -> 0.0
-      | Small -> 0.1
-      | Medium -> 0.3
-      | Large -> if complexity > 0.6 then 0.2 else 0.6
-      | Giant -> if complexity > 0.8 then 0.3 else 0.9
-    in
-    strength_score -. tier_penalty
-  in
-  
-  (* Sort by score and take top N *)
-  let scored = List.map (fun a -> (a, score_agent a)) agents in
+  let scored = List.map (fun a ->
+    (a, score_agent ~requirements ~complexity a)
+  ) agents in
   let sorted = List.sort (fun (_, a) (_, b) -> compare b a) scored in
-  
-  (* Sparse activation: 2-3 agents *)
-  let n = 
+  let n =
     if complexity > 0.7 then min max_agents 3
     else 2
   in
@@ -225,16 +314,16 @@ let select_agents
   |> List.map fst
 
 (** Estimate cost for a routing decision *)
-let estimate_cost 
-    ?(input_tokens = 1000) 
-    ?(output_tokens = 500) 
+let estimate_cost
+    ?(input_tokens = 1000)
+    ?(output_tokens = 500)
     (agents : agent_spec list) : float =
   let total_tokens = input_tokens + output_tokens in
   List.fold_left (fun acc agent ->
     acc +. (agent.cost_per_1k *. float_of_int total_tokens /. 1000.0)
   ) 0.0 agents
 
-(** Generate a user-facing explanation of the heuristic routing result. *)
+(** Generate a user-facing explanation of the routing result. *)
 let generate_reason (query : string) (agents : agent_spec list) : string =
   let classifications = classify_query query in
   let top_class = match classifications with
@@ -242,8 +331,8 @@ let generate_reason (query : string) (agents : agent_spec list) : string =
     | [] -> "Unknown"
   in
   let agent_names = String.concat ", " (List.map (fun a -> a.name) agents) in
-  let tiers = 
-    agents 
+  let tiers =
+    agents
     |> List.map (fun a -> show_model_tier a.tier)
     |> List.sort_uniq String.compare
     |> String.concat "/"
@@ -252,24 +341,29 @@ let generate_reason (query : string) (agents : agent_spec list) : string =
     top_class agent_names tiers
 
 (** Main routing function *)
-let route 
+let route
     ?(agents = default_agents)
     ?(max_agents = 3)
     ?(input_tokens = 1000)
     ?(output_tokens = 500)
     (query : string) : route_decision =
-  let selected = select_agents ~agents ~max_agents query in
+  let requirements = extract_requirements query in
   let complexity = calculate_complexity query in
+  let selected = select_agents ~agents ~max_agents query in
   let cost = estimate_cost ~input_tokens ~output_tokens selected in
   let reason = generate_reason query selected in
-  { agents = selected; reason; estimated_cost = cost; complexity_score = complexity }
+  let match_scores = List.map (fun a ->
+    (a.name, score_agent ~requirements ~complexity a)
+  ) selected in
+  { agents = selected; reason; estimated_cost = cost;
+    complexity_score = complexity; requirements; match_scores }
 
 (** Statistics: track the observed routing tier mix. *)
 module Stats = struct
   type routing_stats = {
     mutable total_queries : int;
-    mutable small_only : int;    (** Tiny/Small tiers only *)
-    mutable has_large : int;     (** At least one Large/Giant *)
+    mutable small_only : int;
+    mutable has_large : int;
   }
 
   let global_stats = {
@@ -280,10 +374,10 @@ module Stats = struct
 
   let record (decision : route_decision) : unit =
     global_stats.total_queries <- global_stats.total_queries + 1;
-    let has_big = List.exists (fun a -> 
+    let has_big = List.exists (fun a ->
       match a.tier with Large | Giant -> true | _ -> false
     ) decision.agents in
-    if has_big 
+    if has_big
     then global_stats.has_large <- global_stats.has_large + 1
     else global_stats.small_only <- global_stats.small_only + 1
 
@@ -302,7 +396,7 @@ module Stats = struct
 end
 
 (** Route and record stats *)
-let route_with_stats 
+let route_with_stats
     ?(agents = default_agents)
     ?(max_agents = 3)
     ?(input_tokens = 1000)

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -264,6 +264,7 @@ let handle_route _ctx args =
     if by_schema <> "" then by_schema else get_string args "input" ""
   in
   let decision = Council.Router.route query in
+  let r = decision.requirements in
   json_ok (`Assoc [
     ("reason", `String decision.reason);
     ("estimated_cost", `Float decision.estimated_cost);
@@ -274,6 +275,15 @@ let handle_route _ctx args =
         ("model", `String a.model);
         ("tier", `String (Council.Router.show_model_tier a.tier));
       ]) decision.agents));
+    ("requirements", `Assoc [
+      ("reasoning_depth", `Float r.reasoning_depth);
+      ("code_ability", `Float r.code_ability);
+      ("creativity", `Float r.creativity);
+      ("factual_precision", `Float r.factual_precision);
+      ("speed_priority", `Float r.speed_priority);
+    ]);
+    ("match_scores", `Assoc (List.map (fun (name, score) ->
+      (name, `Float score)) decision.match_scores));
   ])
 
 let voting_result_of_args args =

--- a/test/test_council.ml
+++ b/test/test_council.ml
@@ -431,6 +431,49 @@ let consensus_tests = [
   test_consensus_persist_vote_failure_is_atomic;
 ]
 
+(* --- New capability-aware router tests --- *)
+
+let test_router_short_complex_query () =
+  let r = Router.extract_requirements "OCaml mutex deadlock analysis" in
+  check bool "reasoning > 0.3" (r.reasoning_depth > 0.3) true;
+  check bool "code > 0.3" (r.code_ability > 0.3) true
+
+let test_router_deep_reasoning () =
+  let r = Router.extract_requirements "why is the halting problem undecidable" in
+  check bool "reasoning > 0.3" (r.reasoning_depth > 0.3) true
+
+let test_router_speed_priority () =
+  let r = Router.extract_requirements "quick one-liner to reverse a string" in
+  check bool "speed > 0.3" (r.speed_priority > 0.3) true
+
+let test_router_complex_selects_large_tier () =
+  let decision = Router.route
+    "prove that this distributed algorithm satisfies safety and liveness under partial synchrony" in
+  let has_large = List.exists (fun (a : Router.agent_spec) ->
+    match a.tier with Router.Large | Router.Giant -> true | _ -> false
+  ) decision.agents in
+  check bool "complex selects large tier" has_large true
+
+let test_router_simple_prefers_cheap () =
+  let decision = Router.route "what is 2+2" in
+  let top = List.hd decision.agents in
+  check bool "cheap top agent" (top.cost_per_1k < 0.01) true
+
+let test_router_dot_product_correctness () =
+  let r = Router.extract_requirements "debug this OCaml concurrent mutex issue" in
+  let complexity = Router.calculate_complexity "debug this OCaml concurrent mutex issue" in
+  let opus_cap = { Router.reasoning_score = 0.95; code_score = 0.9;
+                   creativity_score = 0.9; factual_score = 0.9; speed_score = 0.3 } in
+  let tiny_cap = { Router.reasoning_score = 0.3; code_score = 0.4;
+                   creativity_score = 0.3; factual_score = 0.5; speed_score = 1.0 } in
+  let opus_agent = { Router.name = "opus"; model = "opus"; tier = Router.Large;
+                     capabilities = opus_cap; cost_per_1k = 0.015 } in
+  let tiny_agent = { Router.name = "tiny"; model = "tiny"; tier = Router.Tiny;
+                     capabilities = tiny_cap; cost_per_1k = 0.0 } in
+  let opus_score = Router.score_agent ~requirements:r ~complexity opus_agent in
+  let tiny_score = Router.score_agent ~requirements:r ~complexity tiny_agent in
+  check bool "opus > tiny for complex+code" (opus_score > tiny_score) true
+
 let router_tests = [
   "classify code", `Quick, test_router_classify_code;
   "classify analysis", `Quick, test_router_classify_analysis;
@@ -438,6 +481,12 @@ let router_tests = [
   "complexity complex", `Quick, test_router_complexity_complex;
   "agent selection", `Quick, test_router_agent_selection;
   "reason mentions heuristic", `Quick, test_router_reason_mentions_heuristic;
+  "short complex query", `Quick, test_router_short_complex_query;
+  "deep reasoning", `Quick, test_router_deep_reasoning;
+  "speed priority", `Quick, test_router_speed_priority;
+  "complex selects large tier", `Quick, test_router_complex_selects_large_tier;
+  "simple prefers cheap", `Quick, test_router_simple_prefers_cheap;
+  "dot product correctness", `Quick, test_router_dot_product_correctness;
 ]
 
 let balance_tests = [


### PR DESCRIPTION
## Summary
- Replace keyword-matching classification with structural regex pattern analysis
- Replace binary `strengths` enum with numeric `agent_capabilities` (0.0-1.0 per dimension)
- Score agents via dot product (requirements x capabilities) instead of strength_match - tier_penalty
- Add `requirements` and `match_scores` to route JSON response

## Problem
Short but complex queries like "debug this OCaml concurrent mutex issue" were routed to cheap tiers because the old router relied on text length as a complexity proxy. The keyword list also missed domain-specific complexity markers.

## Solution
5-dimensional query requirements extracted from compiled regex patterns:
- `reasoning_depth`: causal questions, domain complexity markers (mutex, distributed, byzantine, proof)
- `code_ability`: language names, code fences, implementation keywords
- `creativity`: open-ended generation markers
- `factual_precision`: lookup patterns
- `speed_priority`: urgency markers

Agent scoring: `sum(requirement_i * capability_i) - cost_penalty * (1 - complexity * 0.7)`

## Backward compatibility
- `classify_query`, `calculate_complexity`, `route` signatures unchanged
- `route_decision` extended (additive fields only)
- Existing `reason` prefix preserved ("Heuristic query class:")
- Stats module unchanged

## Test plan
- [x] 6 existing router tests pass unchanged
- [x] 6 new tests: short complex query, deep reasoning, speed priority, tier selection, cost preference, dot product correctness
- [x] `dune build` passes
- [ ] CI checks

Closes #3972

🤖 Generated with [Claude Code](https://claude.com/claude-code)