### PR TITLE
[codex] Surface hard failures in verifier and voice flows

### DIFF
--- a/dashboard/src/components/overview/situation-banner.test.ts
+++ b/dashboard/src/components/overview/situation-banner.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { missionError, missionLoading } from '../../mission-signals'
+import { roomTruthError } from '../../room-truth-signals'
+import { synthesizeSituation } from './situation-banner'
+
+describe('synthesizeSituation', () => {
+  afterEach(() => {
+    missionError.value = null
+    missionLoading.value = false
+    roomTruthError.value = null
+  })
+
+  it('treats mission load failures as bad severity', () => {
+    missionError.value = 'mission projection offline'
+
+    const result = synthesizeSituation(null)
+
+    expect(result.tone).toBe('bad')
+    expect(result.text).toContain('mission projection offline')
+  })
+
+  it('treats room truth refresh failures as bad severity even with a stale snapshot', () => {
+    roomTruthError.value = 'room truth offline'
+
+    const result = synthesizeSituation({
+      sessions: [{ session_id: 'sess-1', goal: 'goal-1' }],
+      session_briefs: [],
+      attention_queue: [],
+      incidents: [],
+      agent_briefs: [],
+      keeper_briefs: [],
+    } as never)
+
+    expect(result.tone).toBe('bad')
+    expect(result.text).toContain('데이터 일부 갱신 실패.')
+    expect(result.reasons.some(reason => reason.text.includes('room truth offline'))).toBe(true)
+  })
+})

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { missionError, missionLoading } from '../../mission-store'
+import { roomTruthError } from '../../room-truth-store'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionBrief,
@@ -25,10 +26,24 @@ interface SituationResult {
 
 type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
 
-function synthesizeSituation(snap: DashboardMissionResponse | null): SituationResult {
+export function synthesizeSituation(snap: DashboardMissionResponse | null): SituationResult {
+  const loadErrors = [
+    missionError.value?.trim(),
+    roomTruthError.value?.trim(),
+  ].filter((value): value is string => Boolean(value))
+
   if (!snap) {
-    const error = missionError.value
-    if (error) return { text: `데이터 로드 실패: ${error}`, tone: 'warn', reasons: [] }
+    if (loadErrors.length > 0) {
+      return {
+        text: `데이터 로드 실패: ${loadErrors[0]}`,
+        tone: 'bad',
+        reasons: loadErrors.map(text => ({
+          category: 'incident',
+          text,
+          severity: 'bad',
+        })),
+      }
+    }
     if (missionLoading.value) return { text: '데이터 로딩 중...', tone: 'ok', reasons: [] }
     return { text: '데이터 대기 중...', tone: 'ok', reasons: [] }
   }
@@ -47,6 +62,14 @@ function synthesizeSituation(snap: DashboardMissionResponse | null): SituationRe
   }
 
   const reasons: SituationReason[] = []
+
+  for (const error of loadErrors) {
+    reasons.push({
+      category: 'incident',
+      text: `최근 데이터 갱신 실패: ${error}`,
+      severity: 'bad',
+    })
+  }
 
   let blockerCount = 0
   for (const s of sessions) {
@@ -79,16 +102,41 @@ function synthesizeSituation(snap: DashboardMissionResponse | null): SituationRe
     })
   }
 
-  if (total === 0) return { text: '진행 중인 세션 없음.', tone: 'ok', reasons }
+  if (total === 0) {
+    if (loadErrors.length > 0) {
+      return {
+        text: '데이터 일부 갱신 실패. 진행 중인 세션 없음.',
+        tone: 'bad',
+        reasons,
+      }
+    }
+    return { text: '진행 중인 세션 없음.', tone: 'ok', reasons }
+  }
 
   if (blocked === 0 && attention === 0) {
+    if (loadErrors.length > 0) {
+      return {
+        text: `데이터 일부 갱신 실패. ${total}개 세션은 기존 스냅샷 기준으로 표시 중.`,
+        tone: 'bad',
+        reasons,
+      }
+    }
     return { text: `${total}개 세션 순조롭게 진행 중.`, tone: 'ok', reasons }
   }
 
   if (blocked > 0) {
     const suffix = attention > 0 ? ` ${attention}건 주의 필요.` : ''
-    const tone: SituationTone = blocked > total / 2 ? 'bad' : 'warn'
-    return { text: `${total}개 세션 중 ${blocked}개 막힘.${suffix}`, tone, reasons }
+    const tone: SituationTone = loadErrors.length > 0 || blocked > total / 2 ? 'bad' : 'warn'
+    const prefix = loadErrors.length > 0 ? '데이터 일부 갱신 실패. ' : ''
+    return { text: `${prefix}${total}개 세션 중 ${blocked}개 막힘.${suffix}`, tone, reasons }
+  }
+
+  if (loadErrors.length > 0) {
+    return {
+      text: `데이터 일부 갱신 실패. ${total}개 세션 진행 중. ${attention}건 주의 항목.`,
+      tone: 'bad',
+      reasons,
+    }
   }
 
   return { text: `${total}개 세션 진행 중. ${attention}건 주의 항목.`, tone: 'warn', reasons }

