### PR TITLE
[codex] Record OAS boundary health check

### DIFF
--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -143,12 +143,13 @@ export function handleHarnessSSE(): void {
   if (!evt) return
   const type = evt.type ?? ''
   const rawPayload = (evt as unknown as { payload?: Record<string, unknown> }).payload
-  const payload: Record<string, unknown> =
+  const payload =
     rawPayload && typeof rawPayload === 'object'
       ? rawPayload
-      : (evt as unknown as Record<string, unknown>)
+      : null
 
   if (type === 'oas:masc:harness:verdict_recorded') {
+    if (!payload) return
     const nextItem: HarnessVerdictItem = {
       timestamp:
         typeof payload.timestamp === 'number'
@@ -184,6 +185,7 @@ export function handleHarnessSSE(): void {
   }
 
   if (type === 'oas:masc:harness:pre_compact') {
+    if (!payload) return
     const nextItem: PreCompactEvent = {
       timestamp:
         typeof payload.timestamp === 'number'
@@ -229,30 +231,31 @@ export function handleHarnessSSE(): void {
   if (
     type === 'oas:masc:harness:handoff'
     || type === 'keeper_handoff'
-    || type === 'masc/keeper_handoff'
   ) {
+    const handoffPayload: Record<string, unknown> =
+      payload ?? (evt as unknown as Record<string, unknown>)
     const nextItem: HandoffEvent = {
       timestamp:
-        typeof payload.timestamp === 'number'
-          ? payload.timestamp
-          : typeof payload.ts_unix === 'number'
-            ? payload.ts_unix
+        typeof handoffPayload.timestamp === 'number'
+          ? handoffPayload.timestamp
+          : typeof handoffPayload.ts_unix === 'number'
+            ? handoffPayload.ts_unix
           : Date.now() / 1000,
-      keeper_name: String(payload.keeper_name ?? payload.name ?? ''),
-      trace_id: String(payload.trace_id ?? payload.new_trace_id ?? ''),
-      generation: Number(payload.generation ?? payload.from_generation ?? 0),
+      keeper_name: String(handoffPayload.keeper_name ?? handoffPayload.name ?? ''),
+      trace_id: String(handoffPayload.trace_id ?? handoffPayload.new_trace_id ?? ''),
+      generation: Number(handoffPayload.generation ?? handoffPayload.from_generation ?? 0),
       next_generation:
-        payload.next_generation != null
-          ? Number(payload.next_generation)
-          : payload.to_generation != null
-            ? Number(payload.to_generation)
+        handoffPayload.next_generation != null
+          ? Number(handoffPayload.next_generation)
+          : handoffPayload.to_generation != null
+            ? Number(handoffPayload.to_generation)
             : null,
       prev_trace_id:
-        payload.prev_trace_id == null ? null : String(payload.prev_trace_id),
+        handoffPayload.prev_trace_id == null ? null : String(handoffPayload.prev_trace_id),
       new_trace_id:
-        payload.new_trace_id == null ? null : String(payload.new_trace_id),
+        handoffPayload.new_trace_id == null ? null : String(handoffPayload.new_trace_id),
       to_model:
-        payload.to_model == null ? null : String(payload.to_model),
+        handoffPayload.to_model == null ? null : String(handoffPayload.to_model),
     }
     updateHarnessData(data => ({
       ...data,

--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -142,8 +142,11 @@ export function handleHarnessSSE(): void {
   const evt = lastEvent.value
   if (!evt) return
   const type = evt.type ?? ''
-  const payload = (evt as unknown as { payload?: Record<string, unknown> }).payload
-  if (!payload) return
+  const rawPayload = (evt as unknown as { payload?: Record<string, unknown> }).payload
+  const payload: Record<string, unknown> =
+    rawPayload && typeof rawPayload === 'object'
+      ? rawPayload
+      : (evt as unknown as Record<string, unknown>)
 
   if (type === 'oas:masc:harness:verdict_recorded') {
     const nextItem: HarnessVerdictItem = {
@@ -223,17 +226,27 @@ export function handleHarnessSSE(): void {
     scheduleHarnessReload()
   }
 
-  if (type === 'oas:masc:harness:handoff') {
+  if (
+    type === 'oas:masc:harness:handoff'
+    || type === 'keeper_handoff'
+    || type === 'masc/keeper_handoff'
+  ) {
     const nextItem: HandoffEvent = {
       timestamp:
         typeof payload.timestamp === 'number'
           ? payload.timestamp
+          : typeof payload.ts_unix === 'number'
+            ? payload.ts_unix
           : Date.now() / 1000,
-      keeper_name: String(payload.keeper_name ?? ''),
-      trace_id: String(payload.trace_id ?? ''),
-      generation: Number(payload.generation ?? 0),
+      keeper_name: String(payload.keeper_name ?? payload.name ?? ''),
+      trace_id: String(payload.trace_id ?? payload.new_trace_id ?? ''),
+      generation: Number(payload.generation ?? payload.from_generation ?? 0),
       next_generation:
-        payload.next_generation == null ? null : Number(payload.next_generation),
+        payload.next_generation != null
+          ? Number(payload.next_generation)
+          : payload.to_generation != null
+            ? Number(payload.to_generation)
+            : null,
       prev_trace_id:
         payload.prev_trace_id == null ? null : String(payload.prev_trace_id),
       new_trace_id:

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -12,7 +12,6 @@ export type SSEEventType =
   | 'heartbeat'
   | 'keeper_heartbeat'
   | 'keeper_handoff'
-  | 'masc/keeper_handoff'
   | 'keeper_compaction'
   | 'keeper_guardrail'
   | 'keeper_turn_complete'

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -12,6 +12,7 @@ export type SSEEventType =
   | 'heartbeat'
   | 'keeper_heartbeat'
   | 'keeper_handoff'
+  | 'masc/keeper_handoff'
   | 'keeper_compaction'
   | 'keeper_guardrail'
   | 'keeper_turn_complete'

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -1,8 +1,10 @@
 # MASC-MCP OAS Utilization Audit
 
 Date: 2026-03-25
-OAS Version: 0.89.1 floor (CI/runtime pin on `jeong-sik/oas@3e7da31d54c69fe0aea951ca5301eb59d85f24e5`, latest tagged floor `v0.89.1`)
+OAS Version: 0.99.1 floor (CI/runtime pin on `jeong-sik/oas@61e5314630c3db7b6415b937e83f4beac27897ee`, latest tagged floor `v0.99.1`)
 Snapshot: `main` audit aligned to the current upstream `agent_sdk.opam`; drift is checked against upstream `refs/heads/main`, not GitHub releases
+
+Latest boundary check: `docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md`
 
 ## Current Read
 
@@ -15,7 +17,7 @@ The main remaining problems are no longer “missing migration” at large. They
 
 ## Pin Policy
 
-`masc-mcp` keeps the runtime pin ratcheted against upstream `main`, while the dependency floor tracks the latest tagged SDK version. As of this audit, the runtime pin is ahead of the latest tag `v0.89.1`, while the dependency floor remains pinned to `0.89.1`.
+`masc-mcp` keeps the runtime pin ratcheted against upstream `main`, while the dependency floor tracks the latest tagged SDK version. As of this audit, the runtime pin is ahead of the latest tag `v0.99.1`, while the dependency floor remains pinned to `0.99.1`.
 
 ## Status by Area
 

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -1,6 +1,6 @@
 # MASC-MCP OAS Utilization Audit
 
-Date: 2026-03-25
+Date: 2026-03-31
 OAS Version: 0.99.1 floor (CI/runtime pin on `jeong-sik/oas@61e5314630c3db7b6415b937e83f4beac27897ee`, latest tagged floor `v0.99.1`)
 Snapshot: `main` audit aligned to the current upstream `agent_sdk.opam`; drift is checked against upstream `refs/heads/main`, not GitHub releases
 

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -4,7 +4,7 @@ Date: 2026-03-31
 OAS Version: 0.99.1 floor (CI/runtime pin on `jeong-sik/oas@61e5314630c3db7b6415b937e83f4beac27897ee`, latest tagged floor `v0.99.1`)
 Snapshot: `main` audit aligned to the current upstream `agent_sdk.opam`; drift is checked against upstream `refs/heads/main`, not GitHub releases
 
-Latest boundary check: `docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md`
+Latest boundary check: [docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md](docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md)
 
 ## Current Read
 

--- a/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
+++ b/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
@@ -86,7 +86,7 @@ Checked modules:
 
 Command:
 
-- `rg -n "failwith|Option\\.get|Obj\\.magic|List\\.hd|List\\.tl" ...`
+- `rg -n "failwith|Option\\.get|Obj\\.magic|List\\.hd|List\\.tl" lib/oas_*.ml lib/*oas*.ml lib/team_session/team_session_oas_bridge.ml lib/keeper/*oas*.ml -g '!_build'`
   - Result: no matches
   - [evidence] source: local command; checked: 2026-03-31; confidence: High
 

--- a/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
+++ b/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
@@ -1,0 +1,105 @@
+# OAS Boundary Health Check - 2026-03-31
+
+Scope: `masc-mcp` to OAS boundary health snapshot on commit `aade21ba7402baede95e565c503d3e38a923558b`
+
+## Verdict
+
+Initial boundary health is `healthy with known structural gaps`.
+
+- Boundary build and targeted tests passed.
+- Live OpenAPI export passed when run with local port binding enabled.
+- No unsafe boundary-pattern hits were found in the checked OAS-facing modules.
+- Known risks remain the same as the current audit: team-session bridge fidelity and the narrow boolean `resource_check`.
+
+## Evidence
+
+### Static checks
+
+- `dune build --root .`
+  - Result: pass
+  - [evidence] source: local command; checked: 2026-03-31; confidence: High
+
+- `scripts/check-oas-pin.sh`
+  - Result: pass with drift warning
+  - Warning: pinned `61e5314630c3db7b6415b937e83f4beac27897ee`, upstream `main` `0fea023a7c8a40e5a55eefd6c6c53894641d9c96`
+  - [evidence] source: local command + upstream git ref check; checked: 2026-03-31; confidence: High
+
+- `bash scripts/health_snapshot.sh --skip-build --json-out .health/health-snapshot.json`
+  - Result: completed
+  - Note: repo-wide snapshot still reports `Anti-fake: suspect=16 fake=55` and `.ml` line-cap `manual=159`
+  - Interpretation: this is a repository health concern, not a boundary-specific failure
+  - [evidence] source: local command; checked: 2026-03-31; confidence: High
+
+### Boundary tests
+
+- `_build/default/test/test_oas_integration.exe`
+  - Result: pass, 8 tests
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_oas_adapters.exe`
+  - Result: pass, 9 tests
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_oas_worker.exe`
+  - Result: pass, 34 tests
+  - Focus: cascade config, SSE bridge, OAS checkpoint continuity, keeper handoff rollover
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_team_session_oas_bridge.exe`
+  - Result: pass, 32 tests
+  - Focus: role projection, cascade resolution, supported-tool filtering, `resource_check` presence, telemetry `trace_ref`
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_tool_local_runtime_verify.exe`
+  - Result: pass, 5 tests
+  - Focus: provider health, runtime blockers, contract mismatch handling
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_local_runtime_pool.exe`
+  - Result: pass, 9 tests
+  - Focus: runtime env parsing, slot acquisition, measured ceiling recording
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_dashboard_harness_health.exe`
+  - Result: pass, 6 tests
+  - Focus: persisted runtime-signal surfacing and stale-signal handling
+  - [evidence] source: local test binary; checked: 2026-03-31; confidence: High
+
+- `_build/default/test/test_openapi_api_e2e.exe`
+  - Result: pass, 1 test
+  - Note: sandbox execution skipped because local port bind was unavailable; rerun with local port binding enabled succeeded
+  - [evidence] source: local e2e test; checked: 2026-03-31; confidence: High
+
+### Boundary module hygiene
+
+Checked modules:
+
+- `lib/oas_worker.ml`
+- `lib/worker_oas.ml`
+- `lib/memory_oas_bridge.ml`
+- `lib/context_compact_oas.ml`
+- `lib/tool_council_oas.ml`
+- `lib/verifier_oas.ml`
+- `lib/keeper/keeper_hooks_oas.ml`
+- `lib/keeper/keeper_tools_oas.ml`
+- `lib/team_session/team_session_oas_bridge.ml`
+
+Command:
+
+- `rg -n "failwith|Option\\.get|Obj\\.magic|List\\.hd|List\\.tl" ...`
+  - Result: no matches
+  - [evidence] source: local command; checked: 2026-03-31; confidence: High
+
+## Current Risks
+
+These remain aligned with the existing audit and boundary contract docs, not new regressions found in this check.
+
+1. `team_session` bridge fidelity is still incomplete.
+2. `resource_check` is still a narrow boolean gate rather than a richer runtime-health probe.
+3. Several OAS-facing files remain large enough that future boundary drift is likely to hide in file-size complexity.
+
+## Next Actions
+
+1. Replace the current boolean `resource_check` path with a structured runtime-health probe.
+2. Keep reducing fidelity loss in `team_session_oas_bridge` projection and telemetry export.
+3. Break down the largest OAS-facing files before the next migration step adds more bridge logic.


### PR DESCRIPTION
## Summary
- add a dated OAS boundary health-check snapshot under `docs/qa`
- update `docs/OAS-UTILIZATION-AUDIT.md` to point to the latest boundary check and match the current OAS floor/runtime pin metadata
- fix the audit doc so the latest boundary check renders as a clickable Markdown link
- fix dashboard harness-health SSE handling so legacy `keeper_handoff` events update the handoff rail immediately

## Product impact
- no backend/runtime behavior changes in `masc-mcp`
- improves operator-facing documentation accuracy for current `masc-mcp` to OAS boundary health and known gaps
- restores dashboard compatibility for live handoff SSE events so the harness panel stays in sync with keeper handoffs

## Evidence
- `dune build --root .`
- `scripts/check-oas-pin.sh`
- `bash scripts/health_snapshot.sh --skip-build --json-out .health/health-snapshot.json`
- `_build/default/test/test_oas_integration.exe`
- `_build/default/test/test_oas_adapters.exe`
- `_build/default/test/test_oas_worker.exe`
- `_build/default/test/test_team_session_oas_bridge.exe`
- `_build/default/test/test_tool_local_runtime_verify.exe`
- `_build/default/test/test_local_runtime_pool.exe`
- `_build/default/test/test_dashboard_harness_health.exe`
- `_build/default/test/test_openapi_api_e2e.exe`
- `cd dashboard && pnpm test -- --run src/components/harness-health.test.ts`
- `cd dashboard && pnpm build`

## Review evidence
- direct `sb glm-text` cross-model review with `GLM-5.1`
- round 1 findings fixed in follow-up commits
- latest rerun result will be posted after the dashboard compatibility patch review completes

## Linked issue
- Refs #3015

## Notes
- `scripts/check-oas-pin.sh` still reports upstream `main` drift beyond the pinned OAS SHA; this PR records the current state but does not update the pin
- repo-wide health snapshot findings are recorded as context, but they are not introduced by this PR
- the dashboard fix is included here because it was the only remaining failing PR check after the review-response/documentation updates
