### PR TITLE
refactor: type strictness + god file decomposition

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -432,6 +432,8 @@
    keeper_skill_routing
    keeper_alerting
    keeper_alerting_path
+   keeper_tool_registry
+   keeper_tool_policy
    keeper_exec_tools
    keeper_voice_local
    keeper_voice_loop
@@ -569,6 +571,8 @@
  tool_command_plane_dispatch
  tool_command_plane_schemas_01
  tool_command_plane_schemas_02
+  keeper_tool_registry
+  keeper_tool_policy
   keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/goal/goal_orchestrator.ml
+++ b/lib/goal/goal_orchestrator.ml
@@ -48,9 +48,9 @@ let filter_horizon horizon goals =
   List.filter (fun g -> g.Goal_store.horizon = horizon) goals
 
 let selected_children goals opts =
-  let short = filter_horizon "short" goals |> take opts.fanout_short in
-  let mid = filter_horizon "mid" goals |> take opts.fanout_mid in
-  let long = filter_horizon "long" goals |> take opts.fanout_long in
+  let short = filter_horizon Goal_store.Short goals |> take opts.fanout_short in
+  let mid = filter_horizon Goal_store.Mid goals |> take opts.fanout_mid in
+  let long = filter_horizon Goal_store.Long goals |> take opts.fanout_long in
   (short @ mid @ long) |> take opts.child_limit
 
 let build_plan ~goals opts =

--- a/lib/goal/goal_scheduler.ml
+++ b/lib/goal/goal_scheduler.ml
@@ -22,17 +22,15 @@ let read_state config =
 let write_state config state =
   Room.write_json config (state_path config) (scheduler_state_to_yojson state)
 
-let interval_sec = function
-  | "daily" -> 86_400.0
-  | "weekly" -> 86_400.0 *. 7.0
-  | "monthly" -> 86_400.0 *. 30.0
-  | _ -> 0.0
+let interval_sec : Goal_store.refresh_mode -> float = function
+  | Daily -> 86_400.0
+  | Weekly -> 86_400.0 *. 7.0
+  | Monthly -> 86_400.0 *. 30.0
 
-let last_run state = function
-  | "daily" -> state.last_daily
-  | "weekly" -> state.last_weekly
-  | "monthly" -> state.last_monthly
-  | _ -> None
+let last_run state : Goal_store.refresh_mode -> float option = function
+  | Daily -> state.last_daily
+  | Weekly -> state.last_weekly
+  | Monthly -> state.last_monthly
 
 let should_run_mode state ~mode ~now =
   let gap = interval_sec mode in
@@ -41,15 +39,16 @@ let should_run_mode state ~mode ~now =
   | Some ts -> now -. ts >= gap
 
 let mark_run state ~mode ~now =
-  match mode with
-  | "daily" -> { state with last_daily = Some now }
-  | "weekly" -> { state with last_weekly = Some now }
-  | "monthly" -> { state with last_monthly = Some now }
-  | _ -> state
+  match (mode : Goal_store.refresh_mode) with
+  | Daily -> { state with last_daily = Some now }
+  | Weekly -> { state with last_weekly = Some now }
+  | Monthly -> { state with last_monthly = Some now }
+
+let all_modes : Goal_store.refresh_mode list = [ Daily; Weekly; Monthly ]
 
 let due_modes config ~now =
   let state = read_state config in
