### PR TITLE
feat(keeper): expand hot-reload surface — snapshot, WAH, smart_hb, ring_size (#3903)

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -39,6 +39,11 @@ let deserialize_string json =
   | `String s -> Ok s
   | _ -> Error "expected string"
 
+let deserialize_bool json =
+  match json with
+  | `Bool b -> Ok b
+  | _ -> Error "expected boolean"
+
 (* ── board_policy surface ────────────────────────────────────── *)
 
 let message_max_count =
@@ -161,6 +166,68 @@ let keeper_dead_ttl_sec =
     ~deserialize:deserialize_float
     ()
 
+(* ── keeper_diagnostics surface (Medium risk) ─────────────────── *)
+
+let keeper_snapshot_sec =
+  Runtime_params.register
+    ~key:"keeper.snapshot_sec"
+    ~default:(fun () -> Env_config_keeper.KeeperRuntime.snapshot_sec)
+    ~validate:(validate_int_range ~min:15 ~max:3600 "keeper_snapshot_sec")
+    ~serialize:(fun v -> `Int v)
+    ~meta:{ description = "Snapshot 캡처 주기(초)";
+            value_type = "int";
+            min_value = Some (`Int 15); max_value = Some (`Int 3600) }
+    ~deserialize:deserialize_int
+    ()
+
+let keeper_work_as_hb_enabled =
+  Runtime_params.register
+    ~key:"keeper.work_as_hb_enabled"
+    ~default:(fun () -> Env_config_keeper.WorkAsHeartbeat.enabled)
+    ~validate:(fun _ -> Ok ())
+    ~serialize:(fun v -> `Bool v)
+    ~meta:{ description = "Work-as-heartbeat 활성화 여부";
+            value_type = "bool";
+            min_value = None; max_value = None }
+    ~deserialize:deserialize_bool
+    ()
+
+let keeper_work_as_hb_max_silence_sec =
+  Runtime_params.register
+    ~key:"keeper.work_as_hb_max_silence_sec"
+    ~default:(fun () -> Env_config_keeper.WorkAsHeartbeat.max_silence_sec)
+    ~validate:(validate_float_range ~min:10.0 ~max:600.0 "keeper_work_as_hb_max_silence_sec")
+    ~serialize:(fun v -> `Float v)
+    ~meta:{ description = "Work-as-heartbeat 최대 침묵 시간(초)";
+            value_type = "float";
+            min_value = Some (`Float 10.0); max_value = Some (`Float 600.0) }
+    ~deserialize:deserialize_float
+    ()
+
+let keeper_smart_hb_enabled =
+  Runtime_params.register
+    ~key:"keeper.smart_hb_enabled"
+    ~default:(fun () -> Env_config_keeper.SmartHeartbeat.enabled)
+    ~validate:(fun _ -> Ok ())
+    ~serialize:(fun v -> `Bool v)
+    ~meta:{ description = "Smart heartbeat 적응형 스케줄링 활성화";
+            value_type = "bool";
+            min_value = None; max_value = None }
+    ~deserialize:deserialize_bool
+    ()
+
+let keeper_stage_timing_ring_size =
+  Runtime_params.register
+    ~key:"keeper.stage_timing_ring_size"
+    ~default:(fun () -> Env_config_keeper.KeeperProactive.stage_timing_ring_size)
+    ~validate:(validate_int_range ~min:10 ~max:1000 "keeper_stage_timing_ring_size")
+    ~serialize:(fun v -> `Int v)
+    ~meta:{ description = "Stage timing ring buffer 크기 (fiber restart 시 적용)";
+            value_type = "int";
+            min_value = Some (`Int 10); max_value = Some (`Int 1000) }
+    ~deserialize:deserialize_int
+    ()
+
 (* ── surface catalog ─────────────────────────────────────────── *)
 
 type surface = {
@@ -202,8 +269,21 @@ let surfaces =
         "keeper.max_consecutive_hb_failures";
         "keeper.max_consecutive_turn_failures";
         "keeper.supervisor_max_restarts";
+        "keeper.supervisor_sweep_sec";
         "keeper.keepalive_interval_sec";
         "keeper.dead_ttl_sec";
+      ];
+    };
+    {
+      id = "keeper_diagnostics";
+      description = "Keeper snapshot, heartbeat tuning, and profiling ring";
+      risk = "medium";
+      param_keys = [
+        "keeper.snapshot_sec";
+        "keeper.work_as_hb_enabled";
+        "keeper.work_as_hb_max_silence_sec";
+        "keeper.smart_hb_enabled";
+        "keeper.stage_timing_ring_size";
       ];
     };
   ]

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -125,7 +125,8 @@ type stage_timing = {
   improve_ms : float;
 }
 
-let stage_timing_ring_size = Env_config.KeeperProactive.stage_timing_ring_size
+let stage_timing_ring_size () =
+  Runtime_params.get Governance_registry.keeper_stage_timing_ring_size
 
 let percentile arr p =
   let n = Array.length arr in
@@ -137,7 +138,7 @@ let percentile arr p =
     sorted.(min idx (n - 1))
 
 let stage_timing_to_json ~ring ~count =
-  let n = min count stage_timing_ring_size in
+  let n = min count (stage_timing_ring_size ()) in
   if n = 0 then `Null
   else
     let extract field =
@@ -161,11 +162,15 @@ let stage_timing_to_json ~ring ~count =
 let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
     (m : keeper_meta) (stop : bool Atomic.t) ~(wakeup : bool Atomic.t) : unit =
   let keepalive_started_ts = Time_compat.now () in
-  let snapshot_interval_sec = Env_config.KeeperRuntime.snapshot_sec in
+  let snapshot_interval_sec () =
+    Runtime_params.get Governance_registry.keeper_snapshot_sec in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
-  (* Phase 0: per-stage timing ring buffer *)
-  let timing_ring = Array.make stage_timing_ring_size
+  (* Phase 0: per-stage timing ring buffer.
+     ring_size is read once at fiber start — mid-flight resize requires
+     ring buffer reallocation, so new values apply on next fiber restart. *)
+  let ring_sz = stage_timing_ring_size () in
+  let timing_ring = Array.make ring_sz
     { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
       turn_ms = 0.0; recurring_ms = 0.0; improve_ms = 0.0 } in
   let timing_cursor = ref 0 in
@@ -173,10 +178,13 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Room.heartbeat_in_room success after turn. *)
   let last_successful_heartbeat_ts = ref 0.0 in
-  let work_as_hb = Env_config.WorkAsHeartbeat.enabled in
-  let max_silence = Env_config.WorkAsHeartbeat.max_silence_sec in
+  let work_as_hb () =
+    Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
+  let max_silence () =
+    Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec in
   (* Phase 2: smart heartbeat — adaptive scheduling via Heartbeat_smart *)
-  let smart_hb_enabled = Env_config.SmartHeartbeat.enabled in
+  let smart_hb_enabled () =
+    Runtime_params.get Governance_registry.keeper_smart_hb_enabled in
   let smart_hb_config = Heartbeat_smart.default_config in
   let last_heartbeat_cycle_ts = ref 0.0 in
   let rec loop () =
@@ -191,7 +199,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             in
             (* Phase 2: smart heartbeat — skip cycle when busy or deeply idle *)
             let smart_hb_decision =
-              if smart_hb_enabled then
+              if smart_hb_enabled () then
                 let agent_status =
                   if meta_current.paused then Types.Inactive
                   else match meta_current.current_task_id with
@@ -226,8 +234,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                last_heartbeat_cycle_ts := Time_compat.now ());
             (* Phase 1: skip presence sync when recent room heartbeat proves freshness *)
             let presence_fresh =
