### PR TITLE
fix(shard): remove keeper_board_delete from default board shard

### DIFF
--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -145,18 +145,6 @@ Use when looking for specific topics, past discussions, or related prior work.";
       ("required", `List [`String "query"]);
     ];
   };
-  {
-    name = "keeper_board_delete";
-    description = "Delete a board post and its associated comments and votes. \
-Use for cleanup of stale, test, or expired posts.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("post_id", `Assoc [("type", `String "string"); ("description", `String "ID of the post to delete")]);
-      ]);
-      ("required", `List [`String "post_id"]);
-    ];
-  };
 ]
 
 let select_named_schemas (names : string list) (schemas : Types.tool_schema list) :


### PR DESCRIPTION
## Summary
- `keeper_board_delete`를 default `board` shard에서 제거
- delete는 파괴적 동작 — 모든 keeper에게 기본 제공하면 안 됨
- 후속: `feat/keeper-tools-preset`의 `tool_access` ADT로 재니터에게만 선별 부여

## Changes
- `lib/tool_shard.ml`: `board_tools`에서 `keeper_board_delete` schema 제거 (-12줄)

## Test plan
- [ ] CI 빌드 통과
- [ ] keeper 세션에서 `keeper_board_delete`가 schema에 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)