### PR TITLE
[codex] fix(team-session): scope observe-only local worker tools

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -396,6 +396,7 @@ let run_with_masc_tools
     ~(config : config)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
+    ?contract
     ?on_event
     (goal : string)
   : (run_result, string) result =
@@ -408,7 +409,7 @@ let run_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   let config = { config with tools = oas_tools @ config.tools } in
-  run ~sw ~net ~config ?on_event goal
+  run ~sw ~net ~config ?on_event ?contract goal
 
 (* ================================================================ *)
 (* Cascade profile defaults (moved from Cascade module)              *)
@@ -700,6 +701,7 @@ let run_model_with_masc_tools
     ?hooks
     ?memory
     ?enable_thinking
+    ?contract
     ?raw_trace
     ?on_event
     ?transport
@@ -723,5 +725,5 @@ let run_model_with_masc_tools
           ()
       in
       let config = { config with raw_trace; transport = transport_resolved; priority } in
-      run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch ?on_event
+      run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch ?contract ?on_event
         goal

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -130,6 +130,7 @@ val run_model_with_masc_tools :
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
   ?enable_thinking:bool ->
+  ?contract:Oas.Risk_contract.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -13,6 +13,37 @@ module Oas = Agent_sdk
 let supported_local_worker_tool_names =
   Tool_catalog.tools_for_surface Tool_catalog.Local_worker
 
+let observe_only_blocked_local_worker_tool_names =
+  [
+    "masc_add_task";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_board_post";
+    "masc_board_comment";
+    "masc_board_vote";
+    "masc_worktree_create";
+    "masc_worktree_remove";
+    "masc_run_init";
+    "masc_run_plan";
+    "masc_run_log";
+    "masc_run_deliverable";
+    "masc_repair_loop_start";
+    "masc_repair_loop_iterate";
+    "masc_repair_loop_stop";
+  ]
+
+let supported_local_worker_tool_names_for_scope execution_scope =
+  match execution_scope with
+  | Some Team_session_types.Observe_only ->
+      List.filter
+        (fun name ->
+          not (List.mem name observe_only_blocked_local_worker_tool_names))
+        supported_local_worker_tool_names
+  | Some Team_session_types.Limited_code_change
+  | Some Team_session_types.Autonomous
+  | None ->
+      supported_local_worker_tool_names
+
 let supported_local_worker_tools () =
   match
     Agent_tool_surfaces.local_worker_tool_schemas
@@ -23,6 +54,19 @@ let supported_local_worker_tools () =
       Error
         (Printf.sprintf
            "team_session_oas_bridge: failed to resolve worker tool schemas: %s"
+           msg)
+
+let supported_local_worker_tools_for_scope execution_scope =
+  match
+    Agent_tool_surfaces.local_worker_tool_schemas
+      ~names:(supported_local_worker_tool_names_for_scope execution_scope)
+      ()
+  with
+  | Ok schemas -> Ok schemas
+  | Error msg ->
+      Error
+        (Printf.sprintf
+           "team_session_oas_bridge: failed to resolve scoped worker tool schemas: %s"
            msg)
 
 let add_string_field_if_missing key value fields =
@@ -507,6 +551,15 @@ let planned_worker_to_entry_with_state
   let cascade_name = cascade_of_worker ~session_cascade pw in
   let max_turns = Option.value ~default:10 pw.max_turns in
   let telemetry_ref = ref Swarm.Swarm_types.empty_telemetry in
+  let scoped_tool_names =
+    supported_local_worker_tool_names_for_scope pw.execution_scope
+  in
+  let scoped_masc_tools =
+    List.filter
+      (fun (tool : Types.tool_schema) ->
+        List.mem tool.name scoped_tool_names)
+      masc_tools
+  in
   let system_prompt =
     Printf.sprintf "You are agent '%s' in a team session (room: %s). Your role: %s."
       name config.base_path
