### PR TITLE
feat(auth): unified Tool_access_policy authorization funnel (Phase 0)

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -534,8 +534,9 @@ let local_worker_tool_schemas ?names () :
   | Some values -> resolve_named_schemas all_schemas values
 
 (** Admin tool names that should be excluded from autonomous agents.
-    Delegates to Tool_permissions.admin_tools (SSOT). *)
-let admin_tool_names : string list = Tool_permissions.admin_tools
+    SSOT: Tool_catalog.Admin surface. *)
+let admin_tool_names : string list =
+  Tool_catalog.tools_for_surface Tool_catalog.Admin
 
 (** Coordination tool names for coordinators and fleet leaders. *)
 let coordination_tool_names : string list =

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -371,39 +371,35 @@ let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) res
 (* ============================================ *)
 
 (** Resolve the effective role for an agent from auth context.
-    Extracts the role resolution logic from check_permission. *)
-let resolve_role config ~agent_name ~token : agent_role =
+    Returns Error for invalid tokens (no silent downgrade). *)
+let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
   let auth_cfg = load_auth_config config in
   if not auth_cfg.enabled then
-    Admin  (* Auth disabled = full access *)
+    Ok Admin  (* Auth disabled = full access *)
   else if (match read_initial_admin config with
            | Some admin -> String.equal agent_name admin
            | None -> false) then
-    Admin  (* Bootstrap admin = full access *)
+    Ok Admin  (* Bootstrap admin = full access *)
   else if not auth_cfg.require_token then
-    auth_cfg.default_role
+    Ok auth_cfg.default_role
   else
     match token with
-    | None -> Reader  (* No token = minimum access *)
+    | None -> Error (Unauthorized "Token required")
     | Some t ->
         (match verify_token config ~agent_name ~token:t with
-        | Ok cred -> cred.role
-        | Error _ -> Reader)  (* Invalid/expired token = minimum access *)
+        | Ok cred -> Ok cred.role
+        | Error e -> Error e)
 
 (** Policy-based tool authorization.
     Replaces authorize_tool with a single Tool_access_policy check.
-    The role determines which tools are accessible. *)
+    Invalid/expired tokens are rejected (not silently downgraded). *)
 let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
-  let auth_cfg = load_auth_config config in
-  if not auth_cfg.enabled then
-    Ok ()
-  else
-    let role = resolve_role config ~agent_name ~token in
-    let policy = Tool_access_role.policy_for_role role in
-    if Tool_access_policy.allows_name policy tool_name then
-      Ok ()
-    else
-      Error (Forbidden { agent = agent_name; action = tool_name })
+  match resolve_role config ~agent_name ~token with
+  | Error e -> Error e
+  | Ok role ->
+      let policy = Tool_access_role.policy_for_role role in
+      if Tool_access_policy.allows_name policy tool_name then Ok ()
+      else Error (Forbidden { agent = agent_name; action = tool_name })
 
 (* ============================================ *)
 (* Room secret (for room-level auth)            *)

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -367,6 +367,45 @@ let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) res
   | Some perm -> check_permission config ~agent_name ~token ~permission:perm
 
 (* ============================================ *)
