### PR TITLE
test(dashboard): MCP 403 blocking + non-2xx initialize coverage

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -114,4 +114,61 @@ describe('callMcpTool', () => {
       }),
     )
   })
+
+  it('blocks subsequent calls after tools/call returns 403', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-403' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('Forbidden', { status: 403, statusText: 'Forbidden' }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'MCP 연결이 차단되었습니다',
+    )
+
+    fetchWithTimeout.mockClear()
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'MCP 연결이 차단되었습니다',
+    )
+    expect(fetchWithTimeout).not.toHaveBeenCalled()
+  })
+
+  it('throws on non-2xx initialize response without proceeding', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
+    )
+
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'POST /mcp initialize: 500',
+    )
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks subsequent calls after initialize returns 403', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(
+      new Response('Forbidden', { status: 403, statusText: 'Forbidden' }),
+    )
+
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'MCP 연결이 차단되었습니다',
+    )
+
+    fetchWithTimeout.mockClear()
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'MCP 연결이 차단되었습니다',
+    )
+    expect(fetchWithTimeout).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- #4369 리뷰 코멘트 2건 대응: MCP 403/5xx 에러 처리 테스트 추가

## Added tests (3 cases)

| 테스트 | 검증 내용 |
|--------|----------|
| tools/call 403 → blocked | 403 후 `MCP_SESSION_BLOCKED` 설정, 후속 호출이 fetch 없이 즉시 throw |
| initialize 500 → no proceed | non-2xx initialize에서 throw, notification/tool call 미도달 (fetchWithTimeout 1회만) |
| initialize 403 → blocked | initialize 403 후 `MCP_SESSION_BLOCKED`, 후속 호출 즉시 차단 |

## Validation
- [x] `pnpm vitest run` — 6/6 pass
- [x] `pnpm typecheck` 통과
- [ ] CI green