### PR TITLE
fix: recover 8 post-merge orphan commits from 5 branches

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -22,7 +22,6 @@ import './styles/governance-agent.css'
 import './styles/governance-keeper.css'
 import './styles/mission.css'
 import './styles/ops.css'
-import './styles/roster.css'
 import './styles/tools.css'
 
 import { render } from 'preact'

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -6,5 +6,4 @@
 
 /* agent-runtime-strip, agent-runtime-ctx-fill, agent-event-badge--* → ui.css (single definition) */
 
-/* ── Live Timeline — see live-monitor.css ──────────────────── */
-
+/* ── Live Timeline — timeline styles are in ui.css alongside runtime strip ── */

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -19,7 +19,7 @@
 @import "./base.css";
 @import "./keyframes.css";
 
-/* ── Feature imports (alphabetical) ──────────────────────────── */
+/* ── Feature imports (alphabetical, a11y.css last for cascade) ── */
 @import "./agent-monitor.css";
 @import "./board.css";
 @import "./chat.css";
@@ -36,7 +36,6 @@
 @import "./overview.css";
 @import "./pipeline.css";
 @import "./pixel-avatar.css";
-@import "./roster.css";
 @import "./roster-detail.css";
 @import "./tools.css";
 @import "./ui.css";

--- a/dashboard/src/styles/governance-keeper.css
+++ b/dashboard/src/styles/governance-keeper.css
@@ -1,5 +1,9 @@
 /* ── Keeper Rich Card (Overview) ──────────────────────────── */
