### PR TITLE
fix(security): canonicalize paths in code tool validation

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -40,9 +40,31 @@ let is_binary_file path =
 (* Security: Check file size limit (500KB) *)
 let max_file_size = 500 * 1024
 
-(* Security: Validate path is within git root *)
+(* Security: Normalize path by resolving . and .. segments.
+   Returns a clean absolute path with no traversal components. *)
+let normalize_path path =
+  let parts = String.split_on_char '/' path in
+  let is_absolute = String.length path > 0 && path.[0] = '/' in
+  let rec resolve acc = function
+    | [] -> List.rev acc
+    | ("." | "") :: rest -> resolve acc rest
+    | ".." :: rest ->
+      (match acc with
+       | [] -> resolve [] rest
+       | _ :: tl -> resolve tl rest)
+    | seg :: rest -> resolve (seg :: acc) rest
+  in
+  let resolved = resolve [] parts in
+  let joined = String.concat "/" resolved in
+  if is_absolute then "/" ^ joined else joined
+
+(* Security: Validate path is within git root.
+   Uses canonical path resolution to prevent .. traversal attacks. *)
 let validate_path config path =
   try
+    if String.contains path '\x00' then
+      Error (IoError "Path contains null byte")
+    else
     let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
       | None -> raise (Invalid_argument "Not in a git repository")
       | Some root -> root
@@ -53,9 +75,11 @@ let validate_path config path =
       else
         path
     in
-    (* Simple path traversal check *)
-    if String.starts_with ~prefix:git_root absolute_path then
-      Ok absolute_path
+    let canonical = normalize_path absolute_path in
+    let canonical_root = normalize_path git_root in
+    if String.starts_with ~prefix:(canonical_root ^ "/") canonical
+       || String.equal canonical canonical_root then
+      Ok canonical
     else
       Error (IoError "Path traversal detected: access outside git root")
   with

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -21,11 +21,12 @@ type result = bool * string
 
 let max_write_size = 1024 * 1024 (* 1MB *)
 
-(* Security: Validate path is within a .worktrees/ directory *)
+(* Security: Validate path is within a .worktrees/ directory.
+   Uses canonical paths from Tool_code.validate_path — already normalized. *)
 let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
-  | Ok abs_path ->
+  | Ok canonical_path ->
     let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
       | None -> Error (IoError "Not in a git repository")
       | Some root -> Ok root
@@ -33,12 +34,13 @@ let validate_writable_path config path =
     match git_root with
     | Error e -> Error e
     | Ok root ->
