### PR TITLE
refactor(harness): unify transport stack — migrate 6 scripts to mcp_jsonrpc (#4138)

### DIFF
--- a/scripts/harness/workload/coding_worker_quickwin.sh
+++ b/scripts/harness/workload/coding_worker_quickwin.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 export PYTHONDONTWRITEBYTECODE=1
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-60}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-qwen3.5-35b-a3b-ud-q8-xl}"
 SMOKE_AGENT="${SMOKE_AGENT:-coding-smoke-supervisor}"
@@ -48,72 +50,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-require_json() {
-  printf '%s' "$1" | jq -e . >/dev/null
-}
-
-extract_response_error() {
-  jq -r 'if (.error | type) == "object" and (.error.message | type) == "string" then .error.message else empty end'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "false"'
-}
-
-extract_tool_result() {
-  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
-}
-
-require_success_response() {
-  local payload="$1"
-  require_json "$payload"
-  local err
-  err="$(printf '%s' "$payload" | extract_response_error)"
-  if [ -n "$err" ]; then
-    echo "FAIL: JSON-RPC error: $err"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
-}
-
-require_tool_success() {
-  local payload="$1"
-  require_success_response "$payload"
-  local is_error
-  is_error="$(printf '%s' "$payload" | extract_is_error)"
-  if [ "$is_error" = "true" ]; then
-    echo "FAIL: tool returned isError=true"
-    printf '%s\n' "$payload" | jq -r '.result.content[0].text'
-    exit 1
-  fi
-}
-
-jsonrpc_call() {
-  local session_id="$1"
-  local id="$2"
-  local method="$3"
-  local params="$4"
-  local body_file
-  body_file="$(mktemp "${TMPDIR:-/tmp}/coding-worker-jsonrpc.XXXXXX")"
-  printf '{"jsonrpc":"2.0","id":%s,"method":"%s","params":%s}' "$id" "$method" "$params" >"$body_file"
-  local response
-  response="$(curl -sS --http2-prior-knowledge --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -H "Mcp-Session-Id: $session_id" \
-    --data-binary "@$body_file")"
-  rm -f "$body_file"
-  jsonrpc_normalize_response "$response" "$id"
-}
-
-call_tool() {
-  local session_id="$1"
-  local id="$2"
-  local tool_name="$3"
-  local args_json="$4"
-  jsonrpc_call "$session_id" "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
-}
-
 wait_for_health() {
   local deadline=$(( $(date +%s) + 20 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -142,9 +78,9 @@ start_server() {
 
 bootstrap_room() {
   local session_id="$1"
-  require_tool_success "$(call_tool "$session_id" 1 "masc_init" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a}')")"
-  require_tool_success "$(call_tool "$session_id" 2 "masc_switch_mode" '{"mode":"full"}')"
-  require_tool_success "$(call_tool "$session_id" 3 "masc_join" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a,capabilities:["python","bash","worker"]}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 1 "masc_init" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 2 "masc_switch_mode" '{"mode":"full"}')"
+  mcp_require_tool_ok "$(mcp_call_tool 3 "masc_join" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a,capabilities:["python","bash","worker"]}')")"
 }
 
 start_team_session() {
@@ -152,12 +88,12 @@ start_team_session() {
   local goal="$2"
   local execution_scope="$3"
   local raw
-  raw="$(call_tool "$session_id" 4 "masc_team_session_start" "$(jq -cn \
+  raw="$(mcp_call_tool 4 "masc_team_session_start" "$(jq -cn \
     --arg goal "$goal" \
     --arg scope "$execution_scope" \
     '{goal:$goal,duration_seconds:180,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:$scope,fallback_policy:"cascade_then_task",instruction_profile:"strict",min_agents:1,agents:[]}' )")"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_tool_result | jq -r '.session_id // empty'
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result | jq -r '.session_id // empty'
 }
 
 wait_until_terminal() {
@@ -166,9 +102,9 @@ wait_until_terminal() {
   local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
   while :; do
     local raw status
-    raw="$(call_tool "$client_session_id" 90 "masc_team_session_status" "$(jq -cn --arg s "$team_session_id" '{session_id:$s}')")"
-    require_tool_success "$raw"
-    status="$(printf '%s' "$raw" | extract_tool_result | jq -r '.session.status // empty')"
+    raw="$(mcp_call_tool 90 "masc_team_session_status" "$(jq -cn --arg s "$team_session_id" '{session_id:$s}')")"
+    mcp_require_tool_ok "$raw"
+    status="$(printf '%s' "$raw" | mcp_extract_result | jq -r '.session.status // empty')"
     if [ "$status" != "running" ]; then
       return 0
     fi
@@ -189,9 +125,9 @@ wait_for_worker_run_event() {
   local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
   while :; do
     local raw events_json match
-    raw="$(call_tool "$client_session_id" 91 "masc_team_session_events" "$(jq -cn --arg s "$team_session_id" --arg ev "$expected_event" '{session_id:$s,event_types:[$ev],limit:200}')")"
-    require_tool_success "$raw"
-    events_json="$(printf '%s' "$raw" | extract_tool_result)"
+    raw="$(mcp_call_tool 91 "masc_team_session_events" "$(jq -cn --arg s "$team_session_id" --arg ev "$expected_event" '{session_id:$s,event_types:[$ev],limit:200}')")"
+    mcp_require_tool_ok "$raw"
+    events_json="$(printf '%s' "$raw" | mcp_extract_result)"
     match="$(printf '%s' "$events_json" | jq -c --arg id "$worker_run_id" '.events[]? | select(.detail.worker_run_id? == $id) | .detail' | tail -n1)"
     if [ -n "$match" ]; then
       printf '%s' "$match"
@@ -211,9 +147,9 @@ verify_worker_run_trace() {
   local team_session_id="$2"
   local worker_run_id="$3"
   local raw result
-  raw="$(call_tool "$client_session_id" 92 "masc_team_session_verify_trace" "$(jq -cn --arg s "$team_session_id" --arg r "$worker_run_id" '{session_id:$s,worker_run_id:$r}')")"
-  require_tool_success "$raw"
-  result="$(printf '%s' "$raw" | extract_tool_result)"
+  raw="$(mcp_call_tool 92 "masc_team_session_verify_trace" "$(jq -cn --arg s "$team_session_id" --arg r "$worker_run_id" '{session_id:$s,worker_run_id:$r}')")"
+  mcp_require_tool_ok "$raw"
+  result="$(printf '%s' "$raw" | mcp_extract_result)"
   printf '%s' "$result"
 }
 
@@ -288,13 +224,13 @@ Reply with exactly one short line describing the applied fix.
 Do not call masc_team_session_step yourself.
 EOF
 )"
-  raw="$(call_tool "fixture-client" 10 "masc_team_session_step" "$(jq -cn \
+  raw="$(mcp_call_tool 10 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$inspect_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
     '{session_id:$s,spawn_role:"coder",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$prompt}')")"
-  require_tool_success "$raw"
-  result="$(printf '%s' "$raw" | extract_tool_result)"
+  mcp_require_tool_ok "$raw"
+  result="$(printf '%s' "$raw" | mcp_extract_result)"
   spawn="$(printf '%s' "$result" | jq -c '.spawn')"
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
     local fixture_spawn_run_id fixture_spawn_detail fixture_spawn_verify
@@ -311,13 +247,13 @@ EOF
     printf '%s' "$spawn" | jq -e '.tool_call_count > 0' >/dev/null
     printf '%s' "$spawn" | jq -e '(.tool_names | index("file_read")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
   fi
-  delegate_raw="$(call_tool "fixture-client" 10 "masc_team_session_step" "$(jq -cn \
+  delegate_raw="$(mcp_call_tool 10 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$write_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
     '{session_id:$s,target_agent:"coder",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
-  require_tool_success "$delegate_raw"
-  delegate_json="$(printf '%s' "$delegate_raw" | extract_tool_result | jq -c '.delegate')"
+  mcp_require_tool_ok "$delegate_raw"
+  delegate_json="$(printf '%s' "$delegate_raw" | mcp_extract_result | jq -c '.delegate')"
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
     local fixture_delegate_run_id fixture_delegate_detail fixture_delegate_verify
     printf '%s' "$delegate_json" | jq -e '.status == "accepted"' >/dev/null
@@ -337,12 +273,12 @@ EOF
     echo "FAIL: fixture repo calc.py was not patched to return 5"
     exit 1
   fi
-  require_tool_success "$(call_tool "fixture-client" 11 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"fixture_done",generate_report:true}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 11 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"fixture_done",generate_report:true}')")"
   wait_until_terminal "fixture-client" "$team_session_id"
   local prove_raw prove_result
-  prove_raw="$(call_tool "fixture-client" 12 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
-  require_tool_success "$prove_raw"
-  prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
+  prove_raw="$(mcp_call_tool 12 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
+  mcp_require_tool_ok "$prove_raw"
+  prove_result="$(printf '%s' "$prove_raw" | mcp_extract_result)"
   printf '%s' "$prove_result" | jq -e '.proof.evidence.spawn_tool_call_count > 0' >/dev/null
   printf '%s' "$prove_result" | jq -e '(.proof.evidence.spawn_tool_names | index("file_write")) != null' >/dev/null
   printf '%s' "$prove_result" | jq -e '.proof.evidence.write_capable_spawn_count >= 1' >/dev/null
@@ -384,7 +320,7 @@ Reply with exactly one short line describing the applied patch.
 Do not call masc_team_session_step yourself.
 EOF
 )"
-  raw="$(call_tool "repo-client" 20 "masc_team_session_step" "$(jq -cn \
+  raw="$(mcp_call_tool 20 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg planner "$planner_prompt" \
     --arg implementer "$implementer_prompt" \
@@ -393,8 +329,8 @@ EOF
       {spawn_role:"planner",worker_class:"manager",worker_size:"xlg",execution_scope:"observe_only",wait_mode:$wait_mode,spawn_prompt:$planner},
       {spawn_role:"implementer",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$implementer}
     ]}')")"
-  require_tool_success "$raw"
-  result="$(printf '%s' "$raw" | extract_tool_result)"
+  mcp_require_tool_ok "$raw"
+  result="$(printf '%s' "$raw" | mcp_extract_result)"
   printf '%s' "$result" | jq -e '.spawn.mode == "batch" and .spawn.count == 2 and (.spawn.results | length) == 2' >/dev/null
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
     local planner_run_id implementer_run_id planner_detail implementer_detail planner_verify implementer_verify
@@ -415,13 +351,13 @@ EOF
     printf '%s' "$result" | jq -e '[.spawn.results[] | .execution_scope] | index("limited_code_change") != null' >/dev/null
     printf '%s' "$result" | jq -e '[.spawn.results[] | .tool_names[]?] | index("file_read") != null and index("shell_exec") != null' >/dev/null
   fi
-  delegate_raw="$(call_tool "repo-client" 21 "masc_team_session_step" "$(jq -cn \
+  delegate_raw="$(mcp_call_tool 21 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$implementer_write_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
     '{session_id:$s,target_agent:"implementer",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
-  require_tool_success "$delegate_raw"
-  delegate_json="$(printf '%s' "$delegate_raw" | extract_tool_result | jq -c '.delegate')"
+  mcp_require_tool_ok "$delegate_raw"
+  delegate_json="$(printf '%s' "$delegate_raw" | mcp_extract_result | jq -c '.delegate')"
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
     local repo_delegate_run_id repo_delegate_detail repo_delegate_verify
     printf '%s' "$delegate_json" | jq -e '.status == "accepted"' >/dev/null
@@ -435,7 +371,7 @@ EOF
     printf '%s' "$delegate_json" | jq -e '.tool_call_count > 0' >/dev/null
     printf '%s' "$delegate_json" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
   fi
-  require_tool_success "$(call_tool "repo-client" 21 "masc_team_session_step" "$(jq -cn \
+  mcp_require_tool_ok "$(mcp_call_tool 21 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg message "planner inspected the smoke target and implementer patched calc.py; verification passed" \
     '{session_id:$s,turn_kind:"note",message:$message}')")"
@@ -444,12 +380,12 @@ EOF
     echo "FAIL: real repo smoke calc.py was not patched to return 5"
     exit 1
   fi
-  require_tool_success "$(call_tool "repo-client" 22 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"repo_done",generate_report:true}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 22 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"repo_done",generate_report:true}')")"
   wait_until_terminal "repo-client" "$team_session_id"
   local prove_raw prove_result
-  prove_raw="$(call_tool "repo-client" 23 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
-  require_tool_success "$prove_raw"
-  prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
+  prove_raw="$(mcp_call_tool 23 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
+  mcp_require_tool_ok "$prove_raw"
+  prove_result="$(printf '%s' "$prove_raw" | mcp_extract_result)"
   printf '%s' "$prove_result" | jq -e '.proof.verdict == "proved"' >/dev/null
   printf '%s' "$prove_result" | jq -e '.proof.evidence.unique_turn_actors_count >= 3' >/dev/null
   printf '%s' "$prove_result" | jq -e '.proof.evidence.spawn_success_count >= 2' >/dev/null

--- a/scripts/harness/workload/coding_worker_quickwin.sh
+++ b/scripts/harness/workload/coding_worker_quickwin.sh
@@ -8,7 +8,6 @@ source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
 MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
-MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-60}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-qwen3.5-35b-a3b-ud-q8-xl}"
 SMOKE_AGENT="${SMOKE_AGENT:-coding-smoke-supervisor}"
@@ -78,9 +77,9 @@ start_server() {
 
 bootstrap_room() {
   local session_id="$1"
-  mcp_require_tool_ok "$(mcp_call_tool 1 "masc_init" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a}')")"
-  mcp_require_tool_ok "$(mcp_call_tool 2 "masc_switch_mode" '{"mode":"full"}')"
-  mcp_require_tool_ok "$(mcp_call_tool 3 "masc_join" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a,capabilities:["python","bash","worker"]}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 1 "masc_init" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a}')" "$session_id")"
+  mcp_require_tool_ok "$(mcp_call_tool 2 "masc_switch_mode" '{"mode":"full"}' "$session_id")"
+  mcp_require_tool_ok "$(mcp_call_tool 3 "masc_join" "$(jq -cn --arg a "$SMOKE_AGENT" '{agent_name:$a,capabilities:["python","bash","worker"]}')" "$session_id")"
 }
 
 start_team_session() {
@@ -91,7 +90,7 @@ start_team_session() {
   raw="$(mcp_call_tool 4 "masc_team_session_start" "$(jq -cn \
     --arg goal "$goal" \
     --arg scope "$execution_scope" \
-    '{goal:$goal,duration_seconds:180,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:$scope,fallback_policy:"cascade_then_task",instruction_profile:"strict",min_agents:1,agents:[]}' )")"
+    '{goal:$goal,duration_seconds:180,checkpoint_interval_sec:15,orchestration_mode:"assist",communication_mode:"broadcast",execution_scope:$scope,fallback_policy:"cascade_then_task",instruction_profile:"strict",min_agents:1,agents:[]}' )" "$session_id")"
   mcp_require_tool_ok "$raw"
   printf '%s' "$raw" | mcp_extract_result | jq -r '.session_id // empty'
 }
@@ -102,7 +101,7 @@ wait_until_terminal() {
   local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
   while :; do
     local raw status
-    raw="$(mcp_call_tool 90 "masc_team_session_status" "$(jq -cn --arg s "$team_session_id" '{session_id:$s}')")"
+    raw="$(mcp_call_tool 90 "masc_team_session_status" "$(jq -cn --arg s "$team_session_id" '{session_id:$s}')" "$client_session_id")"
     mcp_require_tool_ok "$raw"
     status="$(printf '%s' "$raw" | mcp_extract_result | jq -r '.session.status // empty')"
     if [ "$status" != "running" ]; then
@@ -125,7 +124,7 @@ wait_for_worker_run_event() {
   local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
   while :; do
     local raw events_json match
-    raw="$(mcp_call_tool 91 "masc_team_session_events" "$(jq -cn --arg s "$team_session_id" --arg ev "$expected_event" '{session_id:$s,event_types:[$ev],limit:200}')")"
+    raw="$(mcp_call_tool 91 "masc_team_session_events" "$(jq -cn --arg s "$team_session_id" --arg ev "$expected_event" '{session_id:$s,event_types:[$ev],limit:200}')" "$client_session_id")"
     mcp_require_tool_ok "$raw"
     events_json="$(printf '%s' "$raw" | mcp_extract_result)"
     match="$(printf '%s' "$events_json" | jq -c --arg id "$worker_run_id" '.events[]? | select(.detail.worker_run_id? == $id) | .detail' | tail -n1)"
@@ -147,7 +146,7 @@ verify_worker_run_trace() {
   local team_session_id="$2"
   local worker_run_id="$3"
   local raw result
-  raw="$(mcp_call_tool 92 "masc_team_session_verify_trace" "$(jq -cn --arg s "$team_session_id" --arg r "$worker_run_id" '{session_id:$s,worker_run_id:$r}')")"
+  raw="$(mcp_call_tool 92 "masc_team_session_verify_trace" "$(jq -cn --arg s "$team_session_id" --arg r "$worker_run_id" '{session_id:$s,worker_run_id:$r}')" "$client_session_id")"
   mcp_require_tool_ok "$raw"
   result="$(printf '%s' "$raw" | mcp_extract_result)"
   printf '%s' "$result"
@@ -228,7 +227,7 @@ EOF
     --arg s "$team_session_id" \
     --arg prompt "$inspect_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
-    '{session_id:$s,spawn_role:"coder",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$prompt}')")"
+    '{session_id:$s,spawn_role:"coder",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$prompt}')" "fixture-client")"
   mcp_require_tool_ok "$raw"
   result="$(printf '%s' "$raw" | mcp_extract_result)"
   spawn="$(printf '%s' "$result" | jq -c '.spawn')"
@@ -251,7 +250,7 @@ EOF
     --arg s "$team_session_id" \
     --arg prompt "$write_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
-    '{session_id:$s,target_agent:"coder",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
+    '{session_id:$s,target_agent:"coder",wait_mode:$wait_mode,delegate_prompt:$prompt}')" "fixture-client")"
   mcp_require_tool_ok "$delegate_raw"
   delegate_json="$(printf '%s' "$delegate_raw" | mcp_extract_result | jq -c '.delegate')"
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
@@ -273,10 +272,10 @@ EOF
     echo "FAIL: fixture repo calc.py was not patched to return 5"
     exit 1
   fi
-  mcp_require_tool_ok "$(mcp_call_tool 11 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"fixture_done",generate_report:true}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 11 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"fixture_done",generate_report:true}')" "fixture-client")"
   wait_until_terminal "fixture-client" "$team_session_id"
   local prove_raw prove_result
