### PR TITLE
fix(config): register MASC_SLOT_YIELD_ENABLED in feature flag registry

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -202,7 +202,7 @@ let all_flags : flag list = [
     lifecycle = Experimental; since = "2.207.0" };
 ]
 
-(** Lookup a flag by env var name. O(n) — acceptable for 25 flags. *)
+(** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)
 let find_opt env_name =
   List.find_opt (fun f -> f.env_name = env_name) all_flags
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -195,6 +195,11 @@ let all_flags : flag list = [
     description = "Aggregate proof bundles across multi-turn sessions";
     default = false; category = "runtime";
     lifecycle = Experimental; since = "2.162.0" };
+
+  { env_name = "MASC_SLOT_YIELD_ENABLED";
+    description = "Release LLM slot during tool execution so other agents can use it";
+    default = false; category = "runtime";
+    lifecycle = Experimental; since = "2.207.0" };
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for 25 flags. *)


### PR DESCRIPTION
## Summary

- Register `MASC_SLOT_YIELD_ENABLED` in `Feature_flag_registry.all_flags`
- Fixes CI lint failure (`check-feature-flag-consistency.sh`)
- Flag: `default=false`, `category=runtime`, `lifecycle=Experimental`

## Test plan

- [x] `dune build @all` — clean build
- [x] `check-feature-flag-consistency.sh` — 31/31 registered, PASS
- [ ] CI green