### PR TITLE
fix(task): task_action variant type replaces string dispatch

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -388,50 +388,51 @@ let transition_task_r config ~agent_name ~task_id ~action
                  | Some task ->
                      let now = now_iso () in
                      let now_ts = Time_compat.now () in
-                     let action_str = String.lowercase_ascii action in
                      let transition =
-                       match Types_core.task_action_of_string action_str with
+                       match Types_core.task_action_of_string action with
                        | None ->
                            Error (Types.TaskInvalidState
                              (Printf.sprintf "Unknown action: %s (valid: %s)"
-                               action_str (String.concat ", " Types_core.valid_task_actions)))
+                               action (String.concat ", " Types_core.valid_task_actions)))
                        | Some act ->
                        (match act, task.task_status with
                        | Types_core.Claim, Types.Todo ->
-                           Ok (Types.Claimed { assignee = agent_name; claimed_at = now }, Some task_id)
+                           Ok (act, Types.Claimed { assignee = agent_name; claimed_at = now }, Some task_id)
                        | Types_core.Start, Types.Claimed { assignee; _ } when assignee = agent_name ->
-                           Ok (Types.InProgress { assignee = agent_name; started_at = now }, Some task_id)
-                       | Types_core.Done, Types.Claimed { assignee; _ }
-                       | Types_core.Done, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-                           Ok (Types.Done {
+                           Ok (act, Types.InProgress { assignee = agent_name; started_at = now }, Some task_id)
+                       | Types_core.Mark_done, Types.Claimed { assignee; _ }
+                       | Types_core.Mark_done, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                           Ok (act, Types.Done {
                              assignee = agent_name;
                              completed_at = now;
                              notes = if notes = "" then None else Some notes;
                            }, None)
                        | Types_core.Cancel, Types.Todo ->
-                           Ok (Types.Cancelled {
+                           Ok (act, Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
                        | Types_core.Cancel, Types.Claimed { assignee; _ }
                        | Types_core.Cancel, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-                           Ok (Types.Cancelled {
+                           Ok (act, Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
                        | Types_core.Release, Types.Claimed { assignee; _ }
                        | Types_core.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-                           Ok (Types.Todo, None)
+                           Ok (act, Types.Todo, None)
                        | _ ->
-                           Error (Types.TaskInvalidState
-                             (Printf.sprintf "Invalid transition: %s -> %s (%s)"
-                               (task_status_to_string task.task_status) action_str task_id)))
+                         let action_str = Types_core.task_action_to_string act in
+                         Error (Types.TaskInvalidState
+                           (Printf.sprintf "Invalid transition: %s -> %s (%s)"
+                             (task_status_to_string task.task_status) action_str task_id)))
                      in
                      (match transition with
                       | Error e -> Error e
-                      | Ok (new_status, set_current) ->
+                      | Ok (act, new_status, set_current) ->
+                          let action_str = Types_core.task_action_to_string act in
                           let new_tasks = List.map (fun t ->
                             if t.id = task_id then { t with task_status = new_status } else t
                           ) backlog.tasks in
@@ -461,20 +462,20 @@ let transition_task_r config ~agent_name ~task_id ~action
                           end;
                           log_event config (Printf.sprintf
                             "{\"type\":\"task_transition\",\"agent\":\"%s\",\"task\":\"%s\",\"action\":\"%s\",\"from\":\"%s\",\"to\":\"%s\",\"ts\":\"%s\"}"
-                            agent_name task_id action
+                            agent_name task_id action_str
                             (task_status_to_string task.task_status)
                             (task_status_to_string new_status)
                             now);
-                          (match action with
-                           | "claim" ->
+                          (match act with
+                           | Types_core.Claim ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.claimed"
                                  ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | "start" ->
+                           | Types_core.Start ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.started"
                                  ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | "done" ->
+                           | Types_core.Mark_done ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.done"
                                  ~payload:
@@ -483,7 +484,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                                        ("task_id", `String task_id);
                                        ("notes", if notes = "" then `Null else `String notes);
                                      ])
-                           | "cancel" ->
+                           | Types_core.Cancel ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.cancelled"
                                  ~payload:
@@ -492,14 +493,13 @@ let transition_task_r config ~agent_name ~task_id ~action
                                        ("task_id", `String task_id);
                                        ("reason", if reason = "" then `Null else `String reason);
                                      ])
-                           | "release" ->
+                           | Types_core.Release ->
                                emit_task_activity config ~agent_name ~task_id
                                  ~kind:"task.released"
-                                 ~payload:(`Assoc [ ("task_id", `String task_id) ])
-                           | _ -> ());
+                                 ~payload:(`Assoc [ ("task_id", `String task_id) ]));
                           let duration_ms =
-                            match action with
-                            | "done" | "cancel" ->
+                            match act with
+                            | Types_core.Mark_done | Types_core.Cancel ->
                                 Some
                                   (max 0
                                      (int_of_float
@@ -509,7 +509,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                             | _ -> None
                           in
                           observe_task_transition config ~agent_name ~task_id
-                            ~transition:action
+                            ~transition:action_str
                             ~details:
                               (task_transition_details
                                  ~from_status:task.task_status ~to_status:new_status

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -388,40 +388,46 @@ let transition_task_r config ~agent_name ~task_id ~action
                  | Some task ->
                      let now = now_iso () in
                      let now_ts = Time_compat.now () in
-                     let action = String.lowercase_ascii action in
+                     let action_str = String.lowercase_ascii action in
                      let transition =
-                       match action, task.task_status with
-                       | "claim", Types.Todo ->
+                       match Types_core.task_action_of_string action_str with
+                       | None ->
+                           Error (Types.TaskInvalidState
+                             (Printf.sprintf "Unknown action: %s (valid: %s)"
+                               action_str (String.concat ", " Types_core.valid_task_actions)))
+                       | Some act ->
+                       (match act, task.task_status with
+                       | Types_core.Claim, Types.Todo ->
                            Ok (Types.Claimed { assignee = agent_name; claimed_at = now }, Some task_id)
-                       | "start", Types.Claimed { assignee; _ } when assignee = agent_name ->
+                       | Types_core.Start, Types.Claimed { assignee; _ } when assignee = agent_name ->
                            Ok (Types.InProgress { assignee = agent_name; started_at = now }, Some task_id)
-                       | "done", Types.Claimed { assignee; _ }
-                       | "done", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types_core.Done, Types.Claimed { assignee; _ }
+                       | Types_core.Done, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Done {
                              assignee = agent_name;
                              completed_at = now;
                              notes = if notes = "" then None else Some notes;
                            }, None)
-                       | "cancel", Types.Todo ->
+                       | Types_core.Cancel, Types.Todo ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
-                       | "cancel", Types.Claimed { assignee; _ }
-                       | "cancel", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types_core.Cancel, Types.Claimed { assignee; _ }
+                       | Types_core.Cancel, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;
                              cancelled_at = now;
                              reason = if reason = "" then None else Some reason;
                            }, None)
-                       | "release", Types.Claimed { assignee; _ }
-                       | "release", Types.InProgress { assignee; _ } when assignee = agent_name || force ->
+                       | Types_core.Release, Types.Claimed { assignee; _ }
+                       | Types_core.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Todo, None)
                        | _ ->
                            Error (Types.TaskInvalidState
                              (Printf.sprintf "Invalid transition: %s -> %s (%s)"
-                               (task_status_to_string task.task_status) action task_id))
+                               (task_status_to_string task.task_status) action_str task_id)))
                      in
                      (match transition with
                       | Error e -> Error e

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -387,7 +387,11 @@ let handle_transition ctx args =
   in
   let evaluator_cascade = get_string_opt args "evaluator_cascade" in
   let expected_version = get_int_opt args "expected_version" in
-  let action_lc = String.lowercase_ascii action in
+  let action_canonical =
+    match Types_core.task_action_of_string action with
+    | Some act -> Types_core.task_action_to_string act
+    | None -> String.lowercase_ascii action
+  in
   let force_raw = get_bool args "force" false in
   (* force=true requires admin privilege: initial_admin or Admin role *)
   let force =
@@ -404,7 +408,7 @@ let handle_transition ctx args =
   let task_opt = List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks in
   (* Anti-rationalization gate: verify completion notes before allowing "done" *)
   let gate_rejection =
-    if action_lc = "done" && not force && can_review_completion ~task_opt ~agent_name:ctx.agent_name then
+    if action_canonical = "done" && not force && can_review_completion ~task_opt ~agent_name:ctx.agent_name then
       review_completion_notes
         ~completion_contract
         ~evaluator_cascade
@@ -444,7 +448,7 @@ let handle_transition ctx args =
   let rec try_transition attempt =
     let ev = if attempt = 0 then expected_version else None in
     let r = Room.transition_task_r ctx.config ~agent_name:ctx.agent_name
-              ~task_id ~action ?expected_version:ev ~notes ~reason () in
+              ~task_id ~action:action_canonical ?expected_version:ev ~notes ~reason () in
     if is_version_mismatch r && attempt < max_cas_retries then begin
       Log.Task.info "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
         task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
@@ -462,21 +466,21 @@ let handle_transition ctx args =
          ~agent:ctx.agent_name
          ~data:(`Assoc [
            ("task_id", `String task_id);
-           ("action", `String action);
+           ("action", `String action_canonical);
            ("notes", `String notes);
          ]);
        (* Notification harness: push task transition to all active sessions *)
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_transition");
          ("task_id", `String task_id);
-         ("action", `String action);
+           ("action", `String action_canonical);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error err ->
        Log.Task.error "task transition failed: %s" (Types.masc_error_to_string err));
   (* Record metrics *)
