### PR TITLE
fix(security): require auth for HTTP mutations, secure token handling

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -13,6 +13,10 @@ import { resolveDashboardActorName, sanitizeDashboardActorName } from '../lib/da
 // Token is read from ?token= on first load, moved to sessionStorage,
 // then stripped from the URL to avoid exposure in history/logs.
 
+function getQueryParams(): URLSearchParams {
+  return new URLSearchParams(window.location.search)
+}
+
 const TOKEN_STORAGE_KEY = 'masc_bearer_token'
 
 function initTokenFromUrl(): void {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -10,9 +10,27 @@ import type {
 import { resolveDashboardActorName, sanitizeDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Auth ---
+// Token is read from ?token= on first load, moved to sessionStorage,
+// then stripped from the URL to avoid exposure in history/logs.
 
-function getQueryParams(): URLSearchParams {
-  return new URLSearchParams(window.location.search)
+const TOKEN_STORAGE_KEY = 'masc_bearer_token'
+
+function initTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search)
+  const urlToken = params.get('token')
+  if (urlToken) {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, urlToken)
+    params.delete('token')
+    const cleaned = params.toString()
+    const newUrl = window.location.pathname + (cleaned ? `?${cleaned}` : '') + window.location.hash
+    history.replaceState(null, '', newUrl)
+  }
+}
+
+initTokenFromUrl()
+
+function getStoredToken(): string | null {
+  return sessionStorage.getItem(TOKEN_STORAGE_KEY)
 }
 
 export function currentDashboardActor(): string {
@@ -24,9 +42,8 @@ type HeaderOptions = {
 }
 
 function authHeaders(options: HeaderOptions = {}): Record<string, string> {
-  const params = getQueryParams()
   const headers: Record<string, string> = {}
-  const token = params.get('token')
+  const token = getStoredToken()
   const agent = resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -74,9 +74,8 @@ export async function sendKeeperMessageDetailed(
 // --- SSE streaming ---
 
 function jsonHeaders(): Record<string, string> {
-  const params = new URLSearchParams(window.location.search)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  const token = params.get('token')
+  const token = sessionStorage.getItem('masc_bearer_token')
   const agent = resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (agent) headers['X-MASC-Agent'] = agent

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -141,7 +141,10 @@ export function buildDashboardSseUrl(sessionId: string, locationSearch = window.
   const urlParams = new URLSearchParams(locationSearch)
   const sseParams = new URLSearchParams()
   const agent = urlParams.get('agent') ?? urlParams.get('agent_name')
-  const token = urlParams.get('token')
+  // Token from sessionStorage (moved from URL on init) — EventSource does not
+  // support custom headers, so query param is the only option.  The token is
+  // no longer visible in the browser address bar or shareable links.
+  const token = sessionStorage.getItem('masc_bearer_token')
   if (agent) sseParams.set('agent', agent)
   if (token) sseParams.set('token', token)
   sseParams.set('session_id', sessionId)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -166,10 +166,20 @@ let host_port_of_request request =
           host_header (Printexc.to_string exn);
         None)
 
+let allow_anonymous_mutations =
+  lazy (match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
+    | Some ("1" | "true") -> true
+    | _ -> false)
+
 let ensure_same_origin_browser_request request :
     (unit, Types.masc_error) result =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
-  | None -> Ok ()
+  | None ->
+    if Lazy.force allow_anonymous_mutations then Ok ()
+    else
+      Error (Types.Unauthorized
+        "Authentication required: provide a bearer token or Origin header. \
+         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development.")
   | Some origin -> (
       match host_port_scheme_of_origin origin, host_port_of_request request with
       | Some (origin_host, origin_port, scheme),


### PR DESCRIPTION
## Summary

- 서버: Origin 헤더 없는 토큰 미인증 요청 거부 (MASC_ALLOW_ANONYMOUS_MUTATIONS=true로 override 가능)
- 대시보드: ?token= → sessionStorage 이동 후 URL에서 제거

## 변경

| 파일 | 변경 |
|------|------|
| `lib/server/server_auth.ml` | Origin 없으면 reject, env var escape hatch |
| `dashboard/src/api/core.ts` | initTokenFromUrl → sessionStorage, URL 정리 |
| `dashboard/src/sse.ts` | sessionStorage에서 token 읽기 |
| `dashboard/src/api/keeper.ts` | sessionStorage에서 token 읽기 |

## 공격 벡터 (수정 전)

```bash
# 토큰 없이 mutation 가능
curl -X POST http://localhost:8935/api/v1/operator/action -d '{...}'
# URL에 토큰 노출
http://localhost:8935/?token=SECRET_TOKEN
```

## 수정 후

- 토큰 없는 curl → 401 Unauthorized
- 브라우저 → Origin 헤더 전송으로 정상 동작
- URL의 ?token= → sessionStorage로 이동, URL에서 즉시 제거

Fixes #4240, Fixes #4242

## Test plan

- [ ] curl POST 없는 토큰 → 401
- [ ] MASC_ALLOW_ANONYMOUS_MUTATIONS=true → 기존처럼 허용
- [ ] 브라우저 대시보드 정상 동작 (Origin 헤더 전송)
- [ ] ?token= 대시보드 접근 → sessionStorage 저장 후 URL 정리
- [ ] SSE 연결 정상 유지

Generated with [Claude Code](https://claude.com/claude-code)