### PR TITLE
feat(dashboard): 게시판 마크다운 렌더러를 marked 라이브러리로 교체

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "packageManager": "pnpm@10.31.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@preact/signals": "^2.0.2",
     "htm": "^3.1.1",
+    "marked": "^17.0.5",
     "mermaid": "^11.12.0",
     "preact": "^10.25.4"
   },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@preact/signals": "^2.0.2",
+    "dompurify": "^3.3.3",
     "htm": "^3.1.1",
     "marked": "^17.0.5",
     "mermaid": "^11.12.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@preact/signals':
         specifier: ^2.0.2
         version: 2.8.1(preact@10.28.3)
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       htm:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1122,9 +1125,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2898,7 +2900,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.2:
+  dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3252,7 +3254,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.19
-      dompurify: 3.3.2
+      dompurify: 3.3.3
       katex: 0.16.37
       khroma: 2.1.0
       lodash-es: 4.17.23

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       htm:
         specifier: ^3.1.1
         version: 3.1.1
+      marked:
+        specifier: ^17.0.5
+        version: 17.0.5
       mermaid:
         specifier: ^11.12.0
         version: 11.12.3
@@ -1470,6 +1473,11 @@ packages:
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@17.0.5:
+    resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -3226,6 +3234,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@16.4.2: {}
+
+  marked@17.0.5: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -103,4 +103,25 @@ describe('Markdown', () => {
     render(html`<${Markdown} text="~~deleted~~" />`, container)
     expect(container.querySelector('del')?.textContent).toBe('deleted')
   })
