### PR TITLE
feat(dashboard): room state health counters in monitoring

### DIFF
--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -44,6 +44,22 @@ type room_state = {
   pause_reason: string option;
 }
 
+(** {1 Health Counters} *)
+
+let state_update_attempts = Atomic.make 0
+let state_update_failures = Atomic.make 0
+
+let state_health_counters () =
+  let attempts = Atomic.get state_update_attempts in
+  let failures = Atomic.get state_update_failures in
+  `Assoc [
+    ("state_update_attempts", `Int attempts);
+    ("state_update_failures", `Int failures);
+    ("failure_rate",
+      `Float (if attempts = 0 then 0.0
+              else float_of_int failures /. float_of_int (max 1 attempts)));
+  ]
+
 (** {1 Helpers} *)
 
 let now_iso () =
@@ -286,6 +302,7 @@ let write_state config state =
     Returns [Ok new_state] on success.
 *)
 let atomic_update_state config ~f =
+  Atomic.incr state_update_attempts;
   let transform json_opt =
     let current_state =
       match json_opt with
@@ -311,6 +328,7 @@ let atomic_update_state config ~f =
         room_state_of_json json
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error e ->
+      Atomic.incr state_update_failures;
       Error (match e with
         | Backend.IOError msg -> msg
         | Backend.NotFound k -> "Not found: " ^ k

--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -57,7 +57,7 @@ let state_health_counters () =
     ("state_update_failures", `Int failures);
     ("failure_rate",
       `Float (if attempts = 0 then 0.0
-              else float_of_int failures /. float_of_int (max 1 attempts)));
+              else float_of_int failures /. float_of_int attempts));
   ]
 
 (** {1 Helpers} *)

--- a/lib/room/room_eio.mli
+++ b/lib/room/room_eio.mli
@@ -279,6 +279,11 @@ val get_recent_events : config -> limit:int -> Yojson.Safe.t list
 
 (** {1 Health & Status} *)
 
+(** In-process counters for [atomic_update_state] attempts and failures.
+    Returns a JSON object with [state_update_attempts], [state_update_failures],
+    and [failure_rate]. *)
+val state_health_counters : unit -> Yojson.Safe.t
+
 (** Run a health check against the backend. *)
 val health_check : config -> (Backend_types.health_result, string) result
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -215,6 +215,7 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
       ("monitoring", `Assoc [
         ("board", board_monitor_json);
         ("governance", governance_monitor_json);
+        ("room_state", Room_eio.state_health_counters ());
       ]);
       ("data_quality", `Assoc [
         ("board_contract_ok", `Bool board_contract_ok);


### PR DESCRIPTION
## Summary
- Room_eio에 `Atomic.t` 카운터 추가: `atomic_update_state` 호출 횟수 및 실패 횟수 집계
- `state_health_counters()` accessor를 `.mli`에 노출
- `/api/v1/dashboard` 응답의 `monitoring.room_state`에 JSON 포함

## Context
#4077에서 `atomic_update_state` 실패 시 `Log.Room.warn`을 추가했으나, 실패율 집계는 없었음.
Atomic 카운터로 lock-free 집계하여 대시보드 monitoring 섹션에 노출.

## Changes
| File | Change |
|------|--------|
| `lib/room/room_eio.ml` | `state_update_attempts`, `state_update_failures` Atomic 카운터 + accessor |
| `lib/room/room_eio.mli` | `val state_health_counters : unit -> Yojson.Safe.t` |
| `lib/server/server_dashboard_http_core.ml` | `monitoring.room_state` 필드 추가 |

## Test plan
- [x] `test_room_eio.exe`: 16/16 통과
- [x] `dune build`: clean
- [ ] Dashboard JSON에 `monitoring.room_state` 확인 (`curl localhost:8935/api/v1/dashboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)