### PR TITLE
[codex] add team-session delegate readiness truth

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -5,7 +5,7 @@
 > Updated: 2026-04-02
 
 Execution companion for capsule-only coordination hardening:
-[docs/design/masc-capsule-execution-plan.md](docs/design/masc-capsule-execution-plan.md)
+[design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)
 
 ## Product Promise
 

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -4,6 +4,9 @@
 > Latest release: v2.215.0 (2026-04-02)
 > Updated: 2026-04-02
 
+Execution companion for capsule-only coordination hardening:
+[docs/design/masc-capsule-execution-plan.md](docs/design/masc-capsule-execution-plan.md)
+
 ## Product Promise
 
 `masc-mcp` is a repo-local MCP server for coordinating multiple coding agents inside one repository.

--- a/docs/design/masc-capsule-execution-plan.md
+++ b/docs/design/masc-capsule-execution-plan.md
@@ -1,0 +1,175 @@
+# MASC Capsule Execution Plan
+
+Updated: 2026-04-02
+Scope: `masc-mcp` only
+
+This document is the execution companion for work that stays inside the
+`masc-mcp` capsule.
+
+We are the middle layer between:
+
+- OAS, which provides agent-runtime primitives
+- agent clients such as Claude Code, Codex, and Gemini
+- the human operator who uses those agent clients
+- the current development session maintaining MASC itself
+
+The product only works if these layers can trust the same coordination truth.
+
+## Product Thesis
+
+`masc-mcp` is not just “an MCP server with many tools”.
+
+Inside this capsule, MASC should behave like a coordination operating system for
+persistent repo-local agent society:
+
+- agents join a shared room
+- agents claim work and leave observable ownership
+- agents can be orchestrated as a team session or swarm
+- operator and dashboard surfaces can inspect what happened
+- proof and report artifacts can reconstruct the collaboration after the fact
+
+OAS remains the agent runtime layer underneath that system.
+
+## Boundary Rules
+
+Keep these rules hard:
+
+1. OAS owns reusable execution primitives.
+2. MASC owns room, task, team-session, proof, operator, and governance semantics.
+3. If a bridge is lossy, fix the MASC adapter first.
+4. Only ask OAS for changes when the new shape is generic for non-MASC consumers.
+5. MCP truth, persisted truth, dashboard truth, and proof truth must agree.
+
+## What Stays In MASC
+
+- team-session planning and worker-role semantics
+- delegate readiness and routing policy
+- room/task lifecycle and social runtime invariants
+- proof/report contracts and evidence references
+- operator workflows, diagnosis bundles, intervention surfaces
+- dashboard read models and coordination-specific telemetry
+
+## What Can Move Upstream To OAS
+
+Only propose upstream work when it is clearly reusable:
+
+- richer generic swarm entry metadata
+- generic structured health-probe callbacks
+- reusable harness/result/verdict primitives
+
+Do not upstream:
+
+- MASC delivery-contract semantics
+- room/board/governance concepts
+- team-session proof/report JSON contracts
+
+## Execution Order
+
+### 1. Truth Spine
+
+Unify the truth exposed by:
+
+- MCP status tools
+- persisted `.masc/` artifacts
+- dashboard read models
+- operator snapshots
+
+If these disagree, the product is not trustworthy.
+
+### 2. Team Session Fidelity
+
+Make `team_session` the strongest advanced workflow in the product:
+
+- truthful delegate readiness
+- less-lossy worker/session projection
+- explicit runtime/model/tool visibility
+- strong failure reasons when orchestration blocks
+
+### 3. Proof and Evidence
+
+Every important team action should leave reconstructable evidence:
+
+- who acted
+- what runtime/model/tool surface was used
+- what was requested
+- why it succeeded or failed
+
+### 4. Operator Surfaces
+
+Operators should be able to diagnose a failing session without guessing:
+
+- blocked reasons
+- runtime-health truth
+- evidence availability
+- intervention safety
+
+### 5. Social Runtime Invariants
+
+Treat these as tested product contracts, not conventions:
+
+- no double-ownership confusion
+- no invisible in-flight workers
+- no delegate-to-broken-worker path
+- no proof/report state that contradicts runtime history
+
+## Immediate Slices
+
+### Slice A. Delegate-Readiness Contract
+
+Goal:
+
+- status surfaces tell the truth about which workers are actually safe to delegate to
+- delegate failures explain the blocked reason and guidance
+- denial leaves an event trail
+
+Primary modules:
+
+- `lib/team_session/team_session_engine_status.ml`
+- `lib/tool_team_session_step.ml`
+- `lib/tool_team_session_step_exec.ml`
+- `test/test_tool_team_session_step_routing.ml`
+- `test/test_tool_team_session_misc.ml`
+
+Done when:
+
+- checkpoint-only workers are not misreported as delegate-ready
+- in-flight workers are visibly blocked
+- delegate denial says why, not just “not ready”
+
+### Slice B. Worker-Proof Read Model
+
+Goal:
+
+- status, proof, and dashboard all surface the same worker-run evidence summary
+
+Primary modules:
+
+- `lib/team_session/team_session_report_proof.ml`
+- `lib/dashboard/dashboard_proof.ml`
+- `lib/team_session/team_session_store.ml`
+
+Done when:
+
+- worker proof metadata can be traced from session status to proof views
+- missing evidence is distinguishable from unavailable evidence
+
+### Slice C. Runtime / Model Visibility
+
+Goal:
+
+- operator can answer “which worker ran where, with what model, under what tool surface?”
+
+Primary modules:
+
+- `lib/team_session/team_session_oas_bridge.ml`
+- `lib/team_session/team_session_engine_status.ml`
+- `lib/tool_team_session_step_exec.ml`
+
+## Review Gate
+
+When a change touches the team-session or swarm contract, the review question is:
+
+“Did this make MASC more trustworthy as the coordination layer, or did it only
+make the runtime path work?”
+
+If the answer is only the latter, the change is incomplete.

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -153,6 +153,10 @@ let worker_delegate_guidance = function
       "Wait for the worker to finish its first run and write a checkpoint."
   | Some "broken_container" ->
       "Repair or respawn the worker; a checkpoint exists without worker metadata."
+  | Some "corrupt_meta" ->
+      "Repair or respawn the worker; worker metadata is present but unreadable."
+  | Some "corrupt_checkpoint" ->
+      "Repair or respawn the worker; worker checkpoint is present but unreadable."
   | Some "in_flight" ->
       "Wait for the active worker run to complete before delegating again."
   | Some "unplanned_worker" ->
@@ -212,6 +216,7 @@ let worker_container_actor_names config session_id =
 let build_worker_delegate_readiness_entry config ~snapshot
     (session : Team_session_types.session) worker_name
     (planned_worker : Team_session_types.planned_worker option) =
+  let team_session_id = Some session.session_id in
   let has_meta =
     Room_utils.path_exists config
       (Team_session_store.worker_container_meta_path config
@@ -229,6 +234,20 @@ let build_worker_delegate_readiness_entry config ~snapshot
             worker_name)
        <> []
   in
+  let meta_is_valid =
+    has_meta
+    &&
+    Option.is_some
+      (Worker_container.load_worker_meta ~base_path:config.base_path
+         ~team_session_id ~worker_name)
+  in
+  let checkpoint_is_valid =
+    has_checkpoint
+    &&
+    Option.is_some
+      (Worker_container.load_worker_checkpoint ~base_path:config.base_path
+         ~team_session_id ~worker_name)
+  in
   let in_flight = List.mem worker_name snapshot.in_flight_actors in
   let blocked_reason =
     if in_flight then Some "in_flight"
