### PR TITLE
refactor(boundary): remove vendor-specific model env vars

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -55,50 +55,10 @@ module Inference = struct
     |> String.lowercase_ascii
 end
 
-(** {1 GLM Configuration} *)
-
-module Glm = struct
-  (** GLM model label.  OAS cascade resolves "auto" to the concrete
-      model via ZAI_DEFAULT_MODEL env var.
-      MASC never hardcodes a model name — cascade is the SSOT. *)
-  let default_model =
-    get_string ~default:"auto" "MASC_GLM_DEFAULT_MODEL"
-
-  let flash_model =
-    get_string ~default:"auto" "MASC_GLM_FLASH_MODEL"
-end
-
-(** {1 Gemini Configuration} *)
-
-module Gemini = struct
-  (** Default Gemini model.
-      Empty = skip Gemini in cascades unless env-var overridden. *)
-  let default_model =
-    get_string ~default:"gemini-2.5-pro" "MASC_GEMINI_DEFAULT_MODEL"
-
-  (** Gemini flash model for lightweight tasks.
-      Empty = skip Gemini flash in cascades. *)
-  let flash_model =
-    get_string ~default:"gemini-2.5-flash" "MASC_GEMINI_FLASH_MODEL"
-end
-
-(** {1 Claude Configuration} *)
-
-module Claude = struct
-  (** Default Claude model.
-      Empty = skip Claude in cascades unless env-var overridden. *)
-  let default_model =
-    get_string ~default:"claude-sonnet-4-6" "MASC_CLAUDE_DEFAULT_MODEL"
-end
-
-(** {1 OpenAI Configuration} *)
-
-module OpenAI = struct
-  (** Default OpenAI model.
-      Empty = skip OpenAI in cascades unless env-var overridden. *)
-  let default_model =
-    get_string ~default:"gpt-4.1" "MASC_OPENAI_DEFAULT_MODEL"
-end
+(* Vendor-specific model modules removed (2026-04-01).
+   Model selection is delegated to OAS cascade via "provider:auto" labels.
+   OAS resolve_auto_model_id handles env-var fallbacks per provider.
+   See: oas/lib/llm_provider/cascade_model_resolve.ml *)
 
 (** {1 Rate Limit Cleanup Configuration} *)
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -175,26 +175,13 @@ let default_model_for_provider provider =
           (match trim_nonempty Env_config_runtime.Llama.default_model with
           | Some value when value <> "explicit-model-required" -> Some value
           | _ -> None))
-  | "claude-api" -> trim_nonempty Env_config_governance.Claude.default_model
-  | "codex-api" -> trim_nonempty Env_config_governance.OpenAI.default_model
-  | "gemini-api" -> trim_nonempty Env_config_governance.Gemini.default_model
-  | "glm" -> Some "auto"
+  | "claude-api" | "codex-api" | "gemini-api" | "glm" -> Some "auto"
   | _ -> None
 
 let candidate_models_for_provider provider =
   match provider with
   | "llama" -> []
