### PR TITLE
feat(dispatch): Tool_token smart constructor for I/O boundary parse

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -352,6 +352,7 @@
    tool_schema_dsl
    tool_result
    tool_spec
+   tool_token
    tool_dispatch
    tool_input_validation
    tool_tag_init

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -1070,7 +1070,14 @@ let execute_keeper_tool_call
       | Some err ->
           Yojson.Safe.to_string (`Assoc [ ("error", `String err) ])
       | None ->
-      let result = Tool_dispatch.dispatch ~name ~args in
+      (match Tool_dispatch.mint_token ~name with
+       | Error reason ->
+           Yojson.Safe.to_string
+             (`Assoc [ ("error", `String "unregistered_masc_tool");
+                       ("tool", `String name);
+                       ("reason", `String reason) ])
+       | Ok token ->
+      let result = Tool_dispatch.dispatch ~token ~args in
       (match result with
         | Some (true, msg) -> msg
         | Some (false, msg) ->
@@ -1078,7 +1085,7 @@ let execute_keeper_tool_call
         | None ->
             Yojson.Safe.to_string
               (`Assoc [ ("error", `String "unregistered_masc_tool");
-                        ("tool", `String name) ])))
+                        ("tool", `String name) ]))))
   | other ->
       Yojson.Safe.to_string
         (`Assoc [ ("error", `String "unknown_tool"); ("tool", `String other) ])

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -628,14 +628,17 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
      Validate). If mint fails, the tool is truly unknown. *)
   match Tool_dispatch.mint_token ~name with
   | Error reason ->
-    (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
+      (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
   | Ok _token ->
-  let tag_result =
-    match Tool_dispatch.lookup_tag name with
-    | Some tag -> dispatch_by_tag tag
-    | None -> None
-  in
-  match tag_result with
-  | Some result -> result
-  | None ->
-    (false, Printf.sprintf "Unknown tool: %s (no tag after mint)" name)
+      (* Token proves the name is registered. lookup_tag None is defensive:
+         both mint_token and lookup_tag check tag_registry, so None here
+         would indicate a registration inconsistency, not a user error. *)
+      let tag_result =
+        match Tool_dispatch.lookup_tag name with
+        | Some tag -> dispatch_by_tag tag
+        | None -> None
+      in
+      (match tag_result with
+       | Some result -> result
+       | None ->
+           (false, Printf.sprintf "Unknown tool: %s (no tag after mint)" name))

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -623,9 +623,13 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_inline_dispatch.dispatch inline_ctx ~name
   in
 
-  (* Primary dispatch: O(1) tag lookup → lazy context creation.
-     All known tools are registered in the tag registry (via register_module_tag
-     or Tool_tag_init). If lookup_tag returns None, the tool is truly unknown. *)
+  (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
+     Tool_token validates the name exists in the tag registry (Parse, Don't
+     Validate). If mint fails, the tool is truly unknown. *)
+  match Tool_dispatch.mint_token ~name with
+  | Error reason ->
+    (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
+  | Ok _token ->
   let tag_result =
     match Tool_dispatch.lookup_tag name with
     | Some tag -> dispatch_by_tag tag
@@ -634,4 +638,4 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   match tag_result with
   | Some result -> result
   | None ->
-    (false, Printf.sprintf "Unknown tool: %s" name)
+    (false, Printf.sprintf "Unknown tool: %s (no tag after mint)" name)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -129,6 +129,11 @@ let ensure_agent_joined ~(config : Room.config) ~(agent_name : string) =
 
 let dispatch_supported_tool ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
+  (* Mint token at team-session I/O boundary (Parse, Don't Validate). *)
+  match Tool_dispatch.mint_token ~name with
+  | Error reason ->
+    (false, Printf.sprintf "team-session: unknown tool '%s' (%s)" name reason)
+  | Ok _token ->
   let agent_name =
     match string_field "agent_name" args with
     | Some agent_name -> agent_name

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -41,7 +41,8 @@ let register_module ~(schemas : Types.tool_schema list) ~(handler : handler) =
     found, [None] when the tool name is unknown to the registry.
     Handler exceptions are caught and returned as error tuples so the
     caller gets a consistent result shape. *)
-let dispatch ~name ~args : (bool * string) option =
+let dispatch ~(token : Tool_token.t) ~args : (bool * string) option =
+  let name = token.name in
   match Hashtbl.find_opt registry name with
   | Some handler -> (
       try handler ~name ~args
@@ -105,13 +106,14 @@ let run_post_hooks result =
     and the pre-hook's result is returned directly.
 
     Returns [None] when the tool is unknown to the registry. *)
-let dispatch_structured ~name ~args : Tool_result.t option =
+let dispatch_structured ~(token : Tool_token.t) ~args : Tool_result.t option =
+  let name = token.name in
   (* Pre-hooks: may short-circuit *)
   match run_pre_hooks ~name ~args with
   | Some _ as blocked -> blocked
   | None ->
     let start_time = Time_compat.now () in
-    (match dispatch ~name ~args with
+    (match dispatch ~token ~args with
      | Some (success, message) ->
        let result = Tool_result.wrap ~tool_name:name ~start_time (success, message) in
        Some (run_post_hooks result)
@@ -195,3 +197,11 @@ let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_regis
 
 let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> tag_registry_initialized := true)
 let is_tag_registry_initialized () = with_dispatch_ro (fun () -> !tag_registry_initialized)
+
+(** Mint a [Tool_token.t] validated against both tag and handler registries.
+    Checks tag_registry first (primary), falls back to handler registry.
+    Convenience wrapper for callers without direct table access. *)
+let mint_token ~name =
+  Tool_token.mint_with
+    ~validate:(fun n -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
+    ~name

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -19,9 +19,14 @@ val register_module : schemas:Types.tool_schema list -> handler:handler -> unit
 
 (** {1 Dispatch} *)
 
-val dispatch : name:string -> args:Yojson.Safe.t -> (bool * string) option
-(** O(1) dispatch. Returns [Some (success, message)] when a handler is
-    found, [None] when the tool name is unknown to the registry. *)
+val dispatch : token:Tool_token.t -> args:Yojson.Safe.t -> (bool * string) option
+(** O(1) dispatch using a validated token. Returns [Some (success, message)]
+    when a handler is found, [None] when the tool name is unknown.
+    The token guarantees the name was validated at the I/O boundary. *)
+
+val mint_token : name:string -> (Tool_token.t, string) result
+(** Mint a [Tool_token.t] validated against both tag and handler registries.
+    Returns [Error] when the tool name is unknown to the dispatch system. *)
 
 (** {2 Dispatch Hooks}
 
@@ -49,9 +54,10 @@ val run_pre_hooks : name:string -> args:Yojson.Safe.t -> Tool_result.t option
 (** Execute registered pre-hooks in order.
     Returns the first short-circuit result, if any. *)
 
-val dispatch_structured : name:string -> args:Yojson.Safe.t -> Tool_result.t option
+val dispatch_structured : token:Tool_token.t -> args:Yojson.Safe.t -> Tool_result.t option
 (** Structured dispatch with hook support.
-    Execution order: pre-hooks -> handler -> post-hooks. *)
+    Execution order: pre-hooks -> handler -> post-hooks.
+    Requires a validated [Tool_token.t]. *)
 
 (** {1 Feature Flag and Introspection} *)
 

--- a/lib/tool_token.ml
+++ b/lib/tool_token.ml
@@ -1,0 +1,13 @@
+(** Tool_token — parse-once proof that a tool name exists in a dispatch table.
+
+    See [tool_token.mli] for API documentation. *)
+
+type t = { name : string; minted_at : float }
+
+let mint_with ~validate ~name =
+  if validate name then
+    Ok { name; minted_at = Unix.gettimeofday () }
+  else
+    Error (Printf.sprintf "not in current tool set: %s" name)
+
+let mint ~tbl ~name = mint_with ~validate:(Hashtbl.mem tbl) ~name

--- a/lib/tool_token.mli
+++ b/lib/tool_token.mli
@@ -1,0 +1,21 @@
+(** Tool_token — parse-once proof that a tool name exists in a dispatch table.
+
+    [private] type: fields are readable but construction requires [mint].
+    This enforces "Parse, Don't Validate" at I/O boundaries — callers
+    must validate the tool name once at entry, then pass the token
+    instead of a raw string.
+
+    Phase 1A of Tool Gate architecture (#4381). *)
+
+type t = private { name : string; minted_at : float }
+(** Immutable token. [name] is the validated tool name.
+    [minted_at] is [Unix.gettimeofday ()] at mint time (diagnostic). *)
+
+val mint : tbl:(string, 'a) Hashtbl.t -> name:string -> (t, string) result
+(** [mint ~tbl ~name] returns [Ok token] when [name] is a key in [tbl],
+    [Error "not in current tool set: <name>"] otherwise. *)
+
+val mint_with : validate:(string -> bool) -> name:string -> (t, string) result
+(** [mint_with ~validate ~name] returns [Ok token] when [validate name] is
+    [true]. Use when the validation source is not a single Hashtbl
+    (e.g., checking multiple registries). *)

--- a/test/dune
+++ b/test/dune
@@ -56,6 +56,7 @@
         test_tool_tier
         test_tool_access_policy
         test_tool_access_role
+        test_tool_token
         test_tool_budget
         test_tool_exposure
         test_code_swarm
@@ -111,6 +112,7 @@
           test_tool_tier
           test_tool_access_policy
         test_tool_access_role
+          test_tool_token
           test_tool_budget
           test_tool_exposure
           test_code_swarm

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -375,9 +375,9 @@ let test_allowlist_gates_shard_tools () =
 
 let test_dispatch_unregistered () =
   let result =
-    Masc_mcp.Tool_dispatch.dispatch ~name:"masc_nonexistent_xyz" ~args:(`Assoc [])
+    Masc_mcp.Tool_dispatch.mint_token ~name:"masc_nonexistent_xyz"
   in
