### PR TITLE
fix(encryption): safe hex key parsing with bounds check and validation

### DIFF
--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -64,10 +64,11 @@ let base64_decode s =
 
 (** Decode hex string to raw bytes. Returns Error on invalid input. *)
 let decode_hex_key content : (string, encryption_error) result =
+  let content = String.trim content in
   let len = String.length content in
-  if len < 64 then
+  if len <> 64 then
     Error (InvalidHexFormat
-      (Printf.sprintf "hex key too short: need 64 chars, got %d" len))
+      (Printf.sprintf "hex key must be exactly 64 characters, got %d" len))
   else
     let buf = Buffer.create 32 in
     let err = ref None in
@@ -79,7 +80,7 @@ let decode_hex_key content : (string, encryption_error) result =
            Buffer.add_char buf (Char.chr v)
        | _ ->
            err := Some (InvalidHexFormat
-             (Printf.sprintf "invalid hex byte at position %d: %S" (!i * 2) hex)));
+             (Printf.sprintf "invalid hex byte at position %d" (!i * 2))));
       incr i
     done;
     match !err with

--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -30,6 +30,7 @@ type envelope = {
 type encryption_error =
   | KeyNotFound of string
   | InvalidKeyLength of int
+  | InvalidHexFormat of string
   | DecryptionFailed
   | InvalidEnvelope of string
   | RngNotInitialized
@@ -37,6 +38,7 @@ type encryption_error =
 let show_encryption_error = function
   | KeyNotFound s -> Printf.sprintf "KeyNotFound: %s" s
   | InvalidKeyLength n -> Printf.sprintf "InvalidKeyLength: expected 32, got %d" n
+  | InvalidHexFormat s -> Printf.sprintf "InvalidHexFormat: %s" s
   | DecryptionFailed -> "DecryptionFailed: authentication tag mismatch"
   | InvalidEnvelope s -> Printf.sprintf "InvalidEnvelope: %s" s
   | RngNotInitialized -> "RngNotInitialized: call initialize() first"
@@ -60,30 +62,53 @@ let base64_decode s =
   | Ok decoded -> Some (Cstruct.of_string decoded)
   | Error _ -> None
 
+(** Decode hex string to raw bytes. Returns Error on invalid input. *)
+let decode_hex_key content : (string, encryption_error) result =
+  let len = String.length content in
+  if len < 64 then
+    Error (InvalidHexFormat
+      (Printf.sprintf "hex key too short: need 64 chars, got %d" len))
+  else
+    let buf = Buffer.create 32 in
+    let err = ref None in
+    let i = ref 0 in
+    while !i < 32 && !err = None do
+      let hex = String.sub content (!i * 2) 2 in
+      (match int_of_string_opt ("0x" ^ hex) with
+       | Some v when v >= 0 && v <= 255 ->
+           Buffer.add_char buf (Char.chr v)
+       | _ ->
+           err := Some (InvalidHexFormat
+             (Printf.sprintf "invalid hex byte at position %d: %S" (!i * 2) hex)));
+      incr i
+    done;
+    match !err with
+    | Some e -> Error e
+    | None -> Ok (Buffer.contents buf)
+
 (** Load encryption key from configured source *)
 let load_key config : (GCM.key, encryption_error) result =
-  let key_string = match config.key_source with
+  let key_result = match config.key_source with
     | `Env var_name ->
-        Sys.getenv_opt var_name
+        (match Sys.getenv_opt var_name with
+         | Some v -> Ok (Some v)
+         | None -> Ok None)
     | `File path ->
         if Sys.file_exists path then
           let content = Fs_compat.load_file path in
-          let content = String.sub content 0 (min 64 (String.length content)) in (* hex-encoded 32 bytes *)
-          (* Decode hex to bytes *)
-          let bytes = ref "" in
-          for i = 0 to 31 do
-            let hex = String.sub content (i * 2) 2 in
-            bytes := !bytes ^ String.make 1 (Char.chr (int_of_string ("0x" ^ hex)))
-          done;
-          Some !bytes
-        else None
-    | `Direct key -> Some key
+          let content = String.trim content in
+          (match decode_hex_key content with
+           | Ok bytes -> Ok (Some bytes)
+           | Error e -> Error e)
+        else Ok None
+    | `Direct key -> Ok (Some key)
   in
-  match key_string with
-  | None -> Error (KeyNotFound "encryption key not configured")
-  | Some key when String.length key <> 32 ->
+  match key_result with
+  | Error e -> Error e
+  | Ok None -> Error (KeyNotFound "encryption key not configured")
+  | Ok (Some key) when String.length key <> 32 ->
       Error (InvalidKeyLength (String.length key))
-  | Some key ->
+  | Ok (Some key) ->
       Ok (GCM.of_secret key)
 
 (** Generate a random 12-byte nonce (GCM recommended size) *)

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -76,10 +76,36 @@ let test_error_invalid_envelope () =
   let s = Encryption.show_encryption_error e in
   check bool "contains Invalid" true (String.sub s 0 15 = "InvalidEnvelope")
 
+let test_error_invalid_hex_format () =
+  let e = Encryption.InvalidHexFormat "bad hex" in
+  let s = Encryption.show_encryption_error e in
+  check bool "contains InvalidHexFormat" true (String.sub s 0 16 = "InvalidHexFormat")
+
 let test_error_rng_not_initialized () =
   let e = Encryption.RngNotInitialized in
   let s = Encryption.show_encryption_error e in
   check bool "contains RNG" true (String.sub s 0 17 = "RngNotInitialized")
+
+let test_decode_hex_key_valid () =
+  let hex = String.init 64 (fun i ->
+    let byte_val = i / 2 in
+    let nibble = if i mod 2 = 0 then byte_val / 16 else byte_val mod 16 in
+    "0123456789abcdef".[nibble]) in
+  match Encryption.decode_hex_key hex with
+  | Ok bytes -> check int "decoded length" 32 (String.length bytes)
+  | Error e -> fail (Encryption.show_encryption_error e)
+
+let test_decode_hex_key_too_short () =
+  match Encryption.decode_hex_key "aabb" with
+  | Error (Encryption.InvalidHexFormat _) -> ()
+  | _ -> fail "Expected InvalidHexFormat for short input"
+
+let test_decode_hex_key_invalid_chars () =
+  let hex = "GG" ^ String.make 62 '0' in
+  match Encryption.decode_hex_key hex with
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions position" true (String.length msg > 0)
+  | _ -> fail "Expected InvalidHexFormat for invalid hex chars"
 
 (* ============================================================
    envelope Tests
@@ -503,9 +529,15 @@ let () =
     "encryption_error", [
       test_case "key not found" `Quick test_error_key_not_found;
       test_case "invalid key length" `Quick test_error_invalid_key_length;
+      test_case "invalid hex format" `Quick test_error_invalid_hex_format;
       test_case "decryption failed" `Quick test_error_decryption_failed;
       test_case "invalid envelope" `Quick test_error_invalid_envelope;
       test_case "rng not initialized" `Quick test_error_rng_not_initialized;
+    ];
+    "decode_hex_key", [
+      test_case "valid hex" `Quick test_decode_hex_key_valid;
+      test_case "too short" `Quick test_decode_hex_key_too_short;
+      test_case "invalid chars" `Quick test_decode_hex_key_invalid_chars;
     ];
     "envelope", [
       test_case "creation" `Quick test_envelope_creation;

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -97,14 +97,23 @@ let test_decode_hex_key_valid () =
 
 let test_decode_hex_key_too_short () =
   match Encryption.decode_hex_key "aabb" with
-  | Error (Encryption.InvalidHexFormat _) -> ()
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions 64 chars" true (String.contains msg '6' && String.contains msg '4')
   | _ -> fail "Expected InvalidHexFormat for short input"
+
+let test_decode_hex_key_too_long () =
+  let long_hex = String.make 66 '0' in
+  match Encryption.decode_hex_key long_hex with
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions 64 chars" true (String.contains msg '6' && String.contains msg '4')
+  | _ -> fail "Expected InvalidHexFormat for long input"
 
 let test_decode_hex_key_invalid_chars () =
   let hex = "GG" ^ String.make 62 '0' in
   match Encryption.decode_hex_key hex with
   | Error (Encryption.InvalidHexFormat msg) ->
-      check bool "mentions position" true (String.length msg > 0)
+      check bool "mentions position" true (String.length msg > 0);
+      check bool "does NOT mention invalid chars (security)" false (String.contains msg 'G')
   | _ -> fail "Expected InvalidHexFormat for invalid hex chars"
 
 (* ============================================================
@@ -242,6 +251,24 @@ let test_load_key_file_not_found () =
   | Ok _ -> fail "should fail for missing file"
   | Error (Encryption.KeyNotFound _) -> ()
   | Error _ -> fail "unexpected error type"
+
+let test_load_key_file_invalid_hex () =
+  let path = Filename.temp_file "masc-key-invalid-" ".txt" in
+  let oc = open_out path in
+  output_string oc (String.make 64 'g');
+  close_out oc;
+  let config : Encryption.config = {
+    enabled = true;
+    key_source = `File path;
+    version = 1;
+  } in
+  let result = Encryption.load_key config in
+  (match result with
+  | Error (Encryption.InvalidHexFormat _) -> ()
+  | Error (Encryption.KeyNotFound _) -> fail "expected invalid format, got missing key"
+  | Error _ -> fail "expected invalid hex format"
+  | Ok _ -> fail "should fail for malformed hex");
+  (try Sys.remove path with _ -> ())
 
 (* ============================================================
    envelope_to_json / envelope_of_json Tests
@@ -537,6 +564,7 @@ let () =
     "decode_hex_key", [
       test_case "valid hex" `Quick test_decode_hex_key_valid;
       test_case "too short" `Quick test_decode_hex_key_too_short;
+      test_case "too long" `Quick test_decode_hex_key_too_long;
       test_case "invalid chars" `Quick test_decode_hex_key_invalid_chars;
     ];
     "envelope", [
@@ -565,6 +593,7 @@ let () =
       test_case "direct wrong length" `Quick test_load_key_direct_wrong_length;
       test_case "env not found" `Quick test_load_key_env_not_found;
       test_case "file not found" `Quick test_load_key_file_not_found;
+      test_case "file invalid hex" `Quick test_load_key_file_invalid_hex;
     ];
     "envelope_json", [
       test_case "to_json" `Quick test_envelope_to_json;

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -112,8 +112,9 @@ let test_decode_hex_key_invalid_chars () =
   let hex = "GG" ^ String.make 62 '0' in
   match Encryption.decode_hex_key hex with
   | Error (Encryption.InvalidHexFormat msg) ->
-      check bool "mentions position" true (String.length msg > 0);
-      check bool "does NOT mention invalid chars (security)" false (String.contains msg 'G')
+      check bool "mentions position index" true
+        (String.starts_with ~prefix:"invalid hex byte at position" msg);
+      check bool "does NOT leak invalid chars (security)" false (String.contains msg 'G')
   | _ -> fail "Expected InvalidHexFormat for invalid hex chars"
 
 (* ============================================================


### PR DESCRIPTION
## Summary

- `decode_hex_key` 함수 추출 — bounds check + hex validation + Buffer 사용
- `InvalidHexFormat` 에러 variant 추가 (위치 정보 포함)
- `String.trim`으로 키 파일 trailing newline 처리

## Problem

기존 hex 파싱은 3가지 crash 경로가 있었음:
1. 키 파일 < 64자 → `String.sub` `Invalid_argument`
2. 비정상 hex (e.g. "GG") → `int_of_string` `Failure`
3. O(n^2) string concat (`ref "" ^ ...`)

## Test plan

- [x] `test_encryption_coverage.exe` — 50 tests pass
- [x] 새 테스트 3건: valid hex, too short, invalid chars
- [ ] CI full suite

Closes #4432

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>