### PR TITLE
fix(council): add mutex protection to consensus session registry

### DIFF
--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -77,8 +77,8 @@ type error =
 (** In-memory session store — protected by [sessions_mutex]. *)
 let sessions : (string, session) Hashtbl.t = Hashtbl.create 16
 let sessions_mutex = Eio.Mutex.create ()
-let with_sessions f = Eio.Mutex.use_rw ~protect:true sessions_mutex f
-let with_sessions_ro f = Eio.Mutex.use_ro sessions_mutex f
+let with_sessions f = Eio_guard.with_mutex sessions_mutex (fun () -> f ())
+let with_sessions_ro f = Eio_guard.with_mutex_ro sessions_mutex (fun () -> f ())
 
 (** {1 File-based Persistence} *)
 
@@ -293,11 +293,13 @@ let persist_session (s : session) : (unit, error) result =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (Persistence_failed (Printexc.to_string e))
 
+(** Persist + replace. Caller must hold sessions_mutex when atomicity
+    with a preceding find is required. *)
 let commit_session (s : session) : (session, error) result =
   match persist_session s with
   | Error _ as err -> err
   | Ok () ->
-    with_sessions (fun () -> Hashtbl.replace sessions s.id s);
+    Hashtbl.replace sessions s.id s;
     Ok s
 
 (** Load all sessions from disk into memory *)
@@ -357,40 +359,44 @@ let start_voting ~topic ~initiator ?(quorum = 2) ?(threshold = 0.5)
   if threshold < 0.0 || threshold > 1.0 then
     Error (Invalid_threshold threshold)
   else
