### PR TITLE
fix(validation): allow colon in Agent_id for keeper namespacing

### DIFF
--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -62,7 +62,7 @@ end = struct
       reject (Printf.sprintf "agent_id too long: %d chars (max 64)" (String.length s))
     else if String.contains s '/' || String.contains s '\\' then
       reject "agent_id cannot contain path separators"
-    else if String.contains s '.' && String.sub s 0 2 = ".." then
+    else if String.contains s '.' && String.length s >= 2 && String.sub s 0 2 = ".." then
       reject "agent_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
       reject (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -46,8 +46,10 @@ module Agent_id : sig
 end = struct
   type t = string
 
-  (* Allow alphanumeric, dash, underscore, colon (for namespacing e.g. keeper:name) *)
-  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_:-]+$|} |> Re.compile
+  (* Allow alphanumeric, dash, underscore, with optional single colon for namespacing
+     e.g. keeper:keeper-test-98295-0. Bare colons, multiple colons, or leading colons
+     are rejected. *)
+  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?$|} |> Re.compile
 
   let validate s =
     let reject reason =

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -46,8 +46,8 @@ module Agent_id : sig
 end = struct
   type t = string
 
-  (* Only allow alphanumeric, dash, underscore *)
-  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_-]+$|} |> Re.compile
+  (* Allow alphanumeric, dash, underscore, colon (for namespacing e.g. keeper:name) *)
+  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_:-]+$|} |> Re.compile
 
   let validate s =
     let reject reason =
@@ -63,7 +63,7 @@ end = struct
     else if String.contains s '.' && String.sub s 0 2 = ".." then
       reject "agent_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
-      reject (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, - allowed)" s)
+      reject (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
     else
       Ok s
 

--- a/test/test_validation_coverage.ml
+++ b/test/test_validation_coverage.ml
@@ -226,6 +226,16 @@ let test_agent_id_dot_only () =
   | Ok _ -> fail "should reject dot"
   | Error _ -> ()
 
+let test_agent_id_single_dot () =
+  match Validation.Agent_id.validate "." with
+  | Ok _ -> fail "should reject single dot"
+  | Error _ -> ()
+
+let test_agent_id_double_dot () =
+  match Validation.Agent_id.validate ".." with
+  | Ok _ -> fail "should reject double dot"
+  | Error _ -> ()
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -285,5 +295,7 @@ let () =
       test_case "agent unicode rejected" `Quick test_agent_id_unicode_rejected;
       test_case "task unicode rejected" `Quick test_task_id_unicode_rejected;
       test_case "agent dot only" `Quick test_agent_id_dot_only;
+      test_case "agent single dot" `Quick test_agent_id_single_dot;
+      test_case "agent double dot" `Quick test_agent_id_double_dot;
     ];
   ]

--- a/test/test_validation_coverage.ml
+++ b/test/test_validation_coverage.ml
@@ -41,6 +41,11 @@ let test_agent_id_valid_mixed () =
   | Ok t -> check string "mixed" "Agent-X_42" (Validation.Agent_id.to_string t)
   | Error e -> fail e
 
+let test_agent_id_valid_colon_namespace () =
+  match Validation.Agent_id.validate "keeper:keeper-test-98295-0" with
+  | Ok t -> check string "colon namespace" "keeper:keeper-test-98295-0" (Validation.Agent_id.to_string t)
+  | Error e -> fail e
+
 let test_agent_id_reject_empty () =
   match Validation.Agent_id.validate "" with
   | Ok _ -> fail "should reject empty"
@@ -213,6 +218,7 @@ let () =
       test_case "with underscore" `Quick test_agent_id_valid_with_underscore;
       test_case "numeric" `Quick test_agent_id_valid_numeric;
       test_case "mixed" `Quick test_agent_id_valid_mixed;
+      test_case "colon namespace" `Quick test_agent_id_valid_colon_namespace;
     ];
     "agent_id.reject", [
       test_case "empty" `Quick test_agent_id_reject_empty;

--- a/test/test_validation_coverage.ml
+++ b/test/test_validation_coverage.ml
@@ -82,6 +82,26 @@ let test_agent_id_reject_space () =
   | Ok _ -> fail "should reject space"
   | Error e -> check bool "error exists" true (String.length e > 0)
 
+let test_agent_id_reject_bare_colon () =
+  match Validation.Agent_id.validate ":" with
+  | Ok _ -> fail "should reject bare colon"
+  | Error _ -> ()
+
+let test_agent_id_reject_multi_colon () =
+  match Validation.Agent_id.validate "a:b:c" with
+  | Ok _ -> fail "should reject multiple colons"
+  | Error _ -> ()
+
+let test_agent_id_reject_leading_colon () =
+  match Validation.Agent_id.validate ":foo" with
+  | Ok _ -> fail "should reject leading colon"
+  | Error _ -> ()
+
+let test_agent_id_reject_trailing_colon () =
+  match Validation.Agent_id.validate "foo:" with
+  | Ok _ -> fail "should reject trailing colon"
+  | Error _ -> ()
+
 let test_agent_id_of_string_unsafe () =
   let t = Validation.Agent_id.of_string_unsafe "unsafe-input" in
   check string "unsafe" "unsafe-input" (Validation.Agent_id.to_string t)
@@ -228,6 +248,10 @@ let () =
       test_case "path traversal" `Quick test_agent_id_reject_path_traversal;
       test_case "special chars" `Quick test_agent_id_reject_special_chars;
       test_case "space" `Quick test_agent_id_reject_space;
+      test_case "bare colon" `Quick test_agent_id_reject_bare_colon;
+      test_case "multi colon" `Quick test_agent_id_reject_multi_colon;
+      test_case "leading colon" `Quick test_agent_id_reject_leading_colon;
+      test_case "trailing colon" `Quick test_agent_id_reject_trailing_colon;
     ];
     "agent_id.unsafe", [
       test_case "of_string_unsafe" `Quick test_agent_id_of_string_unsafe;


### PR DESCRIPTION
## Summary
- `Validation.Agent_id`가 콜론(`:`)을 거부하여 keeper의 namespaced ID가 매 turn 실패 → 공회전 상태
- structural regex `^[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?$`로 단일 namespace:name 패턴만 허용

## Root Cause
`Agent_id.valid_pattern`이 `^[a-zA-Z0-9_-]+$` (콜론 불허). keeper가 `keeper:name` 형식 사용.

## Evidence
- 로그: `Agent_id rejected input 'keeper:keeper-test-98295-0'`
- KST 06시 이후 keeper activity 1800/hr → 30/hr 급감
- `safe_filename`이 콜론을 `_3a`로 이스케이프하므로 파일 시스템 안전

## Review evidence
- GLM-5.1 security-focused review 수행
- 4개 이슈 중 #3(구조적 제약 없음) 수용 → structural regex 적용
- bare colon, multi-colon, leading/trailing colon 모두 거부

## Test plan
- [x] `test_agent_id_valid_colon_namespace` — `keeper:keeper-test-98295-0` 통과
- [x] `test_agent_id_reject_bare_colon` — `:` 거부
- [x] `test_agent_id_reject_multi_colon` — `a:b:c` 거부
- [x] `test_agent_id_reject_leading_colon` — `:foo` 거부
- [x] `test_agent_id_reject_trailing_colon` — `foo:` 거부
- [x] 기존 validation 테스트 38/38 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)