### PR TITLE
refactor(harness): drop passthrough wrappers, use mcp_* directly

### DIFF
--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -291,3 +291,20 @@ mcp_call_tool() {
 
   mcp_jsonrpc_call "$id" "tools/call" "$params_json" "$session_id" "$token" "$endpoint"
 }
+
+# Call tool and assert success. Returns the full payload on success.
+# Usage: payload="$(mcp_call_tool_checked <id> <tool> <args_json> [session_id] [token] [endpoint])"
+mcp_call_tool_checked() {
+  local payload
+  payload="$(mcp_call_tool "$@")"
+  mcp_require_tool_ok "$payload" "${2:-tool}_checked"
+  printf '%s' "$payload"
+}
+
+# Call tool, assert success, extract .result. Returns the parsed result object.
+# Usage: result="$(mcp_call_tool_result <id> <tool> <args_json> [session_id] [token] [endpoint])"
+mcp_call_tool_result() {
+  local payload
+  payload="$(mcp_call_tool_checked "$@")"
+  printf '%s' "$payload" | mcp_extract_result
+}

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -70,14 +70,8 @@ mcp_extract_result() {
   '
 }
 
-mcp_extract_payload() {
-  jq -c '
-    if ._harness_error? then
-      empty
-    else
-      try (.result.content[0].text | fromjson | .payload) catch empty
-    end
-  '
+mcp_extract_is_error() {
+  jq -r 'try (.result.isError) catch "true"'
 }
 
 mcp_extract_error() {

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -123,12 +123,6 @@ extract_result() {
   '
 }
 
-# Extract .payload from MCP tool response content.
-# Usage: echo "$response" | extract_payload
-extract_payload() {
-  jq -c 'if ._harness_error? then empty else try (.result.content[0].text | fromjson | .payload) catch empty end'
-}
-
 # Extract error message from MCP tool response.
 # Usage: echo "$response" | extract_error
 extract_error() {

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -52,40 +52,6 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  mcp_call_tool "$id" "$tool_name" "$args_json"
-}
-
-extract_result() {
-  mcp_extract_result
-}
-
-extract_text() {
-  mcp_extract_text
-}
-
-require_tool_success() {
-  local payload="$1"
-  local label="${2:-agent_swarm_live tool}"
-  mcp_require_tool_ok "$payload" "$label"
-}
-
-call_tool_checked() {
-  local payload
-  payload="$(call_tool "$@")"
-  require_tool_success "$payload"
-  printf "%s" "$payload"
-}
-
-call_tool_result_checked() {
-  local payload
-  payload="$(call_tool_checked "$@")"
-  printf "%s" "$payload" | extract_result
-}
-
 runtime_verify_result() {
   local runtime_pool="${1:-}"
   local expected_model="${2:-}"
@@ -106,7 +72,7 @@ runtime_verify_result() {
       | if $expected_ctx_raw != "" then .expected_ctx = ($expected_ctx_raw | tonumber) else . end
       '
   )"
-  call_tool_result_checked $((98000 + RANDOM % 1000)) "masc_runtime_verify" "$args"
+  mcp_call_tool_result $((98000 + RANDOM % 1000)) "masc_runtime_verify" "$args"
 }
 
 observe_swarm_result() {
@@ -122,20 +88,14 @@ observe_swarm_result() {
       | if $operation_id != "" then .operation_id = $operation_id else . end
       '
   )"
-  call_tool_result_checked $((99000 + RANDOM % 1000)) "masc_observe_swarm" "$args"
+  mcp_call_tool_result $((99000 + RANDOM % 1000)) "masc_observe_swarm" "$args"
 }
 
 extract_added_task_id() {
   local payload="$1"
   local text
-  text="$(printf "%s" "$payload" | extract_text)"
+  text="$(printf "%s" "$payload" | mcp_extract_text)"
   printf "%s\n" "$text" | sed -n 's/^✅ Added \(task-[0-9][0-9][0-9]\):.*$/\1/p' | head -n1
-}
-
-require_json() {
-  local payload="$1"
-  local label="${2:-agent_swarm_live payload}"
-  mcp_require_json "$payload" "$label"
 }
 
 wait_for_http() {
@@ -566,11 +526,11 @@ cleanup() {
     write_failure_summary >/dev/null 2>&1 || true
   fi
   if [ -n "$OPERATION_ID" ]; then
-    call_tool 99090 "masc_operation_stop" \
+    mcp_call_tool 99090 "masc_operation_stop" \
       "$(jq -cn --arg operation_id "$OPERATION_ID" --arg note "harness cleanup after failure" '{operation_id:$operation_id,note:$note}')" \
       >/dev/null 2>&1 || true
   fi
-  call_tool 99091 "masc_leave" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null 2>&1 || true
+  mcp_call_tool 99091 "masc_leave" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null 2>&1 || true
   if [ -n "$SERVER_PID" ]; then
     kill "$SERVER_PID" >/dev/null 2>&1 || true
   fi
@@ -653,31 +613,31 @@ fi
 CURRENT_STAGE="manifest"
 echo "[5/12] describe deterministic swarm manifest"
 MANIFEST_JSON="$(generate_manifest_json)"
-require_json "$MANIFEST_JSON"
+mcp_require_json "$MANIFEST_JSON"
 EXPECTED_WORKERS="$(printf "%s" "$MANIFEST_JSON" | jq -r '.expected_worker_count')"
 SQUAD_ROSTER_JSON="$(printf "%s" "$MANIFEST_JSON" | jq -c '[.workers[].name]')"
 
 CURRENT_STAGE="room-task-hygiene"
 echo "[6/12] room/task hygiene"
-call_tool_checked 90001 "masc_set_room" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')" >/dev/null
-call_tool_checked 90002 "masc_init" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
-call_tool_checked 90003 "masc_join" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a,capabilities:["agent-swarm","command-plane","benchmark"]}')" >/dev/null
-HARNESS_TASK_RAW="$(call_tool_checked 90004 "masc_add_task" "$(jq -cn --arg title "[${RUN_ID}] orchestrate live swarm" --arg desc "Prepare units, tasks, and live harness execution" '{title:$title,description:$desc,priority:1}')")"
+mcp_call_tool_checked 90001 "masc_set_room" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')" >/dev/null
+mcp_call_tool_checked 90002 "masc_init" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
+mcp_call_tool_checked 90003 "masc_join" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a,capabilities:["agent-swarm","command-plane","benchmark"]}')" >/dev/null
+HARNESS_TASK_RAW="$(mcp_call_tool_checked 90004 "masc_add_task" "$(jq -cn --arg title "[${RUN_ID}] orchestrate live swarm" --arg desc "Prepare units, tasks, and live harness execution" '{title:$title,description:$desc,priority:1}')")"
 HARNESS_TASK_ID="$(extract_added_task_id "$HARNESS_TASK_RAW")"
 if [ -z "$HARNESS_TASK_ID" ]; then
   printf "%s\n" "$HARNESS_TASK_RAW" >&2
   echo "failed to extract coordinator task id" >&2
   exit 1
 fi
-call_tool_checked 90005 "masc_transition" "$(jq -cn --arg a "$HARNESS_AGENT" --arg task_id "$HARNESS_TASK_ID" '{action:"claim",agent_name:$a,task_id:$task_id}')" >/dev/null
-call_tool_checked 90006 "masc_plan_set_task" "$(jq -cn --arg task_id "$HARNESS_TASK_ID" '{task_id:$task_id}')" >/dev/null
-call_tool_checked 90007 "masc_heartbeat" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
+mcp_call_tool_checked 90005 "masc_transition" "$(jq -cn --arg a "$HARNESS_AGENT" --arg task_id "$HARNESS_TASK_ID" '{action:"claim",agent_name:$a,task_id:$task_id}')" >/dev/null
+mcp_call_tool_checked 90006 "masc_plan_set_task" "$(jq -cn --arg task_id "$HARNESS_TASK_ID" '{task_id:$task_id}')" >/dev/null
+mcp_call_tool_checked 90007 "masc_heartbeat" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
 
 CURRENT_STAGE="define-units"
 echo "[7/12] define company/platoon/squad"
-call_tool_checked 90010 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{unit_id:("company-" + $run_id),kind:"company",label:("Live Swarm Company " + $run_id),leader_id:"swarm-harness"}')" >/dev/null
-call_tool_checked 90011 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{unit_id:("platoon-" + $run_id),kind:"platoon",label:("Live Swarm Platoon " + $run_id),parent_unit_id:("company-" + $run_id),leader_id:"swarm-harness",policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180}}')" >/dev/null
-call_tool_checked 90012 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" --argjson roster "$SQUAD_ROSTER_JSON" '{unit_id:("squad-" + $run_id),kind:"squad",label:("Live Swarm Squad " + $run_id),parent_unit_id:("platoon-" + $run_id),leader_id:"swarm-harness",roster:$roster,policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180},budget:{headcount_cap:16,active_operation_cap:1}}')" >/dev/null
+mcp_call_tool_checked 90010 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{unit_id:("company-" + $run_id),kind:"company",label:("Live Swarm Company " + $run_id),leader_id:"swarm-harness"}')" >/dev/null
+mcp_call_tool_checked 90011 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{unit_id:("platoon-" + $run_id),kind:"platoon",label:("Live Swarm Platoon " + $run_id),parent_unit_id:("company-" + $run_id),leader_id:"swarm-harness",policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180}}')" >/dev/null
+mcp_call_tool_checked 90012 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" --argjson roster "$SQUAD_ROSTER_JSON" '{unit_id:("squad-" + $run_id),kind:"squad",label:("Live Swarm Squad " + $run_id),parent_unit_id:("platoon-" + $run_id),leader_id:"swarm-harness",roster:$roster,policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180},budget:{headcount_cap:16,active_operation_cap:1}}')" >/dev/null
 
 CURRENT_STAGE="seed-worker-tasks"
 echo "[8/12] seed per-worker tasks"
