### PR TITLE
[codex] Migrate legacy keeper meta before autoboot

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -75,7 +75,7 @@ let restore_persisted_sessions (state : Mcp_server.server_state) =
 let reconcile_active_agents_gauge (state : Mcp_server.server_state) =
   Prometheus.reconcile_active_agents_gauge (Room.masc_dir state.room_config)
 
-(** Migrate legacy directory names: perpetual->traces, perpetual-keepers->keepers.
+(** Migrate legacy directory names: perpetual->traces, resident-keepers->keepers.
     Moves contents via recursive merge. Conflicting files go to _quarantine/,
     except keeper meta files where a fresher valid legacy record may replace a
     stale or invalid current record. *)
@@ -166,14 +166,10 @@ let migrate_legacy_dirs_with_renames (state : Mcp_server.server_state) renames =
 
 let migrate_legacy_dirs (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state
-    [ ("perpetual", "traces");
-      ("perpetual-keepers", "keepers");
-      ("resident-keepers", "keepers") ]
+    [ ("perpetual", "traces"); ("resident-keepers", "keepers") ]
 
 let migrate_legacy_keeper_dirs_blocking (state : Mcp_server.server_state) =
-  migrate_legacy_dirs_with_renames state
-    [ ("perpetual-keepers", "keepers");
-      ("resident-keepers", "keepers") ]
+  migrate_legacy_dirs_with_renames state [ ("resident-keepers", "keepers") ]
 
 let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("perpetual", "traces") ]

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -75,8 +75,115 @@ let restore_persisted_sessions (state : Mcp_server.server_state) =
 let reconcile_active_agents_gauge (state : Mcp_server.server_state) =
   Prometheus.reconcile_active_agents_gauge (Room.masc_dir state.room_config)
 
+(** Migrate legacy directory names: perpetual->traces, perpetual-keepers->keepers.
+    Moves contents via recursive merge. Conflicting files go to _quarantine/,
+    except keeper meta files where a fresher valid legacy record may replace a
+    stale or invalid current record. *)
+let keeper_meta_updated_ts (meta : Keeper_types.keeper_meta) =
+  Resilience.Time.parse_iso8601_opt meta.updated_at
+  |> Option.value ~default:0.0
+
+let should_promote_legacy_keeper_meta ~legacy_path ~current_path =
+  match
+    Keeper_types.read_meta_file_path legacy_path,
+    Keeper_types.read_meta_file_path current_path
+  with
+  | Ok (Some _legacy), Ok (Some _current) -> (
+      keeper_meta_updated_ts _legacy > keeper_meta_updated_ts _current)
+  | Ok (Some _), Ok None | Ok (Some _), Error _ -> true
+  | _ -> false
+
+let migrate_legacy_dirs_with_renames (state : Mcp_server.server_state) renames =
+  let masc_root = Room.masc_root_dir state.room_config in
+  let quarantine_rel_path ~source_name ~rel_path =
+    if rel_path = "" then source_name else Filename.concat source_name rel_path
+  in
+  let quarantine = Filename.concat masc_root "_quarantine" in
+  let rec migrate_recursive ~source_name ~old_dir ~new_dir ~rel_path
+      ~prefer_root_keeper_meta_conflicts =
+    if not (Sys.file_exists old_dir) then ()
+    else begin
+      Keeper_types.mkdir_p new_dir;
+      Array.iter (fun name ->
+        let old_path = Filename.concat old_dir name in
+        let new_path = Filename.concat new_dir name in
+        let rel = if rel_path = "" then name else Filename.concat rel_path name in
+        if Sys.is_directory old_path then begin
+          if Sys.file_exists new_path then
+            migrate_recursive ~source_name ~old_dir:old_path ~new_dir:new_path ~rel_path:rel
+              ~prefer_root_keeper_meta_conflicts
+          else
+            Sys.rename old_path new_path
+        end else begin
+          if Sys.file_exists new_path then begin
+            if prefer_root_keeper_meta_conflicts && rel_path = ""
+               && Filename.check_suffix name ".json"
+               && should_promote_legacy_keeper_meta
+                    ~legacy_path:old_path ~current_path:new_path
+            then begin
+              let replaced_q_path =
+                Filename.concat quarantine
+                  (Filename.concat "_replaced"
+                     (quarantine_rel_path ~source_name ~rel_path:rel))
+              in
+              Keeper_types.mkdir_p (Filename.dirname replaced_q_path);
+              Sys.rename new_path replaced_q_path;
+              Sys.rename old_path new_path
+            end else begin
+              let q_path =
+                Filename.concat quarantine
+                  (quarantine_rel_path ~source_name ~rel_path:rel)
+              in
+              Keeper_types.mkdir_p (Filename.dirname q_path);
+              Sys.rename old_path q_path
+            end
+          end else
+            Sys.rename old_path new_path
+        end
+      ) (Sys.readdir old_dir);
+      (try
+        if Array.length (Sys.readdir old_dir) = 0 then
+          Sys.rmdir old_dir
+        else
+          Log.Misc.warn "migrate: old dir not empty after migration: %s" old_dir
+      with Sys_error _ -> ())
+    end
+  in
+  (try
+    List.iter (fun (old_name, new_name) ->
+      let old_dir = Filename.concat masc_root old_name in
+      let new_dir = Filename.concat masc_root new_name in
+      if Sys.file_exists old_dir then begin
+        Log.Misc.info "migrate: %s -> %s" old_name new_name;
+        migrate_recursive ~source_name:old_name ~old_dir ~new_dir ~rel_path:""
+          ~prefer_root_keeper_meta_conflicts:(String.equal new_name "keepers")
+      end
+    ) renames
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Misc.error "legacy dir migration failed: %s" (Printexc.to_string exn))
+
+let migrate_legacy_dirs (state : Mcp_server.server_state) =
+  migrate_legacy_dirs_with_renames state
+    [ ("perpetual", "traces");
+      ("perpetual-keepers", "keepers");
+      ("resident-keepers", "keepers") ]
+
+let migrate_legacy_keeper_dirs_blocking (state : Mcp_server.server_state) =
+  migrate_legacy_dirs_with_renames state
+    [ ("perpetual-keepers", "keepers");
+      ("resident-keepers", "keepers") ]
+
+let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =
+  migrate_legacy_dirs_with_renames state [ ("perpetual", "traces") ]
+
 let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
   let (_init_msg : string) = Room.init state.room_config ~agent_name:None in
+  (* Promote legacy keeper metadata before any startup readers scan .masc/keepers.
+     Keeper autoboot and other bootstrap readers should see the canonical paths
+     on their first pass, not rely on a later lazy migration task. *)
+  migrate_legacy_keeper_dirs_blocking state;
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
@@ -170,91 +277,6 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn))
-
-(** Migrate legacy directory names: perpetual->traces, resident-keepers->keepers.
-    Moves contents via recursive merge. Conflicting files go to _quarantine/,
-    except keeper meta files where a fresher valid legacy record may replace a
-    stale or invalid current record. *)
-let keeper_meta_updated_ts (meta : Keeper_types.keeper_meta) =
-  Resilience.Time.parse_iso8601_opt meta.updated_at
-  |> Option.value ~default:0.0
-
-let should_promote_legacy_keeper_meta ~legacy_path ~current_path =
-  match
-    Keeper_types.read_meta_file_path legacy_path,
-    Keeper_types.read_meta_file_path current_path
-  with
-  | Ok (Some _legacy), Ok (Some _current) -> (
-      keeper_meta_updated_ts _legacy > keeper_meta_updated_ts _current)
-  | Ok (Some _), Ok None | Ok (Some _), Error _ -> true
-  | _ -> false
-
-let migrate_legacy_dirs (state : Mcp_server.server_state) =
-  let masc = Room.masc_root_dir state.room_config in
-  let quarantine = Filename.concat masc "_quarantine" in
-  let rec migrate_recursive ~old_dir ~new_dir ~rel_path
-      ~prefer_root_keeper_meta_conflicts =
-    if not (Sys.file_exists old_dir) then ()
-    else begin
-      Keeper_types.mkdir_p new_dir;
-      Array.iter (fun name ->
-        let old_path = Filename.concat old_dir name in
-        let new_path = Filename.concat new_dir name in
-        let rel = if rel_path = "" then name else Filename.concat rel_path name in
-        if Sys.is_directory old_path then begin
-          if Sys.file_exists new_path then
-            migrate_recursive ~old_dir:old_path ~new_dir:new_path ~rel_path:rel
-              ~prefer_root_keeper_meta_conflicts
-          else
-            Sys.rename old_path new_path
-        end else begin
-          if Sys.file_exists new_path then begin
-            if prefer_root_keeper_meta_conflicts && rel_path = ""
-               && Filename.check_suffix name ".json"
-               && should_promote_legacy_keeper_meta
-                    ~legacy_path:old_path ~current_path:new_path
-            then begin
-              let replaced_q_path =
-                Filename.concat quarantine (Filename.concat "_replaced" rel)
-              in
-              Keeper_types.mkdir_p (Filename.dirname replaced_q_path);
-              Sys.rename new_path replaced_q_path;
-              Sys.rename old_path new_path
-            end else begin
-              let q_path = Filename.concat quarantine rel in
-              Keeper_types.mkdir_p (Filename.dirname q_path);
-              Sys.rename old_path q_path
-            end
-          end else
-            Sys.rename old_path new_path
-        end
-      ) (Sys.readdir old_dir);
-      (try
-        if Array.length (Sys.readdir old_dir) = 0 then
-          Sys.rmdir old_dir
-        else
-          Log.Misc.warn "migrate: old dir not empty after migration: %s" old_dir
-      with Sys_error _ -> ())
-    end
-  in
-  let renames = [
-    ("perpetual", "traces");
-    ("resident-keepers", "keepers");
-  ] in
-  (try
-    List.iter (fun (old_name, new_name) ->
-      let old_dir = Filename.concat masc old_name in
-      let new_dir = Filename.concat masc new_name in
-      if Sys.file_exists old_dir then begin
-        Log.Misc.info "migrate: %s -> %s" old_name new_name;
-        migrate_recursive ~old_dir ~new_dir ~rel_path:""
-          ~prefer_root_keeper_meta_conflicts:(String.equal new_name "keepers")
-      end
-    ) renames
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Log.Misc.error "legacy dir migration failed: %s" (Printexc.to_string exn))
 
 let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
   (try
@@ -413,7 +435,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("prompt_bootstrap", fun () -> bootstrap_prompt_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
           ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);
-          ("legacy_dir_migration", fun () -> migrate_legacy_dirs state);
+          ("legacy_trace_dir_migration", fun () -> migrate_legacy_trace_dirs state);
           ("jsonl_prune", fun () -> startup_prune_jsonl state);
           ( "keeper_checkpoint_prune",
             fun () -> startup_prune_keeper_checkpoints state );

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -279,7 +279,7 @@ let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
       let keepers_dir = Filename.concat masc_root "keepers" in
       let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_dir =
-        Filename.concat masc_root "_quarantine/_replaced"
+        Filename.concat masc_root "_quarantine/_replaced/perpetual-keepers"
       in
       Fs_compat.mkdir_p keepers_dir;
       Fs_compat.mkdir_p legacy_dir;
@@ -318,7 +318,7 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       let keepers_dir = Filename.concat masc_root "keepers" in
       let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_path =
-        Filename.concat masc_root "_quarantine/sangsu.json"
+        Filename.concat masc_root "_quarantine/perpetual-keepers/sangsu.json"
       in
       Fs_compat.mkdir_p keepers_dir;
       Fs_compat.mkdir_p legacy_dir;
@@ -341,14 +341,43 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       Alcotest.(check bool) "older legacy keeper quarantined" true
         (Sys.file_exists quarantine_path))
 
