### PR TITLE
refactor(dashboard): use downshift for tool editor combobox

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,20 +9,30 @@
       "version": "1.0.0",
       "dependencies": {
         "@preact/signals": "^2.0.2",
+        "dompurify": "^3.3.3",
+        "downshift": "^9.3.2",
         "htm": "^3.1.1",
+        "marked": "^17.0.5",
         "mermaid": "^11.12.0",
-        "preact": "^10.25.4"
+        "preact": "^10.25.4",
+        "vis-data": "^8.0.3",
+        "vis-network": "^10.0.2",
+        "vis-timeline": "^8.5.0"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.9.3",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
+        "@types/hammerjs": "^2.0.46",
         "happy-dom": "^20.8.9",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.7.3",
         "vite": "^6.1.0",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -316,7 +326,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -414,6 +423,19 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
       "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -2067,6 +2089,12 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -2542,6 +2570,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -2600,6 +2644,13 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cytoscape": {
       "version": "3.33.1",
@@ -3299,6 +3350,28 @@
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
+    },
+    "node_modules/downshift": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.2.tgz",
+      "integrity": "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4043,7 +4116,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -4096,6 +4168,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true
     },
     "node_modules/khroma": {
       "version": "2.1.0",
@@ -4399,6 +4478,18 @@
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4430,9 +4521,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -4480,6 +4571,18 @@
         "uuid": "^11.1.0"
       }
     },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -4500,6 +4603,16 @@
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -4557,6 +4670,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4771,6 +4893,43 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/propagating-hammerjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-3.0.0.tgz",
+      "integrity": "sha512-FJTclGll0ysatpF9rKO4jwobyaVDitPb0g/bGlufqqtXPQX8mxf8IXilnIK2iYRMPkVlYeFNhPTrspF9CM1stg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.17"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -5208,6 +5367,12 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5277,6 +5442,77 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.3.tgz",
+      "integrity": "sha512-jhnb6rJNqkKR1Qmlay0VuDXY9ZlvAnYN1udsrP4U+krgZEq7C0yNSKdZqmnCe13mdnf9AdVcdDGFOzy2mpPoqw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-network": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.2.tgz",
+      "integrity": "sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-timeline": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-8.5.0.tgz",
+      "integrity": "sha512-u0+UUuk8qJTxf2SdQ0z0ckCjtks0ECRrjAipbmCZd6vEPf6USGXxeoi7ilRilTU8iVzVE3P0W5TLWzei5KuPfQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "moment": "^2.24.0",
+        "propagating-hammerjs": "^1.4.0 || ^2.0.0 || ^3.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0",
+        "xss": "^1.0.0"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
+      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0"
       }
     },
     "node_modules/vite": {
@@ -5612,6 +5848,30 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@preact/signals": "^2.0.2",
     "dompurify": "^3.3.3",
+    "downshift": "^9.3.2",
     "htm": "^3.1.1",
     "marked": "^17.0.5",
     "mermaid": "^11.12.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
+      downshift:
+        specifier: ^9.3.2
+        version: 9.3.2(react@19.2.4)
       htm:
         specifier: ^3.1.1
         version: 3.1.1
@@ -925,6 +928,9 @@ packages:
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
+  compute-scroll-into-view@3.1.1:
+    resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1158,6 +1164,11 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  downshift@9.3.2:
+    resolution: {integrity: sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==}
+    peerDependencies:
+      react: '>=16.12.0'
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1494,6 +1505,10 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1547,6 +1562,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1611,13 +1630,26 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   propagating-hammerjs@3.0.0:
     resolution: {integrity: sha512-FJTclGll0ysatpF9rKO4jwobyaVDitPb0g/bGlufqqtXPQX8mxf8IXilnIK2iYRMPkVlYeFNhPTrspF9CM1stg==}
     peerDependencies:
       '@egjs/hammerjs': ^2.0.17
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1740,6 +1772,9 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2721,6 +2756,8 @@ snapshots:
 
   component-emitter@1.3.1: {}
 
+  compute-scroll-into-view@3.1.1: {}
+
   confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
@@ -3001,6 +3038,15 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  downshift@9.3.2(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      compute-scroll-into-view: 3.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-is: 18.3.1
+      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3319,6 +3365,10 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3384,6 +3434,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-is@1.1.6:
@@ -3445,11 +3497,23 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   propagating-hammerjs@3.0.0(@egjs/hammerjs@2.0.17):
     dependencies:
       '@egjs/hammerjs': 2.0.17
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react@19.2.4: {}
 
   redent@3.0.0:
     dependencies:
@@ -3608,6 +3672,8 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   ts-dedent@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState, useMemo } from 'preact/hooks'
+import { useCombobox } from 'downshift'
 import { editKeeperTools, type ToolEditResponse } from '../../api/keeper'
 import { toolsData } from './tool-state'
 
@@ -14,11 +15,6 @@ const denyItems = signal<string[]>([])
 const saving = signal(false)
 const lastError = signal<string | null>(null)
 const lastSuccess = signal<string | null>(null)
-
-// Per-section search queries
-const alsoAllowQuery = signal('')
-const customAllowQuery = signal('')
-const denyQuery = signal('')
 
 // Bulk text input: which section is in text mode (null = none)
 const textInputSection = signal<'also_allow' | 'custom' | 'deny' | null>(null)
@@ -72,9 +68,6 @@ function resetEditorState(params: {
   saving.value = false
   lastError.value = null
   lastSuccess.value = null
-  alsoAllowQuery.value = ''
-  customAllowQuery.value = ''
-  denyQuery.value = ''
   textInputSection.value = null
   textInputBuffer.value = ''
 }
@@ -113,31 +106,61 @@ function ReadOnlyChip({ name }: { name: string }) {
   `
 }
 
-/** Search-based tool picker with autocomplete from tool inventory. */
+/** Search-based tool picker using downshift useCombobox for keyboard nav + ARIA. */
 function ToolSearchPicker({
   items,
-  querySig,
   onAdd,
   onRemove,
   placeholder,
   excludeItems,
 }: {
   items: string[]
-  querySig: typeof alsoAllowQuery
   onAdd: (name: string) => void
   onRemove: (name: string) => void
   placeholder: string
   excludeItems?: string[]
 }) {
-  const q = querySig.value.toLowerCase().trim()
-  const excluded = new Set([...items, ...(excludeItems ?? [])])
+  const [inputValue, setInputValue] = useState('')
+  const excluded = useMemo(() => new Set([...items, ...(excludeItems ?? [])]), [items, excludeItems])
   const descMap = inventoryDescMap.value
 
-  const suggestions = q.length > 0
-    ? inventoryNames.value
-        .filter(name => !excluded.has(name) && name.toLowerCase().includes(q))
-        .slice(0, 10)
-    : []
+  const filtered = useMemo(() => {
+    const q = inputValue.toLowerCase().trim()
+    if (q.length === 0) return []
+    return inventoryNames.value
+      .filter(name => !excluded.has(name) && name.toLowerCase().includes(q))
+      .slice(0, 15)
+  }, [inputValue, excluded])
+
+  const {
+    isOpen,
+    highlightedIndex,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+  } = useCombobox({
+    items: filtered,
+    inputValue,
+    itemToString: item => item ?? '',
+    onInputValueChange: ({ inputValue: v }) => setInputValue(v ?? ''),
+    onSelectedItemChange: ({ selectedItem }) => {
+      if (selectedItem) {
+        onAdd(selectedItem)
+        setInputValue('')
+      }
+    },
+    stateReducer: (_state, { type, changes }) => {
+      if (type === useCombobox.stateChangeTypes.InputKeyDownEnter) {
+        if (changes.selectedItem == null && inputValue.trim()) {
+          onAdd(inputValue.trim())
+          return { ...changes, inputValue: '', isOpen: false }
+        }
+      }
+      return changes
+    },
+  })
+
+  const showMenu = isOpen && (filtered.length > 0 || inputValue.trim().length > 1)
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -153,59 +176,42 @@ function ToolSearchPicker({
 
       <div class="relative">
         <input
-          type="text"
-          class="w-full px-3 py-1.5 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
-          placeholder=${placeholder}
-          value=${querySig.value}
-          onInput=${(e: Event) => { querySig.value = (e.target as HTMLInputElement).value }}
-          onKeyDown=${(e: KeyboardEvent) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              const val = querySig.value.trim()
-              const first = suggestions[0]
-              if (first) {
-                onAdd(first)
-              } else if (val) {
-                onAdd(val)
-              }
-              querySig.value = ''
-            } else if (e.key === 'Escape') {
-              querySig.value = ''
-              ;(e.target as HTMLInputElement).blur()
-            }
-          }}
+          ...${getInputProps({
+            placeholder,
+            class: 'w-full px-3 py-1.5 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]',
+          })}
         />
 
-        ${suggestions.length > 0
-          ? html`
-            <div class="absolute z-10 top-full left-0 right-0 mt-1 max-h-[180px] overflow-y-auto rounded-lg border border-[var(--card-border)] bg-[rgba(11,18,32,0.97)] shadow-lg backdrop-blur-sm">
-              ${suggestions.map((name, idx) => html`
-                <button type="button"
-                  class=${`w-full flex items-start gap-2 text-left px-3 py-1.5 cursor-pointer transition-colors ${
-                    idx === 0
-                      ? 'bg-[rgba(71,184,255,0.08)] hover:bg-[rgba(71,184,255,0.16)]'
-                      : 'hover:bg-[rgba(71,184,255,0.12)]'
-                  }`}
-                  onMouseDown=${(e: MouseEvent) => e.preventDefault()}
-                  onClick=${() => { onAdd(name); querySig.value = '' }}
-                >
-                  <span class="text-[11px] text-[var(--text-body)] font-medium shrink-0">${name}</span>
-                  ${descMap.has(name)
-                    ? html`<span class="text-[10px] text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
-                    : null}
-                </button>
-              `)}
-            </div>
-          `
-          : q.length > 1
-            ? html`
-              <div class="absolute z-10 top-full left-0 right-0 mt-1 px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[rgba(11,18,32,0.97)] text-[11px] text-[var(--text-muted)]">
-                ${inventoryNames.value.length === 0
-                  ? '도구 목록 로딩 중... Enter로 직접 추가 가능'
-                  : '일치하는 도구 없음. Enter로 직접 추가 가능'}
-              </div>
-            `
-            : null}
+        <ul ...${getMenuProps({
+          class: showMenu
+            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-[180px] overflow-y-auto rounded-lg border border-[var(--card-border)] bg-[rgba(11,18,32,0.97)] shadow-lg backdrop-blur-sm list-none m-0 p-0'
+            : 'hidden',
+        })}>
+          ${showMenu && filtered.length > 0
+            ? filtered.map((name, idx) => html`
+              <li
+                ...${getItemProps({ item: name, index: idx })}
+                class=${`w-full flex items-start gap-2 text-left px-3 py-1.5 cursor-pointer transition-colors ${
+                  highlightedIndex === idx
+                    ? 'bg-[rgba(71,184,255,0.16)] text-[#9ad9ff]'
+                    : 'hover:bg-[rgba(71,184,255,0.08)]'
+                }`}
+              >
+                <span class="text-[11px] text-[var(--text-body)] font-medium shrink-0">${name}</span>
+                ${descMap.has(name)
+                  ? html`<span class="text-[10px] text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
+                  : null}
+              </li>
+            `)
+            : showMenu && filtered.length === 0
+              ? html`
+                <li class="px-3 py-2 text-[11px] text-[var(--text-muted)]">
+                  ${inventoryNames.value.length === 0
+                    ? '도구 목록 로딩 중... Enter로 직접 추가 가능'
+                    : '일치하는 도구 없음. Enter로 직접 추가 가능'}
+                </li>`
+              : null}
+        </ul>
       </div>
     </div>
   `
@@ -396,7 +402,7 @@ export function ToolAllowlistEditor({
               : html`
                 <${ToolSearchPicker}
                   items=${alsoAllowItems.value}
-                  querySig=${alsoAllowQuery}
+
                   onAdd=${(name: string) => addToList(alsoAllowItems, name)}
                   onRemove=${(name: string) => removeFromList(alsoAllowItems, name)}
                   placeholder="추가 허용 도구 검색..."
@@ -439,7 +445,7 @@ export function ToolAllowlistEditor({
               : html`
                 <${ToolSearchPicker}
                   items=${customAllowItems.value}
-                  querySig=${customAllowQuery}
+
                   onAdd=${(name: string) => addToList(customAllowItems, name)}
                   onRemove=${(name: string) => removeFromList(customAllowItems, name)}
                   placeholder="허용 도구 검색..."
@@ -462,7 +468,6 @@ export function ToolAllowlistEditor({
           : html`
             <${ToolSearchPicker}
               items=${denyItems.value}
-              querySig=${denyQuery}
               onAdd=${(name: string) => addToList(denyItems, name)}
               onRemove=${(name: string) => removeFromList(denyItems, name)}
               placeholder="차단 도구 검색..."


### PR DESCRIPTION
## Summary

- 커스텀 autocomplete를 **downshift `useCombobox`** 로 교체
- Arrow up/down 키보드 네비게이션, WAI-ARIA combobox 속성 자동 적용
- `onMouseDown preventDefault` hack 제거 -> downshift 내장 focus 관리
- Enter로 커스텀 도구명 추가 (stateReducer로 구현)
- 번들 추가: downshift (~12KB gzipped)

## Motivation

이전 PR (#4509)에서 검색 기반 picker를 구현했으나, 키보드 네비게이션과 ARIA 접근성이 부족. downshift는 이 문제를 headless hook으로 해결하며 Preact compat으로 동작.

## Test plan

- [ ] 도구 검색 입력 후 Arrow down/up으로 항목 탐색 확인
- [ ] Enter로 하이라이트된 항목 선택 확인
- [ ] 검색 결과 없을 때 Enter로 직접 추가 확인
- [ ] Escape로 드롭다운 닫힘 확인
- [ ] 스크린리더로 ARIA 속성 동작 확인 (role=combobox, aria-expanded 등)
- [ ] 기존 기능 유지: chip 제거, 프리셋 설명, 빈 allowlist 경고, resolved list 복사

🤖 Generated with [Claude Code](https://claude.com/claude-code)