### PR TITLE
fix(tui): make legacy keeper fields optional in decode_keeper

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -525,7 +525,7 @@ let render_keeper_list (state : state) =
       if idx < List.length state.keepers then begin
         let k = List.nth state.keepers idx in
         let is_selected = idx = state.keeper_cursor in
-        let model_short = short_model k.k_active_model in
+        let model_short = short_model (Option.value ~default:"-" k.k_active_model) in
         let proactive_str = if k.k_proactive_enabled then
           Ansi.green ^ "on" ^ Ansi.reset
         else
@@ -641,7 +641,7 @@ let render_keeper_detail (state : state) =
 
     (* Model section *)
     add_section "Model";
-    add_row "Active Model:" k.k_active_model;
+    add_row "Active Model:" (Option.value ~default:"-" k.k_active_model);
     add_row "Available:" (String.concat ", " k.k_models);
     add_empty ();
 
@@ -660,7 +660,7 @@ let render_keeper_detail (state : state) =
     (* Behavior section *)
     add_section "Behavior";
     add_row "Proactive:" (bool_indicator k.k_proactive_enabled);
-    add_row "Initiative:" (bool_indicator k.k_initiative_enabled);
+    add_row "Initiative:" (bool_indicator (Option.value ~default:false k.k_initiative_enabled));
     add_row "Drift:" (bool_indicator k.k_drift_enabled);
     add_empty ();
 

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -158,11 +158,17 @@ let decode_keeper ~filename json =
   let* k_soul_profile = require_string_field json "soul_profile" in
   let* k_generation = require_int_field json "generation" in
   let* k_active_model = optional_string json "active_model" in
-  let k_models =
+  let* k_models =
     match member "models" json with
+    | `Null -> Ok []
     | `List items ->
-        List.filter_map (function `String s -> Some s | _ -> None) items
-    | _ -> []
+        let rec collect acc = function
+          | [] -> Ok (List.rev acc)
+          | `String s :: rest -> collect (s :: acc) rest
+          | _ -> Error "field 'models' must be a list of strings"
+        in
+        collect [] items
+    | _ -> Error "field 'models' must be a list of strings or null"
   in
   let* k_proactive_enabled = require_bool_field json "proactive_enabled" in
   let* k_initiative_enabled = optional_bool json "initiative_enabled" in
@@ -172,7 +178,7 @@ let decode_keeper ~filename json =
   let* k_last_turn_ts =
     match member "last_turn_ts" json with
     | `String s -> Ok s
-    | `Float f -> Ok (Printf.sprintf "%.0f" f)
+    | `Float f -> Ok (string_of_int (int_of_float f))
     | `Int n -> Ok (string_of_int n)
     | `Null -> Ok ""
     | _ -> Error "field 'last_turn_ts' must be a string or number"

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -21,10 +21,10 @@ type keeper = {
   k_short_goal : string;
   k_soul_profile : string;
   k_generation : int;
-  k_active_model : string;
+  k_active_model : string option;
   k_models : string list;
   k_proactive_enabled : bool;
-  k_initiative_enabled : bool;
+  k_initiative_enabled : bool option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;
@@ -157,14 +157,26 @@ let decode_keeper ~filename json =
   let* k_short_goal = require_string_field json "short_goal" in
   let* k_soul_profile = require_string_field json "soul_profile" in
   let* k_generation = require_int_field json "generation" in
-  let* k_active_model = require_string_field json "active_model" in
-  let* k_models = require_string_list json "models" in
+  let* k_active_model = optional_string json "active_model" in
+  let k_models =
+    match member "models" json with
+    | `List items ->
+        List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> []
+  in
   let* k_proactive_enabled = require_bool_field json "proactive_enabled" in
-  let* k_initiative_enabled = require_bool_field json "initiative_enabled" in
+  let* k_initiative_enabled = optional_bool json "initiative_enabled" in
   let* k_total_turns = require_int_field json "total_turns" in
   let* k_total_tokens = require_int_field json "total_tokens" in
   let* k_total_cost_usd = require_float_field json "total_cost_usd" in
-  let* k_last_turn_ts = require_string_field json "last_turn_ts" in
+  let* k_last_turn_ts =
+    match member "last_turn_ts" json with
+    | `String s -> Ok s
+    | `Float f -> Ok (Printf.sprintf "%.0f" f)
+    | `Int n -> Ok (string_of_int n)
+    | `Null -> Ok ""
+    | _ -> Error "field 'last_turn_ts' must be a string or number"
+  in
   let* k_compaction_count = require_int_field json "compaction_count" in
   let* k_compaction_ratio_gate = require_float_field json "compaction_ratio_gate" in
   let* k_scope_kind = require_string_field json "scope_kind" in

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -19,10 +19,10 @@ type keeper = {
   k_short_goal : string;
   k_soul_profile : string;
   k_generation : int;
-  k_active_model : string;
+  k_active_model : string option;
   k_models : string list;
   k_proactive_enabled : bool;
-  k_initiative_enabled : bool;
+  k_initiative_enabled : bool option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -38,6 +38,84 @@ let test_decode_task_missing_priority_defaults () =
   | Ok task -> Alcotest.(check int) "default priority" 3 task.priority
   | Error err -> Alcotest.fail err
 
+let keeper_json ?(models = `List [ `String "glm-5.1" ]) ?(last_turn_ts = `String "1700000000")
+    ?(active_model = Some (`String "glm-5.1"))
+    ?(initiative_enabled = Some (`Bool true)) () =
+  let optional_field key = function
+    | Some value -> [ (key, value) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("goal", `String "keep the system healthy");
+       ("short_goal", `String "stay responsive");
+       ("soul_profile", `String "balanced");
+       ("generation", `Int 2);
+       ("models", models);
+       ("proactive_enabled", `Bool true);
+       ("total_turns", `Int 4);
+       ("total_tokens", `Int 120);
+       ("total_cost_usd", `Float 0.42);
+       ("last_turn_ts", last_turn_ts);
+       ("compaction_count", `Int 1);
+       ("compaction_ratio_gate", `Float 0.8);
+       ("scope_kind", `String "global");
+       ("room_scope", `String "masc");
+       ("trigger_mode", `String "mention");
+       ("context_budget", `Int 32000);
+       ("handoff_threshold", `Float 0.85);
+       ("drift_enabled", `Bool true);
+       ("verify", `Bool true);
+       ("created_at", `String "2026-03-31T12:00:00Z");
+       ("updated_at", `String "2026-03-31T12:05:00Z");
+     ]
+    @ optional_field "active_model" active_model
+    @ optional_field "initiative_enabled" initiative_enabled)
+
+let test_decode_keeper_missing_legacy_fields_defaults_to_none () =
+  match
+    Tui_decode.decode_keeper ~filename:"keeper-main.json"
+      (keeper_json ~active_model:None ~initiative_enabled:None ())
+  with
+  | Ok keeper ->
+      Alcotest.(check string) "filename fallback" "keeper-main" keeper.k_name;
+      Alcotest.(check (option string)) "missing active_model" None
+        keeper.k_active_model;
+      Alcotest.(check (option bool)) "missing initiative_enabled" None
+        keeper.k_initiative_enabled
+  | Error err -> Alcotest.fail err
+
+let test_decode_keeper_numeric_last_turn_ts_truncates () =
+  match
+    Tui_decode.decode_keeper ~filename:"keeper-main.json"
+      (keeper_json ~last_turn_ts:(`Float 1700000000.9) ())
+  with
+  | Ok keeper ->
+      Alcotest.(check string) "float timestamp truncates" "1700000000"
+        keeper.k_last_turn_ts
+  | Error err -> Alcotest.fail err
+
+let test_decode_keeper_null_last_turn_ts_is_empty () =
+  match
+    Tui_decode.decode_keeper ~filename:"keeper-main.json"
+      (keeper_json ~last_turn_ts:`Null ())
+  with
+  | Ok keeper ->
+      Alcotest.(check string) "null timestamp becomes empty" "" keeper.k_last_turn_ts
+  | Error err -> Alcotest.fail err
+
+let test_decode_keeper_rejects_invalid_models_type () =
+  Alcotest.(check bool) "invalid models rejected" true
+    (Result.is_error
+       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
+          (keeper_json ~models:(`String "glm-5.1") ())))
+
+let test_decode_keeper_rejects_non_string_model_items () =
+  Alcotest.(check bool) "non-string model entries rejected" true
+    (Result.is_error
+       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
+          (keeper_json ~models:(`List [ `String "glm-5.1"; `Int 7 ]) ())))
+
 let test_parse_log_entry_success () =
   let line =
     Yojson.Safe.to_string
