### PR TITLE
refactor(types): replace string task action dispatch with variant type

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -388,40 +388,40 @@ let transition_task_r config ~agent_name ~task_id ~action
                  | Some task ->
                      let now = now_iso () in
                      let now_ts = Time_compat.now () in
-                     let action = String.lowercase_ascii action in
+                     let action_s = Types.task_action_to_string action in
                      let transition =
                        match action, task.task_status with
-                       | "claim", Types.Todo ->
+                       | Types.Claim, Types.Todo ->
                            Ok (Types.Claimed { assignee = agent_name; claimed_at = now }, Some task_id)
-                       | "start", Types.Claimed { assignee; _ } when assignee = agent_name ->
+                       | Types.Start, Types.Claimed { assignee; _ } when assignee = agent_name ->
                            Ok (Types.InProgress { assignee = agent_name; started_at = now }, Some task_id)
-                       | "done", Types.Claimed { assignee; _ }
-                       | "done", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types.Done_action, Types.Claimed { assignee; _ }
+                       | Types.Done_action, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Done {
                              assignee = agent_name;
                              completed_at = now;
                              notes = if notes = "" then None else Some notes;
                            }, None)
-                       | "cancel", Types.Todo ->
+                       | Types.Cancel, Types.Todo ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
-                       | "cancel", Types.Claimed { assignee; _ }
-                       | "cancel", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types.Cancel, Types.Claimed { assignee; _ }
+                       | Types.Cancel, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
-                       | "release", Types.Claimed { assignee; _ }
-                       | "release", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types.Release, Types.Claimed { assignee; _ }
+                       | Types.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Todo, None)
                        | _ ->
                            Error (Types.TaskInvalidState
                              (Printf.sprintf "Invalid transition: %s -> %s (%s)"
-                               (task_status_to_string task.task_status) action task_id))
+                               (task_status_to_string task.task_status) action_s task_id))
                      in
                      (match transition with
                       | Error e -> Error e
@@ -455,20 +455,20 @@ let transition_task_r config ~agent_name ~task_id ~action
                           end;
                           log_event config (Printf.sprintf
                             "{\"type\":\"task_transition\",\"agent\":\"%s\",\"task\":\"%s\",\"action\":\"%s\",\"from\":\"%s\",\"to\":\"%s\",\"ts\":\"%s\"}"
-                            agent_name task_id action
+                            agent_name task_id action_s
                             (task_status_to_string task.task_status)
                             (task_status_to_string new_status)
                             now);
                           (match action with
-                           | "claim" ->
+                           | Types.Claim ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.claimed"
                                  ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | "start" ->
+                           | Types.Start ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.started"
                                  ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | "done" ->
+                           | Types.Done_action ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.done"
                                  ~payload:
@@ -477,7 +477,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                                        ("task_id", `String task_id);
                                        ("notes", if notes = "" then `Null else `String notes);
                                      ])
-                           | "cancel" ->
+                           | Types.Cancel ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.cancelled"
                                  ~payload:
@@ -486,24 +486,23 @@ let transition_task_r config ~agent_name ~task_id ~action
                                        ("task_id", `String task_id);
                                        ("reason", if reason = "" then `Null else `String reason);
                                      ])
-                           | "release" ->
+                           | Types.Release ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.released"
-                                 ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | _ -> ());
+                                 ~payload:(`Assoc [ ("task_id", `String task_id) ]));
                           let duration_ms =
                             match action with
-                            | "done" | "cancel" ->
+                            | Types.Done_action | Types.Cancel ->
                                 Some
                                   (max 0
                                      (int_of_float
                                         ((now_ts
                                          -. task_started_at_unix task.task_status)
                                         *. 1000.0)))
-                            | _ -> None
+                            | Types.Claim | Types.Start | Types.Release -> None
                           in
                           observe_task_transition config ~agent_name ~task_id
