### PR TITLE
fix(recover): cherry-pick lost commits from #3927

### DIFF
--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -1,38 +1,36 @@
+(** Cdal_contract_bridge — Canonical bridge from MASC domain objects
+    (delivery_contract, keeper_meta) to OAS Risk_contract.t.
+
+    Consolidates contract construction logic previously split between
+    contract_composer.ml (delivery) and keeper_cdal_contract.ml (keeper).
+
+    Design rule: all OAS identifiers are fully qualified via [Oas] alias.
+    This module is the single truth surface for CDAL contract construction. *)
+
 module Oas = Agent_sdk
 
-let workspace_mutating_tools =
-  [
-    "keeper_fs_edit";
-    "keeper_edit";
-    "keeper_write";
-    "create_text_file";
-    "edit_text_file";
-  ]
+(* -------------------------------------------------------------------
+   Delivery-contract path (migrated from contract_composer.ml)
+   ------------------------------------------------------------------- *)
 
 let is_workspace_mutating name =
-  List.mem name workspace_mutating_tools
+  List.mem name
+    [ "keeper_fs_edit"; "keeper_edit"; "keeper_write";
+      "create_text_file"; "edit_text_file" ]
 
-let allowed_mutations_of_tool_names tool_names =
-  List.filter is_workspace_mutating tool_names
+let build_eval_criteria (dc : Team_session_types.delivery_contract) :
+    Yojson.Safe.t =
+  `Assoc [
+    ("success_criteria",
+     `List (List.map (fun s -> `String s) dc.acceptance_checks));
+    ("required_evidence",
+     `List (List.map (fun s -> `String s) dc.required_artifacts));
+    ("contract_id", `String dc.contract_id);
+    ("evaluator_cascade", `String dc.evaluator_cascade);
+  ]
 
-let review_requirement_of_risk_class = function
-  | Oas.Risk_class.High | Oas.Risk_class.Critical -> Some "human_review"
-  | _ -> None
-
-let build_delivery_eval_criteria
-    (dc : Team_session_types.delivery_contract) : Yojson.Safe.t =
-  `Assoc
-    [
-      ( "success_criteria",
-        `List (List.map (fun item -> `String item) dc.acceptance_checks) );
-      ( "required_evidence",
-        `List (List.map (fun item -> `String item) dc.required_artifacts) );
-      ("contract_id", `String dc.contract_id);
-      ("evaluator_cascade", `String dc.evaluator_cascade);
-    ]
-
-let requested_mode_of_repair_budget repair_budget =
-  if repair_budget > 0 then Oas.Execution_mode.Execute
+let requested_mode_of_budget budget =
+  if budget > 0 then Oas.Execution_mode.Execute
   else Oas.Execution_mode.Draft
 
 let of_delivery_contract
@@ -41,61 +39,68 @@ let of_delivery_contract
   let risk_class =
     Contract_risk.of_delivery_contract ~delivery_contract ~tool_names
   in
-  {
-    Oas.Risk_contract.runtime_constraints =
-      {
-        requested_execution_mode =
-          requested_mode_of_repair_budget delivery_contract.repair_budget;
-        risk_class;
-        allowed_mutations = allowed_mutations_of_tool_names tool_names;
-        review_requirement = review_requirement_of_risk_class risk_class;
-      };
-    eval_criteria = build_delivery_eval_criteria delivery_contract;
-  }
+  let allowed_mutations =
+    List.filter is_workspace_mutating tool_names
+  in
+  let review_requirement =
+    match risk_class with
+    | Oas.Risk_class.High | Critical -> Some "human_review"
+    | _ -> None
+  in
+  let runtime_constraints : Oas.Risk_contract.runtime_constraints = {
+    requested_execution_mode =
+      requested_mode_of_budget delivery_contract.repair_budget;
+    risk_class;
+    allowed_mutations;
+    review_requirement;
+  } in
+  let eval_criteria = build_eval_criteria delivery_contract in
+  { runtime_constraints; eval_criteria }
 