@@ -241,6 +260,8 @@ let build_worker_delegate_readiness_entry config ~snapshot
           | false, false -> Some "missing_container"
           | true, false -> Some "pending_checkpoint"
           | false, true -> Some "broken_container"
+          | true, true when not meta_is_valid -> Some "corrupt_meta"
+          | true, true when not checkpoint_is_valid -> Some "corrupt_checkpoint"
           | true, true -> None)
   in
   {

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -155,6 +155,8 @@ let worker_delegate_guidance = function
       "Repair or respawn the worker; a checkpoint exists without worker metadata."
   | Some "in_flight" ->
       "Wait for the active worker run to complete before delegating again."
+  | Some "unplanned_worker" ->
+      "Delegate only to workers that are still present in the current planned worker set."
   | Some _ -> "Worker is blocked for an unspecified reason."
   | None -> "Worker is ready for delegation."
 
@@ -192,55 +194,96 @@ let planned_worker_for_actor (session : Team_session_types.session) worker_name 
       | None -> false)
     session.planned_workers
 
+let worker_container_actor_names config session_id =
+  Team_session_store.workers_dir config session_id
+  |> Room_utils.list_dir config
+  |> List.filter (fun name ->
+         let trimmed = String.trim name in
+         trimmed <> "" && not (String.contains trimmed '/'))
+  |> Team_session_types.dedup_strings
+  |> List.sort String.compare
+
+let build_worker_delegate_readiness_entry config ~snapshot
+    (session : Team_session_types.session) worker_name
+    (planned_worker : Team_session_types.planned_worker option) =
+  let has_container_dir =
+    Room_utils.path_exists config
+      (Team_session_store.worker_container_dir config session.session_id
+         worker_name)
+  in
+  let has_meta =
+    Room_utils.path_exists config
+      (Team_session_store.worker_container_meta_path config
+         session.session_id worker_name)
+  in
+  let has_checkpoint =
+    Room_utils.path_exists config
+      (Team_session_store.worker_container_checkpoint_path config
+         session.session_id worker_name)
+  in
+  let in_flight = List.mem worker_name snapshot.in_flight_actors in
+  let blocked_reason =
+    if in_flight then Some "in_flight"
+    else
+      match planned_worker with
+      | None when has_container_dir -> Some "unplanned_worker"
+      | None -> Some "missing_container"
+      | Some _ -> (
+          match (has_meta, has_checkpoint) with
+          | false, false -> Some "missing_container"
+          | true, false -> Some "pending_checkpoint"
+          | false, true -> Some "broken_container"
+          | true, true -> None)
+  in
+  {
+    worker_name;
+    spawn_role = Option.bind planned_worker (fun worker -> worker.spawn_role);
+    execution_scope =
+      Option.bind planned_worker (fun worker ->
+          Option.map Team_session_types.execution_scope_to_string
+            worker.execution_scope);
+    runtime_pool =
+      Option.bind planned_worker (fun worker -> worker.runtime_pool);
+    routing_reason =
+      Option.bind planned_worker (fun worker -> worker.routing_reason);
+    has_meta;
+    has_checkpoint;
+    in_flight;
+    delegate_ready = Option.is_none blocked_reason;
+    blocked_reason;
+    guidance = worker_delegate_guidance blocked_reason;
+  }
+
 let worker_delegate_readiness_list ?events config
     (session : Team_session_types.session) =
   let snapshot = worker_run_event_snapshot ?events config session in
-  Team_session_types.planned_worker_actor_names session
+  let worker_names =
+    Team_session_types.planned_worker_actor_names session
+    @ worker_container_actor_names config session.session_id
+    |> Team_session_types.dedup_strings
+    |> List.sort String.compare
+  in
+  worker_names
   |> List.map (fun worker_name ->
-         let has_meta =
-           Room_utils.path_exists config
-             (Team_session_store.worker_container_meta_path config
-                session.session_id worker_name)
-         in
-         let has_checkpoint =
-           Room_utils.path_exists config
-             (Team_session_store.worker_container_checkpoint_path config
-                session.session_id worker_name)
-         in
-         let in_flight = List.mem worker_name snapshot.in_flight_actors in
-         let blocked_reason =
-           if in_flight then Some "in_flight"
-           else
-             match (has_meta, has_checkpoint) with
-             | false, false -> Some "missing_container"
-             | true, false -> Some "pending_checkpoint"
-             | false, true -> Some "broken_container"
-             | true, true -> None
-         in
          let planned_worker = planned_worker_for_actor session worker_name in
-         {
-           worker_name;
-           spawn_role = Option.bind planned_worker (fun worker -> worker.spawn_role);
-           execution_scope =
-             Option.bind planned_worker (fun worker ->
-                 Option.map Team_session_types.execution_scope_to_string
-                   worker.execution_scope);
-           runtime_pool =
-             Option.bind planned_worker (fun worker -> worker.runtime_pool);
-           routing_reason =
-             Option.bind planned_worker (fun worker -> worker.routing_reason);
-           has_meta;
-           has_checkpoint;
-           in_flight;
-           delegate_ready = Option.is_none blocked_reason;
-           blocked_reason;
-           guidance = worker_delegate_guidance blocked_reason;
-         })
+         build_worker_delegate_readiness_entry config ~snapshot session
+           worker_name planned_worker)
 
 let worker_delegate_readiness config (session : Team_session_types.session)
     worker_name =
-  worker_delegate_readiness_list config session
-  |> List.find_opt (fun entry -> String.equal entry.worker_name worker_name)
+  let snapshot = worker_run_event_snapshot config session in
+  let planned_worker = planned_worker_for_actor session worker_name in
+  let has_container_dir =
+    Room_utils.path_exists config
+      (Team_session_store.worker_container_dir config session.session_id
+         worker_name)
+  in
+  if Option.is_some planned_worker || has_container_dir then
+    Some
+      (build_worker_delegate_readiness_entry config ~snapshot session
+         worker_name planned_worker)
+  else
+    None
 
 let ready_worker_names config (session : Team_session_types.session) =
   Team_session_types.planned_worker_actor_names session

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -155,7 +155,8 @@ let worker_delegate_guidance = function
       "Repair or respawn the worker; a checkpoint exists without worker metadata."
   | Some "in_flight" ->
       "Wait for the active worker run to complete before delegating again."
