### PR TITLE
[codex] test(context): fix summarize_old pairing coverage

### DIFF
--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -102,6 +102,8 @@ let test_compact_summarize_old () =
 let test_summarize_old_masks_tool_results_but_preserves_pairing () =
   let tool_id = "call-123" in
   let msgs = [
+    msg Agent_sdk.Types.User "Start by checking the project layout.";
+    msg Agent_sdk.Types.Assistant "The project has lib/ and test/ directories.";
     msg Agent_sdk.Types.User "Find all reducer references in lib/.";
     tool_use_msg ~id:tool_id ~name:"grep_search" ();
     tool_msg ~id:tool_id "3 matches in lib/\nlib/context_compact_oas.ml\nlib/tool_compact.ml";


### PR DESCRIPTION
## Summary
- `test_context_compact_oas_coverage`의 `summarize_old masks tool results but preserves pairing` fixture를 보강했습니다.
- old prefix에 plain-text 메시지를 2개 추가해서 `SummarizeOld`가 실제로 count reduction을 수행할 수 있는 입력으로 바꿨습니다.
- preserved `ToolUse/ToolResult` pair를 억지로 줄이도록 구현을 바꾸지 않고, 테스트가 의도한 behavior를 검증하도록 맞췄습니다.

## Root cause
- 기존 fixture는 `keep_recent=5` 기준 old prefix가 사실상 `text + ToolUse + ToolResult` 형태로 남았습니다.
- 여기서 `ToolUse/ToolResult` pair를 보존하면 reduction이 일어나지 않아도 구현상 자연스러운 경로인데, 테스트는 무조건 `message count reduced`를 요구하고 있었습니다.

## Product impact
- `Build and Test` quick suite의 `context_compact_oas` failure를 해소합니다.
- `SummarizeOld`의 실제 contract를 유지하면서, regression test가 더 현실적인 compaction path를 검증하게 됩니다.

## Evidence
- local repro passed:
  - `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4091-context-compact-summary --build-dir /tmp/masc-4091-context-test ./test/test_context_compact_oas_coverage.exe`
- failing CI reference:
  - run `23757976001`
  - job `69218473697`
  - failing case `strategy_mapping / summarize_old masks tool results but preserves pairing`

## Review evidence
- direct `sb glm-text` review on current diff: `No findings.`

## Linked issue
- Closes #4091
