### PR TITLE
fix(auth): rename prompt_override to masc_prompt_override in HTTP route

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -328,7 +328,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/prompts" (fun request reqd ->
-       with_tool_auth ~tool_name:"prompt_override"
+       with_tool_auth ~tool_name:"masc_prompt_override"
          (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try


### PR DESCRIPTION
## Summary
- Fix dead button: Prompt Override Set/Clear buttons in dashboard returned 403 Forbidden
- Root cause: `with_tool_auth ~tool_name:"prompt_override"` fails `authorize_tool_v2` strict mode gate because non-`masc_`-prefixed tool names are rejected regardless of role

## Changes
- `server_routes_http_routes_activity.ml:331`: `"prompt_override"` → `"masc_prompt_override"`

## Test plan
- [ ] `curl -X POST localhost:8935/api/v1/prompts -H 'Content-Type: application/json' -d '{"key":"test","value":"val","action":"set"}'` returns 200
- [ ] Dashboard Prompt Override "Apply"/"Clear" buttons work without 403

Closes #4513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
