### PR TITLE
fix(harness): harden observability smoke checks

### DIFF
--- a/scripts/harness/workload/observability_smoke_coding.sh
+++ b/scripts/harness/workload/observability_smoke_coding.sh
@@ -296,7 +296,6 @@ fi
 if [ "$preview_found" -eq 0 ]; then
   echo "FAIL: no tool preview fields found in proof data"
   FAIL_COUNT=$((FAIL_COUNT + 1))
-  exit 1
 fi
 
 # Also check output_preview fields (worker run level)

--- a/scripts/harness/workload/observability_smoke_coding.sh
+++ b/scripts/harness/workload/observability_smoke_coding.sh
@@ -5,12 +5,11 @@
 #
 # Prerequisites:
 #   - MASC server built: dune build --root . bin/main_eio.exe
-#   - jq, curl available
+#   - jq, curl, python3 available
 #
 # Environment variables:
 #   PORT                 - server port (auto-assigned if empty)
 #   BASE_PATH            - room base path (temp dir if empty)
-#   LLAMA_SWARM_MODEL    - model name for llama worker (auto-detected if single)
 #   MCP_URL              - override MCP endpoint (auto-derived from PORT)
 #   SERVER_EXE           - path to compiled server executable
 #   SKIP_SERVER_START    - set to 1 to use an existing server
@@ -40,7 +39,6 @@ SKIP_SERVER_START="${SKIP_SERVER_START:-0}"
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
 HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-60}"
-LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
 MCP_SESSION_ID="obs-smoke-coding"
 AGENT_NAME="obs-smoke-coding"
 TEAM_GOAL="Observability smoke: verify tool preview redaction and length limits"
@@ -60,6 +58,11 @@ fi
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required"
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required"
   exit 1
 fi
 
@@ -84,24 +87,18 @@ assert_no_api_key() {
 
 assert_max_length() {
   local text="$1" max="${2:-200}"
-  local len=${#text}
+  local len
+  len="$(TEXT_FOR_LEN="$text" python3 - <<'PY'
+import os
+print(len(os.environ["TEXT_FOR_LEN"]))
+PY
+)"
   if [ "$len" -gt "$max" ]; then
     echo "FAIL: length $len exceeds max $max"
     FAIL_COUNT=$((FAIL_COUNT + 1))
     return 1
   fi
   echo "OK: length $len within limit $max"
-  PASS_COUNT=$((PASS_COUNT + 1))
-}
-
-assert_not_null() {
-  local field_name="$1" value="$2"
-  if [ -z "$value" ] || [ "$value" = "null" ]; then
-    echo "FAIL: $field_name is null or empty"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    return 1
-  fi
-  echo "OK: $field_name = $value"
   PASS_COUNT=$((PASS_COUNT + 1))
 }
 
@@ -211,22 +208,6 @@ if [ -z "$agent_nickname" ]; then
   exit 1
 fi
 
-# detect llama model
-llama_models_raw="$(call_tool 3 "masc_llama_models" '{}')"
-require_tool_success "$llama_models_raw"
-llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
-
-if [ -z "$LLAMA_SWARM_MODEL" ]; then
-  single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
-  if [ -n "$single_model" ]; then
-    LLAMA_SWARM_MODEL="$single_model"
-    printf '  auto-selected: %s\n' "$LLAMA_SWARM_MODEL"
-  else
-    echo "SKIP: LLAMA_SWARM_MODEL not set and multiple models available"
-    exit 0
-  fi
-fi
-
 # ── step 3: start coding session with worker ──
 
 printf '[3/5] start coding team session with worker\n'
@@ -245,7 +226,7 @@ if [ -z "$TEAM_SESSION_ID" ]; then
 fi
 
 # Spawn a coding worker that will exercise tool calls
-MODEL_SELECTION_NOTE="[model-selection] obs-coding selected $LLAMA_SWARM_MODEL"
+MODEL_SELECTION_NOTE="[routing-note] obs-coding canonical team-session spawn via worker_class/worker_size"
 spawn_raw="$(call_tool 5 "masc_team_session_step" "$(jq -cn \
   --arg s "$TEAM_SESSION_ID" \
   --arg note "$MODEL_SELECTION_NOTE" \
@@ -313,7 +294,9 @@ if [ -n "$tool_output_previews" ]; then
 fi
 
 if [ "$preview_found" -eq 0 ]; then
-  echo "WARN: no tool preview fields found in proof data (worker may not have used tools)"
+  echo "FAIL: no tool preview fields found in proof data"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  exit 1
 fi
 
 # Also check output_preview fields (worker run level)
@@ -349,7 +332,6 @@ fi
 
 printf '\n[summary]\n'
 printf '  session_id: %s\n' "$TEAM_SESSION_ID"
-printf '  llama_model: %s\n' "$LLAMA_SWARM_MODEL"
 printf '  base_path: %s\n' "$BASE_PATH"
 printf '  log_file: %s\n' "$LOG_FILE"
 printf '  previews_checked: %d\n' "$preview_found"

--- a/scripts/harness/workload/observability_smoke_supervisor.sh
+++ b/scripts/harness/workload/observability_smoke_supervisor.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 # observability_smoke_supervisor.sh
 #
-# Verify trace_ref and provider_label in proof endpoint after a team-session.
+# Verify trace_ref and provider-related fields in proof/execution endpoints after a team-session.
 #
 # Prerequisites:
 #   - MASC server built: dune build --root . bin/main_eio.exe
-#   - jq, curl available
+#   - jq, curl, python3 available
 #
 # Environment variables:
 #   PORT                 - server port (auto-assigned if empty)
 #   BASE_PATH            - room base path (temp dir if empty)
-#   LLAMA_SWARM_MODEL    - model name for llama worker (auto-detected if single)
 #   MCP_URL              - override MCP endpoint (auto-derived from PORT)
 #   SERVER_EXE           - path to compiled server executable
 #   SKIP_SERVER_START    - set to 1 to use an existing server
@@ -35,10 +34,9 @@ SKIP_SERVER_START="${SKIP_SERVER_START:-0}"
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-60}"
 HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-30}"
-LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
 MCP_SESSION_ID="obs-smoke-supervisor"
 AGENT_NAME="obs-smoke-supervisor"
-TEAM_GOAL="Observability smoke: verify trace_ref and provider_label in proof endpoint"
+TEAM_GOAL="Observability smoke: verify trace_ref and provider info in proof endpoint"
 TEAM_SESSION_DURATION_SECONDS="${TEAM_SESSION_DURATION_SECONDS:-120}"
 MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 
@@ -58,6 +56,11 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required"
+  exit 1
+fi
+
 if [ "$SKIP_SERVER_START" != "1" ] && [ ! -x "$SERVER_EXE" ]; then
   echo "SKIP: server executable not found: $SERVER_EXE"
   echo "build it first with: dune build --root . bin/main_eio.exe"
@@ -74,17 +77,6 @@ assert_no_api_key() {
     return 1
   fi
   echo "OK: no API key patterns found"
-  PASS_COUNT=$((PASS_COUNT + 1))
-}
-
-assert_not_null() {
-  local field_name="$1" value="$2"
-  if [ -z "$value" ] || [ "$value" = "null" ]; then
-    echo "FAIL: $field_name is null or empty"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    return 1
-  fi
-  echo "OK: $field_name = $value"
   PASS_COUNT=$((PASS_COUNT + 1))
 }
 
@@ -194,28 +186,9 @@ if [ -z "$agent_nickname" ]; then
   exit 1
 fi
 
-# ── step 3: detect llama model ──
+# ── step 3: start team session with spawn ──
 
