### PR TITLE
refactor(harness): migrate last two scripts off direct jsonrpc_sse

### DIFF
--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -9,6 +9,8 @@
 : "${HARNESS_LOG_FILE:=}"
 : "${HARNESS_LOG_TAIL_LINES:=120}"
 : "${MCP_CURL_EXTRA_ARGS:=}"
+: "${MCP_PROTOCOL_VERSION:=}"
+MCP_LAST_TIME_TOTAL=""
 
 _HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/harness/jsonrpc_sse.sh
@@ -187,6 +189,7 @@ mcp_jsonrpc_call() {
 
   local request_body
   if ! request_body="$(_mcp_build_request_body "$id" "$method" "$params_json" 2>/dev/null)"; then
+    MCP_LAST_TIME_TOTAL=""
     _mcp_build_transport_error \
       "failed to build JSON-RPC request" \
       "$endpoint" \
@@ -208,19 +211,25 @@ mcp_jsonrpc_call() {
   fi
 
   while :; do
-    local body_file stderr_file
+    local body_file stderr_file resp_file
     body_file="$(mcp_mktemp_file "masc-jsonrpc-body" ".json")"
     stderr_file="$(mcp_mktemp_file "masc-jsonrpc-stderr" ".log")"
+    resp_file="$(mcp_mktemp_file "masc-jsonrpc-resp" ".json")"
     printf '%s' "$request_body" >"$body_file"
 
     local -a cmd=(
       curl -sS --max-time "$timeout_sec"
       -X POST "$endpoint"
+      -o "$resp_file"
+      -w '%{time_total}'
       -H 'Content-Type: application/json'
       -H 'Accept: application/json, text/event-stream'
     )
     if [[ -n "$session_id" ]]; then
       cmd+=( -H "Mcp-Session-Id: $session_id" )
+    fi
+    if [[ -n "${MCP_PROTOCOL_VERSION:-}" ]]; then
+      cmd+=( -H "Mcp-Protocol-Version: $MCP_PROTOCOL_VERSION" )
     fi
     if [[ -n "$token" ]]; then
       cmd+=( -H "Authorization: Bearer $token" )
@@ -231,11 +240,12 @@ mcp_jsonrpc_call() {
     cmd+=( --data-binary "@$body_file" )
 
     set +e
-    raw="$("${cmd[@]}" 2>"$stderr_file")"
+    MCP_LAST_TIME_TOTAL="$("${cmd[@]}" 2>"$stderr_file")"
     status=$?
     set -e
     stderr_text="$(cat "$stderr_file" 2>/dev/null || true)"
-    rm -f "$body_file" "$stderr_file"
+    raw="$(cat "$resp_file" 2>/dev/null || true)"
+    rm -f "$body_file" "$stderr_file" "$resp_file"
 
     if [[ "$status" -eq 0 ]]; then
       jsonrpc_normalize_response "$raw" "$id"

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -143,34 +143,25 @@ call_mcp_tool() {
   local tool_name="$2"
   local args_json="$3"
   local timeout_sec="${4:-$TURN_TIMEOUT_SEC}"
-  local raw payload error text
 
-  payload="$(jq -cn \
-    --argjson id "$req_id" \
-    --arg tool "$tool_name" \
-    --argjson args "$args_json" \
-    '{jsonrpc:"2.0",id:$id,method:"tools/call",params:{name:$tool,arguments:$args}}')"
+  local saved_timeout="${HTTP_TIMEOUT_SEC:-}"
+  HTTP_TIMEOUT_SEC="$timeout_sec"
+  LAST_TOOL_RAW="$(mcp_call_tool "$req_id" "$tool_name" "$args_json")"
+  HTTP_TIMEOUT_SEC="${saved_timeout:-$CURL_TIMEOUT_SEC}"
 
-  if ! raw="$(curl -sS --http2-prior-knowledge -m "$timeout_sec" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d "$payload")"; then
-    LAST_TOOL_RAW=""
-    LAST_TOOL_ERROR="curl failed for $tool_name"
+  if printf '%s' "$LAST_TOOL_RAW" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
+    LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '._harness_error.message // "transport error"')"
     return 1
   fi
 
-  raw="$(jsonrpc_normalize_response "$raw" "$req_id")"
-  error="$(printf '%s' "$raw" | jq -r '
+  LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '
     if .error?.message then .error.message
     elif (.result?.isError // false) == true then
       ([.result.content[]? | select(.type == "text") | .text] | join(" "))
     else empty end
   ' 2>/dev/null | awk 'NF { print; exit }')"
 
-  LAST_TOOL_RAW="$raw"
-  LAST_TOOL_ERROR="$error"
-  if [[ -n "$error" ]]; then
+  if [[ -n "$LAST_TOOL_ERROR" ]]; then
     return 1
   fi
   return 0

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -147,7 +147,7 @@ call_mcp_tool() {
   local saved_timeout="${HTTP_TIMEOUT_SEC:-}"
   HTTP_TIMEOUT_SEC="$timeout_sec"
   LAST_TOOL_RAW="$(mcp_call_tool "$req_id" "$tool_name" "$args_json")"
-  HTTP_TIMEOUT_SEC="${saved_timeout:-$CURL_TIMEOUT_SEC}"
+  HTTP_TIMEOUT_SEC="$saved_timeout"
 
   if printf '%s' "$LAST_TOOL_RAW" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
     LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '._harness_error.message // "transport error"')"

--- a/scripts/harness/workload/mcp_readpath_revalidation.sh
+++ b/scripts/harness/workload/mcp_readpath_revalidation.sh
@@ -186,7 +186,7 @@ call_tool() {
   MCP_PROTOCOL_VERSION="$protocol_version"
   local response
   response="$(mcp_call_tool "$request_id" "$tool_name" "$args_json" "$session_id" "" "$mcp_url")"
-  HTTP_TIMEOUT_SEC="${saved_timeout:-$CURL_TIMEOUT_SEC}"
+  HTTP_TIMEOUT_SEC="$saved_timeout"
   MCP_PROTOCOL_VERSION="$saved_proto"
 
   LAST_TIME_TOTAL="$MCP_LAST_TIME_TOTAL"

--- a/scripts/harness/workload/mcp_readpath_revalidation.sh
+++ b/scripts/harness/workload/mcp_readpath_revalidation.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-source "$REPO_ROOT/scripts/harness/jsonrpc_sse.sh"
+source "$REPO_ROOT/scripts/harness/lib/mcp_jsonrpc.sh"
 source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
 
 RUN_ID="${RUN_ID:-mcp-readpath-$(date +%Y%m%d_%H%M%S)-$$}"
@@ -180,30 +180,24 @@ call_tool() {
   local request_id="$4"
   local tool_name="$5"
   local args_json="$6"
-  local headers_file body_file raw response
-  local -a curl_headers
 
-  headers_file="$(harness_mktemp_file mcp-call .headers)"
-  body_file="$(harness_mktemp_file mcp-call .body)"
-  curl_headers=(
-    -H 'Content-Type: application/json'
-    -H 'Accept: application/json, text/event-stream'
-    -H "Mcp-Session-Id: $session_id"
-  )
-  if [[ -n "$protocol_version" ]]; then
-    curl_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  local saved_timeout="${HTTP_TIMEOUT_SEC:-}" saved_proto="${MCP_PROTOCOL_VERSION:-}"
+  HTTP_TIMEOUT_SEC="$TOOL_TIMEOUT_SEC"
+  MCP_PROTOCOL_VERSION="$protocol_version"
+  local response
+  response="$(mcp_call_tool "$request_id" "$tool_name" "$args_json" "$session_id" "" "$mcp_url")"
+  HTTP_TIMEOUT_SEC="${saved_timeout:-$CURL_TIMEOUT_SEC}"
+  MCP_PROTOCOL_VERSION="$saved_proto"
+
+  LAST_TIME_TOTAL="$MCP_LAST_TIME_TOTAL"
+  LAST_RESPONSE="$response"
+
+  if printf '%s' "$response" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
+    LAST_TEXT=""
+    LAST_ERROR="$(printf '%s' "$response" | jq -r '._harness_error.message // "transport error"')"
+    return 1
   fi
 
-  LAST_TIME_TOTAL="$(
-    curl -sS --max-time "$TOOL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" \
-      -w '%{time_total}' \
-      -X POST "$mcp_url" \
-      "${curl_headers[@]}" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":${request_id},\"method\":\"tools/call\",\"params\":{\"name\":\"${tool_name}\",\"arguments\":${args_json}}}"
-  )"
-  raw="$(cat "$body_file")"
-  response="$(jsonrpc_normalize_response "$raw" "$request_id")"
-  LAST_RESPONSE="$response"
   LAST_TEXT="$(printf '%s' "$response" | jq -r '[.result.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null || true)"
   LAST_ERROR="$(printf '%s' "$response" | jq -r '
     if .error?.message then .error.message
@@ -211,7 +205,6 @@ call_tool() {
       ([.result.content[]? | select(.type == "text") | .text] | join(" "))
     else "" end
   ' 2>/dev/null || true)"
-  rm -f "$headers_file" "$body_file"
   [[ -z "$LAST_ERROR" ]]
 }
 


### PR DESCRIPTION
## Summary

- `mcp_jsonrpc.sh`에 `MCP_LAST_TIME_TOTAL` timing capture 추가 (`curl -w '%{time_total}'` + `-o resp_file`)
- `MCP_PROTOCOL_VERSION` 헤더 지원 추가 (readpath 스크립트의 protocol version 전달용)
- `keeper_continuity_validation.sh`: 자체 curl + `--http2-prior-knowledge` 제거, `mcp_call_tool()` 위임으로 전환
- `mcp_readpath_revalidation.sh`: `jsonrpc_sse.sh` 직접 source 제거, `mcp_call_tool()` + timing으로 전환

이로써 모든 harness workload 스크립트가 shared transport layer(`lib/mcp_jsonrpc.sh`)를 사용.
`jsonrpc_sse.sh` 직접 consumer는 `lib/mcp_jsonrpc.sh`와 `lib/test_framework.sh`만 남음.

## Changes

| File | Change |
|------|--------|
| `scripts/harness/lib/mcp_jsonrpc.sh` | `MCP_LAST_TIME_TOTAL`, `MCP_PROTOCOL_VERSION` 추가, curl에 `-o`/`-w` |
| `scripts/harness/workload/keeper_continuity_validation.sh` | `call_mcp_tool()` → `mcp_call_tool()` 위임 |
| `scripts/harness/workload/mcp_readpath_revalidation.sh` | source path + `call_tool()` → `mcp_call_tool()` 위임 |

## Test plan

- [x] shellcheck: no new warnings
- [x] bash -n: all 3 files syntax valid
- [ ] CI: Contract Harness, Lint, Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)