### PR TITLE
[codex] fix transport health truth for shared webrtc signaling

### DIFF
--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -1,0 +1,169 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { signal } from '@preact/signals'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    summary: {
+      primary_path: 'streamable_http',
+      queue_pressure: 'steady',
+      recent_messages: null,
+      recent_messages_available: false,
+      recent_messages_source: 'metrics_only',
+      external_fanout_targets: 0,
+    },
+    sse: {
+      sessions_observer: 1,
+      sessions_coordinator: 0,
+      sessions_total: 1,
+      external_subscribers: 0,
+      broadcast_avg_seconds: 0.01,
+      broadcast_count: 2,
+      queue_avg_depth: 0,
+      queue_max_depth: 1,
+      hot_sessions: [],
+    },
+    grpc: {
+      enabled: true,
+      configured: true,
+      listening: true,
+      port: 50052,
+      active_streams: 0,
+      subscribers: 0,
+      heartbeat_avg_seconds: 0,
+      events_delivered: 0,
+    },
+    websocket: {
+      enabled: true,
+      configured: true,
+      listening: true,
+      mode: 'standalone',
+      port: 8936,
+      sessions: 0,
+      relay_source: 'sse_external_subscriber',
+    },
+    webrtc: {
+      enabled: true,
+      configured: true,
+      signaling_available: true,
+      signaling_mode: 'shared_http',
+      pending_offers: 0,
+      active_peers: 0,
+      live_connections: 0,
+      connected_channels: 0,
+      ice_server_count: 2,
+    },
+    streamable_http: {
+      endpoint: '/mcp',
+      observer_stream: '/mcp?sse_kind=observer',
+      managed_endpoint: '/mcp/managed',
+      operator_endpoint: '/mcp/operator',
+      delete_endpoint: '/mcp',
+      legacy_sse_endpoint: '/sse',
+      legacy_messages_endpoint: '/messages',
+      default_transport: 'streamable_http',
+      supports_post: true,
+      supports_sse_upgrade: true,
+      supports_delete: true,
+    },
+    http2: {
+      listener_mode: 'h2',
+      multiplex_ready: true,
+      prior_knowledge_path: '/mcp',
+    },
+    cluster: {
+      cluster: 'default',
+      room_id: 'default',
+      topology_available: false,
+      topology_source: 'metrics_only',
+      total_units: null,
+      managed_units: null,
+      live_agents: null,
+      active_operations: null,
+      stale_units: null,
+    },
+    agent_health: {
+      stale_total: 0,
+    },
+    generated_at: '2026-04-02T00:00:00Z',
+    ...overrides,
+  }
+}
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+async function loadComponentWithApi(api: {
+  get: (path: string) => Promise<unknown>
+  lastEvent: { value: unknown }
+}) {
+  vi.resetModules()
+  vi.doMock('../api/core', () => ({
+    get: api.get,
+  }))
+  vi.doMock('../sse', () => ({
+    lastEvent: api.lastEvent,
+  }))
+  const module = await import('./transport-health')
+  module.resetTransportHealthState()
+  return module
+}
+
+describe('TransportHealthPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    const { resetTransportHealthState } = await import('./transport-health')
+    resetTransportHealthState()
+    render(null, container)
+    container.remove()
+    vi.useRealTimers()
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../api/core')
+    vi.doUnmock('../sse')
+  })
+
+  it('renders WebRTC signaling truth without pretending there is a separate listener', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockResolvedValue(
+      sampleResponse({
+        webrtc: {
+          enabled: true,
+          configured: true,
+          signaling_available: false,
+          signaling_mode: 'shared_http',
+          pending_offers: 0,
+          active_peers: 0,
+          live_connections: 0,
+          connected_channels: 0,
+          ice_server_count: 2,
+        },
+      }),
+    )
+
+    const { TransportHealthPanel } = await loadComponentWithApi({
+      get,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${TransportHealthPanel} />`, container)
+    await flushUi()
+
+    expect(get).toHaveBeenCalledWith('/api/v1/dashboard/transport-health')
+    expect(container.textContent).toContain('WebRTC')
+    expect(container.textContent).toContain('시그널링')
+    expect(container.textContent).toContain('shared_http')
+    expect(container.innerHTML).toContain('signaling down')
+    expect(container.innerHTML).not.toContain('2 ICE')
+  })
+})

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -57,6 +57,9 @@ interface TransportHealthData {
   }
   webrtc: {
     enabled: boolean
+    configured: boolean
+    signaling_available: boolean
+    signaling_mode: string
     pending_offers: number
     active_peers: number
     live_connections: number
@@ -110,6 +113,13 @@ type PracticalCase = {
 const transportHealth: Signal<TransportHealthData | null> = signal(null)
 const loading: Signal<boolean> = signal(false)
 const error: Signal<string | null> = signal(null)
+
+export function resetTransportHealthState(): void {
+  transportHealth.value = null
+  loading.value = false
+  error.value = null
+  inflightTransportHealthRefresh = null
+}
 
 /** Hydrate transport health from SSE payload — zero HTTP fetch. */
 export function hydrateTransportHealthFromSSE(data: unknown): void {
@@ -256,8 +266,18 @@ function websocketTone(data: TransportHealthData): StatusTone {
   )
 }
 
+function webrtcActive(data: TransportHealthData): boolean {
+  return data.webrtc.connected_channels > 0
+    || data.webrtc.live_connections > 0
+    || data.webrtc.active_peers > 0
+}
+
 function webrtcTone(data: TransportHealthData): StatusTone {
-  return transportTone(data.webrtc.enabled, true, data.webrtc.connected_channels > 0)
+  return transportTone(
+    data.webrtc.configured,
+    data.webrtc.signaling_available,
+    webrtcActive(data),
+  )
 }
 
 function http2Tone(data: TransportHealthData): StatusTone {
@@ -289,6 +309,13 @@ function MetricRow({ label, value, sub }: { label: string; value: string | numbe
 function transportEyebrow(configured: boolean, listening: boolean, port: number): string {
   if (!configured) return 'disabled'
   return listening ? `:${port} live` : `:${port} down`
+}
+
+function webrtcEyebrow(data: TransportHealthData): string {
+  if (!data.webrtc.configured) return 'disabled'
+  return data.webrtc.signaling_available
+    ? `${data.webrtc.ice_server_count} ICE · signaling ready`
+    : 'signaling down'
 }
 
 function SectionCard({
@@ -441,7 +468,8 @@ export function TransportHealthPanel() {
               <${MetricRow} label="릴레이 소스" value=${data.websocket.relay_source} />
             <//>
 
-            <${SectionCard} title="WebRTC" status=${webrtcStatus} eyebrow=${data.webrtc.enabled ? `${data.webrtc.ice_server_count} ICE` : 'disabled'}>
+            <${SectionCard} title="WebRTC" status=${webrtcStatus} eyebrow=${webrtcEyebrow(data)}>
+              <${MetricRow} label="시그널링" value=${data.webrtc.signaling_available ? 'ready' : 'down'} sub=${data.webrtc.signaling_mode} />
               <${MetricRow} label="연결된 채널" value=${data.webrtc.connected_channels} />
               <${MetricRow} label="활성 피어" value=${data.webrtc.active_peers} />
               <${MetricRow} label="대기 오퍼" value=${data.webrtc.pending_offers} />

--- a/lib/dune
+++ b/lib/dune
@@ -375,6 +375,7 @@
    agent_reputation
    activity_feed
    transport
+   transport_read_model
    transport_metrics
    ;; gRPC coordination transport (grpc-direct)
    masc_grpc_types

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -55,100 +55,30 @@ let configured_http_host () =
   Env_config_core.masc_host ()
 
 let advertised_host_port request =
-  parse_host_port
-    (Httpun.Headers.get request.Httpun.Request.headers "host")
-    (configured_http_host ()) (configured_http_port ())
+  let (host, port) =
+    parse_host_port
+      (Httpun.Headers.get request.Httpun.Request.headers "host")
+      (configured_http_host ()) (configured_http_port ())
+  in
+  (Transport_read_model.normalize_advertised_host host, port)
 
 let websocket_discovery_json request =
-  let (host, _) = advertised_host_port request in
-  let configured = Server_ws_standalone.is_enabled () in
-  let port = Server_ws_standalone.configured_port () in
-  let listening = Transport_metrics.ws_listening () in
-  let listen_status = Atomic.get Transport_metrics.ws_listen_status in
-  let base_fields =
-    [
-      ("enabled", `Bool configured);
-      ("configured", `Bool configured);
-      ("listening", `Bool listening);
-      ("listen_status", `String listen_status);
-      ("mode", `String "standalone");
-      ("discovery_path", `String "/ws");
-      ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
-    ]
+  let (host, port) = advertised_host_port request in
+  let ctx =
+    Transport_read_model.make_http_context ~include_configured:true
+      ~allow_legacy_accept ~host
+      ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
   in
-  let fields =
-    if configured then
-      base_fields
-      @ [
-          ("ws_port", `Int port);
-          ("ws_url", `String (Printf.sprintf "ws://%s:%d/" host port));
-        ]
-    else
-      base_fields
-  in
-  `Assoc fields
+  Transport_read_model.websocket_discovery_json ctx
 
 let transport_json request =
   let (host, port) = advertised_host_port request in
-  let base_url = Printf.sprintf "http://%s:%d" host port in
-  let grpc_enabled = Masc_grpc_server.is_enabled () in
-  let grpc_port = Masc_grpc_server.configured_port () in
-  let grpc_listening = Transport_metrics.grpc_listening () in
-  (* Note: listen_status is read separately from listening — brief tearing is
-     possible but acceptable for this diagnostic-only endpoint. *)
-  let grpc_listen_status = Atomic.get Transport_metrics.grpc_listen_status in
-  let webrtc_enabled = Server_webrtc_transport.is_enabled () in
-  `Assoc
-    [
-      ("streamable_http_default", `Bool true);
-      ("allow_legacy_accept", `Bool allow_legacy_accept);
-      ("legacy_endpoints_deprecated", `Bool true);
-      ( "http",
-        `Assoc
-          [
-            ("enabled", `Bool true);
-            ("base_url", `String base_url);
-            ("mcp_url", `String (base_url ^ "/mcp"));
-            ("sse_url", `String (base_url ^ "/sse"));
-          ] );
-      ( "grpc",
-        `Assoc
-          ([
-             ("enabled", `Bool grpc_enabled);
-             ("configured", `Bool grpc_enabled);
-             ("listening", `Bool grpc_listening);
-             ("listen_status", `String grpc_listen_status);
-             ("port", `Int grpc_port);
-             ("service", `String Masc_grpc_service.service_name);
-             ("health_service", `String Masc_grpc_server.health_service_name);
-           ]
-          @ if grpc_enabled then
-              [ ("url", `String (Printf.sprintf "grpc://%s:%d" host grpc_port)) ]
-            else
-              []) );
-      ("websocket", websocket_discovery_json request);
-      ( "webrtc",
-        `Assoc
-          ([
-             ("enabled", `Bool webrtc_enabled);
-             ("signaling_path", `String "/webrtc");
-             ("offer_path", `String "/webrtc/offer");
-             ("answer_path", `String "/webrtc/answer");
-             ( "ice_server_urls",
-               `List
-                 (List.map
-                    (fun url -> `String url)
-                    (Server_webrtc_transport.configured_ice_server_urls ())) );
-             ("pending_offers", `Int (Server_webrtc_transport.pending_offer_count ()));
-             ("active_peers", `Int (Server_webrtc_transport.active_peer_count ()));
-             ("live_connections", `Int (Server_webrtc_transport.live_webrtc_count ()));
-             ("connected_channels", `Int (Server_webrtc_transport.connected_channel_count ()));
-           ]
-          @ if webrtc_enabled then
-              [ ("signaling_url", `String (base_url ^ "/webrtc")) ]
-            else
-              []) );
-    ]
+  let ctx =
+    Transport_read_model.make_http_context ~include_configured:true
+      ~allow_legacy_accept ~host
+      ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
+  in
+  Transport_read_model.transport_status_json ctx
 
 let health_path_diagnostics () =
   match current_server_state_opt () with