@@ -523,13 +576,16 @@ let planned_worker_to_entry_with_state
         ~args:(normalize_tool_args ~tool_name ~agent_name:name args)
     in
     let contract = Option.map (fun dc ->
-      let tool_names = List.map (fun (t : Types.tool_schema) -> t.name) masc_tools in
+      let tool_names =
+        List.map (fun (t : Types.tool_schema) -> t.name) scoped_masc_tools
+      in
       Contract_composer.compose ~delivery_contract:dc ~tool_names
     ) delivery_contract in
     match
       Oas_worker.run_named_with_masc_tools
         ~cascade_name ~goal:prompt ~system_prompt
-        ~masc_tools ~dispatch:dispatch_with_defaults ~max_turns
+        ~masc_tools:scoped_masc_tools ~dispatch:dispatch_with_defaults
+        ~max_turns
         ~temperature:(Cascade_inference.resolve_temperature
           ~cascade_name ~fallback:(fun () -> 0.3))
         ~max_tokens:(Cascade_inference.resolve_max_tokens

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -39,8 +39,15 @@ val supported_local_worker_tool_names : string list
 (** Canonical list of tool names supported by local workers in team sessions.
     Exposed for parity testing against [Tool_catalog.tools_for_surface Local_worker]. *)
 
+val supported_local_worker_tool_names_for_scope :
+  Team_session_types.execution_scope option -> string list
+
 val supported_local_worker_tools :
   unit -> (Types.tool_schema list, string) result
+
+val supported_local_worker_tools_for_scope :
+  Team_session_types.execution_scope option ->
+  (Types.tool_schema list, string) result
 
 val dispatch_supported_tool :
   sw:Eio.Switch.t ->

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -78,11 +78,172 @@ let execute_spawn_pipeline
                    fail_all_prepared prepared_spawns ~error:msg;
                    Some (`Assoc [ ("error", `String msg) ])
                | Ok () ->
