### PR TITLE
refactor(keeper): derive keeper_backend_tool_name from surfaces SSOT

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -182,23 +182,12 @@ let privileged_keeper_tool_names : string list =
   [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit"; "keeper_github";
     "masc_worktree_create" ]
 
-let keeper_backend_tool_name = function
-  | "keeper_board_get" -> "masc_board_get"
-  | "keeper_board_post" -> "masc_board_post"
-  | "keeper_board_list" -> "masc_board_list"
-  | "keeper_board_comment" -> "masc_board_comment"
-  | "keeper_board_vote" -> "masc_board_vote"
-  | "keeper_board_stats" -> "masc_board_stats"
-  | "keeper_board_search" -> "masc_board_search"
-  | "keeper_board_delete" -> "masc_board_delete"
-  | "keeper_voice_speak" -> "masc_voice_speak"
-  | "keeper_voice_agent" -> "masc_voice_agent"
-  | "keeper_voice_sessions" -> "masc_voice_sessions"
-  | "keeper_voice_session_start" -> "masc_voice_session_start"
-  | "keeper_voice_session_end" -> "masc_voice_session_end"
-  | "keeper_tasks_list" -> "masc_tasks"
-  | "keeper_broadcast" -> "masc_broadcast"
-  | other -> other
+(* Derived from Tool_catalog_surfaces.keeper_internal_replacement (SSOT).
+   Returns the masc_* backend name for aliased tools, identity otherwise. *)
+let keeper_backend_tool_name name =
+  match Tool_catalog_surfaces.keeper_internal_replacement name with
+  | Some masc_name -> masc_name
+  | None -> name
 
 let public_projection_seeds_from (public_tool_source_schemas : Types.tool_schema list) :
     capability_seed list =

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -258,6 +258,24 @@ let test_board_delete_tag_registered () =
   | None ->
       Alcotest.fail "masc_board_delete missing from tag registry"
 
+(* ── Test: keeper alias SSOT — capability_registry derives from surfaces ── *)
+
+let test_keeper_alias_ssot_consistency () =
+  let open Tool_catalog_surfaces in
+  List.iter (fun keeper_name ->
+    let from_surfaces = keeper_internal_replacement keeper_name in
+    let from_registry = Capability_registry.keeper_backend_tool_name keeper_name in
+    match from_surfaces with
+    | Some masc_name ->
+        Alcotest.(check string)
+          (Printf.sprintf "%s alias must match" keeper_name)
+          masc_name from_registry
+    | None ->
+        Alcotest.(check string)
+          (Printf.sprintf "%s (native) must be identity" keeper_name)
+          keeper_name from_registry
+  ) keeper_internal_tools
+
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -283,5 +301,7 @@ let () =
             test_no_duplicate_schemas;
           Alcotest.test_case "board delete tag registered" `Quick
             test_board_delete_tag_registered;
+          Alcotest.test_case "keeper_backend_tool_name matches keeper_internal_replacement" `Quick
+            test_keeper_alias_ssot_consistency;
         ] );
     ]


### PR DESCRIPTION
## Summary

- `capability_registry.ml`의 `keeper_backend_tool_name`이 `tool_catalog_surfaces.ml`의 `keeper_internal_replacement`와 동일한 매핑을 수동 복제하고 있었음
- 새 keeper alias 추가 시 양쪽 모두 업데이트 필요 → 한쪽만 빠뜨리면 runtime "unregistered" 에러 (#4219 사례)
- `keeper_backend_tool_name`을 `Tool_catalog_surfaces.keeper_internal_replacement`에서 파생하도록 변경 → SSOT 달성
- 일관성 검증 테스트 추가: 모든 keeper_internal_tools에 대해 양 함수의 결과가 일치하는지 확인

## Test plan

- [ ] `dune build` 성공 (CI)
- [ ] `test_tool_registration_consistency` 통과 — `keeper_backend_tool_name matches keeper_internal_replacement` 테스트 케이스
- [ ] 기존 keeper dispatch 동작 변경 없음 (동일 매핑, 구현만 SSOT화)

Closes: 향후 alias 누락 재발 방지 (구조적 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)