### PR TITLE
fix(test): update SSE URL test for sessionStorage token

### DIFF
--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -1,14 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { buildDashboardSseUrl } from './sse'
 
 describe('buildDashboardSseUrl', () => {
-  it('uses /mcp observer stream with dashboard query params', () => {
+  afterEach(() => {
+    sessionStorage.removeItem('masc_bearer_token')
+  })
+
+  it('includes token from sessionStorage and agent from query params', () => {
+    sessionStorage.setItem('masc_bearer_token', 'secret')
     expect(
-      buildDashboardSseUrl(
-        'dash_test',
-        '?agent=keeper-a&token=secret',
-      ),
+      buildDashboardSseUrl('dash_test', '?agent=keeper-a'),
     ).toBe('/mcp?agent=keeper-a&token=secret&session_id=dash_test&sse_kind=observer')
+  })
+
+  it('omits token when sessionStorage is empty', () => {
+    expect(buildDashboardSseUrl('dash_test', '?agent=keeper-a')).toBe(
+      '/mcp?agent=keeper-a&session_id=dash_test&sse_kind=observer',
+    )
   })
 
   it('omits optional params when they are absent', () => {


### PR DESCRIPTION
## Summary

- `buildDashboardSseUrl` 테스트를 sessionStorage 기반으로 업데이트
- PR #4272 squash merge에서 누락된 테스트 수정

## Test plan

- [ ] Dashboard CI typecheck + test 통과

Generated with [Claude Code](https://claude.com/claude-code)