### PR TITLE
fix(ci): add Request_priority type erasure guard to PR hygiene

### DIFF
--- a/scripts/check-pr-hygiene.sh
+++ b/scripts/check-pr-hygiene.sh
@@ -13,6 +13,7 @@ Usage: scripts/check-pr-hygiene.sh --base <git-ref> [--head <git-ref>] [--recent
 Checks:
   - fails on empty commits in the PR range
   - warns or fails on duplicate patch-ids already present in recent base history
+  - fails on Request_priority type erasure (priority : () patterns in .ml/.mli)
 EOF
 }
 
@@ -134,6 +135,18 @@ fi
 
 if [[ "$duplicate_hits" -ne 0 && "$DUPLICATE_POLICY" == "fail" ]]; then
   echo "PR hygiene check failed: duplicate patches detected." >&2
+  exit 1
+fi
+
+# Guard: detect Request_priority type erasure (priority : () or ~priority:())
+# See #4186 — a bulk rewrite once replaced Request_priority.t with () across OAS files.
+priority_erasure=0
+while IFS= read -r line; do
+  echo "::error title=Priority type erasure::Added line matches erased priority pattern: ${line}"
+  priority_erasure=1
+done < <(git diff "$MERGE_BASE" "$HEAD_REF" -- '*.ml' '*.mli' | grep '^+' | grep -v '^+++' | grep -E 'priority\s*:\s*\(\)|~priority:\(\)' || true)
+if [[ "$priority_erasure" -ne 0 ]]; then
+  echo "PR hygiene check failed: Request_priority type erasure detected. See #4186." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- PR hygiene 스크립트에 `Request_priority.t` erasure 감지 guard 추가
- PR diff에서 `.ml`/`.mli` 파일에 `priority : ()` 또는 `~priority:()` 패턴이 추가되면 CI 실패
- 1파일 수정, +13줄

## Context
#4186: dirty worktree에서 bulk rewrite가 `Request_priority.t`를 `()`로 치환한 사고가 발생. 이 guard가 있었으면 PR 단계에서 차단됐을 것.

## Test plan
- [x] 정상 패턴 (`priority : Request_priority.t option`) 매칭 안 됨 확인
- [x] 비정상 패턴 (`priority : ()`, `~priority:()`) 매칭 확인

Closes #4186

🤖 Generated with [Claude Code](https://claude.com/claude-code)