### PR TITLE
fix(dashboard): add MCP session recovery path with reconnect toast

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -7,10 +7,11 @@ import {
   MCP_INITIALIZED_NOTIFY_TIMEOUT_MS,
 } from '../config/constants'
 import { reportToolHostFailure } from './dashboard'
+import { showActionToast } from '../components/common/toast'
 
 // --- MCP Session Management ---
 
-const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.'
+const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
 const MCP_SESSION_BLOCKED = '__blocked__'
 
 let mcpSessionId: string | null = null
@@ -84,8 +85,19 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
   return res.text()
 }
 
+let blockedToastShown = false
+
 async function ensureSession(): Promise<void> {
   if (mcpSessionId === MCP_SESSION_BLOCKED) {
+    if (!blockedToastShown) {
+      blockedToastShown = true
+      showActionToast(
+        'MCP 연결이 차단되었습니다.',
+        { label: '재연결', onClick: () => { resetMcpClientState(); blockedToastShown = false } },
+        'error',
+        15000,
+      )
+    }
     throw new Error(MCP_BLOCKED_MESSAGE)
   }
   if (mcpSessionId) return

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -8,10 +8,16 @@ import { signal } from '@preact/signals'
 
 type ToastType = 'success' | 'warning' | 'error'
 
+interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
 interface Toast {
   id: number
   message: string
   type: ToastType
+  action?: ToastAction
 }
 
 let _nextId = 0
@@ -43,6 +49,14 @@ export function showToast(message: string, type: ToastType = 'success', duration
   }, durationMs)
 }
 
+export function showActionToast(message: string, action: ToastAction, type: ToastType = 'error', durationMs = 12000): void {
+  const id = ++_nextId
+  toasts.value = [...toasts.value, { id, message, type, action }]
+  setTimeout(() => {
+    toasts.value = toasts.value.filter(t => t.id !== id)
+  }, durationMs)
+}
+
 function dismissToast(id: number) {
   toasts.value = toasts.value.filter(t => t.id !== id)
 }
@@ -60,6 +74,12 @@ export function ToastContainer() {
         >
           <span class="text-xs shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
           <span class="flex-1 text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+          ${t.action ? html`
+            <button type="button"
+              class="shrink-0 text-[11px] px-2 py-0.5 rounded border border-[var(--card-border)] bg-[var(--white-6)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
+              onClick=${(e: Event) => { e.stopPropagation(); t.action!.onClick(); dismissToast(t.id) }}
+            >${t.action.label}</button>
+          ` : null}
           <button type="button"
             class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] p-0.5 transition-colors duration-150"
             aria-label="알림 닫기"


### PR DESCRIPTION
## Summary
- MCP session blocked state (`__blocked__`) was permanent until page reload
- `resetMcpClientState()` existed but was never called from production code
- Added "재연결" (Reconnect) action button in error toast to clear blocked state

## Changes
- `toast.ts`: Added `showActionToast()` with action button callback support
- `mcp.ts`: Show reconnect toast when MCP is blocked, guard against toast spam

## Test plan
- [ ] Trigger MCP 403 (e.g., via non-localhost access without token)
- [ ] Verify error toast appears with "재연결" button
- [ ] Click "재연결" and verify MCP tools work again
- [ ] Verify toast only appears once (no spam)

Closes #4515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
