### PR TITLE
refactor(dashboard): 하네스 레이블 한글화 및 가독성 개선

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -88,7 +88,7 @@ function JudgeStatusBar() {
     <div class="mb-4 flex items-center gap-3 rounded-lg border border-white/5 bg-white/3 px-3.5 py-2 text-[12px]" data-testid="judge-status">
       <span class="flex items-center gap-1.5">
         <span class="inline-block w-2 h-2 rounded-full ${dotClass}"></span>
-        <span class="font-medium text-text-muted">Judge ${label}</span>
+        <span class="font-medium text-text-muted">평가 모델 ${label}</span>
       </span>
       ${judge.model_used ? html`<span class="text-text-dim">${judge.model_used}</span>` : null}
       ${judge.generated_at || judge.last_error

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -73,7 +73,7 @@ function emptyReasonText(reason?: string | null): string {
       return '기록은 있지만 최근 신호가 없습니다.'
     case 'no_runtime_activity':
     default:
-      return '아직 이 rail을 통과한 실행이 없습니다.'
+      return '아직 이 감시 채널을 통과한 실행이 없습니다.'
   }
 }
 
@@ -94,40 +94,40 @@ export function heroTitle(data: HarnessHealthData): string {
     data.overview.pre_compact_status,
     data.overview.handoff_status,
   ]
-  if (statuses.includes('warning')) return '실험 기계에 주의가 필요합니다.'
+  if (statuses.includes('warning')) return '감시 채널에 주의가 필요합니다.'
   if (statuses.includes('stale')) return '신호는 있지만 최신성이 떨어집니다.'
-  if (statuses.every(status => status === 'idle')) return '아직 안전 rail 기록이 없습니다.'
-  return '실험 기계는 현재 안정적입니다.'
+  if (statuses.every(status => status === 'idle')) return '아직 감시 기록이 없습니다.'
+  return '감시 채널이 정상 작동 중입니다.'
 }
 
 export function heroBody(data: HarnessHealthData): string {
   if (data.overview.evaluator_status === 'warning') {
     const ratio = Math.round((data.overview.fallback_ratio ?? 0) * 100)
-    return `Evaluator fallback 비중이 ${ratio}%라 verdict를 그대로 신뢰하기 어렵습니다.`
+    return `평가 모델의 대체 처리 비중이 ${ratio}%라 판정을 그대로 신뢰하기 어렵습니다.`
   }
   if (data.overview.handoff_status === 'warning') {
-    return 'Handoff 기록에 누락 필드가 있어 keeper continuity 점검이 필요합니다.'
+    return '세대 교체 기록에 누락 필드가 있어 keeper 연속성 점검이 필요합니다.'
   }
   if (data.overview.pre_compact_status === 'warning') {
-    return 'Compaction 직전 컨텍스트 압력이 높아 keeper continuity가 흔들릴 수 있습니다.'
+    return '압축 직전 컨텍스트 압력이 높아 keeper 연속성이 흔들릴 수 있습니다.'
   }
   if (data.overview.last_signal_at == null) {
-    return 'Autoresearch는 cycle outcome을 보고, Harness는 evaluator와 continuity rail의 건강도를 봅니다.'
+    return 'keeper 장기 실행 중 평가, 압축, 세대 교체가 정상인지 감시합니다.'
   }
   return `마지막 안전 신호는 ${freshnessLabel(data.overview.last_signal_at)}에 들어왔습니다.`
 }
 
 export function railDetail(data: HarnessHealthData, rail: 'evaluator' | 'pre_compact' | 'handoff'): string {
   if (rail === 'evaluator') {
-    if (data.calibration.total_verdicts === 0) return 'verdict 기록 없음'
-    return `${data.calibration.total_verdicts} verdict`
+    if (data.calibration.total_verdicts === 0) return '판정 기록 없음'
+    return `판정 ${data.calibration.total_verdicts}건`
   }
   if (rail === 'pre_compact') {
-    if (data.overview.latest_pre_compact_ratio == null) return '최근 compaction 없음'
-    return `ratio ${data.overview.latest_pre_compact_ratio.toFixed(2)}`
+    if (data.overview.latest_pre_compact_ratio == null) return '최근 압축 없음'
+    return `컨텍스트 ${Math.round(data.overview.latest_pre_compact_ratio * 100)}%`
   }
-  if (data.overview.latest_handoff_generation == null) return '최근 handoff 없음'
-  return `generation ${data.overview.latest_handoff_generation}`
+  if (data.overview.latest_handoff_generation == null) return '최근 교체 없음'
+  return `${data.overview.latest_handoff_generation}세대`
 }
 
 export function railFreshness(data: HarnessHealthData, rail: 'evaluator' | 'pre_compact' | 'handoff'): string {
@@ -216,8 +216,8 @@ export function ScopePairing() {
         <div class="flex flex-col gap-2">
           <div class="flex items-center justify-between gap-3">
             <div>
-              <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Generator Loop</div>
-              <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">Autoresearch가 답하는 것</div>
+              <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">실험 루프</div>
+              <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">오토리서치가 답하는 것</div>
             </div>
             <button
               type="button"
@@ -233,10 +233,10 @@ export function ScopePairing() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex flex-col gap-2">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Safety Rails</div>
-          <div class="text-sm font-medium text-[var(--text-strong)]">Harness가 답하는 것</div>
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">안전 감시</div>
+          <div class="text-sm font-medium text-[var(--text-strong)]">하네스가 답하는 것</div>
           <div class="text-sm leading-[1.6] text-[var(--text-body)]">
-            evaluator가 건강한지, 장기 keeper turn에서 compaction이 어떻게 걸리는지, handoff가 정상인지 봅니다.
+            평가 모델이 건강한지, 장기 실행 중 압축이 정상인지, 세대 교체가 안전한지 봅니다.
           </div>
         </div>
       <//>
@@ -273,7 +273,7 @@ export function RailHeader({
 
 export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
   if (items.length === 0) {
-    return html`<${EmptySignal} text="최근 evaluator verdict가 없습니다." />`
+    return html`<${EmptySignal} text="최근 평가 판정이 없습니다." />`
   }
 
   return html`
@@ -313,10 +313,10 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
             <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
           </div>
           <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
-            <span>ratio ${item.context_ratio.toFixed(3)}</span>
-            <span>messages ${item.message_count}</span>
-            <span>tokens ${item.token_count}</span>
-            <span>${item.model_family || 'model 미상'}</span>
+            <span>컨텍스트 ${Math.round(item.context_ratio * 100)}%</span>
+            <span>메시지 ${item.message_count}건</span>
+            <span>토큰 ${item.token_count.toLocaleString()}</span>
+            <span>${item.model_family || '모델 미확인'}</span>
           </div>
           <div class="mt-2 text-xs text-[var(--text-muted)]">${item.trigger}</div>
           ${item.strategies.length > 0 ? html`
@@ -346,13 +346,13 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
             <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
           </div>
           <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
-            <span>generation ${item.generation}</span>
-            <span>next ${item.next_generation ?? '-'}</span>
+            <span>${item.generation}세대</span>
+            <span>다음 ${item.next_generation ?? '-'}세대</span>
             <span class="font-mono">${item.trace_id.slice(0, 8)}</span>
-            <span>${item.to_model ?? 'model 미상'}</span>
+            <span>${item.to_model ?? '모델 미확인'}</span>
           </div>
           ${item.prev_trace_id ? html`
-            <div class="mt-2 text-xs text-[var(--text-muted)]">prev ${item.prev_trace_id.slice(0, 8)} -> new ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
+            <div class="mt-2 text-xs text-[var(--text-muted)]">이전 ${item.prev_trace_id.slice(0, 8)} → 새 ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
           ` : null}
         </div>
       `)}

--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -156,17 +156,17 @@ describe('HarnessHealth', () => {
     await flushUi()
 
     expect(get).toHaveBeenCalledWith('/api/v1/dashboard/harness-health')
-    expect(container.textContent).toContain('Safety Harness')
-    expect(container.textContent).toContain('Harness Flow')
-    expect(container.textContent).toContain('Can I Trust The Experiment Machinery?')
-    expect(container.textContent).toContain('Judge of the Judge')
-    expect(container.textContent).toContain('Continuity Pressure')
-    expect(container.textContent).toContain('Keeper Handoff')
+    expect(container.textContent).toContain('안전 감시')
+    expect(container.textContent).toContain('감시 흐름도')
+    expect(container.textContent).toContain('keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다')
+    expect(container.textContent).toContain('평가 모델 건강도')
+    expect(container.textContent).toContain('컨텍스트 압축 압력')
+    expect(container.textContent).toContain('keeper 세대 교체')
     expect(container.textContent).toContain('오토리서치 열기')
-    expect(container.textContent).toContain('Fallback 비율')
+    expect(container.textContent).toContain('대체 처리율')
     expect(container.textContent).toContain('judge timeout')
     expect(mermaidSource(container)).toContain('flowchart LR')
-    expect(mermaidSource(container)).toContain('verdict_recorded')
+    expect(mermaidSource(container)).toContain('판정 기록')
     expect(mermaidSource(container)).toContain('debounced reload')
 
     const markup = container.innerHTML
@@ -228,7 +228,7 @@ describe('HarnessHealth', () => {
     expect(source).toContain('class preCompact healthyRail;')
     expect(source).toContain('class handoff healthyRail;')
     expect(source).toContain('class evaluator activeRail;')
-    expect(source).toContain('keeper_handoff')
+    expect(source).toContain('교체 신호')
     expect(source).toContain('/api/v1/dashboard/harness-health')
   })
 
@@ -260,7 +260,7 @@ describe('HarnessHealth', () => {
     await flushUi()
 
     expect(container.textContent).toContain('keeper-b')
-    expect(container.textContent).toContain('generation 9')
+    expect(container.textContent).toContain('9세대')
     expect(mermaidSource(container)).toContain('class handoff activeRail;')
 
     await new Promise(resolve => setTimeout(resolve, 1000))

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -46,12 +46,12 @@ type HarnessRailKey = 'evaluator' | 'pre_compact' | 'handoff'
 function railTitle(rail: HarnessRailKey): string {
   switch (rail) {
     case 'evaluator':
-      return 'Evaluator'
+      return '평가 모델'
     case 'pre_compact':
-      return 'Pre-Compaction'
+      return '압축 전 상태'
     case 'handoff':
     default:
-      return 'Handoff'
+      return '세대 교체'
   }
 }
 
@@ -111,19 +111,19 @@ function flowSummaryLine(title: string, status: RailStatus, detail: string, fres
 function flowFallbackSummary(data: HarnessHealthData): string {
   return [
     flowSummaryLine(
-      'Evaluator',
+      '평가 모델',
       data.overview.evaluator_status,
       railDetail(data, 'evaluator'),
       railFreshness(data, 'evaluator'),
     ),
     flowSummaryLine(
-      'Pre-Compaction',
+      '압축 전 상태',
       data.overview.pre_compact_status,
       railDetail(data, 'pre_compact'),
       railFreshness(data, 'pre_compact'),
     ),
     flowSummaryLine(
-      'Handoff',
+      '세대 교체',
       data.overview.handoff_status,
       railDetail(data, 'handoff'),
       railFreshness(data, 'handoff'),
@@ -142,17 +142,17 @@ export function buildHarnessFlowMermaid(data: HarnessHealthData): string {
     '  classDef staleRail fill:#1f2937,stroke:#94a3b8,color:#e2e8f0,stroke-dasharray: 5 3;',
     '  classDef idleRail fill:#111827,stroke:#475569,color:#94a3b8,stroke-dasharray: 3 4;',
     '  classDef activeRail stroke:#7dd3fc,stroke-width:3px;',
-    '  taskDone["Task completion<br/>anti-rationalization review"]',
-    '  keeperTurn["Keeper turn<br/>continuity pressure"]',
-    '  keeperRollover["Keeper rollover<br/>metrics snapshot"]',
-    `  evaluator["${flowNodeLabel('Evaluator', data.overview.evaluator_status, railDetail(data, 'evaluator'), railFreshness(data, 'evaluator'))}"]`,
-    `  preCompact["${flowNodeLabel('Pre-Compaction', data.overview.pre_compact_status, railDetail(data, 'pre_compact'), railFreshness(data, 'pre_compact'))}"]`,
-    `  handoff["${flowNodeLabel('Handoff', data.overview.handoff_status, railDetail(data, 'handoff'), railFreshness(data, 'handoff'))}"]`,
-    '  readModel["Harness read model<br/>/api/v1/dashboard/harness-health"]',
-    '  labUi["Lab / harness<br/>live Mermaid + detail cards"]',
-    '  taskDone -->|"verdict_recorded"| evaluator',
-    '  keeperTurn -->|"pre_compact"| preCompact',
-    '  keeperRollover -->|"keeper_handoff"| handoff',
+    '  taskDone["작업 완료<br/>판정 검증"]',
+    '  keeperTurn["keeper 턴<br/>압축 압력"]',
+    '  keeperRollover["keeper 교체<br/>지표 스냅샷"]',
+    `  evaluator["${flowNodeLabel('평가 모델', data.overview.evaluator_status, railDetail(data, 'evaluator'), railFreshness(data, 'evaluator'))}"]`,
+    `  preCompact["${flowNodeLabel('압축 전 상태', data.overview.pre_compact_status, railDetail(data, 'pre_compact'), railFreshness(data, 'pre_compact'))}"]`,
+    `  handoff["${flowNodeLabel('세대 교체', data.overview.handoff_status, railDetail(data, 'handoff'), railFreshness(data, 'handoff'))}"]`,
+    '  readModel["하네스 데이터<br/>/api/v1/dashboard/harness-health"]',
+    '  labUi["Lab / 안전 감시<br/>실시간 상태"]',
+    '  taskDone -->|"판정 기록"| evaluator',
+    '  keeperTurn -->|"압축 신호"| preCompact',
+    '  keeperRollover -->|"교체 신호"| handoff',
     '  evaluator --> readModel',
     '  preCompact --> readModel',
     '  handoff --> readModel',
@@ -179,20 +179,20 @@ function HarnessFlowCard({ data }: { data: HarnessHealthData }) {
     <div class="space-y-3">
       <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
         <div>
-          <div class="text-sm font-medium text-[var(--text-strong)]">Live State Graph</div>
+          <div class="text-sm font-medium text-[var(--text-strong)]">실시간 상태 그래프</div>
           <div class="mt-1 text-sm leading-[1.6] text-[var(--text-muted)]">
-            task completion, pre-compaction, handoff가 read model로 모이는 구조를 한 장으로 보여줍니다.
+            작업 완료, 컨텍스트 압축, 세대 교체 신호가 하네스로 모이는 구조입니다.
           </div>
         </div>
         <div class="text-xs text-[var(--text-dim)]">
-          가장 최근 rail ${active ? railTitle(active) : '없음'}
+          가장 최근 채널: ${active ? railTitle(active) : '없음'}
         </div>
       </div>
 
       <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-dim)]">
-        <span class="rounded-full border border-[var(--white-8)] px-2 py-1">실선: live signal</span>
-        <span class="rounded-full border border-[var(--white-8)] px-2 py-1">점선: snapshot reconciliation</span>
-        <span class="rounded-full border border-[var(--accent)] px-2 py-1 text-[var(--text-body)]">강조: 가장 최근 rail</span>
+        <span class="rounded-full border border-[var(--white-8)] px-2 py-1">실선: 실시간 신호</span>
+        <span class="rounded-full border border-[var(--white-8)] px-2 py-1">점선: 스냅샷 갱신</span>
+        <span class="rounded-full border border-[var(--accent)] px-2 py-1 text-[var(--text-body)]">강조: 가장 최근 채널</span>
       </div>
 
       <${MermaidGraph}
@@ -229,19 +229,19 @@ export function HarnessHealth() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="Safety Harness" class="section">
+      <${Card} title="안전 감시" class="section">
         ${s.status === 'loading' || s.status === 'idle' ? html`
           <div class="text-sm text-[var(--text-dim)]">로딩 중...</div>
         ` : s.status === 'error' ? html`
           <div class="text-sm text-[var(--bad)]">${s.message}</div>
         ` : !data ? html`
-          <${EmptySignal} text="Harness 데이터가 없습니다." />
+          <${EmptySignal} text="안전 감시 데이터가 없습니다." />
         ` : html`
           <div class="space-y-4">
             <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
               <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <div class="max-w-3xl">
-                  <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)]">Can I Trust The Experiment Machinery?</div>
+                  <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)]">keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다</div>
                   <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">${heroTitle(data)}</div>
                   <div class="mt-2 text-sm leading-[1.7] text-[var(--text-body)]">${heroBody(data)}</div>
                 </div>