+
+  it('adds target="_blank" and rel="noopener noreferrer" to links', () => {
+    render(html`<${Markdown} text="[example](https://example.com)" />`, container)
+    const a = container.querySelector('a')
+    expect(a).not.toBeNull()
+    expect(a?.getAttribute('target')).toBe('_blank')
+    expect(a?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('sanitizes event handlers via DOMPurify', () => {
+    const md = '<img src=x onerror="alert(1)">'
+    render(html`<${Markdown} text=${md} />`, container)
+    expect(container.innerHTML).not.toContain('onerror')
+  })
+
+  it('handles think block with trailing whitespace in close tag', () => {
+    const md = '<think>reasoning</think >'
+    render(html`<${Markdown} text=${md} />`, container)
+    const details = container.querySelector('details.think-block')
+    expect(details).not.toBeNull()
+  })
 })

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -128,6 +128,31 @@ describe('Markdown', () => {
     expect(href.toLowerCase()).not.toMatch(/^javascript:/)
   })
 
+  it('sanitizes javascript: URLs in images', () => {
+    const md = '![malicious](javascript:alert(1))'
+    render(html`<${Markdown} text=${md} />`, container)
+    const img = container.querySelector('img')
+    if (!img) return // DOMPurify removed entire tag — safe
+    const src = img.getAttribute('src') ?? ''
+    expect(src.toLowerCase()).not.toMatch(/^javascript:/)
+  })
+
+  it('preserves dangerous-looking strings inside code blocks without mangling', () => {
+    const md = [
+      '```html',
+      '<img src="x" onerror="alert(1)">',
+      '<a href="https://example.com/?onclick=alert(1)">click</a>',
+      '```',
+    ].join('\n')
+    render(html`<${Markdown} text=${md} />`, container)
+    const code = container.querySelector('code.language-html') ?? container.querySelector('code')
+    expect(code).not.toBeNull()
+    const text = code?.textContent ?? ''
+    // Literal strings inside code blocks must be preserved, not sanitized
+    expect(text).toContain('onerror=')
+    expect(text).toContain('?onclick=')
+  })
+
   it('handles think block with trailing whitespace in close tag', () => {
     const md = '<think>reasoning</think >'
     render(html`<${Markdown} text=${md} />`, container)

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -118,6 +118,16 @@ describe('Markdown', () => {
     expect(container.innerHTML).not.toContain('onerror')
   })
 
+  it('sanitizes javascript: URLs in links', () => {
+    const md = '[blocked](javascript:alert(1))'
+    render(html`<${Markdown} text=${md} />`, container)
+    const anchor = container.querySelector('a')
+    if (!anchor) return // DOMPurify removed entire tag — safe
+    const href = anchor.getAttribute('href')
+    if (!href) return // DOMPurify removed href attribute — safe
+    expect(href.toLowerCase()).not.toMatch(/^javascript:/)
+  })
+
   it('handles think block with trailing whitespace in close tag', () => {
     const md = '<think>reasoning</think >'
     render(html`<${Markdown} text=${md} />`, container)

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,0 +1,106 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Markdown } from './markdown'
+
+describe('Markdown', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('returns null for empty text', () => {
+    render(html`<${Markdown} text="" />`, container)
+    expect(container.querySelector('.markdown-content')).toBeNull()
+  })
+
+  it('renders a paragraph', () => {
+    render(html`<${Markdown} text="hello world" />`, container)
+    expect(container.querySelector('p')?.textContent).toBe('hello world')
+  })
+
+  it('renders GFM table', () => {
+    const md = '| a | b |\n|---|---|\n| 1 | 2 |'
+    render(html`<${Markdown} text=${md} />`, container)
+    const table = container.querySelector('table')
+    expect(table).not.toBeNull()
+    expect(table?.querySelectorAll('th').length).toBe(2)
+    expect(table?.querySelectorAll('td').length).toBe(2)
+    expect(table?.querySelector('td')?.textContent).toBe('1')
+  })
+
+  it('renders table with alignment', () => {
+    const md = '| left | center | right |\n|:---|:---:|---:|\n| a | b | c |'
+    render(html`<${Markdown} text=${md} />`, container)
+    const ths = container.querySelectorAll('th')
+    expect(ths.length).toBe(3)
+    // marked generates align attributes on th/td
+    const tds = container.querySelectorAll('td')
+    expect(tds.length).toBe(3)
+  })
+
+  it('converts line breaks with breaks: true', () => {
+    render(html`<${Markdown} text=${'line1\nline2'} />`, container)
+    const br = container.querySelector('br')
+    expect(br).not.toBeNull()
+  })
+
+  it('renders code block with language class', () => {
+    const md = '```js\nconsole.log("hi")\n```'
+    render(html`<${Markdown} text=${md} />`, container)
+    const code = container.querySelector('code.language-js')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toContain('console.log')
+  })
+
+  it('renders think block as collapsible details', () => {
+    const md = '<think>some **reasoning**</think>'
+    render(html`<${Markdown} text=${md} />`, container)
+    const details = container.querySelector('details.think-block')
+    expect(details).not.toBeNull()
+    expect(details?.querySelector('summary')?.textContent).toBe('생각 중...')
+    // Think block content is parsed as markdown
+    expect(details?.querySelector('strong')?.textContent).toBe('reasoning')
+  })
+
+  it('strips script tags (XSS prevention)', () => {
+    const md = 'safe text <script>alert("xss")</script> more text'
+    render(html`<${Markdown} text=${md} />`, container)
+    expect(container.innerHTML).not.toContain('<script')
+    expect(container.textContent).toContain('safe text')
+  })
+
+  it('applies custom class alongside markdown-content', () => {
+    render(html`<${Markdown} text="test" class="custom" />`, container)
+    const div = container.querySelector('.markdown-content.custom')
+    expect(div).not.toBeNull()
+  })
+
+  it('renders inline formatting (bold, italic, code)', () => {
+    const md = '**bold** and *italic* and `code`'
+    render(html`<${Markdown} text=${md} />`, container)
+    expect(container.querySelector('strong')?.textContent).toBe('bold')
+    expect(container.querySelector('em')?.textContent).toBe('italic')
+    expect(container.querySelector('code')?.textContent).toBe('code')
+  })
+
+  it('preserves ASCII art inside code blocks', () => {
+    const md = '```\n+-----+-----+\n| A   | B   |\n+-----+-----+\n```'
+    render(html`<${Markdown} text=${md} />`, container)
+    const pre = container.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toContain('+-----+-----+')
+  })
+
+  it('renders strikethrough (GFM)', () => {
+    render(html`<${Markdown} text="~~deleted~~" />`, container)
+    expect(container.querySelector('del')?.textContent).toBe('deleted')
+  })
+})

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -1,13 +1,14 @@
-// Lightweight markdown renderer — no external deps (except mermaid, lazy-loaded)
-// Handles: headings, code fences (with syntax class + mermaid), inline code,
-//          bold, italic, strikethrough, links, blockquotes, <think> blocks,
-//          unordered/ordered lists, horizontal rules
-// CSS classes: .markdown-content, .think-block (defined in components.css)
+// Markdown renderer — uses `marked` for full GFM parsing
+// Handles: tables, code fences, line breaks, inline formatting,
+//          mermaid diagrams (lazy-loaded), <think> blocks (collapsible)
+// CSS classes: .markdown-content (ui.css), .think-block (ui.css),
+//              .mermaid-rendered (ui.css)
 
 import { html } from 'htm/preact'
-import { useRef, useEffect } from 'preact/hooks'
+import { useRef, useEffect, useMemo } from 'preact/hooks'
+import { Marked } from 'marked'
 
-// Lazy mermaid loader — self-contained to avoid transitive import chains
+// ── Lazy mermaid loader ──────────────────────────────────────
 type MermaidApi = typeof import('mermaid')['default']
 let mermaidPromise: Promise<MermaidApi> | null = null
 let mermaidConfigured = false
@@ -25,238 +26,83 @@ function getMermaid(): Promise<MermaidApi> {
   })
 }
 
-/** Render a markdown string to Preact VDOM nodes */
+// ── Marked instance (GFM tables + line-break support) ────────
+const md = new Marked({ gfm: true, breaks: true })
+
+// ── Minimal sanitization (strip script/iframe/event handlers) ─
+function sanitize(raw: string): string {
+  return raw
+    .replace(/<script\b[^]*?<\/script>/gi, '')
+    .replace(/<iframe\b[^]*?<\/iframe>/gi, '')
+    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
+    .replace(/\bon\w+\s*=\s*[^\s>]+/gi, '')
+}
+
+// ── Parse markdown with <think> block extraction ─────────────
+// Think blocks are extracted first, their content is parsed
+// separately as markdown, then reassembled as <details>.
+function renderMarkdown(text: string): string {
+  const parts: string[] = []
+  let lastIdx = 0
+  const thinkRe = /<think>([\s\S]*?)<\/think>/g
+  let m: RegExpExecArray | null
+
+  while ((m = thinkRe.exec(text)) !== null) {
+    if (m.index > lastIdx) {
+      parts.push(md.parse(text.slice(lastIdx, m.index)) as string)
+    }
+    const innerHtml = md.parse((m[1] as string).trim()) as string
+    parts.push(
+      `<details class="think-block rounded-lg"><summary>생각 중...</summary><div>${innerHtml}</div></details>`
+    )
+    lastIdx = m.index + m[0].length
+  }
+
+  if (lastIdx < text.length) {
+    parts.push(md.parse(text.slice(lastIdx)) as string)
+  }
+
+  return sanitize(parts.join(''))
+}
+
+// ── Component ────────────────────────────────────────────────
 export function Markdown({ text, class: className }: { text: string; class?: string }) {
   if (!text) return null
-  const blocks = parseBlocks(text)
-  const classes = ['markdown-content', className].filter(Boolean).join(' ')
-  return html`<div class=${classes}>${blocks}</div>`
-}
-
-// ── Mermaid component ────────────────────────────────────
-
-function MermaidBlock({ code }: { code: string }) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const htmlStr = useMemo(() => renderMarkdown(text), [text])
+  const classes = ['markdown-content', className].filter(Boolean).join(' ')
 
+  // Post-render: replace mermaid code blocks with rendered SVG
   useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const mermaidCodes = el.querySelectorAll<HTMLElement>('pre > code.language-mermaid')
+    if (mermaidCodes.length === 0) return
+
     let cancelled = false
-    const render = async () => {
-      const el = containerRef.current
-      if (!el) return
-      try {
-        const mermaid = await getMermaid()
-        if (cancelled) return
-        const id = `mermaid-md-${++mermaidRenderCount}`
-        const { svg } = await mermaid.render(id, code)
-        if (!cancelled && el) {
-          el.innerHTML = svg
-        }
-      } catch {
-        if (!cancelled && el) {
-          el.textContent = code
-          el.classList.add('mermaid-error')
+    ;(async () => {
+      const mermaid = await getMermaid()
+      if (cancelled) return
+      for (const codeEl of mermaidCodes) {
+        const pre = codeEl.parentElement
+        if (!pre) continue
+        const code = codeEl.textContent ?? ''
+        try {
+          const id = `mermaid-md-${++mermaidRenderCount}`
+          const { svg } = await mermaid.render(id, code)
+          if (!cancelled && pre.parentElement) {
+            const div = document.createElement('div')
+            div.className = 'mermaid-rendered'
+            div.innerHTML = svg
+            pre.replaceWith(div)
+          }
+        } catch {
+          // Keep code block as fallback on render error
         }
       }
-    }
-    render()
+    })()
     return () => { cancelled = true }
-  }, [code])
+  }, [htmlStr])
 
