### PR TITLE
feat(dispatch): Tool_gate ADT for algebraic tool set operations

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -286,6 +286,7 @@
    tool_bridge
    tool_cache
    tool_access_policy
+   tool_gate
    tool_access_role
    tool_tempo
    tool_portal

--- a/lib/tool_gate.ml
+++ b/lib/tool_gate.ml
@@ -47,6 +47,7 @@ let normalize names =
 (* ================================================================ *)
 
 let rec apply op current =
+  let current = normalize current in
   match op with
   | Keep_all -> current
   | Clear_all -> []
@@ -56,7 +57,7 @@ let rec apply op current =
         normalize names
         |> List.filter (fun n -> not (Hashtbl.mem set n))
       in
-      dedupe_keep_order (current @ new_names)
+      current @ new_names
   | Remove names ->
       let rm = set_of_list (normalize names) in
       List.filter (fun n -> not (Hashtbl.mem rm n)) current
@@ -101,15 +102,17 @@ let rec inverse op =
 (* ================================================================ *)
 
 let compose ops =
-  let rec flatten = function
-    | [] -> []
-    | Seq inner :: rest -> flatten inner @ flatten rest
-    | Keep_all :: rest -> flatten rest
-    | Add [] :: rest -> flatten rest
-    | Remove [] :: rest -> flatten rest
-    | op :: rest -> op :: flatten rest
+  let rec flatten acc = function
+    | [] -> acc
+    | Seq inner :: rest ->
+        let acc = flatten acc inner in
+        flatten acc rest
+    | Keep_all :: rest -> flatten acc rest
+    | Add [] :: rest -> flatten acc rest
+    | Remove [] :: rest -> flatten acc rest
+    | op :: rest -> flatten (op :: acc) rest
   in
-  match flatten ops with
+  match List.rev (flatten [] ops) with
   | [] -> Keep_all
   | [ x ] -> x
   | many -> Seq many

