### PR TITLE
refactor(tool): migrate team_session deny lists to Tool_access_policy

### DIFF
--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -13,32 +13,32 @@ module Oas = Agent_sdk
 let supported_local_worker_tool_names =
   Tool_catalog.tools_for_surface Tool_catalog.Local_worker
 
-let observe_only_blocked_local_worker_tool_names =
-  [
-    "masc_add_task";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_board_post";
-    "masc_board_comment";
-    "masc_board_vote";
-    "masc_worktree_create";
-    "masc_worktree_remove";
-    "masc_run_init";
-    "masc_run_plan";
-    "masc_run_log";
-    "masc_run_deliverable";
-    "masc_repair_loop_start";
-    "masc_repair_loop_iterate";
-    "masc_repair_loop_stop";
-  ]
+let observe_only_policy : Tool_access_policy.t =
+  {
+    allow = Surface Tool_catalog.Local_worker;
+    deny = Names [
+      "masc_add_task";
+      "masc_claim_next";
+      "masc_transition";
+      "masc_board_post";
+      "masc_board_comment";
+      "masc_board_vote";
+      "masc_worktree_create";
+      "masc_worktree_remove";
+      "masc_run_init";
+      "masc_run_plan";
+      "masc_run_log";
+      "masc_run_deliverable";
+      "masc_repair_loop_start";
+      "masc_repair_loop_iterate";
+      "masc_repair_loop_stop";
+    ];
+  }
 
 let supported_local_worker_tool_names_for_scope execution_scope =
   match execution_scope with
   | Some Team_session_types.Observe_only ->
-      List.filter
-        (fun name ->
-          not (List.mem name observe_only_blocked_local_worker_tool_names))
-        supported_local_worker_tool_names
+      Tool_access_policy.resolve observe_only_policy
   | Some Team_session_types.Limited_code_change
   | Some Team_session_types.Autonomous
   | None ->

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -89,13 +89,13 @@ let execute_spawn_pipeline
                       deps.effective_execution_scope_of_spec prepared.spec
                     in
                     let local_worker_tool_names =
-                      let all_local_worker_tools =
-                        Team_session_oas_bridge.supported_local_worker_tool_names
-                      in
                       match execution_scope with
                       | Some Team_session_types.Observe_only ->
-                          let denied_observe_only_tools =
-                            [
+                          (* Includes masc_heartbeat in deny — spawned workers
+                             should not heartbeat on behalf of the session. *)
+                          Tool_access_policy.resolve {
+                            allow = Surface Tool_catalog.Local_worker;
+                            deny = Names [
                               "masc_claim_next";
                               "masc_transition";
                               "masc_add_task";
@@ -112,13 +112,10 @@ let execute_spawn_pipeline
                               "masc_repair_loop_start";
                               "masc_repair_loop_iterate";
                               "masc_repair_loop_stop";
-                            ]
-                          in
-                          List.filter
-                            (fun name ->
-                              not (List.mem name denied_observe_only_tools))
-                            all_local_worker_tools
-                      | _ -> all_local_worker_tools
+                            ];
+                          }
+                      | _ ->
+                          Team_session_oas_bridge.supported_local_worker_tool_names
                     in
                     let local_shell_tool_names =
                       match execution_scope with


### PR DESCRIPTION
## Summary
- `team_session_oas_bridge.ml`: `List.mem` + 하드코딩 deny list → `Tool_access_policy.resolve` + `Surface Local_worker`
- `tool_team_session_step_spawn.ml`: 동일 패턴 전환, `masc_heartbeat` 추가 deny 보존

## Context
#4339 tool access policy SSOT 중앙화 이후 남아있던 마지막 2곳의 레거시 `List.mem` 필터링.
이제 모든 tool allow/deny 로직이 `Tool_access_policy` ADT를 경유.

## Detail
spawn 경로는 bridge보다 `masc_heartbeat`를 추가로 deny한다 (spawned worker는 세션 대신 heartbeat하면 안 됨).
이 차이는 의도적이며 주석으로 명시.

## Test plan
- [x] `test_tool_access_policy` — 45/45 통과
- [x] `test_tool_team_session` — 54/54 통과
- [x] `test_worker_oas_scope_gate` — 6/6 통과
- [x] `dune build` 전체 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)