### PR TITLE
[codex] simplify keeper refresh follow-up

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -76,15 +76,7 @@ async function runSocialSweep(): Promise<void> {
 
 async function refreshAfterRuntimeAction(): Promise<void> {
   invalidateDashboardCache()
-  try {
-    await refreshDashboard({ force: true })
-  } catch (err) {
-    const message =
-      err instanceof Error && err.message.trim() !== ''
-        ? err.message
-        : '대시보드 새로고침에 실패했습니다. 잠시 후 다시 시도해 주세요.'
-    showToast(message, 'error')
-  }
+  await refreshDashboard({ force: true })
 }
 
 // ── Status Badge (colored pill) ──────────────────────────

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -140,10 +141,9 @@ describe('KeeperConversationPanel', () => {
     expect(hydrateKeeperStatus).not.toHaveBeenCalled()
   })
 
-  it('keeps lifecycle success visible when dashboard refresh fails after boot', async () => {
+  it('keeps lifecycle success visible after boot', async () => {
     const keeper = { name: 'sangsu', status: 'offline' } as any
     bootKeeper.mockResolvedValue({ ok: true })
-    refreshDashboard.mockRejectedValue('refresh failed')
 
     render(
       html`<${KeeperRuntimeActions}
@@ -159,16 +159,13 @@ describe('KeeperConversationPanel', () => {
     )
     expect(bootButton).not.toBeUndefined()
     bootButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await Promise.resolve()
-    await Promise.resolve()
 
-    expect(bootKeeper).toHaveBeenCalledWith('sangsu')
+    await waitFor(() => {
+      expect(bootKeeper).toHaveBeenCalledWith('sangsu')
+    })
     expect(invalidateDashboardCache).toHaveBeenCalled()
+    expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
     expect(showToast).toHaveBeenCalledWith('sangsu 기동됨', 'success')
-    expect(showToast).toHaveBeenCalledWith(
-      '대시보드 새로고침에 실패했습니다. 잠시 후 다시 시도해 주세요.',
-      'error',
-    )
     expect(showToast).not.toHaveBeenCalledWith('sangsu 기동 실패', 'error')
   })
 })

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -393,15 +393,7 @@ export function KeeperRuntimeActions({
   const isRunning = keeper.status === 'active' || keeper.status === 'running' || keeper.status === 'idle' || keeper.status === 'watching' || keeper.status === 'listening'
   const refreshKeeperRuntime = async () => {
     invalidateDashboardCache()
-    try {
-      await refreshDashboard({ force: true })
-    } catch (err) {
-      const message =
-        err instanceof Error && err.message.trim() !== ''
-          ? err.message
-          : '대시보드 새로고침에 실패했습니다. 잠시 후 다시 시도해 주세요.'
-      showToast(message, 'error')
-    }
+    await refreshDashboard({ force: true })
   }
   const runBoot = async () => {
     keeperBooting.value = { ...keeperBooting.value, [keeper.name]: true }
@@ -428,9 +420,6 @@ export function KeeperRuntimeActions({
       }
       showToast(`${keeper.name} 종료됨`, 'success')
       await refreshKeeperRuntime()
-      setTimeout(() => {
-        void refreshKeeperRuntime()
-      }, 900)
     } catch (err) {
       showToast(err instanceof Error ? err.message : `${keeper.name} 종료 실패`, 'error')
     } finally {


### PR DESCRIPTION
## Summary
- remove dead keeper dashboard refresh error handling that never fired because `refreshDashboard()` swallows fetch failures internally
- remove the extra delayed shutdown refresh and keep a single forced refresh path
- make the keeper runtime action test deterministic with `waitFor` and an explicit forced-refresh assertion

## Validation
- `pnpm test -- src/components/keeper-shared.test.ts src/api/keeper.test.ts`
- `npx tsc --noEmit --pretty`

## Context
- follow-up extracted from merged PR #4499 after review-response work landed on a post-merge branch tip