### PR TITLE
feat(keeper): graceful last turn + deterministic STATE synthesis

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -320,7 +320,7 @@ let run_turn
     Agent_sdk.Hooks.empty with
     before_turn_params = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.BeforeTurnParams { current_params; messages; _ } ->
+      | Agent_sdk.Hooks.BeforeTurnParams { turn; current_params; messages; _ } ->
         (* 1. Dynamic context injection *)
         let ctx =
           if String.trim dynamic_context = "" then
@@ -366,6 +366,54 @@ let run_turn
             "tool_disclosure keeper=%s top_score=%.3f retrieved=%d allowed=%d fallback=%b query_len=%d"
             meta.name top_score (List.length retrieved_names)
             (List.length all_allowed) use_fallback (String.length query_text);
+        (* 3. Graceful last-turn: inject budget warnings and restrict
+           tools when approaching the turn limit.
+           - Warning zone (2 turns before limit): inject budget warning
+           - Last turn (1 turn before limit): restrict to safe tools + force [STATE]
+           The keeper can still call extend_turns to escape the limit. *)
+        let is_last_turn = turn >= max_turns - 1 in
+        let is_warning_zone = turn >= max_turns - 2 in
+        let ctx =
+          if is_last_turn then
+            let warning =
+              Printf.sprintf
+                "[LAST TURN] Turn %d/%d. This is your final turn. \
+                 You MUST emit a [STATE]...[/STATE] block now summarizing \
+                 what you accomplished and what the next generation should do. \
+                 Do NOT start new tool work. If you need more turns, call extend_turns."
+                turn max_turns
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else if is_warning_zone then
+            let warning =
+              Printf.sprintf
+                "[BUDGET] %d/%d turns used. Wrap up current work and emit \
+                 a [STATE] block. Call extend_turns if you need more time."
+                turn max_turns
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else ctx
+        in
+        let all_allowed =
+          if is_last_turn then
+            (* On last turn, only allow state-preserving and communication tools.
+               Removes filesystem/bash/edit tools to prevent starting unfinishable work. *)
+            List.filter (fun name ->
+              List.mem name
+                [ "keeper_board_post"; "keeper_board_comment";
+                  "keeper_context_status"; "extend_turns";
+                  "keeper_time_now"; "keeper_broadcast" ]
+            ) all_allowed
+          else all_allowed
+        in
+        if is_warning_zone then
+          Log.Keeper.info
+            "keeper:%s turn_budget turn=%d/%d last_turn=%b"
+            meta.name turn max_turns is_last_turn;
         let tool_filter =
           Agent_sdk.Guardrails.AllowList all_allowed
         in
