### PR TITLE
fix(research): replace unsafe List.hd with pattern match

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -395,12 +395,13 @@ let run_experiment ~sw ~net ~clock ~(config : Research_config.t)
          Log.Server.info "research: creating PR for kept experiment %s" experiment_id;
          let branch = Printf.sprintf "research/exp-%s" experiment_id in
          let run_git args timeout =
+           let command_label = match args with cmd :: _ -> cmd | [] -> "git" in
            let status, out = Process_eio.run_argv_with_status ~timeout_sec:timeout args in
            match status with
            | Unix.WEXITED 0 -> Ok out
-           | Unix.WEXITED n -> Error (Printf.sprintf "%s exited %d" (List.hd args) n)
-           | Unix.WSIGNALED n -> Error (Printf.sprintf "%s killed by signal %d" (List.hd args) n)
-           | Unix.WSTOPPED n -> Error (Printf.sprintf "%s stopped by signal %d" (List.hd args) n)
+           | Unix.WEXITED n -> Error (Printf.sprintf "%s exited %d" command_label n)
+           | Unix.WSIGNALED n -> Error (Printf.sprintf "%s killed by signal %d" command_label n)
+           | Unix.WSTOPPED n -> Error (Printf.sprintf "%s stopped by signal %d" command_label n)
          in
          (try
            let msg = Printf.sprintf "research(%s): %s" experiment_id


### PR DESCRIPTION
## Summary
- `List.hd args`를 `match args with cmd :: _ -> cmd | [] -> "git"`로 교체
- 빈 리스트에서 예외 발생 방지
- #4116의 실질 변경을 version conflict 없이 적용. Supersedes #4116.

Generated with [Claude Code](https://claude.com/claude-code)