### PR TITLE
fix(keeper): treat turn budget exhaustion as pause, not crash

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -31,6 +31,7 @@ type run_result = {
   tools_used : string list;
   checkpoint : Agent_sdk.Checkpoint.t option;
   proof : Agent_sdk.Cdal_proof.t option;
+  stop_reason : Oas_worker.stop_reason;
 }
 
 let keeper_tool_usage_snapshot ~base_path ~keeper_name : (string * int) list =
@@ -532,4 +533,5 @@ let run_turn
            tools_used = tool_names;
            checkpoint = result.checkpoint;
            proof = result.proof;
+           stop_reason = result.stop_reason;
          })

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -699,7 +699,18 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            | Ok () -> ()
            | Error msg ->
                Log.Keeper.error "write_meta failed after unified turn: %s" msg);
-          (* 8. Reset turn failure counter on success *)
-          Keeper_registry.reset_turn_failures ~base_path:config.base_path
-            meta.name;
+          (* 8. Handle stop reason *)
+          (match result.stop_reason with
+           | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
+             Log.Keeper.warn
+               "keeper:%s turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
+               updated_meta.name turns_used limit;
+             (* Do NOT increment turn_failures — this is not a crash.
+                The keeper made progress and saved a checkpoint.
+                Reset failures since the turn itself ran successfully. *)
+             Keeper_registry.reset_turn_failures ~base_path:config.base_path
+               updated_meta.name
+           | Oas_worker.Completed ->
+             Keeper_registry.reset_turn_failures ~base_path:config.base_path
+               updated_meta.name);
           Ok updated_meta

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -134,6 +134,10 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
 (* Result type                                                       *)
 (* ================================================================ *)
 
+type stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+
 type run_result = {
   response : Oas.Types.api_response;
   checkpoint : Oas.Checkpoint.t option;
@@ -141,6 +145,7 @@ type run_result = {
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
   proof : Oas.Cdal_proof.t option;
+  stop_reason : stop_reason;
 }
 
 (* ================================================================ *)
@@ -366,7 +371,22 @@ let run
     let trace_ref = Oas.Agent.last_raw_trace_run agent in
     Oas.Agent.close agent;
     (match result with
-    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref; proof }
+    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref; proof;
+                          stop_reason = Completed }
+    | Error (Oas.Error.Agent (Oas.Error.MaxTurnsExceeded r)) ->
+      (* Turn budget exhaustion is not a fatal error — the agent made progress.
+         Return Ok with TurnBudgetExhausted so callers can checkpoint and resume
+         instead of treating this as a crash. *)
+      let partial_response : Oas.Types.api_response = {
+        id = session_id; model = "turn-exhausted";
+        stop_reason = Oas.Types.EndTurn;
+        content = [Oas.Types.Text (Printf.sprintf
+          "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
+        usage = None;
+      } in
+      Ok { response = partial_response; checkpoint; session_id; turns;
+           trace_ref; proof;
+           stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit } }
     | Error err ->
       (match proof with
        | Some p ->

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -18,6 +18,10 @@
 
 module Oas = Agent_sdk
 
+type stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+
 type run_result = {
   response : Oas.Types.api_response;
   checkpoint : Oas.Checkpoint.t option;
@@ -25,6 +29,7 @@ type run_result = {
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
   proof : Oas.Cdal_proof.t option;
+  stop_reason : stop_reason;
 }
 
 (** Cascade call/error metrics as JSON array, sorted by call count. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -441,6 +441,7 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     tools_used = tools;
     checkpoint = None;
     proof = None;
+    stop_reason = Masc_mcp.Oas_worker.Completed;
   }
 
 let test_metrics_text_response () =

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -292,6 +292,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
       turns = 3;
       trace_ref = Some trace_ref;
       proof = None;
+      stop_reason = Oas_worker.Completed;
     }
   in
   let telemetry = Team_session_oas_bridge.telemetry_of_run_result result in


### PR DESCRIPTION
## Summary
- Keeper가 max_turns(50) 도달 시 에러로 crash 하던 것을 "일시 중단"으로 변경
- `Oas_worker.stop_reason` variant 추가 (`Completed | TurnBudgetExhausted`)
- OAS `MaxTurnsExceeded`를 `Error` → `Ok + TurnBudgetExhausted`로 승격, checkpoint 보존
- Keeper unified turn에서 턴 고갈을 실패로 카운팅하지 않음

## Problem
```
2026-03-31 11:35:48 ERROR Keeper unified turn failed: Agent run failed: Max turns exceeded (turn 50, limit 50)
2026-03-31 11:29:02 ERROR Keeper unified turn failed: Agent run failed: Max turns exceeded (turn 50, limit 50)
... (40분간 6회 반복)
```

Keeper가 50턴 소진 → Error → turn_failures++ → threshold 도달 시 Crashed → keepalive 재시작 → 또 50턴 소진 → 무한 반복

## Fix
턴 고갈 =/= 장애. Agent가 progress를 만들었으므로:
1. checkpoint 저장 (이미 되고 있었음)
2. `Ok` result로 반환 (caller가 checkpoint 활용 가능)
3. turn_failures 리셋 (crash 카운터에 포함하지 않음)
4. 다음 keepalive cycle에서 checkpoint 기반으로 재개

## Test plan
- [x] `dune build` 통과
- [x] `test_keeper_unified.exe` 45개 통과
- [ ] CI 전체 통과
- [ ] 실제 keeper 50턴 도달 시 crash 대신 정상 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)