### PR TITLE
fix(governance): canonicalize compound phrase synonyms

### DIFF
--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -163,18 +163,28 @@ let rec normalize_json_semantics (json : Yojson.Safe.t) : Yojson.Safe.t =
   | `String value -> `String (normalize_text value)
   | (`Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as value -> value
 
-(** Canonicalize a compound action string like "set_param" or "clear-param".
-    Splits on underscores/hyphens/spaces, maps each token, and rejoins. *)
+(** Canonicalize a compound action string like "set_param" or "turn on".
+    First preserve phrase-level synonyms such as "turn_on"/"scale_up",
+    then fall back to token-wise canonicalization. *)
 let canonicalize_action_str s =
-  s
-  |> normalize_text
-  |> String.to_seq
-  |> Seq.map (fun ch ->
-       match ch with 'a'..'z' | '0'..'9' -> ch | _ -> ' ')
-  |> String.of_seq
-  |> String.split_on_char ' '
-  |> List.filter_map canonical_semantic_token
-  |> String.concat "_"
+  let normalized =
+    s
+    |> normalize_text
+    |> String.to_seq
+    |> Seq.map (fun ch ->
+         match ch with 'a'..'z' | '0'..'9' -> ch | _ -> '_')
+    |> String.of_seq
+    |> String.split_on_char '_'
+    |> List.filter (fun token -> token <> "")
+    |> String.concat "_"
+  in
+  match canonical_semantic_token normalized with
+  | Some whole -> whole
+  | None ->
+      normalized
+      |> String.split_on_char '_'
+      |> List.filter_map canonical_semantic_token
+      |> String.concat "_"
 
 let semantic_action_key = function
   | None -> None

--- a/test/test_governance_v2.ml
+++ b/test/test_governance_v2.ml
@@ -266,6 +266,31 @@ let test_different_target_type_no_merge () =
   check bool "different target_type do not merge" false second.merged;
   check bool "different case ids" true (first.case_.id <> second.case_.id)
 
+(** Compound phrase synonyms like "turn on" should canonicalize before splitting. *)
+let test_turn_on_enable_synonym_merge () =
+  with_base @@ fun () ->
+  let make_action action_type =
+    Some { GV2.action_type; target_type = Some "runtime_param";
+           target_id = Some "feature_gate";
+           payload = Some (`Assoc [("param_key", `String "feature_gate"); ("value", `Bool true)]) }
+  in
+  let first =
+    match submit ~title:"Turn on feature_gate"
+      ~subject_type:"param_change"
+      ~requested_action:(make_action "turn on")
+      ~source_refs:[] ~created_by:"agent-a"
+    with Ok v -> v | Error e -> fail e
+  in
+  let second =
+    match submit ~title:"Enable feature_gate"
+      ~subject_type:"param_change"
+      ~requested_action:(make_action "enable")
+      ~source_refs:[] ~created_by:"agent-b"
+    with Ok v -> v | Error e -> fail e
+  in
+  check bool "turn on/enable synonym merge" true second.merged;
+  check string "same case id" first.case_.id second.case_.id
+
 let () =
   run "governance_v2"
     [
@@ -290,5 +315,7 @@ let () =
             test_clear_vs_revert_no_merge;
           test_case "different target_type no merge" `Quick
             test_different_target_type_no_merge;
+          test_case "turn on/enable synonym merge" `Quick
+            test_turn_on_enable_synonym_merge;
         ] );
     ]


### PR DESCRIPTION
## Summary
- fix the compound phrase synonym regression that shipped in `#4020`
- canonicalize action phrases like `turn on`, `turn_on`, and `scale-up` before token splitting
- add a regression test that proves phrase-level synonyms merge to the same governance case

## Problem
`#4020` expanded `canonical_semantic_token` with entries like `turn_on` and `scale_up`, but `canonicalize_action_str` split non-alphanumeric characters before whole-token lookup. That made the new compound synonyms unreachable on `main`.

## Changes
- `lib/council/governance_v2.ml` — preserve phrase-level normalization before token fallback
- `test/test_governance_v2.ml` — add `turn on/enable` regression coverage

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] `./_build/default/test/test_governance_v2.exe` — 9/9 green
- [x] `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4020-review-sweep ./test/test_governance_v2.exe`
- [ ] CI green

## Review evidence
- direct `GLM-5` review on the latest diff: `No findings.`

## Context
- follow-up to `#4020`
