### PR TITLE
fix(process): add ?cwd to run_argv_with_status, fix research_metric ignored cwd

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -286,20 +286,24 @@ let run_argv_with_stdin_and_status
                 (Printexc.to_string exn);
               (Unix.WEXITED 1, ""))
 
-let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.process_status * string =
+let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) : Unix.process_status * string =
   if not (is_initialized ()) then run_unix_argv_with_status_fallback ?env argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
         run_unix_argv_with_status_fallback ?env argv
-    | Ok pm, Ok clk, Ok cwd ->
+    | Ok pm, Ok clk, Ok default_cwd ->
+        let effective_cwd = match cwd with
+          | None -> default_cwd
+          | Some dir -> Eio.Path.(default_cwd / dir)
+        in
         let buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
               Eio.Switch.run (fun sw ->
                   let proc =
-                    Eio.Process.spawn ~sw pm ~cwd ?env
+                    Eio.Process.spawn ~sw pm ~cwd:effective_cwd ?env
                       ~stdout:(Eio.Flow.buffer_sink buf)
                       argv
                   in

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -54,5 +54,8 @@ val run_argv_with_stdin_and_status :
     Uses spawn + await to get exit status without raising.
     @param timeout_sec Timeout in seconds (default: 60.0)
     @param env Optional environment (Unix-style ["K=V"; ...]).
+    @param cwd Override working directory for the spawned process.
+           Absolute paths replace the default cwd; relative paths append to it.
+           Ignored when falling back to Unix process execution.
     @since 2.45.0 *)
-val run_argv_with_status : ?timeout_sec:float -> ?env:string array -> string list -> (Unix.process_status * string)
+val run_argv_with_status : ?timeout_sec:float -> ?env:string array -> ?cwd:string -> string list -> (Unix.process_status * string)

--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -43,7 +43,7 @@ let default ?(repo = default_repo_config ()) () : t =
     cascade_defaults = ["llama:auto"];
     timeout_sec = 120;
     max_tokens = 8192;  (* research-specific: larger budget for code analysis *)
-    temperature = 0.7;  (* TODO: resolve from cascade config "research" profile *)
+    temperature = 0.7;  (* fallback; tool_research.ml resolves from cascade config *)
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \

--- a/lib/research/research_metric.ml
+++ b/lib/research/research_metric.ml
@@ -32,16 +32,16 @@ let crash_result ~error_message =
     loc_delta = 0; files_changed = 0; build_seconds = 0.0; test_seconds = 0.0;
     binary_changed = false; status = Crash; error_message }
 
-(** Run a command with timeout. Returns (exit_code, stdout, elapsed_seconds). *)
+(** Run a command with timeout in the given directory.
+    Returns (exit_code, stdout, elapsed_seconds). *)
 let run_cmd_timed ~timeout_sec (argv : string list) ~cwd : (int * string * float) =
   let t0 = Unix.gettimeofday () in
   try
     let status, stdout =
-      Process_eio.run_argv_with_status ~timeout_sec argv
+      Process_eio.run_argv_with_status ~timeout_sec ~cwd argv
     in
     let elapsed = Unix.gettimeofday () -. t0 in
     let code = match status with Unix.WEXITED c -> c | _ -> 1 in
-    ignore cwd;  (* Process_eio uses global cwd; caller sets up worktree *)
     (code, stdout, elapsed)
   with exn ->
     let elapsed = Unix.gettimeofday () -. t0 in
@@ -66,10 +66,9 @@ let parse_test_counts ~returncode (stdout : string) : int * int =
 let measure_loc_delta ~cwd : int * int =
   try
     let _, stdout =
-      Process_eio.run_argv_with_status ~timeout_sec:10.0
+      Process_eio.run_argv_with_status ~timeout_sec:10.0 ~cwd
         [ "git"; "diff"; "--stat"; "HEAD" ]
     in