+(* Unified policy-based authorization (v2)      *)
+(* ============================================ *)
+
+(** Resolve the effective role for an agent from auth context.
+    Extracts the role resolution logic from check_permission. *)
+let resolve_role config ~agent_name ~token : agent_role =
+  let auth_cfg = load_auth_config config in
+  if not auth_cfg.enabled then
+    Admin  (* Auth disabled = full access *)
+  else if (match read_initial_admin config with
+           | Some admin -> String.equal agent_name admin
+           | None -> false) then
+    Admin  (* Bootstrap admin = full access *)
+  else if not auth_cfg.require_token then
+    auth_cfg.default_role
+  else
+    match token with
+    | None -> Reader  (* No token = minimum access *)
+    | Some t ->
+        (match verify_token config ~agent_name ~token:t with
+        | Ok cred -> cred.role
+        | Error _ -> Reader)  (* Invalid/expired token = minimum access *)
+
+(** Policy-based tool authorization.
+    Replaces authorize_tool with a single Tool_access_policy check.
+    The role determines which tools are accessible. *)
+let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
+  let auth_cfg = load_auth_config config in
+  if not auth_cfg.enabled then
+    Ok ()
+  else
+    let role = resolve_role config ~agent_name ~token in
+    let policy = Tool_access_role.policy_for_role role in
+    if Tool_access_policy.allows_name policy tool_name then
+      Ok ()
+    else
+      Error (Forbidden { agent = agent_name; action = tool_name })
+
+(* ============================================ *)
 (* Room secret (for room-level auth)            *)
 (* ============================================ *)
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -392,14 +392,36 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
 
 (** Policy-based tool authorization.
     Replaces authorize_tool with a single Tool_access_policy check.
-    Invalid/expired tokens are rejected (not silently downgraded). *)
+    Invalid/expired tokens are rejected (not silently downgraded).
+
+    Strict mode (MASC_TOOL_AUTH_STRICT, default=true):
+    Tools not mapped by permission_for_tool are subject to additional
+    checks — unmapped masc_* tools require at least Worker, and
+    unmapped non-masc tools are forbidden. *)
 let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match resolve_role config ~agent_name ~token with
   | Error e -> Error e
   | Ok role ->
       let policy = Tool_access_role.policy_for_role role in
-      if Tool_access_policy.allows_name policy tool_name then Ok ()
-      else Error (Forbidden { agent = agent_name; action = tool_name })
+      if not (Tool_access_policy.allows_name policy tool_name) then
+        Error (Forbidden { agent = agent_name; action = tool_name })
+      else if not (is_tool_auth_strict_enabled ()) then
+        Ok ()  (* Non-strict: policy check is sufficient *)
+      else
+        (* Strict mode: additional gate for unmapped tools *)
+        match permission_for_tool tool_name with
+        | Some _ -> Ok ()  (* Mapped tool — policy already checked *)
+        | None ->
+            if is_masc_tool_name tool_name
+               || is_protocol_canonical_tool_name tool_name then
+              (* Unmapped internal tool: require at least Worker *)
+              if has_permission role CanBroadcast then Ok ()
+              else Error (Forbidden { agent = agent_name; action = tool_name })
+            else
+              Error (Forbidden {
+                agent = agent_name;
+                action = "use unknown non-masc tool: " ^ tool_name
+              })
 
 (* ============================================ *)
 (* Room secret (for room-level auth)            *)

--- a/lib/dune
+++ b/lib/dune
@@ -286,6 +286,7 @@
    tool_bridge
    tool_cache
    tool_access_policy
+   tool_access_role
    tool_tempo
    tool_portal
    tool_worktree

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -252,8 +252,9 @@ let tool_access_lookup_of_meta (meta : keeper_meta) =
   }
 
 let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =
-  not (is_keeper_denied name)
-  && Hashtbl.mem lookup.candidate_set name
+  (* keeper_denied tools are already excluded from candidate_set via
+     inject_masc_schemas, so the is_keeper_denied check was redundant. *)
+  Hashtbl.mem lookup.candidate_set name
   && Hashtbl.mem lookup.allow_set name
   && not (Hashtbl.mem lookup.deny_set name)
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -237,7 +237,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let auth_enabled = Auth.is_auth_enabled config.base_path in
   let auth_result =
     if auth_enabled then
-      match Auth.authorize_tool config.base_path ~agent_name ~token ~tool_name:name with
+      match Auth.authorize_tool_v2 config.base_path ~agent_name ~token ~tool_name:name with
       | Ok () -> Ok ()
       | Error err -> Error err
     else
@@ -324,7 +324,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       if auth_cfg.require_token && not (Nickname.is_generated_nickname agent_name) then
         false
       else
-        match Auth.authorize_tool config.base_path ~agent_name ~token ~tool_name:"masc_join" with
+        match Auth.authorize_tool_v2 config.base_path ~agent_name ~token ~tool_name:"masc_join" with
         | Ok () -> true
         | Error _ -> false
   in

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -377,7 +377,7 @@ let authorize_tool_request ~base_path ~tool_name request :
               (Types.Unauthorized
                  "Agent name required (X-MASC-Agent or token-bound credential)")
           else
