### PR TITLE
[codex] fix dashboard actor header validation

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { post } from './core'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  try {
+    window.history.replaceState({}, '', 'http://localhost/')
+  } catch {
+    // Ignore cleanup failures in the test environment.
+  }
+})
+
+describe('post', () => {
+  it('sends a sanitized actor header without URL encoding', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-eager-manta%E3%85%8A')
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await post('/api/v1/tools/masc_board_comment', { post_id: 'p-123', content: 'hello' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
+    expect(actorHeader).toBe('dashboard-eager-manta')
+    expect(actorHeader).not.toContain('%')
+  })
+})

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { post } from './core'
+import { defaultBoardVoter, post } from './core'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -30,5 +30,12 @@ describe('post', () => {
     const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
     expect(actorHeader).toBe('dashboard-eager-manta')
     expect(actorHeader).not.toContain('%')
+  })
+
+  it('keeps board voter resolution scoped to query params', () => {
+    window.localStorage?.setItem?.('masc_dashboard_agent_name', 'stored-agent')
+    window.history.replaceState({}, '', '/')
+
+    expect(defaultBoardVoter()).toBe('dashboard-user')
   })
 })

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -7,7 +7,7 @@ import type {
   OperatorDigest,
   OperatorSnapshot,
 } from '../types'
-import { resolveDashboardActorName } from '../lib/dashboard-actor'
+import { resolveDashboardActorName, sanitizeDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Auth ---
 
@@ -114,7 +114,10 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
 }
 
 export function defaultBoardVoter(): string {
-  return resolveDashboardActorName() || 'dashboard-user'
+  const params = getQueryParams()
+  return sanitizeDashboardActorName(params.get('agent'))
+    || sanitizeDashboardActorName(params.get('agent_name'))
+    || 'dashboard-user'
 }
 
 // --- Generic fetcher ---

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -7,6 +7,7 @@ import type {
   OperatorDigest,
   OperatorSnapshot,
 } from '../types'
