### PR TITLE
fix: readonly shell_exec mutation_class misclassified as workspace

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -274,10 +274,10 @@ let make_file_write ?workdir ?on_exec () =
                Printf.sprintf "Cannot write: %s" msg; recoverable = false })
 
 let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_commands
-    ~description =
+    ?(mutation_class = "workspace") ~description () =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
-    ~descriptor:{ kind = None; mutation_class = Some "workspace";
+    ~descriptor:{ kind = None; mutation_class = Some mutation_class;
                   shell = None; notes = []; examples = [] }
     ~description
     ~parameters:[
@@ -368,15 +368,18 @@ let make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock =
        Use for: running tests, git commands, build tools, directory listing. \
        Unlike file_read (single file), this handles approved CLI operations. \
        Commands run in /bin/sh but shell control syntax is rejected."
+    ()
 
 let make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock =
   make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock
     ~allowed_commands:readonly_allowed_commands
+    ~mutation_class:"read_only"
     ~description:
       "Execute a read-only shell command and return stdout+stderr. \
        Timeout: 30s default, max 120s. \
        Use for search, inspection, and verification only. \
        Write-oriented commands are intentionally excluded."
+    ()
 
 (** Create dev tools that close over Eio capabilities.
     Returns [file_read; file_write; shell_exec]. *)


### PR DESCRIPTION
## Summary

`make_shell_exec_with_allowlist`가 `mutation_class = Some "workspace"`를 하드코딩하여,
`make_shell_exec_readonly`로 생성된 read-only shell tool도 `workspace` mutating으로 분류됩니다.
이로 인해 mode_enforcer가 read-only 도구를 부정확하게 게이팅할 수 있습니다.

## Changes

- `make_shell_exec_with_allowlist`에 optional `~mutation_class` 파라미터 추가 (기본값: `"workspace"`)
- `make_shell_exec_readonly`에서 `~mutation_class:"read_only"` 전달

## Source

Copilot inline review on PR #4142.

## Test plan

- [ ] `dune build` 통과
- [ ] Keeper read-only scope에서 shell_exec의 mutation_class가 `read_only`인지 확인

Generated with [Claude Code](https://claude.com/claude-code)