### PR TITLE
fix(tool,gc): preserve reason field + clarify dual-write comment

### DIFF
--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -94,9 +94,10 @@ let cleanup_zombies
               Log.Gc.warn "removing broken agent file %s: %s" name err;
               (try
                  delete_path config path;
-                 (* delete_path only removes the backend entry for dual-write
-                    backends; the local mirror file must be removed separately
-                    to prevent repeated GC warnings on each scan cycle. *)
+                 (* delete_path removes the entry from the configured backend.
+                    For non-filesystem backends that dual-write a local mirror
+                    (should_dual_write_local), explicitly remove the local file
+                    as well to avoid repeated GC warnings on each scan cycle. *)
                  (try Sys.remove path with Sys_error _ -> ())
                with exn ->
                  Log.Gc.warn "failed to remove broken agent %s: %s"

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -464,6 +464,7 @@ let () =
   List.iter
     (fun (s : Types.tool_schema) ->
       let is_destructive = List.mem s.name _tool_spec_hidden_destructive in
+      let existing = Tool_catalog.metadata s.name in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -475,5 +476,6 @@ let () =
            ~visibility:(if is_destructive then Tool_catalog.Hidden else Tool_catalog.Default)
            ~is_destructive
            ~allow_direct_call_when_hidden:is_destructive
+           ?reason:existing.reason
            ()))
     schemas

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -380,6 +380,7 @@ let () =
     (fun (s : tool_schema) ->
       let is_destructive = List.mem s.name _tool_spec_hidden_destructive in
       let is_hidden = List.mem s.name _tool_spec_hidden || is_destructive in
+      let existing = Tool_catalog.metadata s.name in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -392,5 +393,6 @@ let () =
            ~visibility:(if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
            ~is_destructive
            ~allow_direct_call_when_hidden:is_hidden
+           ?reason:existing.reason
            ()))
     schemas


### PR DESCRIPTION
## Summary
- 머지된 PR (#4375, #4389)의 미대응 Copilot 코멘트 4건 처리

## Changes

| 대상 PR | 파일 | 수정 |
|---------|------|------|
| #4375 | tool_operator.ml | `Tool_catalog.metadata`에서 기존 `reason` 읽어 `Tool_spec.create`에 전달 |
| #4375 | tool_council_oas.ml | 동일 — `masc_execute`의 reason 보존 |
| #4389 | room_gc.ml | docstring 정정: "backend entry only" → "dual-write local mirror" 명확화 |

## Why
`Tool_spec.register`가 `Tool_catalog.register_metadata`를 호출하면서 `reason=None`으로 기존 `explicit_metadata`의 reason 문자열을 덮어씀. 이 문자열은 governance risk classification에서 사용됨.

## Validation
- [x] `dune build` — 에러 없음
- [ ] CI green