### PR TITLE
refactor: absorb stopped into is_session_terminal, add formatting test

### DIFF
--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -552,8 +552,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
     detachment_rows
     |> List.filter (fun det ->
            let status = string_opt det "status" |> Option.value ~default:"active" in
-           not (Dashboard_utils.is_session_terminal status
-                || status = "stopped"))
+           not (Dashboard_utils.is_session_terminal status))
   in
   let swarm_workers = list_member swarm_json "workers" in
   let actual_worker_names =

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -125,7 +125,7 @@ let is_health_at_risk health =
   List.mem health [ "bad"; "risk"; "critical" ]
 
 let is_session_terminal status =
-  List.mem status [ "completed"; "cancelled"; "failed" ]
+  List.mem status [ "completed"; "cancelled"; "failed"; "stopped" ]
 
 let is_session_blocked status =
   List.mem status [ "failed"; "cancelled"; "interrupted" ]

--- a/test/test_post_verifier.ml
+++ b/test/test_post_verifier.ml
@@ -70,6 +70,14 @@ let test_quality_normal_tokens () =
   let result = Pv.verify ~content:"The quick brown fox jumps over the lazy dog." in
   check bool "diverse tokens pass quality" true (is_pass result.quality)
 
+let test_quality_formatting_chars_pass () =
+  (* Markdown separators and code fences should NOT trigger repetition detection.
+     Agents using structured output should not be penalized. *)
+  let result = Pv.verify ~content:"Section header\n========\nContent below the line." in
+  check bool "markdown separator passes quality" true (is_pass result.quality);
+  let result2 = Pv.verify ~content:"```ocaml\nlet x = 42\n```\nAbove is a code block." in
+  check bool "code fence passes quality" true (is_pass result2.quality)
+
 (* ================================================================ *)
 (* Dimension 3: Safety                                              *)
 (* ================================================================ *)
@@ -164,6 +172,7 @@ let () =
       test_case "5+ char repetition warns" `Quick test_quality_char_repetition_warn;
       test_case "repetitive tokens fail" `Quick test_quality_token_repetition;
       test_case "diverse tokens pass" `Quick test_quality_normal_tokens;
+      test_case "formatting chars pass" `Quick test_quality_formatting_chars_pass;
     ];
     "safety", [
       test_case "normal content passes" `Quick test_safety_pass;


### PR DESCRIPTION
## Summary

GLM 리뷰 피드백 반영 (#4508 후속):
- `"stopped"`를 `is_session_terminal` 술어에 추가 → `command_plane_orchestra.ml`의 별도 체크 제거
- markdown separator / code fence가 quality 검사를 통과하는지 확인하는 테스트 추가 (22 tests total)

## Context

#4508 merge 이후 GLM 리뷰에서 지적된 2건:
1. `"stopped"` 상태가 `is_session_terminal`에 포함되지 않아 별도 `|| status = "stopped"` 필요했음
2. formatting char exclusion 로직에 대한 테스트 부재

## Test plan

- [x] 로컬 post_verifier 22/22 pass
- [x] `dune build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)