### PR TITLE
fix(recover): cherry-pick lost commits from #3931

### DIFF
--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -153,10 +153,29 @@ let dispatch_supported_tool ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.conf
 let parse_tool_json body =
   try Some (Yojson.Safe.from_string body) with Yojson.Json_error _ -> None
 
+let int_member_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `Int value -> Some value
+  | `Intlit raw -> int_of_string_opt raw
+  | _ -> None
+
 let repair_loop_status_of_body body =
   match parse_tool_json body with
   | Some json -> Tool_repair_loop_types.status_of_json json
   | None -> None
+
+let repair_loop_iteration_budget body =
+  match parse_tool_json body with
+  | Some json ->
+      let attempt_count =
+        Option.value ~default:0 (int_member_opt "attempt_count" json)
+      in
+      let max_attempts =
+        Option.value ~default:(max 1 (attempt_count + 1))
+          (int_member_opt "max_attempts" json)
+      in
+      max 1 (min 64 (max_attempts - attempt_count + 1))
+  | None -> 16
 
 let run_repair_loop_until_terminal_with
     ~(dispatch_tool : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -169,22 +188,26 @@ let run_repair_loop_until_terminal_with
   | Some started_json -> (
       match Yojson.Safe.Util.member "loop_id" started_json with
       | `String loop_id ->
-          let rec loop last_ok last_body =
+          let rec loop remaining last_ok last_body =
             match repair_loop_status_of_body last_body with
             | Some status when Tool_repair_loop_types.is_terminal_status status ->
                 (last_ok, last_body)
+            | Some _ when remaining <= 0 ->
+                ( false,
+                  Printf.sprintf
+                    "repair loop iteration guard exceeded for %s" loop_id )
             | Some _ ->
                 let iterate_ok, iterate_body =
                   dispatch_tool ~name:"masc_repair_loop_iterate"
                     ~args:(`Assoc [ ("loop_id", `String loop_id) ])
                 in
-                if not iterate_ok && Option.is_none (parse_tool_json iterate_body) then
+                if not iterate_ok then
                   (iterate_ok, iterate_body)
                 else
-                  loop iterate_ok iterate_body
+                  loop (remaining - 1) iterate_ok iterate_body
             | None -> (last_ok, last_body)
           in
-          loop started_ok started_body
+          loop (repair_loop_iteration_budget started_body) started_ok started_body
       | _ -> (started_ok, started_body))
 
 let run_repair_loop_until_terminal ~sw ~(clock : _ Eio.Time.clock)

--- a/lib/tool_repair_loop.ml
+++ b/lib/tool_repair_loop.ml
@@ -2,6 +2,7 @@ open Tool_args
 open Tool_repair_loop_types
 
 module Ocaml = Tool_repair_loop_ocaml
+let repair_loop_rng = Random.State.make_self_init ()
 
 let schemas : Types.tool_schema list =
   [
@@ -70,9 +71,7 @@ let schemas : Types.tool_schema list =
   ]
 
 let make_loop_id () =
-  Printf.sprintf "repair-%Ld-%06x"
-    (Int64.of_float (Unix.gettimeofday () *. 1000.0))
-    (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF)
+  Printf.sprintf "repair-%s" (Uuidm.to_string (Uuidm.v4_gen repair_loop_rng ()))
 
 let resolve_target_mode args =
   match String.lowercase_ascii (get_string args "target_mode" "snippet") with

--- a/lib/tool_repair_loop_storage.ml
+++ b/lib/tool_repair_loop_storage.ml
@@ -3,6 +3,28 @@ open Tool_repair_loop_types
 let repair_root config =
   Filename.concat (Room.masc_dir config) "repair_loops"
 
+let is_valid_loop_id_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
+  | _ -> false
+
+let validate_loop_id loop_id =
+  let loop_id = String.trim loop_id in
+  if loop_id = "" then
+    Error "loop_id must not be empty"
+  else if String.equal loop_id "." || String.equal loop_id ".." then
+    Error "loop_id contains invalid path components"
+  else if String.contains loop_id '/' || String.contains loop_id '\\' then
+    Error "loop_id must not contain path separators"
+  else if not (String.for_all is_valid_loop_id_char loop_id) then
+    Error "loop_id contains invalid characters"
+  else
+    Ok loop_id
+
+let validated_loop_id_exn loop_id =
+  match validate_loop_id loop_id with
+  | Ok loop_id -> loop_id
+  | Error message -> invalid_arg message
+
 let loop_dir config loop_id =
   Filename.concat (repair_root config) loop_id
 
@@ -17,34 +39,42 @@ let attempt_code_file config loop_id attempt_index =
   Filename.concat (attempt_dir config loop_id attempt_index) "candidate.ml"
 
 let ensure_loop_dir config loop_id =
+  let loop_id = validated_loop_id_exn loop_id in
   Fs_compat.mkdir_p (loop_dir config loop_id)
 
 let ensure_attempt_dir config loop_id attempt_index =
+  let loop_id = validated_loop_id_exn loop_id in
   Fs_compat.mkdir_p (attempt_dir config loop_id attempt_index)
 
 let save_state config (state : state) =
-  ensure_loop_dir config state.loop_id;
-  Fs_compat.save_file (state_file config state.loop_id)
+  let loop_id = validated_loop_id_exn state.loop_id in
+  ensure_loop_dir config loop_id;
+  Fs_compat.save_file (state_file config loop_id)
     (Yojson.Safe.pretty_to_string (state_to_json state))
 
 let load_state config loop_id =
-  let path = state_file config loop_id in
-  if Sys.file_exists path then
-    try Ok (Yojson.Safe.from_file path |> state_of_json)
-    with exn ->
-      Error
-        (Printf.sprintf "repair loop state load failed for %s: %s" loop_id
-           (Printexc.to_string exn))
-  else
-    Error (Printf.sprintf "repair loop not found: %s" loop_id)
+  match validate_loop_id loop_id with
+  | Error message -> Error message
+  | Ok loop_id ->
+      let path = state_file config loop_id in
+      if Sys.file_exists path then
+        try Ok (Yojson.Safe.from_file path |> state_of_json)
+        with exn ->
+          Error
+            (Printf.sprintf "repair loop state load failed for %s: %s" loop_id
+               (Printexc.to_string exn))
+      else
+        Error (Printf.sprintf "repair loop not found: %s" loop_id)
 
 let write_attempt_code config loop_id attempt_index code =
+  let loop_id = validated_loop_id_exn loop_id in
   ensure_attempt_dir config loop_id attempt_index;
   let path = attempt_code_file config loop_id attempt_index in
   Fs_compat.save_file path code;
   path
 
 let write_attempt_aux config loop_id attempt_index name content =
+  let loop_id = validated_loop_id_exn loop_id in
   ensure_attempt_dir config loop_id attempt_index;
   let path = Filename.concat (attempt_dir config loop_id attempt_index) name in
   Fs_compat.save_file path content;
@@ -61,6 +91,7 @@ let restore_file path original_content =
       if Sys.file_exists path then Sys.remove path
 
 let append_event config loop_id event_type payload =
+  let loop_id = validated_loop_id_exn loop_id in
   ensure_loop_dir config loop_id;
   let path = Filename.concat (loop_dir config loop_id) "events.jsonl" in
   Fs_compat.append_jsonl path

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -420,7 +420,7 @@ let test_run_repair_loop_until_terminal_with_fake_dispatch () =
     | "masc_repair_loop_iterate" ->
         incr iterate_calls;
         if !iterate_calls = 1 then
-          ( false,
+          ( true,
             Yojson.Safe.to_string
               (`Assoc
                 [
@@ -454,6 +454,46 @@ let test_run_repair_loop_until_terminal_with_fake_dispatch () =
   let json = Yojson.Safe.from_string body in
   Alcotest.(check string) "status passed" "passed"
     Yojson.Safe.Util.(json |> member "status" |> to_string)
+
+let test_run_repair_loop_until_terminal_with_guard () =
+  let iterate_calls = ref 0 in
+  let dispatch_tool ~name ~args:_ =
+    match name with
+    | "masc_repair_loop_start" ->
+        ( true,
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("loop_id", `String "loop-guard");
+                ("status", `String "running");
+                ("attempt_count", `Int 0);
+                ("max_attempts", `Int 2);
+              ]) )
+    | "masc_repair_loop_iterate" ->
+        incr iterate_calls;
+        ( true,
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("loop_id", `String "loop-guard");
+                ("status", `String "running");
+                ("attempt_count", `Int !iterate_calls);
+                ("max_attempts", `Int 2);
+              ]) )
+    | other -> Alcotest.failf "unexpected tool call: %s" other
+  in
+  let ok, body =
+    Team_session_oas_bridge.run_repair_loop_until_terminal_with ~dispatch_tool
+      (`Assoc
+        [
+          ("plugin_id", `String "ocaml");
+          ("task_spec", `String "Never reaches terminal state.");
+        ])
+  in
+  Alcotest.(check bool) "guard returns failure" false ok;
+  Alcotest.(check int) "guard caps iterate calls" 3 !iterate_calls;
+  Alcotest.(check string) "guard message"
+    "repair loop iteration guard exceeded for loop-guard" body
 
 (* ================================================================ *)
 (* Runner                                                           *)
@@ -520,5 +560,7 @@ let () =
         test_dispatch_supported_tool_heartbeat_autojoin;
       Alcotest.test_case "repair loop wrapper iterates until terminal" `Quick
         test_run_repair_loop_until_terminal_with_fake_dispatch;
+      Alcotest.test_case "repair loop wrapper guards runaway status" `Quick
+        test_run_repair_loop_until_terminal_with_guard;
     ];
   ]


### PR DESCRIPTION
## Summary
- Cherry-picked 1 unmerged commit from #3931 (feat/repair-loop-host-fresh-main)
- No conflicts - clean cherry-pick

## Commits recovered
1. `f40c11a` fix: harden repair loop ids and iteration guard

## Test plan
- [ ] Verify build compiles (`dune build`)
- [ ] Run tests (`dune runtest`)