### PR TITLE
Fix keeper shutdown response handling and close-flow cleanup

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -114,7 +114,7 @@ describe('keeper lifecycle', () => {
     const result = await bootKeeper('keeper-test')
 
     expect(result.ok).toBe(false)
-    expect(result.error).toBe('Failed to boot keeper-test (HTTP 502)')
+    expect(result.error).toBe('Failed to boot keeper-test (HTTP 502): auth gateway failed')
   })
 
   it('falls back to the HTTP status when boot failure payload is not JSON', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -226,7 +226,20 @@ export interface KeeperLifecycleResponse {
 
 async function safeJsonResponse<T>(resp: Response, fallbackError: string): Promise<T> {
   try {
-    return await resp.json() as T
+    const body = await resp.text()
+    if (!body.trim()) {
+      return resp.ok
+        ? ({ ok: true } as T)
+        : ({ ok: false, error: `${fallbackError} (HTTP ${resp.status})` } as T)
+    }
+
+    try {
+      return JSON.parse(body) as T
+    } catch {
+      return resp.ok
+        ? ({ ok: true, detail: body } as T)
+        : ({ ok: false, error: `${fallbackError} (HTTP ${resp.status}): ${body}` } as T)
+    }
   } catch {
     return { ok: false, error: `${fallbackError} (HTTP ${resp.status})` } as T
   }

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { KeeperConversationEntry } from '../../types'
-import { ChatTranscript } from './primitives'
+import { ChatComposer, ChatTranscript } from './primitives'
 
 function entry(
   overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
@@ -99,5 +99,26 @@ describe('ChatTranscript', () => {
     const bodies = [...container.querySelectorAll('.whitespace-pre-wrap')]
     const latestBody = (bodies[bodies.length - 1]?.textContent ?? '').trim()
     expect(latestBody).toBe('')
+  })
+
+  it('does not show streaming ellipsis before elapsed time starts', () => {
+    render(
+      html`<${ChatComposer}
+        draft="안녕"
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${true}
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+
+    const buttons = [...container.querySelectorAll('button')]
+    const sendButton = buttons.find(button => button.textContent?.includes('보내기') || button.textContent?.includes('응답 중'))
+    expect(sendButton).not.toBeUndefined()
+    const label = sendButton?.textContent ?? ''
+    expect(label).toContain('응답 중')
+    expect(label).not.toContain('...')
   })
 })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -74,4 +74,30 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="saved"]')).toBeNull()
     expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
   })
+
+  it('does not render an ellipsis for empty streaming text', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'u1', text: 'ping' }),
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            delivery: 'streaming',
+            streamState: 'streaming',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bodies = [...container.querySelectorAll('.whitespace-pre-wrap')]
+    const latestBody = (bodies[bodies.length - 1]?.textContent ?? '').trim()
+    expect(latestBody).toBe('')
+  })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -226,7 +226,7 @@ export function ChatMessageBubble({
         : null}
 
       <div class="whitespace-pre-wrap break-words text-[14px] leading-[1.7] text-[var(--text-body)]">
-        ${entry.text || (entry.delivery === 'streaming' ? '…' : '(empty reply)')}
+        ${entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')}
       </div>
       ${entry.error
         ? html`

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -375,7 +375,7 @@ export function ChatComposer({
   }, [streaming, streamStartedAt])
 
   const streamLabel = streaming
-    ? `응답 중${elapsed > 0 ? ` ${elapsed}s` : '...'}`
+    ? `응답 중${elapsed > 0 ? ` ${elapsed}s` : ''}`
     : '보내기'
   const isStreamWarning = streaming && elapsed > 60
 

--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -25,6 +25,16 @@ describe('isKeeperTextContentEvent', () => {
     const event: KeeperChatStreamEvent = { type: 'TEXT_MESSAGE_CONTENT' }
     expect(isKeeperTextContentEvent(event)).toBe(false)
   })
+
+  it('rejects text content events with empty string delta', () => {
+    const event: KeeperChatStreamEvent = { type: 'TEXT_MESSAGE_CONTENT', delta: '' }
+    expect(isKeeperTextContentEvent(event)).toBe(false)
+  })
+
+  it('rejects text content events with non-string delta', () => {
+    const event = { type: 'TEXT_MESSAGE_CONTENT', delta: 123 } as unknown as KeeperChatStreamEvent
+    expect(isKeeperTextContentEvent(event)).toBe(false)
+  })
 })
 
 describe('normalizeKeeperChatErrorValue', () => {

--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -20,6 +20,11 @@ describe('isKeeperTextContentEvent', () => {
     const event: KeeperChatStreamEvent = { type: 'RUN_ERROR', value: { message: 'boom' } }
     expect(isKeeperTextContentEvent(event)).toBe(false)
   })
+
+  it('rejects text content events without delta', () => {
+    const event: KeeperChatStreamEvent = { type: 'TEXT_MESSAGE_CONTENT' }
+    expect(isKeeperTextContentEvent(event)).toBe(false)
+  })
 })
 
 describe('normalizeKeeperChatErrorValue', () => {

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -51,7 +51,7 @@ function toConversationEntry(
 
 export function isKeeperTextContentEvent(
   event: KeeperChatStreamEvent,
-): event is KeeperChatStreamEvent & { type: 'TEXT_MESSAGE_CONTENT' | 'TEXT_DELTA'; delta: string } {
+): event is KeeperChatStreamEvent & { delta: string } {
   return (
     (event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA')
     && typeof event.delta === 'string'
@@ -103,7 +103,7 @@ async function sendChat(keeperName: string): Promise<void> {
     await streamKeeperMessage(keeperName, text, {
       signal: activeAbort.signal,
       onEvent: (event: KeeperChatStreamEvent) => {
-        if (isKeeperTextContentEvent(event)) {
+        if (isKeeperTextContentEvent(event) && typeof event.delta === 'string') {
           streamBuffer.value += event.delta
         } else if (event.type === 'RUN_FINISHED') {
           const finalText = streamBuffer.value.trim() || '(no response)'

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -49,7 +49,11 @@ function toConversationEntry(
 }
 
 export function isKeeperTextContentEvent(event: KeeperChatStreamEvent): boolean {
-  return event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA'
+  return (
+    (event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA')
+    && typeof event.delta === 'string'
+    && event.delta.length > 0
+  )
 }
 
 export function normalizeKeeperChatErrorValue(value: unknown): string {

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -73,11 +73,11 @@ export function normalizeKeeperChatErrorValue(value: unknown): string {
 }
 
 function cancelStream(): void {
-  if (activeAbort) {
-    activeAbort.abort()
-    activeAbort = null
-    streaming.value = false
-  }
+  if (activeAbort) activeAbort.abort()
+  activeAbort = null
+  streaming.value = false
+  streamBuffer.value = ''
+  streamStartedAt.value = null
 }
 
 async function sendChat(keeperName: string): Promise<void> {

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -24,6 +24,7 @@ const chatMessages = signal<ChatMessage[]>([])
 const chatInput = signal('')
 const streaming = signal(false)
 const streamBuffer = signal('')
+const streamStartedAt = signal<number | null>(null)
 const chatError = signal('')
 
 let activeAbort: AbortController | null = null
@@ -86,6 +87,7 @@ async function sendChat(keeperName: string): Promise<void> {
   chatInput.value = ''
   chatError.value = ''
   streamBuffer.value = ''
+  streamStartedAt.value = Date.now()
 
   chatMessages.value = [
     ...chatMessages.value,
@@ -99,7 +101,7 @@ async function sendChat(keeperName: string): Promise<void> {
     await streamKeeperMessage(keeperName, text, {
       signal: activeAbort.signal,
       onEvent: (event: KeeperChatStreamEvent) => {
-        if (isKeeperTextContentEvent(event) && event.delta) {
+        if (isKeeperTextContentEvent(event)) {
           streamBuffer.value += event.delta
         } else if (event.type === 'RUN_FINISHED') {
           const finalText = streamBuffer.value.trim() || '(no response)'
@@ -121,6 +123,7 @@ async function sendChat(keeperName: string): Promise<void> {
   } finally {
     streaming.value = false
     activeAbort = null
+    streamStartedAt.value = null
   }
 }
 
@@ -129,6 +132,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
     cancelStream()
     chatInput.value = ''
     streamBuffer.value = ''
+    streamStartedAt.value = null
     chatError.value = ''
     chatMessages.value = []
     let stale = false
@@ -203,7 +207,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
           placeholder="메시지 입력..."
           disabled=${false}
           streaming=${isStreaming}
-          streamStartedAt=${null}
+          streamStartedAt=${streamStartedAt.value}
           onDraftChange=${(value: string) => { chatInput.value = value }}
           onSend=${() => { void sendChat(name) }}
           onAbort=${cancelStream}

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -49,7 +49,9 @@ function toConversationEntry(
   }
 }
 
-export function isKeeperTextContentEvent(event: KeeperChatStreamEvent): boolean {
+export function isKeeperTextContentEvent(
+  event: KeeperChatStreamEvent,
+): event is KeeperChatStreamEvent & { type: 'TEXT_MESSAGE_CONTENT' | 'TEXT_DELTA'; delta: string } {
   return (
     (event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA')
     && typeof event.delta === 'string'

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { appendThreadEntry } from './keeper-state'
+import { keeperThreads } from './keeper-state'
+import { applyKeeperStreamEvent } from './keeper-stream'
+
+function assistantEntry(): void {
+  appendThreadEntry('sangsu', {
+    id: 'reply-1',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: '',
+    rawText: '',
+    timestamp: new Date().toISOString(),
+    delivery: 'sending',
+    streamState: 'opening',
+    details: null,
+  })
+}
+
+describe('applyKeeperStreamEvent', () => {
+  beforeEach(() => {
+    keeperThreads.value = {}
+  })
+
+  it('appends content for TEXT_MESSAGE_CONTENT', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: '안녕',
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('안녕')
+    expect(entry?.delivery).toBe('streaming')
+    expect(entry?.streamState).toBe('streaming')
+  })
+
+  it('appends legacy TEXT_DELTA events', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_DELTA',
+      delta: '안녕',
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('안녕')
+  })
+
+  it('ignores empty delta text events', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('')
+  })
+
+  it('extracts error messages from events', () => {
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'RUN_ERROR',
+      value: { message: 'boom' },
+    })).toBe('boom')
+  })
+})

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -39,6 +39,11 @@ export function applyKeeperStreamEvent(
   assistantEntryId: string,
   event: KeeperChatStreamEvent,
 ): string | null {
+  const applyTextDelta = (payload: unknown): void => {
+    if (typeof payload !== 'string') return
+    if (payload) appendAssistantDelta(keeperName, assistantEntryId, payload)
+  }
+
   switch (event.type) {
     case 'RUN_STARTED':
       setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'sending')
@@ -47,8 +52,11 @@ export function applyKeeperStreamEvent(
       setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
       return null
     case 'TEXT_MESSAGE_CONTENT': {
-      const delta = typeof event.delta === 'string' ? event.delta : ''
-      if (delta) appendAssistantDelta(keeperName, assistantEntryId, delta)
+      applyTextDelta(event.delta)
+      return null
+    }
+    case 'TEXT_DELTA': {
+      applyTextDelta(event.delta)
       return null
     }
     case 'TEXT_MESSAGE_END':


### PR DESCRIPTION
## Summary
- Fix keeper runtime shutdown handling for empty or non-JSON API responses and make runtime UI state updates consistent after shutdown.
- Tighten direct-chat stream handling so only non-empty string deltas are appended.
- Remove the transient ellipsis placeholder for empty streaming assistant content.

## Product impact
- Keeper shutdown actions now reflect backend success or failure more accurately in the dashboard UI.
- Keeper direct chat no longer flashes a misleading placeholder when the stream has not produced meaningful text.

## Changes
- Update `dashboard/src/api/keeper.ts` lifecycle response parsing for safer shutdown handling.
- Refresh dashboard runtime state after successful shutdown from shared runtime actions and keeper detail actions.
- Convert keeper text-content filtering into an explicit type guard and add regression tests.
- Stop rendering `…` for empty streaming chat entries.

## Evidence
- Added regression coverage for empty-string and non-string text deltas in `dashboard/src/components/keeper-chat-panel.test.ts`.
- Added regression coverage for empty streaming message rendering in `dashboard/src/components/chat/primitives.test.ts`.
- Current GitHub CI state: `Build and Test` is failing on `router contract alignment`, which appears outside this dashboard-focused diff.

## Review evidence
- Copilot review comments on the keeper chat guard and test coverage were addressed.
- All 5 review threads are currently resolved.
- No human approval yet.

## Linked issue
- Refs #4498

## Testing
- Not run locally.
