### PR TITLE
fix: recover 3 post-merge changes (conflict group)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -276,8 +276,8 @@ let run_turn
            || name = "keeper_shell_readonly"
            || name = "keeper_bash"
            || name = "keeper_edit"
-           || name = "keeper_write"
-           || name = "keeper_github" then Some "filesystem"
+           || name = "keeper_write" then Some "filesystem"
+      else if name = "keeper_github" then Some "vcs"
       else None
     in
     let kr_kw = match List.assoc_opt name korean_keywords with

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -274,7 +274,10 @@ let run_turn
       else if String.starts_with ~prefix:"keeper_voice_" name then Some "voice"
       else if String.starts_with ~prefix:"keeper_fs_" name
            || name = "keeper_shell_readonly"
-           || name = "keeper_bash" then Some "filesystem"
+           || name = "keeper_bash"
+           || name = "keeper_edit"
+           || name = "keeper_write"
+           || name = "keeper_github" then Some "filesystem"
       else None
     in
     let kr_kw = match List.assoc_opt name korean_keywords with

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -41,6 +41,7 @@ let keeper_allowed_skills = [
 let canonical_keeper_skill_token (raw : string) : string option =
   match String.lowercase_ascii (String.trim raw) with
   | "masc-heartbeat" | "masc_heartbeat" | "heartbeat" -> Some "masc-heartbeat"
+  | "masc-keeper-autonomy" | "masc_keeper_autonomy" | "autonomy" -> Some "masc-keeper-autonomy"
   | _ -> None
 
 let unique_skills_preserve_order (xs : string list) : string list =

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -255,9 +255,9 @@ let manual_help_entry name =
         {
           name;
           short_description =
-            "Apply auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
+            "Apply auth or unit-policy updates through a single admin entrypoint.";
           when_to_use =
-            "Use when you need to change auth settings, update a unit policy envelope, or adjust keeper policy without bouncing between multiple tools.";
+            "Use when you need to change auth settings or update a unit policy envelope.";
           key_constraints =
             [
               "Section must be one of: auth | unit_policy.";

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -260,7 +260,7 @@ let manual_help_entry name =
             "Use when you need to change auth settings, update a unit policy envelope, or adjust keeper policy without bouncing between multiple tools.";
           key_constraints =
             [
-              "Section must be one of auth, unit_policy, keeper_policy, or persistent_agent_policy.";
+              "Section must be one of: auth | unit_policy.";
               "Unit tool/model allowlists are stored and surfaced, but remain advisory until runtime enforcement is added.";
             ];
           details_markdown =

--- a/test/fixtures/cdal/mismatched_contract.json
+++ b/test/fixtures/cdal/mismatched_contract.json
@@ -2,7 +2,7 @@
   "runtime_constraints": {
     "requested_execution_mode": "draft",
     "risk_class": "medium",
-    "allowed_mutations": ["keeper_read"],
+    "allowed_mutations": ["keeper_fs_read"],
     "review_requirement": "human"
   },
   "eval_criteria": {

--- a/test/fixtures/cdal/mode_escalation_manifest.json
+++ b/test/fixtures/cdal/mode_escalation_manifest.json
@@ -12,7 +12,7 @@
     "api_version": null
   },
   "capability_snapshot": {
-    "tools": ["keeper_read", "keeper_bash"],
+    "tools": ["keeper_fs_read", "keeper_bash"],
     "mcp_servers": [],
     "max_turns": 20,
     "max_tokens": null,

--- a/test/fixtures/cdal/valid_manifest.json
+++ b/test/fixtures/cdal/valid_manifest.json
@@ -12,7 +12,7 @@
     "api_version": null
   },
   "capability_snapshot": {
-    "tools": ["keeper_read", "keeper_fs_edit"],
+    "tools": ["keeper_fs_read", "keeper_fs_edit"],
     "mcp_servers": [],
     "max_turns": 10,
     "max_tokens": 4096,


### PR DESCRIPTION
## Summary

PR #4379에서 clean apply된 8건에 이어, conflict가 있던 8건 중 유효한 3건을 수동 적용합니다.

## Product impact

도구 그룹 정확성 개선 (BM25 disclosure 영향), stale fixture 수정, skill routing 보강.

## Evidence

- 8건 conflict 브랜치를 개별 검토하여 main 반영 여부 확인
- #4174, #4272, #4112, #4092: 이미 다른 경로로 main 반영 → skip
- #4362: PR #4369로 main 반영 → skip  
- #4123: 현재 CI green, 적용 시 test regression → skip

## Changes

| Commit | 원본 PR | 내용 |
|--------|---------|------|
| `352b189` | Refs #4157 | keeper_edit/write/github → filesystem 그룹 추가 |
| `2d16897` | Refs #4188 | keeper_read→keeper_fs_read fixture, autonomy token, stale help text |

## Review evidence

로컬 빌드 통과, 테스트 실행 중.

## Linked issue

Refs #4157, #4188

## Test plan

- [x] `dune build` 성공
- [ ] `dune runtest` 확인 중
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)