-            Auth.authorize_tool base_path ~agent_name ~token ~tool_name))
+            Auth.authorize_tool_v2 base_path ~agent_name ~token ~tool_name))
 
 let authorize_token_bound_permission_request ~base_path ~permission request :
     (string, Types.masc_error) result =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -4,8 +4,9 @@
     subsystem-spawning functions into a focused module. *)
 
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
-  Governance_pipeline.install ~config:state.room_config ~governance_level;
-  Tool_permissions.install ~get_agent_name:(fun () -> None)
+  Governance_pipeline.install ~config:state.room_config ~governance_level
+  (* Tool_permissions pre-hook removed: admin check is now handled by
+     Tool_access_role.policy_for_role in Auth.authorize_tool_v2. *)
 
 let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -1,0 +1,161 @@
+(** Tool_access_role — Role-based tool access policy builder.
+
+    Derived mechanically from legacy_permission_for_tool in auth.ml.
+    Each tool's required permission determines which role tier it belongs to:
+    - Reader tier: CanReadState, CanJoin, CanLeave
+    - Worker tier: CanAddTask, CanClaimTask, CanCompleteTask, CanBroadcast,
+                   CanOpenPortal, CanSendPortal, CanCreateWorktree,
+                   CanRemoveWorktree, CanVote
+    - Admin tier:  CanInit, CanReset, CanInterrupt, CanApprove, CanAdmin
+
+    @since 2.204.0 *)
+
+(* ================================================================ *)
+(* Admin-only tools (CanInit + CanReset + CanInterrupt +             *)
+(*                   CanApprove + CanAdmin)                          *)
+(* ================================================================ *)
+
+let admin_only_tools =
+  [
+    (* CanInit *)
+    "masc_init";
+    "masc_auth_enable";
+    "masc_auth_disable";
+    "masc_auth_revoke";
+    (* CanReset *)
+    "masc_reset";
+    (* CanAdmin — autoresearch *)
+    "masc_autoresearch_start";
+    "masc_autoresearch_swarm_start";
+    "masc_repo_synthesis_swarm_start";
+    "masc_autoresearch_cycle";
+    "masc_autoresearch_inject";
+    "masc_autoresearch_stop";
+    (* CanAdmin — command-plane policy *)
+    "masc_policy_freeze_unit";
+    "masc_policy_kill_switch";
+    (* CanAdmin — board moderation *)
+    "masc_board_reclassify";
+    "masc_board_delete";
+    (* CanAdmin — auth *)
+    "masc_auth_create_token";
+    (* CanAdmin — tool administration *)
+    "masc_tool_grant";
+    "masc_tool_revoke";
+    "masc_tool_admin_update";
+    (* CanInterrupt *)
+    "masc_interrupt";
+    "masc_branch";
+    (* CanApprove *)
+    "masc_approve";
+    "masc_reject";
+  ]
+
+(* ================================================================ *)
+(* Worker-only tools (CanAddTask + CanClaimTask + CanCompleteTask +  *)
+(*                    CanBroadcast + CanOpenPortal + CanSendPortal + *)
+(*                    CanCreateWorktree + CanRemoveWorktree + CanVote) *)
+(* ================================================================ *)
+
+let worker_only_tools =
+  [
+    (* CanAddTask *)
+    "masc_add_task";
+    (* CanClaimTask *)
+    "masc_claim_next";
+    (* CanCompleteTask *)
+    "masc_done";
+    "masc_update_priority";
+    "masc_transition";
+    "masc_release";
+    (* CanBroadcast — messaging *)
+    "masc_broadcast";
+    "masc_listen";
+    "masc_heartbeat";
+    (* CanBroadcast — transport *)
+    "masc_webrtc_offer";
+    "masc_webrtc_answer";
+    (* CanBroadcast — capability registry *)
+    "masc_register_capabilities";
+    "masc_find_by_capability";
+    (* CanBroadcast — agent management *)
+    "masc_agent_update";
+    "masc_operator_action";
+    "masc_operator_confirm";
+    (* CanBroadcast — keeper management *)
+    "masc_keeper_up";
+    "masc_keeper_down";
+    "masc_keeper_msg";
+    "masc_keeper_repair";
+    "masc_keeper_create_from_persona";
+    (* CanBroadcast — voice *)
+    "masc_voice_speak";
+    "masc_voice_session_start";
+    "masc_voice_session_end";
+    "masc_voice_conference_start";
+    "masc_voice_conference_end";
+    (* CanBroadcast — org units *)
+    "masc_unit_define";
+    "masc_unit_reparent";
+    "masc_unit_reassign";
+    (* CanBroadcast — operations *)
+    "masc_operation_start";
+    "masc_operation_checkpoint";
+    "masc_operation_pause";
+    "masc_operation_resume";
+    "masc_operation_stop";
+    "masc_operation_finalize";
+    (* CanBroadcast — dispatch *)
+    "masc_dispatch_assign";
+    "masc_dispatch_rebalance";
+    "masc_dispatch_escalate";
+    "masc_dispatch_recall";
+    (* CanBroadcast — policy decisions *)
+    "masc_policy_approve";
+    "masc_policy_deny";
+    "masc_policy_update";
+    (* CanBroadcast — maintenance *)
+    "masc_cleanup_zombies";
+    (* CanBroadcast — board writes *)
+    "masc_board_post";
+    "masc_board_comment";
+    "masc_board_vote";
+    "masc_board_comment_vote";
+    (* CanOpenPortal *)
+    "masc_portal_open";
+    "masc_portal_close";
+    (* CanSendPortal *)
+    "masc_portal_send";
+    (* CanCreateWorktree *)
+    "masc_worktree_create";
+    (* CanRemoveWorktree *)
+    "masc_worktree_remove";
+    (* CanVote *)
+    "masc_vote_create";
+    "masc_vote_cast";
+  ]
+
+(* ================================================================ *)
+(* Role → Policy                                                     *)
+(* ================================================================ *)
+
+let policy_for_role : Types.agent_role -> Tool_access_policy.t = function
+  | Admin ->
+      { Tool_access_policy.allow = All; deny = Empty }
+  | Worker ->
+      {
+        allow =
+          Diff { base = All; exclude = Names admin_only_tools };
+        deny = Empty;
+      }
+  | Reader ->
+      {
+        allow =
+          Diff
+            {
+              base = All;
+              exclude =
+                Union [ Names admin_only_tools; Names worker_only_tools ];
+            };
+        deny = Empty;
+      }