-  return html`<div ref=${containerRef} class="mermaid-container rounded-lg p-4 my-2 bg-[var(--white-3)] border border-[var(--border-slate-12)] overflow-x-auto"></div>`
-}
-
-// ── Block parsing ────────────────────────────────────────
-
-function parseBlocks(src: string) {
-  const lines = src.split('\n')
-  const nodes: unknown[] = []
-  let i = 0
-
-  while (i < lines.length) {
-    const line = lines[i] as string
-
-    // Code fence (``` or ~~~)
-    if (/^(`{3,}|~{3,})/.test(line)) {
-      const fence = line.match(/^(`{3,}|~{3,})/)![0]
-      const lang = line.slice(fence.length).trim()
-      const codeLines: string[] = []
-      i++
-      while (i < lines.length && !(lines[i] as string).startsWith(fence)) {
-        codeLines.push(lines[i] as string)
-        i++
-      }
-      i++ // skip closing fence
-      const code = codeLines.join('\n')
-
-      // Mermaid diagram
-      if (lang === 'mermaid') {
-        nodes.push(html`<${MermaidBlock} code=${code} />`)
-        continue
-      }
-
-      nodes.push(html`<pre class="code-block rounded-lg p-3 my-2 bg-[var(--white-3)] border border-[var(--border-slate-12)] overflow-x-auto"><code class=${lang ? `language-${lang}` : ''}>${code}</code></pre>`)
-      continue
-    }
-
-    // Think block: <think>...</think>
-    if (line.trim() === '<think>' || line.trim().startsWith('<think>')) {
-      const thinkLines: string[] = []
-      const firstContent = line.trim().replace(/^<think>/, '').trim()
-      if (firstContent && firstContent !== '</think>') {
-        thinkLines.push(firstContent)
-      }
-      i++
-      while (i < lines.length && !(lines[i] as string).includes('</think>')) {
-        thinkLines.push(lines[i] as string)
-        i++
-      }
-      if (i < lines.length) {
-        const lastContent = (lines[i] as string).replace('</think>', '').trim()
-        if (lastContent) thinkLines.push(lastContent)
-        i++ // skip </think>
-      }
-      const inner = thinkLines.join('\n').trim()
-      nodes.push(html`
-        <details class="think-block rounded-lg">
-          <summary>생각 중...</summary>
-          <div>${inlineToVdom(inner)}</div>
-        </details>
-      `)
-      continue
-    }
-
-    // Horizontal rule (---, ***, ___)
-    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trim())) {
-      nodes.push(html`<hr class="my-3 border-[var(--border-slate-16)]" />`)
-      i++
-      continue
-    }
-
-    // Heading (# to ###)
-    const headingMatch = line.match(/^(#{1,3})\s+(.+)$/)
-    if (headingMatch) {
-      const level = (headingMatch[1] as string).length
-      const content = headingMatch[2] as string
-      const cls = level === 1
-        ? 'text-[16px] font-bold mt-4 mb-2 text-[var(--text-heading)]'
-        : level === 2
-          ? 'text-[14px] font-semibold mt-3 mb-1.5 text-[var(--text-heading)]'
-          : 'text-[13px] font-semibold mt-2 mb-1 text-[var(--text-body)]'
-      const inner = inlineToVdom(content)
-      if (level === 1) nodes.push(html`<h1 class=${cls}>${inner}</h1>`)
-      else if (level === 2) nodes.push(html`<h2 class=${cls}>${inner}</h2>`)
-      else nodes.push(html`<h3 class=${cls}>${inner}</h3>`)
-      i++
-      continue
-    }
-
-    // Blockquote (> line)
-    if (line.startsWith('> ')) {
-      const quoteLines: string[] = []
-      while (i < lines.length && (lines[i] as string).startsWith('> ')) {
-        quoteLines.push((lines[i] as string).slice(2))
-        i++
-      }
-      nodes.push(html`<blockquote class="border-l-2 border-[var(--ff-gold-40)] pl-3 my-2 text-[var(--text-muted)]">${inlineToVdom(quoteLines.join('\n'))}</blockquote>`)
-      continue
-    }
-
-    // Unordered list (- or * at start)
-    if (/^[-*]\s+/.test(line)) {
-      const items: string[] = []
-      while (i < lines.length && /^[-*]\s+/.test(lines[i] as string)) {
-        items.push((lines[i] as string).replace(/^[-*]\s+/, ''))
-        i++
-      }
-      nodes.push(html`<ul class="list-disc pl-5 my-2 space-y-0.5">${items.map(item => html`<li class="text-[13px] text-[var(--text-body)]">${inlineToVdom(item)}</li>`)}</ul>`)
-      continue
-    }
-
-    // Ordered list (1. 2. etc.)
-    if (/^\d+\.\s+/.test(line)) {
-      const items: string[] = []
-      while (i < lines.length && /^\d+\.\s+/.test(lines[i] as string)) {
-        items.push((lines[i] as string).replace(/^\d+\.\s+/, ''))
-        i++
-      }
-      nodes.push(html`<ol class="list-decimal pl-5 my-2 space-y-0.5">${items.map(item => html`<li class="text-[13px] text-[var(--text-body)]">${inlineToVdom(item)}</li>`)}</ol>`)
-      continue
-    }
-
-    // Empty line → skip (spacing handled by CSS margins)
-    if (line.trim() === '') {
-      i++
-      continue
-    }
-
-    // Regular paragraph — collect consecutive non-special lines
-    const paraLines: string[] = []
-    while (i < lines.length) {
-      const cur = lines[i] as string
-      if (
-        cur.trim() === '' ||
-        /^(`{3,}|~{3,})/.test(cur) ||
-        cur.startsWith('> ') ||
-        cur.trim().startsWith('<think>') ||
-        /^#{1,3}\s+/.test(cur) ||
-        /^[-*]\s+/.test(cur) ||
-        /^\d+\.\s+/.test(cur) ||
-        /^(-{3,}|\*{3,}|_{3,})\s*$/.test(cur.trim())
-      ) break
-      paraLines.push(cur)
-      i++
-    }
-    if (paraLines.length > 0) {
-      nodes.push(html`<p>${inlineToVdom(paraLines.join('\n'))}</p>`)
-    }
-  }
-
-  return nodes
-}
-
-// ── Inline parsing ────────────────────────────────────────
-
-function inlineToVdom(text: string): (string | unknown)[] {
-  // Process inline elements via regex splitting
-  // Order: code first (protect from bold/italic), then bold, strikethrough, italic, links
-  const parts: (string | unknown)[] = []
-  const regex = /(`[^`]+`)|(~~[^~]+~~)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|\[([^\]]+)\]\(([^)]+)\)/g
-
-  let lastIndex = 0
-  let match: RegExpExecArray | null
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(text.slice(lastIndex, match.index))
-    }
-
-    if (match[1]) {
-      // Inline code: `code`
-      const code = match[1].slice(1, -1)
-      parts.push(html`<code class="px-1 py-0.5 rounded bg-[var(--white-8)] text-[var(--ff-gold-bright)] text-[12px]">${code}</code>`)
-    } else if (match[2]) {
-      // Strikethrough: ~~text~~
-      const struck = match[2].slice(2, -2)
-      parts.push(html`<del class="text-[var(--text-muted)]">${struck}</del>`)
-    } else if (match[3]) {
-      // Bold: **text**
-      const bold = match[3].slice(2, -2)
-      parts.push(html`<strong>${bold}</strong>`)
-    } else if (match[4]) {
-      // Italic: *text*
-      const italic = match[4].slice(1, -1)
-      parts.push(html`<em>${italic}</em>`)
-    } else if (match[5] && match[6]) {
-      // Link: [text](url)
-      parts.push(html`<a href=${match[6]} target="_blank" rel="noopener" class="text-[var(--accent)] hover:underline">${match[5]}</a>`)
-    }
-
-    lastIndex = match.index + match[0].length
-  }
-
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex))
-  }
-
-  return parts.length > 0 ? parts : [text]
+  return html`<div ref=${containerRef} class=${classes} dangerouslySetInnerHTML=${{ __html: htmlStr }}></div>`
 }

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -53,7 +53,7 @@ const PURIFY_CONFIG = {
   ],
   ALLOWED_ATTR: [
     'href', 'title', 'target', 'rel', 'src', 'alt', 'class',
-    'align', 'style',
+    'align',
   ],
 }
 