-  prove_raw="$(mcp_call_tool 12 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
+  prove_raw="$(mcp_call_tool 12 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')" "fixture-client")"
   mcp_require_tool_ok "$prove_raw"
   prove_result="$(printf '%s' "$prove_raw" | mcp_extract_result)"
   printf '%s' "$prove_result" | jq -e '.proof.evidence.spawn_tool_call_count > 0' >/dev/null
@@ -328,7 +327,7 @@ EOF
     '{session_id:$s,spawn_batch:[
       {spawn_role:"planner",worker_class:"manager",worker_size:"xlg",execution_scope:"observe_only",wait_mode:$wait_mode,spawn_prompt:$planner},
       {spawn_role:"implementer",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$implementer}
-    ]}')")"
+    ]}')" "repo-client")"
   mcp_require_tool_ok "$raw"
   result="$(printf '%s' "$raw" | mcp_extract_result)"
   printf '%s' "$result" | jq -e '.spawn.mode == "batch" and .spawn.count == 2 and (.spawn.results | length) == 2' >/dev/null
@@ -355,7 +354,7 @@ EOF
     --arg s "$team_session_id" \
     --arg prompt "$implementer_write_prompt" \
     --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
-    '{session_id:$s,target_agent:"implementer",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
+    '{session_id:$s,target_agent:"implementer",wait_mode:$wait_mode,delegate_prompt:$prompt}')" "repo-client")"
   mcp_require_tool_ok "$delegate_raw"
   delegate_json="$(printf '%s' "$delegate_raw" | mcp_extract_result | jq -c '.delegate')"
   if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
