### PR TITLE
fix: align Cdal_proof.scope with OAS SDK 0.99.6 + bump pin

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.99.1"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.99.6"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="61e5314630c3db7b6415b937e83f4beac27897ee"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.99.1"
+readonly OAS_AGENT_SDK_SHA="78e2e3e4b5f0dde1551d8c7e55c1447ed3c19493"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.99.6"

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -44,6 +44,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -40,6 +40,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let setup_store () =
@@ -397,6 +398,7 @@ let make_proof_for_cross_run
     result_status = Completed;
     started_at = ended_at -. 1.0;
     ended_at;
+    scope = None;
   }
 
 let test_project_window_single_run () =

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -45,6 +45,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -43,6 +43,7 @@ let make_proof
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let make_contract () : Agent_sdk.Risk_contract.t =

--- a/test/test_golden_set_eval.ml
+++ b/test/test_golden_set_eval.ml
@@ -78,6 +78,7 @@ let bundle_of_golden_case (gc : GS.golden_case) : CL.loaded_bundle =
     result_status = Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   } in
   {
     proof;

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -60,6 +60,7 @@ let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
     result_status = Oas.Cdal_proof.Completed;
     started_at = 1000.0;
     ended_at = 1001.0;
+    scope = None;
   }
 
 let with_snapshot_env f =


### PR DESCRIPTION
## Summary

- OAS SDK 0.99.6에서 `Cdal_proof.t`에 `scope: string option` 필드가 재추가됨
- 6개 테스트 파일에 `scope = None` 추가 (7 sites)
- SDK pin: v0.99.1 (61e5314) → v0.99.6 (78e2e3e)
- CI Build fail 근본 원인 수정

Closes #4326

## Test plan

- [x] `dune build` 통과 (OAS 0.99.6 로컬 설치 후)
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)