### PR TITLE
feat(dashboard): governance param audit trail + rollback UI

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -289,6 +289,24 @@ export function clearRuntimeParam(paramKey: string): Promise<{ ok: boolean; mess
   return post('/api/v1/governance/params/clear', { param_key: paramKey })
 }
 
+export interface ParamAuditEntry {
+  timestamp: number
+  key: string
+  old_value: unknown
+  new_value: unknown
+  actor: string
+  case_id?: string
+}
+
+export interface ParamAuditResponse {
+  entries: ParamAuditEntry[]
+  count: number
+}
+
+export function fetchParamAudit(limit = 50): Promise<ParamAuditResponse> {
+  return get(`/api/v1/governance/params/audit?limit=${limit}`)
+}
+
 export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
   return get('/api/v1/dashboard/mission')
 }

--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -3,6 +3,7 @@ import {
   decideGovernanceExecutionOrder,
   fetchDashboardGovernance,
   fetchGovernanceCaseStatus,
+  fetchParamAudit,
   fetchRuntimeParams,
   submitGovernanceCaseBrief,
   submitGovernancePetition,
@@ -27,6 +28,8 @@ import {
   runtimeParams,
   runtimeSurfaces,
   runtimeLoading,
+  paramAuditEntries,
+  paramAuditLoading,
 } from './governance-signals'
 
 async function loadDecisionDetail(item: GovernanceDecisionItem | null) {
@@ -135,5 +138,17 @@ export async function loadRuntimeParams() {
     console.debug('[governance] runtime params load failed (optional)', err instanceof Error ? err.message : err)
   } finally {
     runtimeLoading.value = false
+  }
+}
+
+export async function loadParamAudit(limit = 50) {
+  paramAuditLoading.value = true
+  try {
+    const data = await fetchParamAudit(limit)
+    paramAuditEntries.value = data.entries ?? []
+  } catch (err) {
+    console.debug('[governance] param audit load failed (optional)', err instanceof Error ? err.message : err)
+  } finally {
+    paramAuditLoading.value = false
   }
 }

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -20,7 +20,7 @@ import {
   orderStatusLabel,
   stanceLabel,
 } from './governance-utils'
-import { ActivityRail } from './governance-strips'
+import { ActivityRail, ParamAuditTrail } from './governance-strips'
 
 export function PetitionEntry({ petition }: { petition: GovernanceCaseBundle['petitions'][number] }) {
   return html`
@@ -99,6 +99,7 @@ export function DecisionDetail() {
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}
               </div>
               <${ActivityRail} />
+              <${ParamAuditTrail} />
             `}
     <//>
   `

--- a/dashboard/src/components/governance-signals.ts
+++ b/dashboard/src/components/governance-signals.ts
@@ -3,7 +3,7 @@ import type {
   DashboardGovernanceResponse,
   GovernanceCaseBundle,
 } from '../types'
-import type { RuntimeParam, RuntimeParamsSurface } from '../api'
+import type { RuntimeParam, RuntimeParamsSurface, ParamAuditEntry } from '../api'
 import type { GovernanceFilter } from './governance-utils'
 
 export const governanceLoading = signal(false)
@@ -23,3 +23,5 @@ export const detailLoading = signal(false)
 export const runtimeParams = signal<RuntimeParam[]>([])
 export const runtimeSurfaces = signal<RuntimeParamsSurface[]>([])
 export const runtimeLoading = signal(false)
+export const paramAuditEntries = signal<ParamAuditEntry[]>([])
+export const paramAuditLoading = signal(false)

--- a/dashboard/src/components/governance-store.ts
+++ b/dashboard/src/components/governance-store.ts
@@ -17,6 +17,8 @@ export {
   runtimeParams,
   runtimeSurfaces,
   runtimeLoading,
+  paramAuditEntries,
+  paramAuditLoading,
 } from './governance-signals'
 export {
   selectDecision,
@@ -25,4 +27,5 @@ export {
   submitBrief,
   respondToExecutionOrder,
   loadRuntimeParams,
+  loadParamAudit,
 } from './governance-actions'

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -15,7 +15,11 @@ import {
   runtimeParams,
   runtimeSurfaces,
   loadRuntimeParams,
+  paramAuditEntries,
+  paramAuditLoading,
+  loadParamAudit,
 } from './governance-store'
+import type { ParamAuditEntry } from '../api'
 import {
   activityKindLabel,
   formatParamValue,
@@ -215,4 +219,63 @@ export function RuntimeParamsPanel() {
           `}
     <//>
   `
+}
+
+export function ParamAuditTrail() {
+  const entries = paramAuditEntries.value
+  const loading = paramAuditLoading.value
+
+  if (entries.length === 0 && !loading) return null
+
+  return html`
+    <${Card} title="파라미터 변경 이력" class="section mb-4">
+      ${loading
+        ? html`<${LoadingState}>이력 로딩 중...<//>`
+        : html`
+            <div class="flex flex-col gap-1.5">
+              ${entries.slice(0, 20).map((entry: ParamAuditEntry) => html`
+                <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-white/3 border border-card-border">
+                  <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs font-mono text-accent truncate">${entry.key}</span>
+                      <span class="text-[10px] text-text-dim"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                    </div>
+                    <div class="flex items-center gap-1 text-[11px]">
+                      <span class="text-text-muted">${formatAuditValue(entry.old_value)}</span>
+                      <span class="text-text-dim">${'\u2192'}</span>
+                      <span class="text-text-strong">${formatAuditValue(entry.new_value)}</span>
+                      <span class="text-text-dim ml-1">by ${entry.actor}</span>
+                    </div>
+                  </div>
+                  <button
+                    class="text-[10px] py-0.5 px-2 rounded bg-white/5 text-text-muted hover:bg-white/10 cursor-pointer border-none shrink-0 ml-2"
+                    onClick=${() => rollbackParam(entry)}
+                  >되돌리기</button>
+                </div>
+              `)}
+            </div>
+          `}
+    <//>
+  `
+}
+
+function formatAuditValue(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+async function rollbackParam(entry: ParamAuditEntry) {
+  try {
+    const res = await setRuntimeParam(entry.key, entry.old_value, 'rollback from audit trail')
+    if (res.ok) {
+      showToast('파라미터를 이전 값으로 되돌렸습니다', 'success')
+      void loadRuntimeParams()
+      void loadParamAudit()
+    } else {
+      showToast(res.message || '되돌리기 실패', 'error')
+    }
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : '되돌리기 실패', 'error')
+  }
 }

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -21,6 +21,7 @@ import {
   selectedDecisionKey,
   submitBrief,
   submitPetition,
+  loadParamAudit,
 } from './governance-store'
 import {
   caseStatusLabel,
@@ -35,7 +36,7 @@ import {
 } from './governance-panels'
 
 // Re-export for consumers that import from './governance'
-export { refreshGovernance, loadRuntimeParams } from './governance-store'
+export { refreshGovernance, loadRuntimeParams, loadParamAudit } from './governance-store'
 
 function GovernanceSummaryStrip() {
   const data = governanceData.value
@@ -271,6 +272,7 @@ function JudgmentsSection() {
 export function Governance() {
   useEffect(() => {
     void refreshGovernance()
+    void loadParamAudit()
   }, [])
 
   return html`

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -87,6 +87,18 @@ let add_routes ~sw ~clock router =
          Http.Response.json body reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/governance/params/audit" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+         let entries = Runtime_params.recent_audit ~base_path limit in