@@ -169,6 +247,19 @@ let () =
       [
         Alcotest.test_case "missing priority defaults" `Quick
           test_decode_task_missing_priority_defaults;
+      ] );
+    ( "decode_keeper",
+      [
+        Alcotest.test_case "missing legacy fields default to none" `Quick
+          test_decode_keeper_missing_legacy_fields_defaults_to_none;
+        Alcotest.test_case "numeric last_turn_ts truncates" `Quick
+          test_decode_keeper_numeric_last_turn_ts_truncates;
+        Alcotest.test_case "null last_turn_ts is empty" `Quick
+          test_decode_keeper_null_last_turn_ts_is_empty;
+        Alcotest.test_case "rejects invalid models type" `Quick
+          test_decode_keeper_rejects_invalid_models_type;
+        Alcotest.test_case "rejects non-string model items" `Quick
+          test_decode_keeper_rejects_non_string_model_items;
       ] );
     ( "parse_log_entry",
       [


### PR DESCRIPTION
## Summary
- `decode_keeper`에서 legacy 필드 3개를 optional로 전환
- `last_turn_ts` float/string 양쪽 수용

## Root Cause
PR #4137에서 `decode_keeper`가 `require_*` 함수로 `active_model`, `models`, `initiative_enabled`를 파싱하지만, 이 필드들은 `keeper_types.ml:200`에서 legacy로 표시되어 있고 오래된 keeper JSON에는 없을 수 있음.

## Changes
| 필드 | Before | After |
|------|--------|-------|
| `active_model` | `require_string` | `optional_string` (→ `string option`) |
| `models` | `require_string_list` | `filter_map` with `[]` fallback |
| `initiative_enabled` | `require_bool` | `optional_bool` (→ `bool option`) |
| `last_turn_ts` | `require_string` | accept `string\|float\|int\|null` |

## Test plan
- [ ] CI Build and Test pass
- [ ] TUI loads keeper meta from old JSON files without error

Closes #4144

🤖 Generated with [Claude Code](https://claude.com/claude-code)