### PR TITLE
[codex] Follow up perf review fixes after #4214

### DIFF
--- a/benchmarks/benchmark.sh
+++ b/benchmarks/benchmark.sh
@@ -49,6 +49,30 @@ mkdir -p "$RESULTS_DIR"
 log() { printf '[BENCH] %s\n' "$1"; }
 error() { printf '[ERROR] %s\n' "$1" >&2; }
 
+require_nonnegative_int() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    error "${name} must be a non-negative integer: ${value}"
+    exit 1
+  fi
+}
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+  require_nonnegative_int "$name" "$value"
+  if (( value < 1 )); then
+    error "${name} must be >= 1: ${value}"
+    exit 1
+  fi
+}
+
+require_positive_int "ITERATIONS" "$ITERATIONS"
+require_nonnegative_int "BENCH_WARMUP_ITERATIONS" "$BENCH_WARMUP_ITERATIONS"
+require_nonnegative_int "BENCH_SESSION_WARMUP_ITERATIONS" "$BENCH_SESSION_WARMUP_ITERATIONS"
+require_positive_int "BENCH_COMPARE_MAX_ROWS" "$BENCH_COMPARE_MAX_ROWS"
+
 ms_from_seconds() {
   awk -v seconds="${1:-0}" 'BEGIN { printf "%.0f", seconds * 1000 }'
 }

--- a/benchmarks/quick-bench.sh
+++ b/benchmarks/quick-bench.sh
@@ -32,6 +32,28 @@ export CURL_RETRY_DELAY_SEC
 # shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
 source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
+require_nonnegative_int() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "[ERROR] ${name} must be a non-negative integer: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+  require_nonnegative_int "$name" "$value"
+  if (( value < 1 )); then
+    echo "[ERROR] ${name} must be >= 1: ${value}" >&2
+    exit 1
+  fi
+}
+
+require_positive_int "BENCH_ITERATIONS" "$BENCH_ITERATIONS"
+require_nonnegative_int "BENCH_WARMUP_ITERATIONS" "$BENCH_WARMUP_ITERATIONS"
+
 ms_from_seconds() {
   awk -v seconds="${1:-0}" 'BEGIN { printf "%.0f", seconds * 1000 }'
 }

