### PR TITLE
refactor: consolidate duplicated JSON option helpers to Json_util

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -7,16 +7,7 @@
 
 open Types
 
-let unique_preserve_order items =
-  let rec loop seen rev_items = function
-    | [] -> List.rev rev_items
-    | x :: xs ->
-        if List.mem x seen then
-          loop seen rev_items xs
-        else
-          loop (x :: seen) (x :: rev_items) xs
-  in
-  loop [] [] items
+let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
   let seen = Hashtbl.create (List.length schemas) in

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -63,19 +63,7 @@ let risk_rank = function
 let max_risk left right =
   if risk_rank left >= risk_rank right then left else right
 
-let unique_preserve_order items =
-  let seen = Hashtbl.create (List.length items) in
-  let rec loop rev_items = function
-    | [] -> List.rev rev_items
-    | x :: xs ->
-        if Hashtbl.mem seen x then
-          loop rev_items xs
-        else begin
-          Hashtbl.add seen x ();
-          loop (x :: rev_items) xs
-        end
-  in
-  loop [] items
+let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
   let seen = Hashtbl.create (List.length schemas) in

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -110,6 +110,31 @@ let json_assoc_list kv =
 let parse_json_or_string s =
   try Yojson.Safe.from_string s with Yojson.Json_error _ -> `String s
 
+(** {1 Option serialization helpers}
+
+    Canonical [None -> `Null] converters for building JSON.
+    Use these instead of per-module [let int_opt_to_json = ...] definitions. *)
+
+let option_to_yojson (f : 'a -> Yojson.Safe.t) : 'a option -> Yojson.Safe.t = function
+  | Some value -> f value
+  | None -> `Null
+
+let int_opt_to_json : int option -> Yojson.Safe.t = function
+  | Some n -> `Int n
+  | None -> `Null
+
+let string_opt_to_json : string option -> Yojson.Safe.t = function
+  | Some s -> `String s
+  | None -> `Null
+
+let float_opt_to_json : float option -> Yojson.Safe.t = function
+  | Some f -> `Float f
+  | None -> `Null
+
+let bool_opt_to_json : bool option -> Yojson.Safe.t = function
+  | Some b -> `Bool b
+  | None -> `Null
+
 (** List utilities *)
 
 let dedupe_keep_order xs =

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -50,6 +50,16 @@ val json_assoc_list : (string * string) list -> Yojson.Safe.t
 val parse_json_or_string : string -> Yojson.Safe.t
 (** [parse_json_or_string s] parses JSON or returns string literal *)
 
+(** {1 Option serialization helpers}
+
+    Canonical [None -> `Null] converters for building JSON. *)
+
+val option_to_yojson : ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
+val int_opt_to_json : int option -> Yojson.Safe.t
+val string_opt_to_json : string option -> Yojson.Safe.t
+val float_opt_to_json : float option -> Yojson.Safe.t
+val bool_opt_to_json : bool option -> Yojson.Safe.t
+
 (** List utilities *)
 
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/council/governance_v2_serde.ml
+++ b/lib/council/governance_v2_serde.ml
@@ -144,13 +144,8 @@ let order_status_of_string = function
 let string_list_json values =
   `List (List.map (fun value -> `String value) values)
 
-let string_opt_json = function
-  | Some value -> `String value
-  | None -> `Null
-
-let float_opt_json = function
-  | Some value -> `Float value
-  | None -> `Null
+let string_opt_json = Json_util.string_opt_to_json
+let float_opt_json = Json_util.float_opt_to_json
 
 let action_request_to_yojson (request : action_request) =
   let fields =

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -4,8 +4,8 @@ module GV2 = Council.Governance_v2
 
 type detail_status = [ `OK | `Not_found ]
 
-let option_to_yojson f = function Some value -> f value | None -> `Null
-let string_opt_json = option_to_yojson (fun value -> `String value)
+let option_to_yojson = Json_util.option_to_yojson
+let string_opt_json = Json_util.string_opt_to_json
 let iso_of_unix = Dashboard_utils.iso_of_unix
 
 let rec take n items =

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -61,7 +61,7 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 
 let now_iso () = Types.now_iso ()
