### PR TITLE
fix(security): remove bearer token from URL query string

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -10,9 +10,28 @@ import type {
 import { resolveDashboardActorName, sanitizeDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Auth ---
+// Token is extracted from ?token= on first load, moved to sessionStorage,
+// then stripped from the URL to prevent exposure in browser history,
+// screenshots, copied links, and server logs.
 
-function getQueryParams(): URLSearchParams {
-  return new URLSearchParams(window.location.search)
+const TOKEN_STORAGE_KEY = 'masc_dashboard_token'
+
+function initTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search)
+  const urlToken = params.get('token')
+  if (urlToken) {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, urlToken)
+    params.delete('token')
+    const cleaned = params.toString()
+    const newUrl = window.location.pathname + (cleaned ? `?${cleaned}` : '') + window.location.hash
+    window.history.replaceState(null, '', newUrl)
+  }
+}
+
+initTokenFromUrl()
+
+function getStoredToken(): string | null {
+  return sessionStorage.getItem(TOKEN_STORAGE_KEY)
 }
 
 export function currentDashboardActor(): string {
@@ -24,9 +43,8 @@ type HeaderOptions = {
 }
 
 function authHeaders(options: HeaderOptions = {}): Record<string, string> {
-  const params = getQueryParams()
   const headers: Record<string, string> = {}
-  const token = params.get('token')
+  const token = getStoredToken()
   const agent = resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {

--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -2,18 +2,24 @@ import { describe, expect, it } from 'vitest'
 import { buildDashboardSseUrl } from './sse'
 
 describe('buildDashboardSseUrl', () => {
-  it('uses /mcp observer stream with dashboard query params', () => {
+  it('includes agent but excludes token from SSE URL', () => {
     expect(
       buildDashboardSseUrl(
         'dash_test',
         '?agent=keeper-a&token=secret',
       ),
-    ).toBe('/mcp?agent=keeper-a&token=secret&session_id=dash_test&sse_kind=observer')
+    ).toBe('/mcp?agent=keeper-a&session_id=dash_test&sse_kind=observer')
   })
 
   it('omits optional params when they are absent', () => {
     expect(buildDashboardSseUrl('dash_test', '')).toBe(
       '/mcp?session_id=dash_test&sse_kind=observer',
     )
+  })
+
+  it('never leaks token into URL even when present', () => {
+    const url = buildDashboardSseUrl('s1', '?token=my-secret-token')
+    expect(url).not.toContain('token')
+    expect(url).not.toContain('my-secret-token')
   })
 })

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -141,9 +141,10 @@ export function buildDashboardSseUrl(sessionId: string, locationSearch = window.
   const urlParams = new URLSearchParams(locationSearch)
   const sseParams = new URLSearchParams()
   const agent = urlParams.get('agent') ?? urlParams.get('agent_name')
-  const token = urlParams.get('token')
   if (agent) sseParams.set('agent', agent)
-  if (token) sseParams.set('token', token)
+  // Token is intentionally NOT propagated into the SSE URL.
+  // Bearer credentials in URLs leak to browser history, logs, and screenshots.
+  // The server extracts tokens from Authorization headers, not query params.
   sseParams.set('session_id', sessionId)
   sseParams.set('sse_kind', 'observer')
   return `/mcp?${sseParams.toString()}`


### PR DESCRIPTION
## Summary

- URL `?token=`에서 bearer token을 읽어 `sessionStorage`로 이동 후 URL에서 즉시 제거
- `authHeaders()`가 `sessionStorage`에서 token을 읽도록 변경
- `buildDashboardSseUrl()`에서 token을 SSE URL에 복사하던 코드 제거
- SSE 테스트 업데이트: token이 URL에 포함되지 않는 것을 검증

## 취약점 (수정 전)

- bearer token이 URL query string에 노출 → 브라우저 히스토리, 스크린샷, 서버 로그
- SSE reconnect URL에도 token 복제 → 동일 노출

## Test plan

- [ ] `vitest` 통과 — SSE URL에 token 미포함 확인
- [ ] 수동: `?token=xxx`로 접속 후 URL에서 token 사라지는지 확인
- [ ] 수동: sessionStorage에 `masc_dashboard_token` 키로 저장되는지 확인

Fixes #4242

🤖 Generated with [Claude Code](https://claude.com/claude-code)