### PR TITLE
chore: cleanup keeper persistent path docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -424,7 +424,7 @@
 - **Keeper social model** — remove unused params and mutable ref (#4075).
 
 ### Removed
-- **Mitosis/sentinel dead code** — final cleanup (#4067).
+- **Mitosis dead code cleanup** — final cleanup (#4067).
 
 ## [2.181.0] - 2026-03-31
 
@@ -842,7 +842,7 @@
 - **Prompt frontmatter auto-discovery** — prompts loaded from markdown frontmatter (#3336).
 - **OAS agent_sdk floor** — bumped to 0.92.0 (#3359).
 - **Centralized env config** — revived HTTP and assets config reads (#3374).
-- **Legacy agent cleanup** — purged guardian/sentinel/gardener references (#3378).
+- **Legacy agent cleanup** — removed deprecated references (#3378).
 - **Config dir resolution** — separated from base path (#3377).
 
 ### Fixed

--- a/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
+++ b/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
@@ -45,6 +45,7 @@ Modules that deliver real value in daily operation.
 | tool_operator | 856 | dispatch/assign/rebalance | High |
 | tool_command_plane* | ~960 | command-plane truth layer | High |
 | tool_keeper | 624 | persistent agent runtime | High |
+| tool_perpetual | 643 | autonomous agent loops | Medium |
 | tool_plan | 186 | planning context | High |
 | tool_worktree | 40 | git isolation | High |
 | tool_board/misc | ~770 | bulletin board | Medium |
@@ -100,14 +101,14 @@ Not related to core coordination. Candidates for separation or removal.
 Older cleanup, patrol, and ecosystem-control loops should not shape current architecture decisions.
 They have been retired from the active runtime surface, so the current complexity discussion should stay centered on room, keeper, command-plane, and operator layers.
 
-## Legacy Naming Cleanup
+## Perpetual Keepers Problem
 
 ### Before cleanup (Phase 1 complete)
 
 | Path | Size before | Size after | Action |
 |------|------------|------------|--------|
-| legacy keeper metrics path | 25MB | 0 (deleted) | Stale idle heartbeat logs |
-| legacy trace path | 1.2MB | 0 (deleted) | Ended experiment traces |
+| keepers/*.metrics.jsonl | 25MB | 0 (deleted) | Stale idle heartbeat logs |
+| perpetual/trace-17716*,17724* | 1.2MB | 0 (deleted) | Ended experiment traces |
 | **Total .masc/** | **63MB** | **36MB** | **27MB freed** |
 
 ### Root cause

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -510,7 +510,7 @@ OAS `Checkpoint.t`를 통해 keeper 상태가 저장된다.
 - compaction 시 (checkpoint 갱신)
 - heartbeat snapshot 시 (주기적)
 
-**저장 내용** (OAS Checkpoint 생성, keeper runtime 경로에 인라인):
+**저장 내용** (OAS Checkpoint 생성, perpetual_loop.ml / perpetual_oas.ml에 인라인):
 - `session_id`, `generation`, `turn_count`, `trace_id` (MASC 메타데이터 → OAS Context Session scope)
 - `messages` (MASC 메시지 → OAS 메시지 변환)
 - `system_prompt`
@@ -616,7 +616,7 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는 `docs/
 | TOML declaration | `<CONFIG_ROOT>/keepers/<name>.toml` | Persona 없이 선언적 정의 |
 | Persistent meta | `.masc/keepers/<name>.json` | 런타임 상태 (turn 카운트, context ratio 등) |
 
-별도 keepalive 등록 레지스트리는 없다. keeper의 선언과 런타임 상태는 `.masc/keepers/<name>.json`에 함께 저장되고, keeper는 always-on runtime으로 취급된다. legacy keeper-meta 경로가 있으면 부팅 시 `.masc/keepers/`로 마이그레이션된다. 멈춤은 설정값이 아니라 `paused` 또는 `keeper_down` 상태 전이로 표현한다.
+별도 keepalive 등록 레지스트리는 없다. keeper의 선언과 런타임 상태는 `.masc/keepers/<name>.json`에 함께 저장되고, keeper는 durable always-on으로 취급된다. 멈춤은 설정값이 아니라 `paused` 또는 `keeper_down` 상태 전이로 표현한다.
 
 repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `<MASC_BASE_PATH>/.masc/config`, 그 다음 `~/.masc/config`, 마지막으로 repo `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다. 즉 웹/대시보드는 파일을 직접 읽지 않고, 서버가 해석한 config root와 persona root를 사용한다.
 

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -153,8 +153,8 @@ Dashboard <--Tab--> Keeper List
 | Feature | Source | Server Required |
 |---------|--------|-----------------|
 | Keeper list/detail | `.masc/keepers/*.json` | No |
-| Live context status | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
-| Keeper logs | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
+| Live context status | `<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
+| Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
 | Send messages | `POST /api/v1/keepers/chat/stream` | Yes |
 
 ## Requirements

--- a/docs/design/keeper-continuity-diagnosis-rfc.md
+++ b/docs/design/keeper-continuity-diagnosis-rfc.md
@@ -3,7 +3,7 @@
 **Status**: Draft v3 (post-review, 7 rounds)
 **Date**: 2026-03-29
 **Scope**: MASC Keeper Checkpoint Continuity / GC / Naming
-**Issues**: #3626 (zombie GC), #3627 (legacy naming cleanup), #3630 (memory dead code)
+**Issues**: #3626 (zombie GC), #3627 (perpetual naming), #3630 (memory dead code)
 **One sentence**: keeper가 이전 대화를 기억 못하는 원인을 OAS checkpoint 경로 진단으로 확정하고, 진단 중 발견된 filesystem 부채(dead code, naming, GC)를 정리한다.
 
 ## Related Documents
@@ -159,9 +159,9 @@ Documentation: 13 files, 26 occurrences.
 ### Directory Rename
 
 ```
-legacy trace dir         → .masc/traces/
-legacy keeper-meta dir   → .masc/keepers/
-.masc/resident-keepers/  → .masc/keepers/ (병합 후 삭제)
+.masc/perpetual/          → .masc/traces/
+.masc/keepers/  → .masc/keepers/
+.masc/resident-keepers/   → .masc/keepers/ (병합 후 삭제)
 ```
 
 ### Migration: 재귀 merge + file-level quarantine

--- a/docs/design/keeper-continuity-product-rfc.md
+++ b/docs/design/keeper-continuity-product-rfc.md
@@ -116,7 +116,7 @@ Out of scope for this RFC, but explicitly related:
 
 - history recall for current-trace user messages beyond the keep-last checkpoint window
 - recall observability (`evaluate_memory_recall`, `memory_eval_to_json`, `memory_check`)
-- naming cleanup for legacy runtime paths
+- naming cleanup for `keeper` / `keepers`
 - filesystem cleanup backlog discovered during diagnosis
 
 Any future expansion from bounded continuity to broader recall must ship in a separate RFC with an explicit contract for:

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -15,7 +15,7 @@
 
 ## 1. Purpose
 
-Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, always-on keeper loop, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
+Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행(perpetual) 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
 
 Keeper 하나는 다음을 소유한다:
 - **identity**: `keeper_meta` 레코드 (이름, 목표, soul profile, will/needs/desires)
@@ -422,7 +422,7 @@ Destructive check 대상 도구: `keeper_bash`, `keeper_fs_edit`, `keeper_edit`,
 
 ### 9.3 Keeper Runtime Spec
 
-keeper 선언과 런타임 상태는 `.masc/keepers/{name}.json`에 영속화된다. keeper는 always-on runtime으로 취급되며, `keeper_up`은 inline args, TOML, persona defaults를 합쳐 초기 `keeper_meta`를 생성한다. legacy keeper-meta 경로는 부팅 시 `.masc/keepers/`로 마이그레이션된다. runtime 중지 여부는 `paused` 또는 `keeper_down`으로 표현한다.
+keeper 선언과 런타임 상태는 `.masc/keepers/{name}.json`에 영속화된다. keeper는 durable always-on으로 취급되며, `keeper_up`은 inline args, TOML, persona defaults를 합쳐 초기 `keeper_meta`를 생성한다. runtime 중지 여부는 `paused` 또는 `keeper_down`으로 표현한다.
 
 ---
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -398,7 +398,7 @@ Keeper의 행동을 결정하는 설정은 3곳에서 공급된다.
 | TOML declaration | `<CONFIG_ROOT>/keepers/<name>.toml` | TOML | Persona 없이 선언적으로 keeper 정의 |
 | Persistent meta | `.masc/keepers/<name>.json` | JSON | 런타임 상태. turn 카운트, context ratio 등 포함 |
 
-별도 keepalive 설정 파일은 없다. keeper 선언과 런타임 상태는 `.masc/keepers/<name>.json`에 모이고, keeper는 always-on runtime으로 취급된다. legacy keeper-meta 경로는 부팅 시 `.masc/keepers/`로 마이그레이션된다. runtime 중지 여부는 `paused` 또는 `keeper_down`으로 표현한다.
+별도 keepalive 설정 파일은 없다. keeper 선언과 런타임 상태는 `.masc/keepers/<name>.json`에 모이고, keeper는 durable always-on으로 취급된다. runtime 중지 여부는 `paused` 또는 `keeper_down`으로 표현한다.
 
 ### 12.2 설정 적용 우선순위
 

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -13,7 +13,7 @@ let init config ~agent_name =
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir "keepers" in
-  let root_traces_dir = Filename.concat root_dir "traces" in
+  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
@@ -21,7 +21,7 @@ let init config ~agent_name =
     [
       root_agents_dir;
       root_keepers_dir;
-      root_traces_dir;
+      root_perpetual_dir;
       root_tasks_dir;
       root_messages_dir;
       rooms_root_dir config;

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -395,7 +395,7 @@ let ensure_room_bootstrap config room_id =
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir "keepers" in
-  let root_traces_dir = Filename.concat root_dir "traces" in
+  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
@@ -403,7 +403,7 @@ let ensure_room_bootstrap config room_id =
     [
       root_agents_dir;
       root_keepers_dir;
-      root_traces_dir;
+      root_perpetual_dir;
       root_tasks_dir;
       root_messages_dir;
       rooms_root_dir config;

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -171,13 +171,10 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn))
 
-(** Migrate legacy directory aliases to traces/keepers.
+(** Migrate legacy directory names: perpetual->traces, resident-keepers->keepers.
     Moves contents via recursive merge. Conflicting files go to _quarantine/,
     except keeper meta files where a fresher valid legacy record may replace a
     stale or invalid current record. *)
-let legacy_trace_dir_alias = "perpetual"
-let legacy_keeper_meta_dir_alias = "perpetual-keepers"
-
 let keeper_meta_updated_ts (meta : Keeper_types.keeper_meta) =
   Resilience.Time.parse_iso8601_opt meta.updated_at
   |> Option.value ~default:0.0
@@ -241,8 +238,7 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
     end
   in
   let renames = [
-    (legacy_trace_dir_alias, "traces");
-    (legacy_keeper_meta_dir_alias, "keepers");
+    ("perpetual", "traces");
     ("resident-keepers", "keepers");
   ] in
   (try

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -50,8 +50,6 @@ val bootstrap_prompt_state : Mcp_server.server_state -> unit
 (** {1 Startup Tasks} *)
 
 val warm_tool_registry_from_telemetry : Mcp_server.server_state -> unit
-val legacy_trace_dir_alias : string
-val legacy_keeper_meta_dir_alias : string
 val migrate_legacy_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -1,5 +1,5 @@
 (** Test suite for Keeper_alerting_path.effective_allowed_paths.
-    Verifies computed defaults, sentinel handling, and scope-based behavior. *)
+    Verifies computed defaults, wildcard handling, and scope-based behavior. *)
 
 open Alcotest
 module KAP = Masc_mcp.Keeper_alerting_path
@@ -49,7 +49,7 @@ let test_workspace_explicit_paths () =
   check (list string) "workspace + explicit = explicit"
     ["src/"; "docs/"] effective
 
-let test_workspace_star_sentinel () =
+let test_workspace_star_wildcard () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["*"] ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
@@ -62,9 +62,9 @@ let test_local_empty_paths () =
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "local + [] = []" [] effective
 
-(* ── sentinel handling ── *)
+(* ── wildcard handling ── *)
 
-let test_star_sentinel_any_scope () =
+let test_star_wildcard_any_scope () =
   let scopes = ["observe_only"; "workspace"; "local"; "unknown"] in
   List.iter (fun scope ->
     let meta = make_meta ~execution_scope:scope ~allowed_paths:["*"] ~name:"t" () in
@@ -106,11 +106,11 @@ let () =
           test_case "workspace + explicit = explicit" `Quick
             test_workspace_explicit_paths;
           test_case "workspace + [*] = full access" `Quick
-            test_workspace_star_sentinel;
+            test_workspace_star_wildcard;
           test_case "local + [] = []" `Quick
             test_local_empty_paths;
-          test_case "[*] sentinel any scope" `Quick
-            test_star_sentinel_any_scope;
+          test_case "[*] wildcard any scope" `Quick
+            test_star_wildcard_any_scope;
           test_case "explicit paths any scope" `Quick
             test_explicit_paths_any_scope;
           test_case "keeper name in computed default" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -226,22 +226,12 @@ let test_room_init_bootstraps_keeper_runtime_dirs () =
       let config = Room.default_config dir |> Room.config_with_resolved_scope in
       ignore (Room.init config ~agent_name:None);
       let root_dir = Room.masc_root_dir config in
-      let keepers_dir = Filename.concat root_dir "keepers" in
-      let traces_dir = Filename.concat root_dir "traces" in
-      let legacy_keepers_dir =
-        Filename.concat root_dir Server_runtime_bootstrap.legacy_keeper_meta_dir_alias
-      in
-      let legacy_trace_dir =
-        Filename.concat root_dir Server_runtime_bootstrap.legacy_trace_dir_alias
-      in
-      Alcotest.(check bool) "keepers dir exists" true
-        (Sys.file_exists keepers_dir && Sys.is_directory keepers_dir);
-      Alcotest.(check bool) "traces dir exists" true
-        (Sys.file_exists traces_dir && Sys.is_directory traces_dir);
-      Alcotest.(check bool) "legacy keeper alias not created" false
-        (Sys.file_exists legacy_keepers_dir);
-      Alcotest.(check bool) "legacy trace alias not created" false
-        (Sys.file_exists legacy_trace_dir))
+      let keeper_dir = Filename.concat root_dir "keepers" in
+      let perpetual_dir = Filename.concat root_dir "perpetual" in
+      Alcotest.(check bool) "keeper dir exists" true
+        (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir);
+      Alcotest.(check bool) "perpetual dir exists" true
+        (Sys.file_exists perpetual_dir && Sys.is_directory perpetual_dir))
 
 let test_otel_exporter_setup_failure_is_soft () =
   Otel_spans.shutdown ~enabled:true ();
@@ -282,14 +272,12 @@ let make_keeper_meta_json ?(name = "sangsu")
   | Ok meta -> Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
-let test_migrate_legacy_keeper_dirs_promotes_valid_meta () =
+let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
   with_temp_dir "startup-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
       let keepers_dir = Filename.concat masc_root "keepers" in
-      let legacy_dir =
-        Filename.concat masc_root Server_runtime_bootstrap.legacy_keeper_meta_dir_alias
-      in
+      let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_dir =
         Filename.concat masc_root "_quarantine/_replaced"
       in
@@ -314,23 +302,21 @@ let test_migrate_legacy_keeper_dirs_promotes_valid_meta () =
       let other_meta =
         read_meta_exn (Filename.concat keepers_dir "other.json")
       in
-      Alcotest.(check string) "sangsu trace promoted from legacy keeper alias"
+      Alcotest.(check string) "sangsu trace promoted from resident-keepers"
         "trace-sangsu-live" sangsu_meta.runtime.trace_id;
-      Alcotest.(check string) "other keeper migrated from legacy keeper alias"
+      Alcotest.(check string) "other keeper migrated from resident-keepers"
         "trace-other-live" other_meta.runtime.trace_id;
       Alcotest.(check bool) "legacy dir removed after merge" false
         (Sys.file_exists legacy_dir);
       Alcotest.(check bool) "replaced stale keeper quarantined" true
         (Sys.file_exists (Filename.concat quarantine_dir "sangsu.json")))
 
-let test_migrate_legacy_keeper_dirs_keeps_fresher_current_meta () =
+let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
   with_temp_dir "startup-legacy-keepers-current-wins" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
       let keepers_dir = Filename.concat masc_root "keepers" in
-      let legacy_dir =
-        Filename.concat masc_root Server_runtime_bootstrap.legacy_keeper_meta_dir_alias
-      in
+      let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_path =
         Filename.concat masc_root "_quarantine/sangsu.json"
       in
@@ -512,11 +498,11 @@ let () =
           Alcotest.test_case "otel exporter setup failure is soft" `Quick
             test_otel_exporter_setup_failure_is_soft;
           Alcotest.test_case
-            "legacy keeper migration promotes valid meta"
-            `Quick test_migrate_legacy_keeper_dirs_promotes_valid_meta;
+            "legacy keeper migration promotes valid resident meta"
+            `Quick test_migrate_resident_keeper_dirs_promotes_valid_meta;
           Alcotest.test_case
             "legacy keeper migration keeps fresher current meta"
-            `Quick test_migrate_legacy_keeper_dirs_keeps_fresher_current_meta;
+            `Quick test_migrate_resident_keeper_dirs_keeps_fresher_current_meta;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick


### PR DESCRIPTION
Remove outdated .masc/perpetual-keepers references and normalize to .masc/keepers in keeper docs/spec, plus test wording cleanup.