-    let session = {
-      id = generate_id ();
-      topic;
-      initiator;
-      votes = [];
-      quorum;
-      threshold;
-      state = Open;
-      created_at = Time_compat.now ();
-      closed_at = None;
-      context;
-    } in
-    commit_session session
-
-(** Cast a vote in a session *)
-let cast_vote ~session_id ~agent ~decision ~reason ?(archetype=None) ?(weight=1.0) () : (session, error) Result.t =
-  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
-  | None -> Error (Session_not_found session_id)
-  | Some session ->
-    if session.state <> Open then
-      Error (Session_closed session_id)
-    else if List.exists (fun v -> v.agent = agent) session.votes then
-      Error (Already_voted agent)
-    else
-      let vote = {
-        agent;
-        decision;
-        reason;
-        timestamp = Time_compat.now ();
-        archetype;
-        weight;
+    with_sessions (fun () ->
+      let session = {
+        id = generate_id ();
+        topic;
+        initiator;
+        votes = [];
+        quorum;
+        threshold;
+        state = Open;
+        created_at = Time_compat.now ();
+        closed_at = None;
+        context;
       } in
-      let updated = { session with votes = vote :: session.votes } in
-      commit_session updated
+      commit_session session)
+
+(** Cast a vote in a session.
+    The entire lookup + validate + update is performed under a single
+    write lock to prevent concurrent cast_vote calls from losing votes. *)
+let cast_vote ~session_id ~agent ~decision ~reason ?(archetype=None) ?(weight=1.0) () : (session, error) Result.t =
+  with_sessions (fun () ->
+    match Hashtbl.find_opt sessions session_id with
+    | None -> Error (Session_not_found session_id)
+    | Some session ->
+      if session.state <> Open then
+        Error (Session_closed session_id)
+      else if List.exists (fun v -> v.agent = agent) session.votes then
+        Error (Already_voted agent)
+      else
+        let vote = {
+          agent;
+          decision;
+          reason;
+          timestamp = Time_compat.now ();
+          archetype;
+          weight;
+        } in
+        let updated = { session with votes = vote :: session.votes } in
+        commit_session updated)
 
 (** Count votes by decision type *)
 let count_by_decision votes decision =
@@ -457,29 +463,34 @@ let get_result ~session_id : (voting_result, error) Result.t =
         else
           Ok Escalate
 
-(** Close a voting session *)
+(** Close a voting session.
+    Write lock spans lookup + state transition + commit to prevent
+    concurrent close/vote from overwriting each other. *)
 let close_session ~session_id : (session, error) Result.t =
-  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
-  | None -> Error (Session_not_found session_id)
-  | Some session ->
-    let updated = {
-      session with
-      state = Closed;
-      closed_at = Some (Time_compat.now ());
-    } in
-    commit_session updated
+  with_sessions (fun () ->
+    match Hashtbl.find_opt sessions session_id with
+    | None -> Error (Session_not_found session_id)
+    | Some session ->
+      let updated = {
+        session with
+        state = Closed;
+        closed_at = Some (Time_compat.now ());
+      } in
+      commit_session updated)
 
-(** Cancel a voting session *)
+(** Cancel a voting session.
+    Write lock spans lookup + state transition + commit. *)
 let cancel_session ~session_id : (session, error) Result.t =
-  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
-  | None -> Error (Session_not_found session_id)
-  | Some session ->
-    let updated = {
-      session with
-      state = Cancelled;
-      closed_at = Some (Time_compat.now ());
-    } in
-    commit_session updated
+  with_sessions (fun () ->
+    match Hashtbl.find_opt sessions session_id with
+    | None -> Error (Session_not_found session_id)
+    | Some session ->
+      let updated = {
+        session with
+        state = Cancelled;
+        closed_at = Some (Time_compat.now ());
+      } in
+      commit_session updated)
 
 (** Get session by ID *)
 let get_session ~session_id : session option =

--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -74,8 +74,11 @@ type error =
   | Persistence_failed of string
 [@@deriving show, eq]
 
-(** In-memory session store *)
+(** In-memory session store — protected by [sessions_mutex]. *)
 let sessions : (string, session) Hashtbl.t = Hashtbl.create 16
+let sessions_mutex = Eio.Mutex.create ()
+let with_sessions f = Eio.Mutex.use_rw ~protect:true sessions_mutex f
+let with_sessions_ro f = Eio.Mutex.use_ro sessions_mutex f
 
 (** {1 File-based Persistence} *)
 
@@ -294,7 +297,7 @@ let commit_session (s : session) : (session, error) result =
   match persist_session s with
   | Error _ as err -> err
   | Ok () ->
-    Hashtbl.replace sessions s.id s;
+    with_sessions (fun () -> Hashtbl.replace sessions s.id s);
     Ok s
 
 (** Load all sessions from disk into memory *)
@@ -313,7 +316,7 @@ let load_sessions base =
                 (try
                    let json = Yojson.Safe.from_string content in
                    match full_session_of_yojson json with
-                   | Ok session -> Hashtbl.replace sessions session.id session
+                   | Ok session -> with_sessions (fun () -> Hashtbl.replace sessions session.id session)
                    | Error e -> Log.Council.debug "consensus session parse failed %s: %s" filename e
                  with Yojson.Json_error msg -> Log.Council.debug "consensus JSON error %s: %s" filename msg
                     | Failure msg -> Log.Council.debug "consensus failure %s: %s" filename msg)
@@ -330,16 +333,17 @@ let init ~base_path =
     Returns the count of removed sessions. *)
 let cleanup_closed ?(max_age_s = 3600.0) () =
   let now = Time_compat.now () in
-  let stale = Hashtbl.fold (fun id session acc ->
-    match session.state with
-    | Closed | Cancelled ->
-      (match session.closed_at with
-       | Some t when now -. t > max_age_s -> id :: acc
-       | _ -> acc)
-    | Open -> acc
-  ) sessions [] in
-  List.iter (Hashtbl.remove sessions) stale;
-  List.length stale
+  with_sessions (fun () ->
+    let stale = Hashtbl.fold (fun id session acc ->
+      match session.state with
+      | Closed | Cancelled ->
+        (match session.closed_at with
+         | Some t when now -. t > max_age_s -> id :: acc
+         | _ -> acc)
+      | Open -> acc
+    ) sessions [] in
+    List.iter (Hashtbl.remove sessions) stale;
+    List.length stale)
 
 (** Generate unique session ID *)
 let consensus_rng = Random.State.make_self_init ()