+let test_migrate_legacy_keeper_dirs_uses_source_scoped_quarantine_paths () =
+  with_temp_dir "startup-legacy-keepers-quarantine-sources" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let keepers_dir = Filename.concat masc_root "keepers" in
+      let perpetual_dir = Filename.concat masc_root "perpetual-keepers" in
+      let resident_dir = Filename.concat masc_root "resident-keepers" in
+      Fs_compat.mkdir_p keepers_dir;
+      Fs_compat.mkdir_p perpetual_dir;
+      Fs_compat.mkdir_p resident_dir;
+      write_file (Filename.concat keepers_dir "sangsu.json")
+        (make_keeper_meta_json ~updated_at:"2026-03-29T12:36:57Z" ());
+      write_file (Filename.concat perpetual_dir "sangsu.json")
+        (make_keeper_meta_json ~updated_at:"2026-03-29T10:36:57Z" ());
+      write_file (Filename.concat resident_dir "sangsu.json")
+        (make_keeper_meta_json ~updated_at:"2026-03-29T11:36:57Z" ());
+      Server_runtime_bootstrap.migrate_legacy_dirs state;
+      Alcotest.(check bool) "perpetual keeper quarantined under source dir" true
+        (Sys.file_exists
+           (Filename.concat masc_root
+              "_quarantine/perpetual-keepers/sangsu.json"));
+      Alcotest.(check bool) "resident keeper quarantined under source dir" true
+        (Sys.file_exists
+           (Filename.concat masc_root
+              "_quarantine/resident-keepers/sangsu.json")))
+
 let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
   with_temp_dir "startup-blocking-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
       let legacy_dir = Filename.concat masc_root "perpetual-keepers" in
