### PR TITLE
fix(board): auto-classify post_kind from agent registry

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -480,7 +480,7 @@ let create_state ~base_path =
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event
   );
-  {
+  let state = {
     room_config = config;
     session_registry = registry;
     on_sse_broadcast = None;
@@ -492,7 +492,11 @@ let create_state ~base_path =
     mono_clock = None;
     env = None;
     net = None;
-  }
+  } in
+  Tool_board.set_agent_lookup (fun name ->
+    try Room.is_agent_joined state.room_config ~agent_name:name
+    with Sys_error _ | Not_found | Invalid_argument _ -> false);
+  state
 
 (** Create state with Eio context - required for PostgresNative backend *)
 let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
@@ -520,16 +524,12 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
       base_path
     |> Room.config_with_resolved_scope
   in
-  (* Board post kind auto-classification: agent registry lookup *)
-  Tool_board.set_agent_lookup (fun name ->
-    try Room.is_agent_joined config ~agent_name:name
-    with Sys_error _ | Not_found -> false);
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event
   );
-  {
+  let state = {
     room_config = config;
     session_registry = registry;
     on_sse_broadcast = None;
@@ -541,7 +541,13 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     mono_clock = Some mono_clock;
     env = Some env;
     net = Some net;
-  }
+  } in
+  (* Board post kind auto-classification: reads state.room_config so
+     room changes via set_room are reflected automatically. *)
+  Tool_board.set_agent_lookup (fun name ->
+    try Room.is_agent_joined state.room_config ~agent_name:name
+    with Sys_error _ | Not_found | Invalid_argument _ -> false);
+  state
 
 (** Register SSE broadcast callback *)
 let set_sse_callback state callback =

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -520,6 +520,10 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
       base_path
     |> Room.config_with_resolved_scope
   in
+  (* Board post kind auto-classification: agent registry lookup *)
+  Tool_board.set_agent_lookup (fun name ->
+    try Room.is_agent_joined config ~agent_name:name
+    with Sys_error _ | Not_found -> false);
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -87,16 +87,19 @@ let agent_lookup_hook : (string -> bool) option ref = ref None
 
 let set_agent_lookup f = agent_lookup_hook := Some f
 
-(** Heuristic fallback: agent names have no spaces and are lowercase. *)
+(** Heuristic fallback: agent names have no spaces and are lowercase.
+    "anonymous" is excluded — it is the default author for unauthenticated posts. *)
 let is_agent_heuristic name =
-  name <> "" && not (String.contains name ' ') && String.lowercase_ascii name = name
+  name <> "" && name <> "anonymous"
+  && not (String.contains name ' ')
+  && String.lowercase_ascii name = name
 
 (** Check whether [name] is a registered agent.  Prefers the registry
     lookup (Room.is_agent_joined) when available; falls back to the
     name-shape heuristic so standalone / test usage still works. *)
 let is_agent name =
   match !agent_lookup_hook with
-  | Some lookup -> (try lookup name with Sys_error _ | Not_found -> false)
+  | Some lookup -> lookup name
   | None -> is_agent_heuristic name
 
 let resolve_board_post_kind ~author (raw_kind : string option) :

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -86,6 +86,7 @@ let visibility_of_string = function
 let agent_lookup_hook : (string -> bool) option ref = ref None
 
 let set_agent_lookup f = agent_lookup_hook := Some f
+let set_agent_lookup_none () = agent_lookup_hook := None
 
 (** Heuristic fallback: agent names have no spaces and are lowercase.
     "anonymous" is excluded — it is the default author for unauthenticated posts. *)
@@ -112,9 +113,13 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
        | Some kind -> Ok kind
        | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
+      (* Auto-classify only when registry hook is available.
+         Without a registry, default to Human_post to avoid
+         false positives from the name-shape heuristic. *)
       let author_lc = String.lowercase_ascii (String.trim author) in
-      if is_agent author_lc then Ok Board.Automation_post
-      else Ok Board.Human_post
+      (match !agent_lookup_hook with
+       | Some _ when is_agent author_lc -> Ok Board.Automation_post
+       | _ -> Ok Board.Human_post)
 
 (** {1 Formatters} *)
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -80,40 +80,38 @@ let visibility_of_string = function
   | "direct" -> Some Board.Direct
   | _ -> None
 
