### PR TITLE
fix(board): register masc_board_* tools in dispatch handler hashtable

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -153,6 +153,7 @@ let () =
      that still rely on name-based registration. Called AFTER schema-based
      registrations so it fills gaps without overwriting correct mappings. *)
   Tool_tag_init.register_all ();
+  Tool_board.register ();
   mark_tag_registry_initialized ();
   (* Inject masc_* schemas into keeper bridge for tier-based filtering.
      Uses Config.raw_all_tool_schemas which includes Board/MDAL schemas

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -730,3 +730,8 @@ let handle_tool name args =
   | "masc_board_migrate" -> handle_migrate args
   | "masc_board_reclassify" -> handle_reclassify args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)
+
+let register () =
+  Tool_dispatch.register_module
+    ~schemas:tools
+    ~handler:(fun ~name ~args -> Some (handle_tool name args))


### PR DESCRIPTION
## Summary

- `masc_board_*` 도구 13개가 대시보드에 등록 표시되지만 키퍼 세션에서 호출 시 `unregistered_masc_tool` 에러 반환
- 근본 원인: 키퍼 dispatch 경로(`Tool_dispatch.dispatch`)가 handler hashtable을 사용하는데, board 도구가 tag registry에만 등록되고 handler hashtable에는 미등록
- `Tool_board.register()`를 추가하여 서버 초기화 시 handler hashtable에 등록

## Changes

- `lib/tool_board.ml`: `register()` 함수 추가 — `Tool_dispatch.register_module`로 13개 board 핸들러 등록
- `lib/mcp_server_eio.ml`: 서버 초기화에서 `Tool_board.register()` 호출

## Test plan

- [ ] `dune build` 성공 (기존 research_loop.ml 에러는 pre-existing)
- [ ] 서버 재시작 후 키퍼 세션에서 `masc_board_list` 호출 → 게시글 목록 반환
- [ ] `masc_board_stats` 호출 → 통계 반환
- [ ] 존재하지 않는 `masc_fake_tool` → 여전히 "unregistered" 반환
- [ ] `keeper_board_*` 기존 동작 영향 없음

Closes #4219

🤖 Generated with [Claude Code](https://claude.com/claude-code)