@@ -374,16 +373,16 @@ EOF
   mcp_require_tool_ok "$(mcp_call_tool 21 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg message "planner inspected the smoke target and implementer patched calc.py; verification passed" \
-    '{session_id:$s,turn_kind:"note",message:$message}')")"
+    '{session_id:$s,turn_kind:"note",message:$message}')" "repo-client")"
   (cd "$repo_dir" && python3 test/fixtures/coding_worker_repo_smoke/check.py >/dev/null)
   if ! grep -q 'return 5' "$repo_dir/test/fixtures/coding_worker_repo_smoke/calc.py"; then
     echo "FAIL: real repo smoke calc.py was not patched to return 5"
     exit 1
   fi
-  mcp_require_tool_ok "$(mcp_call_tool 22 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"repo_done",generate_report:true}')")"
+  mcp_require_tool_ok "$(mcp_call_tool 22 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"repo_done",generate_report:true}')" "repo-client")"
   wait_until_terminal "repo-client" "$team_session_id"
   local prove_raw prove_result
-  prove_raw="$(mcp_call_tool 23 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')")"
+  prove_raw="$(mcp_call_tool 23 "masc_team_session_prove" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,generate_report_if_missing:true}')" "repo-client")"
   mcp_require_tool_ok "$prove_raw"
   prove_result="$(printf '%s' "$prove_raw" | mcp_extract_result)"
   printf '%s' "$prove_result" | jq -e '.proof.verdict == "proved"' >/dev/null

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-source "$REPO_ROOT/scripts/harness/jsonrpc_sse.sh"
+source "$REPO_ROOT/scripts/harness/lib/mcp_jsonrpc.sh"
 source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
 
 RUN_ID="${RUN_ID:-keeper-continuity-$(date +%Y%m%d_%H%M%S)-$$}"