--- a/lib/tool_gate.ml
+++ b/lib/tool_gate.ml
@@ -1,0 +1,174 @@
+(** Tool_gate — algebraic tool set operations for zone boundaries.
+    Phase 2A of Tool Gate architecture (#4381). *)
+
+type tool_op =
+  | Keep_all
+  | Clear_all
+  | Add of string list
+  | Remove of string list
+  | Replace_with of string list
+  | Intersect_with of string list
+  | Seq of tool_op list
+
+type inverse_result =
+  | Reversible of tool_op
+  | Irreversible
+
+(* ================================================================ *)
+(* Local helpers                                                     *)
+(* Copied from tool_access_policy.ml (module-private there).         *)
+(* Same Hashtbl-based O(n) pattern.                                  *)
+(* ================================================================ *)
+
+let set_of_list names =
+  let tbl = Hashtbl.create (List.length names) in
+  List.iter (fun n -> Hashtbl.replace tbl n ()) names;
+  tbl
+
+let dedupe_keep_order names =
+  let seen = Hashtbl.create (max 16 (List.length names)) in
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | n :: rest when Hashtbl.mem seen n -> loop acc rest
+    | n :: rest ->
+        Hashtbl.replace seen n ();
+        loop (n :: acc) rest
+  in
+  loop [] names
+
+let normalize names =
+  names
+  |> List.map String.trim
+  |> List.filter (fun n -> n <> "")
+  |> dedupe_keep_order
+
+(* ================================================================ *)
+(* apply                                                             *)
+(* ================================================================ *)
+
+let rec apply op current =
+  match op with
+  | Keep_all -> current
+  | Clear_all -> []
+  | Add names ->
+      let set = set_of_list current in
+      let new_names =
+        normalize names
+        |> List.filter (fun n -> not (Hashtbl.mem set n))
+      in
+      dedupe_keep_order (current @ new_names)
+  | Remove names ->
+      let rm = set_of_list (normalize names) in
+      List.filter (fun n -> not (Hashtbl.mem rm n)) current
+  | Replace_with names -> normalize names
+  | Intersect_with names ->
+      let keep = set_of_list (normalize names) in
+      List.filter (fun n -> Hashtbl.mem keep n) current
+  | Seq ops ->
+      List.fold_left (fun acc op -> apply op acc) current ops
+
+(* ================================================================ *)
+(* inverse                                                           *)
+(* ================================================================ *)
+
+let rec inverse op =
+  match op with
+  | Keep_all -> Reversible Keep_all
+  | Clear_all -> Irreversible
+  | Add names -> Reversible (Remove names)
+  | Remove names -> Reversible (Add names)
+  | Replace_with _ -> Irreversible
+  | Intersect_with _ -> Irreversible
+  | Seq ops ->
+      let rev_inverses =
+        List.fold_left
+          (fun acc op ->
+            match acc with
+            | None -> None
+            | Some invs -> (
+                match inverse op with
+                | Reversible inv -> Some (inv :: invs)
+                | Irreversible -> None))
+          (Some []) ops
+      in
+      (match rev_inverses with
+       | Some invs -> Reversible (Seq invs)
+       | None -> Irreversible)
+
+(* ================================================================ *)
+(* compose                                                           *)
+(* ================================================================ *)
+
+let compose ops =
+  let rec flatten = function
+    | [] -> []
+    | Seq inner :: rest -> flatten inner @ flatten rest
+    | Keep_all :: rest -> flatten rest
+    | Add [] :: rest -> flatten rest
+    | Remove [] :: rest -> flatten rest
+    | op :: rest -> op :: flatten rest
+  in
+  match flatten ops with
+  | [] -> Keep_all
+  | [ x ] -> x
+  | many -> Seq many
+
+(* ================================================================ *)
+(* predicates                                                        *)
+(* ================================================================ *)
+
+let rec is_identity = function
+  | Keep_all -> true
+  | Add names -> normalize names = []
+  | Remove names -> normalize names = []
+  | Seq ops -> List.for_all is_identity ops
+  | Clear_all | Replace_with _ | Intersect_with _ -> false
+
+let rec is_irreversible = function
+  | Clear_all | Replace_with _ | Intersect_with _ -> true
+  | Keep_all | Add _ | Remove _ -> false
+  | Seq ops -> List.exists is_irreversible ops
+
+(* ================================================================ *)
+(* serialization                                                     *)
+(* ================================================================ *)
+
+let names_to_json names = `List (List.map (fun n -> `String n) names)
+
+let rec to_yojson = function
+  | Keep_all -> `Assoc [("op", `String "keep_all")]
+  | Clear_all -> `Assoc [("op", `String "clear_all")]
+  | Add names -> `Assoc [("op", `String "add"); ("names", names_to_json names)]
+  | Remove names -> `Assoc [("op", `String "remove"); ("names", names_to_json names)]
+  | Replace_with names ->
+      `Assoc [("op", `String "replace_with"); ("names", names_to_json names)]
+  | Intersect_with names ->
+      `Assoc [("op", `String "intersect_with"); ("names", names_to_json names)]
+  | Seq ops ->
+      `Assoc [("op", `String "seq"); ("ops", `List (List.map to_yojson ops))]
+
+let inverse_result_to_yojson = function
+  | Reversible op -> `Assoc [("reversible", to_yojson op)]
+  | Irreversible -> `Assoc [("irreversible", `Bool true)]
+
+(* ================================================================ *)
+(* equal                                                             *)
+(* ================================================================ *)
+
+let sort_dedup names =
+  names |> normalize |> List.sort String.compare
+
+let rec equal a b =
+  match (a, b) with
+  | Keep_all, Keep_all -> true
+  | Clear_all, Clear_all -> true
+  | Add a_names, Add b_names -> sort_dedup a_names = sort_dedup b_names
+  | Remove a_names, Remove b_names -> sort_dedup a_names = sort_dedup b_names
+  | Replace_with a_names, Replace_with b_names ->
+      sort_dedup a_names = sort_dedup b_names
+  | Intersect_with a_names, Intersect_with b_names ->
+      sort_dedup a_names = sort_dedup b_names
+  | Seq a_ops, Seq b_ops ->
+      List.length a_ops = List.length b_ops
+      && List.for_all2 equal a_ops b_ops
+  | _ -> false

--- a/lib/tool_gate.ml
+++ b/lib/tool_gate.ml
@@ -173,6 +173,6 @@ let rec equal a b =
   | Intersect_with a_names, Intersect_with b_names ->
       sort_dedup a_names = sort_dedup b_names
   | Seq a_ops, Seq b_ops ->
-      List.length a_ops = List.length b_ops
+      List.compare_lengths a_ops b_ops = 0
       && List.for_all2 equal a_ops b_ops
   | _ -> false

--- a/lib/tool_gate.ml
+++ b/lib/tool_gate.ml
@@ -92,6 +92,7 @@ let rec inverse op =
           (Some []) ops
       in
       (match rev_inverses with
+       | Some [] -> Reversible Keep_all
        | Some invs -> Reversible (Seq invs)
        | None -> Irreversible)
 

--- a/lib/tool_gate.ml
+++ b/lib/tool_gate.ml
@@ -137,7 +137,8 @@ let rec is_irreversible = function
 (* serialization                                                     *)
 (* ================================================================ *)
 
-let names_to_json names = `List (List.map (fun n -> `String n) names)
+let names_to_json names =
+  `List (List.map (fun n -> `String n) (normalize names))
 
 let rec to_yojson = function
   | Keep_all -> `Assoc [("op", `String "keep_all")]

--- a/lib/tool_gate.mli
+++ b/lib/tool_gate.mli
@@ -25,7 +25,12 @@ type inverse_result =
 (** {1 Core Operations} *)
 
 val apply : tool_op -> string list -> string list
