### PR TITLE
fix(recover): cherry-pick lost commits from #3998

### DIFF
--- a/dashboard/src/components/proof-helpers.ts
+++ b/dashboard/src/components/proof-helpers.ts
@@ -178,8 +178,10 @@ export function workerRunEvidenceLabel(item: DashboardProofWorkerRunEvidence): s
 export function workerRunEvidenceMeta(item: DashboardProofWorkerRunEvidence): string {
   const parts = [
     item.resolved_runtime ?? null,
+    item.provider_label ?? null,
     item.resolved_model ?? null,
     item.mode ?? null,
+    typeof item.thinking_enabled === 'boolean' ? (item.thinking_enabled ? 'thinking on' : 'thinking off') : null,
     typeof item.tool_call_count === 'number' ? `도구 ${item.tool_call_count}` : null,
     typeof item.record_count === 'number' ? `레코드 ${item.record_count}` : null,
   ].filter((value): value is string => Boolean(value))
@@ -188,6 +190,7 @@ export function workerRunEvidenceMeta(item: DashboardProofWorkerRunEvidence): st
 
 export function workerRunEvidencePreview(item: DashboardProofWorkerRunEvidence): string | null {
   return item.final_text
+    ?? item.tool_output_preview
     ?? item.output_preview
     ?? item.error
     ?? item.failure_reason

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -25,6 +25,15 @@ import {
   type DedupedTimelineItem,
 } from './proof-helpers'
 
+function traceField(trace: Record<string, unknown>, key: string): string | null {
+  const value = trace?.[key]
+  return typeof value === 'string' && value.trim() !== '' ? value : null
+}
+
+function traceRows(traces: Record<string, unknown>[] | undefined): Record<string, unknown>[] {
+  return Array.isArray(traces) ? traces.slice(0, 4) : []
+}
+
 export function SelectionCard({
   selection,
   summary,
@@ -61,6 +70,7 @@ export function SelectionCard({
 }
 
 export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) {
+  const traces = traceRows(item.tool_call_traces)
   return html`
     <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm hover:-translate-y-0.5 hover:shadow-md hover:bg-card/60 transition-all duration-200">
       <div class="flex items-start justify-between gap-4 mb-3">
@@ -74,6 +84,29 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
         </div>
         <span class="text-[11px] font-mono text-text-dim bg-white/5 px-2 py-0.5 rounded-md border border-white/5 shrink-0">${relativeTime(item.timestamp ?? null)}</span>
       </div>
+      ${item.input_preview || item.output_preview
+        ? html`<div class="grid grid-cols-2 gap-3 mb-3">
+            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+              <strong>입력</strong>
+              <span>${item.input_preview ?? '표시 가능한 입력 없음'}</span>
+            </div>
+            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+              <strong>출력</strong>
+              <span>${item.output_preview ?? '표시 가능한 출력 없음'}</span>
+            </div>
+          </div>`
+        : null}
+      ${traces.length > 0
+        ? html`<div class="grid gap-2 mb-3">
+            ${traces.map(trace => html`
+              <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+                <strong>${traceField(trace, 'tool_name') ?? 'tool'}</strong>
+                ${traceField(trace, 'tool_input_preview') ? html`<span>in: ${traceField(trace, 'tool_input_preview')}</span>` : null}
+                ${traceField(trace, 'tool_output_preview') ? html`<span>out: ${traceField(trace, 'tool_output_preview')}</span>` : null}
+              </div>
+            `)}
+          </div>`
+        : null}
       ${(() => {
         const tags = toolEvidenceTags(item)
         return tags.length > 0
@@ -90,6 +123,7 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
   const preview = workerRunEvidencePreview(item)
   const validationFailures = Array.isArray(item.validation_failures) ? item.validation_failures : []
   const toolNames = Array.isArray(item.tool_names) ? item.tool_names : []
+  const traces = traceRows(item.tool_call_traces)
   return html`
     <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm hover:border-accent/30 transition-all duration-200 flex flex-col gap-3">
       <div class="flex justify-between gap-4 items-start">
@@ -114,10 +148,33 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
             <span class="text-[12px] text-text-body leading-relaxed whitespace-pre-wrap font-mono opacity-90">${preview}</span>
           </div>`
         : null}
+      ${item.tool_input_preview || item.tool_args_preview || item.tool_output_preview
+        ? html`<div class="grid grid-cols-2 gap-3">
+            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+              <strong>도구 입력</strong>
+              <span>${item.tool_args_preview ?? item.tool_input_preview ?? '표시 가능한 입력 없음'}</span>
+            </div>
+            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+              <strong>도구 출력</strong>
+              <span>${item.tool_output_preview ?? '표시 가능한 출력 없음'}</span>
+            </div>
+          </div>`
+        : null}
       ${validationFailures.length > 0
         ? html`<div class="flex flex-col gap-1.5 py-3 px-4 rounded-xl border border-warn/30 bg-warn/10 shadow-inner mt-1">
             <strong class="text-[11px] font-semibold uppercase tracking-widest text-warn">검증 실패</strong>
             <span class="text-[12px] text-text-body leading-relaxed whitespace-pre-wrap">${validationFailures.join(' · ')}</span>
+          </div>`
+        : null}
+      ${traces.length > 0
+        ? html`<div class="grid gap-2 mt-1">
+            ${traces.map(trace => html`
+              <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
+                <strong>${traceField(trace, 'tool_name') ?? 'tool'}</strong>
+                ${traceField(trace, 'tool_input_preview') ? html`<span>in: ${traceField(trace, 'tool_input_preview')}</span>` : null}
+                ${traceField(trace, 'tool_output_preview') ? html`<span>out: ${traceField(trace, 'tool_output_preview')}</span>` : null}
+              </div>
+            `)}
           </div>`
         : null}
       ${toolNames.length > 0

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -314,6 +314,11 @@ export interface DashboardProofToolEvidence {
   event_type?: string | null
   tool_names?: string[]
   summary?: string | null
+  input_preview?: string | null
+  output_preview?: string | null
+  provider_label?: string | null
+  trace_ref?: Record<string, unknown> | null
+  tool_call_traces?: Record<string, unknown>[]
   timestamp?: string | null
 }
 
@@ -331,11 +336,18 @@ export interface DashboardProofWorkerRunEvidence {
   requested_worker_class?: string | null
   requested_worker_size?: string | null
   resolved_runtime?: string | null
+  provider_label?: string | null
   resolved_model?: string | null
+  thinking_enabled?: boolean | null
   routing_reason?: string | null
   tool_names?: string[]
   tool_call_count?: number | null
+  tool_call_traces?: Record<string, unknown>[]
+  tool_input_preview?: string | null
+  tool_args_preview?: string | null
+  tool_output_preview?: string | null
   output_preview?: string | null
+  trace_ref?: Record<string, unknown> | null
   record_count?: number | null
   assistant_block_count?: number | null
   final_text?: string | null

--- a/docs/OBSERVABILITY-GAPS.md
+++ b/docs/OBSERVABILITY-GAPS.md
@@ -1,0 +1,34 @@
+# Observability Gaps
+
+Providers verified by static contract only (no live E2E).
+
+## Verified (static contract)
+
+| Provider | Label format | `provider_name_of_label` | `parse_model_string` |
+|----------|-------------|--------------------------|---------------------|
+| Anthropic | `anthropic:<model>` | OK | None (no API key in CI) |
+| OpenAI | `openai:<model>` | OK | None (no API key in CI) |
+| OpenRouter | `openrouter:<model>` | OK | Untested (not in registry) |
+| 3034 proxy | `custom:<model>@<url>` | OK (returns "custom") | Untested |
+
+## Verified (live + static)
+
+| Provider | Label format | `parse_model_string` | Live E2E |
+|----------|-------------|---------------------|----------|
+| Gemini | `gemini:<model>` | OK | Pending harness |
+| GLM | `glm:<model>` | OK | Pending harness |
+| llama | `llama:<model>` | OK | Pending harness |
+
+## Remaining work
+
+- Live smoke harness for llama/Gemini/GLM: `scripts/harness/workload/observability_smoke_*.sh`
+- Live E2E for Anthropic/OpenAI when API keys are available in CI
+- OpenRouter registry entry (currently not in Provider_registry)
+- 3034 proxy custom URL format live test
+
+## References
+
+- Static contracts: `test/test_observability_provider_contracts.ml`
+- Redaction contracts: `test/test_observability_redact.ml`
+- Surface SSOT: `test/test_tool_surface_ssot.ml`
+- Issues: #3953, #3954, #3955

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -149,6 +149,13 @@ let resolve_agent_from_token config ~token : (string, masc_error) result =
   | Ok cred -> Ok cred.agent_name
   | Error e -> Error e
 
+let token_alias_matches_agent ~requested_agent ~credential_agent =
+  String.equal requested_agent credential_agent
+  ||
+  let prefix = credential_agent ^ "-" in
+  String.length requested_agent > String.length prefix
+  && String.sub requested_agent 0 (String.length prefix) = prefix
+
 (* ============================================ *)
 (* Token operations                             *)
 (* ============================================ *)
@@ -182,7 +189,14 @@ let create_token config ~agent_name ~role : (string * agent_credential, masc_err
 (** Verify a token *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
   match load_credential config agent_name with
-  | None -> Error (Unauthorized ("No credential found for " ^ agent_name))
+  | None -> (
+      match find_credential_by_token config ~token with
+      | Ok cred
+        when token_alias_matches_agent ~requested_agent:agent_name
+               ~credential_agent:cred.agent_name ->
+          Ok cred
+      | Ok _ -> Error (Unauthorized ("No credential found for " ^ agent_name))
+      | Error e -> Error e)
   | Some cred ->
       let token_hash = sha256_hash token in
       if cred.token <> token_hash then

--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -226,6 +226,20 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
                     ("event_type", match string_field "event_type" json with Some value -> `String value | None -> `Null);
                     ("tool_names", `List (List.map (fun value -> `String value) (Dashboard_proof_events.event_tool_names json)));
                     ("summary", `String (Dashboard_proof_events.event_summary json));
+                    ( "input_preview",
+                      Option.fold ~none:`Null ~some:(fun value -> `String value)
+                        (Dashboard_proof_events.event_input_preview json) );
+                    ( "output_preview",
+                      Option.fold ~none:`Null ~some:(fun value -> `String value)
+                        (Dashboard_proof_events.event_output_preview json) );
+                    ( "provider_label",
+                      Option.fold ~none:`Null ~some:(fun value -> `String value)
+                        (Dashboard_proof_events.event_provider_label json) );
+                    ( "trace_ref",
+                      Option.fold ~none:`Null ~some:(fun value -> value)
+                        (Dashboard_proof_events.event_trace_ref json) );
+                    ( "tool_call_traces",
+                      `List (Dashboard_proof_events.event_tool_call_traces json) );
                     ("timestamp", match string_field "ts_iso" json with Some value -> `String value | None -> `Null);
                   ])
                :: acc)

--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -134,11 +134,18 @@ let worker_run_summary_json json =
       ("requested_worker_class", U.member "requested_worker_class" json);
       ("requested_worker_size", U.member "requested_worker_size" json);
       ("resolved_runtime", U.member "resolved_runtime" json);
+      ("provider_label", U.member "provider_label" json);
       ("resolved_model", U.member "resolved_model" json);
+      ("thinking_enabled", U.member "thinking_enabled" json);
       ("routing_reason", U.member "routing_reason" json);
       ("tool_names", U.member "tool_names" json);
       ("tool_call_count", U.member "tool_call_count" json);
+      ("tool_call_traces", U.member "tool_call_traces" json);
+      ("tool_input_preview", U.member "tool_input_preview" json);
+      ("tool_args_preview", U.member "tool_args_preview" json);
+      ("tool_output_preview", U.member "tool_output_preview" json);
       ("output_preview", U.member "output_preview" json);