@@ -686,7 +646,7 @@ printf "%s" "$MANIFEST_JSON" \
   | while IFS= read -r worker; do
       TITLE="$(printf "%s" "$worker" | jq -r '.task_title')"
       DESC="$(printf "%s" "$worker" | jq -r '.task_description')"
-      call_tool_checked 90100 "masc_add_task" "$(jq -cn --arg title "$TITLE" --arg description "$DESC" '{title:$title,description:$description,priority:2}')" >/dev/null
+      mcp_call_tool_checked 90100 "masc_add_task" "$(jq -cn --arg title "$TITLE" --arg description "$DESC" '{title:$title,description:$description,priority:2}')" >/dev/null
     done
 CURRENT_STAGE="run-harness"
 echo "[9/12] run live harness against local qwen"
@@ -711,14 +671,14 @@ done
 
 CURRENT_STAGE="start-operation"
 echo "[10/12] start managed operation"
-OPERATION_RAW="$(call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" --arg expected_workers "$EXPECTED_WORKERS" --arg required_final_markers "$REQUIRED_FINAL_MARKERS" --arg min_hot_slots "$MIN_HOT_SLOTS" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic " + $expected_workers + "-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id + " worker_count=" + $expected_workers + " required_final_markers=" + $required_final_markers + " min_hot_slots=" + $min_hot_slots)}')")"
-OPERATION_ID="$(printf "%s" "$OPERATION_RAW" | extract_result | jq -r '.operation_id // empty')"
+OPERATION_RAW="$(mcp_call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" --arg expected_workers "$EXPECTED_WORKERS" --arg required_final_markers "$REQUIRED_FINAL_MARKERS" --arg min_hot_slots "$MIN_HOT_SLOTS" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic " + $expected_workers + "-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id + " worker_count=" + $expected_workers + " required_final_markers=" + $required_final_markers + " min_hot_slots=" + $min_hot_slots)}')")"
+OPERATION_ID="$(printf "%s" "$OPERATION_RAW" | mcp_extract_result | jq -r '.operation_id // empty')"
 if [ -z "$OPERATION_ID" ]; then
   printf "%s\n" "$OPERATION_RAW" >&2
   echo "operation_id missing" >&2
   exit 1
 fi
-call_tool_checked 90121 "masc_dispatch_tick" "$(jq -cn --arg operation_id "$OPERATION_ID" '{operation_id:$operation_id}')" >/dev/null
+mcp_call_tool_checked 90121 "masc_dispatch_tick" "$(jq -cn --arg operation_id "$OPERATION_ID" '{operation_id:$operation_id}')" >/dev/null
 
 HARNESS_STARTED_AT="$(date +%s)"
 while kill -0 "$HARNESS_PID" >/dev/null 2>&1; do
@@ -743,7 +703,7 @@ if [ "$HARNESS_EXIT" -ne 0 ]; then
 fi
 HARNESS_PID=""
 HARNESS_RESULT="$(cat "$HARNESS_RESULT_FILE")"
-require_json "$HARNESS_RESULT"
+mcp_require_json "$HARNESS_RESULT"
 stop_slot_sampler
 preserve_harness_result
 write_slot_telemetry >/dev/null
@@ -753,10 +713,10 @@ write_harness_summary >/dev/null
 CURRENT_STAGE="checkpoint-finalize"
 echo "[11/12] checkpoint + finalize"
 SUCCESSFUL_WORKERS="$(printf "%s" "$HARNESS_RESULT" | jq -r '.summary.successful_workers')"
-call_tool_checked 90130 "masc_operation_checkpoint" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg checkpoint_ref "live-harness-${RUN_ID}" --arg note "successful_workers=${SUCCESSFUL_WORKERS}/${EXPECTED_WORKERS}" '{operation_id:$operation_id,checkpoint_ref:$checkpoint_ref,note:$note}')" >/dev/null
+mcp_call_tool_checked 90130 "masc_operation_checkpoint" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg checkpoint_ref "live-harness-${RUN_ID}" --arg note "successful_workers=${SUCCESSFUL_WORKERS}/${EXPECTED_WORKERS}" '{operation_id:$operation_id,checkpoint_ref:$checkpoint_ref,note:$note}')" >/dev/null
 
 SWARM_JSON="$(observe_swarm_result "$RUN_ID" "$OPERATION_ID")"
-require_json "$SWARM_JSON"
+mcp_require_json "$SWARM_JSON"
 printf "%s" "$SWARM_JSON" | write_live_swarm_summary >/dev/null
 PASS="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass // false')"
 JOINED="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.joined_workers // 0')"
