### PR TITLE
fix(keeper): prevent burst-then-dormancy on server start

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -304,6 +304,20 @@ let keeper_bootstrap_proactive_warmup_sec () : int =
     ~min_v:0
     ~max_v:172800
 
+let keeper_bootstrap_stagger_step_sec () : int =
+  int_of_env_default
+    "MASC_KEEPER_BOOTSTRAP_STAGGER_STEP_SEC"
+    ~default:15
+    ~min_v:0
+    ~max_v:120
+
+let keeper_proactive_min_cooldown_sec () : int =
+  int_of_env_default
+    "MASC_KEEPER_PROACTIVE_MIN_COOLDOWN_SEC"
+    ~default:300
+    ~min_v:60
+    ~max_v:1800
+
 let keeper_compaction_policy_from_env () : (float * int * int) =
   ( keeper_compact_ratio (),
     keeper_compact_max_messages (),

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -177,7 +177,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let timing_filled = ref 0 in
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Room.heartbeat_in_room success after turn. *)
-  let last_successful_heartbeat_ts = ref 0.0 in
+  let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
   let work_as_hb () =
     Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
   let max_silence () =
@@ -444,32 +444,40 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               last_snapshot_ts := now_ts);
             let t_snapshot_end = Time_compat.now () in
             let t_board_start = t_snapshot_end in
-            let pending_board_events, meta_after_triage =
-              let pending_board_events =
-                (try
-                   let events, _new_count, _mention_count =
-                     Keeper_world_observation.collect_board_events
-                       ~base_path:ctx.config.base_path
-                       ~meta:meta_current
-                       ~continuity_summary:meta_current.continuity_summary
-                   in
-                   events
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                     Log.Keeper.warn "keepalive: board count query failed: %s"
-                       (Printexc.to_string exn);
-                     [])
-              in
-              (pending_board_events, meta_current)
-            in
-            let t_board_end = Time_compat.now () in
-            let t_turn_start = t_board_end in
+            (* Compute warmup state BEFORE board collection so cursor
+               is not advanced while keeper cannot act on events. *)
             let proactive_warmup_elapsed =
               proactive_warmup_sec <= 0
               || now_ts -. keepalive_started_ts
                  >= float_of_int proactive_warmup_sec
             in
+            let pending_board_events, meta_after_triage =
+              if not proactive_warmup_elapsed then
+                (* During warmup: skip board collection to preserve cursor.
+                   First post-warmup cycle will pick up the full bootstrap
+                   window (300s) of board events. *)
+                ([], meta_current)
+              else
+                let pending_board_events =
+                  (try
+                     let events, _new_count, _mention_count =
+                       Keeper_world_observation.collect_board_events
+                         ~base_path:ctx.config.base_path
+                         ~meta:meta_current
+                         ~continuity_summary:meta_current.continuity_summary
+                     in
+                     events
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                       Log.Keeper.warn "keepalive: board count query failed: %s"
+                         (Printexc.to_string exn);
+                       [])
+                in
+                (pending_board_events, meta_current)
+            in
+            let t_board_end = Time_compat.now () in
+            let t_turn_start = t_board_end in
             let meta_after_proactive =
               if proactive_warmup_elapsed then
                 (try

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -338,6 +338,22 @@ let observe ~(pending_board_events : pending_board_event list option)
     last_turn_budget = None;
   }
 
+(** Compute effective proactive cooldown with idle decay.
+    After extended idle (> base cooldown), halve the cooldown each
+    additional period, down to a configurable floor.  This prevents
+    permanent silence when no external events arrive. *)
+let effective_proactive_cooldown ~(base_cooldown : int) ~(since_last : int) : int =
+  let min_cooldown = Keeper_config.keeper_proactive_min_cooldown_sec () in
+  (* Floor must not exceed the base cooldown — otherwise decay would
+     paradoxically increase a short cooldown. *)
+  let floor = min min_cooldown base_cooldown in
+  if since_last <= base_cooldown then base_cooldown
+  else
+    let decay_periods = (since_last - base_cooldown) / (max 1 base_cooldown) in
+    let capped_periods = min decay_periods 4 in
+    let factor = 1.0 /. (Float.pow 2.0 (float_of_int capped_periods)) in
+    max floor (int_of_float (float_of_int base_cooldown *. factor))
+
 let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observation) =
   let has_external_event =
     observation.pending_mentions <> [] || observation.pending_board_events <> []
@@ -351,13 +367,18 @@ let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observati
     in
     if not meta.proactive.enabled then false
     else
-      let cooldown_elapsed = since_last_proactive >= meta.proactive.cooldown_sec in
+      let effective_cooldown =
+        effective_proactive_cooldown
+          ~base_cooldown:meta.proactive.cooldown_sec
+          ~since_last:since_last_proactive
+      in
+      let cooldown_elapsed = since_last_proactive >= effective_cooldown in
       let has_actionable_tasks =
         observation.unclaimed_task_count > 0 || observation.failed_task_count > 0
       in
       (* When actionable tasks sit in the backlog, use a shorter cooldown
          (1/3 of normal, floor 60s) so the keeper reacts faster to work.
-         Regular proactive turns still fire on the full cooldown. *)
-      let task_reactive_cooldown = max 60 (meta.proactive.cooldown_sec / 3) in
+         Regular proactive turns still fire on the effective cooldown. *)
+      let task_reactive_cooldown = max 60 (effective_cooldown / 3) in
       cooldown_elapsed
       || (has_actionable_tasks && since_last_proactive >= task_reactive_cooldown)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -97,5 +97,11 @@ val observe :
   meta:Keeper_types.keeper_meta ->
   world_observation
 