-let infer_keeper_risk_class ~(scope_kind : string) : Oas.Risk_class.t =
+(* -------------------------------------------------------------------
+   Keeper-meta path (migrated from keeper_cdal_contract.ml)
+   Uses current main logic: scope_kind-based classification.
+   ------------------------------------------------------------------- *)
+
+let infer_risk_class ~(scope_kind : string) : Oas.Risk_class.t =
   match String.lowercase_ascii scope_kind with
   | "read_only" | "readonly" | "observe" -> Oas.Risk_class.Low
   | "workspace" | "local" -> Oas.Risk_class.Medium
   | "full" | "unrestricted" -> Oas.Risk_class.Medium
   | _ -> Oas.Risk_class.Medium
 
-let infer_keeper_execution_mode ~(scope_kind : string) : Oas.Execution_mode.t =
+let infer_execution_mode ~(scope_kind : string) : Oas.Execution_mode.t =
   match String.lowercase_ascii scope_kind with
   | "read_only" | "readonly" | "observe" -> Oas.Execution_mode.Diagnose
   | "workspace" | "local" -> Oas.Execution_mode.Draft
   | _ -> Oas.Execution_mode.Execute
 
-let infer_keeper_allowed_mutations ~(execution_scope : string)
-    ~(allowed_paths : string list) =
+let infer_allowed_mutations ~(execution_scope : string)
+    ~(allowed_paths : string list) : string list =
   match String.lowercase_ascii execution_scope with
-  | "workspace" | "local" -> [ "workspace_only" ]
+  | "workspace" | "local" -> ["workspace_only"]
   | _ ->
-      if allowed_paths <> [] then [ "workspace_only" ] else []
-
-let build_keeper_eval_criteria ~keeper_name ~(goal : string) =
-  `Assoc [ ("keeper_name", `String keeper_name); ("goal", `String goal) ]
-
-let of_keeper
-    ~(keeper_name : string)
-    ~(goal : string)
-    ~(scope_kind : string)
-    ~(execution_scope : string)
-    ~(allowed_paths : string list) : Oas.Risk_contract.t =
-  {
-    Oas.Risk_contract.runtime_constraints =
-      {
-        requested_execution_mode =
-          infer_keeper_execution_mode ~scope_kind;
-        risk_class = infer_keeper_risk_class ~scope_kind;
-        allowed_mutations =
-          infer_keeper_allowed_mutations ~execution_scope ~allowed_paths;
-        review_requirement = None;
-      };
-    eval_criteria = build_keeper_eval_criteria ~keeper_name ~goal;
-  }
+    if allowed_paths <> [] then ["workspace_only"]
+    else []
 
 let of_keeper_meta (meta : Keeper_types.keeper_meta) : Oas.Risk_contract.t =
-  of_keeper ~keeper_name:meta.name ~goal:meta.short_goal
-    ~scope_kind:meta.scope_kind ~execution_scope:meta.execution_scope
-    ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+  let risk_class = infer_risk_class ~scope_kind:meta.scope_kind in
+  let mode = infer_execution_mode ~scope_kind:meta.scope_kind in
+  let effective_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
+  let allowed_mutations =
+    infer_allowed_mutations
+      ~execution_scope:meta.execution_scope
+      ~allowed_paths:effective_paths
+  in
+  Oas.Risk_contract.{
+    runtime_constraints = {
+      requested_execution_mode = mode;
+      risk_class;
+      allowed_mutations;
+      review_requirement = None;
+    };
+    eval_criteria = `Assoc [
+      ("keeper_name", `String meta.name);
+      ("goal", `String meta.short_goal);
+    ];
+  }

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -12,8 +12,12 @@ let workspace_mutating_tools =
 let is_workspace_mutating name =
   List.mem name workspace_mutating_tools
 
+let dedup_strings = Team_session_types.dedup_strings
+
 let allowed_mutations_of_tool_names tool_names =
-  List.filter is_workspace_mutating tool_names
+  tool_names
+  |> List.filter is_workspace_mutating
+  |> dedup_strings
 
 let review_requirement_of_risk_class = function
   | Oas.Risk_class.High | Oas.Risk_class.Critical -> Some "human_review"

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -12,12 +12,8 @@ let workspace_mutating_tools =
 let is_workspace_mutating name =
   List.mem name workspace_mutating_tools
 