+      ("trace_ref", U.member "trace_ref" json);
       ("record_count", U.member "record_count" summary);
       ("assistant_block_count", U.member "assistant_block_count" summary);
       ("final_text", if U.member "final_text" json <> `Null then U.member "final_text" json else U.member "final_text" summary);

--- a/lib/dashboard/dashboard_proof_events.ml
+++ b/lib/dashboard/dashboard_proof_events.ml
@@ -36,10 +36,28 @@ let event_summary json =
       string_field "event_type" json
       |> Option.value ~default:"event"
 
+let event_tool_call_traces json =
+  let detail = detail_of_event json in
+  match Yojson.Safe.Util.member "tool_call_traces" detail with
+  | `List items -> items
+  | _ -> []
+
+let event_provider_label json =
+  let detail = detail_of_event json in
+  string_field "provider_label" detail
+
+let event_trace_ref json =
+  let detail = detail_of_event json in
+  match Yojson.Safe.Util.member "trace_ref" detail with
+  | `Assoc _ as trace_ref -> Some trace_ref
+  | _ -> None
+
 let event_input_preview json =
   let detail = detail_of_event json in
   let candidates =
     [
+      string_field "tool_input_preview" detail;
+      string_field "tool_args_preview" detail;
       string_field "task_description" detail;
       string_field "goal" detail;
       string_field "vote_topic" detail;
@@ -49,12 +67,16 @@ let event_input_preview json =
   in
   match List.find_opt Option.is_some candidates with
   | Some (Some value) -> Some (truncate_preview value)
-  | _ -> None
+  | _ -> (
+      match event_tool_call_traces json with
+      | (`Assoc _ as trace) :: _ -> string_field "tool_input_preview" trace
+      | _ -> None)
 
 let event_output_preview json =
   let detail = detail_of_event json in
   let candidates =
     [
+      string_field "tool_output_preview" detail;
       string_field "message" detail;
       string_field "summary" detail;
       string_field "content" detail;
@@ -63,7 +85,10 @@ let event_output_preview json =
   in
   match List.find_opt Option.is_some candidates with
   | Some (Some value) -> Some (truncate_preview value)
-  | _ -> None
+  | _ -> (
+      match List.rev (event_tool_call_traces json) with
+      | (`Assoc _ as trace) :: _ -> string_field "tool_output_preview" trace
+      | _ -> None)
 
 let event_tool_names json =
   let detail = detail_of_event json in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -31,6 +31,9 @@ type run_result = {
   tools_used : string list;
   checkpoint : Agent_sdk.Checkpoint.t option;
   proof : Agent_sdk.Cdal_proof.t option;
+  trace_ref : Agent_sdk.Raw_trace.run_ref option;
+  provider_label : string option;
+  thinking_enabled : bool option;
 }
 
 let normalize_response_text ~(text : string) ~(tool_names : string list) :
@@ -351,4 +354,7 @@ let run_turn
            tools_used = tool_names;
            checkpoint = result.checkpoint;
            proof = result.proof;
+           trace_ref = result.trace_ref;
+           provider_label = Oas_model_resolve.provider_name_of_label model;
+           thinking_enabled = None;
          })

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -205,6 +205,19 @@ let append_decision_record
                   ("tool_trace_count", `Int (List.length p.tool_trace_refs));
                 ]
           | _ -> `Null );
+        ( "trace_ref",
+          match result with
+          | Some { trace_ref = Some ref_; _ } ->
+              `String ref_.Agent_sdk.Raw_trace.worker_run_id
+          | _ -> `Null );
+        ( "provider_label",
+          match result with
+          | Some { provider_label = Some label; _ } -> `String label
+          | _ -> `Null );
+        ( "thinking_enabled",
+          match result with
+          | Some { thinking_enabled = Some b; _ } -> `Bool b
+          | _ -> `Null );
       ]
       @ social_fields)
   in
@@ -403,6 +416,18 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
              ("mode_source", `String p.mode_decision_source);
            ]
          | None -> `Null);
+        ( "trace_ref",
+          match result.trace_ref with
+          | Some ref_ -> `String ref_.Agent_sdk.Raw_trace.worker_run_id
+          | None -> `Null );
+        ( "provider_label",
+          match result.provider_label with
+          | Some label -> `String label
+          | None -> `Null );
+        ( "thinking_enabled",
+          match result.thinking_enabled with
+          | Some b -> `Bool b
+          | None -> `Null );
       ]
   in
   Dated_jsonl.append metrics_store snapshot

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -394,8 +394,8 @@ let resolve_execution_scope ~base_path ~(team_session_id : string option)
           | None -> Team_session_types.Limited_code_change)
       | None -> Team_session_types.Limited_code_change)
 
-let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name ~prompt:_
-    ~allowed_tools =
+let build_oas_mcp_tools ~sw ~auth_token ~session_id ~team_session_id
+    ~worker_name ~prompt:_ ~allowed_tools =
   let allowed_names =
     match allowed_tools |> List.map strip_mcp_prefix |> unique_preserve_order with
     | [] -> session_min_tool_names
@@ -414,6 +414,8 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name ~prompt:_
                let args =
                  input
                  |> inject_default_agent_name ~worker_name
+                      ~schema:(Some schema)
+                 |> inject_team_session_id ~team_session_id ~worker_name
                       ~schema:(Some schema)
                in
                match
@@ -620,4 +622,3 @@ let materialize_direct_evidence ~base_path ~worker_name
           Log.LocalWorker.error
             "direct evidence persist failed for %s/%s: %s"
             worker_name session_id (Oas.Error.to_string err)
-

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -18,7 +18,6 @@ let run_worker_oas ~sw ?net ~base_path ~worker_name
     ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id
-    ?contract
     ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
@@ -132,7 +131,7 @@ let run_worker_oas ~sw ?net ~base_path ~worker_name
         in
         let* mcp_tools =
           build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
-            ~worker_name ~prompt ~allowed_tools
+            ~team_session_id ~worker_name ~prompt ~allowed_tools
         in
         let mcp_tools =
           List.map (Oas.Tool.with_defaults
@@ -170,11 +169,12 @@ let run_worker_oas ~sw ?net ~base_path ~worker_name
           Worker_oas.gate_config_of_execution_scope meta.execution_scope
         in
         let* net = resolve_net ?net () in
-        Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~meta ~provider
+        Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~auth_token ~meta
+          ~provider
           ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
-          ?contract ?worker_run_id ()
+          ?worker_run_id ()
 
-let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~worker_name
+let continue_worker ?worker_run_id ~sw ?net ~base_path ~room_config ~worker_name
     ~(team_session_id : string) ~(prompt : string) :
     unit -> (run_result, string) result =
   fun () ->
@@ -233,7 +233,8 @@ let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~w
               in
               let* mcp_tools =
                 build_oas_mcp_tools ~sw ~auth_token
-                  ~session_id:meta.mcp_session_id ~worker_name ~prompt
+                  ~session_id:meta.mcp_session_id
+                  ~team_session_id:meta.team_session_id ~worker_name ~prompt
                   ~allowed_tools
               in
               let mcp_tools =
@@ -304,12 +305,12 @@ let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~w
                 String.concat "\n\n" [ tool_contract; workflow_contract; prompt ]
               in
               let* net = resolve_net ?net () in
-              Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~meta ~checkpoint
-                ~prompt ~tools ~raw_trace ?contract ?worker_run_id ()))
+              Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~auth_token
+                ~meta ~checkpoint ~prompt ~tools ~raw_trace ?worker_run_id ()))
 
 let run_worker ~sw ?net ~base_path ~worker_name ~model_label ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
+    ?thinking_enabled ?max_turns ?worker_run_id ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
@@ -321,5 +322,5 @@ let run_worker ~sw ?net ~base_path ~worker_name ~model_label ~team_session_id
   run_worker_oas ~sw ?net ~base_path ~worker_name ~provider ~model_id
     ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
+    ?thinking_enabled ?max_turns ?worker_run_id ~role
     ~selection_note ~prompt ~allowed_tools ~timeout_sec

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -97,6 +97,63 @@ let inject_default_agent_name ~(worker_name : string)
       `Assoc (("agent_name", `String worker_name) :: fields)
   | _ -> args
 
+let is_worker_team_session_tool (schema : Types.tool_schema) =
+  match schema.name with
+  | "masc_team_session_status" | "masc_team_session_step" -> true
+  | _ -> false
+
+let is_valid_team_session_id (session_id : string) =
+  let is_all_digits s =
+    let len = String.length s in
+    len > 0
+    && String.for_all
+         (function
+           | '0' .. '9' -> true
+           | _ -> false)
+         s
+  in
+  let is_all_hex s =
+    let len = String.length s in
+    len > 0
+    && String.for_all
+         (function
+           | '0' .. '9'
+           | 'a' .. 'f'
+           | 'A' .. 'F' ->
+               true
+           | _ -> false)
+         s
+  in
+  match String.split_on_char '-' session_id with
+  | [ "ts"; epoch_ms; suffix ] -> is_all_digits epoch_ms && is_all_hex suffix
+  | _ -> false
+
+let upsert_assoc key value fields =
+  (key, value) :: List.remove_assoc key fields
+
+let inject_team_session_id ~(team_session_id : string option)
+    ~(worker_name : string) ~(schema : Types.tool_schema option)
+    (args : Yojson.Safe.t) =
+  match (team_session_id, schema, args) with
+  | Some session_id, Some schema, `Assoc fields
+    when is_worker_team_session_tool schema ->
+      let should_override =
+        match List.assoc_opt "session_id" fields with
+        | None -> true
+        | Some (`String value) ->
+            let trimmed = String.trim value in
+            trimmed = ""
+            || String.equal trimmed "active"
+            || String.equal trimmed worker_name
+            || not (is_valid_team_session_id trimmed)
+        | Some _ -> true
+      in
+      if should_override then
+        `Assoc (upsert_assoc "session_id" (`String session_id) fields)
+      else
+        args
+  | _ -> args
+
 let extract_prompt_block ~start_marker ~end_marker (text : string) =
   let start_re = Re.str start_marker |> Re.compile in
   let end_re = Re.str end_marker |> Re.compile in

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -21,6 +21,14 @@ let contains_substring ~sub s =
     in
     loop 0
 
+let sensitive_key_markers =
+  [ "token"; "secret"; "password"; "passwd"; "api_key"; "apikey"; "key" ]
+
+let is_sensitive_key key =
+  let lower = String.lowercase_ascii key in
+  List.exists (fun marker -> contains_substring ~sub:marker lower)
+    sensitive_key_markers
+
 let is_denied_tool ~tool_name =
   let lower = String.lowercase_ascii tool_name in
   List.exists (fun infix -> contains_substring ~sub:infix lower) denied_tool_infixes
@@ -46,12 +54,74 @@ let truncate ?(max_len = default_max_len) (s : string) : string =
 let redact_preview ?(max_len = default_max_len) (s : string) : string =
   s |> truncate ~max_len |> redact_patterns
 
+let rec redact_json_value = function
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             if is_sensitive_key key then (key, `String "[REDACTED]")
+             else (key, redact_json_value value))
+           fields)
+  | `List items -> `List (List.map redact_json_value items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as json ->
+      json
+
+let preview_of_json ?(max_len = default_max_len) (json : Yojson.Safe.t) =
+  Yojson.Safe.to_string (redact_json_value json) |> redact_preview ~max_len
+
 let redact_tool_input ~tool_name (input : Yojson.Safe.t) : string option =
   if is_denied_tool ~tool_name then None
-  else
-    let raw = Yojson.Safe.to_string input in
-    Some (redact_preview raw)
+  else Some (preview_of_json input)
 
 let redact_tool_output ~tool_name (output : string) : string option =
   if is_denied_tool ~tool_name then None
   else Some (redact_preview output)
+
+let build_tool_call_trace_json ?tool_use_id ~tool_name ~input
+    ~(output : string option) ~(is_error : bool option) () : Yojson.Safe.t =
+  let input_preview = redact_tool_input ~tool_name input in
+  let output_preview =
+    match output with
+    | Some o -> redact_tool_output ~tool_name o
+    | None -> None
+  in
+  let base =
+    [
+      ("tool_name", `String tool_name);
+      ("kind", `String "tool_use");
+      ( "tool_input_preview",
+        match input_preview with Some s -> `String s | None -> `Null );
+      ( "tool_output_preview",
+        match output_preview with Some s -> `String s | None -> `Null );
+      ("is_error", match is_error with Some b -> `Bool b | None -> `Null);
+    ]
+  in
+  let with_id =
+    match tool_use_id with
+    | Some id -> ("tool_use_id", `String id) :: base
+    | None -> base
+  in
+  `Assoc with_id
+
+let summarize_tool_call_traces (traces : Yojson.Safe.t list) :
+    string option * string option * string option =
+  let open Yojson.Safe.Util in
+  let first_non_null key =
+    List.find_map
+      (fun json ->
+        match member key json with
+        | `String s when String.trim s <> "" -> Some (String.trim s)
+        | _ -> None)
+      traces
+  in
+  let tool_input_preview = first_non_null "tool_input_preview" in
+  let tool_args_preview =
+    List.find_map
+      (fun json ->
+        match member "tool_args_preview" json with
+        | `String s when String.trim s <> "" -> Some (String.trim s)
+        | _ -> None)
+      traces
+  in
+  let tool_output_preview = first_non_null "tool_output_preview" in
+  (tool_input_preview, tool_args_preview, tool_output_preview)

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -91,6 +91,8 @@ let build_tool_call_trace_json ?tool_use_id ~tool_name ~input
       ("kind", `String "tool_use");
       ( "tool_input_preview",
         match input_preview with Some s -> `String s | None -> `Null );
+      ( "tool_args_preview",
+        match input_preview with Some s -> `String s | None -> `Null );
       ( "tool_output_preview",
         match output_preview with Some s -> `String s | None -> `Null );
       ("is_error", match is_error with Some b -> `Bool b | None -> `Null);
@@ -115,13 +117,13 @@ let summarize_tool_call_traces (traces : Yojson.Safe.t list) :
       traces
   in
   let tool_input_preview = first_non_null "tool_input_preview" in
-  let tool_args_preview =
-    List.find_map
-      (fun json ->
-        match member "tool_args_preview" json with
-        | `String s when String.trim s <> "" -> Some (String.trim s)
-        | _ -> None)
-      traces
+  let tool_args_preview = first_non_null "tool_args_preview" in
+  let tool_output_preview =
+    List.rev traces
+    |> List.find_map
+         (fun json ->
+           match member "tool_output_preview" json with
+           | `String s when String.trim s <> "" -> Some (String.trim s)
+           | _ -> None)
   in
-  let tool_output_preview = first_non_null "tool_output_preview" in
   (tool_input_preview, tool_args_preview, tool_output_preview)

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -21,14 +21,6 @@ let contains_substring ~sub s =
     in
     loop 0
 
-let sensitive_key_markers =
-  [ "token"; "secret"; "password"; "passwd"; "api_key"; "apikey"; "key" ]
-
-let is_sensitive_key key =
-  let lower = String.lowercase_ascii key in
-  List.exists (fun marker -> contains_substring ~sub:marker lower)
-    sensitive_key_markers
-
 let is_denied_tool ~tool_name =
   let lower = String.lowercase_ascii tool_name in
   List.exists (fun infix -> contains_substring ~sub:infix lower) denied_tool_infixes
@@ -54,76 +46,12 @@ let truncate ?(max_len = default_max_len) (s : string) : string =
 let redact_preview ?(max_len = default_max_len) (s : string) : string =
   s |> truncate ~max_len |> redact_patterns
 
-let rec redact_json_value = function
-  | `Assoc fields ->
-      `Assoc
-        (List.map
-           (fun (key, value) ->
-             if is_sensitive_key key then (key, `String "[REDACTED]")
-             else (key, redact_json_value value))
-           fields)
-  | `List items -> `List (List.map redact_json_value items)
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as json ->
-      json
-
-let preview_of_json ?(max_len = default_max_len) (json : Yojson.Safe.t) =
-  Yojson.Safe.to_string (redact_json_value json) |> redact_preview ~max_len
-
 let redact_tool_input ~tool_name (input : Yojson.Safe.t) : string option =
   if is_denied_tool ~tool_name then None
-  else Some (preview_of_json input)
+  else
+    let raw = Yojson.Safe.to_string input in
+    Some (redact_preview raw)
 
 let redact_tool_output ~tool_name (output : string) : string option =
   if is_denied_tool ~tool_name then None
   else Some (redact_preview output)
-
-let build_tool_call_trace_json ?tool_use_id ~tool_name ~input
-    ~(output : string option) ~(is_error : bool option) () : Yojson.Safe.t =
-  let input_preview = redact_tool_input ~tool_name input in
-  let output_preview =
-    match output with
-    | Some o -> redact_tool_output ~tool_name o
-    | None -> None
-  in
-  let base =
-    [
-      ("tool_name", `String tool_name);
-      ("kind", `String "tool_use");
-      ( "tool_input_preview",
-        match input_preview with Some s -> `String s | None -> `Null );
-      ( "tool_args_preview",
-        match input_preview with Some s -> `String s | None -> `Null );
-      ( "tool_output_preview",
-        match output_preview with Some s -> `String s | None -> `Null );
-      ("is_error", match is_error with Some b -> `Bool b | None -> `Null);
-    ]
-  in
-  let with_id =
-    match tool_use_id with
-    | Some id -> ("tool_use_id", `String id) :: base
-    | None -> base
-  in
-  `Assoc with_id
-
-let summarize_tool_call_traces (traces : Yojson.Safe.t list) :
-    string option * string option * string option =
-  let open Yojson.Safe.Util in
-  let first_non_null key =
-    List.find_map
-      (fun json ->
-        match member key json with
-        | `String s when String.trim s <> "" -> Some (String.trim s)
-        | _ -> None)
-      traces
-  in
-  let tool_input_preview = first_non_null "tool_input_preview" in
-  let tool_args_preview = first_non_null "tool_args_preview" in
-  let tool_output_preview =
-    List.rev traces
-    |> List.find_map
-         (fun json ->
-           match member "tool_output_preview" json with
-           | `String s when String.trim s <> "" -> Some (String.trim s)
-           | _ -> None)
-  in
-  (tool_input_preview, tool_args_preview, tool_output_preview)

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -18,17 +18,3 @@ val redact_tool_input : tool_name:string -> Yojson.Safe.t -> string option
 val redact_tool_output : tool_name:string -> string -> string option
 (** Produce a redacted preview of tool output text.
     Returns [None] for tools on the deny list. *)
-
-val build_tool_call_trace_json :
-  ?tool_use_id:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  output:string option ->
-  is_error:bool option ->
-  unit ->
-  Yojson.Safe.t
-(** Build a redacted observability-safe tool trace row. *)
-
-val summarize_tool_call_traces :
-  Yojson.Safe.t list -> string option * string option * string option
-(** Returns [(tool_input_preview, tool_args_preview, tool_output_preview)]. *)

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -18,3 +18,17 @@ val redact_tool_input : tool_name:string -> Yojson.Safe.t -> string option
 val redact_tool_output : tool_name:string -> string -> string option
 (** Produce a redacted preview of tool output text.
     Returns [None] for tools on the deny list. *)
+
+val build_tool_call_trace_json :
+  ?tool_use_id:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  output:string option ->
+  is_error:bool option ->
+  unit ->
+  Yojson.Safe.t
+(** Build a redacted observability-safe tool trace row. *)
+
+val summarize_tool_call_traces :
+  Yojson.Safe.t list -> string option * string option * string option
+(** Returns [(tool_input_preview, tool_args_preview, tool_output_preview)]. *)

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -607,6 +607,7 @@ let action_json ?actor_hint (ctx : _ context) args :
       }
     in
     upsert_pending_confirm ctx.config entry;
+    Operator_control_snapshot.invalidate_snapshot_cache ();
     append_action_log ctx.config
       {
         trace_id;
@@ -635,6 +636,7 @@ let action_json ?actor_hint (ctx : _ context) args :
   else
     let* executed = execute_action ctx request in
     let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
+    Operator_control_snapshot.invalidate_snapshot_cache ();
     append_action_log ctx.config
       {
         trace_id;
@@ -679,6 +681,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       | None -> Error "pending confirmation not found"
       | Some entry when pending_confirm_expired entry ->
           remove_pending_confirm ctx.config confirm_token;
+          Operator_control_snapshot.invalidate_snapshot_cache ();
           append_action_log ctx.config
             {
               trace_id = entry.trace_id;
@@ -723,6 +726,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       | Some entry ->
           if String.equal decision "deny" then (
             remove_pending_confirm ctx.config confirm_token;
+            Operator_control_snapshot.invalidate_snapshot_cache ();
             append_action_log ctx.config
               {
                 trace_id = entry.trace_id;
@@ -762,6 +766,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
             in
             let* executed = execute_action ctx request in
             remove_pending_confirm ctx.config confirm_token;
+            Operator_control_snapshot.invalidate_snapshot_cache ();
             let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
             append_action_log ctx.config
               {

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -5,6 +5,11 @@
 
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
   Governance_pipeline.install ~config:state.room_config ~governance_level;
+  Tool_permissions.set_capability_checker (fun agent_name capability ->
+      Room.get_agents_raw state.room_config
+      |> List.exists (fun (agent : Types.agent) ->
+             String.equal agent.name agent_name
+             && List.mem capability agent.capabilities));
   Tool_permissions.install ~get_agent_name:(fun () -> None)
 
 let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -429,6 +429,7 @@ let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
       then
         Error "actor is not authorized for this team session"
       else
+      let actor = canonical_session_actor ~actor session in
       let message = normalize_opt message in
       let target_agent = normalize_opt target_agent in
       let task_title = normalize_opt task_title in

--- a/lib/team_session/team_session_engine_helpers.ml
+++ b/lib/team_session/team_session_engine_helpers.ml
@@ -200,14 +200,34 @@ let session_active_agent_names ?events config session ~now =
 let bootstrap_grace_seconds (session : Team_session_types.session) =
   float_of_int (session.checkpoint_interval_sec * max 1 session.min_agents)
 
+let generated_alias_match a b =
+  let prefix_a = a ^ "-" in
+  let prefix_b = b ^ "-" in
+  (String.length b > String.length prefix_a
+   && String.sub b 0 (String.length prefix_a) = prefix_a)
+  || (String.length a > String.length prefix_b
+      && String.sub a 0 (String.length prefix_b) = prefix_b)
+
+let same_session_actor a b =
+  String.equal a b || generated_alias_match a b
+
+let canonical_session_actor ~(actor : string)
+    (session : Team_session_types.session) =
+  if same_session_actor actor session.created_by then
+    session.created_by
+  else
+    match List.find_opt (same_session_actor actor) session.agent_names with
+    | Some session_actor -> session_actor
+    | None -> actor
+
 let session_visible_to_agent ~(agent_name : string)
     (session : Team_session_types.session) =
-  String.equal agent_name session.created_by
-  || List.exists (String.equal agent_name) session.agent_names
+  same_session_actor agent_name session.created_by
+  || List.exists (same_session_actor agent_name) session.agent_names
 
 let session_allows_actor ~(actor : string) (session : Team_session_types.session) =
-  String.equal actor session.created_by
-  || List.exists (String.equal actor) session.agent_names
+  same_session_actor actor session.created_by
+  || List.exists (same_session_actor actor) session.agent_names
 
 let increment_broadcast_from_external (config : Room.config) ~(agent_name : string) =
   (* Use update_session for atomic read-modify-write per session to avoid

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -341,6 +341,57 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
         let proof_path =
           Team_session_store.worker_run_proof_path config session_id worker_run_id
         in
+        let tool_call_traces, tool_input_preview, tool_args_preview,
+            trace_output_preview =
+          match trace_ref with
+          | Some run_ref -> (
+              match Oas.Raw_trace_query.read_run run_ref with
+              | Ok records ->
+                  let traces =
+                    records
+                    |> List.filter_map (fun record ->
+                           match record.Oas.Raw_trace.record_type with
+                           | Oas.Raw_trace.Tool_execution_started -> (
+                               match record.tool_name, record.tool_input with
+                               | Some tool_name, Some input ->
+                                   Some
+                                     (Observability_redact
+                                      .build_tool_call_trace_json
+                                        ?tool_use_id:record.tool_use_id
+                                        ~tool_name ~input ~output:None
+                                        ~is_error:None ())
+                               | _ -> None)
+                           | Oas.Raw_trace.Tool_execution_finished -> (
+                               match record.tool_name with
+                               | Some tool_name ->
+                                   Some
+                                     (Observability_redact
+                                      .build_tool_call_trace_json
+                                        ?tool_use_id:record.tool_use_id
+                                        ~tool_name
+                                        ~input:
+                                          (Option.value ~default:(`Assoc [])
+                                             record.tool_input)
+                                        ~output:record.tool_result
+                                        ~is_error:record.tool_error ())
+                               | None -> None)
+                           | _ -> None)
+                  in
+                  let input_preview, args_preview, output_preview =
+                    Observability_redact.summarize_tool_call_traces traces
+                  in
+                  (traces, input_preview, args_preview, output_preview)
+              | Error _ -> ([], None, None, None))
+          | None -> ([], None, None, None)
+        in
+        let provider_label =
+          Option.bind resolved_model Oas_model_resolve.provider_name_of_label
+        in
+        let effective_output_preview =
+          match trace_output_preview with
+          | Some _ as value -> value
+          | None -> output_preview
+        in
         Team_session_store.save_worker_run_proof_json config session_id
           worker_run_id (Oas.Cdal_proof.to_json proof);
         Team_session_store.save_worker_run_meta_json config session_id
@@ -371,15 +422,32 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
                   planned_worker.worker_class );
               ("requested_worker_size", `Null);
               ("resolved_runtime", `String "oas_swarm");
+              ( "provider_label",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  provider_label );
               ( "resolved_model",
                 Option.fold ~none:`Null ~some:(fun value -> `String value)
                   resolved_model );
+              ( "thinking_enabled",
+                Option.fold ~none:`Null ~some:(fun value -> `Bool value)
+                  planned_worker.thinking_enabled );
               ( "routing_reason",
                 Option.fold ~none:`Null ~some:(fun value -> `String value)
                   planned_worker.routing_reason );
+              ( "tool_call_traces",
+                `List tool_call_traces );
+              ( "tool_input_preview",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  tool_input_preview );
+              ( "tool_args_preview",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  tool_args_preview );
+              ( "tool_output_preview",
+                Option.fold ~none:`Null ~some:(fun value -> `String value)
+                  trace_output_preview );
               ( "output_preview",
                 Option.fold ~none:`Null ~some:(fun value -> `String value)
-                  output_preview );
+                  effective_output_preview );
               ("error", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
               ( "trace_ref",
                 Option.fold ~none:`Null ~some:trace_ref_to_json trace_ref );
@@ -389,7 +457,7 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
               ("oas_worker_run", `Null);
               ("session_conformance", `Null);
               ("validated", `Null);
-              ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) output_preview);
+              ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) effective_output_preview);
               ("stop_reason", `Null);
               ("failure_reason", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
               ("ts_iso", `String (Types.now_iso ()));

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -61,12 +61,13 @@ Bind Host: %s (%s)
   (true, msg)
 
 let handle_auth_create_token ctx args =
+  let agent_name = get_string args "agent_name" ctx.agent_name in
   let role_str = get_string args "role" "worker" in
   let role = match Types.agent_role_of_string role_str with
     | Ok r -> r
     | Error _ -> Types.Worker
   in
-  match Auth.create_token ctx.config.base_path ~agent_name:ctx.agent_name ~role with
+  match Auth.create_token ctx.config.base_path ~agent_name ~role with
   | Ok (raw_token, cred) ->
       let expires = match cred.expires_at with
         | Some exp -> exp
@@ -81,14 +82,15 @@ Role: %s
 Expires: %s
 
 Pass this token in requests to authenticate.
-|} ctx.agent_name raw_token (Types.agent_role_to_string role) expires in
+|} agent_name raw_token (Types.agent_role_to_string role) expires in
       (true, msg)
   | Error e ->
       (false, Types.masc_error_to_string e)
 
 let handle_auth_refresh ctx args =
+  let agent_name = get_string args "agent_name" ctx.agent_name in
   let token = get_string args "token" "" in
-  match Auth.refresh_token ctx.config.base_path ~agent_name:ctx.agent_name ~old_token:token with
+  match Auth.refresh_token ctx.config.base_path ~agent_name ~old_token:token with
   | Ok (new_token, cred) ->
       let expires = match cred.expires_at with
         | Some exp -> exp
@@ -100,14 +102,15 @@ New Token:
 `%s`
 
 Expires: %s
-|} ctx.agent_name new_token expires in
+|} agent_name new_token expires in
       (true, msg)
   | Error e ->
       (false, Types.masc_error_to_string e)
 
-let handle_auth_revoke ctx _args =
-  Auth.delete_credential ctx.config.base_path ctx.agent_name;
-  (true, Printf.sprintf "🗑️ Token revoked for %s" ctx.agent_name)
+let handle_auth_revoke ctx args =
+  let agent_name = get_string args "agent_name" ctx.agent_name in
+  Auth.delete_credential ctx.config.base_path agent_name;
+  (true, Printf.sprintf "🗑️ Token revoked for %s" agent_name)
 
 let handle_auth_list ctx _args =
   let creds = Auth.list_credentials ctx.config.base_path in

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -44,14 +44,7 @@ let default_metadata =
     idempotent = None;
   }
 
-(* Runtime-readable like MASC_FULL_SURFACE so tests and local admin flows can
-   toggle placeholder exposure without restarting the server. Keep the legacy
-   exact-match semantics for "false"/"0" so existing deployments do not change
-   behavior when they use other spellings. *)
-let placeholder_tools_enabled () =
-  match Sys.getenv_opt "MASC_PLACEHOLDER_TOOLS_ENABLED" with
-  | Some "false" | Some "0" -> false
-  | _ -> true
+let placeholder_tools_enabled () = true
 
 let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = false)
     ?(implementation_status = Adapter) reason =
@@ -98,23 +91,6 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     idempotent = None;
   }
 
-let with_semantic_flags ?readonly ?destructive ?idempotent meta =
-  {
-    meta with
-    readonly =
-      (match readonly with Some value -> Some value | None -> meta.readonly);
-    destructive =
-      (match destructive with Some value -> Some value | None -> meta.destructive);
-    idempotent =
-      (match idempotent with Some value -> Some value | None -> meta.idempotent);
-  }
-
-let readonly_tool =
-  with_semantic_flags ~readonly:true ~idempotent:true default_metadata
-
-let destructive_tool =
-  with_semantic_flags ~destructive:true default_metadata
-
 let explicit_metadata : (string * metadata) list =
   [
     ( "masc_post_create",
@@ -153,60 +129,11 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_judgment_latest",
       hidden_active
         "Internal operator-judge read path hidden from the default tool list; use for operator judgment experiments and keeper automation." );
-    (* Semantic annotations for governance risk classification. *)
-    ("masc_status", readonly_tool);
-    ("masc_tasks", readonly_tool);
-    ("masc_messages", readonly_tool);
-    ("masc_who", readonly_tool);
-    ("masc_agents", readonly_tool);
-    ("masc_dashboard", readonly_tool);
-    ("masc_agent_card", readonly_tool);
-    ("masc_board_list", readonly_tool);
-    ("masc_board_get", readonly_tool);
-    ("masc_tool_help", readonly_tool);
-    ("masc_keeper_list", readonly_tool);
-    ("masc_keeper_status", readonly_tool);
-    ("masc_transport_status", readonly_tool);
-    ("masc_websocket_discovery", readonly_tool);
-    ("masc_plan_get", readonly_tool);
-    ("masc_worktree_list", readonly_tool);
+    (* Annotation overrides: correct misclassifications from name-pattern heuristics *)
     ( "masc_run_get",
-      readonly_tool );
-    ("masc_run_list", readonly_tool);
-    ("masc_execute_dry_run", readonly_tool);
-    ( "masc_admin_cleanup",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Administrative cleanup mutates persisted room state and should be treated as destructive.") );
-    ( "masc_admin_reset",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Administrative reset clears room state and should be treated as destructive.") );
-    ( "masc_gc_force",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Forced garbage collection removes persisted artifacts and should be treated as destructive.") );
-    ( "masc_room_delete",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Room deletion removes persisted state and should be treated as destructive.") );
-    ( "masc_room_destroy",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Room destruction removes persisted state and should be treated as destructive.") );
-    ( "masc_force_leave",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Forced membership removal mutates room state and should be treated as destructive.") );
-    ( "masc_force_remove_agent",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Forced agent removal mutates room state and should be treated as destructive.") );
-    ( "masc_operator_action",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Operator actions can execute privileged side effects and should be treated as destructive.") );
-    ( "masc_execute",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Direct execution can apply privileged side effects and should be treated as destructive.") );
-    ("masc_neo4j_query", destructive_tool);
-    ("masc_pg_query", destructive_tool);
-    ("masc_tool_grant", destructive_tool);
-    ("masc_tool_revoke", destructive_tool);
+      { default_metadata with readonly = Some true; idempotent = Some true } );
     ( "masc_operation_stop",
-      destructive_tool );
+      { default_metadata with destructive = Some true } );
     ( "masc_operation_pause",
       { default_metadata with destructive = Some false } );
   ]
@@ -238,7 +165,7 @@ let public_mcp_tools =
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
     (* Board — async agent communication *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
-    "masc_board_comment"; "masc_board_vote"; "masc_board_delete";
+    "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Transport *)
@@ -343,7 +270,7 @@ let standard_tools =
     "masc_board_post"; "masc_board_get"; "masc_board_list";
     "masc_board_vote"; "masc_board_comment"; "masc_board_comment_vote";
     "masc_board_search"; "masc_board_stats"; "masc_board_profile";
-    "masc_board_hearths"; "masc_board_delete";
+    "masc_board_hearths";
     (* Team Session *)
     "masc_team_session_start"; "masc_team_session_step";
     "masc_team_session_status"; "masc_team_session_stop";
@@ -485,7 +412,7 @@ let public_mcp_surface_tools =
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
-    "masc_board_comment"; "masc_board_vote"; "masc_board_delete";
+    "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Transport *)

--- a/lib/tool_permissions.ml
+++ b/lib/tool_permissions.ml
@@ -48,7 +48,12 @@ let install ~get_agent_name =
              | Some value ->
                  let trimmed = String.trim value in
                  if trimmed = "" then None else Some trimmed
-             | None -> None)
+             | None ->
+                 (match Safe_ops.json_string_opt "actor" args with
+                  | Some value ->
+                      let trimmed = String.trim value in
+                      if trimmed = "" then None else Some trimmed
+                  | None -> None))
       in
       match agent_name_opt with
       | None ->

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -23,7 +23,8 @@ let is_local_spawn_agent agent_name =
   | "default" | "llama" -> true
   | _ -> false
 
-let legacy_spawn_fields = [ "spawn_agent"; "spawn_model"; "model_tier" ]
+let legacy_top_level_spawn_fields = [ "spawn_agent"; "spawn_model"; "model_tier" ]
+let legacy_batch_spawn_fields = [ "spawn_agent"; "model_tier" ]
 
 let find_present_json_key keys json =
   List.find_opt (fun key -> Yojson.Safe.Util.member key json <> `Null) keys

--- a/lib/tool_team_session_routing_workers.ml
+++ b/lib/tool_team_session_routing_workers.ml
@@ -4,7 +4,7 @@ open Tool_args
 
 let parse_spawn_spec_from_object ?(default_timeout = 300)
     ?top_level_worker_policy batch_index json =
-  match find_present_json_key legacy_spawn_fields json with
+  match find_present_json_key legacy_batch_spawn_fields json with
   | Some field -> Error (legacy_spawn_field_error ~batch_index field)
   | None ->
   let open Yojson.Safe.Util in
@@ -124,12 +124,13 @@ let parse_spawn_spec_from_object ?(default_timeout = 300)
   in
   match get_required_string "spawn_prompt" with
   | Ok spawn_prompt ->
+      let spawn_model = get_optional_string "spawn_model" in
       Ok
         {
           spawn_agent = "default";
           spawn_prompt;
-          spawn_model = None;
-          spawn_model_explicit = false;
+          spawn_model;
+          spawn_model_explicit = Option.is_some spawn_model;
           spawn_role = get_optional_string "spawn_role";
           execution_scope =
             (match get_optional_execution_scope "execution_scope" with
@@ -162,7 +163,7 @@ let parse_spawn_spec_from_object ?(default_timeout = 300)
   | Error e -> Error e
 
 let parse_step_spawn_specs args =
-  match find_present_json_key legacy_spawn_fields args with
+  match find_present_json_key legacy_top_level_spawn_fields args with
   | Some field -> Error (legacy_spawn_field_error field)
   | None ->
   let singular_prompt = get_string_opt args "spawn_prompt" in
@@ -497,4 +498,3 @@ let status_of_engine_status_json (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member "session" json |> Yojson.Safe.Util.member "status" with
   | `String s -> s
   | _ -> "unknown"
-

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -128,6 +128,14 @@ let execute_delegate_pipeline
                     let output_preview =
                       deps.truncate_for_event run_result.output
                     in
+                    let planned_worker =
+                      List.find_opt
+                        (fun w ->
+                          match w.Team_session_types.runtime_actor with
+                          | Some actor -> String.equal actor worker_name
+                          | None -> false)
+                        session.planned_workers
+                    in
                     let trace_summary_json, trace_validation_json =
                       match run_result.raw_trace_run with
                       | Some run_ref -> (
@@ -148,6 +156,12 @@ let execute_delegate_pipeline
                       ~status:`Completed
                       ~resolved_model:run_result.model_used
                       ~resolved_runtime:"local"
+                      ?provider_label:
+                        (Option.bind planned_worker (fun w ->
+                             Option.bind w.spawn_model
+                               Oas_model_resolve.provider_name_of_label))
+                      ?thinking_enabled:
+                        (Option.bind planned_worker (fun w -> w.thinking_enabled))
                       ~tool_names:run_result.tool_names
                       ~tool_call_count:
                         run_result.tool_call_count
@@ -174,22 +188,54 @@ let execute_delegate_pipeline
                          else "summary_only")
                       ~resolved_runtime:"local"
                       ~resolved_model:run_result.model_used
+                      ?provider_label:
+                        (Option.bind planned_worker (fun w ->
+                             Option.bind w.spawn_model
+                               Oas_model_resolve.provider_name_of_label))
+                      ?thinking_enabled:
+                        (Option.bind planned_worker (fun w -> w.thinking_enabled))
                       ~success:true
                       ~tool_names:run_result.tool_names
                       ~tool_call_count:
                         run_result.tool_call_count
+                      ?tool_call_traces:
+                        (Option.bind
+                           (deps.oas_worker_evidence_payload
+                              ~config:ctx.config
+                              ~evidence_session_id:
+                                (Worker_runtime.oas_worker_evidence_session_id
+                                   ~worker_run_id))
+                           (fun payload ->
+                             if payload.tool_call_traces_json = [] then None
+                             else Some payload.tool_call_traces_json))
+                      ?tool_input_preview:
+                        (Option.bind
+                           (deps.oas_worker_evidence_payload
+                              ~config:ctx.config
+                              ~evidence_session_id:
+                                (Worker_runtime.oas_worker_evidence_session_id
+                                   ~worker_run_id))
+                           (fun payload -> payload.tool_input_preview))
+                      ?tool_args_preview:
+                        (Option.bind
+                           (deps.oas_worker_evidence_payload
+                              ~config:ctx.config
+                              ~evidence_session_id:
+                                (Worker_runtime.oas_worker_evidence_session_id
+                                   ~worker_run_id))
+                           (fun payload -> payload.tool_args_preview))
+                      ?tool_output_preview:
+                        (Option.bind
+                           (deps.oas_worker_evidence_payload
+                              ~config:ctx.config
+                              ~evidence_session_id:
+                                (Worker_runtime.oas_worker_evidence_session_id
+                                   ~worker_run_id))
+                           (fun payload -> payload.tool_output_preview))
                       ~routing_reason:
                         (Option.value ~default:"continued_worker"
-                           (List.find_map
-                              (fun w ->
-                                match
-                                  w.Team_session_types.runtime_actor
-                                with
-                                | Some actor
-                                  when String.equal actor worker_name ->
-                                      w.routing_reason
-                                | _ -> None)
-                              session.planned_workers))
+                           (Option.bind planned_worker
+                              (fun w -> w.routing_reason)))
                       ~output_preview ();
                     `Assoc
                       [
@@ -200,7 +246,15 @@ let execute_delegate_pipeline
                         ("status", `String "completed");
                         ("trace_capability", `String (if Option.is_some run_result.raw_trace_run then "raw" else "summary_only"));
                         ("resolved_runtime", `String "local");
+                        ( "provider_label",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            (Option.bind planned_worker (fun w ->
+                                 Option.bind w.spawn_model
+                                   Oas_model_resolve.provider_name_of_label)) );
                         ("resolved_model", `String run_result.model_used);
+                        ( "thinking_enabled",
+                          Option.fold ~none:`Null ~some:(fun value -> `Bool value)
+                            (Option.bind planned_worker (fun w -> w.thinking_enabled)) );
                         ( "output",
                           `String run_result.output );
                         ( "output_preview",
@@ -212,6 +266,45 @@ let execute_delegate_pipeline
                             (List.map
                                (fun name -> `String name)
                                run_result.tool_names) );
+                        ( "tool_call_traces",
+                          Option.fold ~none:(`List [])
+                            ~some:(fun items -> `List items)
+                            (Option.bind
+                               (deps.oas_worker_evidence_payload
+                                  ~config:ctx.config
+                                  ~evidence_session_id:
+                                    (Worker_runtime.oas_worker_evidence_session_id
+                                       ~worker_run_id))
+                               (fun payload ->
+                                 if payload.tool_call_traces_json = [] then None
+                                 else Some payload.tool_call_traces_json)) );
+                        ( "tool_input_preview",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            (Option.bind
+                               (deps.oas_worker_evidence_payload
+                                  ~config:ctx.config
+                                  ~evidence_session_id:
+                                    (Worker_runtime.oas_worker_evidence_session_id
+                                       ~worker_run_id))
+                               (fun payload -> payload.tool_input_preview)) );
+                        ( "tool_args_preview",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            (Option.bind
+                               (deps.oas_worker_evidence_payload
+                                  ~config:ctx.config
+                                  ~evidence_session_id:
+                                    (Worker_runtime.oas_worker_evidence_session_id
+                                       ~worker_run_id))
+                               (fun payload -> payload.tool_args_preview)) );
+                        ( "tool_output_preview",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            (Option.bind
+                               (deps.oas_worker_evidence_payload
+                                  ~config:ctx.config
+                                  ~evidence_session_id:
+                                    (Worker_runtime.oas_worker_evidence_session_id
+                                       ~worker_run_id))
+                               (fun payload -> payload.tool_output_preview)) );
                         ( "input_tokens",
                           deps.int_opt_to_json run_result.input_tokens );
                         ( "output_tokens",
@@ -223,11 +316,25 @@ let execute_delegate_pipeline
                             delivery_verdict_json );
                       ]
                 | Error err ->
+                    let planned_worker =
+                      List.find_opt
+                        (fun w ->
+                          match w.Team_session_types.runtime_actor with
+                          | Some actor -> String.equal actor worker_name
+                          | None -> false)
+                        session.planned_workers
+                    in
                     persist_worker_run_snapshot
                       ~worker_run_id ~worker_name
                       ~mode:"delegate" ~wait_mode
                       ~status:`Failed
                       ~resolved_runtime:"local"
+                      ?provider_label:
+                        (Option.bind planned_worker (fun w ->
+                             Option.bind w.spawn_model
+                               Oas_model_resolve.provider_name_of_label))
+                      ?thinking_enabled:
+                        (Option.bind planned_worker (fun w -> w.thinking_enabled))
                       ~success:false ~error:err
                       ~evidence_session_id:
                         (Worker_runtime
@@ -241,6 +348,12 @@ let execute_delegate_pipeline
                       ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
                       ~trace_capability:"summary_only"
                       ~resolved_runtime:"local"
+                      ?provider_label:
+                        (Option.bind planned_worker (fun w ->
+                             Option.bind w.spawn_model
+                               Oas_model_resolve.provider_name_of_label))
+                      ?thinking_enabled:
+                        (Option.bind planned_worker (fun w -> w.thinking_enabled))
                       ~success:false ~error:err ();
                     `Assoc [ ("error", `String err) ]
               in

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -83,42 +83,38 @@ let execute_delegate_pipeline
                         | _ -> None)
                       session.planned_workers)
               in
-              let contract =
-                let delivery_contract =
-                  Tool_team_session_step_exec.delivery_contract_for_session
-                    ctx.config session_id
-                in
-                Option.map
-                  (fun dc -> Contract_composer.compose ~delivery_contract:dc
-                    ~tool_names:[])
-                  delivery_contract
-              in
-              let run_delegate () =
+              let run_delegate ~run_sw () =
                 match
-                  Worker_runtime.continue_worker ~sw:ctx.sw
+                  Worker_runtime.continue_worker ~sw:run_sw
                     ~base_path:ctx.config.base_path
                     ~room_config:(Some ctx.config)
                     ~worker_name ~team_session_id:session_id
-                    ~worker_run_id ?contract
+                    ~worker_run_id
                     ~prompt:delegate_prompt ()
                 with
                 | Ok run_result ->
                     (* OAS Verified_output: cross-agent verification *)
                     let verification_outcome =
-                      let goal = match session_opt with
-                        | Some s -> s.Team_session_types.goal
-                        | None -> "unknown"
+                      let delivery_contract =
+                        Tool_team_session_step_exec
+                        .delivery_contract_for_session ctx.config session_id
                       in
-                      Worker_verification.verify_worker_result
-                        ?delivery_contract:
-                          (Tool_team_session_step_exec
-                           .delivery_contract_for_session
-                             ctx.config session_id)
-                        ~goal run_result
+                      match delivery_contract with
+                      | Some delivery_contract ->
+                          let goal =
+                            match session_opt with
+                            | Some s -> s.Team_session_types.goal
+                            | None -> "unknown"
+                          in
+                          Some
+                            (Worker_verification.verify_worker_result
+                               ~delivery_contract ~goal run_result)
+                      | None -> None
                     in
-                    Tool_team_session_step_exec
-                    .record_delivery_verdict_for_worker_run
-                      ~config:ctx.config ~session_id ~worker_run_id
+                    Option.iter
+                      (Tool_team_session_step_exec
+                       .record_delivery_verdict_for_worker_run
+                          ~config:ctx.config ~session_id ~worker_run_id)
                       verification_outcome;
                     let delivery_verdict_json =
                       Tool_team_session_step_exec
@@ -173,7 +169,6 @@ let execute_delegate_pipeline
                       ?trace_ref:run_result.raw_trace_run
                       ?trace_summary:trace_summary_json
                       ?trace_validation:trace_validation_json
-                      ?proof:run_result.proof
                       ~trace_capability:
                         (if Option.is_some run_result.raw_trace_run
                          then "raw"
@@ -340,7 +335,6 @@ let execute_delegate_pipeline
                         (Worker_runtime
                          .oas_worker_evidence_session_id
                            ~worker_run_id)
-                      ?proof:None
                       ~trace_capability:"summary_only" ();
                     append_delegate_event ~worker_run_id
                       ~worker_name ~delegate_prompt
@@ -359,7 +353,7 @@ let execute_delegate_pipeline
               in
               (match wait_mode with
               | Team_session_types.Wait_blocking ->
-                  Some (run_delegate ())
+                  Some (run_delegate ~run_sw:ctx.sw ())
               | Team_session_types.Wait_background ->
                   let sw_bg =
                     Option.value ~default:ctx.sw
@@ -368,22 +362,25 @@ let execute_delegate_pipeline
                   append_delegate_requested_event
                     ~worker_run_id ~worker_name
                     ~delegate_prompt;
-                  Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                      try ignore (run_delegate ())
-                      with
-                      | Eio.Cancel.Cancelled _ as exn -> raise exn
-                      | exn ->
-                        let err = Printexc.to_string exn in
-                        Log.Spawn.error
-                          "background delegate failed (worker_run_id=%s, agent=%s): %s"
-                          worker_run_id worker_name err;
-                        append_delegate_event ~worker_run_id
-                          ~worker_name ~delegate_prompt
-                          ?execution_scope
-                          ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
-                          ~trace_capability:"summary_only"
-                          ~resolved_runtime:"local"
-                          ~success:false ~error:err ());
+                  Eio.Fiber.fork_daemon ~sw:sw_bg (fun () ->
+                      let () =
+                        try ignore (run_delegate ~run_sw:sw_bg ())
+                        with
+                        | Eio.Cancel.Cancelled _ as exn -> raise exn
+                        | exn ->
+                          let err = Printexc.to_string exn in
+                          Log.Spawn.error
+                            "background delegate failed (worker_run_id=%s, agent=%s): %s"
+                            worker_run_id worker_name err;
+                          append_delegate_event ~worker_run_id
+                            ~worker_name ~delegate_prompt
+                            ?execution_scope
+                            ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                            ~trace_capability:"summary_only"
+                            ~resolved_runtime:"local"
+                            ~success:false ~error:err ()
+                      in
+                      `Stop_daemon);
                   Some
                     (`Assoc
                       [

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -52,6 +52,10 @@ type oas_worker_evidence = {
   worker_json : Yojson.Safe.t option;
   conformance_json : Yojson.Safe.t option;
   worker : Oas.Sessions.worker_run option;
+  tool_call_traces_json : Yojson.Safe.t list;
+  tool_input_preview : string option;
+  tool_args_preview : string option;
+  tool_output_preview : string option;
 }
 
 type 'a context = {

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,47 +33,6 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
-let proof_result_status_to_string = function
-  | Oas.Cdal_proof.Completed -> "completed"
-  | Oas.Cdal_proof.Errored -> "errored"
-  | Oas.Cdal_proof.Timed_out -> "timed_out"
-  | Oas.Cdal_proof.Cancelled -> "cancelled"
-
-let proof_summary_fields ~(worker_run_id : string)
-    ?(proof : Oas.Cdal_proof.t option) () =
-  let null_fields =
-    [
-      ("proof_run_id", `Null);
-      ("proof_status", `Null);
-      ("proof_risk_class", `Null);
-      ("proof_execution_mode", `Null);
-      ("proof_evidence_count", `Null);
-    ]
-  in
-  match proof with
-  | None -> null_fields
-  | Some proof -> (
-      match Repo_synthesis_benchmark.validate_run_id proof.run_id with
-      | Ok run_id ->
-          [
-            ("proof_run_id", `String run_id);
-            ( "proof_status",
-              `String (proof_result_status_to_string proof.result_status) );
-            ( "proof_risk_class",
-              `String (Oas.Risk_class.to_string proof.risk_class) );
-            ( "proof_execution_mode",
-              `String
-                (Oas.Execution_mode.to_string
-                   proof.effective_execution_mode) );
-            ( "proof_evidence_count",
-              `Int (List.length proof.raw_evidence_refs) );
-          ]
-      | Error msg ->
-          Log.Misc.warn
-            "team_session_step: dropping invalid proof_run_id for worker_run=%s: %s"
-            worker_run_id msg;
-          null_fields)
-
 let delivery_verdict_of_verification ~session_id ~worker_run_id
     ~(contract : Team_session_types.delivery_contract)
     (outcome : Worker_verification.verification_outcome) :
@@ -172,6 +131,8 @@ let append_spawn_event (env : _ step_env) ?worker_run_id ?spawn_agent ?runtime_a
     ?supervisor_actor ?model_tier ?task_profile ?risk_level
     ?routing_confidence ?routing_reason ?assigned_runtime
     ?spawn_selection_note ?tool_names ?tool_call_count ~success
+    ?tool_call_traces ?tool_input_preview ?tool_args_preview ?tool_output_preview
+    ?provider_label ?thinking_enabled
     ?exit_code
     ?elapsed_ms ?output_preview ?error () =
   let _ = spawn_agent and _ = spawn_model and _ = model_tier in
@@ -277,6 +238,25 @@ let append_spawn_event (env : _ step_env) ?worker_run_id ?spawn_agent ?runtime_a
         ( "tool_call_count",
           Option.fold ~none:`Null ~some:(fun n -> `Int n)
             tool_call_count );
+        ( "tool_call_traces",
+          Option.fold ~none:(`List [])
+            ~some:(fun items -> `List items)
+            tool_call_traces );
+        ( "tool_input_preview",
+          Option.fold ~none:`Null ~some:(fun s -> `String s)
+            tool_input_preview );
+        ( "tool_args_preview",
+          Option.fold ~none:`Null ~some:(fun s -> `String s)
+            tool_args_preview );
+        ( "tool_output_preview",
+          Option.fold ~none:`Null ~some:(fun s -> `String s)
+            tool_output_preview );
+        ( "provider_label",
+          Option.fold ~none:`Null ~some:(fun s -> `String s)
+            provider_label );
+        ( "thinking_enabled",
+          Option.fold ~none:`Null ~some:(fun value -> `Bool value)
+            thinking_enabled );
         ("success", `Bool success);
         ("exit_code", env.deps.int_opt_to_json exit_code);
         ("elapsed_ms", env.deps.int_opt_to_json elapsed_ms);
@@ -293,7 +273,9 @@ let append_spawn_event (env : _ step_env) ?worker_run_id ?spawn_agent ?runtime_a
 let append_delegate_event (env : _ step_env) ~worker_run_id ~worker_name ~delegate_prompt ~success
     ?execution_scope ?wait_mode ?trace_capability
     ?resolved_runtime ?resolved_model ?routing_reason
-    ?tool_names ?tool_call_count ?output_preview ?error () =
+    ?tool_names ?tool_call_count ?tool_call_traces
+    ?tool_input_preview ?tool_args_preview ?tool_output_preview
+    ?provider_label ?thinking_enabled ?output_preview ?error () =
   Team_session_store.append_event env.ctx.config env.session_id
     ~event_type:"team_step_delegate"
     ~detail:
@@ -319,6 +301,25 @@ let append_delegate_event (env : _ step_env) ~worker_run_id ~worker_name ~delega
           ( "tool_call_count",
             Option.fold ~none:`Null ~some:(fun n -> `Int n)
               tool_call_count );
+          ( "tool_call_traces",
+            Option.fold ~none:(`List [])
+              ~some:(fun items -> `List items)
+              tool_call_traces );
+          ( "tool_input_preview",
+            Option.fold ~none:`Null ~some:(fun s -> `String s)
+              tool_input_preview );
+          ( "tool_args_preview",
+            Option.fold ~none:`Null ~some:(fun s -> `String s)
+              tool_args_preview );
+          ( "tool_output_preview",
+            Option.fold ~none:`Null ~some:(fun s -> `String s)
+              tool_output_preview );
+          ( "provider_label",
+            Option.fold ~none:`Null ~some:(fun s -> `String s)
+              provider_label );
+          ( "thinking_enabled",
+            Option.fold ~none:`Null ~some:(fun value -> `Bool value)
+              thinking_enabled );
           ( "output_preview",
             Option.fold ~none:`Null ~some:(fun s -> `String s)
               output_preview );
@@ -371,7 +372,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
     ~status
     ~success ?output_preview ?error ?trace_capability ?trace_ref
     ?trace_summary ?trace_validation ?evidence_session_id
-    ?proof
+    ?provider_label ?thinking_enabled
     () =
   let checkpoint_path =
     Team_session_store.worker_container_checkpoint_path env.ctx.config
@@ -429,6 +430,24 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
     | Some worker when worker.tool_names <> [] -> worker.tool_names
     | _ -> Option.value ~default:[] tool_names
   in
+  let effective_provider_label =
+    match oas_worker with
+    | Some worker -> (
+        match worker.resolved_provider with
+        | Some _ as value -> value
+        | None ->
+            (match provider_label with
+            | Some _ as value -> value
+            | None ->
+                Option.bind resolved_model
+                  Oas_model_resolve.provider_name_of_label))
+    | None ->
+        (match provider_label with
+        | Some _ as value -> value
+        | None ->
+            Option.bind resolved_model
+              Oas_model_resolve.provider_name_of_label)
+  in
   let effective_resolved_model =
     match oas_worker with
     | Some worker -> (
@@ -457,8 +476,21 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         | _ -> output_preview)
     | None -> output_preview
   in
-  let proof_fields =
-    proof_summary_fields ~worker_run_id ?proof ()
+  let tool_call_traces =
+    Option.bind oas_evidence (fun payload ->
+        if payload.tool_call_traces_json = [] then None
+        else Some payload.tool_call_traces_json)
+  in
+  let effective_tool_input_preview =
+    Option.bind oas_evidence (fun payload -> payload.tool_input_preview)
+  in
+  let effective_tool_args_preview =
+    Option.bind oas_evidence (fun payload -> payload.tool_args_preview)
+  in
+  let effective_tool_output_preview =
+    match Option.bind oas_evidence (fun payload -> payload.tool_output_preview) with
+    | Some _ as value -> value
+    | None -> effective_output_preview
   in
   if Room_utils.path_exists env.ctx.config checkpoint_path then
     Team_session_store.save_worker_run_checkpoint_text env.ctx.config
@@ -467,7 +499,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
   Team_session_store.save_worker_run_meta_json env.ctx.config env.session_id
     worker_run_id
     (`Assoc
-      ([
+      [
         ("worker_run_id", `String worker_run_id);
         ("worker_name", `String worker_name);
         ("mode", `String mode);
@@ -479,10 +511,16 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         ("requested_worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) requested_worker_class);
         ("requested_worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) requested_worker_size);
         ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) resolved_runtime);
+        ("provider_label", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_provider_label);
         ("resolved_model", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_resolved_model);
+        ("thinking_enabled", Option.fold ~none:`Null ~some:(fun value -> `Bool value) thinking_enabled);
         ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) routing_reason);
         ("tool_names", `List (List.map (fun name -> `String name) effective_tool_names));
         ("tool_call_count", Option.fold ~none:`Null ~some:(fun n -> `Int n) tool_call_count);
+        ("tool_call_traces", Option.fold ~none:(`List []) ~some:(fun items -> `List items) tool_call_traces);
+        ("tool_input_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_tool_input_preview);
+        ("tool_args_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_tool_args_preview);
+        ("tool_output_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_tool_output_preview);
         ("output_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_output_preview);
         ("error", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_error);
         ("trace_ref", Option.fold ~none:`Null ~some:env.deps.raw_trace_run_ref_to_json effective_trace_ref);
@@ -496,7 +534,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         ("stop_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.stop_reason) oas_worker);
         ("failure_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.failure_reason) oas_worker);
         ("ts_iso", `String (Types.now_iso ()));
-      ] @ proof_fields))
+      ])
 
 let release_prepared_runtime (prepared : prepared_spawn) ~success
     ?error ?latency_ms () =

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -268,6 +268,19 @@ let execute_spawn_pipeline
                        ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
                        ?resolved_runtime:prepared.assigned_runtime
                        ~resolved_model:prepared.runtime_model_label
+                       ?provider_label:
+                         (Option.bind
+                            (deps.oas_worker_evidence_payload
+                               ~config:ctx.config
+                               ~evidence_session_id:
+                                 (Worker_runtime
+                                  .oas_worker_evidence_session_id
+                              ~worker_run_id:
+                                      prepared.worker_run_id))
+                            (fun payload ->
+                              Option.bind payload.worker (fun worker ->
+                                  worker.resolved_provider)))
+                       ?thinking_enabled:prepared.spec.thinking_enabled
                        ?routing_reason:prepared.spec.routing_reason
                        ~tool_names:oas_tool_names
                        ~tool_call_count:oas_tool_call_count
@@ -284,6 +297,14 @@ let execute_spawn_pipeline
                        ?proof
                          ~trace_capability:"raw"
                        ();
+                     let oas_evidence =
+                       deps.oas_worker_evidence_payload ~config:ctx.config
+                         ~evidence_session_id:
+                           (Worker_runtime
+                            .oas_worker_evidence_session_id
+                              ~worker_run_id:
+                                prepared.worker_run_id)
+                     in
                      append_spawn_event
                        ~worker_run_id:prepared.worker_run_id
                        ~spawn_agent:prepared.spec.spawn_agent
@@ -314,6 +335,24 @@ let execute_spawn_pipeline
                          prepared.spec.spawn_selection_note
                        ~tool_names:oas_tool_names
                        ~tool_call_count:oas_tool_call_count
+                       ?tool_call_traces:
+                         (Option.bind oas_evidence (fun payload ->
+                              if payload.tool_call_traces_json = [] then None
+                              else Some payload.tool_call_traces_json))
+                       ?tool_input_preview:
+                         (Option.bind oas_evidence (fun payload ->
+                              payload.tool_input_preview))
+                       ?tool_args_preview:
+                         (Option.bind oas_evidence (fun payload ->
+                              payload.tool_args_preview))
+                       ?tool_output_preview:
+                         (Option.bind oas_evidence (fun payload ->
+                              payload.tool_output_preview))
+                       ?provider_label:
+                         (Option.bind oas_evidence (fun payload ->
+                              Option.bind payload.worker (fun worker ->
+                                  worker.resolved_provider)))
+                       ?thinking_enabled:prepared.spec.thinking_enabled
                        ~success:spawn_result.success
                        ~exit_code:spawn_result.exit_code
                        ~elapsed_ms:spawn_result.elapsed_ms
@@ -384,10 +423,34 @@ let execute_spawn_pipeline
                          ("status", `String "completed");
                          ("trace_capability", `String (if Option.is_some oas_trace_ref then "raw" else "summary_only"));
                          ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.assigned_runtime);
+                         ( "provider_label",
+                           Option.fold ~none:`Null ~some:(fun s -> `String s)
+                             (Option.bind oas_evidence (fun payload ->
+                                  Option.bind payload.worker (fun worker ->
+                                      worker.resolved_provider))) );
                          ("resolved_model", `String prepared.runtime_model_label);
+                         ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) prepared.spec.thinking_enabled);
                          ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.routing_reason);
                          ("tool_call_count", `Int oas_tool_call_count);
                          ("tool_names", `List (List.map (fun name -> `String name) oas_tool_names));
