### PR TITLE
fix: declare mutation_class on all OAS tool creation paths

### DIFF
--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -88,14 +88,22 @@ let of_keeper
     ~(scope_kind : string)
     ~(execution_scope : string)
     ~(allowed_paths : string list) : Oas.Risk_contract.t =
+  let exec_mode = infer_keeper_execution_mode ~scope_kind in
+  let risk = infer_keeper_risk_class ~scope_kind in
+  let mutations = infer_keeper_allowed_mutations ~execution_scope ~allowed_paths in
+  Log.Keeper.info
+    "cdal contract for %s: mode=%s risk=%s mutations=[%s] scope_kind=%s exec_scope=%s"
+    keeper_name
+    (Oas.Execution_mode.to_string exec_mode)
+    (Oas.Risk_class.to_string risk)
+    (String.concat "," mutations)
+    scope_kind execution_scope;
   {
     Oas.Risk_contract.runtime_constraints =
       {
-        requested_execution_mode =
-          infer_keeper_execution_mode ~scope_kind;
-        risk_class = infer_keeper_risk_class ~scope_kind;
-        allowed_mutations =
-          infer_keeper_allowed_mutations ~execution_scope ~allowed_paths;
+        requested_execution_mode = exec_mode;
+        risk_class = risk;
+        allowed_mutations = mutations;
         review_requirement = None;
       };
     eval_criteria = build_keeper_eval_criteria ~keeper_name ~goal;

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -31,6 +31,8 @@ let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
   let open Agent_sdk in
   Tool.create
     ~name:"extend_turns"
+    ~descriptor:{ kind = None; mutation_class = Some "read_only";
+                  shell = None; notes = []; examples = [] }
     ~description:"Request additional turns when you need more time. \
                    Guardrails check cost and idle before granting."
     ~parameters:[

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -404,6 +404,7 @@ let run_with_masc_tools
       ~name:td.name
       ~description:td.description
       ~input_schema:td.input_schema
+      ~mutation_class:"workspace"
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   let config = { config with tools = oas_tools @ config.tools } in
@@ -679,6 +680,7 @@ let run_named_with_masc_tools
     Tool_bridge.oas_tool_of_masc
       ~name:td.name ~description:td.description
       ~input_schema:td.input_schema
+      ~mutation_class:"workspace"
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -163,6 +163,8 @@ type tool_exec_observer =
 let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
+    ~descriptor:{ kind = None; mutation_class = Some "read_only";
+                  shell = None; notes = []; examples = [] }
     ~description:"Read file contents by absolute path. Returns file text. \
       Use shell_exec with 'ls' instead if you need directory listing. \
       Maximum 100KB per read to prevent context overflow."
@@ -215,6 +217,8 @@ let make_file_read ?workdir ?on_exec () =
 let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
+    ~descriptor:{ kind = None; mutation_class = Some "workspace";
+                  shell = None; notes = []; examples = [] }
     ~description:"Write content to a file by absolute path. Creates the file \
       if it doesn't exist, overwrites if it does. Creates parent directories. \
       Use file_read first to check existing content before overwriting."
@@ -273,6 +277,8 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
     ~description =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
+    ~descriptor:{ kind = None; mutation_class = Some "workspace";
+                  shell = None; notes = []; examples = [] }
     ~description
     ~parameters:[
       { name = "command";


### PR DESCRIPTION
## Summary
- **H1 (HIGH)**: `oas_worker.ml` — 2곳의 `Tool_bridge.oas_tool_of_masc` 호출에 `~mutation_class:"workspace"` 추가. mode_enforcer name-based fallback으로 MASC 도구가 External_effect로 분류되어 차단되는 문제 방지.
- **M1**: `worker_dev_tools.ml` — `file_read`(`read_only`), `file_write`/`shell_exec`(`workspace`) descriptor 추가.
- **M2**: `keeper_extend_turns.ml` — `extend_turns` tool에 `read_only` descriptor 추가.
- **M3**: `cdal_contract_bridge.ml` — keeper contract 추론 결과(mode, risk, mutations)를 `Log.Keeper.info`로 로깅.

Follows up on #4131 (keeper mutation_class) — catches remaining tool creation paths that were missed.

## Test plan
- [x] `dune build --root .` pass
- [ ] `dune test` (CI)
- [ ] Keeper가 도구를 정상 사용하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)