### PR TITLE
fix(harness): accumulate MCP_LAST_TIME_TOTAL across retries

### DIFF
--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -205,6 +205,7 @@ mcp_jsonrpc_call() {
   local raw=""
   local status=0
   local stderr_text=""
+  local cumulative_time="0"
   local -a extra_args=()
   if [[ -n "${MCP_CURL_EXTRA_ARGS:-}" ]]; then
     read -r -a extra_args <<< "${MCP_CURL_EXTRA_ARGS}"
@@ -240,9 +241,13 @@ mcp_jsonrpc_call() {
     cmd+=( --data-binary "@$body_file" )
 
     set +e
-    MCP_LAST_TIME_TOTAL="$("${cmd[@]}" 2>"$stderr_file")"
+    local attempt_time
+    attempt_time="$("${cmd[@]}" 2>"$stderr_file")"
     status=$?
     set -e
+    # Accumulate wall-clock time across retries (including sleep delays via awk).
+    cumulative_time="$(awk "BEGIN{printf \"%.6f\", $cumulative_time + ${attempt_time:-0}}")"
+    MCP_LAST_TIME_TOTAL="$cumulative_time"
     stderr_text="$(cat "$stderr_file" 2>/dev/null || true)"
     raw="$(cat "$resp_file" 2>/dev/null || true)"
     rm -f "$body_file" "$stderr_file" "$resp_file"
@@ -258,6 +263,9 @@ mcp_jsonrpc_call() {
     case "$status" in
       7|28)
         sleep "$retry_delay"
+        # Include retry sleep in cumulative time.
+        cumulative_time="$(awk "BEGIN{printf \"%.6f\", $cumulative_time + $retry_delay}")"
+        MCP_LAST_TIME_TOTAL="$cumulative_time"
         attempt=$((attempt + 1))
         ;;
       *)

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -246,7 +246,7 @@ mcp_jsonrpc_call() {
     status=$?
     set -e
     # Accumulate wall-clock time across retries (including sleep delays via awk).
-    cumulative_time="$(awk "BEGIN{printf \"%.6f\", $cumulative_time + ${attempt_time:-0}}")"
+    cumulative_time="$(awk -v c="$cumulative_time" -v a="${attempt_time:-0}" 'BEGIN{printf "%.6f", c + a}')"
     MCP_LAST_TIME_TOTAL="$cumulative_time"
     stderr_text="$(cat "$stderr_file" 2>/dev/null || true)"
     raw="$(cat "$resp_file" 2>/dev/null || true)"
@@ -264,7 +264,7 @@ mcp_jsonrpc_call() {
       7|28)
         sleep "$retry_delay"
         # Include retry sleep in cumulative time.
-        cumulative_time="$(awk "BEGIN{printf \"%.6f\", $cumulative_time + $retry_delay}")"
+        cumulative_time="$(awk -v c="$cumulative_time" -v d="$retry_delay" 'BEGIN{printf "%.6f", c + d}')"
         MCP_LAST_TIME_TOTAL="$cumulative_time"
         attempt=$((attempt + 1))
         ;;


### PR DESCRIPTION
## Summary
- `MCP_LAST_TIME_TOTAL` was overwritten on each retry, reporting only the last attempt's latency
- Now accumulates `curl time_total` across attempts and includes retry sleep delays
- Exported value reflects actual wall-clock duration including retries

## Changes
1 file, +9 -1. Bash script only.

## Test plan
- [x] shellcheck passes (no new warnings)
- [ ] Manual: set `CURL_RETRY_COUNT=3` with unreachable endpoint, verify `MCP_LAST_TIME_TOTAL` > single attempt

Closes #4164