### PR TITLE
fix(ci): update OAS pin to include Tool_op module

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="4531c1bb0284f2a4f881927136208b1a459021a5"
+readonly OAS_AGENT_SDK_SHA="40e09715551dd89b0e98bac050f99ceaee17f6ef"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.0"


### PR DESCRIPTION
## Problem
Main CI broken since #4471 merge: Unbound module Agent_sdk.Tool_op.
OAS pin (oas-agent-sdk-pin.sh) pointed to 4531c1bb (pre-Tool_op).

## Fix
Advance pin to 40e09715 which includes OAS#551 (Tool_op module).

## Impact
Unblocks all open PRs with Build and Test / Contract Harness failures.