### PR TITLE
feat(oas_worker): turn-level slot yield bridge

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -325,6 +325,11 @@ module Cdal = struct
     get_bool ~default:false "MASC_CDAL_PROOF_AGGREGATION"
 end
 
+(** Release LLM slot during tool execution so other agents can use it.
+    Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
+let slot_yield_enabled () =
+  get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+
 (** {1 Board Configuration} *)
 
 module Board = struct

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -452,6 +452,13 @@ let run_turn
     then Keeper_cdal_contract.of_keeper_meta meta
     else None
   in
+  let yield_on_tool = Env_config.slot_yield_enabled () in
+  let on_yield = if yield_on_tool then Some (fun () ->
+    Log.Misc.info "keeper %s: slot yielded (tool execution)" meta.name
+  ) else None in
+  let on_resume = if yield_on_tool then Some (fun () ->
+    Log.Misc.info "keeper %s: slot resumed (next LLM turn)" meta.name
+  ) else None in
   match
         Oas_worker.run_named
           ~cascade_name
@@ -469,10 +476,13 @@ let run_turn
           ~max_tokens
           ?guardrails
           ?on_event
+          ?on_yield
+          ?on_resume
           ~agent_ref
           ?contract
           ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
           ~cache_system_prompt:true
+          ~yield_on_tool
           ()
       with
       | Error e -> Error e

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -102,6 +102,7 @@ type config = {
   allowed_paths : string list;
   working_context : Yojson.Safe.t option;
   cache_system_prompt : bool;
+  yield_on_tool : bool;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -125,8 +126,8 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     transport = Masc_grpc_transport.from_env ();
     allowed_paths = [];
     working_context = None;
-    
     cache_system_prompt = false;
+    yield_on_tool = false;
   }
 
 (* ================================================================ *)
@@ -285,6 +286,11 @@ let build
       Oas.Builder.with_cache_system_prompt true builder
     else builder
   in
+  let builder =
+    if config.yield_on_tool then
+      Oas.Builder.with_yield_on_tool true builder
+    else builder
+  in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string
 
@@ -297,6 +303,8 @@ let run
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
     ?(on_event : (Oas.Types.sse_event -> unit) option)
+    ?(on_yield : (unit -> unit) option)
+    ?(on_resume : (unit -> unit) option)
     ?(agent_ref : Oas.Agent.t option ref option)
     ?(proof_ref : Oas.Cdal_proof.t option ref option)
     ?(contract : Oas.Risk_contract.t option)
@@ -337,8 +345,8 @@ let run
         (cr.response, Some cr.proof)
       | None ->
         let r = match on_event with
-          | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
-          | None -> Oas.Agent.run ~sw agent goal
+          | Some cb -> Oas.Agent.run_stream ~sw ?on_yield ?on_resume ~on_event:cb agent goal
+          | None -> Oas.Agent.run ~sw ?on_yield ?on_resume agent goal
         in
         (r, None)
     in
@@ -413,6 +421,8 @@ let run_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?contract
     ?on_event
+    ?on_yield
+    ?on_resume
     (goal : string)
   : (run_result, string) result =
   let oas_tools = List.map (fun (td : Types.tool_schema) ->
@@ -423,7 +433,7 @@ let run_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   let config = { config with tools = oas_tools @ config.tools } in
-  run ~sw ~net ~config ?on_event ?contract goal
+  run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
 
 (* ================================================================ *)
 (* Cascade profile defaults (moved from Cascade module)              *)
@@ -548,6 +558,8 @@ let run_named
     ?memory
     ?raw_trace
     ?on_event
+    ?on_yield
+    ?on_resume
     ?agent_ref
     ?proof_ref
     ?contract
@@ -555,6 +567,7 @@ let run_named
     ?(allowed_paths = [])
     ?working_context
     ?(cache_system_prompt = false)
+    ?(yield_on_tool = false)
     ?sw
     ?net
     ()
@@ -601,8 +614,8 @@ let run_named
       cache_system_prompt;
     }
   in
-  let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in
-  match run ~sw ~net ~config ?on_event ?agent_ref ?proof_ref ?contract goal with
+  let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in
+  match run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?agent_ref ?proof_ref ?contract goal with
   | Ok result when accept result.response ->
     record_cascade ~cascade_name ~outcome:`Success;
     Ok result
@@ -678,9 +691,12 @@ let run_named_with_masc_tools
     ?memory
     ?raw_trace
     ?on_event
+    ?on_yield
+    ?on_resume
     ?proof_ref
     ?contract
     ?transport
+    ?(yield_on_tool = false)
     ?sw
     ?net
     ()
@@ -695,7 +711,8 @@ let run_named_with_masc_tools
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
-    ?raw_trace ?on_event ?proof_ref ?contract ?transport ?sw ?net ()
+    ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref ?contract
+    ?transport ~yield_on_tool ?sw ?net ()
 
 let run_model_with_masc_tools
     ~(model_label : string)

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -60,6 +60,8 @@ val run_named :
   ?memory:Oas.Memory.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
+  ?on_resume:(unit -> unit) ->
   ?agent_ref:Oas.Agent.t option ref ->
   ?proof_ref:Oas.Cdal_proof.t option ref ->
   ?contract:Oas.Risk_contract.t ->
@@ -67,6 +69,7 @@ val run_named :
   ?allowed_paths:string list ->
   ?working_context:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
+  ?yield_on_tool:bool ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->
@@ -111,9 +114,12 @@ val run_named_with_masc_tools :
   ?memory:Oas.Memory.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
+  ?on_resume:(unit -> unit) ->
   ?proof_ref:Oas.Cdal_proof.t option ref ->
   ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
+  ?yield_on_tool:bool ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="b4cde0870b3e3759a98df31142ce9a0537f056f3"
+readonly OAS_AGENT_SDK_SHA="4531c1bb0284f2a4f881927136208b1a459021a5"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.0"


### PR DESCRIPTION
## Summary

- `oas_worker.ml`에 `on_yield`, `on_resume` 콜백과 `yield_on_tool` config 파라미터 추가
- OAS Agent.run의 turn-level slot yielding API를 MASC run 파이프라인에 연결
- `run`, `run_named`, `run_with_masc_tools`, `run_named_with_masc_tools` 전체 전파
- keeper에서 `MASC_SLOT_YIELD_ENABLED=true` 환경변수로 활성화 (default: false)
- contract run에서는 on_yield/on_resume 미적용 (Contract_runner API 미지원)

## Product impact

keeper swarm 운영 시 tool 실행 중 LLM slot을 반환하여 동일 slot 수로 더 많은 에이전트 동시 운영 가능. `MASC_SLOT_YIELD_ENABLED=true`로 opt-in.

## Evidence

- `dune build --root .` 통과
- `test_oas_worker.exe` 34/34 tests 통과
- ~~Depends on jeong-sik/oas#544~~ Merged.

## Test plan

- [x] `dune build --root .` 통과
- [x] 34/34 oas_worker tests 통과
- [x] OAS dependency resolved (oas#544 merged)
- [x] Feature flag registered in Feature_flag_registry
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)