### PR TITLE
fix(scripts): run-local.sh edge cases — stale binary, empty env, personas coupling

### DIFF
--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -48,7 +48,7 @@ derive_port_for_path() {
 set_default_env() {
   local name="$1"
   local value="$2"
-  if [ "${!name+x}" != "x" ]; then
+  if [ -z "${!name:-}" ]; then
     export "$name=$value"
   fi
 }
@@ -63,7 +63,8 @@ binary_is_stale() {
   fi
   if find "$REPO_ROOT/bin" "$REPO_ROOT/lib" \
       -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
-      -newer "$exe" 2>/dev/null | head -n 1 | grep -q .; then
+      -newer "$exe" -print -quit 2>/dev/null \
+    | grep -q .; then
     return 0
   fi
   return 1
@@ -153,8 +154,8 @@ fi
 bootstrap_local_config "$TARGET_DIR"
 build_dashboard_if_requested
 
-LOCAL_CONFIG_DIR="$TARGET_DIR/.masc/config"
-LOCAL_PERSONAS_DIR="$LOCAL_CONFIG_DIR/personas"
+LOCAL_CONFIG_DIR="${MASC_CONFIG_DIR:-$TARGET_DIR/.masc/config}"
+LOCAL_PERSONAS_DIR="${MASC_PERSONAS_DIR:-$LOCAL_CONFIG_DIR/personas}"
 EXE="$REPO_ROOT/_build/default/bin/main_eio.exe"
 
 if binary_is_stale "$EXE"; then

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -274,6 +274,36 @@ let test_explicit_config_env_is_preserved_without_bootstrap () =
       check bool "target config not bootstrapped" false
         (Sys.file_exists (Filename.concat target ".masc/config/cascade.json")))
 
+let test_config_dir_set_personas_dir_unset_defaults_to_config_personas () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      let override_config = Filename.concat dir "my-config" in
+      mkdir_p target;
+      mkdir_p override_config;
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_CONFIG_DIR", override_config);
+            ]
+          ~unset_env:[ "MASC_PERSONAS_DIR" ]
+          (Printf.sprintf "%s --target-dir %s --port 9960"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local with MASC_CONFIG_DIR only failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      let captured = read_file capture in
+      check bool "config dir uses explicit value" true
+        (contains_substring captured ("MASC_CONFIG_DIR=" ^ override_config));
+      check bool "personas dir defaults to config/personas" true
+        (contains_substring captured
+           ("MASC_PERSONAS_DIR=" ^ Filename.concat override_config "personas")))
+
 let () =
   run "run_local_script"
     [
@@ -289,5 +319,7 @@ let () =
             test_existing_target_config_is_not_overwritten;
           test_case "explicit config env is preserved without bootstrap" `Quick
             test_explicit_config_env_is_preserved_without_bootstrap;
+          test_case "config_dir set personas_dir unset defaults to config/personas" `Quick
+            test_config_dir_set_personas_dir_unset_defaults_to_config_personas;
         ] );
     ]


### PR DESCRIPTION
## Summary
- **Bug 1** (`set_default_env`): `${!name+x}` check missed empty-but-set variables under `set -u`. Fixed with `${!name:-}`.
- **Bug 2** (`binary_is_stale`): `find | head -n 1` caused SIGPIPE under `set -euo pipefail`. Fixed with `find -print -quit`.
- **Bug 3** (`MASC_PERSONAS_DIR` coupling): Hardcoded `$TARGET_DIR/.masc/config` ignored explicit `MASC_CONFIG_DIR`. Fixed with parameter expansion defaults.

## Test plan
- [x] Existing 5 tests pass
- [x] New test: `config_dir set, personas_dir unset → defaults to ${MASC_CONFIG_DIR}/personas`
- [ ] CI green

Closes #4258

🤖 Generated with [Claude Code](https://claude.com/claude-code)