### PR TITLE
fix(mdal): remove board posting from MDAL loop

### DIFF
--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -93,22 +93,7 @@ let handle_start (ctx : context) args =
       | Ok config ->
       let loop_id = Mdal.generate_loop_id () in
 
-      (* Create initial board post *)
-      let state_post_id =
-        match Board_dispatch.create_post
-                ~author:ctx.agent_name
-                ~content:(Printf.sprintf "[MDAL_STATE] %s starting. Profile: %s, Baseline: %.4f, Target: %s"
-                            loop_id profile.name baseline profile.target)
-                ~post_kind:Board.System_post
-                ~meta_json:(`Assoc [ ("source", `String "mdal_state_start") ])
-                ~visibility:Board.Internal
-                ~ttl_hours:24
-                ~hearth:(Mdal.state_hearth loop_id)
-                ()
-        with
-        | Ok post -> Board.Post_id.to_string post.Board.id
-        | Error _ -> "unknown"
-      in
+      let state_post_id = "" in
 
       let started_at = Time_compat.now () in
       let state : Mdal.loop_state = {
@@ -296,19 +281,6 @@ let handle_iterate (ctx : context) args =
                    state.current_iteration <- iter_num;
                    state.history <- record :: state.history;
                    Mdal.update_stagnation state record;
-
-                   (* Post iteration to board *)
-                   (try
-                      ignore (Board_dispatch.create_post
-                                ~author:"mdal"
-                                ~content:(Mdal.format_iter_post record)
-                                ~post_kind:Board.System_post
-                                ~meta_json:(`Assoc [ ("source", `String "mdal_iteration") ])
-                                ~visibility:Board.Internal
-                                ~ttl_hours:24
-                                ~hearth:(Mdal.iter_hearth state.loop_id)
-                                ())
-                    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
 
                    (* Broadcast via SSE *)
                    (try Sse.broadcast (`Assoc [

--- a/lib/tool_mdal_handlers.ml
+++ b/lib/tool_mdal_handlers.ml
@@ -232,21 +232,7 @@ let state_to_json ?config (state : Mdal.loop_state) =
       ("history", `List (List.map iter_record_to_json state.history));
     ]
 
-let post_final_summary (state : Mdal.loop_state) =
-  try
-    ignore
-      (Board_dispatch.create_post
-         ~author:"mdal"
-         ~content:(Mdal.format_final_post state)
-         ~post_kind:Board.System_post
-         ~meta_json:(`Assoc [ ("source", `String "mdal_final") ])
-         ~visibility:Board.Internal
-         ~ttl_hours:24
-         ~hearth:(Mdal.state_hearth state.loop_id)
-         ())
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Log.Misc.warn "tool_mdal: final board post failed: %s" (Printexc.to_string exn)
+let post_final_summary (_state : Mdal.loop_state) = ()
 
 let terminal_response ?config (state : Mdal.loop_state) ~reason ~error_message =
   assoc_with_fields (state_to_json ?config state)


### PR DESCRIPTION
## Summary
- MDAL이 매 iteration마다 board에 글을 올려 노이즈 폭증 (백업 기준 5,551건, delta 0% 개선)
- 3곳의 `Board_dispatch.create_post` 제거: 시작(`[MDAL_STATE]`), iteration(`[MDAL_ITER]`), 종료(`[MDAL_FINAL]`)
- SSE broadcast + `state.history` + 파일 저장이 동일 텔레메트리를 이미 제공

## Changes
- `lib/tool_mdal.ml`: 시작/iteration board 포스팅 제거 (-30줄)
- `lib/tool_mdal_handlers.ml`: `post_final_summary` 본체를 no-op으로 교체 (-14줄)

## Test plan
- [ ] CI 빌드 통과
- [ ] `dune runtest` — MDAL 테스트가 board 포스팅 없이도 통과
- [ ] 서버 기동 후 MDAL loop 실행 → board에 글이 생기지 않는 것 확인
- [ ] SSE broadcast는 그대로 동작하는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)