### PR TITLE
fix(cdal): remove scope field from Cdal_proof.t test literals

### DIFF
--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -44,7 +44,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -40,7 +40,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let setup_store () =
@@ -372,11 +371,10 @@ let test_path_traversal_rejected () =
 (* Cross-run window tests                                            *)
 (* ================================================================ *)
 
-let make_proof_with_scope
+let make_cross_run_proof
     ?(run_id = "cr-001")
     ?(raw_evidence_refs = [])
     ?(ended_at = 1001.0)
-    ?(scope = None)
     () : Agent_sdk.Cdal_proof.t =
   {
     schema_version = Agent_sdk.Cdal_proof.schema_version_current;
@@ -399,7 +397,6 @@ let make_proof_with_scope
     result_status = Completed;
     started_at = ended_at -. 1.0;
     ended_at;
-    scope;
   }
 
 let test_project_window_single_run () =
@@ -412,7 +409,7 @@ let test_project_window_single_run () =
       ~effective_mode:"diagnose";
   ] in
   write_violations_file store ~run_id violations;
-  let proof = make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_] () in
+  let proof = make_cross_run_proof ~run_id ~raw_evidence_refs:[ref_] () in
   match CFP.project_window ~store ~window:CFP.Single_run [proof] with
   | None -> Alcotest.fail "expected Some"
   | Some fp ->
@@ -434,7 +431,7 @@ let test_project_window_last_n_runs () =
         ~effective_mode:"diagnose";
     ] in
     write_violations_file store ~run_id violations;
-    make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_]
+    make_cross_run_proof ~run_id ~raw_evidence_refs:[ref_]
       ~ended_at:(1000.0 +. Float.of_int i) ()
   ) in
   match CFP.project_window ~store
@@ -463,7 +460,7 @@ let test_project_window_tripwire_cross_run () =
         ~effective_mode:"diagnose";
     ] in
     write_violations_file store ~run_id violations;
-    make_proof_with_scope ~run_id ~raw_evidence_refs:[ref_]
+    make_cross_run_proof ~run_id ~raw_evidence_refs:[ref_]
       ~ended_at:(1000.0 +. Float.of_int i) ()
   ) in
   match CFP.project_window ~store

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -45,7 +45,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -43,7 +43,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_golden_set_eval.ml
+++ b/test/test_golden_set_eval.ml
@@ -78,7 +78,6 @@ let bundle_of_golden_case (gc : GS.golden_case) : CL.loaded_bundle =
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   } in
   {
     proof;

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -60,7 +60,6 @@ let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
     result_status = Oas.Cdal_proof.Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let with_snapshot_env f =


### PR DESCRIPTION
## Summary
- OAS 0.99.1의 `Cdal_proof.t`에 `scope` 필드 없음
- PR #4176이 `scope = None`을 테스트에 추가했으나 OAS 핀 업데이트 없이 머지됨
- main CI Build and Test + Health 실패 원인
- 6파일에서 `scope` 필드 8곳 제거

## Product impact
main CI 복구. 현재 모든 PR의 Build and Test가 실패 중.

## Evidence
```
Error: This record expression is expected to have type Oas.Cdal_proof.t
       There is no field scope within type Oas.Cdal_proof.t
```

## Review evidence
로컬 빌드 성공 + 영향받은 6개 테스트 모두 통과 (48 tests)

## Linked issue
Refs #4176

## Test plan
- [x] `dune build` 성공
- [x] 영향받은 6개 테스트 모두 통과 (48 tests total)
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)