### PR TITLE
fix(dashboard): expand MetricsWindow type + replace duplicated RuntimeSignals with quality metrics

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -7,7 +7,6 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
 import { missionSnapshot } from '../mission-store'
-import { formatPct } from '../lib/format-number'
 import type { DashboardMissionKeeperBrief, Keeper } from '../types'
 import { serverStatus } from '../store'
 import { operatorSnapshot } from '../operator-store'
@@ -113,38 +112,118 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 
 // ── Runtime Signals ──────────────────────────────────────
 
+// Helper: format a 0–1 ratio as percentage or '-'
+function fmtRate(v: unknown): string {
+  return typeof v === 'number' ? `${(v * 100).toFixed(1)}%` : '-'
+}
+
+// Helper: format a float with fixed decimals or '-'
+function fmtFixed(v: unknown, digits = 3): string {
+  return typeof v === 'number' ? v.toFixed(digits) : '-'
+}
+
+// Helper: format an integer count or '-'
+function fmtCount(v: unknown): string | number {
+  return typeof v === 'number' ? v : '-'
+}
+
+interface SignalGroup {
+  title: string
+  rows: Array<{ label: string; value: string | number }>
+}
+
 export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
   const mw = keeper.metrics_window
 
-  // Quality/rate metrics only — raw counts (handoffs, compactions, k2k, etc.)
+  // Quality/rate metrics only — raw counts (handoffs, compactions, turns)
   // are authoritative in KpiGrid to avoid duplication.
