### PR TITLE
refactor(dashboard): UI 텍스트 한국어 통일, 기술 약어 제거

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -14,7 +14,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="실시간 활동 스트림">
       ${entries.length === 0
-        ? html`<${EmptyState} message="이 에이전트의 SSE 이벤트가 아직 없습니다. 대시보드 접속 후 발생한 이벤트만 표시됩니다." compact />`
+        ? html`<${EmptyState} message="아직 활동 기록이 없습니다" compact />`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -22,7 +22,7 @@ function timelineEventLabel(type: string): string {
     case 'task_started': return '태스크 시작'
     case 'task_completed': return '태스크 완료'
     case 'task_cancelled': return '태스크 취소'
-    case 'broadcast': return '브로드캐스트'
+    case 'broadcast': return '공지'
     default: return type
   }
 }
@@ -35,7 +35,7 @@ export function AgentTimelineSection() {
   const summary = timeline.summary
 
   return html`
-    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0} events)">
+    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
           ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">완료 ${summary.tasks_completed}</span>` : null}
@@ -45,7 +45,7 @@ export function AgentTimelineSection() {
         </div>
       ` : null}
       ${events.length === 0
-        ? html`<${EmptyState} message="이 에이전트의 작업 기록(태스크 수임/완료, 브로드캐스트 등)이 아직 없습니다." compact />`
+        ? html`<${EmptyState} message="작업 기록이 아직 없습니다" compact />`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">
               ${events.map((evt: AgentTimelineEvent, idx: number) => {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -131,7 +131,7 @@ export function AgentDetailOverlay() {
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
                   ${unified.description !== unified.label ? html`<span class="text-[10px] font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded-md" title=${unified.description}>${unified.description}</span>` : null}
-                  ${isArchivedParticipant ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">archived session participant</span>` : null}
+                  ${isArchivedParticipant ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">이전 세션 참여자</span>` : null}
                   ${agent?.model ? html`<span class="font-mono text-[10px] font-medium bg-white/10 border border-white/5 px-2 py-1 rounded-md text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
@@ -182,7 +182,7 @@ export function AgentDetailOverlay() {
 
         <${AgentSessionReport} agentName=${agentName} />
 
-        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">GitHub Agents 스타일</span>`}>
+        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">통합 타임라인</span>`}>
           <${SessionTraceView} agentName=${agentName} isKeeper=${!!keeper} />
         <//>
 
@@ -195,7 +195,7 @@ export function AgentDetailOverlay() {
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 80개 room 메시지에서 이 에이전트 관련 항목 없음" compact /></div>`
+              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
               : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded-xl shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -167,7 +167,7 @@ function timelineEventLabel(type: string): string {
     case 'task_started': return '시작'
     case 'task_completed': return '완료'
     case 'task_cancelled': return '취소'
-    case 'broadcast': return '방송'
+    case 'broadcast': return '공지'
     default: return type
   }
 }

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -104,7 +104,7 @@ export function AgentsUnified() {
         <div class="px-3 pb-2.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px] text-text-muted">
           <span class="font-mono text-text-body">working</span><span>LLM이 현재 응답을 생성 중 (도구 실행 또는 텍스트 생성)</span>
           <span class="font-mono text-text-body">busy</span><span>작업 중이지만 LLM 응답 대기 아닌 상태 (I/O, 파일 처리 등)</span>
-          <span class="font-mono text-text-body">listening</span><span>SSE/gRPC 스트림 연결 상태. 작업 대기 중</span>
+          <span class="font-mono text-text-body">listening</span><span>실시간 스트림 연결 상태. 작업 대기 중</span>
           <span class="font-mono text-text-body">idle</span><span>최근 활동 없음. 하트비트는 유지 중</span>
           <span class="font-mono text-text-body">offline</span><span>하트비트 끊김. 프로세스 종료됨</span>
         </div>

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -146,9 +146,9 @@ export function SwarmLivePanels() {
                       </article>
                     `)}
                   </div>`
-                : html`<${EmptyState} message="slot telemetry가 아직 없습니다." compact />`}
+                : html`<${EmptyState} message="슬롯 데이터가 아직 없습니다" compact />`}
             `
-          : html`<${EmptyState} message="런타임 telemetry가 아직 없습니다." compact />`}
+          : html`<${EmptyState} message="런타임 데이터가 아직 없습니다" compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -46,14 +46,14 @@ const KPI_VALUE_TONE: Record<KpiTone, string> = {
 }
 
 const KPI_ICON: Record<string, string> = {
-  Generation: '🔄',
-  Turns: '↻',
-  Context: '📊',
-  Activity: '⚡',
-  Tokens: '🔤',
-  Handoffs: '🤝',
-  Compactions: '📦',
-  'Cost (USD)': '💰',
+  '세대': '🔄',
+  '턴': '↻',
+  '컨텍스트': '📊',
+  '활동': '⚡',
+  '토큰': '🔤',
+  '인계': '🤝',
+  '압축': '📦',
+  '비용 (USD)': '💰',
 }
 
 function KpiCard({ label, value, hint, tone = 'default', progress }: {
@@ -111,17 +111,17 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       ${'' /* Primary KPIs — 3 cols (activityLevel removed) */}
       <div class="grid grid-cols-3 gap-3">
         <${KpiCard}
-          label="Generation"
+          label="세대"
           value=${keeper.generation ?? '-'}
           hint="승계 횟수"
         />
         <${KpiCard}
-          label="Turns"
+          label="턴"
           value=${keeper.turn_count ?? '-'}
           hint="총 루프 회차"
         />
         <${KpiCard}
-          label="Context"
+          label="컨텍스트"
           value=${ctxPct != null ? `${ctxPct}%` : '-'}
           hint=${ctxHint}
           tone=${ctxTone}
@@ -131,7 +131,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       ${'' /* Model usage distribution */}
       ${totalCalls > 0 ? html`
         <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-3">
-          <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Provider-Model 호출 분포</div>
+          <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">모델 호출 분포</div>
           <div class="flex flex-col gap-1.5">
             ${modelEntries.slice(0, 4).map(([model, count]) => {
               const pct = Math.round((count / totalCalls) * 100)
@@ -154,49 +154,49 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       ${'' /* Secondary KPIs — 3-4 cols, smaller feel */}
       <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
         <${KpiCard}
-          label="Tokens"
+          label="토큰"
           value=${formatTokens(keeper.context_tokens)}
           hint=${keeper.context_max ? `/ ${formatTokens(keeper.context_max)}` : undefined}
         />
         <${KpiCard}
-          label="Handoffs"
+          label="인계"
           value=${keeper.handoff_count_total ?? '-'}
         />
         <${KpiCard}
-          label="Compactions"
+          label="압축"
           value=${keeper.compaction_count ?? '-'}
         />
         ${latestCost
-          ? html`<${KpiCard} label="Cost (USD)" value=${latestCost} />`
+          ? html`<${KpiCard} label="비용 (USD)" value=${latestCost} />`
           : null}
       </div>
       ${'' /* Autonomy KPIs — always visible for keeper context */}
       <div class="grid grid-cols-4 gap-2">
         <${KpiCard}
-          label="Auto Actions"
+          label="자율 행동"
           value=${keeper.autonomous_action_count ?? 0}
-          hint=${autonomyHint(keeper.autonomous_action_count, keeper.proactive_enabled) ?? '자율 행동 횟수'}
+          hint=${autonomyHint(keeper.autonomous_action_count, keeper.proactive_enabled) ?? '행동 횟수'}
         />
         <${KpiCard}
-          label="Auto Turns"
+          label="자율 턴"
           value=${keeper.autonomous_turn_count ?? 0}
           hint=${keeper.autonomous_text_turn_count != null ? `텍스트 ${keeper.autonomous_text_turn_count} / 도구 ${keeper.autonomous_tool_turn_count ?? 0}` : autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled) ?? '미발동'}
         />
         <${KpiCard}
-          label="Board React"
+          label="보드 반응"
           value=${keeper.board_reactive_turn_count ?? 0}
-          hint="게시판 반응"
+          hint="게시판 반응 턴"
         />
         <${KpiCard}
-          label="Noop"
+          label="비활동"
           value=${keeper.noop_turn_count ?? 0}
-          hint="비활동 턴"
+          hint="아무 작업 없는 턴"
         />
       </div>
       ${'' /* Proactive activity callout */}
       ${keeper.last_proactive_ago_s != null ? html`
         <div class="rounded-xl border border-purple-400/20 bg-purple-500/5 p-3 text-[11px]">
-          <span class="font-semibold text-purple-300">Proactive</span>
+          <span class="font-semibold text-purple-300">자율 활동</span>
           <span class="text-text-muted ml-2">${formatDuration(keeper.last_proactive_ago_s)} 전</span>
           ${keeper.last_proactive_reason ? html`
             <span class="text-text-dim ml-2">| ${keeper.last_proactive_reason}</span>
@@ -306,7 +306,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${'' /* Latency */}
       <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Latency</span>
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
           <span class="text-xs font-mono tabular-nums text-[#9ad9ff]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
@@ -317,7 +317,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${'' /* Cost */}
       <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Cost</span>
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">비용</span>
           <span class="text-xs font-mono tabular-nums text-[#a78bfa]">$${totalCost.toFixed(4)}</span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
@@ -329,8 +329,8 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${modelSwitches.length > 0 ? html`
         <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Model Switches</span>
-            <span class="text-[10px] text-[var(--text-dim)]">${modelSwitches.length} switch${modelSwitches.length > 1 ? 'es' : ''}</span>
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">모델 전환</span>
+            <span class="text-[10px] text-[var(--text-dim)]">${modelSwitches.length}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${modelSwitches.map(s => html`

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -329,13 +329,13 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
       <${ToolSection}
         title="관측된 도구"
-        description="하트비트 또는 런타임 텔레메트리의 최근 실행 근거."
+        description="최근 실행에서 감지된 도구"
         tools=${observedTools}
         fallback=${observedFallback}
       />
 
       <${SignalRow} label="도구 호출" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
-      <${SignalRow} label="근거 출처" value=${auditSource ?? metadataFallback} />
+      <${SignalRow} label="감사 출처" value=${auditSource ?? metadataFallback} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">관측 시점</span>
         <span class="text-xs font-medium text-[var(--text-strong)]">${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</span>
@@ -360,7 +360,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <${ToolSection}
         title="사용 가능한 인근 액션"
         tools=${actions.map(action => actionDescriptorLabel(action.action_type))}
-        fallback="운영자 액션 광고 없음"
+        fallback="사용 가능한 액션 없음"
       />
     </div>
   `

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -117,7 +117,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
       ${isOffline ? html`
         <div class="px-4 py-3 rounded-xl border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-[13px] text-[var(--text-muted)]">
-          이 키퍼는 현재 비활동 상태입니다. Boot 후 메시지를 보낼 수 있습니다.
+          이 키퍼는 현재 비활동 상태입니다. 기동 후 메시지를 보낼 수 있습니다.
         </div>
       ` : null}
 
@@ -125,7 +125,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
         <div class="w-full">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
-            placeholder=${isOffline ? '키퍼 오프라인 — Boot 필요' : '이 키퍼에게 직접 프롬프트 전송'}
+            placeholder=${isOffline ? '키퍼 오프라인 — 기동 필요' : '이 키퍼에게 직접 프롬프트 전송'}
           />
         </div>
 
@@ -193,7 +193,7 @@ function CrashCohortBar({ crash_log }: { crash_log: any[] }) {
   }
   return html`
     <div>
-      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Crash Cohort 분포</div>
+      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 유형 분포</div>
       <div class="flex w-full h-3 rounded-full overflow-hidden bg-[var(--white-5)]">
         ${Object.entries(cohorts).map(([key, count]) => html`
           <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${colors[key] ?? '#6b7280'}"
@@ -217,12 +217,12 @@ function SpEventsPanel({ sp_events }: { sp_events: any[] }) {
   if (!sp_events || sp_events.length === 0) return null
   return html`
     <div>
-      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Self-Preservation 발동 이력</div>
+      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">자기 보호 발동 이력</div>
       <div class="space-y-1 max-h-28 overflow-y-auto">
         ${sp_events.slice(0, 10).map((e: any) => html`
           <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[rgba(139,92,246,0.06)]">
             <span class="font-mono text-[var(--text-muted)]">${new Date((e.ts ?? 0) * 1000).toLocaleTimeString()}</span>
-            <span class="text-[#8b5cf6]">${e.suppressed_count}/${e.total} suppressed (${e.dominant_cohort})</span>
+            <span class="text-[#8b5cf6]">${e.suppressed_count}/${e.total} 억제 (${e.dominant_cohort})</span>
           </div>
         `)}
       </div>
@@ -239,14 +239,14 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
   const hs = typeof health_score === 'number' ? health_score : 100
   const hsColor = hs >= 80 ? '#4ade80' : hs >= 50 ? '#f59e0b' : '#ef4444'
   return html`
-    <${SectionCard} title="Supervisor 진단">
+    <${SectionCard} title="감독 진단">
       <div class="space-y-3">
         <div class="flex items-center justify-between">
-          <span class="text-xs text-[var(--text-muted)]">Health Score</span>
+          <span class="text-xs text-[var(--text-muted)]">건강도</span>
           <span class="text-sm font-bold font-mono" style="color: ${hsColor}">${hs}</span>
         </div>
         <div class="flex items-center justify-between">
-          <span class="text-xs text-[var(--text-muted)]">Fiber 상태</span>
+          <span class="text-xs text-[var(--text-muted)]">실행 상태</span>
           ${registryStateBadge((keeper as any).registry_state)}
         </div>
         <div>
@@ -260,7 +260,7 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         </div>
         ${typeof dead_eta_sec === 'number' && dead_eta_sec > 0 && dead_since == null ? html`
           <div class="flex items-center justify-between">
-            <span class="text-xs text-[var(--text-muted)]">Dead 예상</span>
+            <span class="text-xs text-[var(--text-muted)]">종료 예상</span>
             <span class="text-[11px] font-mono" style="color: ${budgetPct >= 50 ? '#f59e0b' : 'var(--text-body)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
           </div>
         ` : null}
@@ -272,13 +272,13 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         ` : null}
         ${dead_since ? html`
           <div class="py-2 px-3 rounded-lg bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] text-xs text-[#fb7185]">
-            Dead since ${new Date(dead_since * 1000).toLocaleString()}. Reboot 필요.
+            ${new Date(dead_since * 1000).toLocaleString()} 이후 중단됨. 재기동 필요.
           </div>
         ` : null}
         <${CrashCohortBar} crash_log=${crash_log} />
         ${crash_log && crash_log.length > 0 ? html`
           <div>
-            <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">Crash 이력</div>
+            <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 이력</div>
             <div class="space-y-1 max-h-32 overflow-y-auto">
               ${crash_log.slice(0, 10).map((e: any) => html`
                 <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
@@ -344,12 +344,12 @@ export function KeeperDetailOverlay() {
                   onClick=${() => {
                     void bootKeeper(keeper.name).then(res => {
                       if (res.ok) {
-                        showToast(keeper.name + ' booted', 'success')
+                        showToast(keeper.name + ' 기동됨', 'success')
                         void refreshDashboard({ force: true })
                       } else showToast(res.error ?? 'Boot 실패', 'error')
                     }).catch(() => showToast('Boot 실패', 'error'))
                   }}
-                >Boot</button>`
+                >기동</button>`
               if (isRunning) return html`
                 <button type="button"
                   class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
@@ -361,7 +361,7 @@ export function KeeperDetailOverlay() {
                       }).catch(() => showToast('종료 실패', 'error'))
                     }
                   }}
-                >Shutdown</button>`
+                >종료</button>`
               return null
             })()}
             <button
@@ -459,7 +459,7 @@ export function KeeperDetailOverlay() {
           </div>
 
           <div class="md:col-span-2">
-            <${CollapsibleSection} title="통합 활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">브로드캐스트 + 태스크 + 도구 호출</span>`}>
+            <${CollapsibleSection} title="통합 활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">공지 + 태스크 + 도구 호출</span>`}>
               <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} />
             <//>
           </div>
@@ -481,7 +481,7 @@ export function KeeperDetailOverlay() {
         <details class="mt-4">
           <summary class="cursor-pointer py-3 px-4 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
-            Raw Data (Debug)
+            원시 데이터 (디버그)
           </summary>
           <div class="mt-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md">
             <${RawDataDebug} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -346,8 +346,8 @@ export function KeeperDetailOverlay() {
                       if (res.ok) {
                         showToast(keeper.name + ' 기동됨', 'success')
                         void refreshDashboard({ force: true })
-                      } else showToast(res.error ?? 'Boot 실패', 'error')
-                    }).catch(() => showToast('Boot 실패', 'error'))
+                      } else showToast(res.error ?? '기동 실패', 'error')
+                    }).catch(() => showToast('기동 실패', 'error'))
                   }}
                 >기동</button>`
               if (isRunning) return html`

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -407,17 +407,17 @@ export function KeeperRuntimeActions({
           onClick=${() => {
             keeperBooting.value = { ...keeperBooting.value, [keeper.name]: true }
             void bootKeeper(keeper.name).then(res => {
-              if (res.ok) showToast(`${keeper.name} booted`, 'success')
-              else showToast(res.error ?? 'Boot failed', 'error')
+              if (res.ok) showToast(`${keeper.name} 기동됨`, 'success')
+              else showToast(res.error ?? '기동 실패', 'error')
             }).catch(err => {
-              showToast(err instanceof Error ? err.message : `Failed to boot ${keeper.name}`, 'error')
+              showToast(err instanceof Error ? err.message : `${keeper.name} 기동 실패`, 'error')
             }).finally(() => {
               keeperBooting.value = { ...keeperBooting.value, [keeper.name]: false }
             })
           }}
           disabled=${booting}
         >
-          ${booting ? 'Booting...' : 'Boot'}
+          ${booting ? '기동 중...' : '기동'}
         </button>
       ` : null}
       ${isRunning ? html`
@@ -431,7 +431,7 @@ export function KeeperRuntimeActions({
           }}
           disabled=${shuttingDown}
         >
-          ${shuttingDown ? 'Shutting down...' : 'Shutdown'}
+          ${shuttingDown ? '종료 중...' : '종료'}
         </button>
       ` : null}
       <button type="button"

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -53,7 +53,7 @@ export function ActivityStream() {
         ${entries.length === 0
           ? html`<div class="py-6 text-center text-[13px]">
               ${!connected.value
-                ? html`<div class="text-[#e05050]">SSE 연결이 끊겨있습니다. 서버 상태를 확인하세요.</div>`
+                ? html`<div class="text-[#e05050]">실시간 연결이 끊겨있습니다. 서버 상태를 확인하세요.</div>`
                 : liveFilters.value.size > 0
                   ? html`<div class="text-[var(--text-muted)]">선택한 필터에 맞는 이벤트가 없습니다. 필터를 해제해 보세요.</div>`
                   : html`<div class="text-[var(--text-muted)]">아직 수신된 이벤트가 없습니다. 에이전트가 활동하면 여기에 표시됩니다.</div>`

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -242,7 +242,7 @@ export function Mission() {
         <div class="flex flex-col gap-3">
           ${sessionRows.length > 0
             ? sessionRows.map(row => html`<${SessionBriefCard} key=${row.session_id} brief=${row} selected=${activeSessionId === row.session_id} />`)
-            : html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">활성 세션 없음. 세션은 SSE로 연결된 실시간 작업 단위입니다.</div>`}
+            : html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">활성 세션 없음</div>`}
         </div>
       <//>
 

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -88,7 +88,7 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
     return html`
       <div class="flex flex-col items-center gap-2 py-8 text-center">
         <div class="text-[var(--text-muted)] text-sm">이벤트 대기 중</div>
-        <div class="text-[var(--text-muted)] text-xs leading-relaxed max-w-[360px]">에이전트가 task claim, broadcast, board 게시 등 활동을 시작하면 시간순으로 여기에 표시됩니다. SSE 연결이 끊겨있으면 라이브 모니터 탭에서 연결 상태를 확인하세요.</div>
+        <div class="text-[var(--text-muted)] text-xs leading-relaxed max-w-[360px]">에이전트가 활동을 시작하면 시간순으로 여기에 표시됩니다. 연결이 끊겨있으면 라이브 모니터 탭에서 확인하세요.</div>
       </div>
     `
   }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -214,7 +214,7 @@ function HotSessions() {
       />
       ${userSessions.length > 0
         ? html`<div class="grid grid-cols-2 gap-3 max-[960px]:grid-cols-1">${userSessions.map(renderSessionCard)}</div>`
-        : html`<div class="text-xs text-[var(--text-muted)] py-6 text-center">활성 세션 없음. 세션은 SSE로 연결된 실시간 작업 단위입니다. 과거 에이전트는 에이전트 탭에서 확인하세요.</div>`}
+        : html`<div class="text-xs text-[var(--text-muted)] py-6 text-center">활성 세션 없음. 과거 에이전트는 에이전트 탭에서 확인하세요.</div>`}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

- 대시보드 전체 UI 텍스트를 한국어로 통일하고, 기술 약어(SSE, Fiber, telemetry 등)를 사용자 친화적 표현으로 교체
- KPI 카드 라벨 영문 → 한국어 (Generation→세대, Tokens→토큰, Handoffs→인계, Cost→비용 등)
- 장황한 empty state 메시지 간소화 ("최근 80개 room 메시지에서..." → "최근 활동 메시지가 없습니다")
- Supervisor 진단 패널 라벨 번역 (Health Score→건강도, Crash Cohort→장애 유형, Dead→종료)
- Boot/Shutdown 버튼 → 기동/종료 (keeper-detail + keeper-shared 일관성)
- broadcast 라벨 → 공지 (timeline + profile 일관성)
- 14개 파일, 텍스트만 변경. 로직 변경 없음.

## Product impact

대시보드 사용자가 보는 모든 UI 텍스트가 한국어로 통일됨. 기술 약어(SSE, Fiber, telemetry) 노출이 제거되어 비개발자도 상태를 이해할 수 있음.

## Evidence

- `tsc --noEmit` 통과
- `vitest run` 197/197 tests 통과
- GLM-5.1 cross-model review: high/critical 0건

## Review evidence

- GLM-5.1 (direct `sb glm-text`): 전체 diff 리뷰, 이슈 0건
- /simplify 3-agent 병렬 리뷰: reuse/quality/efficiency 각각 검토
  - 발견 3건 (Boot/Shutdown 잔존, broadcast 불일치) → 2nd commit에서 수정 완료

## Linked issue

대시보드 관찰 중심 UX 개선 (feedback memory: dashboard-observation-focus)

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vitest run` 197 tests 전부 통과
- [x] CI checks green (Dashboard, Health, Lint, Contract Harness, PR Hygiene 등)
- [ ] 대시보드 접속하여 사이드바/Overview/Keeper 상세/에이전트 상세 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)