+                   let execution_scope_of_prepared prepared =
+                     deps.effective_execution_scope_of_spec prepared.spec
+                   in
+                   let worker_backend_of_prepared prepared =
+                     if deps.is_local_spawn_agent prepared.spec.spawn_agent then
+                       Some "local"
+                     else None
+                   in
+                   let normalize_spawn_tool_args prepared ~tool_name
+                       (args : Yojson.Safe.t) =
+                     let add_string_field_if_missing key value fields =
+                       if String.trim value = "" || List.mem_assoc key fields then
+                         fields
+                       else
+                         (key, `String value) :: fields
+                     in
+                     match args with
+                     | `Assoc fields ->
+                         let fields =
+                           add_string_field_if_missing "agent_name"
+                             prepared.spec.spawn_agent fields
+                         in
+                         let fields =
+                           match tool_name with
+                           | "masc_board_post" | "masc_board_comment" ->
+                               add_string_field_if_missing "author"
+                                 prepared.spec.spawn_agent fields
+                           | "masc_board_vote" ->
+                               add_string_field_if_missing "voter"
+                                 prepared.spec.spawn_agent fields
+                           | _ -> fields
+                         in
+                         `Assoc fields
+                     | _ -> args
+                   in
+                   let record_spawn_exception index prepared ~started_at exn =
+                     let error = Printexc.to_string exn in
+                     let elapsed_ms =
+                       int_of_float
+                         ((Time_compat.now () -. started_at) *. 1000.0)
+                     in
+                     let output_preview = deps.truncate_for_event error in
+                     let worker_name =
+                       Option.value
+                         ~default:(Printf.sprintf "spawn-%d" index)
+                         prepared.runtime_actor_name
+                     in
+                     release_prepared_runtime prepared ~success:false ~error
+                       ~latency_ms:elapsed_ms ();
+                     persist_worker_run_snapshot
+                       ~worker_run_id:prepared.worker_run_id
+                       ~worker_name ~mode:"spawn" ~wait_mode
+                       ~status:`Failed
+                       ?execution_scope:(execution_scope_of_prepared prepared)
+                       ?requested_worker_class:prepared.spec.worker_class
+                       ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
+                       ?resolved_runtime:prepared.assigned_runtime
+                       ~resolved_model:prepared.runtime_model_label
+                       ?routing_reason:prepared.spec.routing_reason
+                       ~tool_names:[]
+                       ~tool_call_count:0
+                       ~success:false ~output_preview ~error
+                       ();
+                     append_spawn_event
+                       ~worker_run_id:prepared.worker_run_id
+                       ~spawn_agent:prepared.spec.spawn_agent
+                       ?runtime_actor:prepared.runtime_actor_name
+                       ?spawn_role:prepared.spec.spawn_role
+                       ?spawn_model:prepared.spec.spawn_model
+                       ?execution_scope:(execution_scope_of_prepared prepared)
+                       ?worker_class:prepared.spec.worker_class
+                       ?worker_size:(deps.worker_size_of_spec prepared.spec)
+                       ?worker_backend:(worker_backend_of_prepared prepared)
+                       ~wait_mode:
+                         (Team_session_types.wait_mode_to_string wait_mode)
+                       ?parent_actor:prepared.spec.parent_actor
+                       ?capsule_mode:prepared.spec.capsule_mode
+                       ?runtime_pool:prepared.spec.runtime_pool
+                       ?lane_id:prepared.spec.lane_id
+                       ?controller_level:
+                         (deps.inferred_controller_level_of_spec prepared.spec)
+                       ?control_domain:prepared.spec.control_domain
+                       ?supervisor_actor:prepared.spec.supervisor_actor
+                       ?model_tier:prepared.spec.model_tier
+                       ?task_profile:prepared.spec.task_profile
+                       ?risk_level:prepared.spec.risk_level
+                       ?routing_confidence:prepared.spec.routing_confidence
+                       ?routing_reason:prepared.spec.routing_reason
+                       ?assigned_runtime:prepared.assigned_runtime
+                       ?spawn_selection_note:
+                         prepared.spec.spawn_selection_note
+                       ~tool_names:[]
+                       ~tool_call_count:0
+                       ~success:false ~exit_code:1
+                       ~elapsed_ms ~output_preview ~error ();
+                     (match prepared.runtime_actor_name with
+                     | Some worker_actor ->
+                         ignore
+                           (deps.reconcile_failed_spawn_actor ctx.config
+                              session_id worker_actor)
+                     | None -> ());
+                     `Assoc
+                       [
+                         ("worker_run_id", `String prepared.worker_run_id);
+                         ( "runtime_actor",
+                           Option.fold ~none:`Null
+                             ~some:(fun s -> `String s)
+                             prepared.runtime_actor_name );
+                         ( "spawn_role",
+                           Option.fold ~none:`Null
+                             ~some:(fun s -> `String s)
+                             prepared.spec.spawn_role );
+                         ( "execution_scope",
+                           Option.fold ~none:`Null
+                             ~some:(fun scope ->
+                               `String
+                                 (Team_session_types.execution_scope_to_string
+                                    scope))
+                             (execution_scope_of_prepared prepared) );
+                         ( "worker_class",
+                           Option.fold ~none:`Null
+                             ~some:(fun kind ->
+                               `String
+                                 (Team_session_types.worker_class_to_string
+                                    kind))
+                             prepared.spec.worker_class );
+                         ( "worker_size",
+                           Option.fold ~none:`Null
+                             ~some:(fun size ->
+                               `String
+                                 (Team_session_types.worker_size_to_string
+                                    size))
+                             (deps.worker_size_of_spec prepared.spec) );
+                         ( "worker_backend",
+                           Option.fold ~none:`Null
+                             ~some:(fun value -> `String value)
+                             (worker_backend_of_prepared prepared) );
+                         ( "wait_mode",
+                           `String
+                             (Team_session_types.wait_mode_to_string wait_mode)
+                         );
+                         ("status", `String "failed");
+                         ( "resolved_runtime",
+                           Option.fold ~none:`Null
+                             ~some:(fun s -> `String s)
+                             prepared.assigned_runtime );
+                         ("resolved_model", `String prepared.runtime_model_label);
+                         ( "routing_reason",
+                           Option.fold ~none:`Null
+                             ~some:(fun s -> `String s)
+                             prepared.spec.routing_reason );
+                         ("tool_call_count", `Int 0);
+                         ("tool_names", `List []);
+                         ("success", `Bool false);
+                         ("elapsed_ms", `Int elapsed_ms);
+                         ("output_preview", `String output_preview);
+                       ]
+                   in
                    let execute_spawn index prepared =
                    (* Phase C-3a: Route spawn through OAS Agent.run via Oas_worker.
                        This replaces the old Spawn.spawn subprocess call, giving us
                        trace data, tool_names, and tool_call_count for free. *)
                     let start_time = Time_compat.now () in