@@ -369,7 +373,7 @@ let start_voting ~topic ~initiator ?(quorum = 2) ?(threshold = 0.5)
 
 (** Cast a vote in a session *)
 let cast_vote ~session_id ~agent ~decision ~reason ?(archetype=None) ?(weight=1.0) () : (session, error) Result.t =
-  match Hashtbl.find_opt sessions session_id with
+  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
   | None -> Error (Session_not_found session_id)
   | Some session ->
     if session.state <> Open then
@@ -419,7 +423,7 @@ let quorum_met session : bool =
 
 (** Get voting result *)
 let get_result ~session_id : (voting_result, error) Result.t =
-  match Hashtbl.find_opt sessions session_id with
+  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
   | None -> Error (Session_not_found session_id)
   | Some session ->
     let votes = session.votes in
@@ -455,7 +459,7 @@ let get_result ~session_id : (voting_result, error) Result.t =
 
 (** Close a voting session *)
 let close_session ~session_id : (session, error) Result.t =
-  match Hashtbl.find_opt sessions session_id with
+  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
   | None -> Error (Session_not_found session_id)
   | Some session ->
     let updated = {
@@ -467,7 +471,7 @@ let close_session ~session_id : (session, error) Result.t =
 
 (** Cancel a voting session *)
 let cancel_session ~session_id : (session, error) Result.t =
-  match Hashtbl.find_opt sessions session_id with
+  match with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id) with
   | None -> Error (Session_not_found session_id)
   | Some session ->
     let updated = {
@@ -479,20 +483,22 @@ let cancel_session ~session_id : (session, error) Result.t =
 
 (** Get session by ID *)
 let get_session ~session_id : session option =
-  Hashtbl.find_opt sessions session_id
+  with_sessions_ro (fun () -> Hashtbl.find_opt sessions session_id)
 
 (** List all active sessions *)
 let list_active_sessions () : session list =
-  Hashtbl.to_seq_values sessions
-  |> Seq.filter (fun s -> s.state = Open)
-  |> List.of_seq
+  with_sessions_ro (fun () ->
+    Hashtbl.to_seq_values sessions
+    |> Seq.filter (fun s -> s.state = Open)
+    |> List.of_seq)
 
 let list_all_sessions () : session list =
-  Hashtbl.to_seq_values sessions |> List.of_seq
+  with_sessions_ro (fun () ->
+    Hashtbl.to_seq_values sessions |> List.of_seq)
 
 (** Clear all sessions (for testing) *)
 let clear_sessions () =
-  Hashtbl.clear sessions
+  with_sessions (fun () -> Hashtbl.clear sessions)
 
 (** Session to JSON *)
 let session_to_json session : Yojson.Safe.t =


### PR DESCRIPTION
## Summary

- `sessions_mutex` 추가 + `with_sessions`/`with_sessions_ro` 헬퍼
- 모든 sessions Hashtbl 접근을 mutex로 보호
- 기존: concurrent start_voting/cast_vote/close 시 Hashtbl corruption 가능

## Changes

| 함수 | 접근 유형 | 보호 |
|------|----------|------|
| `commit_session` | RW (replace) | `with_sessions` |
| `load_sessions` | RW (replace) | `with_sessions` |
| `cleanup_closed` | RW (fold+remove) | `with_sessions` |
| `cast_vote` | RO (find) | `with_sessions_ro` |
| `get_result` | RO (find) | `with_sessions_ro` |
| `close_session` | RO (find) | `with_sessions_ro` |
| `cancel_session` | RO (find) | `with_sessions_ro` |
| `get_session` | RO (find) | `with_sessions_ro` |
| `list_*` | RO (seq) | `with_sessions_ro` |
| `clear_sessions` | RW (clear) | `with_sessions` |

## Test plan

- [x] Build pass
- [ ] CI full suite

Partially addresses #4433 (consensus.ml done, balance/router/mdal remaining)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>