### PR TITLE
fix: resolve main build break in context_compact_oas.ml

### DIFF
--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -102,6 +102,8 @@ let test_compact_summarize_old () =
 let test_summarize_old_masks_tool_results_but_preserves_pairing () =
   let tool_id = "call-123" in
   let msgs = [
+    msg Agent_sdk.Types.User "Start by checking the project layout.";
+    msg Agent_sdk.Types.Assistant "The project has lib/ and test/ directories.";
     msg Agent_sdk.Types.User "Find all reducer references in lib/.";
     tool_use_msg ~id:tool_id ~name:"grep_search" ();
     tool_msg ~id:tool_id "3 matches in lib/\nlib/context_compact_oas.ml\nlib/tool_compact.ml";


### PR DESCRIPTION
## Summary
- main `dune build` 실패하는 문제 수정 (#4066)
- `context_compact_oas.ml:172`에서 타입 annotation 추가 (record field disambiguation)
- `test_context_compact_oas_coverage.ml`: SummarizeOld 테스트에 old 메시지 추가 (count reduction 검증)

Closes #4066

Generated with [Claude Code](https://claude.com/claude-code)