--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -33,6 +33,15 @@ let extract_reply_text (result_str : string) : string option =
     | _ -> None
   with _ -> None
 
+let parse_reply_text (result_str : string) : (string, string) result =
+  try
+    let json = Yojson.Safe.from_string result_str in
+    match Yojson.Safe.Util.member "reply" json with
+    | `String s when String.trim s <> "" -> Ok (String.trim s)
+    | _ -> Error "keeper reply missing or empty"
+  with Yojson.Json_error msg ->
+    Error (Printf.sprintf "invalid keeper reply JSON: %s" msg)
+
 (** Stop words that end the voice loop. *)
 let is_stop_command (text : string) : bool =
   let lower = String.lowercase_ascii (String.trim text) in
@@ -64,19 +73,19 @@ let run_one_voice_turn ~agent_id ~send_message ~speak
           else
             let (success, result_str) = send_message text in
             if not success then (
-              Log.Keeper.warn "voice_loop: turn failed: %s" result_str;
-              Ok `Continue)
+              Log.Keeper.error "voice_loop: turn failed: %s" result_str;
+              Error (Printf.sprintf "turn failed: %s" result_str))
             else
-              match extract_reply_text result_str with
-              | None ->
-                  Log.Keeper.info "voice_loop: no reply to speak";
-                  Ok `Continue
-              | Some reply ->
+              match parse_reply_text result_str with
+              | Error err ->
+                  Log.Keeper.error "voice_loop: %s" err;
+                  Error err
+              | Ok reply ->
                   (match speak reply with
-                   | Ok _ -> ()
+                   | Ok _ -> Ok `Continue
                    | Error err ->
-                       Log.Keeper.warn "voice_loop: speak failed: %s" err);
-                  Ok `Continue
+                       Log.Keeper.error "voice_loop: speak failed: %s" err;
+                       Error (Printf.sprintf "speak failed: %s" err))
 
 (** Run the voice ping-pong loop.
     @param send_message callback: text -> (success, result_json_string)
@@ -98,7 +107,7 @@ let run ~agent_id ~send_message ~speak
           if turn_count = 0 then
             (false, Printf.sprintf "voice loop failed on first turn: %s" err)
           else
-            (true, Printf.sprintf "voice loop ended after %d turns (error: %s)"
+            (false, Printf.sprintf "voice loop failed after %d turns: %s"
                turn_count err)
       | Ok `Stop ->
           (true, Printf.sprintf "voice loop ended after %d turns (user exit)"

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -69,7 +69,7 @@ let quality_from_result ~success ~message ~attempts =
     ]
   else
     let issue =
-      if contains_casefold message "timeout" then
+      if contains_casefold message "timeout" || contains_casefold message "timed out" then
         quality_issue "error" "tool_timeout" message attempts
       else
         quality_issue "error" "tool_failure" message attempts

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -70,7 +70,7 @@ let quality_from_result ~success ~message ~attempts =
   else
     let issue =
       if contains_casefold message "timeout" then
-        quality_issue "warning" "tool_timeout" message attempts
+        quality_issue "error" "tool_timeout" message attempts
       else
         quality_issue "error" "tool_failure" message attempts
     in
@@ -140,6 +140,12 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(arguments : Yojson.Safe.t) : fl
       (* No fixed timeout for keeper_msg. Keeper has its own internal limits
          (max_turns, max_cost_usd, max_tokens) that control call duration.
          A fixed external timeout conflicts with multi-turn tool-use loops. *)
+      None
+  | "masc_transition" ->
+      (* Transition can trigger anti-rationalization review on completion
+         paths. A fixed timeout can report a false error while the state
+         mutation continues in the background, leaving caller-visible status
+         out of sync with persisted task state. *)
       None
   | _ ->
       let global_default_sec =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -87,8 +87,12 @@ let _execution_cache =
     Best-effort: never raises — cache staleness must not break
     the mutation path. *)
 let invalidate_execution_cache () =
