### PR TITLE
feat(dashboard): overhaul agent/keeper detail page UX

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -14,7 +14,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="실시간 활동 스트림">
       ${entries.length === 0
-        ? html`<${EmptyState} message="관련 이벤트 없음" compact />`
+        ? html`<${EmptyState} message="이 에이전트의 SSE 이벤트가 아직 없습니다. 대시보드 접속 후 발생한 이벤트만 표시됩니다." compact />`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -91,12 +91,18 @@ export function workerBriefForAgent(agentName: string | null) {
 
 export function agentJournalEntries(agentName: string | null): JournalEntry[] {
   if (!agentName) return []
-  const nameLower = agentName.toLowerCase()
+  const keeper = keeperForAgent(agentName)
+  const names = [agentName, keeper?.name, keeper?.agent_name]
+    .filter((n): n is string => n != null && n !== '')
+    .map(n => n.toLowerCase())
+
   return journal.value
     .filter((entry: JournalEntry) => {
       const text = entry.text.toLowerCase()
       const agent = entry.agent.toLowerCase()
-      return agent === nameLower || text.includes(nameLower) || text.includes(`@${nameLower}`)
+      return names.some(name =>
+        agent === name || text.includes(name) || text.includes(`@${name}`),
+      )
     })
     .slice(0, 15)
 }
@@ -150,8 +156,16 @@ export async function refreshAgentDetail(): Promise<void> {
         .catch(() => null),
     ])
 
+    const keeper = keeperForAgent(agentName)
+    const matchNames = [agentName, keeper?.name, keeper?.agent_name]
+      .filter((n): n is string => n != null && n !== '')
+      .map(n => n.toLowerCase())
+
     roomActivity.value = lines
-      .filter(line => line.includes(agentName))
+      .filter(line => {
+        const lower = line.toLowerCase()
+        return matchNames.some(name => lower.includes(name))
+      })
       .slice(0, 20)
 
     agentTimeline.value = timelineResult

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -89,12 +89,17 @@ export function workerBriefForAgent(agentName: string | null) {
   return executionWorkerSupportBriefs.value.find(w => w.name === agentName) ?? null
 }
 
-export function agentJournalEntries(agentName: string | null): JournalEntry[] {
-  if (!agentName) return []
+/** Collect lowercase name variants for an agent (including keeper aliases). */
+function agentMatchNames(agentName: string): string[] {
   const keeper = keeperForAgent(agentName)
-  const names = [agentName, keeper?.name, keeper?.agent_name]
+  return [agentName, keeper?.name, keeper?.agent_name]
     .filter((n): n is string => n != null && n !== '')
     .map(n => n.toLowerCase())
+}
+
+export function agentJournalEntries(agentName: string | null): JournalEntry[] {
+  if (!agentName) return []
+  const names = agentMatchNames(agentName)
 
   return journal.value
     .filter((entry: JournalEntry) => {
@@ -156,10 +161,7 @@ export async function refreshAgentDetail(): Promise<void> {
         .catch(() => null),
     ])
 
-    const keeper = keeperForAgent(agentName)
-    const matchNames = [agentName, keeper?.name, keeper?.agent_name]
-      .filter((n): n is string => n != null && n !== '')
-      .map(n => n.toLowerCase())
+    const matchNames = agentMatchNames(agentName)
 
     roomActivity.value = lines
       .filter(line => {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -7,6 +7,7 @@ import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
+import { resolveUnifiedStatus } from '../lib/unified-status'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { keeperIdentityHint } from './common/keeper-identity'
@@ -88,23 +89,12 @@ export function AgentDetailOverlay() {
   const lines = roomActivity.value
   const displayName = missionBrief?.display_name ?? keeper?.name ?? agentName
   const secondaryLabel = displayName !== agentName ? agentName : null
-  const headerStatus = agent?.status ?? missionBrief?.status ?? 'unknown'
+  const unified = resolveUnifiedStatus(keeper?.status, agent?.status, missionBrief?.signal_truth)
   const isArchivedParticipant = !agent && missionBrief?.is_live === false
   const lastSeenAt =
     agent?.last_seen
     ?? missionBrief?.last_activity_at
     ?? null
-  const signalTruth =
-    missionBrief?.signal_truth === 'live'
-      ? 'live'
-      : missionBrief?.signal_truth === 'stale'
-        ? 'stale'
-        : missionBrief?.signal_truth === 'archived'
-          ? 'archived'
-          : missionBrief?.signal_truth === 'unknown'
-            ? 'unknown'
-            : null
-  const evidenceSource = missionBrief?.evidence_source ?? null
   const agentEmoji = agent?.emoji ?? keeper?.emoji
   const rawKoreanName = agent?.koreanName ?? keeper?.koreanName
   // Don't show koreanName if it's actually an agent runtime name, not Korean text
@@ -125,9 +115,10 @@ export function AgentDetailOverlay() {
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-2xl border border-card-border bg-bg-1/95 backdrop-blur-2xl p-6 shadow-2xl shadow-black/50 ring-1 ring-white/5"
+      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-2xl border border-card-border bg-bg-1/95 backdrop-blur-2xl shadow-2xl shadow-black/50 ring-1 ring-white/5"
     >
-        <div class="flex justify-between items-start gap-4 mb-6">
+      <div class="p-6 flex flex-col gap-5">
+        <div class="flex justify-between items-start gap-4">
           <div class="flex flex-col gap-3 flex-1">
             <div class="flex items-center gap-4">
               ${agentEmoji ? html`<div class="size-12 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
@@ -138,14 +129,13 @@ export function AgentDetailOverlay() {
                   ${showSecondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-white/5 px-2 py-0.5 rounded-md">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
-                  <${StatusBadge} status=${headerStatus} />
+                  <${StatusBadge} status=${unified.canonical} />
+                  ${unified.description !== unified.label ? html`<span class="text-[10px] font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded-md" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">archived session participant</span>` : null}
                   ${agent?.model ? html`<span class="font-mono text-[10px] font-medium bg-white/10 border border-white/5 px-2 py-1 rounded-md text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
                     : null}
-                  ${signalTruth ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">signal · ${signalTruth}</span>` : null}
-                  ${evidenceSource ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">source · ${evidenceSource}</span>` : null}
                 </div>
               </div>
             </div>
@@ -188,15 +178,15 @@ export function AgentDetailOverlay() {
           </div>
         </div>
 
-        ${detailError.value ? html`<div class="p-4 mb-4 text-bad border border-bad/30 rounded-xl bg-bad/10 shadow-sm font-medium text-sm">${detailError.value}</div>` : null}
+        ${detailError.value ? html`<div class="p-4 text-bad border border-bad/30 rounded-xl bg-bad/10 shadow-sm font-medium text-sm">${detailError.value}</div>` : null}
 
         <${AgentSessionReport} agentName=${agentName} />
 
-        <${CollapsibleSection} title="활동 추적" class="mb-5" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">GitHub Agents 스타일</span>`}>
+        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">GitHub Agents 스타일</span>`}>
           <${SessionTraceView} agentName=${agentName} isKeeper=${!!keeper} />
         <//>
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
@@ -205,7 +195,7 @@ export function AgentDetailOverlay() {
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 기록이 없습니다" compact /></div>`
+              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 80개 room 메시지에서 이 에이전트 관련 항목 없음" compact /></div>`
               : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded-xl shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
@@ -263,6 +253,7 @@ export function AgentDetailOverlay() {
             </div>
           <//>
         </div>
+      </div>
     <//>
   `
 }

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -13,6 +13,7 @@ import { EmptyState } from './common/empty-state'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { StatGrid } from './common/stat-tile'
+import { formatTokens } from './keeper-detail-panels'
 import { AgentAvatar } from './overview/agent-avatar'
 import {
   agents,
@@ -234,13 +235,12 @@ function CharacterPlate({ name }: { name: string }) {
             ${displayName}
           </h2>
           ${koreanName ? html`<span class="text-base text-[var(--text-muted)]">(${koreanName})</span>` : ''}
-          ${generation != null ? html`<span class="text-sm font-bold text-[var(--accent)] bg-[var(--accent-10)] border border-[rgba(71,184,255,0.25)] px-1.5 py-px tabular-nums rounded">Lv.${generation}</span>` : null}
+          ${generation != null ? html`<span class="text-sm font-bold text-[var(--accent)] bg-[var(--accent-10)] border border-[rgba(71,184,255,0.25)] px-1.5 py-px tabular-nums rounded" title="세대 번호 — 핸드오프마다 증가 (레벨/등급 아님)">Gen.${generation}</span>` : null}
         </div>
 
         <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
           ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-[11px] text-[var(--text-muted)] bg-[var(--accent-8)] border border-[rgba(71,184,255,0.15)] px-[5px] py-px rounded">${model}</span>` : null}
-          ${signalTruth ? html`<span class="ff-plate__signal rounded ff-plate__signal--${signalTruth}">${signalTruth}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
@@ -250,6 +250,9 @@ function CharacterPlate({ name }: { name: string }) {
               <div class="h-full rounded-full transition-[width] duration-[250ms] ease-[ease] motion-reduce:transition-none ${ctxBarClass(ctxRatio) === 'warn' ? 'bg-linear-to-r from-[var(--warn)] to-[var(--warn-bright)]' : ctxBarClass(ctxRatio) === 'bad' ? 'bg-linear-to-r from-[var(--bad)] to-[var(--warn-bright)]' : 'bg-linear-to-r from-[var(--accent)] to-[var(--ok)]'}" style=${{ width: `${ctxPct}%` }}></div>
             </div>
             <span class="text-[13px] tabular-nums text-[var(--text-strong)] min-w-9 text-right">${ctxPct}%</span>
+            ${keeper?.context_tokens != null && keeper?.context_max != null
+              ? html`<span class="text-[11px] tabular-nums text-[var(--text-muted)] font-mono ml-1">${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}</span>`
+              : null}
           </div>
         ` : null}
 
@@ -281,10 +284,10 @@ function CharacterPlate({ name }: { name: string }) {
       <div class="w-full mt-2">
         ${isKeeper ? html`
           <${StatGrid} cols=${4} items=${[
-            { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', variant: 'gold' },
+            { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', hint: keeper.context_tokens != null && keeper.context_max != null ? `${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}` : undefined, variant: 'gold' },
             { label: '세대', value: generation ?? 0, variant: 'gold' },
             { label: '턴', value: keeper.turn_count ?? 0, variant: 'gold' },
-            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, variant: 'gold' },
+            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, hint: (keeper.autonomous_turn_count ?? 0) === 0 ? (keeper.proactive_enabled ? '활성 · 미발동' : '자율 비활성') : undefined, variant: 'gold' },
           ]} />
         ` : html`
           <${StatGrid} cols=${4} items=${[

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -13,7 +13,7 @@ import { EmptyState } from './common/empty-state'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { StatGrid } from './common/stat-tile'
-import { formatTokens } from './keeper-detail-panels'
+import { autonomyHint, formatTokens } from './keeper-detail-panels'
 import { AgentAvatar } from './overview/agent-avatar'
 import {
   agents,
@@ -287,7 +287,7 @@ function CharacterPlate({ name }: { name: string }) {
             { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', hint: keeper.context_tokens != null && keeper.context_max != null ? `${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}` : undefined, variant: 'gold' },
             { label: '세대', value: generation ?? 0, variant: 'gold' },
             { label: '턴', value: keeper.turn_count ?? 0, variant: 'gold' },
-            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, hint: (keeper.autonomous_turn_count ?? 0) === 0 ? (keeper.proactive_enabled ? '활성 · 미발동' : '자율 비활성') : undefined, variant: 'gold' },
+            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, hint: autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled), variant: 'gold' },
           ]} />
         ` : html`
           <${StatGrid} cols=${4} items=${[

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -24,6 +24,6 @@ export function keeperIdentityHint(
   const keeper = keeperName?.trim()
   const runtime = runtimeAgentName(keeper, agentName)
   if (!keeper) return null
-  if (!runtime) return `keeper key · ${keeper}`
-  return `keeper key · ${keeper} · runtime agent · ${runtime}`
+  if (!runtime) return `키퍼 · ${keeper}`
+  return `키퍼 · ${keeper} · 런타임 · ${runtime}`
 }

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -26,7 +26,7 @@ const LABEL_STYLES = {
 
 export function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
   return html`
-    <div class="flex flex-col items-center rounded-lg border px-3.5 py-2.5 ${VARIANT_STYLES[variant]}">
+    <div class="flex flex-col items-center gap-0.5 rounded-lg border px-4 py-3 ${VARIANT_STYLES[variant]}">
       <span class="text-base font-bold tabular-nums leading-tight">${value}</span>
       <span class="text-[length:var(--fs-2xs)] tracking-wider uppercase ${LABEL_STYLES[variant]}">${label}</span>
       ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -18,7 +18,7 @@ export function Operations() {
   const section = currentSection()
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
         ${section === 'governance'
           ? html`<${Governance} />`

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -28,6 +28,11 @@ export function formatTokens(n: number | undefined): string {
   return String(n)
 }
 
+export function autonomyHint(count: number | undefined, proactiveEnabled: boolean | undefined): string | undefined {
+  if ((count ?? 0) === 0) return proactiveEnabled ? '활성 · 미발동' : '자율 비활성'
+  return undefined
+}
+
 
 // ── KPI Card ─────────────────────────────────────────────
 
@@ -177,12 +182,12 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         <${KpiCard}
           label="Auto Actions"
           value=${keeper.autonomous_action_count ?? 0}
-          hint=${(keeper.autonomous_action_count ?? 0) === 0 ? (keeper.proactive_enabled ? '활성 · 미발동' : '자율 비활성') : '자율 행동 횟수'}
+          hint=${autonomyHint(keeper.autonomous_action_count, keeper.proactive_enabled) ?? '자율 행동 횟수'}
         />
         <${KpiCard}
           label="Auto Turns"
           value=${keeper.autonomous_turn_count ?? 0}
-          hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : (keeper.autonomous_turn_count ?? 0) === 0 ? '미발동' : undefined}
+          hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled) ?? '미발동'}
         />
         <${KpiCard}
           label="Board React"

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -172,31 +172,29 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           ? html`<${KpiCard} label="Cost (USD)" value=${latestCost} />`
           : null}
       </div>
-      ${'' /* Autonomy KPIs — activity breakdown */}
-      ${(keeper.autonomous_action_count ?? 0) > 0 || (keeper.board_reactive_turn_count ?? 0) > 0 ? html`
-        <div class="grid grid-cols-4 gap-2">
-          <${KpiCard}
-            label="Auto Actions"
-            value=${keeper.autonomous_action_count ?? '-'}
-            hint="자율 행동 횟수"
-          />
-          <${KpiCard}
-            label="Auto Turns"
-            value=${keeper.autonomous_turn_count ?? '-'}
-            hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : undefined}
-          />
-          <${KpiCard}
-            label="Board React"
-            value=${keeper.board_reactive_turn_count ?? '-'}
-            hint="게시판 반응"
-          />
-          <${KpiCard}
-            label="Noop"
-            value=${keeper.noop_turn_count ?? '-'}
-            hint="비활동 턴"
-          />
-        </div>
-      ` : null}
+      ${'' /* Autonomy KPIs — always visible for keeper context */}
+      <div class="grid grid-cols-4 gap-2">
+        <${KpiCard}
+          label="Auto Actions"
+          value=${keeper.autonomous_action_count ?? 0}
+          hint=${(keeper.autonomous_action_count ?? 0) === 0 ? (keeper.proactive_enabled ? '활성 · 미발동' : '자율 비활성') : '자율 행동 횟수'}
+        />
+        <${KpiCard}
+          label="Auto Turns"
+          value=${keeper.autonomous_turn_count ?? 0}
+          hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : (keeper.autonomous_turn_count ?? 0) === 0 ? '미발동' : undefined}
+        />
+        <${KpiCard}
+          label="Board React"
+          value=${keeper.board_reactive_turn_count ?? 0}
+          hint="게시판 반응"
+        />
+        <${KpiCard}
+          label="Noop"
+          value=${keeper.noop_turn_count ?? 0}
+          hint="비활동 턴"
+        />
+      </div>
       ${'' /* Proactive activity callout */}
       ${keeper.last_proactive_ago_s != null ? html`
         <div class="rounded-xl border border-purple-400/20 bg-purple-500/5 p-3 text-[11px]">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -32,6 +32,7 @@ import {
 } from './keeper-detail-runtime'
 import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
 import { PipelineStageBar } from './keeper-pipeline-stage'
+import { AgentJournalStream } from './agent-detail-journal'
 import { KeeperTrajectoryTimeline } from './keeper-trajectory-timeline'
 import { DialogOverlay } from './common/dialog'
 import { CollapsibleSection } from './common/collapsible'
@@ -107,15 +108,23 @@ function KeeperStatusPill({ status }: { status: string }) {
 // ── Comms Panel ──────────────────────────────────────────
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
+  const isOffline = keeper.status === 'offline' || keeper.status === 'inactive'
+
   return html`
     <div class="border-t border-[var(--border-slate-12)] pt-5">
       <h3 class="m-0 mb-3 text-[13px] font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
+
+      ${isOffline ? html`
+        <div class="px-4 py-3 rounded-xl border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-[13px] text-[var(--text-muted)]">
+          이 키퍼는 현재 비활동 상태입니다. Boot 후 메시지를 보낼 수 있습니다.
+        </div>
+      ` : null}
 
       <div class="flex flex-col gap-4">
         <div class="w-full">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
-            placeholder="이 키퍼에게 직접 프롬프트 전송"
+            placeholder=${isOffline ? '키퍼 오프라인 — Boot 필요' : '이 키퍼에게 직접 프롬프트 전송'}
           />
         </div>
 
@@ -386,6 +395,9 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
+
+        ${'' /* ── Live journal stream ── */}
+        <${AgentJournalStream} agentName=${keeper.name} />
 
         ${'' /* ── Detail sections grid ── */}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -19,7 +19,7 @@ export function Status() {
   const section = currentSection()
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
         ${section === 'agents'
           ? html`<${AgentsUnified} />`

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -22,7 +22,7 @@ export function Work() {
     : 'board'
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -7,7 +7,6 @@ export interface UnifiedStatusResult {
   canonical: string
   label: string
   description: string
-  dotColor: string
 }
 
 /**
@@ -34,7 +33,7 @@ export function resolveUnifiedStatus(
       description: signal === 'live'
         ? '프로세스 오프라인 (미션 신호는 최근 수신됨)'
         : '프로세스 오프라인',
-      dotColor: 'bg-agent-offline',
+
     }
   }
 
@@ -47,7 +46,7 @@ export function resolveUnifiedStatus(
       canonical: primary,
       label: statusLabel(primary),
       description: desc,
-      dotColor: 'bg-agent-working',
+
     }
   }
 
@@ -59,7 +58,7 @@ export function resolveUnifiedStatus(
       description: signal === 'live'
         ? '대기 중 (미션 신호 수신 중)'
         : '대기 중',
-      dotColor: 'bg-agent-idle',
+
     }
   }
 
@@ -69,20 +68,20 @@ export function resolveUnifiedStatus(
       canonical: primary,
       label: statusLabel(primary),
       description: primary === 'compacting' ? '컨텍스트 압축 중' : '핸드오프 진행 중',
-      dotColor: 'bg-agent-busy',
+
     }
   }
 
   // No keeper/agent status — fall back to signal_truth
   if (!primary && signal) {
     if (signal === 'live') {
-      return { canonical: 'live', label: '활성 (신호)', description: '미션 신호만 확인됨 (프로세스 상태 불명)', dotColor: 'bg-agent-working' }
+      return { canonical: 'live', label: '활성 (신호)', description: '미션 신호만 확인됨 (프로세스 상태 불명)' }
     }
     if (signal === 'stale') {
-      return { canonical: 'stale', label: '오래됨', description: '미션 신호 오래됨, 프로세스 상태 불명', dotColor: 'bg-agent-offline' }
+      return { canonical: 'stale', label: '오래됨', description: '미션 신호 오래됨, 프로세스 상태 불명' }
     }
     if (signal === 'archived') {
-      return { canonical: 'archived', label: '보관됨', description: '미션 종료됨', dotColor: 'bg-agent-offline' }
+      return { canonical: 'archived', label: '보관됨', description: '미션 종료됨' }
     }
   }
 
@@ -91,6 +90,5 @@ export function resolveUnifiedStatus(
     canonical: 'unknown',
     label: '확인 필요',
     description: '상태 정보 없음',
-    dotColor: 'bg-agent-offline',
   }
 }

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -1,0 +1,96 @@
+// Unified status resolution — resolves contradictory status sources
+// into a single canonical status with Korean label and tooltip.
+
+import { statusLabel } from './status-label.js'
+
+export interface UnifiedStatusResult {
+  canonical: string
+  label: string
+  description: string
+  dotColor: string
+}
+
+/**
+ * Resolve three independent status sources into one canonical status.
+ *
+ * Priority:
+ *  1. keeper heartbeat status (most authoritative for "is process alive")
+ *  2. agent store status (runtime projection)
+ *  3. mission signal_truth (activity recency — used as annotation only)
+ */
+export function resolveUnifiedStatus(
+  keeperStatus: string | undefined | null,
+  agentStatus: string | undefined | null,
+  signalTruth: string | undefined | null,
+): UnifiedStatusResult {
+  const primary = (keeperStatus ?? agentStatus ?? '').toLowerCase()
+  const signal = (signalTruth ?? '').toLowerCase()
+
+  // Offline / inactive — process not running
+  if (primary === 'offline' || primary === 'inactive') {
+    return {
+      canonical: 'offline',
+      label: '오프라인',
+      description: signal === 'live'
+        ? '프로세스 오프라인 (미션 신호는 최근 수신됨)'
+        : '프로세스 오프라인',
+      dotColor: 'bg-agent-offline',
+    }
+  }
+
+  // Active states
+  if (primary === 'active' || primary === 'running' || primary === 'busy' || primary === 'working') {
+    const desc = signal === 'stale'
+      ? '프로세스 활성 (미션 활동은 오래됨)'
+      : '프로세스 활성'
+    return {
+      canonical: primary,
+      label: statusLabel(primary),
+      description: desc,
+      dotColor: 'bg-agent-working',
+    }
+  }
+
+  // Listening / idle
+  if (primary === 'listening' || primary === 'idle') {
+    return {
+      canonical: primary,
+      label: statusLabel(primary),
+      description: signal === 'live'
+        ? '대기 중 (미션 신호 수신 중)'
+        : '대기 중',
+      dotColor: 'bg-agent-idle',
+    }
+  }
+
+  // Compacting / handoff — transitional
+  if (primary === 'compacting' || primary === 'handoff') {
+    return {
+      canonical: primary,
+      label: statusLabel(primary),
+      description: primary === 'compacting' ? '컨텍스트 압축 중' : '핸드오프 진행 중',
+      dotColor: 'bg-agent-busy',
+    }
+  }
+
+  // No keeper/agent status — fall back to signal_truth
+  if (!primary && signal) {
+    if (signal === 'live') {
+      return { canonical: 'live', label: '활성 (신호)', description: '미션 신호만 확인됨 (프로세스 상태 불명)', dotColor: 'bg-agent-working' }
+    }
+    if (signal === 'stale') {
+      return { canonical: 'stale', label: '오래됨', description: '미션 신호 오래됨, 프로세스 상태 불명', dotColor: 'bg-agent-offline' }
+    }
+    if (signal === 'archived') {
+      return { canonical: 'archived', label: '보관됨', description: '미션 종료됨', dotColor: 'bg-agent-offline' }
+    }
+  }
+
+  // Unknown
+  return {
+    canonical: 'unknown',
+    label: '확인 필요',
+    description: '상태 정보 없음',
+    dotColor: 'bg-agent-offline',
+  }
+}

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -33,7 +33,6 @@ export function resolveUnifiedStatus(
       description: signal === 'live'
         ? '프로세스 오프라인 (미션 신호는 최근 수신됨)'
         : '프로세스 오프라인',
-
     }
   }
 
@@ -46,7 +45,6 @@ export function resolveUnifiedStatus(
       canonical: primary,
       label: statusLabel(primary),
       description: desc,
-
     }
   }
 
@@ -58,7 +56,6 @@ export function resolveUnifiedStatus(
       description: signal === 'live'
         ? '대기 중 (미션 신호 수신 중)'
         : '대기 중',
-
     }
   }
 
@@ -68,7 +65,6 @@ export function resolveUnifiedStatus(
       canonical: primary,
       label: statusLabel(primary),
       description: primary === 'compacting' ? '컨텍스트 압축 중' : '핸드오프 진행 중',
-
     }
   }
 

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -26,7 +26,7 @@
   background: var(--card);
   border: 1px solid var(--card-border);
   border-radius: 12px;
-  padding: 14px;
+  padding: 16px;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.16),
     0 3px 10px rgba(0, 0, 0, 0.08);

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -48,4 +48,12 @@
   --color-text-slate-light: #cbd5e1;
   --color-cyan: #22d3ee;
   --color-purple: #a78bfa;
+
+  /* Spacing scale (8px grid) */
+  --spacing-page: 20px;        /* gap-5  — page-level section gaps */
+  --spacing-section: 16px;     /* gap-4  — within sections */
+  --spacing-card: 16px;        /* p-4    — card internal padding */
+  --spacing-group: 12px;       /* gap-3  — grouped items */
+  --spacing-element: 8px;      /* gap-2  — tight element spacing */
+  --spacing-overlay-inset: 24px; /* p-6  — overlay viewport inset */
 }


### PR DESCRIPTION
## Summary

에이전트 & 키퍼 상세 페이지의 10개 UI/UX/데이터 이슈를 3축으로 동시 해결.

- **상태 통합**: 진행중/live/offline 3개 모순 배지를 `resolveUnifiedStatus()` 단일 해석으로 통합. `Lv.0` → `Gen.0`, `keeper key` → `키퍼`, CTX 바에 절대 토큰 수 표시, 자율 턴 컨텍스트 제공
- **빈 데이터 수정**: room activity case-sensitive 필터 버그 수정, keeper detail에 누락된 journal stream 추가, empty state 메시지에 원인 설명, 오프라인 keeper direct chat 안내
- **레이아웃 일관성**: agent-detail 이중 패딩(48px→24px) 수정, 전체 페이지 gap-5 통일, spacing 토큰 정의, card/StatTile 패딩 개선

## Changes (14 files)

| 축 | 파일 | 변경 |
|---|---|---|
| Status | `lib/unified-status.ts` | 신규 — 3개 상태 소스 통합 해석 모듈 |
| Status | `agent-detail.ts` | 배지 통합 + 이중 패딩 제거 |
| Status | `agent-profile.ts` | Gen.X, CTX 절대값, 자율 턴 hint |
| Status | `common/keeper-identity.ts` | "keeper key" → "키퍼" |
| Status | `keeper-detail-panels.ts` | Autonomy KPI 항상 표시 |
| Data | `agent-detail-state.ts` | Room activity case-insensitive + keeper alias |
| Data | `agent-detail-journal.ts` | Empty state 메시지 개선 |
| Data | `keeper-detail.ts` | AgentJournalStream 추가 + offline chat 안내 |
| Layout | `tokens.css` | Spacing 토큰 정의 |
| Layout | `global.css` | Card padding 14→16px |
| Layout | `common/stat-tile.ts` | StatTile padding 개선 |
| Layout | `status.ts`, `control.ts`, `work.ts` | gap-4 → gap-5 통일 |

## Test plan

- [ ] `localhost:8935/dashboard#monitoring?section=agents` 에서 keeper-diag-test-agent 클릭
- [ ] 상태 배지가 하나로 통합되었는지 확인 (signal/evidence 별도 배지 제거됨)
- [ ] CTX 바에 `8% · 12K / 150K` 형식 절대값 표시 확인
- [ ] `Gen.0` 라벨 + tooltip 확인
- [ ] `키퍼 ·` 라벨 확인 (keeper key → 키퍼)
- [ ] 자율 턴 0일 때 "자율 비활성" 또는 "활성 · 미발동" hint 확인
- [ ] 오프라인 keeper에서 직접 대화 비활성 안내 표시 확인
- [ ] empty state 메시지에 원인 설명 포함 확인
- [ ] Overview, Status, Control, Work 페이지 gap 통일 확인
- [ ] 반응형 확인: 1440px, 1100px, 768px

🤖 Generated with [Claude Code](https://claude.com/claude-code)