### PR TITLE
feat(keeper): surface tool skip reasons to LLM via Override

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -61,6 +61,53 @@ let consume_skip_reason keeper_name =
           Hashtbl.remove recent_skip_reasons keeper_name;
           Some reason)
 
+(** Percent-encode field value for structured [tool_skipped] output.
+    Matches [Keeper_agent_run.escape_field_value] encoding.
+    Local copy to avoid circular dependency. *)
+let escape_field s =
+  let buf = Buffer.create (String.length s * 3 / 2 + 1) in
+  String.iter (fun ch ->
+    match ch with
+    | ' ' -> Buffer.add_string buf "%20"
+    | '=' -> Buffer.add_string buf "%3D"
+    | '\n' -> Buffer.add_string buf "%0A"
+    | '\r' -> Buffer.add_string buf "%0D"
+    | '\t' -> Buffer.add_string buf "%09"
+    | '%' -> Buffer.add_string buf "%25"
+    | _ -> Buffer.add_char buf ch) s;
+  Buffer.contents buf
+
+(** Render structured skip reason for inline Override injection.
+    The LLM sees this as the ToolResult content immediately within
+    the same turn, enabling in-turn reasoning about alternatives.
+    @since Phase 8 — Skip→Override migration *)
+let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
+  let replacement_hint =
+    match (Tool_catalog.metadata tool_name).Tool_catalog.replacement with
+    | Some replacement ->
+      Printf.sprintf " replacement=%s" (escape_field replacement)
+    | None -> ""
+  in
+  Printf.sprintf
+    "[tool_skipped] tool=%s source=keeper_hook code=%s reason=%s%s"
+    (escape_field tool_name)
+    (escape_field reason_code)
+    (escape_field reason_text)
+    replacement_hint
+
+(** Broadcast a tool skip event via SSE for dashboard visibility. *)
+let broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code =
+  (try
+    Sse.broadcast
+      (`Assoc [
+        ("type", `String "keeper_tool_skipped");
+        ("name", `String keeper_name);
+        ("tool_name", `String tool_name);
+        ("reason_code", `String reason_code);
+        ("ts_unix", `Float (Unix.gettimeofday ()));
+      ])
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+
 (** Extract command or content string from tool input JSON for screening.
     Reads "command", "cmd" (keeper_github), or "content" keys. *)
 let extract_command_from_input (input : Yojson.Safe.t) : string =
@@ -128,10 +175,10 @@ let emit_cost_event
     @param on_tool_executed Optional callback after each tool execution
     @param trajectory_acc Optional trajectory accumulator for cost attribution *)
 let make_hooks
