### PR TITLE
feat(keeper): voice ping-pong turn loop + OAS SDK rebase fix

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -325,10 +325,14 @@ module Cdal = struct
     get_bool ~default:false "MASC_CDAL_PROOF_AGGREGATION"
 end
 
-(** Release LLM slot during tool execution so other agents can use it.
-    Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
-let slot_yield_enabled () =
-  get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+(** {1 Slot Scheduling} *)
+
+module Slot = struct
+  (** Release LLM slot during tool execution so other agents can use it.
+      Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
+  let yield_enabled () =
+    get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+end
 
 (** {1 Board Configuration} *)
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -132,6 +132,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.50.0" };
 
+  { env_name = "MASC_SLOT_YIELD_ENABLED";
+    description = "Turn-level slot yielding during tool execution";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.207.0" };
+
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
     description = "Load dashboard fixture data for testing";

--- a/lib/dune
+++ b/lib/dune
@@ -440,6 +440,7 @@
    keeper_alerting_path
    keeper_exec_tools
    keeper_voice_local
+   keeper_voice_loop
    keeper_exec_status_metrics
    keeper_exec_status
    keeper_exec_persona

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -452,12 +452,12 @@ let run_turn
     then Keeper_cdal_contract.of_keeper_meta meta
     else None
   in
-  let yield_on_tool = Env_config.slot_yield_enabled () in
+  let yield_on_tool = Env_config.Slot.yield_enabled () in
   let on_yield = if yield_on_tool then Some (fun () ->
-    Log.Misc.info "keeper %s: slot yielded (tool execution)" meta.name
+    Log.Misc.debug "keeper %s: slot yielded (tool execution)" meta.name
   ) else None in
   let on_resume = if yield_on_tool then Some (fun () ->
-    Log.Misc.info "keeper %s: slot resumed (next LLM turn)" meta.name
+    Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" meta.name
   ) else None in
   match
         Oas_worker.run_named

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -757,79 +757,16 @@ let execute_keeper_tool_call
         Safe_ops.json_float ~default:15.0 "timeout_seconds" args
       in
       let language_code = Safe_ops.json_string_opt "language_code" args in
-      let audio_file =
-        Filename.concat
-          (Filename.get_temp_dir_name ())
-          (Printf.sprintf "masc_stt_%d_%s.wav"
-             (int_of_float (Unix.gettimeofday ()))
-             (String.map (fun c ->
-                if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
-                then c else '_') meta.name))
-      in
-      let timeout_str = Printf.sprintf "%.0f" timeout_sec in
-      let play_tone freq =
-        try
-          ignore (Process_eio.run_argv_with_stdin_and_status
-            ~timeout_sec:2.0 ~stdin_content:""
-            [ "play"; "-qn"; "synth"; "0.15"; "sine";
-              Printf.sprintf "%.0f" freq ])
-        with _ -> ()
-      in
-      let rec_argv =
-        [ "rec"; "-q"; "-t"; "wav"; audio_file;
-          "rate"; "16k"; "channels"; "1";
-          "silence"; "1"; "0.5"; "1%"; "1"; "2.0"; "1%" ]
-      in
-      play_tone 880.0;
-      let record_result =
-        try
-          let status, _output =
-            Process_eio.run_argv_with_stdin_and_status
-              ~timeout_sec:(timeout_sec +. 5.0)
-              ~stdin_content:"" rec_argv
-          in
-          match status with
-          | Unix.WEXITED 0 -> Ok ()
-          | Unix.WEXITED code ->
-              Error (Printf.sprintf "rec exit %d" code)
-          | _ -> Error "rec process failed"
-        with exn ->
-          Error (Printf.sprintf "rec exception: %s" (Printexc.to_string exn))
-      in
-      play_tone 440.0;
-      let _ = timeout_str in
-      (match record_result with
+      (match Voice_bridge.record_and_transcribe
+               ~agent_id:meta.name ~timeout_sec ?language_code () with
+      | Ok json ->
+          Yojson.Safe.to_string json
       | Error err ->
-          (try Sys.remove audio_file with Sys_error _ -> ());
           Yojson.Safe.to_string
             (`Assoc
               [ ("status", `String "error");
                 ("error", `String err);
-                ("agent_id", `String meta.name) ])
-      | Ok () ->
-          let file_exists =
-            try (Unix.stat audio_file).st_size > 100
-            with Unix.Unix_error _ -> false
-          in
-          if not file_exists then (
-            (try Sys.remove audio_file with Sys_error _ -> ());
-            Yojson.Safe.to_string
-              (`Assoc
-                [ ("status", `String "no_audio");
-                  ("message", `String "no speech detected or recording too short");
-                  ("agent_id", `String meta.name) ]))
-          else
-            match Voice_bridge.transcribe_audio ~audio_file ?language_code () with
-            | Ok json ->
-                (try Sys.remove audio_file with Sys_error _ -> ());
-                Yojson.Safe.to_string json
-            | Error err ->
-                (try Sys.remove audio_file with Sys_error _ -> ());
-                Yojson.Safe.to_string
-                  (`Assoc
-                    [ ("status", `String "error");
-                      ("error", `String err);
-                      ("agent_id", `String meta.name) ]))
+                ("agent_id", `String meta.name) ]))
   | "keeper_voice_agent" ->
       (* No net required — reads local voice config *)
       (match Voice_bridge.get_agent_voice ~agent_id:meta.name with

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -31,7 +31,7 @@ let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
   let open Agent_sdk in
   Tool.create
     ~name:"extend_turns"
-    ~descriptor:{ kind = None; mutation_class = Some "read_only";
+    ~descriptor:{ kind = None;
                   shell = None; notes = []; examples = [] }
     ~description:"Request additional turns when you need more time. \
                    Guardrails check cost and idle before granting."

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -32,7 +32,8 @@ let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
   Tool.create
     ~name:"extend_turns"
     ~descriptor:{ kind = None;
-                  shell = None; notes = []; examples = [] }
+                  shell = None; mutation_class = None;
+                  notes = []; examples = [] }
     ~description:"Request additional turns when you need more time. \
                    Guardrails check cost and idle before granting."
     ~parameters:[

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -538,5 +538,29 @@ let housekeep_schemas : tool_schema list = [
   };
 ]
 
+let voice_schemas : tool_schema list = [
+  {
+    name = "masc_voice_ping_pong";
+    description =
+      "Start a voice conversation loop with a keeper. Records speech, sends to keeper, speaks the response, repeats. Say 'stop' or '종료' to end.";
+    input_schema =
+      `Assoc [
+        ("type", `String "object");
+        ("properties", `Assoc [
+          ("name", `Assoc [
+            ("type", `String "string");
+            ("description", `String "Keeper name to talk to") ]);
+          ("max_turns", `Assoc [
+            ("type", `String "integer");
+            ("description", `String "Max conversation turns (default 50)") ]);
+          ("language_code", `Assoc [
+            ("type", `String "string");
+            ("description", `String "ISO language hint for STT, e.g. ko, en") ]);
+        ]);
+        ("required", `List [ `String "name" ]);
+      ];
+  };
+]
+
 let schemas : tool_schema list =
-  keeper_schemas @ housekeep_schemas
+  keeper_schemas @ housekeep_schemas @ voice_schemas

--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -38,10 +38,12 @@ let is_stop_command (text : string) : bool =
 (** Single voice turn: listen → send_message → speak.
     @param send_message takes text, returns [(success, result_json_string)]
     @param speak takes text, returns [(Yojson.Safe.t, string) result] *)
+let default_record ~agent_id ?language_code () =
+  Voice_bridge.record_and_transcribe ~agent_id ?language_code ()
+
 let run_one_voice_turn ~agent_id ~send_message ~speak
-    ?language_code () =
-  match Voice_bridge.record_and_transcribe
-          ~agent_id ?language_code () with
+    ?(record = default_record) ?language_code () =
+  match record ~agent_id ?language_code () with
   | Error err ->
       Log.Keeper.warn "voice_loop: listen failed: %s" err;
       Error (Printf.sprintf "listen failed: %s" err)
@@ -78,6 +80,7 @@ let run_one_voice_turn ~agent_id ~send_message ~speak
 let max_consecutive_empty = 5
 
 let run ~agent_id ~send_message ~speak
+    ?(record = default_record)
     ?(max_turns = 50) ?language_code () : bool * string =
   let rec loop turn_count empty_count =
     if turn_count >= max_turns then
@@ -85,7 +88,7 @@ let run ~agent_id ~send_message ~speak
          max_turns)
     else
       match run_one_voice_turn ~agent_id ~send_message ~speak
-              ?language_code () with
+              ~record ?language_code () with
       | Error err ->
           if turn_count = 0 then
             (false, Printf.sprintf "voice loop failed on first turn: %s" err)

--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -75,9 +75,11 @@ let run_one_voice_turn ~agent_id ~send_message ~speak
     @param send_message callback: text -> (success, result_json_string)
     @param speak callback: text -> (Ok json, Error msg)
     @param max_turns default 50 *)
+let max_consecutive_empty = 5
+
 let run ~agent_id ~send_message ~speak
     ?(max_turns = 50) ?language_code () : bool * string =
-  let rec loop turn_count =
+  let rec loop turn_count empty_count =
     if turn_count >= max_turns then
       (true, Printf.sprintf "voice loop ended after %d turns (max reached)"
          max_turns)
@@ -94,8 +96,13 @@ let run ~agent_id ~send_message ~speak
           (true, Printf.sprintf "voice loop ended after %d turns (user exit)"
              (turn_count + 1))
       | Ok `Empty ->
-          loop turn_count (* empty STT does not consume a turn *)
+          if empty_count + 1 >= max_consecutive_empty then
+            (true, Printf.sprintf
+               "voice loop ended: %d consecutive empty STT responses"
+               (empty_count + 1))
+          else
+            loop turn_count (empty_count + 1)
       | Ok `Continue ->
-          loop (turn_count + 1)
+          loop (turn_count + 1) 0
   in
-  loop 0
+  loop 0 0

--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -37,7 +37,7 @@ let is_stop_command (text : string) : bool =
 
 (** Single voice turn: listen → send_message → speak.
     @param send_message takes text, returns [(success, result_json_string)]
-    @param speak takes text, returns [Ok () | Error msg] *)
+    @param speak takes text, returns [(Yojson.Safe.t, string) result] *)
 let run_one_voice_turn ~agent_id ~send_message ~speak
     ?language_code () =
   match Voice_bridge.record_and_transcribe
@@ -49,7 +49,7 @@ let run_one_voice_turn ~agent_id ~send_message ~speak
       match extract_text_from_stt stt_json with
       | None ->
           Log.Keeper.info "voice_loop: no text from STT, skipping turn";
-          Ok `Continue
+          Ok `Empty
       | Some text ->
           if is_stop_command text then (
             Log.Keeper.info "voice_loop: stop command: %s" text;
@@ -93,6 +93,8 @@ let run ~agent_id ~send_message ~speak
       | Ok `Stop ->
           (true, Printf.sprintf "voice loop ended after %d turns (user exit)"
              (turn_count + 1))
+      | Ok `Empty ->
+          loop turn_count (* empty STT does not consume a turn *)
       | Ok `Continue ->
           loop (turn_count + 1)
   in

--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -1,0 +1,99 @@
+(** Keeper_voice_loop — voice ping-pong turn loop.
+
+    Wraps keeper text turns with voice I/O: record user speech via
+    microphone (STT), run a keeper turn, then speak the response (TTS).
+    The keeper LLM is unaware of voice mode — this module acts as a
+    transparent I/O adapter.
+
+    To avoid circular module dependencies, [run] takes a [send_message]
+    callback instead of calling [Keeper_turn] directly.
+
+    @since 2.201.0 *)
+
+(** Extract transcribed text from STT JSON response. *)
+let extract_text_from_stt (json : Yojson.Safe.t) : string option =
+  try
+    match Yojson.Safe.Util.member "text" json with
+    | `String s when String.trim s <> "" -> Some (String.trim s)
+    | _ -> None
+  with _ -> None
+
+(** Extract reply text from keeper_msg tool_result.
+    The result_str is JSON with ["reply"]. *)
+let extract_reply_text (result_str : string) : string option =
+  try
+    let json = Yojson.Safe.from_string result_str in
+    match Yojson.Safe.Util.member "reply" json with
+    | `String s when String.trim s <> "" -> Some (String.trim s)
+    | _ -> None
+  with _ -> None
+
+(** Stop words that end the voice loop. *)
+let is_stop_command (text : string) : bool =
+  let lower = String.lowercase_ascii (String.trim text) in
+  List.exists (fun w -> lower = w)
+    [ "stop"; "exit"; "quit"; "bye"; "end";
+      "종료"; "끝"; "그만"; "멈춰"; "바이" ]
+
+(** Single voice turn: listen → send_message → speak.
+    @param send_message takes text, returns [(success, result_json_string)]
+    @param speak takes text, returns [Ok () | Error msg] *)
+let run_one_voice_turn ~agent_id ~send_message ~speak
+    ?language_code () =
+  match Voice_bridge.record_and_transcribe
+          ~agent_id ?language_code () with
+  | Error err ->
+      Log.Keeper.warn "voice_loop: listen failed: %s" err;
+      Error (Printf.sprintf "listen failed: %s" err)
+  | Ok stt_json ->
+      match extract_text_from_stt stt_json with
+      | None ->
+          Log.Keeper.info "voice_loop: no text from STT, skipping turn";
+          Ok `Continue
+      | Some text ->
+          if is_stop_command text then (
+            Log.Keeper.info "voice_loop: stop command: %s" text;
+            Ok `Stop)
+          else
+            let (success, result_str) = send_message text in
+            if not success then (
+              Log.Keeper.warn "voice_loop: turn failed: %s" result_str;
+              Ok `Continue)
+            else
+              match extract_reply_text result_str with
+              | None ->
+                  Log.Keeper.info "voice_loop: no reply to speak";
+                  Ok `Continue
+              | Some reply ->
+                  (match speak reply with
+                   | Ok _ -> ()
+                   | Error err ->
+                       Log.Keeper.warn "voice_loop: speak failed: %s" err);
+                  Ok `Continue
+
+(** Run the voice ping-pong loop.
+    @param send_message callback: text -> (success, result_json_string)
+    @param speak callback: text -> (Ok json, Error msg)
+    @param max_turns default 50 *)
+let run ~agent_id ~send_message ~speak
+    ?(max_turns = 50) ?language_code () : bool * string =
+  let rec loop turn_count =
+    if turn_count >= max_turns then
+      (true, Printf.sprintf "voice loop ended after %d turns (max reached)"
+         max_turns)
+    else
+      match run_one_voice_turn ~agent_id ~send_message ~speak
+              ?language_code () with
+      | Error err ->
+          if turn_count = 0 then
+            (false, Printf.sprintf "voice loop failed on first turn: %s" err)
+          else
+            (true, Printf.sprintf "voice loop ended after %d turns (error: %s)"
+               turn_count err)
+      | Ok `Stop ->
+          (true, Printf.sprintf "voice loop ended after %d turns (user exit)"
+             (turn_count + 1))
+      | Ok `Continue ->
+          loop (turn_count + 1)
+  in
+  loop 0

--- a/lib/keeper/keeper_voice_loop.mli
+++ b/lib/keeper/keeper_voice_loop.mli
@@ -21,6 +21,8 @@ val run :
   agent_id:string ->
   send_message:(string -> bool * string) ->
   speak:(string -> (Yojson.Safe.t, string) result) ->
+  ?record:(agent_id:string -> ?language_code:string -> unit ->
+           (Yojson.Safe.t, string) result) ->
   ?max_turns:int ->
   ?language_code:string ->
   unit ->

--- a/lib/keeper/keeper_voice_loop.mli
+++ b/lib/keeper/keeper_voice_loop.mli
@@ -1,0 +1,27 @@
+(** Keeper_voice_loop — voice ping-pong turn loop.
+
+    Transparent I/O adapter: record → turn → speak → repeat.
+    The keeper LLM does not know it is in voice mode.
+
+    Stop commands: "stop", "exit", "종료", "끝", "그만", etc.
+
+    @since 2.201.0 *)
+
+val extract_text_from_stt : Yojson.Safe.t -> string option
+val extract_reply_text : string -> string option
+val is_stop_command : string -> bool
+
+(** Run the voice ping-pong loop.
+    @param agent_id keeper name (for STT agent_id tag)
+    @param send_message callback: user text -> (success, result_json)
+    @param speak callback: reply text -> (Ok json, Error msg)
+    @param max_turns default 50
+    @param language_code optional BCP-47 hint for STT *)
+val run :
+  agent_id:string ->
+  send_message:(string -> bool * string) ->
+  speak:(string -> (Yojson.Safe.t, string) result) ->
+  ?max_turns:int ->
+  ?language_code:string ->
+  unit ->
+  bool * string

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -93,6 +93,6 @@ let oas_tool_of_masc ~name ~description ~input_schema
     to_oas_tool_result (success, msg)
   in
   let descriptor : Agent_sdk.Tool.descriptor =
-    { kind = None; mutation_class = None; shell = None; notes = []; examples = [] }
+    { kind = None; shell = None; notes = []; examples = [] }
   in
   Agent_sdk.Tool.create ~descriptor ~name ~description ~parameters oas_handler

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -93,6 +93,6 @@ let oas_tool_of_masc ~name ~description ~input_schema
     to_oas_tool_result (success, msg)
   in
   let descriptor : Agent_sdk.Tool.descriptor =
-    { kind = None; shell = None; notes = []; examples = [] }
+    { kind = None; shell = None; mutation_class = None; notes = []; examples = [] }
   in
   Agent_sdk.Tool.create ~descriptor ~name ~description ~parameters oas_handler

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -265,7 +265,7 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
 
 let handle_voice_ping_pong ctx args : tool_result =
   let keeper_name = get_string args "name" "" |> String.trim in
-  let max_turns = max 1 (get_int args "max_turns" 50) in
+  let max_turns = min 200 (max 1 (get_int args "max_turns" 50)) in
   let language_code =
     get_string_opt args "language_code" |> Option.map String.trim
   in
@@ -275,7 +275,13 @@ let handle_voice_ping_pong ctx args : tool_result =
   if keeper_name = "" then
     (false, "Error: keeper name is required")
   else
-    match ensure_keeper_exists ctx args with
+    let trimmed_args = match args with
+      | `Assoc fields ->
+          `Assoc (List.map (fun (k, v) ->
+            if k = "name" then (k, `String keeper_name) else (k, v)) fields)
+      | other -> other
+    in
+    match ensure_keeper_exists ctx trimmed_args with
     | Error err -> (false, err)
     | Ok _ ->
         let send_message text =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -263,6 +263,45 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
            (annotate_keeper_json ~runtime_class:"keeper" json))
       end
 
+let handle_voice_ping_pong ctx args : tool_result =
+  let keeper_name = get_string args "name" "" |> String.trim in
+  let max_turns = get_int args "max_turns" 50 in
+  let language_code =
+    get_string_opt args "language_code" |> Option.map String.trim
+  in
+  let language_code = match language_code with
+    | Some lc when lc <> "" -> Some lc | _ -> None
+  in
+  if keeper_name = "" then
+    (false, "Error: keeper name is required")
+  else
+    match ensure_keeper_exists ctx args with
+    | Error err -> (false, err)
+    | Ok _ ->
+        let send_message text =
+          let msg_args = `Assoc [
+            ("name", `String keeper_name);
+            ("message", `String text);
+          ] in
+          Turn.handle_keeper_msg ctx msg_args
+        in
+        let speak text =
+          match ctx.net with
+          | Some net ->
+              Voice_bridge.agent_speak ~sw:ctx.sw ~clock:ctx.clock ~net
+                ~agent_id:keeper_name ~message:text ()
+          | None -> Error "no network for TTS"
+        in
+        let (success, summary) =
+          Keeper_voice_loop.run ~agent_id:keeper_name
+            ~send_message ~speak ~max_turns ?language_code ()
+        in
+        (success, Yojson.Safe.to_string
+           (`Assoc
+             [ ("status", `String (if success then "ok" else "error"));
+               ("agent_id", `String keeper_name);
+               ("summary", `String summary) ]))
+
 let resolve_keeper_meta ctx args =
   let name = get_string args "name" "" in
   match read_meta ctx.config name with
@@ -495,6 +534,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_up" -> Some (handle_keeper_up ctx args)
   | "masc_keeper_status" -> Some (handle_keeper_status ctx args)
   | "masc_keeper_msg" -> Some (handle_keeper_msg ctx args)
+  | "masc_voice_ping_pong" -> Some (handle_voice_ping_pong ctx args)
   | "masc_keeper_repair" -> Some (handle_keeper_repair ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -281,6 +281,9 @@ let handle_voice_ping_pong ctx args : tool_result =
             if k = "name" then (k, `String keeper_name) else (k, v)) fields)
       | other -> other
     in
+    if ctx.net = None then
+      (false, "Error: voice ping-pong requires network for TTS")
+    else
     match ensure_keeper_exists ctx trimmed_args with
     | Error err -> (false, err)
     | Ok _ ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -265,7 +265,7 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
 
 let handle_voice_ping_pong ctx args : tool_result =
   let keeper_name = get_string args "name" "" |> String.trim in
-  let max_turns = get_int args "max_turns" 50 in
+  let max_turns = max 1 (get_int args "max_turns" 50) in
   let language_code =
     get_string_opt args "language_code" |> Option.map String.trim
   in

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -134,27 +134,6 @@ let schemas : tool_schema list =
             ("required", `List [ `String "agent_ids" ]);
           ];
     };