+(** Compute effective proactive cooldown with idle decay.
+    After extended idle (> base cooldown), halve the cooldown each
+    additional period, down to a configurable floor. *)
+val effective_proactive_cooldown :
+  base_cooldown:int -> since_last:int -> int
+
 val should_run_unified_turn :
   meta:Keeper_types.keeper_meta -> world_observation -> bool

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -208,14 +208,18 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     Log.Keeper.info "autoboot: %d keeper(s) to boot: [%s]"
       (List.length names) (String.concat ", " names);
     let booted = ref 0 in
-    List.iter (fun name ->
+    let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
+    let stagger_step = Keeper_config.keeper_bootstrap_stagger_step_sec () in
+    List.iteri (fun idx name ->
         try
           Log.Keeper.info "autoboot: loading meta for %s" name;
           match Keeper_runtime.ensure_keeper_meta config name with
           | Error e ->
             Log.Keeper.error "autoboot: failed to load meta for %s: %s" name e
           | Ok m ->
-            Log.Keeper.info "autoboot: calling start_keepalive for %s" name;
+            let warmup = base_warmup + (idx * stagger_step) in
+            Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
+              name warmup;
             let ctx : _ Keeper_types.context = {
               config;
               agent_name = m.agent_name;
@@ -224,7 +228,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
               proc_mgr = Some proc_mgr;
               net = state.net;
             } in
-            Keeper_keepalive.start_keepalive ~proactive_warmup_sec:60 ctx m;
+            Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m;
             incr booted;
             Log.Keeper.info "autoboot: started keepalive for %s" m.name
         with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -242,6 +242,58 @@ let test_scheduled_turn_respects_cooldown () =
   check bool "cooldown blocks scheduled turn" false
     (WO.should_run_unified_turn ~meta base_observation)
 
+let test_effective_cooldown_no_decay_within_base () =
+  (* Within the base cooldown period, no decay should apply. *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:900 in
+  check int "no decay within base" 1800 result
+
+let test_effective_cooldown_at_boundary () =
+  (* Exactly at the base cooldown, no decay yet. *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:1800 in
+  check int "no decay at boundary" 1800 result
+
+let test_effective_cooldown_first_decay () =
+  (* One full extra period: cooldown halved. *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:3600 in
+  check int "first decay halves cooldown" 900 result
+
+let test_effective_cooldown_second_decay () =
+  (* Two extra periods: cooldown quartered. *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:5400 in
+  check int "second decay quarters cooldown" 450 result
+
+let test_effective_cooldown_floor () =
+  (* Four+ extra periods: cooldown at floor (300s default). *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:10800 in
+  check int "decay floors at min_cooldown" 300 result
+
+let test_effective_cooldown_max_int () =
+  (* max_int (first proactive ever): should hit floor immediately. *)
+  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:max_int in
+  check int "max_int hits floor" 300 result
+
+let test_idle_decay_triggers_turn () =
+  (* After extended idle, decay should make cooldown_elapsed true
+     even when since_last_proactive < base cooldown_sec. *)
+  let meta =
+    { minimal_meta with
+      proactive =
+        { minimal_meta.proactive with
+          enabled = true;
+          cooldown_sec = 1800;
+        };
+      runtime =
+        { minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 4000.0;
+            };
+        };
+    }
+  in
+  check bool "idle decay triggers turn before base cooldown" true
+    (WO.should_run_unified_turn ~meta base_observation)
+
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
   check bool "contains name" true (String.length sys > 0);
@@ -862,6 +914,20 @@ let () =
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn respects cooldown" `Quick
             test_scheduled_turn_respects_cooldown;
+          test_case "idle decay: no decay within base" `Quick
+            test_effective_cooldown_no_decay_within_base;
+          test_case "idle decay: at boundary" `Quick
+            test_effective_cooldown_at_boundary;
+          test_case "idle decay: first decay" `Quick
+            test_effective_cooldown_first_decay;
+          test_case "idle decay: second decay" `Quick
+            test_effective_cooldown_second_decay;
+          test_case "idle decay: floor" `Quick
+            test_effective_cooldown_floor;
+          test_case "idle decay: max_int" `Quick
+            test_effective_cooldown_max_int;
+          test_case "idle decay: triggers turn" `Quick
+            test_idle_decay_triggers_turn;
           test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );


### PR DESCRIPTION
## Summary

서버 시작 시 keeper들이 일제히 board write를 쏟아내고(burst), ~1시간 후 영구 침묵(dormancy)에 빠지는 현상 수정.

**Root cause**: 5개 요인의 상호작용
1. 동기화된 warmup 만료 (모든 keeper가 동시에 60s warmup 종료)
2. Board signal cascade 증폭
3. 긴 proactive cooldown (1800s) 후 자기 강화 침묵
4. Warmup 중 board cursor 선행 진행
5. 외부 이벤트 없으면 영구 dormancy

**Fixes**:
- Stagger warmup per-keeper (`base + idx * 15s`) to prevent synchronized burst
- Defer board cursor advancement during warmup so first post-warmup cycle sees full bootstrap window
- Idle-aware proactive cooldown decay: halves effective cooldown each idle period, floor 300s
- Initialize `last_successful_heartbeat_ts` to `now()` instead of `0.0`

New env vars (backwards-compatible):
- `MASC_KEEPER_BOOTSTRAP_STAGGER_STEP_SEC` (default: 15)
- `MASC_KEEPER_PROACTIVE_MIN_COOLDOWN_SEC` (default: 300)

## Test plan
- [x] `dune build` passes
- [x] All 7 new idle decay unit tests pass
- [x] Existing `scheduled turn uses cooldown` / `respects cooldown` tests pass
- [ ] Integration: `./start-mcp-server.sh` → verify staggered warmup in logs
- [ ] Integration: observe board activity pattern over 30+ minutes (no synchronized burst, periodic proactive turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)