### PR TITLE
[codex] tighten MASC/OAS/MCP boundary ownership

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -381,9 +381,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                            ("has_checkpoint", `Bool true);
                            ("source", `String "checkpoint");
                            ("context_ratio", `Float (Keeper_exec_context.context_ratio c));
-                           ("context_tokens", `Int c.token_count);
+                           ("context_tokens", `Int (Keeper_exec_context.token_count c));
                            ("context_max", `Int c.max_tokens);
-                           ("message_count", `Int (List.length c.messages));
+                           ("message_count", `Int (Keeper_exec_context.message_count c));
                          ])
           in
 	          let context_source =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -208,9 +208,6 @@ let run_turn
   let history_messages = ctx_work.messages in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
-  let checkpoint_sidecar =
-    Keeper_exec_context.checkpoint_sidecar_json ~generation ctx_work
-  in
   (* 7. Set up agent *)
   let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
@@ -423,7 +420,6 @@ let run_turn
           ~agent_ref
           ?contract
           ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
-          ~working_context:checkpoint_sidecar
           ~priority:(Option.value priority ~default:Llm_provider.Request_priority.Interactive)
           ~cache_system_prompt:true
           ()

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -41,38 +41,32 @@ let log_keeper_exn ~label exn =
   in
   Log.Keeper.info "%s%s: %s" tag label (Printexc.to_string exn)
 
-let checkpoint_sidecar_json ?(generation = 0) (ctx : working_context) :
-    Yojson.Safe.t =
-  `Assoc
-    [
-      ("kind", `String "keeper_working_context_v1");
-      ("max_tokens", `Int ctx.max_tokens);
-      ("generation", `Int generation);
-    ]
+let checkpoint_generation_key = "keeper_generation"
 
-let sidecar_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
+let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
-  match cp.working_context with
-  | Some (`Assoc _ as sidecar) ->
-      sidecar |> member "max_tokens" |> to_int_option |> Option.value ~default:fallback
-  | _ -> fallback
+  match cp.max_total_tokens with
+  | Some value -> value
+  | None -> (
+      match cp.working_context with
+      | Some (`Assoc _ as sidecar) ->
+          sidecar |> member "max_tokens" |> to_int_option
+          |> Option.value ~default:fallback
+      | _ -> fallback)
 
 let context_of_oas_checkpoint
     (cp : Agent_sdk.Checkpoint.t)
     ~(primary_model_max_tokens : int) : working_context =
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
-    sidecar_max_tokens cp ~fallback:primary_model_max_tokens
+    checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
   in
-  let token_count = count_tokens system_prompt cp.messages in
   sync_oas_context
     {
       system_prompt;
       messages = cp.messages;
-      token_count;
       max_tokens;
-      importance_scores = [];
-      oas_context = Agent_sdk.Context.copy cp.context;
+      context = Agent_sdk.Context.copy cp.context;
     }
 
 let context_of_legacy_checkpoint
@@ -95,6 +89,9 @@ let save_oas_checkpoint
     ~(ctx : working_context)
     ~(generation : int)
   : Agent_sdk.Checkpoint.t =
