### PR TITLE
fix(test): remove duplicate MASC_BASE_PATH in test/dune env

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -12,14 +12,12 @@
    (DATABASE_URL "")
    (SUPABASE_DB_URL "")
    (SB_PG_URL "")
-   ; Ignore shell-level workspace overrides so tests stay isolated in temp dirs.
+   ; Prevent inherited shell MASC_BASE_PATH from binding tests to real
+   ; workspace state. Tests that need a base path pass it explicitly.
    (MASC_BASE_PATH "")
    ; Avoid non-deterministic external network calls during unit tests.
    (GRAPHQL_API_KEY "")
-   (ZAI_API_KEY "")
-   ; Prevent inherited shell MASC_BASE_PATH from binding tests to real
-   ; workspace state. Tests that need a base path pass it explicitly.
-   (MASC_BASE_PATH ""))))
+   (ZAI_API_KEY ""))))
 
 ; ============================================================
 ; All standard tests share the masc_test_deps wrapper library


### PR DESCRIPTION
## Summary
- Remove duplicate `MASC_BASE_PATH` definition in `test/dune` env block
- This was blocking **all CI jobs on main** with `Variable MASC_BASE_PATH is specified several times`

## Root cause
Line 16 and line 22 both defined `(MASC_BASE_PATH "")`. Consolidated to a single definition.

## Test plan
- [x] `dune build` succeeds
- [x] 50 shard coverage tests pass
- [ ] CI green (this PR fixes the CI blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)