### PR TITLE
[codex] add dir-local local-dev launcher and config fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,24 +39,25 @@ scripts/opam-pin-external-deps.sh
 opam install . --deps-only
 dune build --root .
 
-./start-masc-mcp.sh --http
-PORT="$(./start-masc-mcp.sh --print-port)"  # query the effective port for this checkout
+scripts/run-local.sh --target-dir "$PWD"
+PORT="$(scripts/run-local.sh --print-port --target-dir "$PWD")"
 curl "http://127.0.0.1:${PORT}/health"
 ```
 
 Defaults:
 
-- repo root checkout HTTP / MCP port: `8935`
-- git worktree checkout HTTP / MCP port: `9100-9999` 범위에서 checkout path 기준으로 자동 파생
+- local-dev HTTP / MCP port: `9100-9999` 범위에서 target path 기준 자동 파생
 - 기본 bind host: `127.0.0.1`
-- repo-managed config root: `MASC_CONFIG_DIR` 우선, 없으면 `~/.masc/config` 우선, 그 다음 repo `config/` 자동 탐색
+- local-dev data root: `<target>/.masc/`
+- local-dev config root: `<target>/.masc/config`
+- local-dev personas root: `<target>/.masc/config/personas`
+- local-dev transports: HTTP on, gRPC/WS/WebRTC off
 
 메모:
 
-- 현재 checkout의 기본 포트 확인: `./start-masc-mcp.sh --print-port`
-- worktree에서 `--port`를 생략하면 script가 worktree별 기본 포트를 자동 선택한다.
-- 고정 포트가 필요하면 `MASC_MCP_PORT=94xx` 또는 `--port 94xx`로 덮어쓴다.
-- `--print-port`는 현재 checkout의 기본 포트 조회용이다. 서버 시작은 보통 `./start-masc-mcp.sh --http`로 충분하다.
+- target 기준 기본 포트 확인: `scripts/run-local.sh --print-port --target-dir /path/to/project`
+- 고정 포트가 필요하면 `scripts/run-local.sh --target-dir /path/to/project --port 94xx`
+- shared repo/full-runtime 경로는 `./start-masc-mcp.sh --http`를 계속 사용한다.
 
 If you bind to a non-loopback address such as `0.0.0.0`, treat that as a remote exposure path and configure auth first. See [docs/REMOTE-MCP-OPERATOR.md](docs/REMOTE-MCP-OPERATOR.md) and [docs/spec/09-server-transport.md](docs/spec/09-server-transport.md).
 
@@ -75,7 +76,7 @@ Local full-surface MCP example:
 }
 ```
 
-worktree에서는 `8935` 대신 `./start-masc-mcp.sh --print-port` 출력값으로 바꾼다.
+dir-local local-dev에서는 `8935` 대신 `scripts/run-local.sh --print-port --target-dir ...` 출력값으로 바꾼다.
 
 메모:
 
@@ -122,8 +123,9 @@ Common entrypoints:
 The dashboard is a read / operate UI. Canonical write and control paths remain MCP tools.
 
 - 대시보드는 read/operate UI이고, canonical write/control path는 MCP입니다.
+- `scripts/run-local.sh`는 dashboard를 자동으로 빌드하지 않습니다. 필요할 때만 `--build-dashboard`를 붙이세요.
 - `start-masc-mcp.sh`는 `pnpm` 또는 `corepack pnpm`이 있을 때 dashboard SPA를 자동으로 빌드합니다.
