### PR TITLE
fix(keeper): set tool_choice=Auto and relax dashboard tools API auth

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -231,6 +231,13 @@ let build
     |> Oas.Builder.with_tools config.tools
     |> Oas.Builder.with_guardrails guardrails
   in
+  (* When tools are present, set tool_choice=Auto so models that require
+     explicit tool_choice (e.g. GLM-5.1) will actually invoke tools. *)
+  let builder =
+    if config.tools <> [] then
+      Oas.Builder.with_tool_choice Oas.Types.Auto builder
+    else builder
+  in
   let builder = match config.hooks with
     | Some h -> Oas.Builder.with_hooks h builder
     | None -> builder

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -518,10 +518,11 @@ let add_routes ~sw ~clock router =
 
   (* Keeper tools — POST /api/v1/keepers/:name/tools
      Body: { "action": "set_allowlist"|"set_denylist"|"add_allow"|"remove_allow"|"add_deny"|"remove_deny",
-             "tools": ["masc_status", ...] } *)
+             "tools": ["masc_status", ...] }
+     Uses with_tool_auth to allow localhost requests without bearer token. *)
   |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       with_token_permission_auth ~permission:Types.CanAdmin
-         (fun state _agent_name req reqd ->
+       with_tool_auth ~tool_name:"masc_keeper_up"
+         (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            let req_path = Http.Request.path req in
            let prefix = "/api/v1/keepers/" in


### PR DESCRIPTION
## Summary
- `Oas_worker.build`에서 tools가 있을 때 `tool_choice=Auto`를 설정. GLM-5.1이 도구를 호출하지 않던 근본 원인 수정.
- Dashboard keeper tools API (`POST /api/v1/keepers/:name/tools`)의 auth를 `with_tool_auth`로 변경하여 localhost에서 bearer token 없이 호출 가능.

## Context
- sangsu keeper가 36턴 동안 `tool_call_count: 0` — 도구가 노출되지만 모델이 호출하지 않음
- Worker 경로는 `tool_choice = Some Auto`를 명시하지만 keeper 경로(`Oas_worker.run_named`)는 누락
- `tool_choice=None`이면 GLM API에 파라미터가 전송되지 않고, GLM-5.1은 도구를 자발적으로 호출하지 않음

## Test plan
- [ ] 서버 재시작 후 sangsu keeper가 도구를 호출하는지 확인 (decision log에서 `tool_call_count > 0`)
- [ ] `curl -X POST localhost:8935/api/v1/keepers/sangsu/tools -d '{"action":"set_allowlist","tools":["masc_status"]}'` 가 401 없이 동작하는지 확인
- [ ] 기존 worker 경로에서 tool_choice 중복 설정이 문제 없는지 확인

Generated with [Claude Code](https://claude.com/claude-code)