### PR TITLE
feat(keeper): 3-layer tool gate — core/policy/universe separation

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -341,6 +341,13 @@ let run_turn
            || name = "keeper_bash"
            || name = "keeper_write" then Some "filesystem"
       else if name = "keeper_github" then Some "vcs"
+      else if String.starts_with ~prefix:"masc_board_" name then Some "masc_board"
+      else if String.starts_with ~prefix:"masc_keeper_" name then Some "masc_keeper"
+      else if String.starts_with ~prefix:"masc_plan_" name then Some "masc_plan"
+      else if String.starts_with ~prefix:"masc_team_session_" name then Some "masc_session"
+      else if String.starts_with ~prefix:"masc_worktree_" name then Some "masc_worktree"
+      else if String.starts_with ~prefix:"masc_code_" name then Some "masc_code"
+      else if String.starts_with ~prefix:"masc_" name then Some "masc_core"
       else None
     in
     let kr_kw = match List.assoc_opt name korean_keywords with
@@ -350,21 +357,34 @@ let run_turn
     Agent_sdk.Tool_index.{ name; description = t.schema.description ^ kr_kw; group }
   ) keeper_tools in
   let tool_index = Agent_sdk.Tool_index.build ~config:tool_index_config tool_entries in
+  (* Layer 0: Core tools — always visible to the LLM regardless of preset.
+     Includes survival-critical masc_* tools so even Minimal keepers
+     can report status, broadcast, and extend turns. *)
   let always_include_tools =
-    [ "keeper_time_now"; "keeper_context_status";
-      "keeper_broadcast"; "keeper_task_claim"; "keeper_task_done";
-      "keeper_tasks_list"; "keeper_fs_read"; "keeper_shell_readonly";
-      "keeper_board_get"; "keeper_board_post";
-      "extend_turns" ]
+    Keeper_exec_tools.core_always_tools
+    @ [ "keeper_broadcast"; "keeper_task_claim"; "keeper_task_done";
+        "keeper_tasks_list"; "keeper_fs_read"; "keeper_shell_readonly";
+        "keeper_board_get"; "keeper_board_post" ]
+    |> Keeper_exec_tools.dedupe_tool_names
   in
-  (* All tool names including extend_turns (added separately from keeper_tools). *)
+  (* Layer 2: Universe — all tool names that the dispatch can handle.
+     keeper_tools is now built from the universe (not just policy), so
+     this includes all candidate tools minus denied.  BM25 retrieval
+     and Tool_op.Add operate within this scope. *)
   let all_tool_names =
     "extend_turns"
     :: List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) keeper_tools
   in
+  (* Layer 1: Policy fallback — when BM25 confidence is low, fall back
+     to the preset/custom-allowed set (not the full universe).
+     This prevents overwhelming the LLM with 80+ tools on every turn. *)
+  let policy_allowed =
+    Keeper_exec_tools.keeper_allowed_tool_names !meta_ref
+  in
   let fallback_tools =
     List.filter (fun name ->
       not (List.mem name always_include_tools)
+      && List.mem name policy_allowed
     ) all_tool_names
   in
   let confidence_threshold = 0.5 in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -291,9 +291,13 @@ let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
   Hashtbl.mem lookup.candidate_set name
   && not (Hashtbl.mem lookup.deny_set name)
 
-(** Execution gate: core tools bypass policy, others require policy allowlist. *)
+(** Execution gate: core tools bypass policy, others require policy allowlist.
+    All tools must exist in candidate_set — rejects hallucinated tool names. *)
 let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
-  if is_core_always_tool name then
+  if not (Hashtbl.mem lookup.candidate_set name
+          || is_core_always_tool name) then
+    false
+  else if is_core_always_tool name then
     filter_by_universe ~lookup name
   else
     filter_by_access ~lookup name

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -157,6 +157,25 @@ let keeper_core_masc_tool_names =
     "masc_tool_help";
   ]
 
