### PR TITLE
fix(keeper): validate tool_access.tools field type

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -176,7 +176,7 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
         | `List l ->
             Ok (List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l)
         | `Null -> Ok []
-        | _ -> Error "tool_access.tools must be an array"
+        | _ -> Error "tool_access.tools must be an array or null"
       in
       match tools with
       | Error msg -> Error msg

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -171,14 +171,23 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
       let kind =
         Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
       in
-      let tools = Safe_ops.json_string_list "tools" access_json in
-      match kind with
-      | Some "unrestricted" -> Ok Unrestricted
-      | Some "restricted" ->
-          Ok (normalize_tool_access (Restricted tools))
-      | Some other ->
-          Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
-      | None -> Error "keeper tool_access.kind required")
+      let tools =
+        match Yojson.Safe.Util.member "tools" access_json with
+        | `List l ->
+            Ok (List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l)
+        | `Null -> Ok []
+        | _ -> Error "tool_access.tools must be an array"
+      in
+      match tools with
+      | Error msg -> Error msg
+      | Ok tools -> (
+          match kind with
+          | Some "unrestricted" -> Ok Unrestricted
+          | Some "restricted" ->
+              Ok (normalize_tool_access (Restricted tools))
+          | Some other ->
+              Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+          | None -> Error "keeper tool_access.kind required"))
   | _ -> Error "keeper tool_access must be an object"
 
 (* -- Updater helpers for nested record updates -- *)

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -136,6 +136,7 @@ val now_iso : unit -> string
 
 val tool_access_allowlist : tool_access -> string list
 val tool_access_to_json : tool_access -> Yojson.Safe.t
+val tool_access_of_meta_json : Yojson.Safe.t -> (tool_access, string) result
 
 (** {1 Updater helpers for nested record updates} *)
 

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -440,4 +440,51 @@ let () =
         check bool "non-empty" true (n > 0);
         check bool "5-30 range" true (n >= 5 && n <= 30));
     ]);
+    ("tool_access_of_meta_json_validation", [
+      test_case "string tools field returns error" `Quick (fun () ->
+        let json = `Assoc [
+          ("kind", `String "restricted");
+          ("tools", `String "masc_status")
+        ] in
+        let outer = `Assoc [("tool_access", json)] in
+        match Keeper_types.tool_access_of_meta_json outer with
+        | Error msg ->
+            check bool "mentions array" true
+              (String.length msg > 0 &&
+               (try ignore (Str.search_forward (Str.regexp_string "array") msg 0); true
+                with Not_found -> false))
+        | Ok _ -> fail "expected Error for string tools field");
+      test_case "valid list tools parses ok" `Quick (fun () ->
+        let json = `Assoc [
+          ("kind", `String "restricted");
+          ("tools", `List [`String "masc_status"; `String "masc_broadcast"])
+        ] in
+        let outer = `Assoc [("tool_access", json)] in
+        match Keeper_types.tool_access_of_meta_json outer with
+        | Ok (Restricted tools) ->
+            check bool "has masc_status" true (List.mem "masc_status" tools);
+            check bool "has masc_broadcast" true (List.mem "masc_broadcast" tools)
+        | Ok Unrestricted -> fail "expected Restricted"
+        | Error msg -> fail ("unexpected error: " ^ msg));
+      test_case "null tools field defaults to empty" `Quick (fun () ->
+        let json = `Assoc [
+          ("kind", `String "restricted");
+          ("tools", `Null)
+        ] in
+        let outer = `Assoc [("tool_access", json)] in
+        match Keeper_types.tool_access_of_meta_json outer with
+        | Ok (Restricted tools) ->
+            check bool "empty list" true (List.length tools = 0)
+        | Ok Unrestricted -> fail "expected Restricted"
+        | Error msg -> fail ("unexpected error: " ^ msg));
+      test_case "integer tools field returns error" `Quick (fun () ->
+        let json = `Assoc [
+          ("kind", `String "restricted");
+          ("tools", `Int 42)
+        ] in
+        let outer = `Assoc [("tool_access", json)] in
+        match Keeper_types.tool_access_of_meta_json outer with
+        | Error _ -> ()
+        | Ok _ -> fail "expected Error for integer tools field");
+    ]);
   ]


### PR DESCRIPTION
## Summary
- `tool_access_of_meta_json` now validates that `tools` field is a JSON array or null
- Previously `Safe_ops.json_string_list` silently coerced non-list values (string, int) to `[]`
- A typo like `"tools": "masc_status"` would become `Restricted []` (deny-all) instead of an error

## Changes
3 files, +65 -8. Keeper types + mli + 4 test cases.

## Test plan
- [x] `dune build` passes
- [x] 4 new tests: string→error, valid list→ok, null→empty, int→error

Closes #4152