### PR TITLE
refactor(dashboard): extract shared utilities — findKeeper, isOfflineStatus, formatTokens

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -6,9 +6,9 @@ import {
   agents,
   executionContinuityBriefs,
   executionWorkerSupportBriefs,
-  keepers,
   tasks,
 } from '../store'
+import { findKeeper } from '../lib/keeper-utils'
 import { currentDashboardActor, fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
 import { callMcpTool } from '../api/mcp'
 import { journal } from '../sse'
@@ -19,7 +19,6 @@ import type {
   Agent,
   DashboardExecutionContinuityBrief,
   DashboardMissionAgentBrief,
-  Keeper,
   Task,
 } from '../types'
 
@@ -63,10 +62,7 @@ export function assignedTasks(agentName: string | null): Task[] {
   return tasks.value.filter(t => t.assignee === agentName)
 }
 
-export function keeperForAgent(agentName: string | null): Keeper | null {
-  if (!agentName) return null
-  return keepers.value.find(keeper => keeper.agent_name === agentName || keeper.name === agentName) ?? null
-}
+export const keeperForAgent = findKeeper
 
 export function missionAgentBrief(agentName: string | null): DashboardMissionAgentBrief | null {
   if (!agentName) return null

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -4,15 +4,8 @@
 
 import { html } from 'htm/preact'
 import { PipelineStageBadge } from '../keeper-pipeline-stage'
-import { keepers } from '../../store'
+import { findKeeper } from '../../lib/keeper-utils'
 import { formatDuration } from '../mission-utils'
-import type { Keeper } from '../../types'
-
-function findKeeper(name: string): Keeper | null {
-  return keepers.value.find(
-    k => k.agent_name === name || k.name === name,
-  ) ?? null
-}
 
 function ctxBarClass(ratio: number | null | undefined): string {
   if (ratio == null) return ''

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -14,13 +14,14 @@ import { EmptyState } from './common/empty-state'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { StatGrid } from './common/stat-tile'
-import { autonomyHint, formatTokens } from './keeper-detail-panels'
+import { formatTokens } from '../lib/format-number'
+import { findKeeper } from '../lib/keeper-utils'
+import { autonomyHint } from './keeper-detail-panels'
 import { AgentAvatar } from './overview/agent-avatar'
 import {
   agents,
   executionContinuityBriefs,
   executionWorkerSupportBriefs,
-  keepers,
   tasks,
 } from '../store'
 import {
@@ -69,12 +70,6 @@ function findAgent(name: string): Agent | null {
 
 function assignedTasks(name: string): Task[] {
   return tasks.value.filter(t => t.assignee === name)
-}
-
-function findKeeper(name: string): Keeper | null {
-  return keepers.value.find(
-    k => k.agent_name === name || k.name === name,
-  ) ?? null
 }
 
 export function keeperChatTargetName(

--- a/dashboard/src/components/common/tool-audit.ts
+++ b/dashboard/src/components/common/tool-audit.ts
@@ -1,4 +1,5 @@
 import type { Keeper } from '../../types'
+import { isOfflineStatus } from '../../lib/status-utils'
 import { navigate } from '../../router'
 
 export type ToolAuditEmptyState =
@@ -8,14 +9,10 @@ export type ToolAuditEmptyState =
   | 'not_applicable'
   | 'unlinked'
 
-function normalizeStatus(value: string | null | undefined): string {
-  return value?.trim().toLowerCase() ?? ''
-}
-
 export function linkedRuntimeState(keeper: Keeper | null | undefined): 'offline' | 'online' | 'unlinked' {
   if (!keeper) return 'unlinked'
   if (keeper.agent?.exists === false) return 'offline'
-  if (normalizeStatus(keeper.status) === 'offline' || normalizeStatus(keeper.status) === 'inactive') {
+  if (isOfflineStatus(keeper.status)) {
     return 'offline'
   }
   return 'online'

--- a/dashboard/src/components/execution/shared.ts
+++ b/dashboard/src/components/execution/shared.ts
@@ -4,7 +4,7 @@ import { ActionButton } from '../common/button'
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { navigate } from '../../router'
-import { keepers } from '../../store'
+import { findKeeper } from '../../lib/keeper-utils'
 import {
   createExecutionWorkflowContext,
   workflowInterveneParams,
@@ -45,10 +45,7 @@ export function queueKindLabel(kind: DashboardExecutionQueueItem['kind']): strin
   return kind === 'session' ? '세션' : '작전'
 }
 
-export function findKeeper(name?: string | null): Keeper | null {
-  if (!name) return null
-  return keepers.value.find(keeper => keeper.name === name || keeper.agent_name === name) ?? null
-}
+export { findKeeper }
 
 /** Build a minimal Keeper from a continuity brief when the full Keeper object is not in the store.
  *  This prevents silent click failures on keeper cards. */

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -7,7 +7,7 @@ import { signal } from '@preact/signals'
 import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig } from '../types'
-import { formatTokens } from './keeper-detail-panels'
+import { formatTokens } from '../lib/format-number'
 import { showToast } from './common/toast'
 import { createAsyncResource, loaded } from '../lib/async-state'
 

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -4,7 +4,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { formatPct } from '../lib/format-number'
+import { formatPct, formatTokens } from '../lib/format-number'
 import { TextInput } from './common/input'
 import type { Keeper, KeeperMetricPoint } from '../types'
 
@@ -20,13 +20,6 @@ function ctxColor(pct: number): string {
 }
 
 // ── Utility functions ────────────────────────────────────
-
-export function formatTokens(n: number | undefined): string {
-  if (!n) return '-'
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
 
 export function autonomyHint(count: number | undefined, proactiveEnabled: boolean | undefined): string | undefined {
   if ((count ?? 0) === 0) return proactiveEnabled ? '활성 · 미발동' : '자율 비활성'

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -3,6 +3,7 @@
 // Redesigned: professional dashboard-grade layout with Tailwind inline styles.
 
 import { html } from 'htm/preact'
+import { isOfflineStatus } from '../lib/status-utils'
 import { signal } from '@preact/signals'
 import { useRef } from 'preact/hooks'
 import { currentDashboardActor, runOperatorAction } from '../api'
@@ -108,7 +109,7 @@ function KeeperStatusPill({ status }: { status: string }) {
 // ── Comms Panel ──────────────────────────────────────────
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
-  const isOffline = keeper.status === 'offline' || keeper.status === 'inactive'
+  const isOffline = isOfflineStatus(keeper.status)
 
   return html`
     <div class="border-t border-[var(--border-slate-12)] pt-5">

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
+import { isOfflineStatus } from '../lib/status-utils'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -387,7 +388,7 @@ export function KeeperRuntimeActions({
   const shuttingDown = keeperShuttingDown.value[keeper.name] ?? false
   const recommended = diagnostic?.next_action_path ?? null
   const canRecover = diagnostic?.recoverable === true
-  const isOffline = keeper.status === 'offline' || keeper.status === 'inactive'
+  const isOffline = isOfflineStatus(keeper.status)
   const isRunning = keeper.status === 'active' || keeper.status === 'running' || keeper.status === 'idle' || keeper.status === 'watching' || keeper.status === 'listening'
 
   const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-medium cursor-pointer transition-colors border'

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,7 +1,7 @@
 import { signal } from '@preact/signals'
 import { navigate } from '../router'
 import { missionSnapshot } from '../mission-store'
-import { keepers } from '../store'
+import { findKeeper } from '../lib/keeper-utils'
 import type {
   Agent,
   DashboardMissionAttentionQueueItem,
@@ -159,7 +159,7 @@ export function attentionAsIncident(item: DashboardMissionAttentionQueueItem): O
 
 export function enrichedKeeperRow(brief: DashboardMissionKeeperBrief): EnrichedKeeperRow {
   const keeper =
-    keepers.value.find(item => item.name === brief.name || item.agent_name === brief.agent_name) ?? null
+    findKeeper(brief.name) ?? findKeeper(brief.agent_name)
   return {
     brief,
     keeper,

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -4,6 +4,7 @@ import type {
   KeeperMetricPoint,
 } from './types'
 import { isRecord, asString, asNumber, asStringArray, toIsoTimestamp } from './components/common/normalize'
+import { isOfflineStatus } from './lib/status-utils'
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
@@ -24,7 +25,7 @@ function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
 
 export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   const status = keeper.status?.toLowerCase() ?? ''
-  if (status === 'offline' || status === 'inactive') return 'offline'
+  if (isOfflineStatus(status)) return 'offline'
 
   const series = keeper.metrics_series
   if (!series || series.length === 0) {

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -5,3 +5,11 @@ export function formatPct(value: number | null | undefined, fallback = '-'): str
   if (value == null || !Number.isFinite(value)) return fallback
   return `${Math.round(value * 100)}%`
 }
+
+/** Abbreviate large token counts: 1234567 → "1.2M", 4500 → "4.5K". */
+export function formatTokens(n: number | undefined): string {
+  if (!n) return '-'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}

--- a/dashboard/src/lib/keeper-utils.ts
+++ b/dashboard/src/lib/keeper-utils.ts
@@ -1,0 +1,10 @@
+// Keeper lookup utilities — canonical keeper resolution by name or agent_name.
+
+import { keepers } from '../store'
+import type { Keeper } from '../types'
+
+/** Find a keeper by name or agent_name. Returns null when not found or name is empty. */
+export function findKeeper(name?: string | null): Keeper | null {
+  if (!name) return null
+  return keepers.value.find(k => k.name === name || k.agent_name === name) ?? null
+}

--- a/dashboard/src/lib/status-utils.ts
+++ b/dashboard/src/lib/status-utils.ts
@@ -1,0 +1,7 @@
+// Status classification utilities for keeper/agent status strings.
+
+/** True when the status indicates the process is not running (offline or inactive). */
+export function isOfflineStatus(status: string | undefined | null): boolean {
+  const s = (status ?? '').toLowerCase()
+  return s === 'offline' || s === 'inactive'
+}

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -1,6 +1,7 @@
 // Live Monitor tab — derived signals and filter state
 
 import { signal, computed, type ReadonlySignal } from '@preact/signals'
+import { isOfflineStatus } from './lib/status-utils'
 import type { JournalEntry } from './types'
 import type { PipelineStage } from './types/core'
 import { journal } from './sse'
@@ -77,7 +78,7 @@ export const agentPulses: ReadonlySignal<AgentPulse[]> = computed(() => {
       } else {
         state = 'working'
       }
-    } else if (agent.status === 'offline' || agent.status === 'inactive') {
+    } else if (isOfflineStatus(agent.status)) {
       state = 'stale'
     }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -3,6 +3,7 @@
 // subscribing components re-render automatically.
 
 import { signal, computed, type ReadonlySignal } from '@preact/signals'
+import { isOfflineStatus } from './lib/status-utils'
 import type {
   Agent,
   Task,
@@ -240,7 +241,7 @@ export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>>
   const map = new Map<string, KeeperLifecycleState>()
   for (const k of keepers.value) {
     const status = k.status?.toLowerCase() ?? ''
-    if (status === 'offline' || status === 'inactive') {
+    if (isOfflineStatus(status)) {
       map.set(k.name, 'offline')
       continue
     }


### PR DESCRIPTION
## Summary
- `formatTokens` → `lib/format-number.ts` (기존 `formatPct`와 합류) — #4204
- `findKeeper()` → `lib/keeper-utils.ts` (5곳 중복 제거) — #4202
- `isOfflineStatus()` → `lib/status-utils.ts` (7곳 인라인 체크 통합) — #4203
- 미사용 import 4건, dead code 1건 제거

16 files changed, +49/-48 (순감소)

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `vite build` 성공
- [x] 기존 테스트 통과 (harness-health flaky timeout은 pre-existing)
- [ ] 브라우저에서 keeper detail, ops, agent profile 탭 확인

Closes #4204, closes #4202, closes #4203

🤖 Generated with [Claude Code](https://claude.com/claude-code)