### PR TITLE
[codex] address #4213 review follow-ups

### DIFF
--- a/lib/dashboard/dashboard_collaboration_evidence.ml
+++ b/lib/dashboard/dashboard_collaboration_evidence.ml
@@ -149,15 +149,13 @@ let explicit_link_reason
           | _ -> None))
 
 let partition_activity_events selected_session events =
-  List.fold_left
-    (fun (linked, unlinked) (event : Activity_graph.event) ->
-      match selected_session with
-      | Some session -> (
-          match explicit_link_reason session event with
-          | Some _ -> (event :: linked, unlinked)
-          | None -> (linked, event :: unlinked))
-      | None -> (linked, event :: unlinked))
-    ([], []) events
+  match selected_session with
+  | Some session ->
+      List.partition
+        (fun (event : Activity_graph.event) ->
+          Option.is_some (explicit_link_reason session event))
+        events
+  | None -> ([], events)
 
 let count_activity_kind kind events =
   List.length

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -34,6 +34,17 @@ let non_empty_string_opt = function
       if value = "" then None else Some value
   | None -> None
 
+let normalized_string_list values =
+  let seen = Hashtbl.create (List.length values) in
+  values
+  |> List.filter_map (fun value -> non_empty_string_opt (Some value))
+  |> List.filter (fun value ->
+         if Hashtbl.mem seen value then
+           false
+         else (
+           Hashtbl.add seen value ();
+           true))
+
 let recover_active_agent_name = function
   | `String name -> non_empty_string_opt (Some name)
   | `Assoc _ as json ->
@@ -184,6 +195,7 @@ let activity_room_id config =
 
 let emit_message_activity config ~from_agent ~content ~mention
     ?session_id ?operation_id ?worker_run_id ?(evidence_refs = []) () =
+  let evidence_refs = normalized_string_list evidence_refs in
   let payload =
     `Assoc
       [

--- a/scripts/audit-event-linkage.sh
+++ b/scripts/audit-event-linkage.sh
@@ -73,6 +73,9 @@ fi
 if [[ "${event_rows_missing_operation}" -gt 0 ]]; then
   gaps_text="${gaps_text}session events missing detail.operation_id: ${event_rows_missing_operation}"$'\n'
 fi
+if [[ "${event_rows_missing_worker}" -gt 0 ]]; then
+  gaps_text="${gaps_text}session events missing detail.worker_run_id: ${event_rows_missing_worker}"$'\n'
+fi
 if [[ "${worker_meta_missing_session}" -gt 0 ]]; then
   gaps_text="${gaps_text}worker meta missing session_id: ${worker_meta_missing_session}"$'\n'
 fi

--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -189,6 +189,73 @@ let test_collaboration_evidence_tracks_unlinked_room_noise () =
       check bool "linkage gaps populated" true
         ((linkage |> member "gaps" |> to_list) <> []))
 
+let test_recent_unlinked_activity_preserves_chronological_order () =
+  with_eio @@ fun _env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      let started_at = Time_compat.now () -. 60.0 in
+      let planned_end_at = started_at +. 600.0 in
+      let session =
+        make_manual_session config ~goal:"recent unlinked ordering"
+          ~created_by:"tester" ~agent_names:[ "alice"; "bob" ] ~min_agents:1
+          ~checkpoint_interval_sec:30 ~started_at ~planned_end_at
+          ~fallback_policy:Team_session_types.Fallback_cascade_then_task
+          ~model_cascade:[ "glm:auto" ]
+      in
+      List.iter
+        (fun index ->
+          ignore
+            (Activity_graph.emit config ~room_id:session.room_id
+               ~kind:"message.broadcast"
+               ~actor:(Activity_graph.entity ~kind:"agent" "system")
+               ~payload:
+                 (`Assoc
+                   [
+                     ("content", `String (Printf.sprintf "unlinked-%d" index));
+                   ])
+               ~tags:[ "message"; "broadcast" ] ()))
+        [ 1; 2; 3; 4; 5; 6; 7; 8 ];
+      let json =
+        Dashboard_collaboration_evidence.json ~session_id:session.session_id
+          ~config ()
+      in
+      let summaries =
+        json |> U.member "recent_unlinked_activity" |> U.to_list
+        |> List.map (fun item -> item |> U.member "summary" |> U.to_string)
+      in
+      check (list string) "keeps most recent six in order"
+        [ "unlinked-3"; "unlinked-4"; "unlinked-5"; "unlinked-6"; "unlinked-7";
+          "unlinked-8" ]
+        summaries)
+
+let test_emit_message_activity_normalizes_evidence_refs () =
+  with_eio @@ fun _env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      Room_state.emit_message_activity config ~from_agent:"alice"
+        ~content:"normalized evidence refs" ~mention:None
+        ~evidence_refs:[ " trace:abc "; ""; "trace:abc"; " proof:xyz " ] ();
+      let payload =
+        Activity_graph.list_events config ~room_id:"default" ~after_seq:0
+          ~limit:20 ()
+        |> List.find (fun (event : Activity_graph.event) ->
+               String.equal event.kind "message.broadcast"
+               && U.member "content" event.payload
+                  = `String "normalized evidence refs")
+        |> fun (event : Activity_graph.event) -> event.payload
+      in
+      check (list string) "evidence refs normalized"
+        [ "trace:abc"; "proof:xyz" ]
+        (payload |> U.member "evidence_refs" |> U.to_list |> List.map U.to_string))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -203,5 +270,9 @@ let () =
             test_append_event_injects_linkage_metadata;
           test_case "tracks unlinked room noise" `Quick
             test_collaboration_evidence_tracks_unlinked_room_noise;
+          test_case "recent unlinked activity preserves order" `Quick
+            test_recent_unlinked_activity_preserves_chronological_order;
+          test_case "emit message activity normalizes evidence refs" `Quick
+            test_emit_message_activity_normalizes_evidence_refs;
         ] );
     ]


### PR DESCRIPTION
## Summary
- preserve chronological order when splitting linked vs unlinked collaboration activity
- normalize message activity evidence refs before persisting room payloads
- add the missing audit gap text for session events without worker_run_id and cover the review fixes with regression tests

## Testing
- /tmp/masc-review-followup-build3/default/test/test_dashboard_collaboration_evidence.exe
- /tmp/masc-review-followup-build3/default/test/test_dashboard_proof.exe
- /tmp/masc-review-followup-build3/default/test/test_activity_graph.exe
- scripts/audit-event-linkage.sh synthetic fixture check via jq