+         let json = `Assoc [
+           ("entries", `List entries);
+           ("count", `Int (List.length entries));
+         ] in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let hearth = query_param req "hearth" in


### PR DESCRIPTION
## Summary
- `GET /api/v1/governance/params/audit?limit=N` API 엔드포인트 추가
- ParamAuditTrail 대시보드 컴포넌트: 파라미터 변경 이력 표시 + 되돌리기 버튼
- Governance 페이지 초기 로딩 시 audit trail 자동 로드

## Motivation
Closes #3906. param_audit.jsonl에 기록되는 파라미터 변경 이력이 대시보드에서 보이지 않았음.

## Changes
| Area | Files | Description |
|------|-------|-------------|
| Backend | `server_routes_http_routes_activity.ml` | audit API endpoint |
| API Client | `api/dashboard.ts` | `fetchParamAudit` + types |
| Signals | `governance-signals.ts` | `paramAuditEntries`, `paramAuditLoading` |
| Actions | `governance-actions.ts` | `loadParamAudit` |
| UI | `governance-strips.ts` | `ParamAuditTrail` + rollback handler |
| Mount | `governance-detail.ts`, `governance.ts` | 컴포넌트 마운트 + 초기 로딩 |

## Test plan
- [ ] OCaml backend builds (our file compiles clean, pre-existing error in context_compact_oas.ml)
- [ ] Dashboard TypeScript type check passes
- [ ] CI green
- [ ] cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)