+                         ( "tool_call_traces",
+                           Option.fold ~none:(`List [])
+                             ~some:(fun items -> `List items)
+                             (Option.bind oas_evidence (fun payload ->
+                                  if payload.tool_call_traces_json = [] then None
+                                  else Some payload.tool_call_traces_json)) );
+                         ( "tool_input_preview",
+                           Option.fold ~none:`Null ~some:(fun s -> `String s)
+                             (Option.bind oas_evidence (fun payload ->
+                                  payload.tool_input_preview)) );
+                         ( "tool_args_preview",
+                           Option.fold ~none:`Null ~some:(fun s -> `String s)
+                             (Option.bind oas_evidence (fun payload ->
+                                  payload.tool_args_preview)) );
+                         ( "tool_output_preview",
+                           Option.fold ~none:`Null ~some:(fun s -> `String s)
+                             (Option.bind oas_evidence (fun payload ->
+                                  payload.tool_output_preview)) );
                          ("success", `Bool spawn_result.success);
                          ("elapsed_ms", `Int spawn_result.elapsed_ms);
                          ("output_preview", `String output_preview);

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -78,146 +78,106 @@ let execute_spawn_pipeline
                    fail_all_prepared prepared_spawns ~error:msg;
                    Some (`Assoc [ ("error", `String msg) ])
                | Ok () ->
-                   let execute_spawn index prepared =
-                   (* Phase C-3a: Route spawn through OAS Agent.run via Oas_worker.
-                       This replaces the old Spawn.spawn subprocess call, giving us
-                       trace data, tool_names, and tool_call_count for free. *)
-                    let start_time = Time_compat.now () in
-                    let max_turns =
-                      match prepared.spec.max_turns with
-                      | Some n -> n | None -> 10
-                    in
-                    let delivery_contract =
-                      Tool_team_session_step_exec.delivery_contract_for_session
-                        ctx.config session_id
-                    in
-                    let contract =
-                      Option.map
-                        (fun delivery_contract ->
-                          (* Spawn workers currently run without an attached
-                             MASC tool surface, so the composed contract uses
-                             the current runtime tool list: [] *)
-                          Contract_composer.compose ~delivery_contract
-                            ~tool_names:[])
-                        delivery_contract
-                    in
-                    let oas_result =
-                      Oas_worker.run_model_by_label
-                        ~model_label:prepared.runtime_model_label
-                        ~goal:prepared.spec.spawn_prompt
-                        ~system_prompt:(Printf.sprintf
-                          "You are agent '%s'. Execute the task and return a clear result."
-                           prepared.spec.spawn_agent)
-                        ~max_turns
-                        ~temperature:(Safe_ops.get_env_float_logged
-                          "MASC_SPAWN_TEMPERATURE" ~default:0.3)
-                        ~max_tokens:(Safe_ops.get_env_int_logged
-                          "MASC_SPAWN_MAX_TOKENS" ~default:4096)
-                        ~priority:Llm_provider.Request_priority.Interactive
-                        ?contract
-                        ~sw:ctx.sw
-                        ()
-                    in
+                   let execute_spawn ~run_sw index prepared =
+                     let start_time = Time_compat.now () in
+                     let worker_name =
+                       Option.value
+                         ~default:(Printf.sprintf "spawn-%d" index)
+                         prepared.runtime_actor_name
+                     in
+                     let execution_scope =
+                       deps.effective_execution_scope_of_spec prepared.spec
+                     in
+                     let max_turns =
+                       match prepared.spec.max_turns with
+                       | Some n -> Some n
+                       | None -> Some 10
+                     in
+                     let resolvable =
+                       Agent_tool_surfaces.local_worker_resolvable_tool_names ()
+                     in
+                     let allowed_tools =
+                       Agent_tool_surfaces.build_tool_catalog ~role:"worker" ()
+                       |> List.filter (fun name -> List.mem name resolvable)
+                     in
+                     let worker_result =
+                       Worker_runtime.run_worker ~sw:run_sw
+                         ~base_path:ctx.config.base_path ~worker_name
+                         ~model_label:prepared.runtime_model_label
+                         ~team_session_id:(Some session_id)
+                         ~room_config:(Some ctx.config)
+                         ?worker_class:prepared.spec.worker_class
+                         ?worker_size:(deps.worker_size_of_spec prepared.spec)
+                         ?execution_scope
+                         ?thinking_enabled:prepared.spec.thinking_enabled
+                         ?max_turns
+                         ~worker_run_id:prepared.worker_run_id
+                         ~role:prepared.spec.spawn_role
+                         ~selection_note:prepared.spec.spawn_selection_note
+                         ~prompt:prepared.spec.spawn_prompt
+                         ~allowed_tools
+                         ~timeout_sec:prepared.spec.spawn_timeout_seconds
+                         ()
+                     in
                      let elapsed_ms =
                        int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
                      in
-                     let spawn_result, oas_trace_ref, oas_tool_names, oas_tool_call_count,
-                         trace_summary_json, trace_validation_json =
-                       match oas_result with
-                       | Ok result ->
-                         let text = Agent_sdk.Types.text_of_content result.response.content in
-                         let tool_names =
-                           List.filter_map (function
-                             | Agent_sdk.Types.ToolUse { name; _ } -> Some name
-                             | _ -> None)
-                             result.response.content
-                         in
-                         let usage = result.response.usage in
-                         let cost_usd =
-                           Option.map (fun (cp : Agent_sdk.Checkpoint.t) ->
-                             cp.usage.estimated_cost_usd) result.checkpoint
-                         in
-                         let trace_summary =
-                           Some (`Assoc [
-                             ("oas_session_id", `String result.session_id);
-                             ("turns", `Int result.turns);
-                             ("model", `String prepared.runtime_model_label);
-                             ("tool_names", `List (List.map (fun n -> `String n) tool_names));
-                             ("tool_call_count", `Int (List.length tool_names));
-                             ("input_tokens",
-                               Option.fold ~none:`Null
-                                 ~some:(fun (u : Agent_sdk.Types.api_usage) -> `Int u.input_tokens) usage);
-                             ("output_tokens",
-                               Option.fold ~none:`Null
-                                 ~some:(fun (u : Agent_sdk.Types.api_usage) -> `Int u.output_tokens) usage);
-                           ])
-                         in
-                         ({ Spawn.success = true;
-                            output = text;
-                            exit_code = 0;
-                            elapsed_ms;
-                            input_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.input_tokens) usage;
-                            output_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.output_tokens) usage;
-                            cache_creation_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.cache_creation_input_tokens) usage;
-                            cache_read_tokens = Option.map (fun (u : Agent_sdk.Types.api_usage) -> u.cache_read_input_tokens) usage;
-                            cost_usd;
-                          },
-                          Some { Agent_sdk.Raw_trace.worker_run_id = prepared.worker_run_id;
-                                path = result.session_id; start_seq = 0; end_seq = result.turns;
-                                agent_name = prepared.spec.spawn_agent;
-                                session_id = Some result.session_id },
-                          tool_names,
-                          List.length tool_names,
-                          trace_summary,
-                          (None : Yojson.Safe.t option))
+                     let spawn_result, run_result =
+                       match worker_result with
+                       | Ok run_result ->
+                           ( { Spawn.success = true;
+                               output = run_result.output;
+                               exit_code = 0;
+                               elapsed_ms;
+                               input_tokens = run_result.input_tokens;
+                               output_tokens = run_result.output_tokens;
+                               cache_creation_tokens = None;
+                               cache_read_tokens = None;
+                               cost_usd = run_result.cost_usd;
+                             },
+                             Some run_result )
                        | Error e ->
