### PR TITLE
fix(dashboard): normalize worktree branch display

### DIFF
--- a/dashboard/src/components/worktrees.test.ts
+++ b/dashboard/src/components/worktrees.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorktreeResponse } from './worktrees'
+
+describe('parseWorktreeResponse', () => {
+  it('parses the current JSON contract that uses path fields', () => {
+    const raw = JSON.stringify({
+      worktrees: [
+        {
+          path: '/repo/.worktrees/fix/dashboard-worktree-listing',
+          branch: 'refs/heads/fix/dashboard-worktree-listing',
+        },
+        {
+          path: '/repo/.worktrees/feat/dir-local-runtime',
+          branch: 'refs/heads/feat/dir-local-runtime',
+        },
+      ],
+    })
+
+    expect(parseWorktreeResponse(raw)).toEqual([
+      {
+        id: 'fix/dashboard-worktree-listing:/repo/.worktrees/fix/dashboard-worktree-listing:0',
+        branch: 'fix/dashboard-worktree-listing',
+        path: '/repo/.worktrees/fix/dashboard-worktree-listing',
+        agent: undefined,
+        task_id: undefined,
+        created_at: undefined,
+      },
+      {
+        id: 'feat/dir-local-runtime:/repo/.worktrees/feat/dir-local-runtime:1',
+        branch: 'feat/dir-local-runtime',
+        path: '/repo/.worktrees/feat/dir-local-runtime',
+        agent: undefined,
+        task_id: undefined,
+        created_at: undefined,
+      },
+    ])
+  })
+
+  it('accepts the legacy worktree field name', () => {
+    const raw = JSON.stringify({
+      worktrees: [
+        {
+          worktree: '/repo/.worktrees/legacy-entry',
+          branch: 'legacy-entry',
+        },
+      ],
+    })
+
+    expect(parseWorktreeResponse(raw)).toEqual([
+      {
+        id: 'legacy-entry:/repo/.worktrees/legacy-entry:0',
+        branch: 'legacy-entry',
+        path: '/repo/.worktrees/legacy-entry',
+        agent: undefined,
+        task_id: undefined,
+        created_at: undefined,
+      },
+    ])
+  })
+
+  it('keeps an empty worktree collection empty instead of showing a raw card', () => {
+    expect(parseWorktreeResponse(JSON.stringify({ worktrees: [] }))).toEqual([])
+  })
+
+  it('recovers multiple entries from raw git worktree porcelain output', () => {
+    const raw = [
+      'worktree /repo/main',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.worktrees/fix/dashboard-worktree-listing',
+      'HEAD def456',
+      'branch refs/heads/fix/dashboard-worktree-listing',
+      '',
+      'worktree /repo/.worktrees/fix/detached-check',
+      'HEAD fedcba',
+      'detached',
+    ].join('\n')
+
+    expect(parseWorktreeResponse(raw)).toEqual([
+      {
+        id: 'main:/repo/main:0',
+        branch: 'main',
+        path: '/repo/main',
+      },
+      {
+        id: 'fix/dashboard-worktree-listing:/repo/.worktrees/fix/dashboard-worktree-listing:1',
+        branch: 'fix/dashboard-worktree-listing',
+        path: '/repo/.worktrees/fix/dashboard-worktree-listing',
+      },
+      {
+        id: '(detached):/repo/.worktrees/fix/detached-check:2',
+        branch: '(detached)',
+        path: '/repo/.worktrees/fix/detached-check',
+      },
+    ])
+  })
+
+  it('keeps the raw response when nothing else can be parsed', () => {
+    expect(parseWorktreeResponse('not-json-and-not-porcelain')).toEqual([
+      {
+        id: 'raw',
+        branch: 'Unknown',
+        path: 'not-json-and-not-porcelain',
+      },
+    ])
+  })
+})

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -4,6 +4,8 @@ import { LoadingState } from './common/feedback-state'
 import { useEffect, useState } from 'preact/hooks'
 import { callMcpTool } from '../api/mcp'
 