@@ -769,7 +729,7 @@ FINAL_MARKERS_SEEN="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.final_markers_
 PASS_HOT="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass_hot_concurrency // false')"
 PASS_E2E="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass_end_to_end // false')"
 if [ "$PASS" = "true" ]; then
-  call_tool_checked 90131 "masc_operation_finalize" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg note "${EXPECTED_WORKERS}-worker live harness passed" '{operation_id:$operation_id,note:$note}')" >/dev/null
+  mcp_call_tool_checked 90131 "masc_operation_finalize" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg note "${EXPECTED_WORKERS}-worker live harness passed" '{operation_id:$operation_id,note:$note}')" >/dev/null
   OPERATION_ID=""
 fi
 

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -89,7 +89,7 @@ team_session_status() {
   local session_id="$1"
   local status_raw
   status_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 14 "masc_team_session_status" "$(jq -cn --arg s "$session_id" '{session_id:$s}')")"
-  require_tool_success "$status_raw"
+  mcp_require_tool_ok "$status_raw"
   printf '%s' "$status_raw" | extract_tool_result | jq -r '.session.status // empty'
 }
 
@@ -99,7 +99,7 @@ team_session_events_result() {
   local limit="${3:-200}"
   local raw
   raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 16 "masc_team_session_events" "$(jq -cn --arg s "$session_id" --argjson event_types "$event_types_json" --argjson limit "$limit" '{session_id:$s,event_types:$event_types,limit:$limit}')")"
-  require_tool_success "$raw"
+  mcp_require_tool_ok "$raw"
   printf '%s' "$raw" | extract_tool_result
 }
 
@@ -184,22 +184,10 @@ normalized_worker_batch_json() {
     '
 }
 
-require_json() {
-  local payload="$1"
-  local label="${2:-supervisor_team_session payload}"
-  mcp_require_json "$payload" "$label"
-}
-
 require_success_response() {
   local payload="$1"
   local label="${2:-supervisor_team_session response}"
   mcp_require_jsonrpc_ok "$payload" "$label"
-}
-
-require_tool_success() {
-  local payload="$1"
-  local label="${2:-supervisor_team_session tool}"
-  mcp_require_tool_ok "$payload" "$label"
 }
 
 parse_token_from_text() {
@@ -256,12 +244,12 @@ create_agent_token() {
   join_payload="$(jq -cn --arg a "$agent_name" --argjson caps "$caps_json" '{agent_name:$a,capabilities:$caps}')"
   local join_raw
   join_raw="$(call_tool "$MCP_URL" "$session_id" "" 10 "masc_join" "$join_payload")"
-  require_tool_success "$join_raw"
+  mcp_require_tool_ok "$join_raw"
   local nickname
   nickname="$(parse_nickname_from_text "$join_raw")"
   local token_raw
   token_raw="$(call_tool "$MCP_URL" "$session_id" "" 11 "masc_auth_create_token" "$(jq -cn --arg role "$role" '{role:$role}')")"
-  require_tool_success "$token_raw"
+  mcp_require_tool_ok "$token_raw"
   printf '%s|%s' "$nickname" "$(parse_token_from_text "$token_raw")"
 }
 
@@ -274,7 +262,7 @@ join_with_token() {
   join_payload="$(jq -cn --arg a "$agent_name" --argjson caps "$caps_json" '{agent_name:$a,capabilities:$caps}')"
   local join_raw
   join_raw="$(call_tool "$MCP_URL" "$session_id" "$token" 20 "masc_join" "$join_payload")"
-  require_tool_success "$join_raw"
+  mcp_require_tool_ok "$join_raw"
 }
 
 spawn_llama_batch() {
@@ -284,7 +272,7 @@ spawn_llama_batch() {
     --arg s "$TEAM_SESSION_ID" \
     --argjson batch "$batch_json" \
     '{session_id:$s,wait_mode:"background",spawn_batch:$batch}')")"
-  require_tool_success "$raw"
+  mcp_require_tool_ok "$raw"
   printf '%s' "$raw" | extract_tool_result | jq -e '.spawn.mode == "batch" and .spawn.count == ($expected | length) and (.spawn.results | length) == ($expected | length) and .turn == null and (.spawn.results | all(.status == "accepted" and .runtime_actor != null and .worker_run_id != null))' --argjson expected "$batch_json" >/dev/null
   printf '%s' "$raw"
 }
@@ -300,21 +288,21 @@ fi
 
 printf '[2/10] bootstrap room and tokens before auth\n'
 init_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "" 1 "masc_init" "$(jq -cn --arg a "$SUPERVISOR_AGENT" '{agent_name:$a}')")"
-require_tool_success "$init_raw"
+mcp_require_tool_ok "$init_raw"
 
 SUPERVISOR_IDENTITY="$(create_agent_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_AGENT" "admin" '["supervisor","operator"]')"
 SUPERVISOR_NICKNAME="${SUPERVISOR_IDENTITY%%|*}"
 SUPERVISOR_TOKEN="${SUPERVISOR_IDENTITY##*|}"
 
 enable_auth_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "" 12 "masc_auth_enable" '{"require_token":true}')"
-require_tool_success "$enable_auth_raw"
+mcp_require_tool_ok "$enable_auth_raw"
 
 printf '[3/10] re-join agents under bearer auth\n'
 join_with_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" "$SUPERVISOR_NICKNAME" '["supervisor","operator"]'
 
 printf '[4/10] inspect llama inventory and validate explicit model\n'
 llama_models_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_llama_models" '{}')"
-require_tool_success "$llama_models_raw"
+mcp_require_tool_ok "$llama_models_raw"
 llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
 if [ -z "$LLAMA_SWARM_MODEL" ]; then
   single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
@@ -354,7 +342,7 @@ start_payload="$(jq -cn \
   --argjson duration "$TEAM_SESSION_DURATION_SECONDS" \
   '{goal:$goal, duration_seconds:$duration, checkpoint_interval_sec:15, orchestration_mode:"assist", communication_mode:"broadcast", execution_scope:"limited_code_change", fallback_policy:"cascade_then_task", instruction_profile:"strict", min_agents:4, agents:[$supervisor]}')"
 start_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 3 "masc_team_session_start" "$start_payload")"
-require_tool_success "$start_raw"
+mcp_require_tool_ok "$start_raw"
 TEAM_SESSION_ID="$(printf '%s' "$start_raw" | extract_tool_result | jq -r '.session_id // empty')"
 if [ -z "$TEAM_SESSION_ID" ]; then
   echo "FAIL: missing session_id"
@@ -363,7 +351,7 @@ if [ -z "$TEAM_SESSION_ID" ]; then
 fi
 
 model_selection_turn_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 14 "masc_team_session_step" "$(jq -cn --arg s "$TEAM_SESSION_ID" --arg msg "$MODEL_SELECTION_NOTE" '{session_id:$s,turn_kind:"note",message:$msg}')")"
-require_tool_success "$model_selection_turn_raw"
+mcp_require_tool_ok "$model_selection_turn_raw"
 
 printf '[6/10] spawn full llama team\n'
 spawn_batch_raw="$(spawn_llama_batch "$MODEL_SELECTION_NOTE" "$NORMALIZED_SWARM_BATCH_JSON")"
