### PR TITLE
fix(audit): expose parse errors via Result type, log corruption at ERROR

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -154,10 +154,20 @@ let entry_of_json_r (json : Yojson.Safe.t) : (audit_entry, string) result =
     let trace_id = Safe_ops.json_string_opt "trace_id" json in
     Ok { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    let snippet = preview (Yojson.Safe.to_string json) in
+    (* Redact details field to prevent sensitive content leaking into logs *)
+    let redacted = match json with
+      | `Assoc fields ->
+        let safe_fields = List.filter_map (fun (k, v) ->
+          if k = "details" then Some (k, `String "<redacted>")
+          else Some (k, v)
+        ) fields in
+        `Assoc safe_fields
+      | _ -> `String "<non-object>"
+    in
+    let snippet = preview (Yojson.Safe.to_string redacted) in
     Error (Printf.sprintf "%s | json: %s" (Printexc.to_string exn) snippet)
 
-(** Lenient wrapper: logs error and returns option for backward compat *)
+(** Lenient wrapper: logs warning and returns option for backward compat *)
 let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
   match entry_of_json_r json with
   | Ok entry -> Some entry

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -123,8 +123,9 @@ let entry_to_json (e : audit_entry) : Yojson.Safe.t =
   in
   `Assoc with_trace
 
-(** Parse a JSON object back into an audit_entry *)
-let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
+(** Parse a JSON object back into an audit_entry.
+    Returns Error with reason on parse failure (never silently drops). *)
+let entry_of_json_r (json : Yojson.Safe.t) : (audit_entry, string) result =
   try
     let module U = Yojson.Safe.Util in
     let timestamp = json |> U.member "timestamp" |> U.to_float in
@@ -147,10 +148,19 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
     let cost_estimate = Safe_ops.json_float_opt "cost_estimate" json in
     let token_count = Safe_ops.json_int_opt "token_count" json in
     let trace_id = Safe_ops.json_string_opt "trace_id" json in
-    Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
+    Ok { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Misc.warn "audit_log: entry parse failed: %s" (Printexc.to_string exn);
-    None
+    let snippet = String.sub (Yojson.Safe.to_string json) 0
+      (min 200 (String.length (Yojson.Safe.to_string json))) in
+    Error (Printf.sprintf "%s | json: %s" (Printexc.to_string exn) snippet)
+
+(** Lenient wrapper: logs error and returns option for backward compat *)
+let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
+  match entry_of_json_r json with
+  | Ok entry -> Some entry
+  | Error reason ->
+      Log.Misc.warn "audit_log: entry parse failed: %s" reason;
+      None
 
 (** {1 File Operations} *)
 
@@ -174,24 +184,45 @@ let get_audit_store (config : config) : Dated_jsonl.t =
     Hashtbl.replace audit_store_cache base store;
     store
 
+(** Partition parsed audit entries, logging and counting failures. *)
+let partition_entries (jsons : Yojson.Safe.t list) : audit_entry list =
+  let ok = ref [] in
+  let err_count = ref 0 in
+  List.iter (fun json ->
+    match entry_of_json_r json with
+    | Ok entry -> ok := entry :: !ok
+    | Error reason ->
+        incr err_count;
+        Log.Misc.error "audit_log: corrupt entry (#%d): %s" !err_count reason
+  ) jsons;
+  if !err_count > 0 then
+    Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)"
+      !err_count (List.length jsons);
+  List.rev !ok
+
 (** Read recent audit entries.
-    Tries date-split store first; falls back to legacy single file. *)
+    Tries date-split store first; falls back to legacy single file.
+    Parse failures are logged at ERROR level with raw JSON snippet. *)
 let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
   let entries = Dated_jsonl.read_recent store n in
   if entries <> [] then
-    List.filter_map entry_of_json entries
+    partition_entries entries
   else
-    (* Legacy fallback: single .masc/audit.jsonl *)
     let path = legacy_audit_path config in
     if not (Sys.file_exists path) then []
     else
       let content = Fs_compat.load_file path in
-      String.split_on_char '\n' content
-      |> List.filter (fun line -> String.trim line <> "")
-      |> List.filter_map (fun line ->
-          try entry_of_json (Yojson.Safe.from_string line)
-          with Yojson.Json_error _ -> None)
+      let jsons = String.split_on_char '\n' content
+        |> List.filter (fun line -> String.trim line <> "")
+        |> List.filter_map (fun line ->
+            match Yojson.Safe.from_string line with
+            | json -> Some json
+            | exception Yojson.Json_error msg ->
+                Log.Misc.error "audit_log: invalid JSON line: %s | line: %s"
+                  msg (String.sub line 0 (min 100 (String.length line)));
+                None) in
+      partition_entries jsons
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -222,7 +222,8 @@ let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
 
 (** Read recent audit entries.
     Tries date-split store first; falls back to legacy single file.
-    Parse failures are logged at ERROR level with raw JSON snippet. *)
+    Legacy JSON parse failures are logged at WARN (rate-limited, first N only).
+    Structural parse failures go through [parse_entries] ERROR path. *)
 let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
   let entries = Dated_jsonl.read_recent store n in
@@ -233,15 +234,24 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
     if not (Sys.file_exists path) then []
     else
       let content = Fs_compat.load_file path in
+      let invalid_count = ref 0 in
       let jsons = String.split_on_char '\n' content
         |> List.filter (fun line -> String.trim line <> "")
         |> List.filter_map (fun line ->
             match Yojson.Safe.from_string line with
             | json -> Some json
             | exception Yojson.Json_error msg ->
-                Log.Misc.error "audit_log: invalid JSON line: %s | line: %s"
-                  msg (preview ~max_len:100 line);
+                incr invalid_count;
+                if !invalid_count <= max_logged_errors then
+                  Log.Misc.warn "audit_log: invalid JSON line (#%d): %s | line: %s"
+                    !invalid_count msg (preview ~max_len:100 line);
                 None) in
+      if !invalid_count > 0 then
+        Log.Misc.warn "audit_log: %d invalid JSON line(s) in legacy audit log%s"
+          !invalid_count
+          (if !invalid_count > max_logged_errors
+           then Printf.sprintf " (%d more suppressed)" (!invalid_count - max_logged_errors)
+           else "");
       parse_entries jsons
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -49,6 +49,10 @@ type audit_entry = {
   trace_id: string option;
 }
 
+let preview ?(max_len = 200) (value : string) =
+  let len = String.length value in
+  if len <= max_len then value else String.sub value 0 max_len ^ "..."
+
 (** {1 Serialization} *)
 
 let action_to_string = function
@@ -150,8 +154,7 @@ let entry_of_json_r (json : Yojson.Safe.t) : (audit_entry, string) result =
     let trace_id = Safe_ops.json_string_opt "trace_id" json in
     Ok { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    let snippet = String.sub (Yojson.Safe.to_string json) 0
-      (min 200 (String.length (Yojson.Safe.to_string json))) in
+    let snippet = preview (Yojson.Safe.to_string json) in
     Error (Printf.sprintf "%s | json: %s" (Printexc.to_string exn) snippet)
 
 (** Lenient wrapper: logs error and returns option for backward compat *)
@@ -220,7 +223,7 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
             | json -> Some json
             | exception Yojson.Json_error msg ->
                 Log.Misc.error "audit_log: invalid JSON line: %s | line: %s"
-                  msg (String.sub line 0 (min 100 (String.length line)));
+                  msg (preview ~max_len:100 line);
                 None) in
       partition_entries jsons
 
@@ -285,9 +288,7 @@ let log_cancel_task config ~agent_id ~room_id ~task_id ~reason ?cost_estimate ?t
 
 let log_broadcast config ~agent_id ~room_id ~message_preview ?cost_estimate ?token_count () =
   (* Truncate message for privacy/size *)
-  let preview = if String.length message_preview > 100
-    then String.sub message_preview 0 100 ^ "..."
-    else message_preview in
+  let preview = preview ~max_len:100 message_preview in
   log_action config ~agent_id ~action:Broadcast ~room_id
     ~details:(`Assoc [("preview", `String preview)])
     ?cost_estimate ?token_count ~outcome:Success ()

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -187,8 +187,11 @@ let get_audit_store (config : config) : Dated_jsonl.t =
     Hashtbl.replace audit_store_cache base store;
     store
 
-(** Partition parsed audit entries, logging and counting failures. *)
-let partition_entries (jsons : Yojson.Safe.t list) : audit_entry list =
+(** Parse JSON list into audit entries. Logs first 5 failures individually,
+    then a summary. Returns only successfully parsed entries. *)
+let max_logged_errors = 5
+
+let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
   let ok = ref [] in
   let err_count = ref 0 in
   List.iter (fun json ->
@@ -196,11 +199,15 @@ let partition_entries (jsons : Yojson.Safe.t list) : audit_entry list =
     | Ok entry -> ok := entry :: !ok
     | Error reason ->
         incr err_count;
-        Log.Misc.error "audit_log: corrupt entry (#%d): %s" !err_count reason
+        if !err_count <= max_logged_errors then
+          Log.Misc.error "audit_log: corrupt entry (#%d): %s" !err_count reason
   ) jsons;
   if !err_count > 0 then
-    Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)"
-      !err_count (List.length jsons);
+    Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)%s"
+      !err_count (List.length jsons)
+      (if !err_count > max_logged_errors
+       then Printf.sprintf " (%d more suppressed)" (!err_count - max_logged_errors)
+       else "");
   List.rev !ok
 
 (** Read recent audit entries.
@@ -210,7 +217,7 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
   let entries = Dated_jsonl.read_recent store n in
   if entries <> [] then
-    partition_entries entries
+    parse_entries entries
   else
     let path = legacy_audit_path config in
     if not (Sys.file_exists path) then []
@@ -225,7 +232,7 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
                 Log.Misc.error "audit_log: invalid JSON line: %s | line: %s"
                   msg (preview ~max_len:100 line);
                 None) in
-      partition_entries jsons
+      parse_entries jsons
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =


### PR DESCRIPTION
## Summary

- `entry_of_json_r` 추출: `(audit_entry, string) result` 반환 — 파싱 실패를 caller가 확인 가능
- `partition_entries`: 배치 파싱 + corruption 건수 집계 + ERROR 레벨 로깅
- raw JSON snippet 포함으로 corruption 디버깅 가능
- 기존 `entry_of_json` (option)은 backward compat 유지

## Problem

기존: 파싱 실패 → WARN 로그 1줄 + `None` 반환 → `List.filter_map`이 조용히 드롭
- 감사 추적(audit trail)에 구멍이 생겨도 감지 불가
- 파일 손상과 정상 스킵 구분 불가

이후: 파싱 실패 → ERROR 로그 + 건수 요약 + raw JSON → 감지 및 대응 가능

## Test plan

- [x] `test_room_coverage.exe` — 55 tests pass
- [ ] CI full suite

Closes #4431

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>