### PR TITLE
chore(release): bump version to 2.189.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 
+## [2.189.0] - 2026-03-31
+
+### Added
+- **Dashboard feature flags nav** — expose ghost FeatureHealth widget in lab navigation (#4146).
+- **Dashboard tab visit counter** — localStorage-based tab/section visit metrics (#4150).
+- **Transport health on config page** — TransportHealthPanel added to Lab > Config (#4149).
+
+### Changed
+- **Dashboard widget dedup** — remove duplicate connection status and counter chips from sidebar and live monitor (#4147, #4148).
+
+### Fixed
+- **Keeper tool_access validation** — validate tool_access.tools field type (#4165).
+- **Keeper JSON envelope** — embed change_block inside JSON envelope (#4161).
+- **TUI legacy decode** — make legacy keeper fields optional in decode_keeper (#4158).
+- **Harness script migration** — migrate last two scripts off direct jsonrpc_sse (#4162).
+
 ## [2.188.0] - 2026-03-31
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.188.0)
+(version 2.189.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
Version bump 2.188.0 -> 2.189.0. See CHANGELOG.md for full details.

Key changes since 2.188.0:
- Dashboard widget audit cleanup (#4155)
- Keeper tool_access validation (#4165)
- Keeper JSON envelope fix (#4161)
- TUI legacy decode fix (#4158)
- Harness script migration (#4162)