### PR TITLE
fix(dashboard): rehydrate keeper detail KPI metrics from execution store

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -12,6 +12,7 @@ import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { selectKeeper } from '../keeper-runtime'
+import { findKeeper } from '../lib/keeper-utils'
 import {
   KeeperConversationPanel,
   KeeperDiagnosticSummary,
@@ -298,8 +299,9 @@ function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
 // ── Main Detail Overlay ─────────────────────────────────
 
 export function KeeperDetailOverlay() {
-  const keeper = selectedKeeper.value
-  if (!keeper) return null
+  const selected = selectedKeeper.value
+  if (!selected) return null
+  const keeper = findKeeper(selected.name) ?? selected
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const titleId = `keeper-detail-title-${keeper.name}`
 

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -266,6 +266,12 @@ let keepers_json ?keeper_names ?(include_recent_activity = true)
                     if String.trim meta.runtime.last_autonomous_action_at = "" then `Null
                     else `String meta.runtime.last_autonomous_action_at );
                   ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
+                  ("autonomous_turn_count", `Int meta.runtime.autonomous_turn_count);
+                  ("autonomous_text_turn_count", `Int meta.runtime.autonomous_text_turn_count);
+                  ("autonomous_tool_turn_count", `Int meta.runtime.autonomous_tool_turn_count);
+                  ("board_reactive_turn_count", `Int meta.runtime.board_reactive_turn_count);
+                  ("mention_reactive_turn_count", `Int meta.runtime.mention_reactive_turn_count);
+                  ("noop_turn_count", `Int meta.runtime.noop_turn_count);
                   ("allowed_tool_names", `List (List.map (fun value -> `String value) allowed_tool_names));
                   ("latest_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
                   ("recent_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));


### PR DESCRIPTION
## Summary
- Fix keeper detail overlay so it resolves keeper data from the execution store by name (`findKeeper`) before rendering, preventing partial `Ops`-snapshot objects from sticking and being shown as zeros.
- Add missing autonomy/noop counters to operator snapshot keeper projection so downstream views can receive full telemetry fields:
  - `autonomous_turn_count`
  - `autonomous_text_turn_count`
  - `autonomous_tool_turn_count`
  - `board_reactive_turn_count`
  - `mention_reactive_turn_count`
  - `noop_turn_count`

## Why
When opening keeper detail from Ops, the UI could pass a fallback object if the keeper wasn't found in execution store at that moment. The overlay used that object directly, and KPI fields were rendered as `value ?? 0`, which appears as zero even when backend counters exist.

## Changes
- `dashboard/src/components/keeper-detail.ts`
  - `KeeperDetailOverlay` now rehydrates current selection via `findKeeper(selected.name)` and falls back only if no full keeper is available.
- `lib/operator/operator_control_snapshot.ml`
  - Added missing autonomy/noop counters to non-paused keeper rows in `keepers_json`.

## Notes
- PR created as draft per repo workflow.
- Runtime-level root-path mismatch can still cause broader telemetry drift; this patch addresses the immediate UI zero rendering issue and fills the snapshot projection gap.