-  Alcotest.(check bool) "unregistered returns None" true (result = None)
+  Alcotest.(check bool) "unregistered mint_token returns Error" true (Result.is_error result)
 
 let test_schemas_match_names () =
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -24,17 +24,18 @@ let () =
           test_case "register single tool and dispatch" `Quick (fun () ->
               let tool = "__test_dispatch_single" in
               Tool_dispatch.register ~tool_name:tool ~handler:echo_handler;
-              let result = Tool_dispatch.dispatch ~name:tool ~args:`Null in
+              let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
+              let result = Tool_dispatch.dispatch ~token ~args:`Null in
               check bool "found" true (Option.is_some result);
               let (ok, msg) = Option.get result in
               check bool "success" true ok;
               check string "message" ("ok:" ^ tool) msg);
-          test_case "dispatch unknown tool returns None" `Quick (fun () ->
+          test_case "mint_token unknown tool returns Error" `Quick (fun () ->
               let result =
-                Tool_dispatch.dispatch
-                  ~name:"__test_dispatch_nonexistent_xyz" ~args:`Null
+                Tool_dispatch.mint_token
+                  ~name:"__test_dispatch_nonexistent_xyz"
               in
-              check bool "not found" true (Option.is_none result));
+              check bool "is Error" true (Result.is_error result));
           test_case "register_module bulk registers" `Quick (fun () ->
               let schemas =
                 List.map make_schema
@@ -47,8 +48,9 @@ let () =
                     (Tool_dispatch.is_registered name))
                 [ "__test_bulk_a"; "__test_bulk_b"; "__test_bulk_c" ]);
           test_case "register_module dispatches each name" `Quick (fun () ->
+              let token = match Tool_dispatch.mint_token ~name:"__test_bulk_b" with Ok t -> t | Error e -> Alcotest.fail e in
               let result =
-                Tool_dispatch.dispatch ~name:"__test_bulk_b" ~args:`Null
+                Tool_dispatch.dispatch ~token ~args:`Null
               in
               let (ok, msg) = Option.get result in
               check bool "ok" true ok;
@@ -59,13 +61,15 @@ let () =
           test_case "re-register replaces handler" `Quick (fun () ->
               let tool = "__test_dispatch_replace" in
               Tool_dispatch.register ~tool_name:tool ~handler:echo_handler;
+              let token1 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let (ok1, _) =
-                Option.get (Tool_dispatch.dispatch ~name:tool ~args:`Null)
+                Option.get (Tool_dispatch.dispatch ~token:token1 ~args:`Null)
               in
               check bool "first ok" true ok1;
               Tool_dispatch.register ~tool_name:tool ~handler:fail_handler;
+              let token2 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let (ok2, msg2) =
-                Option.get (Tool_dispatch.dispatch ~name:tool ~args:`Null)
+                Option.get (Tool_dispatch.dispatch ~token:token2 ~args:`Null)
               in
               check bool "replaced fail" false ok2;
               check string "fail msg" "fail" msg2);
@@ -133,7 +137,8 @@ let () =
               in
               Tool_dispatch.register ~tool_name:tool ~handler:capture_handler;
               let test_args = `Assoc [("key", `String "value")] in
-              let _ = Tool_dispatch.dispatch ~name:tool ~args:test_args in
+              let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
+              let _ = Tool_dispatch.dispatch ~token ~args:test_args in
               check bool "args match" true (!received_args = test_args));
         ] );
       ( "handler_exception_safety",
@@ -144,7 +149,8 @@ let () =
                 failwith "boom"
               in
               Tool_dispatch.register ~tool_name:tool ~handler:throwing_handler;
-              let result = Tool_dispatch.dispatch ~name:tool ~args:`Null in
+              let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
+              let result = Tool_dispatch.dispatch ~token ~args:`Null in
               check bool "still returns Some" true (Option.is_some result);
               let (ok, msg) = Option.get result in
               check bool "marked as failure" false ok;

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -2,6 +2,7 @@
 
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
+module Tool_token = Masc_mcp.Tool_token
 
 (* Track hook execution order *)
 let call_log : string list ref = ref []
@@ -24,7 +25,8 @@ let test_pre_hook_observes () =
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     None);
-  let result = Tool_dispatch.dispatch_structured ~name:"__hook_test" ~args:`Null in
+  let token = match Tool_dispatch.mint_token ~name:"__hook_test" with Ok t -> t | Error e -> Alcotest.fail e in
+  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
   (* Pre-hook ran, then handler *)
   Alcotest.(check (list string)) "execution order"
     ["pre"; "handler"] !call_log;
@@ -43,7 +45,8 @@ let test_pre_hook_short_circuits () =
            data = `String "blocked";
            tool_name = name;
            duration_ms = 0.0 });
-  let result = Tool_dispatch.dispatch_structured ~name:"__hook_blocked" ~args:`Null in
+  let token = match Tool_dispatch.mint_token ~name:"__hook_blocked" with Ok t -> t | Error e -> Alcotest.fail e in
+  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
   (* Handler should NOT have been called *)
   Alcotest.(check (list string)) "only pre ran" ["pre_block"] !call_log;
   match result with
@@ -74,7 +77,8 @@ let test_multiple_pre_hooks_first_wins () =
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre3";
     None);
-  let _ = Tool_dispatch.dispatch_structured ~name:"__hook_multi" ~args:`Null in
+  let token = match Tool_dispatch.mint_token ~name:"__hook_multi" with Ok t -> t | Error e -> Alcotest.fail e in
+  let _ = Tool_dispatch.dispatch_structured ~token ~args:`Null in
   (* pre1 passes, pre2 blocks, pre3 and handler never called *)
   Alcotest.(check (list string)) "chain stops at blocker"
     ["pre1"; "pre2_block"] !call_log
@@ -91,7 +95,8 @@ let test_post_hook_observes () =
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post";
     r);
-  let result = Tool_dispatch.dispatch_structured ~name:"__hook_post" ~args:`Null in
+  let token = match Tool_dispatch.mint_token ~name:"__hook_post" with Ok t -> t | Error e -> Alcotest.fail e in
+  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
   Alcotest.(check (list string)) "handler then post"
     ["handler"; "post"] !call_log;
   match result with
@@ -106,7 +111,8 @@ let test_post_hook_transforms () =
       Some (true, "original"));
   Tool_dispatch.register_post_hook (fun r ->
     { r with Tool_result.data = `String "transformed" });