-      let worktree_prefix = Filename.concat root ".worktrees" in
-      if String.starts_with ~prefix:worktree_prefix abs_path then
-        Ok abs_path
+      let worktree_prefix = Tool_code.normalize_path
+        (Filename.concat root ".worktrees") in
+      if String.starts_with ~prefix:(worktree_prefix ^ "/") canonical_path then
+        Ok canonical_path
       else
         Error (IoError (Printf.sprintf
-          "Write restricted to .worktrees/ directory (got: %s)" abs_path))
+          "Write restricted to .worktrees/ directory (got: %s)" canonical_path))
 
 (* Shell command allowlist *)
 let allowed_shell_commands = [

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -124,12 +124,47 @@ let test_code_read_path_traversal () =
   let args = `Assoc [("path", `String "../../../etc/passwd")] in
   let (ok, msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
   Alcotest.(check bool) "path traversal blocked" false ok;
-  (* validate_path rejects: either "Path traversal" or "Not in a git repository" *)
   let has_security_msg =
     msg_contains ~needle:"traversal" msg ||
     msg_contains ~needle:"git" msg in
   Alcotest.(check bool) "error mentions security boundary" true has_security_msg;
   cleanup_dir base_dir
+
+(* Regression: dotdot hidden inside a valid-looking prefix must be caught *)
+let test_code_read_dotdot_inside_prefix () =
+  let ctx, base_dir = make_ctx () in
+  let attack_path = ".worktrees/../../escape/proof.txt" in
+  let args = `Assoc [("path", `String attack_path)] in
+  let (ok, _msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
+  Alcotest.(check bool) "dotdot inside prefix blocked" false ok;
+  cleanup_dir base_dir
+
+let test_code_read_absolute_sibling () =
+  let ctx, base_dir = make_ctx () in
+  let sibling = Filename.concat (Filename.dirname base_dir) "sibling" in
+  let args = `Assoc [("path", `String sibling)] in
+  let (ok, _msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
+  Alcotest.(check bool) "absolute sibling path blocked" false ok;
+  cleanup_dir base_dir
+
+let test_code_read_null_byte () =
+  let ctx, base_dir = make_ctx () in
+  let args = `Assoc [("path", `String "test.ml\x00../../etc/passwd")] in
+  let (ok, msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
+  Alcotest.(check bool) "null byte blocked" false ok;
+  Alcotest.(check bool) "error mentions null" true (msg_contains ~needle:"null" msg);
+  cleanup_dir base_dir
+
+let test_normalize_path_resolves_dotdot () =
+  let check desc input expected =
+    let result = Tool_code.normalize_path input in
+    Alcotest.(check string) desc expected result
+  in
+  check "simple dotdot" "/a/b/../c" "/a/c";
+  check "multiple dotdot" "/a/b/c/../../d" "/a/d";
+  check "dotdot at root" "/a/../../../x" "/x";
+  check "dot removal" "/a/./b/./c" "/a/b/c";
+  check "trailing slash" "/a/b/" "/a/b"
 
 let test_code_read_with_offset_limit () =
   let ctx, base_dir = make_ctx () in
@@ -180,7 +215,13 @@ let () =
     ("code_read", [
       Alcotest.test_case "no path" `Quick test_code_read_no_path;
       Alcotest.test_case "path traversal" `Quick test_code_read_path_traversal;
+      Alcotest.test_case "dotdot inside prefix" `Quick test_code_read_dotdot_inside_prefix;
+      Alcotest.test_case "absolute sibling path" `Quick test_code_read_absolute_sibling;
+      Alcotest.test_case "null byte injection" `Quick test_code_read_null_byte;
       Alcotest.test_case "offset and limit" `Quick test_code_read_with_offset_limit;
+    ]);
+    ("normalize_path", [
+      Alcotest.test_case "resolves dotdot" `Quick test_normalize_path_resolves_dotdot;
     ]);
     ("code_symbols", [
       Alcotest.test_case "empty args" `Quick test_code_symbols_empty;


### PR DESCRIPTION
## Summary

- `validate_path`의 `String.starts_with` prefix check를 canonical path resolution으로 교체
- `..` traversal로 git root 외부 읽기/쓰기가 가능했던 취약점 수정
- null byte injection 차단 추가

## 변경

| 파일 | 변경 |
|------|------|
| `lib/tool_code.ml` | `normalize_path` 함수 추가, `validate_path`에서 사용 |
| `lib/tool_code_write.ml` | `validate_writable_path`에서 normalized prefix 비교 |
| `test/test_tool_code_coverage.ml` | regression 테스트 4개 추가 |

## 공격 벡터 (수정 전)

```
path = ".worktrees/../../escape/proof.txt"
absolute = "/repo/.worktrees/../../escape/proof.txt"
starts_with "/repo" -> true (통과)
실제 경로: /escape/proof.txt (repo 외부)
```

## 수정 후

```
canonical = normalize_path "/repo/.worktrees/../../escape/proof.txt"
         = "/escape/proof.txt"
starts_with "/repo/" -> false (차단)
```

Fixes #4241

## Test plan

- [ ] `normalize_path` 단위 테스트: dotdot, dot, trailing slash 해석
- [ ] dotdot-inside-prefix 공격 차단
- [ ] absolute sibling path 차단
- [ ] null byte injection 차단
- [ ] 기존 테스트 regression 없음

Generated with [Claude Code](https://claude.com/claude-code)