### PR TITLE
feat(keeper): persona-driven compaction with soul_profile-aware fold

### DIFF
--- a/lib/keeper/keeper_compaction.ml
+++ b/lib/keeper/keeper_compaction.ml
@@ -128,3 +128,92 @@ let fold_completed ~(keep_recent : int)
 
 let fold_completed_strategy ?(keep_recent = 10) () : Agent_sdk.Context_reducer.t =
   Agent_sdk.Context_reducer.custom (fold_completed ~keep_recent)
+
+(* --- Persona-aware compaction (#4318) --- *)
+
+(** Keywords that each soul_profile considers important.
+    Mirrors the keyword lists in {!Keeper_memory_policy.profile_signal_bonus}
+    but exposed as a reusable function for compaction filtering. *)
+let keywords_for_profile (profile : string) : string list =
+  match profile with
+  | "safety" ->
+    ["risk"; "danger"; "unsafe"; "security"; "guardrail";
+     "\xEC\x9C\x84\xED\x97\x98"; "\xEB\xB3\xB4\xEC\x95\x88"; "\xEC\x95\x88\xEC\xA0\x84"]
+  | "delivery" ->
+    ["blocker"; "deadline"; "ship"; "release"; "next step";
+     "\xEB\xA7\x89\xED\x9E\x98"; "\xEB\xB0\xB0\xED\x8F\xAC"; "\xEB\x8B\xA4\xEC\x9D\x8C \xEB\x8B\xA8\xEA\xB3\x84"]
+  | "research" ->
+    ["hypothesis"; "evidence"; "experiment"; "measure";
+     "\xEA\xB0\x80\xEC\x84\xA4"; "\xEA\xB7\xBC\xEA\xB1\xB0"; "\xEC\x8B\xA4\xED\x97\x98"]
+  | "relationship" ->
+    ["preference"; "style"; "tone"; "trust";
+     "\xEC\x84\xA0\xED\x98\xB8"; "\xEC\x8A\xA4\xED\x83\x80\xEC\x9D\xBC"; "\xED\x86\xA4"; "\xEC\x8B\xA0\xEB\xA2\xB0"]
+  | _ -> []
+
+(** Extract up to 3 first-sentence excerpts from messages that contain
+    keywords relevant to the given [soul_profile]. *)
+let extract_profile_relevant_excerpts
+    ~(soul_profile : string)
+    (msgs : Agent_sdk.Types.message list) : string list =
+  let keywords = keywords_for_profile soul_profile in
+  if keywords = [] then []
+  else
+    msgs
+    |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
+      let text = Agent_sdk.Types.text_of_message m in
+      if Keeper_memory_policy.contains_any_ci text keywords
+      then Some (first_sentence text)
+      else None)
+    |> List.filteri (fun i _ -> i < 3)
+
+(** Build a persona-aware fold stub. Extends the standard stub with
+    "Key context" excerpts filtered by [soul_profile] keywords. *)
+let persona_fold_stub_of_turns
+    ~(soul_profile : string)
+    (turns : Agent_sdk.Types.message list list)
+    : Agent_sdk.Types.message =
+  let all_msgs = List.concat turns in
+  let task = task_of_turn all_msgs in
+  let outcome = outcome_of_turn all_msgs in
+  let artifacts = artifacts_of_turn all_msgs in
+  let n_turns = List.length turns in
+  let excerpts = extract_profile_relevant_excerpts ~soul_profile all_msgs in
+  let excerpt_section = match excerpts with
+    | [] -> ""
+    | _ -> "\nKey context: " ^ String.concat " | " excerpts
+  in
+  let stub_text = Printf.sprintf
+    "[Folded: %s | %d turns]\nOutcome: %s\nArtifacts: %s%s"
+    task n_turns outcome (format_artifacts artifacts) excerpt_section
+  in
+  { Agent_sdk.Types.role = Agent_sdk.Types.User;
+    content = [Agent_sdk.Types.Text stub_text];
+    name = None;
+    tool_call_id = None }
+
+(** Persona-aware fold: same grouping and recency logic as [fold_completed],
+    but uses [persona_fold_stub_of_turns] for profile-relevant excerpts. *)
+let persona_fold_completed ~(keep_recent : int) ~(soul_profile : string)
+    (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let turns = Agent_sdk.Context_reducer.group_into_turns msgs in
+  let total = List.length turns in
+  if total <= keep_recent then msgs
+  else
+    let old_count = total - keep_recent in
+    let rec split n acc = function
+      | [] -> (List.rev acc, [])
+      | x :: rest ->
+        if n <= 0 then (List.rev acc, x :: rest)
+        else split (n - 1) (x :: acc) rest
+    in
+    let old_turns, recent_turns = split old_count [] turns in
+    match old_turns with
+    | [] -> msgs
+    | _ ->
+      let stub = persona_fold_stub_of_turns ~soul_profile old_turns in
+      stub :: List.concat recent_turns
+
+let persona_fold_strategy ?(keep_recent = 10) ~(soul_profile : string) ()
+    : Agent_sdk.Context_reducer.t =
+  Agent_sdk.Context_reducer.custom
+    (persona_fold_completed ~keep_recent ~soul_profile)

--- a/lib/keeper/keeper_compaction.mli
+++ b/lib/keeper/keeper_compaction.mli
@@ -18,3 +18,22 @@ val fold_completed_strategy :
   ?keep_recent:int ->
   unit ->
   Agent_sdk.Context_reducer.t
+
+(** Keywords that each [soul_profile] considers important for retention.
+    @since persona-fold *)
+val keywords_for_profile : string -> string list
+
+(** Extract up to 3 profile-relevant first-sentence excerpts. *)
+val extract_profile_relevant_excerpts :
+  soul_profile:string ->
+  Agent_sdk.Types.message list ->
+  string list
+
+(** Persona-aware lossy fold. Same recency logic as [fold_completed_strategy],
+    but stubs include profile-relevant excerpts via [keywords_for_profile].
+    @since persona-fold *)
+val persona_fold_strategy :
+  ?keep_recent:int ->
+  soul_profile:string ->
+  unit ->
+  Agent_sdk.Context_reducer.t

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -359,7 +359,8 @@ let compact_if_needed
       in
       (* FoldCompleted replaces SummarizeOld — applied as a separate
          OAS Custom reducer after the standard strategy pipeline. *)
-      let fold_reducer = Keeper_compaction.fold_completed_strategy () in
+      let fold_reducer = Keeper_compaction.persona_fold_strategy
+        ~soul_profile:meta.soul_profile () in
       let strategy_names =
         List.map Context_compact_oas.strategy_name strategies
         @ ["FoldCompleted"]

--- a/test/test_keeper_compaction.ml
+++ b/test/test_keeper_compaction.ml
@@ -190,6 +190,82 @@ let test_fold_vs_summarize_old () =
 (* Runner                                                            *)
 (* ================================================================ *)
 
+(* ================================================================ *)
+(* Persona-aware compaction tests (#4318)                           *)
+(* ================================================================ *)
+
+let test_keywords_for_profile () =
+  let safety_kw = Masc_mcp.Keeper_compaction.keywords_for_profile "safety" in
+  check bool "safety has 'risk'" true (List.mem "risk" safety_kw);
+  let research_kw = Masc_mcp.Keeper_compaction.keywords_for_profile "research" in
+  check bool "research has 'hypothesis'" true (List.mem "hypothesis" research_kw);
+  let relationship_kw = Masc_mcp.Keeper_compaction.keywords_for_profile "relationship" in
+  check bool "relationship has 'trust'" true (List.mem "trust" relationship_kw);
+  let delivery_kw = Masc_mcp.Keeper_compaction.keywords_for_profile "delivery" in
+  check bool "delivery has 'blocker'" true (List.mem "blocker" delivery_kw);
+  let unknown_kw = Masc_mcp.Keeper_compaction.keywords_for_profile "unknown_profile" in
+  check int "unknown profile => empty" 0 (List.length unknown_kw)
+
+let test_persona_stub_includes_excerpts () =
+  let msgs =
+    [ user "I noticed trust is building between us.";
+      assistant "Yes, the rapport has improved.";
+      user "Let's discuss style preferences.";
+      assistant "Sure, what tone do you prefer?" ]
+    @ make_turns 2
+    @ [user "Final."; assistant "Done."]
+  in
+  let reducer = Masc_mcp.Keeper_compaction.persona_fold_strategy
+    ~keep_recent:1 ~soul_profile:"relationship" () in
+  let result = R.reduce reducer msgs in
+  let stub = List.hd result in
+  let stub_text = T.text_of_message stub in
+  check bool "stub has Key context section" true
+    (try let _ = Str.search_forward (Str.regexp_string "Key context:") stub_text 0 in true
+     with Not_found -> false);
+  check bool "stub mentions trust" true
+    (try let _ = Str.search_forward (Str.regexp_string "trust") stub_text 0 in true
+     with Not_found -> false)
+
+let test_persona_stub_no_excerpts_generic () =
+  let msgs = make_turns 5 @ [user "Final."; assistant "Done."] in
+  let reducer = Masc_mcp.Keeper_compaction.persona_fold_strategy
+    ~keep_recent:1 ~soul_profile:"relationship" () in
+  let result = R.reduce reducer msgs in
+  let stub = List.hd result in
+  let stub_text = T.text_of_message stub in
+  (* No keywords matched => no Key context section *)
+  check bool "no Key context when no keywords match" false
+    (try let _ = Str.search_forward (Str.regexp_string "Key context:") stub_text 0 in true
+     with Not_found -> false)
+
+let test_persona_fold_backward_compat () =
+  (* persona fold with empty soul_profile behaves like original fold *)
+  let msgs = make_turns 5 in
+  let persona_reducer = Masc_mcp.Keeper_compaction.persona_fold_strategy
+    ~keep_recent:3 ~soul_profile:"" () in
+  let original_reducer = Masc_mcp.Keeper_compaction.fold_completed_strategy
+    ~keep_recent:3 () in
+  let persona_result = R.reduce persona_reducer msgs in
+  let original_result = R.reduce original_reducer msgs in
+  check int "same message count" (List.length original_result) (List.length persona_result);
+  (* Stub text should be identical since empty profile yields no keywords *)
+  let persona_stub = T.text_of_message (List.hd persona_result) in
+  let original_stub = T.text_of_message (List.hd original_result) in
+  check string "stub text identical" original_stub persona_stub
+
+let test_persona_fold_keeps_recent_10 () =
+  let msgs = make_turns 15 in
+  let reducer = Masc_mcp.Keeper_compaction.persona_fold_strategy
+    ~keep_recent:10 ~soul_profile:"delivery" () in
+  let result = R.reduce reducer msgs in
+  (* 15 turns, keep 10 => 5 folded into stub + 10 recent (2 msgs each) = 21 msgs *)
+  check int "1 stub + 20 recent msgs" 21 (List.length result)
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
 let () =
   run "keeper_compaction"
     [
@@ -201,5 +277,13 @@ let () =
           test_case "empty messages not folded" `Quick test_empty_not_folded;
           test_case "all within keep_recent" `Quick test_all_within_keep_recent;
           test_case "fold vs SummarizeOld comparison" `Quick test_fold_vs_summarize_old;
+        ] );
+      ( "persona_fold",
+        [
+          test_case "keywords_for_profile" `Quick test_keywords_for_profile;
+          test_case "stub includes excerpts" `Quick test_persona_stub_includes_excerpts;
+          test_case "no excerpts for generic turns" `Quick test_persona_stub_no_excerpts_generic;
+          test_case "backward compat with empty profile" `Quick test_persona_fold_backward_compat;
+          test_case "keeps recent 10" `Quick test_persona_fold_keeps_recent_10;
         ] );
     ]


### PR DESCRIPTION
## Summary\n- fold_completed가 모든 keeper에게 동일한 stub 생성하던 문제 해결\n- soul_profile 기반 keywords_for_profile로 profile-relevant 발췌를 stub에 포함\n- 기존 fold_completed_strategy 유지 (하위 호환)\n\n## Changes (4 files, +194/-1)\n- keeper_compaction.ml: keywords_for_profile + persona_fold_strategy\n- keeper_compaction.mli: 새 함수 export\n- keeper_exec_context.ml: call site 1줄 변경\n- test_keeper_compaction.ml: 5개 테스트 추가 (11 total, all green)\n\n## Research\nACON (2510.00615), A-MAC (2603.04549), A-MEM (NeurIPS 2025)\n\nCloses #4318