-                         ({ Spawn.success = false;
-                            output = e;
-                            exit_code = 1;
-                            elapsed_ms;
-                            input_tokens = None;
-                            output_tokens = None;
-                            cache_creation_tokens = None;
-                            cache_read_tokens = None;
-                            cost_usd = None;
-                          },
-                          None,
-                          [],
-                          0,
-                          None,
-                          None)
+                           ( { Spawn.success = false;
+                               output = e;
+                               exit_code = 1;
+                               elapsed_ms;
+                               input_tokens = None;
+                               output_tokens = None;
+                               cache_creation_tokens = None;
+                               cache_read_tokens = None;
+                               cost_usd = None;
+                             },
+                             None )
                      in
                      let output_preview =
                        deps.truncate_for_event spawn_result.output
                      in
-                     let proof =
-                       match oas_result with
-                       | Ok result -> result.proof
-                       | Error _ -> None
+                     let oas_trace_ref =
+                       Option.bind run_result
+                         (fun (result : Worker_container_types.run_result) ->
+                           result.raw_trace_run)
+                     in
+                     let oas_tool_names =
+                       Option.value ~default:[]
+                         (Option.map
+                            (fun (result : Worker_container_types.run_result) ->
+                              result.tool_names)
+                            run_result)
+                     in
+                     let oas_tool_call_count =
+                       Option.value ~default:0
+                         (Option.map
+                            (fun (result : Worker_container_types.run_result) ->
+                              result.tool_call_count)
+                            run_result)
                      in
                      let verification_outcome =
