### PR TITLE
fix(scheduler): harden slot backoff with Cancel re-raise and logging

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -106,16 +106,19 @@ let has_background_capacity () =
           ~sw ~net ?config_path ["autoresearch"] in
       not (cap.all_discovered && cap.endpoints_found > 0
            && cap.process_available = 0 && cap.process_queue_length >= 2)
-    with _ -> true)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> true)
   | _ -> true
 
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)
 let generate_code_change ~goal ~baseline ~history ~insights
     ~target_file ~file_content =
-  if not (has_background_capacity ()) then
+  if not (has_background_capacity ()) then begin
+    Eio.traceln "[autoresearch] backoff: local slots saturated, skipping cycle";
     Result.error "autoresearch: local slots saturated, skipping cycle"
-  else
+  end else
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -420,6 +420,8 @@ let start ~sw ~clock ~net ~base_path
             if n = 0 then base
             else min (base *. Float.pow 2.0 (float_of_int (min n 5))) 300.0
           in
+          if n > 0 then
+            Eio.traceln "[governance] backoff: sleeping %.0fs (consecutive=%d)" sleep_s n;
           Eio.Time.sleep clock sleep_s;
           loop ()
         in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -351,6 +351,8 @@ let start ~sw ~clock ~net ~(config : Room.config)
             if n = 0 then base
             else min (base *. Float.pow 2.0 (float_of_int (min n 5))) 300.0
           in
+          if n > 0 then
+            Eio.traceln "[operator] backoff: sleeping %.0fs (consecutive=%d)" sleep_s n;
           Eio.Time.sleep clock sleep_s;
           loop ()
         in


### PR DESCRIPTION
## Summary

#4248 의 production hardening:

1. **Cancel re-raise** — `has_background_capacity()` 의 `with _ -> true` 가 `Eio.Cancel.Cancelled` 를 삼키는 문제 수정. fiber cancellation이 정상 동작하도록 보장.
2. **Autoresearch skip 로그** — `[autoresearch] backoff: local slots saturated, skipping cycle` traceln 추가. 기존에는 Error 문자열만 반환되어 caller 로그에서 원인 구분 어려움.
3. **Judge sleep 로그** — exponential backoff 발동 시 `[governance/operator] backoff: sleeping Ns (consecutive=M)` traceln 추가. 실제 sleep 시간과 연속 횟수 관찰 가능.

## Test plan

- [x] `dune build` 성공
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)