### PR TITLE
[codex] Reduce keeper audit log noise

### DIFF
--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -91,13 +91,14 @@ let of_keeper
   let exec_mode = infer_keeper_execution_mode ~scope_kind in
   let risk = infer_keeper_risk_class ~scope_kind in
   let mutations = infer_keeper_allowed_mutations ~execution_scope in
-  Log.Keeper.debug
-    "cdal contract for %s: mode=%s risk=%s mutations=[%s] scope_kind=%s exec_scope=%s"
-    keeper_name
-    (Oas.Execution_mode.to_string exec_mode)
-    (Oas.Risk_class.to_string risk)
-    (String.concat "," mutations)
-    scope_kind execution_scope;
+  if Keeper_types_profile.keeper_debug then
+    Log.Keeper.debug
+      "cdal contract for %s: mode=%s risk=%s mutations=[%s] scope_kind=%s exec_scope=%s"
+      keeper_name
+      (Oas.Execution_mode.to_string exec_mode)
+      (Oas.Risk_class.to_string risk)
+      (String.concat "," mutations)
+      scope_kind execution_scope;
   {
     Oas.Risk_contract.runtime_constraints =
       {

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -91,7 +91,7 @@ let of_keeper
   let exec_mode = infer_keeper_execution_mode ~scope_kind in
   let risk = infer_keeper_risk_class ~scope_kind in
   let mutations = infer_keeper_allowed_mutations ~execution_scope in
-  Log.Keeper.info
+  Log.Keeper.debug
     "cdal contract for %s: mode=%s risk=%s mutations=[%s] scope_kind=%s exec_scope=%s"
     keeper_name
     (Oas.Execution_mode.to_string exec_mode)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -81,6 +81,58 @@ let normalize_response_text
           (Printf.sprintf "Completed without a textual reply. Tools used: %s."
              (String.concat ", " tool_names))
 
+let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
+  let log =
+    match proof.result_status with
+    | Agent_sdk.Cdal_proof.Completed -> Log.Keeper.debug
+    | Agent_sdk.Cdal_proof.Errored
+    | Agent_sdk.Cdal_proof.Timed_out
+    | Agent_sdk.Cdal_proof.Cancelled -> Log.Keeper.warn
+  in
+  log "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+    keeper_name proof.run_id
+    (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+    (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
+    (List.length proof.raw_evidence_refs)
+
+let log_keeper_contract_verdict
+    ~(keeper_name : string)
+    (verdict : Cdal_types.contract_verdict) =
+  let log =
+    match verdict.status with
+    | Cdal_types.Satisfied -> Log.Keeper.debug
+    | Cdal_types.Violated | Cdal_types.Inconclusive -> Log.Keeper.warn
+  in
+  log "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+    keeper_name
+    (Cdal_types.contract_status_to_string verdict.status)
+    verdict.claim_scope
+    verdict.judgment_hash
+
+let log_keeper_friction
+    ~(keeper_name : string)
+    (fp : Cdal_friction_projection.friction_projection) =
+  let blocked = fp.blocked_attempt_count in
+  let groups = List.length fp.blocked_attempt_groups in
+  let tripwires = List.length fp.review_tripwires in
+  let log =
+    if tripwires > 0 then Log.Keeper.warn
+    else if blocked > 0 || groups > 0 then Log.Keeper.info
+    else Log.Keeper.debug
+  in
+  log "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+    keeper_name blocked groups tripwires
+
+let log_keeper_memory_write
+    ~(keeper_name : string)
+    ~(notes_written : int)
+    ~(kinds_written : string list) =
+  let log =
+    if notes_written >= 10 then Log.Keeper.info else Log.Keeper.debug
+  in
+  log "keeper:%s memory_write: %d notes, kinds=[%s]"
+    keeper_name notes_written (String.concat "," kinds_written)
+
 (** Run a single keeper turn via OAS Agent.run().
 
     Loads checkpoint, creates working context with the base keeper system
@@ -570,21 +622,12 @@ let run_turn
              ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
              (match result.proof with
              | Some p ->
-                Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
-                  meta.name p.run_id
-                  (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
-                  (Agent_sdk.Cdal_proof.show_result_status p.result_status)
-                  (List.length p.raw_evidence_refs);
+                log_keeper_proof ~keeper_name:meta.name p;
                 let store = Agent_sdk.Proof_store.default_config in
                 let outcome = Cdal_eval_v1.evaluate ~store p in
                 let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
                 Cdal_eval_v1.persist verdict;
-                Log.Keeper.info
-                  "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
-                  meta.name
-                  (Cdal_types.contract_status_to_string verdict.status)
-                  verdict.claim_scope
-                  verdict.judgment_hash;
+                log_keeper_contract_verdict ~keeper_name:meta.name verdict;
                 (match outcome with
                  | Cdal_eval_v1.Load_failure (err, _) ->
                    Log.Keeper.warn "keeper:%s contract_verdict load failure: %s"
@@ -592,11 +635,7 @@ let run_turn
              | Cdal_eval_v1.Verdict (_, _) -> ());
             (match Cdal_eval_v1.friction_of_outcome outcome with
              | Some fp ->
-               Log.Keeper.info
-                 "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-                 meta.name fp.blocked_attempt_count
-                 (List.length fp.blocked_attempt_groups)
-                 (List.length fp.review_tripwires)
+               log_keeper_friction ~keeper_name:meta.name fp
              | None -> ())
           | None -> ());
          (* Post-turn deterministic memory write.
@@ -608,8 +647,10 @@ let run_turn
                config meta ~turn:result.turns ~reply:response_text
            in
            if notes_written > 0 then
-             Log.Keeper.info "keeper:%s memory_write: %d notes, kinds=[%s]"
-               meta.name notes_written (String.concat "," kinds_written)
+             log_keeper_memory_write
+               ~keeper_name:meta.name
+               ~notes_written
+               ~kinds_written
          with
          | exn ->
            Log.Keeper.warn "keeper:%s memory_write failed: %s"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -102,16 +102,20 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
 let log_keeper_contract_verdict
     ~(keeper_name : string)
     (verdict : Cdal_types.contract_verdict) =
-  let log =
-    match verdict.status with
-    | Cdal_types.Satisfied -> Log.Keeper.debug
-    | Cdal_types.Violated | Cdal_types.Inconclusive -> Log.Keeper.warn
-  in
-  log "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
-    keeper_name
-    (Cdal_types.contract_status_to_string verdict.status)
-    verdict.claim_scope
-    verdict.judgment_hash
+  match verdict.status with
+  | Cdal_types.Satisfied ->
+      if Keeper_types_profile.keeper_debug then
+        Log.Keeper.debug "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+          keeper_name
+          (Cdal_types.contract_status_to_string verdict.status)
+          verdict.claim_scope
+          verdict.judgment_hash
+  | Cdal_types.Violated | Cdal_types.Inconclusive ->
+      Log.Keeper.warn "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+        keeper_name
+        (Cdal_types.contract_status_to_string verdict.status)
+        verdict.claim_scope
+        verdict.judgment_hash
 
 let log_keeper_friction
     ~(keeper_name : string)
@@ -119,13 +123,15 @@ let log_keeper_friction
   let blocked = fp.blocked_attempt_count in
   let groups = List.length fp.blocked_attempt_groups in
   let tripwires = List.length fp.review_tripwires in
-  let log =
-    if tripwires > 0 then Log.Keeper.warn
-    else if blocked > 0 || groups > 0 then Log.Keeper.info
-    else Log.Keeper.debug
-  in
-  log "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-    keeper_name blocked groups tripwires
+  if tripwires > 0 then
+    Log.Keeper.warn "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name blocked groups tripwires
+  else if blocked > 0 || groups > 0 then
+    Log.Keeper.info "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name blocked groups tripwires
+  else if Keeper_types_profile.keeper_debug then
+    Log.Keeper.debug "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name blocked groups tripwires
 
 let log_keeper_memory_write
     ~(keeper_name : string)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -82,18 +82,22 @@ let normalize_response_text
              (String.concat ", " tool_names))
 
 let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
-  let log =
-    match proof.result_status with
-    | Agent_sdk.Cdal_proof.Completed -> Log.Keeper.debug
-    | Agent_sdk.Cdal_proof.Errored
-    | Agent_sdk.Cdal_proof.Timed_out
-    | Agent_sdk.Cdal_proof.Cancelled -> Log.Keeper.warn
-  in
-  log "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
-    keeper_name proof.run_id
-    (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
-    (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
-    (List.length proof.raw_evidence_refs)
+  match proof.result_status with
+  | Agent_sdk.Cdal_proof.Completed ->
+      if Keeper_types_profile.keeper_debug then
+        Log.Keeper.debug "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+          keeper_name proof.run_id
+          (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+          (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
+          (List.length proof.raw_evidence_refs)
+  | Agent_sdk.Cdal_proof.Errored
+  | Agent_sdk.Cdal_proof.Timed_out
+  | Agent_sdk.Cdal_proof.Cancelled ->
+      Log.Keeper.warn "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+        keeper_name proof.run_id
+        (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+        (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
+        (List.length proof.raw_evidence_refs)
 
 let log_keeper_contract_verdict
     ~(keeper_name : string)
@@ -127,11 +131,12 @@ let log_keeper_memory_write
     ~(keeper_name : string)
     ~(notes_written : int)
     ~(kinds_written : string list) =
-  let log =
-    if notes_written >= 10 then Log.Keeper.info else Log.Keeper.debug
-  in
-  log "keeper:%s memory_write: %d notes, kinds=[%s]"
-    keeper_name notes_written (String.concat "," kinds_written)
+  if notes_written >= 10 then
+    Log.Keeper.info "keeper:%s memory_write: %d notes, kinds=[%s]"
+      keeper_name notes_written (String.concat "," kinds_written)
+  else if Keeper_types_profile.keeper_debug then
+    Log.Keeper.debug "keeper:%s memory_write: %d notes, kinds=[%s]"
+      keeper_name notes_written (String.concat "," kinds_written)
 
 (** Run a single keeper turn via OAS Agent.run().
 


### PR DESCRIPTION
## Summary
Reduce keeper success-path audit log noise without removing CDAL artifact persistence.

## Product impact
Normal keeper turns no longer elevate routine audit events into operator-facing `info` noise, so actual warnings are easier to spot during runtime observation.

## Evidence
- local build passed: `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-cdal-log-noise`
- changed hot-path severity handling for proof, verdict, friction, and memory-write events
- preserved `Cdal_eval_v1.persist` so verdict artifacts still land in `data/cdal_verdicts`

## Review evidence
- direct `sb glm-text` review with `GLM-5.1` on `2026-04-02 00:32:19 KST`
- result: `No findings.`
- comment: https://github.com/jeong-sik/masc-mcp/pull/4500#issuecomment-4170928658

## Linked issue
Relates #4501
