### PR TITLE
fix(a2a): use Eio_guard.with_mutex for UUID generation

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -114,7 +114,7 @@ let max_buffered_events = Env_config_governance.Timeouts.event_buffer_size
 let a2a_rng = Random.State.make_self_init ()
 let a2a_rng_mutex = Eio.Mutex.create ()
 let generate_uuid () =
-  Eio.Mutex.use_ro a2a_rng_mutex (fun () ->
+  Eio_guard.with_mutex a2a_rng_mutex (fun () ->
     let uuid = Uuidm.v4_gen a2a_rng () in
     Uuidm.to_string uuid)
 


### PR DESCRIPTION
## Summary
- Replace `Eio.Mutex.use_ro` with `Eio_guard.with_mutex` in `generate_uuid`
- `Random.State` is mutable, so shared/read lock is insufficient -- exclusive lock required
- `Eio_guard` provides pre-runtime fallback, preventing `Effect.Unhandled` in unit tests without `Eio_main.run`

Follow-up to #4455 review comments (already merged with the bug).

## Test plan
- [x] `dune build` passes
- [ ] Existing test suite passes (a2a_tools_coverage tests exercise `generate_uuid`)