### PR TITLE
feat(cdal): cross-run window projection + spec alignment

### DIFF
--- a/docs/design/cross-run-loader-and-window-spec.md
+++ b/docs/design/cross-run-loader-and-window-spec.md
@@ -139,7 +139,7 @@ Rules:
 - `basis_hash` (section 6) makes the snapshot deterministic: the same selected run IDs produce the same hash regardless of what arrives later
 - callers that need consistency across retries must compare `basis_hash` values; a hash change means the underlying run set changed
 - late-arriving runs are picked up by the next window query, not patched into the previous result
-- timestamp proximity (e.g., "runs within 5 seconds of now") must not be used as an ordering key. Use `manifest_creation_time` written atomically at the end of proof capture
+- timestamp proximity (e.g., "runs within 5 seconds of now") must not be used as an ordering key. Use `ended_at` from the proof manifest, which is written atomically at the end of proof capture
 
 This avoids the complexity of retroactive window mutation and keeps aggregation results reproducible.
 
@@ -154,9 +154,7 @@ Runs may use different proof manifest schema versions. The loader must handle ve
 | Unknown schema version | treat as corruption, apply partial-failure policy (section 5) |
 | Schema version too old to normalize | same as unknown |
 
-The normalization step must be explicit: a `normalize_manifest : Cdal_proof.t -> (Cdal_proof.t, string) result` function that handles version-specific field defaults and renames.
-
-No implicit field inference. If a v1 manifest lacks a field that v2 requires, the normalizer must either fill a documented default or return an error.
+Since the current schema remains at version 1 (with optional fields added via `[@yojson.default]`), normalization is handled by the existing `Cdal_proof.of_json` decoder. A separate `normalize_manifest` function is not needed at this time. If a future schema v2 introduces breaking field changes, an explicit normalizer should be added.
 
 ## 11. Proof_store Read-Side API (OAS)
 
@@ -168,31 +166,37 @@ Proposed additions to `proof_store.mli`:
 (** Run metadata for ordering and filtering. *)
 type run_info = {
   run_id: string;
-  created_at: float;       (** manifest creation timestamp *)
+  ended_at: float;         (** from Cdal_proof.t.ended_at *)
   schema_version: int;     (** proof manifest schema version *)
-  scope: string option;    (** declared scope (keeper/task/room/etc.) *)
+  scope: string option;    (** opaque scope label set by producer *)
 }
 
-(** List runs with metadata, ordered by [created_at] ascending.
-    Corrupted manifests (unreadable JSON, missing timestamp) are excluded
-    from the result and reported in the [errors] list. *)
+type window_bounds = {
+  max_runs: int;           (** hard limit on run count, default 50 *)
+  max_bytes: int;          (** hard limit on total bytes scanned, default 50MB *)
+}
+
+(** List runs with metadata, ordered by [ended_at] ascending,
+    tie-broken by [run_id].
+    Corrupted manifests are excluded and reported in the errors list. *)
 val list_runs_ordered :
   config ->
   ?scope:string ->
+  ?bounds:window_bounds ->
+  unit ->
   (run_info list * string list, string) result
-  (* Ok (runs, corruption_errors) | Error fatal *)
 
 (** Load manifests for a window of runs.
-    Applies partial-failure policy: readable runs are returned,
-    unreadable runs are reported as errors. *)
+    Readable runs returned; unreadable runs reported as errors. *)
 val load_window :
   config ->
   run_ids:string list ->
+  ?bounds:window_bounds ->
+  unit ->
   ((Cdal_proof.t * Yojson.Safe.t) list * string list, string) result
-  (* Ok (loaded_manifests, per_run_errors) | Error fatal *)
 ```
 
-These signatures keep the existing `list_runs` unchanged (backward compatible) and add structured alternatives. Implementation is tracked in OAS.
+These signatures keep the existing `list_runs` unchanged (backward compatible) and add structured alternatives. Implemented in OAS `proof_store.ml`.
 
 ## 12. Exit Criteria
 

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -187,6 +187,108 @@ let evidence_gap_group_to_json (g : evidence_gap_group) : Yojson.Safe.t =
     ("reason", `String g.reason);
   ])
 
