### PR TITLE
fix(transport): atomic jsonrpc_id, log WS close failures

### DIFF
--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -60,11 +60,10 @@ type worker_container_meta = {
 
 let worker_container_version = 1
 
-let jsonrpc_id = ref 1000
+let jsonrpc_id = Atomic.make 1000
 
 let next_jsonrpc_id () =
-  incr jsonrpc_id;
-  !jsonrpc_id
+  Atomic.fetch_and_add jsonrpc_id 1
 
 let strip_mcp_prefix name =
   let prefix = "mcp__masc__" in

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -72,8 +72,9 @@ let cleanup_session session_id =
     | None -> ()
     | Some session ->
       session.closed <- true;
-      (* cleanup: best-effort close, ignore any transport error *)
-      (try Httpun_ws.Wsd.close session.wsd with exn -> ignore exn);
+      (try Httpun_ws.Wsd.close session.wsd
+       with Eio.Cancel.Cancelled _ as e -> raise e
+          | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
       Hashtbl.remove sessions session_id);
   Transport_metrics.set_ws_sessions
     (with_sessions_rw (fun () -> Hashtbl.length sessions));


### PR DESCRIPTION
## Summary

- `jsonrpc_id`: `ref` → `Atomic.make` — concurrent worker에서 중복 ID 방지
- WS close: `ignore exn` → `Log.Server.warn` — FD leak 감지 가능하도록

## Test plan

- [x] Build pass
- [ ] CI full suite

Partially addresses #4437 (items 1, 3 of 8)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>