### PR TITLE
fix: resolve main build break in context_compact_oas.ml

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -160,7 +160,7 @@ let summarize_old_messages ~(keep_recent : int)
         | x :: xs -> split (i - 1) (x :: acc) xs
     in
     let old_msgs, recent_msgs = split old_count [] msgs in
-    let rec flush_chunk chunk acc =
+    let flush_chunk chunk acc =
       match summarize_chunk (List.rev chunk) with
       | Some summary -> summary :: acc
       | None -> acc
@@ -168,7 +168,8 @@ let summarize_old_messages ~(keep_recent : int)
     let rec compact_old old chunk acc =
       match old with
       | [] -> List.rev (flush_chunk chunk acc)
-      | ({ content; _ } as m) :: tl ->
+      | (m : Agent_sdk.Types.message) :: tl ->
+        let content = m.content in
         let has_tool_use = List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) content in
         let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult _ -> true | _ -> false) content in
         if has_tool_use then


### PR DESCRIPTION
## Summary
- main에서 `dune build`를 막고 있던 `lib/context_compact_oas.ml` compile break를 복구했습니다.
- `flush_chunk`의 불필요한 `rec`를 제거했습니다.
- `compact_old`에서 `Agent_sdk.Types.message`를 명시적으로 타입 주석 처리하고 `m.content`로 접근해 record field disambiguation 오류를 없앴습니다.

## Root cause
- `compact_old`의 pattern match가 `content` record field를 punning으로 해석하는 과정에서 scope 내 다른 record labels와 충돌했습니다.
- 동시에 `flush_chunk`는 재귀 호출이 없는데 `rec`가 남아 있어 warnings-as-errors 환경에서 즉시 build를 깨고 있었습니다.

## Product impact
- unrelated draft PR들도 `Lint`와 `Build and Test`에서 선행 compile 단계에서 막히던 상태를 해소합니다.
- `#4061` 같은 후속 keeper/tooling PR이 실제 diff 기준으로 검증될 수 있게 됩니다.

## Evidence
- local compile target passed on `2026-03-31 02:08:16 KST`:
  - `env -u DUNE_RPC opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4066-build-break --build-dir /tmp/masc-4066-filecheck lib/.masc_mcp.objs/byte/masc_mcp__Context_compact_oas.cmo`
  - `env -u DUNE_RPC opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4066-build-break --build-dir /tmp/masc-4066-filecheck lib/.masc_mcp.objs/native/masc_mcp__Context_compact_oas.cmx`
- issue repro from `main` matched CI failures before the fix:
  - `Build and Test` job `69213813034`
  - `Lint` job `69213812996`

## Review evidence
- direct `sb glm-text` review on PR diff at `2026-03-31 02:08:16 KST`: `No findings.`

## Linked issue
- Closes #4066