-- dev server를 따로 띄울 때는 `PORT="$(./start-masc-mcp.sh --print-port)"` 후 `cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run dev`를 사용하세요.
+- dev server를 따로 띄울 때는 `PORT="$(scripts/run-local.sh --print-port --target-dir "$PWD")"` 후 `cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run dev`를 사용하세요.
 - 수동 재빌드가 필요하면 `cd dashboard && pnpm run build`를 실행하세요.
 
 ## Verification

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -618,7 +618,7 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는 `docs/
 
 별도 keepalive 등록 레지스트리는 없다. keeper의 선언과 런타임 상태는 `.masc/perpetual-keepers/<name>.json`에 함께 저장되고, keeper는 durable always-on으로 취급된다. 멈춤은 설정값이 아니라 `paused` 또는 `keeper_down` 상태 전이로 표현한다.
 
-repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `~/.masc/config`를 먼저 본 뒤 repo `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다. 즉 웹/대시보드는 파일을 직접 읽지 않고, 서버가 해석한 config root와 persona root를 사용한다.
+repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `<MASC_BASE_PATH>/.masc/config`, 그 다음 `~/.masc/config`, 마지막으로 repo `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다. 즉 웹/대시보드는 파일을 직접 읽지 않고, 서버가 해석한 config root와 persona root를 사용한다.
 
 ### 8.2 Template 변경 반영
 
@@ -633,13 +633,13 @@ masc_keeper_up(name: "sangsu")
 
 ### 8.3 base-path 주의사항
 
-`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. `start-masc-mcp.sh`를 쓰면 worktree에서도 기본적으로 git repo root를 자동 해석한다.
+`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본값으로 쓰고, `start-masc-mcp.sh`는 shared/full-runtime 경로로 유지된다.
 
-공유 keeper 상태가 보이지 않는 흔한 경우는 worktree 실행 자체가 아니라, `--base-path`를 별도 경로로 명시했거나 raw executable을 custom base path로 직접 띄운 경우다.
+dir-local 실행에서 shared keeper 상태가 보이지 않는 것은 정상이다. 공유 keeper 상태가 필요하면 shared/full-runtime 경로를 사용해야 한다.
 
-해결: 기본 start script를 그대로 쓰거나, shared `.masc/`를 봐야 할 때만 `--base-path`를 main repo root로 명시 지정한다.
+해결: dir-local 개발은 `scripts/run-local.sh --target-dir <dir>`를 사용하고, shared `.masc/`를 봐야 할 때만 `./start-masc-mcp.sh --http` 또는 explicit `--base-path`를 사용한다.
 
-이 값은 `.masc/` data root만 바꾼다. `config/cascade.json`, `config/prompts`, `config/keepers`, `config/personas` 같은 repo-managed config는 `MASC_CONFIG_DIR` 계약으로 별도 해석된다.
+이 값은 `.masc/` data root를 결정하고, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 repo-managed config의 첫 fallback으로도 사용한다.
 
 ### 8.4 모델 실행
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -15,21 +15,20 @@ scripts/opam-pin-external-deps.sh
 opam install . --deps-only
 dune build --root .
 
-./start-masc-mcp.sh --http
-PORT="$(./start-masc-mcp.sh --print-port)"  # query the effective port for this checkout
+scripts/run-local.sh --target-dir "$PWD"
+PORT="$(scripts/run-local.sh --print-port --target-dir "$PWD")"
 ```
 
 기본 포트:
 
-- repo root checkout: `8935`
-- git worktree checkout: `9100-9999` 범위에서 checkout path 기준 자동 파생
+- local-dev target: `9100-9999` 범위에서 target path 기준 자동 파생
 - 기본 bind host: `127.0.0.1`
 
 메모:
 
-- 현재 checkout의 기본 포트 확인: `./start-masc-mcp.sh --print-port`
-- worktree에서 `--port`를 생략하면 script가 worktree별 기본 포트를 자동 선택한다.
-- `--print-port`는 현재 checkout의 기본 포트 조회용이다. 서버 시작은 보통 `./start-masc-mcp.sh --http`로 충분하다.
+- target 기준 기본 포트 확인: `scripts/run-local.sh --print-port --target-dir /path/to/project`
+- `scripts/run-local.sh`는 `<target>/.masc/`를 data/config/personas 기본 루트로 사용한다.
+- shared repo/full-runtime을 올릴 때만 `./start-masc-mcp.sh --http`를 쓴다.
 
 ## 2. Health Check
 
@@ -66,7 +65,7 @@ HTTP가 canonical public path다. 템플릿 전체는 `docs/MCP-TEMPLATE.md`를 
 }
 ```
 
-worktree에서는 `8935` 대신 `./start-masc-mcp.sh --print-port` 출력값으로 바꾼다.
+dir-local local-dev에서는 `8935` 대신 `scripts/run-local.sh --print-port --target-dir ...` 출력값으로 바꾼다.
 
 ## 4. 첫 Workflow
 
@@ -138,9 +137,9 @@ masc_keeper_up(name: "sangsu")
 전제조건:
 - `PERSONAS_ROOT/<name>/profile.json`이 존재해야 한다 (또는 `CONFIG_ROOT/keepers/<name>.toml`)
 - `PERSONAS_ROOT`는 `MASC_PERSONAS_DIR` 우선, 없으면 resolved `CONFIG_ROOT/personas`를 사용한다.
-- `start-masc-mcp.sh`는 worktree에서 실행해도 기본적으로 git repo root를 `MASC_BASE_PATH`로 자동 해석한다.
-- shared keeper 상태 대신 별도 `.masc/`를 쓰고 싶을 때만 `--base-path`를 명시적으로 덮어쓴다.
-- repo-managed config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 `~/.masc/config`를 먼저 보고, 없을 때만 repo `config/` 자동 탐색을 사용한다.
+- `scripts/run-local.sh`는 `<target>/.masc/`를 기본 runtime root로 사용하고, `<target>/.masc/config`를 먼저 본다.
+- shared keeper 상태를 봐야 할 때만 `./start-masc-mcp.sh --http` 또는 explicit `--base-path`를 사용한다.
+- repo-managed config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 `<MASC_BASE_PATH>/.masc/config`, 그 다음 `~/.masc/config`, 마지막으로 repo `config/` 자동 탐색을 사용한다.
 - `MASC_PERSONAS_DIR` 환경변수로 persona만 repo 밖 경로로 분리할 수 있다.
 
 공유 config/persona를 repo 밖에 두고 실행하는 예시:

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -52,7 +52,7 @@
 | `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |
 
 작업공간 루트 해석 체인: `MASC_WORKSPACE_ROOT` -> `ME_ROOT` -> `DUNE_SOURCEROOT`. 세 곳 모두 미설정 시 `failwith`.
-repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `~/.masc/config` -> `cwd/config` -> executable-relative `config/` -> legacy `ME_ROOT/workspace/yousleepwhen/masc-mcp/config`.
+repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `<MASC_BASE_PATH>/.masc/config` -> `~/.masc/config` -> `cwd/config` -> executable-relative `config/` -> legacy `ME_ROOT/workspace/yousleepwhen/masc-mcp/config`.
 
 ### 3.2 Runtime (Env_config_runtime)
 
@@ -425,6 +425,8 @@ $MASC_PERSONAS_DIR
 > resolved config root의 personas/
 > where resolved config root =
   $MASC_CONFIG_DIR
+  > $MASC_BASE_PATH/.masc/config
+  > ~/.masc/config
   > executable-relative config/
   > cwd/config
   > legacy ME_ROOT/workspace/yousleepwhen/masc-mcp/config
@@ -439,11 +441,11 @@ Template 변경은 기존 keeper에 자동 전파되지 않는다. 반영 방법
 
 ### 12.5 `--base-path`와 `.masc/` 의존성
 
-`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. 기본값은 repo root.
+`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본으로 사용하고, shared/full-runtime 경로는 별도 launcher가 유지한다.
 
-worktree에서 서버를 실행하면 `.masc/`가 worktree 내부를 가리키므로 main repo의 keeper 상태에 접근할 수 없다. keeper가 보이지 않는 가장 흔한 원인.
+dir-local local-dev에서는 `.masc/`가 target 디렉토리 내부를 가리키므로 shared repo keeper 상태와 분리된다. shared state가 필요하면 canonical shared launcher를 사용해야 한다.
 
-이 값은 runtime data root에만 영향을 준다. repo-managed config root는 `MASC_CONFIG_DIR` 또는 config resolver fallback chain으로 별도 해석한다.
+이 값은 runtime data root를 결정하고, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 repo-managed config의 첫 fallback으로도 사용한다.
 
 ### 12.6 모델 실행
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -427,8 +427,8 @@ $MASC_PERSONAS_DIR
   $MASC_CONFIG_DIR
   > $MASC_BASE_PATH/.masc/config
   > ~/.masc/config
-  > executable-relative config/
   > cwd/config
