### PR TITLE
fix(dashboard): invalidate execution cache on task mutations

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -193,7 +193,8 @@ let () = Room_hooks.observe_agent_lifecycle_fn :=
 let () = Room_hooks.observe_task_transition_fn :=
   (fun config ~agent_name ~room_id ~task_id ~transition ~details ->
     observe_task_transition_event config ~agent_name ~room_id ~task_id
-      ~transition ~details)
+      ~transition ~details;
+    !Room_hooks.on_task_mutation_fn ())
 
 (* Board artifact cleanup — wraps Board_dispatch for GC *)
 let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -124,6 +124,13 @@ let governance_purge_fn
   : (string -> int * int) ref
   = ref (fun _base_path -> (0, 0))
 
+(** Invalidate dashboard execution cache on task mutation (add, transition).
+    Wired by server bootstrap to avoid circular dependency between
+    Room sub-modules and server dashboard surfaces. *)
+let on_task_mutation_fn
+  : (unit -> unit) ref
+  = ref (fun () -> ())
+
 (** Auto-subscribe agent to messages on join — wraps Subscriptions.SubscriptionStore. *)
 let subscribe_messages_fn
   : (subscriber:string -> unit) ref

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -101,6 +101,7 @@ let add_task config ~title ~priority ~description =
           ]);
 
     let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
+    !Room_hooks.on_task_mutation_fn ();
     Printf.sprintf "✅ Added %s: %s" task_id title)
 
 (** Add task with a required role constraint — file-locked *)
@@ -190,6 +191,7 @@ let batch_add_tasks config tasks =
       let summary = String.concat ", " (List.map (fun (t : Types.task) -> t.id) added_tasks) in
       let msg = Printf.sprintf "📋 New batch of %d quests added: %s" (List.length added_tasks) summary in
       let _ = broadcast config ~from_agent:"system" ~content:msg in
+      !Room_hooks.on_task_mutation_fn ();
       Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -7,6 +7,11 @@ include Server_dashboard_http_room_truth
 open Types
 open Server_utils
 
+(* Wire task mutation hook: invalidate execution cache on any task
+   add/transition so the dashboard serves fresh backlog data. *)
+let () =
+  Room_hooks.on_task_mutation_fn := invalidate_execution_cache
+
 let dashboard_room_truth_focus_json =
   Server_dashboard_http_room_truth_support.dashboard_room_truth_focus_json
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -79,6 +79,14 @@ let _execution_cache =
         );
       ])
 
+(** Invalidate the execution surface cache so the next
+    [/api/v1/dashboard/execution] request recomputes fresh data.
+    Call after task mutations (add, transition, cancel) to avoid
+    serving stale backlog state for up to [ttl] seconds. *)
+let invalidate_execution_cache () =
+  invalidate_cached_surface _execution_cache;
+  Dashboard_cache.invalidate "execution:default:light"
+
 (** Bypass the proactive warm-up guard so tests that call
     [dashboard_room_truth_http_json] get the full response instead of
     the "initializing" short-circuit. *)


### PR DESCRIPTION
## Summary
- 대시보드에서 태스크 추가 후 백로그 목록에 반영되지 않던 문제 수정
- execution surface 캐시(TTL 120s)가 task mutation 시 invalidate되지 않아, 대시보드가 최대 2분간 stale 데이터를 반환
- `Room_hooks.on_task_mutation_fn` callback ref 패턴으로 순환 의존 없이 캐시 무효화 wiring

## Root Cause
`/api/v1/dashboard/execution` 응답이 `cached_surface_or_first_success_json`으로 120초 캐시되는데, `masc_add_task`/`masc_transition` 등 task mutation 후 캐시가 invalidate되지 않았음. Keeper가 수 초 내에 auto-claim하므로 사용자가 추가한 태스크가 UI에 나타나지 않는 것처럼 보임.

## Changes
| 파일 | 변경 |
|------|------|
| `lib/room/room_hooks.ml` | `on_task_mutation_fn` callback ref 추가 |
| `lib/room/room_task.ml` | `add_task`, `batch_add_tasks` 후 hook 호출 |
| `lib/room.ml` | `observe_task_transition_fn` wiring에 hook 호출 추가 |
| `lib/server/server_dashboard_http_execution_surfaces.ml` | `invalidate_execution_cache` 함수 추가 |
| `lib/server/server_dashboard_http.ml` | hook → `invalidate_execution_cache` wiring |

## Test plan
- [x] `dune build` 성공
- [x] `dune runtest` 전체 통과
- [ ] 대시보드에서 태스크 추가 후 즉시 백로그에 표시되는지 확인
- [ ] keeper auto-claim 후에도 claimed/done 상태가 대시보드에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)