### PR TITLE
fix(test): align SSE test with sessionStorage token handling

### DIFF
--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -1,14 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { buildDashboardSseUrl } from './sse'
 
 describe('buildDashboardSseUrl', () => {
+  afterEach(() => {
+    sessionStorage.removeItem('masc_bearer_token')
+  })
+
   it('uses /mcp observer stream with dashboard query params', () => {
+    sessionStorage.setItem('masc_bearer_token', 'secret')
     expect(
       buildDashboardSseUrl(
         'dash_test',
-        '?agent=keeper-a&token=secret',
+        '?agent=keeper-a',
       ),
     ).toBe('/mcp?agent=keeper-a&token=secret&session_id=dash_test&sse_kind=observer')
+  })
+
+  it('omits token when sessionStorage has no bearer token', () => {
+    expect(
+      buildDashboardSseUrl('dash_test', '?agent=keeper-a'),
+    ).toBe('/mcp?agent=keeper-a&session_id=dash_test&sse_kind=observer')
   })
 
   it('omits optional params when they are absent', () => {


### PR DESCRIPTION
## Summary
- #4272가 bearer token을 URL query에서 sessionStorage로 이동
- `sse.test.ts`가 여전히 URL로 token을 전달하여 Dashboard CI 실패
- `sessionStorage.setItem`으로 token 설정하도록 수정 + no-token 케이스 추가

## Evidence
- 로컬 vitest: 3/3 pass

## Test plan
- [x] `npx vitest run src/sse.test.ts` — 3/3 pass
- [ ] CI Dashboard green

Refs #4272

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>