### PR TITLE
fix(dashboard): orphan removal + health indicator null safety

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -155,7 +155,7 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   }
 
   return html`
-    <div class="flex items-center gap-2 px-1">
+    <div class="flex items-center gap-2 px-1" role="status" aria-label=${label}>
       ${dot}
       <span class="text-[11px] text-[var(--text-muted)] truncate">${label}</span>
     </div>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -124,7 +124,10 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   const live = connected.value
   const snap = missionSnapshot.value
   const sessions = snap?.sessions ?? snap?.session_briefs ?? []
-  const blockers = sessions.filter(s => s.blocker_summary).length
+  let blockers = 0
+  for (let i = 0; i < sessions.length; i++) {
+    if (sessions[i]?.blocker_summary) blockers++
+  }
   const attentionCount = (snap?.attention_queue ?? []).length
 
   let dotClass: string
@@ -133,9 +136,9 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   if (!live) {
     dotClass = 'bg-[var(--bad)]'
     label = '신호 없음'
-  } else if (!snap && missionLoading.value) {
+  } else if (!snap) {
     dotClass = 'bg-[var(--text-muted)]'
-    label = '로딩 중'
+    label = missionLoading.value ? '로딩 중' : '대기 중'
   } else if (blockers > 0 || attentionCount > 0) {
     dotClass = 'bg-[var(--warn)]'
     const total = blockers + attentionCount
@@ -148,7 +151,7 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   const dot = html`<span class="block size-2 shrink-0 rounded-full ${dotClass} shadow-[0_0_6px_rgba(0,0,0,0.4)]"></span>`
 
   if (collapsed) {
-    return html`<div class="flex justify-center" title=${label}>${dot}</div>`
+    return html`<div class="flex justify-center" title=${label} role="img" aria-label=${label}>${dot}</div>`
   }
 
   return html`


### PR DESCRIPTION
## Summary
- #4363 리뷰 코멘트 5건 대응 (Copilot 4건 + Codex connector 1건 중복)

## Changes

| 수정 | 내용 |
|------|------|
| `runtime-rail.ts` 삭제 | #4363에서 SnapshotCard 제거 후 import 없는 orphan 모듈 |
| `missionSnapshot === null` 처리 | false-positive "정상" 방지. null+loading="로딩 중", null+idle="대기 중" |
| blocker count 최적화 | `sessions.filter().length` -> counted loop (배열 할당 제거) |
| collapsed 접근성 | `role="img"` + `aria-label` 추가 |

## Validation
- [x] `pnpm typecheck` 통과
- [ ] CI green 확인