### PR TITLE
feat(scheduler): slot visibility, autoresearch gate, judge exp backoff

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -97,10 +97,25 @@ let parse_model_code_response response =
     | Ok _ ->
       Result.error "MODEL response must be a JSON object"
 
+let has_background_capacity () =
+  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+  | Some sw, Some net -> (
+    try
+      let config_path = Oas_worker.default_config_path () in
+      let cap = Llm_provider.Cascade_config.local_capacity_for_selections
+          ~sw ~net ?config_path ["autoresearch"] in
+      not (cap.all_discovered && cap.endpoints_found > 0
+           && cap.process_available = 0 && cap.process_queue_length >= 2)
+    with _ -> true)
+  | _ -> true
+
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)
 let generate_code_change ~goal ~baseline ~history ~insights
     ~target_file ~file_content =
+  if not (has_background_capacity ()) then
+    Result.error "autoresearch: local slots saturated, skipping cycle"
+  else
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -408,9 +408,19 @@ let start ~sw ~clock ~net ~base_path
   in
   if should_start then
     Eio.Fiber.fork_daemon ~sw (fun () ->
+        let consecutive_backoffs = Atomic.make 0 in
         let rec loop () =
+          let was_backoff = should_backoff ~sw ~net in
           refresh_once ~sw ~net ~masc_tools ~dispatch ~base_path ~build_facts;
-          Eio.Time.sleep clock (float_of_int (interval_sec ()));
+          if was_backoff then Atomic.incr consecutive_backoffs
+          else Atomic.set consecutive_backoffs 0;
+          let base = float_of_int (interval_sec ()) in
+          let n = Atomic.get consecutive_backoffs in
+          let sleep_s =
+            if n = 0 then base
+            else min (base *. Float.pow 2.0 (float_of_int (min n 5))) 300.0
+          in
+          Eio.Time.sleep clock sleep_s;
           loop ()
         in
         loop ())

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -267,6 +267,33 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("judge_online", `Bool false);
     ], false)
 
+let slot_monitoring_json () : Yojson.Safe.t =
+  try
+    let idle = Discovery_cache.idle_slot_count () in
+    let busy = Discovery_cache.busy_slot_count () in
+    let total = idle + busy in
+    let endpoints = Discovery_cache.get_cached_or_refresh () in
+    `Assoc [
+      ("idle", `Int idle);
+      ("busy", `Int busy);
+      ("total", `Int total);
+      ("utilization",
+        `Float (if total > 0
+                then float_of_int busy /. float_of_int total
+                else 0.0));
+      ("cache_age_s", `Float (Discovery_cache.cache_age_seconds ()));
+      ("endpoints", `List (List.map Discovery_cache.endpoint_to_json endpoints));
+    ]
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ ->
+    `Assoc [
+      ("idle", `Int 0); ("busy", `Int 0); ("total", `Int 0);
+      ("utilization", `Float 0.0);
+      ("cache_age_s", `Float 0.0);
+      ("endpoints", `List []);
+    ]
+
 let executor_outcomes_json (config : Room.config) : Yojson.Safe.t =
   try
     let since = Time_compat.now () -. 86400.0 in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -339,9 +339,19 @@ let start ~sw ~clock ~net ~(config : Room.config)
   in
   if should_start then
     Eio.Fiber.fork_daemon ~sw (fun () ->
+        let consecutive_backoffs = Atomic.make 0 in
         let rec loop () =
+          let was_backoff = should_backoff ~sw ~net in
           refresh_once ~sw ~net ~masc_tools ~dispatch ~config ~build_facts;
-          Eio.Time.sleep clock (float_of_int (interval_sec ()));
+          if was_backoff then Atomic.incr consecutive_backoffs
+          else Atomic.set consecutive_backoffs 0;
+          let base = float_of_int (interval_sec ()) in
+          let n = Atomic.get consecutive_backoffs in
+          let sleep_s =
+            if n = 0 then base
+            else min (base *. Float.pow 2.0 (float_of_int (min n 5))) 300.0
+          in
+          Eio.Time.sleep clock sleep_s;
           loop ()
         in
         loop ())

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -217,6 +217,7 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("governance", governance_monitor_json);
         ("room_state", Room_eio.state_health_counters ());
         ("executor", executor_outcomes_json config);
+        ("slots", slot_monitoring_json ());
       ]);
       ("data_quality", `Assoc [
         ("board_contract_ok", `Bool board_contract_ok);


### PR DESCRIPTION
## Summary

기존 Slot Scheduler 인프라를 활용하지 않던 3개 소비자를 연결하여 성능 개선:

1. **Slot monitoring** — `Discovery_cache` 기반 idle/busy/utilization을 dashboard monitoring JSON에 추가
2. **Autoresearch capacity gate** — `local_capacity_for_selections` 체크로 포화 시 LLM cycle skip (queue storm 방지)
3. **Judge exponential backoff** — 연속 backoff 시 sleep을 `base → 2*base → 4*base → ... → 300s cap`으로 증가. 회복 시 즉시 reset.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/dashboard/dashboard_http_monitoring.ml` | `slot_monitoring_json()` 추가 |
| `lib/server/server_dashboard_http_core.ml` | monitoring에 `("slots", ...)` 추가 |
| `lib/autoresearch_codegen.ml` | `has_background_capacity()` gate 추가 |
| `lib/dashboard/dashboard_governance_judge.ml` | exponential backoff loop |
| `lib/dashboard/dashboard_operator_judge.ml` | 동일 패턴 |

## Test plan

- [x] `dune build` 성공
- [x] `test_ci_hardening_source` 27/27 통과
- [ ] CI checks green
- [ ] `curl localhost:8935/api/v1/dashboard | jq '.monitoring.slots'` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)