### PR TITLE
fix(test): remove stale Cdal_proof.scope field from 6 test files

### DIFF
--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -44,7 +44,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -40,7 +40,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let setup_store () =
@@ -376,7 +375,6 @@ let make_proof_with_scope
     ?(run_id = "cr-001")
     ?(raw_evidence_refs = [])
     ?(ended_at = 1001.0)
-    ?(scope = None)
     () : Agent_sdk.Cdal_proof.t =
   {
     schema_version = Agent_sdk.Cdal_proof.schema_version_current;
@@ -399,7 +397,6 @@ let make_proof_with_scope
     result_status = Completed;
     started_at = ended_at -. 1.0;
     ended_at;
-    scope;
   }
 
 let test_project_window_single_run () =

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -45,7 +45,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -43,7 +43,6 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_golden_set_eval.ml
+++ b/test/test_golden_set_eval.ml
@@ -78,7 +78,6 @@ let bundle_of_golden_case (gc : GS.golden_case) : CL.loaded_bundle =
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   } in
   {
     proof;

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -60,7 +60,6 @@ let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
     result_status = Oas.Cdal_proof.Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
-    scope = None;
   }
 
 let with_snapshot_env f =


### PR DESCRIPTION
## Summary

- OAS SDK에서 `Cdal_proof.t`의 `scope` 필드가 제거되었으나 테스트 6개가 아직 참조
- **main 빌드가 깨진 상태** — 이 PR이 수정
- 모든 open PR의 Build fail 원인

## Test plan

- [x] `dune build` 통과
- [x] test_cdal_loader (9), test_cdal_judge (12), test_golden_set_eval (3), test_cdal_eval_v1 (3), test_cdal_friction_projection (18), test_persist_worker_run_snapshot 전부 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)