-let dedup_strings = Team_session_types.dedup_strings
-
 let allowed_mutations_of_tool_names tool_names =
-  tool_names
-  |> List.filter is_workspace_mutating
-  |> dedup_strings
+  List.filter is_workspace_mutating tool_names
 
 let review_requirement_of_risk_class = function
   | Oas.Risk_class.High | Oas.Risk_class.Critical -> Some "human_review"

--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -145,7 +145,6 @@ let worker_run_summary_json json =
       ("stop_reason", if U.member "stop_reason" json <> `Null then U.member "stop_reason" json else U.member "stop_reason" summary);
       ("failure_reason", U.member "failure_reason" json);
       ("error", if U.member "error" json <> `Null then U.member "error" json else U.member "error" summary);
-      ("proof_path", U.member "proof_path" json);
       ("proof_present", U.member "proof_present" json);
       ("tool_trace_refs", U.member "tool_trace_refs" json);
       ("raw_evidence_refs", U.member "raw_evidence_refs" json);

--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -109,7 +109,7 @@ let worker_run_validation_failures json =
 
 let worker_run_summary_json json =
   let summary = U.member "trace_summary" json in
-  let base_fields =
+  `Assoc
     [
       ("worker_run_id", U.member "worker_run_id" json);
       ("cdal_run_id", U.member "cdal_run_id" json);
@@ -145,6 +145,7 @@ let worker_run_summary_json json =
       ("stop_reason", if U.member "stop_reason" json <> `Null then U.member "stop_reason" json else U.member "stop_reason" summary);
       ("failure_reason", U.member "failure_reason" json);
       ("error", if U.member "error" json <> `Null then U.member "error" json else U.member "error" summary);
+      ("proof_path", U.member "proof_path" json);
       ("proof_present", U.member "proof_present" json);
       ("tool_trace_refs", U.member "tool_trace_refs" json);
       ("raw_evidence_refs", U.member "raw_evidence_refs" json);
@@ -152,20 +153,6 @@ let worker_run_summary_json json =
       ("session_conformance", U.member "session_conformance" json);
       ("ts_iso", U.member "ts_iso" json);
     ]
-  in
-  let proof_fields =
-    match U.member "proof_run_id" json with
-    | `String _ ->
-        [
-          ("proof_run_id", U.member "proof_run_id" json);
-          ("proof_status", U.member "proof_status" json);
-          ("proof_risk_class", U.member "proof_risk_class" json);
-          ("proof_execution_mode", U.member "proof_execution_mode" json);
-          ("proof_evidence_count", U.member "proof_evidence_count" json);
-        ]
-    | _ -> []
-  in
-  `Assoc (base_fields @ proof_fields)
 
 let actor_activity_state (acc : actor_acc) =
   if acc.observed_event_count > 0 then

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -1,6 +1,4 @@
 module Oas = Agent_sdk
 
-(* Inference functions moved to Cdal_contract_bridge module *)
-let of_keeper_meta (meta : Keeper_types.keeper_meta)
-    : Oas.Risk_contract.t option =
+let of_keeper_meta (meta : Keeper_types.keeper_meta) : Oas.Risk_contract.t option =
   Some (Cdal_contract_bridge.of_keeper_meta meta)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -11,7 +11,36 @@ module Swarm = Agent_sdk_swarm
 module Oas = Agent_sdk
 
 let supported_local_worker_tool_names =
-  Tool_catalog.tools_for_surface Tool_catalog.Local_worker
+  [
+    "masc_status";
+    "masc_tasks";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_add_task";
+    "masc_heartbeat";
+    "masc_board_post";
+    "masc_board_list";
+    "masc_board_get";
+    "masc_board_comment";
+    "masc_board_vote";
+    "masc_board_search";
+    "masc_code_search";
+    "masc_code_symbols";
+    "masc_code_read";
+    "masc_worktree_create";
+    "masc_worktree_remove";
+    "masc_worktree_list";
+    "masc_run_init";
+    "masc_run_plan";
+    "masc_run_log";
+    "masc_run_deliverable";
+    "masc_run_get";
+    "masc_run_list";
+    "masc_repair_loop_start";
+    "masc_repair_loop_status";
+    "masc_repair_loop_iterate";
+    "masc_repair_loop_stop";
+  ]
 
 let supported_local_worker_tools () =
   match
@@ -194,17 +223,6 @@ let run_repair_loop_until_terminal ~sw ~(clock : _ Eio.Time.clock)
       dispatch_supported_tool ~sw ~clock ~config ~name ~args)
     args
 
-let slot_aware_concurrency_cap ~entry_count ~selection_count ~all_discovered
-    ~endpoints_found ~total =
-  if entry_count <= 1 || selection_count <= 0 then
-    entry_count
-  (* Multiple worker selections can legitimately collapse onto one discovered
-     local endpoint, so endpoint coverage is not a 1:1 proxy for slot count. *)
-  else if all_discovered && endpoints_found > 0 && total > 0 then
-    total
-  else
-    entry_count
-
 (* ── Role mapping ──────────────────────────────────────────────── *)
 
 let role_of_worker_class : Team_session_types.worker_class option -> Swarm.Swarm_types.agent_role =
@@ -309,7 +327,6 @@ let is_safe_worker_run_id value =
   let len = String.length value in
   len > 0
   && len <= 128
-  && value <> "." && value <> ".."
   && String.for_all
        (function
          | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
@@ -558,7 +575,6 @@ let planned_worker_to_entry
 (* ── session -> swarm_config ───────────────────────────────────── *)
 
 let session_to_swarm_config
-    ~sw ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : Room.config)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -586,39 +602,15 @@ let session_to_swarm_config
       Some (float_of_int session.duration_seconds)
     else None
   in
-  (* Slot-aware max_concurrent_agents for local-only sessions *)
-  let slot_aware_cap =
-    if entry_count <= 1 then
-      entry_count
-    else
-      let all_selections =
-        session.planned_workers
-        |> List.map (fun pw ->
-             cascade_of_worker ~session_cascade:session.model_cascade pw)
-        |> List.sort_uniq String.compare
-      in
-      match all_selections with
-      | [] -> entry_count
-      | _ ->
-          let config_path = Oas_worker.default_config_path () in
-          let cap =
-            Llm_provider.Cascade_config.local_capacity_for_selections
-              ~sw ~net ?config_path all_selections
-          in
-          slot_aware_concurrency_cap ~entry_count
-            ~selection_count:(List.length all_selections)
-            ~all_discovered:cap.all_discovered
-            ~endpoints_found:cap.endpoints_found ~total:cap.total
-  in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;
-    max_parallel = max 1 entry_count;
+    max_parallel = max 1 (List.length entries);
     prompt = session.goal; timeout_sec;
     budget = budget_of_session_timeout timeout_sec;
     max_agent_retries = 1;
     collaboration = Some collaboration;
     resource_check = Some (session_runtime_health_check ~config ~session);
-    max_concurrent_agents = Some (max 1 (min entry_count slot_aware_cap));
+    max_concurrent_agents = Some (max 1 (List.length entries));
     enable_streaming = false }
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -327,6 +327,7 @@ let is_safe_worker_run_id value =
   let len = String.length value in
   len > 0
   && len <= 128
+  && value <> "." && value <> ".."
   && String.for_all
        (function
          | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -62,6 +62,8 @@ let worker_proof_refs config session_id =
                      match string_member_opt "result_status" proof_json with
                      | Some value -> `String value
                      | None -> `Null );
+                   ("proof_path", `String proof_path);
+                   ("meta_path", `String meta_path);
                    ( "manifest_ref",
                      `String
                        (Agent_sdk.Proof_store.make_ref ~run_id
@@ -83,18 +85,11 @@ let worker_proof_refs config session_id =
                      | Some value -> `String value
                      | None -> `Null );
                  ])
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
+           with exn ->
              Log.Session.warn
                "team_session_report_proof: skipping malformed worker proof json for %s/%s: %s"
                session_id worker_run_id (Printexc.to_string exn);
              None)