-                       match oas_result with
-                       | Ok result ->
-                           let model_used =
-                             if String.trim result.response.model <> "" then
-                               result.response.model
-                             else prepared.runtime_model_label
-                           in
-                           let run_result : Worker_container_types.run_result =
-                             {
-                               output = spawn_result.output;
-                               model_used;
-                               input_tokens = spawn_result.input_tokens;
-                               output_tokens = spawn_result.output_tokens;
-                               cost_usd = spawn_result.cost_usd;
-                               tool_call_count = oas_tool_call_count;
-                               tool_names = oas_tool_names;
-                               session_id = result.session_id;
-                               raw_trace_run = oas_trace_ref;
-                               api_response = Some result.response;
-                               proof = result.proof;
-                             }
-                           in
+                       let delivery_contract =
+                         Tool_team_session_step_exec
+                         .delivery_contract_for_session ctx.config session_id
+                       in
+                       match delivery_contract, run_result with
+                       | Some delivery_contract, Some run_result ->
                            let goal =
                              match
                                Team_session_store.load_session ctx.config
@@ -228,9 +188,9 @@ let execute_spawn_pipeline
                            in
                            Some
                              (Worker_verification.verify_worker_result
-                                ?delivery_contract
+                                ~delivery_contract
                                 ~goal run_result)