-    ~(config : Room.config)
+    ~config:(_config : Room.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
-    ~(session : Keeper_working_context.session_context)
-    ~(ctx_ref : Keeper_working_context.working_context ref)
+    ~session:(_session : Keeper_working_context.session_context)
+    ~ctx_ref:(_ctx_ref : Keeper_working_context.working_context ref)
     ~(generation : int)
     ?(max_cost_usd : float option)
     ?(destructive_check : bool = true)
@@ -140,9 +187,6 @@ let make_hooks
     ?(trajectory_acc : Trajectory.accumulator option)
     ()
   : Agent_sdk.Hooks.hooks =
-  ignore config;
-  ignore session;
-  ignore ctx_ref;
   let sse_turn_complete = "keeper_turn_complete" in
   let board_write_tools =
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
@@ -211,7 +255,11 @@ let make_hooks
           | Error { Agent_sdk.Types.message; _ } ->
             Printf.sprintf "error: %s" message
         in
-        on_tool_executed tool_name input output_text;
+        (try on_tool_executed tool_name input output_text
+         with Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Keeper.error "keeper:%s on_tool_executed callback failed for %s: %s"
+                (!meta_ref).name tool_name (Printexc.to_string exn));
         if List.mem tool_name board_write_tools then
           Log.Keeper.info "keeper:%s social_event tool=%s"
             (!meta_ref).name tool_name;
@@ -224,48 +272,45 @@ let make_hooks
         let keeper_name = (!meta_ref).name in
         (* Safety gate 0: Keeper deny list *)
         if List.mem tool_name keeper_denied_tools then begin
-          record_skip_reason
-            ~keeper_name
-            ~tool_name
-            ~source:"keeper_hook"
-            ~reason_code:"keeper_deny"
-            ~reason_text:"tool is on the keeper deny list";
           Log.Keeper.warn "keeper:%s deny list: blocked %s"
             keeper_name tool_name;
-          Agent_sdk.Hooks.Skip
+          broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code:"keeper_deny";
+          Agent_sdk.Hooks.Override
+            (render_inline_skip_reason
+               ~tool_name
+               ~reason_code:"keeper_deny"
+               ~reason_text:"tool is on the keeper deny list")
         end
         else
         (* Safety gate 1: Cost budget *)
         (match max_cost_usd with
          | Some limit when accumulated_cost_usd >= limit ->
-           record_skip_reason
-             ~keeper_name
-             ~tool_name
-             ~source:"keeper_hook"
-             ~reason_code:"cost_gate"
-             ~reason_text:
-               (Printf.sprintf
-                  "accumulated_cost_usd=%.4f exceeded limit=%.4f"
-                  accumulated_cost_usd limit);
+           let reason_text =
+             Printf.sprintf "accumulated_cost_usd=%.4f exceeded limit=%.4f"
+               accumulated_cost_usd limit
+           in
            Log.Keeper.warn "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
              keeper_name accumulated_cost_usd limit tool_name;
-           Agent_sdk.Hooks.Skip
+           broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code:"cost_gate";
+           Agent_sdk.Hooks.Override
+             (render_inline_skip_reason
+                ~tool_name ~reason_code:"cost_gate" ~reason_text)
          | _ ->
            (* Safety gate 2: Destructive pattern detection *)
            if destructive_check && List.mem tool_name destructive_check_tools then
              let cmd = extract_command_from_input input in
              match Eval_gate.detect_destructive cmd with
              | Some (pattern, desc) ->
-               record_skip_reason
-                 ~keeper_name
-                 ~tool_name
-                 ~source:"keeper_hook"
-                 ~reason_code:"destructive_guard"
-                 ~reason_text:
-                   (Printf.sprintf "pattern='%s' (%s)" pattern desc);
+               let reason_text =
+                 Printf.sprintf "pattern='%s' (%s)" pattern desc
+               in
                Log.Keeper.warn "keeper:%s destructive pattern in %s: '%s' (%s)"
                  keeper_name tool_name pattern desc;
-               Agent_sdk.Hooks.Skip
+               broadcast_tool_skipped ~keeper_name ~tool_name
+                 ~reason_code:"destructive_guard";
+               Agent_sdk.Hooks.Override
+                 (render_inline_skip_reason
+                    ~tool_name ~reason_code:"destructive_guard" ~reason_text)
              | None -> Agent_sdk.Hooks.Continue
            else
              Agent_sdk.Hooks.Continue)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -852,6 +852,32 @@ let test_render_inline_skip_reason_destructive () =
   check bool "code" true (str_contains result "code=destructive_guard");
   check bool "pattern encoded" true (str_contains result "pattern%3D")
 
+let test_render_inline_escape_edge_cases () =
+  (* Empty reason text *)
+  let empty = HK.render_inline_skip_reason
+    ~tool_name:"t" ~reason_code:"c" ~reason_text:"" in
+  check bool "empty reason" true (str_contains empty "reason=");
+  (* Percent sign in reason *)
+  let pct = HK.render_inline_skip_reason
+    ~tool_name:"t" ~reason_code:"c" ~reason_text:"CPU at 90%" in
+  check bool "percent encoded" true (str_contains pct "90%25")
+
+let test_render_inline_with_replacement () =
+  (* keeper_board_post has replacement=masc_board_post in Tool_catalog *)
+  let result = HK.render_inline_skip_reason
+    ~tool_name:"keeper_board_post"
+    ~reason_code:"keeper_deny"
+    ~reason_text:"denied"
+  in
+  check bool "has replacement" true (str_contains result "replacement=")
+
+let test_consume_skip_reason_none_after_override () =
+  (* After Override migration, no record_skip_reason is called,
+     so consume_skip_reason should return None *)
+  HK.clear_skip_reason "test-keeper";
+  let result = HK.consume_skip_reason "test-keeper" in
+  check bool "returns None" true (result = None)
+
 let test_normalize_override_passthrough () =
   let override_text =
     "[tool_skipped] tool=keeper_bash source=keeper_hook code=keeper_deny \
@@ -945,5 +971,11 @@ let () =
             test_render_inline_skip_reason_destructive;
           test_case "normalize override passthrough" `Quick
             test_normalize_override_passthrough;
+          test_case "escape edge cases" `Quick
+            test_render_inline_escape_edge_cases;
+          test_case "render_inline with replacement" `Quick
+            test_render_inline_with_replacement;
+          test_case "consume_skip_reason None after Override" `Quick
+            test_consume_skip_reason_none_after_override;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -815,6 +815,56 @@ let test_normalize_response_text_empty_with_skip_reason () =
          found)
   | Error e -> fail ("unexpected error: " ^ e)
 
