### PR TITLE
test: fix main test regressions — prune fixtures + contract composer alignment

### DIFF
--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -46,7 +46,7 @@ let test_merge_contiguous_still_merges_plain_user () =
 (* ================================================================ *)
 
 let test_compact_prune_tool_outputs () =
-  let long_output = String.make 600 'x' in
+  let long_output = String.make 2000 'x' in
   let msgs = [
     msg Agent_sdk.Types.User "query";
     tool_msg long_output;

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -92,7 +92,7 @@ let test_compact_prune_tool_outputs () =
     true (List.length compacted.messages > 0);
   Alcotest.(check bool) "token count positive"
     true (compacted.token_count > 0);
-  (* Short tool output (< 500 chars) should not be truncated *)
+  (* Short tool output (< 1500 chars) should not be truncated *)
   Alcotest.(check int) "message count unchanged for short tool output"
     (List.length (make_test_messages ())) (List.length compacted.messages)
 

--- a/test/test_tool_compact.ml
+++ b/test/test_tool_compact.ml
@@ -63,7 +63,7 @@ let test_basic_compact () =
     check bool "messages_after > 0" true (List.length msgs_after > 0)
 
 let test_prune_tool_outputs () =
-  let long_output = String.make 1000 'x' in
+  let long_output = String.make 2000 'x' in
   let messages = [
     ("user", "Run the command");
     ("tool", long_output);


### PR DESCRIPTION
## Summary
main CI Build and Test를 깨뜨리는 2가지 테스트 regression 수정:

### 1. Prune fixture size (from #4114)
- `max_output_len` 500→1500 변경 후 테스트 fixture가 미갱신
- 600/1000 char → 2000 char로 변경하여 pruning 트리거

### 2. Contract composer expectations (from #4055/#4076)
- keeper boundary PR들이 `infer_keeper_execution_mode`/`infer_keeper_allowed_mutations` 로직 변경
- 테스트 기대값이 이전 로직 기준이라 3개 test fail
- `local` scope_kind → Execute (not Draft)
- `observe_only` execution_scope → `["workspace_only"]` mutations
- default → `[]` mutations

## Test plan
- [x] `test_context_compact_oas_coverage` strategy_mapping pass
- [x] `test_tool_compact` compact_dispatch pass
- [x] `test_contract_composer` compose suite 8/8 pass
- [ ] CI Build and Test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)