### PR TITLE
fix(team-session): deny MASC mutating tools in Observe_only scope

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -140,6 +140,18 @@ let code_mutation_denied_tools =
     "masc_code_write"; "masc_code_edit"; "masc_code_delete";
     "masc_code_shell"; "masc_code_git" ]
 
+(* MASC state-mutating tools denied in observe_only scope.
+   Observe_only workers should only read coordination state, not modify it. *)
+let masc_mutating_denied_tools =
+  [ "masc_add_task"; "masc_claim_next"; "masc_transition";
+    "masc_worktree_create"; "masc_worktree_remove";
+    "masc_portal_open"; "masc_portal_send"; "masc_portal_close";
+    "masc_plan_set_task"; "masc_plan_clear_task";
+    "masc_operator_action"; "masc_operator_confirm";
+    "masc_room_delete"; "masc_admin_cleanup"; "masc_admin_reset";
+    "masc_gc_force"; "masc_spawn"; "masc_force_leave";
+    "masc_config_set"; "masc_execute" ]
+
 (* Local model (Qwen3.5 Q4) — no cloud cost, so generous turn budget. *)
 let local_model_gate =
   { Eval_gate.default_config with
@@ -153,7 +165,10 @@ let gate_config_of_execution_scope
   match scope with
   | Observe_only ->
       { local_model_gate with
-        denied_tools = destructive_denied_tools @ code_mutation_denied_tools;
+        denied_tools =
+          destructive_denied_tools
+          @ code_mutation_denied_tools
+          @ masc_mutating_denied_tools;
       }
   | Limited_code_change ->
       { local_model_gate with

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -141,12 +141,16 @@ let code_mutation_denied_tools =
     "masc_code_shell"; "masc_code_git" ]
 
 (* MASC state-mutating tools denied in observe_only scope.
-   Observe_only workers should only read coordination state, not modify it. *)
+   Observe_only workers should only read coordination state, not modify it.
+   Includes SDK aliases (masc_set_current_task, masc_complete_task) to
+   prevent bypass via alias routing. *)
 let masc_mutating_denied_tools =
   [ "masc_add_task"; "masc_claim_next"; "masc_transition";
+    "masc_complete_task";  (* alias of masc_transition *)
     "masc_worktree_create"; "masc_worktree_remove";
     "masc_portal_open"; "masc_portal_send"; "masc_portal_close";
     "masc_plan_set_task"; "masc_plan_clear_task";
+    "masc_set_current_task";  (* alias of masc_plan_set_task *)
     "masc_operator_action"; "masc_operator_confirm";
     "masc_room_delete"; "masc_admin_cleanup"; "masc_admin_reset";
     "masc_gc_force"; "masc_spawn"; "masc_force_leave";

--- a/test/dune
+++ b/test/dune
@@ -74,7 +74,8 @@
         test_keeper_prompt_metrics
         test_cache_metrics_wiring
         test_tool_surface_ssot
-        test_observability_redact)
+        test_observability_redact
+        test_worker_oas_scope_gate)
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -120,7 +121,8 @@
           test_keeper_prompt_metrics
           test_cache_metrics_wiring
           test_tool_surface_ssot
-          test_observability_redact)
+          test_observability_redact
+          test_worker_oas_scope_gate)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_worker_oas_scope_gate.ml
+++ b/test/test_worker_oas_scope_gate.ml
@@ -1,0 +1,77 @@
+(** Tests for Worker_oas execution scope gate enforcement.
+
+    Verifies that Observe_only scope denies MASC mutating tools,
+    code mutation tools, and destructive operations. *)
+
+open Alcotest
+open Masc_mcp
+
+let test_observe_only_denies_masc_mutating () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Observe_only in
+  let mutating_tools =
+    [ "masc_worktree_create"; "masc_worktree_remove";
+      "masc_add_task"; "masc_transition";
+      "masc_operator_action"; "masc_room_delete" ]
+  in
+  List.iter (fun tool ->
+    check bool (tool ^ " denied in Observe_only") true
+      (List.mem tool gate.Eval_gate.denied_tools))
+    mutating_tools
+
+let test_observe_only_denies_code_mutation () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Observe_only in
+  let code_tools =
+    [ "keeper_bash"; "masc_code_write"; "masc_code_edit" ]
+  in
+  List.iter (fun tool ->
+    check bool (tool ^ " denied in Observe_only") true
+      (List.mem tool gate.Eval_gate.denied_tools))
+    code_tools
+
+let test_limited_allows_masc_mutating () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Limited_code_change in
+  check bool "masc_worktree_create allowed in Limited" false
+    (List.mem "masc_worktree_create" gate.Eval_gate.denied_tools);
+  check bool "masc_add_task allowed in Limited" false
+    (List.mem "masc_add_task" gate.Eval_gate.denied_tools)
+
+let test_limited_denies_destructive () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Limited_code_change in
+  check bool "shell_exec_dangerous denied in Limited" true
+    (List.mem "shell_exec_dangerous" gate.Eval_gate.denied_tools)
+
+let test_autonomous_allows_all () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Autonomous in
+  check bool "no denied tools in Autonomous" true
+    (List.length gate.Eval_gate.denied_tools = 0)
+
+let test_observe_only_allows_read_tools () =
+  let gate = Worker_oas.gate_config_of_execution_scope Team_session_types.Observe_only in
+  let read_tools = [ "masc_status"; "masc_tasks"; "masc_who" ] in
+  List.iter (fun tool ->
+    check bool (tool ^ " allowed in Observe_only") false
+      (List.mem tool gate.Eval_gate.denied_tools))
+    read_tools
+
+let () =
+  run "Worker_oas_scope_gate"
+  [
+    ("observe_only", [
+      test_case "denies MASC mutating tools" `Quick
+        test_observe_only_denies_masc_mutating;
+      test_case "denies code mutation tools" `Quick
+        test_observe_only_denies_code_mutation;
+      test_case "allows read-only tools" `Quick
+        test_observe_only_allows_read_tools;
+    ]);
+    ("limited_code_change", [
+      test_case "allows MASC mutating tools" `Quick
+        test_limited_allows_masc_mutating;
+      test_case "denies destructive tools" `Quick
+        test_limited_denies_destructive;
+    ]);
+    ("autonomous", [
+      test_case "allows all tools" `Quick
+        test_autonomous_allows_all;
+    ]);
+  ]

--- a/test/test_worker_oas_scope_gate.ml
+++ b/test/test_worker_oas_scope_gate.ml
@@ -11,6 +11,8 @@ let test_observe_only_denies_masc_mutating () =
   let mutating_tools =
     [ "masc_worktree_create"; "masc_worktree_remove";
       "masc_add_task"; "masc_transition";
+      "masc_complete_task";  (* alias of masc_transition *)
+      "masc_set_current_task";  (* alias of masc_plan_set_task *)
       "masc_operator_action"; "masc_room_delete" ]
   in
   List.iter (fun tool ->


### PR DESCRIPTION
## Summary
- Observe_only workers could call state-changing MASC tools (worktree create/remove, transition, add_task, etc.)
- Added `masc_mutating_denied_tools` list (18 tools) to `Observe_only` denied set
- Read-only tools (status, tasks, who) remain allowed

## Changes
3 files, +97 -3. worker_oas.ml + test + dune registration.

## Test plan
- [x] `dune build` passes
- [x] 6 new tests: observe_only deny mutating, deny code mutation, allow read; limited allow mutating, deny destructive; autonomous allow all

Closes #4160