-(** Apply op to a tool set. Result is deduplicated, order-preserving. *)
+(** Apply [op] to a tool-name set.
+
+    Names are normalized: surrounding whitespace is trimmed, entries that
+    are empty after trimming are discarded. The same normalization is applied
+    to both the input set and any names embedded in [op]. The resulting set
+    is deduplicated while preserving first-occurrence order. *)
 
 val inverse : tool_op -> inverse_result
 (** Compute algebraic inverse. Structural -- does NOT need the current set.

--- a/lib/tool_gate.mli
+++ b/lib/tool_gate.mli
@@ -1,0 +1,79 @@
+(** Tool_gate — algebraic tool set operations for zone boundaries.
+
+    Phase 2A of Tool Gate architecture (#4381).
+    Pure module: no side effects, no runtime state, no external deps.
+
+    Transforms concrete tool name sets (string list), unlike
+    [Tool_access_policy.selector] which operates as a membership predicate
+    over a candidate universe. See #4381 for the distinction. *)
+
+(** Operations that transform a tool name set. *)
+type tool_op =
+  | Keep_all                      (** Identity -- no change *)
+  | Clear_all                     (** Empty the set *)
+  | Add of string list            (** Set union: current U names *)
+  | Remove of string list         (** Set difference: current \ names *)
+  | Replace_with of string list   (** Replace entire set *)
+  | Intersect_with of string list (** Set intersection: current ∩ names *)
+  | Seq of tool_op list           (** Sequential composition (fold_left) *)
+
+(** Result of computing an algebraic inverse. *)
+type inverse_result =
+  | Reversible of tool_op
+  | Irreversible                  (** Original destroyed information *)
+
+(** {1 Core Operations} *)
+
+val apply : tool_op -> string list -> string list
+(** Apply op to a tool set. Result is deduplicated, order-preserving. *)
+
+val inverse : tool_op -> inverse_result
+(** Compute algebraic inverse. Structural -- does NOT need the current set.
+
+    {b Precondition for roundtrip correctness}: the op must have been
+    effectively applied (not a no-op on the set). Specifically,
+    [Remove names] roundtrip only holds if all [names] were in the set.
+    If [Remove ["b"]] is applied to [["a"]] (no-op), the inverse
+    [Add ["b"]] will ADD "b" -- a phantom addition / privilege escalation.
+    Phase 2B's zone_tbl uses snapshot-based restore as SSOT;
+    inverse is an optimization hint only.
+
+    Inverse mapping:
+    - [Keep_all] -> [Reversible Keep_all]
+    - [Clear_all] -> [Irreversible]
+    - [Add names] -> [Reversible (Remove names)]
+    - [Remove names] -> [Reversible (Add names)]
+    - [Replace_with _] -> [Irreversible]
+    - [Intersect_with _] -> [Irreversible]
+    - [Seq ops] -> [Reversible (Seq (rev-map inverse))] if ALL reversible *)
+
+(** {1 Composition} *)
+
+val compose : tool_op list -> tool_op
+(** Smart [Seq] constructor.
+    - [[]] -> [Keep_all]
+    - [[x]] -> [x]
+    - Nested [Seq] recursively flattened (arbitrary depth).
+    - Identity ops ([Keep_all], [Add []], [Remove []]) eliminated. *)
+
+(** {1 Predicates} *)
+
+val is_identity : tool_op -> bool
+(** [Keep_all], [Add []], [Remove []], [Seq] of all identities (recursive). *)
+
+val is_irreversible : tool_op -> bool
+(** [Clear_all], [Replace_with], [Intersect_with],
+    or [Seq] containing any irreversible op. *)
+
+(** {1 Serialization} *)
+
+val to_yojson : tool_op -> Yojson.Safe.t
+val inverse_result_to_yojson : inverse_result -> Yojson.Safe.t
+
+(** {1 Comparison} *)
+
+val equal : tool_op -> tool_op -> bool
+(** Structural equality with name normalization (trim + sort + dedup).
+    Compares normalized structure, NOT apply semantics.
+    [Add ["a";"b"]] and [Add ["b";"a"]] are equal;
+    [Add ["a"]] and [Seq [Add ["a"]]] are NOT. *)

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_metrics_rotation
         test_tool_tier
         test_tool_access_policy
+        test_tool_gate
         test_tool_access_role
         test_tool_token
         test_tool_budget
@@ -111,6 +112,7 @@
           test_metrics_rotation
           test_tool_tier
           test_tool_access_policy
+          test_tool_gate
         test_tool_access_role
           test_tool_token
           test_tool_budget

--- a/test/dune
+++ b/test/dune
@@ -113,7 +113,7 @@
           test_tool_tier
           test_tool_access_policy
           test_tool_gate
-        test_tool_access_role
+          test_tool_access_role
           test_tool_token
           test_tool_budget
           test_tool_exposure

--- a/test/test_tool_gate.ml
+++ b/test/test_tool_gate.ml
@@ -1,0 +1,399 @@
+(** Tests for Tool_gate — algebraic tool set operations. *)
+
+open Alcotest
+open Masc_mcp
+open Tool_gate
+
+let sl = list string
+
+(** Compare as sorted sets (order-independent). *)
+let check_set_eq msg expected actual =
+  let sort = List.sort String.compare in
+  check sl msg (sort expected) (sort actual)
+
+(* ================================================================ *)
+(* apply — basic                                                     *)
+(* ================================================================ *)
+
+let base = ["a"; "b"; "c"]
+
+let test_apply_keep_all () =
+  check sl "identity" base (Tool_gate.apply Keep_all base)
+
+let test_apply_clear_all () =
+  check sl "empty" [] (Tool_gate.apply Clear_all base)
+
+let test_apply_add () =
+  check sl "union" ["a"; "b"; "c"; "d"]
+    (Tool_gate.apply (Add ["d"]) base)
+
+let test_apply_add_duplicate () =
+  check sl "no dup" ["a"; "b"; "c"]
+    (Tool_gate.apply (Add ["a"]) base)
+
+let test_apply_add_empty () =
+  check sl "identity" base
+    (Tool_gate.apply (Add []) base)
+
+let test_apply_remove () =
+  check sl "diff" ["a"; "c"]
+    (Tool_gate.apply (Remove ["b"]) base)
+
+let test_apply_remove_absent () =
+  check sl "no change" base
+    (Tool_gate.apply (Remove ["x"]) base)
+
+let test_apply_remove_empty () =
+  check sl "identity" base
+    (Tool_gate.apply (Remove []) base)
+
+let test_apply_replace_with () =
+  check sl "replaced" ["x"; "y"]
+    (Tool_gate.apply (Replace_with ["x"; "y"]) base)
+
+let test_apply_replace_with_empty () =
+  check sl "empty" []
+    (Tool_gate.apply (Replace_with []) base)
+
+let test_apply_intersect () =
+  check sl "intersection" ["a"; "c"]
+    (Tool_gate.apply (Intersect_with ["a"; "c"; "z"]) base)
+
+let test_apply_intersect_empty () =
+  check sl "empty" []
+    (Tool_gate.apply (Intersect_with []) base)
+
+let test_apply_intersect_disjoint () =
+  check sl "empty" []
+    (Tool_gate.apply (Intersect_with ["x"; "y"]) base)
+
+let test_apply_seq () =
+  check sl "sequential"
+    ["a"; "c"; "d"]
+    (Tool_gate.apply (Seq [Remove ["b"]; Add ["d"]]) base)
+
+let test_apply_seq_empty () =
+  check sl "identity" base
+    (Tool_gate.apply (Seq []) base)
+
+(* apply on empty input *)
+let test_apply_add_to_empty () =
+  check sl "add to empty" ["x"]
+    (Tool_gate.apply (Add ["x"]) [])
+
+let test_apply_remove_from_empty () =
+  check sl "remove from empty" []
+    (Tool_gate.apply (Remove ["x"]) [])
+
+let test_apply_intersect_on_empty () =
+  check sl "intersect empty" []
+    (Tool_gate.apply (Intersect_with ["x"]) [])
+
+(* whitespace / dedup normalization *)
+let test_apply_add_whitespace () =
+  check sl "trimmed" ["a"; "b"; "c"; "d"]
+    (Tool_gate.apply (Add [" d "; "d"]) base)
+
+(* ================================================================ *)
+(* inverse                                                           *)
+(* ================================================================ *)
+
+let test_inverse_keep_all () =
+  match Tool_gate.inverse Keep_all with
+  | Reversible Keep_all -> ()
+  | _ -> fail "expected Reversible Keep_all"
+
+let test_inverse_clear_all () =
+  match Tool_gate.inverse Clear_all with
+  | Irreversible -> ()
+  | _ -> fail "expected Irreversible"
+
+let test_inverse_add () =
+  match Tool_gate.inverse (Add ["x"; "y"]) with
+  | Reversible (Remove names) ->
+      check sl "inverse names" ["x"; "y"] names
+  | _ -> fail "expected Reversible Remove"
+
+let test_inverse_remove () =
+  match Tool_gate.inverse (Remove ["x"]) with
+  | Reversible (Add names) ->
+      check sl "inverse names" ["x"] names
+  | _ -> fail "expected Reversible Add"
+
+let test_inverse_replace_with () =
+  match Tool_gate.inverse (Replace_with ["x"]) with
+  | Irreversible -> ()
+  | _ -> fail "expected Irreversible"
+
+let test_inverse_intersect_with () =
+  match Tool_gate.inverse (Intersect_with ["x"]) with
+  | Irreversible -> ()
+  | _ -> fail "expected Irreversible"
+
+let test_inverse_seq_reversible () =
+  let op = Seq [Add ["x"]; Remove ["y"]] in
+  match Tool_gate.inverse op with
+  | Reversible (Seq [Add ["y"]; Remove ["x"]]) -> ()
+  | Reversible other ->
+      fail (Printf.sprintf "unexpected: %s"
+        (Yojson.Safe.to_string (Tool_gate.to_yojson other)))
+  | Irreversible -> fail "expected Reversible Seq"
+
+let test_inverse_seq_irreversible () =
+  let op = Seq [Add ["x"]; Clear_all] in
+  match Tool_gate.inverse op with
+  | Irreversible -> ()
+  | _ -> fail "expected Irreversible"
+
+(* roundtrip: apply inverse undoes effective op *)
+let test_roundtrip_add () =
+  let original = ["a"; "b"] in
+  let op = Add ["c"; "d"] in
+  let modified = Tool_gate.apply op original in
+  match Tool_gate.inverse op with
+  | Reversible inv ->
+      let restored = Tool_gate.apply inv modified in
+      check sl "roundtrip" original restored
+  | Irreversible -> fail "Add should be reversible"
+
+let test_roundtrip_remove () =
+  let original = ["a"; "b"; "c"] in
+  let op = Remove ["b"] in
+  let modified = Tool_gate.apply op original in
+  match Tool_gate.inverse op with
+  | Reversible inv ->
+      let restored = Tool_gate.apply inv modified in
+      (* Roundtrip preserves set membership, not insertion order.
+         Add appends to the end, so "b" moves from position 1 to end. *)
+      check_set_eq "roundtrip set" original restored
+  | Irreversible -> fail "Remove should be reversible"
+
+(* Documented limitation: phantom addition when Remove is a no-op *)
+let test_roundtrip_phantom () =
+  let original = ["a"] in
+  let op = Remove ["b"] in
+  let modified = Tool_gate.apply op original in
+  check sl "no-op remove" ["a"] modified;
+  match Tool_gate.inverse op with
+  | Reversible inv ->
+      let restored = Tool_gate.apply inv modified in
+      (* This is the documented phantom: "b" was never in original *)
+      check sl "phantom addition" ["a"; "b"] restored;
+      check bool "not equal to original" false (original = restored)
+  | Irreversible -> fail "Remove should be reversible"
+
+(* ================================================================ *)
+(* compose                                                           *)
+(* ================================================================ *)
+
+let test_compose_empty () =
+  check bool "Keep_all" true
+    (Tool_gate.equal (Tool_gate.compose []) Keep_all)
+
+let test_compose_single () =
+  let op = Add ["x"] in
+  check bool "unwrap" true
+    (Tool_gate.equal (Tool_gate.compose [op]) op)
+
+let test_compose_flatten () =
+  let result = Tool_gate.compose [Seq [Add ["a"]; Add ["b"]]; Remove ["c"]] in
+  match result with
+  | Seq [Add _; Add _; Remove _] -> ()
+  | _ -> fail (Printf.sprintf "expected flat Seq, got %s"
+    (Yojson.Safe.to_string (Tool_gate.to_yojson result)))
+
+let test_compose_identity_elimination () =
+  let op = Remove ["x"] in
+  let result = Tool_gate.compose [Keep_all; op; Keep_all] in
+  check bool "unwrap" true (Tool_gate.equal result op)
+
+let test_compose_all_identity () =
+  let result = Tool_gate.compose [Add []; Remove []] in
+  check bool "Keep_all" true (Tool_gate.equal result Keep_all)
+
+let test_compose_deep_flatten () =
+  let result = Tool_gate.compose [Seq [Seq [Add ["a"]]]; Remove ["b"]] in
+  match result with
+  | Seq [Add _; Remove _] -> ()
+  | _ -> fail (Printf.sprintf "expected deep flatten, got %s"
+    (Yojson.Safe.to_string (Tool_gate.to_yojson result)))
+
+(* ================================================================ *)
+(* is_identity                                                       *)
+(* ================================================================ *)
+
+let test_is_identity_keep_all () =
+  check bool "Keep_all" true (Tool_gate.is_identity Keep_all)
+
+let test_is_identity_add_empty () =
+  check bool "Add []" true (Tool_gate.is_identity (Add []))
+
+let test_is_identity_remove_empty () =
+  check bool "Remove []" true (Tool_gate.is_identity (Remove []))
+
+let test_is_identity_intersect_empty () =
+  check bool "Intersect_with [] is NOT identity" false
+    (Tool_gate.is_identity (Intersect_with []))
+
+let test_is_identity_add_nonempty () =
+  check bool "Add [x]" false (Tool_gate.is_identity (Add ["x"]))
+
+let test_is_identity_seq_recursive () =
+  check bool "Seq of identities" true
+    (Tool_gate.is_identity (Seq [Keep_all; Add []; Remove []]))
+
+let test_is_identity_seq_mixed () =
+  check bool "Seq with non-identity" false
+    (Tool_gate.is_identity (Seq [Keep_all; Add ["x"]]))
+
+(* ================================================================ *)
+(* is_irreversible                                                   *)
+(* ================================================================ *)
+
+let test_is_irreversible_clear () =
+  check bool "Clear_all" true (Tool_gate.is_irreversible Clear_all)
+
+let test_is_irreversible_add () =
+  check bool "Add" false (Tool_gate.is_irreversible (Add ["x"]))
+
+let test_is_irreversible_replace () =
+  check bool "Replace_with" true (Tool_gate.is_irreversible (Replace_with ["x"]))
+
+let test_is_irreversible_intersect () =
+  check bool "Intersect_with" true (Tool_gate.is_irreversible (Intersect_with ["x"]))
+
+let test_is_irreversible_seq () =
+  check bool "Seq with Clear_all" true
+    (Tool_gate.is_irreversible (Seq [Add ["x"]; Clear_all]))
+
+let test_is_irreversible_seq_ok () =
+  check bool "Seq all reversible" false
+    (Tool_gate.is_irreversible (Seq [Add ["x"]; Remove ["y"]]))
+
+(* ================================================================ *)
+(* equal                                                             *)
+(* ================================================================ *)
+
+let test_equal_add_order () =
+  check bool "normalized" true
+    (Tool_gate.equal (Add ["a"; "b"]) (Add ["b"; "a"]))
+
+let test_equal_structural () =
+  check bool "different structure" false
+    (Tool_gate.equal (Add ["a"]) (Seq [Add ["a"]]))
+
+let test_equal_keep_all () =
+  check bool "same" true
+    (Tool_gate.equal Keep_all Keep_all)
+
+let test_equal_different_variant () =
+  check bool "different" false
+    (Tool_gate.equal (Add ["a"]) (Remove ["a"]))
+
+(* ================================================================ *)
+(* to_yojson                                                         *)
+(* ================================================================ *)
+
+let test_to_yojson_keep_all () =
+  let json = Tool_gate.to_yojson Keep_all in
+  match json with
+  | `Assoc [("op", `String "keep_all")] -> ()
+  | _ -> fail "unexpected JSON"
+
+let test_to_yojson_seq () =
+  let json = Tool_gate.to_yojson (Seq [Add ["a"]; Remove ["b"]]) in
+  match json with
+  | `Assoc [("op", `String "seq"); ("ops", `List [_; _])] -> ()
+  | _ -> fail "unexpected JSON"
+
+let test_inverse_result_to_yojson () =
+  let json = Tool_gate.inverse_result_to_yojson Irreversible in
+  match json with
+  | `Assoc [("irreversible", `Bool true)] -> ()
+  | _ -> fail "unexpected JSON"
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  run "Tool_gate"
+    [
+      ( "apply",
+        [
+          test_case "Keep_all" `Quick test_apply_keep_all;
+          test_case "Clear_all" `Quick test_apply_clear_all;
+          test_case "Add" `Quick test_apply_add;
+          test_case "Add duplicate" `Quick test_apply_add_duplicate;
+          test_case "Add empty" `Quick test_apply_add_empty;
+          test_case "Remove" `Quick test_apply_remove;
+          test_case "Remove absent" `Quick test_apply_remove_absent;
+          test_case "Remove empty" `Quick test_apply_remove_empty;
+          test_case "Replace_with" `Quick test_apply_replace_with;
+          test_case "Replace_with empty" `Quick test_apply_replace_with_empty;
+          test_case "Intersect_with" `Quick test_apply_intersect;
+          test_case "Intersect_with empty" `Quick test_apply_intersect_empty;
+          test_case "Intersect_with disjoint" `Quick test_apply_intersect_disjoint;
+          test_case "Seq" `Quick test_apply_seq;
+          test_case "Seq empty" `Quick test_apply_seq_empty;
+          test_case "Add to empty" `Quick test_apply_add_to_empty;
+          test_case "Remove from empty" `Quick test_apply_remove_from_empty;
+          test_case "Intersect on empty" `Quick test_apply_intersect_on_empty;
+          test_case "Add whitespace" `Quick test_apply_add_whitespace;
+        ] );
+      ( "inverse",
+        [
+          test_case "Keep_all" `Quick test_inverse_keep_all;
+          test_case "Clear_all" `Quick test_inverse_clear_all;
+          test_case "Add" `Quick test_inverse_add;
+          test_case "Remove" `Quick test_inverse_remove;
+          test_case "Replace_with" `Quick test_inverse_replace_with;
+          test_case "Intersect_with" `Quick test_inverse_intersect_with;
+          test_case "Seq reversible" `Quick test_inverse_seq_reversible;
+          test_case "Seq irreversible" `Quick test_inverse_seq_irreversible;
+          test_case "roundtrip Add" `Quick test_roundtrip_add;
+          test_case "roundtrip Remove" `Quick test_roundtrip_remove;
+          test_case "roundtrip phantom" `Quick test_roundtrip_phantom;
+        ] );
+      ( "compose",
+        [
+          test_case "empty" `Quick test_compose_empty;
+          test_case "single" `Quick test_compose_single;
+          test_case "flatten" `Quick test_compose_flatten;
+          test_case "identity elimination" `Quick test_compose_identity_elimination;
+          test_case "all identity" `Quick test_compose_all_identity;
+          test_case "deep flatten" `Quick test_compose_deep_flatten;
+        ] );
+      ( "is_identity",
+        [
+          test_case "Keep_all" `Quick test_is_identity_keep_all;
+          test_case "Add []" `Quick test_is_identity_add_empty;
+          test_case "Remove []" `Quick test_is_identity_remove_empty;
+          test_case "Intersect_with []" `Quick test_is_identity_intersect_empty;
+          test_case "Add nonempty" `Quick test_is_identity_add_nonempty;
+          test_case "Seq recursive" `Quick test_is_identity_seq_recursive;
+          test_case "Seq mixed" `Quick test_is_identity_seq_mixed;
+        ] );
+      ( "is_irreversible",
+        [
+          test_case "Clear_all" `Quick test_is_irreversible_clear;
+          test_case "Add" `Quick test_is_irreversible_add;
+          test_case "Replace_with" `Quick test_is_irreversible_replace;
+          test_case "Intersect_with" `Quick test_is_irreversible_intersect;
+          test_case "Seq with irreversible" `Quick test_is_irreversible_seq;
+          test_case "Seq all reversible" `Quick test_is_irreversible_seq_ok;
+        ] );
+      ( "equal",
+        [
+          test_case "Add order" `Quick test_equal_add_order;
+          test_case "structural" `Quick test_equal_structural;
+          test_case "Keep_all" `Quick test_equal_keep_all;
+          test_case "different variant" `Quick test_equal_different_variant;
+        ] );
+      ( "to_yojson",
+        [
+          test_case "Keep_all" `Quick test_to_yojson_keep_all;
+          test_case "Seq" `Quick test_to_yojson_seq;
+          test_case "inverse_result" `Quick test_inverse_result_to_yojson;
+        ] );
+    ]

--- a/test/test_tool_gate.ml
+++ b/test/test_tool_gate.ml
@@ -158,6 +158,20 @@ let test_inverse_seq_irreversible () =
   | Irreversible -> ()
   | _ -> fail "expected Irreversible"
 
+(* Nested Seq: inverse reverses outer AND inner recursively.
+   Seq [Seq [Add ["a"]]; Remove ["b"]]
+   → inverse of inner Seq [Add ["a"]] = Seq [Remove ["a"]]
+   → inverse of Remove ["b"] = Add ["b"]
+   → fold_left + cons reversal: [Add ["b"]; Seq [Remove ["a"]]] *)
+let test_inverse_nested_seq () =
+  let op = Seq [Seq [Add ["a"]]; Remove ["b"]] in
+  match Tool_gate.inverse op with
+  | Reversible (Seq [Add ["b"]; Seq [Remove ["a"]]]) -> ()
+  | Reversible other ->
+      fail (Printf.sprintf "unexpected nested inverse: %s"
+        (Yojson.Safe.to_string (Tool_gate.to_yojson other)))
+  | Irreversible -> fail "expected Reversible"
+
 let test_inverse_seq_empty () =
   match Tool_gate.inverse (Seq []) with
   | Reversible Keep_all -> ()
@@ -380,6 +394,7 @@ let () =
           test_case "Seq reversible" `Quick test_inverse_seq_reversible;
           test_case "Seq irreversible" `Quick test_inverse_seq_irreversible;
           test_case "Seq empty" `Quick test_inverse_seq_empty;
+          test_case "nested Seq" `Quick test_inverse_nested_seq;
           test_case "roundtrip Add" `Quick test_roundtrip_add;
           test_case "roundtrip Remove" `Quick test_roundtrip_remove;
           test_case "roundtrip phantom" `Quick test_roundtrip_phantom;

--- a/test/test_tool_gate.ml
+++ b/test/test_tool_gate.ml
@@ -94,6 +94,10 @@ let test_apply_add_whitespace () =
   check sl "trimmed" ["a"; "b"; "c"; "d"]
     (Tool_gate.apply (Add [" d "; "d"]) base)
 
+let test_apply_replace_with_normalization () =
+  check sl "normalized" ["x"; "y"]
+    (Tool_gate.apply (Replace_with ["x"; " x "; "y"]) base)
+
 (* ================================================================ *)
 (* inverse                                                           *)
 (* ================================================================ *)
@@ -144,6 +148,14 @@ let test_inverse_seq_irreversible () =
   match Tool_gate.inverse op with
   | Irreversible -> ()
   | _ -> fail "expected Irreversible"
+
+let test_inverse_seq_empty () =
+  match Tool_gate.inverse (Seq []) with
+  | Reversible Keep_all -> ()
+  | Reversible other ->
+      fail (Printf.sprintf "expected Reversible Keep_all, got %s"
+        (Yojson.Safe.to_string (Tool_gate.to_yojson other)))
+  | Irreversible -> fail "expected Reversible"
 
 (* roundtrip: apply inverse undoes effective op *)
 let test_roundtrip_add () =
@@ -278,6 +290,10 @@ let test_equal_add_order () =
   check bool "normalized" true
     (Tool_gate.equal (Add ["a"; "b"]) (Add ["b"; "a"]))
 
+let test_equal_intersect_dedup () =
+  check bool "deduped" true
+    (Tool_gate.equal (Intersect_with ["a"; "a"]) (Intersect_with ["a"]))
+
 let test_equal_structural () =
   check bool "different structure" false
     (Tool_gate.equal (Add ["a"]) (Seq [Add ["a"]]))
@@ -340,6 +356,7 @@ let () =
           test_case "Remove from empty" `Quick test_apply_remove_from_empty;
           test_case "Intersect on empty" `Quick test_apply_intersect_on_empty;
           test_case "Add whitespace" `Quick test_apply_add_whitespace;
+          test_case "Replace_with normalization" `Quick test_apply_replace_with_normalization;
         ] );
       ( "inverse",
         [
@@ -351,6 +368,7 @@ let () =
           test_case "Intersect_with" `Quick test_inverse_intersect_with;
           test_case "Seq reversible" `Quick test_inverse_seq_reversible;
           test_case "Seq irreversible" `Quick test_inverse_seq_irreversible;
+          test_case "Seq empty" `Quick test_inverse_seq_empty;
           test_case "roundtrip Add" `Quick test_roundtrip_add;
           test_case "roundtrip Remove" `Quick test_roundtrip_remove;
           test_case "roundtrip phantom" `Quick test_roundtrip_phantom;
@@ -386,6 +404,7 @@ let () =
       ( "equal",
         [
           test_case "Add order" `Quick test_equal_add_order;
+          test_case "Intersect_with dedup" `Quick test_equal_intersect_dedup;
           test_case "structural" `Quick test_equal_structural;
           test_case "Keep_all" `Quick test_equal_keep_all;
           test_case "different variant" `Quick test_equal_different_variant;

--- a/test/test_tool_gate.ml
+++ b/test/test_tool_gate.ml
@@ -98,6 +98,15 @@ let test_apply_replace_with_normalization () =
   check sl "normalized" ["x"; "y"]
     (Tool_gate.apply (Replace_with ["x"; " x "; "y"]) base)
 
+(* Copilot review: current with duplicates must be normalized *)
+let test_apply_keep_all_normalizes_current () =
+  check sl "deduped" ["a"; "b"]
+    (Tool_gate.apply Keep_all ["a"; "b"; "a"])
+
+let test_apply_remove_normalizes_current () =
+  check sl "deduped" ["a"]
+    (Tool_gate.apply (Remove ["b"]) ["a"; "b"; "a"])
+
 (* ================================================================ *)
 (* inverse                                                           *)
 (* ================================================================ *)
@@ -357,6 +366,8 @@ let () =
           test_case "Intersect on empty" `Quick test_apply_intersect_on_empty;
           test_case "Add whitespace" `Quick test_apply_add_whitespace;
           test_case "Replace_with normalization" `Quick test_apply_replace_with_normalization;
+          test_case "Keep_all normalizes current" `Quick test_apply_keep_all_normalizes_current;
+          test_case "Remove normalizes current" `Quick test_apply_remove_normalizes_current;
         ] );
       ( "inverse",
         [


### PR DESCRIPTION
## Summary

Phase 2A of Tool Gate architecture (#4381). Pure `tool_op` ADT for zone boundary tool set transformations.

- **7-variant ADT**: `Keep_all | Clear_all | Add | Remove | Replace_with | Intersect_with | Seq`
- **`apply`**: Transforms concrete `string list` with Hashtbl-based O(n) set operations
- **`inverse`**: Algebraic inverse computation with `Irreversible` for destructive ops (Clear_all, Replace_with, Intersect_with). Documents phantom addition risk for Remove no-ops
- **`compose`**: Smart Seq constructor with recursive flatten + identity elimination
- **`to_yojson`**: JSON serialization for zone event logging
- **56 tests**: All variants, roundtrip, phantom edge case, compose, predicates, equality

Zero external dependencies — pure string list operations. No runtime integration (Phase 2B).

## Design decisions

- **selector vs tool_op**: `Tool_access_policy.selector` = membership predicate over universe. `tool_op` = imperative set transformation with inverse. `of_selector` bridge deferred to Phase 2B
- **normalize duplication**: Local copy of `dedupe_keep_order`/`normalize` (~10 lines) to maintain zero-dependency principle
- **inverse precondition**: Remove roundtrip only correct when op was effective (not a no-op). Phase 2B's `zone_tbl` uses snapshot-based restore as SSOT; inverse is optimization hint only

## Test plan

- [x] `dune exec test/test_tool_gate.exe` — 56 tests pass
- [x] `dune exec test/test_tool_access_policy.exe` — 45 tests pass (unchanged)
- [x] `dune exec test/test_tool_token.exe` — 9 tests pass (unchanged)
- [x] `dune exec test/test_tool_dispatch.exe` — 14 tests pass (unchanged)
- [x] `dune build @all` — full build clean

Refs #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)