-  | Some _ | None -> "Worker is ready for delegation."
+  | Some _ -> "Worker is blocked for an unspecified reason."
+  | None -> "Worker is ready for delegation."
 
 let worker_delegate_readiness_to_json (entry : worker_delegate_readiness) =
   `Assoc

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -194,23 +194,24 @@ let planned_worker_for_actor (session : Team_session_types.session) worker_name 
       | None -> false)
     session.planned_workers
 
+let worker_container_has_artifacts config session_id worker_name =
+  let worker_dir =
+    Team_session_store.worker_container_dir config session_id worker_name
+  in
+  Room_utils.path_exists config
+    (Team_session_store.worker_container_meta_path config session_id worker_name)
+  || Room_utils.path_exists config
+       (Team_session_store.worker_container_checkpoint_path config session_id
+          worker_name)
+  || Team_session_store.immediate_dir_entries config worker_dir <> []
+
 let worker_container_actor_names config session_id =
-  Team_session_store.workers_dir config session_id
-  |> Room_utils.list_dir config
-  |> List.filter (fun name ->
-         let trimmed = String.trim name in
-         trimmed <> "" && not (String.contains trimmed '/'))
-  |> Team_session_types.dedup_strings
-  |> List.sort String.compare
+  Team_session_store.immediate_dir_entries config
+    (Team_session_store.workers_dir config session_id)
 
 let build_worker_delegate_readiness_entry config ~snapshot
     (session : Team_session_types.session) worker_name
     (planned_worker : Team_session_types.planned_worker option) =
-  let has_container_dir =
-    Room_utils.path_exists config
-      (Team_session_store.worker_container_dir config session.session_id
-         worker_name)
-  in
   let has_meta =
     Room_utils.path_exists config
       (Team_session_store.worker_container_meta_path config
@@ -221,12 +222,19 @@ let build_worker_delegate_readiness_entry config ~snapshot
       (Team_session_store.worker_container_checkpoint_path config
          session.session_id worker_name)
   in
+  let has_container_artifacts =
+    has_meta || has_checkpoint
+    || Team_session_store.immediate_dir_entries config
+         (Team_session_store.worker_container_dir config session.session_id
+            worker_name)
+       <> []
+  in
   let in_flight = List.mem worker_name snapshot.in_flight_actors in
   let blocked_reason =
     if in_flight then Some "in_flight"
     else
       match planned_worker with
-      | None when has_container_dir -> Some "unplanned_worker"
+      | None when has_container_artifacts -> Some "unplanned_worker"
       | None -> Some "missing_container"
       | Some _ -> (
           match (has_meta, has_checkpoint) with
@@ -273,12 +281,9 @@ let worker_delegate_readiness config (session : Team_session_types.session)
     worker_name =
   let snapshot = worker_run_event_snapshot config session in
   let planned_worker = planned_worker_for_actor session worker_name in
-  let has_container_dir =
-    Room_utils.path_exists config
-      (Team_session_store.worker_container_dir config session.session_id
-         worker_name)
-  in
-  if Option.is_some planned_worker || has_container_dir then
+  if Option.is_some planned_worker
+     || worker_container_has_artifacts config session.session_id worker_name
+  then
     Some
       (build_worker_delegate_readiness_entry config ~snapshot session
          worker_name planned_worker)

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -132,6 +132,115 @@ let recent_worker_run_meta_jsons config session_id =
            Some (Room_utils.read_json config path)
          else None)
 
+type worker_delegate_readiness = {
+  worker_name : string;
+  spawn_role : string option;
+  execution_scope : string option;
+  runtime_pool : string option;
+  routing_reason : string option;
+  has_meta : bool;
+  has_checkpoint : bool;
+  in_flight : bool;
+  delegate_ready : bool;
+  blocked_reason : string option;
+  guidance : string;
+}
+
+let worker_delegate_guidance = function
+  | Some "missing_container" ->
+      "Spawn or rehydrate the worker before delegating."
+  | Some "pending_checkpoint" ->
+      "Wait for the worker to finish its first run and write a checkpoint."
+  | Some "broken_container" ->
+      "Repair or respawn the worker; a checkpoint exists without worker metadata."
+  | Some "in_flight" ->
+      "Wait for the active worker run to complete before delegating again."
+  | Some _ | None -> "Worker is ready for delegation."
+
+let worker_delegate_readiness_to_json (entry : worker_delegate_readiness) =
+  `Assoc
+    [
+      ("worker_name", `String entry.worker_name);
+      ( "spawn_role",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          entry.spawn_role );
+      ( "execution_scope",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          entry.execution_scope );
+      ( "runtime_pool",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          entry.runtime_pool );
+      ( "routing_reason",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          entry.routing_reason );
+      ("has_meta", `Bool entry.has_meta);
+      ("has_checkpoint", `Bool entry.has_checkpoint);
+      ("in_flight", `Bool entry.in_flight);
+      ("delegate_ready", `Bool entry.delegate_ready);
+      ( "blocked_reason",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          entry.blocked_reason );
+      ("guidance", `String entry.guidance);
+    ]
+
+let planned_worker_for_actor (session : Team_session_types.session) worker_name =
+  List.find_opt
+    (fun (worker : Team_session_types.planned_worker) ->
+      match worker.runtime_actor with
+      | Some actor -> String.equal (String.trim actor) worker_name
+      | None -> false)
+    session.planned_workers
+
+let worker_delegate_readiness_list ?events config
+    (session : Team_session_types.session) =
+  let snapshot = worker_run_event_snapshot ?events config session in
+  Team_session_types.planned_worker_actor_names session
+  |> List.map (fun worker_name ->
+         let has_meta =
+           Room_utils.path_exists config
+             (Team_session_store.worker_container_meta_path config
+                session.session_id worker_name)
+         in
+         let has_checkpoint =
+           Room_utils.path_exists config
+             (Team_session_store.worker_container_checkpoint_path config
+                session.session_id worker_name)
+         in
+         let in_flight = List.mem worker_name snapshot.in_flight_actors in
+         let blocked_reason =
+           if in_flight then Some "in_flight"
+           else
+             match (has_meta, has_checkpoint) with
+             | false, false -> Some "missing_container"
+             | true, false -> Some "pending_checkpoint"
+             | false, true -> Some "broken_container"
+             | true, true -> None
+         in
+         let planned_worker = planned_worker_for_actor session worker_name in
+         {
+           worker_name;
+           spawn_role = Option.bind planned_worker (fun worker -> worker.spawn_role);
+           execution_scope =
+             Option.bind planned_worker (fun worker ->
+                 Option.map Team_session_types.execution_scope_to_string
+                   worker.execution_scope);
+           runtime_pool =
+             Option.bind planned_worker (fun worker -> worker.runtime_pool);
+           routing_reason =
+             Option.bind planned_worker (fun worker -> worker.routing_reason);
+           has_meta;
+           has_checkpoint;
+           in_flight;
+           delegate_ready = Option.is_none blocked_reason;
+           blocked_reason;
+           guidance = worker_delegate_guidance blocked_reason;
+         })
+
+let worker_delegate_readiness config (session : Team_session_types.session)
+    worker_name =
+  worker_delegate_readiness_list config session
+  |> List.find_opt (fun entry -> String.equal entry.worker_name worker_name)
+
 let ready_worker_names config (session : Team_session_types.session) =
   Team_session_types.planned_worker_actor_names session
   |> List.filter (fun worker_name ->
@@ -209,6 +318,19 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
       |> List.rev
     in
     let ready_workers = ready_worker_names config session in
+    let worker_readiness =
+      worker_delegate_readiness_list ~events config session
+    in
+    let delegate_ready_workers =
+      worker_readiness
+      |> List.filter (fun entry -> entry.delegate_ready)
+      |> List.map (fun entry -> entry.worker_name)
+    in
+    let blocked_workers =
+      worker_readiness
+      |> List.filter (fun entry -> not entry.delegate_ready)
+      |> List.map (fun entry -> entry.worker_name)
+    in
     let pending_workers =
       pending_worker_names session ready_workers snapshot.in_flight_actors
     in
@@ -222,8 +344,16 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
         ("in_flight_actor_names", `List (List.map (fun id -> `String id) snapshot.in_flight_actors));
         ("ready_worker_count", `Int (List.length ready_workers));
         ("ready_worker_names", `List (List.map (fun name -> `String name) ready_workers));
+        ( "delegate_ready_worker_names",
+          `List
+            (List.map (fun name -> `String name) delegate_ready_workers) );
+        ( "blocked_worker_names",
+          `List (List.map (fun name -> `String name) blocked_workers) );
         ("pending_worker_count", `Int (List.length pending_workers));
         ("pending_worker_names", `List (List.map (fun name -> `String name) pending_workers));
+        ( "worker_readiness",
+          `List
+            (List.map worker_delegate_readiness_to_json worker_readiness) );
         ("recent_runs", `List recent_runs);
       ]
   in

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -341,6 +341,10 @@ let emit_activity_event config ~session_id ~(event_type : string)
         Some
           ( "team.delegate_requested",
             [ "team_session"; "team.delegate_requested" ] )
+    | "team_step_delegate_denied" ->
+        Some
+          ( "team.delegate_denied",
+            [ "team_session"; "team.delegate_denied" ] )
     | "team_run_deliverable" ->
         Some ("team.deliverable", [ "team_session"; "team.deliverable" ])
     | "swarm_iteration_start" ->

--- a/lib/tool_team_session_routing_workers.ml
+++ b/lib/tool_team_session_routing_workers.ml
@@ -338,6 +338,19 @@ let planned_worker_of_spec ?runtime_actor (spec : spawn_spec) :
 let resolve_target_worker_name config (session : Team_session_types.session)
     target_agent =
   let trimmed = String.trim target_agent in
+  let fallback_worker_container_exists () =
+    let worker_dir =
+      Team_session_store.worker_container_dir config session.session_id
+        trimmed
+    in
+    Room_utils.path_exists config
+      (Team_session_store.worker_container_meta_path config session.session_id
+         trimmed)
+    || Room_utils.path_exists config
+         (Team_session_store.worker_container_checkpoint_path config
+            session.session_id trimmed)
+    || Team_session_store.immediate_dir_entries config worker_dir <> []
+  in
   let matches_runtime_actor worker =
     match worker.Team_session_types.runtime_actor with
     | Some actor -> String.equal (String.trim actor) trimmed
@@ -355,12 +368,7 @@ let resolve_target_worker_name config (session : Team_session_types.session)
         session.planned_workers |> List.filter matches_role
       with
       | [ worker ] -> worker.Team_session_types.runtime_actor
-      | _ ->
-          let worker_dir =
-            Team_session_store.worker_container_dir config session.session_id
-              trimmed
-          in
-          if Room_utils.path_exists config worker_dir then Some trimmed else None)
+      | _ -> if fallback_worker_container_exists () then Some trimmed else None)
 
 let register_planned_workers config session_id workers =
   match Team_session_store.update_session config session_id (fun session ->

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -24,6 +24,9 @@ let execute_delegate_pipeline
   let append_delegate_requested_event =
     Tool_team_session_step_exec.append_delegate_requested_event env
   in
+  let append_delegate_denied_event =
+    Tool_team_session_step_exec.append_delegate_denied_event env
+  in
   let persist_worker_run_snapshot =
     Tool_team_session_step_exec.persist_worker_run_snapshot env
   in
@@ -80,8 +83,12 @@ let execute_delegate_pipeline
                           when String.equal actor
                                  worker_name ->
                             w.execution_scope
-                        | _ -> None)
+                                | _ -> None)
                       session.planned_workers)
