### PR TITLE
feat(mcp): expose voice tools on public surfaces

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -289,7 +289,7 @@ let legacy_permission_for_tool = function
   | "masc_keeper_create_from_persona"
   | "masc_voice_speak" | "masc_voice_session_start"
   | "masc_voice_session_end" | "masc_voice_conference_start"
-  | "masc_voice_conference_end"
+  | "masc_voice_conference_end" | "masc_voice_ping_pong"
   | "masc_operator_confirm" | "masc_unit_define"
   | "masc_unit_reparent"
   | "masc_unit_reassign" | "masc_operation_start"

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -94,6 +94,7 @@ let worker_only_tools =
     "masc_voice_session_end";
     "masc_voice_conference_start";
     "masc_voice_conference_end";
+    "masc_voice_ping_pong";
     (* CanBroadcast — org units *)
     "masc_unit_define";
     "masc_unit_reparent";

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -114,6 +114,11 @@ let public_mcp_surface_tools =
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_list"; "masc_keeper_status";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
+    (* Voice *)
+    "masc_voice_agent"; "masc_voice_sessions"; "masc_voice_speak";
+    "masc_voice_session_start"; "masc_voice_session_end";
+    "masc_voice_conference_start"; "masc_voice_conference_end";
+    "masc_voice_ping_pong";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_delete";
@@ -132,6 +137,10 @@ let spawned_agent_surface_tools =
     "masc_task_history"; "masc_broadcast"; "masc_join"; "masc_leave";
     "masc_who"; "masc_agent_update"; "masc_add_task"; "masc_heartbeat";
     "masc_messages";
+    "masc_voice_agent"; "masc_voice_sessions"; "masc_voice_speak";
+    "masc_voice_session_start"; "masc_voice_session_end";
+    "masc_voice_conference_start"; "masc_voice_conference_end";
+    "masc_voice_ping_pong";
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_handover_create"; "masc_handover_list"; "masc_handover_claim";
     "masc_handover_get";

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -498,6 +498,11 @@ let test_permission_for_tool_voice_speak () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_voice_ping_pong () =
+  match Auth.permission_for_tool "masc_voice_ping_pong" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
 let test_permission_for_tool_autoresearch_status () =
   match Auth.permission_for_tool "masc_autoresearch_status" with
   | Some Types.CanReadState -> ()
@@ -692,6 +697,7 @@ let () =
       test_case "persona_list" `Quick test_permission_for_tool_persona_list;
       test_case "voice_sessions" `Quick test_permission_for_tool_voice_sessions;
       test_case "voice_speak" `Quick test_permission_for_tool_voice_speak;
+      test_case "voice_ping_pong" `Quick test_permission_for_tool_voice_ping_pong;
       test_case "autoresearch_status" `Quick
         test_permission_for_tool_autoresearch_status;
       test_case "autoresearch_start" `Quick

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -16,6 +16,19 @@ let test_public_visible_surface_hides_deprecated_aliases () =
   check bool "public contains masc_transition" true
     (List.mem "masc_transition" names)
 
+let test_public_visible_surface_includes_voice_tools () =
+  let names =
+    Lib.Capability_registry.visible_public_tool_schemas_from
+      Lib.Config.raw_all_tool_schemas
+    |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+  in
+  check bool "public contains masc_voice_agent" true
+    (List.mem "masc_voice_agent" names);
+  check bool "public contains masc_voice_speak" true
+    (List.mem "masc_voice_speak" names);
+  check bool "public contains masc_voice_ping_pong" true
+    (List.mem "masc_voice_ping_pong" names)
+
 let test_board_post_capability_merges_public_and_keeper_projections () =
   let capability =
     Lib.Capability_registry.all_capabilities_from Lib.Config.raw_all_tool_schemas
@@ -65,7 +78,13 @@ let test_spawned_agent_surface_stays_curated () =
   check bool "contains masc_status" true
     (List.mem "mcp__masc__masc_status" names);
   check bool "contains team_session_step" true
-    (List.mem "mcp__masc__masc_team_session_step" names)
+    (List.mem "mcp__masc__masc_team_session_step" names);
+  check bool "contains voice agent" true
+    (List.mem "mcp__masc__masc_voice_agent" names);
+  check bool "contains voice speak" true
+    (List.mem "mcp__masc__masc_voice_speak" names);
+  check bool "contains voice ping pong" true
+    (List.mem "mcp__masc__masc_voice_ping_pong" names)
 
 let test_privileged_keeper_surface_is_split () =
   check bool "keeper_bash privileged" true