+  let checkpoint_context = Agent_sdk.Context.copy ctx.context in
+  Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
+    checkpoint_generation_key (`Int generation);
   let state =
     {
       Agent_sdk.Types.config =
@@ -113,23 +110,29 @@ let save_oas_checkpoint
   let checkpoint =
     Agent_sdk.Agent_checkpoint.build_checkpoint
       ~session_id:session.session_id
-      ~working_context:(checkpoint_sidecar_json ~generation ctx)
       ~state
       ~tools:Agent_sdk.Tool_set.empty
-      ~context:(Agent_sdk.Context.copy ctx.oas_context)
+      ~context:checkpoint_context
       ~mcp_clients:[]
       ()
   in
   Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint;
   checkpoint
 
-let sidecar_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
+let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
-  match cp.working_context with
-  | Some (`Assoc _ as sidecar) ->
-      sidecar |> member "generation" |> to_int_option
-      |> Option.value ~default:fallback
-  | _ -> fallback
+  match
+    Agent_sdk.Context.get_scoped cp.context Agent_sdk.Context.Session
+      checkpoint_generation_key
+  with
+  | Some (`Int value) -> value
+  | Some (`Intlit raw) -> Option.value ~default:fallback (int_of_string_opt raw)
+  | _ -> (
+      match cp.working_context with
+      | Some (`Assoc _ as sidecar) ->
+          sidecar |> member "generation" |> to_int_option
+          |> Option.value ~default:fallback
+      | _ -> fallback)
 
 type handoff_rollover = {
   updated_meta : keeper_meta;
@@ -180,7 +183,7 @@ let maybe_rollover_oas_handoff
   | Some cp ->
       let ctx = context_of_oas_checkpoint cp ~primary_model_max_tokens in
       let current_generation =
-        sidecar_generation cp ~fallback:meta.runtime.generation
+        checkpoint_generation cp ~fallback:meta.runtime.generation
       in
       let base_meta =
         if current_generation = meta.runtime.generation then meta
@@ -197,9 +200,9 @@ let maybe_rollover_oas_handoff
           updated_meta = base_meta;
           handoff_json = None;
           context_ratio = ratio;
-          context_tokens = ctx.token_count;
+          context_tokens = token_count ctx;
           context_max = ctx.max_tokens;
-          message_count = List.length ctx.messages;
+          message_count = message_count ctx;
         }
       in
       if
@@ -311,8 +314,8 @@ let compact_if_needed
     (ctx : working_context) :
     working_context * string option * string =
   let ratio = context_ratio ctx in
-  let message_count = List.length ctx.messages in
-  let token_count = ctx.token_count in
+  let message_count = message_count ctx in
+  let token_count = token_count ctx in
   let ratio_gate, message_gate, token_gate = compaction_policy_of_keeper meta in
   let cooldown = Float.of_int meta.compaction.cooldown_sec in
   let last_reflection_ts = max meta.runtime.last_continuity_update_ts meta.runtime.proactive_rt.last_ts in
@@ -397,7 +400,7 @@ let compact_if_needed
       | exn ->
           Log.Harness.warn "[pre_compact] sse broadcast failed: %s"
             (Printexc.to_string exn));
-      let messages, token_count =
+      let messages =
           let msgs_after_compact, _ =
             Context_compact_oas.compact
               ~system_prompt:ctx.system_prompt
@@ -412,11 +415,11 @@ let compact_if_needed
           let token_count =
             Context_compact_oas.count_tokens ctx.system_prompt msgs_after_fold
           in
-          (msgs_after_fold, token_count)
+          let _ = token_count in
+          msgs_after_fold
         in
         let compacted_ctx =
-          sync_oas_context
-            { ctx with messages; token_count; importance_scores = [] }
+          sync_oas_context { ctx with messages }
         in
         (compacted_ctx, Some reason, "applied:" ^ reason)
 
@@ -482,7 +485,7 @@ let apply_post_turn_lifecycle
   | Some cp ->
       let ctx = context_of_oas_checkpoint cp ~primary_model_max_tokens in
       let current_generation =
-        sidecar_generation cp ~fallback:meta.runtime.generation
+        checkpoint_generation cp ~fallback:meta.runtime.generation
       in
       let base_meta =
         if current_generation = meta.runtime.generation then meta
@@ -491,14 +494,14 @@ let apply_post_turn_lifecycle
             (fun rt -> { rt with generation = current_generation })
             meta
       in
-      let before_tokens = ctx.token_count in
+      let before_tokens = token_count ctx in
       let compacted_ctx, trigger, decision =
         compact_if_needed ~meta:base_meta ~now_ts ctx
       in
       let compaction_applied =
         String.starts_with ~prefix:"applied:" decision
       in
-      let after_tokens = compacted_ctx.token_count in
+      let after_tokens = token_count compacted_ctx in
       let saved_tokens = max 0 (before_tokens - after_tokens) in
       let meta_after_compaction =
         map_runtime

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -29,10 +29,7 @@ val load_latest_checkpoint : session_context -> checkpoint option
 
 val log_keeper_exn : label:string -> exn -> unit
 
-val checkpoint_sidecar_json :
-  ?generation:int -> working_context -> Yojson.Safe.t
-
-val sidecar_max_tokens :
+val checkpoint_max_tokens :
   Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint :
@@ -51,7 +48,7 @@ val save_oas_checkpoint :
   generation:int ->
   Agent_sdk.Checkpoint.t
 
-val sidecar_generation :
+val checkpoint_generation :
   Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 (** {1 Handoff Rollover} *)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -265,9 +265,9 @@ let execute_keeper_tool_call
             ("trace_id", `String meta.runtime.trace_id);
             ("generation", `Int meta.runtime.generation);
             ("context_ratio", `Float (Keeper_working_context.context_ratio ctx_work));
-            ("context_tokens", `Int ctx_work.token_count);
+            ("context_tokens", `Int (Keeper_working_context.token_count ctx_work));
             ("context_max", `Int ctx_work.max_tokens);
-            ("message_count", `Int (List.length ctx_work.messages));
+            ("message_count", `Int (Keeper_working_context.message_count ctx_work));
             ("last_model_used", `String meta.runtime.usage.last_model_used);
             ( "continuity_state",
               match continuity with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -337,8 +337,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                      let auto_rules =
                        evaluate_keeper_auto_rules ~meta:meta_current
                          ~context_ratio:(Keeper_exec_context.context_ratio c)
-                         ~message_count:(List.length c.messages)
-                         ~token_count:c.token_count ~repetition_risk
+                         ~message_count:(Keeper_exec_context.message_count c)
+                         ~token_count:(Keeper_exec_context.token_count c)
+                         ~repetition_risk
                          ~goal_alignment ~response_alignment
                          ()
                      in
@@ -364,17 +365,17 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                            ("cost_usd", `Float 0.0);
                            ( "context_ratio",
                              `Float (Keeper_exec_context.context_ratio c) );
-                           ("context_tokens", `Int c.token_count);
+                           ("context_tokens", `Int (Keeper_exec_context.token_count c));
                            ("context_max", `Int c.max_tokens);
-                           ("message_count", `Int (List.length c.messages));
+                           ("message_count", `Int (Keeper_exec_context.message_count c));
                            ( "continuity_state",
                              match continuity_snapshot with
                              | None -> `Null
                              | Some s -> keeper_state_snapshot_to_json s );
                            ("continuity_summary", `String continuity_summary);
                            ("compacted", `Bool false);
-                           ("compaction_before_tokens", `Int c.token_count);
-                           ("compaction_after_tokens", `Int c.token_count);
+                           ("compaction_before_tokens", `Int (Keeper_exec_context.token_count c));
+                           ("compaction_after_tokens", `Int (Keeper_exec_context.token_count c));
                            ("work_kind", `String "status_tick");
                            ("tool_call_count", `Int 0);
                            ("tools_used", `List []);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -65,9 +65,9 @@ let handle_keeper_status ctx args : tool_result =
                `Assoc [
                  ("has_checkpoint", `Bool true);
                  ("context_ratio", `Float (Keeper_exec_context.context_ratio c));
-                 ("context_tokens", `Int c.token_count);
+                 ("context_tokens", `Int (Keeper_exec_context.token_count c));
                  ("context_max", `Int c.max_tokens);
-                 ("message_count", `Int (List.length c.messages));
+                 ("message_count", `Int (Keeper_exec_context.message_count c));
                ]
          in
          let keepalive_running = runtime_keepalive_running ctx.config m in

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -144,12 +144,18 @@ let append_many ctx msgs =
 
 let sync_oas_context (ctx : working_context) : working_context =
   let context = ctx.context in
+  let message_count = message_count ctx in
+  let token_count = token_count ctx in
+  let context_ratio =
+    if ctx.max_tokens = 0 then 0.0
+    else float_of_int token_count /. float_of_int ctx.max_tokens
+  in
   Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "message_count" (`Int (message_count ctx));
+    "message_count" (`Int message_count);
   Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "token_count" (`Int (token_count ctx));
+    "token_count" (`Int token_count);
   Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "context_ratio" (`Float (context_ratio ctx));
+    "context_ratio" (`Float context_ratio);
   ctx
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -25,10 +25,8 @@ let text_of_message = Agent_sdk.Types.text_of_message
 type working_context = {
   system_prompt : string;
   messages : Agent_sdk.Types.message list;
-  token_count : int;
   max_tokens : int;
-  importance_scores : (int * float) list;
-  oas_context : Agent_sdk.Context.t;
+  context : Agent_sdk.Context.t;
 }
 
 type checkpoint = {
@@ -99,13 +97,19 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
   let sys_tokens = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in
   List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
 
+let token_count (ctx : working_context) =
+  count_tokens ctx.system_prompt ctx.messages
+
+let message_count (ctx : working_context) =
+  List.length ctx.messages
+
 (* ================================================================ *)
 (* Context Ratio                                                     *)
 (* ================================================================ *)
 
 let context_ratio (ctx : working_context) : float =
   if ctx.max_tokens = 0 then 0.0
-  else float_of_int ctx.token_count /. float_of_int ctx.max_tokens
+  else float_of_int (token_count ctx) /. float_of_int ctx.max_tokens
 
 let exceeds_threshold ctx threshold =
   context_ratio ctx >= threshold
@@ -115,10 +119,8 @@ let exceeds_threshold ctx threshold =
 (* ================================================================ *)
 
 let create ~system_prompt ~max_tokens =
-  let token_count = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in
-  let oas_context = Agent_sdk.Context.create () in
-  { system_prompt; messages = []; token_count; max_tokens;
-    importance_scores = []; oas_context }
+  let context = Agent_sdk.Context.create () in
+  { system_prompt; messages = []; max_tokens; context }
 
 let set_system_prompt (ctx : working_context) ~system_prompt =
   let messages =
@@ -126,14 +128,11 @@ let set_system_prompt (ctx : working_context) ~system_prompt =
       if m.role = Agent_sdk.Types.System then { m with role = Agent_sdk.Types.Assistant } else m
     ) ctx.messages
   in
-  let token_count = count_tokens system_prompt messages in
-  { ctx with system_prompt; messages; token_count; importance_scores = [] }
+  { ctx with system_prompt; messages }
 
 let append ctx (msg : Agent_sdk.Types.message) =
-  let new_tokens = msg_tokens msg in
   { ctx with
     messages = ctx.messages @ [msg];
-    token_count = ctx.token_count + new_tokens;
   }
 
 let append_many ctx msgs =
@@ -144,12 +143,12 @@ let append_many ctx msgs =
 (* ================================================================ *)
 
 let sync_oas_context (ctx : working_context) : working_context =
-  let oas = ctx.oas_context in
-  Agent_sdk.Context.set_scoped oas Agent_sdk.Context.Session
-    "message_count" (`Int (List.length ctx.messages));
-  Agent_sdk.Context.set_scoped oas Agent_sdk.Context.Session
-    "token_count" (`Int ctx.token_count);
-  Agent_sdk.Context.set_scoped oas Agent_sdk.Context.Session
+  let context = ctx.context in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "message_count" (`Int (message_count ctx));
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "token_count" (`Int (token_count ctx));
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
     "context_ratio" (`Float (context_ratio ctx));
   ctx
 
@@ -251,7 +250,7 @@ let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
     ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
     ("messages", `List (List.map message_to_json ctx.messages));
-    ("token_count", `Int ctx.token_count);
+    ("token_count", `Int (token_count ctx));
     ("max_tokens", `Int ctx.max_tokens);
   ] in
   Yojson.Safe.to_string json
@@ -261,18 +260,21 @@ let deserialize_context (s : string) ~max_tokens : working_context =
   let open Yojson.Safe.Util in
   let system_prompt = json |> member "system_prompt" |> to_string in
   let messages = json |> member "messages" |> to_list |> List.map message_of_json in
-  let token_count = json |> member "token_count" |> to_int in
-  { system_prompt; messages; token_count; max_tokens; importance_scores = [];
-    oas_context = Agent_sdk.Context.create () }
+  let _legacy_token_count = json |> member "token_count" |> to_int_option in
+  sync_oas_context
+    {
+      system_prompt;
+      messages;
+      max_tokens;
+      context = Agent_sdk.Context.create ();
+    }
 
 let context_to_json (ctx : working_context) : Yojson.Safe.t =
   `Assoc [
     ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
     ("messages", `List (List.map message_to_json ctx.messages));
-    ("token_count", `Int ctx.token_count);
+    ("token_count", `Int (token_count ctx));
     ("max_tokens", `Int ctx.max_tokens);
-    ("importance_scores", `List (List.map (fun (i, s) ->
-      `Assoc [("index", `Int i); ("score", `Float s)]) ctx.importance_scores));
   ]
 
 let create_checkpoint ctx ~generation =
@@ -280,8 +282,8 @@ let create_checkpoint ctx ~generation =
     checkpoint_id = generate_checkpoint_id ();
     timestamp = Time_compat.now ();
     generation;
-    message_count = List.length ctx.messages;
-    token_count = ctx.token_count;
+    message_count = message_count ctx;
+    token_count = token_count ctx;
     serialized = serialize_context ctx;
   }
 

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -20,8 +20,8 @@ Do not assume access to any other MASC tool from this endpoint."
 
 let managed_agent_instructions =
   "MASC managed-agent profile exposes the internal agent control surface. \
-Prefer SDK-style task and room aliases such as masc_room_status, masc_list_tasks, masc_claim_task, masc_set_current_task, masc_complete_task, masc_release_task, masc_cancel_task, masc_add_task, masc_batch_add_tasks, masc_broadcast, and masc_heartbeat. \
-Use canonical passthrough tools only when no managed alias exists on this endpoint. \
+Prefer canonical task-control tools such as masc_status, masc_tasks, masc_claim_next, masc_transition, and masc_plan_set_task. \
+Managed aliases that remain listed on this endpoint are compatibility helpers, not the recommended control plane. \
 Do not assume that the public /mcp surface and the managed-agent surface have the same inventory."
 
 let managed_agent_passthrough_tool_names =
@@ -133,9 +133,10 @@ let tool_allowed_in_profile state profile tool_name =
       else
         Tool_catalog.allow_direct_call tool_name
   | Managed_agent ->
-      tool_schemas_for_profile state Managed_agent
-      |> List.exists (fun (schema : Types.tool_schema) ->
-             String.equal schema.name tool_name)
+      Option.is_some (Sdk_tool_contract.sdk_binding_by_name tool_name)
+      || (tool_schemas_for_profile state Managed_agent
+          |> List.exists (fun (schema : Types.tool_schema) ->
+                 String.equal schema.name tool_name))
   | Operator_remote -> List.mem tool_name Tool_operator.remote_tool_names
 
 let is_destructive_tool_name name =

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -6,14 +6,7 @@
     JSON-RPC core: request/response types, builders, validators.
     Protocol version: supported versions, validation, normalization.
     HTTP negotiation: delegates parsing to {!Mcp_protocol.Http_negotiation}
-    (SDK); adds [accept_mode] with [Legacy_accepted] for backward-compat.
-
-    SDK workarounds (case + quality):
-    - SDK [parse_accept_header] preserves original case; HTTP media types
-      are case-insensitive (RFC 7231 §3.1.1.1).  Wrappers lowercase
-      type/subtype before comparison.
-    - SDK [accepts_sse] / [accepts_json] do not filter [q=0]
-      (mcp-protocol-sdk#80).  Wrappers enforce [q > 0] per §5.3.1. *)
+    (SDK); adds [accept_mode] with [Legacy_accepted] for backward-compat. *)
 
 (* ── JSON-RPC core types ─────────────────────────────────── *)
 
@@ -133,17 +126,11 @@ module Http_negotiation = struct
   let sse_content_type = Mcp_protocol.Http_negotiation.sse_content_type
   let json_content_type = Mcp_protocol.Http_negotiation.json_content_type
 
-  (** Quality-aware, case-insensitive predicate using SDK's parser.
-      [check ~type_ ~subtype] receives lowercased values. *)
   let exists_accepted h ~check =
-    let media_types = Mcp_protocol.Http_negotiation.parse_accept_header h in
-    List.exists
-      (fun (mt : Mcp_protocol.Http_negotiation.media_type) ->
-        mt.quality > 0.0
-        && check
-             ~type_:(String.lowercase_ascii mt.type_)
-             ~subtype:(String.lowercase_ascii mt.subtype))
-      media_types
+    Mcp_protocol.Http_negotiation.parse_accept_header h
+    |> List.exists
+         (fun (mt : Mcp_protocol.Http_negotiation.media_type) ->
+           mt.quality > 0.0 && check ~type_:mt.type_ ~subtype:mt.subtype)
 
   let accepts_sse_header = function
     | None -> false
@@ -161,10 +148,7 @@ module Http_negotiation = struct
   let accepts_streamable_mcp = function
     | None -> false
     | Some h ->
-        exists_accepted h ~check:(fun ~type_ ~subtype ->
-            type_ = "application" && subtype = "json")
-        && exists_accepted h ~check:(fun ~type_ ~subtype ->
-               type_ = "text" && subtype = "event-stream")
+        accepts_json (Some h) && accepts_sse_header (Some h)
 
   let classify_mcp_accept ~allow_legacy accept_header =
     if accepts_streamable_mcp accept_header then Streamable
@@ -172,18 +156,12 @@ module Http_negotiation = struct
     else Rejected
 end
 
-let supported_protocol_versions =
-  [
-    "2024-11-05";
-    "2025-03-26";
-    "2025-06-18";
-    "2025-11-25";
-  ]
+let supported_protocol_versions = Mcp_protocol.Version.supported_versions
 
-let default_protocol_version = "2025-11-25"
+let default_protocol_version = Mcp_protocol.Version.latest
 
 let is_supported_protocol_version version =
-  List.mem version supported_protocol_versions
+  Mcp_protocol.Version.is_supported version
 
 let validate_protocol_version version =
   if is_supported_protocol_version version then

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -130,7 +130,10 @@ module Http_negotiation = struct
     Mcp_protocol.Http_negotiation.parse_accept_header h
     |> List.exists
          (fun (mt : Mcp_protocol.Http_negotiation.media_type) ->
-           mt.quality > 0.0 && check ~type_:mt.type_ ~subtype:mt.subtype)
+           mt.quality > 0.0
+           && check
+                ~type_:(String.lowercase_ascii mt.type_)
+                ~subtype:(String.lowercase_ascii mt.subtype))
 
   let accepts_sse_header = function
     | None -> false

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -9,6 +9,7 @@ type sdk_tool_binding = {
   description : string;
   input_schema : Yojson.Safe.t;
   arg_bindings : (string * arg_source) list;
+  discovery_hidden : bool;
 }
 
 let assoc_field name value = (name, value)
@@ -33,6 +34,7 @@ let sdk_bindings : sdk_tool_binding list =
       description = "List all tasks in the MASC room with status, assignee, and priority. Use after joining a room to find available work or check what others are doing.";
       input_schema = object_schema [];
       arg_bindings = [];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_room_status";
@@ -40,6 +42,7 @@ let sdk_bindings : sdk_tool_binding list =
       description = "Get the current MASC room status including agents and tasks.";
       input_schema = object_schema [];
       arg_bindings = [];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_autoresearch_swarm_start";
@@ -69,6 +72,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("workdir", Input_field "workdir");
           ("program_note", Input_field "program_note");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_repo_synthesis_swarm_start";
@@ -96,6 +100,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("model", Input_field "model");
           ("baseline_label", Input_field "baseline_label");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_add_task";
@@ -112,6 +117,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("title", Input_field "title");
           ("description", Input_field "description");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_batch_add_tasks";
@@ -131,6 +137,7 @@ let sdk_bindings : sdk_tool_binding list =
                 ] );
           ];
       arg_bindings = [ ("tasks", Input_field "tasks") ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_claim_task";
@@ -145,6 +152,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("agent_name", Agent_name);
           ("task_id", Input_field "task_id");
         ];
+      discovery_hidden = true;
     };
     {
       sdk_name = "masc_claim_next";
@@ -152,6 +160,7 @@ let sdk_bindings : sdk_tool_binding list =
       description = "Claim the next available task automatically by priority order. Use when you are ready to work and any pending task is acceptable.";
       input_schema = object_schema [];
       arg_bindings = [ ("agent_name", Agent_name) ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_set_current_task";
@@ -166,6 +175,7 @@ let sdk_bindings : sdk_tool_binding list =
                  "The claimed task ID to bind as the current planning task");
           ];
       arg_bindings = [ ("task_id", Input_field "task_id") ];
+      discovery_hidden = true;
     };
     {
       sdk_name = "masc_complete_task";
@@ -183,6 +193,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("agent_name", Agent_name);
           ("task_id", Input_field "task_id");
         ];
+      discovery_hidden = true;
     };
     {
       sdk_name = "masc_release_task";
@@ -198,6 +209,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("agent_name", Agent_name);
           ("task_id", Input_field "task_id");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_cancel_task";
@@ -217,6 +229,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("task_id", Input_field "task_id");
           ("reason", Input_field "reason");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_broadcast";
@@ -232,6 +245,7 @@ let sdk_bindings : sdk_tool_binding list =
           ("agent_name", Agent_name);
           ("message", Input_field "message");
         ];
+      discovery_hidden = false;
     };
     {
       sdk_name = "masc_heartbeat";
@@ -240,6 +254,7 @@ let sdk_bindings : sdk_tool_binding list =
         "Send an immediate heartbeat so this agent stays fresh in MASC visibility.";
       input_schema = object_schema [];
       arg_bindings = [ ("agent_name", Agent_name) ];
+      discovery_hidden = false;
     };
   ]
 
@@ -535,4 +550,4 @@ let sdk_tool_schemas : Types.tool_schema list =
         description = binding.description;
         input_schema = binding.input_schema;
       })
-    sdk_bindings
+    (List.filter (fun binding -> not binding.discovery_hidden) sdk_bindings)

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -172,6 +172,240 @@ let count_assoc_to_json counts =
     |> List.map (fun (label, count) -> (label, `Int count))
     |> List.sort (fun (a, _) (b, _) -> compare a b))
 
+type projected_worker_spec = {
+  spawn_agent : string;
+  runtime_actor : string option;
+  spawn_role : string option;
+  spawn_model : string option;
+  execution_scope : string option;
+  thinking_enabled : bool option;
+  thinking_budget : int option;
+  max_turns : int option;
+  timeout_seconds : int option;
+  worker_class : string option;
+  parent_actor : string option;
+  capsule_mode : string option;
+  runtime_pool : string option;
+  lane_id : string option;
+  controller_level : string option;
+  control_domain : string option;
+  supervisor_actor : string option;
+  model_tier : string option;
+  task_profile : string option;
+  risk_level : string option;
+  routing_confidence : float option;
+  routing_reason : string option;
+  routing_escalated : bool;
+}
+
+type projected_session_metadata = {
+  room_id : string;
+  created_by : string;
+  origin_kind : string;
+  execution_scope : string;
+  orchestration_mode : string;
+  control_profile : string;
+  scale_profile : string;
+  instruction_profile : string;
+  fallback_policy : string;
+  communication_mode : string;
+  alert_channel : string;
+  duration_seconds : int;
+  checkpoint_interval_sec : int;
+  min_agents : int;
+  auto_resume : bool;
+  planned_worker_count : int;
+  model_cascade : string list;
+  worker_class_counts : (string * int) list;
+  runtime_pool_counts : (string * int) list;
+  lane_counts : (string * int) list;
+  controller_level_counts : (string * int) list;
+  control_domain_counts : (string * int) list;
+  model_tier_counts : (string * int) list;
+  worker_specs : projected_worker_spec list;
+}
+
+type runtime_health = {
+  base_path_exists : bool;
+  room_initialized : bool;
+  session_running : bool;
+}
+
+let projected_worker_spec_of_planned_worker
+    (pw : Team_session_types.planned_worker) : projected_worker_spec =
+  {
+    spawn_agent = pw.spawn_agent;
+    runtime_actor = pw.runtime_actor;
+    spawn_role = pw.spawn_role;
+    spawn_model = pw.spawn_model;
+    execution_scope =
+      Option.map Team_session_types.execution_scope_to_string pw.execution_scope;
+    thinking_enabled = pw.thinking_enabled;
+    thinking_budget = pw.thinking_budget;
+    max_turns = pw.max_turns;
+    timeout_seconds = pw.timeout_seconds;
+    worker_class =
+      Option.map Team_session_types.worker_class_to_string pw.worker_class;
+    parent_actor = pw.parent_actor;
+    capsule_mode =
+      Option.map Team_session_types.capsule_mode_to_string pw.capsule_mode;
+    runtime_pool = pw.runtime_pool;
+    lane_id = pw.lane_id;
+    controller_level =
+      Option.map Team_session_types.controller_level_to_string
+        pw.controller_level;
+    control_domain =
+      Option.map Team_session_types.control_domain_to_string pw.control_domain;
+    supervisor_actor = pw.supervisor_actor;
+    model_tier =
+      Option.map Team_session_types.model_tier_to_string pw.model_tier;
+    task_profile =
+      Option.map Team_session_types.task_profile_to_string pw.task_profile;
+    risk_level =
+      Option.map Team_session_types.risk_level_to_string pw.risk_level;
+    routing_confidence = pw.routing_confidence;
+    routing_reason = pw.routing_reason;
+    routing_escalated = pw.routing_escalated;
+  }
+
+let projected_session_metadata_of_session
+    (session : Team_session_types.session) : projected_session_metadata =
+  {
+    room_id = session.room_id;
+    created_by = session.created_by;
+    origin_kind =
+      Team_session_types.session_origin_kind_to_string session.origin_kind;
+    execution_scope =
+      Team_session_types.execution_scope_to_string session.execution_scope;
+    orchestration_mode =
+      Team_session_types.orchestration_mode_to_string
+        session.orchestration_mode;
+    control_profile =
+      Team_session_types.control_profile_to_string session.control_profile;
+    scale_profile =
+      Team_session_types.scale_profile_to_string session.scale_profile;
+    instruction_profile =
+      Team_session_types.instruction_profile_to_string
+        session.instruction_profile;
+    fallback_policy =
+      Team_session_types.fallback_policy_to_string session.fallback_policy;
+    communication_mode =
+      Team_session_types.communication_mode_to_string
+        session.communication_mode;
+    alert_channel =
+      Team_session_types.alert_channel_to_string session.alert_channel;
+    duration_seconds = session.duration_seconds;
+    checkpoint_interval_sec = session.checkpoint_interval_sec;
+    min_agents = session.min_agents;
+    auto_resume = session.auto_resume;
+    planned_worker_count = List.length session.planned_workers;
+    model_cascade = session.model_cascade;
+    worker_class_counts =
+      Team_session_types.worker_class_counts session.planned_workers;
+    runtime_pool_counts =
+      Team_session_types.runtime_pool_counts session.planned_workers;
+    lane_counts = Team_session_types.lane_counts session.planned_workers;
+    controller_level_counts =
+      Team_session_types.controller_level_counts session.planned_workers;
+    control_domain_counts =
+      Team_session_types.control_domain_counts session.planned_workers;
+    model_tier_counts =
+      Team_session_types.model_tier_counts session.planned_workers;
+    worker_specs =
+      List.map projected_worker_spec_of_planned_worker session.planned_workers;
+  }
+
+let projected_worker_spec_to_json (spec : projected_worker_spec) :
+    Yojson.Safe.t =
+  let fields =
+    []
+    |> add_json_string_if_present "runtime_actor" spec.runtime_actor
+    |> add_json_string_if_present "spawn_role" spec.spawn_role
+    |> add_json_string_if_present "spawn_model" spec.spawn_model
+    |> add_json_string_if_present "execution_scope" spec.execution_scope
+    |> add_json_string_if_present "worker_class" spec.worker_class
+    |> add_json_string_if_present "parent_actor" spec.parent_actor
+    |> add_json_string_if_present "capsule_mode" spec.capsule_mode
+    |> add_json_string_if_present "runtime_pool" spec.runtime_pool
+    |> add_json_string_if_present "lane_id" spec.lane_id
+    |> add_json_string_if_present "controller_level" spec.controller_level
+    |> add_json_string_if_present "control_domain" spec.control_domain
+    |> add_json_string_if_present "supervisor_actor" spec.supervisor_actor
+    |> add_json_string_if_present "model_tier" spec.model_tier
+    |> add_json_string_if_present "task_profile" spec.task_profile
+    |> add_json_string_if_present "risk_level" spec.risk_level
+    |> add_json_string_if_present "routing_reason" spec.routing_reason
+    |> add_json_bool_if_present "thinking_enabled" spec.thinking_enabled
+    |> add_json_int_if_present "thinking_budget" spec.thinking_budget
+    |> add_json_int_if_present "max_turns" spec.max_turns
+    |> add_json_int_if_present "timeout_seconds" spec.timeout_seconds
+    |> add_json_float_if_present "routing_confidence" spec.routing_confidence
+  in
+  `Assoc
+    (List.rev
+       (("spawn_agent", `String spec.spawn_agent)
+        :: ("routing_escalated", `Bool spec.routing_escalated)
+        :: fields))
+
+let metadata_of_session_projection (projection : projected_session_metadata) :
+    (string * Yojson.Safe.t) list =
+  [
+    ("room_id", `String projection.room_id);
+    ("created_by", `String projection.created_by);
+    ("origin_kind", `String projection.origin_kind);
+    ("execution_scope", `String projection.execution_scope);
+    ("orchestration_mode", `String projection.orchestration_mode);
+    ("control_profile", `String projection.control_profile);
+    ("scale_profile", `String projection.scale_profile);
+    ("instruction_profile", `String projection.instruction_profile);
+    ("fallback_policy", `String projection.fallback_policy);
+    ("communication_mode", `String projection.communication_mode);
+    ("alert_channel", `String projection.alert_channel);
+    ("duration_seconds", `Int projection.duration_seconds);
+    ("checkpoint_interval_sec", `Int projection.checkpoint_interval_sec);
+    ("min_agents", `Int projection.min_agents);
+    ("auto_resume", `Bool projection.auto_resume);
+    ("planned_worker_count", `Int projection.planned_worker_count);
+    ("model_cascade", `List (List.map (fun model -> `String model) projection.model_cascade));
+    ("worker_class_counts", count_assoc_to_json projection.worker_class_counts);
+    ("runtime_pool_counts", count_assoc_to_json projection.runtime_pool_counts);
+    ("lane_counts", count_assoc_to_json projection.lane_counts);
+    ( "controller_level_counts",
+      count_assoc_to_json projection.controller_level_counts );
+    ("control_domain_counts", count_assoc_to_json projection.control_domain_counts);
+    ("model_tier_counts", count_assoc_to_json projection.model_tier_counts);
+    ( "worker_specs",
+      `List (List.map projected_worker_spec_to_json projection.worker_specs) );
+  ]
+
+let runtime_health_to_json (health : runtime_health) =
+  `Assoc
+    [
+      ("base_path_exists", `Bool health.base_path_exists);
+      ("room_initialized", `Bool health.room_initialized);
+      ("session_running", `Bool health.session_running);
+      ( "ready",
+        `Bool
+          (health.base_path_exists && health.room_initialized
+         && health.session_running) );
+    ]
+
+let replace_metadata_field key value metadata =
+  let remaining =
+    List.filter (fun (existing, _) -> not (String.equal existing key)) metadata
+  in
+  (key, value) :: remaining
+
+let with_runtime_health
+    (collaboration : Agent_sdk.Collaboration.t)
+    (health : runtime_health) : Agent_sdk.Collaboration.t =
+  {
+    collaboration with
+    metadata =
+      replace_metadata_field "runtime_health" (runtime_health_to_json health)
+        collaboration.metadata;
+  }
+
 let planned_worker_summary (pw : Team_session_types.planned_worker) : string option =
   let parts = ref [] in
   let add label value =
@@ -215,85 +449,6 @@ let planned_worker_summary (pw : Team_session_types.planned_worker) : string opt
   | [] -> None
   | parts -> Some (String.concat "; " parts)
 
-let planned_worker_metadata_json (pw : Team_session_types.planned_worker) :
-    Yojson.Safe.t =
-  let fields =
-    []
-    |> add_json_string_if_present "runtime_actor" pw.runtime_actor
-    |> add_json_string_if_present "spawn_role" pw.spawn_role
-    |> add_json_string_if_present "spawn_model" pw.spawn_model
-    |> add_json_string_if_present "parent_actor" pw.parent_actor
-    |> add_json_string_if_present "runtime_pool" pw.runtime_pool
-    |> add_json_string_if_present "lane_id" pw.lane_id
-    |> add_json_string_if_present "supervisor_actor" pw.supervisor_actor
-    |> add_json_string_if_present "routing_reason" pw.routing_reason
-    |> add_json_bool_if_present "thinking_enabled" pw.thinking_enabled
-    |> add_json_int_if_present "thinking_budget" pw.thinking_budget
-    |> add_json_int_if_present "max_turns" pw.max_turns
-    |> add_json_int_if_present "timeout_seconds" pw.timeout_seconds
-    |> add_json_float_if_present "routing_confidence" pw.routing_confidence
-  in
-  let fields =
-    ("spawn_agent", `String pw.spawn_agent) :: ("routing_escalated", `Bool pw.routing_escalated) :: fields
-  in
-  let fields =
-    match pw.execution_scope with
-    | Some scope ->
-        ("execution_scope", `String (Team_session_types.execution_scope_to_string scope))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.worker_class with
-    | Some worker_class ->
-        ("worker_class", `String (Team_session_types.worker_class_to_string worker_class))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.capsule_mode with
-    | Some mode ->
-        ("capsule_mode", `String (Team_session_types.capsule_mode_to_string mode))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.controller_level with
-    | Some level ->
-        ("controller_level", `String (Team_session_types.controller_level_to_string level))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.control_domain with
-    | Some domain ->
-        ("control_domain", `String (Team_session_types.control_domain_to_string domain))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.model_tier with
-    | Some tier ->
-        ("model_tier", `String (Team_session_types.model_tier_to_string tier))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.task_profile with
-    | Some profile ->
-        ("task_profile", `String (Team_session_types.task_profile_to_string profile))
-        :: fields
-    | None -> fields
-  in
-  let fields =
-    match pw.risk_level with
-    | Some risk ->
-        ("risk_level", `String (Team_session_types.risk_level_to_string risk))
-        :: fields
-    | None -> fields
-  in
-  `Assoc (List.rev fields)
-
 let planned_worker_to_participant
     (pw : Team_session_types.planned_worker)
     : Agent_sdk.Collaboration.participant =
@@ -326,6 +481,7 @@ let collaboration_of_session
     Agent_sdk.Context.set ctx
       (Printf.sprintf "finding_%d" i) (`String f)
   ) findings;
+  let projection = projected_session_metadata_of_session session in
   {
     id = session.session_id;
     goal = session.goal;
@@ -342,67 +498,7 @@ let collaboration_of_session
        | None -> session.started_at);
     outcome = session.stop_reason;
     max_participants = None;
-    metadata =
-      [
-        ("room_id", `String session.room_id);
-        ("created_by", `String session.created_by);
-        ("origin_kind",
-         `String (Team_session_types.session_origin_kind_to_string
-                    session.origin_kind));
-        ("execution_scope",
-         `String
-           (Team_session_types.execution_scope_to_string session.execution_scope));
-        ("orchestration_mode",
-         `String
-           (Team_session_types.orchestration_mode_to_string
-              session.orchestration_mode));
-        ("control_profile",
-         `String
-           (Team_session_types.control_profile_to_string
-              session.control_profile));
-        ("scale_profile",
-         `String
-           (Team_session_types.scale_profile_to_string session.scale_profile));
-        ("instruction_profile",
-         `String
-           (Team_session_types.instruction_profile_to_string
-              session.instruction_profile));
-        ("fallback_policy",
-         `String
-           (Team_session_types.fallback_policy_to_string session.fallback_policy));
-        ("communication_mode",
-         `String
-           (Team_session_types.communication_mode_to_string
-              session.communication_mode));
-        ("alert_channel",
-         `String
-           (Team_session_types.alert_channel_to_string session.alert_channel));
-        ("duration_seconds", `Int session.duration_seconds);
-        ("checkpoint_interval_sec", `Int session.checkpoint_interval_sec);
-        ("min_agents", `Int session.min_agents);
-        ("auto_resume", `Bool session.auto_resume);
-        ("planned_worker_count", `Int (List.length session.planned_workers));
-        ("model_cascade", `List (List.map (fun model -> `String model) session.model_cascade));
-        ("worker_class_counts",
-         count_assoc_to_json
-           (Team_session_types.worker_class_counts session.planned_workers));
-        ("runtime_pool_counts",
-         count_assoc_to_json
-           (Team_session_types.runtime_pool_counts session.planned_workers));
-        ("lane_counts",
-         count_assoc_to_json (Team_session_types.lane_counts session.planned_workers));
-        ("controller_level_counts",
-         count_assoc_to_json
-           (Team_session_types.controller_level_counts session.planned_workers));
-        ("control_domain_counts",
-         count_assoc_to_json
-           (Team_session_types.control_domain_counts session.planned_workers));
-        ("model_tier_counts",
-         count_assoc_to_json
-           (Team_session_types.model_tier_counts session.planned_workers));
-        ("worker_specs",
-         `List (List.map planned_worker_metadata_json session.planned_workers));
-      ];
+    metadata = metadata_of_session_projection projection;
   }
 
 let truncate_list n lst =

--- a/lib/team_context.mli
+++ b/lib/team_context.mli
@@ -68,3 +68,14 @@ val collaboration_of_session :
   base_path:string ->
   Team_session_types.session ->
   Agent_sdk.Collaboration.t
+
+type runtime_health = {
+  base_path_exists : bool;
+  room_initialized : bool;
+  session_running : bool;
+}
+
+val with_runtime_health :
+  Agent_sdk.Collaboration.t ->
+  runtime_health ->
+  Agent_sdk.Collaboration.t

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -518,8 +518,8 @@ let budget_of_session_timeout timeout_sec =
       }
   | None -> Swarm.Swarm_types.no_budget
 
-let session_runtime_health_check ~(config : Room.config)
-    ~(session : Team_session_types.session) () =
+let session_runtime_health ~(config : Room.config)
+    ~(session : Team_session_types.session) : Team_context.runtime_health =
   let base_path_ok =
     String.trim config.base_path <> "" && Sys.file_exists config.base_path
   in
@@ -532,7 +532,18 @@ let session_runtime_health_check ~(config : Room.config)
         && String.equal current.room_id session.room_id
     | None -> false
   in
-  base_path_ok && room_ready && session_ready
+  {
+    Team_context.base_path_exists = base_path_ok;
+    room_initialized = room_ready;
+    session_running = session_ready;
+  }
+
+let session_runtime_health_check ~(config : Room.config)
+    ~(session : Team_session_types.session) () =
+  let health = session_runtime_health ~config ~session in
+  health.Team_context.base_path_exists
+  && health.room_initialized
+  && health.session_running
 
 (* ── planned_worker -> agent_entry ─────────────────────────────── *)
 
@@ -661,8 +672,10 @@ let session_to_swarm_config
       Hashtbl.replace success_by_agent entry.name false)
     entries;
   let mode = mode_of_orchestration session.orchestration_mode in