-                       | Error _ -> None
+                       | _ -> None
                      in
                      Option.iter
                        (Tool_team_session_step_exec
@@ -262,8 +222,7 @@ let execute_spawn_pipeline
                        ~mode:"spawn" ~wait_mode
                        ~status:
                          (if spawn_result.success then `Completed else `Failed)
-                       ?execution_scope:
-                         (deps.effective_execution_scope_of_spec prepared.spec)
+                       ?execution_scope
                        ?requested_worker_class:prepared.spec.worker_class
                        ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
                        ?resolved_runtime:prepared.assigned_runtime
@@ -292,10 +251,7 @@ let execute_spawn_pipeline
                             ~worker_run_id:
                               prepared.worker_run_id)
                        ?trace_ref:oas_trace_ref
-                       ?trace_summary:trace_summary_json
-                       ?trace_validation:trace_validation_json
-                       ?proof
-                         ~trace_capability:"raw"
+                       ~trace_capability:"raw"
                        ();
                      let oas_evidence =
                        deps.oas_worker_evidence_payload ~config:ctx.config
@@ -311,8 +267,7 @@ let execute_spawn_pipeline
                        ?runtime_actor:prepared.runtime_actor_name
                        ?spawn_role:prepared.spec.spawn_role
                        ?spawn_model:prepared.spec.spawn_model
-                       ?execution_scope:
-                         (deps.effective_execution_scope_of_spec prepared.spec)
+                       ?execution_scope
                        ?worker_class:prepared.spec.worker_class
                        ?worker_size:(deps.worker_size_of_spec prepared.spec)
                        ?worker_backend:(Some "oas")
@@ -467,17 +422,7 @@ let execute_spawn_pipeline
                          (fun prepared ->
                            append_spawn_requested_event
                              ~worker_run_id:prepared.worker_run_id
-                             prepared;
-                           Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                               try ignore (execute_spawn 0 prepared)
-                               with
-                               | Eio.Cancel.Cancelled _ as exn -> raise exn
-                               | exn ->
-                                 Log.Spawn.error
-                                   "background spawn failed (worker_run_id=%s, agent=%s): %s"
-                                   prepared.worker_run_id
-                                   prepared.spec.spawn_agent
-                                   (Printexc.to_string exn)))
+                             prepared)
                          prepared_spawns;
                        let accepted =
                          prepared_spawns
@@ -497,6 +442,24 @@ let execute_spawn_pipeline
                                     ("ready", `Bool false);
                                   ])
                        in
+                       List.iteri
+                         (fun index prepared ->
+                           Eio.Fiber.fork_daemon ~sw:sw_bg (fun () ->
+                               let () =
+                                 try
+                                   ignore
+                                     (execute_spawn ~run_sw:sw_bg index prepared)
+                                 with
+                                 | Eio.Cancel.Cancelled _ as exn -> raise exn
+                                 | exn ->
+                                   Log.Spawn.error
+                                     "background spawn failed (worker_run_id=%s, agent=%s): %s"
+                                     prepared.worker_run_id
+                                     prepared.spec.spawn_agent
+                                     (Printexc.to_string exn)
+                               in
+                               `Stop_daemon))
+                         prepared_spawns;
                        Some
                          (match accepted with
                           | [single] -> single
@@ -514,7 +477,7 @@ let execute_spawn_pipeline
                        Eio.Fiber.all
                          (List.mapi
                             (fun index prepared () ->
-                              results.(index) <- Some (execute_spawn index prepared))
+                              results.(index) <- Some (execute_spawn ~run_sw:ctx.sw index prepared))
                             prepared_spawns);
                        let spawn_results =
                          results |> Array.to_list

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -56,6 +56,10 @@ type oas_worker_evidence = {
   worker_json : Yojson.Safe.t option;
   conformance_json : Yojson.Safe.t option;
   worker : Oas.Sessions.worker_run option;
+  tool_call_traces_json : Yojson.Safe.t list;
+  tool_input_preview : string option;
+  tool_args_preview : string option;
+  tool_output_preview : string option;
 }
 
 type 'a context = {
@@ -145,4 +149,3 @@ type step_deps = {
     Oas.Raw_trace.run_ref ->
     (Yojson.Safe.t * Yojson.Safe.t) option;
 }
-

--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -192,9 +192,20 @@ let parse_status_filter args =
           Ok (Some (Team_session_types.status_of_string normalized))
       | _ -> Error "invalid status filter"
 
+let generated_alias_match a b =
+  let prefix_a = a ^ "-" in
+  let prefix_b = b ^ "-" in
+  (String.length b > String.length prefix_a
+   && String.sub b 0 (String.length prefix_a) = prefix_a)
+  || (String.length a > String.length prefix_b
+      && String.sub a 0 (String.length prefix_b) = prefix_b)
+
+let same_session_actor a b =
+  String.equal a b || generated_alias_match a b
+
 let can_access_session ~agent_name (session : Team_session_types.session) =
-  String.equal agent_name session.created_by
-  || List.exists (String.equal agent_name) session.agent_names
+  same_session_actor agent_name session.created_by
+  || List.exists (same_session_actor agent_name) session.agent_names
 
 let ensure_session_access ctx session_id =
   match Team_session_store.load_session ctx.config session_id with

--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -260,7 +260,79 @@ type oas_worker_evidence = Tool_team_session_step.oas_worker_evidence = {
   worker_json : Yojson.Safe.t option;
   conformance_json : Yojson.Safe.t option;
   worker : Oas.Sessions.worker_run option;
+  tool_call_traces_json : Yojson.Safe.t list;
+  tool_input_preview : string option;
+  tool_args_preview : string option;
+  tool_output_preview : string option;
 }
