### PR TITLE
fix(dashboard): review followup — type narrowing, mention count, top-N validation

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -113,18 +113,18 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 // ── Runtime Signals ──────────────────────────────────────
 
 // Helper: format a 0–1 ratio as percentage or '-'
-function fmtRate(v: unknown): string {
-  return typeof v === 'number' ? `${(v * 100).toFixed(1)}%` : '-'
+function fmtRate(v: number | undefined): string {
+  return v != null ? `${(v * 100).toFixed(1)}%` : '-'
 }
 
 // Helper: format a float with fixed decimals or '-'
-function fmtFixed(v: unknown, digits = 3): string {
-  return typeof v === 'number' ? v.toFixed(digits) : '-'
+function fmtFixed(v: number | undefined, digits = 3): string {
+  return v != null ? v.toFixed(digits) : '-'
 }
 
 // Helper: format an integer count or '-'
-function fmtCount(v: unknown): string | number {
-  return typeof v === 'number' ? v : '-'
+function fmtCount(v: number | undefined): string | number {
+  return v != null ? v : '-'
 }
 
 interface SignalGroup {
@@ -200,6 +200,12 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
         { label: '평균', value: fmtRate(mw?.proactive_preview_similarity_avg) },
         { label: '최대', value: fmtRate(mw?.proactive_preview_similarity_max) },
         { label: '경고', value: typeof mw?.proactive_preview_similarity_warn === 'boolean' ? (mw.proactive_preview_similarity_warn ? 'Y' : 'N') : '-' },
+      ],
+    },
+    {
+      title: '반응',
+      rows: [
+        { label: '멘션 반응', value: fmtCount(keeper.mention_reactive_turn_count) },
       ],
     },
   ]

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -114,10 +114,15 @@ function normalizeMetricsWindow(raw: unknown): Keeper['metrics_window'] | undefi
 
   const normalized: Keeper['metrics_window'] = {}
   for (const [key, value] of Object.entries(raw)) {
-    // Top-N lists: array of objects with at least one string field
+    // Top-N lists: array of objects with at least one meaningful value
     if (TOP_LIST_KEYS.has(key)) {
       if (!Array.isArray(value)) continue
-      const items = value.filter(item => isRecord(item))
+      const items = value.filter(item => {
+        if (!isRecord(item)) return false
+        return Object.values(item).some(v =>
+          (typeof v === 'string' && v.trim() !== '') || typeof v === 'number',
+        )
+      })
       if (items.length > 0) normalized[key] = items
       continue
     }


### PR DESCRIPTION
## Summary
#4311 교차 모델 리뷰(GLM-5.1)에서 발견된 3건 수정.

- `fmtRate`/`fmtFixed`/`fmtCount` 파라미터 타입 `unknown` → `number | undefined`로 좁힘
- `mention_reactive_turn_count`가 KpiGrid에 없어 RuntimeSignals 제거 시 표시 위치가 사라진 regression 수정
- Top-N list normalizer가 빈 객체 `{}`를 통과시키던 문제 수정 (string/number 값 존재 검증)

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] Dashboard CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)