-  match Tool_dispatch.dispatch_structured ~name:"__hook_transform" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"__hook_transform" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     (match r.data with
      | `String "transformed" -> ()
@@ -125,7 +131,8 @@ let test_post_hooks_chain () =
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post2";
     { r with Tool_result.data = `String "2" });
-  match Tool_dispatch.dispatch_structured ~name:"__hook_chain" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"__hook_chain" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check (list string)) "post order" ["post1"; "post2"] !call_log;
     (match r.data with
@@ -148,7 +155,8 @@ let test_full_lifecycle () =
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post";
     r);
-  let _ = Tool_dispatch.dispatch_structured ~name:"__hook_full" ~args:`Null in
+  let token = match Tool_dispatch.mint_token ~name:"__hook_full" with Ok t -> t | Error e -> Alcotest.fail e in
+  let _ = Tool_dispatch.dispatch_structured ~token ~args:`Null in
   Alcotest.(check (list string)) "pre → handler → post"
     ["pre"; "handler"; "post"] !call_log
 
@@ -158,7 +166,8 @@ let test_no_hooks_default () =
   Tool_dispatch.register
     ~tool_name:"__hook_none"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "plain"));
-  match Tool_dispatch.dispatch_structured ~name:"__hook_none" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "success" true r.success;
     Alcotest.(check string) "tool_name" "__hook_none" r.tool_name