@@ -86,6 +105,8 @@ let () =
         [
           test_case "public surface hides deprecated aliases" `Quick
             test_public_visible_surface_hides_deprecated_aliases;
+          test_case "public surface includes voice tools" `Quick
+            test_public_visible_surface_includes_voice_tools;
           test_case "board capability merges public and keeper projections"
             `Quick
             test_board_post_capability_merges_public_and_keeper_projections;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -563,6 +563,18 @@ let test_handle_request_tools_list () =
     true
     (List.mem "masc_board_post" names);
   Alcotest.(check bool)
+    "contains masc_voice_agent (public surface)"
+    true
+    (List.mem "masc_voice_agent" names);
+  Alcotest.(check bool)
+    "contains masc_voice_speak (public surface)"
+    true
+    (List.mem "masc_voice_speak" names);
+  Alcotest.(check bool)
+    "contains masc_voice_ping_pong (public surface)"
+    true
+    (List.mem "masc_voice_ping_pong" names);
+  Alcotest.(check bool)
     "board_search hidden from public surface"
     false
     (List.mem "masc_board_search" names);
@@ -803,7 +815,13 @@ let test_handle_request_tools_list_managed_profile () =
                  Alcotest.(check bool) "omits raw masc_status" false
                    (List.mem "masc_status" names);
                  Alcotest.(check bool) "omits raw masc_transition" false
-                   (List.mem "masc_transition" names)
+                   (List.mem "masc_transition" names);
+                 Alcotest.(check bool) "includes managed voice agent" true
+                   (List.mem "masc_voice_agent" names);
+                 Alcotest.(check bool) "includes managed voice speak" true
+                   (List.mem "masc_voice_speak" names);
+                 Alcotest.(check bool) "includes managed voice ping pong" true
+                   (List.mem "masc_voice_ping_pong" names)
              | _ -> Alcotest.fail "tools not a list")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -189,9 +189,9 @@ let test_admin_only_count () =
 let test_worker_only_count () =
   check bool "worker_only_tools is non-empty" true
     (List.length Tool_access_role.worker_only_tools > 0);
-  check bool "worker_only_tools has expected size (54)"
+  check bool "worker_only_tools has expected size (55)"
     true
-    (List.length Tool_access_role.worker_only_tools = 54)
+    (List.length Tool_access_role.worker_only_tools = 55)
 
 let test_no_overlap_admin_worker () =
   List.iter (fun tool_name ->

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -222,10 +222,10 @@ let () =
                   Tool_catalog.public_mcp_tools
               in
               check (list string) "missing from registry" [] missing);
-          test_case "public surface count is between 30 and 40" `Quick
+          test_case "public surface count is between 30 and 50" `Quick
             (fun () ->
               let count = List.length Tool_catalog.public_mcp_tools in
-              check bool "count in range"
+              check bool "count is within expected range"
                 true (count >= 30 && count <= 50));
           test_case "is_public_mcp returns true for listed tools" `Quick
             (fun () ->

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -226,7 +226,7 @@ let () =
             (fun () ->
               let count = List.length Tool_catalog.public_mcp_tools in
               check bool "count in range"
-                true (count >= 30 && count <= 40));
+                true (count >= 30 && count <= 50));
           test_case "is_public_mcp returns true for listed tools" `Quick
             (fun () ->
               List.iter


### PR DESCRIPTION
## Summary
- expose `masc_voice_*` tools on the public MCP surface and the managed-agent surface
- include `masc_voice_ping_pong` in the surfaced tool set and align auth/role mappings
- extend regression coverage for surface exposure, MCP listing, and auth coverage

## Product impact
- public MCP clients can now discover the voice tools via `tools/list`
- managed-agent profiles now expose the same voice entrypoints instead of hiding them behind non-public registration only
- `masc_voice_ping_pong` now has explicit auth coverage aligned with its surfaced availability

## Evidence
- verified public and managed profile exposure in capability and MCP server tests
- verified auth coverage for `masc_voice_ping_pong`
- local validation commands are listed below

## Review evidence
- direct `sb glm-text` review was attempted first but did not return a usable response in-session
- fallback review used `./scripts/review/local-review.sh --base origin/main --head HEAD --format markdown`
- detailed reviewer output is attached as a PR comment

## Linked issue
- Refs #4504

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure -- ./test/test_auth_coverage.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure -- ./test/test_tool_surface_ssot.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure -- ./test/test_capability_registry.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure -- ./test/test_mcp_server_eio.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/voice-surface-exposure -- ./test/test_tool_exposure.exe