### PR TITLE
fix(test): update http_auth test for missing-origin rejection

### DIFF
--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -279,13 +279,14 @@ let test_permission_for_tool_interrupt () =
    HTTP same-origin mutation guard regressions
    ============================================================ *)
 
-let test_same_origin_browser_request_allows_missing_origin () =
+let test_same_origin_browser_request_rejects_missing_origin () =
   let module Server_auth = Masc_mcp.Server_auth in
   let headers = Httpun.Headers.of_list [ ("host", "127.0.0.1:8935") ] in
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
-  | Ok () -> ()
-  | Error e -> fail (Types.masc_error_to_string e)
+  | Ok () -> fail "expected Unauthorized when Origin header is missing"
+  | Error (Types.Unauthorized _) -> ()
+  | Error e -> fail (Printf.sprintf "expected Unauthorized, got %s" (Types.masc_error_to_string e))
 
 let test_same_origin_browser_request_allows_matching_origin () =
   let module Server_auth = Masc_mcp.Server_auth in
@@ -714,8 +715,8 @@ let () =
       test_case "header token only" `Quick test_http_auth_token_from_header_only;
       test_case "reject query token fallback" `Quick
         test_http_auth_rejects_query_token_fallback;
-      test_case "same-origin allows missing origin" `Quick
-        test_same_origin_browser_request_allows_missing_origin;
+      test_case "same-origin rejects missing origin without token" `Quick
+        test_same_origin_browser_request_rejects_missing_origin;
       test_case "same-origin allows matching origin" `Quick
         test_same_origin_browser_request_allows_matching_origin;
       test_case "same-origin rejects cross origin" `Quick


### PR DESCRIPTION
## Summary
- #4272 changed `ensure_same_origin_browser_request` to reject requests without `Origin` header (unless `MASC_ALLOW_ANONYMOUS_MUTATIONS=true`)
- Test `same-origin allows missing origin` was still expecting `Ok ()`
- Updated to expect `Error Unauthorized` and renamed to match new semantics

## Test plan
- [ ] CI Build and Test passes (http_auth test #2 no longer fails)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>