@@ -381,12 +369,12 @@ fi
 printf '%s' "$tools_raw" | jq -e '.result.tools | map(.name) | sort == ["masc_operator_action","masc_operator_confirm","masc_operator_digest","masc_operator_snapshot"]' >/dev/null
 
 snapshot_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-require_tool_success "$snapshot_raw"
+mcp_require_tool_ok "$snapshot_raw"
 printf '%s' "$snapshot_raw" | extract_tool_result | jq -e '.sessions.items | length >= 1' >/dev/null
 printf '%s' "$snapshot_raw" | extract_tool_result | jq -e '.attention_summary.count >= 0 and .recommendation_summary.count >= 0' >/dev/null
 
 digest_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 55 "masc_operator_digest" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,target_type:"team_session",target_id:$s}')")"
-require_tool_success "$digest_raw"
+mcp_require_tool_ok "$digest_raw"
 printf '%s' "$digest_raw" | extract_tool_result | jq -e '.target_type == "team_session" and .target_id == $session and (.health | type == "string") and (.attention_items | type == "array") and (.recommended_actions | type == "array")' --arg session "$TEAM_SESSION_ID" >/dev/null
 
 printf '[8/10] supervisor immediate correction via team_note\n'
@@ -394,12 +382,12 @@ if [ "$SWARM_INTERVENTION_MODE" = "default" ]; then
   TEAM_SESSION_STATUS="$(team_session_status "$TEAM_SESSION_ID")"
   if [ "$TEAM_SESSION_STATUS" = "running" ]; then
     team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"
-    require_tool_success "$team_note_raw"
+    mcp_require_tool_ok "$team_note_raw"
     printf '%s' "$team_note_raw" | extract_tool_text | jq -e '.confirm_required == false' >/dev/null
 
     printf '[9/10] supervisor disruptive correction via preview + confirm\n'
     preview_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_task_inject",target_id:$s,payload:{title:"Capture explicit supervisor proof",description:"Add evidence that preview-confirm changed the session trajectory.",priority:1}}')")"
-    require_tool_success "$preview_raw"
+    mcp_require_tool_ok "$preview_raw"
     CONFIRM_TOKEN="$(printf '%s' "$preview_raw" | extract_tool_text | jq -r '.confirm_token // empty')"
     if [ -z "$CONFIRM_TOKEN" ]; then
       echo "FAIL: missing confirm token"
@@ -408,14 +396,14 @@ if [ "$SWARM_INTERVENTION_MODE" = "default" ]; then
     fi
 
     snapshot_pending_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-    require_tool_success "$snapshot_pending_raw"
+    mcp_require_tool_ok "$snapshot_pending_raw"
     printf '%s' "$snapshot_pending_raw" | extract_tool_result | jq -e '.pending_confirms | length == 1' >/dev/null
 
     confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_operator_confirm" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg token "$CONFIRM_TOKEN" '{actor:$actor,confirm_token:$token}')")"
-    require_tool_success "$confirm_raw"
+    mcp_require_tool_ok "$confirm_raw"
 
     snapshot_after_confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-    require_tool_success "$snapshot_after_confirm_raw"
+    mcp_require_tool_ok "$snapshot_after_confirm_raw"
     printf '%s' "$snapshot_after_confirm_raw" | extract_tool_result | jq -e '.pending_confirms | length == 0' >/dev/null
   else
     printf '[8/10] skip supervisor correction (session status=%s)\n' "$TEAM_SESSION_STATUS"
@@ -430,7 +418,7 @@ wait_for_turn_actor_count "$TEAM_SESSION_ID" 3
 TEAM_SESSION_STATUS="$(team_session_status "$TEAM_SESSION_ID")"
 if [ "$TEAM_SESSION_STATUS" = "running" ]; then
   stop_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"supervisor_harness_complete",generate_report:true}')")"
-  require_tool_success "$stop_raw"
+  mcp_require_tool_ok "$stop_raw"
 else
   echo "skip explicit stop; session already in terminal state: $TEAM_SESSION_STATUS"
 fi
@@ -438,7 +426,7 @@ fi
 deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
 while :; do
   status_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 14 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
-  require_tool_success "$status_raw"
+  mcp_require_tool_ok "$status_raw"
   session_status="$(printf '%s' "$status_raw" | extract_tool_result | jq -r '.session.status // empty')"
   if [ "$session_status" != "running" ]; then
     break
@@ -452,14 +440,14 @@ while :; do
 done
 
 prove_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 15 "masc_team_session_prove" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,generate_report_if_missing:true}')")"
-require_tool_success "$prove_raw"
+mcp_require_tool_ok "$prove_raw"
 prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
 printf '%s' "$prove_result" | jq -e '.proof.verdict == "proved"' >/dev/null
 printf '%s' "$prove_result" | jq -e '.proof.evidence.unique_turn_actors_count >= 3' >/dev/null
 printf '%s' "$prove_result" | jq -e '.proof.evidence.spawn_success_count >= 2' >/dev/null
 printf '%s' "$prove_result" | jq -e '.proof.evidence.empty_note_turn_count == 0' >/dev/null
 report_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 18 "masc_team_session_report" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,force_regenerate:false}')")"
-require_tool_success "$report_raw"
+mcp_require_tool_ok "$report_raw"
 report_result="$(printf '%s' "$report_raw" | extract_tool_result)"
 report_json_path="$(printf '%s' "$report_result" | jq -r '.json_path // empty')"
 if [ -z "$report_json_path" ]; then
@@ -475,11 +463,11 @@ fi
 
 printf '[summary]\n'
 events_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 16 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:200}')")"
-require_tool_success "$events_raw"
+mcp_require_tool_ok "$events_raw"
 events_result="$(printf '%s' "$events_raw" | extract_tool_result)"
 unique_turn_actors="$(printf '%s' "$events_result" | jq -r '[.events[]? | .detail.actor // empty | select(. != "")] | unique | length')"
 spawn_events_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 17 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["team_step_spawn"],limit:200}')")"
-require_tool_success "$spawn_events_raw"
+mcp_require_tool_ok "$spawn_events_raw"
 spawn_events_result="$(printf '%s' "$spawn_events_raw" | extract_tool_result)"
 unique_spawned_llama_actors="$(printf '%s' "$spawn_events_result" | jq -r '[.events[]? | .detail.runtime_actor // empty | select(. != "")] | unique | length')"
 if [ "$unique_spawned_llama_actors" -lt 3 ]; then

--- a/scripts/harness/workload/team_session_failed_batch_spawn.sh
+++ b/scripts/harness/workload/team_session_failed_batch_spawn.sh
@@ -113,22 +113,10 @@ extract_tool_result() {
   mcp_extract_result
 }
 