-  (try invalidate_cached_surface _execution_cache with _ -> ());
-  (try Dashboard_cache.invalidate "execution:default:light" with _ -> ())
+  (try invalidate_cached_surface _execution_cache with exn ->
+     Log.Dashboard.error "Failed to invalidate execution surface cache: %s"
+       (Printexc.to_string exn));
+  (try Dashboard_cache.invalidate "execution:default:light" with exn ->
+     Log.Dashboard.error "Failed to invalidate dashboard execution cache: %s"
+       (Printexc.to_string exn))
 
 (** Bypass the proactive warm-up guard so tests that call
     [dashboard_room_truth_http_json] get the full response instead of

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -218,6 +218,7 @@ let verdict_to_hook_decision (v : verdict) : Agent_sdk.Hooks.hook_decision =
     @param goal The current agent goal (for verification prompt context).
     @param context_summary Brief summary of agent state. *)
 let make_pre_tool_hook
+    ?(verify_fn = verify)
     ~(goal : string)
     ~(context_summary : string)
   : Agent_sdk.Hooks.hook =
@@ -229,25 +230,37 @@ let make_pre_tool_hook
       if should_skip ~action_description then
         Agent_sdk.Hooks.Continue
       else
-        let input_str =
-          try Yojson.Safe.to_string input
-          with Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-                 Log.Verifier.warn "Failed to serialize input: %s" (Printexc.to_string exn);
-                 "{}" in
-        let req : verification_request = {
-          action_description;
-          action_result = input_str;
-          goal;
-          context_summary;
-        } in
-        begin match verify req with
-        | Ok verdict -> verdict_to_hook_decision verdict
-        | Error msg ->
-            Log.Verifier.warn "OAS run failed: %s (defaulting to Continue)" msg;
-            Agent_sdk.Hooks.Continue
-        end
-    | _ -> Agent_sdk.Hooks.Continue
+        (match
+           try Ok (Yojson.Safe.to_string input)
+           with Eio.Cancel.Cancelled _ as e -> raise e
+              | exn -> Error (Printexc.to_string exn)
+         with
+         | Error msg ->
+             Log.Verifier.error "Failed to serialize input for verifier: %s" msg;
+             Agent_sdk.Hooks.Skip
+         | Ok input_str ->
+             let req : verification_request = {
+               action_description;
+               action_result = input_str;
+               goal;
+               context_summary;
+             } in
+             begin match verify_fn req with
+             | Ok verdict -> verdict_to_hook_decision verdict
+             | Error msg ->
+                 Log.Verifier.error "OAS run failed; skipping tool: %s" msg;
+                 Agent_sdk.Hooks.Skip
+             end)
+    | Agent_sdk.Hooks.BeforeTurn _
+    | Agent_sdk.Hooks.BeforeTurnParams _
+    | Agent_sdk.Hooks.AfterTurn _
+    | Agent_sdk.Hooks.PostToolUse _
+    | Agent_sdk.Hooks.PostToolUseFailure _
+    | Agent_sdk.Hooks.OnStop _
+    | Agent_sdk.Hooks.OnIdle _
+    | Agent_sdk.Hooks.OnError _
+    | Agent_sdk.Hooks.OnToolError _
+    | Agent_sdk.Hooks.PreCompact _ -> Agent_sdk.Hooks.Continue
 
 (** Install the verifier hook into an existing OAS hooks record.
 

--- a/test/dune
+++ b/test/dune
@@ -231,6 +231,7 @@
         test_keeper_task_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio
+        test_mcp_server_eio_call_tool
         test_code_navigation_eio
         test_backend
         test_room_eio
@@ -376,6 +377,7 @@
         test_keeper_task_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio
+        test_mcp_server_eio_call_tool
         test_code_navigation_eio
         test_backend
         test_room_eio

--- a/test/test_keeper_voice_loop.ml
+++ b/test/test_keeper_voice_loop.ml
@@ -165,6 +165,57 @@ let test_run_no_audio_treated_as_empty () =
           let re = Re.compile (Re.str "empty STT") in
           Re.execp re msg)
 