-/* @keyframes keeperPulse → keyframes.css (canonical) */
+/* @keyframes keeperPulse → keyframes.css (canonical, general-purpose) */
+/* Keeper-specific animation values differ from general-purpose:
+   lower opacity (0.6), smaller glow radius (10px at peak).
+   Kept separate via the canonical keyframes.css definition which
+   already uses these keeper-appropriate values. */
 
 /* ── Metric explain tooltip ──────────────────────────────── */
 .metric-tip-pop {

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -1,3 +1,0 @@
-/* MASC Dashboard -- Roster (stateful variants + gradients) */
-/* Extracted from global.css for #3915.
-   roster-badge--*, pressure--* → @utility definitions in roster-detail.css. */

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -325,10 +325,14 @@ module Cdal = struct
     get_bool ~default:false "MASC_CDAL_PROOF_AGGREGATION"
 end
 
-(** Release LLM slot during tool execution so other agents can use it.
-    Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
-let slot_yield_enabled () =
-  get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+(** {1 Slot Scheduling} *)
+
+module Slot = struct
+  (** Release LLM slot during tool execution so other agents can use it.
+      Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
+  let yield_enabled () =
+    get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+end
 
 (** {1 Board Configuration} *)
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -132,6 +132,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.50.0" };
 
+  { env_name = "MASC_SLOT_YIELD_ENABLED";
+    description = "Turn-level slot yielding during tool execution";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.207.0" };
+
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
     description = "Load dashboard fixture data for testing";

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -355,37 +355,37 @@ let route
 module Stats = struct
   type routing_stats = {
     mutable total_queries : int;
-    mutable small_only : int;
-    mutable has_large : int;
+    mutable cheap_only : int;
+    mutable has_expensive : int;
   }
 
   let global_stats = {
     total_queries = 0;
-    small_only = 0;
-    has_large = 0;
+    cheap_only = 0;
+    has_expensive = 0;
   }
 
   let record (decision : route_decision) : unit =
     global_stats.total_queries <- global_stats.total_queries + 1;
-    let has_big = List.exists (fun a ->
+    let has_costly = List.exists (fun a ->
       a.cost_per_1k >= 0.005
     ) decision.agents in
-    if has_big
-    then global_stats.has_large <- global_stats.has_large + 1
-    else global_stats.small_only <- global_stats.small_only + 1
+    if has_costly
+    then global_stats.has_expensive <- global_stats.has_expensive + 1
+    else global_stats.cheap_only <- global_stats.cheap_only + 1
 
   let get_ratio () : float * float =
     let total = float_of_int global_stats.total_queries in
     if total = 0.0 then (0.0, 0.0)
     else (
-      float_of_int global_stats.small_only /. total,
-      float_of_int global_stats.has_large /. total
+      float_of_int global_stats.cheap_only /. total,
+      float_of_int global_stats.has_expensive /. total
     )
 
   let reset () : unit =
     global_stats.total_queries <- 0;
-    global_stats.small_only <- 0;
-    global_stats.has_large <- 0
+    global_stats.cheap_only <- 0;
+    global_stats.has_expensive <- 0
 end
 
 (** Route and record stats *)

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -166,6 +166,8 @@ let pre_compact_record_json (event : pre_compact_event) =
       ("token_count", `Int event.token_count);
       ("strategies", `List (List.map (fun value -> `String value) event.strategies));
       ("model_family", `String event.model_family);
+      ("context_window", `Int event.context_window);
+      ("is_local_model", `Bool event.is_local_model);
       ("trigger", `String event.trigger);
     ]
 
@@ -179,6 +181,8 @@ let pre_compact_event_json (event : pre_compact_event) =
       ("token_count", `Int event.token_count);
       ("strategies", `List (List.map (fun value -> `String value) event.strategies));
       ("model_family", `String event.model_family);
+      ("context_window", `Int event.context_window);
+      ("is_local_model", `Bool event.is_local_model);
       ("trigger", `String event.trigger);
     ]
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -452,12 +452,12 @@ let run_turn
     then Keeper_cdal_contract.of_keeper_meta meta
     else None
   in
-  let yield_on_tool = Env_config.slot_yield_enabled () in
+  let yield_on_tool = Env_config.Slot.yield_enabled () in
   let on_yield = if yield_on_tool then Some (fun () ->
-    Log.Misc.info "keeper %s: slot yielded (tool execution)" meta.name
+    Log.Misc.debug "keeper %s: slot yielded (tool execution)" meta.name
   ) else None in
   let on_resume = if yield_on_tool then Some (fun () ->
-    Log.Misc.info "keeper %s: slot resumed (next LLM turn)" meta.name
+    Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" meta.name
   ) else None in
   match
         Oas_worker.run_named

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -630,9 +630,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   | Error reason ->
       (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
   | Ok _token ->
-      (* Token proves the name is registered. lookup_tag None is defensive:
-         both mint_token and lookup_tag check tag_registry, so None here
-         would indicate a registration inconsistency, not a user error. *)
+      (* Token proves the name is registered in at least one registry.
+         lookup_tag None after mint is a registry inconsistency (tool in
+         handler registry but not tag registry), not a user error. *)
       let tag_result =
         match Tool_dispatch.lookup_tag name with
         | Some tag -> dispatch_by_tag tag
@@ -641,4 +641,5 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (match tag_result with
        | Some result -> result
        | None ->
-           (false, Printf.sprintf "Unknown tool: %s (no tag after mint)" name))
+           Log.Mcp.warn "registry inconsistency: %s minted but no tag" name;
+           (false, Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -341,6 +341,8 @@ let run
   (try
     let result, proof = match contract with
       | Some c ->
+        (* on_yield/on_resume not forwarded: Contract_runner.run does not
+           expose yield hooks. Slot yielding is inactive during contract runs. *)
         let cr = Oas.Contract_runner.run ~sw ~contract:c agent goal in
         (cr.response, Some cr.proof)
       | None ->

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -192,9 +192,9 @@ let () = Room_hooks.observe_agent_lifecycle_fn :=
 
 let () = Room_hooks.observe_task_transition_fn :=
   (fun config ~agent_name ~room_id ~task_id ~transition ~details ->
+    !Room_hooks.on_task_mutation_fn ();
     observe_task_transition_event config ~agent_name ~room_id ~task_id
-      ~transition ~details;
-    !Room_hooks.on_task_mutation_fn ())
+      ~transition ~details)
 
 (* Board artifact cleanup — wraps Board_dispatch for GC *)
 let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -37,6 +37,7 @@ let update_priority config ~task_id ~priority =
           log_event config (Printf.sprintf
             "{\"type\":\"priority_change\",\"task\":\"%s\",\"old\":%d,\"new\":%d,\"ts\":\"%s\"}"
             task_id old_priority priority (now_iso ()));
+          !Room_hooks.on_task_mutation_fn ();
 
           Printf.sprintf "✅ Task %s priority: P%d → P%d" task_id old_priority priority
     with

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -100,8 +100,8 @@ let add_task config ~title ~priority ~description =
             ("priority", `Int priority);
           ]);
 
-    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
     !Room_hooks.on_task_mutation_fn ();
+    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
     Printf.sprintf "✅ Added %s: %s" task_id title)
 
 (** Add task with a required role constraint — file-locked *)
@@ -189,9 +189,9 @@ let batch_add_tasks config tasks =
                 ]))
         added_tasks;
       let summary = String.concat ", " (List.map (fun (t : Types.task) -> t.id) added_tasks) in
+      !Room_hooks.on_task_mutation_fn ();
       let msg = Printf.sprintf "📋 New batch of %d quests added: %s" (List.length added_tasks) summary in
       let _ = broadcast config ~from_agent:"system" ~content:msg in
-      !Room_hooks.on_task_mutation_fn ();
       Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -81,11 +81,14 @@ let _execution_cache =
 
 (** Invalidate the execution surface cache so the next
     [/api/v1/dashboard/execution] request recomputes fresh data.
-    Call after task mutations (add, transition, cancel) to avoid
-    serving stale backlog state for up to [ttl] seconds. *)
+    Called via [Room_hooks.on_task_mutation_fn] after task add,
+    batch_add, and all transitions (claim, start, done, cancel,
+    release) routed through [observe_task_transition].
+    Best-effort: never raises — cache staleness must not break
+    the mutation path. *)
 let invalidate_execution_cache () =
-  invalidate_cached_surface _execution_cache;
-  Dashboard_cache.invalidate "execution:default:light"
+  (try invalidate_cached_surface _execution_cache with _ -> ());
+  (try Dashboard_cache.invalidate "execution:default:light" with _ -> ())
 
 (** Bypass the proactive warm-up guard so tests that call
     [dashboard_room_truth_http_json] get the full response instead of

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -198,10 +198,13 @@ let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_regis
 let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> tag_registry_initialized := true)
 let is_tag_registry_initialized () = with_dispatch_ro (fun () -> !tag_registry_initialized)
 
-(** Mint a [Tool_token.t] validated against both tag and handler registries.
-    Checks tag_registry first (primary), falls back to handler registry.
-    Convenience wrapper for callers without direct table access. *)
+(** Mint a [Tool_token.t] validated against both registries.
+    Protected by dispatch_mu for thread safety (Copilot review).
+    Checks tag_registry (primary) then handler registry (fallback).
+    In production both are populated at startup; in test binaries
+    only the handler registry may be populated. *)
 let mint_token ~name =
-  Tool_token.mint_with
-    ~validate:(fun n -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
-    ~name
+  with_dispatch_ro (fun () ->
+    Tool_token.mint_with
+      ~validate:(fun n -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
+      ~name)

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -26,7 +26,7 @@ val dispatch : token:Tool_token.t -> args:Yojson.Safe.t -> (bool * string) optio
 
 val mint_token : name:string -> (Tool_token.t, string) result
 (** Mint a [Tool_token.t] validated against both tag and handler registries.
-    Returns [Error] when the tool name is unknown to the dispatch system. *)
+    Thread-safe (protected by dispatch_mu). *)
 
 (** {2 Dispatch Hooks}
 

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -15,6 +15,13 @@ let echo_handler ~name ~args:_ = Some (true, "ok:" ^ name)
 (** Helper: a handler that returns (false, "fail"). *)
 let fail_handler ~name:_ ~args:_ = Some (false, "fail")
 
+(** Helper: register a tool in both handler and tag registries.
+    mint_token validates against tag_registry, so tests that mint
+    must register in both. *)
+let register_full ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_name_tag ~tool_name ~tag:Mod_misc
+
 let () =
   let open Alcotest in
   run "Tool_dispatch"
@@ -23,7 +30,7 @@ let () =
         [
           test_case "register single tool and dispatch" `Quick (fun () ->
               let tool = "__test_dispatch_single" in
-              Tool_dispatch.register ~tool_name:tool ~handler:echo_handler;
+              register_full ~tool_name:tool ~handler:echo_handler;
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result = Tool_dispatch.dispatch ~token ~args:`Null in
               check bool "found" true (Option.is_some result);
@@ -42,6 +49,7 @@ let () =
                   [ "__test_bulk_a"; "__test_bulk_b"; "__test_bulk_c" ]
               in
               Tool_dispatch.register_module ~schemas ~handler:echo_handler;
+              List.iter (fun s -> Tool_dispatch.register_name_tag ~tool_name:s.Types.name ~tag:Mod_misc) schemas;
               List.iter
                 (fun name ->
                   check bool (name ^ " registered") true
@@ -60,13 +68,13 @@ let () =
         [
           test_case "re-register replaces handler" `Quick (fun () ->
               let tool = "__test_dispatch_replace" in
-              Tool_dispatch.register ~tool_name:tool ~handler:echo_handler;
+              register_full ~tool_name:tool ~handler:echo_handler;
               let token1 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let (ok1, _) =
                 Option.get (Tool_dispatch.dispatch ~token:token1 ~args:`Null)
               in
               check bool "first ok" true ok1;
-              Tool_dispatch.register ~tool_name:tool ~handler:fail_handler;
+              register_full ~tool_name:tool ~handler:fail_handler;
               let token2 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let (ok2, msg2) =
                 Option.get (Tool_dispatch.dispatch ~token:token2 ~args:`Null)
@@ -135,7 +143,7 @@ let () =
                 received_args := args;
                 Some (true, "captured")
               in
-              Tool_dispatch.register ~tool_name:tool ~handler:capture_handler;
+              register_full ~tool_name:tool ~handler:capture_handler;
               let test_args = `Assoc [("key", `String "value")] in
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let _ = Tool_dispatch.dispatch ~token ~args:test_args in
@@ -148,7 +156,7 @@ let () =
               let throwing_handler ~name:_ ~args:_ =
                 failwith "boom"
               in
-              Tool_dispatch.register ~tool_name:tool ~handler:throwing_handler;
+              register_full ~tool_name:tool ~handler:throwing_handler;
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result = Tool_dispatch.dispatch ~token ~args:`Null in
               check bool "still returns Some" true (Option.is_some result);

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -22,6 +22,7 @@ let test_pre_hook_observes () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (true, "ok"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     None);
@@ -39,6 +40,7 @@ let test_pre_hook_short_circuits () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (true, "should not reach"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
     Some { Tool_result.success = false;
@@ -62,6 +64,7 @@ let test_multiple_pre_hooks_first_wins () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (true, "ok"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre1";
@@ -92,6 +95,7 @@ let test_post_hook_observes () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (true, "original"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_post" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post";
     r);
@@ -109,6 +113,7 @@ let test_post_hook_transforms () =
     ~tool_name:"__hook_transform"
     ~handler:(fun ~name:_ ~args:_ ->
       Some (true, "original"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_transform" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     { r with Tool_result.data = `String "transformed" });
   let token = match Tool_dispatch.mint_token ~name:"__hook_transform" with Ok t -> t | Error e -> Alcotest.fail e in
@@ -125,6 +130,7 @@ let test_post_hooks_chain () =
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
       Some (true, "0"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post1";
     { r with Tool_result.data = `String "1" });
@@ -149,6 +155,7 @@ let test_full_lifecycle () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (true, "data"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     None);
@@ -166,6 +173,7 @@ let test_no_hooks_default () =
   Tool_dispatch.register
     ~tool_name:"__hook_none"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "plain"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -85,6 +85,7 @@ let test_dispatch_structured () =
   Tool_dispatch.register
     ~tool_name:"__test_tool"
     ~handler:(fun ~name:_ ~args:_ -> Some (true, {|{"result":"ok"}|}));
+  Tool_dispatch.register_name_tag ~tool_name:"__test_tool" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__test_tool" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.dispatch_structured ~token ~args:`Null with
   | Some r ->

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -82,6 +82,7 @@ let test_mint_token_registered () =
   let tool = "__test_token_registered" in
   Tool_dispatch.register ~tool_name:tool
     ~handler:(fun ~name:_ ~args:_ -> Some (true, "ok"));
+  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
   | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
@@ -95,6 +96,7 @@ let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
   Tool_dispatch.register ~tool_name:tool
     ~handler:(fun ~name ~args:_ -> Some (true, "dispatched:" ^ name));
+  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## Summary
- squash merge 후 브랜치에 남아있던 orphan 커밋 8건을 cherry-pick으로 회수
- 25개 active worktree에서 orphan 커밋을 식별, cherry-pick 가능 여부 테스트 후 clean apply 가능한 것만 포함

## Recovered changes

| 원본 브랜치 | 원본 PR | 내용 |
|------------|---------|------|
| `dashboard-task-cache-invalidation` | #4442 | GLM 리뷰 대응: 방어적 에러 경계 + 순서 수정 |
| `feat/4383-tool-token` | #4414 | mutex guard + dual registry for Tool_token |
| `feat/remove-tier-phase2` | #4413 | Stats 필드 직렬화 + rename |
| `feat/slot-yield-bridge` | #4396 | Copilot 리뷰 수정, flag 등록, on_yield/on_resume 배선 |
| `feat/3915-css-split` | #4398 | CSS dead code 제거, self-referencing var() 수정 |

## Excluded (conflict — separate work needed)
- `fix/dashboard-mcp-auth` (#4362): 4건 전부 conflict
- `feat/4381-tool-gate-2a` (#4439): 1건 conflict

## Test plan
- [x] `dune build` 성공
- [x] cherry-pick 8건 모두 clean apply (no conflict)
- [ ] `dune runtest` 통과 (실행 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)