+const REFS_HEADS_PREFIX = 'refs/heads/'
+
 interface Worktree {
   id: string
   branch: string
@@ -11,6 +13,148 @@ interface Worktree {
   agent?: string
   task_id?: string
   created_at?: string
+}
+
+function normalizeWorktreeBranch(branch: string): string {
+  if (branch.startsWith(REFS_HEADS_PREFIX)) {
+    return branch.slice(REFS_HEADS_PREFIX.length)
+  }
+  return branch
+}
+
+function normalizeWorktreeEntry(entry: unknown, index: number): Worktree | null {
+  if (!entry || typeof entry !== 'object') {
+    return null
+  }
+
+  const record = entry as Record<string, unknown>
+  const rawPath = record.path ?? record.worktree
+  const path = typeof rawPath === 'string' ? rawPath.trim() : ''
+  const rawBranch = typeof record.branch === 'string' ? record.branch.trim() : ''
+  const branch = normalizeWorktreeBranch(rawBranch)
+
+  if (!path || !branch) {
+    return null
+  }
+
+  return {
+    id:
+      typeof record.id === 'string' && record.id.trim()
+        ? record.id
+        : `${branch}:${path}:${index}`,
+    branch,
+    path,
+    agent: typeof record.agent === 'string' ? record.agent : undefined,
+    task_id:
+      typeof record.task_id === 'string'
+        ? record.task_id
+        : typeof record.taskId === 'string'
+          ? record.taskId
+          : undefined,
+    created_at:
+      typeof record.created_at === 'string'
+        ? record.created_at
+        : typeof record.createdAt === 'string'
+          ? record.createdAt
+          : undefined,
+  }
+}
+
+function collectWorktreeItems(parsed: unknown): unknown[] {
+  if (Array.isArray(parsed)) {
+    return parsed
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return []
+  }
+
+  const record = parsed as Record<string, unknown>
+  if (Array.isArray(record.worktrees)) {
+    return record.worktrees
+  }
+  if (Array.isArray(record.items)) {
+    return record.items
+  }
+  return []
+}
+
+function hasWorktreeCollection(parsed: unknown): boolean {
+  if (Array.isArray(parsed)) {
+    return true
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return false
+  }
+
+  const record = parsed as Record<string, unknown>
+  return Array.isArray(record.worktrees) || Array.isArray(record.items)
+}
+
+function parsePorcelainWorktrees(raw: string): Worktree[] {
+  const blocks = raw
+    .trim()
+    .split(/\n\s*\n/)
+    .map(block => block.trim())
+    .filter(Boolean)
+
+  return blocks
+    .map((block, index) => {
+      let path = ''
+      let branch = ''
+      let detached = false
+
+      for (const line of block.split('\n').map(item => item.trim())) {
+        if (line.startsWith('worktree ')) {
+          path = line.slice('worktree '.length).trim()
+        } else if (line.startsWith('branch ')) {
+          branch = normalizeWorktreeBranch(line.slice('branch '.length).trim())
+        } else if (line === 'detached') {
+          detached = true
+        }
+      }
+
+      if (!path) {
+        return null
+      }
+
+      const label = branch || (detached ? '(detached)' : '')
+      if (!label) {
+        return null
+      }
+
+      return {
+        id: `${label}:${path}:${index}`,
+        branch: label,
+        path,
+      } satisfies Worktree
+    })
+    .filter((item): item is Worktree => item !== null)
+}
+
+export function parseWorktreeResponse(raw: string): Worktree[] {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    const worktrees = collectWorktreeItems(parsed)
+      .map((entry, index) => normalizeWorktreeEntry(entry, index))
+      .filter((entry): entry is Worktree => entry !== null)
+    if (worktrees.length > 0 || hasWorktreeCollection(parsed)) {
+      return worktrees
+    }
+  } catch {
+    // Fall through to raw text parsing.
+  }
+
+  const porcelainWorktrees = parsePorcelainWorktrees(raw)
+  if (porcelainWorktrees.length > 0) {
+    return porcelainWorktrees
+  }
+
+  return [{ id: 'raw', branch: 'Unknown', path: raw }]
 }
 
 export function Worktrees() {
@@ -23,12 +167,7 @@ export function Worktrees() {
       try {
         setLoading(true)
         const resText = await callMcpTool('masc_worktree_list', {})
-        try {
-          const parsed = JSON.parse(resText)
-          setWorktrees(Array.isArray(parsed) ? parsed : parsed.worktrees || [])
-        } catch {
-          setWorktrees([{ id: 'raw', branch: 'Unknown', path: resText }])
-        }
+        setWorktrees(parseWorktreeResponse(resText))
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : '워크트리 로드 실패')
       } finally {

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -146,6 +146,25 @@ let add_group label lines empty_msg =
   else
     (label ^ ":") :: List.map (fun line -> "  " ^ line) lines
 
+let normalize_worktree_branch branch =
+  let branch = String.trim branch in
+  let prefix = "refs/heads/" in
+  if String.length branch >= String.length prefix
+     && String.sub branch 0 (String.length prefix) = prefix then
+    String.sub branch (String.length prefix)
+      (String.length branch - String.length prefix)
+  else
+    branch
+
+let worktree_path_of_json item =
+  let module U = Yojson.Safe.Util in
+  match item |> U.member "path" with
+  | `String path when String.trim path <> "" -> Some path
+  | _ ->
+      (match item |> U.member "worktree" with
+       | `String path when String.trim path <> "" -> Some path
+       | _ -> None)
+
 let parse_worktrees (json : Yojson.Safe.t) : (string * string) list =
   let module U = Yojson.Safe.Util in
   match json |> U.member "worktrees" with
@@ -154,14 +173,16 @@ let parse_worktrees (json : Yojson.Safe.t) : (string * string) list =
         (fun item ->
           match item with
           | `Assoc _ ->
-              (try
-                 let worktree = item |> U.member "worktree" |> U.to_string in
-                 let branch = item |> U.member "branch" |> U.to_string in
-                 if String.length branch > 0 && not (String.equal branch "HEAD") then
+              let branch =
+                match item |> U.member "branch" with
+                | `String raw_branch -> Some (normalize_worktree_branch raw_branch)
+                | _ -> None
+              in
+              (match worktree_path_of_json item, branch with
+               | Some worktree, Some branch
+                 when String.length branch > 0 && not (String.equal branch "HEAD") ->
                    Some (branch, worktree)
-                 else
-                   None
-               with Yojson.Safe.Util.Type_error _ -> None)
+               | _ -> None)
           | _ -> None)
         items
   | `Null -> []

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -232,50 +232,5 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
 let worktree_list config =
   if not (is_initialized config) then
     `Assoc [("error", `String "MASC not initialized")]
-  else begin
-    match git_root config with
-    | None -> `Assoc [("error", `String "Not a git repository")]
-    | Some root ->
-        let lines = run_argv_lines ["git"; "-C"; root; "worktree"; "list"; "--porcelain"] in
-
-        (* Parse porcelain output into worktree info *)
-        let rec parse_worktrees lines current acc =
-          match lines with
-          | [] ->
-              if current <> [] then List.rev (List.rev current :: acc)
-              else List.rev acc
-          | "" :: rest ->
-              if current <> [] then parse_worktrees rest [] (List.rev current :: acc)
-              else parse_worktrees rest [] acc
-          | line :: rest ->
-              parse_worktrees rest (line :: current) acc
-        in
-        let worktree_blocks = parse_worktrees lines [] [] in
-
-        let parse_block block =
-          let path = ref "" in
-          let branch = ref "" in
-          List.iter (fun line ->
-            if String.length line > 9 && String.sub line 0 9 = "worktree " then
-              path := String.sub line 9 (String.length line - 9)
-            else if String.length line > 7 && String.sub line 0 7 = "branch " then
-              branch := String.sub line 7 (String.length line - 7)
-          ) block;
-          if !path <> "" then
-            Some (`Assoc [
-              ("path", `String !path);
-              ("branch", `String !branch);
-              ("is_masc", `Bool (String.length !path > 11 &&
-                try String.sub !path (String.length !path - 11) 11 = ".worktrees/"
-                with Invalid_argument _ -> false));
-            ])
-          else None
-        in
-
-        let worktrees = List.filter_map parse_block worktree_blocks in
-        `Assoc [
-          ("worktrees", `List worktrees);
-          ("count", `Int (List.length worktrees));
-          ("masc_hint", `String "Use masc_worktree_create to add a new worktree for your task");
-        ]
-  end
+  else
+    Room_git.list ~base_path:config.base_path

--- a/test/test_dashboard_coverage.ml
+++ b/test/test_dashboard_coverage.ml
@@ -202,18 +202,37 @@ let test_parse_worktrees_missing () =
 let test_parse_worktrees_valid () =
   let json = `Assoc [
     ("worktrees", `List [
-      `Assoc [("worktree", `String "/path/to/wt"); ("branch", `String "feature-x")];
-      `Assoc [("worktree", `String "/path/to/wt2"); ("branch", `String "bugfix")];
+      `Assoc [("path", `String "/path/to/wt"); ("branch", `String "feature-x")];
+      `Assoc [("path", `String "/path/to/wt2"); ("branch", `String "bugfix")];
     ])
   ] in
   let result = Dashboard.parse_worktrees json in
   check int "two worktrees" 2 (List.length result)
 
+let test_parse_worktrees_legacy_worktree_key () =
+  let json = `Assoc [
+    ("worktrees", `List [
+      `Assoc [("worktree", `String "/path/to/wt"); ("branch", `String "feature-x")];
+    ])
+  ] in
+  let result = Dashboard.parse_worktrees json in
+  check int "legacy worktree key still supported" 1 (List.length result)
+
+let test_parse_worktrees_strips_refs_heads_prefix () =
+  let json = `Assoc [
+    ("worktrees", `List [
+      `Assoc [("path", `String "/path/to/wt"); ("branch", `String "refs/heads/feature-x")];
+    ])
+  ] in
+  let result = Dashboard.parse_worktrees json in
+  check (list (pair string string)) "normalizes git refs"
+    [("feature-x", "/path/to/wt")] result
+
 let test_parse_worktrees_skips_head () =
   let json = `Assoc [
     ("worktrees", `List [
-      `Assoc [("worktree", `String "/repo"); ("branch", `String "HEAD")];
-      `Assoc [("worktree", `String "/wt"); ("branch", `String "main")];
+      `Assoc [("path", `String "/repo"); ("branch", `String "HEAD")];
+      `Assoc [("path", `String "/wt"); ("branch", `String "main")];
     ])
   ] in
   let result = Dashboard.parse_worktrees json in
@@ -222,8 +241,8 @@ let test_parse_worktrees_skips_head () =
 let test_parse_worktrees_skips_empty_branch () =
   let json = `Assoc [
     ("worktrees", `List [
-      `Assoc [("worktree", `String "/wt"); ("branch", `String "")];
-      `Assoc [("worktree", `String "/wt2"); ("branch", `String "valid")];
+      `Assoc [("path", `String "/wt"); ("branch", `String "")];
+      `Assoc [("path", `String "/wt2"); ("branch", `String "valid")];
     ])
   ] in
   let result = Dashboard.parse_worktrees json in
@@ -233,7 +252,7 @@ let test_parse_worktrees_malformed_item () =
   let json = `Assoc [
     ("worktrees", `List [
       `String "not an object";
-      `Assoc [("worktree", `String "/wt"); ("branch", `String "ok")];
+      `Assoc [("path", `String "/wt"); ("branch", `String "ok")];
     ])
   ] in
   let result = Dashboard.parse_worktrees json in
@@ -242,8 +261,8 @@ let test_parse_worktrees_malformed_item () =
 let test_parse_worktrees_missing_branch () =
   let json = `Assoc [
     ("worktrees", `List [
-      `Assoc [("worktree", `String "/wt")];
-      `Assoc [("worktree", `String "/wt2"); ("branch", `String "valid")];
+      `Assoc [("path", `String "/wt")];
+      `Assoc [("path", `String "/wt2"); ("branch", `String "valid")];
     ])
   ] in
   let result = Dashboard.parse_worktrees json in
@@ -305,6 +324,8 @@ let () =
       test_case "null" `Quick test_parse_worktrees_null;
       test_case "missing" `Quick test_parse_worktrees_missing;
       test_case "valid" `Quick test_parse_worktrees_valid;
+      test_case "legacy worktree key" `Quick test_parse_worktrees_legacy_worktree_key;
+      test_case "strips refs heads prefix" `Quick test_parse_worktrees_strips_refs_heads_prefix;
       test_case "skips HEAD" `Quick test_parse_worktrees_skips_head;
       test_case "skips empty branch" `Quick test_parse_worktrees_skips_empty_branch;
       test_case "malformed item" `Quick test_parse_worktrees_malformed_item;


### PR DESCRIPTION
## Summary
- `refs/heads/` prefix를 제거하여 worktree 브랜치명 정규화
- Worktree entry 파싱 강화 (fallback ID, camelCase/snake_case 호환)
- Backend `room_worktree.ml` 정리 및 `dashboard.ml` 정렬

## Status
WIP — 방치된 worktree에서 발굴한 미완성 작업. 빌드 검증 필요.

## Test plan
- [ ] `dune build` 통과
- [ ] 대시보드 worktree 목록 표시 확인
- [ ] `worktrees.test.ts` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)