-    {
-      name = "masc_voice_ping_pong";
-      description =
-        "Start a voice conversation loop with a keeper. Records speech, sends to keeper, speaks the response, repeats. Say 'stop' or '종료' to end.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              schema_properties
-                [
-                  ("name", `Assoc [ ("type", `String "string");
-                    ("description", `String "Keeper name to talk to") ]);
-                  ("max_turns", `Assoc [ ("type", `String "integer");
-                    ("description", `String "Max conversation turns (default 50)") ]);
-                  ("language_code", `Assoc [ ("type", `String "string");
-                    ("description", `String "ISO language hint for STT, e.g. ko, en") ]);
-                ] );
-            ("required", `List [ `String "name" ]);
-          ];
-    };
   ]
 
 let require_net_or_error (ctx : 'a context) =

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -134,6 +134,27 @@ let schemas : tool_schema list =
             ("required", `List [ `String "agent_ids" ]);
           ];
     };
+    {
+      name = "masc_voice_ping_pong";
+      description =
+        "Start a voice conversation loop with a keeper. Records speech, sends to keeper, speaks the response, repeats. Say 'stop' or '종료' to end.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [
+                  ("name", `Assoc [ ("type", `String "string");
+                    ("description", `String "Keeper name to talk to") ]);
+                  ("max_turns", `Assoc [ ("type", `String "integer");
+                    ("description", `String "Max conversation turns (default 50)") ]);
+                  ("language_code", `Assoc [ ("type", `String "string");
+                    ("description", `String "ISO language hint for STT, e.g. ko, en") ]);
+                ] );
+            ("required", `List [ `String "name" ]);
+          ];
+    };
   ]
 
 let require_net_or_error (ctx : 'a context) =

--- a/lib/violation_record.ml
+++ b/lib/violation_record.ml
@@ -37,11 +37,9 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
     let ts = json |> member "ts" |> to_float in
     let tool_name = json |> member "tool_name" |> to_string in
     let input_summary = json |> member "input_summary" |> to_string in
-    let effective_mode =
-      match Agent_sdk.Execution_mode.of_yojson (json |> member "effective_mode") with
-      | Ok m -> m
-      | Error _ -> Agent_sdk.Execution_mode.Diagnose
-    in
+    match Agent_sdk.Execution_mode.of_yojson (json |> member "effective_mode") with
+    | Error e -> Error (Printf.sprintf "effective_mode parse: %s" e)
+    | Ok effective_mode ->
     match violation_kind_of_string (json |> member "violation_kind" |> to_string) with
     | Ok violation_kind ->
         Ok { ts; tool_name; input_summary; effective_mode; violation_kind }

--- a/lib/violation_record.ml
+++ b/lib/violation_record.ml
@@ -40,10 +40,10 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
     match Agent_sdk.Execution_mode.of_yojson (json |> member "effective_mode") with
     | Error e -> Error (Printf.sprintf "effective_mode parse: %s" e)
     | Ok effective_mode ->
-    match violation_kind_of_string (json |> member "violation_kind" |> to_string) with
-    | Ok violation_kind ->
-        Ok { ts; tool_name; input_summary; effective_mode; violation_kind }
-    | Error e -> Error e
+        (match violation_kind_of_string (json |> member "violation_kind" |> to_string) with
+         | Ok violation_kind ->
+             Ok { ts; tool_name; input_summary; effective_mode; violation_kind }
+         | Error e -> Error e)
   with exn -> Error (Printexc.to_string exn)
 
 let of_json_list (json : Yojson.Safe.t) : (t list, string) result =

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -885,7 +885,9 @@ let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
       | Unix.WEXITED 0 -> Ok ()
       | Unix.WEXITED code -> Error (Printf.sprintf "rec exit %d" code)
       | _ -> Error "rec process failed"
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Error (Printf.sprintf "rec exception: %s" (Printexc.to_string exn))
   in
   play_tone 440.0;

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -872,37 +872,33 @@ let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
       "rate"; "16k"; "channels"; "1";
       "silence"; "1"; "0.5"; "1%"; "1"; "2.0"; "1%" ]
   in