-let meta_source = function
-  | Some (`Assoc fields) -> (
-      match List.assoc_opt "source" fields with
-      | Some (`String source) ->
-          let trimmed = String.lowercase_ascii (String.trim source) in
-          if trimmed = "" then None else Some trimmed
-      | _ -> None)
-  | _ -> None
+(** Agent lookup callback — set once at server startup with the real
+    Room.is_agent_joined check so that board posts are auto-classified
+    without requiring callers to pass config or post_kind. *)
+let agent_lookup_hook : (string -> bool) option ref = ref None
 
-let resolve_board_post_kind ~author ~(meta_json : Yojson.Safe.t option)
-    (raw_kind : string option) :
+let set_agent_lookup f = agent_lookup_hook := Some f
+
+(** Heuristic fallback: agent names have no spaces and are lowercase. *)
+let is_agent_heuristic name =
+  name <> "" && not (String.contains name ' ') && String.lowercase_ascii name = name
+
+(** Check whether [name] is a registered agent.  Prefers the registry
+    lookup (Room.is_agent_joined) when available; falls back to the
+    name-shape heuristic so standalone / test usage still works. *)
+let is_agent name =
+  match !agent_lookup_hook with
+  | Some lookup -> (try lookup name with Sys_error _ | Not_found -> false)
+  | None -> is_agent_heuristic name
+
+let resolve_board_post_kind ~author (raw_kind : string option) :
     (Board.post_kind, string) Stdlib.result =
