### PR TITLE
feat(keeper): STATE DONE/NEXT split + budget visibility + metrics

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -10,20 +10,40 @@ template_variables: [identity_header, trait_lines, instructions_block, goal_line
 ## Behavior
 You have tools available. Use them when appropriate.
 Decide what to do based on the current world state below.
-The turn budget is limited. If a task will likely need multiple tool steps, call extend_turns early with a short reason instead of waiting until the budget is nearly exhausted.
-Possible actions:
-- Reply to pending mentions (use room broadcast tools)
-- Work on active goals (use planning/execution tools)
-- Inspect or use board tools (`keeper_board_list`, `keeper_board_get`, `keeper_board_post`, `keeper_board_comment`, `keeper_board_vote`) when it helps
-- Search knowledge library (keeper_library_search/read) for research references
-- If you are blocked, set `SPEECH_ACT: request_help` and choose an explicit delivery surface
-- If there is no meaningful outward act, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
+
+### Generation continuity
+You run in a keepalive loop. Each cycle is one Agent.run() call.
+Your checkpoint, memory, decision records, and board posts survive across cycles.
+Do not try to finish everything in this cycle. Focus on one observation and one action.
+The next cycle will see your checkpoint and continue where you left off.
+Use extend_turns only when a single coherent action genuinely requires more steps (e.g., read-edit-build-verify). Do not use it to cram unrelated work into one cycle.
+
+### Possible actions (pick one per cycle)
+- Reply to a pending mention (use room broadcast tools)
+- Claim and work on one task (keeper_task_claim)
+- Post a finding or status update (keeper_board_post)
+- Respond to board activity (keeper_board_comment)
+- Search knowledge library (keeper_library_search/read)
+- If blocked, set `SPEECH_ACT: request_help`
+- If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 
 Board tools are optional. Do not post just to satisfy the loop.
-
-Prefer a single moderate extend_turns request before read/edit/build/verify style work.
 When making claims or decisions, search the library first if relevant documents may exist.
 Do NOT explain your decision-making process at length.
+
+### State block
+End every response with a `[STATE]...[/STATE]` block:
+```
+[STATE]
+DONE: what you accomplished this cycle
+NEXT: what the next cycle should do
+Goal: current active goal
+Decisions: key decisions (semicolon-separated)
+OpenQuestions: unresolved items (semicolon-separated)
+Constraints: active constraints (semicolon-separated)
+[/STATE]
+```
+
 Start every response with machine-readable headers:
 - `SOCIAL_MODEL: bdi_speech_v1`
 - `BELIEF_SUMMARY: ...`

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -193,6 +193,13 @@ let make_hooks
              ~model ~input_tokens:input_tok ~output_tokens:output_tok
              ~cost_usd:0.0
          | None -> ());
+        let text = Agent_sdk.Types.text_of_content response.content in
+        let has_state_block =
+          Option.is_some (Keeper_memory_policy.find_state_block text)
+        in
+        if not has_state_block && turn > 0 then
+          Log.Keeper.info "keeper:%s turn=%d state_block=absent"
+            meta.name turn;
         (try
            Sse.broadcast
              (`Assoc
@@ -204,6 +211,7 @@ let make_hooks
                  ("model_used", `String model);
                  ("input_tokens", `Int input_tok);
                  ("output_tokens", `Int output_tok);
+                 ("has_state_block", `Bool has_state_block);
                  ("ts_unix", `Float (Unix.gettimeofday ()));
                ])
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -385,6 +385,8 @@ let append_memory_notes_from_reply
           Keeper_memory_policy.goal =
             (if meta.goal <> "" then Some meta.goal else None);
           progress = None;
+          done_summary = None;
+          next_summary = None;
           next_items = [];
           decisions = [];
           open_questions = [];

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -279,6 +279,8 @@ let interesting_alert_result_to_json (r : interesting_alert_result) : Yojson.Saf
 type keeper_state_snapshot = {
   goal: string option;
   progress: string option;
+  done_summary: string option;
+  next_summary: string option;
   next_items: string list;
   decisions: string list;
   open_questions: string list;
@@ -288,6 +290,8 @@ type keeper_state_snapshot = {
 let empty_keeper_state_snapshot = {
   goal = None;
   progress = None;
+  done_summary = None;
+  next_summary = None;
   next_items = [];
   decisions = [];
   open_questions = [];
@@ -384,9 +388,21 @@ let parse_state_snapshot_from_reply (reply : string) : keeper_state_snapshot opt
             match strip_prefix_ci ~prefix:"Goal:" line with
             | Some v -> { acc with goal = trim_nonempty v }
             | None ->
+                (match strip_prefix_ci ~prefix:"DONE:" line with
+                | Some v -> { acc with done_summary = trim_nonempty v;
+                                       progress = (match acc.progress with
+                                                   | None -> trim_nonempty v
+                                                   | existing -> existing) }
+                | None ->
                 (match strip_prefix_ci ~prefix:"Progress:" line with
                 | Some v -> { acc with progress = trim_nonempty v }
                 | None ->
+                    (match strip_prefix_ci ~prefix:"NEXT:" line with
+                    | Some v -> { acc with next_summary = trim_nonempty v;
+                                           next_items = (match acc.next_items with
+                                                         | [] -> split_state_items v
+                                                         | existing -> existing) }
+                    | None ->
                     (match strip_prefix_ci ~prefix:"Next:" line with
                     | Some v -> { acc with next_items = split_state_items v }
                     | None ->
@@ -402,7 +418,7 @@ let parse_state_snapshot_from_reply (reply : string) : keeper_state_snapshot opt
                                  with
                                 | Some v ->
                                     { acc with constraints = split_state_items v }
-                                | None -> acc))))))
+                                | None -> acc))))))))
           empty_keeper_state_snapshot lines
       in
       if snapshot.goal = None
