### PR TITLE
[codex] restore team-session spawned worker runtime flow

### DIFF
--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -37,10 +37,12 @@ let requested_mode_of_repair_budget repair_budget =
   else Oas.Execution_mode.Draft
 
 let of_delivery_contract
+    ~execution_scope
     ~(delivery_contract : Team_session_types.delivery_contract)
     ~(tool_names : string list) : Oas.Risk_contract.t =
   let risk_class =
-    Contract_risk.of_delivery_contract ~delivery_contract ~tool_names
+    Contract_risk.of_delivery_contract ~execution_scope ~delivery_contract
+      ~tool_names
   in
   {
     Oas.Risk_contract.runtime_constraints =

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -10,11 +10,17 @@ let workspace_mutating_tools =
     "file_write";
   ]
 
-let is_workspace_mutating name =
-  List.mem name workspace_mutating_tools
+let workspace_mutating_tools_for_scope = function
+  | Some Team_session_types.Observe_only ->
+      List.filter (fun name -> not (String.equal name "file_write"))
+        workspace_mutating_tools
+  | _ -> workspace_mutating_tools
 
-let allowed_mutations_of_tool_names tool_names =
-  List.filter is_workspace_mutating tool_names
+let is_workspace_mutating ~execution_scope name =
+  List.mem name (workspace_mutating_tools_for_scope execution_scope)
+
+let allowed_mutations_of_tool_names ~execution_scope tool_names =
+  List.filter (is_workspace_mutating ~execution_scope) tool_names
 
 let review_requirement_of_risk_class = function
   | Oas.Risk_class.High | Oas.Risk_class.Critical -> Some "human_review"
@@ -50,7 +56,8 @@ let of_delivery_contract
         requested_execution_mode =
           requested_mode_of_repair_budget delivery_contract.repair_budget;
         risk_class;
-        allowed_mutations = allowed_mutations_of_tool_names tool_names;
+        allowed_mutations =
+          allowed_mutations_of_tool_names ~execution_scope tool_names;
         review_requirement = review_requirement_of_risk_class risk_class;
       };
     eval_criteria = build_delivery_eval_criteria delivery_contract;

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -7,6 +7,7 @@ let workspace_mutating_tools =
     "keeper_write";
     "create_text_file";
     "edit_text_file";
+    "file_write";
   ]
 
 let is_workspace_mutating name =

--- a/lib/cdal_contract_bridge.mli
+++ b/lib/cdal_contract_bridge.mli
@@ -7,6 +7,7 @@ val is_workspace_mutating : string -> bool
 val allowed_mutations_of_tool_names : string list -> string list
 
 val of_delivery_contract :
+  execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
   Agent_sdk.Risk_contract.t

--- a/lib/cdal_contract_bridge.mli
+++ b/lib/cdal_contract_bridge.mli
@@ -2,9 +2,13 @@
 
 val workspace_mutating_tools : string list
 
-val is_workspace_mutating : string -> bool
+val is_workspace_mutating :
+  execution_scope:Team_session_types.execution_scope option -> string -> bool
 
-val allowed_mutations_of_tool_names : string list -> string list
+val allowed_mutations_of_tool_names :
+  execution_scope:Team_session_types.execution_scope option ->
+  string list ->
+  string list
 
 val of_delivery_contract :
   execution_scope:Team_session_types.execution_scope option ->

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -188,7 +188,8 @@ let classify_with_contract_risk ~tool_name ~input =
           let tool_names = tool_names_of_input ~tool_name input in
           Some
             (risk_level_of_contract_risk
-               (Contract_risk.of_delivery_contract ~delivery_contract ~tool_names))
+               (Contract_risk.of_delivery_contract ~execution_scope:None
+                  ~delivery_contract ~tool_names))
       | None -> None)
   | _ -> None
 

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -311,10 +311,13 @@ let execute_team_action (ctx : 'a context) (request : action_request) =
         | `List _ as xs -> Ok xs
         | _ -> Error "payload.spawn_batch is required"
       in
-      let wait_mode =
+      let* wait_mode =
         match get_string_opt request.payload "wait_mode" with
-        | Some value -> value
-        | None -> "blocking"
+        | None -> Ok "blocking"
+        | Some ("background" | "blocking" as v) -> Ok v
+        | Some other ->
+            Error (Printf.sprintf
+              "payload.wait_mode must be \"background\" or \"blocking\", got %S" other)
       in
       let args =
         `Assoc

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -313,20 +313,26 @@ let execute_team_action (ctx : 'a context) (request : action_request) =
       in
       let* wait_mode =
         match get_string_opt request.payload "wait_mode" with
-        | None -> Ok "blocking"
-        | Some ("background" | "blocking" as v) -> Ok v
+        | None -> Ok None
+        | Some ("background" | "blocking" as v) -> Ok (Some v)
         | Some other ->
             Error (Printf.sprintf
               "payload.wait_mode must be \"background\" or \"blocking\", got %S" other)
       in
       let args =
-        `Assoc
+        let base_fields =
           [
             ("session_id", `String session_id);
             ("actor", `String request.actor);
-            ("wait_mode", `String wait_mode);
             ("spawn_batch", spawn_batch);
           ]