+  let cleanup () = try Sys.remove audio_file with Sys_error _ -> () in
   play_tone 880.0;
-  let record_result =
-    try
-      let status, _output =
-        Process_eio.run_argv_with_stdin_and_status
-          ~timeout_sec:(timeout_sec +. 5.0)
-          ~stdin_content:"" rec_argv
-      in
-      match status with
-      | Unix.WEXITED 0 -> Ok ()
-      | Unix.WEXITED code -> Error (Printf.sprintf "rec exit %d" code)
-      | _ -> Error "rec process failed"
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn ->
-      Error (Printf.sprintf "rec exception: %s" (Printexc.to_string exn))
-  in
-  play_tone 440.0;
-  match record_result with
-  | Error err ->
-      (try Sys.remove audio_file with Sys_error _ -> ());
-      Error err
-  | Ok () ->
-      let file_exists =
-        try (Unix.stat audio_file).st_size > 100
-        with Unix.Unix_error _ -> false
-      in
-      if not file_exists then (
-        (try Sys.remove audio_file with Sys_error _ -> ());
-        Error "no speech detected or recording too short")
-      else
-        let result = transcribe_audio ~audio_file ?language_code () in
-        (try Sys.remove audio_file with Sys_error _ -> ());
-        result
+  Fun.protect ~finally:cleanup (fun () ->
+    let record_result =
+      try
+        let status, _output =
+          Process_eio.run_argv_with_stdin_and_status
+            ~timeout_sec:(timeout_sec +. 5.0)
+            ~stdin_content:"" rec_argv
+        in
+        match status with
+        | Unix.WEXITED 0 -> Ok ()
+        | Unix.WEXITED code -> Error (Printf.sprintf "rec exit %d" code)
+        | _ -> Error "rec process failed"
+      with exn ->
+        Error (Printf.sprintf "rec exception: %s" (Printexc.to_string exn))
+    in
+    play_tone 440.0;
+    match record_result with
+    | Error err -> Error err
+    | Ok () ->
+        let file_exists =
+          try (Unix.stat audio_file).st_size > 100
+          with Unix.Unix_error _ -> false
+        in
+        if not file_exists then
+          Error "no speech detected or recording too short"
+        else
+          transcribe_audio ~audio_file ?language_code ()
+  )

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -864,7 +864,6 @@ let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
     ?language_code () =
   let audio_file =
     Filename.temp_file
