### PR TITLE
fix(compact): resolve CI build errors in context_compact_oas

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -160,7 +160,7 @@ let summarize_old_messages ~(keep_recent : int)
         | x :: xs -> split (i - 1) (x :: acc) xs
     in
     let old_msgs, recent_msgs = split old_count [] msgs in
-    let rec flush_chunk chunk acc =
+    let flush_chunk chunk acc =
       match summarize_chunk (List.rev chunk) with
       | Some summary -> summary :: acc
       | None -> acc
@@ -168,7 +168,8 @@ let summarize_old_messages ~(keep_recent : int)
     let rec compact_old old chunk acc =
       match old with
       | [] -> List.rev (flush_chunk chunk acc)
-      | ({ content; _ } as m) :: tl ->
+      | (m : Agent_sdk.Types.message) :: tl ->
+        let content = m.content in
         let has_tool_use = List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) content in
         let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult _ -> true | _ -> false) content in
         if has_tool_use then


### PR DESCRIPTION
## Summary
- `let rec flush_chunk` -> `let flush_chunk` (warning 39: unused rec flag)
- Pattern match에 type annotation 추가로 `content` field 해석 ambiguity 해소
- main에서 pre-existing build failure 수리

## 원인
`Agent_sdk.Types`가 `include module type of Llm_provider.Types`로 re-export할 때 field name inference가 ambiguous해짐. 명시적 type annotation으로 해결.

## Test plan
- [ ] CI Build and Test pass
- [ ] CI Lint (warnings as errors) pass

Generated with [Claude Code](https://claude.com/claude-code)