### PR TITLE
fix(dashboard): harden MCP 403 blocked detection and extract constants

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -25,6 +25,23 @@ afterEach(async () => {
   vi.resetModules()
 })
 
+/** Mock MCP session init (initialize + notification) and a successful tools/call response */
+function setupSuccessfulMcpSession(sessionId: string) {
+  fetchWithTimeout
+    .mockResolvedValueOnce(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Mcp-Session-Id': sessionId },
+      }),
+    )
+    .mockResolvedValueOnce(new Response('', { status: 202 }))
+    .mockResolvedValueOnce(
+      new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
+        status: 200,
+      }),
+    )
+}
+
 describe('callMcpTool', () => {
   it('reports tool-host failures after the MCP session is established', async () => {
     fetchWithTimeout
@@ -58,49 +75,21 @@ describe('callMcpTool', () => {
 
   it('includes Authorization header when token is available', async () => {
     storedToken = 'test-bearer-token'
-
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-auth' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
-          status: 200,
-        }),
-      )
+    setupSuccessfulMcpSession('sess-auth')
 
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})
 
-    // initialize request (1st call) should include auth header
     const initHeaders = fetchWithTimeout.mock.calls[0]?.[1]?.headers as Record<string, string>
     expect(initHeaders['Authorization']).toBe('Bearer test-bearer-token')
 
-    // tools/call request (3rd call) should include auth header
     const toolHeaders = fetchWithTimeout.mock.calls[2]?.[1]?.headers as Record<string, string>
     expect(toolHeaders['Authorization']).toBe('Bearer test-bearer-token')
   })
 
   it('omits Authorization header when no token is stored', async () => {
     storedToken = null
-
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-noauth' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
-          status: 200,
-        }),
-      )
+    setupSuccessfulMcpSession('sess-noauth')
 
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -10,6 +10,9 @@ import { reportToolHostFailure } from './dashboard'
 
 // --- MCP Session Management ---
 
+const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.'
+const MCP_SESSION_BLOCKED = '__blocked__'
+
 let mcpSessionId: string | null = null
 let initPromise: Promise<void> | null = null
 let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
@@ -76,7 +79,8 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
   if (sid) mcpSessionId = sid
   if (!res.ok) {
     if (res.status === 403) {
-      throw new Error('MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.')
+      mcpSessionId = MCP_SESSION_BLOCKED
+      throw new Error(MCP_BLOCKED_MESSAGE)
     }
     throw new Error(`POST /mcp: ${res.status} ${res.statusText}`)
   }
@@ -84,8 +88,8 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
 }
 
 async function ensureSession(): Promise<void> {
-  if (mcpSessionId === '__blocked__') {
-    throw new Error('MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.')
+  if (mcpSessionId === MCP_SESSION_BLOCKED) {
+    throw new Error(MCP_BLOCKED_MESSAGE)
   }
   if (mcpSessionId) return
   if (initPromise) return initPromise
@@ -105,6 +109,13 @@ async function ensureSession(): Promise<void> {
           id: 0,
         }),
       }, MCP_INITIALIZE_TIMEOUT_MS)
+      if (!res.ok) {
+        if (res.status === 403) {
+          mcpSessionId = MCP_SESSION_BLOCKED
+          throw new Error(MCP_BLOCKED_MESSAGE)
+        }
+        throw new Error(`POST /mcp initialize: ${res.status} ${res.statusText}`)
+      }
       const sid = res.headers.get('Mcp-Session-Id')
       if (sid) mcpSessionId = sid
       // Send initialized notification
@@ -120,9 +131,6 @@ async function ensureSession(): Promise<void> {
       }
       initPromise = null
     } catch (err) {
-      if (err instanceof Error && err.message.includes('403')) {
-        mcpSessionId = '__blocked__'
-      }
       // Keep initPromise alive briefly to prevent retry storms
       if (initCooldownTimer) {
         clearTimeout(initCooldownTimer)


### PR DESCRIPTION
## Summary
#4362 머지 후 `/simplify` 리뷰에서 발견된 후속 수정.

- `mcpPost()` 403에서 `__blocked__` 미설정 → 세션 확립 후 403 시 재시도 루프 발생 방지
- `ensureSession()` initialize 응답 `res.ok` 미체크 → non-2xx 응답 조용히 무시되던 문제 수정
- catch 블록의 `includes('403')` 문자열 매칭 → explicit status check로 교체 (한국어 메시지에 "403" 미포함 버그)
- `MCP_BLOCKED_MESSAGE`, `MCP_SESSION_BLOCKED` 상수 추출 (4곳 인라인 문자열 제거)
- 테스트 mock 중복 → `setupSuccessfulMcpSession()` 헬퍼 추출

## Relates
Refs #4362

## Test plan
- [x] `npx vitest run src/api/mcp.test.ts` — 3 tests passed
- [ ] auth enabled 환경에서 403 응답 시 `__blocked__` 상태 전환 확인
- [ ] 이후 MCP 호출이 즉시 `MCP_BLOCKED_MESSAGE` 에러 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)