--- a/lib/tool_access_role.mli
+++ b/lib/tool_access_role.mli
@@ -1,0 +1,29 @@
+(** Tool_access_role — Role-based tool access policy builder.
+
+    Maps each authentication role (Reader, Worker, Admin) to a
+    Tool_access_policy.t that determines which tools the role can invoke.
+
+    Replaces the legacy per-tool permission mapping (auth.ml
+    legacy_permission_for_tool) and the Tool_permissions admin pre-hook
+    with a single policy-based funnel.
+
+    @since 2.204.0 — Phase 0 of Tool Gate architecture (#4381) *)
+
+val admin_only_tools : string list
+(** Tools requiring Admin role. Derived from legacy CanInit, CanReset,
+    CanInterrupt, CanApprove, CanAdmin permissions. *)
+
+val worker_only_tools : string list
+(** Tools requiring at least Worker role. Derived from legacy CanAddTask,
+    CanClaimTask, CanCompleteTask, CanBroadcast, CanOpenPortal,
+    CanSendPortal, CanCreateWorktree, CanRemoveWorktree, CanVote. *)
+
+val policy_for_role : Types.agent_role -> Tool_access_policy.t
+(** Build the access policy for a role.
+    - Admin: all tools allowed
+    - Worker: all except admin-only tools
+    - Reader: all except admin-only and worker-only tools
+
+    Note: Keeper_denied and Keeper_internal filtering is handled separately
+    by keeper_exec_tools and the mode gate (allow_direct_call), not by
+    role policies. *)

--- a/lib/tool_permissions.ml
+++ b/lib/tool_permissions.ml
@@ -1,4 +1,10 @@
-(** Tool permission filter *)
+(** Tool permission filter.
+
+    DEPRECATED: The pre-hook installed by [install] is no longer registered
+    in the authorization hot path. Admin tool checking is now handled by
+    [Tool_access_role.policy_for_role] via [Auth.authorize_tool_v2].
+    This module is retained only for backward compatibility with tests.
+    See #4381 Phase 0. *)
 
 (* Derived from Tool_catalog surface SSOT.
    team_session_stop intentionally stays outside this list:

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_metrics_rotation
         test_tool_tier
         test_tool_access_policy
+        test_tool_access_role
         test_tool_budget
         test_tool_exposure
         test_code_swarm
@@ -109,6 +110,7 @@
           test_metrics_rotation
           test_tool_tier
           test_tool_access_policy
+        test_tool_access_role
           test_tool_budget
           test_tool_exposure
           test_code_swarm

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -16,10 +16,15 @@ open Masc_mcp
     permission_for_tool(tool) → permission option
     has_permission(role, permission) → bool
 
-    In non-strict mode, None → allowed (fail-open). *)
+    Tests at the POLICY level (not authorization level).
+    Strict mode checks happen in authorize_tool_v2, not in the policy.
+    For mapped tools, this matches both strict and non-strict behavior.
+    For unmapped tools (None), the policy allows them (All-based),
+    matching the non-strict fail-open path. Strict mode is an
+    authorization-level overlay tested separately. *)
 let old_allows (role : Types.agent_role) (tool_name : string) : bool =
   match Auth.permission_for_tool tool_name with
-  | None -> true  (* Legacy fail-open in non-strict mode *)
+  | None -> true  (* Policy level: fail-open for unmapped tools *)
   | Some perm -> Types.has_permission role perm
 
 (* ================================================================ *)

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -151,6 +151,26 @@ let test_worker_allows_worker_only_tools () =
   ) Tool_access_role.worker_only_tools
 
 (* ================================================================ *)
+(* Unregistered tool behavior                                        *)
+(* ================================================================ *)
+
+let test_unregistered_tool_allowed_all_roles () =
+  let unknown = "masc_future_unknown_tool_xyz" in
+  List.iter (fun (role_name, role) ->
+    let policy = Tool_access_role.policy_for_role role in
+    check bool
+      (Printf.sprintf "%s: unregistered tool allowed (fail-open)" role_name)
+      true
+      (Tool_access_policy.allows_name policy unknown)
+  ) [("Admin", Admin); ("Worker", Worker); ("Reader", Reader)]
+
+let test_empty_string_tool_allowed () =
+  let policy = Tool_access_role.policy_for_role Worker in
+  check bool "empty string tool allowed by All"
+    true
+    (Tool_access_policy.allows_name policy "")
+
+(* ================================================================ *)
 (* Tool list integrity tests                                         *)
 (* ================================================================ *)
 
@@ -206,6 +226,13 @@ let () =
             test_reader_denies_worker_only_tools;
           test_case "Worker allows worker_only" `Quick
             test_worker_allows_worker_only_tools;
+        ] );
+      ( "unregistered",
+        [
+          test_case "unregistered allowed (fail-open)" `Quick
+            test_unregistered_tool_allowed_all_roles;
+          test_case "empty string tool" `Quick
+            test_empty_string_tool_allowed;
         ] );
       ( "integrity",
         [

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -1,0 +1,217 @@
+(** Tests for Tool_access_role — role-based policy equivalence and properties.
+
+    The equivalence test is the critical gate: it verifies that the new
+    policy_for_role produces identical allow/deny decisions to the legacy
+    permission_for_tool + has_permission system for every registered tool
+    and every role. *)
+
+open Alcotest
+open Masc_mcp
+
+(* ================================================================ *)
+(* Old system simulation (from legacy_permission_for_tool)           *)
+(* ================================================================ *)
+
+(** Simulate the old authorization logic:
+    permission_for_tool(tool) → permission option
+    has_permission(role, permission) → bool
+
+    In non-strict mode, None → allowed (fail-open). *)
+let old_allows (role : Types.agent_role) (tool_name : string) : bool =
+  match Auth.permission_for_tool tool_name with
+  | None -> true  (* Legacy fail-open in non-strict mode *)
+  | Some perm -> Types.has_permission role perm
+
+(* ================================================================ *)
+(* Equivalence tests                                                 *)
+(* ================================================================ *)
+
+(** Collect all tool names from all surfaces. *)
+let all_surface_tools () =
+  Tool_catalog.all_surfaces
+  |> List.concat_map Tool_catalog.tools_for_surface
+  |> List.sort_uniq String.compare
+
+let test_equivalence_admin () =
+  let tools = all_surface_tools () in
+  List.iter (fun tool_name ->
+    let old_result = old_allows Admin tool_name in
+    let new_result =
+      Tool_access_policy.allows_name
+        (Tool_access_role.policy_for_role Admin) tool_name
+    in
+    check bool
+      (Printf.sprintf "Admin/%s" tool_name)
+      old_result new_result
+  ) tools
+
+let test_equivalence_worker () =
+  let tools = all_surface_tools () in
+  List.iter (fun tool_name ->
+    let old_result = old_allows Worker tool_name in
+    let new_result =
+      Tool_access_policy.allows_name
+        (Tool_access_role.policy_for_role Worker) tool_name
+    in
+    check bool
+      (Printf.sprintf "Worker/%s" tool_name)
+      old_result new_result
+  ) tools
+
+let test_equivalence_reader () =
+  let tools = all_surface_tools () in
+  List.iter (fun tool_name ->
+    let old_result = old_allows Reader tool_name in
+    let new_result =
+      Tool_access_policy.allows_name
+        (Tool_access_role.policy_for_role Reader) tool_name
+    in
+    check bool
+      (Printf.sprintf "Reader/%s" tool_name)
+      old_result new_result
+  ) tools
+
+(* ================================================================ *)
+(* Hierarchy tests                                                   *)
+(* ================================================================ *)
+
+let test_reader_subset_of_worker () =
+  let tools = all_surface_tools () in
+  let reader_policy = Tool_access_role.policy_for_role Reader in
+  let worker_policy = Tool_access_role.policy_for_role Worker in
+  List.iter (fun tool_name ->
+    let reader_allows = Tool_access_policy.allows_name reader_policy tool_name in
+    let worker_allows = Tool_access_policy.allows_name worker_policy tool_name in
+    if reader_allows then
+      check bool
+        (Printf.sprintf "Reader allows %s, Worker must too" tool_name)
+        true worker_allows
+  ) tools
+
+let test_worker_subset_of_admin () =
+  let tools = all_surface_tools () in
+  let worker_policy = Tool_access_role.policy_for_role Worker in
+  let admin_policy = Tool_access_role.policy_for_role Admin in
+  List.iter (fun tool_name ->
+    let worker_allows = Tool_access_policy.allows_name worker_policy tool_name in
+    let admin_allows = Tool_access_policy.allows_name admin_policy tool_name in
+    if worker_allows then
+      check bool
+        (Printf.sprintf "Worker allows %s, Admin must too" tool_name)
+        true admin_allows
+  ) tools
+
+(* ================================================================ *)
+(* Admin surface denial tests                                        *)
+(* ================================================================ *)
+
+let test_reader_denies_admin_only_tools () =
+  let reader_policy = Tool_access_role.policy_for_role Reader in
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "Reader denies %s" tool_name)
+      false
+      (Tool_access_policy.allows_name reader_policy tool_name)
+  ) Tool_access_role.admin_only_tools
+
+let test_worker_denies_admin_only_tools () =
+  let worker_policy = Tool_access_role.policy_for_role Worker in
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "Worker denies %s" tool_name)
+      false
+      (Tool_access_policy.allows_name worker_policy tool_name)
+  ) Tool_access_role.admin_only_tools
+
+let test_admin_allows_admin_only_tools () =
+  let admin_policy = Tool_access_role.policy_for_role Admin in
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "Admin allows %s" tool_name)
+      true
+      (Tool_access_policy.allows_name admin_policy tool_name)
+  ) Tool_access_role.admin_only_tools
+
+let test_reader_denies_worker_only_tools () =
+  let reader_policy = Tool_access_role.policy_for_role Reader in
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "Reader denies %s" tool_name)
+      false
+      (Tool_access_policy.allows_name reader_policy tool_name)
+  ) Tool_access_role.worker_only_tools
+
+let test_worker_allows_worker_only_tools () =
+  let worker_policy = Tool_access_role.policy_for_role Worker in
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "Worker allows %s" tool_name)
+      true
+      (Tool_access_policy.allows_name worker_policy tool_name)
+  ) Tool_access_role.worker_only_tools
+
+(* ================================================================ *)
+(* Tool list integrity tests                                         *)
+(* ================================================================ *)
+
+let test_admin_only_count () =
+  check bool "admin_only_tools is non-empty" true
+    (List.length Tool_access_role.admin_only_tools > 0);
+  check bool "admin_only_tools has expected size (23)"
+    true
+    (List.length Tool_access_role.admin_only_tools = 23)
+
+let test_worker_only_count () =
+  check bool "worker_only_tools is non-empty" true
+    (List.length Tool_access_role.worker_only_tools > 0);
+  check bool "worker_only_tools has expected size (54)"
+    true
+    (List.length Tool_access_role.worker_only_tools = 54)
+
+let test_no_overlap_admin_worker () =
+  List.iter (fun tool_name ->
+    check bool
+      (Printf.sprintf "%s not in both admin and worker lists" tool_name)
+      false
+      (List.mem tool_name Tool_access_role.worker_only_tools)
+  ) Tool_access_role.admin_only_tools
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  run "Tool_access_role"
+    [
+      ( "equivalence",
+        [
+          test_case "Admin: old == new" `Quick test_equivalence_admin;
+          test_case "Worker: old == new" `Quick test_equivalence_worker;
+          test_case "Reader: old == new" `Quick test_equivalence_reader;
+        ] );
+      ( "hierarchy",
+        [
+          test_case "Reader ⊂ Worker" `Quick test_reader_subset_of_worker;
+          test_case "Worker ⊂ Admin" `Quick test_worker_subset_of_admin;
+        ] );
+      ( "role_boundaries",
+        [
+          test_case "Reader denies admin_only" `Quick
+            test_reader_denies_admin_only_tools;
+          test_case "Worker denies admin_only" `Quick
+            test_worker_denies_admin_only_tools;
+          test_case "Admin allows admin_only" `Quick
+            test_admin_allows_admin_only_tools;
+          test_case "Reader denies worker_only" `Quick
+            test_reader_denies_worker_only_tools;
+          test_case "Worker allows worker_only" `Quick
+            test_worker_allows_worker_only_tools;
+        ] );
+      ( "integrity",
+        [
+          test_case "admin_only count" `Quick test_admin_only_count;
+          test_case "worker_only count" `Quick test_worker_only_count;
+          test_case "no overlap admin/worker" `Quick
+            test_no_overlap_admin_worker;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- 3개 독립 권한 소스를 단일 `Tool_access_policy` 기반 퍼널로 통합
- `tool_access_role.ml`: `policy_for_role(Reader/Worker/Admin)` → `Tool_access_policy.t`
- `auth.ml`: `resolve_role` + `authorize_tool_v2` 추가
- 모든 인가 call site를 `authorize_tool_v2`로 전환
- `Tool_permissions` pre-hook 제거 (admin 체크는 정책에 흡수)
- `keeper_exec_tools.filter_by_access`에서 redundant `is_keeper_denied` 제거

## Architecture

```
Before: 3 independent paths
  auth.ml (85-line match → 17 permissions → role check)
  tool_permissions.ml (admin Hashtbl → capability pre-hook)
  keeper_exec_tools.ml (keeper_denied Hashtbl → schema filter)

After: single funnel
  resolve_role(config, agent, token) → role
  policy_for_role(role) → Tool_access_policy.t
  allows_name(policy, tool_name) → bool
```

## Dependencies
- Builds on #4387 (Phase 1B: Inter/Diff selector variants)
- Part of #4381 (Tool Gate architecture meta)

## Test plan
- [x] 등가성 테스트: 모든 도구 x 모든 역할에 대해 old == new (3 tests)
- [x] 계층 테스트: Reader ⊂ Worker ⊂ Admin (2 tests)
- [x] 역할 경계: admin_only/worker_only 도구 접근 차단/허용 (5 tests)
- [x] 무결성: 도구 목록 개수, admin/worker 비중첩 (3 tests)
- [x] 기존 45개 policy 테스트 regression 없음
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)