--- a/lib/tool_misc_transport.ml
+++ b/lib/tool_misc_transport.ml
@@ -20,17 +20,6 @@ let pretty_json_string raw =
   try Yojson.Safe.from_string raw |> Yojson.Safe.pretty_to_string
   with Yojson.Json_error _ -> raw
 
-let rec trim_trailing_slashes value =
-  let len = String.length value in
-  if len > 0 && value.[len - 1] = '/' then
-    trim_trailing_slashes (String.sub value 0 (len - 1))
-  else
-    value
-
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-
 let env_flag_enabled name =
   match Sys.getenv_opt name with
   | None -> false
@@ -39,154 +28,23 @@ let env_flag_enabled name =
       v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
 
 (* ================================================================ *)
-(* HTTP/Transport helpers                                           *)
-(* ================================================================ *)
-
-let configured_http_port () =
-  Env_config_core.masc_http_port_int ()
-
-let configured_http_host () =
-  Env_config_core.masc_host ()
-
-let ipaddr_is_unspecified = function
-  | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0
-  | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
-
-let is_unspecified_host host =
-  match Ipaddr.of_string (String.trim host) with
-  | Ok ip -> ipaddr_is_unspecified ip
-  | Error _ -> false
-
-let normalize_advertised_host host =
-  if is_unspecified_host host then "127.0.0.1" else host
-
-let effective_http_base_url () =
-  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
-  | Some raw -> (
-      match trim_nonempty raw with
-      | Some value -> trim_trailing_slashes value
-      | None ->
-          let host = configured_http_host () |> normalize_advertised_host in
-          Printf.sprintf "http://%s:%d" host (configured_http_port ()))
-  | None ->
-      let host = configured_http_host () |> normalize_advertised_host in
-      Printf.sprintf "http://%s:%d" host (configured_http_port ())
-
-let advertised_http_host_port () =
-  let base_url = effective_http_base_url () in
-  let uri = Uri.of_string base_url in
-  let host =
-    match Uri.host uri with
-    | Some value -> normalize_advertised_host value
-    | None -> configured_http_host () |> normalize_advertised_host
-  in
-  let port =
-    match Uri.port uri with
-    | Some value -> value
-    | None -> (
-        match Uri.scheme uri with
-        | Some "https" -> 443
-        | _ -> configured_http_port ())
-  in
-  (base_url, host, port)
-
-(* ================================================================ *)
-(* JSON builders                                                    *)
-(* ================================================================ *)
-
-let websocket_discovery_json () =
-  let (_, host, _) = advertised_http_host_port () in
-  let enabled = Server_ws_standalone.is_enabled () in
-  let port = Server_ws_standalone.configured_port () in
-  let base_fields =
-    [
-      ("enabled", `Bool enabled);
-      ("listening", `Bool (Atomic.get Transport_metrics.ws_runtime_listening));
-      ("listen_status", `String (Atomic.get Transport_metrics.ws_listen_status));
-      ("mode", `String "standalone");
-      ("discovery_path", `String "/ws");
-      ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
-    ]
-  in
-  let fields =
-    if enabled then
-      base_fields
-      @
-      [
-        ("ws_port", `Int port);
-        ("ws_url", `String (Printf.sprintf "ws://%s:%d/" host port));
-      ]
-    else
-      base_fields
-  in
-  `Assoc fields
-
-let transport_status_json () =
-  let (base_url, host, _) = advertised_http_host_port () in
-  let grpc_enabled = Masc_grpc_server.is_enabled () in
-  let grpc_port = Masc_grpc_server.configured_port () in
-  let webrtc_enabled = Server_webrtc_transport.is_enabled () in
-  `Assoc
-    [
-      ("streamable_http_default", `Bool true);
-      ("allow_legacy_accept", `Bool (env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT"));
-      ("legacy_endpoints_deprecated", `Bool true);
-      ( "http",
-        `Assoc
-          [
-            ("enabled", `Bool true);
-            ("base_url", `String base_url);
-            ("mcp_url", `String (base_url ^ "/mcp"));
-            ("sse_url", `String (base_url ^ "/sse"));
-          ] );
-      ( "grpc",
-        `Assoc
-          ([
-             ("enabled", `Bool grpc_enabled);
-             ("listening", `Bool (Transport_metrics.grpc_listening ()));
-             ("listen_status", `String (Atomic.get Transport_metrics.grpc_listen_status));
-             ("port", `Int grpc_port);
-             ("service", `String Masc_grpc_service.service_name);
-             ("health_service", `String Masc_grpc_server.health_service_name);
-           ]
-          @ if grpc_enabled then
-              [ ("url", `String (Printf.sprintf "grpc://%s:%d" host grpc_port)) ]
-            else
-              []) );
-      ("websocket", websocket_discovery_json ());
-      ( "webrtc",
-        `Assoc
-          ([
-             ("enabled", `Bool webrtc_enabled);
-             ("signaling_path", `String "/webrtc");
-             ("offer_path", `String "/webrtc/offer");
-             ("answer_path", `String "/webrtc/answer");
-             ( "ice_server_urls",
-               `List
-                 (List.map
-                    (fun url -> `String url)
-                    (Server_webrtc_transport.configured_ice_server_urls ())) );
-             ("pending_offers", `Int (Server_webrtc_transport.pending_offer_count ()));
-             ("active_peers", `Int (Server_webrtc_transport.active_peer_count ()));
-             ("live_connections", `Int (Server_webrtc_transport.live_webrtc_count ()));
-             ("connected_channels", `Int (Server_webrtc_transport.connected_channel_count ()));
-           ]
-          @ if webrtc_enabled then
-              [ ("signaling_url", `String (base_url ^ "/webrtc")) ]
-            else
-              []) );
-    ]
-
-(* ================================================================ *)
 (* Handlers                                                         *)
 (* ================================================================ *)
 
 let handle_transport_status _args : result =
-  let json = transport_status_json () in
+  let ctx =
+    Transport_read_model.context_from_env
+      ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
+  in
+  let json = Transport_read_model.transport_status_json ctx in
   (true, Yojson.Safe.pretty_to_string json)
 
 let handle_websocket_discovery _args : result =
-  let json = websocket_discovery_json () in
+  let ctx =
+    Transport_read_model.context_from_env
+      ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
+  in
+  let json = Transport_read_model.websocket_discovery_json ctx in
   (true, Yojson.Safe.pretty_to_string json)
 
 let handle_webrtc_offer args : result =

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -239,6 +239,7 @@ let transport_health_json ~config =
   let grpc_live = grpc_listening () in
   let ws_configured = ws_enabled () in
   let ws_live = ws_listening () in
+  let webrtc_configured = Server_webrtc_transport.is_enabled () in
   let webrtc_pending = Server_webrtc_transport.pending_offer_count () in
   let webrtc_peers = Server_webrtc_transport.active_peer_count () in
   let webrtc_live = Server_webrtc_transport.live_webrtc_count () in
@@ -302,7 +303,10 @@ let transport_health_json ~config =
       ("relay_source", `String "sse_external_subscriber");
     ]);
     ("webrtc", `Assoc [
-      ("enabled", `Bool (Server_webrtc_transport.is_enabled ()));
+      ("enabled", `Bool webrtc_configured);
+      ("configured", `Bool webrtc_configured);
+      ("signaling_available", `Bool webrtc_configured);
+      ("signaling_mode", `String "shared_http");
       ("pending_offers", `Int webrtc_pending);
       ("active_peers", `Int webrtc_peers);
       ("live_connections", `Int webrtc_live);

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -1,0 +1,162 @@
+type http_context = {
+  base_url : string;
+  host : string;
+  allow_legacy_accept : bool;
+  include_configured : bool;
+}
+
+let rec trim_trailing_slashes value =
+  let len = String.length value in
+  if len > 0 && value.[len - 1] = '/' then
+    trim_trailing_slashes (String.sub value 0 (len - 1))
+  else
+    value
+
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let configured_http_port () =
+  Env_config_core.masc_http_port_int ()
+
+let configured_http_host () =
+  Env_config_core.masc_host ()
+
+let ipaddr_is_unspecified = function
+  | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0
+  | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
+
+let is_unspecified_host host =
+  match Ipaddr.of_string (String.trim host) with
+  | Ok ip -> ipaddr_is_unspecified ip
+  | Error _ -> false
+
+let normalize_advertised_host host =
+  if is_unspecified_host host then "127.0.0.1" else host
+
+let make_http_context ?(include_configured = false) ~base_url ~host
+    ~allow_legacy_accept () =
+  {
+    base_url = trim_trailing_slashes base_url;
+    host = normalize_advertised_host host;
+    allow_legacy_accept;
+    include_configured;
+  }
+
+let context_from_env ?(include_configured = false) ~allow_legacy_accept () =
+  let default_host = configured_http_host () |> normalize_advertised_host in
+  let default_base_url =
+    Printf.sprintf "http://%s:%d" default_host (configured_http_port ())
+  in
+  let base_url =
+    match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+    | Some raw -> (
+        match trim_nonempty raw with
+        | Some value -> trim_trailing_slashes value
+        | None -> default_base_url)
+    | None -> default_base_url
+  in
+  let uri = Uri.of_string base_url in
+  let host =
+    match Uri.host uri with
+    | Some value -> normalize_advertised_host value
+    | None -> default_host
+  in
+  make_http_context ~include_configured ~base_url ~host ~allow_legacy_accept ()
+
+let maybe_configured_fields ~include_configured enabled =
+  if include_configured then [ ("configured", `Bool enabled) ] else []
+
+let websocket_discovery_json (ctx : http_context) =
+  let enabled = Server_ws_standalone.is_enabled () in
+  let port = Server_ws_standalone.configured_port () in
+  let base_fields =
+    [
+      ("enabled", `Bool enabled);
+    ]
+    @ maybe_configured_fields ~include_configured:ctx.include_configured enabled
+    @ [
+        ("listening", `Bool (Transport_metrics.ws_listening ()));
+        ("listen_status", `String (Atomic.get Transport_metrics.ws_listen_status));
+        ("mode", `String "standalone");
+        ("discovery_path", `String "/ws");
+        ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
+      ]
+  in
+  let fields =
+    if enabled then
+      base_fields
+      @
+      [
+        ("ws_port", `Int port);
+        ("ws_url", `String (Printf.sprintf "ws://%s:%d/" ctx.host port));
+      ]
+    else
+      base_fields
+  in
+  `Assoc fields
+
+let transport_status_json (ctx : http_context) =
+  let grpc_enabled = Masc_grpc_server.is_enabled () in
+  let grpc_port = Masc_grpc_server.configured_port () in
+  let webrtc_enabled = Server_webrtc_transport.is_enabled () in
+  `Assoc
+    [
+      ("streamable_http_default", `Bool true);
+      ("allow_legacy_accept", `Bool ctx.allow_legacy_accept);
+      ("legacy_endpoints_deprecated", `Bool true);
+      ( "http",
+        `Assoc
+          [
+            ("enabled", `Bool true);
+            ("base_url", `String ctx.base_url);
+            ("mcp_url", `String (ctx.base_url ^ "/mcp"));
+            ("sse_url", `String (ctx.base_url ^ "/sse"));
+          ] );
+      ( "grpc",
+        `Assoc
+          ([
+             ("enabled", `Bool grpc_enabled);
+           ]
+          @ maybe_configured_fields ~include_configured:ctx.include_configured
+              grpc_enabled
+          @ [
+              ("listening", `Bool (Transport_metrics.grpc_listening ()));
+              ("listen_status", `String (Atomic.get Transport_metrics.grpc_listen_status));
+              ("port", `Int grpc_port);
+              ("service", `String Masc_grpc_service.service_name);
+              ("health_service", `String Masc_grpc_server.health_service_name);
+            ]
+          @ if grpc_enabled then
+              [ ("url", `String (Printf.sprintf "grpc://%s:%d" ctx.host grpc_port)) ]
+            else
+              []) );
+      ("websocket", websocket_discovery_json ctx);
+      ( "webrtc",
+        `Assoc
+          ([
+             ("enabled", `Bool webrtc_enabled);
+           ]
+          @ maybe_configured_fields ~include_configured:ctx.include_configured
+              webrtc_enabled
+          @ [
+             ("signaling_available", `Bool webrtc_enabled);
+             ("signaling_mode", `String "shared_http");
+             ("signaling_path", `String "/webrtc");
+             ("offer_path", `String "/webrtc/offer");
+             ("answer_path", `String "/webrtc/answer");
+             ( "ice_server_urls",
+               `List
+                 (List.map
+                    (fun url -> `String url)
+                    (Server_webrtc_transport.configured_ice_server_urls ())) );
+             ("pending_offers", `Int (Server_webrtc_transport.pending_offer_count ()));
+             ("active_peers", `Int (Server_webrtc_transport.active_peer_count ()));
+             ("live_connections", `Int (Server_webrtc_transport.live_webrtc_count ()));
+             ("connected_channels", `Int (Server_webrtc_transport.connected_channel_count ()));
+           ]
+          @ if webrtc_enabled then
+              [ ("signaling_url", `String (ctx.base_url ^ "/webrtc")) ]
+            else
+              []) );
+    ]

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,7 @@
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
+        test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention test_hat
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier
@@ -97,6 +98,7 @@
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events
+          test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention test_hat
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -243,6 +243,12 @@ let test_transport_health_json () =
     (match ws_json with `Assoc _ -> true | _ -> false);
   check bool "webrtc section exists" true
     (match webrtc_json with `Assoc _ -> true | _ -> false);
+  check bool "webrtc configured field exists" true
+    (match webrtc_json |> U.member "configured" with `Bool _ -> true | _ -> false);
+  check bool "webrtc signaling_available field exists" true
+    (match webrtc_json |> U.member "signaling_available" with `Bool _ -> true | _ -> false);
+  check bool "webrtc signaling_mode field exists" true
+    (match webrtc_json |> U.member "signaling_mode" with `String _ -> true | _ -> false);
   check string "room id" "default"
     (cluster_json |> U.member "room_id" |> U.to_string);
   check bool "summary primary path exists" true

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -1,0 +1,109 @@
+open Alcotest
+
+module TRM = Masc_mcp.Transport_read_model
+
+let with_env name value_opt f =
+  let original = Sys.getenv_opt name in
+  let restore () =
+    match original with
+    | Some value -> Unix.putenv name value
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect
+    ~finally:restore
+    (fun () ->
+      (match value_opt with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "");
+      f ())
+
+let rec strip_configured = function
+  | `Assoc fields ->
+      `Assoc
+        (fields
+         |> List.filter_map (fun (key, value) ->
+                if String.equal key "configured" then None
+                else Some (key, strip_configured value)))
+  | `List values -> `List (List.map strip_configured values)
+  | other -> other
+
+let make_context ?(include_configured = false) () =
+  TRM.make_http_context ~include_configured ~allow_legacy_accept:false
+    ~base_url:"http://127.0.0.1:8935" ~host:"127.0.0.1" ()
+
+let test_websocket_discovery_http_shape_extends_tool_shape () =
+  let tool_json = TRM.websocket_discovery_json (make_context ()) in
+  let http_json =
+    TRM.websocket_discovery_json (make_context ~include_configured:true ())
+  in
+  check bool "http surface adds configured"
+    true
+    (match Yojson.Safe.Util.member "configured" http_json with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "tool and http surfaces match after stripping configured"
+    true (tool_json = strip_configured http_json)
+
+let test_transport_status_http_shape_extends_tool_shape () =
+  let tool_json = TRM.transport_status_json (make_context ()) in
+  let http_json =
+    TRM.transport_status_json (make_context ~include_configured:true ())
+  in
+  check bool "http grpc surface adds configured"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "grpc" |> member "configured")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "http webrtc surface adds configured"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "webrtc" |> member "configured")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "webrtc surface exposes signaling availability"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "webrtc" |> member "signaling_available")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "tool and http transport status match after stripping configured"
+    true (tool_json = strip_configured http_json)
+
+let test_context_from_env_uses_default_loopback_base_url () =
+  with_env "MASC_HTTP_BASE_URL" None (fun () ->
+      with_env "MASC_HOST" (Some "0.0.0.0") (fun () ->
+          with_env "MASC_HTTP_PORT" (Some "8935") (fun () ->
+              let ctx = TRM.context_from_env ~allow_legacy_accept:false () in
+              check string "normalized host" "127.0.0.1" ctx.host;
+              check string "default base_url" "http://127.0.0.1:8935"
+                ctx.base_url)))
+
+let test_context_from_env_trims_explicit_base_url () =
+  with_env "MASC_HTTP_BASE_URL" (Some "https://example.com/root/") (fun () ->
+      let ctx = TRM.context_from_env ~allow_legacy_accept:true () in
+      check string "host derived from base url" "example.com" ctx.host;
+      check string "base_url trimmed" "https://example.com/root" ctx.base_url;
+      check bool "allow_legacy_accept carried" true ctx.allow_legacy_accept)
+
+let () =
+  run "Transport_read_model"
+    [
+      ( "json",
+        [
+          test_case "websocket discovery parity" `Quick
+            test_websocket_discovery_http_shape_extends_tool_shape;
+          test_case "transport status parity" `Quick
+            test_transport_status_http_shape_extends_tool_shape;
+        ] );
+      ( "env",
+        [
+          test_case "default loopback base url" `Quick
+            test_context_from_env_uses_default_loopback_base_url;
+          test_case "trim explicit base url" `Quick
+            test_context_from_env_trims_explicit_base_url;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- stop presenting shared WebRTC signaling as if it were a separate live listener in dashboard transport health
- extract a shared `Transport_read_model` so HTTP and tool transport surfaces report the same transport truth
- add frontend and OCaml regression coverage for the new WebRTC transport fields

## Root Cause
The dashboard treated WebRTC as effectively live whenever it was enabled, even though signaling is shared over HTTP and does not have an independent listener state. At the same time, HTTP and tool transport JSON were built in separate places, which made drift more likely.

## Product impact
Operators now see `configured`, `signaling_available`, and actual activity as separate concerns for WebRTC instead of one optimistic status. Tool and HTTP transport read paths also share one read model, which reduces surface drift.

## Evidence
- `./node_modules/.bin/vitest run src/components/transport-health.test.ts --reporter verbose --testTimeout 10000`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/transport-truth-unify --build-dir /tmp/masc-build-transport-truth lib/.masc_mcp.objs/native/masc_mcp__Transport_metrics.cmx lib/.masc_mcp.objs/native/masc_mcp__Transport_read_model.cmx`

## Review evidence
- `pr-ready-check` on 2026-04-02 found no unresolved review threads and no requested changes on PR #4536
- addressed the GitHub Actions planning-hygiene warning by adding the required sections and linked issue reference

## Linked issue
- Refs #3408
