### PR TITLE
refactor(session): remove [@atomic] fields, unify on mutex-only sync

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -11,24 +11,16 @@ type session = {
   mutable message_queue: Yojson.Safe.t list;  (* Pending messages *)
 }
 
-(** Rate limit tracking per category
+(** Rate limit tracking per category.
 
-    OCaml 5.4 Atomic Fields: burst_used and last_burst_reset use [@atomic]
-    for lock-free concurrent access. This enables safe updates from multiple
-    domains without explicit locks, using compare-and-set semantics.
-
-    Access pattern:
-    - Read:  Atomic.Loc.get [%atomic.loc tracker.burst_used]
-    - Write: Atomic.Loc.set [%atomic.loc tracker.burst_used] value
-    - CAS:   Atomic.Loc.compare_and_set [%atomic.loc tracker.field] old new
-    - Incr:  Atomic.Loc.fetch_and_add [%atomic.loc tracker.burst_used] 1
-*)
+    All fields are mutable and accessed exclusively under [registry.lock].
+    No lock-free access — the mutex is the single synchronization mechanism. *)
 type rate_tracker = {
   mutable general_timestamps: float list;
   mutable broadcast_timestamps: float list;
   mutable task_ops_timestamps: float list;
-  mutable burst_used: int [@atomic];  (* Atomic: concurrent burst tracking *)
-  mutable last_burst_reset: float [@atomic];  (* Atomic: timestamp for reset *)
+  mutable burst_used: int;
+  mutable last_burst_reset: float;
 }
 
 (** Session registry - manages all connected agents *)
@@ -102,25 +94,9 @@ let create_tracker () = {
   general_timestamps = [];
   broadcast_timestamps = [];
   task_ops_timestamps = [];
-  burst_used = 0;  (* Initial value for atomic field *)
-  last_burst_reset = Time_compat.now ();  (* Initial value for atomic field *)
+  burst_used = 0;
+  last_burst_reset = Time_compat.now ();
 }
-
-(** Atomic helpers for rate tracker - OCaml 5.4+ *)
-let get_burst_used tracker =
-  Atomic.Loc.get [%atomic.loc tracker.burst_used]
-
-let set_burst_used tracker v =
-  Atomic.Loc.set [%atomic.loc tracker.burst_used] v
-
-let incr_burst_used tracker =
-  ignore (Atomic.Loc.fetch_and_add [%atomic.loc tracker.burst_used] 1)
-
-let get_last_burst_reset tracker =
-  Atomic.Loc.get [%atomic.loc tracker.last_burst_reset]
-
-let set_last_burst_reset tracker v =
-  Atomic.Loc.set [%atomic.loc tracker.last_burst_reset] v
 
 (** Get timestamps for category *)
 let get_timestamps tracker = function
@@ -152,10 +128,10 @@ let check_rate_limit_ex registry ~agent_name ~category ~role =
     in
 
     (* Reset burst if a minute has passed - atomic compare-and-set *)
-    let last_reset = get_last_burst_reset tracker in
+    let last_reset = tracker.last_burst_reset in
     if now -. last_reset > 60.0 then begin
-      set_burst_used tracker 0;
-      set_last_burst_reset tracker now
+      tracker.burst_used <- 0;
+      tracker.last_burst_reset <- now
     end;
 
     (* Filter to last minute only *)
@@ -175,9 +151,9 @@ let check_rate_limit_ex registry ~agent_name ~category ~role =
 
     if current >= limit then begin
       (* Check if burst is available - using atomic read/increment *)
-      let burst = get_burst_used tracker in
+      let burst = tracker.burst_used in
       if burst < registry.config.burst_allowed then begin
-        incr_burst_used tracker;  (* Atomic increment *)
+        tracker.burst_used <- burst + 1;
         set_timestamps tracker category (now :: recent);
         (true, 0)  (* Burst allowed *)
       end else begin
@@ -220,7 +196,7 @@ let get_rate_limit_status registry ~agent_name ~role =
       ]
     in
 