+  let runtime_health = session_runtime_health ~config ~session in
   let collaboration =
     Team_context.collaboration_of_session ~base_path:config.base_path session
+    |> fun collab -> Team_context.with_runtime_health collab runtime_health
   in
   let entry_count = List.length entries in
   let timeout_sec =

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -156,7 +156,7 @@ let local_worker_surface_tools =
 let session_min_surface_tools =
   [
     "masc_room_status"; "masc_list_tasks"; "masc_claim_next";
-    "masc_set_current_task"; "masc_complete_task"; "masc_add_task";
+    "masc_plan_set_task"; "masc_transition"; "masc_add_task";
     "masc_broadcast"; "masc_heartbeat";
   ]
 

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -149,18 +149,18 @@ let handle_compact args : result =
     (* Build a working_context from the input *)
     let ctx = Keeper_exec_context.create ~system_prompt ~max_tokens in
     let ctx = Keeper_exec_context.append_many ctx messages in
-    let tokens_before = ctx.token_count in
+    let tokens_before = Keeper_exec_context.token_count ctx in
     let msg_count_before = List.length ctx.messages in
     (* Apply compaction *)
-    let messages, token_count =
+    let messages, _ =
       Context_compact_oas.compact
         ~system_prompt:ctx.system_prompt
         ~messages:ctx.messages
         ~strategies
         ()
     in