--- a/dashboard/src/components/perf-snapshot.test.ts
+++ b/dashboard/src/components/perf-snapshot.test.ts
@@ -1,0 +1,157 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+async function loadPanel(fetchDashboardPerf: () => Promise<unknown>) {
+  vi.resetModules()
+  vi.doMock('../api', () => ({
+    fetchDashboardPerf,
+  }))
+  vi.doMock('./common/time-ago', () => ({
+    TimeAgo: ({ timestamp }: { timestamp: string }) => html`<span>${timestamp}</span>`,
+  }))
+  return import('./perf-snapshot')
+}
+
+describe('PerfSnapshotPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api')
+    vi.doUnmock('./common/time-ago')
+  })
+
+  it('renders empty-state guidance when no benchmark artifact exists', async () => {
+    const fetchDashboardPerf = vi.fn().mockResolvedValue({
+      status: 'empty',
+      generated_at: '2026-03-31T05:00:00Z',
+      benchmarks: [],
+      comparison: null,
+      candidate_dirs: ['benchmarks/results'],
+      message: 'No benchmark artifacts found',
+    })
+
+    const { PerfSnapshotPanel } = await loadPanel(fetchDashboardPerf)
+    render(html`<${PerfSnapshotPanel} />`, container)
+    await flushUi()
+
+    expect(fetchDashboardPerf).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('Perf Snapshot')
+    expect(container.textContent).toContain('benchmark artifact가 아직 없습니다')
+    expect(container.textContent).toContain('benchmark.sh')
+  })
+
+  it('renders benchmark highlights and diff badges for ok status', async () => {
+    const fetchDashboardPerf = vi.fn().mockResolvedValue({
+      status: 'ok',
+      generated_at: '2026-03-31T05:00:00Z',
+      benchmarks: [],
+      source: {
+        results_dir: 'benchmarks/results',
+        result_file: 'benchmarks/results/results_20260331_140000.csv',
+        baseline_file: 'benchmarks/results/results_20260331_130000.csv',
+      },
+      latest_run: {
+        started_at: '2026-03-31T05:00:00Z',
+      },
+      highlights: {
+        session_init: {
+          benchmark: 'mcp_session_init',
+          avg_ms: 7,
+          p50_ms: 7,
+          p95_ms: 9,
+          max_ms: 12,
+          notes: 'session',
+          note_tags: {},
+        },
+        worst_live_mcp: {
+          benchmark: 'mcp_read_status',
+          avg_ms: 8,
+          p50_ms: 7,
+          p95_ms: 66,
+          max_ms: 88,
+          notes: 'source=live',
+          note_tags: { source: 'live' },
+        },
+        runtime_status: {
+          benchmark: 'oas_runtime_status',
+          avg_ms: 111,
+          p50_ms: 110,
+          p95_ms: 132,
+          max_ms: 150,
+          notes: 'configured_capacity=16;healthy_runtime_count=4',
+          note_tags: { configured_capacity: '16', healthy_runtime_count: '4' },
+        },
+        runtime_single: {
+          benchmark: 'oas_runtime_single',
+          avg_ms: 820,
+          p50_ms: 805,
+          p95_ms: 1010,
+          max_ms: 1160,
+          notes: 'measured_ceiling=1',
+          note_tags: { measured_ceiling: '1' },
+        },
+      },
+      comparison: {
+        baseline_file: 'benchmarks/results/results_20260331_130000.csv',
+        verdict_counts: {
+          improved: 1,
+          stable: 2,
+          mixed: 0,
+          regressed: 1,
+        },
+        top_changes: [
+          {
+            benchmark: 'oas_runtime_single',
+            avg_delta_ms: -180,
+            avg_delta_pct: -18,
+            p95_delta_ms: -290,
+            p95_delta_pct: -22.3,
+            max_delta_ms: -190,
+            verdict: 'improved',
+          },
+        ],
+      },
+    })
+
+    const { PerfSnapshotPanel } = await loadPanel(fetchDashboardPerf)
+    render(html`<${PerfSnapshotPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Session Init')
+    expect(container.textContent).toContain('Worst MCP p95')
+    expect(container.textContent).toContain('Runtime Avg')
+    expect(container.textContent).toContain('Runtime Status')
+    expect(container.textContent).toContain('improved 1')
+    expect(container.textContent).toContain('regressed 1')
+    expect(container.textContent).toContain('oas_runtime_single')
+    expect(container.textContent).toContain('measured ceiling 1')
+  })
+
+  it('renders request errors', async () => {
+    const fetchDashboardPerf = vi.fn().mockRejectedValue(new Error('perf endpoint failed'))
+
+    const { PerfSnapshotPanel } = await loadPanel(fetchDashboardPerf)
+    render(html`<${PerfSnapshotPanel} />`, container)
+    await flushUi()
+
+    expect(fetchDashboardPerf).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('perf endpoint failed')
+  })
+})

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -112,8 +112,10 @@ let note_episode_flush (episode : Institution_eio.episode) =
   Eio_guard.with_mutex episode_cache_mu (fun () ->
     let path = Institution_eio.episodes_jsonl_path () in
     let cache = load_all_episodes_cached_unlocked () in
-    cache.episodes <- cache.episodes @ [episode];
-    Hashtbl.replace cache.ids episode.id ();
+    if not (Hashtbl.mem cache.ids episode.id) then begin
+      cache.episodes <- cache.episodes @ [episode];
+      Hashtbl.replace cache.ids episode.id ();
+    end;
     cache.stamp <- file_stamp_opt path;
     Hashtbl.replace episode_file_cache_tbl path cache)
 

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -73,6 +73,8 @@ type episode_file_cache = {
 let episode_file_cache_tbl : (string, episode_file_cache) Hashtbl.t =
   Hashtbl.create 4
 
+let episode_cache_mu = Eio.Mutex.create ()
+
 let episode_ids_of episodes =
   let ids = Hashtbl.create (max 16 (List.length episodes)) in
   List.iter
@@ -80,7 +82,7 @@ let episode_ids_of episodes =
     episodes;
   ids
 
-let load_all_episodes_cached () =
+let load_all_episodes_cached_unlocked () =
   let path = Institution_eio.episodes_jsonl_path () in
   let stamp = file_stamp_opt path in
   match Hashtbl.find_opt episode_file_cache_tbl path with
@@ -90,6 +92,9 @@ let load_all_episodes_cached () =
       let cache = { stamp; episodes; ids = episode_ids_of episodes } in
       Hashtbl.replace episode_file_cache_tbl path cache;
       cache
+
+let load_all_episodes_cached () =
+  Eio_guard.with_mutex episode_cache_mu load_all_episodes_cached_unlocked
 
 let cached_recent_episodes ~limit =
   let cache = load_all_episodes_cached () in
@@ -104,12 +109,13 @@ let cached_recent_episodes ~limit =
     drop (total - limit) cache.episodes
 
 let note_episode_flush (episode : Institution_eio.episode) =
-  let path = Institution_eio.episodes_jsonl_path () in
-  let cache = load_all_episodes_cached () in
-  cache.episodes <- cache.episodes @ [episode];
-  Hashtbl.replace cache.ids episode.id ();
-  cache.stamp <- file_stamp_opt path;
-  Hashtbl.replace episode_file_cache_tbl path cache
+  Eio_guard.with_mutex episode_cache_mu (fun () ->
+    let path = Institution_eio.episodes_jsonl_path () in
+    let cache = load_all_episodes_cached_unlocked () in
+    cache.episodes <- cache.episodes @ [episode];
+    Hashtbl.replace cache.ids episode.id ();
+    cache.stamp <- file_stamp_opt path;
+    Hashtbl.replace episode_file_cache_tbl path cache)
 
 type procedure_file_cache = {
   mutable stamp : file_stamp option;
@@ -119,21 +125,25 @@ type procedure_file_cache = {
 let procedure_file_cache_tbl : (string, procedure_file_cache) Hashtbl.t =
   Hashtbl.create 16
 
+let procedure_cache_mu = Eio.Mutex.create ()
+
 let load_procedures_cached ~(agent_name : string) =
-  let path = Procedural_memory.procedures_path ~agent_name in
-  let stamp = file_stamp_opt path in
-  match Hashtbl.find_opt procedure_file_cache_tbl path with
-  | Some cache when cache.stamp = stamp -> cache.procedures
-  | _ ->
-      let procedures = Procedural_memory.load_procedures ~agent_name in
-      Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures };
-      procedures
+  Eio_guard.with_mutex procedure_cache_mu (fun () ->
+    let path = Procedural_memory.procedures_path ~agent_name in
+    let stamp = file_stamp_opt path in
+    match Hashtbl.find_opt procedure_file_cache_tbl path with
+    | Some cache when cache.stamp = stamp -> cache.procedures
+    | _ ->
+        let procedures = Procedural_memory.load_procedures ~agent_name in
+        Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures };
+        procedures)
 
 let store_procedures_cache ~(agent_name : string)
     (procedures : Procedural_memory.procedure list) =
-  let path = Procedural_memory.procedures_path ~agent_name in
-  let stamp = file_stamp_opt path in
-  Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures }
+  Eio_guard.with_mutex procedure_cache_mu (fun () ->
+    let path = Procedural_memory.procedures_path ~agent_name in
+    let stamp = file_stamp_opt path in
+    Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures })
 
 let top_procedures_cached ~(agent_name : string) ~(limit : int) =
   load_procedures_cached ~agent_name

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -289,7 +289,9 @@ let parse_benchmark_timestamp path =
 let current_worktree_results_dir (config : Room.config) =
   let cwd = Sys.getcwd () in
   let worktrees_root = Filename.concat config.base_path ".worktrees" in
-  if path_descends_from ~root:worktrees_root cwd then
+  if String.equal cwd worktrees_root then
+    None
+  else if path_descends_from ~root:worktrees_root cwd then
     let rel = String.sub cwd (String.length worktrees_root + 1)
         (String.length cwd - String.length worktrees_root - 1) in
     let worktree_name =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -24,6 +24,15 @@ let list_hd_opt = function
   | [] -> None
   | x :: _ -> Some x
 
+let path_descends_from ~root path =
+  String.equal path root || String.starts_with ~prefix:(root ^ "/") path
+
+let path_relative_to ~root path =
+  if String.equal path root then Some "."
+  else if String.starts_with ~prefix:(root ^ "/") path then
+    Some (String.sub path (String.length root + 1) (String.length path - String.length root - 1))
+  else None
+
 let git_rev_parse_short path =
   match trim_to_option path with
   | None -> None
@@ -277,38 +286,36 @@ let parse_benchmark_timestamp path =
       (String.sub base (String.length prefix)
          (String.length base - String.length prefix - String.length suffix))
 
-let rec worktree_results_dirs ~root ~depth =
-  if depth < 0 || not (Sys.file_exists root && Sys.is_directory root) then []
-  else
-    let entries =
-      try Sys.readdir root |> Array.to_list
-      with Sys_error _ -> []
-    in
-    let direct_hit =
-      if Filename.basename root = "results"
-         && Filename.basename (Filename.dirname root) = "benchmarks"
-      then [ root ]
-      else []
-    in
-    let child_hits =
-      entries
-      |> List.filter (fun entry -> entry <> "." && entry <> "..")
-      |> List.map (Filename.concat root)
-      |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)
-      |> List.concat_map (fun path -> worktree_results_dirs ~root:path ~depth:(depth - 1))
-    in
-    direct_hit @ child_hits
+let current_worktree_results_dir (config : Room.config) =
+  let cwd = Sys.getcwd () in
+  let worktrees_root = Filename.concat config.base_path ".worktrees" in
+  if path_descends_from ~root:worktrees_root cwd then
+    Some (Filename.concat cwd "benchmarks/results")
+  else None
+
+let display_benchmark_path (config : Room.config) path =
+  match path_relative_to ~root:config.base_path path with
+  | Some relative -> relative
+  | None ->
+      let cwd = Sys.getcwd () in
+      if path_descends_from ~root:config.base_path cwd then
+        (match path_relative_to ~root:cwd path with
+         | Some relative -> relative
+         | None -> Filename.basename path)
+      else Filename.basename path
 
 let benchmark_results_dir_candidates (config : Room.config) =
   let env_dir = Sys.getenv_opt "MASC_BENCHMARK_RESULTS_DIR" in
-  let worktree_root = Filename.concat config.base_path ".worktrees" in
+  let scoped_dirs =
+    [
+      Option.value ~default:"" (current_worktree_results_dir config);
+      Filename.concat config.base_path "benchmarks/results";
+    ]
+  in
   dedupe_strings
-    ([
-       Option.value ~default:"" env_dir;
-       Filename.concat config.workspace_path "benchmarks/results";
-       Filename.concat config.base_path "benchmarks/results";
-     ]
-    @ worktree_results_dirs ~root:worktree_root ~depth:6)
+    (match trim_to_option (Option.value ~default:"" env_dir) with
+     | Some dir -> [ dir ]
+     | None -> scoped_dirs)
   |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)
 
 let benchmark_result_files results_dir =
@@ -334,7 +341,8 @@ let latest_file_by_mtime files =
 
 let latest_benchmark_result_file (config : Room.config) =
   benchmark_results_dir_candidates config
-  |> List.find_map (fun results_dir -> latest_file_by_mtime (benchmark_result_files results_dir))
+  |> List.concat_map benchmark_result_files
+  |> latest_file_by_mtime
 
 let split_csv_row line =
   match String.split_on_char ',' line with
@@ -471,13 +479,19 @@ let baseline_file_for ~current_file ~meta =
       |> List.filter (fun path -> not (String.equal path current_file))
       |> latest_file_by_mtime
 
-let benchmark_source_json ~results_dir ~result_file ~meta_file ~baseline_file =
+let benchmark_source_json config ~results_dir ~result_file ~meta_file ~baseline_file =
   `Assoc
     [
-      ("results_dir", `String results_dir);
-      ("result_file", `String result_file);
-      ("meta_file", Option.fold ~none:`Null ~some:(fun path -> `String path) meta_file);
-      ("baseline_file", Option.fold ~none:`Null ~some:(fun path -> `String path) baseline_file);
+      ("results_dir", `String (display_benchmark_path config results_dir));
+      ("result_file", `String (display_benchmark_path config result_file));
+      ( "meta_file",
+        Option.fold ~none:`Null
+          ~some:(fun path -> `String (display_benchmark_path config path))
+          meta_file );
+      ( "baseline_file",
+        Option.fold ~none:`Null
+          ~some:(fun path -> `String (display_benchmark_path config path))
+          baseline_file );
     ]
 
 let latest_run_json ~result_file ~meta rows =
