### PR TITLE
feat(dispatch): Zone_tbl per-keeper tool zone stack (#4381 Phase 2B)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -287,6 +287,7 @@
    tool_cache
    tool_access_policy
    tool_gate
+   zone_tbl
    tool_access_role
    tool_tempo
    tool_portal

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -214,7 +214,14 @@ let run_turn
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
   let meta_ref = ref meta in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in
-  let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+  (* Phase 2B: zone table for tool boundary management.
+     Created per-turn with the keeper's allowed tools as base.
+     No zones entered by default; zone_enter/exit triggers are Phase 2C. *)
+  let zone =
+    Zone_tbl.create
+      ~base_tools:(Keeper_exec_tools.keeper_allowed_tool_names meta)
+  in
+  let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref ~zone () in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
   let tool_usage_before =

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -732,7 +732,7 @@ let run_proactive_generation
       ~continuity_summary
   in
   let ctx_ref = ref ctx_work in
-  let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+  let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
   let rec loop attempt usage_acc latency_acc cost_acc retry_hint =
     if attempt > max_attempts then
       Some {

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -149,9 +149,14 @@ let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
     ~(ctx_ref : Keeper_working_context.working_context ref)
+    ?zone
+    ()
   : Agent_sdk.Tool.t list =
   let allowed_names =
-    Keeper_exec_tools.keeper_allowed_tool_names meta
+    let base = Keeper_exec_tools.keeper_allowed_tool_names meta in
+    match zone with
+    | None -> base
+    | Some zt -> List.filter (fun n -> Zone_tbl.is_tool_allowed zt n) base
   in
   let tool_defs =
     Keeper_exec_tools.keeper_allowed_model_tools meta

--- a/lib/zone_tbl.ml
+++ b/lib/zone_tbl.ml
@@ -32,28 +32,14 @@ let set_of_list names =
   List.iter (fun n -> Hashtbl.replace tbl n ()) names;
   tbl
 
-(** Normalize: trim whitespace, drop empty strings, deduplicate.
-    Same contract as Tool_gate.apply's input normalization. *)
-let normalize names =
-  let seen = Hashtbl.create (max 16 (List.length names)) in
-  let rec loop acc = function
-    | [] -> List.rev acc
-    | n :: rest ->
-        let n = String.trim n in
-        if n = "" || Hashtbl.mem seen n then loop acc rest
-        else begin
-          Hashtbl.replace seen n ();
-          loop (n :: acc) rest
-        end
-  in
-  loop [] names
-
 (* ================================================================ *)
 (* create                                                            *)
 (* ================================================================ *)
 
 let create ~base_tools =
-  let base = normalize base_tools in
+  (* Delegate normalization to Tool_gate.apply Keep_all to avoid
+     duplicating trim/dedup logic (GLM-5.1 review P2.2). *)
+  let base = Tool_gate.apply Tool_gate.Keep_all base_tools in
   {
     base;
     base_lookup = set_of_list base;

--- a/lib/zone_tbl.ml
+++ b/lib/zone_tbl.ml
@@ -1,0 +1,142 @@
+(** Zone_tbl — per-keeper tool zone stack with O(1) membership check.
+    Phase 2B of Tool Gate architecture (#4381). *)
+
+(* ================================================================ *)
+(* Types                                                             *)
+(* ================================================================ *)
+
+type zone_id = int
+
+type zone_frame = {
+  id : zone_id;
+  op : Tool_gate.tool_op;
+  snapshot : string list;
+  current : string list;
+  lookup : (string, unit) Hashtbl.t;
+}
+
+type t = {
+  base : string list;
+  base_lookup : (string, unit) Hashtbl.t;
+  stack : zone_frame list;
+  next_id : int;
+}
+
+(* ================================================================ *)
+(* Local helpers                                                     *)
+(* Reuses normalize from Tool_gate via apply; build Hashtbl locally. *)
+(* ================================================================ *)
+
+let set_of_list names =
+  let tbl = Hashtbl.create (max 16 (List.length names)) in
+  List.iter (fun n -> Hashtbl.replace tbl n ()) names;
+  tbl
+
+(** Normalize: trim whitespace, drop empty strings, deduplicate.
+    Same contract as Tool_gate.apply's input normalization. *)
+let normalize names =
+  let seen = Hashtbl.create (max 16 (List.length names)) in
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | n :: rest ->
+        let n = String.trim n in
+        if n = "" || Hashtbl.mem seen n then loop acc rest
+        else begin
+          Hashtbl.replace seen n ();
+          loop (n :: acc) rest
+        end
+  in
+  loop [] names
+
+(* ================================================================ *)
+(* create                                                            *)
+(* ================================================================ *)
+
+let create ~base_tools =
+  let base = normalize base_tools in
+  {
+    base;
+    base_lookup = set_of_list base;
+    stack = [];
+    next_id = 0;
+  }
+
+(* ================================================================ *)
+(* Query                                                             *)
+(* ================================================================ *)
+
+let current_tools t =
+  match t.stack with
+  | [] -> t.base
+  | frame :: _ -> frame.current
+
+let base_tools t = t.base
+
+let is_tool_allowed t name =
+  let lookup =
+    match t.stack with
+    | [] -> t.base_lookup
+    | frame :: _ -> frame.lookup
+  in
+  Hashtbl.mem lookup name
+
+let depth t = List.length t.stack
+
+let is_base t = t.stack = []
+
+(* ================================================================ *)
+(* enter                                                             *)
+(* ================================================================ *)
+
+let enter ~op t =
+  let prev = current_tools t in
+  let cur = Tool_gate.apply op prev in
+  let frame =
+    { id = t.next_id;
+      op;
+      snapshot = prev;
+      current = cur;
+      lookup = set_of_list cur;
+    }
+  in
+  (t.next_id, { t with stack = frame :: t.stack; next_id = t.next_id + 1 })
+
+(* ================================================================ *)
+(* exit                                                              *)
+(* ================================================================ *)
+
+let exit ~zone_id t =
+  match t.stack with
+  | [] ->
+      Error "cannot exit base: zone stack is empty"
+  | top :: rest ->
+      if top.id <> zone_id then
+        Error
+          (Printf.sprintf
+            "LIFO violation: expected zone_id %d (top), got %d"
+            top.id zone_id)
+      else
+        Ok { t with stack = rest }
+
+let exit_all t =
+  { t with stack = [] }
+
+(* ================================================================ *)
+(* to_yojson                                                         *)
+(* ================================================================ *)
+
+let to_yojson t =
+  let zone_frame_to_yojson f =
+    `Assoc [
+      ("zone_id", `Int f.id);
+      ("op", Tool_gate.to_yojson f.op);
+      ("tool_count", `Int (List.length f.current));
+      ("snapshot_count", `Int (List.length f.snapshot));
+    ]
+  in
+  `Assoc [
+    ("depth", `Int (depth t));
+    ("base_tool_count", `Int (List.length t.base));
+    ("current_tools", `List (List.map (fun n -> `String n) (current_tools t)));
+    ("zones", `List (List.map zone_frame_to_yojson t.stack));
+  ]

--- a/lib/zone_tbl.mli
+++ b/lib/zone_tbl.mli
@@ -1,0 +1,68 @@
+(** Zone_tbl — per-keeper tool zone stack with O(1) membership check.
+
+    Phase 2B of Tool Gate architecture (#4381).
+    Pure functional module: no side effects, no mutable state.
+
+    Manages a LIFO stack of zone frames. Each frame captures:
+    - The [tool_op] that created the zone
+    - A snapshot of the tool set before the op was applied
+    - A pre-built O(1) lookup Hashtbl for the current tool set
+
+    Zone enter: apply [Tool_gate.tool_op] to current set, push frame.
+    Zone exit: pop frame, restore snapshot. Strict LIFO.
+
+    Snapshot-based restore is SSOT (not inverse-based).
+    See [Tool_gate.inverse] for the optimization-hint contract. *)
+
+(** Opaque zone identifier. Returned by [enter], required by [exit].
+    Prevents accidental LIFO violations at the type level. *)
+type zone_id
+
+(** The zone table state. Immutable — each operation returns a new value. *)
+type t
+
+(** {1 Creation} *)
+
+val create : base_tools:string list -> t
+(** Create from initial tool set. Normalizes names (trim, dedup).
+    Returns a zone table at depth 0 (no zones entered). *)
+
+(** {1 Zone Lifecycle} *)
+
+val enter : op:Tool_gate.tool_op -> t -> zone_id * t
+(** Push a new zone frame.
+    Applies [op] to the current tool set via [Tool_gate.apply],
+    builds a fresh O(1) lookup Hashtbl.
+    Returns [(zone_id, new_t)]. The [zone_id] is needed for [exit]. *)
+
+val exit : zone_id:zone_id -> t -> (t, string) result
+(** Pop the top zone frame, restoring the previous tool set.
+    Returns [Error] if:
+    - [zone_id] does not match the top frame (LIFO violation)
+    - the stack is empty (cannot exit base) *)
+
+val exit_all : t -> t
+(** Exit all zones. Returns to base tool set. Depth becomes 0. *)
+
+(** {1 Query} *)
+
+val current_tools : t -> string list
+(** Current effective tool set (top frame, or base if no zones). *)
+
+val base_tools : t -> string list
+(** Original base tool set (before any zones). Immutable. *)
+
+val is_tool_allowed : t -> string -> bool
+(** O(1) Hashtbl membership check against current tool set. *)
+
+val depth : t -> int
+(** Number of active zone frames (0 = base, no zones entered). *)
+
+val is_base : t -> bool
+(** [depth t = 0]. No zones entered. *)
+
+(** {1 Diagnostics} *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** JSON snapshot for logging and dashboard display.
+    Includes depth, base tool count, current tools, and zone stack. *)

--- a/test/dune
+++ b/test/dune
@@ -56,6 +56,7 @@
         test_tool_tier
         test_tool_access_policy
         test_tool_gate
+        test_zone_tbl
         test_tool_access_role
         test_tool_token
         test_tool_budget
@@ -113,6 +114,7 @@
           test_tool_tier
           test_tool_access_policy
           test_tool_gate
+          test_zone_tbl
           test_tool_access_role
           test_tool_token
           test_tool_budget

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -45,7 +45,7 @@ let test_make_tools_returns_nonempty () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       check bool "tools nonempty" true (List.length tools > 0))
 
 let test_tools_have_valid_schemas () =
@@ -63,7 +63,7 @@ let test_tools_have_valid_schemas () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       List.iter (fun (tool : Agent_sdk.Tool.t) ->
         check bool (Printf.sprintf "tool %s has name" tool.schema.name)
           true (String.length tool.schema.name > 0);
@@ -86,7 +86,7 @@ let test_tool_count_matches_allowed () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
       let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
       check bool "all tools are in allowed list" true
@@ -125,7 +125,7 @@ let test_error_json_is_returned_as_tool_error () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       let tool = find_tool "keeper_fs_read" tools in
       match Tool.execute tool
               (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
@@ -157,7 +157,7 @@ let test_repeated_error_results_are_blocked () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       let tool = find_tool "keeper_fs_read" tools in
       let args =
         `Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")]
@@ -190,7 +190,7 @@ let test_failure_count_resets_after_success () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       let tool = find_tool "keeper_fs_read" tools in
       let path = "reset-after-success.txt" in
       let args = `Assoc [("path", `String path)] in
@@ -234,7 +234,7 @@ let test_failure_tracking_is_independent_per_args () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
       let tool = find_tool "keeper_fs_read" tools in
       let args_a = `Assoc [("path", `String "missing-a.txt")] in
       let args_b = `Assoc [("path", `String "missing-b.txt")] in

--- a/test/test_zone_tbl.ml
+++ b/test/test_zone_tbl.ml
@@ -305,6 +305,20 @@ let test_base_tools_invariant () =
         (Zone_tbl.current_tools zt_back)
   | Error e -> Alcotest.fail e
 
+let test_empty_base () =
+  let zt = Zone_tbl.create ~base_tools:[] in
+  Alcotest.(check int) "depth 0" 0 (Zone_tbl.depth zt);
+  Alcotest.(check bool) "is_base" true (Zone_tbl.is_base zt);
+  Alcotest.(check str_list) "empty current" [] (Zone_tbl.current_tools zt);
+  Alcotest.(check bool) "nothing allowed" false
+    (Zone_tbl.is_tool_allowed zt "anything");
+  (* enter on empty base *)
+  let _zid, zt1 = Zone_tbl.enter ~op:(Add ["x"]) zt in
+  Alcotest.(check str_list) "added to empty" ["x"]
+    (Zone_tbl.current_tools zt1);
+  Alcotest.(check bool) "x allowed" true
+    (Zone_tbl.is_tool_allowed zt1 "x")
+
 (* ================================================================ *)
 (* Test registration                                                 *)
 (* ================================================================ *)
@@ -363,5 +377,6 @@ let () =
       ( "invariance",
         [
           Alcotest.test_case "base_tools invariant" `Quick test_base_tools_invariant;
+          Alcotest.test_case "empty base" `Quick test_empty_base;
         ] );
     ]

--- a/test/test_zone_tbl.ml
+++ b/test/test_zone_tbl.ml
@@ -1,0 +1,367 @@
+(** Tests for Zone_tbl — Phase 2B of Tool Gate architecture (#4381). *)
+
+open Masc_mcp
+open Tool_gate
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let str_list = Alcotest.(list string)
+
+(** Sort for order-independent set comparison. *)
+let check_set_eq msg expected actual =
+  Alcotest.(check (list string)) msg
+    (List.sort String.compare expected)
+    (List.sort String.compare actual)
+
+let base = ["alpha"; "beta"; "gamma"]
+
+(* ================================================================ *)
+(* create                                                            *)
+(* ================================================================ *)
+
+let test_create_basic () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  Alcotest.(check int) "depth 0" 0 (Zone_tbl.depth zt);
+  Alcotest.(check bool) "is_base" true (Zone_tbl.is_base zt);
+  check_set_eq "current = base" base (Zone_tbl.current_tools zt)
+
+let test_create_normalizes () =
+  let zt = Zone_tbl.create ~base_tools:["  a "; "b"; ""; "a"; " b "] in
+  Alcotest.(check str_list) "normalized + deduped" ["a"; "b"]
+    (Zone_tbl.current_tools zt)
+
+let test_is_tool_allowed_base () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  Alcotest.(check bool) "alpha allowed" true
+    (Zone_tbl.is_tool_allowed zt "alpha");
+  Alcotest.(check bool) "unknown denied" false
+    (Zone_tbl.is_tool_allowed zt "unknown")
+
+(* ================================================================ *)
+(* enter                                                             *)
+(* ================================================================ *)
+
+let test_enter_add () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:(Add ["delta"]) zt in
+  Alcotest.(check int) "depth 1" 1 (Zone_tbl.depth zt2);
+  check_set_eq "added delta" ["alpha"; "beta"; "gamma"; "delta"]
+    (Zone_tbl.current_tools zt2)
+
+let test_enter_remove () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:(Remove ["beta"]) zt in
+  check_set_eq "removed beta" ["alpha"; "gamma"]
+    (Zone_tbl.current_tools zt2)
+
+let test_enter_replace_with () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:(Replace_with ["x"; "y"]) zt in
+  check_set_eq "replaced" ["x"; "y"] (Zone_tbl.current_tools zt2)
+
+let test_enter_intersect_with () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:(Intersect_with ["alpha"; "gamma"]) zt in
+  check_set_eq "intersection" ["alpha"; "gamma"]
+    (Zone_tbl.current_tools zt2)
+
+let test_enter_keep_all () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:Keep_all zt in
+  Alcotest.(check int) "depth 1" 1 (Zone_tbl.depth zt2);
+  check_set_eq "unchanged" base (Zone_tbl.current_tools zt2)
+
+let test_enter_is_tool_allowed () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _zid, zt2 = Zone_tbl.enter ~op:(Remove ["beta"]) zt in
+  Alcotest.(check bool) "alpha still allowed" true
+    (Zone_tbl.is_tool_allowed zt2 "alpha");
+  Alcotest.(check bool) "beta blocked" false
+    (Zone_tbl.is_tool_allowed zt2 "beta")
+
+let test_enter_nested_depth2 () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _z1, zt1 = Zone_tbl.enter ~op:(Remove ["gamma"]) zt in
+  let _z2, zt2 = Zone_tbl.enter ~op:(Add ["delta"]) zt1 in
+  Alcotest.(check int) "depth 2" 2 (Zone_tbl.depth zt2);
+  check_set_eq "gamma removed, delta added" ["alpha"; "beta"; "delta"]
+    (Zone_tbl.current_tools zt2)
+
+let test_enter_nested_depth3 () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _, zt1 = Zone_tbl.enter ~op:(Remove ["gamma"]) zt in
+  let _, zt2 = Zone_tbl.enter ~op:(Remove ["beta"]) zt1 in
+  let _, zt3 = Zone_tbl.enter ~op:(Add ["omega"]) zt2 in
+  Alcotest.(check int) "depth 3" 3 (Zone_tbl.depth zt3);
+  check_set_eq "only alpha + omega" ["alpha"; "omega"]
+    (Zone_tbl.current_tools zt3)
+
+(* ================================================================ *)
+(* exit                                                              *)
+(* ================================================================ *)
+
+let test_exit_restores_base () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:(Remove ["beta"]) zt in
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 ->
+      Alcotest.(check int) "depth 0" 0 (Zone_tbl.depth zt2);
+      check_set_eq "base restored" base (Zone_tbl.current_tools zt2)
+
+let test_exit_ok_zone_id () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:Keep_all zt in
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Ok _ -> ()
+  | Error e -> Alcotest.fail (Printf.sprintf "expected Ok, got Error: %s" e)
+
+let test_exit_wrong_zone_id () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _z1, zt1 = Zone_tbl.enter ~op:Keep_all zt in
+  let _z2, zt2 = Zone_tbl.enter ~op:Keep_all zt1 in
+  (* Try to exit z1 (not on top) *)
+  match Zone_tbl.exit ~zone_id:_z1 zt2 with
+  | Error msg ->
+      Alcotest.(check bool) "contains LIFO" true
+        (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "expected LIFO violation error"
+
+let test_exit_empty_stack () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:Keep_all zt in
+  (* Exit correctly first *)
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 ->
+      (* Now stack is empty; try to exit again *)
+      match Zone_tbl.exit ~zone_id:zid zt2 with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "expected empty stack error"
+
+let test_exit_nested_restores_outer () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _z1, zt1 = Zone_tbl.enter ~op:(Remove ["gamma"]) zt in
+  let z2, zt2 = Zone_tbl.enter ~op:(Add ["delta"]) zt1 in
+  match Zone_tbl.exit ~zone_id:z2 zt2 with
+  | Error e -> Alcotest.fail e
+  | Ok zt3 ->
+      Alcotest.(check int) "depth 1" 1 (Zone_tbl.depth zt3);
+      check_set_eq "outer zone state" ["alpha"; "beta"]
+        (Zone_tbl.current_tools zt3)
+
+let test_exit_irreversible_snapshot () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:(Replace_with ["x"]) zt in
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 ->
+      check_set_eq "full base restored via snapshot" base
+        (Zone_tbl.current_tools zt2)
+
+(* ================================================================ *)
+(* exit_all                                                          *)
+(* ================================================================ *)
+
+let test_exit_all_from_depth2 () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _, zt1 = Zone_tbl.enter ~op:(Replace_with ["x"]) zt in
+  let _, zt2 = Zone_tbl.enter ~op:(Add ["y"]) zt1 in
+  let zt3 = Zone_tbl.exit_all zt2 in
+  Alcotest.(check int) "depth 0" 0 (Zone_tbl.depth zt3);
+  check_set_eq "base restored" base (Zone_tbl.current_tools zt3)
+
+let test_exit_all_from_base () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zt2 = Zone_tbl.exit_all zt in
+  Alcotest.(check int) "still depth 0" 0 (Zone_tbl.depth zt2);
+  check_set_eq "same base" base (Zone_tbl.current_tools zt2)
+
+(* ================================================================ *)
+(* snapshot correctness                                              *)
+(* ================================================================ *)
+
+let test_snapshot_replace_with () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:(Replace_with ["only"]) zt in
+  Alcotest.(check str_list) "replaced" ["only"]
+    (Zone_tbl.current_tools zt1);
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 -> check_set_eq "restored" base (Zone_tbl.current_tools zt2)
+
+let test_snapshot_intersect_with () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:(Intersect_with ["alpha"]) zt in
+  Alcotest.(check str_list) "intersected" ["alpha"]
+    (Zone_tbl.current_tools zt1);
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 -> check_set_eq "restored" base (Zone_tbl.current_tools zt2)
+
+let test_snapshot_clear_all () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let zid, zt1 = Zone_tbl.enter ~op:Clear_all zt in
+  Alcotest.(check str_list) "cleared" [] (Zone_tbl.current_tools zt1);
+  match Zone_tbl.exit ~zone_id:zid zt1 with
+  | Error e -> Alcotest.fail e
+  | Ok zt2 -> check_set_eq "restored" base (Zone_tbl.current_tools zt2)
+
+(* ================================================================ *)
+(* Tool_gate integration                                             *)
+(* ================================================================ *)
+
+let test_compose_enter () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let op = Tool_gate.compose [Remove ["gamma"]; Add ["delta"]] in
+  let _zid, zt1 = Zone_tbl.enter ~op zt in
+  check_set_eq "composed" ["alpha"; "beta"; "delta"]
+    (Zone_tbl.current_tools zt1)
+
+let test_inverse_matches_snapshot_reversible () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let op = Add ["delta"] in
+  let zid, zt1 = Zone_tbl.enter ~op zt in
+  (* Exit via snapshot *)
+  let snapshot_result =
+    match Zone_tbl.exit ~zone_id:zid zt1 with
+    | Ok zt2 -> Zone_tbl.current_tools zt2
+    | Error e -> Alcotest.fail e
+  in
+  (* Compute via inverse *)
+  let inverse_result =
+    match Tool_gate.inverse op with
+    | Reversible inv -> Tool_gate.apply inv (Zone_tbl.current_tools zt1)
+    | Irreversible -> Alcotest.fail "expected reversible"
+  in
+  check_set_eq "snapshot == inverse for reversible" snapshot_result inverse_result
+
+let test_inverse_differs_irreversible () =
+  (* Replace_with is irreversible -- inverse cannot recover original *)
+  let op = Replace_with ["x"] in
+  match Tool_gate.inverse op with
+  | Irreversible -> () (* correct: cannot compute inverse *)
+  | Reversible _ -> Alcotest.fail "Replace_with should be irreversible"
+
+(* ================================================================ *)
+(* to_yojson                                                         *)
+(* ================================================================ *)
+
+let test_to_yojson_base () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let j = Zone_tbl.to_yojson zt in
+  match j with
+  | `Assoc fields ->
+      let depth = List.assoc "depth" fields in
+      Alcotest.(check string) "depth 0" "0"
+        (Yojson.Safe.to_string depth);
+      let base_count = List.assoc "base_tool_count" fields in
+      Alcotest.(check string) "base 3" "3"
+        (Yojson.Safe.to_string base_count)
+  | _ -> Alcotest.fail "expected Assoc"
+
+let test_to_yojson_with_zone () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let _, zt1 = Zone_tbl.enter ~op:(Remove ["beta"]) zt in
+  let j = Zone_tbl.to_yojson zt1 in
+  match j with
+  | `Assoc fields ->
+      let depth = List.assoc "depth" fields in
+      Alcotest.(check string) "depth 1" "1"
+        (Yojson.Safe.to_string depth);
+      let zones = List.assoc "zones" fields in
+      (match zones with
+       | `List [_one] -> ()
+       | _ -> Alcotest.fail "expected 1 zone in list")
+  | _ -> Alcotest.fail "expected Assoc"
+
+(* ================================================================ *)
+(* base_tools invariance                                             *)
+(* ================================================================ *)
+
+let test_base_tools_invariant () =
+  let zt = Zone_tbl.create ~base_tools:base in
+  let z1, zt1 = Zone_tbl.enter ~op:(Replace_with ["x"]) zt in
+  let _, zt2 = Zone_tbl.enter ~op:Clear_all zt1 in
+  let zt3 = Zone_tbl.exit_all zt2 in
+  let _, zt4 = Zone_tbl.enter ~op:(Add ["y"]) zt3 in
+  (* base_tools must be the same at every point *)
+  let check_base msg t =
+    check_set_eq msg base (Zone_tbl.base_tools t)
+  in
+  check_base "after create" zt;
+  check_base "after enter replace" zt1;
+  check_base "after enter clear" zt2;
+  check_base "after exit_all" zt3;
+  check_base "after re-enter" zt4;
+  (* Also check original zt unchanged (functional) *)
+  Alcotest.(check int) "original depth unchanged" 0 (Zone_tbl.depth zt);
+  (* Check exit from z1 on zt1 still works *)
+  match Zone_tbl.exit ~zone_id:z1 zt1 with
+  | Ok zt_back ->
+      check_set_eq "zt1 exit restores base" base
+        (Zone_tbl.current_tools zt_back)
+  | Error e -> Alcotest.fail e
+
+(* ================================================================ *)
+(* Test registration                                                 *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Zone_tbl"
+    [
+      ( "create",
+        [
+          Alcotest.test_case "basic" `Quick test_create_basic;
+          Alcotest.test_case "normalizes" `Quick test_create_normalizes;
+          Alcotest.test_case "is_tool_allowed" `Quick test_is_tool_allowed_base;
+        ] );
+      ( "enter",
+        [
+          Alcotest.test_case "add" `Quick test_enter_add;
+          Alcotest.test_case "remove" `Quick test_enter_remove;
+          Alcotest.test_case "replace_with" `Quick test_enter_replace_with;
+          Alcotest.test_case "intersect_with" `Quick test_enter_intersect_with;
+          Alcotest.test_case "keep_all" `Quick test_enter_keep_all;
+          Alcotest.test_case "is_tool_allowed" `Quick test_enter_is_tool_allowed;
+          Alcotest.test_case "nested depth 2" `Quick test_enter_nested_depth2;
+          Alcotest.test_case "nested depth 3" `Quick test_enter_nested_depth3;
+        ] );
+      ( "exit",
+        [
+          Alcotest.test_case "restores base" `Quick test_exit_restores_base;
+          Alcotest.test_case "ok zone_id" `Quick test_exit_ok_zone_id;
+          Alcotest.test_case "wrong zone_id" `Quick test_exit_wrong_zone_id;
+          Alcotest.test_case "empty stack" `Quick test_exit_empty_stack;
+          Alcotest.test_case "nested restores outer" `Quick test_exit_nested_restores_outer;
+          Alcotest.test_case "irreversible snapshot" `Quick test_exit_irreversible_snapshot;
+        ] );
+      ( "exit_all",
+        [
+          Alcotest.test_case "from depth 2" `Quick test_exit_all_from_depth2;
+          Alcotest.test_case "from base" `Quick test_exit_all_from_base;
+        ] );
+      ( "snapshot",
+        [
+          Alcotest.test_case "replace_with" `Quick test_snapshot_replace_with;
+          Alcotest.test_case "intersect_with" `Quick test_snapshot_intersect_with;
+          Alcotest.test_case "clear_all" `Quick test_snapshot_clear_all;
+        ] );
+      ( "tool_gate_integration",
+        [
+          Alcotest.test_case "compose enter" `Quick test_compose_enter;
+          Alcotest.test_case "inverse matches snapshot" `Quick test_inverse_matches_snapshot_reversible;
+          Alcotest.test_case "irreversible inverse" `Quick test_inverse_differs_irreversible;
+        ] );
+      ( "to_yojson",
+        [
+          Alcotest.test_case "base state" `Quick test_to_yojson_base;
+          Alcotest.test_case "with zone" `Quick test_to_yojson_with_zone;
+        ] );
+      ( "invariance",
+        [
+          Alcotest.test_case "base_tools invariant" `Quick test_base_tools_invariant;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Phase 2B of Tool Gate architecture (#4381)
- `Zone_tbl` 모듈: 순수 함수형 per-keeper zone stack with O(1) Hashtbl 멤버십 체크
- Zone enter: `Tool_gate.apply`로 도구 집합 변환 + snapshot 기반 LIFO 프레임 push
- Zone exit: snapshot 복원 (inverse가 아닌 snapshot이 SSOT)
- `make_tools`에 `?zone` optional parameter로 keeper 실행 경로에 연결

### 변경 파일

| 파일 | 유형 | 설명 |
|------|------|------|
| `lib/zone_tbl.mli` | NEW | Zone stack 인터페이스 (~65줄) |
| `lib/zone_tbl.ml` | NEW | Zone stack 구현 (~120줄) |
| `lib/keeper/keeper_tools_oas.ml` | MOD | `?zone` param, tool list에서 zone 필터링 |
| `lib/keeper/keeper_agent_run.ml` | MOD | zone_tbl 생성 + make_tools에 전달 |
| `lib/keeper/keeper_exec_context.ml` | MOD | make_tools 시그니처 호환 (unit 추가) |
| `test/test_zone_tbl.ml` | NEW | 28 Alcotest tests |
| `test/test_keeper_tools_oas.ml` | MOD | make_tools 시그니처 호환 |

### 아키텍처

```
Phase 1B (Inter/Diff)     ── DONE #4387
Phase 0  (Unified funnel) ── DONE #4408
Phase 1A (Tool_token)     ── DONE #4414
Phase 2A (tool_op ADT)    ── DONE #4439
Phase 2B (zone_tbl)       ── THIS PR
Phase 2C (MCP notify)     ── NEXT
```

## Test plan

- [x] zone_tbl 28 단위 테스트 (create, enter, exit, exit_all, snapshot, integration, yojson, invariance)
- [x] tool_gate 62 기존 테스트 통과
- [x] test_keeper_tools_oas 기존 테스트 통과
- [x] `dune build @all` 성공

Refs #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)