### PR TITLE
feat(pulse): add set_rhythm/get_rhythm API for runtime interval update

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -113,6 +113,18 @@ let keeper_max_turn_failures =
     ~deserialize:deserialize_int
     ()
 
+let keeper_supervisor_sweep_sec =
+  Runtime_params.register
+    ~key:"keeper.supervisor_sweep_sec"
+    ~default:(fun () -> Env_config_keeper.KeeperSupervisor.sweep_interval_sec)
+    ~validate:(validate_float_range ~min:10.0 ~max:120.0 "keeper_supervisor_sweep_sec")
+    ~serialize:(fun v -> `Float v)
+    ~meta:{ description = "Supervisor sweep 주기(초)";
+            value_type = "float";
+            min_value = Some (`Float 10.0); max_value = Some (`Float 120.0) }
+    ~deserialize:deserialize_float
+    ()
+
 let keeper_supervisor_max_restarts =
   Runtime_params.register
     ~key:"keeper.supervisor_max_restarts"

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -139,6 +139,18 @@ let stop_supervisor_sweep base_path =
       Hashtbl.remove supervisor_sweeps base_path
     | None -> ())
 
+let update_supervisor_sweep_interval base_path interval_sec =
+  with_sweeps_ro (fun () ->
+    match Hashtbl.find_opt supervisor_sweeps base_path with
+    | Some pulse ->
+      let rhythm : Pulse.rhythm =
+        { base_s = interval_sec; min_s = interval_sec;
+          max_s = interval_sec; quiet = (0, 0) }
+      in
+      Pulse.set_rhythm pulse rhythm;
+      true
+    | None -> false)
+
 let start_supervisor_sweep ctx =
   let base_path = ctx.config.base_path in
   if supervisor_sweep_running base_path then ()
@@ -155,11 +167,12 @@ let start_supervisor_sweep ctx =
           Ok ()
       end)
     in
+    let sweep_sec = Runtime_params.get Governance_registry.keeper_supervisor_sweep_sec in
     let p = Pulse.create
       ~clock:ctx.clock
-      ~rhythm:{ Pulse.base_s = Env_config.KeeperSupervisor.sweep_interval_sec;
-                 min_s = Env_config.KeeperSupervisor.sweep_interval_sec;
-                 max_s = Env_config.KeeperSupervisor.sweep_interval_sec;
+      ~rhythm:{ Pulse.base_s = sweep_sec;
+                 min_s = sweep_sec;
+                 max_s = sweep_sec;
                  quiet = (0, 0) }
       ~lifecycle:Perpetual
       ~consumers:[consumer]
@@ -167,8 +180,7 @@ let start_supervisor_sweep ctx =
     with_sweeps_rw (fun () ->
       Hashtbl.replace supervisor_sweeps base_path p);
     Pulse.run ~sw:ctx.sw p;
-    Log.Keeper.info "keeper supervisor sweep started (interval %.0fs)"
-      Env_config.KeeperSupervisor.sweep_interval_sec
+    Log.Keeper.info "keeper supervisor sweep started (interval %.0fs)" sweep_sec
   end
 
 let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -64,7 +64,7 @@ let recovery_config_from_env () = {
 
 type t = {
   clock      : any_clock;
-  rhythm     : rhythm;
+  mutable rhythm : rhythm;
   lifecycle  : lifecycle;
   mutable consumers : (module Consumer) list;
   (* nudge signaling — Stream is cancellation-safe under Fiber.first *)
@@ -286,6 +286,13 @@ let nudge t ~reason =
 let shutdown t =
   if not (is_shutdown t) then
     Eio.Promise.resolve t.shutdown_r ()
+
+let set_rhythm t rhythm =
+  t.rhythm <- rhythm;
+  Log.Pulse.info "rhythm updated: base=%.1fs min=%.1fs max=%.1fs"
+    rhythm.base_s rhythm.min_s rhythm.max_s
+
+let get_rhythm t = t.rhythm
 
 let stats t =
   let uptime = (now t.clock) -. t.start_ts in

--- a/lib/pulse.mli
+++ b/lib/pulse.mli
@@ -110,6 +110,13 @@ val nudge : t -> reason:string -> unit
     automatically when the predicate returns true. *)
 val shutdown : t -> unit
 
+(** Update the rhythm configuration. Takes effect on the next beat cycle.
+    Non-yielding — safe to call from any fiber. *)
+val set_rhythm : t -> rhythm -> unit
+
+(** Current rhythm configuration. *)
+val get_rhythm : t -> rhythm
+
 (** {1 Queries} *)
 
 (** Current runtime statistics. *)

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -517,6 +517,57 @@ let () = test "circuit_breaker wrap_exn catches exceptions" (fun () ->
   assert (s.recent_failures = 1)
 )
 
+(* ── Test: set_rhythm updates interval ────────────────────── *)
+
+let () = test "set_rhythm changes interval" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 100.0; min_s = 50.0; max_s = 200.0; quiet = (0, 0) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.05;  (* startup beat *)
+  let before = (Pulse.stats t).total_beats in
+  (* Switch to fast rhythm via set_rhythm *)
+  Pulse.set_rhythm t { Pulse.base_s = 0.05; min_s = 0.03; max_s = 1.0; quiet = (0, 0) };
+  (* Nudge to break the current long sleep and pick up new rhythm *)
+  Pulse.nudge t ~reason:"rhythm-changed";
+  Eio.Time.sleep clock 0.4;
+  let after = (Pulse.stats t).total_beats in
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.1;
+  (* Rhythm beats should have accumulated from the fast interval *)
+  let gained = after - before in
+  if gained < 3 then
+    failwith (Printf.sprintf "expected >=3 beats after set_rhythm, got %d" gained)
+)
+
+(* ── Test: get_rhythm returns current value ──────────────── *)
+
+let () = test "get_rhythm returns current rhythm" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:Pulse.default_rhythm
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[]
+  in
+  let r = Pulse.get_rhythm t in
+  assert (r.base_s = 60.0);
+  assert (r.min_s = 30.0);
+  Pulse.set_rhythm t { Pulse.base_s = 15.0; min_s = 10.0; max_s = 60.0; quiet = (2, 5) };
+  let r2 = Pulse.get_rhythm t in
+  assert (r2.base_s = 15.0);
+  assert (r2.min_s = 10.0);
+  assert (r2.max_s = 60.0);
+  assert (r2.quiet = (2, 5))
+)
+
 (* ── Summary ───────────────────────────────────────────────── *)
 
 let () =


### PR DESCRIPTION
## Summary
- `Pulse.set_rhythm` / `Pulse.get_rhythm` API 추가 — runtime 중 beat interval 변경 가능
- `keeper.supervisor_sweep_sec` 파라미터를 Governance_registry에 등록 (범위: 10-120초)
- keeper_runtime에서 `update_supervisor_sweep_interval` 함수로 Pulse rhythm 업데이트

## Motivation
Closes #3904. Pulse 생성 시 rhythm이 baked-in되어 runtime 변경이 불가능했음. Runtime_params로 등록하더라도 실제 적용 경로가 없었음.

## Changes
| File | Change |
|------|--------|
| `lib/pulse.ml` | `rhythm` 필드 mutable + `set_rhythm`/`get_rhythm` 함수 |
| `lib/pulse.mli` | 시그니처 추가 |
| `lib/governance_registry.ml` | `keeper.supervisor_sweep_sec` float 파라미터 등록 |
| `lib/keeper/keeper_runtime.ml` | 초기값을 Governance_registry에서 읽기 + `update_supervisor_sweep_interval` |
| `test/test_pulse.ml` | 2 tests: interval 변경 확인, get_rhythm 값 확인 |

## Test plan
- [ ] 23/23 pulse tests pass locally
- [ ] CI green
- [ ] cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)