### PR TITLE
fix(security): harden code tool path validation with realpath

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -40,7 +40,9 @@ let is_binary_file path =
 (* Security: Check file size limit (500KB) *)
 let max_file_size = 500 * 1024
 
-(* Security: Validate path is within git root *)
+(* Security: Validate path is within git root.
+   Uses Unix.realpath to resolve symlinks and ".." before comparison,
+   preventing path traversal attacks. *)
 let validate_path config path =
   try
     let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
@@ -53,9 +55,28 @@ let validate_path config path =
       else
         path
     in
-    (* Simple path traversal check *)
-    if String.starts_with ~prefix:git_root absolute_path then
-      Ok absolute_path
+    (* For non-existent paths, resolve the deepest existing ancestor
+       then re-append the remaining segments, rejecting if the ancestor
+       itself escapes. *)
+    let real_root = Unix.realpath git_root in
+    let real_path =
+      try Unix.realpath absolute_path
+      with Unix.Unix_error (Unix.ENOENT, _, _) ->
+        (* Path doesn't exist yet (write case). Resolve parent. *)
+        let parent = Filename.dirname absolute_path in
+        let base = Filename.basename absolute_path in
+        let real_parent =
+          try Unix.realpath parent
+          with Unix.Unix_error _ ->
+            raise (Invalid_argument
+              (Printf.sprintf "Parent directory does not exist: %s" parent))
+        in
+        Filename.concat real_parent base
+    in
+    let prefix = real_root ^ "/" in
+    if real_path = real_root
+       || String.starts_with ~prefix real_path then
+      Ok real_path
     else
       Error (IoError "Path traversal detected: access outside git root")
   with

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -21,11 +21,12 @@ type result = bool * string
 
 let max_write_size = 1024 * 1024 (* 1MB *)
 
-(* Security: Validate path is within a .worktrees/ directory *)
+(* Security: Validate path is within a .worktrees/ directory.
+   Uses the already-resolved path from Tool_code.validate_path. *)
 let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
-  | Ok abs_path ->
+  | Ok resolved_path ->
     let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
       | None -> Error (IoError "Not in a git repository")
       | Some root -> Ok root
@@ -33,12 +34,13 @@ let validate_writable_path config path =
     match git_root with
     | Error e -> Error e
     | Ok root ->
-      let worktree_prefix = Filename.concat root ".worktrees" in
-      if String.starts_with ~prefix:worktree_prefix abs_path then
-        Ok abs_path
+      let real_root = try Unix.realpath root with Unix.Unix_error _ -> root in
+      let worktree_prefix = Filename.concat real_root ".worktrees" ^ "/" in
+      if String.starts_with ~prefix:worktree_prefix resolved_path then
+        Ok resolved_path
       else
         Error (IoError (Printf.sprintf
-          "Write restricted to .worktrees/ directory (got: %s)" abs_path))
+          "Write restricted to .worktrees/ directory (got: %s)" resolved_path))
 
 (* Shell command allowlist *)
 let allowed_shell_commands = [

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -131,6 +131,31 @@ let test_code_read_path_traversal () =
   Alcotest.(check bool) "error mentions security boundary" true has_security_msg;
   cleanup_dir base_dir
 
+let test_code_read_path_traversal_dotdot_in_middle () =
+  let ctx, base_dir = make_ctx () in
+  (* Simulates .worktrees/../../outside — the exact vector from #4241 *)
+  let args = `Assoc [("path", `String ".worktrees/../../outside/secret.txt")] in
+  let (ok, msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
+  Alcotest.(check bool) "dotdot-in-middle blocked" false ok;
+  let has_security_msg =
+    msg_contains ~needle:"traversal" msg ||
+    msg_contains ~needle:"git" msg ||
+    msg_contains ~needle:"not found" msg in
+  Alcotest.(check bool) "error mentions boundary" true has_security_msg;
+  cleanup_dir base_dir
+
+let test_code_read_absolute_sibling () =
+  let ctx, base_dir = make_ctx () in
+  (* Absolute path outside git root *)
+  let args = `Assoc [("path", `String "/tmp/should-not-read.txt")] in
+  let (ok, msg) = dispatch_exn ctx ~name:"masc_code_read" ~args in
+  Alcotest.(check bool) "absolute sibling blocked" false ok;
+  let has_security_msg =
+    msg_contains ~needle:"traversal" msg ||
+    msg_contains ~needle:"git" msg in
+  Alcotest.(check bool) "error mentions boundary" true has_security_msg;
+  cleanup_dir base_dir
+
 let test_code_read_with_offset_limit () =
   let ctx, base_dir = make_ctx () in
   let args = `Assoc [
@@ -180,6 +205,8 @@ let () =
     ("code_read", [
       Alcotest.test_case "no path" `Quick test_code_read_no_path;
       Alcotest.test_case "path traversal" `Quick test_code_read_path_traversal;
+      Alcotest.test_case "path traversal dotdot-in-middle" `Quick test_code_read_path_traversal_dotdot_in_middle;
+      Alcotest.test_case "absolute sibling path" `Quick test_code_read_absolute_sibling;
       Alcotest.test_case "offset and limit" `Quick test_code_read_with_offset_limit;
     ]);
     ("code_symbols", [


### PR DESCRIPTION
## Summary

- `validate_path`가 `String.starts_with`로만 경로 검증 → symlink, `..` 미해결
- `Unix.realpath`로 canonical path 변환 후 비교하도록 수정
- `validate_writable_path`도 동일하게 강화
- 비존재 경로(write case)는 부모 디렉토리까지 resolve 후 basename 재결합

## 공격 벡터 (수정 전)

| 벡터 | 결과 |
|------|------|
| `masc_code_read` + `/Users/.../sibling/proof.txt` | repo 밖 파일 읽기 성공 |
| `masc_code_write` + `.worktrees/../../outside/file.txt` | repo 밖 파일 쓰기 성공 |

## Test plan

- [ ] `dune build` 성공
- [ ] `test_tool_code_coverage` 통과
  - `path traversal dotdot-in-middle` — `.worktrees/../../outside` 차단 확인
  - `absolute sibling path` — `/tmp/should-not-read.txt` 차단 확인
- [ ] 기존 `path traversal` 테스트 (`../../../etc/passwd`) 여전히 통과

Fixes #4241

🤖 Generated with [Claude Code](https://claude.com/claude-code)