--- a/scripts/harness/workload/team_session_local64_chaos.sh
+++ b/scripts/harness/workload/team_session_local64_chaos.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8945/mcp}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 COORD_AGENT="${COORD_AGENT:-team-session-local64-chaos}"
 WAVE1_WORKER_COUNT="${WAVE1_WORKER_COUNT:-8}"
 WAVE2_WORKER_COUNT="${WAVE2_WORKER_COUNT:-12}"
@@ -47,26 +48,6 @@ SESSION_ID=""
 VICTIM_RUNTIME_ID=""
 VICTIM_PORT=""
 
-jsonrpc_call() {
-  local id="$1"
-  local method="$2"
-  local params="$3"
-  local raw
-  raw="$(curl -sS --http2-prior-knowledge --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -H "mcp-session-id: $MCP_SESSION_ID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}")"
-  jsonrpc_normalize_response "$raw" "$id"
-}
-
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  jsonrpc_call "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
-}
-
 runtime_verify_result() {
   local runtime_pool="${1:-}"
   local args
@@ -79,51 +60,18 @@ runtime_verify_result() {
       '
   )"
   local payload
-  payload="$(call_tool 92898 "masc_runtime_verify" "$args")"
-  require_tool_success "$payload"
-  printf '%s' "$payload" | extract_result
-}
-
-extract_text() {
-  jq -r 'try (.result.content[0].text) catch empty'
-}
-
-extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "true"'
-}
-
-require_json() {
-  local payload="$1"
-  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid payload"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
-}
-
-require_tool_success() {
-  local payload="$1"
-  require_json "$payload"
-  local is_error
-  is_error="$(printf '%s' "$payload" | extract_is_error)"
-  if [ "$is_error" = "true" ]; then
-    echo "FAIL: tool returned isError=true"
-    printf '%s\n' "$payload" | extract_text
-    exit 1
-  fi
+  payload="$(mcp_call_tool 92898 "masc_runtime_verify" "$args")"
+  mcp_require_tool_ok "$payload"
+  printf '%s' "$payload" | mcp_extract_result
 }
 
 cleanup() {
   if [ -n "$SESSION_ID" ]; then
-    call_tool 92981 "masc_team_session_stop" \
+    mcp_call_tool 92981 "masc_team_session_stop" \
       "{\"session_id\":\"$SESSION_ID\",\"reason\":\"local64_chaos_cleanup\",\"generate_report\":false}" \
       >/dev/null 2>&1 || true
   fi
-  call_tool 92982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
+  mcp_call_tool 92982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -212,7 +160,7 @@ run_spawn_wave() {
   spawn_batch_json="$(build_spawn_batch "$SESSION_ID" "$worker_count" "$LLAMA_SWARM_MODEL" "$phase")"
   step_args="$(jq -cn --arg s "$SESSION_ID" --arg a "$COORD_AGENT" --argjson batch "$spawn_batch_json" --argjson timeout "$SPAWN_TIMEOUT_SEC" \
     '{session_id:$s,actor:$a,spawn_batch:$batch,spawn_timeout_seconds:$timeout}')"
-  call_tool "$call_id" "masc_team_session_step" "$step_args"
+  mcp_call_tool "$call_id" "masc_team_session_step" "$step_args"
 }
 
 wait_for_runtime_down() {
@@ -231,17 +179,17 @@ wait_for_runtime_down() {
 }
 
 echo "[1/10] init + join coordinator"
-init_raw="$(call_tool 92901 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
-require_tool_success "$init_raw"
-join_raw="$(call_tool 92902 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator","chaos"]}')")"
-require_tool_success "$join_raw"
+init_raw="$(mcp_call_tool 92901 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
+mcp_require_tool_ok "$init_raw"
+join_raw="$(mcp_call_tool 92902 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator","chaos"]}')")"
+mcp_require_tool_ok "$join_raw"
 
 echo "[2/10] start local64 chaos session"
 start_args="$(jq -cn --arg goal "$GOAL" --argjson duration "$SESSION_DURATION_SEC" \
   '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:20,min_agents:1,orchestration_mode:"assist",communication_mode:"hybrid",scale_profile:"local64",fallback_policy:"strict_local_only",instruction_profile:"strict",alert_channel:"both",report_formats:["markdown","json"],agents:["team-session-local64-chaos"]}')"