-  | "claude-api" ->
-      dedupe_keep_order [ Env_config_governance.Claude.default_model ]
-  | "codex-api" ->
-      dedupe_keep_order [ Env_config_governance.OpenAI.default_model ]
-  | "gemini-api" ->
-      dedupe_keep_order
-        [
-          Env_config_governance.Gemini.default_model;
-          Env_config_governance.Gemini.flash_model;
-        ]
-  | "glm" -> ["auto"]
+  | "claude-api" | "codex-api" | "gemini-api" | "glm" -> ["auto"]
   | _ -> []
 
 let llama_snapshot () =

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -112,11 +112,9 @@ let transport_entries = [
 let inference_entries = [
   entry ~default:"30" "MASC_INFERENCE_TIMEOUT_SEC" "Inference call timeout (seconds)";
   entry ~default:"true" "MASC_INFERENCE_CACHE_ENABLED" "Enable inference result cache";
-  entry ~default:"auto" "MASC_GLM_DEFAULT_MODEL" "Default GLM model";
-  entry ~default:"auto" "MASC_GLM_FLASH_MODEL" "GLM flash model";
-  entry ~default:"gemini-2.5-pro" "MASC_GEMINI_DEFAULT_MODEL" "Default Gemini model";
-  entry ~default:"claude-sonnet-4-6" "MASC_CLAUDE_DEFAULT_MODEL" "Default Claude model";
-  entry ~default:"gpt-4.1" "MASC_OPENAI_DEFAULT_MODEL" "Default OpenAI model";
+  (* Vendor-specific model env vars removed. Model selection delegated to
+     OAS cascade via "provider:auto". Per-provider env vars (GEMINI_DEFAULT_MODEL,
+     ANTHROPIC_DEFAULT_MODEL, OPENAI_DEFAULT_MODEL) are read by OAS directly. *)
 ]
 
 let keeper_entries = [

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -578,23 +578,14 @@ let provider_model_label provider model =
 
 (** Centralized family → model label mapping.
     Vendor-specific env var resolution happens here only. *)
+(** Family → model label. Uses "provider:auto" for cloud providers;
+    OAS cascade resolves the concrete model at runtime. *)
 let default_model_label_for_family = function
-  | Claude_family ->
-      let m = Env_config.Claude.default_model in
-      if m = "" then Error "No Claude model configured (MASC_CLAUDE_DEFAULT_MODEL)"
-      else Ok ("claude:" ^ m)
-  | Gemini_family ->
-      let m = Env_config.Gemini.default_model in
-      if m = "" then Error "No Gemini model configured (MASC_GEMINI_DEFAULT_MODEL)"
-      else Ok ("gemini:" ^ m)
-  | OpenAI_family ->
-      let m = Env_config.OpenAI.default_model in
-      if m = "" then Error "No OpenAI model configured (MASC_OPENAI_DEFAULT_MODEL)"
-      else Ok ("openai:" ^ m)
-  | Glm_family ->
-      Ok "glm:auto"
-  | Llama_family ->
-      explicit_llama_model_label_result ()
+  | Claude_family -> Ok "claude:auto"
+  | Gemini_family -> Ok "gemini:auto"
+  | OpenAI_family -> Ok "openai:auto"
+  | Glm_family -> Ok "glm:auto"
+  | Llama_family -> explicit_llama_model_label_result ()
   | OpenRouter_family ->
       Error "OpenRouter requires explicit runtime_model"
   | Custom_family _ ->
@@ -611,22 +602,12 @@ let preferred_execution_model_labels () =
          (match explicit_llama_model_label_result () with
          | Ok label -> Some label
          | Error _ -> None);
-         (* GLM: even with empty model config, include as "glm:" —
-            the GLM provider selects the model at runtime. *)
-         (if env_present "ZAI_API_KEY" then
-           Some "glm:auto"
-         else None);
-         (* Non-GLM providers: only include when model is explicitly configured.
-            APIs require a model field, so empty model = skip. *)
-         (if gemini_direct_available () then
-           provider_model_label "gemini" Env_config.Gemini.default_model
-         else None);
-         (if env_present "ANTHROPIC_API_KEY" then
-           provider_model_label "claude" Env_config.Claude.default_model
-         else None);
-         (if env_present "OPENAI_API_KEY" then
-           provider_model_label "openai" Env_config.OpenAI.default_model
-         else None);
+         (* Provider auto-detection: check API key presence, delegate
+            model selection to OAS cascade via "provider:auto". *)
+         (if env_present "ZAI_API_KEY" then Some "glm:auto" else None);
+         (if gemini_direct_available () then Some "gemini:auto" else None);
+         (if env_present "ANTHROPIC_API_KEY" then Some "claude:auto" else None);
+         (if env_present "OPENAI_API_KEY" then Some "openai:auto" else None);
        ])
 
 let preferred_verifier_model_labels () =
@@ -640,18 +621,10 @@ let preferred_verifier_model_labels () =
          (match explicit_llama_model_label_result () with
          | Ok label -> Some label
          | Error _ -> None);
-         (if env_present "ZAI_API_KEY" then
-           Some "glm:auto"
-         else None);
-         (if gemini_direct_available () then
-           provider_model_label "gemini" Env_config.Gemini.flash_model
-         else None);
-         (if env_present "ANTHROPIC_API_KEY" then
-           provider_model_label "claude" Env_config.Claude.default_model
-         else None);
-         (if env_present "OPENAI_API_KEY" then
-           provider_model_label "openai" Env_config.OpenAI.default_model
-         else None);
+         (if env_present "ZAI_API_KEY" then Some "glm:auto" else None);
+         (if gemini_direct_available () then Some "gemini:auto" else None);
+         (if env_present "ANTHROPIC_API_KEY" then Some "claude:auto" else None);
+         (if env_present "OPENAI_API_KEY" then Some "openai:auto" else None);
        ])
 
 let default_model_labels_result () =


### PR DESCRIPTION
## Summary
- Remove `MASC_GLM_DEFAULT_MODEL`, `MASC_GLM_FLASH_MODEL`, `MASC_GEMINI_DEFAULT_MODEL`, `MASC_GEMINI_FLASH_MODEL`, `MASC_CLAUDE_DEFAULT_MODEL`, `MASC_OPENAI_DEFAULT_MODEL`
- Replace with `"provider:auto"` cascade labels — OAS resolves concrete models
- -108 lines, 4 files

## Why
MASC는 orchestration layer — 벤더별 모델명을 알 필요가 없다.
OAS `cascade_model_resolve.ml`이 `"provider:auto"` → env var fallback → default 해결을 담당한다.

## Dependencies
- OAS oas#541 (openai:auto resolution) — 머지 후 OAS pin 업데이트 필요

## Test plan
- [x] `dune build @all` 성공
- [ ] CI green
- [ ] OAS #541 머지 후 pin 업데이트

Refs #4365

🤖 Generated with [Claude Code](https://claude.com/claude-code)