+        in
+        let fields =
+          match wait_mode with
+          | Some value -> ("wait_mode", `String value) :: base_fields
+          | None -> base_fields
+        in
+        `Assoc fields
       in
       let* result_json =
         dispatch_team_session_json_as ctx ~session_id ~requested_actor:request.actor

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -313,7 +313,7 @@ let execute_team_action (ctx : 'a context) (request : action_request) =
       in
       let* wait_mode =
         match get_string_opt request.payload "wait_mode" with
-        | None -> Ok (Some "blocking")
+        | None -> Ok None
         | Some ("background" | "blocking" as v) -> Ok (Some v)
         | Some other ->
             Error (Printf.sprintf

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -312,7 +312,9 @@ let execute_team_action (ctx : 'a context) (request : action_request) =
         | _ -> Error "payload.spawn_batch is required"
       in
       let wait_mode =
-        get_string request.payload "wait_mode" "blocking"
+        match get_string_opt request.payload "wait_mode" with
+        | Some value -> value
+        | None -> "blocking"
       in
       let args =
         `Assoc

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -313,7 +313,7 @@ let execute_team_action (ctx : 'a context) (request : action_request) =
       in
       let* wait_mode =
         match get_string_opt request.payload "wait_mode" with
-        | None -> Ok None
+        | None -> Ok (Some "blocking")
         | Some ("background" | "blocking" as v) -> Ok (Some v)
         | Some other ->
             Error (Printf.sprintf

--- a/lib/team_session/contract_composer.ml
+++ b/lib/team_session/contract_composer.ml
@@ -1,3 +1,5 @@
-let compose ~(delivery_contract : Team_session_types.delivery_contract)
+let compose ~execution_scope
+    ~(delivery_contract : Team_session_types.delivery_contract)
     ~(tool_names : string list) : Agent_sdk.Risk_contract.t =
-  Cdal_contract_bridge.of_delivery_contract ~delivery_contract ~tool_names
+  Cdal_contract_bridge.of_delivery_contract ~execution_scope ~delivery_contract
+    ~tool_names

--- a/lib/team_session/contract_composer.mli
+++ b/lib/team_session/contract_composer.mli
@@ -7,6 +7,7 @@
     - tool set → allowed_mutations + risk_class *)
 
 val compose :
+  execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
   Agent_sdk.Risk_contract.t

--- a/lib/team_session/contract_risk.ml
+++ b/lib/team_session/contract_risk.ml
@@ -35,6 +35,14 @@ let external_effect_tools_for_scope = function
         external_effect_tools
   | _ -> external_effect_tools
 
+let workspace_mutating_tools_for_scope = function
+  | Some Team_session_types.Observe_only ->
+      (* observe_only file_write is denied before dispatch, so it should not
+         inflate contract risk when callers preserve the original tool list. *)
+      List.filter (fun name -> not (String.equal name "file_write"))
+        workspace_mutating_tools
+  | _ -> workspace_mutating_tools
+
 (** Blast radius: how many things could break.
     - Large: external-effect tools or 5+ required artifacts
     - Medium: workspace-mutating tools or 2-4 artifacts
@@ -46,7 +54,9 @@ let assess_blast_radius ~(dc : Team_session_types.delivery_contract)
      || artifact_count >= 5
   then
     Large
-  else if has_any tool_names workspace_mutating_tools || artifact_count >= 2 then
+  else if has_any tool_names (workspace_mutating_tools_for_scope execution_scope)
+            || artifact_count >= 2
+  then
     Medium
   else Small
 
@@ -57,7 +67,9 @@ let assess_blast_radius ~(dc : Team_session_types.delivery_contract)
 let assess_irreversibility ~execution_scope ~tool_names =
   if has_any tool_names (external_effect_tools_for_scope execution_scope) then
     Irreversible
-  else if has_any tool_names workspace_mutating_tools then Partial
+  else if has_any tool_names (workspace_mutating_tools_for_scope execution_scope)
+  then
+    Partial
   else Reversible
 
 (** Recovery cost: effort to fix if things go wrong.

--- a/lib/team_session/contract_risk.ml
+++ b/lib/team_session/contract_risk.ml
@@ -27,14 +27,25 @@ let workspace_mutating_tools =
 let has_any tools patterns =
   List.exists (fun t -> List.mem t patterns) tools
 
+let external_effect_tools_for_scope = function
+  | Some Team_session_types.Observe_only ->
+      (* observe_only shell_exec is routed through the readonly allowlist,
+         so it should not be treated like unrestricted bash here. *)
+      List.filter (fun name -> not (String.equal name "shell_exec"))
+        external_effect_tools
+  | _ -> external_effect_tools
+
 (** Blast radius: how many things could break.
     - Large: external-effect tools or 5+ required artifacts
     - Medium: workspace-mutating tools or 2-4 artifacts
     - Small: read-only tools and 0-1 artifacts *)
 let assess_blast_radius ~(dc : Team_session_types.delivery_contract)
-    ~tool_names =
+    ~execution_scope ~tool_names =
   let artifact_count = List.length dc.required_artifacts in
-  if has_any tool_names external_effect_tools || artifact_count >= 5 then Large
+  if has_any tool_names (external_effect_tools_for_scope execution_scope)
+     || artifact_count >= 5
+  then
+    Large
   else if has_any tool_names workspace_mutating_tools || artifact_count >= 2 then
     Medium
   else Small
@@ -43,8 +54,9 @@ let assess_blast_radius ~(dc : Team_session_types.delivery_contract)
     - Irreversible: external-effect tools (git push, bash commands)
     - Partial: workspace-mutating tools (files can be reverted)
     - Reversible: read-only tools *)
-let assess_irreversibility ~tool_names =
-  if has_any tool_names external_effect_tools then Irreversible
+let assess_irreversibility ~execution_scope ~tool_names =
+  if has_any tool_names (external_effect_tools_for_scope execution_scope) then
+    Irreversible
   else if has_any tool_names workspace_mutating_tools then Partial
   else Reversible
 
@@ -58,10 +70,11 @@ let assess_recovery_cost ~(dc : Team_session_types.delivery_contract) =
   else if dc.repair_budget <= 2 then Rc_medium
   else Rc_low
 
-let assess ~(delivery_contract : Team_session_types.delivery_contract)
+let assess ~execution_scope ~(delivery_contract : Team_session_types.delivery_contract)
     ~(tool_names : string list) =
-  { blast_radius = assess_blast_radius ~dc:delivery_contract ~tool_names;
-    irreversibility = assess_irreversibility ~tool_names;
+  { blast_radius =
+      assess_blast_radius ~dc:delivery_contract ~execution_scope ~tool_names;
+    irreversibility = assess_irreversibility ~execution_scope ~tool_names;
     recovery_cost = assess_recovery_cost ~dc:delivery_contract;
   }
 
@@ -88,5 +101,5 @@ let to_risk_class axes =
   else if mid_count >= 1 then Medium
   else Low
 
-let of_delivery_contract ~delivery_contract ~tool_names =
-  to_risk_class (assess ~delivery_contract ~tool_names)
+let of_delivery_contract ~execution_scope ~delivery_contract ~tool_names =
+  to_risk_class (assess ~execution_scope ~delivery_contract ~tool_names)

--- a/lib/team_session/contract_risk.ml
+++ b/lib/team_session/contract_risk.ml
@@ -17,12 +17,12 @@ type risk_axes = {
    Mode_enforcer.classify_tool External_effect in OAS. *)
 let external_effect_tools =
   [ "keeper_bash"; "keeper_github"; "masc_broadcast";
-    "masc_spawn"; "masc_execute" ]
+    "masc_spawn"; "masc_execute"; "shell_exec" ]
 
 (* Tools that mutate workspace but have no external effect. *)
 let workspace_mutating_tools =
   [ "keeper_fs_edit"; "keeper_edit"; "keeper_write";
-    "create_text_file"; "edit_text_file" ]
+    "create_text_file"; "edit_text_file"; "file_write" ]
 
 let has_any tools patterns =
   List.exists (fun t -> List.mem t patterns) tools

--- a/lib/team_session/contract_risk.mli
+++ b/lib/team_session/contract_risk.mli
@@ -14,6 +14,7 @@ type risk_axes = {
 }
 
 val assess :
+  execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
   risk_axes
@@ -21,6 +22,7 @@ val assess :
 val to_risk_class : risk_axes -> Agent_sdk.Risk_class.t
 
 val of_delivery_contract :
+  execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
   Agent_sdk.Risk_class.t

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -583,7 +583,8 @@ let planned_worker_to_entry_with_state
       let tool_names =
         List.map (fun (t : Types.tool_schema) -> t.name) scoped_masc_tools
       in
-      Contract_composer.compose ~delivery_contract:dc ~tool_names
+      Contract_composer.compose ~delivery_contract:dc
+        ~execution_scope:pw.execution_scope ~tool_names
     ) delivery_contract in
     match
       Oas_worker.run_named_with_masc_tools

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -90,6 +90,7 @@ let execute_delegate_pipeline
                 in
                 Option.map
                   (fun dc -> Contract_composer.compose ~delivery_contract:dc
+                    ~execution_scope
                     ~tool_names:[])
                   delivery_contract
               in

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -78,175 +78,53 @@ let execute_spawn_pipeline
                    fail_all_prepared prepared_spawns ~error:msg;
                    Some (`Assoc [ ("error", `String msg) ])
                | Ok () ->
-                   let execution_scope_of_prepared prepared =
-                     deps.effective_execution_scope_of_spec prepared.spec
-                   in
-                   let worker_backend_of_prepared prepared =
-                     if deps.is_local_spawn_agent prepared.spec.spawn_agent then
-                       Some "local"
-                     else None
-                   in
-                   let normalize_spawn_tool_args prepared ~tool_name
-                       (args : Yojson.Safe.t) =
-                     let add_string_field_if_missing key value fields =
-                       if String.trim value = "" || List.mem_assoc key fields then
-                         fields
-                       else
-                         (key, `String value) :: fields
-                     in
-                     match args with
-                     | `Assoc fields ->
-                         let fields =
-                           add_string_field_if_missing "agent_name"
-                             prepared.spec.spawn_agent fields
-                         in
-                         let fields =
-                           match tool_name with
-                           | "masc_board_post" | "masc_board_comment" ->
-                               add_string_field_if_missing "author"
-                                 prepared.spec.spawn_agent fields
-                           | "masc_board_vote" ->
-                               add_string_field_if_missing "voter"
-                                 prepared.spec.spawn_agent fields
-                           | _ -> fields
-                         in
-                         `Assoc fields
-                     | _ -> args
-                   in
-                   let record_spawn_exception index prepared ~started_at exn =
-                     let error = Printexc.to_string exn in
-                     let elapsed_ms =
-                       int_of_float
-                         ((Time_compat.now () -. started_at) *. 1000.0)
-                     in
-                     let output_preview = deps.truncate_for_event error in
-                     let worker_name =
-                       Option.value
-                         ~default:(Printf.sprintf "spawn-%d" index)
-                         prepared.runtime_actor_name
-                     in
-                     release_prepared_runtime prepared ~success:false ~error
-                       ~latency_ms:elapsed_ms ();
-                     persist_worker_run_snapshot
-                       ~worker_run_id:prepared.worker_run_id
-                       ~worker_name ~mode:"spawn" ~wait_mode
-                       ~status:`Failed
-                       ?execution_scope:(execution_scope_of_prepared prepared)
-                       ?requested_worker_class:prepared.spec.worker_class
-                       ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?resolved_runtime:prepared.assigned_runtime
-                       ~resolved_model:prepared.runtime_model_label
-                       ?routing_reason:prepared.spec.routing_reason
-                       ~tool_names:[]
-                       ~tool_call_count:0
-                       ~success:false ~output_preview ~error
-                       ();
-                     append_spawn_event
-                       ~worker_run_id:prepared.worker_run_id
-                       ~spawn_agent:prepared.spec.spawn_agent
-                       ?runtime_actor:prepared.runtime_actor_name
-                       ?spawn_role:prepared.spec.spawn_role
-                       ?spawn_model:prepared.spec.spawn_model
-                       ?execution_scope:(execution_scope_of_prepared prepared)
-                       ?worker_class:prepared.spec.worker_class
-                       ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?worker_backend:(worker_backend_of_prepared prepared)
-                       ~wait_mode:
-                         (Team_session_types.wait_mode_to_string wait_mode)
-                       ?parent_actor:prepared.spec.parent_actor
-                       ?capsule_mode:prepared.spec.capsule_mode
-                       ?runtime_pool:prepared.spec.runtime_pool
-                       ?lane_id:prepared.spec.lane_id
-                       ?controller_level:
-                         (deps.inferred_controller_level_of_spec prepared.spec)
-                       ?control_domain:prepared.spec.control_domain
-                       ?supervisor_actor:prepared.spec.supervisor_actor
-                       ?model_tier:prepared.spec.model_tier
-                       ?task_profile:prepared.spec.task_profile
-                       ?risk_level:prepared.spec.risk_level
-                       ?routing_confidence:prepared.spec.routing_confidence
-                       ?routing_reason:prepared.spec.routing_reason
-                       ?assigned_runtime:prepared.assigned_runtime
-                       ?spawn_selection_note:
-                         prepared.spec.spawn_selection_note
-                       ~tool_names:[]
-                       ~tool_call_count:0
-                       ~success:false ~exit_code:1
-                       ~elapsed_ms ~output_preview ~error ();
-                     (match prepared.runtime_actor_name with
-                     | Some worker_actor ->
-                         ignore
-                           (deps.reconcile_failed_spawn_actor ctx.config
-                              session_id worker_actor)
-                     | None -> ());
-                     `Assoc
-                       [
-                         ("worker_run_id", `String prepared.worker_run_id);
-                         ( "runtime_actor",
-                           Option.fold ~none:`Null
-                             ~some:(fun s -> `String s)
-                             prepared.runtime_actor_name );
-                         ( "spawn_role",
-                           Option.fold ~none:`Null
-                             ~some:(fun s -> `String s)
-                             prepared.spec.spawn_role );
-                         ( "execution_scope",
-                           Option.fold ~none:`Null
-                             ~some:(fun scope ->
-                               `String
-                                 (Team_session_types.execution_scope_to_string
-                                    scope))
-                             (execution_scope_of_prepared prepared) );
-                         ( "worker_class",
-                           Option.fold ~none:`Null
-                             ~some:(fun kind ->
-                               `String
-                                 (Team_session_types.worker_class_to_string
-                                    kind))
-                             prepared.spec.worker_class );
-                         ( "worker_size",
-                           Option.fold ~none:`Null
-                             ~some:(fun size ->
-                               `String
-                                 (Team_session_types.worker_size_to_string
-                                    size))
-                             (deps.worker_size_of_spec prepared.spec) );
-                         ( "worker_backend",
-                           Option.fold ~none:`Null
-                             ~some:(fun value -> `String value)
-                             (worker_backend_of_prepared prepared) );
-                         ( "wait_mode",
-                           `String
-                             (Team_session_types.wait_mode_to_string wait_mode)
-                         );
-                         ("status", `String "failed");
-                         ( "resolved_runtime",
-                           Option.fold ~none:`Null
-                             ~some:(fun s -> `String s)
-                             prepared.assigned_runtime );
-                         ("resolved_model", `String prepared.runtime_model_label);
-                         ( "routing_reason",
-                           Option.fold ~none:`Null
-                             ~some:(fun s -> `String s)
-                             prepared.spec.routing_reason );
-                         ("tool_call_count", `Int 0);
-                         ("tool_names", `List []);
-                         ("success", `Bool false);
-                         ("elapsed_ms", `Int elapsed_ms);
-                         ("output_preview", `String output_preview);
-                       ]
-                   in
-                   let execute_spawn index prepared =
-                   (* Phase C-3a: Route spawn through OAS Agent.run via Oas_worker.
-                       This replaces the old Spawn.spawn subprocess call, giving us
-                       trace data, tool_names, and tool_call_count for free. *)
+                   let execute_spawn ~run_sw index prepared =
                     let start_time = Time_compat.now () in
-                    let execution_scope =
-                      execution_scope_of_prepared prepared
+                    let worker_name =
+                      Option.value
+                        ~default:(Printf.sprintf "spawn-%d-%s" index prepared.worker_run_id)
+                        prepared.runtime_actor_name
                     in
-                    let max_turns =
-                      match prepared.spec.max_turns with
-                      | Some n -> n | None -> 10
+                    let execution_scope =
+                      deps.effective_execution_scope_of_spec prepared.spec
+                    in
+                    let local_worker_tool_names =
+                      let all_local_worker_tools =
+                        Team_session_oas_bridge.supported_local_worker_tool_names
+                      in
+                      match execution_scope with
+                      | Some Team_session_types.Observe_only ->
+                          let denied_observe_only_tools =
+                            [
+                              "masc_claim_next";
+                              "masc_transition";
+                              "masc_add_task";
+                              "masc_heartbeat";
+                              "masc_board_post";
+                              "masc_board_comment";
+                              "masc_board_vote";
+                              "masc_worktree_create";
+                              "masc_worktree_remove";
+                              "masc_run_init";
+                              "masc_run_plan";
+                              "masc_run_log";
+                              "masc_run_deliverable";
+                              "masc_repair_loop_start";
+                              "masc_repair_loop_iterate";
+                              "masc_repair_loop_stop";
+                            ]
+                          in
+                          List.filter
+                            (fun name ->
+                              not (List.mem name denied_observe_only_tools))
+                            all_local_worker_tools
+                      | _ -> all_local_worker_tools
+                    in
+                    let local_shell_tool_names =
+                      match execution_scope with
+                      | Some Team_session_types.Observe_only ->
+                          [ "file_read"; "shell_exec" ]
+                      | _ -> [ "file_read"; "file_write"; "shell_exec" ]
                     in
                     let delivery_contract =
                       Tool_team_session_step_exec.delivery_contract_for_session
@@ -255,211 +133,272 @@ let execute_spawn_pipeline
                     let contract =
                       Option.map
                         (fun delivery_contract ->
-                          let tool_names =
-                            if deps.is_local_spawn_agent
-                                 prepared.spec.spawn_agent
-                            then
-                              Team_session_oas_bridge
-                              .supported_local_worker_tool_names_for_scope
-                                execution_scope
-                            else []
-                          in
                           Contract_composer.compose ~delivery_contract
-                            ~tool_names)
+                            ~execution_scope
+                            ~tool_names:
+                              (List.sort_uniq String.compare
+                                 (local_worker_tool_names @ local_shell_tool_names)))
                         delivery_contract
                     in
-                    let oas_result =
-                      if deps.is_local_spawn_agent prepared.spec.spawn_agent then
-                        match
-                          Team_session_oas_bridge
-                          .supported_local_worker_tools_for_scope execution_scope
-                        with
-                        | Error msg ->
-                            Error
-                              (Printf.sprintf
-                                 "team session local worker tools unavailable: %s"
-                                 msg)
-                        | Ok masc_tools ->
-                            Oas_worker.run_model_with_masc_tools
-                              ~model_label:prepared.runtime_model_label
-                              ~goal:prepared.spec.spawn_prompt
-                              ~system_prompt:(Printf.sprintf
-                                "You are agent '%s'. Execute the task and return a clear result."
-                                 prepared.spec.spawn_agent)
-                              ~masc_tools
-                              ~dispatch:(fun ~name ~args ->
-                                Team_session_oas_bridge.dispatch_supported_tool
-                                  ~sw:ctx.sw ~clock:ctx.clock
-                                  ~config:ctx.config ~name
-                                  ~args:
-                                    (normalize_spawn_tool_args prepared
-                                       ~tool_name:name args))
-                              ~max_turns
-                              ~temperature:(Safe_ops.get_env_float_logged
-                                "MASC_SPAWN_TEMPERATURE" ~default:0.3)
-                              ~max_tokens:(Safe_ops.get_env_int_logged
-                                "MASC_SPAWN_MAX_TOKENS" ~default:4096)
-                              ~priority:
-                                Llm_provider.Request_priority.Interactive
-                              ?enable_thinking:prepared.spec.thinking_enabled
-                              ?contract ?net:ctx.net ~sw:ctx.sw
-                              ()
-                      else
-                        Oas_worker.run_model_by_label
-                          ~model_label:prepared.runtime_model_label
-                          ~goal:prepared.spec.spawn_prompt
-                          ~system_prompt:(Printf.sprintf
-                            "You are agent '%s'. Execute the task and return a clear result."
-                             prepared.spec.spawn_agent)
-                          ~max_turns
-                          ~temperature:(Safe_ops.get_env_float_logged
-                            "MASC_SPAWN_TEMPERATURE" ~default:0.3)
-                          ~max_tokens:(Safe_ops.get_env_int_logged
-                            "MASC_SPAWN_MAX_TOKENS" ~default:4096)
-                          ~priority:Llm_provider.Request_priority.Interactive
-                          ?contract ?net:ctx.net ~sw:ctx.sw
-                          ()
+                    let worker_backend =
+                      if deps.is_local_spawn_agent prepared.spec.spawn_agent
+                      then Some "local"
+                      else None
                     in
-                     let elapsed_ms =
-                       int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
-                     in
-                     let resolved_model =
-                       match oas_result with
-                       | Ok result ->
-                           let model =
-                             String.trim
-                               (Oas_response.model_used result.response)
-                           in
-                           if model <> "" then model
-                           else prepared.runtime_model_label
-                       | Error _ -> prepared.runtime_model_label
-                     in
-                     let spawn_result, oas_trace_ref, oas_tool_names, oas_tool_call_count,
-                         trace_summary_json, trace_validation_json =
-                       match oas_result with
-                       | Ok result ->
-                         let text = Agent_sdk.Types.text_of_content result.response.content in
-                         let tool_names =
-                           List.filter_map (function
-                             | Agent_sdk.Types.ToolUse { name; _ } -> Some name
-                             | _ -> None)
-                             result.response.content
-                         in
-                         let usage = result.response.usage in
-                         let cost_usd =
-                           Option.map (fun (cp : Agent_sdk.Checkpoint.t) ->
-                             cp.usage.estimated_cost_usd) result.checkpoint
-                         in
-                         let trace_summary =
-                           Some (`Assoc [
-                             ("oas_session_id", `String result.session_id);
-                             ("turns", `Int result.turns);
-                             ("model", `String resolved_model);
-                             ("tool_names", `List (List.map (fun n -> `String n) tool_names));
-                             ("tool_call_count", `Int (List.length tool_names));
-                             ("input_tokens",
-                               Option.fold ~none:`Null
-                                 ~some:(fun (u : Agent_sdk.Types.api_usage) -> `Int u.input_tokens) usage);
-                             ("output_tokens",
-                               Option.fold ~none:`Null
-                                 ~some:(fun (u : Agent_sdk.Types.api_usage) -> `Int u.output_tokens) usage);
-                           ])
-                         in
-                         let scope =
-                           deps.effective_execution_scope_of_spec prepared.spec
-                         in
-                         let requires_tools = match scope with
-                           | Some Team_session_types.Limited_code_change
-                           | Some Team_session_types.Autonomous -> true
-                           | _ -> false
-                         in
-                         let actual_success =
-                           if requires_tools && List.length tool_names = 0 then false
-                           else true
-                         in
-                         let output =
-                           if not actual_success then
-                             text ^ "\n[contract-violation] Worker completed without tool use in " ^
-                             (Option.fold ~none:"unknown"
-                                ~some:Team_session_types.execution_scope_to_string scope) ^
-                             " scope."
-                           else text
-                         in
-                         ({ Spawn.success = actual_success;
-                            output;
-                            exit_code = (if actual_success then 0 else 1);
-                            elapsed_ms;
-                            input_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.input_tokens) usage;
-                            output_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.output_tokens) usage;
-                            cache_creation_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.cache_creation_input_tokens) usage;
-                            cache_read_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.cache_read_input_tokens) usage;
-                            cost_usd;
-                          },
-                          Some { Agent_sdk.Raw_trace.worker_run_id = prepared.worker_run_id;
-                                path = result.session_id; start_seq = 0; end_seq = result.turns;
-                                agent_name = prepared.spec.spawn_agent;
-                                session_id = Some result.session_id },
-                          tool_names,
-                          List.length tool_names,
-                          trace_summary,
-                          (None : Yojson.Safe.t option))
-                       | Error e ->
-                         ({ Spawn.success = false;
-                            output = e;
-                            exit_code = 1;
-                            elapsed_ms;
-                            input_tokens = None;
-                            output_tokens = None;
-                            cache_creation_tokens = None;
-                            cache_read_tokens = None;
-                            cost_usd = None;
-                          },
-                          None,
-                          [],
-                          0,
-                          None,
-                          None)
-                     in
-                     let output_preview =
-                       deps.truncate_for_event spawn_result.output
-                     in
-                     let proof =
-                       match oas_result with
-                       | Ok result -> result.proof
-                       | Error _ -> None
-                     in
-                     let verification_outcome =
-                       match oas_result with
-                       | Ok result ->
-                           let run_result : Worker_container_types.run_result =
-                             {
-                               output = spawn_result.output;
-                               model_used = resolved_model;
-                               input_tokens = spawn_result.input_tokens;
-                               output_tokens = spawn_result.output_tokens;
-                               cost_usd = spawn_result.cost_usd;
-                               tool_call_count = oas_tool_call_count;
-                               tool_names = oas_tool_names;
-                               session_id = result.session_id;
-                               raw_trace_run = oas_trace_ref;
-                               api_response = Some result.response;
-                               proof = result.proof;
-                             }
-                           in
-                           let goal =
-                             match
-                               Team_session_store.load_session ctx.config
-                                 session_id
-                             with
-                             | Some session -> session.goal
-                             | None -> prepared.spec.spawn_prompt
-                           in
-                           Some
-                             (Worker_verification.verify_worker_result
-                                ?delivery_contract
-                                ~goal run_result)
-                       | Error _ -> None
-                     in
+                    let unexpected_failure ~elapsed_ms error =
+                      let output_preview = deps.truncate_for_event error in
+                      release_prepared_runtime prepared ~success:false ~error
+                        ~latency_ms:elapsed_ms ();
+                      persist_worker_run_snapshot
+                        ~worker_run_id:prepared.worker_run_id
+                        ~worker_name
+                        ~mode:"spawn" ~wait_mode
+                        ~status:`Failed
+                        ?execution_scope
+                        ?requested_worker_class:prepared.spec.worker_class
+                        ?requested_worker_size:
+                          (deps.worker_size_of_spec prepared.spec)
+                        ?resolved_runtime:prepared.assigned_runtime
+                        ~resolved_model:prepared.runtime_model_label
+                        ?routing_reason:prepared.spec.routing_reason
+                        ~tool_names:[]
+                        ~tool_call_count:0
+                        ~success:false
+                        ~output_preview
+                        ~evidence_session_id:
+                          (Worker_runtime.oas_worker_evidence_session_id
+                             ~worker_run_id:prepared.worker_run_id)
+                        ~trace_capability:"summary_only"
+                        ();
+                      append_spawn_event
+                        ~worker_run_id:prepared.worker_run_id
+                        ~spawn_agent:prepared.spec.spawn_agent
+                        ?runtime_actor:prepared.runtime_actor_name
+                        ?spawn_role:prepared.spec.spawn_role
+                        ?spawn_model:prepared.spec.spawn_model
+                        ?execution_scope
+                        ?worker_class:prepared.spec.worker_class
+                        ?worker_size:(deps.worker_size_of_spec prepared.spec)
+                        ?worker_backend
+                        ~wait_mode:
+                          (Team_session_types.wait_mode_to_string wait_mode)
+                        ~trace_capability:"summary_only"
+                        ?parent_actor:prepared.spec.parent_actor
+                        ?capsule_mode:prepared.spec.capsule_mode
+                        ?runtime_pool:prepared.spec.runtime_pool
+                        ?lane_id:prepared.spec.lane_id
+                        ?controller_level:
+                          (deps.inferred_controller_level_of_spec prepared.spec)
+                        ?control_domain:prepared.spec.control_domain
+                        ?supervisor_actor:prepared.spec.supervisor_actor
+                        ?model_tier:prepared.spec.model_tier
+                        ?task_profile:prepared.spec.task_profile
+                        ?risk_level:prepared.spec.risk_level
+                        ?routing_confidence:prepared.spec.routing_confidence
+                        ?routing_reason:prepared.spec.routing_reason
+                        ?assigned_runtime:prepared.assigned_runtime
+                        ?spawn_selection_note:prepared.spec.spawn_selection_note
+                        ~tool_names:[]
+                        ~tool_call_count:0
+                        ~success:false
+                        ~exit_code:1
+                        ~elapsed_ms
+                        ~output_preview
+                        ~error
+                        ();
+                      (match prepared.runtime_actor_name with
+                      | Some worker_actor ->
+                          ignore
+                            (deps.reconcile_failed_spawn_actor ctx.config
+                               session_id worker_actor)
+                      | None -> ());
+                      `Assoc
+                        [
+                          ("worker_run_id", `String prepared.worker_run_id);
+                          ( "runtime_actor",
+                            Option.fold ~none:`Null
+                              ~some:(fun s -> `String s)
+                              prepared.runtime_actor_name );
+                          ( "spawn_role",
+                            Option.fold ~none:`Null
+                              ~some:(fun s -> `String s)
+                              prepared.spec.spawn_role );
+                          ( "execution_scope",
+                            Option.fold ~none:`Null
+                              ~some:(fun scope ->
+                                `String
+                                  (Team_session_types
+                                   .execution_scope_to_string scope))
+                              execution_scope );
+                          ( "thinking_enabled",
+                            Option.fold ~none:`Null
+                              ~some:(fun v -> `Bool v)
+                              prepared.spec.thinking_enabled );
+                          ( "max_turns",
+                            Option.fold ~none:`Null
+                              ~some:(fun n -> `Int n)
+                              prepared.spec.max_turns );
+                          ( "worker_class",
+                            Option.fold ~none:`Null
+                              ~some:(fun kind ->
+                                `String
+                                  (Team_session_types
+                                   .worker_class_to_string kind))
+                              prepared.spec.worker_class );
+                          ( "worker_size",
+                            Option.fold ~none:`Null
+                              ~some:(fun size ->
+                                `String
+                                  (Team_session_types
+                                   .worker_size_to_string size))
+                              (deps.worker_size_of_spec prepared.spec) );
+                          ( "worker_backend",
+                            Option.fold ~none:`Null
+                              ~some:(fun s -> `String s)
+                              worker_backend );
+                          ( "wait_mode",
+                            `String
+                              (Team_session_types.wait_mode_to_string wait_mode)
+                          );
+                          ("status", `String "failed");
+                          ("trace_capability", `String "summary_only");
+                          ( "resolved_runtime",
+                            Option.fold ~none:`Null
+                              ~some:(fun s -> `String s)
+                              prepared.assigned_runtime );
+                          ("resolved_model", `String prepared.runtime_model_label);
+                          ( "routing_reason",
+                            Option.fold ~none:`Null
+                              ~some:(fun s -> `String s)
+                              prepared.spec.routing_reason );
+                          ("tool_call_count", `Int 0);
+                          ("tool_names", `List []);
+                          ("success", `Bool false);
+                          ("error", `String error);
+                          ("exit_code", `Int 1);
+                          ("elapsed_ms", `Int elapsed_ms);
+                          ("output_preview", `String output_preview);
+                        ]
+                    in
+                    try
+                      let worker_result =
+                        Worker_runtime.run_worker ~sw:run_sw ?net:ctx.net
+                          ~base_path:ctx.config.base_path ~worker_name
+                          ~model_label:prepared.runtime_model_label
+                          ~team_session_id:(Some session_id)
+                          ~room_config:(Some ctx.config)
+                          ?worker_class:prepared.spec.worker_class
+                          ?worker_size:(deps.worker_size_of_spec prepared.spec)
+                          ?execution_scope
+                          ?thinking_enabled:prepared.spec.thinking_enabled
+                          ~max_turns:(Option.value ~default:10 prepared.spec.max_turns)
+                          ~worker_run_id:prepared.worker_run_id
+                          ~role:prepared.spec.spawn_role
+                          ~selection_note:prepared.spec.spawn_selection_note
+                          ~prompt:prepared.spec.spawn_prompt
+                          ~allowed_tools:local_worker_tool_names
+                          ~timeout_sec:prepared.spec.spawn_timeout_seconds
+                          ?contract
+                          ()
+                      in
+                      let elapsed_ms =
+                        int_of_float
+                          ((Time_compat.now () -. start_time) *. 1000.0)
+                      in
+                      let spawn_result, run_result =
+                        match worker_result with
+                        | Ok run_result ->
+                            ( { Spawn.success = true;
+                                output = run_result.output;
+                                exit_code = 0;
+                                elapsed_ms;
+                                input_tokens = run_result.input_tokens;
+                                output_tokens = run_result.output_tokens;
+                                cache_creation_tokens = None;
+                                cache_read_tokens = None;
+                                cost_usd = run_result.cost_usd;
+                              },
+                              Some run_result )
+                        | Error e ->
+                            ( { Spawn.success = false;
+                                output = e;
+                                exit_code = 1;
+                                elapsed_ms;
+                                input_tokens = None;
+                                output_tokens = None;
+                                cache_creation_tokens = None;
+                                cache_read_tokens = None;
+                                cost_usd = None;
+                              },
+                              None )
+                      in
+                    let output_preview =
+                      deps.truncate_for_event spawn_result.output
+                    in
+                    let oas_trace_ref =
+                      Option.bind run_result
+                        (fun (result : Worker_container_types.run_result) ->
+                          result.raw_trace_run)
+                    in
+                    let oas_tool_names =
+                      Option.value ~default:[]
+                        (Option.map
+                           (fun (result : Worker_container_types.run_result) ->
+                             result.tool_names)
+                           run_result)
+                    in
+                    let oas_tool_call_count =
+                      Option.value ~default:0
+                        (Option.map
+                           (fun (result : Worker_container_types.run_result) ->
+                             result.tool_call_count)
+                           run_result)
+                    in
+                    let resolved_model =
+                      Option.value ~default:prepared.runtime_model_label
+                        (Option.map
+                           (fun (result : Worker_container_types.run_result) ->
+                             result.model_used)
+                           run_result)
+                    in
+                    let trace_summary_json, trace_validation_json =
+                      match oas_trace_ref with
+                      | Some run_ref -> (
+                          match
+                            deps.raw_trace_session_payloads
+                              ~config:ctx.config
+                              ~fallback_session_id:session_id run_ref
+                          with
+                          | Some pair -> (Some (fst pair), Some (snd pair))
+                          | None -> (None, None))
+                      | None -> (None, None)
+                    in
+                      let proof =
+                      Option.bind run_result
+                        (fun (result : Worker_container_types.run_result) ->
+                          result.proof)
+                    in
+                      let verification_outcome =
+                      match run_result with
+                      | Some run_result ->
+                          let goal =
+                            match
+                              Team_session_store.load_session ctx.config
+                                session_id
+                            with
+                            | Some session -> session.goal
+                            | None -> prepared.spec.spawn_prompt
+                          in
+                          Some
+                            (Worker_verification.verify_worker_result
+                               ?delivery_contract
+                               ~goal run_result)
+                      | None -> None
+                      in
+                      let trace_capability =
+                        if Option.is_some oas_trace_ref then "raw"
+                        else "summary_only"
+                      in
                      Option.iter
                        (Tool_team_session_step_exec
                         .record_delivery_verdict_for_worker_run
@@ -483,14 +422,11 @@ let execute_spawn_pipeline
                            ~latency_ms:spawn_result.elapsed_ms ());
                      persist_worker_run_snapshot
                        ~worker_run_id:prepared.worker_run_id
-                       ~worker_name:
-                         (Option.value
-                            ~default:(Printf.sprintf "spawn-%d" index)
-                            prepared.runtime_actor_name)
+                       ~worker_name
                        ~mode:"spawn" ~wait_mode
                        ~status:
                          (if spawn_result.success then `Completed else `Failed)
-                       ?execution_scope:execution_scope
+                       ?execution_scope
                        ?requested_worker_class:prepared.spec.worker_class
                        ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
                        ?resolved_runtime:prepared.assigned_runtime
@@ -509,7 +445,7 @@ let execute_spawn_pipeline
                        ?trace_summary:trace_summary_json
                        ?trace_validation:trace_validation_json
                        ?proof
-                         ~trace_capability:"raw"
+                        ~trace_capability
                        ();
                      append_spawn_event
                        ~worker_run_id:prepared.worker_run_id
@@ -517,12 +453,12 @@ let execute_spawn_pipeline
                        ?runtime_actor:prepared.runtime_actor_name
                        ?spawn_role:prepared.spec.spawn_role
                        ?spawn_model:prepared.spec.spawn_model
-                       ?execution_scope:execution_scope
+                       ?execution_scope
                        ?worker_class:prepared.spec.worker_class
                        ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?worker_backend:(worker_backend_of_prepared prepared)
+                       ?worker_backend
                        ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
-                       ~trace_capability:"raw"
+                       ~trace_capability
                        ?parent_actor:prepared.spec.parent_actor
                        ?capsule_mode:prepared.spec.capsule_mode
                        ?runtime_pool:prepared.spec.runtime_pool
@@ -600,12 +536,12 @@ let execute_spawn_pipeline
                          ("worker_run_id", `String prepared.worker_run_id);
                          ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
                          ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
-                         ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) execution_scope);
+                         ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) (deps.effective_execution_scope_of_spec prepared.spec));
                          ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) prepared.spec.thinking_enabled);
                          ("max_turns", Option.fold ~none:`Null ~some:(fun n -> `Int n) prepared.spec.max_turns);
                          ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
                          ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (deps.worker_size_of_spec prepared.spec));
-                         ("worker_backend", Option.fold ~none:`Null ~some:(fun value -> `String value) (worker_backend_of_prepared prepared));
+                         ("worker_backend", if deps.is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
                          ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
                          ("status", `String "completed");
                          ("trace_capability", `String (if Option.is_some oas_trace_ref then "raw" else "summary_only"));
@@ -619,7 +555,16 @@ let execute_spawn_pipeline
                          ("output_preview", `String output_preview);
                          ("delivery_verdict", Option.value ~default:`Null delivery_verdict_json);
                        ]
-                   in
+                    with
+                    | Eio.Cancel.Cancelled _ as exn -> raise exn
+                    | exn ->
+                        let elapsed_ms =
+                          int_of_float
+                            ((Time_compat.now () -. start_time) *. 1000.0)
+                        in
+                        unexpected_failure ~elapsed_ms
+                          (Printexc.to_string exn)
+                  in
                    (match wait_mode with
                    | Team_session_types.Wait_background ->
                        let sw_bg =
@@ -628,23 +573,11 @@ let execute_spawn_pipeline
                        in
                        List.iteri
                          (fun index prepared ->
-                           let started_at = Time_compat.now () in
                            append_spawn_requested_event
                              ~worker_run_id:prepared.worker_run_id
                              prepared;
                            Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                               try ignore (execute_spawn index prepared)
-                               with
-                               | Eio.Cancel.Cancelled _ as exn -> raise exn
-                               | exn ->
-                                 Log.Spawn.error
-                                   "background spawn failed (worker_run_id=%s, agent=%s): %s"
-                                   prepared.worker_run_id
-                                   prepared.spec.spawn_agent
-                                   (Printexc.to_string exn);
-                                 ignore
-                                   (record_spawn_exception index prepared
-                                      ~started_at exn)))
+                             ignore (execute_spawn ~run_sw:sw_bg index prepared)))
                          prepared_spawns;
                        let accepted =
                          prepared_spawns
@@ -675,13 +608,13 @@ let execute_spawn_pipeline
                                 ("results", `List accepted);
                               ])
                    | Team_session_types.Wait_blocking ->
-                       let results =
-                         Array.make (List.length prepared_spawns) None
-                       in
-                       Eio.Fiber.all
+                      let results =
+                        Array.make (List.length prepared_spawns) None
+                      in
+                      Eio.Fiber.all
                          (List.mapi
                             (fun index prepared () ->
-                              results.(index) <- Some (execute_spawn index prepared))
+                              results.(index) <- Some (execute_spawn ~run_sw:ctx.sw index prepared))
                             prepared_spawns);
                        let spawn_results =
                          results |> Array.to_list

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -147,6 +147,9 @@ let execute_spawn_pipeline
                     in
                     let unexpected_failure ~elapsed_ms error =
                       let output_preview = deps.truncate_for_event error in
+                      Log.Spawn.error
+                        "spawn worker failed (worker_run_id=%s, agent=%s): %s"
+                        prepared.worker_run_id worker_name error;
                       release_prepared_runtime prepared ~success:false ~error
                         ~latency_ms:elapsed_ms ();
                       persist_worker_run_snapshot

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -24,7 +24,7 @@ let make_dc ?(acceptance_checks = ["tests pass"]) ?(required_artifacts = ["main.
 let test_compose_basic () =
   let dc = make_dc () in
   let tools = ["keeper_read"; "keeper_fs_edit"] in
-  let rc = CC.compose ~delivery_contract:dc ~tool_names:tools in
+  let rc = CC.compose ~execution_scope:None ~delivery_contract:dc ~tool_names:tools in
   check string "requested_mode Execute (budget > 0)"
     "execute"
     (EM.to_string rc.runtime_constraints.requested_execution_mode);
@@ -37,7 +37,7 @@ let test_compose_basic () =
 let test_compose_zero_budget () =
   let dc = make_dc ~repair_budget:0 () in
   let tools = ["keeper_read"] in
-  let rc = CC.compose ~delivery_contract:dc ~tool_names:tools in
+  let rc = CC.compose ~execution_scope:None ~delivery_contract:dc ~tool_names:tools in
   check string "requested_mode Draft (budget = 0)"
     "draft"
     (EM.to_string rc.runtime_constraints.requested_execution_mode)
@@ -45,7 +45,7 @@ let test_compose_zero_budget () =
 let test_compose_high_risk_review () =
   let dc = make_dc ~repair_budget:0 () in
   let tools = ["keeper_fs_edit"] in
-  let rc = CC.compose ~delivery_contract:dc ~tool_names:tools in
+  let rc = CC.compose ~execution_scope:None ~delivery_contract:dc ~tool_names:tools in
   check string "risk_class high"
     "high"
     (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class);
@@ -53,10 +53,22 @@ let test_compose_high_risk_review () =
     (Some "human_review")
     rc.runtime_constraints.review_requirement
 
+let test_compose_observe_only_shell_exec () =
+  let dc = make_dc () in
+  let rc =
+    CC.compose ~delivery_contract:dc ~tool_names:["shell_exec"]
+      ~execution_scope:(Some Team_session_types.Observe_only)
+  in
+  check string "observe_only shell_exec stays low"
+    "low"
+    (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class);
+  check (option string) "observe_only shell_exec does not require review"
+    None rc.runtime_constraints.review_requirement
+
 let test_eval_criteria_fields () =
   let dc = make_dc ~acceptance_checks:["lint"; "test"]
     ~required_artifacts:["a.ml"; "b.ml"] () in
-  let rc = CC.compose ~delivery_contract:dc ~tool_names:[] in
+  let rc = CC.compose ~execution_scope:None ~delivery_contract:dc ~tool_names:[] in
   let open Yojson.Safe.Util in
   let criteria = rc.eval_criteria in
   let success = criteria |> member "success_criteria" |> to_list
@@ -150,6 +162,8 @@ let () =
       "basic compose", `Quick, test_compose_basic;
       "zero budget → Draft", `Quick, test_compose_zero_budget;
       "high risk → review required", `Quick, test_compose_high_risk_review;
+      "observe_only shell_exec stays low", `Quick,
+      test_compose_observe_only_shell_exec;
       "eval_criteria fields", `Quick, test_eval_criteria_fields;
       "keeper bridge workspace", `Quick, test_keeper_bridge_compose_workspace;
       "keeper bridge read_only", `Quick, test_keeper_bridge_compose_read_only;

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -65,6 +65,20 @@ let test_compose_observe_only_shell_exec () =
   check (option string) "observe_only shell_exec does not require review"
     None rc.runtime_constraints.review_requirement
 
+let test_compose_observe_only_file_write () =
+  let dc = make_dc () in
+  let rc =
+    CC.compose ~delivery_contract:dc ~tool_names:["file_write"]
+      ~execution_scope:(Some Team_session_types.Observe_only)
+  in
+  check string "observe_only file_write stays low"
+    "low"
+    (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class);
+  check (list string) "observe_only file_write does not allow mutations"
+    [] rc.runtime_constraints.allowed_mutations;
+  check (option string) "observe_only file_write does not require review"
+    None rc.runtime_constraints.review_requirement
+
 let test_eval_criteria_fields () =
   let dc = make_dc ~acceptance_checks:["lint"; "test"]
     ~required_artifacts:["a.ml"; "b.ml"] () in
@@ -164,6 +178,8 @@ let () =
       "high risk → review required", `Quick, test_compose_high_risk_review;
       "observe_only shell_exec stays low", `Quick,
       test_compose_observe_only_shell_exec;
+      "observe_only file_write stays low", `Quick,
+      test_compose_observe_only_file_write;
       "eval_criteria fields", `Quick, test_eval_criteria_fields;
       "keeper bridge workspace", `Quick, test_keeper_bridge_compose_workspace;
       "keeper bridge read_only", `Quick, test_keeper_bridge_compose_read_only;

--- a/test/test_contract_risk.ml
+++ b/test/test_contract_risk.ml
@@ -76,6 +76,24 @@ let test_axes_assessment () =
     "Rc_medium"
     (match axes.recovery_cost with Rc_low -> "Rc_low" | Rc_medium -> "Rc_medium" | Rc_high -> "Rc_high")
 
+let test_shell_exec_is_external_effect () =
+  let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc
+      ~tool_names:["shell_exec"]
+  in
+  check_risk "shell_exec raises risk to critical" Agent_sdk.Risk_class.Critical
+    risk
+
+let test_file_write_is_workspace_mutation () =
+  let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc
+      ~tool_names:["file_write"]
+  in
+  check_risk "file_write raises risk to medium" Agent_sdk.Risk_class.Medium
+    risk
+
 let () =
   Eio_main.run @@ fun _env ->
   run "Contract_risk" [
@@ -86,5 +104,7 @@ let () =
       "critical risk (multi-axis max)", `Quick, test_critical_risk;
       "empty tools", `Quick, test_empty_tools;
       "axes assessment", `Quick, test_axes_assessment;
+      "shell_exec is external effect", `Quick, test_shell_exec_is_external_effect;
+      "file_write is workspace mutation", `Quick, test_file_write_is_workspace_mutation;
     ];
   ]

--- a/test/test_contract_risk.ml
+++ b/test/test_contract_risk.ml
@@ -114,6 +114,15 @@ let test_observe_only_shell_exec_is_read_only () =
   check_risk "observe_only shell_exec stays low risk" Agent_sdk.Risk_class.Low
     risk
 
+let test_observe_only_file_write_is_read_only () =
+  let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:(Some Team_session_types.Observe_only)
+      ~delivery_contract:dc ~tool_names:["file_write"]
+  in
+  check_risk "observe_only file_write stays low risk" Agent_sdk.Risk_class.Low
+    risk
+
 let test_file_write_is_workspace_mutation () =
   let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
   let risk =
@@ -137,6 +146,8 @@ let () =
       "shell_exec is external effect", `Quick, test_shell_exec_is_external_effect;
       "observe_only shell_exec stays read-only", `Quick,
       test_observe_only_shell_exec_is_read_only;
+      "observe_only file_write stays read-only", `Quick,
+      test_observe_only_file_write_is_read_only;
       "file_write is workspace mutation", `Quick, test_file_write_is_workspace_mutation;
     ];
   ]

--- a/test/test_contract_risk.ml
+++ b/test/test_contract_risk.ml
@@ -27,14 +27,20 @@ let check_risk msg expected actual =
 let test_low_risk () =
   let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:5 () in
   let tools = ["keeper_read"; "keeper_board_list"] in
-  let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:tools in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc ~tool_names:tools
+  in
   check_risk "read-only + generous budget = Low" Agent_sdk.Risk_class.Low risk
 
 let test_medium_risk () =
   let dc = make_dc ~required_artifacts:["src/main.ml"; "test/test.ml"]
     ~repair_budget:3 () in
   let tools = ["keeper_fs_edit"; "keeper_read"] in
-  let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:tools in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc ~tool_names:tools
+  in
   check_risk "workspace-mutating + 2 artifacts = Medium"
     Agent_sdk.Risk_class.Medium risk
 
@@ -44,14 +50,20 @@ let test_high_risk () =
      recovery_cost=Rc_high (budget=0) → 1 max axis = High *)
   let dc = make_dc ~required_artifacts:["src/main.ml"] ~repair_budget:0 () in
   let tools = ["keeper_fs_edit"; "keeper_read"] in
-  let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:tools in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc ~tool_names:tools
+  in
   check_risk "workspace-mutating + zero budget = High" Agent_sdk.Risk_class.High risk
 
 let test_critical_risk () =
   let dc = make_dc ~required_artifacts:["a";"b";"c";"d";"e"]
     ~repair_budget:0 () in
   let tools = ["keeper_bash"; "keeper_github"] in
-  let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:tools in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc ~tool_names:tools
+  in
   check_risk "external tools + zero budget = Critical"
     Agent_sdk.Risk_class.Critical risk
 
@@ -59,13 +71,19 @@ let test_critical_risk () =
 
 let test_empty_tools () =
   let dc = make_dc () in
-  let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:[] in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc ~tool_names:[]
+  in
   check_risk "no tools + generous budget = Low" Agent_sdk.Risk_class.Low risk
 
 let test_axes_assessment () =
   let dc = make_dc ~required_artifacts:["a";"b"] ~repair_budget:1 () in
   let tools = ["keeper_fs_edit"] in
-  let axes = Masc_mcp.Contract_risk.assess ~delivery_contract:dc ~tool_names:tools in
+  let axes =
+    Masc_mcp.Contract_risk.assess ~execution_scope:None ~delivery_contract:dc
+      ~tool_names:tools
+  in
   check string "blast_radius medium"
     "Medium"
     (match axes.blast_radius with Small -> "Small" | Medium -> "Medium" | Large -> "Large");
@@ -79,16 +97,28 @@ let test_axes_assessment () =
 let test_shell_exec_is_external_effect () =
   let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
   let risk =
-    Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc
       ~tool_names:["shell_exec"]
   in
   check_risk "shell_exec raises risk to critical" Agent_sdk.Risk_class.Critical
     risk
 
-let test_file_write_is_workspace_mutation () =
+let test_observe_only_shell_exec_is_read_only () =
   let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
   let risk =
     Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc
+      ~tool_names:["shell_exec"]
+      ~execution_scope:(Some Team_session_types.Observe_only)
+  in
+  check_risk "observe_only shell_exec stays low risk" Agent_sdk.Risk_class.Low
+    risk
+
+let test_file_write_is_workspace_mutation () =
+  let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:3 () in
+  let risk =
+    Masc_mcp.Contract_risk.of_delivery_contract ~execution_scope:None
+      ~delivery_contract:dc
       ~tool_names:["file_write"]
   in
   check_risk "file_write raises risk to medium" Agent_sdk.Risk_class.Medium
@@ -105,6 +135,8 @@ let () =
       "empty tools", `Quick, test_empty_tools;
       "axes assessment", `Quick, test_axes_assessment;
       "shell_exec is external effect", `Quick, test_shell_exec_is_external_effect;
+      "observe_only shell_exec stays read-only", `Quick,
+      test_observe_only_shell_exec_is_read_only;
       "file_write is workspace mutation", `Quick, test_file_write_is_workspace_mutation;
     ];
   ]

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -263,6 +263,7 @@ let test_team_worker_spawn_batch_requires_confirm_then_executes () =
                               ("spawn_timeout_seconds", `Int 1);
                             ];
                         ] );
+                    ("wait_mode", `String "blocking");
                   ] );
             ])
       in


### PR DESCRIPTION
## Summary
- restore the team-session spawn path to use `Worker_runtime.run_worker` instead of calling `Oas_worker.run_model_by_label` directly
- scope delivery contract risk by `execution_scope` so `observe_only` workers keep readonly `shell_exec` semantics instead of over-escalating to `human_review`
- keep operator-driven `team_worker_spawn_batch` confirmations on the blocking path so the confirm response observes the emitted `team_step_spawn` event
- realign `masc_mcp.opam`, front-door docs, and spec references with the current `dune-project` release truth

## Product impact
- spawned coding workers regain the expected local runtime flow, tool surface, and worker-run evidence path
- readonly `observe_only` spawns no longer advertise a broader mutation risk than the runtime actually allows
- operator confirm flows for worker spawn batches stay deterministic for callers and the existing regression test
- version-truth and doc-truth checks pass again on this branch

## Evidence
- `dune build --root . --build-dir /tmp/masc-4092-review masc_mcp.opam test/test_contract_risk.exe test/test_contract_composer.exe test/test_tool_team_session.exe test/test_operator_control.exe`
- `/tmp/masc-4092-review/default/test/test_contract_risk.exe`
- `/tmp/masc-4092-review/default/test/test_contract_composer.exe`
- `/tmp/masc-4092-review/default/test/test_operator_control.exe test operator 21 -e`
- `bash scripts/check-version-truth.sh`
- `bash scripts/check-doc-truth.sh`
- `git diff --check`

## Review evidence
- Reviewed at: 2026-03-31 05:02:51 UTC
- Reviewer path: direct ZAI GLM via `sb glm-text`
- Scope reviewed: incremental review-response diff on `fix/4050-team-session-stall` at `3fe756c178a427770bf23b5c8a39912730688065`
- Result: `No findings.`

## Linked issue
- Fixes #4050
