### PR TITLE
fix(transport): add mutex protection to SSE connection registries

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -475,7 +475,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
             }
           in
           info_ref := Some info;
-          Hashtbl.replace sse_conn_by_session session_id info;
+          register_sse_conn ~session_id ~info;
           ignore (send_raw info (sse_prime_event ()));
           (match legacy_messages_endpoint with
           | None -> ()

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -77,7 +77,7 @@ let handle_ag_ui_events ~deps request reqd =
         }
       in
       info_ref := Some info;
-      Hashtbl.replace sse_conn_by_session session_id info;
+      register_sse_conn ~session_id ~info;
       let prime =
         Ag_ui.(
           make_event ~thread_id:room_id ~run_id:(Some session_id) Run_started

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -48,6 +48,12 @@ let sse_connect_window_s =
 let sse_connect_max_in_window =
   env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0 |> max 0
 
+(** Register an SSE connection under [sse_registry_mutex].
+    All call sites must use this instead of direct [Hashtbl.replace]. *)
+let register_sse_conn ~session_id ~info =
+  Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    Hashtbl.replace sse_conn_by_session session_id info)
+
 let close_sse_conn info =
   if not info.closed then (
     info.closed <- true;

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -1,4 +1,7 @@
-(** Server_mcp_transport_http_conn — SSE connection lifecycle management. *)
+(** Server_mcp_transport_http_conn — SSE connection lifecycle management.
+
+    All access to global registries is protected by [sse_registry_mutex].
+    Individual connection writes are protected by per-connection [info.mutex]. *)
 
 type sse_conn_info = {
   session_id : string;
@@ -19,6 +22,9 @@ type sse_connect_guard_state = {
 let sse_connect_guard_by_session :
     (string, sse_connect_guard_state) Hashtbl.t =
   Hashtbl.create 256
+
+(** Single mutex protecting both Hashtbl registries. *)
+let sse_registry_mutex = Eio.Mutex.create ()
 
 let env_float_or ~name ~default =
   match Sys.getenv_opt name with
@@ -55,31 +61,41 @@ let close_sse_conn info =
     Sse.unregister_if_current info.session_id info.client_id)
 
 let stop_sse_session session_id =
-  match Hashtbl.find_opt sse_conn_by_session session_id with
+  let info_opt = Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    match Hashtbl.find_opt sse_conn_by_session session_id with
+    | None -> None
+    | Some info ->
+        Hashtbl.remove sse_conn_by_session session_id;
+        Hashtbl.remove sse_connect_guard_by_session session_id;
+        Some info) in
+  match info_opt with
   | None -> ()
-  | Some info ->
-      Hashtbl.remove sse_conn_by_session session_id;
-      Hashtbl.remove sse_connect_guard_by_session session_id;
-      close_sse_conn info
+  | Some info -> close_sse_conn info
 
 let is_active_sse_session session_id =
-  Hashtbl.mem sse_conn_by_session session_id
+  Eio.Mutex.use_ro sse_registry_mutex (fun () ->
+    Hashtbl.mem sse_conn_by_session session_id)
 
 let reap_stale_guards () =
-  let stale =
-    Hashtbl.fold (fun sid _ acc ->
-      if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
-      else acc
-    ) sse_connect_guard_by_session []
-  in
-  List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
-  List.length stale
+  Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    let stale =
+      Hashtbl.fold (fun sid _ acc ->
+        if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
+        else acc
+      ) sse_connect_guard_by_session []
+    in
+    List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
+    List.length stale)
 
 let close_all_sse_connections () =
-  let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in
-  List.iter stop_sse_session sessions;
+  let infos = Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    let all = Hashtbl.fold (fun _k v acc -> v :: acc) sse_conn_by_session [] in
+    Hashtbl.clear sse_conn_by_session;
+    Hashtbl.clear sse_connect_guard_by_session;
+    all) in
+  List.iter close_sse_conn infos;
   Log.Server.info "MASC MCP: Closed %d SSE connections"
-    (List.length sessions)
+    (List.length infos)
 
 let send_raw info data =
   if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then (
@@ -113,37 +129,38 @@ let prune_connect_times ~now times =
   else List.filter (fun ts -> now -. ts <= sse_connect_window_s) times
 
 let check_sse_connect_guard session_id =
-  let now = Time_compat.now () in
-  let state =
-    match Hashtbl.find_opt sse_connect_guard_by_session session_id with
-    | Some v -> v
-    | None -> { last_connect_at = -.1.0; connect_times = [] }
-  in
-  let recent = prune_connect_times ~now state.connect_times in
-  state.connect_times <- recent;
-  let session_wait_s =
-    if sse_reconnect_min_interval_s <= 0.0 then
-      0.0
-    else
-      sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
-  in
-  if session_wait_s > 0.0 then
-    Error ("session_cooldown", session_wait_s)
-  else
-    let window_wait_s =
-      if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
-        0.0
-      else if List.length recent >= sse_connect_max_in_window then
-        match List.rev recent with
-        | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
-        | [] -> 0.0
-      else
-        0.0
+  Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    let now = Time_compat.now () in
+    let state =
+      match Hashtbl.find_opt sse_connect_guard_by_session session_id with
+      | Some v -> v
+      | None -> { last_connect_at = -.1.0; connect_times = [] }
     in
-    if window_wait_s > 0.0 then
-      Error ("window_limit", window_wait_s)
-    else (
-      state.last_connect_at <- now;
-      state.connect_times <- now :: recent;
-      Hashtbl.replace sse_connect_guard_by_session session_id state;
-      Ok ())
+    let recent = prune_connect_times ~now state.connect_times in
+    state.connect_times <- recent;
+    let session_wait_s =
+      if sse_reconnect_min_interval_s <= 0.0 then
+        0.0
+      else
+        sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
+    in
+    if session_wait_s > 0.0 then
+      Error ("session_cooldown", session_wait_s)
+    else
+      let window_wait_s =
+        if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
+          0.0
+        else if List.length recent >= sse_connect_max_in_window then
+          match List.rev recent with
+          | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
+          | [] -> 0.0
+        else
+          0.0
+      in
+      if window_wait_s > 0.0 then
+        Error ("window_limit", window_wait_s)
+      else (
+        state.last_connect_at <- now;
+        state.connect_times <- now :: recent;
+        Hashtbl.replace sse_connect_guard_by_session session_id state;
+        Ok ()))


### PR DESCRIPTION
## Summary

- `sse_registry_mutex` 추가 — SSE conn + guard 테이블 보호
- 기존: mutex 없이 find/remove/iterate → concurrent corruption 가능
- I/O(close_sse_conn)는 mutex 밖에서 실행하여 lock 기간 최소화

## Key Safety Fixes

| 함수 | 기존 | 수정 |
|------|------|------|
| `stop_sse_session` | 보호 없이 2테이블 수정 | atomic find+remove under mutex |
| `close_all_sse_connections` | iterate 중 수정 (corruption) | collect+clear, then close |
| `reap_stale_guards` | cross-table check 보호 없음 | mutex 안에서 전체 처리 |
| `check_sse_connect_guard` | read-modify-write 보호 없음 | mutex 안에서 atomic |

## Test plan

- [x] Build pass
- [ ] CI full suite

Closes #4430

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>