### PR TITLE
chore: remove last mitosis and sentinel dead code

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -63,9 +63,6 @@ jobs:
           {
             "governance_judge_models": ["glm:glm-4.7-flash"],
             "operator_judge_models": ["glm:glm-4.7-flash"],
-            "sentinel_board_models": ["glm:glm-4.7-flash"],
-            "sentinel_task_models": ["glm:glm-4.7-flash"],
-            "sentinel_keeper_models": ["glm:glm-4.7-flash"],
             "heartbeat_action_models": ["glm:glm-4.7-flash"],
             "heartbeat_wake_models": ["glm:glm-4.7-flash"],
             "autonomy_direct_models": ["glm:glm-4.7-flash"],

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -265,26 +265,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
           ];
     };
     {
-      Types.name = "masc_memento_mori";
-      description =
-        "Check context pressure and auto-handle prepare or handoff when thresholds are crossed.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("context_ratio", `Assoc [ ("type", `String "number") ]);
-                  ("full_context", `Assoc [ ("type", `String "string") ]);
-                  ("summary", `Assoc [ ("type", `String "string") ]);
-                  ("current_task", `Assoc [ ("type", `String "string") ]);
-                  ("target_agent", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "context_ratio" ]);
-          ];
-    };
-    {
       Types.name = "keeper_research";
       description = "Research a topic using the MODEL and share findings with the board.";
       input_schema =


### PR DESCRIPTION
## Summary
- `agent_tool_surfaces.ml`에서 `masc_memento_mori` dead schema 삭제 (dispatch handler 없음, #3883에서 제거됨)
- `deploy-railway.yml`에서 `sentinel_board/task/keeper_models` dead config 삭제 (OCaml 소비 코드 없음)

## Context
Mitosis runtime removal (#3883) + legacy agent cleanup 최종 잔여물.
이 PR 후 codebase에 mitosis/sentinel/gardener/guardian 코드가 완전히 없어짐 (제거 검증 테스트 제외).

## Test plan
- [ ] CI green (기존 `test_legacy_mitosis_tools_removed` 테스트가 여전히 pass)
- [ ] deploy-railway.yml JSON 유효성

🤖 Generated with [Claude Code](https://claude.com/claude-code)