### PR TITLE
[codex] Fix keeper/public tool boundary

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -38,26 +38,48 @@ let contains_casefold haystack needle =
   let needle = String.lowercase_ascii needle in
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
-  let rec loop idx =
-    if idx + needle_len > hay_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
+  let rec matches_at idx j =
+    if j = needle_len then true
+    else if String.get haystack (idx + j) <> String.get needle j then false
+    else matches_at idx (j + 1)
   in
-  needle_len > 0 && loop 0
+  let rec search idx =
+    if idx + needle_len > hay_len then false
+    else if matches_at idx 0 then true
+    else search (idx + 1)
+  in
+  needle_len > 0 && search 0
+
+(* Percent-encode field values for structured key=value output.
+   Encodes separators and control characters to keep the output unambiguous. *)
+let escape_field_value (s : string) : string =
+  let buf = Buffer.create (String.length s * 3 / 2 + 1) in
+  String.iter
+    (fun ch ->
+      match ch with
+      | ' ' -> Buffer.add_string buf "%20"
+      | '=' -> Buffer.add_string buf "%3D"
+      | '\n' -> Buffer.add_string buf "%0A"
+      | '\r' -> Buffer.add_string buf "%0D"
+      | '\t' -> Buffer.add_string buf "%09"
+      | '%' -> Buffer.add_string buf "%25"
+      | _ -> Buffer.add_char buf ch)
+    s;
+  Buffer.contents buf
 
 let render_skip_reason_text (reason : Keeper_hooks_oas.skip_reason) : string =
   let replacement_hint =
     match (Tool_catalog.metadata reason.tool_name).Tool_catalog.replacement with
     | Some replacement ->
-        Printf.sprintf " replacement=%s" replacement
+        Printf.sprintf " replacement=%s" (escape_field_value replacement)
     | None -> ""
   in
   Printf.sprintf
     "[tool_skipped] tool=%s source=%s code=%s reason=%s%s"
-    reason.tool_name
-    reason.source
-    reason.reason_code
-    reason.reason_text
+    (escape_field_value reason.tool_name)
+    (escape_field_value reason.source)
+    (escape_field_value reason.reason_code)
+    (escape_field_value reason.reason_text)
     replacement_hint
 
 let normalize_response_text
@@ -273,91 +295,94 @@ let run_turn
     then Keeper_cdal_contract.of_keeper_meta meta
     else None
   in
