### PR TITLE
chore(keeper): remove dead skip_reason machinery

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -33,71 +33,14 @@ type run_result = {
   proof : Agent_sdk.Cdal_proof.t option;
 }
 
-let contains_casefold haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec matches_at idx j =
-    if j = needle_len then true
-    else if String.get haystack (idx + j) <> String.get needle j then false
-    else matches_at idx (j + 1)
-  in
-  let rec search idx =
-    if idx + needle_len > hay_len then false
-    else if matches_at idx 0 then true
-    else search (idx + 1)
-  in
-  needle_len > 0 && search 0
-
-(* Percent-encode field values for structured key=value output.
-   Encodes separators and control characters to keep the output unambiguous. *)
-let escape_field_value (s : string) : string =
-  let buf = Buffer.create (String.length s * 3 / 2 + 1) in
-  String.iter
-    (fun ch ->
-      match ch with
-      | ' ' -> Buffer.add_string buf "%20"
-      | '=' -> Buffer.add_string buf "%3D"
-      | '\n' -> Buffer.add_string buf "%0A"
-      | '\r' -> Buffer.add_string buf "%0D"
-      | '\t' -> Buffer.add_string buf "%09"
-      | '%' -> Buffer.add_string buf "%25"
-      | _ -> Buffer.add_char buf ch)
-    s;
-  Buffer.contents buf
-
-let render_skip_reason_text (reason : Keeper_hooks_oas.skip_reason) : string =
-  let replacement_hint =
-    match (Tool_catalog.metadata reason.tool_name).Tool_catalog.replacement with
-    | Some replacement ->
-        Printf.sprintf " replacement=%s" (escape_field_value replacement)
-    | None -> ""
-  in
-  Printf.sprintf
-    "[tool_skipped] tool=%s source=%s code=%s reason=%s%s"
-    (escape_field_value reason.tool_name)
-    (escape_field_value reason.source)
-    (escape_field_value reason.reason_code)
-    (escape_field_value reason.reason_text)
-    replacement_hint
-
 let normalize_response_text
-    ?skip_reason
     ~(text : string)
     ~(tool_names : string list)
     () :
     (string, string) result =
   let trimmed = String.trim text in
-  if trimmed <> "" then
-    match skip_reason with
-    | Some reason when contains_casefold trimmed "skipped by hook" ->
-        Ok (render_skip_reason_text reason)
-    | _ -> Ok text
+  if trimmed <> "" then Ok text
   else
-    match skip_reason with
-    | Some reason -> Ok (render_skip_reason_text reason)
-    | None ->
     match tool_names with
     | [] -> Error "keeper turn completed with no textual reply"
     | _ ->
@@ -217,7 +160,6 @@ let run_turn
     Keeper_exec_context.set_system_prompt base_ctx
       ~system_prompt:base_system_prompt
   in
-  Keeper_hooks_oas.clear_skip_reason meta.name;
   (* 5. Build final turn system prompt via caller callback.
      Hard constraints stay in system_prompt; soft context is injected
      via OAS extra_system_context (prepended as User message after reduction). *)
@@ -341,10 +283,7 @@ let run_turn
     then Keeper_cdal_contract.of_keeper_meta meta
     else None
   in
-  Fun.protect
-    ~finally:(fun () -> Keeper_hooks_oas.clear_skip_reason meta.name)
-    (fun () ->
-      match
+  match
         Oas_worker.run_named
           ~cascade_name
           ~goal:user_message
@@ -399,8 +338,7 @@ let run_turn
             result.response.content
         in
         let usage = Keeper_exec_context.usage_of_response result.response in
-        let skip_reason = Keeper_hooks_oas.consume_skip_reason meta.name in
-        (match normalize_response_text ?skip_reason ~text ~tool_names () with
+        (match normalize_response_text ~text ~tool_names () with
          | Error e -> Error e
          | Ok response_text ->
              let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
@@ -463,4 +401,4 @@ let run_turn
            tools_used = tool_names;
            checkpoint = result.checkpoint;
            proof = result.proof;
-         }))
+         })

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -25,42 +25,6 @@ let destructive_check_tools =
 let keeper_denied_tools =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
 
-type skip_reason = {
-  tool_name : string;
-  source : string;
-  reason_code : string;
-  reason_text : string;
-  skipped_at_unix : float;
-}
-
-let recent_skip_reasons : (string, skip_reason) Hashtbl.t = Hashtbl.create 16
-let recent_skip_reasons_mu = Eio.Mutex.create ()
-
-let with_skip_rw f = Eio_guard.with_mutex recent_skip_reasons_mu f
-
-let clear_skip_reason keeper_name =
-  with_skip_rw (fun () -> Hashtbl.remove recent_skip_reasons keeper_name)
-
-let record_skip_reason ~keeper_name ~tool_name ~source ~reason_code ~reason_text =
-  let reason =
-    {
-      tool_name;
-      source;
-      reason_code;
-      reason_text;
-      skipped_at_unix = Unix.gettimeofday ();
-    }
-  in
-  with_skip_rw (fun () -> Hashtbl.replace recent_skip_reasons keeper_name reason)
-
-let consume_skip_reason keeper_name =
-  with_skip_rw (fun () ->
-      match Hashtbl.find_opt recent_skip_reasons keeper_name with
-      | None -> None
-      | Some reason ->
-          Hashtbl.remove recent_skip_reasons keeper_name;
-          Some reason)
-
 (** Percent-encode field value for structured [tool_skipped] output.
     Matches [Keeper_agent_run.escape_field_value] encoding.
     Local copy to avoid circular dependency. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -729,92 +729,6 @@ let test_social_model_routes_blocker_to_board_post () =
             (contains_substring post.body "blocked")
       | _ -> fail "expected one request-help board post")
 
