### PR TITLE
docs(release): fix v2.181.0 updated dates after merge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v2.181.0
 > Latest release: v2.181.0 (2026-03-31)
-> Updated: 2026-03-30
+> Updated: 2026-03-31
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -2,7 +2,7 @@
 
 > Current package version: v2.181.0
 > Latest release: v2.181.0 (2026-03-31)
-> Updated: 2026-03-30
+> Updated: 2026-03-31
 
 ## Product Promise
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,7 +2,7 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-03-30
+> Last Updated: 2026-03-31
 > Snapshot baseline: `dune-project` version `2.181.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.


### PR DESCRIPTION
## Summary
- fix the remaining `v2.181.0` date drift left on `main` after `#4049` merged
- align `ROADMAP.md`, `docs/PRODUCT-OPERATING-PLAN.md`, and `docs/spec/SPEC-INDEX.md` to `2026-03-31`

## Product impact
- restores version truth across the front-door docs for the current release
- removes the inconsistency where `CHANGELOG.md` said `2026-03-31` but other release-truth docs still showed `2026-03-30`

## Evidence
- `git diff --check`
- verified `origin/main` after `#4049` merge and confirmed drift remained in:
  - `ROADMAP.md`
  - `docs/PRODUCT-OPERATING-PLAN.md`
  - `docs/spec/SPEC-INDEX.md`

## Review evidence
- direct `GLM-5` review on the final diff: `No findings.`

## Linked issue
- Refs #4049
