### PR TITLE
fix(recover): cherry-pick lost commits from #3758

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -430,6 +430,10 @@ let add_routes ~sw ~clock router =
            if String.length name = 0 then
              Http.Response.json ~status:`Bad_request
                {|{"error":"keeper name is required"}|} reqd
+           else if not (Keeper_config.validate_name name) then
+             Http.Response.json ~status:`Bad_request
+               (Printf.sprintf {|{"error":"invalid keeper name: %S"}|}
+                  (String.escaped name)) reqd
            else
              let config = state.Mcp_server.room_config in
              (match Keeper_types.read_meta config name with


### PR DESCRIPTION
## Summary

Cherry-pick unmerged commits from #3758 (`feat/keeper-observability`).

**Recovered (1/4):**
- `74ce3c1` fix(security): validate keeper name in trajectory endpoint

**Skipped due to conflicts (2/4):**
- `e90abeb` feat(dashboard): add keeper/agent observability pipeline — conflicts in `keeper-detail-panels.ts`, `keeper-detail.ts`, `keeper-shared.ts`, `keeper-trajectory-timeline.ts`, `keeper_registry.ml`, `server_routes_http_routes_dashboard.ml`
- `eebb0b1` fix: address GLM-5.1 cross-model review findings — conflicts in `keeper-trajectory-timeline.ts`, `keeper_registry.ml`

**Resolved to empty (1/4):**
- `238e031` fix(test): move tool_usage persistence to subdirectory — changes already in main

## Test plan
- [ ] Verify trajectory endpoint validates keeper name input
- [ ] Run `dune build` to confirm compilation
- [ ] Assess whether skipped commits need manual re-implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)