### PR TITLE
feat(policy): add Inter and Diff selector variants

### DIFF
--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -6,6 +6,8 @@ type selector =
   | Names of string list
   | Surface of Tool_catalog.surface
   | Union of selector list
+  | Inter of selector list
+  | Diff of { base : selector; exclude : selector }
 
 type t = {
   allow : selector;
@@ -41,6 +43,18 @@ let union selectors =
   | [ selector ] -> selector
   | many -> Union many
 
+let inter selectors =
+  match selectors with
+  | [] -> All
+  | [ selector ] -> selector
+  | many -> Inter many
+
+let diff ~base ~exclude =
+  match (base, exclude) with
+  | Empty, _ -> Empty
+  | _, Empty -> base
+  | _ -> Diff { base; exclude }
+
 let with_deny_selector policy selector =
   {
     policy with
@@ -64,6 +78,11 @@ let rec selector_matches_name selector name =
       Tool_catalog.is_on_surface surface name
   | Union selectors ->
       List.exists (fun item -> selector_matches_name item name) selectors
+  | Inter selectors ->
+      List.for_all (fun item -> selector_matches_name item name) selectors
+  | Diff { base; exclude } ->
+      selector_matches_name base name
+      && not (selector_matches_name exclude name)
 
 let allows_name policy name =
   selector_matches_name policy.allow name
@@ -87,6 +106,27 @@ let rec resolve_selector ?candidates selector =
   | Union selectors ->
       selectors
       |> List.concat_map (resolve_selector ?candidates)
+      |> normalize_names
+  | Inter selectors ->
+      (match selectors with
+      | [] ->
+          normalize_names
+            (match candidates with
+            | Some names -> names
+            | None -> default_candidates ())
+      | first :: rest ->
+          let first_set = resolve_selector ?candidates first in
+          List.fold_left
+            (fun acc sel ->
+              let resolved = resolve_selector ?candidates sel in
+              List.filter (fun name -> List.mem name resolved) acc)
+            first_set rest
+          |> normalize_names)
+  | Diff { base; exclude } ->
+      let base_resolved = resolve_selector ?candidates base in
+      let exclude_resolved = resolve_selector ?candidates exclude in
+      base_resolved
+      |> List.filter (fun name -> not (List.mem name exclude_resolved))
       |> normalize_names
 
 let resolve ?candidates policy =

--- a/lib/tool_access_policy.mli
+++ b/lib/tool_access_policy.mli
@@ -11,6 +11,8 @@ type selector =
   | Names of string list
   | Surface of Tool_catalog.surface
   | Union of selector list
+  | Inter of selector list
+  | Diff of { base : selector; exclude : selector }
 
 type t = {
   allow : selector;
@@ -23,6 +25,8 @@ val of_allowlist : ?deny:string list -> string list -> t
 val with_deny_names : t -> string list -> t
 val with_deny_selector : t -> selector -> t
 val union : selector list -> selector
+val inter : selector list -> selector
+val diff : base:selector -> exclude:selector -> selector
 
 val selector_matches_name : selector -> string -> bool
 val allows_name : t -> string -> bool

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -377,6 +377,66 @@ let test_resolve_diff_disjoint_is_base () =
 (* Inter + Diff composition                                          *)
 (* ================================================================ *)
 
+let test_inter_with_all_narrows_to_other () =
+  let sel =
+    Tool_access_policy.Inter [ All; Names [ "a"; "b" ] ]
+  in
+  check bool "a in both" true
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "c not in Names" false
+    (Tool_access_policy.selector_matches_name sel "c")
+
+let test_resolve_inter_with_all () =
+  let sel =
+    Tool_access_policy.Inter
+      [ All; Names [ "x"; "y" ] ]
+  in
+  let resolved =
+    Tool_access_policy.resolve_selector ~candidates:[ "x"; "y"; "z" ] sel
+  in
+  check (list string) "All ∩ Names = Names" [ "x"; "y" ] resolved
+
+let test_deny_with_inter () =
+  let policy =
+    {
+      Tool_access_policy.allow = Names [ "a"; "b"; "c"; "d" ];
+      deny = Inter [ Names [ "b"; "c"; "d" ]; Names [ "c"; "d"; "e" ] ];
+    }
+  in
+  check bool "a allowed (not in deny inter)" true
+    (Tool_access_policy.allows_name policy "a");
+  check bool "b allowed (only in one deny arm)" true
+    (Tool_access_policy.allows_name policy "b");
+  check bool "c denied (in both deny arms)" false
+    (Tool_access_policy.allows_name policy "c");
+  check bool "d denied (in both deny arms)" false
+    (Tool_access_policy.allows_name policy "d")
+
+let test_deny_with_diff () =
+  let policy =
+    {
+      Tool_access_policy.allow = Names [ "a"; "b"; "c" ];
+      deny =
+        Diff
+          { base = Names [ "a"; "b"; "c" ]; exclude = Names [ "a" ] };
+    }
+  in
+  check bool "a survives (excluded from deny)" true
+    (Tool_access_policy.allows_name policy "a");
+  check bool "b denied" false
+    (Tool_access_policy.allows_name policy "b");
+  check bool "c denied" false
+    (Tool_access_policy.allows_name policy "c")
+
+let test_diff_constructor_bypass_empty_exclude () =
+  let sel =
+    Tool_access_policy.Diff { base = Names [ "a"; "b" ]; exclude = Empty }
+  in
+  check bool "a matches through raw Diff" true
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "c rejected" false
+    (Tool_access_policy.selector_matches_name sel "c")
+
 let test_inter_then_diff () =
   let sel =
     Tool_access_policy.Diff
@@ -516,6 +576,16 @@ let () =
         ] );
       ( "inter_diff_composition",
         [
+          test_case "Inter with All narrows" `Quick
+            test_inter_with_all_narrows_to_other;
+          test_case "resolve Inter with All" `Quick
+            test_resolve_inter_with_all;
+          test_case "deny with Inter" `Quick
+            test_deny_with_inter;
+          test_case "deny with Diff" `Quick
+            test_deny_with_diff;
+          test_case "Diff bypass empty exclude" `Quick
+            test_diff_constructor_bypass_empty_exclude;
           test_case "inter then diff" `Quick
             test_inter_then_diff;
           test_case "diff in policy deny" `Quick

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -243,6 +243,167 @@ let test_of_allowlist_empty () =
     (Tool_access_policy.resolve policy = [])
 
 (* ================================================================ *)
+(* Inter selector                                                    *)
+(* ================================================================ *)
+
+let test_inter_matches_common_only () =
+  let sel =
+    Tool_access_policy.Inter
+      [ Names [ "a"; "b"; "c" ]; Names [ "b"; "c"; "d" ] ]
+  in
+  check bool "a only in first" false
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "b in both" true
+    (Tool_access_policy.selector_matches_name sel "b");
+  check bool "c in both" true
+    (Tool_access_policy.selector_matches_name sel "c");
+  check bool "d only in second" false
+    (Tool_access_policy.selector_matches_name sel "d")
+
+let test_inter_empty_list_is_all () =
+  let sel = Tool_access_policy.inter [] in
+  check bool "inter [] matches anything" true
+    (Tool_access_policy.selector_matches_name sel "anything")
+
+let test_inter_single_unwraps () =
+  let inner = Tool_access_policy.Names [ "a"; "b" ] in
+  let sel = Tool_access_policy.inter [ inner ] in
+  check bool "matches a" true
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "rejects c" false
+    (Tool_access_policy.selector_matches_name sel "c")
+
+let test_inter_with_empty_yields_nothing () =
+  let sel =
+    Tool_access_policy.Inter [ Names [ "a"; "b" ]; Empty ]
+  in
+  check bool "Empty kills intersection" false
+    (Tool_access_policy.selector_matches_name sel "a")
+
+let test_inter_is_commutative () =
+  let s1 = Tool_access_policy.Names [ "a"; "b"; "c" ] in
+  let s2 = Tool_access_policy.Names [ "b"; "c"; "d" ] in
+  let forward = Tool_access_policy.Inter [ s1; s2 ] in
+  let reverse = Tool_access_policy.Inter [ s2; s1 ] in
+  List.iter
+    (fun name ->
+      check bool
+        (Printf.sprintf "%s: forward = reverse" name)
+        (Tool_access_policy.selector_matches_name forward name)
+        (Tool_access_policy.selector_matches_name reverse name))
+    [ "a"; "b"; "c"; "d"; "e" ]
+
+let test_resolve_inter_computes_intersection () =
+  let sel =
+    Tool_access_policy.Inter
+      [ Names [ "a"; "b"; "c" ]; Names [ "b"; "c"; "d" ] ]
+  in
+  let resolved = Tool_access_policy.resolve_selector sel in
+  check (list string) "intersection of two sets" [ "b"; "c" ] resolved
+
+let test_resolve_inter_three_way () =
+  let sel =
+    Tool_access_policy.Inter
+      [
+        Names [ "a"; "b"; "c"; "d" ];
+        Names [ "b"; "c"; "d"; "e" ];
+        Names [ "c"; "d"; "e"; "f" ];
+      ]
+  in
+  let resolved = Tool_access_policy.resolve_selector sel in
+  check (list string) "three-way intersection" [ "c"; "d" ] resolved
+
+(* ================================================================ *)
+(* Diff selector                                                     *)
+(* ================================================================ *)
+
+let test_diff_subtracts_exclude () =
+  let sel =
+    Tool_access_policy.Diff
+      { base = Names [ "a"; "b"; "c" ]; exclude = Names [ "b" ] }
+  in
+  check bool "a kept" true
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "b excluded" false
+    (Tool_access_policy.selector_matches_name sel "b");
+  check bool "c kept" true
+    (Tool_access_policy.selector_matches_name sel "c")
+
+let test_diff_empty_exclude_is_identity () =
+  let base = Tool_access_policy.Names [ "a"; "b" ] in
+  let sel = Tool_access_policy.diff ~base ~exclude:Empty in
+  check bool "a kept" true
+    (Tool_access_policy.selector_matches_name sel "a");
+  check bool "b kept" true
+    (Tool_access_policy.selector_matches_name sel "b")
+
+let test_diff_empty_base_is_empty () =
+  let sel =
+    Tool_access_policy.diff ~base:Empty ~exclude:(Names [ "a" ])
+  in
+  check bool "empty base -> nothing" false
+    (Tool_access_policy.selector_matches_name sel "a")
+
+let test_diff_with_surface () =
+  let sel =
+    Tool_access_policy.Diff
+      {
+        base = Surface Tool_catalog.Public_mcp;
+        exclude = Names [ "masc_board_delete" ];
+      }
+  in
+  check bool "status still in public" true
+    (Tool_access_policy.selector_matches_name sel "masc_status");
+  check bool "board_delete excluded" false
+    (Tool_access_policy.selector_matches_name sel "masc_board_delete")
+
+let test_resolve_diff () =
+  let sel =
+    Tool_access_policy.Diff
+      { base = Names [ "a"; "b"; "c"; "d" ]; exclude = Names [ "b"; "d" ] }
+  in
+  let resolved = Tool_access_policy.resolve_selector sel in
+  check (list string) "base minus exclude" [ "a"; "c" ] resolved
+
+let test_resolve_diff_disjoint_is_base () =
+  let sel =
+    Tool_access_policy.Diff
+      { base = Names [ "a"; "b" ]; exclude = Names [ "x"; "y" ] }
+  in
+  let resolved = Tool_access_policy.resolve_selector sel in
+  check (list string) "disjoint exclude = base unchanged" [ "a"; "b" ] resolved
+
+(* ================================================================ *)
+(* Inter + Diff composition                                          *)
+(* ================================================================ *)
+
+let test_inter_then_diff () =
+  let sel =
+    Tool_access_policy.Diff
+      {
+        base = Inter [ Names [ "a"; "b"; "c" ]; Names [ "b"; "c"; "d" ] ];
+        exclude = Names [ "c" ];
+      }
+  in
+  let resolved = Tool_access_policy.resolve_selector sel in
+  check (list string) "inter then diff" [ "b" ] resolved
+
+let test_diff_in_policy_deny () =
+  let policy =
+    {
+      Tool_access_policy.allow =
+        Diff
+          {
+            base = Names [ "a"; "b"; "c"; "d" ];
+            exclude = Names [ "c"; "d" ];
+          };
+      deny = Names [ "b" ];
+    }
+  in
+  let resolved = Tool_access_policy.resolve policy in
+  check (list string) "diff allow + deny" [ "a" ] resolved
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -320,5 +481,44 @@ let () =
         [
           test_case "no deny" `Quick test_of_allowlist_no_deny;
           test_case "empty allowlist" `Quick test_of_allowlist_empty;
+        ] );
+      ( "inter",
+        [
+          test_case "matches common only" `Quick
+            test_inter_matches_common_only;
+          test_case "empty list is All" `Quick
+            test_inter_empty_list_is_all;
+          test_case "single element unwraps" `Quick
+            test_inter_single_unwraps;
+          test_case "with Empty yields nothing" `Quick
+            test_inter_with_empty_yields_nothing;
+          test_case "is commutative" `Quick
+            test_inter_is_commutative;
+          test_case "resolve computes intersection" `Quick
+            test_resolve_inter_computes_intersection;
+          test_case "resolve three-way" `Quick
+            test_resolve_inter_three_way;
+        ] );
+      ( "diff",
+        [
+          test_case "subtracts exclude" `Quick
+            test_diff_subtracts_exclude;
+          test_case "empty exclude is identity" `Quick
+            test_diff_empty_exclude_is_identity;
+          test_case "empty base is empty" `Quick
+            test_diff_empty_base_is_empty;
+          test_case "with surface" `Quick
+            test_diff_with_surface;
+          test_case "resolve diff" `Quick
+            test_resolve_diff;
+          test_case "resolve disjoint is base" `Quick
+            test_resolve_diff_disjoint_is_base;
+        ] );
+      ( "inter_diff_composition",
+        [
+          test_case "inter then diff" `Quick
+            test_inter_then_diff;
+          test_case "diff in policy deny" `Quick
+            test_diff_in_policy_deny;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `Tool_access_policy.selector`에 `Inter of selector list`와 `Diff of { base; exclude }` 추가
- `selector_matches_name`, `resolve_selector` 모두에 match arm 구현
- Smart constructors: `inter`, `diff` (edge case 처리: 빈 리스트, Empty base/exclude)
- 15개 신규 테스트 (교환법칙, 3-way 교집합, Surface 조합, 정책 통합)

Closes #4382

## Context
Tool Gate 아키텍처(#4381)의 Phase 1B. 도구 조합 대수를 Union만에서 Inter/Diff로 확장하여 다음과 같은 표현이 가능해짐:

```ocaml
(* "Coding에서 worktree 도구만 제외" *)
Diff { base = Names (preset_allowlist Coding); exclude = Names ["masc_worktree_create"] }

(* "Research와 Messaging의 공통 도구" *)
Inter [Names (preset_allowlist Research); Names (preset_allowlist Messaging)]
```

## Test plan
- [x] 기존 25개 테스트 통과 (regression 없음)
- [x] Inter 7개 테스트 (매칭, 교환법칙, 3-way, Edge cases)
- [x] Diff 6개 테스트 (차집합, Surface 조합, disjoint)
- [x] Inter+Diff 조합 2개 테스트 (중첩, 정책 통합)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)