-    let burst = get_burst_used tracker in  (* Atomic read *)
+    let burst = tracker.burst_used in
     `Assoc [
       ("agent", `String agent_name);
       ("role", `String (agent_role_to_string role));

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -127,7 +127,7 @@ let check_rate_limit_ex registry ~agent_name ~category ~role =
           t
     in
 
-    (* Reset burst if a minute has passed - atomic compare-and-set *)
+    (* Reset burst if a minute has passed - mutex-protected *)
     let last_reset = tracker.last_burst_reset in
     if now -. last_reset > 60.0 then begin
       tracker.burst_used <- 0;
@@ -150,7 +150,7 @@ let check_rate_limit_ex registry ~agent_name ~category ~role =
     let current = List.length recent in
 
     if current >= limit then begin
-      (* Check if burst is available - using atomic read/increment *)
+      (* Check if burst is available - mutex-protected read/increment *)
       let burst = tracker.burst_used in
       if burst < registry.config.burst_allowed then begin
         tracker.burst_used <- burst + 1;

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -19,14 +19,14 @@ type session = {
 
 (** Rate-limit tracking per category.
 
-    Uses OCaml 5.4 [[@atomic]] fields for lock-free concurrent access
-    to burst counters. *)
+    All fields are mutable and accessed exclusively under [registry.lock].
+    No lock-free access — the mutex is the single synchronization mechanism. *)
 type rate_tracker = {
   mutable general_timestamps: float list;
   mutable broadcast_timestamps: float list;
   mutable task_ops_timestamps: float list;
-  mutable burst_used: int; [@atomic]
-  mutable last_burst_reset: float; [@atomic]
+  mutable burst_used: int;
+  mutable last_burst_reset: float;
 }
 
 (** Session registry managing all connected agents. *)
@@ -65,21 +65,6 @@ val update_activity :
 
 (** Create an empty rate tracker. *)
 val create_tracker : unit -> rate_tracker
-
-(** Atomic read of [burst_used]. *)
-val get_burst_used : rate_tracker -> int
-
-(** Atomic write of [burst_used]. *)
-val set_burst_used : rate_tracker -> int -> unit
-
-(** Atomic increment of [burst_used] (fetch-and-add). *)
-val incr_burst_used : rate_tracker -> unit
-
-(** Atomic read of [last_burst_reset]. *)
-val get_last_burst_reset : rate_tracker -> float
-
-(** Atomic write of [last_burst_reset]. *)
-val set_last_burst_reset : rate_tracker -> float -> unit
 
 (** Get timestamps for a given rate-limit category. *)
 val get_timestamps : rate_tracker -> rate_limit_category -> float list

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -20,7 +20,8 @@ type session = {
 (** Rate-limit tracking per category.
 
     All fields are mutable and accessed exclusively under [registry.lock].
-    No lock-free access — the mutex is the single synchronization mechanism. *)
+    No lock-free access — the mutex is the single synchronization mechanism.
+    Callers must hold [registry.lock] before reading or writing any field. *)
 type rate_tracker = {
   mutable general_timestamps: float list;
   mutable broadcast_timestamps: float list;

--- a/test/test_session_coverage.ml
+++ b/test/test_session_coverage.ml
@@ -132,7 +132,7 @@ let test_set_get_roundtrip () =
   check (list (float 0.1)) "roundtrip" ts ts'
 
 (* ============================================================
-   Atomic Helpers Tests
+   Burst Counters Tests
    ============================================================ *)
 
 let test_burst_used_initial () =
@@ -425,7 +425,7 @@ let () =
       test_case "task_ops" `Quick test_set_timestamps_task_ops;
       test_case "roundtrip" `Quick test_set_get_roundtrip;
     ];
-    "atomic_helpers", [
+    "burst_counters", [
       test_case "burst_used initial" `Quick test_burst_used_initial;
       test_case "burst_used set" `Quick test_burst_used_set;
       test_case "burst_used incr" `Quick test_burst_used_incr;

--- a/test/test_session_coverage.ml
+++ b/test/test_session_coverage.ml
@@ -5,7 +5,7 @@
     - rate_tracker type
     - create_tracker function
     - get_timestamps / set_timestamps
-    - Atomic helpers: get_burst_used, set_burst_used, incr_burst_used
+    - Burst counters: burst_used, last_burst_reset (direct field access)
     - McpSessionStore: generate_id, to_json
     - extract_mcp_session_id
 *)
@@ -135,43 +135,37 @@ let test_set_get_roundtrip () =
    Atomic Helpers Tests
    ============================================================ *)
 
-let test_get_burst_used_initial () =
+let test_burst_used_initial () =
   let rt = Session.create_tracker () in
-  let burst = Session.get_burst_used rt in
-  check int "initial burst" 0 burst
+  check int "initial burst" 0 rt.burst_used
 
-let test_set_burst_used () =
+let test_burst_used_set () =
   let rt = Session.create_tracker () in