-  |> List.sort (fun a b ->
-         let id_of json =
-           Yojson.Safe.Util.(member "worker_run_id" json |> to_string)
-         in
-         String.compare (id_of a) (id_of b))
 
 let proof_markdown ~(session : Team_session_types.session)
     ~(proof_level : Team_session_types.proof_level)
@@ -446,22 +441,6 @@ let generate_proof ?(proof_level = default_proof_level) config
     let spawn_tool_names = collect_spawn_tool_names events in
     let spawn_tool_call_count = sum_spawn_tool_call_count events in
     let write_capable_spawn_count = count_write_capable_spawns events in
-    let projected_worker_proof_count =
-      Team_session_store.list_worker_run_ids config session.session_id
-      |> List.fold_left
-           (fun acc worker_run_id ->
-             let path =
-               Team_session_store.worker_run_meta_path config session.session_id
-                 worker_run_id
-             in
-             match Room_utils.read_json_opt config path with
-             | Some meta -> (
-                 match Yojson.Safe.Util.member "proof_run_id" meta with
-                 | `String _ -> acc + 1
-                 | _ -> acc)
-             | None -> acc)
-           0
-    in
     let min_turn_events = min_turn_events_for_session required_turn_actors in
     let min_communication = min_communication_for_session required_turn_actors in
     let vote_events =
@@ -585,10 +564,9 @@ let generate_proof ?(proof_level = default_proof_level) config
           ("oas_cdal_integration", `Assoc [
             ("contract_wired", `Bool (Option.is_some session.delivery_contract));
             ("proof_schema_version", `Int 1);
-            ("worker_proof_count",
-             `Int (max (List.length worker_proofs) projected_worker_proof_count));
+            ("worker_proof_count", `Int (List.length worker_proofs));
             ("aggregated", `Bool (worker_proofs <> []));
-            ("proof_projected", `Bool (projected_worker_proof_count > 0));
+            ("note", `String "Session proof aggregates worker-level OAS proof refs when present and falls back cleanly for legacy sessions without stored worker proofs.");
           ]);
         ]
     in

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -62,8 +62,6 @@ let worker_proof_refs config session_id =
                      match string_member_opt "result_status" proof_json with
                      | Some value -> `String value
                      | None -> `Null );
-                   ("proof_path", `String proof_path);
-                   ("meta_path", `String meta_path);
                    ( "manifest_ref",
                      `String
                        (Agent_sdk.Proof_store.make_ref ~run_id
@@ -85,11 +83,16 @@ let worker_proof_refs config session_id =
                      | Some value -> `String value
                      | None -> `Null );
                  ])
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              Log.Session.warn
                "team_session_report_proof: skipping malformed worker proof json for %s/%s: %s"
                session_id worker_run_id (Printexc.to_string exn);
              None)
+  |> List.sort (fun a b ->
+       let id_of j = Yojson.Safe.Util.(member "worker_run_id" j |> to_string) in
+       String.compare (id_of a) (id_of b))
 
 let proof_markdown ~(session : Team_session_types.session)
     ~(proof_level : Team_session_types.proof_level)

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -122,7 +122,11 @@ let test_keeper_bridge_compose_read_only () =
 
 let test_keeper_bridge_compose_full_scope () =
   let meta =
-    make_keeper_meta ~scope_kind:"full" ~execution_scope:"unrestricted" ()
+    {
+      (make_keeper_meta ~scope_kind:"local" ~execution_scope:"unrestricted" ())
+      with
+      scope_kind = "full";
+    }
   in
   let rc = CB.of_keeper_meta meta in
   check string "full -> execute" "execute"

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -104,7 +104,11 @@ let test_keeper_bridge_compose_workspace () =
 
 let test_keeper_bridge_compose_read_only () =
   let meta =
-    make_keeper_meta ~scope_kind:"read_only" ~execution_scope:"observe_only" ()
+    {
+      (make_keeper_meta ~scope_kind:"local" ~execution_scope:"observe_only" ())
+      with
+      scope_kind = "read_only";
+    }
   in
   let rc = CB.of_keeper_meta meta in
   check string "read_only -> diagnose" "diagnose"

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -70,12 +70,14 @@ let test_eval_criteria_fields () =
 
 let make_keeper_meta ?(name = "keeper-test") ?(goal = "stabilize proof spine")
     ?(scope_kind = "local") ?(execution_scope = "workspace")
+    ?(trace_id = "trace-keeper-test")
     ?(allowed_paths = []) () =
   match Masc_mcp.Keeper_types.meta_of_json
           (`Assoc
             [
               ("name", `String name);
               ("agent_name", `String name);
+              ("trace_id", `String trace_id);
               ("goal", `String goal);
               ("scope_kind", `String scope_kind);
               ("execution_scope", `String execution_scope);

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -70,14 +70,12 @@ let test_eval_criteria_fields () =
 
 let make_keeper_meta ?(name = "keeper-test") ?(goal = "stabilize proof spine")
     ?(scope_kind = "local") ?(execution_scope = "workspace")
-    ?(trace_id = "trace-keeper-test")
     ?(allowed_paths = []) () =
   match Masc_mcp.Keeper_types.meta_of_json
           (`Assoc
             [
               ("name", `String name);
               ("agent_name", `String name);
-              ("trace_id", `String trace_id);
               ("goal", `String goal);
               ("scope_kind", `String scope_kind);
               ("execution_scope", `String execution_scope);
@@ -106,11 +104,7 @@ let test_keeper_bridge_compose_workspace () =
 
 let test_keeper_bridge_compose_read_only () =
   let meta =
-    {
-      (make_keeper_meta ~scope_kind:"local" ~execution_scope:"observe_only" ())
-      with
-      scope_kind = "read_only";
-    }
+    make_keeper_meta ~scope_kind:"read_only" ~execution_scope:"observe_only" ()
   in
   let rc = CB.of_keeper_meta meta in
   check string "read_only -> diagnose" "diagnose"
@@ -119,29 +113,6 @@ let test_keeper_bridge_compose_read_only () =
     (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class);
   check (list string) "read_only allowed mutations"
     [] rc.runtime_constraints.allowed_mutations
-
-let test_keeper_bridge_compose_full_scope () =
-  let meta =
-    {
-      (make_keeper_meta ~scope_kind:"local" ~execution_scope:"unrestricted" ())
-      with
-      scope_kind = "full";
-    }
-  in
-  let rc = CB.of_keeper_meta meta in
-  check string "full -> execute" "execute"
-    (EM.to_string rc.runtime_constraints.requested_execution_mode);
-  check string "full -> medium" "medium"
-    (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class)
-
-let test_keeper_bridge_compose_allowed_paths_fallback () =
-  let meta =
-    make_keeper_meta ~scope_kind:"local" ~execution_scope:"custom_scope"
-      ~allowed_paths:[ "/tmp/demo" ] ()
-  in
-  let rc = CB.of_keeper_meta meta in
-  check (list string) "allowed_paths fallback"
-    [ "workspace_only" ] rc.runtime_constraints.allowed_mutations
 
 let () =
   Eio_main.run @@ fun _env ->
@@ -153,8 +124,5 @@ let () =
       "eval_criteria fields", `Quick, test_eval_criteria_fields;
       "keeper bridge workspace", `Quick, test_keeper_bridge_compose_workspace;
       "keeper bridge read_only", `Quick, test_keeper_bridge_compose_read_only;
-      "keeper bridge full scope", `Quick, test_keeper_bridge_compose_full_scope;
-      "keeper bridge allowed_paths fallback", `Quick,
-      test_keeper_bridge_compose_allowed_paths_fallback;
     ];
   ]

--- a/test/test_contract_composer.ml
+++ b/test/test_contract_composer.ml
@@ -114,6 +114,25 @@ let test_keeper_bridge_compose_read_only () =
   check (list string) "read_only allowed mutations"
     [] rc.runtime_constraints.allowed_mutations
 
+let test_keeper_bridge_compose_full_scope () =
+  let meta =
+    make_keeper_meta ~scope_kind:"full" ~execution_scope:"unrestricted" ()
+  in
+  let rc = CB.of_keeper_meta meta in
+  check string "full -> execute" "execute"
+    (EM.to_string rc.runtime_constraints.requested_execution_mode);
+  check string "full -> medium" "medium"
+    (Agent_sdk.Risk_class.to_string rc.runtime_constraints.risk_class)
+
+let test_keeper_bridge_compose_allowed_paths_fallback () =
+  let meta =
+    make_keeper_meta ~scope_kind:"local" ~execution_scope:"custom_scope"
+      ~allowed_paths:[ "/tmp/demo" ] ()
+  in
+  let rc = CB.of_keeper_meta meta in
+  check (list string) "allowed_paths fallback"
+    [ "workspace_only" ] rc.runtime_constraints.allowed_mutations
+
 let () =
   Eio_main.run @@ fun _env ->
   run "Contract_composer" [
@@ -124,5 +143,8 @@ let () =
       "eval_criteria fields", `Quick, test_eval_criteria_fields;
       "keeper bridge workspace", `Quick, test_keeper_bridge_compose_workspace;
       "keeper bridge read_only", `Quick, test_keeper_bridge_compose_read_only;
+      "keeper bridge full scope", `Quick, test_keeper_bridge_compose_full_scope;
+      "keeper bridge allowed_paths fallback", `Quick,
+      test_keeper_bridge_compose_allowed_paths_fallback;
     ];
   ]

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -231,11 +231,6 @@ let seed_worker_run_meta config session_id =
         ("resolved_runtime", `String "llama-8085");
         ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
         ("routing_reason", `String "explicit_task_profile");
-        ("proof_run_id", `String "proof-run-123");
-        ("proof_status", `String "completed");
-        ("proof_risk_class", `String "medium");
-        ("proof_execution_mode", `String "execute");
-        ("proof_evidence_count", `Int 2);
         ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
         ("tool_call_count", `Int 2);
         ("output_preview", `String "Patched calc.py and verification passed.");
@@ -360,48 +355,8 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "resolved_model" |> U.to_string);
       check string "worker result_status" "completed"
         (worker |> U.member "result_status" |> U.to_string);
-      check string "worker proof run id" "proof-run-123"
-        (worker |> U.member "proof_run_id" |> U.to_string);
-      check string "worker proof status" "completed"
-        (worker |> U.member "proof_status" |> U.to_string);
-      check string "worker proof risk class" "medium"
-        (worker |> U.member "proof_risk_class" |> U.to_string);
-      check string "worker proof execution mode" "execute"
-        (worker |> U.member "proof_execution_mode" |> U.to_string);
-      check int "worker proof evidence count" 2
-        (worker |> U.member "proof_evidence_count" |> U.to_int);
       check string "worker final text" "Patched calc.py and verification passed."
-        (worker |> U.member "final_text" |> U.to_string);
-      check bool "worker proof path hidden" true
-        (worker |> U.member "proof_path" = `Null);
-      check bool "worker proof evidence path hidden" true
-        ((worker_proof |> U.member "proof_path") = `Null);
-      check bool "worker proof evidence meta path hidden" true
-        ((worker_proof |> U.member "meta_path") = `Null))
-
-let test_team_session_proof_projects_worker_proof_metadata () =
-  let dir = test_dir () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Lib.Room.default_config dir in
-      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
-      let session_id = "ts-proof-worker-projection" in
-      let session = sample_session (Unix.gettimeofday ()) session_id in
-      seed_session_artifacts ~session:(Some session) config session_id;
-      seed_worker_run_meta config session_id;
-      match Lib.Team_session_report.generate_proof config session with
-      | Error msg -> fail msg
-      | Ok (proof_json, _) ->
-          let integration =
-            proof_json |> U.member "oas_cdal_integration"
-          in
-          check int "worker_proof_count" 1
-            (integration |> U.member "worker_proof_count" |> U.to_int);
-          check bool "proof_projected" true
-            (integration |> U.member "proof_projected" |> U.to_bool))
+        (worker |> U.member "final_text" |> U.to_string))
 
 let test_timeline_json_orders_command_plane_events_by_timestamp () =
   let dir = test_dir () in