-    let compacted = { ctx with messages; token_count; importance_scores = [] } in
-    let tokens_after = compacted.token_count in
+    let compacted = Keeper_exec_context.sync_oas_context { ctx with messages } in
+    let tokens_after = Keeper_exec_context.token_count compacted in
     let msg_count_after = List.length compacted.messages in
     let result_json = `Assoc [
       ("success", `Bool true);

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -79,6 +79,10 @@ let test_accepts_json_in_list () =
   check bool "json in list" true
     (Http_negotiation.accepts_json (Some "text/html, application/json"))
 
+let test_accepts_json_case_insensitive () =
+  check bool "mixed-case json" true
+    (Http_negotiation.accepts_json (Some "Application/Json"))
+
 (* ============================================================
    accepts_sse_header Tests
    ============================================================ *)
@@ -106,6 +110,10 @@ let test_accepts_sse_with_q () =
 let test_accepts_sse_q_zero () =
   check bool "q=0 rejected" false
     (Http_negotiation.accepts_sse_header (Some "text/event-stream;q=0"))
+
+let test_accepts_sse_case_insensitive () =
+  check bool "mixed-case sse" true
+    (Http_negotiation.accepts_sse_header (Some "Text/Event-Stream"))
 
 (* ============================================================
    accepts_streamable_mcp Tests
@@ -141,6 +149,11 @@ let test_streamable_sse_q_zero () =
   check bool "sse q=0" false
     (Http_negotiation.accepts_streamable_mcp
       (Some "application/json, text/event-stream;q=0"))
+
+let test_streamable_case_insensitive () =
+  check bool "mixed-case streamable" true
+    (Http_negotiation.accepts_streamable_mcp
+      (Some "Application/Json, Text/Event-Stream"))
 
 (* ============================================================
    classify_mcp_accept Tests
@@ -222,6 +235,7 @@ let () =
       test_case "not found" `Quick test_accepts_json_not_found;
       test_case "wildcard */*" `Quick test_accepts_json_wildcard;
       test_case "in list" `Quick test_accepts_json_in_list;
+      test_case "case-insensitive" `Quick test_accepts_json_case_insensitive;
     ];
     "accepts_sse_header", [
       test_case "none" `Quick test_accepts_sse_none;
@@ -230,6 +244,7 @@ let () =
       test_case "exact" `Quick test_accepts_sse_exact;
       test_case "with q" `Quick test_accepts_sse_with_q;
       test_case "q zero" `Quick test_accepts_sse_q_zero;
+      test_case "case-insensitive" `Quick test_accepts_sse_case_insensitive;
     ];
     "accepts_streamable_mcp", [
       test_case "none" `Quick test_streamable_none;
@@ -239,6 +254,7 @@ let () =
       test_case "reversed" `Quick test_streamable_both_reversed;
       test_case "json q=0" `Quick test_streamable_json_q_zero;
       test_case "sse q=0" `Quick test_streamable_sse_q_zero;
+      test_case "case-insensitive" `Quick test_streamable_case_insensitive;
     ];
     "classify_mcp_accept", [
       test_case "streamable" `Quick test_classify_streamable;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -809,8 +809,8 @@ let test_handle_request_initialize_managed_profile () =
             in
             Alcotest.(check bool) "mentions managed profile" true
               (contains_substring instructions "managed-agent profile");
-            Alcotest.(check bool) "mentions sdk aliases" true
-              (contains_substring instructions "masc_room_status")
+            Alcotest.(check bool) "mentions canonical task control" true
+              (contains_substring instructions "masc_transition")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
@@ -848,7 +848,7 @@ let test_handle_request_tools_list_managed_profile () =
                    (List.mem "masc_room_status" names);
                  Alcotest.(check bool) "has managed list tasks alias" true
                    (List.mem "masc_list_tasks" names);
-                 Alcotest.(check bool) "has managed claim alias" true
+                 Alcotest.(check bool) "hides managed claim alias" false
                    (List.mem "masc_claim_task" names);
                  Alcotest.(check bool) "omits raw masc_status" false
                    (List.mem "masc_status" names);

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -77,10 +77,11 @@ let test_roundtrip_tool_msg () =
 (* Compaction tests (via Context_compact_oas directly) *)
 
 let compact_ctx (ctx : Keeper_exec_context.working_context) strategies =
-  let messages, token_count =
+  let messages, _ =
     Context_compact_oas.compact
       ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies () in
-  { ctx with Keeper_exec_context.messages; token_count; importance_scores = [] }
+  Keeper_exec_context.sync_oas_context
+    { ctx with Keeper_exec_context.messages }
 (* ================================================================ *)
 
 let test_compact_prune_tool_outputs () =
@@ -91,7 +92,7 @@ let test_compact_prune_tool_outputs () =
   Alcotest.(check bool) "messages preserved"
     true (List.length compacted.messages > 0);
   Alcotest.(check bool) "token count positive"
-    true (compacted.token_count > 0);
+    true (Keeper_exec_context.token_count compacted > 0);
   (* Short tool output (< 1500 chars) should not be truncated *)
   Alcotest.(check int) "message count unchanged for short tool output"
     (List.length (make_test_messages ())) (List.length compacted.messages)
@@ -124,7 +125,7 @@ let test_compact_summarize_old () =
   Alcotest.(check bool) "summarize_old reduces messages"
     true (List.length compacted.messages < List.length msgs);
   Alcotest.(check bool) "token count positive"
-    true (compacted.token_count > 0)
+    true (Keeper_exec_context.token_count compacted > 0)
 
 let test_compact_small_list_unchanged () =
   let ctx = Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000 in

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -99,7 +99,7 @@ let test_oas_context_sync () =
     (Agent_sdk.Types.user_msg "hello") in
   let ctx = Keeper_exec_context.sync_oas_context ctx in
   let msg_count =
-    Context.get_scoped ctx.oas_context Context.Session "message_count" in
+    Context.get_scoped ctx.context Context.Session "message_count" in
   (match msg_count with
    | Some (`Int n) -> Alcotest.(check int) "message count synced" 1 n
    | _ -> Alcotest.fail "expected message_count in oas_context")