-  [ "daily"; "weekly"; "monthly" ]
+  all_modes
   |> List.filter (fun mode -> should_run_mode state ~mode ~now)
 
 let commit_run config ~mode ~now =

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -1,12 +1,73 @@
+(* Variant types for domain values — Parse, Don't Validate.
+   Custom yojson serializers maintain backward-compatible JSON ("active", "short", etc.). *)
+
+type goal_status = Active | Paused | Done | Dropped
+
+let goal_status_to_yojson = function
+  | Active -> `String "active"
+  | Paused -> `String "paused"
+  | Done -> `String "done"
+  | Dropped -> `String "dropped"
+
+let goal_status_of_yojson = function
+  | `String "active" -> Ok Active
+  | `String "paused" -> Ok Paused
+  | `String "done" -> Ok Done
+  | `String "dropped" -> Ok Dropped
+  | j -> Error ("goal_status_of_yojson: " ^ Yojson.Safe.to_string j)
+
+type horizon = Short | Mid | Long
+
+let horizon_to_yojson = function
+  | Short -> `String "short"
+  | Mid -> `String "mid"
+  | Long -> `String "long"
+
+let horizon_of_yojson = function
+  | `String "short" -> Ok Short
+  | `String "mid" -> Ok Mid
+  | `String "long" -> Ok Long
+  | j -> Error ("horizon_of_yojson: " ^ Yojson.Safe.to_string j)
+
+type refresh_mode = Daily | Weekly | Monthly
+
+let refresh_mode_to_yojson = function
+  | Daily -> `String "daily"
+  | Weekly -> `String "weekly"
+  | Monthly -> `String "monthly"
+
+let refresh_mode_of_yojson = function
+  | `String "daily" -> Ok Daily
+  | `String "weekly" -> Ok Weekly
+  | `String "monthly" -> Ok Monthly
+  | j -> Error ("refresh_mode_of_yojson: " ^ Yojson.Safe.to_string j)
+
+type review_outcome = ReviewDone | ReviewProgress | ReviewBlocked | ReviewDropped
+
+let review_outcome_to_yojson = function
+  | ReviewDone -> `String "done"
+  | ReviewProgress -> `String "progress"
+  | ReviewBlocked -> `String "blocked"
+  | ReviewDropped -> `String "dropped"
+
+let review_outcome_of_yojson = function
+  | `String "done" -> Ok ReviewDone
+  | `String "progress" -> Ok ReviewProgress
+  | `String "blocked" -> Ok ReviewBlocked
+  | `String "dropped" -> Ok ReviewDropped
+  | j -> Error ("review_outcome_of_yojson: " ^ Yojson.Safe.to_string j)
+
+(* Record types *)
+
 type goal = {
   id : string;
-  horizon : string;
+  horizon : horizon;
   title : string;
   metric : string option;
   target_value : string option;
   due_date : string option;
   priority : int;
-  status : string;
+  status : goal_status;
   parent_goal_id : string option;
   last_review_note : string option;
   last_review_at : string option;
@@ -36,7 +97,7 @@ type rollup = {
 type snapshot = {
   snapshot_id : string;
   created_at : string;
-  mode : string;
+  mode : refresh_mode;
   goals : goal list;
   rollup : rollup;
 }
@@ -45,30 +106,51 @@ type snapshot = {
 type upsert_kind = [ `created | `updated ]
 
 type refresh_result = {
-  mode : string;
+  mode : refresh_mode;
   scanned : int;
   updated : int;
   snapshot_id : string;
 }
 [@@deriving yojson]
 
-let horizons = [ "short"; "mid"; "long" ]
-let statuses = [ "active"; "paused"; "done"; "dropped" ]
+(* Parsing: string -> variant at the boundary *)
 
 let normalize_lower s =
   String.trim s |> String.lowercase_ascii
 
-let normalize_horizon = function
-  | Some s ->
-      let v = normalize_lower s in
-      if List.mem v horizons then Some v else None
+let parse_horizon = function
+  | Some s -> (
+      match normalize_lower s with
+      | "short" -> Some Short
+      | "mid" -> Some Mid
+      | "long" -> Some Long
+      | _ -> None)
   | None -> None
 
-let normalize_status = function
-  | Some s ->
-      let v = normalize_lower s in
-      if List.mem v statuses then Some v else None
+let parse_goal_status = function
+  | Some s -> (
+      match normalize_lower s with
+      | "active" -> Some Active
+      | "paused" -> Some Paused
+      | "done" -> Some Done
+      | "dropped" -> Some Dropped
+      | _ -> None)
   | None -> None
+
+let parse_refresh_mode s =
+  match normalize_lower s with
+  | "daily" -> Some Daily
+  | "weekly" -> Some Weekly
+  | "monthly" -> Some Monthly
+  | _ -> None
+
+let parse_review_outcome s =
+  match normalize_lower s with
+  | "done" -> Some ReviewDone
+  | "progress" -> Some ReviewProgress
+  | "blocked" -> Some ReviewBlocked
+  | "dropped" -> Some ReviewDropped
+  | _ -> None
 
 let clamp_priority p = max 1 (min 5 p)
 
@@ -138,10 +220,9 @@ let delete_goal config ~goal_id =
 
 let sort_goals goals =
   let horizon_rank = function
-    | "short" -> 0
-    | "mid" -> 1
-    | "long" -> 2
-    | _ -> 3
+    | Short -> 0
+    | Mid -> 1
+    | Long -> 2
   in
   List.sort
     (fun a b ->
@@ -168,100 +249,88 @@ let list_goals config ?horizon ?status () =
 
 let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
     ?priority ?status ?parent_goal_id () =
-  let normalized_horizon = normalize_horizon horizon in
-  let normalized_status = normalize_status status in
   let is_new_goal = id = None in
-  match horizon with
-  | Some _ when normalized_horizon = None -> Error "invalid horizon (short|mid|long)"
-  | _ -> (
-      match status with
-      | Some _ when normalized_status = None ->
-          Error "invalid status (active|paused|done|dropped)"
-      | _ when is_new_goal && (title = None || title = Some "") ->
-          Error "title required for new goal"
-      | _ ->
-          let now = Types.now_iso () in
-          let resolved_id = Option.value id ~default:(gen_goal_id ()) in
-          let was_created = ref false in
-          let updated_goal =
-            update_state config (fun st ->
-                match find_goal st.goals resolved_id with
-                | Some existing ->
-                    let next_goal =
-                      {
-                        existing with
-                        horizon =
-                          Option.value normalized_horizon ~default:existing.horizon;
-                        title = Option.value title ~default:existing.title;
-                        metric = (match metric with Some _ -> metric | None -> existing.metric);
-                        target_value =
-                          (match target_value with
-                          | Some _ -> target_value
-                          | None -> existing.target_value);
-                        due_date =
-                          (match due_date with Some _ -> due_date | None -> existing.due_date);
-                        priority =
-                          clamp_priority
-                            (Option.value priority ~default:existing.priority);
-                        status = Option.value normalized_status ~default:existing.status;
-                        parent_goal_id =
-                          (match parent_goal_id with
-                          | Some _ -> parent_goal_id
-                          | None -> existing.parent_goal_id);
-                        updated_at = now;
-                      }
-                    in
-                    {
-                      version = st.version + 1;
-                      updated_at = now;
-                      goals = replace_goal st.goals next_goal;
-                    }
-                | None ->
-                    let horizon_value =
-                      Option.value normalized_horizon ~default:"short"
-                    in
-                    let title_value = Option.value title ~default:"Untitled goal" in
-                    let new_goal =
-                      {
-                        id = resolved_id;
-                        horizon = horizon_value;
-                        title = title_value;
-                        metric;
-                        target_value;
-                        due_date;
-                        priority =
-                          clamp_priority (Option.value priority ~default:3);
-                        status = Option.value normalized_status ~default:"active";
-                        parent_goal_id;
-                        last_review_note = None;
-                        last_review_at = None;
-                        created_at = now;
-                        updated_at = now;
-                      }
-                    in
-                    was_created := true;
-                    {
-                      version = st.version + 1;
-                      updated_at = now;
-                      goals = st.goals @ [ new_goal ];
-                    })
-          in
-          let saved = find_goal updated_goal.goals resolved_id in
-          match saved with
-          | Some g ->
-              Ok (g, if !was_created then `created else `updated)
-          | None -> Error "failed to save goal")
+  if is_new_goal && (title = None || title = Some "") then
+    Error "title required for new goal"
+  else
+    let now = Types.now_iso () in
+    let resolved_id = Option.value id ~default:(gen_goal_id ()) in
+    let was_created = ref false in
+    let updated_goal =
+      update_state config (fun st ->
+          match find_goal st.goals resolved_id with
+          | Some existing ->
+              let next_goal =
+                {
+                  existing with
+                  horizon =
+                    Option.value horizon ~default:existing.horizon;
+                  title = Option.value title ~default:existing.title;
+                  metric = (match metric with Some _ -> metric | None -> existing.metric);
+                  target_value =
+                    (match target_value with
+                    | Some _ -> target_value
+                    | None -> existing.target_value);
+                  due_date =
+                    (match due_date with Some _ -> due_date | None -> existing.due_date);
+                  priority =
+                    clamp_priority
+                      (Option.value priority ~default:existing.priority);
+                  status = Option.value status ~default:existing.status;
+                  parent_goal_id =
+                    (match parent_goal_id with
+                    | Some _ -> parent_goal_id
+                    | None -> existing.parent_goal_id);
+                  updated_at = now;
+                }
+              in
+              {
+                version = st.version + 1;
+                updated_at = now;
+                goals = replace_goal st.goals next_goal;
+              }
+          | None ->
+              let new_goal =
+                {
+                  id = resolved_id;
+                  horizon = Option.value horizon ~default:Short;
+                  title = Option.value title ~default:"Untitled goal";
+                  metric;
+                  target_value;
+                  due_date;
+                  priority =
+                    clamp_priority (Option.value priority ~default:3);
+                  status = Option.value status ~default:Active;
+                  parent_goal_id;
+                  last_review_note = None;
+                  last_review_at = None;
+                  created_at = now;
+                  updated_at = now;
+                }
+              in
+              was_created := true;
+              {
+                version = st.version + 1;
+                updated_at = now;
+                goals = st.goals @ [ new_goal ];
+              })
+    in
+    let saved = find_goal updated_goal.goals resolved_id in
+    match saved with
+    | Some g ->
+        Ok (g, if !was_created then `created else `updated)
+    | None -> Error "failed to save goal"
 
 let compute_rollup goals =
   let count p = List.length (List.filter p goals) in
   {
-    short_count = count (fun g -> g.horizon = "short");
-    mid_count = count (fun g -> g.horizon = "mid");
-    long_count = count (fun g -> g.horizon = "long");
-    active_count = count (fun g -> g.status = "active");
-    paused_count = count (fun g -> g.status = "paused");
-    done_count = count (fun g -> g.status = "done");
-    dropped_count = count (fun g -> g.status = "dropped");
+    short_count = count (fun g -> g.horizon = Short);
+    mid_count = count (fun g -> g.horizon = Mid);
+    long_count = count (fun g -> g.horizon = Long);
+    active_count = count (fun g -> g.status = Active);
+    paused_count = count (fun g -> g.status = Paused);
+    done_count = count (fun g -> g.status = Done);
+    dropped_count = count (fun g -> g.status = Dropped);
   }
 
 let snapshot config ~mode =
@@ -319,18 +388,17 @@ let days_until due_date =
 
 let should_refresh_goal mode goal =
   match mode with
-  | "daily" -> goal.horizon = "short" && goal.status = "active"
-  | "weekly" -> goal.horizon = "mid" && goal.status = "active"
-  | "monthly" -> goal.horizon = "long" && goal.status = "active"
-  | _ -> false
+  | Daily -> goal.horizon = Short && goal.status = Active
+  | Weekly -> goal.horizon = Mid && goal.status = Active
+  | Monthly -> goal.horizon = Long && goal.status = Active
 
 let reprioritize mode goal =
   let next_priority =
     match days_until goal.due_date with
     | Some d when d < 0 -> 1
-    | Some d when mode = "daily" && d <= 3 -> max 1 (goal.priority - 1)
-    | Some d when mode = "weekly" && d <= 14 -> max 1 (goal.priority - 1)
-    | Some d when mode = "monthly" && d <= 45 -> max 1 (goal.priority - 1)
+    | Some d when mode = Daily && d <= 3 -> max 1 (goal.priority - 1)
+    | Some d when mode = Weekly && d <= 14 -> max 1 (goal.priority - 1)
+    | Some d when mode = Monthly && d <= 45 -> max 1 (goal.priority - 1)
     | _ -> goal.priority
   in
   if next_priority = goal.priority then
@@ -339,75 +407,64 @@ let reprioritize mode goal =
     ({ goal with priority = next_priority; updated_at = Types.now_iso () }, true)
 
 let refresh config ~mode =
-  let mode = normalize_lower mode in
-  if not (List.mem mode [ "daily"; "weekly"; "monthly" ]) then
-    Error "mode must be daily|weekly|monthly"
-  else
-    let scanned = ref 0 in
-    let updated = ref 0 in
-    ignore
-      (update_state config (fun st ->
-           let goals =
-             List.map
-               (fun g ->
-                 if should_refresh_goal mode g then (
-                   incr scanned;
-                   let g', changed = reprioritize mode g in
-                   if changed then incr updated;
-                   g')
-                 else g)
-               st.goals
-           in
-           { version = st.version + 1; updated_at = Types.now_iso (); goals }));
-    let snap = snapshot config ~mode in
-    Ok { mode; scanned = !scanned; updated = !updated; snapshot_id = snap.snapshot_id }
+  let scanned = ref 0 in
+  let updated = ref 0 in
+  ignore
+    (update_state config (fun st ->
+         let goals =
+           List.map
+             (fun g ->
+               if should_refresh_goal mode g then (
+                 incr scanned;
+                 let g', changed = reprioritize mode g in
+                 if changed then incr updated;
+                 g')
+               else g)
+             st.goals
+         in
+         { version = st.version + 1; updated_at = Types.now_iso (); goals }));
+  let snap = snapshot config ~mode in
+  { mode; scanned = !scanned; updated = !updated; snapshot_id = snap.snapshot_id }
 
-let review_goal config ~goal_id ~outcome ?new_horizon ?note () =
-  let outcome = normalize_lower outcome in
-  let normalized_horizon = normalize_horizon new_horizon in
-  match new_horizon with
-  | Some _ when normalized_horizon = None ->
-      Error "invalid new_horizon (short|mid|long)"
-  | _ ->
-      let now = Types.now_iso () in
-      let found = ref false in
-      let st =
-        update_state config (fun state ->
-            let goals =
-              List.map
-                (fun g ->
-                  if g.id <> goal_id then g
-                  else (
-                    found := true;
-                    let status, priority =
-                      match outcome with
-                      | "done" -> ("done", g.priority)
-                      | "progress" -> ("active", max 1 (g.priority - 1))
-                      | "blocked" -> ("paused", min 5 (g.priority + 1))
-                      | "dropped" -> ("dropped", g.priority)
-                      | _ -> (g.status, g.priority)
-                    in
-                    {
-                      g with
-                      status;
-                      priority;
-                      horizon = Option.value normalized_horizon ~default:g.horizon;
-                      last_review_note = note;
-                      last_review_at = Some now;
-                      updated_at = now;
-                    }))
-                state.goals
-            in
-            { version = state.version + 1; updated_at = now; goals })
-      in
-      if not !found then Error "goal not found"
-      else
-        match find_goal st.goals goal_id with
-        | Some g -> Ok g
-        | None -> Error "goal not found after review"
+let review_goal config ~goal_id ~(outcome : review_outcome) ?new_horizon ?note () =
+  let now = Types.now_iso () in
+  let found = ref false in
+  let st =
+    update_state config (fun state ->
+        let goals =
+          List.map
+            (fun g ->
+              if g.id <> goal_id then g
+              else (
+                found := true;
+                let status, priority =
+                  match outcome with
+                  | ReviewDone -> (Done, g.priority)
+                  | ReviewProgress -> (Active, max 1 (g.priority - 1))
+                  | ReviewBlocked -> (Paused, min 5 (g.priority + 1))
+                  | ReviewDropped -> (Dropped, g.priority)
+                in
+                {
+                  g with
+                  status;
+                  priority;
+                  horizon = Option.value new_horizon ~default:g.horizon;
+                  last_review_note = note;
+                  last_review_at = Some now;
+                  updated_at = now;
+                }))
+            state.goals
+        in
+        { version = state.version + 1; updated_at = now; goals })
+  in
+  if not !found then Error "goal not found"
+  else
+    match find_goal st.goals goal_id with
+    | Some g -> Ok g
+    | None -> Error "goal not found after review"
 
 let active_goals config =
-  list_goals config ~status:"active" ()
+  list_goals config ~status:Active ()
 
 let has_scheduler_state config =
   Room.path_exists config (scheduler_state_path config)

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -42,6 +42,34 @@ let refresh_mode_of_yojson = function
   | `String "monthly" -> Ok Monthly
   | j -> Error ("refresh_mode_of_yojson: " ^ Yojson.Safe.to_string j)
 
+type snapshot_mode = SnapDaily | SnapWeekly | SnapMonthly | SnapManual
+
+let snapshot_mode_to_yojson = function
+  | SnapDaily -> `String "daily"
+  | SnapWeekly -> `String "weekly"
+  | SnapMonthly -> `String "monthly"
+  | SnapManual -> `String "manual"
+
+let snapshot_mode_of_yojson = function
+  | `String "daily" -> Ok SnapDaily
+  | `String "weekly" -> Ok SnapWeekly
+  | `String "monthly" -> Ok SnapMonthly
+  | `String "manual" -> Ok SnapManual
+  | j -> Error ("snapshot_mode_of_yojson: " ^ Yojson.Safe.to_string j)
+
+let snapshot_mode_of_refresh_mode = function
+  | Daily -> SnapDaily
+  | Weekly -> SnapWeekly
+  | Monthly -> SnapMonthly
+
+let parse_snapshot_mode s =
+  match String.trim s |> String.lowercase_ascii with
+  | "daily" -> Some SnapDaily
+  | "weekly" -> Some SnapWeekly
+  | "monthly" -> Some SnapMonthly
+  | "manual" -> Some SnapManual
+  | _ -> None
+
 type review_outcome = ReviewDone | ReviewProgress | ReviewBlocked | ReviewDropped
 
 let review_outcome_to_yojson = function
@@ -97,7 +125,7 @@ type rollup = {
 type snapshot = {
   snapshot_id : string;
   created_at : string;
-  mode : refresh_mode;
+  mode : snapshot_mode;
   goals : goal list;
   rollup : rollup;
 }
@@ -423,7 +451,7 @@ let refresh config ~mode =
              st.goals
          in
          { version = st.version + 1; updated_at = Types.now_iso (); goals }));
-  let snap = snapshot config ~mode in
+  let snap = snapshot config ~mode:(snapshot_mode_of_refresh_mode mode) in
   { mode; scanned = !scanned; updated = !updated; snapshot_id = snap.snapshot_id }
 
 let review_goal config ~goal_id ~(outcome : review_outcome) ?new_horizon ?note () =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -85,7 +85,7 @@ let execute_keeper_tool_call
   let args = input in
   let now_ts = Time_compat.now () in
   let lookup = tool_access_lookup_of_meta meta in
-  if not (filter_by_access ~lookup name) then
+  if not (can_execute ~lookup name) then
     Yojson.Safe.to_string
       (`Assoc [ ("error", `String "tool_not_allowed");
                 ("tool", `String name) ])

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -1,8 +1,18 @@
-(** Keeper_exec_tools — keeper tool execution and tool-loop helpers. *)
+(** Keeper_exec_tools — keeper tool execution and tool-loop helpers.
+
+    Split into three layers:
+    - [Keeper_tool_registry]: declarative tool name lists (data)
+    - [Keeper_tool_policy]: access control, presets, allowed-tool resolution (logic)
+    - This module: execution dispatch + shared helpers (side-effects) *)
 
 open Keeper_types
 open Keeper_memory
 open Keeper_alerting
+
+(* Re-export registry and policy so external callers keep using
+   [Keeper_exec_tools.foo] without changing import paths. *)
+include Keeper_tool_registry
+include Keeper_tool_policy
 
 (** Callback for recording keeper-internal tool calls.
     Set at server initialization to avoid Config dependency cycle.
@@ -41,363 +51,6 @@ let ensure_keeper_board_post_args ~author ~source = function
         @ fields)
   | other -> other
 
-let keeper_coordination_tool_names =
-  [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_task_done"; "keeper_broadcast" ]
-
-let keeper_board_tool_names =
-  [
-    "keeper_board_get";
-    "keeper_board_post";
-    "keeper_board_comment";
-    "keeper_board_vote";
-    "keeper_board_list";
-    "keeper_board_stats";
-    "keeper_board_search";
-    (* keeper_board_delete removed from default shard in #4309 *)
-  ]
-
-let keeper_voice_tool_names =
-  [ "keeper_voice_speak"; "keeper_voice_listen"; "keeper_voice_agent";
-    "keeper_voice_sessions";
-    "keeper_voice_session_start"; "keeper_voice_session_end" ]
-
-let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
-
-let keeper_governance_tool_names =
-  Tool_shard.governance_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_coding_shard_tool_names =
-  Tool_shard.coding_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_autoresearch_tool_names =
-  Tool_shard.autoresearch_keeper_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_research_loop_tool_names =
-  Tool_research.schemas
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_coding_tool_names = Tool_code_write.tool_names
-
-let keeper_internal_candidate_tool_names =
-  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-
-let keeper_voice_tool_schemas =
-  match Tool_shard.get_shard "voice" with
-  | Some shard -> shard.tools
-  | None -> []
-
-(** masc_* bridge for keepers.
-    All masc_* schemas are injected at server init and exposed to keepers
-    unconditionally. Execution dispatch (catch-all at bottom of
-    execute_keeper_tool_call) already handles any masc_* tool. *)
-
-let masc_schemas_ref : Types.tool_schema list ref = ref []
-
-(** Tool_catalog.Keeper_denied as a Hashtbl for O(1) lookup.
-    Tools in this set are denied at hook execution time (pre_tool_use Skip),
-    so they must also be excluded from the schema list sent to the LLM.
-    Otherwise the LLM sees tools it can never execute, wastes turns
-    selecting them, and appears to make poor tool choices. *)
-let keeper_denied_set : (string, unit) Hashtbl.t =
-  let tbl = Hashtbl.create 32 in
-  List.iter (fun name -> Hashtbl.replace tbl name ())
-    (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied);
-  tbl
-
-let is_keeper_denied (name : string) : bool =
-  Hashtbl.mem keeper_denied_set name
-
-let inject_masc_schemas (schemas : Types.tool_schema list) =
-  masc_schemas_ref :=
-    List.filter (fun (s : Types.tool_schema) ->
-      String.starts_with ~prefix:"masc_" s.name
-      && not (is_keeper_denied s.name))
-      schemas
-
-let dedupe_tool_names names =
-  dedupe_keep_order
-    (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
-
-let keeper_base_tool_names =
-  [ "keeper_time_now"; "keeper_context_status"; "keeper_memory_search" ]
-
-let keeper_filesystem_tool_names = [ "keeper_fs_read" ]
-let keeper_library_tool_names = [ "keeper_library_search"; "keeper_library_read" ]
-
-let injected_masc_tool_names () =
-  !masc_schemas_ref
-  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
-
-let select_existing_masc_tool_names names =
-  let injected = injected_masc_tool_names () in
-  names
-  |> List.filter (fun name -> List.mem name injected)
-  |> dedupe_tool_names
-
-let keeper_core_masc_tool_names =
-  [
-    "masc_status";
-    "masc_messages";
-    "masc_broadcast";
-    "masc_join";
-    "masc_leave";
-    "masc_who";
-    "masc_heartbeat";
-    "masc_tasks";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_add_task";
-    "masc_batch_add_tasks";
-    "masc_agents";
-    "masc_dashboard";
-    "masc_agent_card";
-    "masc_tool_help";
-  ]
-
-(* ── Layer 0: Core tools (always executable, always visible) ───── *)
-
-(** Tools that bypass policy restrictions.  A keeper with Minimal
-    preset still needs masc_status/broadcast/heartbeat to function.
-    These are the survival-critical tools. *)
-let core_always_tools =
-  [ "keeper_time_now"; "keeper_context_status";
-    "masc_status"; "masc_broadcast"; "masc_heartbeat";
-    "masc_messages"; "masc_who"; "masc_tool_help";
-    "extend_turns" ]
-
-let core_always_set : (string, unit) Hashtbl.t =
-  let tbl = Hashtbl.create (List.length core_always_tools) in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) core_always_tools;
-  tbl
-
-let is_core_always_tool (name : string) : bool =
-  Hashtbl.mem core_always_set name
-
-let keeper_coding_masc_tool_names =
-  [
-    "masc_code_search";
-    "masc_code_symbols";
-    "masc_code_read";
-    "masc_worktree_create";
-    "masc_worktree_remove";
-    "masc_worktree_list";
-  ]
-
-let keeper_all_candidate_tool_names () =
-  dedupe_tool_names
-    ( keeper_internal_candidate_tool_names
-    @ keeper_voice_tool_names
-    @ keeper_governance_tool_names
-    @ keeper_coding_shard_tool_names
-    @ keeper_coding_tool_names
-    @ keeper_autoresearch_tool_names
-    @ keeper_research_loop_tool_names
-    @ keeper_voice_tool_names
-    @ injected_masc_tool_names () )
-
-let preset_allowlist = function
-  | Minimal ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ select_existing_masc_tool_names [ "masc_status"; "masc_tool_help" ] )
-  | Messaging ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_board_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_voice_tool_names
-        @ keeper_governance_tool_names
-        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
-  | Coding ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_filesystem_tool_names
-        @ keeper_library_tool_names
-        @ keeper_shell_readonly_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_coding_shard_tool_names
-        @ keeper_coding_tool_names
-        @ select_existing_masc_tool_names
-            (keeper_core_masc_tool_names @ keeper_coding_masc_tool_names) )
-  | Research ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_filesystem_tool_names
-        @ keeper_library_tool_names
-        @ keeper_shell_readonly_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_board_tool_names
-        @ keeper_governance_tool_names
-        @ keeper_autoresearch_tool_names
-        @ keeper_research_loop_tool_names
-        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
-  | Full -> keeper_all_candidate_tool_names ()
-
-let tool_policy_of_meta (meta : keeper_meta) =
-  let allow =
-    match meta.tool_access with
-    | Preset { preset; also_allow } ->
-        Tool_access_policy.Names (preset_allowlist preset @ also_allow)
-    | Custom allowlist ->
-        Tool_access_policy.Names allowlist
-  in
-  {
-    Tool_access_policy.allow;
-    deny = Tool_access_policy.Names meta.tool_denylist;
-  }
-
-type tool_access_lookup = {
-  candidate_names : string list;
-  candidate_set : (string, unit) Hashtbl.t;
-  allow_set : (string, unit) Hashtbl.t;
-  deny_set : (string, unit) Hashtbl.t;
-}
-
-let tool_name_set names =
-  let tbl = Hashtbl.create (max 16 (List.length names)) in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
-  tbl
-
-let tool_access_lookup_of_meta (meta : keeper_meta) =
-  let candidate_names = keeper_all_candidate_tool_names () in
-  let candidate_set = tool_name_set candidate_names in
-  let allow_names =
-    Tool_access_policy.resolve
-      ~candidates:candidate_names
-      (tool_policy_of_meta meta)
-    |> List.filter (fun name -> Hashtbl.mem candidate_set name)
-    |> dedupe_tool_names
-  in
-  {
-    candidate_names;
-    candidate_set;
-    allow_set = tool_name_set allow_names;
-    deny_set = tool_name_set meta.tool_denylist;
-  }
-
-let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =
-  (* keeper_denied tools are already excluded from candidate_set via
-     inject_masc_schemas, so the is_keeper_denied check was redundant. *)
-  Hashtbl.mem lookup.candidate_set name
-  && Hashtbl.mem lookup.allow_set name
-  && not (Hashtbl.mem lookup.deny_set name)
-
-(** Universe check: candidate minus denied, ignoring policy allowlist.
-    Core tools and BM25-discovered tools use this gate at execution time. *)
-let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
-  Hashtbl.mem lookup.candidate_set name
-  && not (Hashtbl.mem lookup.deny_set name)
-
-(** Execution gate: core tools bypass policy, others require policy allowlist.
-    All tools must exist in candidate_set — rejects hallucinated tool names. *)
-let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
-  if not (Hashtbl.mem lookup.candidate_set name
-          || is_core_always_tool name) then
-    false
-  else if is_core_always_tool name then
-    filter_by_universe ~lookup name
-  else
-    filter_by_access ~lookup name
-
-let keeper_masc_tool_names (meta : keeper_meta) : string list =
-  let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
-  |> List.filter_map (fun (schema : Types.tool_schema) ->
-    if filter_by_access ~lookup schema.name
-    then Some schema.name
-    else None)
-
-let keeper_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
-  let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
-  |> List.filter (fun (schema : Types.tool_schema) -> filter_by_access ~lookup schema.name)
-
-(* ── Layer 2: Universe (all executable tools, policy-independent) ── *)
-
-(** Universe masc_* schemas: candidate minus denied, no policy filter.
-    Used by make_tools to build Tool.t for BM25 retrieval scope. *)
-let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
-  let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
-  |> List.filter (fun (schema : Types.tool_schema) ->
-    filter_by_universe ~lookup schema.name)
-
-let keeper_default_model_tools (_meta : keeper_meta) : Types.tool_schema list =
-  keeper_model_tools @ keeper_voice_tool_schemas
-
-(** Return keeper tool names under the active preset/custom policy. *)
-let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
-    string list =
-  if write_done then
-    []
-  else
-    let lookup = tool_access_lookup_of_meta meta in
-    lookup.candidate_names
-    |> List.filter (fun name -> filter_by_access ~lookup name)
-    |> dedupe_tool_names
-
-(** Universe tool names: candidates minus denied, no policy filter.
-    Superset of keeper_allowed_tool_names.  BM25 indexes this set so
-    progressive disclosure can discover tools beyond the active preset.
-    Core tools are always included even if masc_schemas haven't been
-    injected yet (startup race) or the tool is not in any preset. *)
-let keeper_universe_tool_names (meta : keeper_meta) : string list =
-  let lookup = tool_access_lookup_of_meta meta in
-  let from_candidates =
-    lookup.candidate_names
-    |> List.filter (fun name -> filter_by_universe ~lookup name)
-  in
-  let from_core =
-    core_always_tools
-    |> List.filter (fun name -> not (Hashtbl.mem lookup.deny_set name))
-  in
-  dedupe_tool_names (from_candidates @ from_core)
-
-(** Universe model tool schemas for make_tools.
-    Returns schemas for all universe tools so Agent.run() can call them. *)
-let keeper_universe_model_tools (meta : keeper_meta) : Types.tool_schema list =
-  let universe = keeper_universe_tool_names meta in
-  let all_schemas =
-    (keeper_default_model_tools meta)
-    @ Tool_research.schemas
-    @ Tool_shard.autoresearch_keeper_tools
-    @ Tool_shard.coding_tools
-    @ Tool_code_write.schemas
-    @ (keeper_universe_masc_tool_schemas meta)
-  in
-  all_schemas
-  |> List.filter (fun tool -> List.mem tool.Types.name universe)
-
-(** Return keeper model tool schemas under the active preset/custom policy. *)
-let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
-    Types.tool_schema list =
-  let allowed = keeper_allowed_tool_names ~write_done meta in
-  if allowed = [] then
-    []
-  else
-    let all_schemas =
-      (keeper_default_model_tools meta)
-      @ Tool_research.schemas
-      @ Tool_shard.autoresearch_keeper_tools
-      @ Tool_shard.coding_tools
-      @ Tool_code_write.schemas
-      @ (keeper_masc_tool_schemas meta)
-    in
-    let result =
-      all_schemas
-      |> List.filter (fun tool -> List.mem tool.Types.name allowed)
-    in
-    let count = List.length result in
-    if count > 100 then
-      Log.Keeper.warn
-        "tool budget exceeded: %d schemas in LLM context (~%dKB estimated). \
-         Consider using a narrower preset or custom allowlist."
-        count (count * 470 / 1024);
-    result
-
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in
   `Assoc
@@ -422,6 +75,8 @@ let lines_to_json ?(limit = max_int) (text : string) : Yojson.Safe.t =
   in
   `List (List.map (fun line -> `String line) lines)
 
+(* ── Tool execution dispatch ──────────────────────────────────── *)
+
 let execute_keeper_tool_call
     ~(config : Room.config)
     ~(meta : keeper_meta)
@@ -430,7 +85,7 @@ let execute_keeper_tool_call
   let args = input in
   let now_ts = Time_compat.now () in
   let lookup = tool_access_lookup_of_meta meta in
-  if not (can_execute ~lookup name) then
+  if not (filter_by_access ~lookup name) then
     Yojson.Safe.to_string
       (`Assoc [ ("error", `String "tool_not_allowed");
                 ("tool", `String name) ])
@@ -859,7 +514,6 @@ let execute_keeper_tool_call
                 ("error", `String err);
                 ("agent_id", `String meta.name) ]))
   | "keeper_voice_agent" ->
-      (* No net required — reads local voice config *)
       (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
       | Ok json -> Yojson.Safe.to_string json
       | Error err ->
@@ -869,7 +523,6 @@ let execute_keeper_tool_call
                 ("agent_id", `String meta.name);
                 ("message", `String err) ]))
   | "keeper_voice_sessions" ->
-      (* Local session manager — no net/MCP dependency *)
       let mgr = Keeper_voice_local.get_session_manager () in
       let sessions = Voice_session_manager.list_sessions mgr in
       Yojson.Safe.to_string
@@ -878,7 +531,6 @@ let execute_keeper_tool_call
             ("sessions",
               `List (List.map Voice_session_manager.session_to_json sessions)) ])
   | "keeper_voice_session_start" ->
-      (* Local session manager — no net/MCP dependency *)
       let voice =
         Safe_ops.json_string_opt "session_name" args
         |> Option.map String.trim
@@ -891,7 +543,6 @@ let execute_keeper_tool_call
       Yojson.Safe.to_string
         (Voice_session_manager.session_to_json session)
   | "keeper_voice_session_end" ->
-      (* Local session manager — no net/MCP dependency *)
       let mgr = Keeper_voice_local.get_session_manager () in
       let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
       Yojson.Safe.to_string
@@ -1023,8 +674,6 @@ let execute_keeper_tool_call
       let result = Room.claim_next config ~agent_name:meta.agent_name in
       Yojson.Safe.to_string (`Assoc [ ("result", `String result) ])
   | "keeper_task_done" ->
-      (* Uses force_done intentionally: keepers may close tasks from
-         agents who left the room. Regular agent completion uses masc_done. *)
       let task_id =
         Safe_ops.json_string ~default:"" "task_id" args |> String.trim
       in
@@ -1065,13 +714,10 @@ let execute_keeper_tool_call
             (`Assoc [ ("error", `String "unknown_autoresearch_tool");
                       ("tool", `String name) ]))
   | name when String.starts_with ~prefix:"masc_" name ->
-      (* Pre-dispatch path guard: if the tool args contain a path/file_path
-         key, validate it against effective_allowed_paths before dispatching. *)
       let effective_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
       let path_blocked =
         if effective_paths = [] && meta.execution_scope <> "observe_only" then None
         else if meta.execution_scope = "observe_only" && effective_paths = [] then
-          (* observe_only with no explicit paths: block write-capable tool args *)
           let has_path_arg =
             List.exists (fun key ->
               match Yojson.Safe.Util.member key args with

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -44,7 +44,6 @@ let keeper_all_candidate_tool_names () =
     @ keeper_coding_tool_names
     @ keeper_autoresearch_tool_names
     @ keeper_research_loop_tool_names
-    @ keeper_voice_tool_names
     @ injected_masc_tool_names () )
 
 (* ── Presets ──────────────────────────────────────────────────── *)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -1,0 +1,250 @@
+(** Keeper_tool_policy — tool access control, presets, and allowed-tool resolution.
+
+    Consumes [Keeper_tool_registry] for tool name lists.
+    Produces the access-policy types and functions used by the dispatch layer. *)
+
+open Keeper_types
+open Keeper_alerting
+open Keeper_tool_registry
+
+(* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
+
+let keeper_denied_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create 32 in
+  List.iter (fun name -> Hashtbl.replace tbl name ())
+    (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied);
+  tbl
+
+let is_keeper_denied (name : string) : bool =
+  Hashtbl.mem keeper_denied_set name
+
+(* ── Schema injection filter ──────────────────────────────────── *)
+
+let inject_masc_schemas (schemas : Types.tool_schema list) =
+  masc_schemas_ref :=
+    List.filter (fun (s : Types.tool_schema) ->
+      String.starts_with ~prefix:"masc_" s.name
+      && not (is_keeper_denied s.name))
+      schemas
+
+let select_existing_masc_tool_names names =
+  let injected = injected_masc_tool_names () in
+  names
+  |> List.filter (fun name -> List.mem name injected)
+  |> dedupe_tool_names
+
+(* ── Candidate aggregation ────────────────────────────────────── *)
+
+let keeper_all_candidate_tool_names () =
+  dedupe_tool_names
+    ( keeper_internal_candidate_tool_names
+    @ keeper_voice_tool_names
+    @ keeper_governance_tool_names
+    @ keeper_coding_shard_tool_names
+    @ keeper_coding_tool_names
+    @ keeper_autoresearch_tool_names
+    @ keeper_research_loop_tool_names
+    @ keeper_voice_tool_names
+    @ injected_masc_tool_names () )
+
+(* ── Presets ──────────────────────────────────────────────────── *)
+
+let preset_allowlist = function
+  | Minimal ->
+      dedupe_tool_names
+        ( keeper_base_tool_names
+        @ select_existing_masc_tool_names [ "masc_status"; "masc_tool_help" ] )
+  | Messaging ->
+      dedupe_tool_names
+        ( keeper_base_tool_names
+        @ keeper_board_tool_names
+        @ keeper_coordination_tool_names
+        @ keeper_voice_tool_names
+        @ keeper_governance_tool_names
+        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
+  | Coding ->
+      dedupe_tool_names
+        ( keeper_base_tool_names
+        @ keeper_filesystem_tool_names
+        @ keeper_library_tool_names
+        @ keeper_shell_readonly_tool_names
+        @ keeper_coordination_tool_names
+        @ keeper_coding_shard_tool_names
+        @ keeper_coding_tool_names
+        @ select_existing_masc_tool_names
+            (keeper_core_masc_tool_names @ keeper_coding_masc_tool_names) )
+  | Research ->
+      dedupe_tool_names
+        ( keeper_base_tool_names
+        @ keeper_filesystem_tool_names
+        @ keeper_library_tool_names
+        @ keeper_shell_readonly_tool_names
+        @ keeper_coordination_tool_names
+        @ keeper_board_tool_names
+        @ keeper_governance_tool_names
+        @ keeper_autoresearch_tool_names
+        @ keeper_research_loop_tool_names
+        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
+  | Full -> keeper_all_candidate_tool_names ()
+
+let tool_policy_of_meta (meta : keeper_meta) =
+  let allow =
+    match meta.tool_access with
+    | Preset { preset; also_allow } ->
+        Tool_access_policy.Names (preset_allowlist preset @ also_allow)
+    | Custom allowlist ->
+        Tool_access_policy.Names allowlist
+  in
+  {
+    Tool_access_policy.allow;
+    deny = Tool_access_policy.Names meta.tool_denylist;
+  }
+
+(* ── Access lookup (O(1) per tool) ────────────────────────────── *)
+
+type tool_access_lookup = {
+  candidate_names : string list;
+  candidate_set : (string, unit) Hashtbl.t;
+  allow_set : (string, unit) Hashtbl.t;
+  deny_set : (string, unit) Hashtbl.t;
+}
+
+let tool_name_set names =
+  let tbl = Hashtbl.create (max 16 (List.length names)) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
+  tbl
+
+let tool_access_lookup_of_meta (meta : keeper_meta) =
+  let candidate_names = keeper_all_candidate_tool_names () in
+  let candidate_set = tool_name_set candidate_names in
+  let allow_names =
+    Tool_access_policy.resolve
+      ~candidates:candidate_names
+      (tool_policy_of_meta meta)
+    |> List.filter (fun name -> Hashtbl.mem candidate_set name)
+    |> dedupe_tool_names
+  in
+  {
+    candidate_names;
+    candidate_set;
+    allow_set = tool_name_set allow_names;
+    deny_set = tool_name_set meta.tool_denylist;
+  }
+
+let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =
+  Hashtbl.mem lookup.candidate_set name
+  && Hashtbl.mem lookup.allow_set name
+  && not (Hashtbl.mem lookup.deny_set name)
+
+(** Universe check: candidate minus denied, ignoring policy allowlist.
+    Core tools and BM25-discovered tools use this gate at execution time. *)
+let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
+  Hashtbl.mem lookup.candidate_set name
+  && not (Hashtbl.mem lookup.deny_set name)
+
+(** Execution gate: core tools bypass policy, others require policy allowlist.
+    All tools must exist in candidate_set — rejects hallucinated tool names. *)
+let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
+  if not (Hashtbl.mem lookup.candidate_set name
+          || Keeper_tool_registry.is_core_always_tool name) then
+    false
+  else if Keeper_tool_registry.is_core_always_tool name then
+    filter_by_universe ~lookup name
+  else
+    filter_by_access ~lookup name
+
+(* ── Public query functions ───────────────────────────────────── *)
+
+let keeper_masc_tool_names (meta : keeper_meta) : string list =
+  let lookup = tool_access_lookup_of_meta meta in
+  !masc_schemas_ref
+  |> List.filter_map (fun (schema : Types.tool_schema) ->
+    if filter_by_access ~lookup schema.name
+    then Some schema.name
+    else None)
+
+let keeper_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
+  let lookup = tool_access_lookup_of_meta meta in
+  !masc_schemas_ref
+  |> List.filter (fun (schema : Types.tool_schema) -> filter_by_access ~lookup schema.name)
+
+(* ── Layer 2: Universe (all executable tools, policy-independent) ── *)
+
+(** Universe masc_* schemas: candidate minus denied, no policy filter.
+    Used by make_tools to build Tool.t for BM25 retrieval scope. *)
+let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Types.tool_schema list =
+  let lookup = tool_access_lookup_of_meta meta in
+  !masc_schemas_ref
+  |> List.filter (fun (schema : Types.tool_schema) ->
+    filter_by_universe ~lookup schema.name)
+
+let keeper_default_model_tools (_meta : keeper_meta) : Types.tool_schema list =
+  keeper_model_tools @ keeper_voice_tool_schemas
+
+let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
+    string list =
+  if write_done then
+    []
+  else
+    let lookup = tool_access_lookup_of_meta meta in
+    lookup.candidate_names
+    |> List.filter (fun name -> filter_by_access ~lookup name)
+    |> dedupe_tool_names
+
+(** Universe tool names: candidates minus denied, no policy filter.
+    Superset of keeper_allowed_tool_names.  BM25 indexes this set so
+    progressive disclosure can discover tools beyond the active preset.
+    Core tools are always included even if masc_schemas haven't been
+    injected yet (startup race) or the tool is not in any preset. *)
+let keeper_universe_tool_names (meta : keeper_meta) : string list =
+  let lookup = tool_access_lookup_of_meta meta in
+  let from_candidates =
+    lookup.candidate_names
+    |> List.filter (fun name -> filter_by_universe ~lookup name)
+  in
+  let from_core =
+    Keeper_tool_registry.core_always_tools
+    |> List.filter (fun name -> not (Hashtbl.mem lookup.deny_set name))
+  in
+  dedupe_tool_names (from_candidates @ from_core)
+
+let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
+    Types.tool_schema list =
+  let allowed = keeper_allowed_tool_names ~write_done meta in
+  if allowed = [] then
+    []
+  else
+    let all_schemas =
+      (keeper_default_model_tools meta)
+      @ Tool_research.schemas
+      @ Tool_shard.autoresearch_keeper_tools
+      @ Tool_shard.coding_tools
+      @ Tool_code_write.schemas
+      @ (keeper_masc_tool_schemas meta)
+    in
+    let result =
+      all_schemas
+      |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+    in
+    let count = List.length result in
+    if count > 100 then
+      Log.Keeper.warn
+        "tool budget exceeded: %d schemas in LLM context (~%dKB estimated). \
+         Consider using a narrower preset or custom allowlist."
+        count (count * 470 / 1024);
+    result
+
+(** Universe model tool schemas for make_tools.
+    Returns schemas for all universe tools so Agent.run() can call them. *)
+let keeper_universe_model_tools (meta : keeper_meta) : Types.tool_schema list =
+  let universe = keeper_universe_tool_names meta in
+  let all_schemas =
+    (keeper_default_model_tools meta)
+    @ Tool_research.schemas
+    @ Tool_shard.autoresearch_keeper_tools
+    @ Tool_shard.coding_tools
+    @ Tool_code_write.schemas
+    @ (keeper_universe_masc_tool_schemas meta)
+  in
+  all_schemas
+  |> List.filter (fun tool -> List.mem tool.Types.name universe)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -1,0 +1,123 @@
+(** Keeper_tool_registry — declarative tool name lists and schema injection.
+
+    This module is pure data: tool name constants grouped by family,
+    plus the mutable schema registry for dynamically injected masc_* tools.
+    No access-policy logic lives here; see [Keeper_tool_policy]. *)
+
+open Keeper_types
+
+let dedupe_tool_names names =
+  dedupe_keep_order
+    (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
+
+(* ── Static tool name lists ────────────────────────────────────── *)
+
+let keeper_coordination_tool_names =
+  [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_task_done"; "keeper_broadcast" ]
+
+let keeper_board_tool_names =
+  [
+    "keeper_board_get";
+    "keeper_board_post";
+    "keeper_board_comment";
+    "keeper_board_vote";
+    "keeper_board_list";
+    "keeper_board_stats";
+    "keeper_board_search";
+  ]
+
+let keeper_voice_tool_names =
+  [ "keeper_voice_speak"; "keeper_voice_listen"; "keeper_voice_agent";
+    "keeper_voice_sessions";
+    "keeper_voice_session_start"; "keeper_voice_session_end" ]
+
+let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
+
+let keeper_governance_tool_names =
+  Tool_shard.governance_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
+let keeper_coding_shard_tool_names =
+  Tool_shard.coding_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
+let keeper_autoresearch_tool_names =
+  Tool_shard.autoresearch_keeper_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
+let keeper_research_loop_tool_names =
+  Tool_research.schemas
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
+let keeper_coding_tool_names = Tool_code_write.tool_names
+
+let keeper_internal_candidate_tool_names =
+  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+
+let keeper_voice_tool_schemas =
+  match Tool_shard.get_shard "voice" with
+  | Some shard -> shard.tools
+  | None -> []
+
+let keeper_base_tool_names =
+  [ "keeper_time_now"; "keeper_context_status"; "keeper_memory_search" ]
+
+let keeper_filesystem_tool_names = [ "keeper_fs_read" ]
+let keeper_library_tool_names = [ "keeper_library_search"; "keeper_library_read" ]
+
+let keeper_core_masc_tool_names =
+  [
+    "masc_status";
+    "masc_messages";
+    "masc_broadcast";
+    "masc_join";
+    "masc_leave";
+    "masc_who";
+    "masc_heartbeat";
+    "masc_tasks";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_add_task";
+    "masc_batch_add_tasks";
+    "masc_agents";
+    "masc_dashboard";
+    "masc_agent_card";
+    "masc_tool_help";
+  ]
+
+let keeper_coding_masc_tool_names =
+  [
+    "masc_code_search";
+    "masc_code_symbols";
+    "masc_code_read";
+    "masc_worktree_create";
+    "masc_worktree_remove";
+    "masc_worktree_list";
+  ]
+
+(* ── Layer 0: Core tools (always executable, always visible) ───── *)
+
+(** Tools that bypass policy restrictions.  A keeper with Minimal
+    preset still needs masc_status/broadcast/heartbeat to function.
+    These are the survival-critical tools. *)
+let core_always_tools =
+  [ "keeper_time_now"; "keeper_context_status";
+    "masc_status"; "masc_broadcast"; "masc_heartbeat";
+    "masc_messages"; "masc_who"; "masc_tool_help";
+    "extend_turns" ]
+
+let core_always_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length core_always_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) core_always_tools;
+  tbl
+
+let is_core_always_tool (name : string) : bool =
+  Hashtbl.mem core_always_set name
+
+(* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
+
+let masc_schemas_ref : Types.tool_schema list ref = ref []
+
+let injected_masc_tool_names () =
+  !masc_schemas_ref
+  |> List.map (fun (schema : Types.tool_schema) -> schema.name)

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -632,8 +632,8 @@ let action_json ?actor_hint (ctx : _ context) args :
         target_type = request.target_type;
         target_id = request.target_id;
         delegated_tool;
-        confirmation_state = "preview";
-        result_status = "ok";
+        confirmation_state = Preview;
+        result_status = ActionOk;
         latency_ms = 0;
         created_at = Types.now_iso ();
       };
@@ -660,8 +660,8 @@ let action_json ?actor_hint (ctx : _ context) args :
         target_type = request.target_type;
         target_id = request.target_id;
         delegated_tool;
-        confirmation_state = "immediate";
-        result_status = "ok";
+        confirmation_state = Immediate;
+        result_status = ActionOk;
         latency_ms;
         created_at = Types.now_iso ();
       };
@@ -704,15 +704,15 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               target_type = entry.target_type;
               target_id = entry.target_id;
               delegated_tool = entry.delegated_tool;
-              confirmation_state = "expired";
-              result_status = "error";
+              confirmation_state = Expired;
+              result_status = ActionError;
               latency_ms = 0;
               created_at = Types.now_iso ();
             };
           Audit_log.log_governance_decision ctx.config
             ~agent_id:actor ~trace_id:entry.trace_id
             ~decision:"expired" ~action_type:entry.action_type
-            ~confirmation_state:"expired" ();
+            ~confirmation_state:(confirmation_state_to_string Expired) ();
           Error "pending confirmation expired"
       | Some entry when not (String.equal actor entry.actor) ->
           append_action_log ctx.config
@@ -725,15 +725,15 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               target_type = entry.target_type;
               target_id = entry.target_id;
               delegated_tool = entry.delegated_tool;
-              confirmation_state = "denied";
-              result_status = "error";
+              confirmation_state = Denied;
+              result_status = ActionError;
               latency_ms = 0;
               created_at = Types.now_iso ();
             };
           Audit_log.log_governance_decision ctx.config
             ~agent_id:actor ~trace_id:entry.trace_id
             ~decision:"unauthorized" ~action_type:entry.action_type
-            ~confirmation_state:"denied" ();
+            ~confirmation_state:(confirmation_state_to_string Denied) ();
           Error "actor is not allowed to confirm this action"
       | Some entry ->
           if String.equal decision "deny" then (
@@ -748,15 +748,15 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 target_type = entry.target_type;
                 target_id = entry.target_id;
                 delegated_tool = entry.delegated_tool;
-                confirmation_state = "denied";
-                result_status = "ok";
+                confirmation_state = Denied;
+                result_status = ActionOk;
                 latency_ms = 0;
                 created_at = Types.now_iso ();
               };
             Audit_log.log_governance_decision ctx.config
               ~agent_id:actor ~trace_id:entry.trace_id
               ~decision:"deny" ~action_type:entry.action_type
-              ~confirmation_state:"denied" ();
+              ~confirmation_state:(confirmation_state_to_string Denied) ();
             Ok
               (json_ok
                  [
@@ -788,15 +788,15 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 target_type = entry.target_type;
                 target_id = entry.target_id;
                 delegated_tool = entry.delegated_tool;
-                confirmation_state = "confirmed";
-                result_status = "ok";
+                confirmation_state = Confirmed;
+                result_status = ActionOk;
                 latency_ms;
                 created_at = Types.now_iso ();
               };
             Audit_log.log_governance_decision ctx.config
               ~agent_id:entry.actor ~trace_id:entry.trace_id
               ~decision:"confirm" ~action_type:entry.action_type
-              ~confirmation_state:"confirmed" ();
+              ~confirmation_state:(confirmation_state_to_string Confirmed) ();
             Ok
               (json_ok
                  [

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -13,6 +13,26 @@ let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
       if max_ctx = 0 then None
       else Some (float_of_int input_tokens /. float_of_int max_ctx)
 
+type action_result_status = ActionOk | ActionError
+
+let action_result_status_to_string = function
+  | ActionOk -> "ok"
+  | ActionError -> "error"
+
+type confirmation_state =
+  | Preview
+  | Immediate
+  | Expired
+  | Denied
+  | Confirmed
+
+let confirmation_state_to_string = function
+  | Preview -> "preview"
+  | Immediate -> "immediate"
+  | Expired -> "expired"
+  | Denied -> "denied"
+  | Confirmed -> "confirmed"
+
 type action_log_entry = {
   trace_id : string;
   actor : string;
@@ -22,8 +42,8 @@ type action_log_entry = {
   target_type : string;
   target_id : string option;
   delegated_tool : string;
-  confirmation_state : string;
-  result_status : string;
+  confirmation_state : confirmation_state;
+  result_status : action_result_status;
   latency_ms : int;
   created_at : string;
 }
@@ -76,8 +96,8 @@ let action_log_entry_to_yojson (entry : action_log_entry) =
       ("target_type", `String entry.target_type);
       ("target_id", string_option_to_json entry.target_id);
       ("delegated_tool", `String entry.delegated_tool);
-      ("confirmation_state", `String entry.confirmation_state);
-      ("result_status", `String entry.result_status);
+      ("confirmation_state", `String (confirmation_state_to_string entry.confirmation_state));
+      ("result_status", `String (action_result_status_to_string entry.result_status));
       ("latency_ms", `Int entry.latency_ms);
       ("created_at", `String entry.created_at);
     ]

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -153,7 +153,7 @@ let handle_keeper_tools_post state req reqd =
              Http.Response.json ~status:`Bad_request
                (Printf.sprintf {|{"error":"invalid json: %s"}|} (String.escaped e)) reqd))
 
-let add_routes ~sw ~clock router =
+let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
        (* POST /api/v1/broadcast - HTTP API for external tools like autocov *)
@@ -797,6 +797,14 @@ let add_routes ~sw ~clock router =
          ) request reqd
        end)
 
+  |> add_agent_api_routes
+  |> add_autoresearch_routes
+  |> add_repo_synthesis_routes
+
+(* ── Agent API routes ─────────────────────────────────────────── *)
+
+and add_agent_api_routes router =
+  router
   (* Agent activity — per-agent tool call stats from telemetry *)
   |> Http.Router.get "/api/v1/agent-activity" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -880,6 +888,10 @@ let add_routes ~sw ~clock router =
              (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+(* ── Autoresearch routes ───────────────────────────────────────── *)
+
+and add_autoresearch_routes router =
+  router
   (* Autoresearch loops list — all active + persisted loops *)
   |> Http.Router.get "/api/v1/autoresearch/loops" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -1025,6 +1037,10 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
 
+(* ── Repo synthesis routes ─────────────────────────────────────── *)
+
+and add_repo_synthesis_routes router =
+  router
   |> Http.Router.get "/api/v1/dashboard/repo-synthesis" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -202,34 +202,44 @@ let schemas : tool_schema list =
 
 let handle_goal_upsert ctx args =
   let id = get_string_opt args "id" in
-  let horizon = get_string_opt args "horizon" in
+  let horizon_raw = get_string_opt args "horizon" in
   let title = get_string_opt args "title" in
   let metric = get_string_opt args "metric" in
   let target_value = get_string_opt args "target_value" in
   let due_date = get_string_opt args "due_date" in
   let priority = get_int_opt args "priority" in
-  let status = get_string_opt args "status" in
+  let status_raw = get_string_opt args "status" in
   let parent_goal_id = get_string_opt args "parent_goal_id" in
-  match
-    Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric ?target_value
-      ?due_date ?priority ?status ?parent_goal_id ()
-  with
-  | Ok (goal, kind) ->
-      let kind_str = match kind with `created -> "created" | `updated -> "updated" in
-      ( true,
-        tool_result_json
-          [
-            ("result", `String kind_str);
-            ("goal", Goal_store.goal_to_yojson goal);
-          ] )
-  | Error msg -> (false, error_result_json msg)
+  let horizon = Goal_store.parse_horizon horizon_raw in
+  let status = Goal_store.parse_goal_status status_raw in
+  match horizon_raw with
+  | Some _ when horizon = None ->
+      (false, error_result_json "invalid horizon (short|mid|long)")
+  | _ -> (
+      match status_raw with
+      | Some _ when status = None ->
+          (false, error_result_json "invalid status (active|paused|done|dropped)")
+      | _ -> (
+          match
+            Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric ?target_value
+              ?due_date ?priority ?status ?parent_goal_id ()
+          with
+          | Ok (goal, kind) ->
+              let kind_str = match kind with `created -> "created" | `updated -> "updated" in
+              ( true,
+                tool_result_json
+                  [
+                    ("result", `String kind_str);
+                    ("goal", Goal_store.goal_to_yojson goal);
+                  ] )
+          | Error msg -> (false, error_result_json msg)))
 
 let validate_horizon_filter args =
   let raw = get_string_opt args "horizon" in
   match raw with
   | None -> Ok None
   | Some _ -> (
-      match Goal_store.normalize_horizon raw with
+      match Goal_store.parse_horizon raw with
       | Some v -> Ok (Some v)
       | None -> Error "invalid horizon filter")
 
@@ -238,7 +248,7 @@ let validate_status_filter args =
   match raw with
   | None -> Ok None
   | Some _ -> (
-      match Goal_store.normalize_status raw with
+      match Goal_store.parse_goal_status raw with
       | Some v -> Ok (Some v)
       | None -> Error "invalid status filter")
 
@@ -257,67 +267,65 @@ let handle_goal_list ctx args =
           ] )
 
 let handle_goal_snapshot ctx args =
-  let mode = get_string args "mode" "manual" in
-  let snap = Goal_store.snapshot ctx.config ~mode in
-  ( true,
-    tool_result_json
-      [
-        ("snapshot", Goal_store.snapshot_to_yojson snap);
-      ] )
+  let mode_raw = get_string args "mode" "daily" in
+  match Goal_store.parse_refresh_mode mode_raw with
+  | None -> (false, error_result_json "invalid mode (daily|weekly|monthly)")
+  | Some mode ->
+      let snap = Goal_store.snapshot ctx.config ~mode in
+      ( true,
+        tool_result_json
+          [
+            ("snapshot", Goal_store.snapshot_to_yojson snap);
+          ] )
 
 let refresh_one_mode ctx ~mode ~now =
-  match Goal_store.refresh ctx.config ~mode with
-  | Error e -> Error e
-  | Ok result ->
-      Goal_scheduler.commit_run ctx.config ~mode ~now;
-      Ok result
+  let result = Goal_store.refresh ctx.config ~mode in
+  Goal_scheduler.commit_run ctx.config ~mode ~now;
+  result
 
 let handle_goal_refresh ctx args =
-  let mode = get_string args "mode" "daily" |> String.lowercase_ascii in
+  let mode_raw = get_string args "mode" "daily" |> String.lowercase_ascii in
   let force = get_bool args "force" false in
   let now = Time_compat.now () in
-  let valid_mode = mode = "auto" || List.mem mode [ "daily"; "weekly"; "monthly" ] in
-  if not valid_mode then
+  let is_auto = mode_raw = "auto" in
+  let parsed_mode = Goal_store.parse_refresh_mode mode_raw in
+  if not is_auto && parsed_mode = None then
     (false, error_result_json "mode must be daily|weekly|monthly|auto")
   else
   let selected_modes =
-    if mode = "auto" then
-      if force then [ "daily"; "weekly"; "monthly" ]
+    if is_auto then
+      if force then Goal_scheduler.all_modes
       else Goal_scheduler.due_modes ctx.config ~now
     else
-      if force then [ mode ]
-      else
-        let due = Goal_scheduler.due_modes ctx.config ~now in
-        if List.mem mode due then [ mode ] else []
+      match parsed_mode with
+      | None -> []
+      | Some m ->
+          if force then [ m ]
+          else
+            let due = Goal_scheduler.due_modes ctx.config ~now in
+            if List.mem m due then [ m ] else []
   in
   if selected_modes = [] then
     ( true,
       tool_result_json
         [
-          ("mode", `String mode);
+          ("mode", `String mode_raw);
           ("skipped", `Bool true);
           ("message", `String "no cadence window due");
         ] )
   else
-    let rec collect acc = function
-      | [] -> Ok (List.rev acc)
-      | m :: rest -> (
-          match refresh_one_mode ctx ~mode:m ~now with
-          | Ok r -> collect (r :: acc) rest
-          | Error e -> Error (Printf.sprintf "[%s] %s" m e))
+    let results =
+      List.map (fun m -> refresh_one_mode ctx ~mode:m ~now) selected_modes
     in
-    match collect [] selected_modes with
-    | Error e -> (false, error_result_json e)
-    | Ok results ->
-        ( true,
-          tool_result_json
-            [
-              ("mode", `String mode);
-              ("skipped", `Bool false);
-              ( "results",
-                `List
-                  (List.map Goal_store.refresh_result_to_yojson results) );
-            ] )
+    ( true,
+      tool_result_json
+        [
+          ("mode", `String mode_raw);
+          ("skipped", `Bool false);
+          ( "results",
+            `List
+              (List.map Goal_store.refresh_result_to_yojson results) );
+        ] )
 
 let filter_goal_ids goals ids =
   if ids = [] then goals
@@ -616,20 +624,29 @@ let handle_goal_dispatch ctx args =
 
 let handle_goal_review ctx args =
   let goal_id = get_string args "goal_id" "" in
-  let outcome = get_string args "outcome" "" in
-  let new_horizon = get_string_opt args "new_horizon" in
+  let outcome_raw = get_string args "outcome" "" in
+  let new_horizon_raw = get_string_opt args "new_horizon" in
   let note = get_string_opt args "note" in
-  if goal_id = "" || outcome = "" then
+  if goal_id = "" || outcome_raw = "" then
     (false, error_result_json "goal_id and outcome are required")
   else
-    match Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon ?note () with
-    | Ok goal ->
-        ( true,
-          tool_result_json
-            [
-              ("goal", Goal_store.goal_to_yojson goal);
-            ] )
-    | Error msg -> (false, error_result_json msg)
+    match Goal_store.parse_review_outcome outcome_raw with
+    | None ->
+        (false, error_result_json "invalid outcome (done|progress|blocked|dropped)")
+    | Some outcome ->
+        let new_horizon = Goal_store.parse_horizon new_horizon_raw in
+        (match new_horizon_raw with
+         | Some _ when new_horizon = None ->
+             (false, error_result_json "invalid new_horizon (short|mid|long)")
+         | _ ->
+             match Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon ?note () with
+             | Ok goal ->
+                 ( true,
+                   tool_result_json
+                     [
+                       ("goal", Goal_store.goal_to_yojson goal);
+                     ] )
+             | Error msg -> (false, error_result_json msg))
 
 let dispatch ctx ~name ~args =
   match name with

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -267,9 +267,9 @@ let handle_goal_list ctx args =
           ] )
 
 let handle_goal_snapshot ctx args =
-  let mode_raw = get_string args "mode" "daily" in
-  match Goal_store.parse_refresh_mode mode_raw with
-  | None -> (false, error_result_json "invalid mode (daily|weekly|monthly)")
+  let mode_raw = get_string args "mode" "manual" in
+  match Goal_store.parse_snapshot_mode mode_raw with
+  | None -> (false, error_result_json "invalid mode (daily|weekly|monthly|manual)")
   | Some mode ->
       let snap = Goal_store.snapshot ctx.config ~mode in
       ( true,


### PR DESCRIPTION
## Summary

- **Variant types 도입**: string 기반 상태 비교를 variant type으로 전환하여 컴파일 타임 검증 강화
  - `goal_status` (Active|Paused|Done|Dropped), `horizon` (Short|Mid|Long), `refresh_mode` (Daily|Weekly|Monthly), `review_outcome` — goal_store.ml
  - `action_result_status` (ActionOk|ActionError), `confirmation_state` (Preview|Immediate|Expired|Denied|Confirmed) — operator_control_snapshot.ml
- **God file 분리**: keeper_exec_tools.ml(1044줄)을 3개 모듈로 분리
  - `keeper_tool_registry.ml` (104줄) — 도구 이름 목록 (선언적 데이터)
  - `keeper_tool_policy.ml` (191줄) — 접근 정책, 프리셋, 허용 도구 해석
  - `keeper_exec_tools.ml` (768줄) — dispatch + include 재export
- **라우트 구조화**: server_routes_http_routes_dashboard.ml의 913줄 add_routes를 4개 named sub-function으로 분해

## 변경 효과
- catch-all `_ ->` 5개 제거 (exhaustive pattern match 강제)
- JSON 직렬화 100% 호환 (custom `_to_yojson`/`_of_yojson`)
- 외부 caller 변경 0 (include 패턴으로 API 유지)
- 빌드 green

## Rebase 필요
- main과 keeper_exec_tools.ml에서 `core_always_tools` conflict 예상 — registry/policy에 통합 필요

## Test plan
- [x] `dune build` 통과
- [x] `dune test` exit 0
- [ ] rebase onto main 후 재빌드
- [ ] keeper tool access 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)