### PR TITLE
refactor: replace let _ = with explicit naming in 3 modules

### DIFF
--- a/lib/council/loop_guard.ml
+++ b/lib/council/loop_guard.ml
@@ -101,12 +101,10 @@ let check_floor ~floor_holder ~speaker =
   match floor_holder with
   | None -> None  (* No floor holder = open floor *)
   | Some holder when holder = speaker -> None  (* Speaker has the floor *)
-  | Some holder ->
-      (* Allow response if floor holder addressed the speaker *)
-      (* For now, allow anyone to speak (relaxed floor) *)
-      (* Future: enforce strict floor with yield/request *)
-      let _ = holder in  (* Suppress unused warning *)
-      None  (* Relaxed: anyone can respond *)
+  | Some _holder ->
+      (* Relaxed floor: anyone can respond.
+         Future: enforce strict floor with yield/request. *)
+      None
 
 (** {1 Main Check Function} *)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -124,7 +124,7 @@ let spawn_orchestrator ~sw:_ ~proc_mgr:_ ?domain_mgr:_ config room_config =
   end else begin
   Log.Orchestrator.info "spawning agent: %s (with MCP tools)" config.orchestrator_agent;
 
-  let _ = Room.broadcast room_config ~from_agent:"system"
+  let _msg = Room.broadcast room_config ~from_agent:"system"
     ~content:"Auto-orchestrator activated - spawning coordinator with MCP tools" in
 
   let prompt = make_orchestrator_prompt ~port:config.port in

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -52,7 +52,7 @@ let handle_relay_checkpoint _ctx args =
      Log.Misc.info "[RELAY] active_goal_ids provided but not persisted (goal store not integrated): %s"
        (String.concat "," goal_ids));
   let metrics = Relay.estimate_context ~messages ~tool_calls ~model:"claude" in
-  let _ = Relay.save_checkpoint ~summary ~task:current_task ~todos ~pdca:pdca_state ~files:relevant_files ~metrics in
+  let _cp = Relay.save_checkpoint ~summary ~task:current_task ~todos ~pdca:pdca_state ~files:relevant_files ~metrics in
   let json = `Assoc [
     ("status", `String "checkpoint_saved");
     ("usage_ratio", `Float metrics.Relay.usage_ratio);


### PR DESCRIPTION
## Summary
Backlog items #5, #6, #7을 하나의 PR로 묶음 (각 1줄 변경):
- `tool_relay.ml`: `let _cp =` (save_checkpoint는 in-memory, 실패 없음)
- `orchestrator.ml`: `let _msg =` (broadcast returns string)
- `loop_guard.ml`: `Some _holder ->` 패턴 매칭으로 unused-var hack 제거

## Test plan
- [x] 빌드 통과
- [x] 5/5 LoopGuard 테스트 통과
- [ ] CI Build and Test 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)