### PR TITLE
refactor(boundary): remove MASC branding from prompt markers

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -57,7 +57,7 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
 (* Importance Scoring (inlined from Context_scoring)                 *)
 (* ================================================================ *)
 
-let memory_summary_prefix = "[MASC_MEMORY_SUMMARY v1]"
+let memory_summary_prefix = "[MEMORY_SUMMARY]"
 
 let goal_prefix = Keeper_working_context.goal_prefix
 

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -58,8 +58,10 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
 (* ================================================================ *)
 
 let memory_summary_prefix = "[MEMORY_SUMMARY]"
+let _legacy_memory_summary_prefix = "[MASC_MEMORY_SUMMARY v1]"
 
 let goal_prefix = Keeper_working_context.goal_prefix
+let _legacy_goal_prefix = "[MASC_GOAL]"
 
 let starts_with ~prefix s =
   let lp = String.length prefix in
@@ -240,7 +242,9 @@ let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
     let score = 0.4 *. recency +. 0.25 *. role_w +. 0.2 *. content_w +. 0.15 *. tool_w in
     let score =
       if starts_with ~prefix:memory_summary_prefix msg_text
-         || starts_with ~prefix:goal_prefix msg_text then
+         || starts_with ~prefix:_legacy_memory_summary_prefix msg_text
+         || starts_with ~prefix:goal_prefix msg_text
+         || starts_with ~prefix:_legacy_goal_prefix msg_text then
         Float.max score 0.95
       else score
     in

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -48,7 +48,7 @@ type session_context = {
 (* Memory Formats                                                    *)
 (* ================================================================ *)
 
-let goal_prefix = "[MASC_GOAL]"
+let goal_prefix = "[GOAL]"
 
 let state_block_start = "[STATE]"
 let state_block_end = "[/STATE]"

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -166,7 +166,7 @@ let test_scoring_ssot () =
 
 let test_scoring_sticky_memory () =
   let msgs = [
-    msg Agent_sdk.Types.Assistant "[MASC_MEMORY_SUMMARY v1] important summary";
+    msg Agent_sdk.Types.Assistant "[MEMORY_SUMMARY] important summary";
     msg Agent_sdk.Types.Assistant "normal message";
   ] in
   let scores = Scoring.score_messages msgs in
@@ -177,7 +177,7 @@ let test_scoring_sticky_memory () =
 
 let test_scoring_goal_sticky () =
   let msgs = [
-    msg Agent_sdk.Types.User "[MASC_GOAL] Monitor CI";
+    msg Agent_sdk.Types.User "[GOAL] Monitor CI";
   ] in
   let scores = Scoring.score_messages msgs in
   let score = List.assoc 0 scores in

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -195,6 +195,29 @@ let test_scoring_single () =
   check bool "score in range" true (score >= 0.0 && score <= 1.0)
 
 (* ================================================================ *)
+(* Backward Compatibility: Legacy Marker Tests                      *)
+(* ================================================================ *)
+
+let test_scoring_legacy_memory_summary () =
+  let msgs = [
+    msg Agent_sdk.Types.Assistant "[MASC_MEMORY_SUMMARY v1] old format summary";
+    msg Agent_sdk.Types.Assistant "normal message";
+  ] in
+  let scores = Scoring.score_messages msgs in
+  let legacy_score = List.assoc 0 scores in
+  let normal_score = List.assoc 1 scores in
+  check bool "legacy memory summary still sticky" true (legacy_score >= 0.95);
+  check bool "legacy > normal" true (legacy_score > normal_score)
+
+let test_scoring_legacy_goal () =
+  let msgs = [
+    msg Agent_sdk.Types.User "[MASC_GOAL] old format goal";
+  ] in
+  let scores = Scoring.score_messages msgs in
+  let score = List.assoc 0 scores in
+  check bool "legacy goal still sticky" true (score >= 0.95)
+
+(* ================================================================ *)
 (* Dynamic Strategy Resolution Tests (#3164)                        *)
 (* ================================================================ *)
 
@@ -276,6 +299,8 @@ let () =
       test_case "sticky goal" `Quick test_scoring_goal_sticky;
       test_case "empty input" `Quick test_scoring_empty;
       test_case "single message" `Quick test_scoring_single;
+      test_case "legacy memory summary compat" `Quick test_scoring_legacy_memory_summary;
+      test_case "legacy goal compat" `Quick test_scoring_legacy_goal;
     ];
     "dynamic_strategy", [
       test_case "high pressure multi-agent" `Quick test_dynamic_high_pressure_multi_agent;


### PR DESCRIPTION
## Summary
- `[MASC_GOAL]` → `[GOAL]`, `[MASC_MEMORY_SUMMARY v1]` → `[MEMORY_SUMMARY]`
- #3527 Phase 3 부분 완료 (MASC branding 제거)
- `[STATE]...[/STATE]` 마커는 keeper continuity 메커니즘이므로 Phase 2 (OAS native state)와 함께 처리 예정

## Changes
- `lib/keeper/keeper_working_context.ml`: goal_prefix 변경
- `lib/context_compact_oas.ml`: memory_summary_prefix 변경
- `test/test_context_compact_oas_coverage.ml`: 테스트 문자열 동기화

## Test plan
- [x] `test_context_compact_oas_coverage.exe` — 16/16 pass
- [ ] CI green 확인

Closes #3527 partially (Phase 3 마커 rename). Phase 2 (keeper_working_context 제거) + [STATE] 마커 제거는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)