### PR TITLE
fix(ci): bump OAS agent_sdk pin to v0.99.7

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.99.1))
+  (agent_sdk (>= 0.99.7))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.99.1"}
+  "agent_sdk" {>= "0.99.7"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.99.6"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.99.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="78e2e3e4b5f0dde1551d8c7e55c1447ed3c19493"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.99.6"
+readonly OAS_AGENT_SDK_SHA="669b0d83aaae968d3d9f057a7f2ba0ee3e7c5af3"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.99.7"


### PR DESCRIPTION
## Summary
- Bumps OAS pin SHA from 78e2e3e (opam 0.99.3) to 669b0d8 (opam 0.99.7)
- Root cause: previous pin had agent_sdk.opam at version 0.99.3 while dune-project requires >= 0.99.6
- New SHA points to OAS main HEAD where opam file matches dune-project version 0.99.7

## Test plan
- [ ] CI Build job passes
- [ ] CI Contract Harness passes
- [ ] CI Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)