+                    let execution_scope =
+                      execution_scope_of_prepared prepared
+                    in
                     let max_turns =
                       match prepared.spec.max_turns with
                       | Some n -> n | None -> 10
@@ -94,32 +255,85 @@ let execute_spawn_pipeline
                     let contract =
                       Option.map
                         (fun delivery_contract ->
-                          (* Spawn workers currently run without an attached
-                             MASC tool surface, so the composed contract uses
-                             the current runtime tool list: [] *)
+                          let tool_names =
+                            if deps.is_local_spawn_agent
+                                 prepared.spec.spawn_agent
+                            then
+                              Team_session_oas_bridge
+                              .supported_local_worker_tool_names_for_scope
+                                execution_scope
+                            else []
+                          in
                           Contract_composer.compose ~delivery_contract
-                            ~tool_names:[])
+                            ~tool_names)
                         delivery_contract
                     in
                     let oas_result =
-                      Oas_worker.run_model_by_label
-                        ~model_label:prepared.runtime_model_label
-                        ~goal:prepared.spec.spawn_prompt
-                        ~system_prompt:(Printf.sprintf
-                          "You are agent '%s'. Execute the task and return a clear result."
-                           prepared.spec.spawn_agent)
-                        ~max_turns
-                        ~temperature:(Safe_ops.get_env_float_logged
-                          "MASC_SPAWN_TEMPERATURE" ~default:0.3)
-                        ~max_tokens:(Safe_ops.get_env_int_logged
-                          "MASC_SPAWN_MAX_TOKENS" ~default:4096)
-                        ~priority:Llm_provider.Request_priority.Interactive
-                        ?contract
-                        ~sw:ctx.sw
-                        ()
+                      if deps.is_local_spawn_agent prepared.spec.spawn_agent then
+                        match
+                          Team_session_oas_bridge
+                          .supported_local_worker_tools_for_scope execution_scope
+                        with
+                        | Error msg ->
+                            Error
+                              (Printf.sprintf
+                                 "team session local worker tools unavailable: %s"
+                                 msg)
+                        | Ok masc_tools ->
+                            Oas_worker.run_model_with_masc_tools
+                              ~model_label:prepared.runtime_model_label
+                              ~goal:prepared.spec.spawn_prompt
+                              ~system_prompt:(Printf.sprintf
+                                "You are agent '%s'. Execute the task and return a clear result."
+                                 prepared.spec.spawn_agent)
+                              ~masc_tools
+                              ~dispatch:(fun ~name ~args ->
+                                Team_session_oas_bridge.dispatch_supported_tool
+                                  ~sw:ctx.sw ~clock:ctx.clock
+                                  ~config:ctx.config ~name
+                                  ~args:
+                                    (normalize_spawn_tool_args prepared
+                                       ~tool_name:name args))
+                              ~max_turns
+                              ~temperature:(Safe_ops.get_env_float_logged
+                                "MASC_SPAWN_TEMPERATURE" ~default:0.3)
+                              ~max_tokens:(Safe_ops.get_env_int_logged
+                                "MASC_SPAWN_MAX_TOKENS" ~default:4096)
+                              ~priority:
+                                Llm_provider.Request_priority.Interactive
+                              ?enable_thinking:prepared.spec.thinking_enabled
+                              ?contract ?net:ctx.net ~sw:ctx.sw
+                              ()
+                      else
+                        Oas_worker.run_model_by_label
+                          ~model_label:prepared.runtime_model_label
+                          ~goal:prepared.spec.spawn_prompt
+                          ~system_prompt:(Printf.sprintf
+                            "You are agent '%s'. Execute the task and return a clear result."
+                             prepared.spec.spawn_agent)
+                          ~max_turns
+                          ~temperature:(Safe_ops.get_env_float_logged
+                            "MASC_SPAWN_TEMPERATURE" ~default:0.3)
+                          ~max_tokens:(Safe_ops.get_env_int_logged
+                            "MASC_SPAWN_MAX_TOKENS" ~default:4096)
+                          ~priority:Llm_provider.Request_priority.Interactive
+                          ?enable_thinking:prepared.spec.thinking_enabled
+                          ?contract ?net:ctx.net ~sw:ctx.sw
+                          ()
                     in
                      let elapsed_ms =
                        int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
