### PR TITLE
refactor(dashboard): remove duplicate chat.css (#3915 phase 1)

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -14,7 +14,7 @@ import './styles/global.css'
 import './styles/ui.css'
 import './styles/agent-monitor.css'
 import './styles/board.css'
-import './styles/chat.css'
+/* chat.css: styles merged into global.css @utility blocks (#3915) */
 import './styles/command-swarm.css'
 import './styles/dashboard.css'
 import './styles/governance.css'


### PR DESCRIPTION
## Summary
- Remove `import './styles/chat.css'` from main.ts — the @utility blocks in global.css (lines 616-700) already provide identical chat styles with better variant coverage

## Context
Issue #3915 tracks splitting the 1844-line global.css monolith. Chat section is 1:1 duplication between `chat.css` (raw CSS) and `global.css` (@utility), making it the safest first extraction.

## Verification
- `vite build` succeeds
- Chat styles are provided by `@utility chat-transcript`, `@utility chat-bubble`, etc. in global.css

## Next steps for #3915
- Tools section: global.css extends tools.css (superset, needs careful merge)
- Ops section: global.css extends ops.css (same pattern)
- Extract unique sections (Command Plane, Pixel Avatars, etc.) to dedicated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)