-  let author = String.lowercase_ascii (String.trim author) in
-  let source = meta_source meta_json in
-  let requested =
-    match raw_kind with
-    | Some raw -> Board.post_kind_of_string (String.lowercase_ascii (String.trim raw))
-    | None -> None
-  in
-  match source, requested with
-  | Some "keeper_board_post", Some Board.Automation_post
-  | Some "keeper_board_post", None ->
-      Ok Board.Automation_post
-  | Some "keeper_board_post", Some _ ->
-      Error "keeper board posts must use post_kind=automation"
-  | _, Some Board.Human_post
-  | _, None when author <> "anonymous" ->
-      Ok Board.Human_post
-  | _, Some Board.Automation_post ->
-      Ok Board.Automation_post
-  | _, Some Board.System_post ->
-      Error "system posts are reserved for internal surfaces (keeper, operator)"
-  | _ ->
-      Ok Board.Human_post
+  match raw_kind with
+  | Some raw ->
+      (match Board.post_kind_of_string (String.lowercase_ascii (String.trim raw)) with
+       | Some Board.System_post ->
+           Error "system posts are reserved for internal surfaces (keeper, operator)"
+       | Some kind -> Ok kind
+       | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
+  | None ->
+      let author_lc = String.lowercase_ascii (String.trim author) in
+      if is_agent author_lc then Ok Board.Automation_post
+      else Ok Board.Human_post
 
 (** {1 Formatters} *)
 
@@ -212,7 +210,7 @@ let handle_post_create args =
     | Some v -> v
     | None -> Board.Internal
   in
-  match resolve_board_post_kind ~author ~meta_json raw_post_kind with
+  match resolve_board_post_kind ~author raw_post_kind with
   | Error msg -> (false, "❌ " ^ msg)
   | Ok post_kind ->
       match
@@ -367,11 +365,6 @@ let handle_comment_add args =
       (true, Printf.sprintf "✅ Comment added:\n%s" (Yojson.Safe.pretty_to_string json))
   | Error e ->
       (false, Printf.sprintf "❌ %s" (board_error_to_string e))
-
-(** Check if a name looks like an agent (not a human user) *)
-let is_agent name =
-  (* Agent names don't contain spaces and are lowercase *)
-  name <> "" && not (String.contains name ' ') && String.lowercase_ascii name = name
 
 (** SOUL Evolution callback - registered at startup to break dependency cycle *)
 type evolution_callback = {

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -686,4 +686,56 @@ let () =
           Alcotest.test_case "unique names" `Quick test_tools_names_unique;
           Alcotest.test_case "all have descriptions" `Quick test_tools_all_have_descriptions;
         ] );
+      ( "post_kind_registry",
+        [
+          Alcotest.test_case "no hook: defaults to human" `Quick (fun () ->
+            Eio_main.run @@ fun env ->
+            Fs_compat.set_fs (Eio.Stdenv.fs env);
+            cleanup ();
+            Tool_board.set_agent_lookup_none ();
+            let (ok, msg) = dispatch "masc_board_post" (make_args [
+              ("title", `String "test"); ("content", `String "hello");
+              ("author", `String "claude-agent")
+            ]) in
+            Alcotest.(check bool) "post created" true ok;
+            Alcotest.(check bool) "classified as human" true
+              (contains_substring msg {|"post_kind": "human"|}));
+          Alcotest.test_case "with hook: agent classified as automation" `Quick (fun () ->
+            Eio_main.run @@ fun env ->
+            Fs_compat.set_fs (Eio.Stdenv.fs env);
+            cleanup ();
+            Tool_board.set_agent_lookup (fun name -> name = "claude-agent");
+            let (ok, msg) = dispatch "masc_board_post" (make_args [
+              ("title", `String "test"); ("content", `String "hello");
+              ("author", `String "claude-agent")
+            ]) in
+            Alcotest.(check bool) "post created" true ok;
+            Alcotest.(check bool) "classified as automation" true
+              (contains_substring msg {|"post_kind": "automation"|}));
+          Alcotest.test_case "with hook: non-agent stays human" `Quick (fun () ->
+            Eio_main.run @@ fun env ->
+            Fs_compat.set_fs (Eio.Stdenv.fs env);
+            cleanup ();
+            Tool_board.set_agent_lookup (fun _name -> false);
+            let (ok, msg) = dispatch "masc_board_post" (make_args [
+              ("title", `String "test"); ("content", `String "hello");
+              ("author", `String "sangsu")
+            ]) in
+            Alcotest.(check bool) "post created" true ok;
+            Alcotest.(check bool) "classified as human" true
+              (contains_substring msg {|"post_kind": "human"|}));
+          Alcotest.test_case "explicit override respected" `Quick (fun () ->
+            Eio_main.run @@ fun env ->
+            Fs_compat.set_fs (Eio.Stdenv.fs env);
+            cleanup ();
+            Tool_board.set_agent_lookup (fun _name -> true);
+            let (ok, msg) = dispatch "masc_board_post" (make_args [
+              ("title", `String "test"); ("content", `String "hello");
+              ("author", `String "claude-agent");
+              ("post_kind", `String "human")
+            ]) in
+            Alcotest.(check bool) "post created" true ok;
+            Alcotest.(check bool) "explicit human override" true
+              (contains_substring msg {|"post_kind": "human"|}));
+        ] );
     ]


### PR DESCRIPTION
## Summary

- 대시보드에서 에이전트가 쓴 글이 "사람이 쓴 글"로 분류되던 버그 수정
- `resolve_board_post_kind`가 `meta.source` 문자열 매칭과 author 이름 heuristic 대신 **agent registry 조회**로 post_kind를 자동 결정
- 서버 startup 시 `Room.is_agent_joined`를 callback ref로 주입하여, 모든 entry point에서 caller 변경 없이 동작

## Changes

| 파일 | 변경 |
|---|---|
| `lib/tool_board.ml` | `agent_lookup_hook` 추가, `resolve_board_post_kind` 15줄→4줄 단순화, Keeper 특수 분기 제거, dead `meta_source` 제거 |
| `lib/mcp_server.ml` | `create_state_eio`에서 agent lookup 등록 (4줄) |

## Product impact

대시보드 Board 탭에서 에이전트 글이 "자율 글" 섹션에 올바르게 표시된다. 기존에는 Keeper 외 모든 에이전트 글이 "사람이 쓴 글"로 잘못 분류되었다.

## Evidence

- `resolve_board_post_kind`의 `(_, None) when author <> "anonymous"` 패턴이 joined agent를 포함한 모든 named author를 Human_post로 분류하는 것을 코드 경로 추적으로 확인
- Entry point 3개(MCP, HTTP, Keeper)가 동일한 `handle_tool`로 합류하면서 출처 정보가 소실됨을 확인

## Review evidence

GLM-5.1 교차 리뷰 완료 (4개 이슈 발견):
1. **anonymous 오분류 (Bug)** — `is_agent_heuristic`에 `"anonymous"` 제외 추가로 수정 ✅
2. **Keeper source metadata 삭제 (Regression 주장)** — Keeper는 joined agent이므로 registry에서 자동 분류됨. 오탐 ❌
3. **Unknown post_kind 에러 변경 (Breaking change 주장)** — 의도된 stricter contract (Parse, Don't Validate) ❌
4. **이중 try-catch (Dead code)** — `is_agent`에서 제거, injection site에만 유지 ✅

## Linked issue

Relates #4441

## Test plan

- [x] `dune build --root . @all` 통과
- [x] `dune runtest --root .` 전체 테스트 통과 (mcp_tool_matrix 포함)
- [x] GLM-5.1 교차 모델 리뷰 완료 + 대응
- [ ] 대시보드에서 에이전트 글이 "자율 글" 섹션에 표시되는지 확인
- [ ] Dashboard UI에서 직접 쓴 글이 "사람이 쓴 글"에 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)