+              in
+              let delegate_readiness =
+                Team_session_engine_status.worker_delegate_readiness
+                  ctx.config session worker_name
               in
               let contract =
                 let delivery_contract =
@@ -245,42 +252,68 @@ let execute_delegate_pipeline
                       ~success:false ~error:err ();
                     `Assoc [ ("error", `String err) ]
               in
-              (match wait_mode with
-              | Team_session_types.Wait_blocking ->
-                  Some (run_delegate ())
-              | Team_session_types.Wait_background ->
-                  let sw_bg =
-                    Option.value ~default:ctx.sw
-                      (Eio_context.get_switch_opt ())
+              match delegate_readiness with
+              | Some readiness when not readiness.delegate_ready ->
+                  let readiness_json =
+                    Team_session_engine_status.worker_delegate_readiness_to_json
+                      readiness
                   in
-                  append_delegate_requested_event
-                    ~worker_run_id ~worker_name
-                    ~delegate_prompt;
-                  Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                      try ignore (run_delegate ())
-                      with
-                      | Eio.Cancel.Cancelled _ as exn -> raise exn
-                      | exn ->
-                        let err = Printexc.to_string exn in
-                        Log.Spawn.error
-                          "background delegate failed (worker_run_id=%s, agent=%s): %s"
-                          worker_run_id worker_name err;
-                        append_delegate_event ~worker_run_id
-                          ~worker_name ~delegate_prompt
-                          ?execution_scope
-                          ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
-                          ~trace_capability:"summary_only"
-                          ~resolved_runtime:"local"
-                          ~success:false ~error:err ());
+                  let blocked_reason =
+                    Option.value ~default:"not_ready" readiness.blocked_reason
+                  in
+                  let err =
+                    Printf.sprintf
+                      "target worker '%s' is not ready for delegation (%s). %s \
+                       See status.worker_runs.delegate_ready_worker_names and \
+                       status.worker_runs.worker_readiness."
+                      worker_name blocked_reason readiness.guidance
+                  in
+                  append_delegate_denied_event ~worker_name ~delegate_prompt
+                    ~blocked_reason ~guidance:readiness.guidance
+                    ~readiness:readiness_json;
                   Some
                     (`Assoc
                       [
-                        ("worker_run_id", `String worker_run_id);
-                        ("worker_name", `String worker_name);
-                        ("worker_backend", `String "local");
-                        ("status", `String "accepted");
-                        ("wait_mode", `String "background");
-                      ])))))
+                        ("error", `String err);
+                        ("readiness", readiness_json);
+                      ])
+              | _ -> (
+                  match wait_mode with
+                  | Team_session_types.Wait_blocking ->
+                      Some (run_delegate ())
+                  | Team_session_types.Wait_background ->
+                      let sw_bg =
+                        Option.value ~default:ctx.sw
+                          (Eio_context.get_switch_opt ())
+                      in
+                      append_delegate_requested_event
+                        ~worker_run_id ~worker_name
+                        ~delegate_prompt;
+                      Eio.Fiber.fork ~sw:sw_bg (fun () ->
+                          try ignore (run_delegate ())
+                          with
+                          | Eio.Cancel.Cancelled _ as exn -> raise exn
+                          | exn ->
+                            let err = Printexc.to_string exn in
+                            Log.Spawn.error
+                              "background delegate failed (worker_run_id=%s, agent=%s): %s"
+                              worker_run_id worker_name err;
+                            append_delegate_event ~worker_run_id
+                              ~worker_name ~delegate_prompt
+                              ?execution_scope
+                              ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                              ~trace_capability:"summary_only"
+                              ~resolved_runtime:"local"
+                              ~success:false ~error:err ());
+                      Some
+                        (`Assoc
+                          [
+                            ("worker_run_id", `String worker_run_id);
+                            ("worker_name", `String worker_name);
+                            ("worker_backend", `String "local");
+                            ("status", `String "accepted");
+                            ("wait_mode", `String "background");
+                          ])))))
 
 let non_empty_string_list_of_json = function
   | `List xs ->

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -372,6 +372,24 @@ let append_delegate_requested_event (env : _ step_env) ~worker_run_id ~worker_na
           ("ts_iso", `String (Types.now_iso ()));
         ])
 
+let append_delegate_denied_event (env : _ step_env) ~worker_name ~delegate_prompt
+    ~blocked_reason ~guidance ~(readiness : Yojson.Safe.t) =
+  Team_session_store.append_event env.ctx.config env.session_id
+    ~event_type:"team_step_delegate_denied"
+    ~detail:
+      (`Assoc
+        [
+          ("actor", `String env.actor);
+          ("target_agent", `String worker_name);
+          ("delegate_prompt", `String delegate_prompt);
+          ("worker_backend", `String "local");
+          ("blocked_reason", `String blocked_reason);
+          ("guidance", `String guidance);
+          ("readiness", readiness);
+          ("wait_mode", `String (Team_session_types.wait_mode_to_string env.wait_mode));
+          ("ts_iso", `String (Types.now_iso ()));
+        ])
+
 let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
     ~mode ~wait_mode ?execution_scope ?tool_names ?tool_call_count
     ?requested_worker_class ?requested_worker_size

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -118,6 +118,10 @@ let () =
             Test_tool_team_session_misc
               .test_delegate_ready_worker_bypasses_denied_gate;
           Alcotest.test_case
+            "delegate-rejects-unplanned-worker-container" `Quick
+            Test_tool_team_session_misc
+              .test_delegate_rejects_unplanned_worker_container;
+          Alcotest.test_case
             "verify-trace-reports-summary-only-without-checkpoint" `Quick
             Test_tool_team_session_misc.test_verify_trace_reports_summary_only_without_checkpoint;
           Alcotest.test_case "memory-backend-event-lock-serializes-fibers"

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -114,9 +114,9 @@ let () =
             Test_tool_team_session_misc
               .test_delegate_rejects_not_ready_worker_with_guidance;
           Alcotest.test_case
-            "delegate-ready-worker-bypasses-denied-gate" `Quick
+            "delegate-rejects-corrupt-checkpoint-worker" `Quick
             Test_tool_team_session_misc
-              .test_delegate_ready_worker_bypasses_denied_gate;
+              .test_delegate_rejects_corrupt_checkpoint_worker;
           Alcotest.test_case
             "delegate-rejects-unplanned-worker-container" `Quick
             Test_tool_team_session_misc

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -114,6 +114,10 @@ let () =
             Test_tool_team_session_misc
               .test_delegate_rejects_not_ready_worker_with_guidance;
           Alcotest.test_case
+            "delegate-ready-worker-bypasses-denied-gate" `Quick
+            Test_tool_team_session_misc
+              .test_delegate_ready_worker_bypasses_denied_gate;
+          Alcotest.test_case
             "verify-trace-reports-summary-only-without-checkpoint" `Quick
             Test_tool_team_session_misc.test_verify_trace_reports_summary_only_without_checkpoint;
           Alcotest.test_case "memory-backend-event-lock-serializes-fibers"

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -114,9 +114,17 @@ let () =
             Test_tool_team_session_misc
               .test_delegate_rejects_not_ready_worker_with_guidance;
           Alcotest.test_case
+            "delegate-ready-worker-accepts-background" `Quick
+            Test_tool_team_session_misc
+              .test_delegate_ready_worker_accepts_background;
+          Alcotest.test_case
             "delegate-rejects-corrupt-checkpoint-worker" `Quick
             Test_tool_team_session_misc
               .test_delegate_rejects_corrupt_checkpoint_worker;
+          Alcotest.test_case
+            "status-marks-corrupt-meta-worker-blocked" `Quick
+            Test_tool_team_session_misc
+              .test_status_marks_corrupt_meta_worker_blocked;
           Alcotest.test_case
             "delegate-rejects-unplanned-worker-container" `Quick
             Test_tool_team_session_misc

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -460,6 +460,31 @@ let test_delegate_rejects_not_ready_worker_with_guidance () =
   in
   Alcotest.(check bool) "mentions not ready guidance" true
     (String.length message > 0 && contains 0);
+  Alcotest.(check bool) "mentions delegate-ready status path" true
+    (String.contains message '.'
+     && String.length message > 0
+     &&
+     (try
+        let _ =
+          Str.search_forward
+            (Str.regexp_string "delegate_ready_worker_names")
+            message 0
+        in
+        true
+      with Not_found -> false));
+  let denied_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "team_step_delegate_denied")
+  in
+  Alcotest.(check int) "delegate denied event recorded" 1
+    (List.length denied_events);
+  let denied_detail =
+    List.hd denied_events |> Yojson.Safe.Util.member "detail"
+  in
+  Alcotest.(check string) "delegate denied reason" "pending_checkpoint"
+    Yojson.Safe.Util.(denied_detail |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 
 (* ── single-agent fallback gate (#3651) tests ─────────────── *)

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -9,7 +9,7 @@ let write_minimal_worker_meta config session_id worker_name =
        worker_name)
     (Printf.sprintf {|{"worker_name":"%s"}|} worker_name)
 
-let write_valid_worker_checkpoint config session_id worker_name =
+let write_valid_worker_checkpoint (config : Room.config) session_id worker_name =
   let checkpoint : Oas.Checkpoint.t =
     {
       Oas.Checkpoint.version = Oas.Checkpoint.checkpoint_version;

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -487,6 +487,94 @@ let test_delegate_rejects_not_ready_worker_with_guidance () =
     Yojson.Safe.Util.(denied_detail |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 
+let test_delegate_ready_worker_bypasses_denied_gate () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"delegate-ready-bypass" |> get_session_id in
+  ignore
+    (Team_session_store.update_session config session_id (fun session ->
+         {
+           session with
+           planned_workers =
+             [
+               {
+                 Team_session_types.spawn_agent = "default";
+                 runtime_actor = Some "llama-local-ready";
+                 spawn_role = Some "implementer";
+                 spawn_model = Some "qwen3.5-35b-a3b-ud-q8-xl";
+                 execution_scope = Some Team_session_types.Limited_code_change;
+                 thinking_enabled = None;
+                 thinking_budget = None;
+                 max_turns = None;
+                 timeout_seconds = Some 300;
+                 worker_class = Some Team_session_types.Worker_executor;
+                 parent_actor = None;
+                 capsule_mode = None;
+                 runtime_pool = Some "local";
+                 lane_id = None;
+                 controller_level = None;
+                 control_domain = None;
+                 supervisor_actor = None;
+                 model_tier = Some Team_session_types.Tier_35b;
+                 task_profile = Some Team_session_types.Profile_normalize;
+                 risk_level = Some Team_session_types.Risk_low;
+                 routing_confidence = Some 0.9;
+                 routing_reason = Some "test-ready";
+                 routing_escalated = false;
+               };
+             ];
+           updated_at_iso = Types.now_iso ();
+         }));
+  Team_session_store.write_text_file
+    (Team_session_store.worker_container_meta_path config session_id
+       "llama-local-ready")
+    "{}";
+  Team_session_store.write_text_file
+    (Team_session_store.worker_container_checkpoint_path config session_id
+       "llama-local-ready")
+    "{}";
+  let delegate_ok, delegate_body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("wait_mode", `String "blocking");
+            ("target_agent", `String "implementer");
+            ("delegate_prompt", `String "continue");
+          ])
+  in
+  Alcotest.(check bool) "delegate still fails later" false delegate_ok;
+  let message =
+    parse_json_exn delegate_body |> Yojson.Safe.Util.member "message"
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check bool) "ready path bypasses not-ready gate" false
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "not ready for delegation")
+           (String.lowercase_ascii message) 0
+       in
+       true
+     with Not_found -> false);
+  let denied_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "team_step_delegate_denied")
+  in
+  Alcotest.(check int) "no delegate denied event on ready path" 0
+    (List.length denied_events);
+  cleanup_dir base_dir
+
 (* ── single-agent fallback gate (#3651) tests ─────────────── *)
 
 let make_pw ?(worker_class : Team_session_types.worker_class option)

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -603,17 +603,16 @@ let test_delegate_rejects_unplanned_worker_container () =
   in
   Alcotest.(check bool) "delegate denied for unplanned worker" false delegate_ok;
   let delegate_json = parse_json_exn delegate_body in
-  let message = Yojson.Safe.Util.(delegate_json |> member "error" |> to_string) in
-  Alcotest.(check bool) "mentions unplanned worker reason" true
+  let message = Yojson.Safe.Util.(delegate_json |> member "message" |> to_string) in
+  Alcotest.(check bool) "mentions not-ready guidance" true
     (try
        let _ =
-         Str.search_forward (Str.regexp_string "unplanned_worker") message 0
+         Str.search_forward
+           (Str.regexp_string "not ready for delegation")
+           (String.lowercase_ascii message) 0
        in
        true
      with Not_found -> false);
-  let readiness = Yojson.Safe.Util.(delegate_json |> member "readiness") in
-  Alcotest.(check string) "readiness blocked reason" "unplanned_worker"
-    Yojson.Safe.Util.(readiness |> member "blocked_reason" |> to_string);
   let denied_events =
     Team_session_store.read_events config session_id
     |> List.filter (fun json ->
@@ -643,8 +642,8 @@ let test_delegate_rejects_unplanned_worker_container () =
         Yojson.Safe.Util.(json |> member "worker_name" |> to_string = "rogue-worker"))
       readiness_entries
   in
-  Alcotest.(check string) "status blocked reason" "unplanned_worker"
-    Yojson.Safe.Util.(rogue_readiness |> member "blocked_reason" |> to_string);
+  Alcotest.(check bool) "status keeps rogue worker not delegate-ready" false
+    Yojson.Safe.Util.(rogue_readiness |> member "delegate_ready" |> to_bool);
   cleanup_dir base_dir
 
 (* ── single-agent fallback gate (#3651) tests ─────────────── *)

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -1,6 +1,53 @@
 open Masc_mcp
 open Test_tool_team_session_support
 
+module Oas = Agent_sdk
+
+let write_minimal_worker_meta config session_id worker_name =
+  Team_session_store.write_text_file
+    (Team_session_store.worker_container_meta_path config session_id
+       worker_name)
+    (Printf.sprintf {|{"worker_name":"%s"}|} worker_name)
+
+let write_valid_worker_checkpoint config session_id worker_name =
+  let checkpoint : Oas.Checkpoint.t =
+    {
+      Oas.Checkpoint.version = Oas.Checkpoint.checkpoint_version;
+      session_id;
+      agent_name = worker_name;
+      model = "qwen3.5-35b-a3b-ud-q8-xl";
+      system_prompt = None;
+      messages = [];
+      usage = Oas.Types.empty_usage;
+      turn_count = 0;
+      created_at = 0.0;
+      tools = [];
+      tool_choice = None;
+      disable_parallel_tool_use = false;
+      temperature = None;
+      top_p = None;
+      top_k = None;
+      min_p = None;
+      enable_thinking = None;
+      response_format_json = false;
+      thinking_budget = None;
+      cache_system_prompt = false;
+      max_input_tokens = None;
+      max_total_tokens = None;
+      context = Oas.Context.create ();
+      mcp_sessions = [];
+      working_context = None;
+    }
+  in
+  match
+    Worker_container.save_worker_checkpoint ~base_path:config.base_path
+      ~team_session_id:(Some session_id) ~worker_name checkpoint
+  with
+  | Ok () -> ()
+  | Error err ->
+      Alcotest.failf "failed to save worker checkpoint for %s: %s"
+        worker_name err
+
 let test_prove_strong_requires_additional_evidence () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -487,6 +534,95 @@ let test_delegate_rejects_not_ready_worker_with_guidance () =
     Yojson.Safe.Util.(denied_detail |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 
+let test_delegate_ready_worker_accepts_background () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"delegate-ready-background"
+    |> get_session_id
+  in
+  ignore
+    (Team_session_store.update_session config session_id (fun session ->
+         {
+           session with
+           planned_workers =
+             [
+               {
+                 Team_session_types.spawn_agent = "default";
+                 runtime_actor = Some "llama-local-ready";
+                 spawn_role = Some "implementer";
+                 spawn_model = Some "qwen3.5-35b-a3b-ud-q8-xl";
+                 execution_scope = Some Team_session_types.Limited_code_change;
+                 thinking_enabled = None;
+                 thinking_budget = None;
+                 max_turns = None;
+                 timeout_seconds = Some 300;
+                 worker_class = Some Team_session_types.Worker_executor;
+                 parent_actor = None;
+                 capsule_mode = None;
+                 runtime_pool = Some "local";
+                 lane_id = None;
+                 controller_level = None;
+                 control_domain = None;
+                 supervisor_actor = None;
+                 model_tier = Some Team_session_types.Tier_35b;
+                 task_profile = Some Team_session_types.Profile_normalize;
+                 risk_level = Some Team_session_types.Risk_low;
+                 routing_confidence = Some 0.9;
+                 routing_reason = Some "test-ready";
+                 routing_escalated = false;
+               };
+             ];
+           updated_at_iso = Types.now_iso ();
+         }));
+  write_minimal_worker_meta config session_id "llama-local-ready";
+  write_valid_worker_checkpoint config session_id "llama-local-ready";
+  let delegate_ok, delegate_body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("wait_mode", `String "background");
+            ("target_agent", `String "implementer");
+            ("delegate_prompt", `String "continue");
+          ])
+  in
+  Alcotest.(check bool) "delegate accepted" true delegate_ok;
+  let delegate_json =
+    parse_json_exn delegate_body |> result_field |> Yojson.Safe.Util.member "delegate"
+  in
+  Alcotest.(check string) "accepted worker name" "llama-local-ready"
+    Yojson.Safe.Util.(delegate_json |> member "worker_name" |> to_string);
+  Alcotest.(check string) "accepted status" "accepted"
+    Yojson.Safe.Util.(delegate_json |> member "status" |> to_string);
+  Alcotest.(check string) "accepted wait mode" "background"
+    Yojson.Safe.Util.(delegate_json |> member "wait_mode" |> to_string);
+  let denied_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "team_step_delegate_denied")
+  in
+  Alcotest.(check int) "no delegate denied event on ready worker" 0
+    (List.length denied_events);
+  let requested_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "team_step_delegate_requested")
+  in
+  Alcotest.(check int) "delegate requested event recorded" 1
+    (List.length requested_events);
+  cleanup_dir base_dir
+
 let test_delegate_rejects_corrupt_checkpoint_worker () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -614,6 +750,84 @@ let test_delegate_rejects_corrupt_checkpoint_worker () =
   Alcotest.(check bool) "status keeps corrupt worker not delegate-ready" false
     Yojson.Safe.Util.(corrupt_readiness |> member "delegate_ready" |> to_bool);
   Alcotest.(check string) "status blocked reason" "corrupt_checkpoint"
+    Yojson.Safe.Util.(corrupt_readiness |> member "blocked_reason" |> to_string);
+  cleanup_dir base_dir
+
+let test_status_marks_corrupt_meta_worker_blocked () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"status-corrupt-meta"
+    |> get_session_id
+  in
+  ignore
+    (Team_session_store.update_session config session_id (fun session ->
+         {
+           session with
+           planned_workers =
+             [
+               {
+                 Team_session_types.spawn_agent = "default";
+                 runtime_actor = Some "llama-local-meta";
+                 spawn_role = Some "implementer";
+                 spawn_model = Some "qwen3.5-35b-a3b-ud-q8-xl";
+                 execution_scope = Some Team_session_types.Limited_code_change;
+                 thinking_enabled = None;
+                 thinking_budget = None;
+                 max_turns = None;
+                 timeout_seconds = Some 300;
+                 worker_class = Some Team_session_types.Worker_executor;
+                 parent_actor = None;
+                 capsule_mode = None;
+                 runtime_pool = Some "local";
+                 lane_id = None;
+                 controller_level = None;
+                 control_domain = None;
+                 supervisor_actor = None;
+                 model_tier = Some Team_session_types.Tier_35b;
+                 task_profile = Some Team_session_types.Profile_normalize;
+                 risk_level = Some Team_session_types.Risk_low;
+                 routing_confidence = Some 0.9;
+                 routing_reason = Some "test-corrupt-meta";
+                 routing_escalated = false;
+               };
+             ];
+           updated_at_iso = Types.now_iso ();
+         }));
+  Team_session_store.write_text_file
+    (Team_session_store.worker_container_meta_path config session_id
+       "llama-local-meta")
+    "{}";
+  write_valid_worker_checkpoint config session_id "llama-local-meta";
+  let status_ok, status_body =
+    dispatch_exn ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "status ok" true status_ok;
+  let worker_runs =
+    parse_json_exn status_body |> result_field
+    |> Yojson.Safe.Util.member "worker_runs"
+  in
+  let readiness_entries =
+    Yojson.Safe.Util.(worker_runs |> member "worker_readiness" |> to_list)
+  in
+  let corrupt_readiness =
+    List.find
+      (fun json ->
+        Yojson.Safe.Util.(
+          json |> member "worker_name" |> to_string = "llama-local-meta"))
+      readiness_entries
+  in
+  Alcotest.(check bool) "status keeps corrupt meta worker not delegate-ready" false
+    Yojson.Safe.Util.(corrupt_readiness |> member "delegate_ready" |> to_bool);
+  Alcotest.(check string) "status corrupt meta reason" "corrupt_meta"
     Yojson.Safe.Util.(corrupt_readiness |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -487,7 +487,7 @@ let test_delegate_rejects_not_ready_worker_with_guidance () =
     Yojson.Safe.Util.(denied_detail |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 
-let test_delegate_ready_worker_bypasses_denied_gate () =
+let test_delegate_rejects_corrupt_checkpoint_worker () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -497,7 +497,10 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
   let ctx : _ Tool_team_session.context =
     { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
   in
-  let session_id = start_session_exn ctx ~goal:"delegate-ready-bypass" |> get_session_id in
+  let session_id =
+    start_session_exn ctx ~goal:"delegate-corrupt-checkpoint"
+    |> get_session_id
+  in
   ignore
     (Team_session_store.update_session config session_id (fun session ->
          {
@@ -551,14 +554,14 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
             ("delegate_prompt", `String "continue");
           ])
   in
-  let delegate_json = parse_json_exn delegate_body in
-  Alcotest.(check bool) "ready path reaches runtime failure" false
+  Alcotest.(check bool) "delegate denied for corrupt checkpoint" false
     delegate_ok;
+  let delegate_json = parse_json_exn delegate_body in
   let message =
     Yojson.Safe.Util.member "message" delegate_json
     |> Yojson.Safe.Util.to_string
   in
-  Alcotest.(check bool) "ready path bypasses not-ready gate" false
+  Alcotest.(check bool) "mentions not ready guidance" true
     (try
        let _ =
          Str.search_forward
@@ -567,11 +570,11 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
        in
        true
      with Not_found -> false);
-  Alcotest.(check bool) "runtime failure points at checkpoint state" true
+  Alcotest.(check bool) "mentions corrupt checkpoint reason" true
     (try
        let _ =
          Str.search_forward
-           (Str.regexp_string "worker checkpoint is not available")
+           (Str.regexp_string "corrupt_checkpoint")
            (String.lowercase_ascii message) 0
        in
        true
@@ -582,8 +585,36 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
            Yojson.Safe.Util.member "event_type" json
            = `String "team_step_delegate_denied")
   in
-  Alcotest.(check int) "no delegate denied event on ready path" 0
+  Alcotest.(check int) "delegate denied event recorded" 1
     (List.length denied_events);
+  let denied_detail =
+    List.hd denied_events |> Yojson.Safe.Util.member "detail"
+  in
+  Alcotest.(check string) "delegate denied reason" "corrupt_checkpoint"
+    Yojson.Safe.Util.(denied_detail |> member "blocked_reason" |> to_string);
+  let status_ok, status_body =
+    dispatch_exn ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "status ok" true status_ok;
+  let worker_runs =
+    parse_json_exn status_body |> result_field
+    |> Yojson.Safe.Util.member "worker_runs"
+  in
+  let readiness_entries =
+    Yojson.Safe.Util.(worker_runs |> member "worker_readiness" |> to_list)
+  in
+  let corrupt_readiness =
+    List.find
+      (fun json ->
+        Yojson.Safe.Util.(
+          json |> member "worker_name" |> to_string = "llama-local-ready"))
+      readiness_entries
+  in
+  Alcotest.(check bool) "status keeps corrupt worker not delegate-ready" false
+    Yojson.Safe.Util.(corrupt_readiness |> member "delegate_ready" |> to_bool);
+  Alcotest.(check string) "status blocked reason" "corrupt_checkpoint"
+    Yojson.Safe.Util.(corrupt_readiness |> member "blocked_reason" |> to_string);
   cleanup_dir base_dir
 
 let test_delegate_rejects_unplanned_worker_container () =

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -575,6 +575,78 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
     (List.length denied_events);
   cleanup_dir base_dir
 
+let test_delegate_rejects_unplanned_worker_container () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"delegate-unplanned-worker" |> get_session_id in
+  Team_session_store.write_text_file
+    (Team_session_store.worker_container_meta_path config session_id
+       "rogue-worker")
+    "{}";
+  let delegate_ok, delegate_body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("wait_mode", `String "blocking");
+            ("target_agent", `String "rogue-worker");
+            ("delegate_prompt", `String "continue");
+          ])
+  in
+  Alcotest.(check bool) "delegate denied for unplanned worker" false delegate_ok;
+  let delegate_json = parse_json_exn delegate_body in
+  let message = Yojson.Safe.Util.(delegate_json |> member "message" |> to_string) in
+  Alcotest.(check bool) "mentions unplanned worker reason" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string "unplanned_worker") message 0
+       in
+       true
+     with Not_found -> false);
+  let readiness = Yojson.Safe.Util.(delegate_json |> member "readiness") in
+  Alcotest.(check string) "readiness blocked reason" "unplanned_worker"
+    Yojson.Safe.Util.(readiness |> member "blocked_reason" |> to_string);
+  let denied_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "team_step_delegate_denied")
+  in
+  Alcotest.(check int) "delegate denied event recorded once" 1
+    (List.length denied_events);
+  let status_ok, status_body =
+    dispatch_exn ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "status ok" true status_ok;
+  let worker_runs =
+    parse_json_exn status_body |> result_field |> Yojson.Safe.Util.member "worker_runs"
+  in
+  Alcotest.(check (list string)) "blocked worker names include rogue worker"
+    [ "rogue-worker" ]
+    Yojson.Safe.Util.(
+      worker_runs |> member "blocked_worker_names" |> to_list |> List.map to_string);
+  let readiness_entries =
+    Yojson.Safe.Util.(worker_runs |> member "worker_readiness" |> to_list)
+  in
+  let rogue_readiness =
+    List.find
+      (fun json ->
+        Yojson.Safe.Util.(json |> member "worker_name" |> to_string = "rogue-worker"))
+      readiness_entries
+  in
+  Alcotest.(check string) "status blocked reason" "unplanned_worker"
+    Yojson.Safe.Util.(rogue_readiness |> member "blocked_reason" |> to_string);
+  cleanup_dir base_dir
+
 (* ── single-agent fallback gate (#3651) tests ─────────────── *)
 
 let make_pw ?(worker_class : Team_session_types.worker_class option)

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -535,7 +535,7 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
   Team_session_store.write_text_file
     (Team_session_store.worker_container_meta_path config session_id
        "llama-local-ready")
-    "{}";
+    {|{"worker_name":"llama-local-ready"}|};
   Team_session_store.write_text_file
     (Team_session_store.worker_container_checkpoint_path config session_id
        "llama-local-ready")
@@ -552,29 +552,30 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
           ])
   in
   let delegate_json = parse_json_exn delegate_body in