-              work_as_hb
-              && t_presence_start -. !last_successful_heartbeat_ts < max_silence
+              work_as_hb ()
+              && t_presence_start -. !last_successful_heartbeat_ts < max_silence ()
             in
             let meta_current =
               if presence_fresh then (
@@ -267,7 +275,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             let t_presence_end = Time_compat.now () in
             let now_ts = t_presence_end in
             let t_snapshot_start = now_ts in
-            if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
+            if now_ts -. !last_snapshot_ts >= float_of_int (snapshot_interval_sec ())
             then (
               (try
                  let metrics_store =
@@ -510,7 +518,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                After turn, call Room.heartbeat_in_room to prove room I/O health.
                On success: refresh freshness lease + reset consecutive_failures.
                On failure: leave timestamp unchanged → presence sync resumes next cycle. *)
-            (if work_as_hb && proactive_warmup_elapsed then
+            (if work_as_hb () && proactive_warmup_elapsed then
                let hb_ok = List.exists (fun room_id ->
                  try
                    ignore
@@ -559,7 +567,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             let t_recurring_end = Time_compat.now () in
             let t_improve_start = t_recurring_end in
             let base =
-              if smart_hb_enabled then
+              if smart_hb_enabled () then
                 Heartbeat_smart.effective_interval
                   ~config:smart_hb_config
                   ~last_activity:!last_successful_heartbeat_ts
@@ -588,8 +596,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               improve_ms = (t_improve_end -. t_improve_start) *. 1000.0;
             } in
             timing_ring.(!timing_cursor) <- timing;
-            timing_cursor := (!timing_cursor + 1) mod stage_timing_ring_size;
-            if !timing_filled < stage_timing_ring_size then incr timing_filled;
+            timing_cursor := (!timing_cursor + 1) mod ring_sz;
+            if !timing_filled < ring_sz then incr timing_filled;
             let jitter = base *. Env_config.KeeperKeepalive.jitter_factor *. Random.float 1.0 in
             interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
             if Atomic.get stop then ()

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -138,7 +138,7 @@ let percentile arr p =
     sorted.(min idx (n - 1))
 
 let stage_timing_to_json ~ring ~count =
-  let n = min count (stage_timing_ring_size ()) in
+  let n = min count (Array.length ring) in
   if n = 0 then `Null
   else
     let extract field =

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -282,11 +282,36 @@ let () =
     | None -> Alcotest.fail "keeper_lifecycle surface not found"
     | Some s ->
         Alcotest.(check string) "risk" "medium" s.risk;
-        Alcotest.(check int) "param count" 5 (List.length s.param_keys);
+        Alcotest.(check int) "param count" 6 (List.length s.param_keys);
         Alcotest.(check bool) "has hb_failures"
           true (List.mem "keeper.max_consecutive_hb_failures" s.param_keys);
         Alcotest.(check bool) "has supervisor_max_restarts"
-          true (List.mem "keeper.supervisor_max_restarts" s.param_keys)
+          true (List.mem "keeper.supervisor_max_restarts" s.param_keys);
+        Alcotest.(check bool) "has supervisor_sweep_sec"
+          true (List.mem "keeper.supervisor_sweep_sec" s.param_keys)
+  in
+
+  let test_keeper_diagnostics_surface () =
+    Governance_registry.ensure_init ();
+    let surfaces = Governance_registry.surfaces in
+    let diag_surface =
+      List.find_opt
+        (fun (s : Governance_registry.surface) -> s.id = "keeper_diagnostics")
+        surfaces
+    in
+    match diag_surface with
+    | None -> Alcotest.fail "keeper_diagnostics surface not found"
+    | Some s ->
+        Alcotest.(check string) "risk" "medium" s.risk;
+        Alcotest.(check int) "param count" 5 (List.length s.param_keys);
+        Alcotest.(check bool) "has snapshot_sec"
+          true (List.mem "keeper.snapshot_sec" s.param_keys);
+        Alcotest.(check bool) "has work_as_hb_enabled"
+          true (List.mem "keeper.work_as_hb_enabled" s.param_keys);
+        Alcotest.(check bool) "has smart_hb_enabled"
+          true (List.mem "keeper.smart_hb_enabled" s.param_keys);
+        Alcotest.(check bool) "has stage_timing_ring_size"
+          true (List.mem "keeper.stage_timing_ring_size" s.param_keys)
   in
 
   let test_keeper_params_meta_shape () =
@@ -490,6 +515,8 @@ let () =
             test_keeper_params_meta_shape;
           Alcotest.test_case "keeper param override persist/restore" `Quick
             test_keeper_param_override_persist_restore;
+          Alcotest.test_case "keeper_diagnostics surface" `Quick
+            test_keeper_diagnostics_surface;
         ] );
       ( "handle_set_param",
         [

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -308,6 +308,8 @@ let () =
           true (List.mem "keeper.snapshot_sec" s.param_keys);
         Alcotest.(check bool) "has work_as_hb_enabled"
           true (List.mem "keeper.work_as_hb_enabled" s.param_keys);
+        Alcotest.(check bool) "has work_as_hb_max_silence_sec"
+          true (List.mem "keeper.work_as_hb_max_silence_sec" s.param_keys);
         Alcotest.(check bool) "has smart_hb_enabled"
           true (List.mem "keeper.smart_hb_enabled" s.param_keys);
         Alcotest.(check bool) "has stage_timing_ring_size"


### PR DESCRIPTION
## Summary
- Phase 2 of keeper hot-reload: 4종 파라미터(5개 값)를 `Runtime_params`에 등록하여 런타임 변경 가능하게 전환
- `keeper_diagnostics` governance surface 신규 추가 (risk: medium)
- `keeper_lifecycle` surface에 누락된 `supervisor_sweep_sec` 추가

## Parameters

| Key | Type | Range | Default | Note |
|-----|------|-------|---------|------|
| `keeper.snapshot_sec` | int | [15, 3600] | 300 | Snapshot 캡처 주기 |
| `keeper.work_as_hb_enabled` | bool | — | true | Work-as-heartbeat 토글 |
| `keeper.work_as_hb_max_silence_sec` | float | [10.0, 600.0] | 120.0 | WAH 최대 침묵 시간 |
| `keeper.smart_hb_enabled` | bool | — | true | 적응형 heartbeat 토글 |
| `keeper.stage_timing_ring_size` | int | [10, 1000] | 100 | Ring buffer 크기 (fiber restart 시 적용) |

## Design decisions
- `ring_size`는 fiber start 시 한 번만 읽음 — ring buffer는 mid-flight 재할당이 불가하므로 새 값은 다음 fiber restart에 적용
- `snapshot_sec`, `work_as_hb_*`, `smart_hb_enabled`는 매 cycle마다 읽어 즉시 반영
- `deserialize_bool` helper 추가 (기존에 없었음)

## Test plan
- [x] `dune build` — 전체 빌드 성공
- [x] `test_runtime_params` — 21/21 통과 (keeper_diagnostics surface 테스트 포함)
- [ ] CI green

Closes #3903

🤖 Generated with [Claude Code](https://claude.com/claude-code)