+                     in
+                     let resolved_model =
+                       match oas_result with
+                       | Ok result ->
+                           let model =
+                             String.trim
+                               (Oas_response.model_used result.response)
+                           in
+                           if model <> "" then model
+                           else prepared.runtime_model_label
+                       | Error _ -> prepared.runtime_model_label
                      in
                      let spawn_result, oas_trace_ref, oas_tool_names, oas_tool_call_count,
                          trace_summary_json, trace_validation_json =
@@ -141,7 +355,7 @@ let execute_spawn_pipeline
                            Some (`Assoc [
                              ("oas_session_id", `String result.session_id);
                              ("turns", `Int result.turns);
-                             ("model", `String prepared.runtime_model_label);
+                             ("model", `String resolved_model);
                              ("tool_names", `List (List.map (fun n -> `String n) tool_names));
                              ("tool_call_count", `Int (List.length tool_names));
                              ("input_tokens",
@@ -198,15 +412,10 @@ let execute_spawn_pipeline
                      let verification_outcome =
                        match oas_result with
                        | Ok result ->
-                           let model_used =
-                             if String.trim result.response.model <> "" then
-                               result.response.model
-                             else prepared.runtime_model_label
-                           in
                            let run_result : Worker_container_types.run_result =
                              {
                                output = spawn_result.output;
-                               model_used;
+                               model_used = resolved_model;
                                input_tokens = spawn_result.input_tokens;
                                output_tokens = spawn_result.output_tokens;
                                cost_usd = spawn_result.cost_usd;
@@ -262,12 +471,11 @@ let execute_spawn_pipeline
                        ~mode:"spawn" ~wait_mode
                        ~status:
                          (if spawn_result.success then `Completed else `Failed)
-                       ?execution_scope:
-                         (deps.effective_execution_scope_of_spec prepared.spec)
+                       ?execution_scope:execution_scope
                        ?requested_worker_class:prepared.spec.worker_class
                        ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
                        ?resolved_runtime:prepared.assigned_runtime
-                       ~resolved_model:prepared.runtime_model_label
+                       ~resolved_model
                        ?routing_reason:prepared.spec.routing_reason
                        ~tool_names:oas_tool_names
                        ~tool_call_count:oas_tool_call_count
@@ -290,11 +498,10 @@ let execute_spawn_pipeline
                        ?runtime_actor:prepared.runtime_actor_name
                        ?spawn_role:prepared.spec.spawn_role
                        ?spawn_model:prepared.spec.spawn_model
-                       ?execution_scope:
-                         (deps.effective_execution_scope_of_spec prepared.spec)
+                       ?execution_scope:execution_scope
                        ?worker_class:prepared.spec.worker_class
                        ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?worker_backend:(Some "oas")
+                       ?worker_backend:(worker_backend_of_prepared prepared)
                        ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
                        ~trace_capability:"raw"
                        ?parent_actor:prepared.spec.parent_actor
@@ -374,17 +581,17 @@ let execute_spawn_pipeline
                          ("worker_run_id", `String prepared.worker_run_id);
                          ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
                          ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
-                         ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) (deps.effective_execution_scope_of_spec prepared.spec));
+                         ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) execution_scope);
                          ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) prepared.spec.thinking_enabled);
                          ("max_turns", Option.fold ~none:`Null ~some:(fun n -> `Int n) prepared.spec.max_turns);
                          ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
                          ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (deps.worker_size_of_spec prepared.spec));
-                         ("worker_backend", if deps.is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
+                         ("worker_backend", Option.fold ~none:`Null ~some:(fun value -> `String value) (worker_backend_of_prepared prepared));
                          ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
                          ("status", `String "completed");
                          ("trace_capability", `String (if Option.is_some oas_trace_ref then "raw" else "summary_only"));
                          ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.assigned_runtime);
-                         ("resolved_model", `String prepared.runtime_model_label);
+                         ("resolved_model", `String resolved_model);
                          ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.routing_reason);
                          ("tool_call_count", `Int oas_tool_call_count);
                          ("tool_names", `List (List.map (fun name -> `String name) oas_tool_names));
@@ -400,13 +607,14 @@ let execute_spawn_pipeline
                          Option.value ~default:ctx.sw
                            (Eio_context.get_switch_opt ())
                        in
-                       List.iter
-                         (fun prepared ->
+                       List.iteri
+                         (fun index prepared ->
+                           let started_at = Time_compat.now () in
                            append_spawn_requested_event
                              ~worker_run_id:prepared.worker_run_id
                              prepared;
                            Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                               try ignore (execute_spawn 0 prepared)
+                               try ignore (execute_spawn index prepared)
                                with
                                | Eio.Cancel.Cancelled _ as exn -> raise exn
                                | exn ->
@@ -414,7 +622,10 @@ let execute_spawn_pipeline
                                    "background spawn failed (worker_run_id=%s, agent=%s): %s"
                                    prepared.worker_run_id
                                    prepared.spec.spawn_agent
-                                   (Printexc.to_string exn)))
+                                   (Printexc.to_string exn);
+                                 ignore
+                                   (record_spawn_exception index prepared
+                                      ~started_at exn)))
                          prepared_spawns;
                        let accepted =
                          prepared_spawns

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -317,7 +317,6 @@ let execute_spawn_pipeline
                           ~max_tokens:(Safe_ops.get_env_int_logged
                             "MASC_SPAWN_MAX_TOKENS" ~default:4096)
                           ~priority:Llm_provider.Request_priority.Interactive
-                          ?enable_thinking:prepared.spec.thinking_enabled
                           ?contract ?net:ctx.net ~sw:ctx.sw
                           ()
                     in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -147,10 +147,15 @@ let code_mutation_denied_tools =
 let masc_mutating_denied_tools =
   [ "masc_add_task"; "masc_claim_next"; "masc_transition";
     "masc_complete_task";  (* alias of masc_transition *)
+    "masc_board_post"; "masc_board_comment"; "masc_board_vote";
     "masc_worktree_create"; "masc_worktree_remove";
     "masc_portal_open"; "masc_portal_send"; "masc_portal_close";
     "masc_plan_set_task"; "masc_plan_clear_task";
     "masc_set_current_task";  (* alias of masc_plan_set_task *)
+    "masc_run_init"; "masc_run_plan"; "masc_run_log";
+    "masc_run_deliverable";
+    "masc_repair_loop_start"; "masc_repair_loop_iterate";
+    "masc_repair_loop_stop";
     "masc_operator_action"; "masc_operator_confirm";
     "masc_room_delete"; "masc_admin_cleanup"; "masc_admin_reset";
     "masc_gc_force"; "masc_spawn"; "masc_force_leave";

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -489,6 +489,24 @@ let test_team_session_spawn_tool_contracts () =
   check bool "team session spawn uses explicit masc tools path" true
     (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
        "Oas_worker.run_model_with_masc_tools");
+  check bool "team session spawn branches on local spawn agents" true
+    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
+       "if deps.is_local_spawn_agent prepared.spec.spawn_agent then");
+  check bool "team session spawn keeps non-local model-only path" true
+    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
+       {|Oas_worker.run_model_by_label
+                          ~model_label:prepared.runtime_model_label
+                          ~goal:prepared.spec.spawn_prompt
+                          ~system_prompt:(Printf.sprintf
+                            "You are agent '%s'. Execute the task and return a clear result."
+                             prepared.spec.spawn_agent)
+                          ~max_turns
+                          ~temperature:(Safe_ops.get_env_float_logged
+                            "MASC_SPAWN_TEMPERATURE" ~default:0.3)
+                          ~max_tokens:(Safe_ops.get_env_int_logged
+                            "MASC_SPAWN_MAX_TOKENS" ~default:4096)
+                          ~priority:Llm_provider.Request_priority.Interactive
+                          ?contract ?net:ctx.net ~sw:ctx.sw|});
   check bool "team session spawn contract uses scoped tool names" true
     (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
        "supported_local_worker_tool_names_for_scope");

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -485,6 +485,17 @@ let test_oas_worker_capability_threading_contracts () =
     (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
        "?raw_trace ~proof_ref ?contract ~sw")
 
+let test_team_session_spawn_tool_contracts () =
+  check bool "team session spawn uses explicit masc tools path" true
+    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
+       "Oas_worker.run_model_with_masc_tools");
+  check bool "team session spawn contract uses scoped tool names" true
+    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
+       "supported_local_worker_tool_names_for_scope");
+  check bool "team session bridge exposes scoped local worker tools" true
+    (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
+       "supported_local_worker_tool_names_for_scope")
+
 let test_dashboard_timeout_guard_contracts () =
   check bool "http transport health route uses cached dashboard helper" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
