### PR TITLE
refactor: consolidate dedupe_keep_order to Json_util SSOT

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -215,16 +215,6 @@ let tempo_section (config : Room_utils.config) : section =
   let content = [Tempo.format_state state] in
   { title = "Tempo"; content; empty_msg = "" }
 
-let dedupe_keep_order strings =
-  let seen = Hashtbl.create 16 in
-  List.filter (fun value ->
-    if Hashtbl.mem seen value then false
-    else (
-      Hashtbl.add seen value ();
-      true
-    )
-  ) strings
-
 let ordered_room_ids (config : Room_utils.config) =
   let current_room = Room.current_room_id config in
   (current_room, [ current_room ])

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -49,7 +49,7 @@ let trim_nonempty value =
 let dedupe_keep_order values =
   values
   |> List.filter_map trim_nonempty
-  |> Provider_adapter.dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let string_of_run_status = function
   | Queued -> "queued"

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -468,17 +468,6 @@ let nonempty_env name =
 
 let env_present name = Option.is_some (nonempty_env name)
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item then
-        false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-
 let bare_ollama_migration_message () =
   "Bare `ollama` is no longer supported. Use `default` for normal selection, or `llama:<model>` / another explicit provider:model label as an override."
 
@@ -571,7 +560,7 @@ let default_model_label_for_family = function
       Error "Custom provider requires explicit runtime_model"
 
 let preferred_execution_model_labels () =
-  dedupe_keep_order
+  Json_util.dedupe_keep_order
     (List.filter_map
        Fun.id
        [
@@ -600,7 +589,7 @@ let preferred_execution_model_labels () =
        ])
 
 let preferred_verifier_model_labels () =
-  dedupe_keep_order
+  Json_util.dedupe_keep_order
     (List.filter_map
        Fun.id
        [


### PR DESCRIPTION
## Summary
`dedupe_keep_order` 함수가 5곳에서 독립 정의. `Json_util.dedupe_keep_order`를 SSOT로 지정하고 2개 중복 제거:
- `dashboard.ml`: 정의만 있고 caller 없음 → 삭제
- `provider_adapter.ml`: 정의 삭제, caller 2곳 `Json_util.dedupe_keep_order`로 교체
- `dashboard_provider_runs.ml`: `Provider_adapter.dedupe_keep_order` → `Json_util.dedupe_keep_order`

남은 정의 (`keeper_types_profile.ml`, `voice_config.ml`)는 follow-up 대상.

## Test plan
- [x] 빌드 통과
- [ ] CI Build and Test 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)