+      let legacy_trace_dir = Filename.concat masc_root "perpetual" in
       Fs_compat.mkdir_p legacy_dir;
+      Fs_compat.mkdir_p legacy_trace_dir;
       write_file (Filename.concat legacy_dir "sangsu.json")
         (make_keeper_meta_json ());
+      write_file (Filename.concat legacy_trace_dir "ckpt-1.json") {|{"ok":true}|};
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Alcotest.(check bool) "legacy keeper meta promoted during blocking bootstrap"
         true
@@ -357,6 +386,8 @@ let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
               "sangsu.json"));
       Alcotest.(check bool) "legacy dir removed before later startup readers" false
         (Sys.file_exists legacy_dir);
+      Alcotest.(check bool) "legacy traces stay deferred to lazy startup" true
+        (Sys.file_exists legacy_trace_dir);
       Alcotest.(check (list string))
         "autoboot sees promoted keepers on first scan"
         [ "sangsu" ]
@@ -524,6 +555,10 @@ let () =
           Alcotest.test_case
             "legacy keeper migration keeps fresher current meta"
             `Quick test_migrate_resident_keeper_dirs_keeps_fresher_current_meta;
+          Alcotest.test_case
+            "legacy keeper migration uses source-scoped quarantine paths"
+            `Quick
+            test_migrate_legacy_keeper_dirs_uses_source_scoped_quarantine_paths;
           Alcotest.test_case
             "blocking bootstrap promotes legacy keeper meta"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -341,6 +341,27 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       Alcotest.(check bool) "older legacy keeper quarantined" true
         (Sys.file_exists quarantine_path))
 