+  > executable-relative config/
   > legacy ME_ROOT/workspace/yousleepwhen/masc-mcp/config
 ```
 

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -1,5 +1,6 @@
 type source =
   | Env
+  | Local_masc
   | Home_masc
   | Invalid_env
   | Exe_relative
@@ -32,6 +33,7 @@ type resolution = {
 type inputs = {
   cwd : string;
   executable_name : string;
+  env_base_path : string option;
   env_config_dir : string option;
   env_personas_dir : string option;
   env_home : string option;
@@ -52,6 +54,7 @@ let absolute_path_from ~cwd path =
 
 let source_to_string = function
   | Env -> "env"
+  | Local_masc -> "local_masc"
   | Home_masc -> "home_masc"
   | Invalid_env -> "invalid_env"
   | Exe_relative -> "exe_relative"
@@ -120,6 +123,14 @@ let path_from_home_masc (inputs : inputs) =
       let candidate = Filename.concat home ".masc/config" in
       if config_signature_exists candidate then Some candidate else None
 
+let path_from_local_masc (inputs : inputs) =
+  match trim_opt inputs.env_base_path with
+  | None -> None
+  | Some base_path ->
+      let base_path = absolute_path_from ~cwd:inputs.cwd base_path in
+      let candidate = Filename.concat (Filename.concat base_path ".masc") "config" in
+      if config_signature_exists candidate then Some candidate else None
+
 let legacy_me_root_candidates (inputs : inputs) =
   [ inputs.env_me_root; inputs.env_workspace_root; inputs.env_dune_sourceroot ]
   |> List.filter_map trim_opt
@@ -149,28 +160,31 @@ let config_root_resolution (inputs : inputs) =
           [ Printf.sprintf
               "MASC_CONFIG_DIR is set but does not point to a directory: %s"
               path ] )
-  | None -> (
-      match path_from_home_masc inputs with
-      | Some path -> ({ path; exists = true; source = Home_masc }, [])
-      | None -> (
-      match path_from_cwd inputs.cwd with
-      | Some path -> ({ path; exists = true; source = Cwd }, [])
-      | None -> (
-          match path_from_executable ~cwd:inputs.cwd inputs.executable_name with
-          | Some path -> ({ path; exists = true; source = Exe_relative }, [])
-          | None -> (
-              match path_from_legacy_me_root inputs with
-              | Some path ->
-                  ( { path; exists = true; source = Legacy_me_root },
-                    [ Printf.sprintf
-                        "Using legacy config fallback from ME_ROOT-style path: %s"
-                        path ] )
+  | None ->
+      match path_from_local_masc inputs with
+      | Some path -> ({ path; exists = true; source = Local_masc }, [])
+      | None ->
+          match path_from_home_masc inputs with
+          | Some path -> ({ path; exists = true; source = Home_masc }, [])
+          | None ->
+              match path_from_cwd inputs.cwd with
+              | Some path -> ({ path; exists = true; source = Cwd }, [])
               | None ->
-                  let path = default_missing_root inputs in
-                  ( { path; exists = false; source = Missing },
-                    [ Printf.sprintf
-                        "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                        path ] ) ) ) ))
+                  match path_from_executable ~cwd:inputs.cwd inputs.executable_name with
+                  | Some path -> ({ path; exists = true; source = Exe_relative }, [])
+                  | None ->
+                      match path_from_legacy_me_root inputs with
+                      | Some path ->
+                          ( { path; exists = true; source = Legacy_me_root },
+                            [ Printf.sprintf
+                                "Using legacy config fallback from ME_ROOT-style path: %s"
+                                path ] )
+                      | None ->
+                          let path = default_missing_root inputs in
+                          ( { path; exists = false; source = Missing },
+                            [ Printf.sprintf
+                                "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
+                                path ] )
 
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in
@@ -198,6 +212,7 @@ let inputs_from_env () =
   {
     cwd = Sys.getcwd ();
     executable_name = Sys.executable_name;
+    env_base_path = Env_config_core.base_path_opt ();
     env_config_dir = Env_config_core.config_dir_opt ();
     env_personas_dir = Env_config_core.personas_dir_opt ();
     env_home = Sys.getenv_opt "HOME";
@@ -225,7 +240,7 @@ let resolve_with inputs =
     match config_root.source with
     | Invalid_env -> Invalid_env_status
     | Missing -> Missing_status
-    | Env | Home_masc | Exe_relative | Cwd | Legacy_me_root ->
+    | Env | Local_masc | Home_masc | Exe_relative | Cwd | Legacy_me_root ->
         if warnings = [] then Ready else Warn
   in
   { status; warnings; config_root; cascade; prompts; keepers; personas }

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# run-local.sh — dir-local local-dev launcher.
+# Starts the repo binary against a target directory and defaults runtime/config
+# state to <target>/.masc/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="${PWD}"
+HOST="${MASC_HOST:-127.0.0.1}"
+PORT="${MASC_MCP_PORT:-}"
+PORT_EXPLICIT=0
+PRINT_PORT_ONLY=0
+BUILD_DASHBOARD=0
+DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/run-local.sh [--target-dir PATH] [--host HOST] [--port PORT] [--print-port] [--build-dashboard]
+
+Dir-local local-dev launcher:
+  - runtime data root defaults to <target>/.masc/
+  - config root defaults to <target>/.masc/config
+  - personas root defaults to <target>/.masc/config/personas
+  - gRPC / WS / WebRTC are disabled by default
+
+For shared repo/full-runtime startup, use ./start-masc-mcp.sh instead.
+EOF
+}
+
+absolute_path() {
+  local path="$1"
+  if [ -d "$path" ]; then
+    (cd "$path" && pwd -P)
+  else
+    return 1
+  fi
+}
+
+derive_port_for_path() {
+  local path="$1"
+  local checksum
+  checksum="$(printf '%s' "$path" | cksum | cut -d' ' -f1)"
+  echo $((9100 + (checksum % 900)))
+}
+
+set_default_env() {
+  local name="$1"
+  local value="$2"
+  if [ "${!name+x}" != "x" ]; then
+    export "$name=$value"
+  fi
+}
+
+binary_is_stale() {
+  local exe="$1"
+  if [ ! -x "$exe" ]; then
+    return 0
+  fi
+  if [ "$REPO_ROOT/dune-project" -nt "$exe" ]; then
+    return 0
+  fi
+  if find "$REPO_ROOT/bin" "$REPO_ROOT/lib" \
+      -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
+      -newer "$exe" 2>/dev/null | head -n 1 | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
+bootstrap_local_config() {
+  local target="$1"
+  local local_masc_dir="$target/.masc"
+  local local_config_dir="$local_masc_dir/config"
+  if [ -d "$local_config_dir" ]; then
+    return 0
+  fi
+
+  mkdir -p "$local_masc_dir"
+  if [ -d "$REPO_ROOT/config" ]; then
+    cp -R "$REPO_ROOT/config" "$local_config_dir"
+    echo "[local-run] Bootstrapped config into $local_config_dir" >&2
+  else
+    mkdir -p "$local_config_dir"
+    echo "[local-run] Repo config/ missing; created empty $local_config_dir" >&2
+  fi
+}
+
+build_dashboard_if_requested() {
+  if [ "$BUILD_DASHBOARD" != "1" ]; then
+    return 0
+  fi
+  if [ -x "$REPO_ROOT/scripts/build-dashboard-if-needed.sh" ]; then
+    "$REPO_ROOT/scripts/build-dashboard-if-needed.sh"
+  else
+    echo "[local-run] Dashboard build helper missing, skipping." >&2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-dir)
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      PORT_EXPLICIT=1
+      shift 2
+      ;;
+    --print-port)
+      PRINT_PORT_ONLY=1
+      shift
+      ;;
+    --build-dashboard)
+      BUILD_DASHBOARD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+TARGET_DIR="$(absolute_path "$TARGET_DIR")" || {
+  echo "Target directory does not exist: $TARGET_DIR" >&2
+  exit 1
+}
+
+if [ "$PORT_EXPLICIT" != "1" ] && [ -z "$PORT" ]; then
+  PORT="$(derive_port_for_path "$TARGET_DIR")"
+fi
+
+if [ "$PRINT_PORT_ONLY" = "1" ]; then
+  echo "$PORT"
+  exit 0
+fi
+
+bootstrap_local_config "$TARGET_DIR"
+build_dashboard_if_requested
+
+LOCAL_CONFIG_DIR="$TARGET_DIR/.masc/config"
+LOCAL_PERSONAS_DIR="$LOCAL_CONFIG_DIR/personas"
+EXE="$REPO_ROOT/_build/default/bin/main_eio.exe"
+
+if binary_is_stale "$EXE"; then
+  echo "[local-run] Building local binary..." >&2
+  dune build -j "$DUNE_JOBS" --root "$REPO_ROOT" bin/main_eio.exe
+fi
+
+if [ ! -x "$EXE" ]; then
+  echo "Failed to resolve built binary: $EXE" >&2
+  exit 1
+fi
+
+if lsof -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+  listener_pid="$(lsof -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -n 1)"
+  listener_cmd=""
+  if [ -n "$listener_pid" ]; then
+    listener_cmd="$(ps -p "$listener_pid" -o command= 2>/dev/null || true)"
+  fi
+  echo "Port $PORT already in use." >&2
+  if [ -n "$listener_pid" ]; then
+    echo "  Existing listener: pid=$listener_pid ${listener_cmd}" >&2
+  fi
+  exit 1
+fi
+
+export MASC_BASE_PATH="$TARGET_DIR"
+export MASC_CONFIG_DIR="$LOCAL_CONFIG_DIR"
+export MASC_PERSONAS_DIR="$LOCAL_PERSONAS_DIR"
+set_default_env MASC_GRPC_ENABLED "0"
+set_default_env MASC_WS_ENABLED "0"
+set_default_env MASC_WEBRTC_ENABLED "0"
+
+echo "Starting MASC MCP local-dev server..." >&2
+echo "  Target dir: $TARGET_DIR" >&2
+echo "  Data root: $TARGET_DIR/.masc" >&2
+echo "  Config root: ${MASC_CONFIG_DIR}" >&2
+echo "  Personas root: ${MASC_PERSONAS_DIR}" >&2
+echo "  Host: $HOST" >&2
+echo "  Port: $PORT" >&2
+echo "  Dashboard build: $(if [ "$BUILD_DASHBOARD" = "1" ]; then echo enabled; else echo skipped; fi)" >&2
+echo "  Transports: http=on grpc=${MASC_GRPC_ENABLED} ws=${MASC_WS_ENABLED} webrtc=${MASC_WEBRTC_ENABLED}" >&2
+
+exec "$EXE" --host="$HOST" --port="$PORT" --base-path="$TARGET_DIR"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -73,6 +73,9 @@ bootstrap_local_config() {
   local target="$1"
   local local_masc_dir="$target/.masc"
   local local_config_dir="$local_masc_dir/config"
+  if [ "${MASC_CONFIG_DIR+x}" = "x" ]; then
+    return 0
+  fi
   if [ -d "$local_config_dir" ]; then
     return 0
   fi
@@ -178,8 +181,8 @@ if lsof -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
 fi
 
 export MASC_BASE_PATH="$TARGET_DIR"
-export MASC_CONFIG_DIR="$LOCAL_CONFIG_DIR"
-export MASC_PERSONAS_DIR="$LOCAL_PERSONAS_DIR"
+set_default_env MASC_CONFIG_DIR "$LOCAL_CONFIG_DIR"
+set_default_env MASC_PERSONAS_DIR "$LOCAL_PERSONAS_DIR"
 set_default_env MASC_GRPC_ENABLED "0"
 set_default_env MASC_WS_ENABLED "0"
 set_default_env MASC_WEBRTC_ENABLED "0"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# MASC MCP Server (OCaml) - Start Script (HTTP/SSE default)
+# MASC MCP Server (OCaml) - Shared/full-runtime start script (HTTP/SSE default)
 # Usage: ./start-masc-mcp.sh [--print-port] [--stdio] [--http] [--eio] [--lwt] [--host HOST] [--port PORT] [--base-path PATH|--path PATH]
 # Note: Eio is the default runtime; --lwt exits with an error.
+# For dir-local local-dev startup, prefer scripts/run-local.sh.
 
 set -e
 
@@ -352,6 +353,7 @@ while [[ $# -gt 0 ]]; do
         *)
             echo "Unknown option: $1" >&2
             echo "Usage: $0 [--print-port] [--stdio] [--http] [--eio] [--lwt] [--host HOST] [--port PORT] [--base-path PATH|--path PATH]" >&2
+            echo "Dir-local local-dev launcher: scripts/run-local.sh" >&2
             echo "Note: Eio is the default runtime; --lwt exits with an error." >&2
             exit 1
             ;;

--- a/test/dune
+++ b/test/dune
@@ -79,7 +79,8 @@
         test_tool_surface_ssot
         test_observability_redact
         test_worker_oas_scope_gate
-        test_keeper_delta_activation)
+        test_keeper_delta_activation
+        test_run_local_script)
  (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -130,7 +131,8 @@
           test_tool_surface_ssot
           test_observability_redact
           test_worker_oas_scope_gate
-          test_keeper_delta_activation)
+          test_keeper_delta_activation
+          test_run_local_script)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -37,12 +37,13 @@ let make_config_root root =
   write_file (Filename.concat config "cascade.json") "{}";
   config
 
-let make_inputs ?env_config_dir ?env_personas_dir ?env_me_root ?env_workspace_root
+let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir ?env_me_root ?env_workspace_root
     ?env_dune_sourceroot ?env_home ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
   Lib.Config_dir_resolver.
     {
       cwd;
       executable_name;
+      env_base_path;
       env_config_dir;
       env_personas_dir;
       env_home;
@@ -108,6 +109,23 @@ let test_home_masc_fallback () =
   check string "root path" config resolution.config_root.path;
   check bool "prompts exists" true resolution.prompts.exists
 
+let test_local_masc_fallback_precedes_home_masc () =
+  with_temp_dir "config-dir-local" @@ fun root ->
+  let target = Filename.concat root "target" in
+  let local_config = make_config_root (Filename.concat target ".masc") in
+  let home = Filename.concat root "home" in
+  ignore (make_config_root (Filename.concat home ".masc"));
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~cwd:root ~env_base_path:target ~env_home:home
+         ~executable_name:"/tmp/nonexistent-masc" ())
+  in
+  check string "status" "ready"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "root source" "local_masc"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check string "root path" local_config resolution.config_root.path
+
 let test_legacy_me_root_fallback () =
   with_temp_dir "config-dir-legacy" @@ fun me_root ->
   let repo_root =
@@ -135,6 +153,8 @@ let () =
           test_case "env override invalid does not fallback" `Quick
             test_env_override_invalid_no_fallback;
           test_case "cwd fallback" `Quick test_cwd_fallback;
+          test_case "local masc fallback precedes home masc" `Quick
+            test_local_masc_fallback_precedes_home_masc;
           test_case "home masc fallback" `Quick test_home_masc_fallback;
           test_case "legacy me_root fallback" `Quick
             test_legacy_me_root_fallback;

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -53,17 +53,29 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let run_shell ?(env = []) ~cwd cmd =
+let run_shell ?(env = []) ?(unset_env = []) ~cwd cmd =
+  let unset_prefix =
+    unset_env
+    |> List.map (fun name -> Printf.sprintf "-u %s" (quote name))
+    |> String.concat " "
+  in
   let env_prefix =
     env
     |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
     |> String.concat " "
   in
