### PR TITLE
[codex] fix(keeper): validate tool_access.tools parsing

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -171,11 +171,17 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
       let kind =
         Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
       in
-      let tools = Safe_ops.json_string_list "tools" access_json in
       match kind with
       | Some "unrestricted" -> Ok Unrestricted
-      | Some "restricted" ->
-          Ok (normalize_tool_access (Restricted tools))
+      | Some "restricted" -> (
+          match Yojson.Safe.Util.member "tools" access_json with
+          | `Null ->
+              Ok (normalize_tool_access (Restricted []))
+          | `List _ ->
+              let tools = Safe_ops.json_string_list "tools" access_json in
+              Ok (normalize_tool_access (Restricted tools))
+          | _ ->
+              Error "keeper tool_access.tools must be an array")
       | Some other ->
           Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
       | None -> Error "keeper tool_access.kind required")

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -181,7 +181,7 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
               let tools = Safe_ops.json_string_list "tools" access_json in
               Ok (normalize_tool_access (Restricted tools))
           | _ ->
-              Error "keeper tool_access.tools must be an array")
+              Error "keeper tool_access.tools must be an array or null")
       | Some other ->
           Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
       | None -> Error "keeper tool_access.kind required")

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -164,6 +164,27 @@ let test_tool_access_restricted_empty_json_preserved () =
   | Masc_mcp.Keeper_types.Unrestricted ->
       Alcotest.fail "expected Restricted []"
 
+let test_tool_access_restricted_missing_tools_defaults_empty () =
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "restricted-missing-tools");
+          ("agent_name", `String "restricted-missing-tools");
+          ("trace_id", `String "restricted-missing-tools-trace");
+          ("tool_access", `Assoc [ ("kind", `String "restricted") ]);
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  match meta.Masc_mcp.Keeper_types.tool_access with
+  | Masc_mcp.Keeper_types.Restricted names ->
+      Alcotest.(check int) "restricted missing tools defaults empty" 0
+        (List.length names)
+  | Masc_mcp.Keeper_types.Unrestricted ->
+      Alcotest.fail "expected Restricted []"
+
 (** Malformed tool_access JSON is rejected. *)
 let test_tool_access_invalid_kind_rejected () =
   match Masc_mcp.Keeper_types.meta_of_json
@@ -197,6 +218,28 @@ let test_tool_access_missing_kind_rejected () =
       Alcotest.(check string)
         "missing kind error"
         "meta parse error: Invalid_argument(\"keeper tool_access.kind required\")"
+        e
+
+let test_tool_access_invalid_tools_type_rejected () =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc
+      [
+        ("name", `String "invalid-tools-type");
+        ("agent_name", `String "invalid-tools-type");
+        ("trace_id", `String "invalid-tools-type-trace");
+        ( "tool_access",
+          `Assoc
+            [
+              ("kind", `String "restricted");
+              ("tools", `String "masc_status");
+            ] );
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected invalid tools type to fail"
+  | Error e ->
+      Alcotest.(check string)
+        "invalid tools type error"
+        "meta parse error: Invalid_argument(\"keeper tool_access.tools must be an array\")"
         e
 
 (** Allowlist also gates shard-sourced masc_* in allowed_tool_names. *)
@@ -316,10 +359,14 @@ let () =
             test_legacy_empty_allowlist_migrates_to_standard;
           Alcotest.test_case "restricted empty json preserved" `Quick
             test_tool_access_restricted_empty_json_preserved;
+          Alcotest.test_case "restricted missing tools defaults empty" `Quick
+            test_tool_access_restricted_missing_tools_defaults_empty;
           Alcotest.test_case "invalid kind rejected" `Quick
             test_tool_access_invalid_kind_rejected;
           Alcotest.test_case "missing kind rejected" `Quick
             test_tool_access_missing_kind_rejected;
+          Alcotest.test_case "invalid tools type rejected" `Quick
+            test_tool_access_invalid_tools_type_rejected;
         ] );
       ( "dispatch",
         [

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -220,6 +220,33 @@ let test_tool_access_missing_kind_rejected () =
         "meta parse error: Invalid_argument(\"keeper tool_access.kind required\")"
         e
 
+(** Explicit "tools": null is treated as Restricted [] (same as absent). *)
+let test_tool_access_explicit_null_tools () =
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "null-tools");
+          ("agent_name", `String "null-tools");
+          ("trace_id", `String "null-tools-trace");
+          ( "tool_access",
+            `Assoc
+              [
+                ("kind", `String "restricted");
+                ("tools", `Null);
+              ] );
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  match meta.Masc_mcp.Keeper_types.tool_access with
+  | Masc_mcp.Keeper_types.Restricted names ->
+      Alcotest.(check int) "explicit null tools defaults empty" 0
+        (List.length names)
+  | Masc_mcp.Keeper_types.Unrestricted ->
+      Alcotest.fail "expected Restricted []"
+
 let test_tool_access_invalid_tools_type_rejected () =
   match Masc_mcp.Keeper_types.meta_of_json
     (`Assoc
@@ -239,7 +266,7 @@ let test_tool_access_invalid_tools_type_rejected () =
   | Error e ->
       Alcotest.(check string)
         "invalid tools type error"
-        "meta parse error: Invalid_argument(\"keeper tool_access.tools must be an array\")"
+        "meta parse error: Invalid_argument(\"keeper tool_access.tools must be an array or null\")"
         e
 
 (** Allowlist also gates shard-sourced masc_* in allowed_tool_names. *)
@@ -365,6 +392,8 @@ let () =
             test_tool_access_invalid_kind_rejected;
           Alcotest.test_case "missing kind rejected" `Quick
             test_tool_access_missing_kind_rejected;
+          Alcotest.test_case "explicit null tools defaults empty" `Quick
+            test_tool_access_explicit_null_tools;
           Alcotest.test_case "invalid tools type rejected" `Quick
             test_tool_access_invalid_tools_type_rejected;
         ] );


### PR DESCRIPTION
## Summary
- validate `tool_access.tools` type when parsing keeper meta JSON
- preserve `Restricted []` only when `tools` is absent or an explicit empty array
- reject malformed `"tools": "masc_status"` payloads with a clear parser error

## Root Cause
`tool_access_of_meta_json` used `Safe_ops.json_string_list "tools"`, which silently coerced non-array values to `[]`. For `kind = "restricted"`, a malformed string value was treated as `Restricted []` instead of surfacing invalid input.

## Changes
- add an explicit type check for `tool_access.tools` in restricted mode
- keep the legacy missing-field behavior as `Restricted []`
- add regression tests for missing `tools` and invalid non-array `tools`

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4152-tool-access-tools-type --build-dir /tmp/masc-4152b ./test/test_keeper_masc_bridge.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4152-tool-access-tools-type --build-dir /tmp/masc-4152d ./lib/keeper/keeper_types.ml`

Closes #4152.