### PR TITLE
feat: keeper tool mutation_class + bump agent_sdk 0.99.1

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -109,6 +109,7 @@ let make_tools
         ~name:td.name
         ~description:td.description
         ~input_schema:td.input_schema
+        ~mutation_class:"workspace"
         (fun input ->
           let key = args_key td.name input in
           let prior_fails =

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -85,10 +85,14 @@ let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param 
         ~input_schema:schema_json
         (fun args -> handle_vote_create ctx args)
     ]} *)
-let oas_tool_of_masc ~name ~description ~input_schema handler : Agent_sdk.Tool.t =
+let oas_tool_of_masc ~name ~description ~input_schema
+    ?(mutation_class : string option) handler : Agent_sdk.Tool.t =
   let parameters = params_of_json_schema input_schema in
   let oas_handler json_args =
     let success, msg = handler json_args in
     to_oas_tool_result (success, msg)
   in
-  Agent_sdk.Tool.create ~name ~description ~parameters oas_handler
+  let descriptor : Agent_sdk.Tool.descriptor =
+    { kind = None; mutation_class; shell = None; notes = []; examples = [] }
+  in
+  Agent_sdk.Tool.create ~descriptor ~name ~description ~parameters oas_handler

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -35,6 +35,7 @@ val oas_tool_of_masc :
   name:string ->
   description:string ->
   input_schema:Yojson.Safe.t ->
+  ?mutation_class:string ->
   (Yojson.Safe.t -> bool * string) ->
   Agent_sdk.Tool.t
 (** Create an OAS [Tool.t] from a MASC tool name, description,

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.98.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.99.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="08f54b973c993613cb320682337e9a567477b414"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.98.0"
+readonly OAS_AGENT_SDK_SHA="61e5314630c3db7b6415b937e83f4beac27897ee"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.99.1"


### PR DESCRIPTION
## Summary
- Bump agent_sdk pin to 0.99.1 (tool-declared mutation_class support)
- `oas_tool_of_masc` accepts `?mutation_class` parameter
- Keeper tools registered with `mutation_class="workspace"` so OAS mode_enforcer classifies them correctly

## Context
OAS mode_enforcer classified all unknown tools as `External_Effect`, blocking keeper tool execution via CDAL contract. OAS #511 added `tool_classifications` support; this PR connects it from the MASC side.

## Companion PRs
- jeong-sik/oas#511 (mode_enforcer tool classification)
- jeong-sik/oas#512 (version bump to 0.99.1)
- jeong-sik/masc-mcp#4104 (CDAL contract workaround - already merged)

## Test plan
- [x] `test_keeper_tools_oas` (14 tests pass)
- [x] `test_keeper_safety_gates` (54 tests pass)
- [x] Build passes with new agent_sdk 0.99.1

Generated with [Claude Code](https://claude.com/claude-code)