### PR TITLE
refactor(keeper): remove unused params and mutable ref in social model

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -168,13 +168,12 @@ let summarize_old_messages ~(keep_recent : int)
       | Some summary -> summary :: acc
       | None -> acc
     in
-    let rec compact_old old chunk acc =
+    let rec compact_old (old : Agent_sdk.Types.message list) chunk acc =
       match old with
       | [] -> List.rev (flush_chunk chunk acc)
-      | (m : Agent_sdk.Types.message) :: tl ->
-        let content = m.content in
-        let has_tool_use = List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) content in
-        let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult _ -> true | _ -> false) content in
+      | m :: tl ->
+        let has_tool_use = List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) m.content in
+        let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult _ -> true | _ -> false) m.content in
         if has_tool_use then
           compact_old tl [] (m :: flush_chunk chunk acc)
         else if has_tool_result then

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -121,28 +121,35 @@ let nonempty_header_opt headers key =
 
 let belief_summary_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
-  let beliefs = ref [] in
-  let add value =
-    if String.trim value <> "" then beliefs := value :: !beliefs
+  let parts =
+    List.filter_map Fun.id [
+      (if observation.pending_mentions <> [] then
+         Some (Printf.sprintf "mentions=%d" (List.length observation.pending_mentions))
+       else None);
+      (if observation.pending_board_events <> [] then
+         Some (Printf.sprintf "board_events=%d"
+                 (List.length observation.pending_board_events))
+       else None);
+      (if observation.unclaimed_task_count > 0 then
+         Some (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count)
+       else None);
+      (if observation.failed_task_count > 0 then
+         Some (Printf.sprintf "failed_tasks=%d" observation.failed_task_count)
+       else None);
+      (if observation.active_goals <> [] then
+         Some (Printf.sprintf "active_goals=%d" (List.length observation.active_goals))
+       else None);
+      (if observation.idle_seconds > 0 then
+         Some (Printf.sprintf "idle=%ds" observation.idle_seconds)
+       else None);
+      (if Option.is_some observation.worktree_change_summary then
+         Some "worktree_delta"
+       else None);
+    ]
   in
-  if observation.pending_mentions <> [] then
-    add (Printf.sprintf "mentions=%d" (List.length observation.pending_mentions));
-  if observation.pending_board_events <> [] then
-    add
-      (Printf.sprintf "board_events=%d"
-         (List.length observation.pending_board_events));
-  if observation.unclaimed_task_count > 0 then
-    add (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count);
-  if observation.failed_task_count > 0 then
-    add (Printf.sprintf "failed_tasks=%d" observation.failed_task_count);
-  if observation.active_goals <> [] then
-    add (Printf.sprintf "active_goals=%d" (List.length observation.active_goals));
-  if observation.idle_seconds > 0 then
-    add (Printf.sprintf "idle=%ds" observation.idle_seconds);
-  if Option.is_some observation.worktree_change_summary then add "worktree_delta";
-  match List.rev !beliefs with
+  match parts with
   | [] -> "quiet_room"
-  | values -> String.concat "; " values
+  | _ -> String.concat "; " parts
 
 let protocol_violation_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation) ~(reason : string)
@@ -159,10 +166,7 @@ let protocol_violation_state ~(meta : keeper_meta)
   }
 
 let social_state_of_headers ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) headers
-    ~response_body ~(tools_used : string list) =
-  let _ = response_body in
-  let _ = tools_used in
+    ~(observation : Keeper_world_observation.world_observation) headers =
   match nonempty_header_opt headers "SPEECH_ACT", header_assoc_opt headers "DELIVERY_SURFACE" with
   | Some speech_raw, Some delivery_raw -> (
       match
@@ -257,14 +261,12 @@ let deliver_request_help_post ~(meta : keeper_meta) ~(state : social_state) =
       | Ok _ -> Request_help_posted
       | Error _ -> Request_help_failed
 
-let apply_to_result ~(config : Room.config) ~(meta : keeper_meta)
+let apply_to_result ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     (result : Keeper_agent_run.run_result) =
-  let _ = config in
   let headers, response_body = parse_header_block result.response_text in
   let state =
-    social_state_of_headers ~meta ~observation headers ~response_body
-      ~tools_used:result.tools_used
+    social_state_of_headers ~meta ~observation headers
   in
   match state.speech_act, state.delivery_surface with
   | Request_help, Board_post when result.tools_used = [] ->

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -43,7 +43,6 @@ val derive_failure_state :
   social_state
 
 val apply_to_result :
-  config:Room.config ->
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   Keeper_agent_run.run_result ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -540,7 +540,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           Error e
       | Ok result ->
           let result, social_state =
-            Social.apply_to_result ~config ~meta ~observation result
+            Social.apply_to_result ~meta ~observation result
           in
           let used_model_id =
             let strip_latest s =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -502,9 +502,8 @@ let test_metrics_persist_social_state_fields () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Room.default_config base_dir in
       let routed, social_state =
-        KSM.apply_to_result ~config ~meta:minimal_meta
+        KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation result
       in
       let updated =
@@ -652,9 +651,8 @@ let test_social_model_silences_skip_only_turn () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Room.default_config base_dir in
       let routed, state =
-        KSM.apply_to_result ~config ~meta:minimal_meta
+        KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation result
       in
       check string "speech act" "stay_silent"
@@ -673,9 +671,8 @@ let test_social_model_requires_explicit_headers () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Room.default_config base_dir in
       let routed, state =
-        KSM.apply_to_result ~config ~meta:minimal_meta
+        KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation result
       in
       check string "speech act" "defer"
@@ -708,7 +705,7 @@ let test_social_model_routes_blocker_to_board_post () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
       let routed, state =
-        KSM.apply_to_result ~config ~meta:minimal_meta
+        KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation result
       in
       let posts =


### PR DESCRIPTION
## Summary
- `apply_to_result`에서 미사용 `~config` 파라미터 제거 (API + .mli + caller 1곳)
- 내부 `social_state_of_headers`에서 `~response_body`, `~tools_used` 제거 (즉시 `let _ =`로 버려지던 값)
- `belief_summary_of_observation`의 mutable `ref []` → `List.filter_map` 함수형 구성
- `context_compact_oas.ml` main 빌드 에러 수정 (타입 주석 + unused rec flag)

## Test plan
- [x] 58/58 council 테스트 통과
- [x] 36/36 keeper unified 테스트 통과
- [ ] CI Build and Test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)