### PR TITLE
feat(telemetry): executor decision outcomes tracking

### DIFF
--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -310,7 +310,9 @@ let handle_execute ctx args =
     | Error msg -> json_err msg
     | Ok result ->
         let preview = Council.ExecutorApi.dry_run ~topic ~result in
+        let t0 = Time_compat.now () in
         let outcome = Council.ExecutorApi.execute ~topic ~result in
+        let elapsed_ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
         let matched = Option.is_some outcome in
         let executed =
           match outcome with
@@ -322,13 +324,23 @@ let handle_execute ctx args =
          | Some config, Some exec ->
            let tool_name = Printf.sprintf "executor:%s" topic in
            (try Telemetry_eio.track_tool_called config
-             ~tool_name ~success:exec.success ~duration_ms:0
+             ~tool_name ~success:exec.success ~duration_ms:elapsed_ms
              ~source:"council" ()
-           with _ -> ());
-           if not exec.success then
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | _ -> ());
+           if not exec.success then begin
+             let msg =
+               if String.length exec.output > 512
+               then String.sub exec.output 0 512
+               else exec.output
+             in
              (try Telemetry_eio.track_error config
-               ~code:"executor_failed" ~message:exec.output ~context:topic
-             with _ -> ())
+               ~code:"executor_failed" ~message:msg ~context:topic
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ -> ())
+           end
          | _ -> ());
         let output =
           match outcome with

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -302,7 +302,7 @@ let voting_result_of_args args =
            "invalid result %S (expected unanimous, majority, deadlock, or escalate)"
            value)
 
-let handle_execute _ctx args =
+let handle_execute ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
@@ -317,6 +317,19 @@ let handle_execute _ctx args =
           | Some exec -> exec.success
           | None -> false
         in
+        (* Track executor decision in telemetry *)
+        (match ctx.room_config, outcome with
+         | Some config, Some exec ->
+           let tool_name = Printf.sprintf "executor:%s" topic in
+           (try Telemetry_eio.track_tool_called config
+             ~tool_name ~success:exec.success ~duration_ms:0
+             ~source:"council" ()
+           with _ -> ());
+           if not exec.success then
+             (try Telemetry_eio.track_error config
+               ~code:"executor_failed" ~message:exec.output ~context:topic
+             with _ -> ())
+         | _ -> ());
         let output =
           match outcome with
           | Some exec when String.trim exec.output <> "" -> exec.output

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -319,29 +319,30 @@ let handle_execute ctx args =
           | Some exec -> exec.success
           | None -> false
         in
-        (* Track executor decision in telemetry *)
-        (match ctx.room_config, outcome with
-         | Some config, Some exec ->
-           let tool_name = Printf.sprintf "executor:%s" topic in
-           (try Telemetry_eio.track_tool_called config
-             ~tool_name ~success:exec.success ~duration_ms:elapsed_ms
-             ~source:"council" ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | _ -> ());
-           if not exec.success then begin
-             let msg =
-               if String.length exec.output > 512
-               then String.sub exec.output 0 512
-               else exec.output
-             in
-             (try Telemetry_eio.track_error config
-               ~code:"executor_failed" ~message:msg ~context:topic
+        (* Track executor decision in telemetry, gated by toggle *)
+        if Env_config_core.telemetry_enabled () then
+          (match ctx.room_config, outcome with
+           | Some config, Some exec ->
+             let tool_name = Printf.sprintf "executor:%s" topic in
+             (try Telemetry_eio.track_tool_called config
+               ~tool_name ~success:exec.success ~duration_ms:elapsed_ms
+               ~agent_id:ctx.agent_name ~source:"council" ()
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
-             | _ -> ())
-           end
-         | _ -> ());
+             | _ -> ());
+             if not exec.success then begin
+               let msg =
+                 if String.length exec.output > 512
+                 then String.sub exec.output 0 512
+                 else exec.output
+               in
+               (try Telemetry_eio.track_error config
+                 ~code:"executor_failed" ~message:msg ~context:topic
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | _ -> ())
+             end
+           | _ -> ());
         let output =
           match outcome with
           | Some exec when String.trim exec.output <> "" -> exec.output


### PR DESCRIPTION
## Summary
- Council executor `handle_execute`에서 action 실행 결과를 telemetry에 기록
- 성공/실패가 `telemetry.jsonl`에 `Tool_called` 이벤트로 저장
- 실패 시 `Error_occurred` 이벤트도 함께 기록

## Context
#4062에서 executor의 `build_action`이 `Result.t`를 반환하게 됐지만,
실행 결과가 telemetry/audit에 기록되지 않았음.

`tool_council_oas.ml:handle_execute`에서 `ctx.room_config`를 통해
telemetry 기록. executor.ml 자체는 council 라이브러리 내부라 수정하지 않음.

## Changes
| File | Change |
|------|--------|
| `lib/tool_council_oas.ml` | `handle_execute`에 telemetry track 추가 (~14줄) |

## Dashboard Visibility
- `telemetry.jsonl` → 기존 `/api/v1/tool-metrics` 자동 집계
- 실패 → Log ring buffer에 `Error_occurred`로 확인 가능
- 새 엔드포인트/프론트엔드 불필요

## Test plan
- [x] `test_council.exe`: 61/61 통과
- [x] `dune build`: clean
- [ ] 실행 후 `telemetry.jsonl`에 `executor:*` 이벤트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)