-start_raw="$(call_tool 92903 "masc_team_session_start" "$start_args")"
-require_tool_success "$start_raw"
-SESSION_ID="$(printf '%s' "$start_raw" | extract_result | jq -r '.session_id // empty')"
+start_raw="$(mcp_call_tool 92903 "masc_team_session_start" "$start_args")"
+mcp_require_tool_ok "$start_raw"
+SESSION_ID="$(printf '%s' "$start_raw" | mcp_extract_result | jq -r '.session_id // empty')"
 if [ -z "$SESSION_ID" ]; then
   echo "FAIL: session_id missing"
   printf '%s\n' "$start_raw"
@@ -250,9 +198,9 @@ fi
 echo "session_id=$SESSION_ID"
 
 echo "[3/10] inspect runtime pool and pick victim"
-runtime_raw="$(call_tool 92904 "masc_llama_runtime_status" '{"include_models":true}')"
-require_tool_success "$runtime_raw"
-runtime_result="$(printf '%s' "$runtime_raw" | extract_result)"
+runtime_raw="$(mcp_call_tool 92904 "masc_llama_runtime_status" '{"include_models":true}')"
+mcp_require_tool_ok "$runtime_raw"
+runtime_result="$(printf '%s' "$runtime_raw" | mcp_extract_result)"
 if ! printf '%s' "$runtime_result" | jq -e '.runtime_count >= 2' >/dev/null; then
   echo "FAIL: chaos requires at least 2 local runtimes"
   printf '%s\n' "$runtime_result"
@@ -269,11 +217,11 @@ echo "victim_runtime=${VICTIM_RUNTIME_ID} port=${VICTIM_PORT}"
 
 echo "[4/10] wave1 baseline (spawn_timeout=${SPAWN_TIMEOUT_SEC}s http_timeout=${HTTP_TIMEOUT_SEC}s max_wave_workers=${max_wave_workers})"
 wave1_raw="$(run_spawn_wave 92905 "$WAVE1_WORKER_COUNT" "wave1")"
-require_tool_success "$wave1_raw"
-wave1_success="$(printf '%s' "$wave1_raw" | extract_result | jq -r '.spawn.results | map(select(.success == true)) | length')"
+mcp_require_tool_ok "$wave1_raw"
+wave1_success="$(printf '%s' "$wave1_raw" | mcp_extract_result | jq -r '.spawn.results | map(select(.success == true)) | length')"
 if [ "$wave1_success" -lt "$WAVE1_WORKER_COUNT" ]; then
   echo "FAIL: baseline wave succeeded only $wave1_success/$WAVE1_WORKER_COUNT"
-  printf '%s\n' "$wave1_raw" | extract_result
+  printf '%s\n' "$wave1_raw" | mcp_extract_result
   exit 1
 fi
 sleep "$WAIT_AFTER_SPAWN_SEC"
@@ -292,8 +240,8 @@ fi
 
 echo "[6/10] wave2 after dropout"
 wave2_raw="$(run_spawn_wave 92906 "$WAVE2_WORKER_COUNT" "wave2")"
-require_tool_success "$wave2_raw"
-wave2_result="$(printf '%s' "$wave2_raw" | extract_result)"
+mcp_require_tool_ok "$wave2_raw"
+wave2_result="$(printf '%s' "$wave2_raw" | mcp_extract_result)"
 wave2_success="$(printf '%s' "$wave2_result" | jq -r '.spawn.results | map(select(.success == true)) | length')"
 wave2_failure="$(printf '%s' "$wave2_result" | jq -r '.spawn.results | map(select(.success != true)) | length')"
 wave2_victim_assignments="$(printf '%s' "$wave2_result" | jq -r --arg victim "$VICTIM_RUNTIME_ID" '.spawn.results | map(select(.assigned_runtime == $victim)) | length')"
@@ -305,10 +253,10 @@ fi
 sleep "$WAIT_AFTER_SPAWN_SEC"
 
 echo "[7/10] verify cooldown after failures"
-post_failure_runtime_raw="$(call_tool 92907 "masc_llama_runtime_status" '{"include_models":true}')"
-require_tool_success "$post_failure_runtime_raw"
-require_json "$post_failure_runtime_raw"
-post_failure_runtime_result="$(printf '%s' "$post_failure_runtime_raw" | extract_result)"
+post_failure_runtime_raw="$(mcp_call_tool 92907 "masc_llama_runtime_status" '{"include_models":true}')"
+mcp_require_tool_ok "$post_failure_runtime_raw"
+mcp_require_json "$post_failure_runtime_raw"
+post_failure_runtime_result="$(printf '%s' "$post_failure_runtime_raw" | mcp_extract_result)"
 if ! printf '%s' "$post_failure_runtime_result" | jq -e --arg victim "$VICTIM_RUNTIME_ID" '
   .healthy_runtime_count >= 1
   and (.runtimes | map(select(.id == $victim and (.failure_streak >= 3) and (.cooldown_until != null))) | length == 1)
@@ -320,8 +268,8 @@ fi
 
 echo "[8/10] wave3 reroute on surviving runtime"
 wave3_raw="$(run_spawn_wave 92908 "$WAVE3_WORKER_COUNT" "wave3")"
