### PR TITLE
fix(a2a): protect Random.State with mutex for fiber safety

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -109,11 +109,14 @@ let event_buffers_mutex = Eio.Mutex.create ()
 (* Max events per subscription to prevent memory bloat *)
 let max_buffered_events = Env_config_governance.Timeouts.event_buffer_size
 
-(** Generate stable UUIDv4 identifiers for subscriptions and delegated tasks. *)
+(** Generate stable UUIDv4 identifiers for subscriptions and delegated tasks.
+    Mutex-protected for fiber safety (Random.State is mutable). *)
 let a2a_rng = Random.State.make_self_init ()
+let a2a_rng_mutex = Eio.Mutex.create ()
 let generate_uuid () =
-  let uuid = Uuidm.v4_gen a2a_rng () in
-  Uuidm.to_string uuid
+  Eio.Mutex.use_ro a2a_rng_mutex (fun () ->
+    let uuid = Uuidm.v4_gen a2a_rng () in
+    Uuidm.to_string uuid)
 
 (** Get current ISO8601 timestamp *)
 let now_iso8601 () : string =


### PR DESCRIPTION
## Summary
- Add `a2a_rng_mutex` to protect `Random.State` in `generate_uuid()` from concurrent fiber access
- The Hashtbl → immutable Map conversion was already applied before this fix; this commit addresses the last remaining unprotected mutable global

## Context
Closes #4421

The issue reported 4 unprotected `Hashtbl.t` globals. Upon inspection, all 4 have already been converted to immutable `SMap.t ref` + `Eio.Mutex.use_rw/use_ro` (atomic swap pattern). The only remaining unprotected mutable was `a2a_rng : Random.State.make_self_init()`.

While OCaml 5 single-domain runtime prevents true parallel access, defensive mutex wrapping ensures consistency with the codebase pattern and future multi-domain safety.

## Test plan
- [x] `dune build @install` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)