### PR TITLE
fix(gc): auto-remove broken agent files instead of skipping

### DIFF
--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -92,9 +92,10 @@ let cleanup_zombies
           | Ok _ -> () (* not a zombie, skip *)
           | Error err ->
               Log.Gc.warn "removing broken agent file %s: %s" name err;
-              (try Sys.remove path
-               with Sys_error msg ->
-                 Log.Gc.warn "failed to remove broken agent %s: %s" name msg)
+              (try delete_path config path
+               with exn ->
+                 Log.Gc.warn "failed to remove broken agent %s: %s"
+                   path (Printexc.to_string exn))
         end
       )
     ) scan_paths;

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -90,7 +90,11 @@ let cleanup_zombies
                   Resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
               zombie_entries := (agent.name, path) :: !zombie_entries
           | Ok _ -> () (* not a zombie, skip *)
-          | Error err -> Log.Gc.warn "skipping agent %s: parse error: %s" name err
+          | Error err ->
+              Log.Gc.warn "removing broken agent file %s: %s" name err;
+              (try Sys.remove path
+               with Sys_error msg ->
+                 Log.Gc.warn "failed to remove broken agent %s: %s" name msg)
         end
       )
     ) scan_paths;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -710,6 +710,21 @@ let test_cleanup_zombies_removes_broken_agent_file () =
       false (Sys.file_exists path)
   )
 
+let test_cleanup_zombies_preserves_non_json_files () =
+  with_test_env (fun config ->
+    (* Place a non-JSON file in the agents directory *)
+    let agents_path = Filename.concat (Room.masc_dir config) "agents" in
+    let path = Filename.concat agents_path ".gitkeep" in
+    let oc = open_out path in
+    output_string oc "";
+    close_out oc;
+    Alcotest.(check bool) "non-json file exists before GC"
+      true (Sys.file_exists path);
+    let _result = Room.cleanup_zombies config in
+    Alcotest.(check bool) "non-json file preserved by GC"
+      true (Sys.file_exists path)
+  )
+
 (* ============================================================ *)
 (* Agent Discovery / Capability Tests                           *)
 (* ============================================================ *)
@@ -1581,6 +1596,7 @@ let () =
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;
       Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
       Alcotest.test_case "cleanup removes broken agent file" `Quick test_cleanup_zombies_removes_broken_agent_file;
+      Alcotest.test_case "cleanup preserves non-json files" `Quick test_cleanup_zombies_preserves_non_json_files;
     ];
 
     (* === Agent Discovery / Capability Tests === *)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -697,6 +697,19 @@ let test_cleanup_zombies_spares_recent_keeper () =
       true (not (str_contains result "keeper-active-agent"))
   )
 
+let test_cleanup_zombies_removes_broken_agent_file () =
+  with_test_env (fun config ->
+    (* Write an empty JSON object — unparseable as agent *)
+    let agents_path = Filename.concat (Room.masc_dir config) "agents" in
+    let path = Filename.concat agents_path "broken-agent.json" in
+    Room.write_json config path (Yojson.Safe.from_string "{}");
+    Alcotest.(check bool) "broken file exists before GC"
+      true (Sys.file_exists path);
+    let _result = Room.cleanup_zombies config in
+    Alcotest.(check bool) "broken file removed by GC"
+      false (Sys.file_exists path)
+  )
+
 (* ============================================================ *)
 (* Agent Discovery / Capability Tests                           *)
 (* ============================================================ *)
@@ -1567,6 +1580,7 @@ let () =
       Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;
       Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
+      Alcotest.test_case "cleanup removes broken agent file" `Quick test_cleanup_zombies_removes_broken_agent_file;
     ];
 
     (* === Agent Discovery / Capability Tests === *)


### PR DESCRIPTION
## Summary
- GC가 매 사이클마다 `Types_core.agent.last_seen` parse error를 로깅하면서 corrupt agent 파일(`{}`)을 skip만 하고 정리하지 않던 문제 수정
- `read_agent_with_repair`로 복구 불가한 파일은 `Sys.remove`로 자동 제거
- `Sys.remove` 실패 시 warn 로그만 남기고 계속 진행 (권한 문제 등 방어)

## Root Cause
`focus-room/agents/`에 빈 JSON 객체 `{}`로 된 agent 파일(`root-agent.json`, `alice.json`)이 존재. 필수 필드(`name`, `status`, `last_seen` 등)가 없어 파싱 실패하고, normalization 경로도 `last_seen` 필드 자체가 없어 복구 불가. 매분 GC 사이클마다 동일 경고 반복.

## Product impact
- GC 로그 노이즈 제거 (매분 2건 warn → 0)
- corrupt agent 파일이 stale 상태로 남아 GC 정리를 방해하던 문제 해소

## Evidence
- `write_json_local`은 tmp+rename atomic write 사용 (room_utils_ops.ml:124-126) — partial write race condition 없음
- `.json` suffix 가드 (room_gc.ml:80)가 non-JSON 파일 삭제 방지

## Review evidence
- GLM-5.1 cross-model review 수행
- 5개 이슈 중 1개(non-JSON 파일 보호 테스트) 수용, 4개는 기존 코드의 가드로 미해당 판정

Refs #4368

## Test plan
- [x] `test_cleanup_zombies_removes_broken_agent_file` — 빈 `{}` agent 파일이 GC에 의해 제거됨
- [x] `test_cleanup_zombies_preserves_non_json_files` — `.gitkeep` 등 non-JSON 파일이 보존됨
- [x] 기존 heartbeat 테스트 13/13 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)