@@ -261,19 +261,19 @@ export function HarnessHealth() {
 
               <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
                 <${HeroRailCard}
-                  label="Evaluator"
+                  label="평가 모델"
                   status=${data.overview.evaluator_status}
                   detail=${railDetail(data, 'evaluator')}
                   freshness=${railFreshness(data, 'evaluator')}
                 />
                 <${HeroRailCard}
-                  label="Pre-Compaction"
+                  label="압축 전 상태"
                   status=${data.overview.pre_compact_status}
                   detail=${railDetail(data, 'pre_compact')}
                   freshness=${railFreshness(data, 'pre_compact')}
                 />
                 <${HeroRailCard}
-                  label="Handoff"
+                  label="세대 교체"
                   status=${data.overview.handoff_status}
                   detail=${railDetail(data, 'handoff')}
                   freshness=${railFreshness(data, 'handoff')}
@@ -294,32 +294,32 @@ export function HarnessHealth() {
         `}
       <//>
 
-      <${Card} title="Harness Flow" class="section">
+      <${Card} title="감시 흐름도" class="section">
         ${!data || !flowSource ? html`
-          <${EmptySignal} text="Harness flow 데이터가 없습니다." />
+          <${EmptySignal} text="감시 흐름 데이터가 없습니다." />
         ` : html`
           <${HarnessFlowCard} data=${data} />
         `}
       <//>
 
-      <${Card} title="Evaluator Calibration" class="section">
+      <${Card} title="평가 모델 건강도" class="section">
         ${!data || !cal ? html`
-          <${EmptySignal} text="Evaluator calibration 데이터가 없습니다." />
+          <${EmptySignal} text="평가 모델 데이터가 없습니다." />
         ` : html`
           <div class="space-y-4">
             <${RailHeader}
-              title="Judge of the Judge"
-              description="실험 cycle 자체가 아니라, verdict 기계가 얼마나 건강하게 작동하는지 봅니다."
+              title="평가 모델 건강도"
+              description="keeper 출력을 채점하는 모델이 제대로 작동하는지 봅니다."
               status=${data.overview.evaluator_status}
               lastEventAt=${data.overview.evaluator_last_event_at}
             />
 
             ${fallbackPct > 80 ? html`
               <div class="rounded-lg border border-[var(--warn-30)] bg-[var(--warn-12)] px-4 py-3">
-                <div class="mb-1 text-sm font-medium text-[var(--warn)]">Evaluator 미연결</div>
+                <div class="mb-1 text-sm font-medium text-[var(--warn)]">평가 모델 미연결</div>
                 <div class="text-xs text-[var(--warn)]">
-                  전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됐습니다.
-                  지금은 LLM evaluator보다 fallback gate가 더 많이 작동합니다.
+                  전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 대체 처리됐습니다.
+                  지금은 평가 모델보다 기본 규칙이 더 많이 작동합니다.
                 </div>
                 ${fallbackReasons.length > 0 ? html`
                   <details class="mt-2">
@@ -335,9 +335,9 @@ export function HarnessHealth() {
             ` : null}
 
             <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <${StatCard} label="총 Verdict" value=${cal.total_verdicts} />
-              <${StatCard} label="Reject 비율" value="${rejectRate}%" />
-              <${StatCard} label="Fallback 비율" value="${fallbackPct}%" />
+              <${StatCard} label="총 판정" value=${cal.total_verdicts} />
+              <${StatCard} label="거부율" value="${rejectRate}%" />
+              <${StatCard} label="대체 처리율" value="${fallbackPct}%" />
               <${StatCard}
                 label="일치율"
                 value="${agreementPct}%"
@@ -350,41 +350,41 @@ export function HarnessHealth() {
             </div>
 
             <div>
-              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">Gate 분포</div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">게이트 분포</div>
               <${GateChart} distribution=${cal.gate_distribution} />
             </div>
 
             <div>
-              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 Verdict</div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 판정</div>
               <${RecentVerdictsList} items=${data.recent_verdicts} />
             </div>
           </div>
         `}
       <//>
 
-      <${Card} title="Pre-Compaction Rail" class="section">
+      <${Card} title="압축 전 상태" class="section">
         ${!data ? html`
-          <${EmptySignal} text="Pre-compaction 데이터가 없습니다." />
+          <${EmptySignal} text="압축 전 상태 데이터가 없습니다." />
         ` : html`
           <div class="space-y-4">
             <${RailHeader}
-              title="Continuity Pressure"
+              title="컨텍스트 압축 압력"
               description=${data.pre_compact.description}
               status=${data.pre_compact.status}
               lastEventAt=${data.pre_compact.last_event_at}
             />
             <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
               <${StatCard}
-                label="최근 ratio"
-                value=${data.overview.latest_pre_compact_ratio != null ? data.overview.latest_pre_compact_ratio.toFixed(2) : '-'}
+                label="최근 컨텍스트 사용률"
+                value=${data.overview.latest_pre_compact_ratio != null ? `${Math.round(data.overview.latest_pre_compact_ratio * 100)}%` : '-'}
                 sub=${`최근 ${data.pre_compact.total_recent}건`}
               />
               <${StatCard}
-                label="최근 freshness"
+                label="최근 신호"
                 value=${freshnessLabel(data.pre_compact.last_event_at)}
               />
               <${StatCard}
-                label="status"
+                label="상태"
                 value=${railStatusLabel(data.pre_compact.status)}
               />
             </div>
@@ -393,29 +393,29 @@ export function HarnessHealth() {
         `}
       <//>
 
-      <${Card} title="Handoff Rail" class="section">
+      <${Card} title="세대 교체 기록" class="section">
         ${!data ? html`
-          <${EmptySignal} text="Handoff 데이터가 없습니다." />
+          <${EmptySignal} text="세대 교체 데이터가 없습니다." />
         ` : html`
           <div class="space-y-4">
             <${RailHeader}
-              title="Keeper Handoff"
+              title="keeper 세대 교체"
               description=${data.recent_handoffs.description}
               status=${data.recent_handoffs.status}
               lastEventAt=${data.recent_handoffs.last_event_at}
             />
             <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
               <${StatCard}
-                label="최근 generation"
-                value=${data.overview.latest_handoff_generation != null ? data.overview.latest_handoff_generation : '-'}
+                label="최근 세대"
+                value=${data.overview.latest_handoff_generation != null ? `${data.overview.latest_handoff_generation}세대` : '-'}
                 sub=${`최근 ${data.recent_handoffs.total_recent}건`}
               />
               <${StatCard}
-                label="최근 freshness"
+                label="최근 신호"
                 value=${freshnessLabel(data.recent_handoffs.last_event_at)}
               />
               <${StatCard}
-                label="status"
+                label="상태"
                 value=${railStatusLabel(data.recent_handoffs.status)}
               />
             </div>


### PR DESCRIPTION
## Summary

- Safety Harness 패널의 불명확한 영문 기술 지표를 한글로 교체
- 숫자에 단위와 맥락 추가 (`ratio 0.78` → `컨텍스트 78%`, `messages 37` → `메시지 37건`)
- 은유적 제목 제거 (`Judge of the Judge` → `평가 모델 건강도`, `Can I Trust The Experiment Machinery?` → 기능 설명)
- Mermaid 흐름도 노드/엣지 레이블도 한글화
- 레이아웃/스타일/백엔드 변경 없음 (순수 레이블 교체, +96/-96)

## 변경 파일

| 파일 | 내용 |
|------|------|
| `harness-health-sections.ts` | 숫자 포맷 + 레이블 한글화 |
| `harness-health.ts` | 섹션 제목, hero, Mermaid, StatCard |
| `governance.ts` | JudgeStatusBar "Judge" → "평가 모델" |
| `harness-health.test.ts` | 테스트 단언 업데이트 |

## Test plan

- [x] `pnpm build` 통과
- [x] `pnpm test` 186/186 통과
- [ ] 대시보드 Lab > Safety Harness 페이지에서 한글 레이블 확인
- [ ] "ratio", "messages", "generation" 단독 영문 수치 사라졌는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)