### PR TITLE
fix(transport): add registry_mutex for SSE Hashtbl concurrent access

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -73,7 +73,7 @@ let stream_post_sse_start ~deps ~origin ~session_id ~protocol_version
   in
   let response = Httpun.Response.create ~headers `OK in
   let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let info = make_inline_sse_conn ~session_id writer in
+  let info = make_inline_sse_conn ~session_id ~writer in
   ignore (send_raw info (sse_prime_event ()));
   info
 
@@ -475,7 +475,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
             }
           in
           info_ref := Some info;
-          Hashtbl.replace sse_conn_by_session session_id info;
+          register_sse_conn ~session_id ~info;
           ignore (send_raw info (sse_prime_event ()));
           (match legacy_messages_endpoint with
           | None -> ()

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -77,7 +77,7 @@ let handle_ag_ui_events ~deps request reqd =
         }
       in
       info_ref := Some info;
-      Hashtbl.replace sse_conn_by_session session_id info;
+      register_sse_conn ~session_id ~info;
       let prime =
         Ag_ui.(
           make_event ~thread_id:room_id ~run_id:(Some session_id) Run_started

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -1,4 +1,9 @@
-(** Server_mcp_transport_http_conn — SSE connection lifecycle management. *)
+(** Server_mcp_transport_http_conn — SSE connection lifecycle management.
+
+    Uses [registry_mutex] for table-level protection of shared mutable state.
+    All direct Hashtbl access to the two global tables
+    ([sse_conn_by_session], [sse_connect_guard_by_session])
+    must go through the module-level [registry_mutex]. *)
 
 type sse_conn_info = {
   session_id : string;
@@ -19,6 +24,9 @@ type sse_connect_guard_state = {
 let sse_connect_guard_by_session :
     (string, sse_connect_guard_state) Hashtbl.t =
   Hashtbl.create 256
+
+(** Module-level mutex protecting both SSE Hashtbl operations. *)
+let registry_mutex = Eio.Mutex.create ()
 
 let env_float_or ~name ~default =
   match Sys.getenv_opt name with
@@ -42,6 +50,7 @@ let sse_connect_window_s =
 let sse_connect_max_in_window =
   env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0 |> max 0
 
+(** Close a single SSE connection (no registry mutation). *)
 let close_sse_conn info =
   if not info.closed then (
     info.closed <- true;
@@ -54,35 +63,52 @@ let close_sse_conn info =
          (Printexc.to_string exn));
     Sse.unregister_if_current info.session_id info.client_id)
 
+(** Register an SSE connection under [registry_mutex].
+    Replaces direct [Hashtbl.replace sse_conn_by_session] at call sites. *)
+let register_sse_conn ~session_id ~info =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      Hashtbl.replace sse_conn_by_session session_id info;
+      (* Reset guard on register — new connections reset it *)
+      Hashtbl.remove sse_connect_guard_by_session session_id)
+
 let stop_sse_session session_id =
-  match Hashtbl.find_opt sse_conn_by_session session_id with
-  | None -> ()
-  | Some info ->
-      Hashtbl.remove sse_conn_by_session session_id;
-      Hashtbl.remove sse_connect_guard_by_session session_id;
-      close_sse_conn info
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      match Hashtbl.find_opt sse_conn_by_session session_id with
+      | None -> ()
+      | Some info ->
+          Hashtbl.remove sse_conn_by_session session_id;
+          Hashtbl.remove sse_connect_guard_by_session session_id;
+          close_sse_conn info)
 
 let is_active_sse_session session_id =
-  Hashtbl.mem sse_conn_by_session session_id
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      Hashtbl.mem sse_conn_by_session session_id)
 
 let reap_stale_guards () =
-  let stale =
-    Hashtbl.fold (fun sid _ acc ->
-      if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
-      else acc
-    ) sse_connect_guard_by_session []
-  in
-  List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
-  List.length stale
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      let stale =
+        Hashtbl.fold (fun sid _ acc ->
+            if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
+            else acc)
+          sse_connect_guard_by_session []
+      in
+      List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
+      List.length stale)
 
+(** Snapshot sessions under mutex, then close each outside the lock
+    to avoid deadlock (each [stop_sse_session] acquires [registry_mutex]). *)
 let close_all_sse_connections () =
-  let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in
+  let sessions =
+    Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+        Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [])
+  in
   List.iter stop_sse_session sessions;
   Log.Server.info "MASC MCP: Closed %d SSE connections"
     (List.length sessions)
 
 let send_raw info data =
-  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then (
+  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer
+  then (
     close_sse_conn info;
     false)
   else
@@ -98,7 +124,8 @@ let send_raw info data =
       close_sse_conn info;
       false
 
-let make_inline_sse_conn ~session_id writer =
+(** Inline SSE conn for HTTP response — no registry tracking. *)
+let make_inline_sse_conn ~session_id ~writer =
   {
     session_id;
     client_id = -1;
@@ -113,37 +140,35 @@ let prune_connect_times ~now times =
   else List.filter (fun ts -> now -. ts <= sse_connect_window_s) times
 
 let check_sse_connect_guard session_id =
-  let now = Time_compat.now () in
-  let state =
-    match Hashtbl.find_opt sse_connect_guard_by_session session_id with
-    | Some v -> v
-    | None -> { last_connect_at = -.1.0; connect_times = [] }
-  in
-  let recent = prune_connect_times ~now state.connect_times in
-  state.connect_times <- recent;
-  let session_wait_s =
-    if sse_reconnect_min_interval_s <= 0.0 then
-      0.0
-    else
-      sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
-  in
-  if session_wait_s > 0.0 then
-    Error ("session_cooldown", session_wait_s)
-  else
-    let window_wait_s =
-      if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
-        0.0
-      else if List.length recent >= sse_connect_max_in_window then
-        match List.rev recent with
-        | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
-        | [] -> 0.0
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      let now = Time_compat.now () in
+      let state =
+        match Hashtbl.find_opt sse_connect_guard_by_session session_id with
+        | Some v -> v
+        | None -> { last_connect_at = -.1.0; connect_times = [] }
+      in
+      let recent = prune_connect_times ~now state.connect_times in
+      state.connect_times <- recent;
+      let session_wait_s =
+        if sse_reconnect_min_interval_s <= 0.0 then 0.0
+        else sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
+      in
+      if session_wait_s > 0.0 then
+        Error ("session_cooldown", session_wait_s)
       else
-        0.0
-    in
-    if window_wait_s > 0.0 then
-      Error ("window_limit", window_wait_s)
-    else (
-      state.last_connect_at <- now;
-      state.connect_times <- now :: recent;
-      Hashtbl.replace sse_connect_guard_by_session session_id state;
-      Ok ())
+        let window_wait_s =
+          if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
+            0.0
+          else if List.length recent >= sse_connect_max_in_window then
+            match List.rev recent with
+            | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
+            | [] -> 0.0
+          else 0.0
+        in
+        if window_wait_s > 0.0 then
+          Error ("window_limit", window_wait_s)
+        else (
+          state.last_connect_at <- now;
+          state.connect_times <- now :: recent;
+          Hashtbl.replace sse_connect_guard_by_session session_id state;
+          Ok ()))

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -67,9 +67,7 @@ let close_sse_conn info =
     Replaces direct [Hashtbl.replace sse_conn_by_session] at call sites. *)
 let register_sse_conn ~session_id ~info =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.replace sse_conn_by_session session_id info;
-      (* Reset guard on register — new connections reset it *)
-      Hashtbl.remove sse_connect_guard_by_session session_id)
+      Hashtbl.replace sse_conn_by_session session_id info)
 
 let stop_sse_session session_id =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->


### PR DESCRIPTION
## Summary
- Add module-level `registry_mutex` to `server_mcp_transport_http_conn.ml` protecting both `sse_conn_by_session` and `sse_connect_guard_by_session` Hashtbls
- All Hashtbl operations now go through `Eio.Mutex.use_rw ~protect:true registry_mutex`
- Introduce `register_sse_conn` to replace direct `Hashtbl.replace` at call sites in http.ml and agui.ml
- `close_all_sse_connections` uses snapshot-under-lock then close-outside-lock pattern to avoid deadlock

## Test plan
- [x] `dune build @install` passes
- [ ] Manual SSE connection test with concurrent clients
- [ ] Verify no deadlock during graceful shutdown

Closes #4430

🤖 Generated with [Claude Code](https://claude.com/claude-code)