### PR TITLE
fix(encryption): add InvalidHexFormat error and hex parsing tests

### DIFF
--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -30,6 +30,7 @@ type envelope = {
 type encryption_error =
   | KeyNotFound of string
   | InvalidKeyLength of int
+  | InvalidHexFormat of string
   | DecryptionFailed
   | InvalidEnvelope of string
   | RngNotInitialized
@@ -37,6 +38,7 @@ type encryption_error =
 let show_encryption_error = function
   | KeyNotFound s -> Printf.sprintf "KeyNotFound: %s" s
   | InvalidKeyLength n -> Printf.sprintf "InvalidKeyLength: expected 32, got %d" n
+  | InvalidHexFormat s -> Printf.sprintf "InvalidHexFormat: %s" s
   | DecryptionFailed -> "DecryptionFailed: authentication tag mismatch"
   | InvalidEnvelope s -> Printf.sprintf "InvalidEnvelope: %s" s
   | RngNotInitialized -> "RngNotInitialized: call initialize() first"
@@ -60,37 +62,54 @@ let base64_decode s =
   | Ok decoded -> Some (Cstruct.of_string decoded)
   | Error _ -> None
 
+(** Decode hex string to raw bytes. Returns Error on invalid input.
+    Does not include input content in error messages to avoid leaking
+    key material through diagnostics/logs. *)
+let decode_hex_key content : (string, encryption_error) result =
+  let content = String.trim content in
+  let len = String.length content in
+  if len <> 64 then
+    Error (InvalidHexFormat
+      (Printf.sprintf "hex key must be exactly 64 characters, got %d" len))
+  else
+    let buf = Buffer.create 32 in
+    let err = ref None in
+    let i = ref 0 in
+    while !i < 32 && Option.is_none !err do
+      let hex = String.sub content (!i * 2) 2 in
+      (match int_of_string_opt ("0x" ^ hex) with
+       | Some v when v >= 0 && v <= 255 ->
+           Buffer.add_char buf (Char.chr v)
+       | _ ->
+           err := Some (InvalidHexFormat
+             (Printf.sprintf "invalid hex byte at position %d" (!i * 2))));
+      incr i
+    done;
+    match !err with
+    | Some e -> Error e
+    | None -> Ok (Buffer.contents buf)
+
 (** Load encryption key from configured source *)
 let load_key config : (GCM.key, encryption_error) result =
-  let key_string = match config.key_source with
+  let key_result = match config.key_source with
     | `Env var_name ->
-        Sys.getenv_opt var_name
+        (match Sys.getenv_opt var_name with
+         | Some v -> Ok (Some v)
+         | None -> Ok None)
     | `File path ->
         if Sys.file_exists path then
-          let content = Fs_compat.load_file path in
-          let content = String.trim content in
-          if String.length content <> 64 then
-            None  (* hex-encoded 32 bytes requires exactly 64 chars *)
-          else
-            let buf = Buffer.create 32 in
-            let valid = ref true in
-            for i = 0 to 31 do
-              if !valid then
-                let hex = String.sub content (i * 2) 2 in
-                match int_of_string_opt ("0x" ^ hex) with
-                | Some v when v >= 0 && v <= 255 ->
-                    Buffer.add_char buf (Char.chr v)
-                | _ -> valid := false
-            done;
-            if !valid then Some (Buffer.contents buf) else None
-        else None
-    | `Direct key -> Some key
+          (match decode_hex_key (Fs_compat.load_file path) with
+           | Ok bytes -> Ok (Some bytes)
+           | Error e -> Error e)
+        else Ok None
+    | `Direct key -> Ok (Some key)
   in
-  match key_string with
-  | None -> Error (KeyNotFound "encryption key not configured")
-  | Some key when String.length key <> 32 ->
+  match key_result with
+  | Error e -> Error e
+  | Ok None -> Error (KeyNotFound "encryption key not configured")
+  | Ok (Some key) when String.length key <> 32 ->
       Error (InvalidKeyLength (String.length key))
-  | Some key ->
+  | Ok (Some key) ->
       Ok (GCM.of_secret key)
 
 (** Generate a random 12-byte nonce (GCM recommended size) *)

--- a/test/test_encryption.ml
+++ b/test/test_encryption.ml
@@ -165,6 +165,24 @@ let test_invalid_key_length () =
   | Ok _ -> fail "should reject short key"
   | Error e -> fail (Encryption.show_encryption_error e)
 
+(* Test: file with invalid hex returns InvalidHexFormat, not KeyNotFound *)
+let test_load_key_file_invalid_hex () =
+  let path = Filename.temp_file "masc-key-invalid-" ".txt" in
+  let oc = open_out path in
+  output_string oc (String.make 64 'g');
+  close_out oc;
+  let bad_config = {
+    Encryption.enabled = true;
+    key_source = `File path;
+    version = 1;
+  } in
+  (match Encryption.load_key bad_config with
+   | Error (Encryption.InvalidHexFormat _) -> ()
+   | Ok _ -> fail "should reject invalid file key"
+   | Error (Encryption.KeyNotFound _) -> fail "expected invalid hex format, not key not found"
+   | Error _ -> fail "expected invalid hex format");
+  (try Sys.remove path with _ -> ())
+
 (* Test: generate_key_hex produces valid hex *)
 let test_generate_key_hex () =
   match Encryption.generate_key_hex () with
@@ -203,6 +221,7 @@ let () =
     ];
     "key_management", [
       test_case "invalid key length" `Quick test_invalid_key_length;
+      test_case "file invalid hex" `Quick test_load_key_file_invalid_hex;
       test_case "generate_key_hex" `Quick test_generate_key_hex;
     ];
     "diagnostics", [

--- a/test/test_encryption.ml
+++ b/test/test_encryption.ml
@@ -169,19 +169,23 @@ let test_invalid_key_length () =
 let test_load_key_file_invalid_hex () =
   let path = Filename.temp_file "masc-key-invalid-" ".txt" in
   let oc = open_out path in
-  output_string oc (String.make 64 'g');
-  close_out oc;
-  let bad_config = {
-    Encryption.enabled = true;
-    key_source = `File path;
-    version = 1;
-  } in
-  (match Encryption.load_key bad_config with
-   | Error (Encryption.InvalidHexFormat _) -> ()
-   | Ok _ -> fail "should reject invalid file key"
-   | Error (Encryption.KeyNotFound _) -> fail "expected invalid hex format, not key not found"
-   | Error _ -> fail "expected invalid hex format");
-  (try Sys.remove path with _ -> ())
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      (try Sys.remove path with _ -> ()))
+    (fun () ->
+      output_string oc (String.make 64 'g');
+      close_out oc;
+      let bad_config = {
+        Encryption.enabled = true;
+        key_source = `File path;
+        version = 1;
+      } in
+      match Encryption.load_key bad_config with
+      | Error (Encryption.InvalidHexFormat _) -> ()
+      | Ok _ -> fail "should reject invalid file key"
+      | Error (Encryption.KeyNotFound _) -> fail "expected invalid hex format, not key not found"
+      | Error _ -> fail "expected invalid hex format")
 
 (* Test: generate_key_hex produces valid hex *)
 let test_generate_key_hex () =

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -76,10 +76,46 @@ let test_error_invalid_envelope () =
   let s = Encryption.show_encryption_error e in
   check bool "contains Invalid" true (String.sub s 0 15 = "InvalidEnvelope")
 
+let test_error_invalid_hex_format () =
+  let e = Encryption.InvalidHexFormat "bad hex" in
+  let s = Encryption.show_encryption_error e in
+  check bool "contains InvalidHexFormat" true (String.sub s 0 16 = "InvalidHexFormat")
+
 let test_error_rng_not_initialized () =
   let e = Encryption.RngNotInitialized in
   let s = Encryption.show_encryption_error e in
   check bool "contains RNG" true (String.sub s 0 17 = "RngNotInitialized")
+
+let test_decode_hex_key_valid () =
+  let hex = String.init 64 (fun i ->
+    let byte_val = i / 2 in
+    let nibble = if i mod 2 = 0 then byte_val / 16 else byte_val mod 16 in
+    "0123456789abcdef".[nibble]) in
+  match Encryption.decode_hex_key hex with
+  | Ok bytes -> check int "decoded length" 32 (String.length bytes)
+  | Error e -> fail (Encryption.show_encryption_error e)
+
+let test_decode_hex_key_too_short () =
+  match Encryption.decode_hex_key "aabb" with
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions 64 chars" true (String.contains msg '6' && String.contains msg '4')
+  | _ -> fail "Expected InvalidHexFormat for short input"
+
+let test_decode_hex_key_too_long () =
+  let long_hex = String.make 66 '0' in
+  match Encryption.decode_hex_key long_hex with
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions 64 chars" true (String.contains msg '6' && String.contains msg '4')
+  | _ -> fail "Expected InvalidHexFormat for long input"
+
+let test_decode_hex_key_invalid_chars () =
+  let hex = "GG" ^ String.make 62 '0' in
+  match Encryption.decode_hex_key hex with
+  | Error (Encryption.InvalidHexFormat msg) ->
+      check bool "mentions position index" true
+        (String.starts_with ~prefix:"invalid hex byte at position" msg);
+      check bool "does NOT leak invalid chars (security)" false (String.contains msg 'G')
+  | _ -> fail "Expected InvalidHexFormat for invalid hex chars"
 
 (* ============================================================
    envelope Tests
@@ -216,6 +252,24 @@ let test_load_key_file_not_found () =
   | Ok _ -> fail "should fail for missing file"
   | Error (Encryption.KeyNotFound _) -> ()
   | Error _ -> fail "unexpected error type"
+
+let test_load_key_file_invalid_hex () =
+  let path = Filename.temp_file "masc-key-invalid-" ".txt" in
+  let oc = open_out path in
+  output_string oc (String.make 64 'g');
+  close_out oc;
+  let config : Encryption.config = {
+    enabled = true;
+    key_source = `File path;
+    version = 1;
+  } in
+  let result = Encryption.load_key config in
+  (match result with
+  | Error (Encryption.InvalidHexFormat _) -> ()
+  | Error (Encryption.KeyNotFound _) -> fail "expected invalid format, got missing key"
+  | Error _ -> fail "expected invalid hex format"
+  | Ok _ -> fail "should fail for malformed hex");
+  (try Sys.remove path with _ -> ())
 
 (* ============================================================
    envelope_to_json / envelope_of_json Tests
@@ -503,9 +557,16 @@ let () =
     "encryption_error", [
       test_case "key not found" `Quick test_error_key_not_found;
       test_case "invalid key length" `Quick test_error_invalid_key_length;
+      test_case "invalid hex format" `Quick test_error_invalid_hex_format;
       test_case "decryption failed" `Quick test_error_decryption_failed;
       test_case "invalid envelope" `Quick test_error_invalid_envelope;
       test_case "rng not initialized" `Quick test_error_rng_not_initialized;
+    ];
+    "decode_hex_key", [
+      test_case "valid hex" `Quick test_decode_hex_key_valid;
+      test_case "too short" `Quick test_decode_hex_key_too_short;
+      test_case "too long" `Quick test_decode_hex_key_too_long;
+      test_case "invalid chars" `Quick test_decode_hex_key_invalid_chars;
     ];
     "envelope", [
       test_case "creation" `Quick test_envelope_creation;
@@ -533,6 +594,7 @@ let () =
       test_case "direct wrong length" `Quick test_load_key_direct_wrong_length;
       test_case "env not found" `Quick test_load_key_env_not_found;
       test_case "file not found" `Quick test_load_key_file_not_found;
+      test_case "file invalid hex" `Quick test_load_key_file_invalid_hex;
     ];
     "envelope_json", [
       test_case "to_json" `Quick test_envelope_to_json;

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -256,20 +256,23 @@ let test_load_key_file_not_found () =
 let test_load_key_file_invalid_hex () =
   let path = Filename.temp_file "masc-key-invalid-" ".txt" in
   let oc = open_out path in
-  output_string oc (String.make 64 'g');
-  close_out oc;
-  let config : Encryption.config = {
-    enabled = true;
-    key_source = `File path;
-    version = 1;
-  } in
-  let result = Encryption.load_key config in
-  (match result with
-  | Error (Encryption.InvalidHexFormat _) -> ()
-  | Error (Encryption.KeyNotFound _) -> fail "expected invalid format, got missing key"
-  | Error _ -> fail "expected invalid hex format"
-  | Ok _ -> fail "should fail for malformed hex");
-  (try Sys.remove path with _ -> ())
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      (try Sys.remove path with _ -> ()))
+    (fun () ->
+      output_string oc (String.make 64 'g');
+      close_out oc;
+      let config : Encryption.config = {
+        enabled = true;
+        key_source = `File path;
+        version = 1;
+      } in
+      match Encryption.load_key config with
+      | Error (Encryption.InvalidHexFormat _) -> ()
+      | Error (Encryption.KeyNotFound _) -> fail "expected invalid format, got missing key"
+      | Error _ -> fail "expected invalid hex format"
+      | Ok _ -> fail "should fail for malformed hex")
 
 (* ============================================================
    envelope_to_json / envelope_of_json Tests


### PR DESCRIPTION
## Summary
- Follow-up to #4452 addressing unresolved Copilot review comments from #4449 and #4452
- Add `InvalidHexFormat` error variant so malformed key files return a specific error instead of being masked as `KeyNotFound`
- Extract `decode_hex_key` as a public function with early-exit loop (replaces `valid` ref + for-loop that iterated all 32 times after failure)
- Error messages report byte position only -- no key material leaked via diagnostics/logs
- Add file-based hex parsing tests in both `test_encryption.ml` and `test_encryption_coverage.ml`

## Copilot comments addressed
| PR | Comment | Fix |
|----|---------|-----|
| #4452 | [3021186865](https://github.com/jeong-sik/masc-mcp/pull/4452#discussion_r3021186865) - `None` -> `KeyNotFound` masks real cause | `InvalidHexFormat` with proper error propagation |
| #4452 | [3021186884](https://github.com/jeong-sik/masc-mcp/pull/4452#discussion_r3021186884) - No file-based hex tests | Added `test_load_key_file_invalid_hex` in both test files |
| #4452 | [3021186899](https://github.com/jeong-sik/masc-mcp/pull/4452#discussion_r3021186899) - `valid` ref + for loop | Extracted `decode_hex_key` with while-loop early exit |
| #4449 | [3021167652](https://github.com/jeong-sik/masc-mcp/pull/4449#discussion_r3021167652) - Key material in error msg | Position-only error messages |
| #4449 | [3021167681](https://github.com/jeong-sik/masc-mcp/pull/4449#discussion_r3021167681) - >64 chars silently ignored | Strict `len <> 64` check |
| #4449 | [3021327533](https://github.com/jeong-sik/masc-mcp/pull/4449#discussion_r3021327533) - Weak test assertion | `String.starts_with ~prefix:"invalid hex byte at position"` |

## Test plan
- [x] `dune build` passes
- [x] `test_encryption.exe` -- 10/10 tests pass (including new `file invalid hex`)
- [x] `test_encryption_coverage.exe` -- 52/52 tests pass (including new `decode_hex_key` suite and `file invalid hex`)

Generated with [Claude Code](https://claude.com/claude-code)