### PR TITLE
fix(keeper): normalize tool results to consistent JSON envelope

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -86,6 +86,63 @@ let keeper_tool_result_is_failure (result : string) : bool =
     has_error_field || has_error_status || has_ok_false
   with Yojson.Json_error _ -> false
 
+(** Normalize a raw tool result string into a consistent JSON envelope.
+
+    The LLM sees this output directly. Without normalization, tool results
+    use 6+ different schemas ({ok,error,status,...} in various combinations),
+    making it hard for the LLM to parse success/failure reliably.
+
+    After normalization, all results follow:
+    - Success: [{"ok": true, "result": <original_json_or_string>}]
+    - Failure: [{"ok": false, "error": <message>, "detail": <original_json>}]
+
+    The [success] flag comes from [keeper_tool_result_is_failure], which
+    already handles all legacy schema variants. *)
+let normalize_tool_result ~(success : bool) (raw : string) : string =
+  try
+    let json = Yojson.Safe.from_string raw in
+    if success then
+      (* Success: wrap original JSON under "result" key.
+         If original already has "ok":true, the normalized envelope
+         is still consistent — "ok" at the top level is authoritative. *)
+      Yojson.Safe.to_string (`Assoc [
+        ("ok", `Bool true);
+        ("result", json);
+      ])
+    else
+      (* Failure: extract error message from whichever field is present,
+         preserve original JSON as "detail" for debugging. *)
+      let error_msg =
+        match Safe_ops.json_string_opt "error" json with
+        | Some msg when String.trim msg <> "" -> msg
+        | _ ->
+          match Safe_ops.json_string_opt "message" json with
+          | Some msg when String.trim msg <> "" -> msg
+          | _ ->
+            match Safe_ops.json_string_opt "status" json with
+            | Some s when String.lowercase_ascii (String.trim s) = "error" ->
+              "tool returned error status"
+            | _ -> "tool call failed"
+      in
+      Yojson.Safe.to_string (`Assoc [
+        ("ok", `Bool false);
+        ("error", `String error_msg);
+        ("detail", json);
+      ])
+  with Yojson.Json_error _ ->
+    (* Raw is not JSON (e.g. plain text from keeper_tasks_list).
+       Wrap as-is. *)
+    if success then
+      Yojson.Safe.to_string (`Assoc [
+        ("ok", `Bool true);
+        ("result", `String raw);
+      ])
+    else
+      Yojson.Safe.to_string (`Assoc [
+        ("ok", `Bool false);
+        ("error", `String raw);
+      ])
+
 let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -119,9 +176,10 @@ let make_tools
           if prior_fails >= max_consecutive_failures then begin
             Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
               td.name prior_fails;
-            (false, Printf.sprintf
+            let msg = Printf.sprintf
               "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
-              prior_fails)
+              prior_fails in
+            (false, normalize_tool_result ~success:false msg)
           end else
             try
               let result =
@@ -129,27 +187,29 @@ let make_tools
                   ~config ~meta ~ctx_work:(!ctx_ref)
                   ~name:td.name ~input
               in
-              if keeper_tool_result_is_failure result then begin
+              let is_failure = keeper_tool_result_is_failure result in
+              if is_failure then begin
                 let count = prior_fails + 1 in
                 Hashtbl.replace failure_counts key count;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 Log.Keeper.warn
                   "tool %s returned error result (%d/%d) for same args"
                   td.name count max_consecutive_failures;
-                (false, result)
+                (false, normalize_tool_result ~success:false result)
               end else begin
                 Hashtbl.remove failure_counts key;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
                 (* PR#814 Gap 1: Capture git status delta after successful tool execution.
                    If the working tree changed, log it so the keeper is aware of
                    file-system side effects from its tool calls. *)
+                let base_result = normalize_tool_result ~success:true result in
                 (match Worktree_live_context.capture_change_block
                          ~base_path:config.base_path ~actor_key:meta.name with
                  | Some change_block ->
                      Log.Keeper.info "post-tool git delta detected for %s after %s"
                        meta.name td.name;
-                     (true, result ^ "\n" ^ change_block)
-                 | None -> (true, result))
+                     (true, base_result ^ "\n" ^ change_block)
+                 | None -> (true, base_result))
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               let count = prior_fails + 1 in
@@ -159,6 +219,6 @@ let make_tools
                 td.name count max_consecutive_failures
                 (Printexc.to_string exn) in
               Log.Keeper.error "%s" msg;
-              (false, msg)))
+              (false, normalize_tool_result ~success:false msg)))
     else None
   ) tool_defs

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -132,10 +132,14 @@ let test_error_json_is_returned_as_tool_error () =
       with
       | Error { Agent_sdk.Types.message; _ } ->
           let json = Yojson.Safe.from_string message in
-          check bool "error field preserved" true
+          (* After normalization, error results follow {"ok":false,"error":"...","detail":{...}} *)
+          check bool "ok is false" false
+            (Yojson.Safe.Util.(member "ok" json |> to_bool));
+          check bool "error field present" true
             (Option.is_some (Safe_ops.json_string_opt "error" json));
-          check bool "path field preserved" true
-            (Option.is_some (Safe_ops.json_string_opt "path" json))
+          let detail = Yojson.Safe.Util.member "detail" json in
+          check bool "detail preserves path" true
+            (Option.is_some (Safe_ops.json_string_opt "path" detail))
       | Ok _ -> fail "missing file should be surfaced as tool error")
 
 let test_repeated_error_results_are_blocked () =
@@ -373,6 +377,64 @@ let test_library_read_missing_topic () =
     (`Assoc [("topic", `String "nonexistent-topic-xyz-999")]) in
   check bool "missing topic fails" false ok
 
+(* ── normalize_tool_result tests ──────────────────────────── *)
+
+let parse json_str =
+  Yojson.Safe.from_string json_str
+
+let json_bool key json =
+  Yojson.Safe.Util.(member key json |> to_bool)
+
+let json_string key json =
+  Yojson.Safe.Util.(member key json |> to_string)
+
+let test_normalize_success_json () =
+  let raw = {|{"ok":true,"path":"/tmp/a.ml","bytes":42}|} in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:true raw in
+  let json = parse normalized in
+  check bool "ok is true" true (json_bool "ok" json);
+  let result = Yojson.Safe.Util.member "result" json in
+  check string "path preserved" "/tmp/a.ml"
+    Yojson.Safe.Util.(member "path" result |> to_string)
+
+let test_normalize_success_plain_text () =
+  let raw = "📋 No tasks yet." in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:true raw in
+  let json = parse normalized in
+  check bool "ok is true" true (json_bool "ok" json);
+  check string "result is text" "📋 No tasks yet." (json_string "result" json)
+
+let test_normalize_failure_error_field () =
+  let raw = {|{"error":"file not found","path":"/tmp/missing"}|} in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check string "error extracted" "file not found" (json_string "error" json);
+  let detail = Yojson.Safe.Util.member "detail" json in
+  check string "detail preserves path" "/tmp/missing"
+    Yojson.Safe.Util.(member "path" detail |> to_string)
+
+let test_normalize_failure_status_error () =
+  let raw = {|{"status":"error","agent_id":"v1","message":"voice unavailable"}|} in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check string "error from message" "voice unavailable" (json_string "error" json)
+
+let test_normalize_failure_ok_false () =
+  let raw = {|{"ok":false,"error":"command_blocked","reason":"not in allowlist"}|} in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check string "error extracted" "command_blocked" (json_string "error" json)
+
+let test_normalize_failure_plain_text () =
+  let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check string "error is raw text" raw (json_string "error" json)
+
 let () =
   run "Keeper_tools_oas" [
     "make_tools", [
@@ -383,6 +445,14 @@ let () =
       test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;
       test_case "failure count resets after success" `Quick test_failure_count_resets_after_success;
       test_case "failure tracking is independent per args" `Quick test_failure_tracking_is_independent_per_args;
+    ];
+    "normalize_tool_result", [
+      test_case "success JSON wraps under result" `Quick test_normalize_success_json;
+      test_case "success plain text wraps as string" `Quick test_normalize_success_plain_text;
+      test_case "failure extracts error field" `Quick test_normalize_failure_error_field;
+      test_case "failure extracts message from status:error" `Quick test_normalize_failure_status_error;
+      test_case "failure handles ok:false hybrid" `Quick test_normalize_failure_ok_false;
+      test_case "failure plain text wraps as error" `Quick test_normalize_failure_plain_text;
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;


### PR DESCRIPTION
## Summary
Keeper tool 결과가 6+ 가지 JSON 스키마를 혼용하여 LLM이 성공/실패를 안정적으로 파싱하지 못하는 문제 수정.

`keeper_tools_oas.ml`의 OAS 경계에서 `normalize_tool_result`로 모든 결과를 일관된 형식으로 정규화:
- 성공: `{"ok": true, "result": <원본 JSON/텍스트>}`
- 실패: `{"ok": false, "error": "<메시지>", "detail": <원본 JSON>}`

4개 출구 경로 전부 적용 (성공, 실패 감지, 예외, guardrail 차단).
원본 데이터는 `result`/`detail` 필드에 보존.

## 변경 파일
- `lib/keeper/keeper_tools_oas.ml` — `normalize_tool_result` 함수 추가 + 4개 경로 적용
- `test/test_keeper_tools_oas.ml` — 6개 단위 테스트 추가, 기존 테스트 정규화 형식 반영

## Test plan
- [x] 20 tests pass (기존 14 + 신규 6)
- [x] `dune build --root .` pass
- [ ] CI checks

Closes #4102

🤖 Generated with [Claude Code](https://claude.com/claude-code)