@@ -432,10 +448,19 @@ let keeper_state_snapshot_to_summary_text (snapshot : keeper_state_snapshot) : s
         "Goal";
       maybe_line
         (fun () ->
-           match snapshot.progress with
+           match snapshot.done_summary with
+           | Some v when String.trim v <> "" -> Some (String.trim v)
+           | _ ->
+             match snapshot.progress with
+             | Some v when String.trim v <> "" -> Some (String.trim v)
+             | _ -> None)
+        "Done";
+      maybe_line
+        (fun () ->
+           match snapshot.next_summary with
            | Some v when String.trim v <> "" -> Some (String.trim v)
            | _ -> None)
-        "Progress";
+        "Next plan";
       maybe_line
         (fun () ->
            match snapshot.next_items with
@@ -469,6 +494,8 @@ let keeper_state_snapshot_to_json (snapshot : keeper_state_snapshot) : Yojson.Sa
   `Assoc [
     ("goal", Json_util.string_opt_to_json snapshot.goal);
     ("progress", Json_util.string_opt_to_json snapshot.progress);
+    ("done_summary", Json_util.string_opt_to_json snapshot.done_summary);
+    ("next_summary", Json_util.string_opt_to_json snapshot.next_summary);
     ("next_items", `List (List.map (fun s -> `String s) snapshot.next_items));
     ("decisions", `List (List.map (fun s -> `String s) snapshot.decisions));
     ("open_questions", `List (List.map (fun s -> `String s) snapshot.open_questions));
@@ -665,6 +692,10 @@ let synthesize_state_from_run_result
   in
   { goal = (let g = String.trim goal in if g = "" then None else Some g);
     progress;
+    done_summary = progress;
+    next_summary = (match next_items with
+                    | [] -> None
+                    | items -> Some (String.concat "; " items));
     next_items;
     decisions;
     open_questions = [];
@@ -675,13 +706,21 @@ let synthesize_state_from_run_result
 let render_state_block (snapshot : keeper_state_snapshot) : string =
   let buf = Buffer.create 256 in
   Buffer.add_string buf "[STATE]\n";
+  (match snapshot.done_summary with
+   | Some d when String.trim d <> "" ->
+     Buffer.add_string buf (Printf.sprintf "DONE: %s\n" d)
+   | _ ->
+     (match snapshot.progress with
+      | Some p when String.trim p <> "" ->
+        Buffer.add_string buf (Printf.sprintf "DONE: %s\n" p)
+      | _ -> ()));
+  (match snapshot.next_summary with
+   | Some n when String.trim n <> "" ->
+     Buffer.add_string buf (Printf.sprintf "NEXT: %s\n" n)
+   | _ -> ());
   (match snapshot.goal with
    | Some g when String.trim g <> "" ->
      Buffer.add_string buf (Printf.sprintf "Goal: %s\n" g)
-   | _ -> ());
-  (match snapshot.progress with
-   | Some p when String.trim p <> "" ->
-     Buffer.add_string buf (Printf.sprintf "Progress: %s\n" p)
    | _ -> ());
   (match snapshot.next_items with
    | [] -> ()

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -99,6 +99,7 @@ let direct_turn_observation (meta : keeper_meta) :
     unclaimed_task_count = 0;
     failed_task_count = 0;
     active_agent_count = 0;
+    last_turn_budget = None;
   }
 
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -170,6 +170,12 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
        (observation.context_ratio *. 100.0)
        observation.idle_seconds);
+  (* Turn budget from previous generation *)
+  (match observation.last_turn_budget with
+   | Some (used, total) when used > 0 ->
+     Buffer.add_string ubuf
+       (Printf.sprintf "- Previous turn budget: %d/%d used\n" used total)
+   | _ -> ());
   (* Economic pressure *)
   (match observation.economic_pressure with
    | Agent_economy.Normal -> ()

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -98,6 +98,8 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
   let turn_intent_block =
     "Use the world state below as raw context.\n\
      Pending mentions, board events, and worktree changes are observations.\n\
+     Focus on one observation and one action per cycle. \
+     Your checkpoint survives across cycles — do not rush to finish everything now.\n\
      Unclaimed tasks in the backlog are actionable work — if your skills match, \
      claim one with keeper_task_claim and work on it.\n\
      When you have findings, opinions, or status updates worth sharing, post them to the board \
@@ -111,7 +113,12 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
      NEED: <value or none>\n\
      SPEECH_ACT: stay_silent|inform|request_help|claim_task|comment_board|post_board|broadcast|defer\n\
      DELIVERY_SURFACE: silent|visible_reply|board_post|board_comment|task_claim|broadcast\n\
-     If DELIVERY_SURFACE is silent, emit no visible body after the headers."
+     If DELIVERY_SURFACE is silent, emit no visible body after the headers.\n\
+     End every response with a [STATE]...[/STATE] block:\n\
+     DONE: what you accomplished this cycle\n\
+     NEXT: what the next cycle should do\n\
+     Goal: current active goal\n\
+     Decisions: key decisions (semicolon-separated)"
   in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -33,6 +33,7 @@ type world_observation = {
   unclaimed_task_count : int;
   failed_task_count : int;
   active_agent_count : int;
+  last_turn_budget : (int * int) option;
 }
 
 type board_signal_match = {
@@ -334,6 +335,7 @@ let observe ~(pending_board_events : pending_board_event list option)
     unclaimed_task_count;
     failed_task_count;
     active_agent_count;
+    last_turn_budget = None;
   }
 
 let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observation) =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -54,6 +54,9 @@ type world_observation = {
   active_agent_count : int;
   (** Number of agents currently active in the room. *)
 
+  last_turn_budget : (int * int) option;
+  (** Previous generation's turn usage as [(used, total)], if available. *)
+
 }
 
 type board_signal_match = {

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -268,11 +268,11 @@ let test_prompt_mentions_extend_turns_guidance () =
          true
        with Not_found -> false
      in found);
-  check bool "mentions early extension guidance" true
+  check bool "mentions generation continuity" true
     (let found =
        try
          ignore
-           (Str.search_forward (Str.regexp_string "call extend_turns early") sys 0);
+           (Str.search_forward (Str.regexp_string "checkpoint survives across cycles") sys 0);
          true
        with Not_found -> false
      in found)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -71,6 +71,7 @@ let base_observation : WO.world_observation =
     unclaimed_task_count = 0;
     failed_task_count = 0;
     active_agent_count = 0;
+    last_turn_budget = None;
   }
 
 let sample_board_event : WO.pending_board_event =


### PR DESCRIPTION
## Summary

Issue #4308 Phase 2 + Phase 4 + Phase 5: 세대 연속성 재설계 후속.

### Phase 2: [STATE] DONE/NEXT Split
- `keeper_state_snapshot`에 `done_summary`/`next_summary` 필드 추가
- 파서가 `DONE:`/`NEXT:` 접두사를 인식 (기존 `Progress:`/`Next:`도 하위 호환)
- `keeper.unified.system.md` 프롬프트에 generation continuity + [STATE] 형식 문서화
- `turn_intent_block`에 [STATE] 블록 요구사항 추가

### Phase 4: Turn Budget Visibility
- `world_observation`에 `last_turn_budget` 필드 추가
- 프롬프트 Context 섹션에 이전 세대 turn 사용량 표시

### Phase 5: STATE Block Metrics
- `after_turn` hook에서 [STATE] 존재 여부 로깅
- SSE `turn_complete` 이벤트에 `has_state_block` 필드 추가

## 변경 파일

| 파일 | Phase |
|------|-------|
| `lib/keeper/keeper_memory_policy.ml` | 2 |
| `lib/keeper/keeper_memory_bank.ml` | 2 |
| `config/prompts/keeper.unified.system.md` | 2 |
| `lib/keeper/keeper_unified_prompt.ml` | 2, 4 |
| `lib/keeper/keeper_world_observation.ml` + `.mli` | 4 |
| `lib/keeper/keeper_hooks_oas.ml` | 5 |
| `lib/keeper/keeper_turn.ml` | 4 |
| `test/test_keeper_unified.ml` | 2, 4 |

## Test plan

- [x] `dune build` 성공
- [x] `test_keeper_unified.exe` 45 tests pass
- [x] `test_keeper_memory.exe` 20 tests pass
- [ ] CI green
- [ ] Cross-model review

Refs: #4308, #4317

🤖 Generated with [Claude Code](https://claude.com/claude-code)