### PR TITLE
refactor(cdal): remove unused allowed_paths from contract bridge

### DIFF
--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -68,9 +68,7 @@ let infer_keeper_execution_mode ~(scope_kind : string) : Oas.Execution_mode.t =
   | "read_only" | "readonly" | "observe" -> Oas.Execution_mode.Diagnose
   | _ -> Oas.Execution_mode.Execute
 
-let infer_keeper_allowed_mutations ~(execution_scope : string)
-    ~(allowed_paths : string list) =
-  ignore allowed_paths;
+let infer_keeper_allowed_mutations ~(execution_scope : string) =
   match String.lowercase_ascii execution_scope with
   | "observe_only" ->
     (* observe_only keepers should not mutate — preserve CDAL enforcement. *)
@@ -89,11 +87,10 @@ let of_keeper
     ~(keeper_name : string)
     ~(goal : string)
     ~(scope_kind : string)
-    ~(execution_scope : string)
-    ~(allowed_paths : string list) : Oas.Risk_contract.t =
+    ~(execution_scope : string) : Oas.Risk_contract.t =
   let exec_mode = infer_keeper_execution_mode ~scope_kind in
   let risk = infer_keeper_risk_class ~scope_kind in
-  let mutations = infer_keeper_allowed_mutations ~execution_scope ~allowed_paths in
+  let mutations = infer_keeper_allowed_mutations ~execution_scope in
   Log.Keeper.info
     "cdal contract for %s: mode=%s risk=%s mutations=[%s] scope_kind=%s exec_scope=%s"
     keeper_name
@@ -115,4 +112,3 @@ let of_keeper
 let of_keeper_meta (meta : Keeper_types.keeper_meta) : Oas.Risk_contract.t =
   of_keeper ~keeper_name:meta.name ~goal:meta.short_goal
     ~scope_kind:meta.scope_kind ~execution_scope:meta.execution_scope
-    ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)

--- a/lib/cdal_contract_bridge.mli
+++ b/lib/cdal_contract_bridge.mli
@@ -21,7 +21,6 @@ val of_keeper :
   goal:string ->
   scope_kind:string ->
   execution_scope:string ->
-  allowed_paths:string list ->
   Agent_sdk.Risk_contract.t
 
 val of_keeper_meta : Keeper_types.keeper_meta -> Agent_sdk.Risk_contract.t


### PR DESCRIPTION
## Summary
- `infer_keeper_allowed_mutations`가 `~allowed_paths`를 받지만 `ignore`로 무시하고 있었다
- filesystem path(경로 기반 접근 제어)와 mutation kind(의미론적 라벨)를 혼동한 API
- 실제 keeper path access control은 `keeper_hooks_oas.ml` deny list에서 처리
- `of_keeper`, .mli, `of_keeper_meta`에서 파라미터 제거

## Changes
- `lib/cdal_contract_bridge.ml` — `~allowed_paths` 파라미터 제거 (infer 함수 + of_keeper + of_keeper_meta)
- `lib/cdal_contract_bridge.mli` — `allowed_paths:string list ->` 시그니처 제거

## Test plan
- [x] `test_contract_composer.exe` 10/10 통과 (allowed_paths fallback 테스트 포함)
- [x] `dune build` 성공
- [ ] CI Build and Test 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)