### PR TITLE
refactor(test): body-based call matching for MCP tests

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -34,6 +34,15 @@ function setupMcpSessionMocks(sessionId: string) {
     )
 }
 
+/** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
+function findCallByMethod(method: string) {
+  const calls = fetchWithTimeout.mock.calls as Array<[string, { headers: Record<string, string>; body: string }]>
+  return calls.find(([, opts]) => {
+    try { return JSON.parse(opts.body).method === method }
+    catch { return false }
+  })
+}
+
 describe('mcpHeaders auth integration', () => {
   it('includes Authorization header from authHeaders in MCP initialize request', async () => {
     authHeaders.mockReturnValue({
@@ -45,14 +54,16 @@ describe('mcpHeaders auth integration', () => {
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})
 
-    const initHeaders = fetchWithTimeout.mock.calls[0]![1]!.headers as Record<string, string>
+    const initCall = findCallByMethod('initialize')
+    expect(initCall).toBeDefined()
+    const initHeaders = initCall![1].headers
     expect(initHeaders['Authorization']).toBe('Bearer test-token-123')
     expect(initHeaders['X-MASC-Agent']).toBe('dashboard')
     expect(initHeaders['Content-Type']).toBe('application/json')
 
-    // tools/call request (3rd call) should also include auth headers
-    const toolHeaders = fetchWithTimeout.mock.calls[2]![1]!.headers as Record<string, string>
-    expect(toolHeaders['Authorization']).toBe('Bearer test-token-123')
+    const toolCall = findCallByMethod('tools/call')
+    expect(toolCall).toBeDefined()
+    expect(toolCall![1].headers['Authorization']).toBe('Bearer test-token-123')
   })
 
   it('works without token when authHeaders returns empty', async () => {
@@ -62,9 +73,10 @@ describe('mcpHeaders auth integration', () => {
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})
 
-    const initHeaders = fetchWithTimeout.mock.calls[0]![1]!.headers as Record<string, string>
-    expect(initHeaders['Authorization']).toBeUndefined()
-    expect(initHeaders['Content-Type']).toBe('application/json')
+    const initCall = findCallByMethod('initialize')
+    expect(initCall).toBeDefined()
+    expect(initCall![1].headers['Authorization']).toBeUndefined()
+    expect(initCall![1].headers['Content-Type']).toBe('application/json')
   })
 })
 

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -36,9 +36,11 @@ function setupMcpSessionMocks(sessionId: string) {
 
 /** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
 function findCallByMethod(method: string) {
-  const calls = fetchWithTimeout.mock.calls as Array<[string, { headers: Record<string, string>; body: string }]>
-  return calls.find(([, opts]) => {
-    try { return JSON.parse(opts.body).method === method }
+  const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
+  return calls.find(([, init]) => {
+    const body = init.body
+    if (typeof body !== 'string') return false
+    try { return JSON.parse(body).method === method }
     catch { return false }
   })
 }
@@ -56,14 +58,15 @@ describe('mcpHeaders auth integration', () => {
 
     const initCall = findCallByMethod('initialize')
     expect(initCall).toBeDefined()
-    const initHeaders = initCall![1].headers
+    const initHeaders = initCall![1].headers as Record<string, string>
     expect(initHeaders['Authorization']).toBe('Bearer test-token-123')
     expect(initHeaders['X-MASC-Agent']).toBe('dashboard')
     expect(initHeaders['Content-Type']).toBe('application/json')
 
     const toolCall = findCallByMethod('tools/call')
     expect(toolCall).toBeDefined()
-    expect(toolCall![1].headers['Authorization']).toBe('Bearer test-token-123')
+    const toolHeaders = toolCall![1].headers as Record<string, string>
+    expect(toolHeaders['Authorization']).toBe('Bearer test-token-123')
   })
 
   it('works without token when authHeaders returns empty', async () => {
@@ -75,8 +78,9 @@ describe('mcpHeaders auth integration', () => {
 
     const initCall = findCallByMethod('initialize')
     expect(initCall).toBeDefined()
-    expect(initCall![1].headers['Authorization']).toBeUndefined()
-    expect(initCall![1].headers['Content-Type']).toBe('application/json')
+    const noAuthHeaders = initCall![1].headers as Record<string, string>
+    expect(noAuthHeaders['Authorization']).toBeUndefined()
+    expect(noAuthHeaders['Content-Type']).toBe('application/json')
   })
 })
 


### PR DESCRIPTION
## Summary
- #4362 리뷰 코멘트 대응: 테스트에서 call index 대신 body 매칭

## Changes
- `findCallByMethod(method)` 헬퍼 추가: `fetchWithTimeout` mock calls에서 JSON body의 `method` 필드로 검색
- `calls[0]` / `calls[2]` 하드코딩 제거 → `findCallByMethod('initialize')` / `findCallByMethod('tools/call')`
- 호출 순서 변경에 강건한 테스트

## Note
- #4362 코멘트 중 `mcpHeaders` spread 순서 이슈는 main에서 이미 `authHeaders()` 리팩터로 해결됨

## Validation
- [x] `pnpm vitest run` — 3/3 pass
- [ ] CI green