-    ignore cwd;
     let lines = String.split_on_char '\n' stdout in
     let summary = match List.rev lines with
       | [] -> ""

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -110,6 +110,22 @@ let test_run_argv_with_stdin_and_status_propagates_cancelled () =
   check bool "Cancelled propagated from run_argv_with_stdin_and_status" true
     !raised
 
+let test_run_argv_with_status_cwd_override () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let status, stdout =
+    Process_eio.run_argv_with_status ~cwd:"/tmp" [ "/bin/pwd" ]
+  in
+  let code = match status with Unix.WEXITED c -> c | _ -> 1 in
+  check int "pwd exit code" 0 code;
+  let trimmed = String.trim stdout in
+  (* /tmp may resolve to /private/tmp on macOS *)
+  check bool "cwd is /tmp or /private/tmp"
+    (trimmed = "/tmp" || trimmed = "/private/tmp") true
+
 let test_reset_for_testing_clears_runtime () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -148,6 +164,8 @@ let () =
             test_run_argv_with_stdin_propagates_cancelled;
           test_case "run_argv_with_stdin_and_status-propagates-cancelled" `Quick
             test_run_argv_with_stdin_and_status_propagates_cancelled;
+          test_case "run_argv_with_status-cwd-override" `Quick
+            test_run_argv_with_status_cwd_override;
           test_case "reset_for_testing-clears-runtime" `Quick
             test_reset_for_testing_clears_runtime;
         ] );

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -114,13 +114,23 @@ let test_run_argv_with_status_cwd_override () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
-  let cwd_default = Eio.Stdenv.fs env in
+  (* Use a non-root default cwd (/usr) so the test verifies that an
+     absolute ~cwd:"/tmp" truly replaces it, not just appends to root. *)
+  let cwd_default = Eio.Path.(Eio.Stdenv.fs env / "/usr") in
   Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  (* Without ~cwd, pwd should return /usr *)
+  let status_default, stdout_default =
+    Process_eio.run_argv_with_status [ "/bin/pwd" ]
+  in
+  let code_d = match status_default with Unix.WEXITED c -> c | _ -> 1 in
+  check int "default pwd exit code" 0 code_d;
+  check string "default cwd is /usr" "/usr" (String.trim stdout_default);
+  (* With ~cwd:"/tmp", pwd should return /tmp, not /usr/tmp *)
   let status, stdout =
     Process_eio.run_argv_with_status ~cwd:"/tmp" [ "/bin/pwd" ]
   in
   let code = match status with Unix.WEXITED c -> c | _ -> 1 in
-  check int "pwd exit code" 0 code;
+  check int "override pwd exit code" 0 code;
   let trimmed = String.trim stdout in
   (* /tmp may resolve to /private/tmp on macOS *)
   check bool "cwd is /tmp or /private/tmp"


### PR DESCRIPTION
## Summary
- `research_metric.ml`의 `run_cmd_timed`과 `measure_loc_delta`가 `~cwd` 파라미터를 받지만 `ignore cwd`로 무시하고 있었다
- 실험 worktree에서 빌드/테스트를 실행해야 하는데, 항상 서버의 기본 cwd에서 실행되는 버그
- `Process_eio.run_argv_with_status`에 `?cwd:string` optional 파라미터 추가 — Eio.Path.(/) 활용으로 thread-safe

## Changes
- `lib/process/process_eio.ml` — `?cwd` 파라미터 추가, `Eio.Path.(default_cwd / dir)`로 effective cwd 계산
- `lib/process/process_eio.mli` — 시그니처 업데이트 + `@param cwd` 문서화
- `lib/research/research_metric.ml` — `ignore cwd` 제거, `~cwd`를 `Process_eio.run_argv_with_status`에 전달
- `test/test_process_eio_coverage.ml` — `cwd-override` regression 테스트 추가 (`/tmp`에서 `pwd` 실행)

## Test plan
- [x] `test_process_eio_coverage.exe` 11/11 통과 (새 cwd-override 포함)
- [x] `dune build` 성공
- [ ] CI Build and Test 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)