### PR TITLE
feat(compact): add large-context cloud strategy branch

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -382,6 +382,7 @@ let observation_summary = function
     - High context + multi-agent: aggressive compaction (preserve coordination)
     - High context + single task: summarize old + drop low importance
     - Small local model: prefer pruning (cheaper, faster)
+    - Large-context cloud (>= 500K): quality-preserving with summarization
     - Normal: standard DropLowImportance *)
 let default_dynamic_selector (obs : observation_context) : strategy list =
   if obs.context_ratio >= 0.80 && obs.active_agent_count > 1 then
@@ -393,6 +394,9 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
   else if obs.is_local_model && obs.context_window < 32_000 then
     (* Small local models: lightweight compaction only *)
     [PruneToolOutputs; MergeContiguous]
+  else if obs.context_window >= 500_000 then
+    (* Large-context cloud: invest in quality-preserving strategies *)
+    [DropLowImportance; SummarizeOld]
   else
     (* Default: importance-based *)
     [DropLowImportance]

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -268,6 +268,28 @@ let test_dynamic_small_local_model () =
   check (list string) "small local strategies"
     ["PruneToolOutputs"; "MergeContiguous"] names
 
+let test_dynamic_large_context_cloud () =
+  let obs : Compact.observation_context = {
+    context_ratio = 0.50; active_agent_count = 1;
+    unclaimed_task_count = 0; is_single_focused_task = false;
+    context_window = 1_000_000; is_local_model = false } in
+  let resolved = Compact.resolve_strategies ~obs:(Some obs)
+    [Compact.Dynamic Compact.default_dynamic_selector] in
+  let names = strategy_names resolved in
+  check (list string) "large context cloud strategies"
+    ["DropLowImportance"; "SummarizeOld"] names
+
+let test_dynamic_medium_cloud_default () =
+  let obs : Compact.observation_context = {
+    context_ratio = 0.50; active_agent_count = 1;
+    unclaimed_task_count = 0; is_single_focused_task = false;
+    context_window = 128_000; is_local_model = false } in
+  let resolved = Compact.resolve_strategies ~obs:(Some obs)
+    [Compact.Dynamic Compact.default_dynamic_selector] in
+  let names = strategy_names resolved in
+  check (list string) "medium cloud default strategies"
+    ["DropLowImportance"] names
+
 let test_dynamic_no_observation () =
   let resolved = Compact.resolve_strategies ~obs:None
     [Compact.Dynamic Compact.default_dynamic_selector] in
@@ -306,6 +328,8 @@ let () =
       test_case "high pressure multi-agent" `Quick test_dynamic_high_pressure_multi_agent;
       test_case "single focused task" `Quick test_dynamic_single_focused_task;
       test_case "small local model" `Quick test_dynamic_small_local_model;
+      test_case "large context cloud" `Quick test_dynamic_large_context_cloud;
+      test_case "medium cloud default" `Quick test_dynamic_medium_cloud_default;
       test_case "no observation fallback" `Quick test_dynamic_no_observation;
     ];
   ]


### PR DESCRIPTION
## Summary

- Models with `context_window >= 500K` (opus, sonnet-4.x, gpt-4.1, gemini) now get `[DropLowImportance; SummarizeOld]` instead of plain `[DropLowImportance]`
- Leverages abundant context budget for quality-preserving compaction with summarization
- Builds on the `observation_context` typed fields already on main

## Test plan

- [x] `dune build @all` — clean build
- [x] `test_context_compact_oas_coverage.exe` — 20/20 tests pass (2 new: large context cloud, medium cloud default)
- [x] GLM cross-model review
- [ ] CI green