-                            ~transition:action
+                            ~transition:action_s
                             ~details:
                               (task_transition_details
                                  ~from_status:task.task_status ~to_status:new_status
@@ -521,15 +520,15 @@ let transition_task_r config ~agent_name ~task_id ~action
 
 (** Release task back to backlog - transition wrapper *)
 let release_task_r config ~agent_name ~task_id ?expected_version () : string Types.masc_result =
-  transition_task_r config ~agent_name ~task_id ~action:"release" ?expected_version ()
+  transition_task_r config ~agent_name ~task_id ~action:Types.Release ?expected_version ()
 
 (** Force-release a task regardless of assignee. Keeper privilege. *)
 let force_release_task_r config ~agent_name ~task_id () : string Types.masc_result =
-  transition_task_r config ~agent_name ~task_id ~action:"release" ~force:true ()
+  transition_task_r config ~agent_name ~task_id ~action:Types.Release ~force:true ()
 
 (** Force-done a task regardless of assignee. Keeper privilege. *)
 let force_done_task_r config ~agent_name ~task_id ~notes () : string Types.masc_result =
-  transition_task_r config ~agent_name ~task_id ~action:"done" ~notes ~force:true ()
+  transition_task_r config ~agent_name ~task_id ~action:Types.Done_action ~notes ~force:true ()
 
 (** Complete task with file locking *)
 let complete_task config ~agent_name ~task_id ~notes =

--- a/lib/room/room_task.mli
+++ b/lib/room/room_task.mli
@@ -51,7 +51,7 @@ val claim_task_r :
 (** {1 Task transitions} *)
 
 val transition_task_r :
-  config -> agent_name:string -> task_id:string -> action:string ->
+  config -> agent_name:string -> task_id:string -> action:Types_core.task_action ->
   ?expected_version:int -> ?notes:string -> ?reason:string ->
   ?force:bool -> unit -> string Types.masc_result
 

--- a/lib/tool_fire_task.ml
+++ b/lib/tool_fire_task.ml
@@ -54,7 +54,7 @@ let run_background_agent config ~agent_cli ~agent_name ~task_id ~goal
   Log.Misc.info "[fire_task] claim %s by %s: %s" task_id agent_name claim_msg;
 
   (* Step 3: transition to in_progress *)
-  let _start = Room.transition_task_r config ~agent_name ~task_id ~action:"start" () in
+  let _start = Room.transition_task_r config ~agent_name ~task_id ~action:Types.Start () in
 
   (* Step 4: spawn the agent subprocess *)
   let prompt = build_agent_prompt ~goal ~task_id ~worktree_path in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -374,10 +374,14 @@ let handle_transition ctx args =
   match validate_task_id task_id with
   | Error e -> result_to_response (Error e)
   | Ok task_id ->
-  let action = get_string args "action" "" in
-  if action = "" then
-    (false, "action is required (claim, start, done, cancel, release, block, unblock)")
+  let action_raw = get_string args "action" "" in
+  if action_raw = "" then
+    (false, "action is required (claim, start, done, cancel, release)")
   else
+  match Types.task_action_of_string action_raw with
+  | Error msg -> (false, msg)
+  | Ok action ->
+  let action_s = Types.task_action_to_string action in
   let notes = get_string args "notes" "" in
   let reason = get_string args "reason" "" in
   let completion_contract =
@@ -387,7 +391,6 @@ let handle_transition ctx args =
   in
   let evaluator_cascade = get_string_opt args "evaluator_cascade" in
   let expected_version = get_int_opt args "expected_version" in
-  let action_lc = String.lowercase_ascii action in
   let force_raw = get_bool args "force" false in
   (* force=true requires admin privilege: initial_admin or Admin role *)
   let force =
@@ -404,7 +407,7 @@ let handle_transition ctx args =
   let task_opt = List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks in
   (* Anti-rationalization gate: verify completion notes before allowing "done" *)
   let gate_rejection =
-    if action_lc = "done" && not force && can_review_completion ~task_opt ~agent_name:ctx.agent_name then
+    if action = Types.Done_action && not force && can_review_completion ~task_opt ~agent_name:ctx.agent_name then
       review_completion_notes
         ~completion_contract
         ~evaluator_cascade
@@ -462,22 +465,22 @@ let handle_transition ctx args =
          ~agent:ctx.agent_name
          ~data:(`Assoc [
            ("task_id", `String task_id);
-           ("action", `String action);
+           ("action", `String action_s);
            ("notes", `String notes);
          ]);
        (* Notification harness: push task transition to all active sessions *)
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_transition");
          ("task_id", `String task_id);
-         ("action", `String action);
+         ("action", `String action_s);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error err ->
        Log.Task.error "task transition failed: %s" (Types.masc_error_to_string err));
   (* Record metrics *)
-  (match result, action_lc with
-   | Ok _, "done" ->
+  (match result, action with
+   | Ok _, Types.Done_action ->
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));
          agent_id = ctx.agent_name;
@@ -494,7 +497,7 @@ let handle_transition ctx args =
         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-done) failed: %s" (Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
        Prometheus.record_task_completed ()
-   | Ok _, "cancel" ->
+   | Ok _, Types.Cancel ->
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));
          agent_id = ctx.agent_name;

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -223,6 +223,30 @@ type room_registry = {
 } [@@deriving yojson { strict = false }, show]
 
 (** Task status - state transitions enforced by types *)
+type task_action =
+  | Claim
+  | Start
+  | Done_action
+  | Cancel
+  | Release
+[@@deriving show]
+
+let task_action_of_string s =
+  match String.lowercase_ascii s with
+  | "claim" -> Ok Claim
+  | "start" -> Ok Start
+  | "done" -> Ok Done_action
+  | "cancel" -> Ok Cancel
+  | "release" -> Ok Release
+  | other -> Error (Printf.sprintf "Unknown task action: %s" other)
+
+let task_action_to_string = function
+  | Claim -> "claim"
+  | Start -> "start"
+  | Done_action -> "done"
+  | Cancel -> "cancel"
+  | Release -> "release"
+
 type task_status =
   | Todo
   | Claimed of { assignee: string; claimed_at: string }

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1204,7 +1204,7 @@ let test_force_release_bypasses_assignee () =
     let _ = Room.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
     (* Different agent cannot release without force *)
     let normal = Room.transition_task_r config ~agent_name:admin_keeper_agent ~task_id:"task-001"