-let option_to_yojson f = function Some value -> f value | None -> `Null
+let option_to_yojson = Json_util.option_to_yojson
 
 let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -3,10 +3,6 @@
 
 open Keeper_types
 
-let maybe_promote_live_persistent_keeper config name =
-  ignore config;
-  ignore name
-
 let ensure_keeper_meta config name =
   match read_meta config name with
   | Ok (Some meta) ->

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -75,13 +75,7 @@ let strip_mcp_prefix name =
   else
     name
 
-let unique_preserve_order items =
-  let rec loop seen = function
-    | [] -> List.rev seen
-    | x :: xs ->
-        if List.mem x seen then loop seen xs else loop (x :: seen) xs
-  in
-  loop [] items
+let unique_preserve_order = Json_util.dedupe_keep_order
 
 let has_agent_name_field (schema : Types.tool_schema) =
   let open Yojson.Safe.Util in

--- a/lib/mdal/mdal_worker.ml
+++ b/lib/mdal/mdal_worker.ml
@@ -37,13 +37,7 @@ type runner =
 let auditable_tool_catalog : string list =
   Agent_tool_surfaces.mdal_auditable_tool_names
 
-let unique_preserve_order items =
-  let rec loop seen = function
-    | [] -> List.rev seen
-    | x :: xs ->
-        if List.mem x seen then loop seen xs else loop (x :: seen) xs
-  in
-  loop [] items
+let unique_preserve_order = Json_util.dedupe_keep_order
 
 let trunc ?(limit = 48) text =
   if String.length text <= limit then text else String.sub text 0 limit

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -120,16 +120,6 @@ let seed_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limi
     List.length procs
   end
 
-(** Legacy keeper memory-bank adapter.
-
-    Historical call sites still invoke this helper, but the current 5-tier path
-    seeds episodic memory through [seed_episodes]. The removed Memory_stream
-    backend is not revived here, so this remains an intentional no-op.
-    Returns 0 to preserve legacy callers. *)
-let seed_memory_bank ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limit : int) : int =
-  ignore (memory, agent_name, limit);
-  0
-
 (* ================================================================ *)
 (* Episodic tier: Institution_eio JSONL <-> OAS episodes            *)
 (* ================================================================ *)

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -90,7 +90,7 @@ val recommended_confirm_required : string -> bool
 val recommended_action_to_yojson : actor:string -> recommended_action -> Yojson.Safe.t
 val worker_card_to_yojson : worker_card -> Yojson.Safe.t
 
-val spawn_batch_stub_of_cards : worker_card list -> Yojson.Safe.t
+val spawn_batch_template_of_cards : worker_card list -> Yojson.Safe.t
 
 val aggregate_worker_class_counts : Team_session_types.session list -> Yojson.Safe.t
 val aggregate_runtime_pool_counts : Team_session_types.session list -> Yojson.Safe.t

--- a/lib/operator/operator_digest_session.ml
+++ b/lib/operator/operator_digest_session.ml
@@ -464,7 +464,7 @@ let session_recommendations ~(session : Team_session_types.session)
                      severity = item.severity;
                      reason = item.summary;
                    suggested_payload =
-                       spawn_batch_stub_of_cards no_turn_worker_cards;
+                       spawn_batch_template_of_cards no_turn_worker_cards;
                    }
            | "local64_role_gap" ->
 	               let missing_roles =

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -211,7 +211,7 @@ let worker_card_to_yojson (card : worker_card) =
       ("authoritative", `Bool true);
     ]
 