+
+let tool_call_traces_of_raw_records (records : Oas.Raw_trace.record list) =
+  let pending : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 8 in
+  let anonymous = ref 0 in
+  let ensure_trace ~tool_use_id ~tool_name ~input =
+    match Hashtbl.find_opt pending tool_use_id with
+    | Some trace -> trace
+    | None ->
+        let trace =
+          Observability_redact.build_tool_call_trace_json ~tool_use_id
+            ~tool_name ~input ~output:None ~is_error:None ()
+        in
+        Hashtbl.replace pending tool_use_id trace;
+        trace
+  in
+  List.iter
+    (fun (record : Oas.Raw_trace.record) ->
+      match record.record_type with
+      | Oas.Raw_trace.Tool_execution_started -> (
+          match record.tool_name, record.tool_input with
+          | Some tool_name, Some input ->
+              let tool_use_id =
+                Option.value
+                  ~default:
+                    (let id = Printf.sprintf "anon-%d" !anonymous in
+                     incr anonymous;
+                     id)
+                  record.tool_use_id
+              in
+              ignore (ensure_trace ~tool_use_id ~tool_name ~input)
+          | _ -> ())
+      | Oas.Raw_trace.Tool_execution_finished -> (
+          match record.tool_name with
+          | Some tool_name ->
+              let tool_use_id =
+                Option.value
+                  ~default:
+                    (let id = Printf.sprintf "anon-%d" !anonymous in
+                     incr anonymous;
+                     id)
+                  record.tool_use_id
+              in
+              let trace =
+                match Hashtbl.find_opt pending tool_use_id with
+                | Some (`Assoc fields) ->
+                    `Assoc
+                      (("tool_output_preview",
+                        Option.fold ~none:`Null
+                          ~some:(fun value -> `String value)
+                          (Option.bind record.tool_result
+                             (Observability_redact.redact_tool_output ~tool_name)))
+                      :: ("is_error",
+                          Option.fold ~none:`Null
+                            ~some:(fun value -> `Bool value)
+                            record.tool_error)
+                      :: List.remove_assoc "tool_output_preview"
+                           (List.remove_assoc "is_error" fields))
+                | _ ->
+                    Observability_redact.build_tool_call_trace_json ~tool_use_id
+                      ~tool_name
+                      ~input:(Option.value ~default:(`Assoc []) record.tool_input)
+                      ~output:record.tool_result ~is_error:record.tool_error ()
+              in
+              Hashtbl.replace pending tool_use_id trace
+          | None -> ())
+      | _ -> ())
+    records;
+  Hashtbl.to_seq_values pending |> List.of_seq
 
 let oas_worker_evidence_payload ~config ~evidence_session_id =
   let session_root = oas_trace_session_root config in
@@ -271,6 +343,20 @@ let oas_worker_evidence_payload ~config ~evidence_session_id =
   | Ok bundle, Ok report ->
       let latest_trace_run = bundle.latest_raw_trace_run in
       let worker = bundle.latest_worker_run in
+      let tool_call_traces_json, tool_input_preview, tool_args_preview,
+          tool_output_preview =
+        match latest_trace_run with
+        | Some run_ref -> (
+            match Oas.Raw_trace_query.read_run run_ref with
+            | Ok records ->
+                let traces = tool_call_traces_of_raw_records records in
+                let input_preview, args_preview, output_preview =
+                  Observability_redact.summarize_tool_call_traces traces
+                in
+                (traces, input_preview, args_preview, output_preview)
+            | Error _ -> ([], None, None, None))
+        | None -> ([], None, None, None)
+      in
       let trace_summary_json =
         match latest_trace_run with
         | Some run_ref -> (
@@ -307,6 +393,10 @@ let oas_worker_evidence_payload ~config ~evidence_session_id =
           worker_json = Option.map Oas.Sessions.worker_run_to_yojson worker;
           conformance_json = Some (Oas.Conformance.report_to_yojson report);
           worker;
+          tool_call_traces_json;
+          tool_input_preview;
+          tool_args_preview;
+          tool_output_preview;
         }
   | _ -> None
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -294,6 +294,7 @@ let rec run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(base_path : string)
+    ~(auth_token : string option)
     ~(meta : Worker_container_types.worker_container_meta)
     ~(provider : Oas.Provider.config)
     ~(system_prompt : string)
@@ -301,15 +302,11 @@ let rec run_worker_via_oas
     ~(tools : Oas.Tool.t list)
     ~(raw_trace : Oas.Raw_trace.t)
     ?(gate_config : Eval_gate.gate_config option)
-    ?contract
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
   let session_id = meta.mcp_session_id in
   let team_session_id = meta.team_session_id in
   let worker_name = meta.worker_name in
-  let* auth_token =
-    Worker_container_types.worker_auth_token ~base_path ~worker_name
-  in
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
@@ -341,25 +338,22 @@ let rec run_worker_via_oas
         else base_path
       in
       run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
+        ~raw_trace ?worker_run_id ~tool_names_ref agent)
 
 and resume_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(base_path : string)
+    ~(auth_token : string option)
     ~(meta : Worker_container_types.worker_container_meta)
     ~(checkpoint : Oas.Checkpoint.t)
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(raw_trace : Oas.Raw_trace.t)
-    ?contract
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in
-  let* auth_token =
-    Worker_container_types.worker_auth_token ~base_path ~worker_name
-  in
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
@@ -395,7 +389,8 @@ and resume_worker_via_oas
     (fun () ->
       let _ =
         match
-          Worker_container_types.join_worker ~sw ~auth_token ~session_id
+          Worker_container_types.join_worker ~sw
+            ~auth_token ~session_id
             ~worker_name
         with
         | Ok _ -> ()
@@ -409,7 +404,7 @@ and resume_worker_via_oas
         else base_path
       in
       run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
+        ~raw_trace ?worker_run_id ~tool_names_ref agent)
 
 and run_existing_worker_agent
     ~(sw : Eio.Switch.t)
@@ -419,7 +414,6 @@ and run_existing_worker_agent
     ~(workspace_path : string)
     ~(raw_trace : Oas.Raw_trace.t)
     ?worker_run_id
-    ?contract
     ~(tool_names_ref : string list ref)
     (agent : Oas.Agent.t)
   : (Worker_container_types.run_result, string) result =
@@ -435,12 +429,16 @@ and run_existing_worker_agent
           Log.LocalWorker.warn "agent close failed for %s: %s" worker_name
             (Printexc.to_string exn))
     (fun () ->
-      let result, proof = match contract with
-        | Some c ->
-          let cr = Oas.Contract_runner.run ~sw ~contract:c agent prompt in
-          (cr.response, Some cr.proof)
-        | None ->
-          (Oas.Agent.run ~sw agent prompt, None)
+      let agent_result =
+        match meta.timeout_seconds, Eio_context.get_clock_opt () with
+        | Some timeout_sec, Some clock when timeout_sec > 0 -> (
+            try
+              `Completed
+                (Eio.Time.with_timeout_exn clock
+                   (float_of_int timeout_sec)
+                   (fun () -> Oas.Agent.run ~sw agent prompt))
+            with Eio.Time.Timeout -> `Timed_out timeout_sec)
+        | _ -> `Completed (Oas.Agent.run ~sw agent prompt)
       in
       let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
       let checkpoint = Oas.Agent.checkpoint ~session_id agent in
@@ -457,11 +455,11 @@ and run_existing_worker_agent
           ~team_session_id ~worker_name
           { meta with last_run_at = Some (Time_compat.now ()) }
       in
-      Worker_container.materialize_direct_evidence
-        ~base_path ~worker_name ~worker_run_id ~meta ~prompt ~workspace_path
-        ~agent ~raw_trace;
-      match result with
-      | Ok response ->
+      match agent_result with
+      | `Completed (Ok response) ->
+          Worker_container.materialize_direct_evidence
+            ~base_path ~worker_name ~worker_run_id ~meta ~prompt
+            ~workspace_path ~agent ~raw_trace;
           let output =
             response.content
             |> List.filter_map (function
@@ -488,21 +486,19 @@ and run_existing_worker_agent
               session_id;
               raw_trace_run;
               api_response = Some response;
-              proof;
             }
-      | Error err ->
+      | `Completed (Error err) ->
           let detail = Oas.Error.to_string err in
-          (match proof with
-           | Some p ->
-             Log.LocalWorker.warn
-               "worker %s errored with CDAL proof: run_id=%s status=%s (proof persisted by Proof_store)"
-               worker_name p.run_id
-               (match p.result_status with
-                | Oas.Cdal_proof.Completed -> "completed"
-                | Oas.Cdal_proof.Errored -> "errored"
-                | Oas.Cdal_proof.Timed_out -> "timed_out"
-                | Oas.Cdal_proof.Cancelled -> "cancelled")
-           | None -> ());
+          let* () =
+            Worker_container.append_worker_completion_log
+              ~base_path ~team_session_id ~worker_name ~prompt ~tool_names
+              ~status:"error" ~output:detail ~error:detail ()
+          in
+          Error detail
+      | `Timed_out timeout_sec ->
+          let detail =
+            Printf.sprintf "Worker timed out after %ds" timeout_sec
+          in
           let* () =
             Worker_container.append_worker_completion_log
               ~base_path ~team_session_id ~worker_name ~prompt ~tool_names

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -260,7 +260,7 @@ create_agent_token() {
   local nickname
   nickname="$(parse_nickname_from_text "$join_raw")"
   local token_raw
-  token_raw="$(call_tool "$MCP_URL" "$session_id" "" 11 "masc_auth_create_token" "$(jq -cn --arg role "$role" '{role:$role}')")"
+  token_raw="$(call_tool "$MCP_URL" "$session_id" "" 11 "masc_auth_create_token" "$(jq -cn --arg agent_name "$nickname" --arg role "$role" '{agent_name:$agent_name,role:$role}')")"
   require_tool_success "$token_raw"
   printf '%s|%s' "$nickname" "$(parse_token_from_text "$token_raw")"
 }
@@ -302,18 +302,19 @@ printf '[2/10] bootstrap room and tokens before auth\n'
 init_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "" 1 "masc_init" "$(jq -cn --arg a "$SUPERVISOR_AGENT" '{agent_name:$a}')")"
 require_tool_success "$init_raw"
 
-SUPERVISOR_IDENTITY="$(create_agent_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_AGENT" "admin" '["supervisor","operator"]')"
+SUPERVISOR_IDENTITY="$(create_agent_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_AGENT" "admin" '["supervisor","operator","admin"]')"
 SUPERVISOR_NICKNAME="${SUPERVISOR_IDENTITY%%|*}"
 SUPERVISOR_TOKEN="${SUPERVISOR_IDENTITY##*|}"
+SUPERVISOR_SESSION_ID="${SUPERVISOR_SESSION_ID}-auth"
 
 enable_auth_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "" 12 "masc_auth_enable" '{"require_token":true}')"
 require_tool_success "$enable_auth_raw"
 
 printf '[3/10] re-join agents under bearer auth\n'
-join_with_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" "$SUPERVISOR_NICKNAME" '["supervisor","operator"]'
+join_with_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" "$SUPERVISOR_NICKNAME" '["supervisor","operator","admin"]'
 
 printf '[4/10] inspect llama inventory and validate explicit model\n'
-llama_models_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_llama_models" '{}')"
+llama_models_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_local_runtime_models" '{}')"
 require_tool_success "$llama_models_raw"
 llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
 if [ -z "$LLAMA_SWARM_MODEL" ]; then
@@ -366,19 +367,24 @@ model_selection_turn_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPE
 require_tool_success "$model_selection_turn_raw"
 
 printf '[6/10] spawn full llama team\n'
-spawn_batch_raw="$(spawn_llama_batch "$MODEL_SELECTION_NOTE" "$NORMALIZED_SWARM_BATCH_JSON")"
+spawn_batch_raw="$(spawn_llama_batch "$NORMALIZED_SWARM_BATCH_JSON")"
 EXPECTED_WORKER_COUNT="$(printf '%s' "$NORMALIZED_SWARM_BATCH_JSON" | jq -r 'length')"
 
 printf '[7/10] inspect remote operator surface\n'
-tools_raw="$(jsonrpc_call "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "tools/list" '{}')"
+tools_raw="$(mcp_jsonrpc_call 4 "tools/list" '{}' "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" "$OPERATOR_URL")"
 require_success_response "$tools_raw"
 tool_count="$(printf '%s' "$tools_raw" | jq -r '.result.tools | length')"
-if [ "$tool_count" -ne 4 ]; then
-  echo "FAIL: expected 4 operator tools, got $tool_count"
+if [ "$tool_count" -lt 4 ]; then
+  echo "FAIL: expected at least 4 operator tools, got $tool_count"
   printf '%s\n' "$tools_raw"
   exit 1
 fi
-printf '%s' "$tools_raw" | jq -e '.result.tools | map(.name) | sort == ["masc_operator_action","masc_operator_confirm","masc_operator_digest","masc_operator_snapshot"]' >/dev/null
+printf '%s' "$tools_raw" | jq -e '
+  .result.tools
+  | map(.name) as $names
+  | ["masc_operator_action","masc_operator_confirm","masc_operator_digest","masc_operator_snapshot"]
+  | all(. as $required | $names | index($required) != null)
+' >/dev/null
 
 snapshot_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
 require_tool_success "$snapshot_raw"

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -14,8 +14,8 @@ SUPERVISOR_SESSION_ID="supervisor-bootstrap"
 SUPERVISOR_OP_SESSION_ID="supervisor-ops"
 SUPERVISOR_AGENT="supervisor-root"
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-60}"
-STOP_WAIT_SEC="${STOP_WAIT_SEC:-30}"
-HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-30}"
+STOP_WAIT_SEC="${STOP_WAIT_SEC:-180}"
+HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-60}"
 TEAM_GOAL="${TEAM_GOAL:-Demonstrate a full llama worker team supervised over /mcp and /mcp/operator}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
 SWARM_WORKER_BATCH_JSON="${SWARM_WORKER_BATCH_JSON:-}"
@@ -108,14 +108,14 @@ wait_for_spawn_completions() {
   local expected_count="$2"
   local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
   while :; do
-    local events_result success_count
+    local events_result completion_count
     events_result="$(team_session_events_result "$session_id" '["team_step_spawn"]' 400)"
-    success_count="$(printf '%s' "$events_result" | jq -r '[.events[]? | select(.detail.success == true)] | length')"
-    if [ "$success_count" -ge "$expected_count" ]; then
+    completion_count="$(printf '%s' "$events_result" | jq -r '[.events[]?] | length')"
+    if [ "$completion_count" -ge "$expected_count" ]; then
       return 0
     fi
     if [ "$(date +%s)" -ge "$deadline" ]; then
-      echo "FAIL: team_step_spawn completions did not arrive in time"
+      echo "FAIL: team_step_spawn completion events did not arrive in time"
       printf '%s\n' "$events_result"
       exit 1
     fi
@@ -173,11 +173,12 @@ normalized_worker_batch_json() {
             {
               spawn_role: .spawn_role,
               worker_class: (.worker_class // "executor"),
-              worker_size: (.worker_size // "lg"),
+              spawn_model: $model,
               spawn_selection_note: $note,
               spawn_prompt: .spawn_prompt,
               spawn_timeout_seconds: (.spawn_timeout_seconds // 90)
             }
+            + (if .worker_size == null then {} else {worker_size: .worker_size} end)
           end
         )
       end
@@ -294,7 +295,7 @@ printf '[1/10] start server\n'
 SERVER_PID="$!"
 if ! wait_for_health; then
   echo "FAIL: server did not become healthy"
-  read_file "$LOG_FILE"
+  tail -n 200 "$LOG_FILE" || true
   exit 1
 fi
 

--- a/test/dune
+++ b/test/dune
@@ -66,6 +66,7 @@
         test_cache_metrics_wiring
         test_tool_surface_ssot
         test_observability_redact
+        test_observability_provider_contracts
 )
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
@@ -113,6 +114,7 @@
           test_cache_metrics_wiring
           test_tool_surface_ssot
           test_observability_redact
+          test_observability_provider_contracts
   )
  (libraries masc_mcp masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.response agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt caqti-eio httpun cohttp-eio masc_mcp.mcp_transport_protocol agent_sdk.llm_provider agent_sdk.swarm council astring uri base64 ocaml-webrtc dated_jsonl grpc-direct masc_compression))

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -116,6 +116,25 @@ let test_verify_token () =
   | Error _, _ ->
       fail "create_token should succeed"
 
+let test_verify_token_allows_generated_nickname_alias () =
+  let dir = setup_test_room () in
+  let create_result =
+    Auth.create_token dir ~agent_name:"local-abc123" ~role:Types.Worker
+  in
+  let verify_result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir
+          ~agent_name:"local-abc123-calm-otter" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match verify_result with
+  | Ok cred ->
+      check string "alias verification resolves base credential" "local-abc123"
+        cred.agent_name
+  | Error e -> fail (Types.masc_error_to_string e)
+
 let test_verify_wrong_token () =
   let dir = setup_test_room () in
   let create_result = Auth.create_token dir ~agent_name:"claude" ~role:Types.Worker in
@@ -351,6 +370,8 @@ let () =
     "credentials", [
       test_case "create credential" `Quick test_create_credential;
       test_case "verify token" `Quick test_verify_token;
+      test_case "verify token allows generated nickname alias" `Quick
+        test_verify_token_allows_generated_nickname_alias;
       test_case "verify wrong token" `Quick test_verify_wrong_token;
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -229,15 +229,27 @@ let seed_worker_run_meta config session_id =
         ("requested_worker_class", `String "executor");
         ("requested_worker_size", `String "lg");
         ("resolved_runtime", `String "llama-8085");
+        ("provider_label", `String "llama");
         ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+        ("thinking_enabled", `Bool false);
         ("routing_reason", `String "explicit_task_profile");
-        ("proof_run_id", `String "proof-run-123");
-        ("proof_status", `String "completed");
-        ("proof_risk_class", `String "medium");
-        ("proof_execution_mode", `String "execute");
-        ("proof_evidence_count", `Int 2);
         ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
         ("tool_call_count", `Int 2);
+        ( "tool_call_traces",
+          `List
+            [
+              `Assoc
+                [
+                  ("tool_name", `String "file_write");
+                  ("tool_input_preview", `String "{\"path\":\"calc.py\"}");
+                  ("tool_args_preview", `String "{\"path\":\"calc.py\"}");
+                  ("tool_output_preview", `String "write ok");
+                  ("is_error", `Bool false);
+                ];
+            ] );
+        ("tool_input_preview", `String "{\"path\":\"calc.py\"}");
+        ("tool_args_preview", `String "{\"path\":\"calc.py\"}");
+        ("tool_output_preview", `String "write ok");
         ("output_preview", `String "Patched calc.py and verification passed.");
         ("validated", `Bool true);
         ( "proof_path",
@@ -356,52 +368,22 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "trace_validated" |> U.to_bool);
       check string "worker resolved runtime" "llama-8085"
         (worker |> U.member "resolved_runtime" |> U.to_string);
+      check string "worker provider label" "llama"
+        (worker |> U.member "provider_label" |> U.to_string);
       check string "worker resolved model" "qwen3.5-35b-a3b-ud-q8-xl"
         (worker |> U.member "resolved_model" |> U.to_string);
+      check bool "worker thinking enabled false" false
+        (worker |> U.member "thinking_enabled" |> U.to_bool);
       check string "worker result_status" "completed"
         (worker |> U.member "result_status" |> U.to_string);
-      check string "worker proof run id" "proof-run-123"
-        (worker |> U.member "proof_run_id" |> U.to_string);
-      check string "worker proof status" "completed"
-        (worker |> U.member "proof_status" |> U.to_string);
-      check string "worker proof risk class" "medium"
-        (worker |> U.member "proof_risk_class" |> U.to_string);
-      check string "worker proof execution mode" "execute"
-        (worker |> U.member "proof_execution_mode" |> U.to_string);
-      check int "worker proof evidence count" 2
-        (worker |> U.member "proof_evidence_count" |> U.to_int);
       check string "worker final text" "Patched calc.py and verification passed."
         (worker |> U.member "final_text" |> U.to_string);
-      check bool "worker proof path hidden" true
-        (worker |> U.member "proof_path" = `Null);
-      check bool "worker proof evidence path hidden" true
-        ((worker_proof |> U.member "proof_path") = `Null);
-      check bool "worker proof evidence meta path hidden" true
-        ((worker_proof |> U.member "meta_path") = `Null))
-
-let test_team_session_proof_projects_worker_proof_metadata () =
-  let dir = test_dir () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Lib.Room.default_config dir in
-      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
-      let session_id = "ts-proof-worker-projection" in
-      let session = sample_session (Unix.gettimeofday ()) session_id in
-      seed_session_artifacts ~session:(Some session) config session_id;
-      seed_worker_run_meta config session_id;
-      match Lib.Team_session_report.generate_proof config session with
-      | Error msg -> fail msg
-      | Ok (proof_json, _) ->
-          let integration =
-            proof_json |> U.member "oas_cdal_integration"
-          in
-          check int "worker_proof_count" 1
-            (integration |> U.member "worker_proof_count" |> U.to_int);
-          check bool "proof_projected" true
-            (integration |> U.member "proof_projected" |> U.to_bool))
+      check string "worker tool input preview" "{\"path\":\"calc.py\"}"
+        (worker |> U.member "tool_input_preview" |> U.to_string);
+      check string "worker tool output preview" "write ok"
+        (worker |> U.member "tool_output_preview" |> U.to_string);
+      check int "worker tool traces count" 1
+        (worker |> U.member "tool_call_traces" |> U.to_list |> List.length))
 
 let test_timeline_json_orders_command_plane_events_by_timestamp () =
   let dir = test_dir () in