-require_tool_success "$wave3_raw"
-wave3_result="$(printf '%s' "$wave3_raw" | extract_result)"
+mcp_require_tool_ok "$wave3_raw"
+wave3_result="$(printf '%s' "$wave3_raw" | mcp_extract_result)"
 wave3_success="$(printf '%s' "$wave3_result" | jq -r '.spawn.results | map(select(.success == true)) | length')"
 wave3_victim_assignments="$(printf '%s' "$wave3_result" | jq -r --arg victim "$VICTIM_RUNTIME_ID" '.spawn.results | map(select(.assigned_runtime == $victim)) | length')"
 if [ "$wave3_success" -lt "$WAVE3_WORKER_COUNT" ] || [ "$wave3_victim_assignments" -ne 0 ]; then
@@ -332,20 +280,20 @@ fi
 sleep "$WAIT_AFTER_SPAWN_SEC"
 
 echo "[9/10] verify operator digest"
-digest_raw="$(call_tool 92909 "masc_operator_digest" '{"target_type":"room"}')"
-require_tool_success "$digest_raw"
-if ! printf '%s' "$digest_raw" | extract_result | jq -e '.runtime_pools.local64 >= 1 and .local_runtime != null' >/dev/null; then
+digest_raw="$(mcp_call_tool 92909 "masc_operator_digest" '{"target_type":"room"}')"
+mcp_require_tool_ok "$digest_raw"
+if ! printf '%s' "$digest_raw" | mcp_extract_result | jq -e '.runtime_pools.local64 >= 1 and .local_runtime != null' >/dev/null; then
   echo "FAIL: operator digest did not expose local64 runtime state after chaos"
-  printf '%s\n' "$digest_raw" | extract_result
+  printf '%s\n' "$digest_raw" | mcp_extract_result
   exit 1
 fi
 
 echo "[10/10] benchmark surviving runtime"
-bench_raw="$(call_tool 92910 "masc_llama_runtime_bench" '{"parallelism":4,"rounds":1,"runtime_pool":"local64"}')"
-require_tool_success "$bench_raw"
-if ! printf '%s' "$bench_raw" | extract_result | jq -e '.total_requests >= 1 and .success_count >= 1' >/dev/null; then
+bench_raw="$(mcp_call_tool 92910 "masc_llama_runtime_bench" '{"parallelism":4,"rounds":1,"runtime_pool":"local64"}')"
+mcp_require_tool_ok "$bench_raw"
+if ! printf '%s' "$bench_raw" | mcp_extract_result | jq -e '.total_requests >= 1 and .success_count >= 1' >/dev/null; then
   echo "FAIL: bench did not succeed after runtime dropout"
-  printf '%s\n' "$bench_raw" | extract_result
+  printf '%s\n' "$bench_raw" | mcp_extract_result
   exit 1
 fi
 

--- a/scripts/harness/workload/team_session_local64_context_chaos.sh
+++ b/scripts/harness/workload/team_session_local64_context_chaos.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8945/mcp}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 COORD_AGENT="${COORD_AGENT:-team-session-local64-context-chaos}"
 WORKER_COUNT="${WORKER_COUNT:-4}"
 PRESSURE_WORKER_COUNT="${PRESSURE_WORKER_COUNT:-2}"
@@ -44,65 +45,12 @@ fi
 
 SESSION_ID=""
 
-jsonrpc_call() {
-  local id="$1"
-  local method="$2"
-  local params="$3"
-  local raw
-  raw="$(curl -sS --http2-prior-knowledge --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -H "mcp-session-id: $MCP_SESSION_ID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}")"
-  jsonrpc_normalize_response "$raw" "$id"
-}
-
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  jsonrpc_call "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
-}
-
-extract_text() {
-  jq -r 'try (.result.content[0].text) catch empty'
-}
-
-extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "true"'
-}
-
-require_json() {
-  local payload="$1"
-  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid payload"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
-}
-
-require_tool_success() {
-  local payload="$1"
-  require_json "$payload"
-  local is_error
-  is_error="$(printf '%s' "$payload" | extract_is_error)"
-  if [ "$is_error" = "true" ]; then
-    echo "FAIL: tool returned isError=true"
-    printf '%s\n' "$payload" | extract_text
-    exit 1
-  fi
-}
-
 require_result_condition() {
   local payload="$1"
   local jq_expr="$2"
   local failure_message="$3"
   local result_json
-  result_json="$(printf '%s' "$payload" | extract_result)"
+  result_json="$(printf '%s' "$payload" | mcp_extract_result)"
   if ! printf '%s' "$result_json" | jq -e "$jq_expr" >/dev/null; then
     echo "FAIL: $failure_message"
     printf '%s\n' "$result_json"
@@ -112,11 +60,11 @@ require_result_condition() {
 
 cleanup() {
   if [ -n "$SESSION_ID" ]; then
-    call_tool 93981 "masc_team_session_stop" \
+    mcp_call_tool 93981 "masc_team_session_stop" \
       "{\"session_id\":\"$SESSION_ID\",\"reason\":\"local64_context_chaos_cleanup\",\"generate_report\":false}" \
       >/dev/null 2>&1 || true
   fi
-  call_tool 93982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
+  mcp_call_tool 93982 "masc_leave" "{\"agent_name\":\"$COORD_AGENT\"}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -223,17 +171,17 @@ build_spawn_batch() {
 }
 
 echo "[1/8] init + join coordinator"
-init_raw="$(call_tool 93901 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
-require_tool_success "$init_raw"
-join_raw="$(call_tool 93902 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator","context-chaos"]}')")"
-require_tool_success "$join_raw"
+init_raw="$(mcp_call_tool 93901 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
+mcp_require_tool_ok "$init_raw"
+join_raw="$(mcp_call_tool 93902 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","local64","operator","context-chaos"]}')")"
+mcp_require_tool_ok "$join_raw"
 
 echo "[2/8] start local64 context-chaos session"
 start_args="$(jq -cn --arg goal "$GOAL" --argjson duration "$SESSION_DURATION_SEC" \
   '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:20,min_agents:1,orchestration_mode:"assist",communication_mode:"hybrid",scale_profile:"local64",fallback_policy:"strict_local_only",instruction_profile:"strict",alert_channel:"both",report_formats:["markdown","json"],agents:["team-session-local64-context-chaos"]}')"
-start_raw="$(call_tool 93903 "masc_team_session_start" "$start_args")"
-require_tool_success "$start_raw"
-SESSION_ID="$(printf '%s' "$start_raw" | extract_result | jq -r '.session_id // empty')"
+start_raw="$(mcp_call_tool 93903 "masc_team_session_start" "$start_args")"
+mcp_require_tool_ok "$start_raw"
+SESSION_ID="$(printf '%s' "$start_raw" | mcp_extract_result | jq -r '.session_id // empty')"
 if [ -z "$SESSION_ID" ]; then
   echo "FAIL: session_id missing"
   printf '%s\n' "$start_raw"