@@ -470,6 +518,31 @@ let run_turn
         (match normalize_response_text ~text ~tool_names () with
          | Error e -> Error e
          | Ok response_text ->
+             (* Ensure every generation has a [STATE] block for continuity.
+                If the model omitted it, synthesize one deterministically
+                from tool usage and stop reason. *)
+             let response_text =
+               match Keeper_memory_policy.find_state_block response_text with
+               | Some _ -> response_text
+               | None ->
+                 let stop_reason_str =
+                   match result.stop_reason with
+                   | Oas_worker.Completed -> "completed"
+                   | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
+                 in
+                 let synth =
+                   Keeper_memory_policy.synthesize_state_from_run_result
+                     ~goal:meta.goal
+                     ~tools_used:tool_names
+                     ~stop_reason:stop_reason_str
+                     ~response_text
+                 in
+                 let block = Keeper_memory_policy.render_state_block synth in
+                 Log.Keeper.info
+                   "keeper:%s [STATE] missing, synthesized from %d tools (stop=%s)"
+                   meta.name (List.length tool_names) stop_reason_str;
+                 response_text ^ "\n" ^ block
+             in
              let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
              Keeper_exec_context.persist_message
                ~source:history_assistant_source

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -628,3 +628,80 @@ let profile_kind_caps (profile : string) : (string * int) list =
 
 let cap_for_kind (caps : (string * int) list) (kind : string) : int =
   List.assoc_opt kind caps |> Option.value ~default:1
+
+(** Synthesize a [STATE] block from run metadata when the model omits one.
+    Produces a deterministic snapshot from tool usage, stop reason, and goal
+    so generation continuity is never broken. Tagged [SYNTHETIC] for
+    downstream consumers to distinguish from model-generated blocks. *)
+let synthesize_state_from_run_result
+    ~(goal : string)
+    ~(tools_used : string list)
+    ~(stop_reason : string)
+    ~(response_text : string)
+    : keeper_state_snapshot =
+  let progress =
+    match tools_used with
+    | [] -> Some "No tools used this generation"
+    | ts ->
+      let unique = List.sort_uniq String.compare ts in
+      Some (Printf.sprintf "Used: %s" (String.concat ", " unique))
+  in
+  let next_items =
+    if stop_reason = "budget_exhausted" then
+      ["Continue previous work"; "Review results from last generation"]
+    else []
+  in
+  let response_hint =
+    let trimmed = String.trim response_text in
+    if String.length trimmed > 100 then
+      Some (String.sub trimmed 0 100 ^ "...")
+    else if trimmed <> "" then Some trimmed
+    else None
+  in
+  let decisions =
+    match response_hint with
+    | Some hint -> [Printf.sprintf "[SYNTHETIC] Last output: %s" hint]
+    | None -> ["[SYNTHETIC] No visible output this generation"]
+  in
+  { goal = (let g = String.trim goal in if g = "" then None else Some g);
+    progress;
+    next_items;
+    decisions;
+    open_questions = [];
+    constraints = [];
+  }
+
+(** Render a [keeper_state_snapshot] back into a [\[STATE\]...\[/STATE\]] block. *)
+let render_state_block (snapshot : keeper_state_snapshot) : string =
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf "[STATE]\n";
+  (match snapshot.goal with
+   | Some g when String.trim g <> "" ->
+     Buffer.add_string buf (Printf.sprintf "Goal: %s\n" g)
+   | _ -> ());
+  (match snapshot.progress with
+   | Some p when String.trim p <> "" ->
+     Buffer.add_string buf (Printf.sprintf "Progress: %s\n" p)
+   | _ -> ());
+  (match snapshot.next_items with
+   | [] -> ()
+   | items ->
+     Buffer.add_string buf
+       (Printf.sprintf "Next: %s\n" (String.concat "; " items)));
+  (match snapshot.decisions with
+   | [] -> ()
+   | items ->
+     Buffer.add_string buf
+       (Printf.sprintf "Decisions: %s\n" (String.concat "; " items)));
+  (match snapshot.open_questions with
+   | [] -> ()
+   | items ->
+     Buffer.add_string buf
+       (Printf.sprintf "OpenQuestions: %s\n" (String.concat "; " items)));
+  (match snapshot.constraints with
+   | [] -> ()
+   | items ->
+     Buffer.add_string buf
+       (Printf.sprintf "Constraints: %s\n" (String.concat "; " items)));
+  Buffer.add_string buf "[/STATE]";
+  Buffer.contents buf

--- a/lib/opentelemetry_client_cohttp_eio.ml
+++ b/lib/opentelemetry_client_cohttp_eio.ml
@@ -210,7 +210,7 @@ module type EMITTER = sig
   val cleanup : on_done:(unit -> unit) -> unit -> unit
 end
 
-let mk_emitter ~stop ~net (config : Config.t) : (module EMITTER) =
+let mk_emitter ~stop ~clock ~net (config : Config.t) : (module EMITTER) =
   let open struct
     let client =
       Mirage_crypto_rng_unix.use_default ();
@@ -226,7 +226,7 @@ let mk_emitter ~stop ~net (config : Config.t) : (module EMITTER) =
       | Error err ->
           Atomic.incr n_errors;
           report_err_ err;
-          Eio_unix.sleep 3.
+          Eio.Time.sleep clock 3.
 
     let timeout =
       if config.batch_timeout_ms > 0 then
@@ -423,7 +423,7 @@ end
 
 let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) env
     : (module OT.Collector.BACKEND) =
-  let module E = (val mk_emitter ~stop ~net:env#net config) in
+  let module E = (val mk_emitter ~stop ~clock:env#clock ~net:env#net config) in
   let module B = Backend (E) in
   Eio.Fiber.fork ~sw (fun () ->
       while not @@ Atomic.get stop do


### PR DESCRIPTION
## Summary

Issue #4308 Phase 1 + Phase 3: 세대 연속성 기반 keeper 재설계의 핵심 두 축.

### Phase 1: Graceful Last Turn
- `before_turn_params` hook에서 `turn` 카운트를 감시
- **Warning zone** (N-2): 예산 경고 주입 via `extra_system_context`
- **Last turn** (N-1): 도구를 communication-only로 제한 + [STATE] 강제 요청
- `extend_turns`는 유지 — keeper가 정당한 경우 탈출 가능

### Phase 3: Deterministic [STATE] Synthesis
- 모델이 `[STATE]` 블록을 생략하면 도구 사용 이력 + stop_reason에서 결정론적으로 합성
- `[SYNTHETIC]` 태그로 모델 생성분과 구별
- 세대 연속성 끊김 0건 보장

## 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_agent_run.ml` | hook 확장 + synthesis injection |
| `lib/keeper/keeper_memory_policy.ml` | `synthesize_state_from_run_result` + `render_state_block` |

## 경계 준수

- OAS 변경 없음
- 벤더명 참조 없음
- OAS Agent.run hook으로만 제어

## Test plan

- [x] `dune build` 성공
- [x] `test_keeper_unified.exe` 45 tests pass
- [x] `test_keeper_memory.exe` 20 tests pass
- [ ] CI green
- [ ] Cross-model review

Refs: #4308, #4298

🤖 Generated with [Claude Code](https://claude.com/claude-code)