+  let shell_prefix =
+    match (String.trim unset_prefix, String.trim env_prefix) with
+    | "", "" -> ""
+    | unset_prefix, "" -> Printf.sprintf "env %s" unset_prefix
+    | "", env_prefix -> env_prefix
+    | unset_prefix, env_prefix -> Printf.sprintf "env %s %s" unset_prefix env_prefix
+  in
   let full =
-    if env_prefix = "" then
+    if shell_prefix = "" then
       Printf.sprintf "cd %s && %s" (quote cwd) cmd
     else
-      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+      Printf.sprintf "cd %s && %s %s" (quote cwd) shell_prefix cmd
   in
   let out = Filename.temp_file "run-local-out" ".txt" in
   let err = Filename.temp_file "run-local-err" ".txt" in
@@ -127,6 +139,8 @@ let test_bootstraps_local_config_and_sets_http_only_env () =
       let code, stdout, stderr =
         run_shell ~cwd:repo_root
           ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          ~unset_env:
+            [ "MASC_BASE_PATH"; "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ]
           (Printf.sprintf "%s --target-dir %s --port 9955"
              (quote script) (quote target))
       in
@@ -228,6 +242,38 @@ let test_existing_target_config_is_not_overwritten () =
       let cascade = read_file (Filename.concat target_config "cascade.json") in
       check string "target config preserved" "{\"seed\":\"target\"}" cascade)
 