-      ~temp_dir:(Filename.get_temp_dir_name ())
       (Printf.sprintf "masc_stt_%s_" (safe_agent_id agent_id))
       ".wav"
   in

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -843,3 +843,59 @@ let health_check ~sw:_ ~clock:_ ~net () =
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
         Error (Printf.sprintf "Not reachable: %s" (Printexc.to_string exn))
+
+(** {1 Microphone record + transcribe} *)
+
+let play_tone freq =
+  try
+    ignore (Process_eio.run_argv_with_stdin_and_status
+      ~timeout_sec:2.0 ~stdin_content:""
+      [ "play"; "-qn"; "synth"; "0.15"; "sine";
+        Printf.sprintf "%.0f" freq ])
+  with _ -> ()
+
+let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
+    ?language_code () =
+  let audio_file =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_stt_%d_%s.wav"
+         (int_of_float (Unix.gettimeofday ()))
+         (safe_agent_id agent_id))
+  in
+  let rec_argv =
+    [ "rec"; "-q"; "-t"; "wav"; audio_file;
+      "rate"; "16k"; "channels"; "1";
+      "silence"; "1"; "0.5"; "1%"; "1"; "2.0"; "1%" ]
+  in
+  play_tone 880.0;
+  let record_result =
+    try
+      let status, _output =
+        Process_eio.run_argv_with_stdin_and_status
+          ~timeout_sec:(timeout_sec +. 5.0)
+          ~stdin_content:"" rec_argv
+      in
+      match status with
+      | Unix.WEXITED 0 -> Ok ()
+      | Unix.WEXITED code -> Error (Printf.sprintf "rec exit %d" code)
+      | _ -> Error "rec process failed"
+    with exn ->
+      Error (Printf.sprintf "rec exception: %s" (Printexc.to_string exn))
+  in
+  play_tone 440.0;
+  match record_result with
+  | Error err ->
+      (try Sys.remove audio_file with Sys_error _ -> ());
+      Error err
+  | Ok () ->
+      let file_exists =
+        try (Unix.stat audio_file).st_size > 100
+        with Unix.Unix_error _ -> false
+      in
+      if not file_exists then (
+        (try Sys.remove audio_file with Sys_error _ -> ());
+        Error "no speech detected or recording too short")
+      else
+        let result = transcribe_audio ~audio_file ?language_code () in
+        (try Sys.remove audio_file with Sys_error _ -> ());
+        result

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -130,7 +130,12 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
   match status with
   | Unix.WEXITED 0 -> (
       match Yojson.Safe.from_string body with
-      | json -> Ok json
+      | json ->
+          (* Check for HTTP error responses — curl exit 0 does not imply 2xx *)
+          (match Yojson.Safe.Util.member "error" json with
+           | `Null -> Ok json
+           | err -> Error (Printf.sprintf "STT API error: %s"
+                     (Yojson.Safe.to_string err)))
       | exception Yojson.Json_error msg ->
           Error (Printf.sprintf "STT response parse error: %s" msg))
   | Unix.WEXITED 28 -> Error "STT request timed out"
@@ -852,15 +857,17 @@ let play_tone freq =
       ~timeout_sec:2.0 ~stdin_content:""
       [ "play"; "-qn"; "synth"; "0.15"; "sine";
         Printf.sprintf "%.0f" freq ])
-  with _ -> ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> ()
 
 let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
     ?language_code () =
   let audio_file =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc_stt_%d_%s.wav"
-         (int_of_float (Unix.gettimeofday ()))
-         (safe_agent_id agent_id))
+    Filename.temp_file
+      ~temp_dir:(Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_stt_%s_" (safe_agent_id agent_id))
+      ".wav"
   in
   let rec_argv =
     [ "rec"; "-q"; "-t"; "wav"; audio_file;

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -120,7 +120,8 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
   let field_name, file_path = req.file_field in
   let file_arg = [ "-F"; Printf.sprintf "%s=@%s" field_name file_path ] in
   let argv =
-    [ "curl"; "-sS"; "--max-time"; "30"; "-X"; "POST"; req.url ]
+    [ "curl"; "-sS"; "--fail-with-body"; "--max-time"; "30";
+      "-X"; "POST"; req.url ]
     @ header_args @ form_args @ file_arg
   in
   let status, body =
@@ -130,14 +131,12 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
   match status with
   | Unix.WEXITED 0 -> (
       match Yojson.Safe.from_string body with
-      | json ->
-          (* Check for HTTP error responses — curl exit 0 does not imply 2xx *)
-          (match Yojson.Safe.Util.member "error" json with
-           | `Null -> Ok json
-           | err -> Error (Printf.sprintf "STT API error: %s"
-                     (Yojson.Safe.to_string err)))
+      | json -> Ok json
       | exception Yojson.Json_error msg ->
           Error (Printf.sprintf "STT response parse error: %s" msg))