-let test_normalize_response_text_rewrites_generic_skip () =
-  let skip_reason : HK.skip_reason =
-    {
-      tool_name = "keeper_board_post";
-      source = "keeper_hook";
-      reason_code = "keeper_deny";
-      reason_text = "tool is on the keeper deny list";
-      skipped_at_unix = 0.0;
-    }
-  in
-  match KAR.normalize_response_text
-          ~text:"Tool execution skipped by hook"
-          ~tool_names:["keeper_board_post"]
-          ~skip_reason
-          ()
-  with
-  | Ok text ->
-      check bool "structured prefix" true
-        (String.starts_with ~prefix:"[tool_skipped]" text);
-      check bool "mentions tool" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "keeper_board_post")
-                  text 0);
-             true
-           with Not_found -> false
-         in
-         found);
-      check bool "mentions replacement" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "replacement=masc_board_post")
-                  text 0);
-             true
-           with Not_found -> false
-         in
-         found);
-      check bool "encodes reason spaces" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "reason=tool%20is%20on%20the%20keeper%20deny%20list")
-                  text 0);
-             true
-           with Not_found -> false
-         in
-         found)
-  | Error e -> fail ("unexpected error: " ^ e)
-
-let test_normalize_response_text_empty_with_skip_reason () =
-  let skip_reason : HK.skip_reason =
-    {
-      tool_name = "keeper_bash";
-      source = "keeper_hook";
-      reason_code = "destructive_guard";
-      reason_text = "pattern='rm -rf' (recursive forced deletion)";
-      skipped_at_unix = 0.0;
-    }
-  in
-  match KAR.normalize_response_text
-          ~text:""
-          ~tool_names:[]
-          ~skip_reason
-          ()
-  with
-  | Ok text ->
-      check bool "structured prefix" true
-        (String.starts_with ~prefix:"[tool_skipped]" text);
-      check bool "mentions code" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "destructive_guard")
-                  text 0);
-             true
-           with Not_found -> false
-         in
-         found)
-  | Error e -> fail ("unexpected error: " ^ e)
-
 (* ---------- render_inline_skip_reason tests ---------- *)
 
 let str_contains s sub =
@@ -870,13 +784,6 @@ let test_render_inline_with_replacement () =
     ~reason_text:"denied"
   in
   check bool "has replacement" true (str_contains result "replacement=")
-
-let test_consume_skip_reason_none_after_override () =
-  (* After Override migration, no record_skip_reason is called,
-     so consume_skip_reason should return None *)
-  HK.clear_skip_reason "test-keeper";
-  let result = HK.consume_skip_reason "test-keeper" in
-  check bool "returns None" true (result = None)
 
 let test_normalize_override_passthrough () =
   let override_text =
@@ -959,10 +866,6 @@ let () =
             test_social_model_requires_explicit_headers;
           test_case "social model routes blocker to board post" `Quick
             test_social_model_routes_blocker_to_board_post;
-          test_case "normalize rewrites generic skip" `Quick
-            test_normalize_response_text_rewrites_generic_skip;
-          test_case "normalize empty with skip reason" `Quick
-            test_normalize_response_text_empty_with_skip_reason;
           test_case "render_inline deny" `Quick
             test_render_inline_skip_reason_deny;
           test_case "render_inline cost" `Quick
@@ -975,7 +878,5 @@ let () =
             test_render_inline_escape_edge_cases;
           test_case "render_inline with replacement" `Quick
             test_render_inline_with_replacement;
-          test_case "consume_skip_reason None after Override" `Quick
-            test_consume_skip_reason_none_after_override;
         ] );
     ]


### PR DESCRIPTION
## Summary
#4127에서 `Hooks.Skip → Hooks.Override` 전환 이후 `record_skip_reason`에 caller가 0.
전체 skip_reason 파이프라인 (Hashtbl + Mutex + record/consume/clear + render) 제거.

**-201 lines** across 3 files.

## Removed
- `keeper_hooks_oas.ml`: `skip_reason` type, Hashtbl, Mutex, `with_skip_rw`, record/consume/clear
- `keeper_agent_run.ml`: `render_skip_reason_text`, `escape_field_value`, `contains_casefold`, `?skip_reason` param, `Fun.protect` wrapper
- `test_keeper_unified.ml`: 3 dead tests

## What stays
- `render_inline_skip_reason` (still used in Override hooks)
- `escape_field` in keeper_hooks_oas.ml (used by render_inline)

## Test plan
- [x] `test_keeper_unified.exe` — 42 tests pass
- [x] `dune build` success
- [ ] CI Build and Test

Closes #4135

🤖 Generated with [Claude Code](https://claude.com/claude-code)