@@ -606,9 +617,11 @@ let () =
            test_case "transport health contracts" `Quick
              test_transport_health_contracts;
            test_case "worktree list contracts" `Quick
-             test_worktree_list_contracts;
+           test_worktree_list_contracts;
            test_case "oas worker capability threading contracts" `Quick
              test_oas_worker_capability_threading_contracts;
+           test_case "team session spawn tool contracts" `Quick
+             test_team_session_spawn_tool_contracts;
            test_case "dashboard timeout guard contracts" `Quick
              test_dashboard_timeout_guard_contracts;
            test_case "mermaid xss contracts" `Quick test_mermaid_xss_contracts;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -617,7 +617,7 @@ let () =
            test_case "transport health contracts" `Quick
              test_transport_health_contracts;
            test_case "worktree list contracts" `Quick
-           test_worktree_list_contracts;
+             test_worktree_list_contracts;
            test_case "oas worker capability threading contracts" `Quick
              test_oas_worker_capability_threading_contracts;
            test_case "team session spawn tool contracts" `Quick

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -371,6 +371,48 @@ let test_supported_local_worker_tools_present () =
   Alcotest.(check bool) "masc_repair_loop_start present" true
     (List.mem "masc_repair_loop_start" names)
 
+let test_supported_local_worker_tools_for_observe_only_filter_mutations () =
+  let names =
+    Team_session_oas_bridge.supported_local_worker_tool_names_for_scope
+      (Some Team_session_types.Observe_only)
+  in
+  Alcotest.(check bool) "observe_only keeps masc_status" true
+    (List.mem "masc_status" names);
+  Alcotest.(check bool) "observe_only keeps masc_code_read" true
+    (List.mem "masc_code_read" names);
+  Alcotest.(check bool) "observe_only keeps masc_worktree_list" true
+    (List.mem "masc_worktree_list" names);
+  Alcotest.(check bool) "observe_only blocks masc_worktree_create" false
+    (List.mem "masc_worktree_create" names);
+  Alcotest.(check bool) "observe_only blocks masc_worktree_remove" false
+    (List.mem "masc_worktree_remove" names);
+  Alcotest.(check bool) "observe_only blocks masc_run_init" false
+    (List.mem "masc_run_init" names);
+  Alcotest.(check bool) "observe_only blocks masc_board_post" false
+    (List.mem "masc_board_post" names)
+
+let test_supported_local_worker_tools_for_observe_only_resolve_subset () =
+  let schemas =
+    match
+      Team_session_oas_bridge.supported_local_worker_tools_for_scope
+        (Some Team_session_types.Observe_only)
+    with
+    | Ok schemas -> schemas
+    | Error message ->
+        Alcotest.failf "expected scoped schemas, got error: %s" message
+  in
+  let names =
+    List.map (fun (schema : Types.tool_schema) -> schema.name) schemas
+  in
+  Alcotest.(check bool) "scoped schemas keep masc_status" true
+    (List.mem "masc_status" names);
+  Alcotest.(check bool) "scoped schemas keep masc_code_read" true
+    (List.mem "masc_code_read" names);
+  Alcotest.(check bool) "scoped schemas block masc_worktree_create" false
+    (List.mem "masc_worktree_create" names);
+  Alcotest.(check bool) "scoped schemas block masc_run_log" false
+    (List.mem "masc_run_log" names)
+
 let test_dispatch_supported_tool_status () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -554,6 +596,10 @@ let () =
     "supported_tools", [
       Alcotest.test_case "schemas present" `Quick
         test_supported_local_worker_tools_present;
+      Alcotest.test_case "observe_only filters mutating names" `Quick
+        test_supported_local_worker_tools_for_observe_only_filter_mutations;
+      Alcotest.test_case "observe_only resolves scoped schemas" `Quick
+        test_supported_local_worker_tools_for_observe_only_resolve_subset;
       Alcotest.test_case "status dispatch" `Quick
         test_dispatch_supported_tool_status;
       Alcotest.test_case "heartbeat autojoin" `Quick

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -288,6 +288,27 @@ let test_observe_only_roundtrip () =
   Alcotest.(check (option int)) "Observe_only max_calls = 30"
     (Some 30) g.max_tool_calls_per_turn
 
+let test_observe_only_denies_mutating_masc_tools () =
+  let gate =
+    Worker_oas.gate_config_of_execution_scope
+      Team_session_types.Observe_only
+  in
+  List.iter
+    (fun name ->
+      Alcotest.(check bool) (name ^ " denied in observe_only") true
+        (List.mem name gate.denied_tools))
+    [
+      "masc_worktree_create";
+      "masc_worktree_remove";
+      "masc_run_init";
+      "masc_run_plan";
+      "masc_run_log";
+      "masc_run_deliverable";
+      "masc_board_post";
+      "masc_board_comment";
+      "masc_board_vote";
+    ]
+
 let test_limited_code_change_roundtrip () =
   let gate =
     Worker_oas.gate_config_of_execution_scope
@@ -369,6 +390,8 @@ let () =
     ("execution_scope roundtrip", [
       Alcotest.test_case "Observe_only -> DenyList" `Quick
         test_observe_only_roundtrip;
+      Alcotest.test_case "Observe_only denies mutating masc tools" `Quick
+        test_observe_only_denies_mutating_masc_tools;
       Alcotest.test_case "Limited -> DenyList" `Quick
         test_limited_code_change_roundtrip;
       Alcotest.test_case "Autonomous -> AllowAll" `Quick


### PR DESCRIPTION
## Summary
- scope local worker MASC tools by `execution_scope` so `Observe_only` workers do not receive mutating tools
- route team-session local spawn through the explicit MASC tool bridge instead of the tool-less model-only path
- persist background spawn failures as failed worker-run snapshots/events and align `resolved_model` with the actual OAS response model

## Root Cause
`team-session` had two gaps around local worker spawning:

1. `Observe_only` relied on a broad local worker surface, so state-mutating MASC tools like worktree/task/board mutations were still exposed.
2. direct spawn execution used `Oas_worker.run_model_by_label` without the MASC tool bridge, so local workers could run with no attached tool surface and contracts were composed with `tool_names = []`.

That combination meant the guardrail story was inconsistent between swarm workers and direct spawn workers, and background exceptions could also fail without emitting a failed worker-run record.

## Changes
- add scope-aware local worker tool selection helpers in `team_session_oas_bridge`
- filter swarm worker tool exposure by each planned worker's `execution_scope`
- thread optional `contract` through `run_model_with_masc_tools`
- switch direct local spawn execution to `run_model_with_masc_tools` with normalized MASC tool args
- compose delivery contracts from the scoped local worker tool names instead of `[]`
- treat background spawn exceptions as failed worker runs with snapshot + event emission + runtime release
- extend `Observe_only` deny lists to cover board/run/repair-loop mutations as well
- add regression tests for scoped tool exposure and observe-only denylist coverage

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4160-observe-scope-leak --build-dir /tmp/masc-4160-rebuild ./lib/oas_worker.ml ./lib/worker_oas.ml ./lib/team_session/team_session_oas_bridge.ml ./lib/tool_team_session_step_spawn.ml`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4160-observe-scope-leak --build-dir /tmp/masc-4160-retest-3 ./test/test_ci_hardening_source.exe`

Closes #4160.