-  match
-    Oas_worker.run_named
-      ~cascade_name
-      ~goal:user_message
-      ~session_id:meta.runtime.trace_id
-      ~system_prompt:turn_system_prompt
-      ~tools
-      ~initial_messages:history_messages
-      ~hooks
-      ~context_reducer:reducer
-      ~memory
-      ~max_turns
-      ~max_idle_turns:5
-      ~temperature
-      ~max_tokens
-      ?guardrails
-      ?on_event
-      ~agent_ref
-      ?contract
-      ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
-      ~working_context:checkpoint_sidecar
-      ~priority:(Option.value priority ~default:Llm_provider.Request_priority.Interactive)
-      ~cache_system_prompt:true
-      ()
-  with
-  | Error e -> Error e
-  | Ok result ->
-    (match result.checkpoint with
-     | Some checkpoint -> (
-         try
-           (* Unify session_id to trace_id so load_oas can find this
-              checkpoint on the next turn. oas_worker generates a per-turn
-              session_id that differs from trace_id, causing a load miss. *)
-           let checkpoint =
-             { checkpoint with Agent_sdk.Checkpoint.session_id = meta.runtime.trace_id }
-           in
-           Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
-             checkpoint
-         with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-             Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s"
-               meta.name (Printexc.to_string exn))
-     | None ->
-         Log.Keeper.warn "keeper:%s missing OAS checkpoint after run"
-           meta.name);
-    let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
-    let text = Agent_sdk.Types.text_of_content result.response.content in
-    let model = result.response.model in
-    let tool_names =
-      List.filter_map (function
-        | Agent_sdk.Types.ToolUse { name; _ } -> Some name | _ -> None)
-        result.response.content
-    in
-    let usage = Keeper_exec_context.usage_of_response result.response in
-    let skip_reason = Keeper_hooks_oas.consume_skip_reason meta.name in
-    (match normalize_response_text ?skip_reason ~text ~tool_names () with
-     | Error e -> Error e
-     | Ok response_text ->
-         let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
-         Keeper_exec_context.persist_message
-           ~source:history_assistant_source
-           session assistant_msg;
-         ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
-         (match result.proof with
-         | Some p ->
-            Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
-              meta.name p.run_id
-              (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
-              (Agent_sdk.Cdal_proof.show_result_status p.result_status)
-              (List.length p.raw_evidence_refs);
-            let store = Agent_sdk.Proof_store.default_config in
-            let outcome = Cdal_eval_v1.evaluate ~store p in
-            let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
-            Cdal_eval_v1.persist verdict;
-            Log.Keeper.info
-              "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
-              meta.name
-              (Cdal_types.contract_status_to_string verdict.status)
-              verdict.claim_scope
-              verdict.judgment_hash;
-            (match outcome with
-             | Cdal_eval_v1.Load_failure (err, _) ->
-               Log.Keeper.warn "keeper:%s contract_verdict load failure: %s"
-                 meta.name (Cdal_loader.load_error_to_string err)
+  Fun.protect
+    ~finally:(fun () -> Keeper_hooks_oas.clear_skip_reason meta.name)
+    (fun () ->
+      match
+        Oas_worker.run_named
+          ~cascade_name
+          ~goal:user_message
+          ~session_id:meta.runtime.trace_id
+          ~system_prompt:turn_system_prompt
+          ~tools
+          ~initial_messages:history_messages
+          ~hooks
+          ~context_reducer:reducer
+          ~memory
+          ~max_turns
+          ~max_idle_turns:5
+          ~temperature
+          ~max_tokens
+          ?guardrails
+          ?on_event
+          ~agent_ref
+          ?contract
+          ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+          ~working_context:checkpoint_sidecar
+          ~priority:(Option.value priority ~default:Llm_provider.Request_priority.Interactive)
+          ~cache_system_prompt:true
+          ()
+      with
+      | Error e -> Error e
+      | Ok result ->
+        (match result.checkpoint with
+         | Some checkpoint -> (
+             try
+               (* Unify session_id to trace_id so load_oas can find this
+                  checkpoint on the next turn. oas_worker generates a per-turn
+                  session_id that differs from trace_id, causing a load miss. *)
+               let checkpoint =
+                 { checkpoint with Agent_sdk.Checkpoint.session_id = meta.runtime.trace_id }
+               in
+               Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
+                 checkpoint
+             with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn ->
+                 Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s"
+                   meta.name (Printexc.to_string exn))
+         | None ->
+             Log.Keeper.warn "keeper:%s missing OAS checkpoint after run"
+               meta.name);
+        let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
+        let text = Agent_sdk.Types.text_of_content result.response.content in
+        let model = result.response.model in
+        let tool_names =
+          List.filter_map (function
+            | Agent_sdk.Types.ToolUse { name; _ } -> Some name | _ -> None)
+            result.response.content
+        in
+        let usage = Keeper_exec_context.usage_of_response result.response in
+        let skip_reason = Keeper_hooks_oas.consume_skip_reason meta.name in
+        (match normalize_response_text ?skip_reason ~text ~tool_names () with
+         | Error e -> Error e
+         | Ok response_text ->
+             let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
+             Keeper_exec_context.persist_message
+               ~source:history_assistant_source
+               session assistant_msg;
+             ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
+             (match result.proof with
+             | Some p ->
+                Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+                  meta.name p.run_id
+                  (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
+                  (Agent_sdk.Cdal_proof.show_result_status p.result_status)
+                  (List.length p.raw_evidence_refs);
+                let store = Agent_sdk.Proof_store.default_config in
+                let outcome = Cdal_eval_v1.evaluate ~store p in
+                let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
+                Cdal_eval_v1.persist verdict;
+                Log.Keeper.info
+                  "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+                  meta.name
+                  (Cdal_types.contract_status_to_string verdict.status)
+                  verdict.claim_scope
+                  verdict.judgment_hash;
+                (match outcome with
+                 | Cdal_eval_v1.Load_failure (err, _) ->
+                   Log.Keeper.warn "keeper:%s contract_verdict load failure: %s"
+                     meta.name (Cdal_loader.load_error_to_string err)
              | Cdal_eval_v1.Verdict (_, _) -> ());
             (match Cdal_eval_v1.friction_of_outcome outcome with
              | Some fp ->
@@ -392,4 +417,4 @@ let run_turn
            tools_used = tool_names;
            checkpoint = result.checkpoint;
            proof = result.proof;
-         })
+         }))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -33,10 +33,49 @@ type run_result = {
   proof : Agent_sdk.Cdal_proof.t option;
 }
 
-let normalize_response_text ~(text : string) ~(tool_names : string list) :
+let contains_casefold haystack needle =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if idx + needle_len > hay_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  needle_len > 0 && loop 0
+
+let render_skip_reason_text (reason : Keeper_hooks_oas.skip_reason) : string =
+  let replacement_hint =
+    match (Tool_catalog.metadata reason.tool_name).Tool_catalog.replacement with
+    | Some replacement ->
+        Printf.sprintf " replacement=%s" replacement
+    | None -> ""
+  in
+  Printf.sprintf
+    "[tool_skipped] tool=%s source=%s code=%s reason=%s%s"
+    reason.tool_name
+    reason.source
+    reason.reason_code
+    reason.reason_text
+    replacement_hint
+
+let normalize_response_text
+    ?skip_reason
+    ~(text : string)
+    ~(tool_names : string list)
+    () :
     (string, string) result =
-  if String.trim text <> "" then Ok text
+  let trimmed = String.trim text in
+  if trimmed <> "" then
+    match skip_reason with
+    | Some reason when contains_casefold trimmed "skipped by hook" ->
+        Ok (render_skip_reason_text reason)
+    | _ -> Ok text
   else
+    match skip_reason with
+    | Some reason -> Ok (render_skip_reason_text reason)
+    | None ->
     match tool_names with
     | [] -> Error "keeper turn completed with no textual reply"
     | _ ->
@@ -156,6 +195,7 @@ let run_turn
     Keeper_exec_context.set_system_prompt base_ctx
       ~system_prompt:base_system_prompt
   in
+  Keeper_hooks_oas.clear_skip_reason meta.name;
   (* 5. Build final turn system prompt via caller callback.
      Hard constraints stay in system_prompt; soft context is injected
      via OAS extra_system_context (prepended as User message after reduction). *)
@@ -288,7 +328,8 @@ let run_turn
         result.response.content
     in
     let usage = Keeper_exec_context.usage_of_response result.response in
-    (match normalize_response_text ~text ~tool_names with
+    let skip_reason = Keeper_hooks_oas.consume_skip_reason meta.name in
+    (match normalize_response_text ?skip_reason ~text ~tool_names () with
      | Error e -> Error e
      | Ok response_text ->
          let assistant_msg = Agent_sdk.Types.assistant_msg response_text in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -25,6 +25,42 @@ let destructive_check_tools =
 let keeper_denied_tools =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
 
+type skip_reason = {
+  tool_name : string;
+  source : string;
+  reason_code : string;
+  reason_text : string;
+  skipped_at_unix : float;
+}
+
+let recent_skip_reasons : (string, skip_reason) Hashtbl.t = Hashtbl.create 16
+let recent_skip_reasons_mu = Eio.Mutex.create ()
+
+let with_skip_rw f = Eio_guard.with_mutex recent_skip_reasons_mu f
+
+let clear_skip_reason keeper_name =
+  with_skip_rw (fun () -> Hashtbl.remove recent_skip_reasons keeper_name)
+
+let record_skip_reason ~keeper_name ~tool_name ~source ~reason_code ~reason_text =
+  let reason =
+    {
+      tool_name;
+      source;
+      reason_code;
+      reason_text;
+      skipped_at_unix = Unix.gettimeofday ();
+    }
+  in
+  with_skip_rw (fun () -> Hashtbl.replace recent_skip_reasons keeper_name reason)
+
+let consume_skip_reason keeper_name =
+  with_skip_rw (fun () ->
+      match Hashtbl.find_opt recent_skip_reasons keeper_name with
+      | None -> None
+      | Some reason ->
+          Hashtbl.remove recent_skip_reasons keeper_name;
+          Some reason)
+
 (** Extract command or content string from tool input JSON for screening.
     Reads "command", "cmd" (keeper_github), or "content" keys. *)
 let extract_command_from_input (input : Yojson.Safe.t) : string =
@@ -185,18 +221,34 @@ let make_hooks
     pre_tool_use = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
+        let keeper_name = (!meta_ref).name in
         (* Safety gate 0: Keeper deny list *)
         if List.mem tool_name keeper_denied_tools then begin
+          record_skip_reason
+            ~keeper_name
+            ~tool_name
+            ~source:"keeper_hook"
+            ~reason_code:"keeper_deny"
+            ~reason_text:"tool is on the keeper deny list";
           Log.Keeper.warn "keeper:%s deny list: blocked %s"
-            (!meta_ref).name tool_name;
+            keeper_name tool_name;
           Agent_sdk.Hooks.Skip
         end
         else
         (* Safety gate 1: Cost budget *)
         (match max_cost_usd with
          | Some limit when accumulated_cost_usd >= limit ->
+           record_skip_reason
+             ~keeper_name
+             ~tool_name
+             ~source:"keeper_hook"
+             ~reason_code:"cost_gate"
+             ~reason_text:
+               (Printf.sprintf
+                  "accumulated_cost_usd=%.4f exceeded limit=%.4f"
+                  accumulated_cost_usd limit);
            Log.Keeper.warn "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
-             (!meta_ref).name accumulated_cost_usd limit tool_name;
+             keeper_name accumulated_cost_usd limit tool_name;
            Agent_sdk.Hooks.Skip
          | _ ->
            (* Safety gate 2: Destructive pattern detection *)
@@ -204,8 +256,15 @@ let make_hooks
              let cmd = extract_command_from_input input in
              match Eval_gate.detect_destructive cmd with
              | Some (pattern, desc) ->
+               record_skip_reason
+                 ~keeper_name
+                 ~tool_name
+                 ~source:"keeper_hook"
+                 ~reason_code:"destructive_guard"
+                 ~reason_text:
+                   (Printf.sprintf "pattern='%s' (%s)" pattern desc);
                Log.Keeper.warn "keeper:%s destructive pattern in %s: '%s' (%s)"
-                 (!meta_ref).name tool_name pattern desc;
+                 keeper_name tool_name pattern desc;
                Agent_sdk.Hooks.Skip
              | None -> Agent_sdk.Hooks.Continue
            else

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -21,6 +21,22 @@ let is_ephemeral_agent_name name =
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
   (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name
 
+let direct_call_block_message name =
+  if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name then
+    let replacement_hint =
+      match (Tool_catalog.metadata name).Tool_catalog.replacement with
+      | Some replacement ->
+          Printf.sprintf " Try `%s` instead." replacement
+      | None -> ""
+    in
+    Printf.sprintf
+      "Tool '%s' is keeper-internal and not callable from external MCP clients.%s"
+      name replacement_hint
+  else
+    Printf.sprintf
+      "Tool '%s' is hidden from the default tool surface and not callable directly."
+      name
+
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
@@ -136,10 +152,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   let mode_gate_error =
     if not (Tool_catalog.allow_direct_call name) then
-      Some
-        (Printf.sprintf
-           "Tool '%s' is hidden from the default tool surface and not callable directly."
-           name)
+      Some (direct_call_block_message name)
     else
       None
   in

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -20,6 +20,22 @@ let get_id = Mcp_server.get_id
 let is_valid_request_id = Mcp_server.is_valid_request_id
 let jsonrpc_request_of_yojson = Mcp_server.jsonrpc_request_of_yojson
 
+let unavailable_tool_message name =
+  if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name then
+    let replacement_hint =
+      match (Tool_catalog.metadata name).Tool_catalog.replacement with
+      | Some replacement ->
+          Printf.sprintf " Try `%s` instead." replacement
+      | None -> ""
+    in
+    Printf.sprintf
+      "Tool '%s' is keeper-internal and unavailable on this MCP endpoint.%s"
+      name replacement_hint
+  else
+    Printf.sprintf
+      "Tool '%s' is not available on this MCP endpoint."
+      name
+
 (** {1 Resource Subscriptions} *)
 
 let resource_subscription_mutex = Eio.Mutex.create ()
@@ -467,15 +483,13 @@ let handle_request
                        | Some params ->
                            (try
                              let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
-                             let call_profile = match profile with
-                               | Operator_remote | Managed_agent -> profile
-                               | _ -> Full
-                             in
+                            let call_profile = match profile with
+                              | Operator_remote | Managed_agent -> profile
+                              | _ -> Full
+                            in
                             if not (TP.tool_allowed_in_profile state call_profile name) then
                                make_error ~id (-32601)
-                                 (Printf.sprintf
-                                    "Tool '%s' is not available on this MCP endpoint."
-                                    name)
+                                 (unavailable_tool_message name)
                              else (
                                Log.Mcp.info "tools/call: %s (id=%s, session=%s)" name
                                  (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -94,12 +94,18 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
           Config.visible_tool_schemas
             ~include_hidden:show_all ~include_deprecated ()
         in
-        if show_all then all
+        let without_keeper_internal =
+          List.filter
+            (fun (schema : Types.tool_schema) ->
+              not (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal schema.name))
+            all
+        in
+        if show_all then without_keeper_internal
         else
           List.filter
             (fun (schema : Types.tool_schema) ->
               Tool_catalog.is_public_mcp schema.name)
-            all
+            without_keeper_internal
     | Managed_agent ->
         let passthrough =
           Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false ()
@@ -116,11 +122,16 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
 let tool_allowed_in_profile state profile tool_name =
   match profile with
   | Full ->
-      (* tools/call accepts any registered tool regardless of the public MCP
-         surface or visibility. include_hidden ensures Hidden tools are callable. *)
-      Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
-      |> List.exists (fun (schema : Types.tool_schema) ->
-             String.equal schema.name tool_name)
+      if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name then
+        false
+      else if Tool_catalog.full_surface_override () then
+        Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
+        |> List.exists (fun (schema : Types.tool_schema) ->
+               String.equal schema.name tool_name)
+      else if Tool_catalog.is_public_mcp tool_name then
+        true
+      else
+        Tool_catalog.allow_direct_call tool_name
   | Managed_agent ->
       tool_schemas_for_profile state Managed_agent
       |> List.exists (fun (schema : Types.tool_schema) ->

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -214,9 +214,9 @@ let explicit_metadata : (string * metadata) list =
 (** {1 Public MCP Surface}
 
     The subset of tools exposed via tools/list on the Full (external MCP client)
-    profile. Internal tools remain callable via [Tool_dispatch.dispatch] but are
-    hidden from discovery. This keeps the MCP surface focused on agent
-    communication and coordination.
+    profile. Some hidden tools remain callable directly, but keeper-internal
+    adapters do not. This keeps the MCP surface focused on agent communication,
+    coordination, and stable public operations.
 
     Override: set [MASC_FULL_SURFACE=1] to restore the full inventory. *)
 
@@ -247,6 +247,76 @@ let public_mcp_tools =
     (* Utility *)
     "masc_tool_help"; "masc_check";
   ]
+
+let keeper_internal_tools =
+  [
+    "keeper_read";
+    "keeper_fs_read";
+    "keeper_fs_edit";
+    "keeper_edit";
+    "keeper_memory_search";
+    "keeper_library_search";
+    "keeper_library_read";
+    "keeper_time_now";
+    "keeper_context_status";
+    "keeper_tasks_list";
+    "keeper_tasks_audit";
+    "keeper_task_claim";
+    "keeper_task_done";
+    "keeper_task_force_release";
+    "keeper_task_force_done";
+    "keeper_broadcast";
+    "keeper_board_get";
+    "keeper_board_post";
+    "keeper_board_list";
+    "keeper_board_comment";
+    "keeper_board_vote";
+    "keeper_shell_readonly";
+    "keeper_bash";
+    "keeper_github";
+    "keeper_voice_speak";
+    "keeper_voice_agent";
+    "keeper_voice_sessions";
+    "keeper_voice_session_start";
+    "keeper_voice_session_end";
+    "keeper_search";
+    "keeper_profile";
+    "keeper_research";
+  ]
+
+let keeper_internal_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length keeper_internal_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) keeper_internal_tools;
+  tbl
+
+let keeper_internal_replacement = function
+  | "keeper_board_get" -> Some "masc_board_get"
+  | "keeper_board_post" -> Some "masc_board_post"
+  | "keeper_board_list" -> Some "masc_board_list"
+  | "keeper_board_comment" -> Some "masc_board_comment"
+  | "keeper_board_vote" -> Some "masc_board_vote"
+  | "keeper_voice_speak" -> Some "masc_voice_speak"
+  | "keeper_voice_agent" -> Some "masc_voice_agent"
+  | "keeper_voice_sessions" -> Some "masc_voice_sessions"
+  | "keeper_voice_session_start" -> Some "masc_voice_session_start"
+  | "keeper_voice_session_end" -> Some "masc_voice_session_end"
+  | "keeper_tasks_list" -> Some "masc_tasks"
+  | "keeper_broadcast" -> Some "masc_broadcast"
+  | _ -> None
+
+let keeper_internal_metadata name =
+  let replacement = keeper_internal_replacement name in
+  let implementation_status =
+    match replacement with
+    | Some _ -> Adapter
+    | None -> Real
+  in
+  hidden_active
+    ?canonical_name:replacement
+    ?replacement
+    ~allow_direct_call_when_hidden:false
+    ~implementation_status
+    "Keeper-internal tool. Use the keeper runtime or the public MASC equivalent when available."
 
 let public_mcp_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 64 in
@@ -281,6 +351,8 @@ let metadata name =
   | Some meta -> meta
   | None ->
     if is_public_mcp name then default_metadata
+    else if Hashtbl.mem keeper_internal_set name then
+      keeper_internal_metadata name
     else
       (* Non-public, non-explicit tools are internal: hidden from tools/list
          but callable via tools/call (tool_allowed_in_profile uses include_hidden). *)
@@ -464,6 +536,7 @@ type surface =
   | Local_worker
   | Session_min
   | Admin
+  | Keeper_internal
   | Keeper_denied
   | Mdal_auditable
 
@@ -551,6 +624,8 @@ let admin_surface_tools =
     "masc_team_session_finalize"; "masc_tool_admin_snapshot";
   ]
 
+let keeper_internal_surface_tools = keeper_internal_tools
+
 let keeper_denied_surface_tools =
   [
     "masc_room_delete"; "masc_room_destroy";
@@ -579,12 +654,13 @@ let tools_for_surface = function
   | Local_worker -> local_worker_surface_tools
   | Session_min -> session_min_surface_tools
   | Admin -> admin_surface_tools
+  | Keeper_internal -> keeper_internal_surface_tools
   | Keeper_denied -> keeper_denied_surface_tools
   | Mdal_auditable -> mdal_auditable_surface_tools
 
 let all_surfaces =
   [Public_mcp; Spawned_agent; Local_worker; Session_min;
-   Admin; Keeper_denied; Mdal_auditable]
+   Admin; Keeper_internal; Keeper_denied; Mdal_auditable]
 
 let surface_sets : (surface * (string, unit) Hashtbl.t) list =
   List.map (fun surface ->
@@ -605,5 +681,6 @@ let surface_to_string = function
   | Local_worker -> "local_worker"
   | Session_min -> "session_min"
   | Admin -> "admin"
+  | Keeper_internal -> "keeper_internal"
   | Keeper_denied -> "keeper_denied"
   | Mdal_auditable -> "mdal_auditable"

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -218,7 +218,8 @@ let explicit_metadata : (string * metadata) list =
     adapters do not. This keeps the MCP surface focused on agent communication,
     coordination, and stable public operations.
 
-    Override: set [MASC_FULL_SURFACE=1] to restore the full inventory. *)
+    Override: set [MASC_FULL_SURFACE=1] to restore the full inventory,
+    excluding keeper-internal tools. *)
 
 let public_mcp_tools =
   [

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -120,6 +120,7 @@ type surface =
   | Local_worker
   | Session_min
   | Admin
+  | Keeper_internal
   | Keeper_denied
   | Mdal_auditable
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -597,7 +597,7 @@ let test_metrics_mixed_response () =
      in found)
 
 let test_normalize_response_text_passthrough () =
-  match KAR.normalize_response_text ~text:"All good." ~tool_names:[] with
+  match KAR.normalize_response_text ~text:"All good." ~tool_names:[] () with
   | Ok text -> check string "keeps text" "All good." text
   | Error e -> fail ("unexpected error: " ^ e)
 
@@ -605,6 +605,7 @@ let test_normalize_response_text_tool_only_synthesizes () =
   match KAR.normalize_response_text
           ~text:""
           ~tool_names:["keeper_board_post"; "keeper_board_comment"]
+          ()
   with
   | Ok text ->
       check bool "mentions no textual reply" true
@@ -624,7 +625,7 @@ let test_normalize_response_text_tool_only_synthesizes () =
   | Error e -> fail ("unexpected error: " ^ e)
 
 let test_normalize_response_text_empty_without_tools_errors () =
-  match KAR.normalize_response_text ~text:"" ~tool_names:[] with
+  match KAR.normalize_response_text ~text:"" ~tool_names:[] () with
   | Ok text -> fail ("expected error, got: " ^ text)
   | Error e ->
       check bool "error mentions textual reply" true
@@ -728,6 +729,81 @@ let test_social_model_routes_blocker_to_board_post () =
             (contains_substring post.body "blocked")
       | _ -> fail "expected one request-help board post")
 
+let test_normalize_response_text_rewrites_generic_skip () =
+  let skip_reason : HK.skip_reason =
+    {
+      tool_name = "keeper_board_post";
+      source = "keeper_hook";
+      reason_code = "keeper_deny";
+      reason_text = "tool is on the keeper deny list";
+      skipped_at_unix = 0.0;
+    }
+  in
+  match KAR.normalize_response_text
+          ~text:"Tool execution skipped by hook"
+          ~tool_names:["keeper_board_post"]
+          ~skip_reason
+          ()
+  with
+  | Ok text ->
+      check bool "structured prefix" true
+        (String.starts_with ~prefix:"[tool_skipped]" text);
+      check bool "mentions tool" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "keeper_board_post")
+                  text 0);
+             true
+           with Not_found -> false
+         in
+         found);
+      check bool "mentions replacement" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "replacement=masc_board_post")
+                  text 0);
+             true
+           with Not_found -> false
+         in
+         found)
+  | Error e -> fail ("unexpected error: " ^ e)
+
+let test_normalize_response_text_empty_with_skip_reason () =
+  let skip_reason : HK.skip_reason =
+    {
+      tool_name = "keeper_bash";
+      source = "keeper_hook";
+      reason_code = "destructive_guard";
+      reason_text = "pattern='rm -rf' (recursive forced deletion)";
+      skipped_at_unix = 0.0;
+    }
+  in
+  match KAR.normalize_response_text
+          ~text:""
+          ~tool_names:[]
+          ~skip_reason
+          ()
+  with
+  | Ok text ->
+      check bool "structured prefix" true
+        (String.starts_with ~prefix:"[tool_skipped]" text);
+      check bool "mentions code" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "destructive_guard")
+                  text 0);
+             true
+           with Not_found -> false
+         in
+         found)
+  | Error e -> fail ("unexpected error: " ^ e)
+
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -796,5 +872,9 @@ let () =
             test_social_model_requires_explicit_headers;
           test_case "social model routes blocker to board post" `Quick
             test_social_model_routes_blocker_to_board_post;
+          test_case "normalize rewrites generic skip" `Quick
+            test_normalize_response_text_rewrites_generic_skip;
+          test_case "normalize empty with skip reason" `Quick
+            test_normalize_response_text_empty_with_skip_reason;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -769,6 +769,17 @@ let test_normalize_response_text_rewrites_generic_skip () =
              true
            with Not_found -> false
          in
+         found);
+      check bool "encodes reason spaces" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "reason=tool%20is%20on%20the%20keeper%20deny%20list")
+                  text 0);
+             true
+           with Not_found -> false
+         in
          found)
   | Error e -> fail ("unexpected error: " ^ e)
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1765,6 +1765,34 @@ let test_handle_request_tools_call_board_post_structured_content () =
     Yojson.Safe.Util.(structured |> member "author" |> to_string);
   cleanup_dir base_path
 
+let test_handle_request_tools_call_blocks_keeper_internal_tool () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 118);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String "keeper_time_now");
+      ("arguments", `Assoc []);
+    ]);
+  ]) in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "error code" (-32601) (error_code_exn response);
+  let msg = error_message_exn response in
+  Alcotest.(check bool) "mentions keeper-internal" true
+    (String.contains msg 'k' &&
+     try
+       ignore (Str.search_forward (Str.regexp_string "keeper-internal") msg 0);
+       true
+     with Not_found -> false);
+  cleanup_dir base_path
+
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2630,6 +2658,8 @@ let eio_tests = [
   (* cache get structured content test removed: cache tools retired (#3640) *)
   "handle tools/call board post structured content", `Quick,
     test_handle_request_tools_call_board_post_structured_content;
+  "handle tools/call blocks keeper internal tool", `Quick,
+    test_handle_request_tools_call_blocks_keeper_internal_tool;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1786,9 +1786,8 @@ let test_handle_request_tools_call_blocks_keeper_internal_tool () =
   Alcotest.(check int) "error code" (-32601) (error_code_exn response);
   let msg = error_message_exn response in
   Alcotest.(check bool) "mentions keeper-internal" true
-    (String.contains msg 'k' &&
-     try
-       ignore (Str.search_forward (Str.regexp_string "keeper-internal") msg 0);
+    (try
+       ignore (Str.search_forward (Str.regexp_case_fold "keeper-internal") msg 0);
        true
      with Not_found -> false);
   cleanup_dir base_path

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -140,6 +140,20 @@ let () =
         ] );
       ( "hidden_tools_contract",
         [
+          test_case "keeper internal tools are hidden and not directly callable" `Quick
+            (fun () ->
+              List.iter
+                (fun name ->
+                  let meta = Tool_catalog.metadata name in
+                  check bool (name ^ " hidden") false
+                    (Tool_catalog.is_visible name);
+                  check bool (name ^ " direct call blocked") false
+                    (Tool_catalog.allow_direct_call name);
+                  check bool (name ^ " on keeper_internal surface") true
+                    (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name);
+                  check bool (name ^ " reason present") true
+                    (Option.is_some meta.reason))
+                [ "keeper_time_now"; "keeper_board_post"; "keeper_bash" ]);
           test_case "known hidden tools are not visible by default" `Quick
             (fun () ->
               let hidden_names =

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -87,6 +87,23 @@ let test_keeper_denied_disjoint_from_public_mcp () =
   Alcotest.(check bool) "Keeper_denied disjoint from Public_mcp" true
     (SS.is_empty overlap)
 
+let test_keeper_internal_disjoint_from_public_mcp () =
+  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
+  let public = set_of (Tool_catalog.tools_for_surface Tool_catalog.Public_mcp) in
+  let overlap = SS.inter internal public in
+  if not (SS.is_empty overlap) then
+    Alcotest.failf "Keeper_internal overlaps with Public_mcp: {%s}"
+      (String.concat ", " (SS.elements overlap));
+  Alcotest.(check bool) "Keeper_internal disjoint from Public_mcp" true
+    (SS.is_empty overlap)
+
+let test_keeper_internal_contains_known_tools () =
+  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
+  List.iter
+    (fun name ->
+      Alcotest.(check bool) (name ^ " is internal") true (SS.mem name internal))
+    [ "keeper_time_now"; "keeper_board_post"; "keeper_bash"; "keeper_search" ]
+
 let test_is_on_surface_consistent () =
   List.iter (fun surface ->
     let tools = Tool_catalog.tools_for_surface surface in
@@ -116,6 +133,10 @@ let () =
             test_session_min_and_local_worker_share_core;
           Alcotest.test_case "Keeper_denied ∩ Public_mcp = ∅" `Quick
             test_keeper_denied_disjoint_from_public_mcp;
+          Alcotest.test_case "Keeper_internal ∩ Public_mcp = ∅" `Quick
+            test_keeper_internal_disjoint_from_public_mcp;
+          Alcotest.test_case "Keeper_internal contains known tools" `Quick
+            test_keeper_internal_contains_known_tools;
           Alcotest.test_case "is_on_surface consistent" `Quick
             test_is_on_surface_consistent;
         ] );


### PR DESCRIPTION
## Summary
- introduce an explicit `Keeper_internal` tool surface for internal keeper helper tools
- block `keeper_*` tools from external/public MCP `tools/list` and `tools/call`
- replace opaque keeper hook skip output with structured skip reason text and replacement hints
- add coverage for the new surface boundary and external call blocking behavior

## Why
External clients were able to see or call keeper-internal tools depending on profile and mode interactions. That made the `masc_*` vs `keeper_*` boundary inconsistent and confusing, and generic `Tool execution skipped by hook` messages gave no actionable reason.

## Product impact
- external/public MCP clients now get a hard failure for keeper-internal tools, with a hint when a public `masc_*` replacement exists
- keeper runtime still retains internal helper tools
- public `tools/list` and `tools/call` now share the same boundary for keeper-internal tools
- keeper hook skips now surface structured reason text instead of a useless generic skip message

## Evidence
- `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-boundary test/test_tool_surface_ssot.exe test/test_tool_exposure.exe test/test_keeper_unified.exe test/test_mcp_server_eio.exe`
- `./_build/default/test/test_tool_surface_ssot.exe`
- `./_build/default/test/test_tool_exposure.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-boundary test/test_mcp_server_eio.exe`

## Review evidence
- Cross-model review: GLM-5 via direct `sb glm-text`
- Timestamp: 2026-03-31 01:37:27 KST
- Result: No findings.
- PR comment: https://github.com/jeong-sik/masc-mcp/pull/4055#issuecomment-4156468559

## Linked issue
- Refs #4035

## Notes
- direct execution of `./_build/default/test/test_mcp_server_eio.exe` hit a local CA trust-anchor environment issue, but the `dune exec` path passed