-  (match result, action_lc with
+  (match result, action_canonical with
    | Ok _, "done" ->
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -376,7 +376,7 @@ let handle_transition ctx args =
   | Ok task_id ->
   let action = get_string args "action" "" in
   if action = "" then
-    (false, "action is required (claim, start, done, cancel, release, block, unblock)")
+    (false, Printf.sprintf "action is required (%s)" (String.concat ", " Types_core.valid_task_actions))
   else
   let notes = get_string args "notes" "" in
   let reason = get_string args "reason" "" in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -241,6 +241,35 @@ let task_status_to_string = function
 
 let string_of_task_status = task_status_to_string
 
+(** Task action — algebraic type for task transitions.
+    Replaces string-based dispatch in room_task.ml and tool_task.ml.
+    @since 2.210.0 *)
+type task_action =
+  | Claim
+  | Start
+  | Done
+  | Cancel
+  | Release
+
+let task_action_to_string = function
+  | Claim -> "claim"
+  | Start -> "start"
+  | Done -> "done"
+  | Cancel -> "cancel"
+  | Release -> "release"
+
+let task_action_of_string s =
+  match String.lowercase_ascii s with
+  | "claim" -> Some Claim
+  | "start" -> Some Start
+  | "done" -> Some Done
+  | "cancel" -> Some Cancel
+  | "release" -> Some Release
+  | _ -> None
+
+(** Valid action strings for error messages *)
+let valid_task_actions = ["claim"; "start"; "done"; "cancel"; "release"]
+
 (* Manual yojson conversion for task_status (sum type with records) *)
 let task_status_to_yojson = function
   | Todo -> `Assoc [("status", `String "todo")]

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -247,14 +247,14 @@ let string_of_task_status = task_status_to_string
 type task_action =
   | Claim
   | Start
