### PR TITLE
fix(config): register MASC_SLOT_YIELD_ENABLED in feature flag registry

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -180,6 +180,11 @@ let all_flags : flag list = [
     default = false; category = "runtime";
     lifecycle = Deprecated "use MASC_LOCAL_RUNTIME_DEBUG"; since = "2.100.0" };
 
+  { env_name = "MASC_SLOT_YIELD_ENABLED";
+    description = "Release LLM slot during tool execution so other agents can use it";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "2.208.0" };
+
   (* ── CDAL (Contract-Driven Agent Loop) ───────────────────── *)
   { env_name = "MASC_CDAL_ENABLED";
     description = "Contract-driven agent loop: proof capture and verdict evaluation";


### PR DESCRIPTION
## Summary
- `MASC_SLOT_YIELD_ENABLED` was added to `env_config_runtime.ml` but never registered in `feature_flag_registry.ml`
- CI lint `check-feature-flag-consistency.sh` fails with `UNREGISTERED: MASC_SLOT_YIELD_ENABLED` on ALL open PRs
- This hotfix unblocks PR #4417 and any other open PRs

## Test plan
- [x] `scripts/check-feature-flag-consistency.sh` passes locally (31 flags, 0 errors)
- [ ] CI lint passes on this PR
- [ ] CI lint passes on other open PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)