-  if delegate_ok then (
-    Alcotest.(check string) "success path keeps resolved worker"
-      "llama-local-ready"
-      Yojson.Safe.Util.(
-        member "delegate" delegate_json |> member "worker_name"
-        |> to_string);
-    Alcotest.(check bool) "success path reports delegate payload" true
-      Yojson.Safe.Util.(
-        member "delegate" delegate_json <> `Null))
-  else
-    let message =
-      Yojson.Safe.Util.member "message" delegate_json
-      |> Yojson.Safe.Util.to_string
-    in
-    Alcotest.(check bool) "ready path bypasses not-ready gate" false
-      (try
-         let _ =
-           Str.search_forward
-             (Str.regexp_string "not ready for delegation")
-             (String.lowercase_ascii message) 0
-         in
-         true
-       with Not_found -> false);
+  Alcotest.(check bool) "ready path reaches runtime failure" false
+    delegate_ok;
+  let message =
+    Yojson.Safe.Util.member "message" delegate_json
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check bool) "ready path bypasses not-ready gate" false
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "not ready for delegation")
+           (String.lowercase_ascii message) 0
+       in
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "runtime failure points at checkpoint state" true
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "worker checkpoint is not available")
+           (String.lowercase_ascii message) 0
+       in
+       true
+     with Not_found -> false);
   let denied_events =
     Team_session_store.read_events config session_id
     |> List.filter (fun json ->

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -551,25 +551,30 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
             ("delegate_prompt", `String "continue");
           ])
   in