+(* ── Layer 0: Core tools (always executable, always visible) ───── *)
+
+(** Tools that bypass policy restrictions.  A keeper with Minimal
+    preset still needs masc_status/broadcast/heartbeat to function.
+    These are the survival-critical tools. *)
+let core_always_tools =
+  [ "keeper_time_now"; "keeper_context_status";
+    "masc_status"; "masc_broadcast"; "masc_heartbeat";
+    "masc_messages"; "masc_who"; "masc_tool_help";
+    "extend_turns" ]
+
+let core_always_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length core_always_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) core_always_tools;
+  tbl
+
+let is_core_always_tool (name : string) : bool =
+  Hashtbl.mem core_always_set name
+
 let keeper_coding_masc_tool_names =
   [
     "masc_code_search";
@@ -266,6 +285,19 @@ let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =
   && Hashtbl.mem lookup.allow_set name
   && not (Hashtbl.mem lookup.deny_set name)
 
+(** Universe check: candidate minus denied, ignoring policy allowlist.
+    Core tools and BM25-discovered tools use this gate at execution time. *)
+let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
+  Hashtbl.mem lookup.candidate_set name
+  && not (Hashtbl.mem lookup.deny_set name)
+
+(** Execution gate: core tools bypass policy, others require policy allowlist. *)
+let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
+  if is_core_always_tool name then
+    filter_by_universe ~lookup name
+  else
+    filter_by_access ~lookup name
+
 let keeper_masc_tool_names (meta : keeper_meta) : string list =
   let lookup = tool_access_lookup_of_meta meta in
   !masc_schemas_ref
@@ -278,6 +310,16 @@ let keeper_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
   let lookup = tool_access_lookup_of_meta meta in
   !masc_schemas_ref
   |> List.filter (fun (schema : Types.tool_schema) -> filter_by_access ~lookup schema.name)
+
+(* ── Layer 2: Universe (all executable tools, policy-independent) ── *)
+
+(** Universe masc_* schemas: candidate minus denied, no policy filter.
+    Used by make_tools to build Tool.t for BM25 retrieval scope. *)
+let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
+  let lookup = tool_access_lookup_of_meta meta in
+  !masc_schemas_ref
+  |> List.filter (fun (schema : Types.tool_schema) ->
+    filter_by_universe ~lookup schema.name)
 
 let keeper_default_model_tools (_meta : keeper_meta) : Types.tool_schema list =
   keeper_model_tools @ keeper_voice_tool_schemas
@@ -292,6 +334,38 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     lookup.candidate_names
     |> List.filter (fun name -> filter_by_access ~lookup name)
     |> dedupe_tool_names
+
+(** Universe tool names: candidates minus denied, no policy filter.
+    Superset of keeper_allowed_tool_names.  BM25 indexes this set so
+    progressive disclosure can discover tools beyond the active preset.
+    Core tools are always included even if masc_schemas haven't been
+    injected yet (startup race) or the tool is not in any preset. *)
+let keeper_universe_tool_names (meta : keeper_meta) : string list =
+  let lookup = tool_access_lookup_of_meta meta in
+  let from_candidates =
+    lookup.candidate_names
+    |> List.filter (fun name -> filter_by_universe ~lookup name)
+  in
+  let from_core =
+    core_always_tools
+    |> List.filter (fun name -> not (Hashtbl.mem lookup.deny_set name))
+  in
+  dedupe_tool_names (from_candidates @ from_core)
+
+(** Universe model tool schemas for make_tools.
+    Returns schemas for all universe tools so Agent.run() can call them. *)
+let keeper_universe_model_tools (meta : keeper_meta) : Types.tool_schema list =
+  let universe = keeper_universe_tool_names meta in
+  let all_schemas =
+    (keeper_default_model_tools meta)
+    @ Tool_research.schemas
+    @ Tool_shard.autoresearch_keeper_tools
+    @ Tool_shard.coding_tools
+    @ Tool_code_write.schemas
+    @ (keeper_universe_masc_tool_schemas meta)
+  in
+  all_schemas
+  |> List.filter (fun tool -> List.mem tool.Types.name universe)
 
 (** Return keeper model tool schemas under the active preset/custom policy. *)
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
@@ -352,7 +426,7 @@ let execute_keeper_tool_call
   let args = input in
   let now_ts = Time_compat.now () in
   let lookup = tool_access_lookup_of_meta meta in
-  if not (filter_by_access ~lookup name) then
+  if not (can_execute ~lookup name) then
     Yojson.Safe.to_string
       (`Assoc [ ("error", `String "tool_not_allowed");
                 ("tool", `String name) ])

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -7,6 +7,25 @@ val keeper_allowed_tool_names : ?write_done:bool -> keeper_meta -> string list
 val keeper_allowed_model_tools :
   ?write_done:bool -> keeper_meta -> Types.tool_schema list
 
+(** Universe tool names: candidates minus denied, no policy filter.
+    Superset of [keeper_allowed_tool_names].  Used as the BM25 retrieval
+    scope so progressive disclosure can surface tools beyond the preset. *)
+val keeper_universe_tool_names : keeper_meta -> string list
+
+(** Universe model tool schemas.  Returns schemas for all universe tools
+    so [make_tools] can build Agent_sdk.Tool.t for the full search scope. *)
+val keeper_universe_model_tools : keeper_meta -> Types.tool_schema list
+
+(** Core tools that are always executable and visible regardless of preset.
+    E.g. masc_status, masc_broadcast, masc_heartbeat, extend_turns. *)
+val core_always_tools : string list
+
+(** [is_core_always_tool name] — true if [name] bypasses policy restrictions. *)
+val is_core_always_tool : string -> bool
+
+(** Deduplicate tool names, preserving order. *)
+val dedupe_tool_names : string list -> string list
+
 (** Inject all masc_* schemas for keeper allowlist/denylist filtering.
     Must be called once during server initialization.
     Keeper_denied tools are excluded at injection time. *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -151,9 +151,13 @@ let make_tools
     ~(ctx_ref : Keeper_types.working_context ref)
     ()
   : Agent_sdk.Tool.t list =
-  let allowed_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  (* Build Tool.t for the full universe so BM25 and Tool_op can
+     discover tools beyond the active preset.  Progressive disclosure
+     (AllowList filter in before_turn_hook) controls LLM visibility;
+     execute_keeper_tool_call uses can_execute for the execution gate. *)
+  let universe_names = Keeper_exec_tools.keeper_universe_tool_names meta in
   let tool_defs =
-    Keeper_exec_tools.keeper_allowed_model_tools meta
+    Keeper_exec_tools.keeper_universe_model_tools meta
   in
   let failure_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   (* No mutex: Hashtbl ops are non-yielding, single domain. *)
@@ -162,7 +166,7 @@ let make_tools
     Printf.sprintf "%s:%d" name h
   in
   List.filter_map (fun (td : Types.tool_schema) ->
-    if List.mem td.name allowed_names then
+    if List.mem td.name universe_names then
       Some (Tool_bridge.oas_tool_of_masc
         ~name:td.name
         ~description:td.description

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -464,6 +464,61 @@ let test_diff_in_policy_deny () =
   check (list string) "diff allow + deny" [ "a" ] resolved
 
 (* ================================================================ *)
+(* 3-Layer Tool Gate tests                                           *)
+(* ================================================================ *)
+
+let make_gate_test_meta ?(name = "test-gate") () : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+    (`Assoc [("name", `String name); ("agent_name", `String name);
+             ("trace_id", `String "test-trace-gate")]) with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_gate_test_meta failed: %s" e)
+
+let test_core_tools_are_core () =
+  let core = Keeper_exec_tools.core_always_tools in
+  check bool "masc_status is core" true
+    (List.mem "masc_status" core);
+  check bool "masc_broadcast is core" true
+    (List.mem "masc_broadcast" core);
+  check bool "masc_heartbeat is core" true
+    (List.mem "masc_heartbeat" core);
+  check bool "extend_turns is core" true
+    (List.mem "extend_turns" core);
+  check bool "is_core_always_tool masc_status" true
+    (Keeper_exec_tools.is_core_always_tool "masc_status");
+  check bool "non-core tool" false
+    (Keeper_exec_tools.is_core_always_tool "keeper_bash")
+
+let test_universe_superset_of_policy () =
+  let base = make_gate_test_meta () in
+  let meta = { base with
+    tool_access = Preset { preset = Minimal; also_allow = [] };
+    tool_denylist = [];
+  } in
+  let policy = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let universe = Keeper_exec_tools.keeper_universe_tool_names meta in
+  let missing =
+    List.filter (fun name -> not (List.mem name universe)) policy
+  in
+  check (list string) "all policy tools in universe" [] missing;
+  check bool "universe >= policy" true
+    (List.length universe >= List.length policy)
+
+let test_minimal_preset_includes_core_masc () =
+  let base = make_gate_test_meta ~name:"test-minimal" () in
+  let meta = { base with
+    tool_access = Preset { preset = Minimal; also_allow = [] };
+    tool_denylist = [];
+  } in
+  let universe = Keeper_exec_tools.keeper_universe_tool_names meta in
+  check bool "masc_status in universe" true
+    (List.mem "masc_status" universe);
+  check bool "masc_broadcast in universe" true
+    (List.mem "masc_broadcast" universe);
+  check bool "masc_heartbeat in universe" true
+    (List.mem "masc_heartbeat" universe)
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -590,5 +645,17 @@ let () =
             test_inter_then_diff;
           test_case "diff in policy deny" `Quick
             test_diff_in_policy_deny;
+        ] );
+      (* ======================================================== *)
+      (* 3-Layer Tool Gate: core / universe / policy               *)
+      (* ======================================================== *)
+      ( "tool_gate_3layer",
+        [
+          test_case "core tools are core" `Quick
+            test_core_tools_are_core;
+          test_case "universe superset of policy" `Quick
+            test_universe_superset_of_policy;
+          test_case "minimal preset includes core masc" `Quick
+            test_minimal_preset_includes_core_masc;
         ] );
     ]


### PR DESCRIPTION
## Summary

- **Root cause**: keeper tool outage when preset is Minimal or restrictive — `make_tools` only built `Tool.t` for policy-allowed tools, so BM25/Tool_op could never surface tools beyond the active preset
- **Fix**: 3-layer tool access architecture (Core/Policy/Universe) that guarantees survival-critical tools are always available while maintaining policy-based progressive disclosure
- **Layer 0 (Core)**: `masc_status`, `masc_broadcast`, `masc_heartbeat` etc. always executable and visible regardless of preset
- **Layer 2 (Universe)**: BM25 indexes and retrieves from full candidate set, not just policy-filtered subset

## Architecture

```
Layer 0: Core (always visible, always executable)
  bypass policy via can_execute()
Layer 1: Policy (preset/custom allowlist)
  controls default visibility + fallback set
Layer 2: Universe (candidates - denied)
  BM25 retrieval scope, Tool.t built for all
```

## Changed files
- `keeper_exec_tools.ml` — core_always_tools, universe functions, can_execute gate
- `keeper_exec_tools.mli` — expose new API
- `keeper_tools_oas.ml` — make_tools uses universe
- `keeper_agent_run.ml` — always_include from core, fallback from policy, BM25 masc_* groups
- `test_tool_access_policy.ml` — 3 new tests for layer invariants

## Test plan
- [x] Build passes (`dune build`)
- [x] test_tool_access_policy: 48/48 pass (3 new 3-layer tests)
- [x] test_tool_goals_coverage: 23/23 pass
- [x] test_contract_composer: 10/10 pass
- [ ] Full test suite (CI)
- [ ] Manual: start Minimal preset keeper, verify masc_status callable

Closes #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)