-let spawn_batch_stub_of_cards (cards : worker_card list) =
+let spawn_batch_template_of_cards (cards : worker_card list) =
   let items =
     cards
     |> List.filter_map (fun (card : worker_card) ->

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -37,9 +37,7 @@ let target_type_of_string = function
   | "team_session" -> Some Team_session
   | _ -> None
 
-let option_to_yojson f = function
-  | Some value -> f value
-  | None -> `Null
+let option_to_yojson = Json_util.option_to_yojson
 
 let ensure_dir path =
   Fs_compat.mkdir_p path

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -440,15 +440,8 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
 (** Spawn and wait for result (synchronous) *)
 let spawn_sync = spawn
 
-(** Helper for optional int to JSON *)
-let int_opt_to_json = function
-  | Some n -> `Int n
-  | None -> `Null
-
-(** Helper for optional float to JSON *)
-let float_opt_to_json = function
-  | Some f -> `Float f
-  | None -> `Null
+let int_opt_to_json = Json_util.int_opt_to_json
+let float_opt_to_json = Json_util.float_opt_to_json
 
 (** Result to JSON *)
 let result_to_json result =

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -447,8 +447,6 @@ let allow_direct_call name =
   | Default -> true
   | Hidden -> meta.allow_direct_call_when_hidden
 
-let hidden_placeholder_tools () = []
-
 (** {1 Tool Surface System}
 
     Canonical per-surface tool name lists — the SSOT for tool surface

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -95,15 +95,11 @@ val metadata_to_fields : string -> (string * Yojson.Safe.t) list
 val public_contract_fields : string -> (string * Yojson.Safe.t) list
 (** Minimal metadata for public contract responses. *)
 
-(** {1 Hidden placeholder tools} *)
-
 val explicit_metadata : (string * metadata) list
 (** Explicitly configured tool metadata entries (for test verification). *)
 
 val deprecated_tool_entries : (string * metadata) list
 (** Precomputed subset of [explicit_metadata] where lifecycle = Deprecated. *)
-
-val hidden_placeholder_tools : unit -> string list
 
 val implementation_allows_public_visibility : implementation_status -> bool
 (** [true] when an implementation status permits public surface listing. *)

--- a/lib/tool_council_json.ml
+++ b/lib/tool_council_json.ml
@@ -7,9 +7,7 @@ module GV2 = Council.Governance_v2
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)
 
-let string_opt_json = function
-  | Some value -> `String value
-  | None -> `Null
+let string_opt_json = Json_util.string_opt_to_json
 
 let action_request_json (request : GV2.action_request) =
   `Assoc

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -33,20 +33,14 @@ let json_error message =
 let json_ok fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
-let int_opt_to_json = function Some value -> `Int value | None -> `Null
-let string_opt_to_json = function Some value -> `String value | None -> `Null
-let float_opt_to_json = function Some value -> `Float value | None -> `Null
+let int_opt_to_json = Json_util.int_opt_to_json
+let string_opt_to_json = Json_util.string_opt_to_json
+let float_opt_to_json = Json_util.float_opt_to_json
 
 let parse_int_opt value =
   try Some (int_of_string (String.trim value)) with Failure _ -> None
 
-let unique_preserve_order items =
-  let rec loop seen = function
-    | [] -> List.rev seen
-    | x :: xs ->
-        if List.mem x seen then loop seen xs else loop (x :: seen) xs
-  in
-  loop [] items
+let unique_preserve_order = Json_util.dedupe_keep_order
 
 let split_ws text =
   text

--- a/lib/tool_model_catalog.ml
+++ b/lib/tool_model_catalog.ml
@@ -19,7 +19,7 @@ let json_error message =
 let json_ok fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
-let string_opt_to_json = function Some v -> `String v | None -> `Null
+let string_opt_to_json = Json_util.string_opt_to_json
 
 (* ── Handlers ────────────────────────────────────────────── *)
 

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -1,8 +1,8 @@
 (** Routing, spawn spec parsing, model inference, and worker management
     for team session step execution. *)
 
-let int_opt_to_json = function Some n -> `Int n | None -> `Null
-let float_opt_to_json = function Some v -> `Float v | None -> `Null
+let int_opt_to_json = Json_util.int_opt_to_json
+let float_opt_to_json = Json_util.float_opt_to_json
 
 let truncate_for_event ?(max_len = 320) (s : string) =
   if String.length s <= max_len then

--- a/test/test_json_util.ml
+++ b/test/test_json_util.ml
@@ -2,6 +2,9 @@
 
 open Alcotest
 
+let yojson = testable (fun fmt v -> Format.pp_print_string fmt (Yojson.Safe.to_string v))
+  (fun a b -> Yojson.Safe.equal a b)
+
 (* ================================================================
    Test data
    ================================================================ *)
@@ -352,5 +355,39 @@ let () =
       test_case "get_int" `Quick test_empty_obj_get_int;
       test_case "get_float" `Quick test_empty_obj_get_float;
       test_case "get_bool" `Quick test_empty_obj_get_bool;
+    ];
+    "option_to_yojson", [
+      test_case "some" `Quick (fun () ->
+        let result = Json_util.option_to_yojson (fun s -> `String s) (Some "x") in
+        check yojson "Some wraps" (`String "x") result);
+      test_case "none" `Quick (fun () ->
+        let result = Json_util.option_to_yojson (fun s -> `String s) None in
+        check yojson "None -> Null" `Null result);
+    ];
+    "int_opt_to_json", [
+      test_case "some" `Quick (fun () ->
+        check yojson "Some 42" (`Int 42) (Json_util.int_opt_to_json (Some 42)));
+      test_case "none" `Quick (fun () ->
+        check yojson "None" `Null (Json_util.int_opt_to_json None));
+    ];
+    "string_opt_to_json", [
+      test_case "some" `Quick (fun () ->
+        check yojson "Some s" (`String "hi") (Json_util.string_opt_to_json (Some "hi")));
+      test_case "none" `Quick (fun () ->
+        check yojson "None" `Null (Json_util.string_opt_to_json None));
+    ];
+    "float_opt_to_json", [
+      test_case "some" `Quick (fun () ->
+        check yojson "Some f" (`Float 3.14) (Json_util.float_opt_to_json (Some 3.14)));
+      test_case "none" `Quick (fun () ->
+        check yojson "None" `Null (Json_util.float_opt_to_json None));
+    ];
+    "bool_opt_to_json", [
+      test_case "some true" `Quick (fun () ->
+        check yojson "Some true" (`Bool true) (Json_util.bool_opt_to_json (Some true)));
+      test_case "some false" `Quick (fun () ->
+        check yojson "Some false" (`Bool false) (Json_util.bool_opt_to_json (Some false)));
+      test_case "none" `Quick (fun () ->
+        check yojson "None" `Null (Json_util.bool_opt_to_json None));
     ];
   ]

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -380,13 +380,6 @@ let test_jsonl_backend_uses_explicit_base_dir () =
   Alcotest.(check bool) "writes under explicit base_dir" true (Sys.file_exists expected_path);
   cleanup_tmp_dir dir
 
-let test_seed_memory_bank_legacy_noop () =
-  let dir = setup_tmp_dir () in
-  let memory = Memory_oas_bridge.create_memory ~agent_name:"test-bank" () in
-  let count = Memory_oas_bridge.seed_memory_bank ~memory ~agent_name:"test-bank" ~limit:10 in
-  Alcotest.(check int) "seed_memory_bank returns 0" 0 count;
-  cleanup_tmp_dir dir
-
 let test_seed_episodes_loads_recent_jsonl () =
   let dir = setup_tmp_dir () in
   let first =
@@ -523,8 +516,6 @@ let () =
       Alcotest.test_case "query returns empty" `Quick test_jsonl_backend_query;
       Alcotest.test_case "uses explicit base_dir" `Quick
         test_jsonl_backend_uses_explicit_base_dir;
-      Alcotest.test_case "seed_memory_bank legacy noop" `Quick
-        test_seed_memory_bank_legacy_noop;
       Alcotest.test_case "seed_episodes loads recent jsonl" `Quick
         test_seed_episodes_loads_recent_jsonl;
       Alcotest.test_case "seed_episodes respects limit" `Quick


### PR DESCRIPTION
## Summary

PR #814(Agent SDK Workshop) 교훈 적용: 가짜/흉내 구현 제거, 중복 코드 통합, unsafe 패턴 수정.

### 1. JSON option 직렬화 헬퍼 통합 (12개 → 1개)
- `option_to_yojson`, `int_opt_to_json`, `string_opt_to_json`, `float_opt_to_json`, `bool_opt_to_json` → `Json_util` canonical 정의
- 7개 파일의 로컬 중복 정의를 alias re-export로 교체
- `string_opt_json`, `float_opt_json` 2개 추가 파일도 통합 (GLM-5.1 리뷰 피드백)

### 2. `unique_preserve_order` 통합 (5개 → 1개)
- `Json_util.dedupe_keep_order`와 동일 로직. 5개 파일의 독립 정의를 alias로 교체

### 3. Dead no-op 함수 제거 (caller 0)
- `maybe_promote_live_persistent_keeper`: config+name을 받아서 둘 다 ignore
- `seed_memory_bank`: "intentional no-op" 주석, returns 0
- `hidden_placeholder_tools`: always returns `[]`

### 4. 오해 유발 이름 수정
- `spawn_batch_stub_of_cards` → `spawn_batch_template_of_cards`

### 5. Unsafe 패턴 수정
- `List.hd` 3개 → `match` 패턴으로 교체 (lib_list_hd ratchet: 2→0)
- Health baseline을 현실에 맞게 조정 (lib_failwith 26→14, lib_list_tl 2→0)

## Test plan

- [x] `test_json_util` 58/58 (11개 새 테스트 추가)
- [x] `test_memory_oas_5tier` 20/20 (dead test 제거)
- [x] `dune build` 전체 빌드 성공
- [x] GLM-5.1 교차 모델 리뷰 완료 (2개 missed site 수정)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)