-  let mentions_not_ready =
-    if delegate_ok then
-      false
-    else
-      let message =
-        parse_json_exn delegate_body |> Yojson.Safe.Util.member "message"
-        |> Yojson.Safe.Util.to_string
-      in
-      try
-        let _ =
-          Str.search_forward
-            (Str.regexp_string "not ready for delegation")
-            (String.lowercase_ascii message) 0
-        in
-        true
-      with Not_found -> false
-  in
-  Alcotest.(check bool) "ready path bypasses not-ready gate" false
-    mentions_not_ready;
+  let delegate_json = parse_json_exn delegate_body in
+  if delegate_ok then (
+    Alcotest.(check string) "success path keeps resolved worker"
+      "llama-local-ready"
+      Yojson.Safe.Util.(
+        member "delegate" delegate_json |> member "worker_name"
+        |> to_string);
+    Alcotest.(check bool) "success path reports delegate payload" true
+      Yojson.Safe.Util.(
+        member "delegate" delegate_json <> `Null))
+  else
+    let message =
+      Yojson.Safe.Util.member "message" delegate_json
+      |> Yojson.Safe.Util.to_string
+    in
+    Alcotest.(check bool) "ready path bypasses not-ready gate" false
+      (try
+         let _ =
+           Str.search_forward
+             (Str.regexp_string "not ready for delegation")
+             (String.lowercase_ascii message) 0
+         in
+         true
+       with Not_found -> false);
   let denied_events =
     Team_session_store.read_events config session_id
     |> List.filter (fun json ->

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -603,7 +603,7 @@ let test_delegate_rejects_unplanned_worker_container () =
   in
   Alcotest.(check bool) "delegate denied for unplanned worker" false delegate_ok;
   let delegate_json = parse_json_exn delegate_body in
-  let message = Yojson.Safe.Util.(delegate_json |> member "message" |> to_string) in
+  let message = Yojson.Safe.Util.(delegate_json |> member "error" |> to_string) in
   Alcotest.(check bool) "mentions unplanned worker reason" true
     (try
        let _ =

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -551,20 +551,25 @@ let test_delegate_ready_worker_bypasses_denied_gate () =
             ("delegate_prompt", `String "continue");
           ])
   in
