### PR TITLE
fix(tool): preserve per-tool metadata in Tool_spec registration

### DIFF
--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -367,20 +367,27 @@ let schemas = Tool_schemas_agent.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_agents" ]
-let _tool_spec_requires_join = [ "masc_heartbeat"; "masc_register_capabilities" ]
+let _tool_spec_read_only = [ "masc_agents"; "masc_agent_card" ]
+let _tool_spec_requires_join = [ "masc_register_capabilities" ]
+
+(* Heartbeat tools are dispatched by Tool_heartbeat, not Tool_agent.
+   Registering them here under Mod_agent would create a module_tag conflict.
+   Derived from Tool_heartbeat.schemas to stay in sync automatically. *)
+let _heartbeat_tool_names =
+  List.map (fun (s : Types.tool_schema) -> s.name) Tool_heartbeat.schemas
 
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
-      Tool_spec.register
-        (Tool_spec.create
-           ~name:s.name
-           ~description:s.description
-           ~module_tag:Tool_dispatch.Mod_agent
-           ~input_schema:s.input_schema
-           ~is_read_only:(List.mem s.name _tool_spec_read_only)
-           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
-           ~requires_join:(List.mem s.name _tool_spec_requires_join)
-           ()))
+      if not (List.mem s.name _heartbeat_tool_names) then
+        Tool_spec.register
+          (Tool_spec.create
+             ~name:s.name
+             ~description:s.description
+             ~module_tag:Tool_dispatch.Mod_agent
+             ~input_schema:s.input_schema
+             ~is_read_only:(List.mem s.name _tool_spec_read_only)
+             ~is_idempotent:(List.mem s.name _tool_spec_read_only)
+             ~requires_join:(List.mem s.name _tool_spec_requires_join)
+             ()))
     schemas

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -457,14 +457,23 @@ let dispatch (ctx : context) ~name ~args : result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
+let _tool_spec_read_only = [ "masc_execute_dry_run" ]
+let _tool_spec_hidden_destructive = [ "masc_execute" ]
+
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
+      let is_destructive = List.mem s.name _tool_spec_hidden_destructive in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
            ~description:s.description
            ~module_tag:Tool_dispatch.Mod_council
            ~input_schema:s.input_schema
+           ~is_read_only:(List.mem s.name _tool_spec_read_only)
+           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
+           ~visibility:(if is_destructive then Tool_catalog.Hidden else Tool_catalog.Default)
+           ~is_destructive
+           ~allow_direct_call_when_hidden:is_destructive
            ()))
     schemas

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -524,6 +524,8 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
+let _tool_spec_read_only = [ "masc_keeper_list"; "masc_keeper_status" ]
+
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
@@ -533,5 +535,7 @@ let () =
            ~description:s.description
            ~module_tag:Tool_dispatch.Mod_keeper
            ~input_schema:s.input_schema
+           ~is_read_only:(List.mem s.name _tool_spec_read_only)
+           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
            ()))
     schemas

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -219,7 +219,7 @@ let schemas = Tool_schemas_misc.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_transport_status"; "masc_websocket_discovery"; "masc_verify_handoff"; "masc_tool_help" ]
+let _tool_spec_read_only = [ "masc_transport_status"; "masc_websocket_discovery"; "masc_verify_handoff"; "masc_tool_help"; "masc_dashboard" ]
 
 let () =
   List.iter

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -371,9 +371,15 @@ let remote_tool_names : string list =
 let _tool_spec_read_only = [ "masc_operator_snapshot"; "masc_operator_digest"; "masc_surface_audit"; "masc_collaboration_evidence" ]
 let _tool_spec_requires_join = [ "masc_operator_action"; "masc_operator_confirm" ]
 
+(* Tools with explicit catalog metadata that must be preserved. *)
+let _tool_spec_hidden = [ "masc_operator_judgment_write"; "masc_operator_judgment_latest" ]
+let _tool_spec_hidden_destructive = [ "masc_operator_action" ]
+
 let () =
   List.iter
     (fun (s : tool_schema) ->
+      let is_destructive = List.mem s.name _tool_spec_hidden_destructive in
+      let is_hidden = List.mem s.name _tool_spec_hidden || is_destructive in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -383,5 +389,8 @@ let () =
            ~is_read_only:(List.mem s.name _tool_spec_read_only)
            ~is_idempotent:(List.mem s.name _tool_spec_read_only)
            ~requires_join:(List.mem s.name _tool_spec_requires_join)
+           ~visibility:(if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
+           ~is_destructive
+           ~allow_direct_call_when_hidden:is_hidden
            ()))
     schemas

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -194,6 +194,7 @@ let schemas = Tool_schemas_plan.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
+let _tool_spec_read_only = [ "masc_plan_get" ]
 let _tool_spec_requires_join = [ "masc_plan_set_task"; "masc_plan_clear_task" ]
 
 let () =
@@ -205,6 +206,8 @@ let () =
            ~description:s.description
            ~module_tag:Tool_dispatch.Mod_plan
            ~input_schema:s.input_schema
+           ~is_read_only:(List.mem s.name _tool_spec_read_only)
+           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
            ~requires_join:(List.mem s.name _tool_spec_requires_join)
            ()))
     schemas


### PR DESCRIPTION
## Summary
- #4329 머지 후 `Tool_spec.register`가 `Tool_catalog.explicit_metadata`를 기본값으로 덮어쓰는 3가지 회귀 수정
- Copilot 리뷰 코멘트 8건 + `/simplify` 리뷰 3건 대응

## Regressions fixed

| 심각도 | 문제 | 영향 도구 수 |
|--------|------|-------------|
| Critical | `allow_direct_call_when_hidden` 소실 (`hidden_active`=true → `Tool_spec.create`=false) | 4 |
| Critical | heartbeat tools 이중 등록 (Mod_agent + Mod_heartbeat module_tag 충돌) | 4 |
| Important | readonly/idempotent/visibility/destructive 플래그 소실 | 10+ |

## Changes per module
- `tool_agent.ml`: heartbeat 제외 (Tool_heartbeat.schemas에서 파생), agent_card readonly
- `tool_operator.ml`: judgment_* Hidden, operator_action Hidden+destructive, allow_direct_call_when_hidden
- `tool_plan.ml`: plan_get readonly/idempotent
- `tool_keeper.ml`: keeper_list/status readonly/idempotent
- `tool_misc.ml`: dashboard readonly/idempotent
- `tool_council_oas.ml`: execute Hidden+destructive+allow_direct_call, execute_dry_run readonly

## Build status
- 수정 6개 파일: 컴파일 에러 없음
- 기존 `mutation_class` 에러 3건 (worker_dev_tools, keeper_extend_turns, tool_bridge): OAS SDK 인터페이스 변경, 이 PR 범위 밖

## Test plan
- [x] `dune build --root .` — 수정 파일 에러 없음
- [ ] CI green 확인
- [ ] 교차 모델 리뷰