### PR TITLE
docs(release): refresh 2.181.0 updated stamp

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v2.181.0
 > Latest release: v2.181.0 (2026-03-31)
-> Updated: 2026-03-30
+> Updated: 2026-03-31
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -2,7 +2,7 @@
 
 > Current package version: v2.181.0
 > Latest release: v2.181.0 (2026-03-31)
-> Updated: 2026-03-30
+> Updated: 2026-03-31
 
 ## Product Promise
 


### PR DESCRIPTION
## Summary
- update the front-door `Updated:` stamp in `ROADMAP.md` and `docs/PRODUCT-OPERATING-PLAN.md` to match the merged `2.181.0` release date

## Product impact
- keeps release-truth metadata internally consistent after `#4049` merged with stale `Updated:` values

## Evidence
- `git diff --check`

## Review evidence
- direct `GLM-5` follow-up review on the tiny metadata diff; comment will be added immediately after opening.

## Linked issue
- Follow-up to merged #4049

## Context
- `#4049` landed `Latest release: v2.181.0 (2026-03-31)` but left `Updated: 2026-03-30` in two front-door docs.