### PR TITLE
fix(test): align harness-health SSE event format with handler

### DIFF
--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -247,17 +247,20 @@ describe('HarnessHealth', () => {
     expect(container.textContent).toContain('keeper-a')
 
     lastEvent.value = {
-      type: 'keeper_handoff',
-      name: 'keeper-b',
-      ts_unix: 1711440900,
-      from_generation: 8,
-      to_generation: 9,
-      to_model: 'glm-5',
+      type: 'oas:masc:harness:handoff',
+      payload: {
+        timestamp: 1711440900,
+        keeper_name: 'keeper-b',
+        trace_id: 'trace-b',
+        generation: 8,
+        next_generation: 9,
+        to_model: 'glm-5',
+      },
     }
     await flushUi()
 
     expect(container.textContent).toContain('keeper-b')
-    expect(container.textContent).toContain('generation 8')
+    expect(container.textContent).toContain('generation 9')
     expect(mermaidSource(container)).toContain('class handoff activeRail;')
 
     await new Promise(resolve => setTimeout(resolve, 1000))


### PR DESCRIPTION
## Summary
- `harness-health.test.ts`의 keeper_handoff SSE 테스트가 raw 이벤트 형식(`type: 'keeper_handoff'`)을 사용하고 있었으나, handler는 `type: 'oas:masc:harness:handoff'` + `payload` wrapper를 기대
- `generation` assertion을 `next_generation` 우선 로직에 맞게 수정 (8 → 9)

## Evidence
- 로컬 vitest: 4/4 통과
- main CI Dashboard job 실패 원인과 정확히 일치

## Test plan
- [x] `npx vitest run src/components/harness-health.test.ts` — 4/4 pass
- [ ] CI Dashboard job green

Refs #4233

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>