### PR TITLE
fix(test): rename misleading variable + full surface coverage

### DIFF
--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -210,20 +210,20 @@ let test_surface_resolution_respects_candidates () =
   check bool "drops candidate outside surface" false
     (List.mem "totally_unknown" resolved)
 
-let test_keeper_denied_surface_blocks_admin_tools () =
-  let admin_tools = Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied in
+let test_keeper_denied_surface_blocks_tools () =
+  let denied_tools = Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied in
   let policy = {
     Tool_access_policy.allow = All;
     deny = Surface Tool_catalog.Keeper_denied;
   } in
   check bool "keeper_denied surface has tools" true
-    (List.length admin_tools > 0);
+    (List.length denied_tools > 0);
   List.iter (fun tool_name ->
     check bool
       (Printf.sprintf "%s denied by Keeper_denied surface" tool_name)
       false
       (Tool_access_policy.allows_name policy tool_name)
-  ) (List.filteri (fun i _ -> i < 5) admin_tools)
+  ) denied_tools
 
 (* ================================================================ *)
 (* of_allowlist convenience constructor                              *)
@@ -314,7 +314,7 @@ let () =
           test_case "surface respects candidates" `Quick
             test_surface_resolution_respects_candidates;
           test_case "Keeper_denied surface blocks" `Quick
-            test_keeper_denied_surface_blocks_admin_tools;
+            test_keeper_denied_surface_blocks_tools;
         ] );
       ( "of_allowlist",
         [


### PR DESCRIPTION
## Summary
- #4370 리뷰 코멘트 2건 대응

## Changes
- `admin_tools` -> `denied_tools` (Keeper_denied surface를 담는 변수에 맞는 이름)
- `List.filteri (fun i _ -> i < 5)` 제거 — surface 전체 도구를 테스트
- 함수명 `test_keeper_denied_surface_blocks_admin_tools` -> `test_keeper_denied_surface_blocks_tools`

## Note
- #4367 코멘트 3건 (docstring, 경로 참조)은 현재 main에서 이미 해결됨

## Validation
- [x] `dune build` — 에러 없음
- [ ] CI green