+(* ---------- render_inline_skip_reason tests ---------- *)
+
+let str_contains s sub =
+  try ignore (Str.search_forward (Str.regexp_string sub) s 0); true
+  with Not_found -> false
+
+let test_render_inline_skip_reason_deny () =
+  let result = HK.render_inline_skip_reason
+    ~tool_name:"keeper_bash"
+    ~reason_code:"keeper_deny"
+    ~reason_text:"tool is on the keeper deny list"
+  in
+  check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
+  check bool "tool" true (str_contains result "tool=keeper_bash");
+  check bool "code" true (str_contains result "code=keeper_deny");
+  check bool "reason encoded" true (str_contains result "reason=tool%20is%20on")
+
+let test_render_inline_skip_reason_cost () =
+  let result = HK.render_inline_skip_reason
+    ~tool_name:"keeper_bash"
+    ~reason_code:"cost_gate"
+    ~reason_text:"accumulated_cost_usd=0.5100 exceeded limit=0.5000"
+  in
+  check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
+  check bool "code" true (str_contains result "code=cost_gate");
+  check bool "reason encoded equals" true (str_contains result "0.5100%20exceeded")
+
+let test_render_inline_skip_reason_destructive () =
+  let result = HK.render_inline_skip_reason
+    ~tool_name:"keeper_bash"
+    ~reason_code:"destructive_guard"
+    ~reason_text:"pattern='rm -rf' (recursive forced deletion)"
+  in
+  check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
+  check bool "code" true (str_contains result "code=destructive_guard");
+  check bool "pattern encoded" true (str_contains result "pattern%3D")
+
+let test_normalize_override_passthrough () =
+  let override_text =
+    "[tool_skipped] tool=keeper_bash source=keeper_hook code=keeper_deny \
+     reason=tool%20is%20on%20the%20keeper%20deny%20list"
+  in
+  match KAR.normalize_response_text
+          ~text:override_text
+          ~tool_names:["keeper_bash"]
+          ()
+  with
+  | Ok text -> check string "passes through" override_text text
+  | Error e -> fail ("unexpected error: " ^ e)
+
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -887,5 +937,13 @@ let () =
             test_normalize_response_text_rewrites_generic_skip;
           test_case "normalize empty with skip reason" `Quick
             test_normalize_response_text_empty_with_skip_reason;
+          test_case "render_inline deny" `Quick
+            test_render_inline_skip_reason_deny;
+          test_case "render_inline cost" `Quick
+            test_render_inline_skip_reason_cost;
+          test_case "render_inline destructive" `Quick
+            test_render_inline_skip_reason_destructive;
+          test_case "normalize override passthrough" `Quick
+            test_normalize_override_passthrough;
         ] );
     ]


### PR DESCRIPTION
## Summary

Keeper가 safety gate에서 차단될 때 LLM에게 즉시 구조화된 사유를 전달하도록 개선.

- **Before**: `"Tool execution skipped by hook"` (generic, 턴 후 보정)
- **After**: `"[tool_skipped] tool=keeper_bash code=destructive_guard reason=... replacement=masc_bash"` (즉시 ToolResult로 전달)

### 변경 내용

- 3개 safety gate (deny list, cost budget, destructive pattern)에서 `Hooks.Skip` → `Hooks.Override` 전환
- `render_inline_skip_reason`: 구조화된 skip 메시지 생성 함수 추가
- `broadcast_tool_skipped`: per-skip SSE 이벤트로 dashboard 가시성 확보
- `on_tool_executed` 콜백 try-catch 래핑 (크래시 방지)
- `ignore` → `_` prefix (OCaml 관습)

### 설계 근거

Claude Code와 Codex CLI는 모두 차단 사유를 tool result 자체에 주입. OAS의 `Override of string`이 이미 존재하므로 OAS 변경 없이 MASC만 수정.

## Test plan

- [x] `test_keeper_unified` (42 tests) — 기존 + 신규 4개 통과
- [x] `render_inline_skip_reason` 단위 테스트 3개 (deny, cost, destructive)
- [x] `normalize_override_passthrough` — Override 텍스트가 그대로 전달되는지 확인
- [ ] keeper 실행 시 deny된 tool 시도 → ToolResult에 [tool_skipped] 확인
- [ ] Dashboard SSE에서 keeper_tool_skipped 이벤트 확인

Generated with [Claude Code](https://claude.com/claude-code)