### PR TITLE
fix(gc): remove local mirror after backend-aware delete

### DIFF
--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -92,7 +92,12 @@ let cleanup_zombies
           | Ok _ -> () (* not a zombie, skip *)
           | Error err ->
               Log.Gc.warn "removing broken agent file %s: %s" name err;
-              (try delete_path config path
+              (try
+                 delete_path config path;
+                 (* delete_path only removes the backend entry for dual-write
+                    backends; the local mirror file must be removed separately
+                    to prevent repeated GC warnings on each scan cycle. *)
+                 if Sys.file_exists path then Sys.remove path
                with exn ->
                  Log.Gc.warn "failed to remove broken agent %s: %s"
                    path (Printexc.to_string exn))

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -97,7 +97,7 @@ let cleanup_zombies
                  (* delete_path only removes the backend entry for dual-write
                     backends; the local mirror file must be removed separately
                     to prevent repeated GC warnings on each scan cycle. *)
-                 if Sys.file_exists path then Sys.remove path
+                 (try Sys.remove path with Sys_error _ -> ())
                with exn ->
                  Log.Gc.warn "failed to remove broken agent %s: %s"
                    path (Printexc.to_string exn))


### PR DESCRIPTION
## Summary
- #4368 리뷰 코멘트 대응: `delete_path`가 dual-write backend에서 local mirror를 삭제하지 않는 문제

## Problem
`cleanup_zombies`가 broken agent를 `delete_path`로 삭제할 때:
- `key_of_path` → `Some key` 경로: backend만 삭제, local `.json` 파일 잔존
- 매 GC 사이클마다 같은 파일을 읽고 경고 로그 반복

## Fix
`delete_path` 호출 후 `Sys.file_exists path`이면 `Sys.remove path`로 local mirror도 삭제.
`delete_path` 자체는 수정하지 않음 (다른 caller에 영향 방지).

## Note
이전에 `ab90cad` → revert → `29a5c91` → `9e1ad73` 시도가 있었으나 main에 미반영.
이 PR은 room_gc.ml의 cleanup_zombies에만 국한된 수정.

## Validation
- [x] `dune build` — room_gc.ml 에러 없음
- [ ] CI green