+let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
+  with_temp_dir "startup-blocking-legacy-keepers" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let legacy_dir = Filename.concat masc_root "perpetual-keepers" in
+      Fs_compat.mkdir_p legacy_dir;
+      write_file (Filename.concat legacy_dir "sangsu.json")
+        (make_keeper_meta_json ());
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      Alcotest.(check bool) "legacy keeper meta promoted during blocking bootstrap"
+        true
+        (Sys.file_exists
+           (Filename.concat (Keeper_types.keeper_dir state.Mcp_server.room_config)
+              "sangsu.json"));
+      Alcotest.(check bool) "legacy dir removed before later startup readers" false
+        (Sys.file_exists legacy_dir);
+      Alcotest.(check (list string))
+        "autoboot sees promoted keepers on first scan"
+        [ "sangsu" ]
+        (Keeper_types.keepalive_keeper_names state.Mcp_server.room_config))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -503,6 +524,10 @@ let () =
           Alcotest.test_case
             "legacy keeper migration keeps fresher current meta"
             `Quick test_migrate_resident_keeper_dirs_keeps_fresher_current_meta;
+          Alcotest.test_case
+            "blocking bootstrap promotes legacy keeper meta"
+            `Quick
+            test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -279,7 +279,7 @@ let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
       let keepers_dir = Filename.concat masc_root "keepers" in
       let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_dir =
-        Filename.concat masc_root "_quarantine/_replaced/perpetual-keepers"
+        Filename.concat masc_root "_quarantine/_replaced/resident-keepers"
       in
       Fs_compat.mkdir_p keepers_dir;
       Fs_compat.mkdir_p legacy_dir;