+import { resolveDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Auth ---
 
@@ -14,24 +15,8 @@ function getQueryParams(): URLSearchParams {
   return new URLSearchParams(window.location.search)
 }
 
-const DASHBOARD_AGENT_NAME_KEY = 'masc_dashboard_agent_name'
-
-function readStoredAgentName(): string | null {
-  try {
-    return localStorage.getItem(DASHBOARD_AGENT_NAME_KEY)?.trim() || null
-  } catch {
-    return null
-  }
-}
-
 export function currentDashboardActor(): string {
-  const params = getQueryParams()
-  return (
-    params.get('agent')?.trim()
-    || params.get('agent_name')?.trim()
-    || readStoredAgentName()
-    || 'dashboard'
-  )
+  return resolveDashboardActorName() || 'dashboard'
 }
 
 type HeaderOptions = {
@@ -42,11 +27,10 @@ function authHeaders(options: HeaderOptions = {}): Record<string, string> {
   const params = getQueryParams()
   const headers: Record<string, string> = {}
   const token = params.get('token')
-  const storedAgent = readStoredAgentName()
-  const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
+  const agent = resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {
-    headers['X-MASC-Agent'] = encodeURIComponent(agent)
+    headers['X-MASC-Agent'] = agent
   }
   return headers
 }
@@ -130,12 +114,7 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
 }
 
 export function defaultBoardVoter(): string {
-  const params = getQueryParams()
-  return (
-    params.get('agent')?.trim() ||
-    params.get('agent_name')?.trim() ||
-    'dashboard-user'
-  )
+  return resolveDashboardActorName() || 'dashboard-user'
 }
 
 // --- Generic fetcher ---

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -50,6 +50,8 @@ describe('sendKeeperMessageDetailed', () => {
 
 describe('streamKeeperMessage', () => {
   it('posts direct reply mode to the keeper chat stream endpoint', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-eager-manta%E3%85%8A')
+
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('data: {"type":"RUN_FINISHED"}\n\n', {
         status: 200,
@@ -67,11 +69,15 @@ describe('streamKeeperMessage', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
     expect(JSON.parse(String(init.body))).toEqual({
       name: 'sangsu',
       message: 'ping',
       direct_reply: true,
     })
+    const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
+    expect(actorHeader).toBe('dashboard-eager-manta')
+    expect(actorHeader).not.toContain('%')
     expect(events).toEqual(['RUN_FINISHED'])
   })
 })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -7,6 +7,7 @@ import {
 } from '../keeper-message'
 import type { KeeperConversationDetails } from '../types'
 import { currentDashboardActor, runOperatorAction } from './core'
+import { resolveDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Types ---
 
@@ -76,16 +77,9 @@ function jsonHeaders(): Record<string, string> {
   const params = new URLSearchParams(window.location.search)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   const token = params.get('token')
-  const storedAgent = (() => {
-    try {
-      return localStorage.getItem('masc_dashboard_agent_name')?.trim() || null
-    } catch {
-      return null
-    }
-  })()
-  const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
+  const agent = resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
-  if (agent) headers['X-MASC-Agent'] = encodeURIComponent(agent)
+  if (agent) headers['X-MASC-Agent'] = agent
   return headers
 }
 

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -9,7 +9,7 @@ import {
   keepers,
   tasks,
 } from '../store'
-import { fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
+import { currentDashboardActor, fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
 import { callMcpTool } from '../api/mcp'
 import { journal } from '../sse'
 import { route, navigate } from '../router'
@@ -22,8 +22,6 @@ import type {
   Keeper,
   Task,
 } from '../types'
-
-const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
 export type TaskHistoryRow = {
   taskId: string
@@ -200,11 +198,9 @@ export async function submitMention(): Promise<void> {
   const text = mentionText.value.trim()
   if (!target || !text) return
 
-  const sender = localStorage.getItem(AGENT_NAME_KEY)?.trim() || 'dashboard'
-
   sendingMention.value = true
   try {
-    await sendBroadcast(sender, `@${target} ${text}`)
+    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
     showToast(`${target}에게 멘션 전송 완료`, 'success')
     void refreshAgentDetail()

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -28,6 +28,7 @@ import {
   sendBroadcast,
   fetchAgentTimeline,
   fetchAgentRelations,
+  currentDashboardActor,
   type AgentTimelineEvent,
   type AgentTimelineResponse,
   type AgentRelationsResponse,
@@ -46,8 +47,6 @@ import type {
 import { AgentRuntimeStrip } from './agent-monitor/runtime-strip'
 import { AgentLiveTimeline } from './agent-monitor/live-timeline'
 import { KeeperChatPanel } from './keeper-chat-panel'
-
-const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
 type TaskHistoryRow = { taskId: string; text: string }
 
@@ -145,10 +144,9 @@ async function loadProfile(name: string): Promise<void> {
 async function submitMention(target: string): Promise<void> {
   const text = mentionText.value.trim()
   if (!target || !text) return
-  const sender = localStorage.getItem(AGENT_NAME_KEY)?.trim() || 'dashboard'
   sendingMention.value = true
   try {
-    await sendBroadcast(sender, `@${target} ${text}`)
+    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
     showToast(`${target}에게 전송`, 'success')
     void loadProfile(target)

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -1,26 +1,11 @@
 import { signal } from '@preact/signals'
-
-const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
-
-function safeStorage(): Storage | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const storage = window.localStorage
-    return storage && typeof storage.getItem === 'function' ? storage : null
-  } catch {
-    return null
-  }
-}
+import {
+  persistDashboardActorName,
+  resolveDashboardActorName,
+} from '../../lib/dashboard-actor'
 
 function initialActorName(): string {
-  const params = new URLSearchParams(window.location.search)
-  const storage = safeStorage()
-  return (
-    params.get('agent')?.trim()
-    || params.get('agent_name')?.trim()
-    || storage?.getItem(AGENT_NAME_KEY)?.trim()
-    || 'dashboard'
-  )
+  return resolveDashboardActorName() || 'dashboard'
 }
 
 export type OpsTeamTurnKind =
@@ -56,7 +41,5 @@ export const quickTarget = signal('room')
 export const quickMessage = signal('')
 
 export function persistActorName(value: string): void {
-  const trimmed = value.trim() || 'dashboard'
-  actorName.value = trimmed
-  safeStorage()?.setItem(AGENT_NAME_KEY, trimmed)
+  actorName.value = persistDashboardActorName(value)
 }

--- a/dashboard/src/lib/dashboard-actor.ts
+++ b/dashboard/src/lib/dashboard-actor.ts
@@ -1,0 +1,54 @@
+const DASHBOARD_AGENT_NAME_RE = /[^A-Za-z0-9._-]+/g
+const DASHBOARD_AGENT_NAME_MAX_LENGTH = 32
+
+export const DASHBOARD_AGENT_NAME_KEY = 'masc_dashboard_agent_name'
+
+function safeStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const storage = window.localStorage
+    return storage && typeof storage.getItem === 'function' ? storage : null
+  } catch {
+    return null
+  }
+}
+
+export function sanitizeDashboardActorName(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value
+    .trim()
+    .replace(DASHBOARD_AGENT_NAME_RE, '')
+    .slice(0, DASHBOARD_AGENT_NAME_MAX_LENGTH)
+  return normalized || null
+}
+
+export function readStoredDashboardActorName(storage: Storage | null = safeStorage()): string | null {
+  try {
+    return sanitizeDashboardActorName(storage?.getItem(DASHBOARD_AGENT_NAME_KEY))
+  } catch {
+    return null
+  }
+}
+
+export function resolveDashboardActorName(
+  search = typeof window === 'undefined' ? '' : window.location.search,
+  storage: Storage | null = safeStorage(),
+): string | null {
+  const params = new URLSearchParams(search)
+  return sanitizeDashboardActorName(params.get('agent'))
+    || sanitizeDashboardActorName(params.get('agent_name'))
+    || readStoredDashboardActorName(storage)
+}
+
+export function persistDashboardActorName(
+  value: string,
+  storage: Storage | null = safeStorage(),
+): string {
+  const normalized = sanitizeDashboardActorName(value) || 'dashboard'
+  try {
+    storage?.setItem(DASHBOARD_AGENT_NAME_KEY, normalized)
+  } catch {
+    // Ignore storage write failures and keep the in-memory value.
+  }
+  return normalized
+}


### PR DESCRIPTION
## What changed
- stopped URL-encoding `X-MASC-Agent` for dashboard write requests
- added shared dashboard actor normalization so query/localStorage actor values are sanitized to the server-accepted charset
- reused the normalized actor for board/keeper traffic and mention broadcasts
- added dashboard tests covering the sanitized actor header path

## Why
Board comment writes were failing with `400 Bad Request` because the dashboard sent an encoded actor header like `dashboard-eager-manta%E3%85%8A`, while the server validates `agent_id` against `[A-Za-z0-9._-]+`.

## Impact
- board comment/post flows no longer fail when the dashboard actor source contains stray non-ASCII input
- keeper stream requests use the same normalized actor header behavior
- existing bad actor values now degrade to a safe ASCII actor name instead of poisoning write requests

## Validation
- `npm run typecheck`
- `npm run test -- src/api/core.test.ts src/api/keeper.test.ts`
