### PR TITLE
fix(keeper): include voice tool names in candidate set

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -162,6 +162,7 @@ let keeper_coding_masc_tool_names =
 let keeper_all_candidate_tool_names () =
   dedupe_tool_names
     ( keeper_internal_candidate_tool_names
+    @ keeper_voice_tool_names
     @ keeper_governance_tool_names
     @ keeper_coding_shard_tool_names
     @ keeper_coding_tool_names


### PR DESCRIPTION
## Summary

- Add `keeper_voice_tool_names` to `keeper_all_candidate_tool_names()` candidate aggregation
- Voice tools are now always in the candidate set regardless of voice shard registration

## Root Cause

`Tool_shard.get_shard "voice"` returns `None` in test environment → `keeper_voice_tool_schemas` returns `[]` → voice tools missing from candidate set → `filter_by_access` excludes them even when preset allowlists include them

- Fixes flaky `policy_mode_tool_grants` tests (all 54 pass)

Closes #4358

## Test plan
- [x] `test_keeper_safety_gates` — all 54 tests pass (verified locally)
- [x] Existing `test_voice_enabled` / `test_voice_disabled` / `test_all_keepers_get_full_toolset` all cover voice tool membership