-printf '[3/6] detect llama model\n'
-llama_models_raw="$(call_tool 3 "masc_llama_models" '{}')"
-require_tool_success "$llama_models_raw"
-llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
-
-if [ -z "$LLAMA_SWARM_MODEL" ]; then
-  single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
-  if [ -n "$single_model" ]; then
-    LLAMA_SWARM_MODEL="$single_model"
-    printf '  auto-selected: %s\n' "$LLAMA_SWARM_MODEL"
-  else
-    echo "SKIP: LLAMA_SWARM_MODEL not set and multiple models available"
-    printf '%s\n' "$llama_models_result" | jq -r '.models[]?'
-    exit 0
-  fi
-fi
-
-# ── step 4: start team session with spawn ──
-
-printf '[4/6] start team session and spawn worker\n'
+printf '[3/5] start team session and spawn worker\n'
 start_raw="$(call_tool 4 "masc_team_session_start" "$(jq -cn \
   --arg goal "$TEAM_GOAL" \
   --arg agent "$agent_nickname" \
@@ -230,10 +203,9 @@ if [ -z "$TEAM_SESSION_ID" ]; then
   exit 1
 fi
 
-MODEL_SELECTION_NOTE="[model-selection] obs-smoke selected $LLAMA_SWARM_MODEL"
+MODEL_SELECTION_NOTE="[routing-note] obs-smoke canonical team-session spawn via worker_class/worker_size"
 spawn_raw="$(call_tool 5 "masc_team_session_step" "$(jq -cn \
   --arg s "$TEAM_SESSION_ID" \
-  --arg model "$LLAMA_SWARM_MODEL" \
   --arg note "$MODEL_SELECTION_NOTE" \
   '{session_id:$s,wait_mode:"blocking",spawn_batch:[{spawn_role:"obs-worker",worker_class:"executor",worker_size:"lg",spawn_selection_note:$note,spawn_prompt:"Reply with one line: observability smoke check complete.",spawn_timeout_seconds:90}]}')")"
 require_tool_success "$spawn_raw"
@@ -264,9 +236,9 @@ if [ "$session_status" = "running" ]; then
   done
 fi
 
-# ── step 5: query proof endpoint and assert observability fields ──
+# ── step 4: query proof endpoint and assert observability fields ──
 
-printf '[5/6] query proof endpoint and verify observability\n'
+printf '[4/5] query proof endpoint and verify observability\n'
 proof_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
   "http://127.0.0.1:${PORT}/api/v1/dashboard/proof?session_id=${TEAM_SESSION_ID}" 2>/dev/null || true)"
 
@@ -291,7 +263,14 @@ fi
 has_provider_info="$(printf '%s' "$proof_json" | jq -r '
   [.. | objects | select(.provider_name? != null or .resolved_model? != null or .provider_snapshot? != null)] | length > 0
 ' 2>/dev/null || echo "false")"
-assert_not_null "provider_info_in_proof" "$has_provider_info"
+if [ "$has_provider_info" = "true" ]; then
+  echo "OK: provider info found in proof data"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: provider info missing in proof data"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  exit 1
+fi
 
 # Assert: no raw API key patterns in all preview fields
 all_previews="$(printf '%s' "$proof_json" | jq -r '
@@ -304,9 +283,9 @@ else
   PASS_COUNT=$((PASS_COUNT + 1))
 fi
 
-# ── step 6: verify execution endpoint has provider_label ──
+# ── step 5: verify execution endpoint ──
 
-printf '[6/6] verify execution endpoint\n'
+printf '[5/5] verify execution endpoint\n'
 execution_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
   "http://127.0.0.1:${PORT}/api/v1/dashboard/execution" 2>/dev/null || true)"
 
@@ -337,7 +316,6 @@ fi
 
 printf '\n[summary]\n'
 printf '  session_id: %s\n' "$TEAM_SESSION_ID"
-printf '  llama_model: %s\n' "$LLAMA_SWARM_MODEL"
 printf '  base_path: %s\n' "$BASE_PATH"
 printf '  log_file: %s\n' "$LOG_FILE"
 printf '  pass: %d\n' "$PASS_COUNT"

--- a/scripts/harness/workload/observability_smoke_supervisor.sh
+++ b/scripts/harness/workload/observability_smoke_supervisor.sh
@@ -269,7 +269,6 @@ if [ "$has_provider_info" = "true" ]; then
 else
   echo "FAIL: provider info missing in proof data"
   FAIL_COUNT=$((FAIL_COUNT + 1))
-  exit 1
 fi
 
 # Assert: no raw API key patterns in all preview fields

--- a/scripts/harness/workload/observability_smoke_swarm.sh
+++ b/scripts/harness/workload/observability_smoke_swarm.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # observability_smoke_swarm.sh
 #
