### PR TITLE
fix: AI code review followup (P0-P2) v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - **Pulse rhythm API** — set_rhythm/get_rhythm for runtime interval (#4063).
 
 ### Fixed
-- **Keeper tool_allowlist** — correct semantics: empty means none (#4059).
+- **Keeper tool_allowlist** — correct runtime semantics: empty list means no tools allowed; JSON deserialization migrates empty to standard_tools for backward compatibility (#4059).
 - **Keeper bridge tests** — update for allowlist semantics + shard bypass (#4088).
 - **Json_util dedup** — consolidate to canonical SSOT (#4085).
 

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -373,6 +373,50 @@ function handleHarnessSSE(): void {
     }))
     scheduleHarnessReload()
   }
+
+  if (type === 'oas:masc:harness:handoff') {
+    const nextItem: HandoffEvent = {
+      timestamp:
+        typeof payload.timestamp === 'number'
+          ? payload.timestamp
+          : Date.now() / 1000,
+      keeper_name: String(payload.keeper_name ?? ''),
+      trace_id: String(payload.trace_id ?? ''),
+      generation: Number(payload.generation ?? 0),
+      next_generation:
+        payload.next_generation == null ? null : Number(payload.next_generation),
+      prev_trace_id:
+        payload.prev_trace_id == null ? null : String(payload.prev_trace_id),
+      new_trace_id:
+        payload.new_trace_id == null ? null : String(payload.new_trace_id),
+      to_model:
+        payload.to_model == null ? null : String(payload.to_model),
+    }
+    updateHarnessData(data => ({
+      ...data,
+      recent_handoffs: {
+        ...data.recent_handoffs,
+        recent_events: mergeRecent(
+          data.recent_handoffs.recent_events,
+          nextItem,
+          (left, right) =>
+            left.timestamp === right.timestamp
+            && left.trace_id === right.trace_id,
+          8,
+        ),
+        total_recent: data.recent_handoffs.total_recent + 1,
+        last_event_at: nextItem.timestamp,
+        empty_reason: null,
+      },
+      overview: {
+        ...data.overview,
+        last_signal_at: nextItem.timestamp,
+        handoff_last_event_at: nextItem.timestamp,
+        latest_handoff_generation: nextItem.next_generation ?? nextItem.generation,
+      },
+    }))
+    scheduleHarnessReload()
+  }
 }
 
 function StatusPill({ status }: { status: RailStatus }) {

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -257,10 +257,13 @@ let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
     - DropLowImportance uses OAS Custom with importance scoring (OAS has no scoring).
     - SummarizeOld uses OAS Custom with extractive summaries plus ToolResult
       structured stubs so ToolUse/ToolResult pairing survives compaction. *)
+(** Max length for tool output before pruning. Shared with keeper_agent_run. *)
+let tool_output_prune_limit = 1500
+
 let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
   match s with
   | PruneToolOutputs ->
-    Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 1500 }
+    Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = tool_output_prune_limit }
   | MergeContiguous ->
     Agent_sdk.Context_reducer.Merge_contiguous
   | DropLowImportance ->

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -138,12 +138,15 @@ let bool_opt_to_json : bool option -> Yojson.Safe.t = function
 (** List utilities *)
 
 let dedupe_keep_order xs =
-  let rec loop seen acc = function
+  let seen = Hashtbl.create (List.length xs) in
+  let rec loop acc = function
     | [] -> List.rev acc
     | x :: rest ->
-        if List.mem x seen then
-          loop seen acc rest
-        else
-          loop (x :: seen) (x :: acc) rest
+        if Hashtbl.mem seen x then
+          loop acc rest
+        else begin
+          Hashtbl.replace seen x ();
+          loop (x :: acc) rest
+        end
   in
-  loop [] [] xs
+  loop [] xs

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -332,7 +332,7 @@ let run_turn
   let reducer = Agent_sdk.Context_reducer.compose [
     Agent_sdk.Context_reducer.keep_last 30;
     { Agent_sdk.Context_reducer.strategy =
-        Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 1500 } };
+        Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = Context_compact_oas.tool_output_prune_limit } };
     { strategy = Agent_sdk.Context_reducer.Merge_contiguous };
   ] in
   (* 8. Run Agent *)

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -27,31 +27,34 @@ let warm_shell_cache (state : Mcp_server.server_state) =
 let _last_broadcast_hash : (string, Digestif.SHA256.t) Hashtbl.t =
   Hashtbl.create 8
 
+let _broadcast_hash_mu = Eio.Mutex.create ()
+
 (** Broadcast a single cached surface to all Observer SSE sessions.
     [event_type] becomes the SSE event "type" field.
     Skips broadcast when payload hash matches the previous one (delta push).
-    Safe to call from any fiber — reads only from a cached ref. *)
+    Mutex-protected: safe to call from concurrent fibers. *)
 let broadcast_cached_surface ~event_type (json : Yojson.Safe.t) : unit =
   let serialized = Yojson.Safe.to_string json in
   let hash = Digestif.SHA256.digest_string serialized in