+let test_run_mid_loop_send_message_failure_is_error () =
+  let send_calls = ref 0 in
+  let record = make_record [
+    Ok (`Assoc [("text", `String "hello")]);
+    Ok (`Assoc [("text", `String "again")]);
+  ] in
+  let send_message text =
+    incr send_calls;
+    if !send_calls = 1 then echo_send text
+    else (false, "keeper backend unavailable")
+  in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message
+      ~speak:noop_speak ~record ~max_turns:10 ()
+  in
+  check bool "fails after mid-loop tool error" false success;
+  check bool "contains turn failure"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "turn failed") in
+          Re.execp re msg)
+
+let test_run_malformed_reply_is_error () =
+  let record = make_record [
+    Ok (`Assoc [("text", `String "hello")]);
+  ] in
+  let send_message _text = (true, "{bad json") in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message
+      ~speak:noop_speak ~record ~max_turns:10 ()
+  in
+  check bool "malformed reply fails" false success;
+  check bool "mentions invalid keeper reply JSON"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "invalid keeper reply JSON") in
+          Re.execp re msg)
+
+let test_run_speak_failure_is_error () =
+  let record = make_record [
+    Ok (`Assoc [("text", `String "hello")]);
+  ] in
+  let speak _text = Error "tts offline" in
+  let (success, msg) =
+    Keeper_voice_loop.run ~agent_id:"test" ~send_message:echo_send
+      ~speak ~record ~max_turns:10 ()
+  in
+  check bool "tts failure is not silent" false success;
+  check bool "mentions speak failed"
+    true (String.length msg > 0 &&
+          let re = Re.compile (Re.str "speak failed") in
+          Re.execp re msg)
+
 let () =
   run "Keeper_voice_loop"
     [
@@ -194,5 +245,8 @@ let () =
           test_case "empty count resets on success" `Quick test_run_empty_resets_on_success;
           test_case "error on first turn" `Quick test_run_error_on_first_turn;
           test_case "no_audio treated as empty" `Quick test_run_no_audio_treated_as_empty;
+          test_case "mid-loop tool failure is error" `Quick test_run_mid_loop_send_message_failure_is_error;
+          test_case "malformed reply is error" `Quick test_run_malformed_reply_is_error;
+          test_case "speak failure is error" `Quick test_run_speak_failure_is_error;
         ] );
     ]

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -1,0 +1,68 @@
+open Alcotest
+
+module U = Yojson.Safe.Util
+
+let first_issue quality =
+  quality |> U.member "issues" |> U.to_list |> List.hd
+
+let test_timeout_quality_is_error () =
+  let quality =
+    Masc_mcp.Mcp_server_eio_call_tool.quality_from_result
+      ~success:false
+      ~message:"Tool timed out after 30s"
+      ~attempts:1
+  in
+  let issue = first_issue quality in
+  check string "timeout code" "tool_timeout" (issue |> U.member "code" |> U.to_string);
+  check string "timeout severity" "error" (issue |> U.member "severity" |> U.to_string)
+
+let test_generic_failure_quality_is_error () =
+  let quality =
+    Masc_mcp.Mcp_server_eio_call_tool.quality_from_result
+      ~success:false
+      ~message:"subprocess exited 1"
+      ~attempts:2
+  in
+  let issue = first_issue quality in
+  check string "failure code" "tool_failure" (issue |> U.member "code" |> U.to_string);
+  check string "failure severity" "error" (issue |> U.member "severity" |> U.to_string)
+
+let test_success_quality_has_no_issues () =
+  let quality =
+    Masc_mcp.Mcp_server_eio_call_tool.quality_from_result
+      ~success:true
+      ~message:"ok"
+      ~attempts:1
+  in
+  check bool "passed" true (quality |> U.member "passed" |> U.to_bool);
+  check int "issue count" 0 (quality |> U.member "issues" |> U.to_list |> List.length)
+
+let test_transition_has_no_fixed_timeout () =
+  check bool "masc_transition has no fixed timeout"
+    true
+    (Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+       ~tool_name:"masc_transition"
+       ~arguments:(`Assoc [])
+     = None)
+
+let test_regular_tool_uses_default_timeout () =
+  match
+    Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+      ~tool_name:"masc_status"
+      ~arguments:(`Assoc [])
+  with
+  | Some timeout_sec -> check bool "default timeout remains enabled" true (timeout_sec >= 5.)
+  | None -> fail "expected masc_status to keep fixed timeout"
+
+let () =
+  run "mcp_server_eio_call_tool"
+    [
+      ( "quality",
+        [
+          test_case "timeout is error" `Quick test_timeout_quality_is_error;
+          test_case "generic failure is error" `Quick test_generic_failure_quality_is_error;
+          test_case "success has no issues" `Quick test_success_quality_has_no_issues;
+          test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;
+          test_case "regular tool keeps default timeout" `Quick test_regular_tool_uses_default_timeout;
+        ] );
+    ]

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -244,6 +244,54 @@ let test_verify_skips_readonly () =
   Alcotest.(check bool) "read-only skips to Pass" true
     (Verifier_oas.verify req = Ok Pass)
 
+let test_hook_skips_on_verify_error () =
+  let verify_called = ref false in
+  let hook =
+    Verifier_oas.make_pre_tool_hook
+      ~verify_fn:(fun _req ->
+        verify_called := true;
+        Error "verifier backend unavailable")
+      ~goal:"test goal"
+      ~context_summary:"test context"
+  in
+  let decision =
+    hook
+      (Oas.Hooks.PreToolUse {
+         tool_name = "keeper_bash";
+         input = `Assoc [ ("cmd", `String "echo hi") ];
+         accumulated_cost_usd = 0.0;
+         turn = 1;
+       })
+  in
+  Alcotest.(check bool) "verify called" true !verify_called;
+  Alcotest.(check bool) "verifier errors fail closed"
+    true
+    (decision = Oas.Hooks.Skip)
+
+let test_hook_readonly_skips_verifier () =
+  let verify_called = ref false in
+  let hook =
+    Verifier_oas.make_pre_tool_hook
+      ~verify_fn:(fun _req ->
+        verify_called := true;
+        Ok (Fail "should not run"))
+      ~goal:"test goal"
+      ~context_summary:"test context"
+  in
+  let decision =
+    hook
+      (Oas.Hooks.PreToolUse {
+         tool_name = "read file";
+         input = `Assoc [ ("path", `String "README.md") ];
+         accumulated_cost_usd = 0.0;
+         turn = 1;
+       })
+  in
+  Alcotest.(check bool) "verify skipped" false !verify_called;
+  Alcotest.(check bool) "readonly still continues"
+    true
+    (decision = Oas.Hooks.Continue)
+
 (* ================================================================ *)
 (* Roundtrip: keeper_default_gate_config -> guardrails               *)
 (* ================================================================ *)