@@ -318,7 +318,7 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       let keepers_dir = Filename.concat masc_root "keepers" in
       let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let quarantine_path =
-        Filename.concat masc_root "_quarantine/perpetual-keepers/sangsu.json"
+        Filename.concat masc_root "_quarantine/resident-keepers/sangsu.json"
       in
       Fs_compat.mkdir_p keepers_dir;
       Fs_compat.mkdir_p legacy_dir;
@@ -341,27 +341,19 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       Alcotest.(check bool) "older legacy keeper quarantined" true
         (Sys.file_exists quarantine_path))
 
-let test_migrate_legacy_keeper_dirs_uses_source_scoped_quarantine_paths () =
-  with_temp_dir "startup-legacy-keepers-quarantine-sources" (fun dir ->
+let test_migrate_resident_keeper_dirs_use_source_scoped_quarantine_path () =
+  with_temp_dir "startup-resident-keepers-quarantine-source" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
       let keepers_dir = Filename.concat masc_root "keepers" in
-      let perpetual_dir = Filename.concat masc_root "perpetual-keepers" in
-      let resident_dir = Filename.concat masc_root "resident-keepers" in
+      let legacy_dir = Filename.concat masc_root "resident-keepers" in
       Fs_compat.mkdir_p keepers_dir;
-      Fs_compat.mkdir_p perpetual_dir;
-      Fs_compat.mkdir_p resident_dir;
+      Fs_compat.mkdir_p legacy_dir;
       write_file (Filename.concat keepers_dir "sangsu.json")
         (make_keeper_meta_json ~updated_at:"2026-03-29T12:36:57Z" ());
-      write_file (Filename.concat perpetual_dir "sangsu.json")
-        (make_keeper_meta_json ~updated_at:"2026-03-29T10:36:57Z" ());
-      write_file (Filename.concat resident_dir "sangsu.json")
+      write_file (Filename.concat legacy_dir "sangsu.json")
         (make_keeper_meta_json ~updated_at:"2026-03-29T11:36:57Z" ());
       Server_runtime_bootstrap.migrate_legacy_dirs state;
-      Alcotest.(check bool) "perpetual keeper quarantined under source dir" true
-        (Sys.file_exists
-           (Filename.concat masc_root
-              "_quarantine/perpetual-keepers/sangsu.json"));
       Alcotest.(check bool) "resident keeper quarantined under source dir" true
         (Sys.file_exists
            (Filename.concat masc_root
@@ -371,7 +363,7 @@ let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
   with_temp_dir "startup-blocking-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
-      let legacy_dir = Filename.concat masc_root "perpetual-keepers" in
+      let legacy_dir = Filename.concat masc_root "resident-keepers" in
       let legacy_trace_dir = Filename.concat masc_root "perpetual" in
       Fs_compat.mkdir_p legacy_dir;
       Fs_compat.mkdir_p legacy_trace_dir;
@@ -558,7 +550,7 @@ let () =
           Alcotest.test_case
             "legacy keeper migration uses source-scoped quarantine paths"
             `Quick
-            test_migrate_legacy_keeper_dirs_uses_source_scoped_quarantine_paths;
+            test_migrate_resident_keeper_dirs_use_source_scoped_quarantine_path;
           Alcotest.test_case
             "blocking bootstrap promotes legacy keeper meta"
             `Quick


### PR DESCRIPTION
## Summary

- move legacy keeper dir promotion into `bootstrap_server_state_blocking` so startup readers see canonical `.masc/keepers` data on their first pass
- remove legacy dir migration from lazy startup to eliminate the autoboot race found during PR #4502 review
- add a regression test that proves blocking bootstrap promotes legacy keeper meta before `keepalive_keeper_names` scans

## Product impact

- Promise affected: `delivery swarm`
- User-visible change: first boot after the naming migration no longer misses keeper autoboot when persisted keeper meta still lives in legacy keeper directories

## Evidence

- `dune build --root .`
- `./_build/default/test/test_server_runtime_bootstrap.exe`

## Review evidence

- External review: direct GLM via `sb glm-text` on 2026-04-02 KST. Result: `No findings.`

## Linked issue

- Closes #4511
- Relates #4502