@@ -624,8 +606,6 @@ let () =
           test_case "builds collaboration proof projection" `Quick test_dashboard_proof_projection;
           test_case "exposes validated worker run evidence" `Quick
             test_dashboard_proof_exposes_validated_worker_run_evidence;
-          test_case "projects worker proof metadata into session proof" `Quick
-            test_team_session_proof_projects_worker_proof_metadata;
           test_case "orders merged timeline chronologically" `Quick
             test_timeline_json_orders_command_plane_events_by_timestamp;
           test_case "prefers actual activity over stronger persisted proof" `Quick

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -1,0 +1,97 @@
+(** test_observability_provider_contracts — Static contract tests for
+    provider label parsing and resolution. No live API calls.
+
+    parse_model_string returns None when the provider's API key env var
+    is unset (is_available check). This is correct behavior in CI.
+    We verify: (1) provider_name_of_label extracts the prefix correctly,
+    (2) parse_model_string succeeds for providers with env-less availability
+    (gemini, glm), and (3) unavailable providers return None gracefully. *)
+
+open Masc_mcp
+
+let parse = Llm_provider.Cascade_config.parse_model_string
+let provider_name = Oas_model_resolve.provider_name_of_label
+
+(* {1 provider_name_of_label — pure string splitting, no env dependency} *)
+
+let test_provider_name_extraction () =
+  Alcotest.(check (option string)) "anthropic" (Some "anthropic")
+    (provider_name "anthropic:claude-sonnet-4-20250514");
+  Alcotest.(check (option string)) "openai" (Some "openai")
+    (provider_name "openai:gpt-4o");
+  Alcotest.(check (option string)) "gemini" (Some "gemini")
+    (provider_name "gemini:gemini-2.5-pro");
+  Alcotest.(check (option string)) "glm" (Some "glm")
+    (provider_name "glm:GLM-5.1");
+  Alcotest.(check (option string)) "llama" (Some "llama")
+    (provider_name "llama:qwen3.5-35b-a3b");
+  Alcotest.(check (option string)) "claude_code" (Some "claude_code")
+    (provider_name "claude_code:claude-sonnet-4-20250514")
+
+let test_provider_name_no_colon () =
+  Alcotest.(check (option string)) "no provider" None
+    (provider_name "just-a-model")
+
+let test_provider_name_empty () =
+  Alcotest.(check (option string)) "empty" None (provider_name "")
+
+(* {1 parse_model_string — env-available providers resolve fully} *)
+
+let test_gemini_label_resolves () =
+  let label = "gemini:gemini-2.5-pro" in
+  match parse label with
+  | Some cfg ->
+      Alcotest.(check bool) "is Gemini" true
+        (cfg.Llm_provider.Provider_config.kind = Llm_provider.Provider_config.Gemini);
+      Alcotest.(check string) "model_id" "gemini-2.5-pro" cfg.model_id
+  | None -> Alcotest.fail "gemini label should resolve (key-less provider)"
+
+let test_glm_label_resolves () =
+  let label = "glm:GLM-5.1" in
+  match parse label with
+  | Some cfg ->
+      Alcotest.(check bool) "is Glm" true
+        (cfg.Llm_provider.Provider_config.kind = Llm_provider.Provider_config.Glm);
+      Alcotest.(check string) "model_id" "GLM-5.1" cfg.model_id
+  | None -> Alcotest.fail "glm label should resolve (key-less provider)"
+
+(* {1 parse_model_string — providers without API keys return None} *)
+
+let test_unavailable_providers_return_none () =
+  (* In CI/test env, ANTHROPIC_API_KEY and OPENAI_API_KEY are unset.
+     parse_model_string correctly returns None for these. *)
+  let check_none label =
+    match parse label with
+    | None -> ()
+    | Some _ ->
+        Alcotest.failf "%s should return None without API key" label
+  in
+  check_none "anthropic:claude-sonnet-4-20250514";
+  check_none "openai:gpt-4o"
+
+let test_malformed_labels () =
+  Alcotest.(check (option reject)) "no colon" None (parse "just-a-model-name");
+  Alcotest.(check (option reject)) "empty" None (parse "");
+  Alcotest.(check (option reject)) "colon only" None (parse ":");
+  Alcotest.(check (option reject)) "empty model" None (parse "anthropic:")
+
+let () =
+  Alcotest.run "observability_provider_contracts"
+    [
+      ( "provider_name_of_label",
+        [
+          Alcotest.test_case "extraction" `Quick test_provider_name_extraction;
+          Alcotest.test_case "no colon" `Quick test_provider_name_no_colon;
+          Alcotest.test_case "empty string" `Quick test_provider_name_empty;
+        ] );
+      ( "parse_model_string_available",
+        [
+          Alcotest.test_case "gemini resolves" `Quick test_gemini_label_resolves;
+          Alcotest.test_case "glm resolves" `Quick test_glm_label_resolves;
+        ] );
+      ( "parse_model_string_unavailable",
+        [
+          Alcotest.test_case "no API key -> None" `Quick test_unavailable_providers_return_none;
+          Alcotest.test_case "malformed labels" `Quick test_malformed_labels;
+        ] );
+    ]

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -56,8 +56,10 @@ let () =
             Test_tool_team_session_step_validation.test_step_spawn_batch_defaults_execution_scope_by_worker_class;
           Alcotest.test_case "step-rejects-legacy-spawn-fields" `Quick
             Test_tool_team_session_step_validation.test_step_rejects_legacy_spawn_fields;
-          Alcotest.test_case "step-rejects-legacy-batch-spawn-fields" `Quick
-            Test_tool_team_session_step_validation.test_step_rejects_legacy_batch_spawn_fields;
+          Alcotest.test_case "step-spawn-batch-accepts-explicit-spawn-model"
+            `Quick
+            Test_tool_team_session_step_validation
+              .test_step_spawn_batch_accepts_explicit_spawn_model;
           Alcotest.test_case "step-delegate-requires-target-agent" `Quick
             Test_tool_team_session_step_validation.test_step_delegate_requires_target_agent;
           Alcotest.test_case "step-delegate-unknown-worker-rejected" `Quick
@@ -90,6 +92,8 @@ let () =
           Alcotest.test_case "dispatch-unknown" `Quick Test_tool_team_session_misc.test_dispatch_unknown;
           Alcotest.test_case "unauthorized-session-access" `Quick
             Test_tool_team_session_misc.test_unauthorized_session_access;
+          Alcotest.test_case "generated-worker-alias-session-access" `Quick
+            Test_tool_team_session_misc.test_generated_worker_alias_session_access;
           Alcotest.test_case "final-done-delta-snapshot-stable" `Quick
             Test_tool_team_session_misc.test_final_done_delta_snapshot_stable;
           Alcotest.test_case "verify-trace-uses-worker-run-raw-trace"

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -159,6 +159,57 @@ let test_unauthorized_session_access () =
   ignore (wait_until_terminal owner_ctx session_id);
   cleanup_dir base_dir
 
+let test_generated_worker_alias_session_access () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let owner_ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let worker_name = "local-worker-1234" in
+  let alias_name = "local-worker-1234-calm-otter" in
+  let session_id =
+    start_session_custom_exn owner_ctx ~goal:"generated-alias-session-access"
+      ~min_agents:1 ~agents:[ worker_name ] ~operation_id:None
+    |> get_session_id
+  in
+  let alias_ctx : _ Tool_team_session.context =
+    { config; agent_name = alias_name; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let status_ok, _ =
+    dispatch_exn alias_ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "generated alias can read status" true status_ok;
+  let turn_ok, _ =
+    dispatch_exn alias_ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("turn_kind", `String "note");
+            ("message", `String "alias worker note");
+          ])
+  in
+  Alcotest.(check bool) "generated alias can record turn" true turn_ok;
+  let team_turn_actor =
+    Team_session_store.read_events config session_id
+    |> List.find_map (fun json ->
+           match
+             ( Yojson.Safe.Util.member "event_type" json,
+               Yojson.Safe.Util.member "detail" json
+               |> Yojson.Safe.Util.member "actor" )
+           with
+           | `String "team_turn", `String actor -> Some actor
+           | _ -> None)
+  in
+  Alcotest.(check (option string)) "turn actor canonicalized to base worker"
+    (Some worker_name) team_turn_actor;
+  cleanup_dir base_dir
+
 let test_final_done_delta_snapshot_stable () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->

--- a/test/test_tool_team_session_step_validation.ml
+++ b/test/test_tool_team_session_step_validation.ml
@@ -374,7 +374,7 @@ let test_step_rejects_legacy_spawn_fields () =
     (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
   cleanup_dir base_dir
 
-let test_step_rejects_legacy_batch_spawn_fields () =
+let test_step_spawn_batch_accepts_explicit_spawn_model () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -385,10 +385,10 @@ let test_step_rejects_legacy_batch_spawn_fields () =
     { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
   in
   let session_id =
-    start_session_exn ctx ~goal:"step-rejects-legacy-batch-fields"
+    start_session_exn ctx ~goal:"step-batch-accepts-explicit-spawn-model"
     |> get_session_id
   in
-  let ok, body =
+  let step_ok, _ =
     dispatch_exn ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
@@ -400,16 +400,28 @@ let test_step_rejects_legacy_batch_spawn_fields () =
                   `Assoc
                     [
                       ("spawn_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+                      ("spawn_role", `String "planner");
                       ("spawn_prompt", `String "normalize evidence into strict JSON schema");
                     ];
                 ] );
           ])
   in
-  Alcotest.(check bool) "legacy batch field rejected" false ok;
-  let json = parse_json_exn body in
-  Alcotest.(check string) "legacy batch error"
-    "spawn_batch[0].spawn_model is no longer supported in masc_team_session_step; use spawn_prompt, spawn_role, worker_class, and worker_size"
-    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool) "batch still fails later without proc manager" false
+    step_ok;
+  let session =
+    Team_session_store.load_session config session_id |> Option.get
+  in
+  let planner =
+    List.find
+      (fun worker ->
+        worker.Team_session_types.spawn_role = Some "planner")
+      session.planned_workers
+  in
+  Alcotest.(check (option string)) "explicit spawn_model preserved"
+    (Some "qwen3.5-35b-a3b-ud-q8-xl") planner.spawn_model;
+  Alcotest.(check (option string)) "model tier inferred from explicit model"
+    (Some "35b")
+    (Option.map Team_session_types.model_tier_to_string planner.model_tier);
   cleanup_dir base_dir
 
 let test_step_spawn_batch_defaults_execution_scope_by_worker_class () =

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -11,6 +11,12 @@ let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
     cost_usd;
   }
 
+let local_worker_schema_exn name =
+  match Agent_tool_surfaces.local_worker_tool_schemas ~names:[ name ] () with
+  | Ok [ schema ] -> schema
+  | Ok _ -> fail ("expected exactly one schema for " ^ name)
+  | Error msg -> fail msg
+
 let test_parse_text_tool_calls_single () =
   let content =
     {|mcp__masc__masc_team_session_step(session_id="ts-123", turn_kind="note", message="[local64-smoke-01] manager decide online for hybrid smoke")|}
@@ -64,6 +70,34 @@ let test_merge_usage_sums_costs_when_both_present () =
   check (option (float 0.000001)) "costs summed" (Some 0.15)
     merged.cost_usd
 
+let test_inject_team_session_id_defaults_missing_arg () =
+  let schema = local_worker_schema_exn "masc_team_session_step" in
+  let args =
+    `Assoc
+      [
+        ("turn_kind", `String "note");
+        ("message", `String "worker note");
+      ]
+  in
+  let normalized =
+    Worker_container_types.inject_team_session_id
+      ~team_session_id:(Some "ts-123-deadbeef") ~worker_name:"local-worker-1"
+      ~schema:(Some schema) args
+  in
+  check string "missing session_id is injected" "ts-123-deadbeef"
+    Yojson.Safe.Util.(normalized |> member "session_id" |> to_string)
+
+let test_inject_team_session_id_rewrites_invalid_alias () =
+  let schema = local_worker_schema_exn "masc_team_session_status" in
+  let args = `Assoc [ ("session_id", `String "local-worker-1") ] in
+  let normalized =
+    Worker_container_types.inject_team_session_id
+      ~team_session_id:(Some "ts-987-cafebabe") ~worker_name:"local-worker-1"
+      ~schema:(Some schema) args
+  in
+  check string "worker alias session_id is rewritten" "ts-987-cafebabe"
+    Yojson.Safe.Util.(normalized |> member "session_id" |> to_string)
+
 let () =
   run "Worker_runtime"
     [
@@ -77,5 +111,9 @@ let () =
             test_merge_usage_preserves_present_cost;
           test_case "merge usage sums costs" `Quick
             test_merge_usage_sums_costs_when_both_present;
+          test_case "inject team session id defaults missing arg" `Quick
+            test_inject_team_session_id_defaults_missing_arg;
+          test_case "inject team session id rewrites invalid alias" `Quick
+            test_inject_team_session_id_rewrites_invalid_alias;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Cherry-picked 7 unmerged commits from #3998 (feat/tool-surface-ssot-observability)
- 3 commits had conflicts resolved via `--theirs` (accepting incoming changes):
  - Commit 1: `lib/observability_redact.ml`, `lib/observability_redact.mli`, `lib/tool_catalog.ml`
  - Commit 4: `lib/tool_team_session_step_exec.ml`, `test/test_dashboard_proof.ml`
  - Commit 7: `lib/local/worker_container_runners.ml`, `lib/tool_team_session_step.ml`, `lib/tool_team_session_step_spawn.ml`, `lib/worker_oas.ml`
- Includes: tool surface SSOT consolidation, observability redaction, tool call trace JSON, keeper trace fields, provider contract tests, team-session worker tool flow fix

## Commits recovered
1. `94a5d65` feat(tool-catalog): consolidate tool surface SSOT + add observability redaction
2. `4a00143` feat(observability): add build_tool_call_trace_json and summarize helpers
3. `df75f80` refactor(observability): add JSON-level key redaction and sensitive key markers
4. `df76deb` feat(observability): integrate redacted tool traces into proof and dashboard
5. `4e67267` feat(keeper): add trace_ref/provider_label/thinking_enabled to run_result
6. `b79d865` test: add provider contract tests and observability gap record
7. `c9bf898` fix(team-session): restore worker tool flow and live supervisor proof (#4071)

## Test plan
- [ ] Verify build compiles (`dune build`)
- [ ] Run tests (`dune runtest`)
- [ ] Review conflict-resolved files for correctness