### PR TITLE
fix(dashboard): include bearer token in MCP protocol requests

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -33,7 +33,7 @@ function initTokenFromUrl(): void {
 
 initTokenFromUrl()
 
-function getStoredToken(): string | null {
+export function getStoredToken(): string | null {
   return sessionStorage.getItem(TOKEN_STORAGE_KEY)
 }
 

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -8,6 +8,7 @@ const { fetchWithTimeout, reportToolHostFailure } = vi.hoisted(() => ({
 vi.mock('./core', () => ({
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
+  getStoredToken: () => null,
 }))
 
 vi.mock('./dashboard', () => ({

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+let storedToken: string | null = null
+
 const { fetchWithTimeout, reportToolHostFailure } = vi.hoisted(() => ({
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
@@ -8,7 +10,7 @@ const { fetchWithTimeout, reportToolHostFailure } = vi.hoisted(() => ({
 vi.mock('./core', () => ({
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
-  getStoredToken: () => null,
+  getStoredToken: () => storedToken,
 }))
 
 vi.mock('./dashboard', () => ({
@@ -18,6 +20,7 @@ vi.mock('./dashboard', () => ({
 afterEach(async () => {
   const { resetMcpClientState } = await import('./mcp')
   resetMcpClientState()
+  storedToken = null
   vi.clearAllMocks()
   vi.resetModules()
 })
@@ -51,5 +54,58 @@ describe('callMcpTool', () => {
         timeout_ms: 30000,
       }),
     )
+  })
+
+  it('includes Authorization header when token is available', async () => {
+    storedToken = 'test-bearer-token'
+
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-auth' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
+          status: 200,
+        }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    // initialize request (1st call) should include auth header
+    const initHeaders = fetchWithTimeout.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(initHeaders['Authorization']).toBe('Bearer test-bearer-token')
+
+    // tools/call request (3rd call) should include auth header
+    const toolHeaders = fetchWithTimeout.mock.calls[2]?.[1]?.headers as Record<string, string>
+    expect(toolHeaders['Authorization']).toBe('Bearer test-bearer-token')
+  })
+
+  it('omits Authorization header when no token is stored', async () => {
+    storedToken = null
+
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-noauth' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
+          status: 200,
+        }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    const initHeaders = fetchWithTimeout.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(initHeaders['Authorization']).toBeUndefined()
   })
 })

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — MCP-over-HTTP client with session lifecycle
 
-import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS } from './core'
+import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS, getStoredToken } from './core'
 import {
   MCP_INIT_COOLDOWN_MS,
   MCP_INITIALIZE_TIMEOUT_MS,
@@ -55,6 +55,10 @@ function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
     Accept: 'application/json, text/event-stream',
     ...(extra ?? {}),
   }
+  const token = getStoredToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
   if (mcpSessionId) {
     headers['Mcp-Session-Id'] = mcpSessionId
   }
@@ -89,10 +93,7 @@ async function ensureSession(): Promise<void> {
     try {
       const res = await fetchWithTimeout('/mcp', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json, text/event-stream',
-        },
+        headers: mcpHeaders(),
         body: JSON.stringify({
           jsonrpc: '2.0',
           method: 'initialize',


### PR DESCRIPTION
## Summary
- `mcpHeaders()`가 `Authorization: Bearer <token>` 헤더를 누락하여 POST /mcp 요청 시 401 Unauthorized 발생
- `authHeaders()` (REST API용)는 토큰을 포함하지만, `mcpHeaders()` (MCP 프로토콜용)는 포함하지 않는 불일치 수정
- `ensureSession()` initialize 요청의 인라인 헤더도 `mcpHeaders()`로 통일

## Root Cause
Dashboard에 auth 헤더 생성 함수가 두 벌 존재:
- `authHeaders()` (core.ts) → REST API 호출용, Bearer 토큰 포함
- `mcpHeaders()` (mcp.ts) → MCP 프로토콜용, Bearer 토큰 **미포함**

서버의 `verify_mcp_auth`는 `require_token=true`일 때 토큰 없으면 401 반환.

## Changes
- `core.ts`: `getStoredToken()` export
- `mcp.ts`: `mcpHeaders()`에 Bearer 토큰 추가 + `ensureSession()` 인라인 헤더 제거
- `mcp.test.ts`: mock에 `getStoredToken` 추가

## Follow-up
서버 측 defense-in-depth (`verify_mcp_auth`에 same-origin fallback 추가)는 OCaml 함수 순서 재배치가 필요하여 별도 이슈로 분리.

## Test plan
- [x] `npx vitest run src/api/mcp.test.ts` 통과
- [ ] auth enabled + require_token=true 환경에서 dashboard 401 해소 확인
- [ ] DevTools Network에서 POST /mcp 요청에 Authorization 헤더 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)