@@ -544,7 +558,10 @@ let dashboard_perf_http_json (config : Room.config) : Yojson.Safe.t =
           ("status", `String "empty");
           ("benchmarks", `List []);
           ("comparison", `Null);
-          ("candidate_dirs", `List (List.map (fun path -> `String path) (benchmark_results_dir_candidates config)));
+          ( "candidate_dirs",
+            `List
+              (benchmark_results_dir_candidates config
+              |> List.map (fun path -> `String (display_benchmark_path config path))) );
           ("message", `String "No benchmark artifacts found");
         ]
   | Some result_file ->
@@ -567,7 +584,9 @@ let dashboard_perf_http_json (config : Room.config) : Yojson.Safe.t =
         [
           ("generated_at", `String (Types.now_iso ()));
           ("status", `String "ok");
-          ("source", benchmark_source_json ~results_dir ~result_file ~meta_file ~baseline_file);
+          ( "source",
+            benchmark_source_json config ~results_dir ~result_file ~meta_file
+              ~baseline_file );
           ("latest_run", latest_run_json ~result_file ~meta rows);
           ( "highlights",
             `Assoc
@@ -592,7 +611,7 @@ let dashboard_perf_http_json (config : Room.config) : Yojson.Safe.t =
             | Some path ->
                 `Assoc
                   [
-                    ("baseline_file", `String path);
+                    ("baseline_file", `String (display_benchmark_path config path));
                     ("verdict_counts", verdict_counts_json comparison_rows);
                     ( "top_changes",
                       `List

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -290,7 +290,15 @@ let current_worktree_results_dir (config : Room.config) =
   let cwd = Sys.getcwd () in
   let worktrees_root = Filename.concat config.base_path ".worktrees" in
   if path_descends_from ~root:worktrees_root cwd then
-    Some (Filename.concat cwd "benchmarks/results")
+    let rel = String.sub cwd (String.length worktrees_root + 1)
+        (String.length cwd - String.length worktrees_root - 1) in
+    let worktree_name =
+      match String.index_opt rel '/' with
+      | Some i -> String.sub rel 0 i
+      | None -> rel
+    in
+    let worktree_root = Filename.concat worktrees_root worktree_name in
+    Some (Filename.concat worktree_root "benchmarks/results")
   else None
 
 let display_benchmark_path (config : Room.config) path =
@@ -305,7 +313,11 @@ let display_benchmark_path (config : Room.config) path =
       else Filename.basename path
 
 let benchmark_results_dir_candidates (config : Room.config) =
-  let env_dir = Sys.getenv_opt "MASC_BENCHMARK_RESULTS_DIR" in
+  let env_dir =
+    match Sys.getenv_opt "MASC_BENCHMARK_RESULTS_DIR" with
+    | Some "" | None -> None
+    | some -> some
+  in
   let scoped_dirs =
     [
       Option.value ~default:"" (current_worktree_results_dir config);

--- a/test/test_dashboard_perf.ml
+++ b/test/test_dashboard_perf.ml
@@ -51,6 +51,21 @@ let with_temp_base f =
   let dir = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () -> f dir)
 
+let with_cwd dir f =
+  let old = Sys.getcwd () in
+  Unix.chdir dir;
+  Fun.protect ~finally:(fun () -> Unix.chdir old) f
+
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
 let test_dashboard_perf_reads_root_benchmarks () =
   with_temp_base @@ fun base_path ->
   let config = Lib.Room.default_config base_path in
@@ -87,9 +102,9 @@ let test_dashboard_perf_reads_root_benchmarks () =
   let json = Lib.Server_dashboard_http.dashboard_perf_http_json config in
   let open Yojson.Safe.Util in
   check string "status" "ok" (json |> member "status" |> to_string);
-  check string "result file" latest_file
+  check string "result file" "benchmarks/results/results_20260331_140000.csv"
     (json |> member "source" |> member "result_file" |> to_string);
-  check string "baseline file" baseline_file
+  check string "baseline file" "benchmarks/results/results_20260331_130000.csv"
     (json |> member "comparison" |> member "baseline_file" |> to_string);
   check int "improved count" 1
     (json |> member "comparison" |> member "verdict_counts" |> member "improved" |> to_int);
@@ -109,9 +124,8 @@ let test_dashboard_perf_reads_root_benchmarks () =
 let test_dashboard_perf_reads_worktree_benchmarks () =
   with_temp_base @@ fun base_path ->
   let config = Lib.Room.default_config base_path in
-  let worktree_results_dir =
-    Filename.concat base_path ".worktrees/feat-perf/benchmarks/results"
-  in
+  let worktree_root = Filename.concat base_path ".worktrees/feat-perf" in
+  let worktree_results_dir = Filename.concat worktree_root "benchmarks/results" in
   let latest_file = Filename.concat worktree_results_dir "results_20260331_150000.csv" in
   write_csv latest_file
     [
@@ -121,16 +135,46 @@ let test_dashboard_perf_reads_worktree_benchmarks () =
       "oas_runtime_single,820,805,1010,1160,measured_ceiling=1";
     ];
   set_mtime latest_file 3_000.0;
+  with_env "MASC_BENCHMARK_RESULTS_DIR" worktree_results_dir @@ fun () ->
   let json = Lib.Server_dashboard_http.dashboard_perf_http_json config in
   let open Yojson.Safe.Util in
   check string "status" "ok" (json |> member "status" |> to_string);
-  check string "worktree dir selected" worktree_results_dir
+  check string "worktree dir selected" ".worktrees/feat-perf/benchmarks/results"
     (json |> member "source" |> member "results_dir" |> to_string);
   check int "benchmark count" 4
     (json |> member "latest_run" |> member "benchmark_count" |> to_int);
   check string "runtime file tag" "1"
     (json |> member "highlights" |> member "runtime_single" |> member "note_tags"
      |> member "measured_ceiling" |> to_string)
+
+let test_dashboard_perf_prefers_latest_scoped_artifact () =
+  with_temp_base @@ fun base_path ->
+  let config = Lib.Room.default_config base_path in
+  let root_results_dir = Filename.concat base_path "benchmarks/results" in
+  let root_file = Filename.concat root_results_dir "results_20260331_160000.csv" in
+  let worktree_root = Filename.concat base_path ".worktrees/feat-perf" in
+  let worktree_results_dir = Filename.concat worktree_root "benchmarks/results" in
+  let worktree_file =
+    Filename.concat worktree_results_dir "results_20260331_150000.csv"
+  in
+  write_csv root_file
+    [
+      "mcp_session_init,6,6,8,10,session";
+      "oas_runtime_single,790,780,980,1100,measured_ceiling=1";
+    ];
+  write_csv worktree_file
+    [
+      "mcp_session_init,7,7,9,12,session";
+      "oas_runtime_single,820,805,1010,1160,measured_ceiling=1";
+    ];
+  set_mtime worktree_file 2_000.0;
+  set_mtime root_file 3_000.0;
+  with_cwd worktree_root @@ fun () ->
+  let json = Lib.Server_dashboard_http.dashboard_perf_http_json config in
+  let open Yojson.Safe.Util in
+  check string "status" "ok" (json |> member "status" |> to_string);
+  check string "latest scoped file wins" "benchmarks/results/results_20260331_160000.csv"
+    (json |> member "source" |> member "result_file" |> to_string)
 
 let test_dashboard_perf_empty_shape () =
   with_temp_base @@ fun base_path ->
@@ -154,5 +198,7 @@ let () =
             test_dashboard_perf_reads_root_benchmarks;
           test_case "falls back to worktree benchmark artifacts" `Quick
             test_dashboard_perf_reads_worktree_benchmarks;
+          test_case "prefers latest artifact within scoped dirs" `Quick
+            test_dashboard_perf_prefers_latest_scoped_artifact;
         ] );
     ]

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -556,6 +556,12 @@ let test_flush_episodes_appends_only_new_records () =
   let ids = List.map (fun (episode : Institution_eio.episode) -> episode.id) persisted in
   Alcotest.(check bool) "existing record preserved" true (List.mem existing.id ids);
   Alcotest.(check bool) "new record appended" true (List.mem "new-episode-id" ids);
+  let memory_reseed = Memory_oas_bridge.create_memory ~agent_name:"test-ep-flush" () in
+  let reseeded =
+    Memory_oas_bridge.seed_episodes ~memory:memory_reseed ~agent_name:"test-ep-flush"
+      ~limit:10
+  in
+  Alcotest.(check int) "reseed count stays deduped" 2 reseeded;
   cleanup_tmp_dir dir
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary
- land the post-merge perf review-response fixes that were left out after `#4214` was squash-merged
- keep the follow-up diff scoped to the remaining 7 files only
- add the missing regression coverage for the perf snapshot and memory cache follow-ups

## Why this exists
`#4214` was already merged via squash while the final review-response commits were still only on the feature branch. This PR carries the remaining delta on top of `main`.

## Included follow-ups
- redact/scope perf artifact discovery in the dashboard runtime info endpoint
- validate benchmark iteration and warmup inputs
- add `perf-snapshot` component coverage
- guard `memory_oas_bridge` caches and verify immediate reseed behavior after flush

## Verification
- `env -u DUNE_RPC dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4214-perf-review-followup --build-dir /tmp/masc-4214-followup-build2 test/test_dashboard_perf.exe test/test_memory_oas_5tier.exe test/test_tool_registration_consistency.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4214-perf-review-followup --build-dir /tmp/masc-4214-followup-build2 --no-build test/test_dashboard_perf.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4214-perf-review-followup --build-dir /tmp/masc-4214-followup-build2 --no-build test/test_memory_oas_5tier.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4214-perf-review-followup --build-dir /tmp/masc-4214-followup-build2 --no-build test/test_tool_registration_consistency.exe`

## Notes
- local frontend typecheck was not run because `dashboard/node_modules` is absent in this worktree (`tsc` unavailable locally)
- follow-up to `#4214`