+  | Unix.WEXITED 22 ->
+      Error (Printf.sprintf "STT HTTP error: %s"
+        (if String.length body > 200 then String.sub body 0 200 else body))
   | Unix.WEXITED 28 -> Error "STT request timed out"
   | Unix.WEXITED code -> Error (Printf.sprintf "STT curl exit %d" code)
   | _ -> Error "STT curl process failed"

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -128,3 +128,17 @@ val health_check :
   net:_ Eio.Net.t ->
   unit ->
   (Yojson.Safe.t, string) result
+
+(** {1 Microphone record + transcribe} *)
+
+val play_tone : float -> unit
+(** Play a short sine beep at the given frequency. *)
+
+val record_and_transcribe :
+  agent_id:string ->
+  ?timeout_sec:float ->
+  ?language_code:string ->
+  unit ->
+  (Yojson.Safe.t, string) result
+(** Record from microphone (with beep tones), transcribe via STT.
+    Returns transcription JSON on success. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -164,7 +164,8 @@ let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
     ~descriptor:{ kind = None;
-                  shell = None; notes = []; examples = [] }
+                  shell = None; mutation_class = None;
+                  notes = []; examples = [] }
     ~description:"Read file contents by absolute path. Returns file text. \
       Use shell_exec with 'ls' instead if you need directory listing. \
       Maximum 100KB per read to prevent context overflow."
