### PR TITLE
fix(task): task_action variant type replaces string dispatch

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -376,7 +376,8 @@ let handle_transition ctx args =
   | Ok task_id ->
   let action_raw = get_string args "action" "" in
   if action_raw = "" then
-    (false, "action is required (claim, start, done, cancel, release)")
+    (false, Printf.sprintf "action is required (%s)"
+       (String.concat ", " Types.valid_task_action_strings))
   else
   match Types.task_action_of_string action_raw with
   | Error msg -> (false, msg)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -222,7 +222,7 @@ type room_registry = {
   current_room: string option; [@default None] (* currently active room *)
 } [@@deriving yojson { strict = false }, show]
 
-(** Task status - state transitions enforced by types *)
+(** Task action — parsed at system boundary, matched exhaustively inside. *)
 type task_action =
   | Claim
   | Start
@@ -247,6 +247,11 @@ let task_action_to_string = function
   | Cancel -> "cancel"
   | Release -> "release"
 
+(** All task actions as strings — single source of truth for help/error text. *)
+let all_task_actions = [ Claim; Start; Done_action; Cancel; Release ]
+let valid_task_action_strings = List.map task_action_to_string all_task_actions
+
+(** Task status — state transitions enforced by types. *)
 type task_status =
   | Todo
   | Claimed of { assignee: string; claimed_at: string }


### PR DESCRIPTION
## Summary
- task_action ADT (Claim|Start|Done_action|Cancel|Release) 추가
- valid_task_action_strings를 생성자에서 derive (single source of truth)
- 하드코딩된 action 문자열을 derive된 목록으로 교체

Replaces #4454 (GitHub merge cache stale after force push).

## Product impact
task_action 문자열 디스패치를 ADT 기반으로 교체. 타입 안전성 향상. 런타임 동작 동일.

## Evidence
CI Build, Lint 통과. Copilot 리뷰 4건 대응 완료.

## Review evidence
Copilot review 4건 대응: Done 생성자 충돌, valid_task_actions 중복, 케이싱 통일, 이중 lowercase.

## Linked issue
코드 품질 개선 (string dispatch → ADT)