### PR TITLE
fix(keeper): centralize resolve_config, scoped lookup first

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -438,6 +438,22 @@ let tool_usage_of_by_name name =
     Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
     |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
 
+(* -- Config resolution --------------------------------------------- *)
+
+let resolve_config (config : Room_utils_backend_setup.config) keeper_name
+    : Room_utils_backend_setup.config =
+  if keeper_name = "" then config
+  else
+    (* Fast path: scoped lookup in the caller's base_path (O(1) map) *)
+    match get ~base_path:config.base_path keeper_name with
+    | Some _ -> config  (* already in the right scope *)
+    | None ->
+      (* Slow path: cross-base_path scan (O(n) registry) *)
+      match find_by_name keeper_name with
+      | Some entry when entry.base_path <> config.base_path ->
+        { config with base_path = entry.base_path }
+      | _ -> config  (* not found anywhere, keep original *)
+
 (* -- Tool usage persistence ---------------------------------------- *)
 
 let tool_usage_path ~base_path name =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -188,6 +188,13 @@ val find_by_agent_name : string -> registry_entry option
 val tool_usage_of_by_name : string ->
   (string * Keeper_types.tool_call_entry) list
 
+(** Resolve config for a keeper tool dispatch.
+    Tries scoped lookup first (O(1) map lookup), then falls back to
+    cross-base_path scan (O(n)) when not found in the caller's scope.
+    Returns config with the keeper's actual base_path, or the original
+    config unchanged if the keeper is not in the registry. *)
+val resolve_config : Room_utils_backend_setup.config -> string -> Room_utils_backend_setup.config
+
 (** Flush in-memory tool usage stats to disk for persistence across restarts. *)
 val flush_tool_usage : base_path:string -> string -> unit
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -379,10 +379,6 @@ let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();
   Turn.handle_keeper_down ctx args
 
-let keeper_rows_json ctx names =
-  names
-  |> List.filter_map (keeper_list_row_json ~runtime_class:"keeper" ctx.config)
-
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
@@ -390,11 +386,23 @@ let handle_keeper_list ctx args : tool_result =
   let body =
     cached_text_by_key _keeper_list_cache ~key:cache_key
       ~ttl_s:(keeper_list_cache_ttl_s ()) (fun () ->
-        let names =
-          keeper_names ctx.config
+        (* Use registry as source of truth for live keepers.
+           Each entry carries its own base_path so cross-base_path
+           keepers are listed correctly. *)
+        let entries =
+          Keeper_registry.all ()
+          |> List.sort (fun (a : Keeper_registry.registry_entry)
+                            (b : Keeper_registry.registry_entry) ->
+               String.compare a.name b.name)
           |> take limit
         in
-        let rows = keeper_rows_json ctx names in
+        let names = List.map (fun (e : Keeper_registry.registry_entry) -> e.name) entries in
+        let rows =
+          entries
+          |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
+               let config = { ctx.config with base_path = e.base_path } in
+               keeper_list_row_json ~runtime_class:"keeper" config e.name)
+        in
         let json =
           if not detailed then
             `Assoc
@@ -467,23 +475,21 @@ let maybe_bootstrap_existing_keepalives ctx ~name ~args =
        Log.Keeper.error "start_existing_keepalives failed: %s"
          (Printexc.to_string exn))
 
-(** Resolve base_path from keeper registry.  Dashboard/external sessions may
-    use a different base_path than the target keeper.  Skipped for creation
-    tools where the caller's base_path is authoritative. *)
-let resolve_keeper_base_path ctx ~name args =
+(** Resolve context base_path via central Keeper_registry.resolve_config.
+    Skipped for creation tools where the caller's base_path is authoritative. *)
+let resolve_ctx ctx ~name args =
   match name with
   | "masc_keeper_up" | "masc_keeper_create_from_persona" | "masc_persona_list" -> ctx
   | _ ->
     let keeper_name = get_string args "name" "" in
-    if keeper_name = "" then ctx
-    else match Keeper_registry.find_by_name keeper_name with
-    | Some entry when entry.base_path <> ctx.config.base_path ->
-        { ctx with config = { ctx.config with base_path = entry.base_path } }
-    | _ -> ctx
+    let config = Keeper_registry.resolve_config ctx.config keeper_name in
+    if config == ctx.config then ctx
+    else { ctx with config }
 
 let dispatch ctx ~name ~args : tool_result option =
+  (* Resolve base_path first so bootstrap runs in the correct scope. *)
+  let ctx = resolve_ctx ctx ~name args in
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
-  let ctx = resolve_keeper_base_path ctx ~name args in
   match name with
   | "masc_persona_list" -> Some (Persona.handle_persona_list ctx args)
   | "masc_keeper_create_from_persona" -> Some (handle_keeper_create_from_persona ctx args)
@@ -508,8 +514,8 @@ let dispatch ctx ~name ~args : tool_result option =
     Returns None for all other tool names.
     Called from server_routes_http_keeper_stream. *)
 let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
+  let ctx = resolve_ctx ctx ~name args in
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
-  let ctx = resolve_keeper_base_path ctx ~name args in
   match name with
   | "masc_keeper_msg" ->
       Some (handle_keeper_msg_stream ~on_text_delta ctx args)

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -327,6 +327,57 @@ let test_find_by_agent_name () =
   check bool "not found returns None" true
     (Option.is_none (R.find_by_agent_name "agent-nonexistent"))
 
+(* ── resolve_config tests ────────────────────────────────── *)
+
+module Room_setup = Room_utils_backend_setup
+
+(** Minimal in-memory config for testing resolve_config.
+    Only base_path matters; backend is a throwaway Memory instance. *)
+let make_test_config base_path : Room_setup.config =
+  let backend_config : Backend_types.config = {
+    backend_type = Backend_types.Memory;
+    base_path;
+    postgres_url = None;
+    node_id = "test";
+    cluster_name = "test";
+    pubsub_max_messages = 100;
+  } in
+  {
+    base_path;
+    workspace_path = base_path;
+    lock_expiry_minutes = 2;
+    backend_config;
+    backend = Room_setup.Memory (Backend.Memory.create ());
+    scope = Room_setup.Default;
+  }
+
+let test_resolve_config_scoped_hit () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "rc1" (make_meta "rc1") in
+  let config = make_test_config bp in
+  let resolved = R.resolve_config config "rc1" in
+  check string "scoped hit keeps base_path" bp resolved.base_path
+
+let test_resolve_config_cross_base_path () =
+  R.clear ();
+  let bp2 = "/tmp/other" in
+  let _entry = R.register ~base_path:bp2 "rc2" (make_meta "rc2") in
+  let config = make_test_config bp in
+  let resolved = R.resolve_config config "rc2" in
+  check string "cross-base_path resolves" bp2 resolved.base_path
+
+let test_resolve_config_not_found () =
+  R.clear ();
+  let config = make_test_config bp in
+  let resolved = R.resolve_config config "nonexistent" in
+  check string "unknown keeper keeps original" bp resolved.base_path
+
+let test_resolve_config_empty_name () =
+  R.clear ();
+  let config = make_test_config bp in
+  let resolved = R.resolve_config config "" in
+  check string "empty name keeps original" bp resolved.base_path
+
 (* ── Directive processing tests ─────────────────────────── *)
 
 module KK = Masc_mcp.Keeper_keepalive
@@ -417,6 +468,13 @@ let () =
       ( "agent_name_lookup",
         [
           eio_test "find_by_agent_name" test_find_by_agent_name;
+        ] );
+      ( "resolve_config",
+        [
+          eio_test "scoped hit" test_resolve_config_scoped_hit;
+          eio_test "cross base_path" test_resolve_config_cross_base_path;
+          eio_test "not found" test_resolve_config_not_found;
+          eio_test "empty name" test_resolve_config_empty_name;
         ] );
       ( "directives",
         [


### PR DESCRIPTION
## Summary

#4237 리뷰 피드백 후속 수정 (원본 PR은 이미 merged):

1. **resolve_config 중앙화** — 3곳에 중복된 base_path resolution 로직을 `Keeper_registry.resolve_config`로 통합
2. **Scoped lookup first** — `get ~base_path` (O(1)) 먼저 시도, cross-base_path scan은 fallback으로만
3. **handle_keeper_list from registry** — filesystem scan 대신 `Keeper_registry.all()` 사용
4. **Bootstrap reorder** — resolve 후 bootstrap 실행
5. **Regression tests** — 4 test cases 추가 (scoped hit, cross-base_path fallback, not-found, empty name)

## Test plan

- [x] `dune build` 성공
- [x] 41 tests pass (37 existing + 4 new)
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)