### PR TITLE
fix(recover): cherry-pick lost commits from #3937

### DIFF
--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -453,7 +453,7 @@ let json_int_opt_member key json =
   match Yojson.Safe.Util.member key json with
   | `Int value -> Some value
   | `Intlit raw -> (try Some (int_of_string raw) with Failure _ -> None)
-  | `Float value -> Some (int_of_float value)
+  | `Float value -> Some (Float.to_int value) (* JSON source is integer-valued *)
   | _ -> None
 
 let json_iso_opt json =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -69,13 +69,15 @@ let observed_affordances_of_observation
 
 let response_requests_confirmation (text : string) : bool =
   let trimmed = String.trim text in
-  trimmed <> ""
-  && (String.contains trimmed '?'
-      || string_contains_substring_ci ~needle:"would you like" trimmed
-      || string_contains_substring_ci ~needle:"do you want" trimmed
-      || string_contains_substring_ci ~needle:"let me know" trimmed
-      || string_contains_substring_ci ~needle:"어떻게 할까" trimmed
-      || string_contains_substring_ci ~needle:"할까" trimmed)
+  if trimmed = "" then false
+  else
+    let lower = String.lowercase_ascii trimmed in
+    String.contains trimmed '?'
+    || string_contains_substring ~needle:"would you like" lower
+    || string_contains_substring ~needle:"do you want" lower
+    || string_contains_substring ~needle:"let me know" lower
+    || string_contains_substring ~needle:{|어떻게 할까|} trimmed
+    || string_contains_substring ~needle:{|할까|} trimmed
 
 let decision_id ~(meta : keeper_meta) ~(ts : float) ~(suffix_seed : string) : string =
   let digest =


### PR DESCRIPTION
## Summary

Cherry-pick unmerged commits from #3937 (`fix/unified-keeper-decision-log`).

**Recovered (1/3):**
- `19a9455` fix: hoist lowercase in confirmation check, clarify Float.to_int

**Skipped due to conflicts (2/3):**
- `748b077` Add keeper decision logs and tool audit fallback — conflicts in `dashboard_mission_assembly.ml`, `keeper_status_detail.ml`, `keeper_unified_turn.ml`, `operator_control_snapshot.ml`, `test_operator_control_keeper.ml`, `test_tool_keeper.ml`
- `6e70a0f` Normalize tool audit timestamps in CI — conflicts in `keeper_status_detail.ml`

## Test plan
- [ ] Verify `keeper_unified_turn.ml` confirmation check uses lowercase correctly
- [ ] Run `dune build` to confirm compilation
- [ ] Assess whether skipped commits need manual re-implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)