### PR TITLE
fix(test): remove keeper_search references from test invariants

### DIFF
--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -46,7 +46,6 @@ let test_local_worker_projection_exposes_internal_and_auditable_tools () =
       ~names:
         [
           "masc_heartbeat";
-          "keeper_search";
           "masc_code_search";
           "masc_run_plan";
         ]
@@ -58,7 +57,6 @@ let test_local_worker_projection_exposes_internal_and_auditable_tools () =
         List.map (fun (schema : Types.tool_schema) -> schema.name) schemas
       in
       check bool "heartbeat" true (List.mem "masc_heartbeat" names);
-      check bool "keeper_search" true (List.mem "keeper_search" names);
       check bool "masc_code_search" true (List.mem "masc_code_search" names);
       check bool "masc_run_plan" true (List.mem "masc_run_plan" names)
 
@@ -81,13 +79,12 @@ let test_privileged_keeper_surface_is_split () =
     (List.mem "keeper_board_post"
        Lib.Capability_registry.keeper_privileged_tool_names)
 
-let test_mdal_auditable_tools_do_not_include_keeper_search () =
+let test_mdal_auditable_tools_stay_curated () =
   let names = Lib.Capability_registry.mdal_auditable_tool_names in
   check bool "contains masc_code_search" true
     (List.mem "masc_code_search" names);
   check bool "contains masc_run_plan" true
-    (List.mem "masc_run_plan" names);
-  check bool "omits keeper_search" false (List.mem "keeper_search" names)
+    (List.mem "masc_run_plan" names)
 
 let () =
   Alcotest.run "capability_registry"
@@ -110,6 +107,6 @@ let () =
           test_case "privileged keeper surface is split" `Quick
             test_privileged_keeper_surface_is_split;
           test_case "mdal auditable tools stay curated" `Quick
-            test_mdal_auditable_tools_do_not_include_keeper_search;
+            test_mdal_auditable_tools_stay_curated;
         ] );
     ]

--- a/test/test_contract_risk.ml
+++ b/test/test_contract_risk.ml
@@ -26,7 +26,7 @@ let check_risk msg expected actual =
 
 let test_low_risk () =
   let dc = make_dc ~required_artifacts:["readme"] ~repair_budget:5 () in
-  let tools = ["keeper_read"; "keeper_search"] in
+  let tools = ["keeper_read"; "keeper_board_list"] in
   let risk = Masc_mcp.Contract_risk.of_delivery_contract ~delivery_contract:dc ~tool_names:tools in
   check_risk "read-only + generous budget = Low" Agent_sdk.Risk_class.Low risk
 

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -290,7 +290,7 @@ let test_dashboard_mission_projection () =
         ~agent:"llama-local-alpha"
         ~goal:"Inspect board state with allowed MCP tools."
         ~context:"fixture context"
-        ~allowed_tools:[ "masc_board_get"; "masc_board_vote"; "keeper_search" ]
+        ~allowed_tools:[ "masc_board_get"; "masc_board_vote"; "keeper_board_list" ]
         ();
       ignore
         (Lib.A2a_tools.submit_heartbeat_result

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -102,7 +102,7 @@ let test_keeper_internal_contains_known_tools () =
   List.iter
     (fun name ->
       Alcotest.(check bool) (name ^ " is internal") true (SS.mem name internal))
-    [ "keeper_time_now"; "keeper_board_post"; "keeper_bash"; "keeper_search" ]
+    [ "keeper_time_now"; "keeper_board_post"; "keeper_bash"; "keeper_memory_search" ]
 
 let test_is_on_surface_consistent () =
   List.iter (fun surface ->


### PR DESCRIPTION
## Summary
- #4188에서 `keeper_search` 스키마를 제거했으나 테스트 4개 파일에서 참조가 남아 Build and Test CI 실패
- `test_tool_surface_ssot.ml`: `keeper_search` → `keeper_memory_search` (실존 internal tool)
- `test_capability_registry.ml`: `keeper_search` 참조 제거, `mdal_auditable` 테스트 이름 정리
- `test_dashboard_mission.ml`: fixture tool → `keeper_board_list`
- `test_contract_risk.ml`: fixture tool → `keeper_board_list`

## Test plan
- [x] `dune build @all` 성공
- [x] `test_tool_surface_ssot.exe` 12 tests pass
- [x] `test_capability_registry.exe` 7 tests pass
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)