-  let changed =
-    match Hashtbl.find_opt _last_broadcast_hash event_type with
-    | Some prev -> not (Digestif.SHA256.equal prev hash)
-    | None -> true
-  in
-  if changed then begin
-    Hashtbl.replace _last_broadcast_hash event_type hash;
-    let sse_json =
-      `Assoc
-        [
-          ("type", `String event_type);
-          ("payload", json);
-          ("ts_unix", `Float (Time_compat.now ()));
-        ]
+  Eio.Mutex.use_rw ~protect:true _broadcast_hash_mu (fun () ->
+    let changed =
+      match Hashtbl.find_opt _last_broadcast_hash event_type with
+      | Some prev -> not (Digestif.SHA256.equal prev hash)
+      | None -> true
     in
-    Sse.broadcast_to Observers sse_json
-  end else
-    Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type
+    if changed then begin
+      Hashtbl.replace _last_broadcast_hash event_type hash;
+      let sse_json =
+        `Assoc
+          [
+            ("type", `String event_type);
+            ("payload", json);
+            ("ts_unix", `Float (Time_compat.now ()));
+          ]
+      in
+      Sse.broadcast_to Observers sse_json
+    end else
+      Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type)
 
 (* Wire operator broadcast refs now that Sse is in scope. *)
 let () =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -36,25 +36,28 @@ let _broadcast_hash_mu = Eio.Mutex.create ()
 let broadcast_cached_surface ~event_type (json : Yojson.Safe.t) : unit =
   let serialized = Yojson.Safe.to_string json in
   let hash = Digestif.SHA256.digest_string serialized in
-  Eio.Mutex.use_rw ~protect:true _broadcast_hash_mu (fun () ->
-    let changed =
-      match Hashtbl.find_opt _last_broadcast_hash event_type with
-      | Some prev -> not (Digestif.SHA256.equal prev hash)
-      | None -> true
-    in
-    if changed then begin
-      Hashtbl.replace _last_broadcast_hash event_type hash;
-      let sse_json =
-        `Assoc
-          [
-            ("type", `String event_type);
-            ("payload", json);
-            ("ts_unix", `Float (Time_compat.now ()));
-          ]
+  let should_broadcast =
+    Eio.Mutex.use_rw ~protect:true _broadcast_hash_mu (fun () ->
+      let changed =
+        match Hashtbl.find_opt _last_broadcast_hash event_type with
+        | Some prev -> not (Digestif.SHA256.equal prev hash)
+        | None -> true
       in
-      Sse.broadcast_to Observers sse_json
-    end else
-      Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type)
+      if changed then (Hashtbl.replace _last_broadcast_hash event_type hash; true)
+      else false)
+  in
+  if should_broadcast then begin
+    let sse_json =
+      `Assoc
+        [
+          ("type", `String event_type);
+          ("payload", json);
+          ("ts_unix", `Float (Time_compat.now ()));
+        ]
+    in
+    Sse.broadcast_to Observers sse_json
+  end else
+    Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type
 
 (* Wire operator broadcast refs now that Sse is in scope. *)
 let () =

--- a/lib/server/server_dashboard_http_room_truth.ml
+++ b/lib/server/server_dashboard_http_room_truth.ml
@@ -128,7 +128,7 @@ let room_truth_snapshot_from_caches (state : Mcp_server.server_state) :
     let shell_json =
       if !(Execution_surfaces._shell_warmed) then
         try dashboard_shell_http_json ?clock:state.Mcp_server.clock config
-        with _ -> `Assoc []
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> `Assoc []
       else `Assoc []
     in
     let execution_json = cached_surface_json Execution_surfaces._execution_cache in


### PR DESCRIPTION
## Summary

AI 코드리뷰 코멘트(Copilot/Codex) 중 현재 main에 아직 남아있는 이슈를 일괄 대응합니다.
v2: PR #4069 (dashboard split) 이후 최신 main(v2.187.0)에서 재적용.

Supersedes #4129 (충돌으로 인해 재생성).

### P0 (정합성 버그)
- `server_dashboard_http_room_truth.ml:131` — `with _ ->` 가 `Eio.Cancel.Cancelled` 삼키는 문제 수정
- `server_dashboard_http_execution_surfaces.ml:27-54` — `_last_broadcast_hash` Hashtbl race condition에 `Eio.Mutex` 보호 추가

### P1 (기능/안전)
- `harness-health.ts` — `oas:masc:harness:handoff` SSE 이벤트 handler 추가 (실시간 handoff 갱신)
- `CHANGELOG.md` — `tool_allowlist` "empty means none" → 런타임/역직렬화 의미론 명확화

### P2 (기술 부채)
- `context_compact_oas.ml` + `keeper_agent_run.ml` — 1500 prune 상수 → 공유 `tool_output_prune_limit`
- `json_util.ml` — `dedupe_keep_order` O(n^2) → O(n)

## Review evidence
- Sources: Copilot/Codex inline comments on PRs #4069, #4112, #4113, #4114, #4116
- OCaml build: `dune build` 변경 파일 5개 통과
- TypeScript: `tsc --noEmit` 통과

## Test plan
- [ ] CI Build and Test 통과
- [ ] CI Health 통과
- [ ] Dashboard tsc 통과
- [ ] Harness health SSE handoff 이벤트 실시간 갱신 확인

Refs #4069 #4112 #4113 #4114 #4116

Generated with [Claude Code](https://claude.com/claude-code)