@@ -217,7 +218,8 @@ let make_file_read ?workdir ?on_exec () =
 let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
-    ~descriptor:{ kind = None; shell = None; notes = []; examples = [] }
+    ~descriptor:{ kind = None; shell = None; mutation_class = None;
+                  notes = []; examples = [] }
     ~description:"Write content to a file by absolute path. Creates the file \
       if it doesn't exist, overwrites if it does. Creates parent directories. \
       Use file_read first to check existing content before overwriting."
@@ -277,7 +279,8 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
   Agent_sdk.Tool.create
     ~name:"shell_exec"
     ~descriptor:{ kind = None;
-                  shell = None; notes = []; examples = [] }
+                  shell = None; mutation_class = None;
+                  notes = []; examples = [] }
     ~description
     ~parameters:[
       { name = "command";

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -163,7 +163,7 @@ type tool_exec_observer =
 let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
-    ~descriptor:{ kind = None; mutation_class = Some "read_only";
+    ~descriptor:{ kind = None;
                   shell = None; notes = []; examples = [] }
     ~description:"Read file contents by absolute path. Returns file text. \
       Use shell_exec with 'ls' instead if you need directory listing. \
@@ -217,8 +217,7 @@ let make_file_read ?workdir ?on_exec () =
 let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
-    ~descriptor:{ kind = None; mutation_class = Some "workspace";
-                   shell = None; notes = []; examples = [] }
+    ~descriptor:{ kind = None; shell = None; notes = []; examples = [] }
     ~description:"Write content to a file by absolute path. Creates the file \
       if it doesn't exist, overwrites if it does. Creates parent directories. \
       Use file_read first to check existing content before overwriting."
@@ -277,7 +276,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
     ~description () =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
-    ~descriptor:{ kind = None; mutation_class = Some "workspace";
+    ~descriptor:{ kind = None;
                   shell = None; notes = []; examples = [] }
     ~description
     ~parameters:[

--- a/test/dune
+++ b/test/dune
@@ -230,6 +230,7 @@
         test_tool_keeper
         test_keeper_tools_oas
         test_keeper_tool_exposure
+        test_keeper_voice_loop
         test_keeper_task_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio
@@ -377,6 +378,7 @@
         test_tool_keeper
         test_keeper_tools_oas
         test_keeper_tool_exposure
+        test_keeper_voice_loop
         test_keeper_task_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio

--- a/test/test_keeper_voice_loop.ml
+++ b/test/test_keeper_voice_loop.ml
@@ -1,0 +1,174 @@
+open Alcotest
+
+(* ============================================================ *)
+(* Pure function tests                                           *)
+(* ============================================================ *)
+
+let test_extract_text_from_stt_valid () =
+  let json = `Assoc [("text", `String "hello world")] in
+  check (option string) "extracts text"
+    (Some "hello world")
+    (Keeper_voice_loop.extract_text_from_stt json)
+
+let test_extract_text_from_stt_empty () =
+  let json = `Assoc [("text", `String "   ")] in
+  check (option string) "empty text returns None"
+    None
+    (Keeper_voice_loop.extract_text_from_stt json)
+
+let test_extract_text_from_stt_missing () =
+  let json = `Assoc [("other", `String "data")] in
+  check (option string) "missing text returns None"
+    None
+    (Keeper_voice_loop.extract_text_from_stt json)
+
+let test_extract_reply_text_valid () =
+  let json_str = Yojson.Safe.to_string
+    (`Assoc [("reply", `String "keeper says hi")]) in
+  check (option string) "extracts reply"
+    (Some "keeper says hi")
+    (Keeper_voice_loop.extract_reply_text json_str)
+
+let test_extract_reply_text_missing () =
+  let json_str = Yojson.Safe.to_string
+    (`Assoc [("status", `String "ok")]) in
+  check (option string) "missing reply returns None"
+    None
+    (Keeper_voice_loop.extract_reply_text json_str)
+
+let test_is_stop_command_english () =
+  check bool "stop" true (Keeper_voice_loop.is_stop_command "stop");
+  check bool "EXIT" true (Keeper_voice_loop.is_stop_command "EXIT");
+  check bool "  quit  " true (Keeper_voice_loop.is_stop_command "  quit  ")
+
+let test_is_stop_command_korean () =
+  check bool "종료" true (Keeper_voice_loop.is_stop_command "종료");
+  check bool "그만" true (Keeper_voice_loop.is_stop_command "그만");
+  check bool "끝" true (Keeper_voice_loop.is_stop_command "끝")
+
+let test_is_stop_command_negative () =
+  check bool "hello" false (Keeper_voice_loop.is_stop_command "hello");
+  check bool "empty" false (Keeper_voice_loop.is_stop_command "")
+
+(* ============================================================ *)
+(* Integration tests via mock injection                          *)
+(* ============================================================ *)
+
+let make_record responses =
+  let idx = ref 0 in
+  fun ~agent_id:_ ?language_code:_ () ->
+    let r = List.nth responses !idx in
+    idx := min (!idx + 1) (List.length responses - 1);
+    r
+
+let noop_speak _text = Ok (`Assoc [("status", `String "ok")])
+
+let echo_send text =
+  (true, Yojson.Safe.to_string
+    (`Assoc [("reply", `String (Printf.sprintf "echo: %s" text))]))
+
+let test_run_stop_command () =
+  let record = make_record [
+    Ok (`Assoc [("text", `String "hello")]);
+    Ok (`Assoc [("text", `String "종료")]);
+  ] in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak:noop_speak ~record ~max_turns:10 ()
+  in
+  check bool "success" true success;
+  check bool "contains user exit"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "user exit") in
+          Re.execp re msg)
+
+let test_run_max_turns () =
+  let record = make_record [
+    Ok (`Assoc [("text", `String "talk")]);
+  ] in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak:noop_speak ~record ~max_turns:3 ()
+  in
+  check bool "success" true success;
+  check bool "contains max reached"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "max reached") in
+          Re.execp re msg)
+
+let test_run_consecutive_empty_stops () =
+  let record = make_record [
+    Ok (`Assoc [("text", `String "")]);
+  ] in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak:noop_speak ~record ~max_turns:100 ()
+  in
+  check bool "success" true success;
+  check bool "contains empty STT"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "empty STT") in
+          Re.execp re msg)
+
+let test_run_empty_resets_on_success () =
+  let call_count = ref 0 in
+  let record ~agent_id:_ ?language_code:_ () =
+    incr call_count;
+    if !call_count <= 3 then
+      Ok (`Assoc [("text", `String "")])
+    else if !call_count = 4 then
+      Ok (`Assoc [("text", `String "hello")])
+    else if !call_count <= 7 then
+      Ok (`Assoc [("text", `String "")])
+    else
+      Ok (`Assoc [("text", `String "종료")])
+  in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak:noop_speak ~record ~max_turns:100 ()
+  in
+  check bool "success" true success;
+  check bool "exited via stop not empty limit"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "user exit") in
+          Re.execp re msg)
+
+let test_run_error_on_first_turn () =
+  let record = make_record [
+    Error "mic not found";
+  ] in
+  let (success, _msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak:noop_speak ~record ~max_turns:10 ()
+  in
+  check bool "fails on first turn" false success
+
+let () =
+  run "Keeper_voice_loop"
+    [
+      ( "extract_text_from_stt",
+        [
+          test_case "valid text" `Quick test_extract_text_from_stt_valid;
+          test_case "empty text" `Quick test_extract_text_from_stt_empty;
+          test_case "missing field" `Quick test_extract_text_from_stt_missing;
+        ] );
+      ( "extract_reply_text",
+        [
+          test_case "valid reply" `Quick test_extract_reply_text_valid;
+          test_case "missing reply" `Quick test_extract_reply_text_missing;
+        ] );
+      ( "is_stop_command",
+        [
+          test_case "english" `Quick test_is_stop_command_english;
+          test_case "korean" `Quick test_is_stop_command_korean;
+          test_case "negative" `Quick test_is_stop_command_negative;
+        ] );
+      ( "run",
+        [
+          test_case "stop command ends loop" `Quick test_run_stop_command;
+          test_case "max turns ends loop" `Quick test_run_max_turns;
+          test_case "consecutive empty STT stops loop" `Quick test_run_consecutive_empty_stops;
+          test_case "empty count resets on success" `Quick test_run_empty_resets_on_success;
+          test_case "error on first turn" `Quick test_run_error_on_first_turn;
+        ] );
+    ]

--- a/test/test_keeper_voice_loop.ml
+++ b/test/test_keeper_voice_loop.ml
@@ -1,5 +1,7 @@
 open Alcotest
 
+module Keeper_voice_loop = Masc_mcp.Keeper_voice_loop
+
 (* ============================================================ *)
 (* Pure function tests                                           *)
 (* ============================================================ *)

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -311,6 +311,7 @@ let all_known_tool_names =
     "masc_voice_agent";
     "masc_voice_conference_end";
     "masc_voice_conference_start";
+    "masc_voice_ping_pong";
     "masc_voice_session_end";
     "masc_voice_session_start";
     "masc_voice_sessions";


### PR DESCRIPTION
## Summary
- Add `masc_voice_ping_pong` MCP tool: records user speech, runs keeper turn, speaks response, repeats
- `keeper_voice_loop.ml`: callback-based loop that avoids circular module dependencies
- `voice_bridge.record_and_transcribe`: reusable mic recording + STT helper
- Fix `mutation_class` fields after OAS SDK 0.99.7 rebase
- Include voice tools in `Full` preset candidate list (test fix)

## Architecture
The keeper LLM is unaware of voice mode. The loop acts as a transparent I/O adapter:
```
voice_listen() → text → keeper_turn → response → voice_speak() → loop
```
Stop commands: "stop", "exit", "종료", "끝", "그만"

## Test plan
- [x] 50 tool shard coverage tests pass
- [x] 54 keeper safety gates tests pass  
- [x] 14 provider adapter tests pass
- [ ] Manual: start keeper, call `masc_voice_ping_pong`, verify mic→turn→TTS loop
- [ ] CI green

Closes #4336

🤖 Generated with [Claude Code](https://claude.com/claude-code)