### PR TITLE
feat(keeper): lossy fold compaction strategy

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -441,6 +441,7 @@
    keeper_working_context
    keeper_checkpoint_store
    keeper_text_processing
+   keeper_compaction
    keeper_exec_context
    keeper_tools_oas
    keeper_hooks_oas
@@ -579,6 +580,7 @@
   keeper_working_context
   keeper_checkpoint_store
   keeper_text_processing
+  keeper_compaction
   keeper_exec_context
   keeper_turn_session
   keeper_turn_setup

--- a/lib/keeper/keeper_compaction.ml
+++ b/lib/keeper/keeper_compaction.ml
@@ -1,0 +1,130 @@
+(** Keeper-private compaction: lossy fold for completed subtask turns.
+
+    Compresses older turn groups into structured stubs that preserve
+    task description, outcome, and tool artifact counts.
+    More informative than SummarizeOld's first-sentence summaries.
+
+    @since keeper-lossy-fold *)
+
+(** Extract first sentence from a string (up to 120 chars). *)
+let first_sentence (s : string) : string =
+  let s = String.trim s in
+  let max_len = 120 in
+  let cut_at =
+    let period = try Some (String.index s '.') with Not_found -> None in
+    let newline = try Some (String.index s '\n') with Not_found -> None in
+    match period, newline with
+    | Some p, Some n -> Some (min p n + 1)
+    | Some p, None -> Some (p + 1)
+    | None, Some n -> Some n
+    | None, None -> None
+  in
+  match cut_at with
+  | Some pos when pos <= max_len -> String.sub s 0 pos
+  | _ ->
+    if String.length s > max_len then String.sub s 0 max_len ^ "..."
+    else s
+
+(** Extract task description from the first User message in a turn group. *)
+let task_of_turn (msgs : Agent_sdk.Types.message list) : string =
+  let rec find = function
+    | [] -> "(no description)"
+    | (m : Agent_sdk.Types.message) :: rest ->
+      if m.role = Agent_sdk.Types.User then
+        let text = Agent_sdk.Types.text_of_message m in
+        if text = "" then find rest
+        else first_sentence text
+      else find rest
+  in
+  find msgs
+
+(** Determine outcome from the last Assistant message in a turn group.
+    "success" if it contains Text content, "partial" if only tool calls. *)
+let outcome_of_turn (msgs : Agent_sdk.Types.message list) : string =
+  let rec find_last_assistant = function
+    | [] -> None
+    | (m : Agent_sdk.Types.message) :: rest ->
+      let later = find_last_assistant rest in
+      if Option.is_some later then later
+      else if m.role = Agent_sdk.Types.Assistant then Some m
+      else None
+  in
+  match find_last_assistant msgs with
+  | None -> "partial"
+  | Some m ->
+    let has_text = List.exists (function
+      | Agent_sdk.Types.Text s -> String.trim s <> ""
+      | _ -> false
+    ) m.content in
+    if has_text then "success" else "partial"
+
+(** Count tool calls by name across all messages in a turn group. *)
+let artifacts_of_turn (msgs : Agent_sdk.Types.message list) : (string * int) list =
+  let tbl = Hashtbl.create 8 in
+  List.iter (fun (m : Agent_sdk.Types.message) ->
+    List.iter (function
+      | Agent_sdk.Types.ToolUse { name; _ } ->
+        let cur = try Hashtbl.find tbl name with Not_found -> 0 in
+        Hashtbl.replace tbl name (cur + 1)
+      | _ -> ()
+    ) m.content
+  ) msgs;
+  Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+(** Format artifact counts as "name(N calls), ..." *)
+let format_artifacts (arts : (string * int) list) : string =
+  match arts with
+  | [] -> "none"
+  | _ ->
+    arts
+    |> List.map (fun (name, count) ->
+      Printf.sprintf "%s(%d calls)" name count)
+    |> String.concat ", "
+
+(** Build a fold stub message for a group of turns. *)
+let fold_stub_of_turns (turns : Agent_sdk.Types.message list list)
+    : Agent_sdk.Types.message =
+  let all_msgs = List.concat turns in
+  let task = task_of_turn all_msgs in
+  let outcome = outcome_of_turn all_msgs in
+  let artifacts = artifacts_of_turn all_msgs in
+  let n_turns = List.length turns in
+  let stub_text = Printf.sprintf
+    "[Folded: %s | %d turns]\nOutcome: %s\nArtifacts: %s"
+    task n_turns outcome (format_artifacts artifacts)
+  in
+  { Agent_sdk.Types.role = Agent_sdk.Types.User;
+    content = [Agent_sdk.Types.Text stub_text];
+    name = None;
+    tool_call_id = None }
+
+(** The fold compaction function.
+
+    Groups messages into turns via OAS [group_into_turns], preserves
+    the last [keep_recent] turns, and folds the rest into a single
+    structured stub. Only complete turns are folded — ToolUse/ToolResult
+    pairs are never split because [group_into_turns] respects turn
+    boundaries. *)
+let fold_completed ~(keep_recent : int)
+    (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let turns = Agent_sdk.Context_reducer.group_into_turns msgs in
+  let total = List.length turns in
+  if total <= keep_recent then msgs
+  else
+    let old_count = total - keep_recent in
+    let rec split_at n acc = function
+      | [] -> (List.rev acc, [])
+      | x :: rest ->
+        if n <= 0 then (List.rev acc, x :: rest)
+        else split_at (n - 1) (x :: acc) rest
+    in
+    let old_turns, recent_turns = split_at old_count [] turns in
+    match old_turns with
+    | [] -> msgs
+    | _ ->
+      let stub = fold_stub_of_turns old_turns in
+      stub :: List.concat recent_turns
+
+let fold_completed_strategy ?(keep_recent = 10) () : Agent_sdk.Context_reducer.t =
+  Agent_sdk.Context_reducer.custom (fold_completed ~keep_recent)

--- a/lib/keeper/keeper_compaction.mli
+++ b/lib/keeper/keeper_compaction.mli
@@ -1,0 +1,20 @@
+(** Keeper-private compaction strategies.
+
+    These strategies are used only by keeper's destructive compaction path
+    (keeper_exec_context.ml). They are NOT exposed as public
+    Context_compact_oas.strategy variants.
+
+    @since keeper-lossy-fold *)
+
+(** Create a lossy fold strategy that compresses completed subtask turns
+    into structured stubs. More informative than SummarizeOld.
+
+    The strategy uses OAS [Context_reducer.Custom] internally.
+    Fold is lossy (no unfold) since keeper compaction is destructive —
+    compacted messages are persisted to checkpoint.
+
+    [keep_recent] turns are preserved unchanged (default 10). *)
+val fold_completed_strategy :
+  ?keep_recent:int ->
+  unit ->
+  Agent_sdk.Context_reducer.t

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -331,17 +331,14 @@ let compact_if_needed
         (* PreCompact observability: log strategy and context state (#3165) *)
       let strategies = Context_compact_oas.[
         PruneToolOutputs; MergeContiguous;
-        DropLowImportance; SummarizeOld]
+        DropLowImportance]
       in
+      (* FoldCompleted replaces SummarizeOld — applied as a separate
+         OAS Custom reducer after the standard strategy pipeline. *)
+      let fold_reducer = Keeper_compaction.fold_completed_strategy () in
       let strategy_names =
-        List.map
-          (function
-            | Context_compact_oas.PruneToolOutputs -> "PruneToolOutputs"
-            | Context_compact_oas.MergeContiguous -> "MergeContiguous"
-            | Context_compact_oas.DropLowImportance -> "DropLowImportance"
-            | Context_compact_oas.SummarizeOld -> "SummarizeOld"
-            | Context_compact_oas.Dynamic _ -> "Dynamic")
-          strategies
+        List.map Context_compact_oas.strategy_name strategies
+        @ ["FoldCompleted"]
       in
       Log.Harness.info
         "[pre_compact] keeper=%s ratio=%.4f messages=%d tokens=%d trigger=%s"
@@ -380,11 +377,21 @@ let compact_if_needed
           Log.Harness.warn "[pre_compact] sse broadcast failed: %s"
             (Printexc.to_string exn));
       let messages, token_count =
-          Context_compact_oas.compact
-            ~system_prompt:ctx.system_prompt
-            ~messages:ctx.messages
-            ~strategies
-            ()
+          let msgs_after_compact, _ =
+            Context_compact_oas.compact
+              ~system_prompt:ctx.system_prompt
+              ~messages:ctx.messages
+              ~strategies
+              ()
+          in
+          (* Apply keeper-private fold after standard strategies *)
+          let msgs_after_fold =
+            Agent_sdk.Context_reducer.reduce fold_reducer msgs_after_compact
+          in
+          let token_count =
+            Context_compact_oas.count_tokens ctx.system_prompt msgs_after_fold
+          in
+          (msgs_after_fold, token_count)
         in
         let compacted_ctx =
           sync_oas_context

--- a/test/dune
+++ b/test/dune
@@ -45,6 +45,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_compaction
         test_metrics_rotation
         test_tool_tier
         test_tool_budget
@@ -92,6 +93,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_compaction
           test_metrics_rotation
           test_tool_tier
           test_tool_budget

--- a/test/test_keeper_compaction.ml
+++ b/test/test_keeper_compaction.ml
@@ -1,0 +1,205 @@
+open Alcotest
+
+module T = Agent_sdk.Types
+module R = Agent_sdk.Context_reducer
+
+(** Helper: create a text message with given role. *)
+let msg role text : T.message =
+  { T.role; content = [T.Text text]; name = None; tool_call_id = None }
+
+(** Helper: create a User message. *)
+let user text = msg T.User text
+
+(** Helper: create an Assistant message. *)
+let assistant text = msg T.Assistant text
+
+(** Helper: create an Assistant message with a ToolUse block. *)
+let assistant_tool_use ~id ~name ~input : T.message =
+  { T.role = T.Assistant;
+    content = [T.ToolUse { id; name; input }];
+    name = None; tool_call_id = None }
+
+(** Helper: create a Tool result message. *)
+let tool_result ~tool_use_id ~content : T.message =
+  { T.role = T.Tool;
+    content = [T.ToolResult { tool_use_id; content; is_error = false }];
+    name = None; tool_call_id = None }
+
+(** Build N turns of User+Assistant pairs. *)
+let make_turns n =
+  List.init n (fun i ->
+    [ user (Printf.sprintf "Task %d. Do the thing." (i + 1));
+      assistant (Printf.sprintf "Done task %d." (i + 1)) ]
+  ) |> List.concat
+
+(** Build a turn with tool calls. *)
+let make_tool_turn ~turn_idx ~tool_name =
+  let id = Printf.sprintf "tool_%d" turn_idx in
+  [ user (Printf.sprintf "Run %s for task %d." tool_name turn_idx);
+    assistant_tool_use ~id ~name:tool_name ~input:`Null;
+    tool_result ~tool_use_id:id ~content:"ok";
+    assistant (Printf.sprintf "Completed %s." tool_name) ]
+
+(* ================================================================ *)
+(* Test: fold preserves recent turns                                 *)
+(* ================================================================ *)
+
+let test_fold_preserves_recent () =
+  let msgs = make_turns 10 in
+  let reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:3 () in
+  let result = R.reduce reducer msgs in
+  (* 10 turns, keep 3 => 7 folded into 1 stub + 3 recent turns (2 msgs each) = 7 msgs *)
+  let expected_count = 1 + (3 * 2) in
+  check int "message count after fold" expected_count (List.length result);
+  (* First message should be the fold stub *)
+  let first = List.hd result in
+  check bool "stub is User role" true (first.role = T.User);
+  let stub_text = T.text_of_message first in
+  check bool "stub contains [Folded:" true
+    (String.length stub_text > 0
+     && let prefix = "[Folded:" in
+        String.length stub_text >= String.length prefix
+        && String.sub stub_text 0 (String.length prefix) = prefix);
+  check bool "stub contains turn count" true
+    (let pat = "7 turns" in
+     try let _ = Str.search_forward (Str.regexp_string pat) stub_text 0 in true
+     with Not_found -> false);
+  (* Last 3 turns should be intact *)
+  let last_6 = List.filteri (fun i _ -> i >= 1) result in
+  let task_8_text = T.text_of_message (List.nth last_6 0) in
+  check bool "recent turn 8 preserved" true
+    (try let _ = Str.search_forward (Str.regexp_string "Task 8") task_8_text 0 in true
+     with Not_found -> false)
+
+(* ================================================================ *)
+(* Test: fold stub format (task/outcome/artifacts)                   *)
+(* ================================================================ *)
+
+let test_fold_stub_format () =
+  let msgs =
+    make_tool_turn ~turn_idx:1 ~tool_name:"bash"
+    @ make_tool_turn ~turn_idx:2 ~tool_name:"bash"
+    @ make_tool_turn ~turn_idx:3 ~tool_name:"read_file"
+    @ [user "Final question."; assistant "Here is the answer."]
+  in
+  let reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:1 () in
+  let result = R.reduce reducer msgs in
+  let stub = List.hd result in
+  let stub_text = T.text_of_message stub in
+  check bool "contains Outcome:" true
+    (try let _ = Str.search_forward (Str.regexp_string "Outcome:") stub_text 0 in true
+     with Not_found -> false);
+  check bool "contains Artifacts:" true
+    (try let _ = Str.search_forward (Str.regexp_string "Artifacts:") stub_text 0 in true
+     with Not_found -> false);
+  check bool "contains bash calls" true
+    (try let _ = Str.search_forward (Str.regexp_string "bash(") stub_text 0 in true
+     with Not_found -> false);
+  check bool "contains read_file calls" true
+    (try let _ = Str.search_forward (Str.regexp_string "read_file(") stub_text 0 in true
+     with Not_found -> false);
+  check bool "outcome is success" true
+    (try let _ = Str.search_forward (Str.regexp_string "Outcome: success") stub_text 0 in true
+     with Not_found -> false)
+
+(* ================================================================ *)
+(* Test: turn boundary invariant (ToolUse/ToolResult not split)      *)
+(* ================================================================ *)
+
+let test_turn_boundary_invariant () =
+  (* A single turn with ToolUse+ToolResult should not be split *)
+  let msgs =
+    make_tool_turn ~turn_idx:1 ~tool_name:"bash"
+    @ [user "Done."; assistant "All done."]
+  in
+  let reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:1 () in
+  let result = R.reduce reducer msgs in
+  (* Turn 1 (4 msgs) folded into stub, turn 2 (2 msgs) preserved *)
+  check int "message count" 3 (List.length result);
+  (* Verify no orphan ToolUse or ToolResult in the output *)
+  let has_orphan = List.exists (fun (m : T.message) ->
+    let has_tool_use = List.exists (function T.ToolUse _ -> true | _ -> false) m.content in
+    let has_tool_result = List.exists (function T.ToolResult _ -> true | _ -> false) m.content in
+    (* Stub messages should not contain raw ToolUse/ToolResult *)
+    m.role = T.User && (has_tool_use || has_tool_result)
+  ) result in
+  check bool "no orphan tool blocks in stubs" false has_orphan
+
+(* ================================================================ *)
+(* Test: empty messages not folded                                   *)
+(* ================================================================ *)
+
+let test_empty_not_folded () =
+  let reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:5 () in
+  let result = R.reduce reducer [] in
+  check int "empty input => empty output" 0 (List.length result)
+
+(* ================================================================ *)
+(* Test: all within keep_recent => no folding                        *)
+(* ================================================================ *)
+
+let test_all_within_keep_recent () =
+  let msgs = make_turns 3 in
+  let reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:5 () in
+  let result = R.reduce reducer msgs in
+  check int "no folding when within budget" (List.length msgs) (List.length result);
+  (* Messages should be identical *)
+  List.iter2 (fun (orig : T.message) (res : T.message) ->
+    check string "message text preserved"
+      (T.text_of_message orig) (T.text_of_message res)
+  ) msgs result
+
+(* ================================================================ *)
+(* Test: fold vs SummarizeOld — fold is more structured              *)
+(* ================================================================ *)
+
+let test_fold_vs_summarize_old () =
+  let msgs =
+    make_tool_turn ~turn_idx:1 ~tool_name:"bash"
+    @ make_tool_turn ~turn_idx:2 ~tool_name:"read_file"
+    @ [user "Wrap up."; assistant "All done."]
+  in
+  (* Fold result *)
+  let fold_reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy ~keep_recent:1 () in
+  let fold_result = R.reduce fold_reducer msgs in
+  let fold_stub_text = T.text_of_message (List.hd fold_result) in
+  (* SummarizeOld result *)
+  let summarize_result =
+    Masc_mcp.Context_compact_oas.summarize_old_messages ~keep_recent:2 msgs
+  in
+  let summarize_first_text =
+    match summarize_result with
+    | m :: _ -> T.text_of_message m
+    | [] -> ""
+  in
+  (* Fold stub should contain structured fields that SummarizeOld lacks *)
+  let has_outcome s =
+    try let _ = Str.search_forward (Str.regexp_string "Outcome:") s 0 in true
+    with Not_found -> false
+  in
+  let has_artifacts s =
+    try let _ = Str.search_forward (Str.regexp_string "Artifacts:") s 0 in true
+    with Not_found -> false
+  in
+  check bool "fold has Outcome:" true (has_outcome fold_stub_text);
+  check bool "fold has Artifacts:" true (has_artifacts fold_stub_text);
+  check bool "summarize lacks Outcome:" false (has_outcome summarize_first_text);
+  check bool "summarize lacks Artifacts:" false (has_artifacts summarize_first_text)
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  run "keeper_compaction"
+    [
+      ( "fold_completed",
+        [
+          test_case "preserves recent turns" `Quick test_fold_preserves_recent;
+          test_case "stub contains task/outcome/artifacts" `Quick test_fold_stub_format;
+          test_case "turn boundary invariant" `Quick test_turn_boundary_invariant;
+          test_case "empty messages not folded" `Quick test_empty_not_folded;
+          test_case "all within keep_recent" `Quick test_all_within_keep_recent;
+          test_case "fold vs SummarizeOld comparison" `Quick test_fold_vs_summarize_old;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Keeper-private FoldCompleted replaces SummarizeOld in the keeper compaction pipeline
- Structured fold stubs preserve task description, outcome status, and tool artifact counts
- No OAS changes — uses Context_reducer.Custom internally
- SummarizeOld remains available in Context_compact_oas for other callers

## Changes
- lib/keeper/keeper_compaction.ml / .mli — new module with fold_completed_strategy
- lib/keeper/keeper_exec_context.ml — replace SummarizeOld with fold reducer applied after standard strategies
- lib/dune — add keeper_compaction to modules and private_modules
- test/test_keeper_compaction.ml — 6 test cases covering fold behavior, stub format, turn boundary invariant

## Test plan
- [x] dune build passes
- [x] test_keeper_compaction passes (6/6)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)