-  Session.set_burst_used rt 5;
-  let burst = Session.get_burst_used rt in
-  check int "set burst" 5 burst
+  rt.burst_used <- 5;
+  check int "set burst" 5 rt.burst_used
 
-let test_incr_burst_used () =
+let test_burst_used_incr () =
   let rt = Session.create_tracker () in
-  Session.set_burst_used rt 3;
-  Session.incr_burst_used rt;
-  let burst = Session.get_burst_used rt in
-  check int "incr burst" 4 burst
+  rt.burst_used <- 3;
+  rt.burst_used <- rt.burst_used + 1;
+  check int "incr burst" 4 rt.burst_used
 
-let test_incr_burst_used_multiple () =
+let test_burst_used_incr_multiple () =
   let rt = Session.create_tracker () in
-  Session.incr_burst_used rt;
-  Session.incr_burst_used rt;
-  Session.incr_burst_used rt;
-  let burst = Session.get_burst_used rt in
-  check int "incr 3 times" 3 burst
+  rt.burst_used <- rt.burst_used + 1;
+  rt.burst_used <- rt.burst_used + 1;
+  rt.burst_used <- rt.burst_used + 1;
+  check int "incr 3 times" 3 rt.burst_used
 
-let test_get_last_burst_reset () =
+let test_last_burst_reset () =
   let rt = Session.create_tracker () in
-  let reset = Session.get_last_burst_reset rt in
-  check bool "positive reset time" true (reset > 0.0)
+  check bool "positive reset time" true (rt.last_burst_reset > 0.0)
 
-let test_set_last_burst_reset () =
+let test_last_burst_reset_set () =
   let rt = Session.create_tracker () in
   let new_time = 12345.0 in
-  Session.set_last_burst_reset rt new_time;
-  let reset = Session.get_last_burst_reset rt in
-  check (float 0.1) "set reset time" new_time reset
+  rt.last_burst_reset <- new_time;
+  check (float 0.1) "set reset time" new_time rt.last_burst_reset
 
 (* ============================================================
    McpSessionStore Tests
@@ -432,12 +426,12 @@ let () =
       test_case "roundtrip" `Quick test_set_get_roundtrip;
     ];
     "atomic_helpers", [
-      test_case "get_burst_used initial" `Quick test_get_burst_used_initial;
-      test_case "set_burst_used" `Quick test_set_burst_used;
-      test_case "incr_burst_used" `Quick test_incr_burst_used;
-      test_case "incr_burst_used multiple" `Quick test_incr_burst_used_multiple;
-      test_case "get_last_burst_reset" `Quick test_get_last_burst_reset;
-      test_case "set_last_burst_reset" `Quick test_set_last_burst_reset;
+      test_case "burst_used initial" `Quick test_burst_used_initial;
+      test_case "burst_used set" `Quick test_burst_used_set;
+      test_case "burst_used incr" `Quick test_burst_used_incr;
+      test_case "burst_used incr multiple" `Quick test_burst_used_incr_multiple;
+      test_case "last_burst_reset" `Quick test_last_burst_reset;
+      test_case "last_burst_reset set" `Quick test_last_burst_reset_set;
     ];
     "mcp_session_store", [
       test_case "generate_id prefix" `Quick test_generate_id_prefix;


### PR DESCRIPTION
## Summary

- `[@atomic]` 제거: `burst_used`, `last_burst_reset` → 일반 `mutable` 필드
- atomic accessor 함수 5개 삭제 (get/set/incr_burst_used, get/set_last_burst_reset)
- 직접 필드 접근으로 통일 (모든 접근이 이미 `with_lock` 내부)

## Motivation

Audit #4422 (Impact 5/5): mixed atomicity antipattern. `[@atomic]`과 non-atomic 필드가 같은 레코드에 공존하면 "lock 없이 읽어도 된다"는 잘못된 신호를 준다. 실제로는 모든 접근이 `registry.lock` 안에서 발생하므로 atomic이 불필요하다.

## Changes

| 변경 | 이유 |
|------|------|
| `[@atomic]` 제거 | 모든 접근이 mutex 안 — 불필요한 복잡성 |
| accessor 함수 삭제 | 간접 참조 제거, 직접 필드 접근이 명확 |
| .mli 문서 수정 | "lock-free" → "mutex-only" |

## Test plan

- [x] `test_session_coverage.exe` — 49 tests pass
- [ ] CI full suite

Closes #4422

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>