### PR TITLE
[codex] add unified failure envelope spine

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { LogEntry } from '../api/dashboard'
-import { mergeLogEntries } from './logs'
+import { failureEnvelope, mergeLogEntries } from './logs'
 
 function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
   return {
@@ -35,5 +35,60 @@ describe('mergeLogEntries', () => {
     const incoming = [entry(5), entry(1)]
 
     expect(mergeLogEntries(current, incoming, 3).map(item => item.seq)).toEqual([5, 4, 3])
+  })
+})
+
+describe('failureEnvelope', () => {
+  it('parses a valid envelope from log details', () => {
+    const parsed = failureEnvelope(
+      entry(7, {
+        details: {
+          failure_envelope: {
+            surface: 'tool_host',
+            entity_kind: 'tool_call',
+            entity_id: 'req-7',
+            cause_code: 'tool_host_timeout',
+            severity: 'bad',
+            summary: 'codex masc_keeper_msg failed during tools/call on mcp_http',
+            recoverability: 'operator_action_required',
+            operator_action: 'masc_operator_digest',
+            evidence_ref: {
+              request_id: 'req-7',
+              tool_name: 'masc_keeper_msg',
+            },
+          },
+        },
+      }),
+    )
+
+    expect(parsed).toEqual({
+      surface: 'tool_host',
+      entity_kind: 'tool_call',
+      entity_id: 'req-7',
+      cause_code: 'tool_host_timeout',
+      severity: 'bad',
+      summary: 'codex masc_keeper_msg failed during tools/call on mcp_http',
+      recoverability: 'operator_action_required',
+      operator_action: 'masc_operator_digest',
+      evidence_ref: {
+        request_id: 'req-7',
+        tool_name: 'masc_keeper_msg',
+      },
+    })
+  })
+
+  it('returns null for malformed envelopes', () => {
+    expect(
+      failureEnvelope(
+        entry(8, {
+          details: {
+            failure_envelope: {
+              surface: 'tool_host',
+              cause_code: 'tool_host_timeout',
+            },
+          },
+        }),
+      ),
+    ).toBeNull()
   })
 })

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -20,7 +20,7 @@ const logLimit = signal(200)
 const latestSeq = signal<number | null>(null)
 
 const POLL_INTERVAL_MS = 3000
-const LOG_ROW_HEIGHT = 76
+const LOG_ROW_HEIGHT = 92
 
 let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let latestRequestId = 0
@@ -41,6 +41,17 @@ const SOURCE_LABELS: Record<string, string> = {
 }
 
 type LoadMode = 'reset' | 'delta'
