### PR TITLE
docs(redact): clarify infix deny list vs Tool_access_policy

### DIFF
--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -5,7 +5,11 @@
 
 let default_max_len = 200
 
-(** Tools whose input/output must never be previewed. *)
+(** Tools whose input/output must never be previewed.
+
+    This uses substring (infix) matching, not [Tool_access_policy] exact-name
+    matching, because redaction must catch tool name variants and prefixed
+    aliases (e.g. [mcp__foo_auth_bar]) without enumerating every name. *)
 let denied_tool_infixes =
   ["_auth"; "_encryption"; "_credential"; "_secret"]
 


### PR DESCRIPTION
## Summary
- `observability_redact.ml`의 `denied_tool_infixes`가 `Tool_access_policy` ADT 밖에 있는 이유를 주석으로 명시
- infix substring 매칭 vs exact-name 매칭의 의도적 차이

## Context
#4339 tool access policy SSOT 중앙화 이후, 이 모듈만 독자적 deny 로직을 유지하는 이유가 불분명했음.
다음 사람이 "왜 여기만 Tool_access_policy를 안 쓰지?" 하고 궁금해할 때를 위한 주석.

## Test plan
- [x] `dune build` 통과 (주석만 변경)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)