### PR TITLE
fix(recover): cherry-pick lost commits from #3871

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -279,7 +279,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      | Some fs ->
          (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
-                ~source:"external_mcp" ()
+                ~source:(Tool_registry.string_of_source External_mcp) ()
           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             log_mcp_exn ~label:"telemetry tracking failed" exn)
      | None -> ());

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -89,7 +89,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
         (try
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
-             ~source:"keeper_internal" ()
+             ~source:(Tool_registry.string_of_source Keeper_internal) ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -277,7 +277,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
         (try
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
-             ~duration_ms ~source:"keeper_internal" ()
+             ~duration_ms ~source:(Tool_registry.string_of_source Keeper_internal) ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->


### PR DESCRIPTION
## Summary
- Cherry-picked unmerged commits from #3871 (feat/source-aware-telemetry)
- 1 of 3 commits applied cleanly: `c2eac30` (use string_of_source for JSONL source field)
- 2 commits conflicted and were skipped:
  - `a5fe6fb` feat(profile): add Keeper tool profile for keeper-internal surface
  - `e998cc0` feat(catalog): deprecate persistent_agent and llama aliases

## Conflicted files
- `lib/mcp_sdk_adapter_masc.ml`
- `lib/tool_catalog.ml`

## Test plan
- [ ] Verify applied commit compiles with `dune build`
- [ ] Review skipped commits for manual re-application if needed