+let test_explicit_config_env_is_preserved_without_bootstrap () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      let override_root = Filename.concat dir "override-config" in
+      let override_personas = Filename.concat override_root "personas" in
+      mkdir_p target;
+      mkdir_p override_personas;
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_CONFIG_DIR", override_root);
+              ("MASC_PERSONAS_DIR", override_personas);
+            ]
+          (Printf.sprintf "%s --target-dir %s --port 9959"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local with explicit config env failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      let captured = read_file capture in
+      check bool "explicit config dir preserved" true
+        (contains_substring captured ("MASC_CONFIG_DIR=" ^ override_root));
+      check bool "explicit personas dir preserved" true
+        (contains_substring captured ("MASC_PERSONAS_DIR=" ^ override_personas));
+      check bool "target config not bootstrapped" false
+        (Sys.file_exists (Filename.concat target ".masc/config/cascade.json")))
+
 let () =
   run "run_local_script"
     [
@@ -241,5 +287,7 @@ let () =
             test_build_dashboard_flag_is_opt_in;
           test_case "existing target config is not overwritten" `Quick
             test_existing_target_config_is_not_overwritten;
+          test_case "explicit config env is preserved without bootstrap" `Quick
+            test_explicit_config_env_is_preserved_without_bootstrap;
         ] );
     ]

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -1,0 +1,245 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let run_local_script_path () =
+  Filename.concat (Filename.concat (source_root ()) "scripts") "run-local.sh"
+
+let quote = Filename.quote
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let write_executable path content =
+  write_file path content;
+  Unix.chmod path 0o755
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "run-local-out" ".txt" in
+  let err = Filename.temp_file "run-local-err" ".txt" in
+  let wrapped = Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err) in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let copy_script src dst =
+  write_executable dst (read_file src)
+
+let make_config_root root =
+  let config = Filename.concat root "config" in
+  mkdir_p (Filename.concat config "prompts");
+  mkdir_p (Filename.concat config "keepers");
+  mkdir_p (Filename.concat config "personas");
+  write_file (Filename.concat config "cascade.json") "{\"seed\":\"repo\"}";
+  config
+
+let write_fake_eio_exe exe_path =
+  mkdir_p (Filename.dirname exe_path);
+  let content =
+    {|
+#!/bin/sh
+set -eu
+capture="${FAKE_CAPTURE_FILE:?}"
+{
+  printf 'MASC_BASE_PATH=%s\n' "${MASC_BASE_PATH:-}"
+  printf 'MASC_CONFIG_DIR=%s\n' "${MASC_CONFIG_DIR:-}"
+  printf 'MASC_PERSONAS_DIR=%s\n' "${MASC_PERSONAS_DIR:-}"
+  printf 'MASC_GRPC_ENABLED=%s\n' "${MASC_GRPC_ENABLED:-}"
+  printf 'MASC_WS_ENABLED=%s\n' "${MASC_WS_ENABLED:-}"
+  printf 'MASC_WEBRTC_ENABLED=%s\n' "${MASC_WEBRTC_ENABLED:-}"
+  printf 'ARGS=%s\n' "$*"
+} >"$capture"
+exit 0
+|}
+  in
+  write_executable exe_path content
+
+let setup_fake_repo root =
+  let repo_root = Filename.concat root "repo" in
+  let scripts_dir = Filename.concat repo_root "scripts" in
+  let build_dir = Filename.concat repo_root "_build/default/bin" in
+  mkdir_p scripts_dir;
+  ignore (make_config_root repo_root);
+  copy_script (run_local_script_path ()) (Filename.concat scripts_dir "run-local.sh");
+  write_fake_eio_exe (Filename.concat build_dir "main_eio.exe");
+  repo_root
+
+let test_bootstraps_local_config_and_sets_http_only_env () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      mkdir_p target;
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          (Printf.sprintf "%s --target-dir %s --port 9955"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      let target_abs = Unix.realpath target in
+      let captured = read_file capture in
+      check bool "bootstrapped cascade" true
+        (Sys.file_exists (Filename.concat target_abs ".masc/config/cascade.json"));
+      check bool "base path set" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ target_abs));
+      check bool "config dir set" true
+        (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat target_abs ".masc/config"));
+      check bool "personas dir set" true
+        (contains_substring captured ("MASC_PERSONAS_DIR=" ^ Filename.concat target_abs ".masc/config/personas"));
+      check bool "grpc disabled by default" true
+        (contains_substring captured "MASC_GRPC_ENABLED=0");
+      check bool "ws disabled by default" true
+        (contains_substring captured "MASC_WS_ENABLED=0");
+      check bool "webrtc disabled by default" true
+        (contains_substring captured "MASC_WEBRTC_ENABLED=0");
+      check bool "port passed through" true
+        (contains_substring captured "ARGS=--host=127.0.0.1 --port=9955"))
+
+let test_print_port_is_stable_for_target_dir () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      mkdir_p target;
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code1, stdout1, stderr1 =
+        run_shell ~cwd:repo_root
+          (Printf.sprintf "%s --print-port --target-dir %s"
+             (quote script) (quote target))
+      in
+      let code2, stdout2, stderr2 =
+        run_shell ~cwd:repo_root
+          (Printf.sprintf "%s --print-port --target-dir %s"
+             (quote script) (quote target))
+      in
+      if code1 <> 0 || code2 <> 0 then
+        failf "print-port failed (%d/%d)\nstdout1:\n%s\nstderr1:\n%s\nstdout2:\n%s\nstderr2:\n%s"
+          code1 code2 stdout1 stderr1 stdout2 stderr2;
+      let port1 = int_of_string (String.trim stdout1) in
+      let port2 = int_of_string (String.trim stdout2) in
+      check int "stable port" port1 port2;
+      check bool "port range" true (port1 >= 9100 && port1 <= 9999))
+
+let test_build_dashboard_flag_is_opt_in () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let marker = Filename.concat dir "dashboard-build.marker" in
+      let helper = Filename.concat repo_root "scripts/build-dashboard-if-needed.sh" in
+      write_executable helper
+        (Printf.sprintf "#!/bin/sh\nset -eu\necho invoked > %s\n" (quote marker));
+      let target = Filename.concat dir "target" in
+      mkdir_p target;
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code_no_flag, stdout_no_flag, stderr_no_flag =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          (Printf.sprintf "%s --target-dir %s --port 9956"
+             (quote script) (quote target))
+      in
+      if code_no_flag <> 0 then
+        failf "run-local without flag failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_no_flag stdout_no_flag stderr_no_flag;
+      check bool "helper not invoked without flag" false (Sys.file_exists marker);
+      let code_flag, stdout_flag, stderr_flag =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          (Printf.sprintf "%s --target-dir %s --port 9957 --build-dashboard"
+             (quote script) (quote target))
+      in
+      if code_flag <> 0 then
+        failf "run-local with flag failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_flag stdout_flag stderr_flag;
+      check bool "helper invoked with flag" true (Sys.file_exists marker))
+
+let test_existing_target_config_is_not_overwritten () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      let target_config = Filename.concat target ".masc/config" in
+      mkdir_p target_config;
+      write_file (Filename.concat target_config "cascade.json")
+        "{\"seed\":\"target\"}";
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          (Printf.sprintf "%s --target-dir %s --port 9958"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      let cascade = read_file (Filename.concat target_config "cascade.json") in
+      check string "target config preserved" "{\"seed\":\"target\"}" cascade)
+
+let () =
+  run "run_local_script"
+    [
+      ( "script",
+        [
+          test_case "bootstraps local config and sets http-only env" `Quick
+            test_bootstraps_local_config_and_sets_http_only_env;
+          test_case "print-port is stable for target dir" `Quick
+            test_print_port_is_stable_for_target_dir;
+          test_case "build-dashboard flag is opt-in" `Quick
+            test_build_dashboard_flag_is_opt_in;
+          test_case "existing target config is not overwritten" `Quick
+            test_existing_target_config_is_not_overwritten;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add `scripts/run-local.sh` as a dir-local local-dev launcher
- default local-dev runtime, config, and personas roots to `<target>/.masc/...`
- disable gRPC, WS, and WebRTC by default in the local-dev launcher
- teach `Config_dir_resolver` to prefer `<MASC_BASE_PATH>/.masc/config` before `~/.masc/config`
- update front-door docs to distinguish dir-local local-dev startup from shared/full-runtime startup
- add launcher coverage and extend resolver coverage for the new fallback path

## Product impact
- local development can now target an arbitrary directory cleanly with isolated `.masc` state
- shared repo/full-runtime workflows continue to use `./start-masc-mcp.sh`
- config and persona discovery now line up with the dir-local launcher model

## Evidence
- `bash -n scripts/run-local.sh start-masc-mcp.sh scripts/build-dashboard-if-needed.sh`
- `dune exec --root . --build-dir /tmp/masc-dir-local-build ./test/test_run_local_script.exe`
- `scripts/run-local.sh --print-port --target-dir "$PWD"`
- `scripts/run-local.sh --help`
- not completed in-turn: full `dune build --root .`
- not completed in-turn: `test/test_config_dir_resolver.exe` because it currently pulls in a heavy shared test link path

## Review evidence
- reviewer path: direct `sb glm-text --no-thinking` via `scripts/review/local-review.sh` stdin bridge
- fallback reason: default local review endpoint `http://127.0.0.1:8085` was unavailable locally (`curl: (7) Failed to connect`)
- result: no high or critical findings; non-blocking notes were limited to stale-binary heuristics and theoretical port race windows in the launcher

## Linked issue
- Refs #4206