@@ -242,16 +190,16 @@ fi
 echo "session_id=$SESSION_ID"
 
 echo "[3/8] inspect runtime pool"
-runtime_raw="$(call_tool 93904 "masc_llama_runtime_status" '{"include_models":true}')"
-require_tool_success "$runtime_raw"
+runtime_raw="$(mcp_call_tool 93904 "masc_llama_runtime_status" '{"include_models":true}')"
+mcp_require_tool_ok "$runtime_raw"
 require_result_condition "$runtime_raw" '.runtime_count >= 1 and .configured_capacity >= 1' "runtime status missing local64 runtime data"
 
 echo "[4/8] spawn pressure batch (spawn_timeout=${SPAWN_TIMEOUT_SEC}s http_timeout=${HTTP_TIMEOUT_SEC}s workers=${WORKER_COUNT} pressure=${PRESSURE_WORKER_COUNT})"
 spawn_batch_json="$(build_spawn_batch "$SESSION_ID" "$WORKER_COUNT" "$PRESSURE_WORKER_COUNT" "$LLAMA_SWARM_MODEL")"
 step_args="$(jq -cn --arg s "$SESSION_ID" --arg a "$COORD_AGENT" --argjson batch "$spawn_batch_json" --argjson timeout "$SPAWN_TIMEOUT_SEC" \
   '{session_id:$s,actor:$a,spawn_batch:$batch,spawn_timeout_seconds:$timeout}')"
-step_raw="$(call_tool 93905 "masc_team_session_step" "$step_args")"
-require_tool_success "$step_raw"
+step_raw="$(mcp_call_tool 93905 "masc_team_session_step" "$step_args")"
+mcp_require_tool_ok "$step_raw"
 require_result_condition "$step_raw" '
   if .spawn == null then false
   else
@@ -273,8 +221,8 @@ echo "[5/8] wait for events to settle"
 sleep "$WAIT_AFTER_SPAWN_SEC"
 
 echo "[6/8] verify team session status visibility"
-status_raw="$(call_tool 93906 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-require_tool_success "$status_raw"
+status_raw="$(mcp_call_tool 93906 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
+mcp_require_tool_ok "$status_raw"
 require_result_condition "$status_raw" '
   .summary.scale_profile == "local64"
   and (.summary.planned_worker_count >= '"$WORKER_COUNT"')
@@ -286,8 +234,8 @@ require_result_condition "$status_raw" '
 ' "session status did not expose local64 pressure visibility"
 
 echo "[7/8] verify operator digest"
-digest_raw="$(call_tool 93907 "masc_operator_digest" '{"target_type":"room"}')"
-require_tool_success "$digest_raw"
+digest_raw="$(mcp_call_tool 93907 "masc_operator_digest" '{"target_type":"room"}')"
+mcp_require_tool_ok "$digest_raw"
 require_result_condition "$digest_raw" '
   ((.role_census.manager // 0) >= 1)
   and ((.role_census.metacog // 0) >= 1)
@@ -297,8 +245,8 @@ require_result_condition "$digest_raw" '
 ' "operator digest did not expose local64 census/runtime state"
 
 echo "[8/8] benchmark runtime pool"
-bench_raw="$(call_tool 93908 "masc_llama_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
-require_tool_success "$bench_raw"
+bench_raw="$(mcp_call_tool 93908 "masc_llama_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
+mcp_require_tool_ok "$bench_raw"
 require_result_condition "$bench_raw" '.total_requests >= 1 and .per_runtime_breakdown != null' "runtime bench did not return local64 breakdown"
 
 echo "PASS: local64 context chaos session=${SESSION_ID} workers=${WORKER_COUNT} pressure_workers=${PRESSURE_WORKER_COUNT}"

--- a/scripts/harness/workload/team_session_local64_soak.sh
+++ b/scripts/harness/workload/team_session_local64_soak.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SMOKE_SCRIPT="$ROOT_DIR/scripts/harness/workload/team_session_local64_smoke.sh"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8945/mcp}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 COORD_AGENT="${COORD_AGENT:-team-session-local64-soak}"
 WORKER_COUNT="${WORKER_COUNT:-8}"
 ROUNDS="${ROUNDS:-10}"
@@ -27,77 +28,25 @@ fi
 
 mkdir -p "$(dirname "$METRICS_FILE")"
 
-jsonrpc_call() {
-  local id="$1"
-  local method="$2"
-  local params="$3"
-  local raw
-  raw="$(curl -sS --http2-prior-knowledge --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}")"
-  jsonrpc_normalize_response "$raw" "$id"
-}
-
-call_tool() {
-  local id="$1"
-  local tool_name="$2"
-  local args_json="$3"
-  jsonrpc_call "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
-}
-
-extract_text() {
-  jq -r 'try (.result.content[0].text) catch empty'
-}
-
-extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "true"'
-}
-
-require_json() {
-  local payload="$1"
-  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid payload"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
-}
-
-require_tool_success() {
-  local payload="$1"
-  require_json "$payload"
-  local is_error
-  is_error="$(printf '%s' "$payload" | extract_is_error)"
-  if [ "$is_error" = "true" ]; then
-    echo "FAIL: tool returned isError=true"
-    printf '%s\n' "$payload" | extract_text
-    exit 1
-  fi
-}
-
 sample_running_session_count() {
   local raw
-  raw="$(call_tool 92001 "masc_team_session_list" '{"status":"running","limit":200}')"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_result | jq -r '.count // 0'
+  raw="$(mcp_call_tool 92001 "masc_team_session_list" '{"status":"running","limit":200}')"
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result | jq -r '.count // 0'
 }
 
 sample_allocated_slots() {
   local raw
-  raw="$(call_tool 92002 "masc_llama_runtime_status" '{"include_models":false}')"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_result | jq -r '.allocated_slots // 0'
+  raw="$(mcp_call_tool 92002 "masc_llama_runtime_status" '{"include_models":false}')"
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_result | jq -r '.allocated_slots // 0'
 }
 
 sample_zombie_cleanup_text() {
   local raw
-  raw="$(call_tool 92003 "masc_cleanup_zombies" '{}')"
-  require_tool_success "$raw"
-  printf '%s' "$raw" | extract_text
+  raw="$(mcp_call_tool 92003 "masc_cleanup_zombies" '{}')"
+  mcp_require_tool_ok "$raw"
+  printf '%s' "$raw" | mcp_extract_text
 }
 
 sample_rss_kb() {

--- a/scripts/harness/workload/team_session_soak.sh
+++ b/scripts/harness/workload/team_session_soak.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 AGENT_NAME="${AGENT_NAME:-team-session-soak}"
@@ -10,75 +10,46 @@ ROUNDS="${ROUNDS:-5}"
 DURATION_SEC="${DURATION_SEC:-120}"
 SLEEP_SEC="${SLEEP_SEC:-1}"
 MCP_SESSION_ID="${MCP_SESSION_ID:-team-session-soak-$(date +%s)-$RANDOM}"
-
-call_tool() {
-  local id="$1"
-  local name="$2"
-  local args_json="$3"
-  local raw
-  local sse_data
-  local attempts=0
-  local max_attempts=4
-  raw=""
-  while [ "$attempts" -lt "$max_attempts" ]; do
-    if raw="$(curl -sS --http2-prior-knowledge -m 25 -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -H "mcp-session-id: $MCP_SESSION_ID" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}" 2>/dev/null)"; then
-      break
-    fi
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  if [ -z "$raw" ]; then
-    echo "{\"error\":\"curl_failed\"}"
-    return 1
-  fi
-  jsonrpc_normalize_response "$raw" "$id"
-}
-
-extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
-}
+CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-4}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"
   exit 1
 fi
 