@@ -71,7 +71,7 @@ function sanitizeMermaidSvg(raw: string): SVGElement | null {
   const parsed = new DOMParser().parseFromString(safeSvg, 'image/svg+xml')
   const svg = parsed.documentElement
   if (!svg || svg.tagName.toLowerCase() !== 'svg') return null
-  return document.importNode(svg, true) as SVGElement
+  return document.importNode(svg, true) as unknown as SVGElement
 }
 
 // ── Parse markdown with <think> block extraction ─────────────
@@ -130,12 +130,8 @@ export function Markdown({ text, class: className }: { text: string; class?: str
             const div = document.createElement('div')
             div.className = 'mermaid-rendered'
             const safeSvg = sanitizeMermaidSvg(svg)
-            if (safeSvg) {
-              div.appendChild(safeSvg)
-            } else {
-              pre.replaceWith(div)
-              continue
-            }
+            if (!safeSvg) continue // keep original code block on sanitization failure
+            div.appendChild(safeSvg)
             pre.replaceWith(div)
           }
         } catch {

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -61,6 +61,19 @@ function sanitize(raw: string): string {
   return DOMPurify.sanitize(raw, PURIFY_CONFIG)
 }
 
+function sanitizeMermaidSvg(raw: string): SVGElement | null {
+  const safeSvg = DOMPurify.sanitize(raw, {
+    USE_PROFILES: { svg: true },
+  })
+  if (!safeSvg || !safeSvg.includes('<svg')) {
+    return null
+  }
+  const parsed = new DOMParser().parseFromString(safeSvg, 'image/svg+xml')
+  const svg = parsed.documentElement
+  if (!svg || svg.tagName.toLowerCase() !== 'svg') return null
+  return document.importNode(svg, true) as SVGElement
+}
+
 // ── Parse markdown with <think> block extraction ─────────────
 // Think blocks are extracted first, their content is parsed
 // separately as markdown, then reassembled as <details>.
@@ -116,7 +129,13 @@ export function Markdown({ text, class: className }: { text: string; class?: str
           if (!cancelled && pre.parentElement) {
             const div = document.createElement('div')
             div.className = 'mermaid-rendered'
-            div.innerHTML = svg
+            const safeSvg = sanitizeMermaidSvg(svg)
+            if (safeSvg) {
+              div.appendChild(safeSvg)
+            } else {
+              pre.replaceWith(div)
+              continue
+            }
             pre.replaceWith(div)
           }
         } catch {

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -7,6 +7,7 @@
 import { html } from 'htm/preact'
 import { useRef, useEffect, useMemo } from 'preact/hooks'
 import { Marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 // ── Lazy mermaid loader ──────────────────────────────────────
 type MermaidApi = typeof import('mermaid')['default']
@@ -29,13 +30,35 @@ function getMermaid(): Promise<MermaidApi> {
 // ── Marked instance (GFM tables + line-break support) ────────
 const md = new Marked({ gfm: true, breaks: true })
 
-// ── Minimal sanitization (strip script/iframe/event handlers) ─
+// Custom renderer: links open in new tab with noopener
+md.use({
+  renderer: {
+    link({ href, title, text }) {
+      const titleAttr = title ? ` title="${title}"` : ''
+      return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+    }
+  }
+})
+
+// ── HTML sanitization via DOMPurify ──────────────────────────
+// VDOM→innerHTML migration requires explicit sanitization.
+// DOMPurify handles script/iframe/event handler/SVG attacks.
+const PURIFY_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'em', 'del', 'code', 'pre', 'blockquote',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'ul', 'ol', 'li', 'hr', 'a', 'img',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'details', 'summary', 'div', 'span',
+  ],
+  ALLOWED_ATTR: [
+    'href', 'title', 'target', 'rel', 'src', 'alt', 'class',
+    'align', 'style',
+  ],
+}
+
 function sanitize(raw: string): string {
-  return raw
-    .replace(/<script\b[^]*?<\/script>/gi, '')
-    .replace(/<iframe\b[^]*?<\/iframe>/gi, '')
-    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
-    .replace(/\bon\w+\s*=\s*[^\s>]+/gi, '')
+  return DOMPurify.sanitize(raw, PURIFY_CONFIG)
 }
 
 // ── Parse markdown with <think> block extraction ─────────────
@@ -44,7 +67,7 @@ function sanitize(raw: string): string {
 function renderMarkdown(text: string): string {
   const parts: string[] = []
   let lastIdx = 0
-  const thinkRe = /<think>([\s\S]*?)<\/think>/g
+  const thinkRe = /<think>([\s\S]*?)<\/think\s*>/g
   let m: RegExpExecArray | null
 
   while ((m = thinkRe.exec(text)) !== null) {

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -6,11 +6,76 @@
 /* ── Toast Notifications (styling moved to component Tailwind) ── */
 /* @keyframes slideInRight → keyframes.css (canonical) */
 
-/* ── Markdown Rendered Content ─────────────────────────────── */
+/* ── Markdown Rendered Content (marked GFM output) ────────── */
 @utility markdown-content {
-  & code { background: var(--white-8); padding: 1px 5px; font-size: var(--fs-sm); }
-  & pre { background: rgba(0,0,0,0.3); padding: 12px; overflow-x: auto; font-size: var(--fs-sm); }
-  & blockquote { border-left: 3px solid var(--cyan); padding-left: 12px; color: #aaa; }
+  line-height: 1.55;
+  color: var(--text-body);
+
+  & p { margin: 6px 0; }
+
+  & h1 { font-size: 16px; font-weight: 700; margin: 16px 0 8px; color: var(--text-heading); }
+  & h2 { font-size: 14px; font-weight: 600; margin: 12px 0 6px; color: var(--text-heading); }
+  & h3 { font-size: 13px; font-weight: 600; margin: 8px 0 4px; color: var(--text-body); }
+
+  & code {
+    background: var(--white-8);
+    color: var(--ff-gold-bright);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  & pre {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 12px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--border-slate-12);
+    overflow-x: auto;
+    font-size: var(--fs-sm);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    line-height: 1.6;
+    margin: 8px 0;
+  }
+
+  & pre code {
+    background: none;
+    color: inherit;
+    padding: 0;
+    font-size: inherit;
+    border-radius: 0;
+  }
+
+  & blockquote {
+    border-left: 3px solid var(--ff-gold-40);
+    padding-left: 12px;
+    color: var(--text-muted);
+    margin: 8px 0;
+  }
+
+  & ul { list-style: disc; padding-left: 20px; margin: 6px 0; }
+  & ol { list-style: decimal; padding-left: 20px; margin: 6px 0; }
+  & li { margin: 2px 0; }
+  & li > ul, & li > ol { margin: 2px 0; }
+
+  & hr { border: none; border-top: 1px solid var(--border-slate-16); margin: 12px 0; }
+
+  & a { color: var(--accent); &:hover { text-decoration: underline; } }
+  & strong { font-weight: 600; }
+  & del { color: var(--text-muted); }
+
+  & table { margin: 8px 0; }
+
+  & img { max-width: 100%; height: auto; border-radius: 8px; margin: 4px 0; }
+}
+
+/* ── Mermaid rendered output ──────────────────────────────── */
+.mermaid-rendered {
+  border-radius: 8px;
+  padding: 16px;
+  margin: 8px 0;
+  background: var(--white-3);
+  border: 1px solid var(--border-slate-12);
+  overflow-x: auto;
 }
 
 /* ── Think Block (collapsible) ─────────────────────────────── */

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -26,7 +26,7 @@
   }
 
   & pre {
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--white-3);
     padding: 12px 14px;
     border-radius: 8px;
     border: 1px solid var(--border-slate-12);


### PR DESCRIPTION
## Summary
- 262줄 커스텀 마크다운 파서를 `marked` v17 (GFM 모드)로 교체
- 게시판/게시판 상세에서 **마크다운 테이블**, **개행**, **코드 블럭**, **ASCII 테이블**이 제대로 렌더링됨
- `<think>` 블럭, mermaid 다이어그램 지원 유지

Refs #4451

## Product impact
게시판(board) UI에서 에이전트가 작성한 마크다운 콘텐츠(테이블, 코드 블럭, 개행 등)가 올바르게 렌더링된다. 기존에는 테이블이 파이프 문자로 노출되고, 줄바꿈이 무시되어 가독성이 낮았다.

## Changes
| 파일 | 변경 |
|------|------|
| `markdown.ts` | `marked` 기반 재작성 (GFM 테이블, `breaks: true`, think 블럭 추출/별도 파싱, mermaid post-render) |
| `ui.css` | `.markdown-content` CSS 보강 (heading/list/table/pre 타이포그래피, 모노스페이스 폰트, `.mermaid-rendered`) |
| `markdown.test.ts` | 16개 테스트 (테이블, 개행, think, XSS, DOMPurify, link attrs, javascript: URL, strikethrough) |
| `package.json` | `marked` v17.0.5 + `dompurify` v3.3.3 의존성, `engines.node >= 20` |

## Evidence
- typecheck, build, test 전부 통과 (50 files, 215+ tests)
- `marked` v17 GFM 출력 검증: 테이블 → `<table>`, 개행 → `<br>`, strikethrough → `<del>`
- DOMPurify XSS 테스트: script, event handler, javascript: URL 제거 확인
- Mermaid SVG: DOMPurify SVG profile + DOMParser 안전 삽입

## Review evidence
- **GLM-5.1 교차 리뷰**: 5건 (3 수정, 2 오진 판정 + 근거 댓글)
- **Copilot 리뷰**: 5건 전부 대응 완료 (DOMPurify, mermaid SVG 살균, link noopener, javascript: URL 테스트, engines.node)
- CI: Build, Dashboard, Lint, Contract Harness, Health 전부 green

## Linked issue
대시보드 게시판 마크다운 렌더링 품질 개선 (사용자 요청)

## Test plan
- [x] `pnpm run typecheck` 통과
- [x] `pnpm run build` 통과
- [x] `pnpm run test` — 50 files, 215+ tests 전부 통과
- [ ] 대시보드에서 게시판 목록/상세 확인 (테이블, 코드 블럭, 개행 포함 게시글)
- [ ] mermaid 다이어그램 포함 게시글 렌더링 확인
- [ ] think 블럭 접기/펼치기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)