-require_json() {
-  local payload="$1"
-  local label="${2:-team_session_failed_batch_spawn}"
-  mcp_require_json "$payload" "$label"
-}
-
 require_success_response() {
   local payload="$1"
   local label="${2:-team_session_failed_batch_spawn response}"
   mcp_require_jsonrpc_ok "$payload" "$label"
-}
-
-require_tool_success() {
-  local payload="$1"
-  local label="${2:-team_session_failed_batch_spawn tool}"
-  mcp_require_tool_ok "$payload" "$label"
 }
 
 require_json_condition() {
@@ -200,12 +188,12 @@ create_agent_token() {
   join_payload="$(jq -cn --arg a "$agent_name" --argjson caps "$caps_json" '{agent_name:$a,capabilities:$caps}')"
   local join_raw
   join_raw="$(call_tool "$session_id" "" 10 "masc_join" "$join_payload")"
-  require_tool_success "$join_raw"
+  mcp_require_tool_ok "$join_raw"
   local nickname
   nickname="$(parse_nickname_from_text "$join_raw")"
   local token_raw
   token_raw="$(call_tool "$session_id" "" 11 "masc_auth_create_token" "$(jq -cn --arg role "$role" '{role:$role}')")"
-  require_tool_success "$token_raw"
+  mcp_require_tool_ok "$token_raw"
   printf '%s|%s' "$nickname" "$(parse_token_from_text "$token_raw")"
 }
 
@@ -218,7 +206,7 @@ join_with_token() {
   join_payload="$(jq -cn --arg a "$agent_name" --argjson caps "$caps_json" '{agent_name:$a,capabilities:$caps}')"
   local join_raw
   join_raw="$(call_tool "$session_id" "$token" 20 "masc_join" "$join_payload")"
-  require_tool_success "$join_raw"
+  mcp_require_tool_ok "$join_raw"
 }
 
 printf '[1/8] start server with deterministic llama failure endpoint\n'
@@ -252,14 +240,14 @@ fi
 
 printf '[2/9] bootstrap room and auth\n'
 init_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 1 "masc_init" "$(jq -cn --arg a "$SUPERVISOR_AGENT" '{agent_name:$a}')")"
-require_tool_success "$init_raw"
+mcp_require_tool_ok "$init_raw"
 switch_mode_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 2 "masc_switch_mode" '{"mode":"full"}')"
-require_tool_success "$switch_mode_raw"
+mcp_require_tool_ok "$switch_mode_raw"
 SUPERVISOR_IDENTITY="$(create_agent_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_AGENT" "admin" '["supervisor","failure-replay"]')"
 SUPERVISOR_NICKNAME="${SUPERVISOR_IDENTITY%%|*}"
 SUPERVISOR_TOKEN="${SUPERVISOR_IDENTITY##*|}"
 enable_auth_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 12 "masc_auth_enable" '{"require_token":true}')"
-require_tool_success "$enable_auth_raw"
+mcp_require_tool_ok "$enable_auth_raw"
 join_with_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" "$SUPERVISOR_NICKNAME" '["supervisor","failure-replay"]'
 
 printf '[3/9] start team session\n'
@@ -268,7 +256,7 @@ start_payload="$(jq -cn \
   --arg supervisor "$SUPERVISOR_NICKNAME" \
   '{goal:$goal,duration_seconds:180,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:"limited_code_change",fallback_policy:"none",instruction_profile:"strict",min_agents:1,agents:[$supervisor]}')"
 start_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 3 "masc_team_session_start" "$start_payload")"
-require_tool_success "$start_raw"
+mcp_require_tool_ok "$start_raw"
 TEAM_SESSION_ID="$(printf '%s' "$start_raw" | extract_tool_result | jq -r '.session_id // empty')"
 if [ -z "$TEAM_SESSION_ID" ]; then
   echo "FAIL: missing session_id"
@@ -278,7 +266,7 @@ fi
 
 FAILURE_NOTE="[failure-replay] explicit model=${LLAMA_SWARM_MODEL}; llama endpoint intentionally unreachable at ${FAIL_LLAMA_SERVER_URL}"
 note_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "masc_team_session_turn" "$(jq -cn --arg s "$TEAM_SESSION_ID" --arg msg "$FAILURE_NOTE" '{session_id:$s,turn_kind:"note",message:$msg}')")"
-require_tool_success "$note_raw"
+mcp_require_tool_ok "$note_raw"
 
 printf '[4/9] replay deterministic failed batch spawn\n'
 spawn_batch_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "masc_team_session_step" "$(jq -cn \
@@ -289,7 +277,7 @@ spawn_batch_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "mas
     {spawn_role:"planner",worker_class:"manager",worker_size:"xlg",spawn_selection_note:$note,spawn_prompt:"planner failure replay worker",spawn_timeout_seconds:30},
     {spawn_role:"implementer-a",worker_class:"executor",worker_size:"lg",spawn_selection_note:$note,spawn_prompt:"implementer failure replay worker",spawn_timeout_seconds:30}
   ]}')")"
-require_tool_success "$spawn_batch_raw"
+mcp_require_tool_ok "$spawn_batch_raw"
 spawn_result="$(printf '%s' "$spawn_batch_raw" | extract_tool_result)"
 require_json_condition "$spawn_result" '.spawn.mode == "batch" and .spawn.count == 2 and (.spawn.results | length) == 2' "spawn batch result shape is wrong"
 require_json_condition "$spawn_result" '.spawn.results | all(.success == false)' "spawn batch unexpectedly succeeded"
@@ -299,7 +287,7 @@ FAILED_RUNTIME_ACTOR_2="$(printf '%s' "$spawn_result" | jq -r '.spawn.results[1]
 
 printf '[5/9] verify detach + participant accounting\n'
 spawn_events_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["team_step_spawn"],limit:100}')")"
-require_tool_success "$spawn_events_raw"
+mcp_require_tool_ok "$spawn_events_raw"
 spawn_events_result="$(printf '%s' "$spawn_events_raw" | extract_tool_result)"
 spawn_event_count="$(printf '%s' "$spawn_events_result" | jq -r '.count // 0')"
 if [ "$spawn_event_count" -gt 0 ]; then
@@ -310,22 +298,22 @@ else
 fi
 
 detached_events_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["session_agent_detached"],limit:100}')")"
-require_tool_success "$detached_events_raw"
+mcp_require_tool_ok "$detached_events_raw"
 detached_events_result="$(printf '%s' "$detached_events_raw" | extract_tool_result)"
 require_json_condition "$detached_events_result" '.count == 2' "unexpected number of detached-agent events"
 
 status_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
-require_tool_success "$status_raw"
+mcp_require_tool_ok "$status_raw"
 status_result="$(printf '%s' "$status_raw" | extract_tool_result)"
 require_json_condition "$status_result" '.summary.active_agents | length == 1' "active_agents accounting is wrong after failed spawn replay"
 require_json_condition "$status_result" '.summary.planned_workers | length == 2' "planned_workers accounting is wrong after failed spawn replay"
 
 replay_note_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_team_session_turn" "$(jq -cn --arg s "$TEAM_SESSION_ID" --arg msg "[failure-replay] observed 2 failed spawns and 2 detached actors" '{session_id:$s,turn_kind:"note",message:$msg}')")"
-require_tool_success "$replay_note_raw"
+mcp_require_tool_ok "$replay_note_raw"
 
 printf '[6/9] verify operator digest signals\n'
 digest_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 92 "masc_operator_digest" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,target_type:"team_session",target_id:$s}')")"
-require_tool_success "$digest_raw"
+mcp_require_tool_ok "$digest_raw"
 digest_result="$(printf '%s' "$digest_raw" | extract_tool_result)"
 require_json_condition "$digest_result" '.target_type == "team_session"' "digest target_type mismatch"
 require_json_condition "$digest_result" '[.attention_items[]?.kind] | index("spawn_failure_present") != null' "digest missing spawn_failure_present"