@@ -383,6 +431,10 @@ let () =
     ]);
     ("verify_skip", [
       Alcotest.test_case "read-only skips" `Quick test_verify_skips_readonly;
+      Alcotest.test_case "hook verifier errors fail closed" `Quick
+        test_hook_skips_on_verify_error;
+      Alcotest.test_case "hook skips verifier for readonly tools" `Quick
+        test_hook_readonly_skips_verifier;
     ]);
     ("autonomous_gate roundtrip", [
       Alcotest.test_case "default -> AllowList (strict)" `Quick test_default_gate_roundtrip;


### PR DESCRIPTION
## Summary
Fail-open or silent failure paths in verifier, keeper voice, tool timeout reporting, and dashboard execution surfaces are tightened so operators see hard failures instead of misleading `warn`/`ok` states.

## Product impact
- guarded tool execution now blocks when verifier execution itself fails
- keeper voice sessions stop on real turn/reply/TTS errors instead of returning `status: ok`
- timed-out tool invocations are ranked as `error`
- overview surfaces reflect mission or room-truth fetch degradation as `bad`
- execution cache invalidation failures are logged instead of disappearing silently

## What changed
- fail closed in the OAS verifier pre-tool hook when verifier execution or input serialization fails
- stop treating keeper voice-loop failures as successful continuation when a turn fails, reply JSON is malformed, or TTS fails
- classify timed-out tool calls as `error` quality instead of `warning`
- remove the fixed external timeout for `masc_transition` so long-running completion/review paths do not surface false failures while the mutation keeps running
- log execution cache invalidation exceptions instead of swallowing them silently
- surface mission and room-truth load failures as `bad` severity in the overview situation banner
- add regression tests for the verifier hook, voice loop failures, timeout severity, and overview banner severity

## Root cause
Several reliability-critical paths mixed best-effort logging with success continuation. That let runtime failures be recorded in logs while the surrounding control flow still reported success or warning-only degradation.

## Evidence
- `lib/verifier_oas.ml`: pre-tool verifier failures no longer default to `Continue`
- `lib/keeper/keeper_voice_loop.ml`: failed turn, malformed reply JSON, and TTS errors now return failure
- `lib/mcp_server_eio_call_tool.ml`: timeout severity upgraded from `warning` to `error`
- `dashboard/src/components/overview/situation-banner.ts`: load errors now drive `bad` severity
- `lib/server/server_dashboard_http_execution_surfaces.ml`: cache invalidation exceptions are logged

## Review evidence
- Cross-model review posted in PR comment: direct `sb glm-text` review, no high/critical findings
- Medium note accepted intentionally: verifier path now shifts from fail-open to fail-closed

## Validation
Completed:
- `pnpm exec vitest run src/components/overview/situation-banner.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `scripts/ci-run-tests.sh "env DUNE_BUILD_DIR=.ci_build_pr dune build --root . test/test_verifier_oas_bridge.exe test/test_keeper_voice_loop.exe test/test_mcp_server_eio_call_tool.exe"`

## Linked issue
Refs #4539
