### PR TITLE
refactor(test): gate E2E server tests behind MASC_E2E_TESTS env (#3807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           CI_TEST_HEARTBEAT_SEC: 30
           MASC_LLAMA_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
           MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
+          MASC_E2E_TESTS: "true"
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh

--- a/test/dune
+++ b/test/dune
@@ -581,37 +581,44 @@
 
 ; ============================================================
 ; Special: E2E tests requiring server binary
+; These tests start/connect to an actual MASC MCP server process.
+; Skip by default; run with: MASC_E2E_TESTS=true dune test
 ; ============================================================
 
 (test
  (name test_mcp_post_sse_e2e)
  (modules test_mcp_post_sse_e2e)
  (libraries alcotest yojson unix)
- (deps ../bin/main_eio.exe))
+ (deps ../bin/main_eio.exe)
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test
  (name test_sse_storm_e2e)
  (modules test_sse_storm_e2e)
  (libraries alcotest yojson unix)
- (deps ../bin/main_eio.exe))
+ (deps ../bin/main_eio.exe)
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test
  (name test_board_api_e2e)
  (modules test_board_api_e2e)
  (libraries alcotest unix)
- (deps ../bin/main_eio.exe))
+ (deps ../bin/main_eio.exe)
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test
  (name test_openapi_api_e2e)
  (modules test_openapi_api_e2e)
  (libraries alcotest yojson unix)
- (deps ../bin/main_eio.exe))
+ (deps ../bin/main_eio.exe)
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test
  (name test_operator_mcp_e2e)
  (modules test_operator_mcp_e2e)
  (libraries masc_test_deps)
- (deps ../bin/main_eio.exe))
+ (deps ../bin/main_eio.exe)
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test
  (name test_compression_boundary)


### PR DESCRIPTION
## Summary
- E2E 테스트 5개(서버 바이너리 의존)를 `MASC_E2E_TESTS` 환경변수로 게이트
- 로컬에서 `dune test` 실행 시 서버 없이도 동작 (E2E 스킵)
- CI에서는 `MASC_E2E_TESTS=true`로 기존대로 전체 실행

## Gated tests
| Test | Dependency |
|------|-----------|
| `test_mcp_post_sse_e2e` | curl → server HTTP |
| `test_sse_storm_e2e` | SSE streaming |
| `test_board_api_e2e` | curl → board API |
| `test_openapi_api_e2e` | curl → OpenAPI |
| `test_operator_mcp_e2e` | operator MCP |

## Usage
```bash
dune test                     # unit tests only (default)
MASC_E2E_TESTS=true dune test # full suite including E2E
```

## Test plan
- [x] `dune build` — 빌드 성공
- [ ] CI green (E2E tests enabled via env var)

Closes #3807

🤖 Generated with [Claude Code](https://claude.com/claude-code)