@@ -333,12 +321,12 @@ require_json_condition "$digest_result" '[.attention_items[]?.kind] | index("det
 
 printf '[7/9] stop session and generate artifacts\n'
 stop_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 10 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"failed_batch_spawn_replay_complete",generate_report:true}')")"
-require_tool_success "$stop_raw"
+mcp_require_tool_ok "$stop_raw"
 
 deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
 while :; do
   stop_status_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 11 "masc_team_session_status" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s}')")"
-  require_tool_success "$stop_status_raw"
+  mcp_require_tool_ok "$stop_status_raw"
   stop_status_result="$(printf '%s' "$stop_status_raw" | extract_tool_result)"
   stop_status="$(printf '%s' "$stop_status_result" | jq -r '.session.status // empty')"
   if [ "$stop_status" != "running" ]; then
@@ -353,7 +341,7 @@ while :; do
 done
 
 report_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_team_session_report" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,force_regenerate:false}')")"
-require_tool_success "$report_raw"
+mcp_require_tool_ok "$report_raw"
 report_result="$(printf '%s' "$report_raw" | extract_tool_result)"
 report_json_path="$(printf '%s' "$report_result" | jq -r '.json_path // empty')"
 report_md_path="$(printf '%s' "$report_result" | jq -r '.markdown_path // empty')"
@@ -364,7 +352,7 @@ if [ -z "$report_json_path" ] || [ -z "$report_md_path" ]; then
 fi
 
 prove_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_team_session_prove" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,generate_report_if_missing:true}')")"
-require_tool_success "$prove_raw"
+mcp_require_tool_ok "$prove_raw"
 prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
 require_json_condition "$prove_result" '.proof.evidence.spawn_failure_count == 2' "proof evidence is missing spawn_failure_count=2"
 require_json_condition "$prove_result" '.proof.evidence.detached_agent_count == 2' "proof evidence is missing detached_agent_count=2"

--- a/scripts/harness/workload/team_session_local64_smoke.sh
+++ b/scripts/harness/workload/team_session_local64_smoke.sh
@@ -47,59 +47,38 @@ SESSION_ID=""
 CALL_ID=91008
 SPAWN_RESULTS_FILE="$(mcp_mktemp_file "local64-smoke-spawn-results" ".jsonl")"
 
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  mcp_call_tool "$id" "$tool_name" "$args_json"
-}
-
-extract_text() {
-  mcp_extract_text
-}
-
-extract_result() {
-  mcp_extract_result
-}
-
 next_call_id() {
   CALL_ID=$((CALL_ID + 1))
   printf '%s\n' "$CALL_ID"
 }
 