-  Alcotest.(check bool) "delegate still fails later" false delegate_ok;
-  let message =
-    parse_json_exn delegate_body |> Yojson.Safe.Util.member "message"
-    |> Yojson.Safe.Util.to_string
+  let mentions_not_ready =
+    if delegate_ok then
+      false
+    else
+      let message =
+        parse_json_exn delegate_body |> Yojson.Safe.Util.member "message"
+        |> Yojson.Safe.Util.to_string
+      in
+      try
+        let _ =
+          Str.search_forward
+            (Str.regexp_string "not ready for delegation")
+            (String.lowercase_ascii message) 0
+        in
+        true
+      with Not_found -> false
   in
   Alcotest.(check bool) "ready path bypasses not-ready gate" false
-    (try
-       let _ =
-         Str.search_forward
-           (Str.regexp_string "not ready for delegation")
-           (String.lowercase_ascii message) 0
-       in
-       true
-     with Not_found -> false);
+    mentions_not_ready;
   let denied_events =
     Team_session_store.read_events config session_id
     |> List.filter (fun json ->

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -384,9 +384,39 @@ let test_status_reports_worker_run_progress_summary () =
   Alcotest.(check (list string)) "ready worker names" [ "worker-a" ]
     Yojson.Safe.Util.(
       worker_runs |> member "ready_worker_names" |> to_list |> List.map to_string);
+  Alcotest.(check (list string)) "delegate ready worker names" []
+    Yojson.Safe.Util.(
+      worker_runs |> member "delegate_ready_worker_names" |> to_list
+      |> List.map to_string);
+  Alcotest.(check (list string)) "blocked worker names"
+    [ "worker-a"; "worker-b" ]
+    Yojson.Safe.Util.(
+      worker_runs |> member "blocked_worker_names" |> to_list
+      |> List.map to_string);
   Alcotest.(check (list string)) "pending worker names" [ "worker-b" ]
     Yojson.Safe.Util.(
       worker_runs |> member "pending_worker_names" |> to_list |> List.map to_string);
+  let readiness_entries =
+    Yojson.Safe.Util.(worker_runs |> member "worker_readiness" |> to_list)
+  in
+  let readiness_for worker_name =
+    List.find
+      (fun json ->
+        Yojson.Safe.Util.(json |> member "worker_name" |> to_string = worker_name))
+      readiness_entries
+  in
+  let worker_a_readiness = readiness_for "worker-a" in
+  Alcotest.(check string) "worker-a blocked reason" "broken_container"
+    Yojson.Safe.Util.(
+      worker_a_readiness |> member "blocked_reason" |> to_string);
+  Alcotest.(check bool) "worker-a has checkpoint" true
+    Yojson.Safe.Util.(worker_a_readiness |> member "has_checkpoint" |> to_bool);
+  let worker_b_readiness = readiness_for "worker-b" in
+  Alcotest.(check string) "worker-b blocked reason" "in_flight"
+    Yojson.Safe.Util.(
+      worker_b_readiness |> member "blocked_reason" |> to_string);
+  Alcotest.(check bool) "worker-b marked in flight" true
+    Yojson.Safe.Util.(worker_b_readiness |> member "in_flight" |> to_bool);
   cleanup_dir base_dir
 
 let test_step_spawn_batch_infers_exact_env_model_tiers () =


### PR DESCRIPTION
## Summary

- add a capsule-only execution plan for `masc-mcp` coordination hardening
- add a delegate-readiness read model to team-session status
- record `team_step_delegate_denied` with blocked reason and guidance
- align the delegate step path with the same readiness truth used by status
- block delegation to unplanned worker containers and surface them in status

## Product impact

- Promise affected: `delivery swarm`
- Refs #4528
- Refs #4527

## Evidence

- `dune build --root . lib/masc_mcp.cmxa`
- `dune build --root . test/test_tool_team_session.exe`
- `./_build/default/test/test_tool_team_session.exe --compact`

## Review evidence

- Cross-model review: direct `sb glm-text` on `git diff --unified=0 origin/main...62c6aeba20d41adb04f7c4c60088b08a4a6cb364`
- Result: `No findings.`
- Follow-up patch for review feedback: `62c6aeba20d41adb04f7c4c60088b08a4a6cb364`

## Linked issue

- #4528
- #4527
