### PR TITLE
feat(board): enforce TTL retention for automation posts and author cap (#3657)

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -83,8 +83,40 @@ let sweep store =
       Hashtbl.remove store.comments cid
     ) expired_comments;
 
+    (* Author cap enforcement: evict oldest posts from authors exceeding the cap *)
+    let cap_evicted = ref 0 in
+    if Limits.author_post_cap > 0 then begin
+      let author_posts = Hashtbl.create 64 in
+      Hashtbl.iter (fun _ (post : post) ->
+        let key = Agent_id.to_string post.author in
+        let existing = Hashtbl.find_opt author_posts key |> Option.value ~default:[] in
+        Hashtbl.replace author_posts key (post :: existing)
+      ) store.posts;
+      Hashtbl.iter (fun _author posts ->
+        if List.length posts > Limits.author_post_cap then begin
+          let sorted = List.sort (fun (a : post) (b : post) ->
+            compare a.created_at b.created_at
+          ) posts in
+          let excess = List.length sorted - Limits.author_post_cap in
+          let rec take_first n = function
+            | _ when n <= 0 -> []
+            | [] -> []
+            | x :: xs -> x :: take_first (n - 1) xs
+          in
+          let to_evict = take_first excess sorted in
+          List.iter (fun (post : post) ->
+            let id = Post_id.to_string post.id in
+            Hashtbl.remove store.posts id;
+            Hashtbl.remove store.comments_by_post id;
+            decr store.post_count;
+            incr cap_evicted
+          ) to_evict
+        end
+      ) author_posts
+    end;
+
     (* Invalidate caches if anything was swept *)
-    if !removed_posts > 0 then invalidate_post_caches store;
+    if !removed_posts > 0 || !cap_evicted > 0 then invalidate_post_caches store;
     if !removed_comments > 0 then invalidate_comment_caches store;
 
     store.last_sweep <- now;
@@ -443,7 +475,15 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
   | Error e -> Error e
   | Ok author_id ->
 
-  let ttl = if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours in
+  let ttl =
+    match post_kind with
+    | Automation_post | System_post ->
+        let forced = Limits.automation_ttl_hours in
+        if ttl_hours = 0 then forced
+        else min ttl_hours forced
+    | Human_post ->
+        if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
+  in
 
   (* Normalize hearth: lowercase + trim *)
   let hearth = Option.map (fun h -> String.lowercase_ascii (String.trim h)) hearth in
@@ -701,7 +741,15 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
           Error (Capacity_exceeded { current = post_comment_count; max = Limits.max_comments_per_post })
         else begin
           let now = Time_compat.now () in
-          let ttl = if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours in
+          let ttl =
+            match post.post_kind with
+            | Automation_post | System_post ->
+                let forced = Limits.automation_ttl_hours in
+                if ttl_hours = 0 then forced
+                else min ttl_hours forced
+            | Human_post ->
+                if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
+          in
           let comment = {
             id = Comment_id.generate ();
             post_id = pid;

--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -223,7 +223,15 @@ let create_post t ~author ~content ?title ?body ~post_kind ?meta_json
   match Agent_id.of_string author with
   | Error e -> Error e
   | Ok author_id ->
-  let ttl = if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours in
+  let ttl =
+    match post_kind with
+    | Automation_post | System_post ->
+        let forced = Limits.automation_ttl_hours in
+        if ttl_hours = 0 then forced
+        else min ttl_hours forced
+    | Human_post ->
+        if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
+  in
   let hearth = Option.map (fun h -> String.lowercase_ascii (String.trim h)) hearth in
   let now = Time_compat.now () in
   let expires_at = if ttl = 0 then 0.0 else now +. (float_of_int ttl *. 3600.0) in
@@ -354,9 +362,20 @@ let add_comment t ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.defaul
   ) t.pool with
   | Error err -> Error (caqti_err err)
   | Ok None -> Error (Post_not_found post_id)
