### PR TITLE
chore(release): bump version to 2.186.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## [2.186.0] - 2026-03-31
+
+### Fixed
+- **Harness health dashboard** — align frontend schema with backend after #3883 mitosis removal (#4113).
+- **Research List.hd** — replace unsafe List.hd with pattern match in run_git (#4121).
+- **CDAL tool block** — remove restriction blocking keeper tool execution (#4104).
+- **Tool output prune** — raise keeper tool output prune limit from 500 to 1500 chars (#4114).
+
+### Changed
+- **Harness smoke scripts** — extract shared boilerplate from observability smoke scripts (#4095).
+- **Json_util** — consolidate duplicated JSON option helpers (#4112).
+
 ## [2.185.0] - 2026-03-31
 
 ### Fixed

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.185.0)
+(version 2.186.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Version bump 2.185.0 -> 2.186.0
- Changelog updated with 6 PRs since last release

Generated with [Claude Code](https://claude.com/claude-code)