-  | Done
+  | Mark_done
   | Cancel
   | Release
 
 let task_action_to_string = function
   | Claim -> "claim"
   | Start -> "start"
-  | Done -> "done"
+  | Mark_done -> "done"
   | Cancel -> "cancel"
   | Release -> "release"
 
@@ -262,13 +262,14 @@ let task_action_of_string s =
   match String.lowercase_ascii s with
   | "claim" -> Some Claim
   | "start" -> Some Start
-  | "done" -> Some Done
+  | "done" -> Some Mark_done
   | "cancel" -> Some Cancel
   | "release" -> Some Release
   | _ -> None
 
-(** Valid action strings for error messages *)
-let valid_task_actions = ["claim"; "start"; "done"; "cancel"; "release"]
+(** Valid action strings for error messages (single source of truth). *)
+let valid_task_actions =
+  List.map task_action_to_string [ Claim; Start; Mark_done; Cancel; Release ]
 
 (* Manual yojson conversion for task_status (sum type with records) *)
 let task_status_to_yojson = function


### PR DESCRIPTION
## Summary
- Add `task_action` ADT (Claim|Start|Done|Cancel|Release) to `types_core.ml`
- Replace string-based match in `room_task.ml:transition_task_r` with variant matching
- Fix error message in `tool_task.ml`: remove fictitious "block"/"unblock" from help text
- Unknown actions now produce clear error with valid actions list

## Why
String-based dispatch is the #1 source of silent runtime failures:
- Typos like `"calim"` silently fall to catch-all
- Missing actions are invisible until runtime
- `block`/`unblock` mentioned in error message but never implemented

Variant types give compile-time exhaustiveness checking and make invalid states unrepresentable.

Fixes #4420

## Test plan
- [ ] `dune build` passes
- [ ] Existing task transition tests pass
- [ ] Invalid action strings return clear error, not silent catch-all

## Product impact
task_action 문자열 디스패치를 ADT 기반으로 교체. 타입 안전성 향상. 런타임 동작 동일.

## Evidence
CI Build, Lint 통과. Copilot 리뷰 4건 대응 완료.

## Review evidence
Copilot review 4건: Done 생성자 충돌, valid_task_actions 중복, 케이싱 통일, 이중 lowercase. 전부 대응.

## Linked issue
코드 품질 개선 (string dispatch → ADT)