### PR TITLE
fix(test): scrub MASC_BASE_PATH from test env to prevent workspace binding

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -14,7 +14,10 @@
    (SB_PG_URL "")
    ; Avoid non-deterministic external network calls during unit tests.
    (GRAPHQL_API_KEY "")
-   (ZAI_API_KEY ""))))
+   (ZAI_API_KEY "")
+   ; Prevent inherited shell MASC_BASE_PATH from binding tests to real
+   ; workspace state. Tests that need a base path pass it explicitly.
+   (MASC_BASE_PATH ""))))
 
 ; ============================================================
 ; All standard tests share the masc_test_deps wrapper library


### PR DESCRIPTION
## Summary
- Add `(MASC_BASE_PATH "")` to `test/dune` env-vars to prevent inherited shell `MASC_BASE_PATH` from binding tests to the real workspace.
- When `MASC_BASE_PATH=""`, `trim_opt` converts it to `None`, so `resolve_masc_base_path` uses the test's explicit temp dir.

## Test plan
- [x] Existing test suite builds
- [ ] CI green
- [ ] Manual: `MASC_BASE_PATH=/Users/dancer/me dune test` — tests should use temp dirs, not the real workspace

Closes #4343

🤖 Generated with [Claude Code](https://claude.com/claude-code)