@@ -167,17 +176,16 @@ let test_no_hooks_default () =
 let test_unknown_tool_skips_hooks () =
   setup ();
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
-    log_call "pre_should_run";
+    log_call "pre_should_not_run";
     None);
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post_should_not_run";
     r);
-  match Tool_dispatch.dispatch_structured ~name:"__nonexistent_hook" ~args:`Null with
-  | None ->
-    (* Pre-hook runs (it doesn't know the tool is missing), post-hook does not *)
-    Alcotest.(check (list string)) "only pre ran"
-      ["pre_should_run"] !call_log
-  | Some _ -> Alcotest.fail "should be None for unknown tool"
+  match Tool_dispatch.mint_token ~name:"__nonexistent_hook" with
+  | Error _ ->
+    (* mint_token rejects unregistered tools; no hooks run *)
+    Alcotest.(check (list string)) "no hooks ran" [] !call_log
+  | Ok _ -> Alcotest.fail "mint_token should return Error for unknown tool"
 
 let () =
   Alcotest.run "Tool_hooks" [

--- a/test/test_tool_permissions.ml
+++ b/test/test_tool_permissions.ml
@@ -74,8 +74,8 @@ let test_hook_blocks_admin_no_identity () =
     ~tool_name:"masc_tool_admin_update"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "should not reach"));
   Tool_permissions.install ~get_agent_name:(fun () -> None);
-  match Tool_dispatch.dispatch_structured
-          ~name:"masc_tool_admin_update" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"masc_tool_admin_update" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "blocked" false r.success
   | None -> Alcotest.fail "expected Some from short-circuit"
@@ -87,8 +87,8 @@ let test_hook_blocks_admin_no_cap () =
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "should not reach"));
   Tool_permissions.set_capability_checker (fun _agent _cap -> false);
   Tool_permissions.install ~get_agent_name:(fun () -> Some "normal");
-  match Tool_dispatch.dispatch_structured
-          ~name:"masc_tool_admin_update" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"masc_tool_admin_update" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "blocked" false r.success
   | None -> Alcotest.fail "expected Some from short-circuit"
@@ -100,8 +100,8 @@ let test_hook_allows_admin_with_cap () =
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "allowed"));
   Tool_permissions.set_capability_checker (fun _agent cap -> cap = "admin");
   Tool_permissions.install ~get_agent_name:(fun () -> Some "admin_agent");
-  match Tool_dispatch.dispatch_structured
-          ~name:"masc_tool_admin_update" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"masc_tool_admin_update" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "allowed" true r.success
   | None -> Alcotest.fail "expected Some"
@@ -112,7 +112,8 @@ let test_hook_allows_non_admin () =
     ~tool_name:"masc_status"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "ok"));
   Tool_permissions.install ~get_agent_name:(fun () -> Some "anyone");
-  match Tool_dispatch.dispatch_structured ~name:"masc_status" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"masc_status" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "allowed" true r.success
   | None -> Alcotest.fail "expected Some"
@@ -125,8 +126,9 @@ let test_hook_uses_agent_name_from_args () =
   Tool_permissions.set_capability_checker
     (fun agent cap -> String.equal agent "admin_agent" && cap = "admin");
   Tool_permissions.install ~get_agent_name:(fun () -> None);
+  let token = match Tool_dispatch.mint_token ~name:"masc_autoresearch_start" with Ok t -> t | Error e -> Alcotest.fail e in
   match
-    Tool_dispatch.dispatch_structured ~name:"masc_autoresearch_start"
+    Tool_dispatch.dispatch_structured ~token
       ~args:(`Assoc [ ("agent_name", `String "admin_agent") ])
   with
   | Some r ->

--- a/test/test_tool_permissions_exhaustive.ml
+++ b/test/test_tool_permissions_exhaustive.ml
@@ -64,7 +64,8 @@ let test_dispatch_blocks_all_admin_no_identity () =
     Tool_dispatch.register ~tool_name
       ~handler:(fun ~name:_ ~args:_ -> Some (true, "should not reach"));
     Tool_permissions.install ~get_agent_name:(fun () -> None);
-    match Tool_dispatch.dispatch_structured ~name:tool_name ~args:`Null with
+    let token = match Tool_dispatch.mint_token ~name:tool_name with Ok t -> t | Error e -> Alcotest.fail e in
+    match Tool_dispatch.dispatch_structured ~token ~args:`Null with
     | Some r ->
       Alcotest.(check bool)
         (tool_name ^ " blocked at dispatch")
@@ -104,7 +105,8 @@ let test_non_admin_dispatch_passthrough () =
     Tool_dispatch.register ~tool_name
       ~handler:(fun ~name:_ ~args:_ -> Some (true, "reached handler"));
     Tool_permissions.install ~get_agent_name:(fun () -> Some "regular_agent");
-    match Tool_dispatch.dispatch_structured ~name:tool_name ~args:`Null with
+    let token = match Tool_dispatch.mint_token ~name:tool_name with Ok t -> t | Error e -> Alcotest.fail e in
+    match Tool_dispatch.dispatch_structured ~token ~args:`Null with
     | Some r ->
       Alcotest.(check bool)
         (tool_name ^ " handler reached")

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -85,7 +85,8 @@ let test_dispatch_structured () =
   Tool_dispatch.register
     ~tool_name:"__test_tool"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, {|{"result":"ok"}|}));
-  match Tool_dispatch.dispatch_structured ~name:"__test_tool" ~args:`Null with
+  let token = match Tool_dispatch.mint_token ~name:"__test_tool" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->
     Alcotest.(check bool) "success" true r.success;
     Alcotest.(check string) "tool_name" "__test_tool" r.tool_name;
@@ -93,9 +94,9 @@ let test_dispatch_structured () =
   | None -> Alcotest.fail "dispatch_structured returned None for registered tool"
 
 let test_dispatch_structured_unknown () =
-  match Tool_dispatch.dispatch_structured ~name:"__nonexistent" ~args:`Null with
-  | None -> ()
-  | Some _ -> Alcotest.fail "should return None for unknown tool"
+  match Tool_dispatch.mint_token ~name:"__nonexistent" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "mint_token should return Error for unknown tool"
 
 let () =
   Alcotest.run "Tool_result" [

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -1,0 +1,135 @@
+(** Tests for Tool_token — private type, mint validation, dispatch integration. *)
+
+open Alcotest
+open Masc_mcp
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_tbl entries =
+  let tbl = Hashtbl.create (List.length entries) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) entries;
+  tbl
+
+let empty_tbl = make_tbl []
+let full_tbl = make_tbl [ "masc_status"; "masc_heartbeat"; "masc_tasks" ]
+
+(* ================================================================ *)
+(* mint — table variant                                              *)
+(* ================================================================ *)
+
+let test_mint_success () =
+  match Tool_token.mint ~tbl:full_tbl ~name:"masc_status" with
+  | Ok token ->
+    check string "name preserved" "masc_status" token.name;
+    check bool "minted_at > 0" true (token.minted_at > 0.0)
+  | Error e -> fail e
+
+let test_mint_failure () =
+  match Tool_token.mint ~tbl:empty_tbl ~name:"any" with
+  | Error msg ->
+    check bool "contains tool name" true
+      (String.length msg > 0 && Astring.String.is_infix ~affix:"any" msg)
+  | Ok _ -> fail "expected Error for empty table"
+
+let test_mint_unknown_tool () =
+  match Tool_token.mint ~tbl:full_tbl ~name:"masc_nonexistent_xyz" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for unknown tool"
+
+(* ================================================================ *)
+(* mint_with — validate variant                                      *)
+(* ================================================================ *)
+
+let test_mint_with_success () =
+  let validate name = name = "allowed" in
+  match Tool_token.mint_with ~validate ~name:"allowed" with
+  | Ok token -> check string "name" "allowed" token.name
+  | Error e -> fail e
+
+let test_mint_with_failure () =
+  let validate _ = false in
+  match Tool_token.mint_with ~validate ~name:"denied" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error when validate returns false"
+
+(* ================================================================ *)
+(* Token properties                                                  *)
+(* ================================================================ *)
+
+let test_token_name_readable () =
+  match Tool_token.mint ~tbl:full_tbl ~name:"masc_heartbeat" with
+  | Ok token ->
+    (* Private type: fields are readable *)
+    check string "name field" "masc_heartbeat" token.name;
+    check bool "minted_at is recent" true
+      (token.minted_at > 0.0 && token.minted_at <= Unix.gettimeofday () +. 1.0)
+  | Error e -> fail e
+
+(* Private type: { name = "fake"; minted_at = 0. } would be a compile error.
+   This is a structural guarantee, not a runtime test.
+   Uncomment below to verify:
+
+   let _compile_error = { Tool_token.name = "fake"; minted_at = 0. }
+*)
+
+(* ================================================================ *)
+(* Tool_dispatch.mint_token integration                              *)
+(* ================================================================ *)
+
+let test_mint_token_registered () =
+  let tool = "__test_token_registered" in
+  Tool_dispatch.register ~tool_name:tool
+    ~handler:(fun ~name:_ ~args:_ -> Some (true, "ok"));
+  match Tool_dispatch.mint_token ~name:tool with
+  | Ok token -> check string "name" tool token.name
+  | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
+
+let test_mint_token_unregistered () =
+  match Tool_dispatch.mint_token ~name:"__test_token_definitely_not_registered" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for unregistered tool"
+
+let test_dispatch_with_token () =
+  let tool = "__test_token_dispatch" in
+  Tool_dispatch.register ~tool_name:tool
+    ~handler:(fun ~name ~args:_ -> Some (true, "dispatched:" ^ name));
+  match Tool_dispatch.mint_token ~name:tool with
+  | Error e -> fail e
+  | Ok token ->
+    match Tool_dispatch.dispatch ~token ~args:`Null with
+    | Some (true, msg) ->
+      check string "dispatch result" ("dispatched:" ^ tool) msg
+    | Some (false, msg) -> fail ("dispatch returned false: " ^ msg)
+    | None -> fail "dispatch returned None for minted token"
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  run "Tool_token"
+    [
+      ( "mint",
+        [
+          test_case "success" `Quick test_mint_success;
+          test_case "empty table" `Quick test_mint_failure;
+          test_case "unknown tool" `Quick test_mint_unknown_tool;
+        ] );
+      ( "mint_with",
+        [
+          test_case "validate true" `Quick test_mint_with_success;
+          test_case "validate false" `Quick test_mint_with_failure;
+        ] );
+      ( "token_properties",
+        [
+          test_case "fields readable" `Quick test_token_name_readable;
+        ] );
+      ( "dispatch_integration",
+        [
+          test_case "mint_token registered" `Quick test_mint_token_registered;
+          test_case "mint_token unregistered" `Quick test_mint_token_unregistered;
+          test_case "dispatch with token" `Quick test_dispatch_with_token;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `Tool_token.t` (private type) — `mint`를 통해서만 생성 가능. I/O 경계에서 "Parse, Don't Validate" 적용
- `Tool_dispatch.dispatch` / `dispatch_structured` 시그니처 변경: `~name:string` → `~token:Tool_token.t`
- 3개 I/O boundary에서 mint: MCP execute, keeper catch-all, team session bridge

## Product impact
Tool Gate architecture (#4381)의 Phase 1A. dispatch 시그니처를 강화하여 등록되지 않은 도구 호출을 I/O 경계에서 차단. LLM hallucination 루프 방지.

## Evidence
- 9개 신규 테스트 (mint success/failure, properties, dispatch integration)
- 기존 96개 관련 테스트 전부 통과 (dispatch, hooks, permissions, access_role, keeper bridge)
- GLM-5.1 교차 리뷰 완료: 2건 수정(indentation, defensive comment), 나머지 N/A

## Review evidence
- Cross-model: GLM-5.1 via `sb glm-text` (2026-04-01)
- 7 findings: 2 addressed (style), 5 N/A (theoretical concerns for Phase 1A scope)

## Linked issue
Refs #4383, #4381

## Design

```ocaml
(* tool_token.mli *)
type t = private { name : string; minted_at : float }
val mint : tbl:(string, 'a) Hashtbl.t -> name:string -> (t, string) result
val mint_with : validate:(string -> bool) -> name:string -> (t, string) result
```

- `private` type: 필드 읽기 허용, 직접 생성은 컴파일 타임 차단
- `mint_with`: 복수 registry 검증 등 유연한 사용
- `Tool_dispatch.mint_token`: tag + handler 양쪽 registry 검사

## Changed files

| File | Change |
|------|--------|
| `lib/tool_token.ml` + `.mli` | NEW: private type + mint + mint_with |
| `lib/tool_dispatch.ml` + `.mli` | dispatch/dispatch_structured → ~token, mint_token 추가 |
| `lib/mcp_server_eio_execute.ml` | MCP I/O boundary mint |
| `lib/keeper/keeper_exec_tools.ml` | Keeper catch-all mint |
| `lib/team_session/team_session_oas_bridge.ml` | Team session entry mint |
| `test/test_tool_token.ml` | NEW: 9 tests |
| 5 existing test files | ~name → ~token signature adaptation |

## Test plan
- [x] `test_tool_token.exe` — 9/9
- [x] `test_tool_dispatch.exe` — 14/14
- [x] `test_tool_hooks.exe` — 9/9
- [x] `test_tool_result.exe` — 8/8
- [x] `test_tool_permissions.exe` — 10/10
- [x] `test_tool_permissions_exhaustive.exe` — 7/7
- [x] `test_tool_access_role.exe` — 15/15
- [x] `test_keeper_masc_bridge.exe` — 24/24
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)