### PR TITLE
fix: Live Monitor data clarity + base_path stability

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -138,6 +138,7 @@ masc_keeper_up(name: "sangsu")
 - `PERSONAS_ROOT/<name>/profile.json`이 존재해야 한다 (또는 `CONFIG_ROOT/keepers/<name>.toml`)
 - `PERSONAS_ROOT`는 `MASC_PERSONAS_DIR` 우선, 없으면 resolved `CONFIG_ROOT/personas`를 사용한다.
 - `scripts/run-local.sh`는 `<target>/.masc/`를 기본 runtime root로 사용하고, `<target>/.masc/config`를 먼저 본다.
+- `MASC_BASE_PATH` 환경변수가 명시적으로 설정되어 있으면 그 값을 그대로 사용한다. 설정되지 않은 경우 기본적으로 git repo root를 `MASC_BASE_PATH`로 자동 해석한다.
 - shared keeper 상태를 봐야 할 때만 `./start-masc-mcp.sh --http` 또는 explicit `--base-path`를 사용한다.
 - repo-managed config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 `<MASC_BASE_PATH>/.masc/config`, 그 다음 `~/.masc/config`, 마지막으로 repo `config/` 자동 탐색을 사용한다.
 - `MASC_PERSONAS_DIR` 환경변수로 persona만 repo 밖 경로로 분리할 수 있다.

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -138,16 +138,23 @@ let rec find_git_root path =
     else find_git_root parent
   end
 
-(** Resolve base_path: if in worktree, use main repo's path for .masc/
-    This ensures all worktrees share the same MASC coordination space *)
+(** Resolve base_path: when MASC_BASE_PATH is explicitly set, use it
+    directly — git root detection only applies for worktree auto-resolution
+    when no explicit path is configured.  This prevents a sub-repo .git
+    (e.g. masc-mcp/) from hijacking the intended base path. *)
 let resolve_masc_base_path path =
-  match find_git_root path with
-  | Some git_root ->
-      Log.Room.info "MASC base resolved: %s → %s (git root)" path git_root;
-      git_root
-  | None ->
-      Log.Room.info "MASC base: %s (no git root found)" path;
+  match Env_config_core.base_path_opt () with
+  | Some explicit when explicit = path ->
+      Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" path;
       path
+  | _ ->
+      match find_git_root path with
+      | Some git_root ->
+          Log.Room.info "MASC base resolved: %s → %s (git root)" path git_root;
+          git_root
+      | None ->
+          Log.Room.info "MASC base: %s (no git root found)" path;
+          path
 
 (* ============================================ *)
 (* Environment helpers                          *)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -144,10 +144,10 @@ let rec find_git_root path =
     (e.g. masc-mcp/) from hijacking the intended base path. *)
 let resolve_masc_base_path path =
   match Env_config_core.base_path_opt () with
-  | Some explicit when explicit = path ->
-      Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" path;
-      path
-  | _ ->
+  | Some explicit ->
+      Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
+      explicit
+  | None ->
       match find_git_root path with
       | Some git_root ->
           Log.Room.info "MASC base resolved: %s → %s (git root)" path git_root;


### PR DESCRIPTION
## Summary

- **KeeperHealthStrip**: Live Monitor에 keeper 활성/전체 수 + context pressure bar + alert 표시 추가
- **ActivityStream 카운터 안정화**: FIFO buffer length 대신 누적 카운터(`totalEvents`) 사용으로 이벤트 수 요동 제거
- **PostCard 마크다운 렌더링**: 게시판 미리보기에서 `previewText()` 제거, `<Markdown />` 컴포넌트로 교체
- **base_path 안정화**: `MASC_BASE_PATH` 명시 설정 시 git root 탐색을 건너뛰어 sub-repo `.git`에 의한 경로 하이재킹 방지

## Changed files

| File | Change |
|------|--------|
| `lib/room/room_utils_backend_setup.ml` | `resolve_masc_base_path` — explicit env var 우선 |
| `dashboard/src/live-store.ts` | `keeperHealthSummary` computed signal 추가 |
| `dashboard/src/components/live/keeper-health-strip.ts` | 신규 컴포넌트 |
| `dashboard/src/components/live.ts` | KeeperHealthStrip 레이아웃 삽입 |
| `dashboard/src/components/live/activity-stream.ts` | 누적 카운터 표시 |
| `dashboard/src/components/memory.ts` | PostCard Markdown 렌더링 |

## Test plan

- [x] 서버 빌드 성공 (dune build)
- [x] 대시보드 빌드 성공 (vite build)
- [x] 서버 재시작 후 shell/execution API `room_base_path` 일치 확인
- [x] keeper_fibers=5, SSE clients 정상 연결 확인
- [ ] 브라우저에서 Live Monitor 탭 KeeperHealthStrip 표시 확인
- [ ] ActivityStream 이벤트 수 안정성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)