-require_json() {
-  local payload="$1"
-  local label="${2:-team_session_local64_smoke payload}"
-  mcp_require_json "$payload" "$label"
-}
-
 session_status_result() {
   local raw
-  raw="$(call_tool "$(next_call_id)" "masc_team_session_status" \
+  raw="$(mcp_call_tool "$(next_call_id)" "masc_team_session_status" \
     "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_result
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result
 }
 
 session_events_result() {
   local limit="${1:-2000}"
   local raw
-  raw="$(call_tool "$(next_call_id)" "masc_team_session_events" \
+  raw="$(mcp_call_tool "$(next_call_id)" "masc_team_session_events" \
     "$(jq -cn --arg s "$SESSION_ID" --argjson limit "$limit" '{session_id:$s,limit:$limit}')")"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_result
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result
 }
 
 operator_digest_result() {
   local raw
-  raw="$(call_tool "$(next_call_id)" "masc_operator_digest" '{"target_type":"room"}')"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_result
+  raw="$(mcp_call_tool "$(next_call_id)" "masc_operator_digest" '{"target_type":"room"}')"
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result
 }
 
 append_spawn_results() {
   local payload="$1"
-  printf '%s' "$payload" | extract_result | jq -c '
+  printf '%s' "$payload" | mcp_extract_result | jq -c '
     if .spawn.results? then
       .spawn.results[]
     else
@@ -110,7 +89,7 @@ append_spawn_results() {
 
 count_step_accepts() {
   local payload="$1"
-  printf '%s' "$payload" | extract_result | jq '
+  printf '%s' "$payload" | mcp_extract_result | jq '
     if .spawn.results? then
       [.spawn.results[] | select((.status // "") == "accepted" or .success == true)] | length
     else
@@ -147,18 +126,12 @@ wait_for_session_progress() {
   exit 1
 }
 
-require_tool_success() {
-  local payload="$1"
-  local label="${2:-team_session_local64_smoke tool}"
-  mcp_require_tool_ok "$payload" "$label"
-}
-
 require_result_condition() {
   local payload="$1"
   local jq_expr="$2"
   local failure_message="$3"
   local result_json
-  result_json="$(printf '%s' "$payload" | extract_result)"
+  result_json="$(printf '%s' "$payload" | mcp_extract_result)"
   if ! printf '%s' "$result_json" | jq -e "$jq_expr" >/dev/null; then
     echo "FAIL: $failure_message"
     printf '%s\n' "$result_json"
@@ -179,11 +152,11 @@ require_json_condition() {
 
 cleanup() {
   if [ -n "$SESSION_ID" ]; then
-    call_tool 90981 "masc_team_session_stop" \
+    mcp_call_tool 90981 "masc_team_session_stop" \
       "{\"session_id\":\"$SESSION_ID\",\"reason\":\"local64_smoke_cleanup\",\"generate_report\":false}" \
       >/dev/null 2>&1 || true
   fi
-  call_tool 90982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
+  mcp_call_tool 90982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
   rm -f "$SPAWN_RESULTS_FILE" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -349,13 +322,13 @@ run_spawn_wave() {
   spawn_batch_json="$(build_spawn_batch "$start_idx" "$end_idx" "$LLAMA_SWARM_MODEL")"
   step_args="$(jq -cn --arg s "$SESSION_ID" --arg a "$COORD_AGENT" --argjson batch "$spawn_batch_json" --argjson timeout "$SPAWN_TIMEOUT_SEC" \
     '{session_id:$s,actor:$a,wait_mode:"background",spawn_batch:$batch,spawn_timeout_seconds:$timeout}')"
-  step_raw="$(call_tool "$(next_call_id)" "masc_team_session_step" "$step_args")"
-  require_tool_success "$step_raw"
+  step_raw="$(mcp_call_tool "$(next_call_id)" "masc_team_session_step" "$step_args")"
+  mcp_require_tool_ok "$step_raw"
   append_spawn_results "$step_raw"
   wave_success="$(count_step_accepts "$step_raw")"
   if [ "$wave_success" -lt "$expected_count" ]; then
     echo "FAIL: ${wave_name} spawn accepted ${wave_success}/${expected_count}" >&2
-    printf '%s\n' "$step_raw" | extract_result | jq .
+    printf '%s\n' "$step_raw" | mcp_extract_result | jq .
     exit 1
   fi
 
@@ -364,17 +337,17 @@ run_spawn_wave() {
 }
 
 echo "[1/8] init + join coordinator"
-init_raw="$(call_tool 91001 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
-require_tool_success "$init_raw"
-join_raw="$(call_tool 91002 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator"]}')")"
-require_tool_success "$join_raw"
+init_raw="$(mcp_call_tool 91001 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
+mcp_require_tool_ok "$init_raw"
+join_raw="$(mcp_call_tool 91002 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator"]}')")"
+mcp_require_tool_ok "$join_raw"
 
 echo "[2/8] start local64 session"
 start_args="$(jq -cn --arg goal "$GOAL" --argjson duration "$SESSION_DURATION_SEC" \
   '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:20,min_agents:1,orchestration_mode:"assist",communication_mode:"hybrid",scale_profile:"local64",fallback_policy:"strict_local_only",instruction_profile:"strict",alert_channel:"both",report_formats:["markdown","json"],agents:["team-session-local64-smoke"]}')"
-start_raw="$(call_tool 91003 "masc_team_session_start" "$start_args")"
-require_tool_success "$start_raw"
-SESSION_ID="$(printf '%s' "$start_raw" | extract_result | jq -r '.session_id // empty')"
+start_raw="$(mcp_call_tool 91003 "masc_team_session_start" "$start_args")"
+mcp_require_tool_ok "$start_raw"
+SESSION_ID="$(printf '%s' "$start_raw" | mcp_extract_result | jq -r '.session_id // empty')"
 if [ -z "$SESSION_ID" ]; then
   echo "FAIL: session_id missing"
   printf '%s\n' "$start_raw"
@@ -383,8 +356,8 @@ fi
 echo "session_id=$SESSION_ID"
 
 echo "[3/8] inspect local llama runtime"
-runtime_raw="$(call_tool 91004 "masc_local_runtime_status" '{"include_models":true}')"
-require_tool_success "$runtime_raw"
+runtime_raw="$(mcp_call_tool 91004 "masc_local_runtime_status" '{"include_models":true}')"
+mcp_require_tool_ok "$runtime_raw"
 require_result_condition "$runtime_raw" '.runtime_count >= 1 and .configured_capacity >= 1' "runtime status missing pool data"
 
 echo "[4/8] spawn local64 workers (spawn_timeout=${SPAWN_TIMEOUT_SEC}s http_timeout=${HTTP_TIMEOUT_SEC}s workers=${WORKER_COUNT})"
@@ -458,8 +431,8 @@ fi
 require_json_condition "$digest_json" "$digest_expr" "operator digest did not expose local64 census/runtime visibility"
 
 echo "[8/8] benchmark runtime pool"
-bench_raw="$(call_tool 91008 "masc_local_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
-require_tool_success "$bench_raw"
+bench_raw="$(mcp_call_tool 91008 "masc_local_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
+mcp_require_tool_ok "$bench_raw"
 require_result_condition "$bench_raw" '.total_requests >= 1 and .per_runtime_breakdown != null' "runtime bench did not return breakdown"
 
 spawn_success_count="$(printf '%s' "$final_events_json" | jq -r '[.events[] | select(.event_type == "team_step_spawn" and .detail.success == true)] | length')"

--- a/scripts/harness/workload/team_session_real_spawn.sh
+++ b/scripts/harness/workload/team_session_real_spawn.sh
@@ -53,45 +53,24 @@ if [ "$EFFECTIVE_SESSION_DURATION_SEC" -lt "$required_duration_sec" ]; then
   EFFECTIVE_SESSION_DURATION_SEC="$required_duration_sec"
 fi
 
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  mcp_call_tool "$id" "$tool_name" "$args_json"
-}
-
-extract_result() {
-  mcp_extract_result
-}
-
-extract_text() {
-  mcp_extract_text
-}
-
-require_json() {
-  local payload="$1"
-  local label="${2:-team_session_real_spawn}"
-  mcp_require_tool_ok "$payload" "$label"
-}
-
 cleanup() {
   if [ -n "$SESSION_ID" ]; then
-    call_tool 90981 "masc_team_session_stop" \
+    mcp_call_tool 90981 "masc_team_session_stop" \
       "{\"session_id\":\"$SESSION_ID\",\"reason\":\"harness_cleanup\",\"generate_report\":false}" \
       >/dev/null 2>&1 || true
   fi
-  call_tool 90982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
+  mcp_call_tool 90982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 echo "[1/9] init + join coordinator"
-r1="$(call_tool 90001 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
-require_json "$r1" "masc_init"
-r2="$(call_tool 90002 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
-require_json "$r2" "masc_join"
+r1="$(mcp_call_tool 90001 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
+mcp_require_tool_ok "$r1" "masc_init"
+r2="$(mcp_call_tool 90002 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
+mcp_require_tool_ok "$r2" "masc_join"
 
 echo "[2/9] preflight cleanup"
-call_tool 90011 "masc_cleanup_zombies" "{}" >/dev/null 2>&1 || true
+mcp_call_tool 90011 "masc_cleanup_zombies" "{}" >/dev/null 2>&1 || true
 
 echo "[3/9] start team session (min_agents=${#PARTICIPANTS[@]}, duration=${EFFECTIVE_SESSION_DURATION_SEC}s)"
 participants_json="$(printf '%s\n' "${PARTICIPANTS[@]}" | jq -R . | jq -s .)"
@@ -114,9 +93,9 @@ start_args="$(jq -cn \
      report_formats:["markdown","json"],
      agents:$participants
    }')"
-start_raw="$(call_tool 90003 "masc_team_session_start" "$start_args")"
-require_json "$start_raw" "masc_team_session_start"
-SESSION_ID="$(printf "%s" "$start_raw" | extract_result | jq -r '.session_id // empty')"
+start_raw="$(mcp_call_tool 90003 "masc_team_session_start" "$start_args")"
+mcp_require_tool_ok "$start_raw" "masc_team_session_start"
+SESSION_ID="$(printf "%s" "$start_raw" | mcp_extract_result | jq -r '.session_id // empty')"
 if [ -z "$SESSION_ID" ]; then
   echo "FAIL: session_id missing"
   printf "%s\n" "$start_raw"
@@ -148,22 +127,22 @@ for i in "${!PARTICIPANTS[@]}"; do
     --arg wd "$WORKING_DIR" \
     --argjson timeout "$SPAWN_TIMEOUT_SEC" \
     '{agent_name:$runtime,prompt:$prompt,timeout_seconds:$timeout,working_dir:$wd}')"
-  spawn_raw="$(call_tool $((90100 + i)) "masc_spawn" "$spawn_args")"
-  require_json "$spawn_raw" "masc_spawn(${actor})"
-  spawn_text="$(printf "%s" "$spawn_raw" | extract_text)"
+  spawn_raw="$(mcp_call_tool $((90100 + i)) "masc_spawn" "$spawn_args")"
+  mcp_require_tool_ok "$spawn_raw" "masc_spawn(${actor})"
+  spawn_text="$(printf "%s" "$spawn_raw" | mcp_extract_text)"
   if ! printf "%s" "$spawn_text" | rg -q "✅ Agent completed|done:${actor}"; then
     echo "WARN: spawned agent ${actor} completion text did not match strict pattern"
   fi
 done
 
 echo "[5/9] restore coordinator identity"
-restore_raw="$(call_tool 90012 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
-require_json "$restore_raw" "restore masc_join"
+restore_raw="$(mcp_call_tool 90012 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
+mcp_require_tool_ok "$restore_raw" "restore masc_join"
 
 echo "[6/9] verify team_turn actor diversity"
-events_raw="$(call_tool 90004 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:400}')")"
-require_json "$events_raw" "masc_team_session_events"
-events_result="$(printf "%s" "$events_raw" | extract_result)"
+events_raw="$(mcp_call_tool 90004 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:400}')")"
+mcp_require_tool_ok "$events_raw" "masc_team_session_events"
+events_result="$(printf "%s" "$events_raw" | mcp_extract_result)"
 team_turn_count="$(printf "%s" "$events_result" | jq -r '.count // 0')"
 unique_turn_actors="$(printf "%s" "$events_result" | jq -r '[.events[]? | .detail.actor // empty | select(. != "")] | unique | length')"
 if [ "$unique_turn_actors" -lt "${#PARTICIPANTS[@]}" ]; then
@@ -198,14 +177,14 @@ if [ "$unique_turn_actors" -lt "${#PARTICIPANTS[@]}" ]; then
         --arg wd "$WORKING_DIR" \
         --argjson timeout "$SPAWN_TIMEOUT_SEC" \
         '{agent_name:$runtime,prompt:$prompt,timeout_seconds:$timeout,working_dir:$wd}')"
-      recovery_raw="$(call_tool $((90200 + recovery_idx)) "masc_spawn" "$recovery_args")"
-      require_json "$recovery_raw" "recovery masc_spawn(${actor})"
+      recovery_raw="$(mcp_call_tool $((90200 + recovery_idx)) "masc_spawn" "$recovery_args")"
+      mcp_require_tool_ok "$recovery_raw" "recovery masc_spawn(${actor})"
       recovery_idx=$((recovery_idx + 1))
     done
 
-    events_raw="$(call_tool 90013 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:600}')")"
-    require_json "$events_raw" "recovery masc_team_session_events"
-    events_result="$(printf "%s" "$events_raw" | extract_result)"
+    events_raw="$(mcp_call_tool 90013 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:600}')")"
+    mcp_require_tool_ok "$events_raw" "recovery masc_team_session_events"
+    events_result="$(printf "%s" "$events_raw" | mcp_extract_result)"
     team_turn_count="$(printf "%s" "$events_result" | jq -r '.count // 0')"
     unique_turn_actors="$(printf "%s" "$events_result" | jq -r '[.events[]? | .detail.actor // empty | select(. != "")] | unique | length')"
   fi
