### PR TITLE
fix(team-session): prevent double-release of runtime lease on spawn exception

### DIFF
--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -87,6 +87,7 @@ type prepared_spawn = Tool_team_session_step.prepared_spawn = {
   runtime_model_label : string;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
+  mutable lease_released : bool;
 }
 
 let trim_opt = function

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -42,6 +42,7 @@ type prepared_spawn = {
   runtime_model_label : string;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
+  mutable lease_released : bool;
 }
 
 (** OAS worker evidence payload for trace integration. *)

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -508,10 +508,13 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
 
 let release_prepared_runtime (prepared : prepared_spawn) ~success
     ?error ?latency_ms () =
-  match prepared.runtime_lease with
-  | Some lease ->
-      Local_runtime_pool.release lease ~success ?error ?latency_ms ()
-  | None -> ()
+  if prepared.lease_released then ()
+  else (
+    prepared.lease_released <- true;
+    match prepared.runtime_lease with
+    | Some lease ->
+        Local_runtime_pool.release lease ~success ?error ?latency_ms ()
+    | None -> ())
 
 let release_all_prepared prepareds ~error =
   List.iter
@@ -628,4 +631,5 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
           runtime_model_label;
           runtime_lease;
           assigned_runtime;
+          lease_released = false;
         }

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -46,6 +46,7 @@ type prepared_spawn = {
   runtime_model_label : string;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
+  mutable lease_released : bool;
 }
 
 (** OAS worker evidence payload for trace integration. *)


### PR DESCRIPTION
## Summary
- Background spawn exception handler가 이미 해제된 runtime lease를 다시 해제하는 버그 수정
- `prepared_spawn`에 `mutable lease_released` 플래그 추가
- `release_prepared_runtime`에서 플래그 체크 후 중복 해제 방지
- 4파일 수정, +11/-4 (최소 변경)

## Root Cause
1. Worker 실행 완료 → `release_prepared_runtime` 호출 (lease 해제)
2. 이후 persistence/event 단계에서 exception 발생
3. Exception handler가 `unexpected_failure` → `release_prepared_runtime` 재호출
4. `active_slots` 이중 감소 → pool counter 손상

## Test plan
- [x] `dune build` 성공
- [ ] spawn exception 시나리오에서 lease count 정합성 확인

Closes #4190

🤖 Generated with [Claude Code](https://claude.com/claude-code)