### PR TITLE
fix(encryption): safe hex parsing for key file loading

### DIFF
--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -68,14 +68,21 @@ let load_key config : (GCM.key, encryption_error) result =
     | `File path ->
         if Sys.file_exists path then
           let content = Fs_compat.load_file path in
-          let content = String.sub content 0 (min 64 (String.length content)) in (* hex-encoded 32 bytes *)
-          (* Decode hex to bytes *)
-          let bytes = ref "" in
-          for i = 0 to 31 do
-            let hex = String.sub content (i * 2) 2 in
-            bytes := !bytes ^ String.make 1 (Char.chr (int_of_string ("0x" ^ hex)))
-          done;
-          Some !bytes
+          let content = String.trim content in
+          if String.length content <> 64 then
+            None  (* hex-encoded 32 bytes requires exactly 64 chars *)
+          else
+            let buf = Buffer.create 32 in
+            let valid = ref true in
+            for i = 0 to 31 do
+              if !valid then
+                let hex = String.sub content (i * 2) 2 in
+                match int_of_string_opt ("0x" ^ hex) with
+                | Some v when v >= 0 && v <= 255 ->
+                    Buffer.add_char buf (Char.chr v)
+                | _ -> valid := false
+            done;
+            if !valid then Some (Buffer.contents buf) else None
         else None
     | `Direct key -> Some key
   in


### PR DESCRIPTION
## Summary
- Replace unsafe `int_of_string` with `int_of_string_opt` for hex key parsing
- Add exact 64-char length validation (hex-encoded 32 bytes)
- Use `Buffer` instead of ref+concatenation for O(n) string building
- Per-byte range validation (0-255) to prevent `Invalid_argument` on malformed hex

Fixes #4432

## Test plan
- [ ] Existing encryption tests pass
- [ ] Malformed hex key file (wrong length, invalid chars) returns `None` instead of crashing
- [ ] Valid 64-char hex key file parses correctly