### PR TITLE
fix(transport): WS close FD leak + jsonrpc_id atomic race (#4437)

### DIFF
--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -60,11 +60,9 @@ type worker_container_meta = {
 
 let worker_container_version = 1
 
-let jsonrpc_id = ref 1000
-
+let jsonrpc_id = Atomic.make 1000
 let next_jsonrpc_id () =
-  incr jsonrpc_id;
-  !jsonrpc_id
+  Atomic.fetch_and_add jsonrpc_id 1
 
 let strip_mcp_prefix name =
   let prefix = "mcp__masc__" in

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -72,8 +72,11 @@ let cleanup_session session_id =
     | None -> ()
     | Some session ->
       session.closed <- true;
-      (* cleanup: best-effort close, ignore any transport error *)
-      (try Httpun_ws.Wsd.close session.wsd with exn -> ignore exn);
+      (* cleanup: best-effort close, log on transport error *)
+      (try Httpun_ws.Wsd.close session.wsd
+       with exn ->
+         Log.Server.warn "WebSocket close error for session_id: %s"
+           (Printexc.to_string exn));
       Hashtbl.remove sessions session_id);
   Transport_metrics.set_ws_sessions
     (with_sessions_rw (fun () -> Hashtbl.length sessions));


### PR DESCRIPTION
## Summary
- Log WebSocket close errors instead of silently ignoring (prevents FD leak tracking blindspot)
- Convert `jsonrpc_id` counter from `ref`+`incr` pattern to `Atomic.fetch_and_add` for fiber-safe ID generation
- Audit remaining sub-issues: runtime_state mutable fields already protected by mutex, Atomic.fetch_and_add counter uses are legitimate

## Test plan
- [x] `dune build @install` passes
- [ ] Verify WS session cleanup logs errors on abnormal close
- [ ] Verify JSON-RPC IDs are sequential and unique under concurrent access

Fixes #4437

🤖 Generated with [Claude Code](https://claude.com/claude-code)