-        ~action:"release" () in
+        ~action:Types.Release () in
     Alcotest.(check bool) "normal release blocked" true
       (match normal with Error _ -> true | Ok _ -> false);
     (* Force release succeeds *)
@@ -1223,7 +1223,7 @@ let test_force_done_bypasses_assignee () =
     let _ = Room.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
     (* Normal done by different agent fails *)
     let normal = Room.transition_task_r config ~agent_name:admin_keeper_agent ~task_id:"task-001"
-        ~action:"done" ~notes:"forced" () in
+        ~action:Types.Done_action ~notes:"forced" () in
     Alcotest.(check bool) "normal done blocked" true
       (match normal with Error _ -> true | Ok _ -> false);
     (* Force done succeeds *)

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -368,7 +368,7 @@ let test_cancel_done_task () =
 let test_transition_claim () =
   with_test_env (fun config ->
     let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
-    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:"claim" () in
+    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Claim () in
     match result with
     | Ok msg -> Alcotest.(check bool) "claim via transition" true (str_contains msg "todo" && str_contains msg "claimed")
     | Error _ -> Alcotest.fail "Expected Ok"
@@ -379,7 +379,7 @@ let test_transition_start () =
     let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
     let _ = Room.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
 
-    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:"start" () in
+    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Start () in
     match result with
     | Ok msg -> Alcotest.(check bool) "start via transition" true (str_contains msg "in_progress")
     | Error _ -> Alcotest.fail "Expected Ok"
@@ -400,7 +400,7 @@ let test_transition_invalid () =
   with_test_env (fun config ->
     let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
     (* Try to start without claiming first *)
-    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:"start" () in
+    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Start () in
     match result with
     | Error Types.TaskInvalidState _ -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState"
@@ -412,7 +412,7 @@ let test_transition_version_mismatch () =
 
     (* Pass wrong expected version *)
     let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001"
-                   ~action:"claim" ~expected_version:999 () in
+                   ~action:Types.Claim ~expected_version:999 () in
     match result with
     | Error Types.TaskInvalidState _ -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState for version mismatch"
@@ -508,7 +508,7 @@ let test_task_transitions_emit_observability () =
           (Types.show_masc_error err));
     (match
        Room.transition_task_r config ~agent_name:claude ~task_id:"task-001"
-         ~action:"start" ()
+         ~action:Types.Start ()
      with
     | Ok _ -> ()
     | Error err ->

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -200,9 +200,9 @@ let test_final_done_delta_snapshot_stable () =
   let session_id = start_session_exn ctx ~goal:"snapshot-stability" |> get_session_id in
 
   let task_before = add_task_id config ~title:"before-finalize" in
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:"claim";
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:"start";
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:"done";
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:Types.Claim;
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:Types.Start;
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_before ~action:Types.Done_action;
 
   let stop_ok, _ =
     dispatch_exn ctx ~name:"masc_team_session_stop"
@@ -226,9 +226,9 @@ let test_final_done_delta_snapshot_stable () =
   Alcotest.(check int) "done delta before finalize snapshot" 1 done_before;
 
   let task_after = add_task_id config ~title:"after-finalize" in
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:"claim";
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:"start";
-  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:"done";
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:Types.Claim;
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:Types.Start;
+  transition_task_ok config ~agent_name:"owner" ~task_id:task_after ~action:Types.Done_action;
 
   let status_ok_after, status_body_after =
     dispatch_exn ctx ~name:"masc_team_session_status"


### PR DESCRIPTION
## Summary

- `task_action` ADT 도입 (`Claim | Start | Done_action | Cancel | Release`) — `types_core.ml`
- 시스템 경계(`tool_task.ml`)에서 string→variant 파싱, 내부는 exhaustive variant match
- `room_task.ml`의 3개 string match 블록 (transition, activity emission, duration calc) 모두 variant 전환
- `| _ -> ()` catch-all 제거 — 새 action 추가 시 컴파일러가 누락을 강제

## Motivation

Audit #4420 (Impact 5/5): string dispatch로 인한 silent fail 위험 제거. "calim" 같은 오타가 catch-all로 빠져 런타임 에러만 반환하던 것을 컴파일 타임 에러로 전환.

## Changes

| File | Change |
|------|--------|
| `lib/types/types_core.ml` | `task_action` type + `of_string`/`to_string` |
| `lib/room/room_task.mli` | signature `action:string` → `action:task_action` |
| `lib/room/room_task.ml` | variant match (transition + emission + metrics) |
| `lib/tool_task.ml` | boundary parse + variant propagation |
| `lib/tool_fire_task.ml` | caller update |
| `test/` (3 files) | string literal → variant constructor |

## Test plan

- [x] `test_room_coverage.exe` — 55 tests pass
- [x] `test_room.exe` — 89 tests pass  
- [x] `test_tool_team_session.exe` — 54 tests pass
- [ ] CI full suite

Closes #4420

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>