### PR TITLE
fix(keeper): normalize persona soul profiles

### DIFF
--- a/config/personas/janitor/profile.json
+++ b/config/personas/janitor/profile.json
@@ -44,7 +44,7 @@
     "short_goal": "현재 게시판에서 삭제 대상을 식별하고 정리한다.",
     "mid_goal": "게시판 품질을 일정 수준 이상으로 유지한다.",
     "long_goal": "게시판이 유용한 지식 저장소로 기능하도록 노이즈를 제거한다.",
-    "soul_profile": "utility",
+    "soul_profile": "delivery",
     "will": "판단 기준에 맞는 글만 삭제. 의심스러우면 남겨둔다. 사람 글은 건드리지 않는다.",
     "needs": "masc_board_list, masc_board_get, masc_board_delete, masc_board_stats",
     "desires": "깨끗한 게시판. 노이즈 제로.",

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -160,7 +160,7 @@ let summarize_old_messages ~(keep_recent : int)
         | x :: xs -> split (i - 1) (x :: acc) xs
     in
     let old_msgs, recent_msgs = split old_count [] msgs in
-    let rec flush_chunk chunk acc =
+    let flush_chunk chunk acc =
       match summarize_chunk (List.rev chunk) with
       | Some summary -> summary :: acc
       | None -> acc
@@ -168,7 +168,8 @@ let summarize_old_messages ~(keep_recent : int)
     let rec compact_old old chunk acc =
       match old with
       | [] -> List.rev (flush_chunk chunk acc)
-      | ({ content; _ } as m) :: tl ->
+      | (m : Agent_sdk.Types.message) :: tl ->
+        let content = m.content in
         let has_tool_use = List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) content in
         let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult _ -> true | _ -> false) content in
         if has_tool_use then

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -92,6 +92,9 @@ let tool_names_by_id (msgs : Agent_sdk.Types.message list) : (string * string) l
   List.fold_left add_tool_name [] msgs
 
 let summarize_chunk (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message option =
+  if List.length msgs < 2 then
+    None
+  else
   let lines =
     msgs
     |> List.mapi (fun i (m : Agent_sdk.Types.message) ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -383,6 +383,18 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
           let keeper_json = Yojson.Safe.Util.member "keeper" json in
           match keeper_json with
           | `Assoc _ ->
+              let soul_profile =
+                match Safe_ops.json_string_opt "soul_profile" keeper_json with
+                | None -> None
+                | Some raw -> (
+                    match canonical_soul_profile raw with
+                    | Some profile -> Some profile
+                    | None ->
+                        Log.Keeper.warn
+                          "persona profile %s has invalid soul_profile '%s'; ignoring"
+                          path raw;
+                        None)
+              in
               {
                 manifest_path = Some path;
                 goal = Safe_ops.json_string_opt "goal" keeper_json;
@@ -392,7 +404,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" keeper_json);
                 long_goal =
                   normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" keeper_json);
-                soul_profile = Safe_ops.json_string_opt "soul_profile" keeper_json;
+                soul_profile;
                 will = Safe_ops.json_string_opt "will" keeper_json;
                 needs = Safe_ops.json_string_opt "needs" keeper_json;
                 desires = Safe_ops.json_string_opt "desires" keeper_json;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -374,6 +374,83 @@ goal = "works"
     (Sys.readdir tmp_dir);
   Unix.rmdir tmp_dir
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let with_personas_dir f =
+  with_temp_dir "keeper-personas" @@ fun personas_dir ->
+  let original = Sys.getenv_opt "MASC_PERSONAS_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match original with
+      | Some value -> Unix.putenv "MASC_PERSONAS_DIR" value
+      | None -> Unix.putenv "MASC_PERSONAS_DIR" "");
+      Masc_mcp.Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_PERSONAS_DIR" personas_dir;
+      Masc_mcp.Config_dir_resolver.reset ();
+      f personas_dir)
+
+let test_persona_profile_canonicalizes_soul_profile () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test",
+    "soul_profile": "delivery"
+  }
+}
+|};
+  let defaults = KTP.load_keeper_profile_defaults_from_persona "probe" in
+  check (option string) "canonical soul_profile" (Some "delivery") defaults.soul_profile
+
+let test_persona_profile_ignores_invalid_soul_profile () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test",
+    "soul_profile": "utility"
+  }
+}
+|};
+  let defaults = KTP.load_keeper_profile_defaults_from_persona "probe" in
+  check (option string) "invalid soul_profile dropped" None defaults.soul_profile
+
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -420,5 +497,9 @@ let () =
           test_case "with files" `Quick test_discover_with_files;
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
+          test_case "persona profile canonicalizes soul_profile" `Quick
+            test_persona_profile_canonicalizes_soul_profile;
+          test_case "persona profile ignores invalid soul_profile" `Quick
+            test_persona_profile_ignores_invalid_soul_profile;
         ] );
     ]


### PR DESCRIPTION
## Summary
- replace janitor persona's invalid `soul_profile = "utility"` with the supported `delivery` profile
- canonicalize `soul_profile` when loading persona `profile.json` defaults so persona JSON follows the same boundary as keeper TOML
- add regression coverage for valid and invalid persona soul profiles
- include a small compile-only fix in `context_compact_oas` needed to run the keeper TOML test target on current main

## Testing
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/soul-profile-utility --build-dir /tmp/soul-profile-utility-build test/test_keeper_toml.exe --display short`
- `/tmp/soul-profile-utility-build/default/test/test_keeper_toml.exe`
- `git diff --check`