@@ -220,9 +199,9 @@ if [ "$unique_turn_actors" -lt "${#PARTICIPANTS[@]}" ]; then
 fi
 
 echo "[7/9] stop session + report"
-stop_raw="$(call_tool 90005 "masc_team_session_stop" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,reason:"real_spawn_harness_done",generate_report:true}')")"
-require_json "$stop_raw" "masc_team_session_stop"
-stop_result="$(printf "%s" "$stop_raw" | extract_result)"
+stop_raw="$(mcp_call_tool 90005 "masc_team_session_stop" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,reason:"real_spawn_harness_done",generate_report:true}')")"
+mcp_require_tool_ok "$stop_raw" "masc_team_session_stop"
+stop_result="$(printf "%s" "$stop_raw" | mcp_extract_result)"
 if [ -z "$stop_result" ]; then
   echo "FAIL: stop_session did not return result payload"
   printf "%s\n" "$stop_raw"
@@ -230,9 +209,9 @@ if [ -z "$stop_result" ]; then
 fi
 stop_deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
 while :; do
-  stop_status_raw="$(call_tool 90008 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-  require_json "$stop_status_raw" "stop poll masc_team_session_status"
-  stop_status_result="$(printf "%s" "$stop_status_raw" | extract_result)"
+  stop_status_raw="$(mcp_call_tool 90008 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
+  mcp_require_tool_ok "$stop_status_raw" "stop poll masc_team_session_status"
+  stop_status_result="$(printf "%s" "$stop_status_raw" | mcp_extract_result)"
   stop_status="$(printf "%s" "$stop_status_result" | jq -r '.session.status // empty')"
   if [ "$stop_status" != "running" ]; then
     break
@@ -246,9 +225,9 @@ while :; do
 done
 
 echo "[8/9] generate proof"
-prove_raw="$(call_tool 90006 "masc_team_session_prove" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,generate_report_if_missing:true}')")"
-require_json "$prove_raw" "masc_team_session_prove"
-prove_result="$(printf "%s" "$prove_raw" | extract_result)"
+prove_raw="$(mcp_call_tool 90006 "masc_team_session_prove" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,generate_report_if_missing:true}')")"
+mcp_require_tool_ok "$prove_raw" "masc_team_session_prove"
+prove_result="$(printf "%s" "$prove_raw" | mcp_extract_result)"
 verdict="$(printf "%s" "$prove_result" | jq -r '.proof.verdict // empty')"
 required_turn_actors="$(printf "%s" "$prove_result" | jq -r '.proof.evidence.required_turn_actors // 0')"
 proof_unique_turn_actors="$(printf "%s" "$prove_result" | jq -r '.proof.evidence.unique_turn_actors_count // 0')"
@@ -266,9 +245,9 @@ if [ "$proof_unique_turn_actors" -lt "$required_turn_actors" ]; then
 fi
 
 echo "[9/9] final status snapshot"
-status_raw="$(call_tool 90007 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-require_json "$status_raw" "final masc_team_session_status"
-status_result="$(printf "%s" "$status_raw" | extract_result)"
+status_raw="$(mcp_call_tool 90007 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
+mcp_require_tool_ok "$status_raw" "final masc_team_session_status"
+status_result="$(printf "%s" "$status_raw" | mcp_extract_result)"
 session_status="$(printf "%s" "$status_result" | jq -r '.session.status // empty')"
 model_cache_hits="$(printf "%s" "$status_result" | jq -r '.inference_cache_metrics.hits // 0')"
 model_cache_misses="$(printf "%s" "$status_result" | jq -r '.inference_cache_metrics.misses // 0')"


### PR DESCRIPTION
## Summary
- Remove redundant passthrough wrapper functions from 5 harness scripts
- Add `mcp_call_tool_checked` and `mcp_call_tool_result` to `mcp_jsonrpc.sh`
- Unify naming convention: all harness scripts use `mcp_*` prefix directly

## Details

**Problem**: 13 workload scripts defined local wrapper functions like `call_tool()`, `extract_text()`, `require_tool_success()` that were 1:1 delegations to `mcp_jsonrpc.sh` functions. Investigation revealed only 5 of these were pure passthroughs; the other 8 had custom curl/SSE logic or different signatures.

**Changes**:
| File | Removed | Type |
|------|---------|------|
| `agent_swarm_live.sh` | 7 wrappers | Full removal |
| `team_session_local64_smoke.sh` | 5 wrappers | Full removal |
| `team_session_real_spawn.sh` | 4 wrappers | Full removal |
| `supervisor_team_session.sh` | 2 wrappers (require_* only) | Partial |
| `team_session_failed_batch_spawn.sh` | 2 wrappers (require_* only) | Partial |
| `mcp_jsonrpc.sh` | +2 composition functions | New lib functions |

**Net**: -95 LOC, 0 new files

## Test plan
- [x] `bash -n` syntax check on all 6 changed files
- [ ] CI contract harness passes
- [ ] CI build + test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)