### PR TITLE
feat(team-session): add single-agent fallback gate (#3651)

### DIFF
--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -194,6 +194,41 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
             finalizing = false;
             generate_report_on_finalize = true;
           });
+    (* Phase C-2b-gate: Single-agent fallback gate (#3651).
+       Classify task decomposability before swarm dispatch.
+       Low → trim to single worker to avoid swarm overhead on sequential tasks. *)
+    let decomp, decomp_reason =
+      Team_session_engine_policy.classify_decomposability
+        ~orchestration_mode
+        ~planned_workers:session.planned_workers
+    in
+    let session =
+      if decomp = Team_session_types.Decomposability_low
+         && List.length session.planned_workers > 1 then begin
+        let kept = match session.planned_workers with w :: _ -> [w] | [] -> [] in
+        let trimmed = List.length session.planned_workers - List.length kept in
+        Team_session_store.append_event config session_id
+          ~event_type:"single_agent_gate"
+          ~detail:(`Assoc [
+            ("decomposability", `String (Team_session_types.decomposability_to_string decomp));
+            ("reason", `String decomp_reason);
+            ("original_worker_count", `Int (List.length session.planned_workers));
+            ("trimmed_workers", `Int trimmed);
+            ("ts_iso", `String (Types.now_iso ()));
+          ]);
+        { session with planned_workers = kept }
+      end else begin
+        Team_session_store.append_event config session_id
+          ~event_type:"decomposability_classified"
+          ~detail:(`Assoc [
+            ("decomposability", `String (Team_session_types.decomposability_to_string decomp));
+            ("reason", `String decomp_reason);
+            ("worker_count", `Int (List.length session.planned_workers));
+            ("ts_iso", `String (Types.now_iso ()));
+          ]);
+        session
+      end
+    in
     (* Phase C-2c: All modes use OAS Swarm Runner.
        orchestration_mode is mapped by the bridge:
          Auto → Decentralized, Manual/Assist → Supervisor.

--- a/lib/team_session/team_session_engine_policy.ml
+++ b/lib/team_session/team_session_engine_policy.ml
@@ -145,6 +145,61 @@ let maybe_add_fallback_task ~(config : Room.config)
       updated_at_iso = now_iso ();
     }
 
+(** Classify task decomposability from planned workers.
+    Returns (classification, human-readable reason). *)
+let classify_decomposability
+    ~(orchestration_mode : Team_session_types.orchestration_mode)
+    ~(planned_workers : Team_session_types.planned_worker list) :
+    Team_session_types.decomposability * string =
+  (* Manual mode: user explicitly configured workers, skip gate *)
+  if orchestration_mode = Team_session_types.Manual then
+    (Team_session_types.Decomposability_high, "manual orchestration — gate skipped")
+  else
+    let n = List.length planned_workers in
+    if n <= 1 then
+      (Team_session_types.Decomposability_low,
+       Printf.sprintf "single planned worker (n=%d)" n)
+    else
+      let classes =
+        List.filter_map
+          (fun (pw : Team_session_types.planned_worker) -> pw.worker_class)
+          planned_workers
+      in
+      let profiles =
+        List.filter_map
+          (fun (pw : Team_session_types.planned_worker) -> pw.task_profile)
+          planned_workers
+      in
+      (* Manager + Executor only → sequential dependency chain *)
+      let only_manager_executor =
+        classes <> [] &&
+        List.for_all
+          (fun c ->
+            c = Team_session_types.Worker_manager
+            || c = Team_session_types.Worker_executor)
+          classes
+      in
+      (* High-coupling profiles: synthesize, decide *)
+      let has_high_coupling =
+        List.exists
+          (fun p ->
+            p = Team_session_types.Profile_synthesize
+            || p = Team_session_types.Profile_decide)
+          profiles
+      in
+      if only_manager_executor then
+        (Team_session_types.Decomposability_low,
+         "all workers are manager/executor — sequential dependency")
+      else if has_high_coupling && n <= 2 then
+        (Team_session_types.Decomposability_low,
+         "high-coupling profiles (synthesize/decide) with few workers")
+      else if has_high_coupling then
+        (Team_session_types.Decomposability_medium,
+         "high-coupling profiles present but sufficient worker count")
+      else
+        (Team_session_types.Decomposability_high,
+         Printf.sprintf "independent subtasks (n=%d)" n)
+
 let apply_runtime_policy ~(config : Room.config)
     (session : Team_session_types.session) : Team_session_types.session =
   let session =

--- a/lib/team_session/team_session_engine_policy.ml
+++ b/lib/team_session/team_session_engine_policy.ml
@@ -156,9 +156,10 @@ let classify_decomposability
     (Team_session_types.Decomposability_high, "manual orchestration — gate skipped")
   else
     let n = List.length planned_workers in
-    if n <= 1 then
-      (Team_session_types.Decomposability_low,
-       Printf.sprintf "single planned worker (n=%d)" n)
+    if n = 0 then
+      (Team_session_types.Decomposability_high, "no planned workers — gate deferred")
+    else if n = 1 then
+      (Team_session_types.Decomposability_low, "single planned worker")
     else
       let classes =
         List.filter_map
@@ -172,7 +173,7 @@ let classify_decomposability
       in
       (* Manager + Executor only → sequential dependency chain *)
       let only_manager_executor =
-        classes <> [] &&
+        List.length classes >= 2 &&
         List.for_all
           (fun c ->
             c = Team_session_types.Worker_manager

--- a/lib/team_session_types/team_session_types_enums.ml
+++ b/lib/team_session_types/team_session_types_enums.ml
@@ -105,6 +105,11 @@ type risk_level =
   | Risk_medium
   | Risk_high
 
+type decomposability =
+  | Decomposability_high
+  | Decomposability_medium
+  | Decomposability_low
+
 type capsule_mode =
   | Capsule_fresh
   | Capsule_inherit
@@ -520,3 +525,13 @@ let control_domain_of_string = function
   | "runtime" -> Some Domain_runtime
   | "meta" -> Some Domain_meta
   | _ -> None
+
+let decomposability_to_string = function
+  | Decomposability_high -> "high"
+  | Decomposability_medium -> "medium"
+  | Decomposability_low -> "low"
+
+let decomposability_of_string = function
+  | "high" -> Decomposability_high
+  | "low" -> Decomposability_low
+  | _ -> Decomposability_medium

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -119,5 +119,15 @@ let () =
             `Quick
             Test_tool_team_session_flow
               .test_filesystem_backend_event_lock_serializes_fibers;
+          Alcotest.test_case "decomposability-single-worker" `Quick
+            Test_tool_team_session_misc.test_decomposability_single_worker;
+          Alcotest.test_case "decomposability-manager-executor-only" `Quick
+            Test_tool_team_session_misc.test_decomposability_manager_executor_only;
+          Alcotest.test_case "decomposability-independent-workers" `Quick
+            Test_tool_team_session_misc.test_decomposability_independent_workers;
+          Alcotest.test_case "decomposability-manual-skips-gate" `Quick
+            Test_tool_team_session_misc.test_decomposability_manual_skips_gate;
+          Alcotest.test_case "decomposability-synthesize-few-workers" `Quick
+            Test_tool_team_session_misc.test_decomposability_synthesize_few_workers;
         ] );
     ]

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -461,3 +461,73 @@ let test_delegate_rejects_not_ready_worker_with_guidance () =
   Alcotest.(check bool) "mentions not ready guidance" true
     (String.length message > 0 && contains 0);
   cleanup_dir base_dir
+
+(* ── single-agent fallback gate (#3651) tests ─────────────── *)
+
+let make_pw ?(worker_class : Team_session_types.worker_class option)
+    ?(task_profile : Team_session_types.task_profile option)
+    (name : string) : Team_session_types.planned_worker =
+  { spawn_agent = name; runtime_actor = None; spawn_role = None;
+    spawn_model = None; execution_scope = None; thinking_enabled = None;
+    thinking_budget = None; max_turns = None; timeout_seconds = None;
+    worker_class; parent_actor = None; capsule_mode = None;
+    runtime_pool = None; lane_id = None; controller_level = None;
+    control_domain = None; supervisor_actor = None; model_tier = None;
+    task_profile; risk_level = None; routing_confidence = None;
+    routing_reason = None; routing_escalated = false }
+
+let test_decomposability_single_worker () =
+  let pw = make_pw "solo" in
+  let decomp, _reason =
+    Team_session_engine_policy.classify_decomposability
+      ~orchestration_mode:Team_session_types.Auto
+      ~planned_workers:[pw]
+  in
+  Alcotest.(check string) "single worker → low"
+    "low" (Team_session_types.decomposability_to_string decomp)
+
+let test_decomposability_manager_executor_only () =
+  let pw1 = make_pw ~worker_class:Worker_manager "mgr" in
+  let pw2 = make_pw ~worker_class:Worker_executor "exec" in
+  let decomp, _reason =
+    Team_session_engine_policy.classify_decomposability
+      ~orchestration_mode:Team_session_types.Auto
+      ~planned_workers:[pw1; pw2]
+  in
+  Alcotest.(check string) "manager+executor → low"
+    "low" (Team_session_types.decomposability_to_string decomp)
+
+let test_decomposability_independent_workers () =
+  let pw1 = make_pw ~worker_class:Worker_scout "scout1" in
+  let pw2 = make_pw ~worker_class:Worker_librarian "lib1" in
+  let pw3 = make_pw ~worker_class:Worker_scout "scout2" in
+  let decomp, _reason =
+    Team_session_engine_policy.classify_decomposability
+      ~orchestration_mode:Team_session_types.Auto
+      ~planned_workers:[pw1; pw2; pw3]
+  in
+  Alcotest.(check string) "diverse workers → high"
+    "high" (Team_session_types.decomposability_to_string decomp)
+
+let test_decomposability_manual_skips_gate () =
+  let pw = make_pw "solo" in
+  let decomp, reason =
+    Team_session_engine_policy.classify_decomposability
+      ~orchestration_mode:Team_session_types.Manual
+      ~planned_workers:[pw]
+  in
+  Alcotest.(check string) "manual → high (gate skipped)"
+    "high" (Team_session_types.decomposability_to_string decomp);
+  Alcotest.(check bool) "reason mentions manual" true
+    (String.length reason > 0)
+
+let test_decomposability_synthesize_few_workers () =
+  let pw1 = make_pw ~task_profile:Profile_synthesize "synth" in
+  let pw2 = make_pw ~task_profile:Profile_extract "extract" in
+  let decomp, _reason =
+    Team_session_engine_policy.classify_decomposability
+      ~orchestration_mode:Team_session_types.Auto
+      ~planned_workers:[pw1; pw2]
+  in
+  Alcotest.(check string) "synthesize + 2 workers → low"
+    "low" (Team_session_types.decomposability_to_string decomp)


### PR DESCRIPTION
## Summary
- Multi-agent swarm 전에 task decomposability를 분류하는 pre-swarm gate 추가
- Low decomposability → single worker로 trim하여 swarm 오버헤드 방지
- Deterministic 분류: LLM 판단이 아닌 구조적 분석 (worker class, task profile, worker count)

## Classification rules

| Condition | Classification | Reason |
|-----------|---------------|--------|
| `planned_workers` = 1 | Low | Single worker, no parallelism |
| All workers are Manager/Executor | Low | Sequential dependency chain |
| Synthesize/Decide profile + <= 2 workers | Low | High coupling, insufficient parallelism |
| Synthesize/Decide profile + 3+ workers | Medium | High coupling but worker count mitigates |
| Manual orchestration | High (gate skipped) | User explicitly configured |
| Otherwise | High | Independent subtasks |

## Changes

| File | Action |
|------|--------|
| `team_session_types_enums.ml` | `decomposability` type + to/of_string |
| `team_session_engine_policy.ml` | `classify_decomposability` function |
| `team_session_engine_eio.ml` | Gate integration before swarm fork |
| `test_tool_team_session_misc.ml` | 5 unit tests |
| `test_tool_team_session.ml` | Test registration |

## Design decisions
- Gate는 **선행 필터** — 기존 `fallback_policy`(후행 정책)와 독립
- Manual mode에서는 gate skip — 사용자가 명시적으로 구성한 worker set을 존중
- Event system으로 audit trail 자동 기록 (`single_agent_gate` / `decomposability_classified`)

## Test plan
- [x] `dune build` — 전체 빌드 성공
- [x] `test_tool_team_session` — 54/54 통과 (5개 decomposability 테스트 포함)
- [ ] CI green

Closes #3651

🤖 Generated with [Claude Code](https://claude.com/claude-code)