-# Verify provider_label diversity across multiple keepers with different cascade profiles.
+# Verify cascade/model diversity across multiple keepers with different cascade profiles.
 #
 # Prerequisites:
 #   - MASC server built: dune build --root . bin/main_eio.exe
-#   - jq, curl available
+#   - jq, curl, python3 available
 #
 # Environment variables:
 #   PORT                 - server port (auto-assigned if empty)
@@ -22,7 +22,7 @@
 #   1. Start 2 keepers with different cascade profiles
 #   2. Send a message to each keeper
 #   3. Query operator snapshot for keeper rows
-#   4. Assert: at least 1 distinct provider_label/active_model among keepers
+#   4. Assert: distinct cascade_name values and visible model/cascade evidence across keepers
 #
 # Exit codes:
 #   0 - PASS (or graceful skip if server unavailable)
@@ -65,6 +65,11 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required"
+  exit 1
+fi
+
 if [ "$SKIP_SERVER_START" != "1" ] && [ ! -x "$SERVER_EXE" ]; then
   echo "SKIP: server executable not found: $SERVER_EXE"
   echo "build it first with: dune build --root . bin/main_eio.exe"
@@ -81,17 +86,6 @@ assert_no_api_key() {
     return 1
   fi
   echo "OK: no API key patterns found"
-  PASS_COUNT=$((PASS_COUNT + 1))
-}
-
-assert_not_null() {
-  local field_name="$1" value="$2"
-  if [ -z "$value" ] || [ "$value" = "null" ]; then
-    echo "FAIL: $field_name is null or empty"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    return 1
-  fi
-  echo "OK: $field_name = $value"
   PASS_COUNT=$((PASS_COUNT + 1))
 }
 
@@ -279,7 +273,7 @@ fi
 
 HTTP_TIMEOUT_SEC="$ORIG_HTTP_TIMEOUT_SEC"
 
-# ── step 5: query operator snapshot and verify provider diversity ──
+# ── step 5: query operator snapshot and verify diversity ──
 
 printf '[5/5] query operator snapshot for keeper rows\n'
 snapshot_raw="$(call_operator_tool 30 "masc_operator_snapshot" "$(jq -cn --arg actor "$agent_nickname" '{actor:$actor,view:"full"}')")"
@@ -304,8 +298,11 @@ cascade_count="$(printf '%s' "$keeper_rows" | jq '[.[].cascade_name // empty] | 
 
 printf '  cascade names: %s\n' "$(echo "$cascade_names" | tr '\n' ', ')"
 
-# Assert: at least 1 distinct cascade_name (2 if both are different, which they should be)
-assert_gte "distinct_cascade_names" "$cascade_count" 1
+if [ "$KEEPER_A_CASCADE" != "$KEEPER_B_CASCADE" ]; then
+  assert_gte "distinct_cascade_names" "$cascade_count" 2
+else
+  assert_gte "distinct_cascade_names" "$cascade_count" 1
+fi
 
 # Extract active_model / last_model_used diversity
 model_labels="$(printf '%s' "$keeper_rows" | jq -r '


### PR DESCRIPTION
## Summary
- tighten the new observability smoke harnesses merged in #4031
- fail supervisor/coding smoke when target observability evidence is missing instead of passing silently
- align swarm wording/assertions with the keeper snapshot fields that actually exist today
- add explicit `python3` prerequisite checks for scripts that already depend on it

## Product impact
- reduces false-positive green runs in live observability smoke coverage
- keeps failure summaries visible instead of exiting mid-script

## Evidence
- `git diff --stat origin/main...HEAD`
- `git diff --check origin/main...HEAD`
- `bash -n scripts/harness/workload/observability_smoke_supervisor.sh`
- `bash -n scripts/harness/workload/observability_smoke_coding.sh`
- `bash -n scripts/harness/workload/observability_smoke_swarm.sh`

## Review evidence
- GLM-5 incremental diff review: `No findings.`
- PR comment with timestamp/model evidence will be added immediately after opening.

## Linked issue
- Refs #3955
- Follow-up to merged #4031

## Context
- #4031 merged while still pinned to its stale recreated-branch head, so this PR carries only the post-merge hardening commits.