-_="$(call_tool 4201 "masc_init" "{\"agent_name\":\"$AGENT_NAME\"}")"
-_="$(call_tool 4202 "masc_join" "{\"agent_name\":\"$AGENT_NAME\",\"capabilities\":[\"soak\",\"team-session\"]}")"
+_="$(mcp_call_tool 4201 "masc_init" "{\"agent_name\":\"$AGENT_NAME\"}")"
+_="$(mcp_call_tool 4202 "masc_join" "{\"agent_name\":\"$AGENT_NAME\",\"capabilities\":[\"soak\",\"team-session\"]}")"
 
 success=0
 failure=0
 for i in $(seq 1 "$ROUNDS"); do
   echo "[soak] round=$i/$ROUNDS"
   start_args="$(jq -cn --arg goal "soak-round-$i" --argjson duration "$DURATION_SEC" '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:10,min_agents:1,orchestration_mode:"assist",communication_mode:"hybrid",model_cascade:["glm:auto"],fallback_policy:"cascade_then_task",instruction_profile:"standard",alert_channel:"both"}')"
-  start_raw="$(call_tool $((4300 + i)) "masc_team_session_start" "$start_args")"
-  session_id="$(printf "%s" "$start_raw" | extract_result | jq -r '.session_id // empty')"
+  start_raw="$(mcp_call_tool $((4300 + i)) "masc_team_session_start" "$start_args")"
+  session_id="$(printf "%s" "$start_raw" | mcp_extract_result | jq -r '.session_id // empty')"
   if [ -z "$session_id" ]; then
     echo "[soak] FAIL start round=$i"
     failure=$((failure + 1))
     continue
   fi
 
-  status_raw="$(call_tool $((4400 + i)) "masc_team_session_status" "{\"session_id\":\"$session_id\"}")"
-  if ! printf "%s" "$status_raw" | extract_result | jq -e '.team_health and .communication_metrics and .cascade_metrics and .inference_cache_metrics' >/dev/null 2>&1; then
+  status_raw="$(mcp_call_tool $((4400 + i)) "masc_team_session_status" "{\"session_id\":\"$session_id\"}")"
+  if ! printf "%s" "$status_raw" | mcp_extract_result | jq -e '.team_health and .communication_metrics and .cascade_metrics and .inference_cache_metrics' >/dev/null 2>&1; then
     echo "[soak] FAIL status round=$i session=$session_id"
     failure=$((failure + 1))
     continue
   fi
 
-  _="$(call_tool $((4500 + i)) "masc_team_session_stop" "{\"session_id\":\"$session_id\",\"reason\":\"soak_round_done\",\"generate_report\":false}")"
+  _="$(mcp_call_tool $((4500 + i)) "masc_team_session_stop" "{\"session_id\":\"$session_id\",\"reason\":\"soak_round_done\",\"generate_report\":false}")"
   success=$((success + 1))
   sleep "$SLEEP_SEC"
 done
 
-list_raw="$(call_tool 4998 "masc_team_session_list" "{\"limit\":50}")"
-count="$(printf "%s" "$list_raw" | extract_result | jq -r '.count // 0')"
+list_raw="$(mcp_call_tool 4998 "masc_team_session_list" "{\"limit\":50}")"
+count="$(printf "%s" "$list_raw" | mcp_extract_result | jq -r '.count // 0')"
 
-_="$(call_tool 4999 "masc_leave" "{\"agent_name\":\"$AGENT_NAME\"}")"
+_="$(mcp_call_tool 4999 "masc_leave" "{\"agent_name\":\"$AGENT_NAME\"}")"
 
 echo "[soak] success=$success failure=$failure listed_sessions=$count"
 if [ "$failure" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Migrate 6 harness workload scripts from direct `jsonrpc_sse.sh` to `mcp_jsonrpc.sh`
- Eliminates duplicate `jsonrpc_call`, `call_tool`, `extract_*`, `require_*` implementations
- Fixes missing `_harness_error` guards in extract functions (transport errors were silently passing through)
- Fixes `extract_result` not unwrapping nested `.result` in `team_session_soak.sh`

## Migration scope

| File | Migration | Removed |
|------|-----------|---------|
| `team_session_local64_chaos.sh` | Full | jsonrpc_call, call_tool, extract_*, require_* |
| `team_session_local64_context_chaos.sh` | Full | Same |
| `team_session_local64_soak.sh` | Full | Same |
| `team_session_soak.sh` | Full | call_tool (retry curl), extract_result |
| `coding_worker_quickwin.sh` | Partial | require_*, extract_* helpers only |
| `keeper_continuity_validation.sh` | Source path | LAST_TOOL_* globals prevent full migration |

**Not migrated**: `mcp_readpath_revalidation.sh` (requires `curl -w '%{time_total}'` for latency measurement)

## Net change
-248 LOC across 6 files

## Test plan
- [x] `bash -n` syntax check on all 6 files
- [ ] CI build + test
- [ ] CI contract harness

Closes #4138

🤖 Generated with [Claude Code](https://claude.com/claude-code)