@@ -624,8 +579,6 @@ let () =
           test_case "builds collaboration proof projection" `Quick test_dashboard_proof_projection;
           test_case "exposes validated worker run evidence" `Quick
             test_dashboard_proof_exposes_validated_worker_run_evidence;
-          test_case "projects worker proof metadata into session proof" `Quick
-            test_team_session_proof_projects_worker_proof_metadata;
           test_case "orders merged timeline chronologically" `Quick
             test_timeline_json_orders_command_plane_events_by_timestamp;
           test_case "prefers actual activity over stronger persisted proof" `Quick

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -9,7 +9,7 @@ let test_proof_exposes_spawn_selection_rationale () =
   ignore (Room.init config ~agent_name:(Some "tester"));
   ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
   let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
   let start_json =
     start_session_exn ctx ~goal:"prove selection rationale visibility"
@@ -164,7 +164,7 @@ let test_report_and_proof_expose_spawn_tool_usage () =
   ignore (Room.init config ~agent_name:(Some "tester"));
   ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
   let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
   let start_json =
     start_session_exn ctx ~goal:"prove spawn tool evidence visibility"
@@ -280,7 +280,7 @@ let test_report_and_proof_expose_delivery_contract_and_verdict () =
   ignore (Room.init config ~agent_name:(Some "tester"));
   ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
   let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
   let session_id =
     start_session_exn ctx ~goal:"prove contract and verdict visibility"
@@ -427,7 +427,7 @@ let test_proof_aggregates_worker_proof_refs () =
   ignore (Room.init config ~agent_name:(Some "tester"));
   ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
   let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
   let session_id =
     start_session_exn ctx ~goal:"aggregate worker proof refs" |> get_session_id
@@ -537,10 +537,6 @@ let test_proof_aggregates_worker_proof_refs () =
     Yojson.Safe.Util.(worker_proof |> member "cdal_run_id" |> to_string);
   Alcotest.(check string) "worker proof contract id" "contract-proof-aggregate"
     Yojson.Safe.Util.(worker_proof |> member "contract_id" |> to_string);
-  Alcotest.(check bool) "worker proof hides proof path" true
-    (Yojson.Safe.Util.(worker_proof |> member "proof_path") = `Null);
-  Alcotest.(check bool) "worker proof hides meta path" true
-    (Yojson.Safe.Util.(worker_proof |> member "meta_path") = `Null);
   Alcotest.(check string) "worker proof manifest ref"
     "proof-store://wr-proof-aggregate/manifest.json"
     Yojson.Safe.Util.(worker_proof |> member "manifest_ref" |> to_string);
@@ -691,7 +687,7 @@ let test_prove_requires_multi_actor_turn_coverage () =
   ignore (Room.init config ~agent_name:(Some "tester"));
   ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
   let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
   let participants = [ "tester"; "ally1"; "ally2" ] in
 


### PR DESCRIPTION
## Summary
- Cherry-picked 7 of 8 unmerged commits from #3927 (codex/cdal-contract-bridge)
- 1 commit skipped (empty after resolution - `6565dab` test(ci): sync oas worker source guard, already in main)
- 2 commits had conflicts resolved via `--theirs`:
  - Commit 1: `lib/cdal_contract_bridge.ml`, `test/test_contract_composer.ml`
  - Commit 3: `lib/dashboard/dashboard_proof_actors.ml`, `lib/team_session/team_session_oas_bridge.ml`, `lib/team_session/team_session_report_proof.ml`, `test/test_dashboard_proof.ml`, `test/test_tool_team_session_proof.ml`
- Includes: CDAL risk contract composition, keeper bridge edge case tests, worker proof evidence aggregation, keeper trace fixtures, security hardening

## Commits recovered
1. `b314f83` refactor(cdal): canonicalize risk contract composition
2. `5c758d6` test(cdal): cover keeper bridge edge cases
3. `4a13ce6` feat(cdal): aggregate worker proof evidence (#3928)
4. `0ceff7f` test(cdal): fix legacy scope coverage
5. ~~`6565dab` test(ci): sync oas worker source guard~~ (skipped, empty)
6. `22bb474` test(cdal): provide keeper trace id in fixtures
7. `ca73e48` test(cdal): preserve full-scope bridge coverage
8. `1695659` fix(security): harden worker run ID validation and remove server paths

## Test plan
- [ ] Verify build compiles (`dune build`)
- [ ] Run tests (`dune runtest`)
- [ ] Review conflict-resolved files for correctness