### PR TITLE
fix(room): delete_path removes local mirror for dual-write backends

### DIFF
--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -158,7 +158,9 @@ let delete_path_root config path =
   | Some key ->
     (match backend_delete config ~key with
      | Ok _ -> ()
-     | Error e -> Log.Misc.error "delete_path_root: backend_delete failed for %s: %s" key (Backend_types.show_error e))
+     | Error e -> Log.Misc.error "delete_path_root: backend_delete failed for %s: %s" key (Backend_types.show_error e));
+    if Sys.file_exists path then
+      (try Sys.remove path with Sys_error _ -> ())
   | None -> if Sys.file_exists path then Sys.remove path
 
 let path_exists_root config path =
@@ -235,7 +237,9 @@ let delete_path config path =
   | Some key ->
     (match backend_delete config ~key with
      | Ok _ -> ()
-     | Error e -> Log.Misc.error "delete_path: backend_delete failed for %s: %s" key (Backend_types.show_error e))
+     | Error e -> Log.Misc.error "delete_path: backend_delete failed for %s: %s" key (Backend_types.show_error e));
+    if should_dual_write_local config && Sys.file_exists path then
+      (try Sys.remove path with Sys_error _ -> ())
   | None -> if Sys.file_exists path then Sys.remove path
 
 let path_exists config path =

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -157,9 +157,9 @@ let delete_path_root config path =
   match root_key_of_path config path with
   | Some key ->
     (match backend_delete config ~key with
-     | Ok _ -> ()
-     | Error e -> Log.Misc.error "delete_path_root: backend_delete failed for %s: %s" key (Backend_types.show_error e));
-    (try Sys.remove path with Sys_error _ -> ())
+     | Ok _ ->
+       (try Sys.remove path with Sys_error _ -> ())
+     | Error e -> Log.Misc.error "delete_path_root: backend_delete failed for %s: %s" key (Backend_types.show_error e))
   | None -> if Sys.file_exists path then Sys.remove path
 
 let path_exists_root config path =
@@ -235,10 +235,10 @@ let delete_path config path =
   match key_of_path config path with
   | Some key ->
     (match backend_delete config ~key with
-     | Ok _ -> ()
-     | Error e -> Log.Misc.error "delete_path: backend_delete failed for %s: %s" key (Backend_types.show_error e));
-    if should_dual_write_local config then
-      (try Sys.remove path with Sys_error _ -> ())
+     | Ok _ ->
+       if should_dual_write_local config then
+         (try Sys.remove path with Sys_error _ -> ())
+     | Error e -> Log.Misc.error "delete_path: backend_delete failed for %s: %s" key (Backend_types.show_error e))
   | None -> if Sys.file_exists path then Sys.remove path
 
 let path_exists config path =

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -159,8 +159,7 @@ let delete_path_root config path =
     (match backend_delete config ~key with
      | Ok _ -> ()
      | Error e -> Log.Misc.error "delete_path_root: backend_delete failed for %s: %s" key (Backend_types.show_error e));
-    if Sys.file_exists path then
-      (try Sys.remove path with Sys_error _ -> ())
+    (try Sys.remove path with Sys_error _ -> ())
   | None -> if Sys.file_exists path then Sys.remove path
 
 let path_exists_root config path =
@@ -238,7 +237,7 @@ let delete_path config path =
     (match backend_delete config ~key with
      | Ok _ -> ()
      | Error e -> Log.Misc.error "delete_path: backend_delete failed for %s: %s" key (Backend_types.show_error e));
-    if should_dual_write_local config && Sys.file_exists path then
+    if should_dual_write_local config then
       (try Sys.remove path with Sys_error _ -> ())
   | None -> if Sys.file_exists path then Sys.remove path
 


### PR DESCRIPTION
## Summary
- `delete_path`와 `delete_path_root`가 non-filesystem backend 사용 시 backend key만 삭제하고 local mirror 파일은 남기던 비대칭 수정
- `write_json`/`write_text`는 dual-write하지만, delete 쪽은 dual-delete하지 않았음
- GC 등에서 `Sys.readdir`로 local 파일을 스캔하므로, 삭제되지 않은 local mirror가 매 cycle 재감지됨

## Root Cause
write/delete 비대칭: write는 backend + local mirror, delete는 backend만.

## Evidence
- `write_json` (line 200-211): `should_dual_write_local` 후 `write_json_local` 호출
- `write_json_root` (line 144-154): 항상 `write_json_local` 호출
- `delete_path` / `delete_path_root`: `Some key` 분기에서 local 삭제 없음 (수정 전)

## Review evidence
- GLM-5.1 cross-model review 수행, 5개 이슈 중 1개(backend_delete 실패 시 local 보존) 수용
- /simplify 3-agent review: TOCTOU Sys.file_exists 제거 수용

Refs jeong-sik/masc-mcp#4368

## Test plan
- [x] 기존 heartbeat 테스트 13/13 통과
- [x] 빌드 성공
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)