### PR TITLE
[codex] refactor(keeper): replace tool_allowlist with tool_access ADT

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -753,8 +753,10 @@ let keeper_config_json (config : Room.config) (name : string)
           allowed
           |> List.filter (fun n -> String.starts_with ~prefix:"masc_" n)
         in
+        let tool_allowlist = Keeper_types.tool_access_allowlist m.tool_access in
         `Assoc [
-          ("tool_allowlist", `List (List.map (fun s -> `String s) m.tool_allowlist));
+          ("tool_access", Keeper_types.tool_access_to_json m.tool_access);
+          ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
           ("tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist));
           ("active_masc_tool_count", `Int (List.length masc_tools));
           ("active_keeper_tool_count",

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -93,18 +93,15 @@ let inject_masc_schemas (schemas : Types.tool_schema list) =
       schemas
 
 (** Apply allowlist/denylist filtering to masc_* tool names.
-    - allowlist empty → all masc_* tools allowed (no restriction).
-      This matches keeper_turn_up_create default (tool_allowlist=[]).
-      TODO: replace string list with [Unrestricted | Restricted of string list]
-      to make empty-vs-unrestricted semantics explicit.
-    - allowlist non-empty → only listed tools allowed
+    - unrestricted → all masc_* tools allowed
+    - restricted → only listed tools allowed
     - denylist always wins (deny overrides allow) *)
-let filter_by_access ~(allowlist : string list) ~(denylist : string list)
+let filter_by_access ~(tool_access : tool_access) ~(denylist : string list)
     (name : string) : bool =
   let allowed =
-    match allowlist with
-    | [] -> true
-    | _ -> List.mem name allowlist
+    match tool_access with
+    | Unrestricted -> true
+    | Restricted allowlist -> List.mem name allowlist
   in
   allowed && not (List.mem name denylist)
 
@@ -112,7 +109,7 @@ let keeper_masc_tool_names (meta : keeper_meta) : string list =
   !masc_schemas_ref
   |> List.filter_map (fun (schema : Types.tool_schema) ->
     if filter_by_access
-         ~allowlist:meta.tool_allowlist
+         ~tool_access:meta.tool_access
          ~denylist:meta.tool_denylist
          schema.name
     then Some schema.name
@@ -122,7 +119,7 @@ let keeper_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
   !masc_schemas_ref
   |> List.filter (fun (schema : Types.tool_schema) ->
     filter_by_access
-      ~allowlist:meta.tool_allowlist
+      ~tool_access:meta.tool_access
       ~denylist:meta.tool_denylist
       schema.name)
 
@@ -138,7 +135,7 @@ let keeper_default_model_tools (_meta : keeper_meta) : Types.tool_schema list =
 
 (** Return keeper tool names with allowlist/denylist gating on masc_*.
     keeper_* tools pass unconditionally. masc_* tools from any source
-    (shards, passthrough, defaults) are filtered by tool_allowlist/tool_denylist. *)
+    (shards, passthrough, defaults) are filtered by tool_access/tool_denylist. *)
 let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     string list =
   if write_done then
@@ -161,7 +158,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     |> List.filter (fun name ->
       if String.starts_with ~prefix:"masc_" name then
         filter_by_access
-          ~allowlist:meta.tool_allowlist
+          ~tool_access:meta.tool_access
           ~denylist:meta.tool_denylist
           name
       else
@@ -805,7 +802,7 @@ let execute_keeper_tool_call
                           ("error", `String (Types.masc_error_to_string e)) ]))
   | name when String.starts_with ~prefix:"masc_autoresearch_" name ->
       if not (filter_by_access
-                ~allowlist:meta.tool_allowlist
+                ~tool_access:meta.tool_access
                 ~denylist:meta.tool_denylist name) then
         Yojson.Safe.to_string
           (`Assoc [ ("error", `String "tool_not_allowed");
@@ -833,7 +830,7 @@ let execute_keeper_tool_call
          Even if the LLM hallucinates a tool name that wasn't in the schema,
          this gate blocks execution. Deny always wins. *)
       if not (filter_by_access
-                ~allowlist:meta.tool_allowlist
+                ~tool_access:meta.tool_access
                 ~denylist:meta.tool_denylist name) then
         Yojson.Safe.to_string
           (`Assoc [ ("error", `String "tool_not_allowed");

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -202,7 +202,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            execution_scope;
            allowed_paths;
            scope_kind;
-           tool_allowlist = [];
+           tool_access = Unrestricted;
            tool_denylist = [];
            room_scope;
            voice_enabled;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -22,6 +22,10 @@ type proactive_policy = {
   cooldown_sec: int;
 }
 
+type tool_access =
+  | Unrestricted
+  | Restricted of string list
+
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
 type compaction_runtime = {
@@ -96,7 +100,7 @@ type keeper_meta = {
   execution_scope: string;
   allowed_paths: string list;
   scope_kind: string;
-  tool_allowlist: string list;
+  tool_access: tool_access;
   tool_denylist: string list;
   room_scope: string;
   mention_targets: string list;
@@ -130,6 +134,52 @@ type keeper_meta = {
 }
 
 let default_social_model = "bdi_speech_v1"
+
+let normalize_tool_access = function
+  | Unrestricted -> Unrestricted
+  | Restricted names ->
+      Restricted
+        (names
+        |> List.filter (fun name -> String.trim name <> "")
+        |> dedupe_keep_order)
+
+let tool_access_allowlist = function
+  | Unrestricted -> []
+  | Restricted names -> names
+
+let tool_access_to_json access =
+  match normalize_tool_access access with
+  | Unrestricted ->
+      `Assoc [ ("kind", `String "unrestricted") ]
+  | Restricted names ->
+      `Assoc
+        [
+          ("kind", `String "restricted");
+          ("tools", `List (List.map (fun s -> `String s) names));
+        ]
+
+let tool_access_of_meta_json (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member "tool_access" json with
+  | `Null ->
+      Ok
+        (match normalize_tool_access
+                 (Restricted (Safe_ops.json_string_list "tool_allowlist" json))
+         with
+         | Restricted [] -> Unrestricted
+         | other -> other)
+  | `Assoc _ as access_json -> (
+      let kind =
+        Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+      in
+      let tools = Safe_ops.json_string_list "tools" access_json in
+      match kind with
+      | Some "unrestricted" -> Ok Unrestricted
+      | Some "restricted" ->
+          Ok (normalize_tool_access (Restricted tools))
+      | Some other ->
+          Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+      | None -> Error "keeper tool_access.kind required")
+  | _ -> Error "keeper tool_access must be an object"
 
 (* -- Updater helpers for nested record updates -- *)
 
@@ -256,7 +306,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("execution_scope", `String m.execution_scope);
       ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
       ("scope_kind", `String m.scope_kind);
-      ("tool_allowlist", `List (List.map (fun s -> `String s) m.tool_allowlist));
+      ("tool_access", tool_access_to_json m.tool_access);
       ("tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist));
       ("room_scope", `String m.room_scope);
       ("mention_targets", `List (List.map (fun s -> `String s) m.mention_targets));
@@ -391,7 +441,11 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let scope_kind =
       Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
     in
-    let tool_allowlist = Safe_ops.json_string_list "tool_allowlist" json in
+    let tool_access =
+      match tool_access_of_meta_json json with
+      | Ok access -> access
+      | Error msg -> raise (Invalid_argument msg)
+    in
     let tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
     let room_scope =
       Safe_ops.json_string ~default:"current" "room_scope" json |> canonical_room_scope
@@ -562,7 +616,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           execution_scope;
           allowed_paths;
           scope_kind;
-          tool_allowlist;
+          tool_access;
           tool_denylist;
           room_scope;
           mention_targets;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -23,6 +23,10 @@ type proactive_policy = {
   cooldown_sec: int;
 }
 
+type tool_access =
+  | Unrestricted
+  | Restricted of string list
+
 (** {1 Runtime types (embedded in agent_runtime_state)} *)
 
 type compaction_runtime = {
@@ -99,7 +103,7 @@ type keeper_meta = {
   execution_scope: string;
   allowed_paths: string list;
   scope_kind: string;
-  tool_allowlist: string list;
+  tool_access: tool_access;
   tool_denylist: string list;
   room_scope: string;
   mention_targets: string list;
@@ -129,6 +133,9 @@ type keeper_meta = {
 val default_social_model : string
 
 val now_iso : unit -> string
+
+val tool_access_allowlist : tool_access -> string list
+val tool_access_to_json : tool_access -> Yojson.Safe.t
 
 (** {1 Updater helpers for nested record updates} *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -517,7 +517,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   (* Keeper tools — POST /api/v1/keepers/:name/tools
-     Body: { "action": "set_allowlist"|"set_denylist"|"add_allow"|"remove_allow"|"add_deny"|"remove_deny",
+     Body: { "action": "set_allowlist"|"set_unrestricted"|"set_denylist"|"add_allow"|"remove_allow"|"add_deny"|"remove_deny",
              "tools": ["masc_status", ...] }
      Uses with_tool_auth to allow localhost requests without bearer token. *)
   |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
@@ -562,20 +562,41 @@ let add_routes ~sw ~clock router =
                           if List.mem x acc then acc else x :: acc) [] xs
                         |> List.rev
                       in
+                      let allowlist_of_meta (meta : Keeper_types.keeper_meta) =
+                        Keeper_types.tool_access_allowlist meta.tool_access
+                      in
+                      let add_allow (meta : Keeper_types.keeper_meta) tools =
+                        match meta.tool_access with
+                        | Keeper_types.Unrestricted -> meta.tool_access
+                        | Keeper_types.Restricted current ->
+                            Keeper_types.Restricted (dedupe (current @ tools))
+                      in
+                      let remove_allow (meta : Keeper_types.keeper_meta) tools =
+                        match meta.tool_access with
+                        | Keeper_types.Unrestricted -> meta.tool_access
+                        | Keeper_types.Restricted current ->
+                            Keeper_types.Restricted
+                              (List.filter (fun n -> not (List.mem n tools)) current)
+                      in
                       let updated_meta = match action with
                         | "set_allowlist" ->
-                            Ok { meta with tool_allowlist = dedupe tools;
+                            Ok { meta with
+                                   tool_access = Keeper_types.Restricted (dedupe tools);
+                                   updated_at = Keeper_types.now_iso () }
+                        | "set_unrestricted" ->
+                            Ok { meta with
+                                   tool_access = Keeper_types.Unrestricted;
                                            updated_at = Keeper_types.now_iso () }
                         | "set_denylist" ->
                             Ok { meta with tool_denylist = dedupe tools;
                                            updated_at = Keeper_types.now_iso () }
                         | "add_allow" ->
-                            Ok { meta with tool_allowlist = dedupe (meta.tool_allowlist @ tools);
+                            Ok { meta with
+                                   tool_access = add_allow meta tools;
                                            updated_at = Keeper_types.now_iso () }
                         | "remove_allow" ->
-                            Ok { meta with tool_allowlist =
-                                             List.filter (fun n -> not (List.mem n tools))
-                                               meta.tool_allowlist;
+                            Ok { meta with
+                                   tool_access = remove_allow meta tools;
                                            updated_at = Keeper_types.now_iso () }
                         | "add_deny" ->
                             Ok { meta with tool_denylist = dedupe (meta.tool_denylist @ tools);
@@ -585,7 +606,7 @@ let add_routes ~sw ~clock router =
                                              List.filter (fun n -> not (List.mem n tools))
                                                meta.tool_denylist;
                                            updated_at = Keeper_types.now_iso () }
-                        | "" -> Error "action required (set_allowlist|add_allow|remove_allow|set_denylist|add_deny|remove_deny)"
+                        | "" -> Error "action required (set_allowlist|set_unrestricted|add_allow|remove_allow|set_denylist|add_deny|remove_deny)"
                         | other -> Error (Printf.sprintf "unknown action: %s" other)
                       in
                       match updated_meta with
@@ -601,11 +622,13 @@ let add_routes ~sw ~clock router =
                                  List.length (List.filter
                                    (fun n -> String.starts_with ~prefix:"masc_" n) allowed)
                                in
+                               let tool_allowlist = allowlist_of_meta meta' in
                                Http.Response.json ~compress:true ~request:req
                                  (Yojson.Safe.to_string
                                     (`Assoc [
                                        ("ok", `Bool true);
-                                       ("tool_allowlist", `List (List.map (fun s -> `String s) meta'.tool_allowlist));
+                                       ("tool_access", Keeper_types.tool_access_to_json meta'.tool_access);
+                                       ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
                                        ("tool_denylist", `List (List.map (fun s -> `String s) meta'.tool_denylist));
                                        ("active_masc_tool_count", `Int masc_count);
                                        ("total_active", `Int (List.length allowed));

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -4,13 +4,18 @@
 module KET = Masc_mcp.Keeper_exec_tools
 
 let make_meta ?(tool_allowlist = []) ?(tool_denylist = []) () =
+  let tool_access =
+    match tool_allowlist with
+    | [] -> Masc_mcp.Keeper_types.Unrestricted
+    | names -> Masc_mcp.Keeper_types.Restricted names
+  in
   match Masc_mcp.Keeper_types.meta_of_json
     (`Assoc
       [
         ("name", `String "keeper-bridge-test");
         ("agent_name", `String "keeper-bridge-test");
         ("trace_id", `String "keeper-bridge-trace");
-        ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
+        ("tool_access", Masc_mcp.Keeper_types.tool_access_to_json tool_access);
         ("tool_denylist", `List (List.map (fun s -> `String s) tool_denylist));
       ])
   with

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -3,11 +3,12 @@
 
 module KET = Masc_mcp.Keeper_exec_tools
 
-let make_meta ?(tool_allowlist = []) ?(tool_denylist = []) () =
+let make_meta ?tool_access ?tool_allowlist ?(tool_denylist = []) () =
   let tool_access =
-    match tool_allowlist with
-    | [] -> Masc_mcp.Keeper_types.Unrestricted
-    | names -> Masc_mcp.Keeper_types.Restricted names
+    match tool_access, tool_allowlist with
+    | Some access, _ -> access
+    | None, Some names -> Masc_mcp.Keeper_types.Restricted names
+    | None, None -> Masc_mcp.Keeper_types.Unrestricted
   in
   match Masc_mcp.Keeper_types.meta_of_json
     (`Assoc
@@ -106,6 +107,97 @@ let test_denylist_restricts_unrestricted_default () =
   Alcotest.(check bool) "other masc tools remain" true
     (List.mem "masc_autoresearch_cycle" names)
 
+(** Explicit empty allowlist is restricted, not unrestricted. *)
+let test_restricted_empty_allowlist_blocks_masc () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta = make_meta
+    ~tool_access:(Masc_mcp.Keeper_types.Restricted []) () in
+  let names = KET.keeper_masc_tool_names meta in
+  Alcotest.(check int) "no masc tools" 0 (List.length names);
+  Alcotest.(check bool) "masc_status blocked" false
+    (List.mem "masc_status" names)
+
+(** Legacy persisted empty tool_allowlist still maps to unrestricted. *)
+let test_legacy_empty_allowlist_remains_unrestricted () =
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "legacy-keeper");
+          ("agent_name", `String "legacy-keeper");
+          ("trace_id", `String "legacy-trace");
+          ("tool_allowlist", `List []);
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  let names = KET.keeper_masc_tool_names meta in
+  Alcotest.(check bool) "legacy empty allowlist still exposes masc tools" true
+    (List.mem "masc_status" names)
+
+(** Restricted JSON preserves an explicit empty tools list. *)
+let test_tool_access_restricted_empty_json_preserved () =
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "restricted-json");
+          ("agent_name", `String "restricted-json");
+          ("trace_id", `String "restricted-json-trace");
+          ( "tool_access",
+            `Assoc
+              [
+                ("kind", `String "restricted");
+                ("tools", `List []);
+              ] );
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  match meta.Masc_mcp.Keeper_types.tool_access with
+  | Masc_mcp.Keeper_types.Restricted names ->
+      Alcotest.(check int) "restricted empty preserved" 0 (List.length names)
+  | Masc_mcp.Keeper_types.Unrestricted ->
+      Alcotest.fail "expected Restricted []"
+
+(** Malformed tool_access JSON is rejected. *)
+let test_tool_access_invalid_kind_rejected () =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc
+      [
+        ("name", `String "invalid-kind");
+        ("agent_name", `String "invalid-kind");
+        ("trace_id", `String "invalid-kind-trace");
+        ("tool_access", `Assoc [ ("kind", `String "bogus") ]);
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected invalid kind to fail"
+  | Error e ->
+      Alcotest.(check string)
+        "invalid kind error"
+        "invalid keeper tool_access.kind: bogus"
+        e
+
+let test_tool_access_missing_kind_rejected () =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc
+      [
+        ("name", `String "missing-kind");
+        ("agent_name", `String "missing-kind");
+        ("trace_id", `String "missing-kind-trace");
+        ("tool_access", `Assoc [ ("tools", `List []) ]);
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected missing kind to fail"
+  | Error e ->
+      Alcotest.(check string)
+        "missing kind error"
+        "keeper tool_access.kind required"
+        e
+
 (** Allowlist also gates shard-sourced masc_* in allowed_tool_names. *)
 let test_allowlist_gates_shard_tools () =
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
@@ -170,6 +262,19 @@ let () =
             test_deny_overrides_allow;
           Alcotest.test_case "deny restricts unrestricted default" `Quick
             test_denylist_restricts_unrestricted_default;
+          Alcotest.test_case "restricted empty allowlist blocks masc" `Quick
+            test_restricted_empty_allowlist_blocks_masc;
+        ] );
+      ( "meta_json",
+        [
+          Alcotest.test_case "legacy empty allowlist remains unrestricted" `Quick
+            test_legacy_empty_allowlist_remains_unrestricted;
+          Alcotest.test_case "restricted empty json preserved" `Quick
+            test_tool_access_restricted_empty_json_preserved;
+          Alcotest.test_case "invalid kind rejected" `Quick
+            test_tool_access_invalid_kind_rejected;
+          Alcotest.test_case "missing kind rejected" `Quick
+            test_tool_access_missing_kind_rejected;
         ] );
       ( "dispatch",
         [

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -21,13 +21,18 @@ let make_meta
     ?(name = "test-keeper")
     ?(tool_allowlist = [])
     () : Keeper_types.keeper_meta =
+  let tool_access =
+    match tool_allowlist with
+    | [] -> Keeper_types.Unrestricted
+    | names -> Keeper_types.Restricted names
+  in
   let json = `Assoc [
     ("name", `String name);
     ("agent_name", `String name);
     ("trace_id", `String "safety-test-trace");
     ("policy_voice_enabled", `Bool policy_voice_enabled);
     ("soul_profile", `String soul_profile);
-    ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
+    ("tool_access", Keeper_types.tool_access_to_json tool_access);
   ] in
   match Keeper_types.meta_of_json json with
   | Ok meta -> meta

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -19,12 +19,14 @@ let make_meta
     ?(policy_voice_enabled = false)
     ?(soul_profile = "default")
     ?(name = "test-keeper")
-    ?(tool_allowlist = [])
+    ?tool_access
+    ?tool_allowlist
     () : Keeper_types.keeper_meta =
   let tool_access =
-    match tool_allowlist with
-    | [] -> Keeper_types.Unrestricted
-    | names -> Keeper_types.Restricted names
+    match tool_access, tool_allowlist with
+    | Some access, _ -> access
+    | None, Some names -> Keeper_types.Restricted names
+    | None, None -> Keeper_types.Unrestricted
   in
   let json = `Assoc [
     ("name", `String name);

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -13,6 +13,11 @@ open Masc_mcp
 
 let make_meta ?(name = "test-keeper") ?(soul_profile = "")
     ?(policy_voice_enabled = false) ?(tool_allowlist = []) () : Keeper_types.keeper_meta =
+  let tool_access =
+    match tool_allowlist with
+    | [] -> Keeper_types.Unrestricted
+    | names -> Keeper_types.Restricted names
+  in
   let json =
     `Assoc
       [
@@ -21,7 +26,7 @@ let make_meta ?(name = "test-keeper") ?(soul_profile = "")
         ("trace_id", `String "test-trace-exposure");
         ("soul_profile", `String soul_profile);
         ("policy_voice_enabled", `Bool policy_voice_enabled);
-        ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist));
+        ("tool_access", Keeper_types.tool_access_to_json tool_access);
       ]
   in
   match Keeper_types.meta_of_json json with

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -12,11 +12,13 @@ open Masc_mcp
    ============================================================ *)
 
 let make_meta ?(name = "test-keeper") ?(soul_profile = "")
-    ?(policy_voice_enabled = false) ?(tool_allowlist = []) () : Keeper_types.keeper_meta =
+    ?(policy_voice_enabled = false) ?tool_access ?tool_allowlist ()
+    : Keeper_types.keeper_meta =
   let tool_access =
-    match tool_allowlist with
-    | [] -> Keeper_types.Unrestricted
-    | names -> Keeper_types.Restricted names
+    match tool_access, tool_allowlist with
+    | Some access, _ -> access
+    | None, Some names -> Keeper_types.Restricted names
+    | None, None -> Keeper_types.Unrestricted
   in
   let json =
     `Assoc
@@ -84,6 +86,14 @@ let test_default_has_research_tools () =
                      "masc_autoresearch_inject"; "masc_autoresearch_stop"] () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has autoresearch" true (has_any_prefix "masc_autoresearch_" tools)
+
+let test_explicit_empty_allowlist_blocks_masc_only () =
+  let meta = make_meta ~tool_access:(Keeper_types.Restricted []) () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "keeper tool still available" true
+    (has_tool "keeper_time_now" tools);
+  check bool "masc tool blocked" false
+    (has_tool "masc_status" tools)
 
 (* ============================================================
    3. Voice tools are always available
@@ -350,6 +360,8 @@ let () =
       test_case "has voice tools" `Quick test_default_has_voice;
       test_case "has governance tools" `Quick test_default_has_governance_tools;
       test_case "has research tools" `Quick test_default_has_research_tools;
+      test_case "explicit empty allowlist blocks masc only" `Quick
+        test_explicit_empty_allowlist_blocks_masc_only;
     ]);
     ("voice_profile", [
       test_case "enabled adds voice" `Quick test_voice_enabled_adds_voice_tools;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -12,11 +12,16 @@ let autoresearch_allowlist =
    "masc_research_start"; "masc_research_status"]
 
 let make_test_meta ?(name = "test-keeper") ?(tool_allowlist = []) () : Keeper_types.keeper_meta =
+  let tool_access =
+    match tool_allowlist with
+    | [] -> Keeper_types.Unrestricted
+    | names -> Keeper_types.Restricted names
+  in
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-001");
              ("allowed_paths", `List [`String "*"]);
-             ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist))]) with
+             ("tool_access", Keeper_types.tool_access_to_json tool_access)]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
 
@@ -245,12 +250,17 @@ let test_failure_tracking_is_independent_per_args () =
 
 let make_research_meta ?(tool_allowlist = autoresearch_allowlist) ()
     : Keeper_types.keeper_meta =
+  let tool_access =
+    match tool_allowlist with
+    | [] -> Keeper_types.Unrestricted
+    | names -> Keeper_types.Restricted names
+  in
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String "test-researcher");
              ("agent_name", `String "test-researcher");
              ("trace_id", `String "test-trace-research");
              ("soul_profile", `String "research");
-             ("tool_allowlist", `List (List.map (fun s -> `String s) tool_allowlist))]) with
+             ("tool_access", Keeper_types.tool_access_to_json tool_access)]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_research_meta failed: %s" e)
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -11,11 +11,13 @@ let autoresearch_allowlist =
    "masc_autoresearch_search_findings";
    "masc_research_start"; "masc_research_status"]
 
-let make_test_meta ?(name = "test-keeper") ?(tool_allowlist = []) () : Keeper_types.keeper_meta =
+let make_test_meta ?(name = "test-keeper") ?tool_access ?tool_allowlist ()
+    : Keeper_types.keeper_meta =
   let tool_access =
-    match tool_allowlist with
-    | [] -> Keeper_types.Unrestricted
-    | names -> Keeper_types.Restricted names
+    match tool_access, tool_allowlist with
+    | Some access, _ -> access
+    | None, Some names -> Keeper_types.Restricted names
+    | None, None -> Keeper_types.Unrestricted
   in
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
@@ -248,12 +250,12 @@ let test_failure_tracking_is_independent_per_args () =
             (is_guardrail_message message)
       | Ok _ -> fail "guardrail should block original failing args")
 
-let make_research_meta ?(tool_allowlist = autoresearch_allowlist) ()
+let make_research_meta ?tool_access ?(tool_allowlist = autoresearch_allowlist) ()
     : Keeper_types.keeper_meta =
   let tool_access =
-    match tool_allowlist with
-    | [] -> Keeper_types.Unrestricted
-    | names -> Keeper_types.Restricted names
+    match tool_access with
+    | Some access -> access
+    | None -> Keeper_types.Restricted tool_allowlist
   in
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String "test-researcher");


### PR DESCRIPTION
## Summary

This replaces keeper `tool_allowlist: string list` with an explicit `tool_access` ADT so the empty-list case is no longer semantically ambiguous.

## What Changed

- introduced `tool_access = Unrestricted | Restricted of string list` in keeper metadata
- updated keeper tool gating to pattern match on `tool_access`
- defaulted new keepers to `Unrestricted`
- kept backward-compatible JSON parsing for legacy `tool_allowlist`
- exposed `tool_access` through dashboard keeper JSON and dashboard tool mutation responses
- added dashboard support for `set_unrestricted` while keeping existing allowlist actions as `Restricted [...]`
- updated keeper test helpers and coverage to construct metadata through `tool_access`

## Why

`tool_allowlist = []` had already meant both “deny all” and “unrestricted” in different contexts. This PR makes the policy explicit in type space and removes that ambiguity from runtime logic.

## Impact

- keeper policy semantics are explicit and easier to reason about
- existing persisted keeper JSON still loads via the legacy `tool_allowlist` fallback
- dashboard/API consumers can move toward `tool_access` without losing the current allowlist view

## Validation

- `./_build/default/test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_keeper_safety_gates.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_masc_bridge.exe`
