### PR TITLE
fix(keeper): bypass fresher_meta in dashboard tool API writes

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -768,8 +768,8 @@ let fresher_meta config (meta : keeper_meta) : keeper_meta =
       if existing_ts > incoming_ts then existing else meta
   | Ok None | Error _ -> meta
 
-let write_meta config (m : keeper_meta) : (unit, string) result =
-  let persisted = fresher_meta config m in
+let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result =
+  let persisted = if force then m else fresher_meta config m in
   let path = keeper_meta_path config persisted.name in
   let json = meta_to_json persisted in
   try

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -176,7 +176,7 @@ val keeper_names : Room.config -> string list
 val keepalive_keeper_names : Room.config -> string list
 val persistent_agent_names : Room.config -> string list
 val fresher_meta : Room.config -> keeper_meta -> keeper_meta
-val write_meta : Room.config -> keeper_meta -> (unit, string) result
+val write_meta : ?force:bool -> Room.config -> keeper_meta -> (unit, string) result
 val read_meta : Room.config -> string -> (keeper_meta option, string) result
 
 (** {1 Re-exports from Keeper_types_support} *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -96,7 +96,7 @@ let handle_keeper_tools_post state req reqd =
                  Http.Response.json ~status:`Bad_request
                    (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg)) reqd
              | Ok meta' ->
-                 (match Keeper_types.write_meta config meta' with
+                 (match Keeper_types.write_meta ~force:true config meta' with
                   | Ok () ->
                       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta' in
                       let masc_count = List.length (List.filter (fun n -> String.starts_with ~prefix:"masc_" n) allowed) in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -96,6 +96,9 @@ let handle_keeper_tools_post state req reqd =
                  Http.Response.json ~status:`Bad_request
                    (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg)) reqd
              | Ok meta' ->
+                 (* force: user-initiated tool config is authoritative.
+                    fresher_meta would discard this write if a concurrent
+                    keeper turn updated meta between our read and write. *)
                  (match Keeper_types.write_meta ~force:true config meta' with
                   | Ok () ->
                       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta' in


### PR DESCRIPTION
## Summary

- `write_meta`가 `fresher_meta`를 호출하여 디스크 meta의 `updated_at`이 더 크면 incoming을 버림
- dashboard API와 keeper turn이 동시에 meta를 수정하면 API 변경이 silent drop됨
- `write_meta`에 `~force:bool` 옵션 추가 (기본 false, 기존 동작 유지)
- dashboard tool API에서 `~force:true`로 호출하여 mutation 보장

## Test plan

- [ ] `dune build` 성공
- [ ] 기존 write_meta callers (15+ 곳) 변경 없음 (optional param, default false)
- [ ] dashboard tool API에서 set_allowlist 후 meta.json 실제 갱신 확인

Fixes #4247

🤖 Generated with [Claude Code](https://claude.com/claude-code)