-  const rows: Array<{ label: string; value: string | number }> = [
-    { label: '자율 턴', value: keeper.autonomous_turn_count ?? '-' },
-    { label: '도구 턴', value: keeper.autonomous_tool_turn_count ?? '-' },
-    { label: '텍스트 턴', value: keeper.autonomous_text_turn_count ?? '-' },
-    { label: '게시판 반응', value: keeper.board_reactive_turn_count ?? '-' },
-    { label: '멘션 반응', value: keeper.mention_reactive_turn_count ?? '-' },
-    { label: 'No-op 턴', value: keeper.noop_turn_count ?? '-' },
-    { label: '모델 폴백', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
-    { label: '프로액티브 폴백', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
-    { label: '메모리 통과율', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
-    { label: '프리뷰 유사도', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
-    { label: '메모리 평균 점수', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
-    { label: '폴백 비율', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
+  const groups: SignalGroup[] = [
+    {
+      title: '폴백',
+      rows: [
+        { label: '전체 폴백', value: fmtRate(mw?.fallback_rate) },
+        { label: '모델 폴백', value: fmtRate(mw?.model_fallback_rate) },
+        { label: '프로액티브 폴백', value: fmtRate(mw?.proactive_fallback_rate) },
+      ],
+    },
+    {
+      title: '정렬 품질',
+      rows: [
+        { label: '목표 정렬', value: fmtFixed(mw?.goal_alignment_avg) },
+        { label: '응답 정렬', value: fmtFixed(mw?.response_alignment_avg) },
+        { label: '목표 드리프트', value: fmtFixed(mw?.goal_drift_avg) },
+        { label: '반복 위험', value: fmtFixed(mw?.repetition_risk_avg) },
+      ],
+    },
+    {
+      title: '자율 행동',
+      rows: [
+        { label: '자동 성찰 비율', value: fmtRate(mw?.auto_reflect_rate) },
+        { label: '자동 계획 비율', value: fmtRate(mw?.auto_plan_rate) },
+        { label: '자동 컴팩션 비율', value: fmtRate(mw?.auto_compact_rate) },
+        { label: '자동 핸드오프 비율', value: fmtRate(mw?.auto_handoff_rate) },
+        { label: '가드레일 정지', value: fmtCount(mw?.guardrail_stop_count) },
+        { label: '가드레일 비율', value: fmtRate(mw?.guardrail_stop_rate) },
+      ],
+    },
+    {
+      title: '드리프트 보정',
+      rows: [
+        { label: '보정 횟수', value: fmtCount(mw?.drift_applied_count) },
+        { label: '보정 비율', value: fmtRate(mw?.drift_applied_rate) },
+        { label: '개입 비중', value: fmtRate(mw?.intervention_share) },
+        { label: '턴당 개입', value: fmtFixed(mw?.intervention_per_turn, 2) },
+      ],
+    },
+    {
+      title: '메모리',
+      rows: [
+        { label: '메모리 통과율', value: fmtRate(mw?.memory_pass_rate) },
+        { label: '메모리 평균 점수', value: fmtFixed(mw?.memory_avg_score) },
+        { label: '메모리 교정', value: fmtCount(mw?.memory_corrections) },
+        { label: '교정 성공', value: fmtCount(mw?.memory_correction_success) },
+        { label: '날씨 통과율', value: fmtRate(mw?.memory_weather_pass_rate) },
+      ],
+    },
+    {
+      title: '메모리 컴팩션',
+      rows: [
+        { label: '드롭 비율', value: fmtRate(mw?.memory_compaction_drop_ratio) },
+        { label: '평균 드롭', value: fmtFixed(mw?.memory_compaction_drop_avg, 1) },
+        { label: '컴팩션 절감', value: fmtRate(mw?.compaction_saved_ratio) },
+        { label: '평균 절감 토큰', value: fmtFixed(mw?.avg_compaction_saved_tokens, 0) },
+      ],
+    },
+    {
+      title: '프리뷰 유사도',
+      rows: [
+        { label: '평균', value: fmtRate(mw?.proactive_preview_similarity_avg) },
+        { label: '최대', value: fmtRate(mw?.proactive_preview_similarity_max) },
+        { label: '경고', value: typeof mw?.proactive_preview_similarity_warn === 'boolean' ? (mw.proactive_preview_similarity_warn ? 'Y' : 'N') : '-' },
+      ],
+    },
   ]
 
-  const visibleRows = rows.filter(row =>
-    !(
-      row.value === '-'
-      || row.value === '\u2014'
-      || row.value === ''
-    ))
+  // Filter out groups where all rows are '-'
+  const visibleGroups = groups
+    .map(g => ({
+      ...g,
+      rows: g.rows.filter(r => r.value !== '-' && r.value !== '\u2014' && r.value !== ''),
+    }))
+    .filter(g => g.rows.length > 0)
 
-  if (visibleRows.length === 0) return null
+  if (visibleGroups.length === 0) return null
 
   return html`
-    <div class="flex flex-col gap-1.5">
-      ${visibleRows.map(r => html`<${SignalRow} label=${r.label} value=${r.value} />`)}
+    <div class="flex flex-col gap-3">
+      ${visibleGroups.map(g => html`
+        <div class="flex flex-col gap-1">
+          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] px-1">${g.title}</span>
+          <div class="flex flex-col gap-1">
+            ${g.rows.map(r => html`<${SignalRow} label=${r.label} value=${r.value} />`)}
+          </div>
+        </div>
+      `)}
     </div>
   `
 }

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -103,25 +103,41 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
     .filter((item): item is KeeperMetricPoint => item !== null)
 }
 
+// Top-N list keys that contain arrays of { tool/kind/model/..., count } objects
+const TOP_LIST_KEYS = new Set([
+  'top_tools', 'top_work_kinds', 'top_models', 'top_memory_kinds',
+  'top_drift_reasons', 'top_compaction_triggers', 'generation_equipment',
+])
+
 function normalizeMetricsWindow(raw: unknown): Keeper['metrics_window'] | undefined {
   if (!isRecord(raw)) return undefined
 
   const normalized: Keeper['metrics_window'] = {}
   for (const [key, value] of Object.entries(raw)) {
-    if (key === 'top_tools') {
+    // Top-N lists: array of objects with at least one string field
+    if (TOP_LIST_KEYS.has(key)) {
       if (!Array.isArray(value)) continue
-      const topTools = value.filter(item =>
-        isRecord(item)
-        && typeof item.tool === 'string'
-        && item.tool.trim() !== '',
-      )
-      if (topTools.length > 0) normalized.top_tools = topTools
+      const items = value.filter(item => isRecord(item))
+      if (items.length > 0) normalized[key] = items
       continue
     }
 
+    // Numbers (majority of fields)
     const numberValue = asNumber(value)
     if (numberValue != null) {
       normalized[key] = numberValue
+      continue
+    }
+
+    // Booleans (e.g. proactive_preview_similarity_warn)
+    if (typeof value === 'boolean') {
+      normalized[key] = value
+      continue
+    }
+
+    // Strings (e.g. primary_model, proactive_preview_similarity_method)
+    if (typeof value === 'string' && value.trim() !== '') {
+      normalized[key] = value
     }
   }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -303,6 +303,131 @@ export type PipelineStage =
   | 'proactive'
   | 'offline'
 
+// Aggregated metrics computed by the backend over a sliding window.
+// Fields mirror dashboard_http_keeper_detail.ml summary output.
+export interface MetricsWindowTopItem {
+  tool?: string
+  kind?: string
+  model?: string
+  reason?: string
+  trigger?: string
+  count?: number
+  [key: string]: unknown
+}
+
+export interface MetricsWindow {
+  // -- Sample metadata --
+  sample_points?: number
+  window_sample_points?: number
+  turn_points?: number
+  window_turn_points?: number
+  heartbeat_points?: number
+  window_heartbeat_points?: number
+  proactive_points?: number
+  window_proactive_points?: number
+  window_interactions?: number
+  window_turns?: number
+  window_series_max_lines?: number
+  window_series_max_bytes?: number
+  primary_model?: string
+
+  // -- Handoff / Compaction counts --
+  handoff_count?: number
+  compaction_events?: number
+  compaction_before_tokens?: number
+  compaction_saved_tokens?: number
+  compaction_saved_ratio?: number
+  avg_compaction_saved_tokens?: number
+
+  // -- Fallback rates --
+  fallback_count?: number
+  fallback_rate?: number
+  model_fallback_count?: number
+  model_fallback_rate?: number
+  model_fallback_numerator?: number
+  model_fallback_denominator?: number
+  proactive_fallback_count?: number
+  proactive_fallback_rate?: number
+  proactive_template_fallback_count?: number
+  proactive_template_fallback_rate?: number
+  proactive_template_fallback_numerator?: number
+  proactive_template_fallback_denominator?: number
+
+  // -- Intervention --
+  intervention_share?: number
+  intervention_per_turn?: number
+
+  // -- Automation counts & rates --
+  auto_reflect_count?: number
+  auto_plan_count?: number
+  auto_compact_count?: number
+  auto_handoff_count?: number
+  guardrail_stop_count?: number
+  auto_reflect_rate?: number
+  auto_plan_rate?: number
+  auto_compact_rate?: number
+  auto_handoff_rate?: number
+  guardrail_stop_rate?: number
+
+  // -- Drift --
+  drift_applied_count?: number
+  drift_applied_rate?: number
+
+  // -- Alignment quality --
+  repetition_risk_avg?: number
+  goal_alignment_avg?: number
+  response_alignment_avg?: number
+  goal_drift_avg?: number
+
+  // -- Proactive preview similarity --
+  proactive_preview_sample_count?: number
+  proactive_preview_pair_count?: number
+  proactive_preview_similarity_avg?: number
+  proactive_preview_similarity_max?: number
+  proactive_preview_similarity_warn?: boolean
+  proactive_preview_similarity_method?: string
+  proactive_preview_similarity_window?: number
+
+  // -- Tool --
+  tool_call_count?: number
+
+  // -- Memory --
+  memory_checks?: number
+  memory_passed?: number
+  memory_failed?: number
+  memory_pass_rate?: number
+  memory_avg_score?: number
+  memory_threshold?: number
+  memory_corrections?: number
+  memory_correction_success?: number
+  memory_notes_added?: number
+
+  // -- Memory compaction --
+  memory_compaction_events?: number
+  memory_compaction_before_notes?: number
+  memory_compaction_dropped_notes?: number
+  memory_compaction_invalid_dropped?: number
+  memory_compaction_drop_ratio?: number
+  memory_compaction_drop_avg?: number
+
+  // -- Memory weather --
+  memory_weather_checks?: number
+  memory_weather_passed?: number
+  memory_weather_pass_rate?: number
+
+  // -- Top-N lists --
+  top_work_kinds?: MetricsWindowTopItem[]
+  top_models?: MetricsWindowTopItem[]
+  top_tools?: MetricsWindowTopItem[]
+  top_memory_kinds?: MetricsWindowTopItem[]
+  top_drift_reasons?: MetricsWindowTopItem[]
+  top_compaction_triggers?: MetricsWindowTopItem[]
+  generation_equipment?: MetricsWindowTopItem[]
+
+  // Catch-all for future fields
+  [key: string]: unknown
+}
+
 export interface Keeper {
   name: string
   pipeline_stage?: PipelineStage
@@ -384,19 +509,7 @@ export interface Keeper {
   skill_primary?: string | null
   skill_secondary?: string[]
   skill_reason?: string | null
-  metrics_window?: {
-    fallback_rate?: number
-    model_fallback_rate?: number
-    proactive_fallback_rate?: number
-    proactive_preview_similarity_avg?: number
-    memory_pass_rate?: number
-    memory_avg_score?: number
-    handoff_count?: number
-    compaction_events?: number
-    compaction_saved_tokens?: number
-    tool_call_count?: number
-    [key: string]: unknown
-  }
+  metrics_window?: MetricsWindow
   agent?: {
     name?: string
     exists?: boolean


### PR DESCRIPTION
## Summary
- `MetricsWindow` 인터페이스를 별도 타입으로 분리하고 백엔드(`dashboard_http_keeper_detail.ml`)가 계산하는 80+ 필드를 카테고리별로 명시 (기존 10개만 선언됨)
- `RuntimeSignals`에서 KpiGrid와 중복되던 턴 카운트 6개 제거, 7개 그룹의 품질 메트릭으로 대체:
  - 폴백 비율, 정렬 품질, 자율 행동, 드리프트 보정, 메모리 건강, 메모리 컴팩션 효율, 프리뷰 유사도
- 데이터 없는 그룹은 자동 숨김 (기존 동작과 동일)

## Changes
| 파일 | 변경 |
|------|------|
| `dashboard/src/types/core.ts` | `MetricsWindow` + `MetricsWindowTopItem` 인터페이스 추가 |
| `dashboard/src/components/keeper-detail-runtime.ts` | 중복 제거, 그룹화된 품질 메트릭 표시 |

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `vite build` 성공
- [ ] 실제 keeper가 있는 대시보드에서 RuntimeSignals 패널 확인
- [ ] metrics_window 데이터가 없는 keeper에서 빈 그룹 숨김 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)