+type FailureEnvelope = {
+  surface: string
+  entity_kind: string
+  entity_id: string | null
+  cause_code: string
+  severity: string
+  summary: string
+  recoverability: string
+  operator_action: string | null
+  evidence_ref: Record<string, unknown> | null
+}
 
 function normalizedLevel(entry: LogEntry): string {
   return (entry.normalized_level || entry.level || 'INFO').toUpperCase()
@@ -84,6 +95,46 @@ function detailLabel(details: Record<string, unknown> | null, key: string): stri
   if (typeof value === 'string' && value.trim() !== '') return value.trim()
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return null
+}
+
+function nestedRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function nestedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+export function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
+  const details = entryDetails(entry)
+  const envelope = nestedRecord(details?.failure_envelope)
+  if (!envelope) return null
+
+  const surface = nestedString(envelope.surface)
+  const entityKind = nestedString(envelope.entity_kind)
+  const causeCode = nestedString(envelope.cause_code)
+  const severity = nestedString(envelope.severity)
+  const summary = nestedString(envelope.summary)
+  const recoverability = nestedString(envelope.recoverability)
+
+  if (!surface || !entityKind || !causeCode || !severity || !summary || !recoverability) {
+    return null
+  }
+
+  return {
+    surface,
+    entity_kind: entityKind,
+    entity_id: nestedString(envelope.entity_id),
+    cause_code: causeCode,
+    severity,
+    summary,
+    recoverability,
+    operator_action: nestedString(envelope.operator_action),
+    evidence_ref: nestedRecord(envelope.evidence_ref),
+  }
 }
 
 function sourceTone(source: string): string {
@@ -148,6 +199,7 @@ function renderLogRow(entry: LogEntry) {
   const phase = detailLabel(details, 'phase')
   const requestId = detailLabel(details, 'request_id')
   const sessionId = detailLabel(details, 'session_id')
+  const failure = failureEnvelope(entry)
   const sourceClass = sourceTone(source)
   const backgroundClass =
     level === 'ERROR'
@@ -195,10 +247,19 @@ function renderLogRow(entry: LogEntry) {
         ${sessionId
           ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">session ${sessionId}</span>`
           : null}
+        ${failure
+          ? html`<span class="rounded-full border border-[rgba(224,80,80,0.24)] bg-[rgba(224,80,80,0.12)] px-2 py-0.5 text-[10px] text-[#ffb4b4]">${failure.cause_code}</span>`
+          : null}
+        ${failure
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${failure.recoverability}</span>`
+          : null}
+        ${failure?.operator_action
+          ? html`<span class="rounded-full border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)] px-2 py-0.5 text-[10px] text-[#dff3ff]">next ${failure.operator_action}</span>`
+          : null}
       </div>
       <div
         class="text-[12px] leading-relaxed text-[var(--text-body)]"
-        title=${entry.message}
+        title=${failure ? `${entry.message}\n${failure.summary}` : entry.message}
         style=${{
           display: '-webkit-box',
           overflow: 'hidden',
@@ -206,7 +267,7 @@ function renderLogRow(entry: LogEntry) {
           WebkitLineClamp: 2,
         }}
       >
-        ${entry.message}
+        ${failure ? `${entry.message} (${failure.summary})` : entry.message}
       </div>
     </div>
   `

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -118,7 +118,9 @@ let ring_message (report : report) =
 
 let record ?fs config (report : report) =
   let details = details_json report in
-  Log.client_tool_host_error ~details (ring_message report);
+  Log.client_tool_host_error
+    ~module_name:Failure_envelope.tool_host_log_module_name ~details
+    (ring_message report);
   Audit_log.log_client_tool_host_failure config ~agent_id:report.agent_name
     ~client_name:report.client_name ~tool_name:report.tool_name
     ~transport:report.transport ~message:report.message ?phase:report.phase

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -83,19 +83,29 @@ let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
   | _ -> Error "request body must be a JSON object"
 
 let details_json (report : report) =
-  `Assoc
-    (List.filter_map
-       Fun.id
-       [
-         Some ("client_name", `String report.client_name);
-         Some ("tool_name", `String report.tool_name);
-         Some ("transport", `String report.transport);
-         Option.map (fun value -> ("phase", `String value)) report.phase;
-         Option.map (fun value -> ("request_id", `String value)) report.request_id;
-         Option.map (fun value -> ("session_id", `String value)) report.session_id;
-         Option.map (fun value -> ("trace_id", `String value)) report.trace_id;
-         Option.map (fun value -> ("timeout_ms", `Int value)) report.timeout_ms;
-       ])
+  let envelope =
+    Failure_envelope.tool_host_failure ~agent_name:report.agent_name
+      ~client_name:report.client_name ~tool_name:report.tool_name
+      ~transport:report.transport ?phase:report.phase
+      ?request_id:report.request_id ?session_id:report.session_id
+      ?trace_id:report.trace_id ?timeout_ms:report.timeout_ms
+      ~message:report.message ()
+  in
+  Failure_envelope.attach_to_details
+    (`Assoc
+      (List.filter_map
+         Fun.id
+         [
+           Some ("client_name", `String report.client_name);
+           Some ("tool_name", `String report.tool_name);
+           Some ("transport", `String report.transport);
+           Option.map (fun value -> ("phase", `String value)) report.phase;
+           Option.map (fun value -> ("request_id", `String value)) report.request_id;
+           Option.map (fun value -> ("session_id", `String value)) report.session_id;
+           Option.map (fun value -> ("trace_id", `String value)) report.trace_id;
+           Option.map (fun value -> ("timeout_ms", `Int value)) report.timeout_ms;
+         ]))
+    envelope
 
 let ring_message (report : report) =
   let phase =

--- a/lib/dune
+++ b/lib/dune
@@ -49,6 +49,7 @@
    config
    config_dir_resolver
    dashboard
+   failure_envelope
    dashboard_labels
    dashboard_agent_relations
    dashboard_attention

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -20,6 +20,8 @@ type t = {
   evidence_ref : Yojson.Safe.t;
 }
 
+let tool_host_log_module_name = "ToolHost"
+
 let severity_to_string = function
   | Warn -> "warn"
   | Bad -> "bad"
@@ -50,25 +52,15 @@ let trim_to_option value =
   let trimmed = String.trim value in
   if trimmed = "" then None else Some trimmed
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > haystack_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  needle_len > 0 && haystack_len >= needle_len && loop 0
-
 let tool_host_cause_code ?timeout_ms message =
   let lower = String.lowercase_ascii message in
   if Option.is_some timeout_ms
-     || contains_substring ~needle:"timed out" lower
-     || contains_substring ~needle:"timeout" lower then
+     || String_util.contains_substring lower "timed out"
+     || String_util.contains_substring lower "timeout" then
     "tool_host_timeout"
-  else if contains_substring ~needle:"port already in use" lower
-          || contains_substring ~needle:"connection refused" lower
-          || contains_substring ~needle:"transport unavailable" lower then
+  else if String_util.contains_substring lower "port already in use"
+          || String_util.contains_substring lower "connection refused"
+          || String_util.contains_substring lower "transport unavailable" then
     "tool_host_transport_unavailable"
   else
     "tool_host_failure"
@@ -76,7 +68,6 @@ let tool_host_cause_code ?timeout_ms message =
 let operator_action_for_cause_code = function
   | "tool_host_timeout" -> Some "masc_operator_digest"
   | "tool_host_transport_unavailable" -> Some "masc_operator_digest"
-  | "tool_host_failure" -> Some "masc_operator_digest"
   | _ -> None
 
 let summary_for_tool_host ~client_name ~tool_name ~transport = function

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -1,0 +1,210 @@
+type severity =
+  | Warn
+  | Bad
+  | Critical
+
+type recoverability =
+  | Retryable
+  | Operator_action_required
+  | Fatal
+
+type t = {
+  surface : string;
+  entity_kind : string;
+  entity_id : string option;
+  cause_code : string;
+  severity : severity;
+  summary : string;
+  recoverability : recoverability;
+  operator_action : string option;
+  evidence_ref : Yojson.Safe.t;
+}
+
+let severity_to_string = function
+  | Warn -> "warn"
+  | Bad -> "bad"
+  | Critical -> "critical"
+
+let severity_of_string = function
+  | "warn" -> Ok Warn
+  | "bad" -> Ok Bad
+  | "critical" -> Ok Critical
+  | other -> Error ("unknown failure severity: " ^ other)
+
+let recoverability_to_string = function
+  | Retryable -> "retryable"
+  | Operator_action_required -> "operator_action_required"
+  | Fatal -> "fatal"
+
+let recoverability_of_string = function
+  | "retryable" -> Ok Retryable
+  | "operator_action_required" -> Ok Operator_action_required
+  | "fatal" -> Ok Fatal
+  | other -> Error ("unknown failure recoverability: " ^ other)
+
+let option_to_json f = function
+  | Some value -> f value
+  | None -> `Null
+
+let trim_to_option value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  needle_len > 0 && haystack_len >= needle_len && loop 0
+
+let tool_host_cause_code ?timeout_ms message =
+  let lower = String.lowercase_ascii message in
+  if Option.is_some timeout_ms
+     || contains_substring ~needle:"timed out" lower
+     || contains_substring ~needle:"timeout" lower then
+    "tool_host_timeout"
+  else if contains_substring ~needle:"port already in use" lower
+          || contains_substring ~needle:"connection refused" lower
+          || contains_substring ~needle:"transport unavailable" lower then
+    "tool_host_transport_unavailable"
+  else
+    "tool_host_failure"
+
+let operator_action_for_cause_code = function
+  | "tool_host_timeout" -> Some "masc_operator_digest"
+  | "tool_host_transport_unavailable" -> Some "masc_operator_digest"
+  | "tool_host_failure" -> Some "masc_operator_digest"
+  | _ -> None
+
+let summary_for_tool_host ~client_name ~tool_name ~transport = function
+  | Some phase when String.trim phase <> "" ->
+      Printf.sprintf "%s %s failed during %s on %s" client_name tool_name phase
+        transport
+  | _ -> Printf.sprintf "%s %s failed on %s" client_name tool_name transport
+
+let tool_host_failure ~agent_name ~client_name ~tool_name ~transport ?phase
+    ?request_id ?session_id ?trace_id ?timeout_ms ~message () =
+  let cause_code = tool_host_cause_code ?timeout_ms message in
+  {
+    surface = "tool_host";
+    entity_kind = "tool_call";
+    entity_id =
+      (match request_id with
+       | Some _ -> request_id
+       | None -> (match session_id with Some _ -> session_id | None -> trace_id));
+    cause_code;
+    severity = Bad;
+    summary = summary_for_tool_host ~client_name ~tool_name ~transport phase;
+    recoverability =
+      (match cause_code with
+       | "tool_host_timeout" | "tool_host_transport_unavailable" ->
+           Operator_action_required
+       | _ -> Retryable);
+    operator_action = operator_action_for_cause_code cause_code;
+    evidence_ref =
+      `Assoc
+        (List.filter_map
+           Fun.id
+           [
+             Some ("agent_name", `String agent_name);
+             Some ("client_name", `String client_name);
+             Some ("tool_name", `String tool_name);
+             Some ("transport", `String transport);
+             Some ("message", `String message);
+             Option.map (fun value -> ("phase", `String value)) (Option.bind phase trim_to_option);
+             Option.map (fun value -> ("request_id", `String value)) (Option.bind request_id trim_to_option);
+             Option.map (fun value -> ("session_id", `String value)) (Option.bind session_id trim_to_option);
+             Option.map (fun value -> ("trace_id", `String value)) (Option.bind trace_id trim_to_option);
+             Option.map (fun value -> ("timeout_ms", `Int value)) timeout_ms;
+           ]);
+  }
+
+let to_yojson (envelope : t) =
+  `Assoc
+    [
+      ("surface", `String envelope.surface);
+      ("entity_kind", `String envelope.entity_kind);
+      ("entity_id", option_to_json (fun value -> `String value) envelope.entity_id);
+      ("cause_code", `String envelope.cause_code);
+      ("severity", `String (severity_to_string envelope.severity));
+      ("summary", `String envelope.summary);
+      ("recoverability", `String (recoverability_to_string envelope.recoverability));
+      ("operator_action", option_to_json (fun value -> `String value) envelope.operator_action);
+      ("evidence_ref", envelope.evidence_ref);
+    ]
+
+let required_string json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `String value -> Ok value
+  | _ -> Error ("missing required failure field: " ^ key)
+
+let optional_string json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `String value -> trim_to_option value
+  | _ -> None
+
+let of_yojson json =
+  match json with
+  | `Assoc _ -> (
+      match required_string json "surface" with
+      | Error _ as err -> err
+      | Ok surface -> (
+          match required_string json "entity_kind" with
+          | Error _ as err -> err
+          | Ok entity_kind -> (
+              match required_string json "cause_code" with
+              | Error _ as err -> err
+              | Ok cause_code -> (
+                  match required_string json "severity" with
+                  | Error _ as err -> err
+                  | Ok severity_raw -> (
+                      match severity_of_string severity_raw with
+                      | Error _ as err -> err
+                      | Ok severity -> (
+                          match required_string json "summary" with
+                          | Error _ as err -> err
+                          | Ok summary -> (
+                              match required_string json "recoverability" with
+                              | Error _ as err -> err
+                              | Ok recoverability_raw -> (
+                                  match
+                                    recoverability_of_string recoverability_raw
+                                  with
+                                  | Error _ as err -> err
+                                  | Ok recoverability ->
+                                      Ok
+                                        {
+                                          surface;
+                                          entity_kind;
+                                          entity_id =
+                                            optional_string json "entity_id";
+                                          cause_code;
+                                          severity;
+                                          summary;
+                                          recoverability;
+                                          operator_action =
+                                            optional_string json
+                                              "operator_action";
+                                          evidence_ref =
+                                            Yojson.Safe.Util.member
+                                              "evidence_ref" json;
+                                        }))))))))
+  | _ -> Error "failure envelope must be a JSON object"
+
+let attach_to_details details envelope =
+  match details with
+  | `Assoc fields -> `Assoc (("failure_envelope", to_yojson envelope) :: fields)
+  | _ -> `Assoc [ ("failure_envelope", to_yojson envelope) ]
+
+let find_in_json json =
+  match json with
+  | `Assoc _ -> (
+      match of_yojson (Yojson.Safe.Util.member "failure_envelope" json) with
+      | Ok envelope -> Some envelope
+      | Error _ -> None)
+  | _ -> None

--- a/lib/failure_envelope.mli
+++ b/lib/failure_envelope.mli
@@ -1,0 +1,42 @@
+type severity =
+  | Warn
+  | Bad
+  | Critical
+
+type recoverability =
+  | Retryable
+  | Operator_action_required
+  | Fatal
+
+type t = {
+  surface : string;
+  entity_kind : string;
+  entity_id : string option;
+  cause_code : string;
+  severity : severity;
+  summary : string;
+  recoverability : recoverability;
+  operator_action : string option;
+  evidence_ref : Yojson.Safe.t;
+}
+
+val severity_to_string : severity -> string
+val recoverability_to_string : recoverability -> string
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) result
+val attach_to_details : Yojson.Safe.t -> t -> Yojson.Safe.t
+val find_in_json : Yojson.Safe.t -> t option
+
+val tool_host_failure :
+  agent_name:string ->
+  client_name:string ->
+  tool_name:string ->
+  transport:string ->
+  ?phase:string ->
+  ?request_id:string ->
+  ?session_id:string ->
+  ?trace_id:string ->
+  ?timeout_ms:int ->
+  message:string ->
+  unit ->
+  t

--- a/lib/failure_envelope.mli
+++ b/lib/failure_envelope.mli
@@ -20,6 +20,7 @@ type t = {
   evidence_ref : Yojson.Safe.t;
 }
 
+val tool_host_log_module_name : string
 val severity_to_string : severity -> string
 val recoverability_to_string : recoverability -> string
 val to_yojson : t -> Yojson.Safe.t

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -14,7 +14,7 @@ let recent_tool_host_failures ~now () =
         let fresh =
           match Types.parse_iso8601_opt entry.ts with
           | Some ts -> now -. ts <= tool_host_attention_window_sec
-          | None -> true
+          | None -> false
         in
         if not fresh then
           dedup seen acc rest
@@ -54,7 +54,7 @@ let recent_tool_host_failures ~now () =
                 in
                 dedup (fingerprint :: seen) (item :: acc) rest
   in
-  Log.Ring.recent ~limit:12 ~module_filter:"ToolHost" ()
+  Log.Ring.recent ~limit:12 ~module_filter:Failure_envelope.tool_host_log_module_name ()
   |> dedup [] []
 
 let build_room_attention_items ?command_plane_summary config =

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -5,6 +5,58 @@ include Operator_digest_types
 include Operator_digest_session
 open Operator_digest_guidance
 
+let tool_host_attention_window_sec = 900.0
+
+let recent_tool_host_failures ~now () =
+  let rec dedup seen acc = function
+    | [] -> List.rev acc
+    | (entry : Log.Ring.entry) :: rest ->
+        let fresh =
+          match Types.parse_iso8601_opt entry.ts with
+          | Some ts -> now -. ts <= tool_host_attention_window_sec
+          | None -> true
+        in
+        if not fresh then
+          dedup seen acc rest
+        else
+          match Failure_envelope.find_in_json entry.details with
+          | None -> dedup seen acc rest
+          | Some envelope ->
+              let fingerprint =
+                String.concat "|"
+                  [
+                    envelope.cause_code;
+                    Option.value ~default:"" envelope.entity_id;
+                    envelope.summary;
+                  ]
+              in
+              if List.mem fingerprint seen then
+                dedup seen acc rest
+              else
+                let item =
+                  {
+                    kind = envelope.cause_code;
+                    severity =
+                      Failure_envelope.severity_to_string envelope.severity;
+                    summary = envelope.summary;
+                    target_type = "room";
+                    target_id = None;
+                    actor = None;
+                    evidence =
+                      `Assoc
+                        [
+                          ("log_seq", `Int entry.seq);
+                          ("log_ts", `String entry.ts);
+                          ( "failure_envelope",
+                            Failure_envelope.to_yojson envelope );
+                        ];
+                  }
+                in
+                dedup (fingerprint :: seen) (item :: acc) rest
+  in
+  Log.Ring.recent ~limit:12 ~module_filter:"ToolHost" ()
+  |> dedup [] []
+
 let build_room_attention_items ?command_plane_summary config =
   let command_plane_summary =
     match command_plane_summary with
@@ -126,7 +178,9 @@ let build_room_attention_items ?command_plane_summary config =
         };
       ]
   in
-  List.sort compare_attention (pending_items @ signal_items @ intent_items)
+  List.sort compare_attention
+    (recent_tool_host_failures ~now:(Time_compat.now ()) ()
+    @ pending_items @ signal_items @ intent_items)
 
 let room_recommendations ?command_plane_summary config =
   let command_plane_summary =

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -133,6 +133,30 @@ let test_record_writes_audit_ring_and_telemetry () =
       in
       check bool "telemetry error recorded" true has_client_error)
 
+let test_generic_failure_envelope_is_retryable_without_operator_action () =
+  let details =
+    Dashboard_tool_host_events.details_json
+      {
+        agent_name = "codex";
+        client_name = "codex";
+        tool_name = "masc_keeper_msg";
+        transport = "mcp_http";
+        phase = Some "tools/call";
+        message = "upstream returned malformed payload";
+        request_id = Some "generic-1";
+        session_id = None;
+        trace_id = None;
+        timeout_ms = None;
+      }
+  in
+  let failure_envelope = Yojson.Safe.Util.member "failure_envelope" details in
+  check string "generic cause code" "tool_host_failure"
+    Yojson.Safe.Util.(failure_envelope |> member "cause_code" |> to_string);
+  check string "generic recoverability" "retryable"
+    Yojson.Safe.Util.(failure_envelope |> member "recoverability" |> to_string);
+  check bool "generic operator action omitted" true
+    Yojson.Safe.Util.(failure_envelope |> member "operator_action" = `Null)
+
 let () =
   run "Dashboard_tool_host_events"
     [
@@ -143,5 +167,7 @@ let () =
             test_report_of_yojson_accepts_stringish_ids;
           test_case "record writes audit ring and telemetry" `Quick
             test_record_writes_audit_ring_and_telemetry;
+          test_case "generic failure envelope stays retryable" `Quick
+            test_generic_failure_envelope_is_retryable_without_operator_action;
         ] );
     ]

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -105,6 +105,21 @@ let test_record_writes_audit_ring_and_telemetry () =
       check string "ring module" "ToolHost" latest.module_name;
       check bool "ring details object" true
         (match latest.details with `Assoc _ -> true | _ -> false);
+      let failure_envelope =
+        Yojson.Safe.Util.member "failure_envelope" latest.details
+      in
+      check string "failure cause code" "tool_host_timeout"
+        Yojson.Safe.Util.(failure_envelope |> member "cause_code" |> to_string);
+      check string "failure recoverability" "operator_action_required"
+        Yojson.Safe.Util.
+          (failure_envelope |> member "recoverability" |> to_string);
+      check string "failure operator action" "masc_operator_digest"
+        Yojson.Safe.Util.
+          (failure_envelope |> member "operator_action" |> to_string);
+      check string "failure evidence request_id" "99"
+        Yojson.Safe.Util.
+          (failure_envelope |> member "evidence_ref" |> member "request_id"
+         |> to_string);
       let telemetry_events = Telemetry_eio.read_all_events config in
       let has_client_error =
         List.exists

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -27,6 +27,9 @@ let () =
           Alcotest.test_case "digest room pending confirm attention" `Quick
             Test_operator_control_snapshot
             .test_digest_room_exposes_pending_confirm_attention;
+          Alcotest.test_case "digest room tool host attention" `Quick
+            Test_operator_control_snapshot
+            .test_digest_room_includes_tool_host_failure_attention;
           Alcotest.test_case "digest room prefers fresh operator judgment"
             `Quick
             Test_operator_control_judgment

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -400,6 +400,63 @@ let test_digest_team_session_shape () =
         | `List _ -> true
         | _ -> false))
 
+let test_digest_room_includes_tool_host_failure_attention () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      Dashboard_tool_host_events.record ~fs:() config
+        {
+          Dashboard_tool_host_events.agent_name = "codex";
+          client_name = "codex";
+          tool_name = "masc_keeper_msg";
+          transport = "mcp_http";
+          phase = Some "tools/call";
+          message = "timed out awaiting tools/call after 90s";
+          request_id = Some "opsd-toolhost-1";
+          session_id = Some "sess-toolhost-1";
+          trace_id = Some "trace-toolhost-1";
+          timeout_ms = Some 90000;
+        };
+      let digest =
+        match Operator_control.digest_json ~actor:"dashboard"
+                (operator_ctx env sw config "dashboard")
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let attention_items =
+        Yojson.Safe.Util.(digest |> member "attention_items" |> to_list)
+      in
+      let tool_host_attention =
+        List.find_opt
+          (fun item ->
+            Yojson.Safe.Util.(item |> member "kind" |> to_string)
+            = "tool_host_timeout"
+            && Yojson.Safe.Util.
+                 (item |> member "evidence" |> member "failure_envelope"
+                |> member "evidence_ref" |> member "request_id" |> to_string)
+               = "opsd-toolhost-1")
+          attention_items
+      in
+      let item =
+        match tool_host_attention with
+        | Some item -> item
+        | None -> Alcotest.fail "expected tool host attention item"
+      in
+      Alcotest.(check string) "tool host severity" "bad"
+        Yojson.Safe.Util.(item |> member "severity" |> to_string);
+      Alcotest.(check string) "tool host operator action" "masc_operator_digest"
+        Yojson.Safe.Util.
+          (item |> member "evidence" |> member "failure_envelope"
+         |> member "operator_action" |> to_string))
+
 let test_digest_team_session_can_skip_workers () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## What changed
- added a shared `failure_envelope` contract for runtime failures
- attached the envelope to tool-host failure log details
- promoted recent tool-host failures into operator room digest attention items
- surfaced envelope metadata in the dashboard system log UI
- added backend and frontend regression tests for the new spine

## Why
Tool-host failures were previously emitted as loosely structured strings across logs, operator digest, and dashboard UI.
That made the same incident hard to correlate across surfaces and blocked a consistent intervention path.

## Impact
- system logs now carry stable failure fields such as `cause_code`, `recoverability`, and `operator_action`
- operator digest can elevate the same failure into a room-level attention item without string matching
- dashboard users can see the normalized failure code and suggested next operator action directly in the log view

## Root cause
Failure semantics were not modeled as a shared contract.
Each surface translated the same incident independently, so observability and intervention drifted apart.

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope ./test/test_dashboard_tool_host_events.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope ./test/test_operator_control.exe`
- `dashboard`: `./node_modules/.bin/vitest run src/components/logs.test.ts`
- `dashboard`: `./node_modules/.bin/tsc --noEmit --pretty`