-  | Ok (Some _) ->
+  | Ok (Some row) ->
+  (match post_of_row row with
+   | None -> Error (Validation_error "Corrupt parent post")
+   | Some parent_post ->
   let now = Time_compat.now () in
-  let ttl = if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours in
+  let ttl =
+    match parent_post.post_kind with
+    | Automation_post | System_post ->
+        let forced = Limits.automation_ttl_hours in
+        if ttl_hours = 0 then forced
+        else min ttl_hours forced
+    | Human_post ->
+        if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
+  in
   let comment = {
     id = Comment_id.generate ();
     post_id = pid;
@@ -388,6 +407,7 @@ let add_comment t ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.defaul
         author = Agent_id.to_string author_id
       });
       Ok comment
+  )
 
 let get_comments t ~post_id =
   match Post_id.of_string post_id with
@@ -717,7 +737,13 @@ let sweep t =
     let module C = (val conn : Caqti_eio.CONNECTION) in
     let* posts_removed = C.find sweep_posts_q Limits.sweeper_batch_size in
     let* comments_removed = C.find sweep_comments_q Limits.sweeper_batch_size in
-    Ok (posts_removed, comments_removed)
+    let* cap_evicted =
+      if Limits.author_post_cap > 0 then
+        C.find sweep_author_cap_q Limits.author_post_cap
+      else Ok 0
+    in
+    let total_posts = posts_removed + cap_evicted in
+    Ok (total_posts, comments_removed)
   ) t.pool with
   | Ok (p, c) -> (p, c)
   | Error err ->

--- a/lib/board_pg_queries.ml
+++ b/lib/board_pg_queries.ml
@@ -327,6 +327,22 @@ let sweep_posts_q =
      ) RETURNING 1 \
    ) SELECT COUNT(*)::int FROM deleted"
 
+(** Author cap enforcement: delete oldest posts from authors exceeding the cap.
+    $1 = author_post_cap limit. *)
+let sweep_author_cap_q =
+  (Caqti_type.int ->! Caqti_type.int)
+  "WITH ranked AS ( \
+     SELECT id, author, \
+       ROW_NUMBER() OVER (PARTITION BY author ORDER BY created_at ASC) as rn, \
+       COUNT(*) OVER (PARTITION BY author) as total \
+     FROM masc_board_posts \
+   ), to_delete AS ( \
+     DELETE FROM masc_board_posts \
+     WHERE id IN ( \
+       SELECT id FROM ranked WHERE total > $1 AND rn <= total - $1 \
+     ) RETURNING 1 \
+   ) SELECT COUNT(*)::int FROM to_delete"
+
 let sweep_comments_q =
   (Caqti_type.int ->! Caqti_type.int)
   "WITH deleted AS ( \

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -158,9 +158,11 @@ module Limits = struct
   let max_comments_per_post = 1_000
   let max_content_length = 4_000
   let default_ttl_hours = 0    (* 0 = permanent (no expiry) *)
+  let automation_ttl_hours = 168 (* 7 days for Automation_post / System_post *)
   let max_ttl_hours = 720      (* 30 days max; ignored when ttl=0 *)
   let sweeper_interval_sec = 10  (* Much more aggressive than OpenClaw's 60s *)
   let sweeper_batch_size = 100   (* Backpressure: don't delete too many at once *)
+  let author_post_cap = 100     (* Max active posts per author; oldest auto-expired *)
 end
 
 (** {1 Vote Direction} *)


### PR DESCRIPTION
## Summary
- Force 7-day TTL for `Automation_post` and `System_post` (previously unlimited when `ttl_hours=0`)
- Add `author_post_cap=100` limit: oldest posts auto-evicted when author exceeds cap
- Apply TTL inheritance for comments based on parent post kind
- Both JSONL and PG backends updated with parallel logic
- PG sweep query uses `ROW_NUMBER() OVER (PARTITION BY author)` for efficient author cap enforcement

Closes #3657 (Phase 1)

## Test plan
- [ ] Verify automation/system posts get forced 7-day TTL even when `ttl_hours=0`
- [ ] Verify human posts remain permanent when `ttl_hours=0`
- [ ] Verify sweeper evicts oldest posts when author exceeds 100 cap
- [ ] Verify comments inherit TTL from parent post kind
- [ ] Run `dune build @install` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)