### PR TITLE
fix(oas_worker): always generate checkpoint regardless of checkpoint_dir

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -351,19 +351,16 @@ let run
         (r, None)
     in
     (match proof_ref with Some ref_ -> ref_ := proof | None -> ());
-    let checkpoint = match config.checkpoint_dir with
-      | Some dir ->
-        let ckpt = build_checkpoint ~session_id ?working_context:config.working_context agent in
-        (try persist_checkpoint ~dir ~session_id ckpt
-         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-           Log.Misc.error "oas_worker: Checkpoint save failed: %s"
-             (Printexc.to_string exn));
-        Some ckpt
-      | None ->
-        Option.map
-          (fun _ ->
-            build_checkpoint ~session_id ?working_context:config.working_context agent)
-          config.working_context
+    let checkpoint =
+      let ckpt = build_checkpoint ~session_id ?working_context:config.working_context agent in
+      (match config.checkpoint_dir with
+       | Some dir ->
+         (try persist_checkpoint ~dir ~session_id ckpt
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+            Log.Misc.error "oas_worker: Checkpoint save failed: %s"
+              (Printexc.to_string exn))
+       | None -> ());
+      Some ckpt
     in
     Option.iter (fun bus ->
       let status = match result with Ok _ -> "completed" | Error _ -> "failed" in


### PR DESCRIPTION
## Summary

- `Oas_worker.run`에서 `checkpoint_dir`이 없고 `working_context`도 없으면 checkpoint가 `None`으로 반환되던 문제 수정
- 모든 keeper에서 "missing OAS checkpoint after run" 경고 발생의 근본 원인
- 항상 메모리에서 checkpoint를 생성하되, disk 저장은 `checkpoint_dir` 설정 시에만 수행

## Root Cause

`oas_worker.ml` line 362-366:
```ocaml
| None ->
    Option.map (fun _ -> build_checkpoint ...) config.working_context
```
`working_context = None`이면 checkpoint도 `None`. keeper_agent_run은 `~working_context`를 전달하지 않았음.

## Fix

항상 `build_checkpoint`를 호출하여 `Some ckpt`를 반환. 결정론적 연산 — agent state에서 순수 계산.

## Test plan

- [x] `dune build` 통과
- [x] `test_oas_worker` 34/34 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)