@@ -108,14 +108,14 @@ let test_compact_syncs_oas_context () =
   let ctx = Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:1000 in
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "msg1") in
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "msg2") in
-  let messages, token_count =
+  let messages, _ =
     Context_compact_oas.compact
       ~system_prompt:ctx.system_prompt ~messages:ctx.messages
       ~strategies:[Context_compact_oas.MergeContiguous] () in
   let ctx = Keeper_exec_context.sync_oas_context
-    { ctx with messages; token_count; importance_scores = [] } in
+    { ctx with messages } in
   let ratio =
-    Context.get_scoped ctx.oas_context Context.Session "context_ratio" in
+    Context.get_scoped ctx.context Context.Session "context_ratio" in
   (match ratio with
    | Some (`Float r) ->
      Alcotest.(check bool) "ratio is non-negative" true (r >= 0.0)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -568,7 +568,7 @@ let test_keeper_checkpoint_prefers_oas_checkpoint () =
       | Some loaded ->
           Alcotest.(check string) "system prompt from OAS checkpoint"
             "oas system" loaded.system_prompt;
-          Alcotest.(check int) "max_tokens from OAS sidecar" 4096
+          Alcotest.(check int) "max_tokens from OAS checkpoint" 4096
             loaded.max_tokens;
           Alcotest.(check string) "loaded OAS message" "oas"
             (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
@@ -691,12 +691,15 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
       with
       | Some loaded ->
           let generation =
-            Option.bind loaded.working_context (fun json ->
-                Yojson.Safe.Util.(
-                  json |> member "generation" |> to_int_option))
+            Agent_sdk.Context.get_scoped loaded.context Agent_sdk.Context.Session
+              "keeper_generation"
           in
           Alcotest.(check (option int)) "new checkpoint generation preserved"
-            (Some 1) generation
+            (Some 1)
+            (Option.bind generation (function
+              | `Int value -> Some value
+              | `Intlit raw -> int_of_string_opt raw
+              | _ -> None))
       | None -> Alcotest.fail "expected rollover checkpoint")
 
 let test_keeper_oas_handoff_rollover_below_threshold_noop () =

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -257,6 +257,11 @@ let test_session_to_swarm_config_health_contract () =
        Alcotest.(check string) "session execution_scope metadata" "autonomous"
          scope
    | _ -> Alcotest.fail "expected execution_scope metadata");
+  (match List.assoc_opt "runtime_health" collaboration.metadata with
+   | Some (`Assoc fields) ->
+       Alcotest.(check bool) "runtime health marks ready" true
+         (List.assoc_opt "ready" fields = Some (`Bool true))
+   | _ -> Alcotest.fail "expected runtime_health metadata");
   let resource_ok = Option.get swarm_cfg.resource_check () in
   Alcotest.(check bool) "resource check passes for initialized room" true
     resource_ok;


### PR DESCRIPTION
## What changed
- stop keeper working_context from mirroring OAS runtime/checkpoint state
- use mcp-protocol-sdk as the protocol-version SSOT and keep only a thin MASC accept classifier
- project team_session metadata through typed projection records and attach runtime_health metadata
- hide managed-agent task aliases from discovery while keeping direct-call compatibility

## Why
The boundary cleanup removes duplicated ownership between `masc-mcp`, `oas`, and `mcp-protocol-sdk`, and makes the intended adapter layers thinner.

## Impact
- keeper checkpoints now persist generation in OAS context instead of a MASC sidecar
- team-session bridge carries typed runtime health in collaboration metadata
- managed-agent discovery prefers canonical task-control tools

## Validation
- `./_build/default/test/test_oas_worker.exe`
- `./_build/default/test/test_team_session_oas_bridge.exe`
- `./_build/default/test/test_mcp_protocol_coverage.exe`
- `./_build/default/test/test_oas_integration.exe`
- `MASC_TELEMETRY_ENABLED=false ./_build/default/test/test_mcp_server_eio.exe`
- `MASC_TELEMETRY_ENABLED=false ./_build/default/test/test_tool_registration_consistency.exe`