+(* ================================================================ *)
+(* Cross-run window support                                          *)
+(* ================================================================ *)
+
+type run_window =
+  | Single_run
+  | Last_n_runs of int
+  | Session of string
+  | Rolling_seconds of float
+
+let window_to_string = function
+  | Single_run -> "single_run"
+  | Last_n_runs n -> Printf.sprintf "last_%d_runs" n
+  | Session s -> Printf.sprintf "session:%s" s
+  | Rolling_seconds s -> Printf.sprintf "rolling_%.0fs" s
+
+let compute_window_basis_hash ~window ~run_ids =
+  let sorted_ids = List.sort String.compare run_ids in
+  let input =
+    window_to_string window ^ "|"
+    ^ String.concat "," sorted_ids
+    ^ "|friction_v1"
+  in
+  "md5:" ^ (Digest.string input |> Digest.to_hex)
+
+let merge_groups (all_groups : blocked_attempt_group list list)
+    : blocked_attempt_group list =
+  let module H = Hashtbl.Make(struct
+    type t = blocked_attempt_key
+    let equal a b = compare_key a b = 0
+    let hash k =
+      Hashtbl.hash (k.tool_name, k.violation_kind, k.effective_mode)
+  end) in
+  let tbl = H.create 32 in
+  List.iter (fun groups ->
+    List.iter (fun (g : blocked_attempt_group) ->
+      let prev = try H.find tbl g.key with Not_found -> 0 in
+      H.replace tbl g.key (prev + g.count)
+    ) groups
+  ) all_groups;
+  H.fold (fun key count acc -> { key; count } :: acc) tbl []
+  |> List.sort (fun a b -> compare_key a.key b.key)
+
+let project_single_run_groups
+    ~(store : Agent_sdk.Proof_store.config)
+    (proof : Agent_sdk.Cdal_proof.t)
+    : blocked_attempt_group list * int =
+  match find_violations_ref proof with
+  | None -> ([], 0)
+  | Some ref_ ->
+    match Proof_artifact_reader.read_json store ref_ with
+    | Error _ -> ([], 0)
+    | Ok json ->
+      match Violation_record.of_json_list json with
+      | Error _ | Ok [] -> ([], 0)
+      | Ok violations ->
+        let g = group_violations violations in
+        let c = List.fold_left
+          (fun acc (grp : blocked_attempt_group) -> acc + grp.count) 0 g in
+        (g, c)
+
+let project_window
+    ~(store : Agent_sdk.Proof_store.config)
+    ~(window : run_window)
+    ?(completeness_gaps : Cdal_types.completeness_gap list = [])
+    ?(tripwire_threshold = 3)
+    (proofs : Agent_sdk.Cdal_proof.t list)
+    : friction_projection option =
+  match window, proofs with
+  | Single_run, [proof] ->
+    project_single_run ~store ~completeness_gaps ~tripwire_threshold proof
+  | Single_run, _ ->
+    None  (* Single_run requires exactly one proof *)
+  | _, [] ->
+    None
+  | _, _ ->
+    let all_groups = List.map (fun proof ->
+      let groups, _ = project_single_run_groups ~store proof in
+      groups
+    ) proofs in
+    let merged = merge_groups all_groups in
+    let blocked_attempt_count =
+      List.fold_left (fun acc (g : blocked_attempt_group) -> acc + g.count) 0 merged in
+    let gap_groups = compute_gap_groups completeness_gaps in
+    if blocked_attempt_count = 0 && gap_groups = [] then None
+    else
+      let run_ids = List.map (fun (p : Agent_sdk.Cdal_proof.t) -> p.run_id) proofs in
+      Some {
+        window = window_to_string window;
+        based_on_run_ids = run_ids;
+        basis_hash = compute_window_basis_hash ~window ~run_ids;
+        blocked_attempt_count;
+        blocked_tool_counts = compute_tool_counts merged;
+        blocked_attempt_groups = merged;
+        evidence_gap_groups = gap_groups;
+        review_tripwires = compute_tripwires ~threshold:tripwire_threshold merged;
+      }
+
+(* ================================================================ *)
+(* JSON serialization                                                *)
+(* ================================================================ *)
+
 let to_json (fp : friction_projection) : Yojson.Safe.t =
   Yojson.Safe.sort (`Assoc [
     ("based_on_run_ids", `List (List.map (fun s -> `String s) fp.based_on_run_ids));

--- a/lib/cdal_friction_projection.mli
+++ b/lib/cdal_friction_projection.mli
@@ -57,3 +57,42 @@ val project_single_run :
 
 (** Canonical JSON serialization with sorted keys. *)
 val to_json : friction_projection -> Yojson.Safe.t
+
+(** {1 Cross-run window support}
+
+    @since CDAL Phase 3 *)
+
+(** Cross-run window specification. *)
+type run_window =
+  | Single_run
+  | Last_n_runs of int
+  | Session of string
+  | Rolling_seconds of float
+
+(** [project_window ~store ~window ?scope ?completeness_gaps
+     ?tripwire_threshold proofs]
+    Projects friction across a set of runs. For [Single_run],
+    delegates to [project_single_run] using the first proof.
+    For cross-run windows, aggregates violations across multiple
+    manifests.
+
+    @since CDAL Phase 3 *)
+val project_window :
+  store:Agent_sdk.Proof_store.config ->
+  window:run_window ->
+  ?completeness_gaps:Cdal_types.completeness_gap list ->
+  ?tripwire_threshold:int ->
+  Agent_sdk.Cdal_proof.t list ->
+  friction_projection option
+
+(** Compute deterministic basis hash for cross-run window.
+    Includes window type, run IDs (sorted), and version.
+
+    @since CDAL Phase 3 *)
+val compute_window_basis_hash :
+  window:run_window ->
+  run_ids:string list ->
+  string
+
+(** String representation of a run window. *)
+val window_to_string : run_window -> string

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -44,6 +44,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -40,6 +40,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let setup_store () =
@@ -368,6 +369,143 @@ let test_path_traversal_rejected () =
     Alcotest.fail (Printf.sprintf "should reject, got Ok: %s" path)
 
 (* ================================================================ *)
+(* Cross-run window tests                                            *)
+(* ================================================================ *)
+
+let make_proof_with_scope
+    ?(run_id = "cr-001")
+    ?(raw_evidence_refs = [])
+    ?(ended_at = 1001.0)
+    ?(scope = None)
+    () : Agent_sdk.Cdal_proof.t =
+  {
+    schema_version = Agent_sdk.Cdal_proof.schema_version_current;
+    run_id;
+    contract_id = "md5:test";
+    requested_execution_mode = Execute;
+    effective_execution_mode = Execute;
+    mode_decision_source = "passthrough";
+    risk_class = Agent_sdk.Risk_class.Low;
+    provider_snapshot = {
+      provider_name = "test"; model_id = "test-model"; api_version = None;
+    };
+    capability_snapshot = {
+      tools = ["read"]; mcp_servers = []; max_turns = 10;
+      max_tokens = Some 4096; thinking_enabled = None;
+    };
+    tool_trace_refs = [];
+    raw_evidence_refs;
+    checkpoint_ref = None;
+    result_status = Completed;
+    started_at = ended_at -. 1.0;
+    ended_at;
+    scope;
+  }
+
+let test_project_window_single_run () =
+  let store, _dir = setup_store () in
+  let run_id = "cr-single-001" in
+  let ref_ = make_ref ~run_id in
+  let violations = `List [
+    make_violation ~tool_name:"fs_edit"
+      ~violation_kind:"mutating_in_diagnose"
+      ~effective_mode:"diagnose";
+  ] in
+  write_violations_file store ~run_id violations;
+  let proof = make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_] () in
+  match CFP.project_window ~store ~window:CFP.Single_run [proof] with
+  | None -> Alcotest.fail "expected Some"
+  | Some fp ->
+    Alcotest.(check string) "window" "single_run" fp.window;
+    Alcotest.(check int) "blocked" 1 fp.blocked_attempt_count
+
+let test_project_window_last_n_runs () =
+  let store, _dir = setup_store () in
+  (* 3 runs, each with 2 violations of the same type *)
+  let proofs = List.init 3 (fun i ->
+    let run_id = Printf.sprintf "cr-last-%d" i in
+    let ref_ = make_ref ~run_id in
+    let violations = `List [
+      make_violation ~tool_name:"fs_edit"
+        ~violation_kind:"mutating_in_diagnose"
+        ~effective_mode:"diagnose";
+      make_violation ~tool_name:"fs_edit"
+        ~violation_kind:"mutating_in_diagnose"
+        ~effective_mode:"diagnose";
+    ] in
+    write_violations_file store ~run_id violations;
+    make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_]
+      ~ended_at:(1000.0 +. Float.of_int i) ()
+  ) in
+  match CFP.project_window ~store
+          ~window:(CFP.Last_n_runs 3) proofs with
+  | None -> Alcotest.fail "expected Some for cross-run"
+  | Some fp ->
+    Alcotest.(check string) "window" "last_3_runs" fp.window;
+    Alcotest.(check int) "3 run ids" 3 (List.length fp.based_on_run_ids);
+    (* 3 runs x 2 violations = 6 total, all same group *)
+    Alcotest.(check int) "blocked_attempt_count" 6 fp.blocked_attempt_count;
+    Alcotest.(check int) "1 merged group" 1
+      (List.length fp.blocked_attempt_groups)
+
+let test_project_window_tripwire_cross_run () =
+  let store, _dir = setup_store () in
+  (* 5 runs, each with 2 violations — total 10, threshold 5 should trip *)
+  let proofs = List.init 5 (fun i ->
+    let run_id = Printf.sprintf "cr-tw-%d" i in
+    let ref_ = make_ref ~run_id in
+    let violations = `List [
+      make_violation ~tool_name:"fs_edit"
+        ~violation_kind:"mutating_in_diagnose"
+        ~effective_mode:"diagnose";
+      make_violation ~tool_name:"fs_edit"
+        ~violation_kind:"mutating_in_diagnose"
+        ~effective_mode:"diagnose";
+    ] in
+    write_violations_file store ~run_id violations;
+    make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_]
+      ~ended_at:(1000.0 +. Float.of_int i) ()
+  ) in
+  match CFP.project_window ~store
+          ~window:(CFP.Last_n_runs 5)
+          ~tripwire_threshold:5 proofs with
+  | None -> Alcotest.fail "expected Some"
+  | Some fp ->
+    Alcotest.(check bool) "tripwire fires" true
+      (List.length fp.review_tripwires > 0);
+    Alcotest.(check int) "10 total" 10 fp.blocked_attempt_count
+
+let test_project_window_empty () =
+  let store, _dir = setup_store () in
+  match CFP.project_window ~store ~window:(CFP.Last_n_runs 3) [] with
+  | None -> ()
+  | Some _ -> Alcotest.fail "expected None for empty proofs"
+
+let test_basis_hash_deterministic () =
+  let h1 = CFP.compute_window_basis_hash
+    ~window:(CFP.Last_n_runs 3) ~run_ids:["a"; "b"; "c"] in
+  let h2 = CFP.compute_window_basis_hash
+    ~window:(CFP.Last_n_runs 3) ~run_ids:["c"; "a"; "b"] in
+  Alcotest.(check string) "same hash regardless of order" h1 h2
+
+let test_basis_hash_changes_with_window () =
+  let h1 = CFP.compute_window_basis_hash
+    ~window:(CFP.Last_n_runs 3) ~run_ids:["a"] in
+  let h2 = CFP.compute_window_basis_hash
+    ~window:(CFP.Last_n_runs 5) ~run_ids:["a"] in
+  Alcotest.(check bool) "different window = different hash" true (h1 <> h2)
+
+let test_window_to_string () =
+  Alcotest.(check string) "single" "single_run"
+    (CFP.window_to_string CFP.Single_run);
+  Alcotest.(check string) "last 5" "last_5_runs"
+    (CFP.window_to_string (CFP.Last_n_runs 5));
+  Alcotest.(check string) "session" "session:abc"
+    (CFP.window_to_string (CFP.Session "abc"));
+  Alcotest.(check string) "rolling" "rolling_3600s"
+    (CFP.window_to_string (CFP.Rolling_seconds 3600.0))
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -398,5 +536,21 @@ let () =
          test_tripwire_below_threshold;
        Alcotest.test_case "path traversal rejected" `Quick
          test_path_traversal_rejected;
+     ]);
+    ("cross_run", [
+       Alcotest.test_case "single run via project_window" `Quick
+         test_project_window_single_run;
+       Alcotest.test_case "last_n_runs aggregation" `Quick
+         test_project_window_last_n_runs;
+       Alcotest.test_case "cross-run tripwire" `Quick
+         test_project_window_tripwire_cross_run;
+       Alcotest.test_case "empty proofs" `Quick
+         test_project_window_empty;
+       Alcotest.test_case "basis hash deterministic" `Quick
+         test_basis_hash_deterministic;
+       Alcotest.test_case "basis hash changes with window" `Quick
+         test_basis_hash_changes_with_window;
+       Alcotest.test_case "window_to_string" `Quick
+         test_window_to_string;
      ]);
   ]

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -45,6 +45,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -43,6 +43,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_golden_set_eval.ml
+++ b/test/test_golden_set_eval.ml
@@ -78,6 +78,7 @@ let bundle_of_golden_case (gc : GS.golden_case) : CL.loaded_bundle =
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   } in
   {
     proof;

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -60,6 +60,7 @@ let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
     result_status = Oas.Cdal_proof.Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let with_snapshot_env f =


### PR DESCRIPTION
## Summary
- `run_window` type: `Single_run | Last_n_runs | Session | Rolling_seconds`
- `project_window`: aggregates violations across multiple runs, merged groups, cross-run tripwires
- `compute_window_basis_hash`: deterministic hash including window type + sorted run IDs
- Spec §9/§10/§11 aligned with code: `ended_at` ordering, no `normalize_manifest`, opaque scope

## Changed
- `lib/cdal_friction_projection.mli` + `.ml` — cross-run API
- `docs/design/cross-run-loader-and-window-spec.md` — spec alignment
- 5 test files — `scope = None` added to `Cdal_proof.t` record literals

## Test plan
- [x] `dune build --root .` passes
- [x] `dune exec test/test_cdal_friction_projection.exe` — 18/18 tests pass (11 existing + 7 cross-run)

Depends on jeong-sik/oas#527 (OAS-side Proof_store API + scope field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)