### PR TITLE
refactor(keeper): replace model_family tier with OAS Model_meta

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.99.7))
+  (agent_sdk (>= 0.100.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -261,48 +261,24 @@ let keeper_reflection_payload_of_auto_rules (e : keeper_auto_rule_eval) : Yojson
 
     See: Anthropic "Harness Design" blog — Opus 4.6 removed context
     anxiety, but smaller models still exhibit it. *)
-type model_family =
-  | Small_local   (** Local LLMs via llama.cpp — limited context handling *)
-  | Medium_cloud  (** Mid-tier cloud models — moderate context handling *)
-  | Large_cloud   (** Top-tier models (Opus, Gemini Ultra) — strong context *)
-  | Unknown       (** Unrecognized model — use configured defaults *)
-
-let classify_model_family (model_id : string) : model_family =
-  let id = String.lowercase_ascii model_id in
-  let contains needle =
-    let nlen = String.length needle in
-    let hlen = String.length id in
-    if nlen > hlen then false
-    else
-      let rec scan i =
-        if i > hlen - nlen then false
-        else if String.sub id i nlen = needle then true
-        else scan (i + 1)
-      in scan 0
-  in
-  if contains "qwen" || contains "llama" || contains "mistral"
-     || contains "phi-" || contains "deepseek" then
-    Small_local
-  else if contains "opus" || contains "gemini-2" || contains "gpt-4o" then
-    Large_cloud
-  else if contains "sonnet" || contains "haiku" || contains "gemini"
-          || contains "glm" || contains "gpt-4" then
-    Medium_cloud
-  else
-    Unknown
-
-(** Adjust compaction/handoff thresholds based on model family.
+(** Adjust compaction/handoff thresholds based on model metadata from OAS.
     Returns [(ratio_gate_multiplier, handoff_threshold_multiplier)].
 
-    Small local models: lower thresholds (0.75x) → earlier handoff.
-    Large cloud models: higher thresholds (1.15x, clamped to 0.95) → prefer compaction.
-    Medium/Unknown: no adjustment (1.0x). *)
-let model_threshold_multipliers (family : model_family) : float * float =
-  match family with
-  | Small_local  -> (0.75, 0.75)   (* 0.70 * 0.75 = 0.525, 0.85 * 0.75 = 0.6375 *)
-  | Large_cloud  -> (1.15, 1.10)   (* 0.70 * 1.15 = 0.805, 0.85 * 1.10 = 0.935 *)
-  | Medium_cloud -> (1.0, 1.0)
-  | Unknown      -> (1.0, 1.0)
+    Uses concrete parameters (context_window, is_local) from
+    [Llm_provider.Model_meta] instead of tier classification.
+
+    - Local models with small context (< 32K): 0.75x — earlier handoff.
+    - Models with large context (>= 200K): 1.15x — prefer compaction.
+    - Everything else: 1.0x (no adjustment). *)
+let model_threshold_multipliers_of_model_id (model_id : string) : float * float =
+  let meta = Llm_provider.Model_meta.for_model_id model_id in
+  let ctx = meta.context_window in
+  if meta.is_local && ctx < 32_000 then
+    (0.75, 0.75)
+  else if ctx >= 200_000 then
+    (1.15, 1.10)
+  else
+    (1.0, 1.0)
 
 let evaluate_keeper_auto_rules
     ~(meta : keeper_meta)
@@ -316,7 +292,7 @@ let evaluate_keeper_auto_rules
   (* Apply model-aware threshold adjustment when model_id is provided *)
   let (ratio_mult, handoff_mult) =
     match model_id with
-    | Some id -> model_threshold_multipliers (classify_model_family id)
+    | Some id -> model_threshold_multipliers_of_model_id id
     | None -> (1.0, 1.0)
   in
   let ratio_gate = Float.min 0.95 (meta.compaction.ratio_gate *. ratio_mult) in
@@ -480,7 +456,7 @@ let learned_policy_auto_rules
     ?(model_id : string option) () : keeper_auto_rule_eval =
   let (ratio_mult, handoff_mult) =
     match model_id with
-    | Some id -> model_threshold_multipliers (classify_model_family id)
+    | Some id -> model_threshold_multipliers_of_model_id id
     | None -> (1.0, 1.0)
   in
   let ratio_gate = Float.min 0.95 (meta.compaction.ratio_gate *. ratio_mult) in

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -254,22 +254,15 @@ let keeper_reflection_payload_of_auto_rules (e : keeper_auto_rule_eval) : Yojson
 (* Model-aware threshold adjustment (#3069)                          *)
 (* ================================================================ *)
 
-(** Categorize model_id into a family for threshold selection.
-    Small local models (llama, qwen) are more susceptible to context
-    anxiety and benefit from earlier handoff. Large cloud models
-    (claude opus, gemini) handle long context well and prefer compaction.
-
-    See: Anthropic "Harness Design" blog — Opus 4.6 removed context
-    anxiety, but smaller models still exhibit it. *)
 (** Adjust compaction/handoff thresholds based on model metadata from OAS.
     Returns [(ratio_gate_multiplier, handoff_threshold_multiplier)].
 
     Uses concrete parameters (context_window, is_local) from
     [Llm_provider.Model_meta] instead of tier classification.
 
-    - Local models with small context (< 32K): 0.75x — earlier handoff.
-    - Models with large context (>= 200K): 1.15x — prefer compaction.
-    - Everything else: 1.0x (no adjustment). *)
+    - Local models with small context (< 32K): (0.75, 0.75) — earlier handoff.
+    - Models with large context (>= 200K): (1.15, 1.10) — prefer compaction.
+    - Everything else: (1.0, 1.0) (no adjustment). *)
 let model_threshold_multipliers_of_model_id (model_id : string) : float * float =
   let meta = Llm_provider.Model_meta.for_model_id model_id in
   let ctx = meta.context_window in

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -92,9 +92,9 @@ val keeper_reflection_payload_of_auto_rules :
 
 (** {1 Model-Aware Threshold Adjustment} *)
 
-val model_threshold_multipliers_of_model_id : string -> float * float
-(** Compute threshold multipliers from OAS [Model_meta] parameters.
+(** Compute threshold multipliers from OAS [Llm_provider.Model_meta] parameters.
     Uses [context_window] and [is_local] instead of model name matching. *)
+val model_threshold_multipliers_of_model_id : string -> float * float
 
 val evaluate_keeper_auto_rules :
   meta:keeper_meta ->

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -92,14 +92,9 @@ val keeper_reflection_payload_of_auto_rules :
 
 (** {1 Model-Aware Threshold Adjustment} *)
 
-type model_family =
-  | Small_local
-  | Medium_cloud
-  | Large_cloud
-  | Unknown
-
-val classify_model_family : string -> model_family
-val model_threshold_multipliers : model_family -> float * float
+val model_threshold_multipliers_of_model_id : string -> float * float
+(** Compute threshold multipliers from OAS [Model_meta] parameters.
+    Uses [context_window] and [is_local] instead of model name matching. *)
 
 val evaluate_keeper_auto_rules :
   meta:keeper_meta ->

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.99.7"}
+  "agent_sdk" {>= "0.100.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.99.7"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.100.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="669b0d83aaae968d3d9f057a7f2ba0ee3e7c5af3"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.99.7"
+readonly OAS_AGENT_SDK_SHA="b4cde0870b3e3759a98df31142ce9a0537f056f3"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.100.0"


### PR DESCRIPTION
## Summary

- Remove `model_family` type (`Small_local | Medium_cloud | Large_cloud | Unknown`) and `classify_model_family` function which string-matched vendor model names
- Replace with `model_threshold_multipliers_of_model_id` that queries OAS `Model_meta` for concrete parameters (`context_window`, `is_local`)
- Decision logic: `context_window < 32K && is_local` -> 0.75x, `context_window >= 200K` -> 1.15x, else -> 1.0x
- Net -29 lines (50 deleted, 21 added)

## Motivation

MASC was independently classifying models by string matching (`"opus" -> Large_cloud`, `"qwen" -> Small_local`), bypassing OAS cascade abstraction. New models required code changes. Now uses OAS `Model_meta` which consolidates `Capabilities` + `Pricing` lookups.

## Dependencies

- Requires oas#545 (`Model_meta` module) — currently Draft
- agent_sdk opam pin updated to `feat/model-meta` branch

## Test plan

- [x] `DUNE_SOURCEROOT=. dune build @all --root .` succeeds
- [x] `DUNE_SOURCEROOT=. dune runtest --root .` — all tests pass
- [ ] Cross-model review
- [ ] CI green (after oas#545 merges and pin is updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)