### PR TITLE
fix(recover): cherry-pick lost commits from #3913

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -65,14 +65,31 @@ let resolve_keeper_target_path ~(config : Room.config)
     - [] + workspace → keeper's own dirs (computed default)
     - [] + otherwise → [] (observe_only blocks writes; local = full access) *)
 let sanitize_keeper_name (name : string) : string =
-  String.map (fun c ->
+  let mapped = String.map (fun c ->
     if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
        || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
     then c else '_') name
+  in
+  (* Collapse consecutive dots to prevent ".." traversal in paths *)
+  let len = String.length mapped in
+  let buf = Buffer.create len in
+  let prev_dot = ref false in
+  String.iter (fun c ->
+    if c = '.' then begin
+      if not !prev_dot then Buffer.add_char buf c;
+      prev_dot := true
+    end else begin
+      prev_dot := false;
+      Buffer.add_char buf c
+    end) mapped;
+  Buffer.contents buf
 
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   match meta.allowed_paths with
   | ["*"] -> []
+  | paths when List.mem "*" paths ->
+    (* Mixed sentinel: strip "*" and use remaining explicit paths *)
+    List.filter (fun p -> p <> "*") paths
   | _ :: _ as explicit -> explicit
   | [] ->
     (match String.lowercase_ascii meta.execution_scope with

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -90,6 +90,39 @@ let test_computed_default_uses_keeper_name () =
   check (list string) "name embedded in path"
     [".masc/keepers/cdal-formalist/"; ".masc/traces/"] effective
 
+(* ── Edge cases: security boundaries ── *)
+
+let test_dotdot_in_keeper_name () =
+  (* sanitize_keeper_name is the defense-in-depth layer.
+     meta_of_json already rejects ".." in name, but sanitize_keeper_name
+     is called on the already-parsed meta.name as a second barrier. *)
+  let sanitized = KAP.sanitize_keeper_name "../escape" in
+  let has_dotdot =
+    try ignore (Str.search_forward (Str.regexp_string "..") sanitized 0); true
+    with Not_found -> false in
+  check bool "no .. in sanitized name" false has_dotdot;
+  check bool "sanitized non-empty" true (String.length sanitized > 0)
+
+let test_mixed_sentinel_strips_star () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["*"; "src/"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "mixed sentinel strips *" ["src/"] effective
+
+let test_absolute_path_in_allowed_paths () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["/etc/passwd"; "src/"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "absolute path passed through (caller validates)"
+    ["/etc/passwd"; "src/"] effective
+
+let test_dotdot_path_in_allowed_paths () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["../../../etc/"; "src/"] ~name:"t" () in
+  let effective = KAP.effective_allowed_paths ~meta in
+  check (list string) "traversal path passed through (resolve_keeper_target_path validates)"
+    ["../../../etc/"; "src/"] effective
+
 (* ── Runner ── *)
 
 let () =
@@ -115,5 +148,16 @@ let () =
             test_explicit_paths_any_scope;
           test_case "keeper name in computed default" `Quick
             test_computed_default_uses_keeper_name;
+        ] );
+      ( "security_edge_cases",
+        [
+          test_case ".. in keeper name rejected" `Quick
+            test_dotdot_in_keeper_name;
+          test_case "mixed sentinel strips *" `Quick
+            test_mixed_sentinel_strips_star;
+          test_case "absolute path passed through" `Quick
+            test_absolute_path_in_allowed_paths;
+          test_case ".. traversal passed through" `Quick
+            test_dotdot_path_in_allowed_paths;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Cherry-picked unmerged commits from #3913 (feat/allowed-paths-guardrail)
- 1 of 4 commits applied cleanly: `1005293` (harden sanitize_keeper_name + security edge case tests)
- 3 commits conflicted and were skipped:
  - `62ae79c` feat(keeper): effective_allowed_paths guardrail for workspace scope
  - `26ede91` fix(keeper): address review — observe_only guard, name sanitize
  - `effdcf8` test: set allowed_paths=["*"] in test meta for unrestricted tool tests

## Conflicted files
- `lib/keeper/keeper_alerting_path.ml`
- `lib/keeper/keeper_cdal_contract.ml`
- `lib/keeper/keeper_exec_tools.ml`
- `test/test_keeper_tools_oas.ml`

## Test plan
- [ ] Verify applied commit compiles with `dune build`
- [ ] Review skipped commits for manual re-application if needed