### PR TITLE
refactor(operator): extract review_item type to dedicated module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -208,6 +208,7 @@
    operator_digest_event
    operator_digest_guidance
    operator_digest_types
+   operator_digest_review_types
    opentelemetry_client_cohttp_eio
    observability_redact
    risk_digest

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -272,7 +272,35 @@ let room_recommendations ?command_plane_summary config =
   in
   dedup_recommendations signal_recommendations
 
-include Operator_digest_review_types
+(* Re-export from Operator_digest_review_types without [include] to
+   avoid conflicting [module U] and leaking [open] directives. *)
+type review_item = Operator_digest_review_types.review_item = {
+  id : string;
+  kind : string;
+  target_type : string;
+  target_id : string option;
+  severity : string;
+  urgency : string;
+  summary : string;
+  why_now : string;
+  source : string;
+  authoritative : bool;
+  fingerprint : string;
+  stale_sec : int option;
+  confirm_required : bool;
+  recommended_action : recommended_action option;
+  truth_ref : Yojson.Safe.t;
+  friction : Yojson.Safe.t;
+  advice : Yojson.Safe.t;
+}
+let review_empty_advice_json = Operator_digest_review_types.review_empty_advice_json
+let review_truth_ref_json = Operator_digest_review_types.review_truth_ref_json
+let json_string_opt = Operator_digest_review_types.json_string_opt
+let json_float_opt = Operator_digest_review_types.json_float_opt
+let json_bool_opt = Operator_digest_review_types.json_bool_opt
+let review_fingerprint = Operator_digest_review_types.review_fingerprint
+let stale_sec_of_iso = Operator_digest_review_types.stale_sec_of_iso
+let review_action_copy = Operator_digest_review_types.review_action_copy
 
 let room_state_json config =
   if not (Room.is_initialized config) then

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -272,55 +272,7 @@ let room_recommendations ?command_plane_summary config =
   in
   dedup_recommendations signal_recommendations
 
-type review_item = {
-  id : string;
-  kind : string;
-  target_type : string;
-  target_id : string option;
-  severity : string;
-  urgency : string;
-  summary : string;
-  why_now : string;
-  source : string;
-  authoritative : bool;
-  fingerprint : string;
-  stale_sec : int option;
-  confirm_required : bool;
-  recommended_action : recommended_action option;
-  truth_ref : Yojson.Safe.t;
-  friction : Yojson.Safe.t;
-  advice : Yojson.Safe.t;
-}
-
-let review_empty_advice_json =
-  `Assoc
-    [
-      ("active_summary", `Null);
-      ("active_guidance_layer", `Null);
-      ("authoritative_judgment_available", `Bool false);
-    ]
-
-let review_truth_ref_json ~target_type ~target_id =
-  `Assoc
-    [
-      ("target_type", `String target_type);
-      ("target_id", string_option_to_json target_id);
-    ]
-
-let json_string_opt json key =
-  json |> U.member key |> U.to_string_option
-
-let json_float_opt json key =
-  match json |> U.member key with
-  | `Float value -> Some value
-  | `Int value -> Some (float_of_int value)
-  | `Intlit raw -> (try Some (float_of_string raw) with Failure _ -> None)
-  | _ -> None
-
-let json_bool_opt json key =
-  match json |> U.member key with
-  | `Bool value -> Some value
-  | _ -> None
+include Operator_digest_review_types
 
 let room_state_json config =
   if not (Room.is_initialized config) then
@@ -378,30 +330,8 @@ let lightweight_keeper_rows config =
                    ("updated_at", `String meta.updated_at);
                  ]))
 
-let review_fingerprint parts =
-  let payload = String.concat "|" parts in
-  Digestif.SHA256.(digest_string payload |> to_hex)
-
-let stale_sec_of_iso ~now iso =
-  Option.bind iso (fun value ->
-      try Some (max 0 (int_of_float (now -. Types.parse_iso8601 value)))
-      with Failure _ -> None)
-
-let review_action_copy = function
-  | "broadcast" -> "전체 공지"
-  | "room_pause" -> "방 일시정지"
-  | "room_resume" -> "방 재개"
-  | "team_note" -> "세션 메모"
-  | "team_broadcast" -> "세션 공지"
-  | "team_task_inject" -> "세션 작업 주입"
-  | "team_worker_spawn_batch" -> "세션 작업자 교체"
-  | "team_stop" -> "세션 중지"
-  | "keeper_message" -> "키퍼 메시지"
-  | "keeper_probe" -> "키퍼 점검"
-  | "keeper_recover" -> "키퍼 복구"
-  | "review_resolve" -> "검토 해결"
-  | "review_defer" -> "검토 보류"
-  | other -> other
+(* review_fingerprint, stale_sec_of_iso, review_action_copy
+   — now in Operator_digest_review_types (available via include above) *)
 
 let urgency_rank = function
   | "now" -> 1

--- a/lib/operator/operator_digest_review_types.ml
+++ b/lib/operator/operator_digest_review_types.ml
@@ -1,0 +1,85 @@
+(** Operator_digest_review_types — review item type and shared helpers.
+
+    Separated from Operator_digest_types to avoid record field collision:
+    both [attention_item] and [review_item] have fields named [kind],
+    [severity], [target_type], [target_id]. Modules that include
+    Operator_digest_types would see ambiguous field resolution. *)
+
+module U = Yojson.Safe.Util
+open Operator_pending_confirm
+open Operator_digest_types
+
+type review_item = {
+  id : string;
+  kind : string;
+  target_type : string;
+  target_id : string option;
+  severity : string;
+  urgency : string;
+  summary : string;
+  why_now : string;
+  source : string;
+  authoritative : bool;
+  fingerprint : string;
+  stale_sec : int option;
+  confirm_required : bool;
+  recommended_action : recommended_action option;
+  truth_ref : Yojson.Safe.t;
+  friction : Yojson.Safe.t;
+  advice : Yojson.Safe.t;
+}
+
+let review_empty_advice_json =
+  `Assoc
+    [
+      ("active_summary", `Null);
+      ("active_guidance_layer", `Null);
+      ("authoritative_judgment_available", `Bool false);
+    ]
+
+let review_truth_ref_json ~target_type ~target_id =
+  `Assoc
+    [
+      ("target_type", `String target_type);
+      ("target_id", string_option_to_json target_id);
+    ]
+
+let json_string_opt json key =
+  json |> U.member key |> U.to_string_option
+
+let json_float_opt json key =
+  match json |> U.member key with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit raw -> (try Some (float_of_string raw) with Failure _ -> None)
+  | _ -> None
+
+let json_bool_opt json key =
+  match json |> U.member key with
+  | `Bool value -> Some value
+  | _ -> None
+
+let review_fingerprint parts =
+  let payload = String.concat "|" parts in
+  Digestif.SHA256.(digest_string payload |> to_hex)
+
+let stale_sec_of_iso ~now iso =
+  Option.bind iso (fun value ->
+      try Some (max 0 (int_of_float (now -. Types.parse_iso8601 value)))
+      with Failure _ -> None)
+
+let review_action_copy = function
+  | "broadcast" -> "전체 공지"
+  | "room_pause" -> "방 일시정지"
+  | "room_resume" -> "방 재개"
+  | "team_note" -> "세션 메모"
+  | "team_broadcast" -> "세션 공지"
+  | "team_task_inject" -> "세션 작업 주입"
+  | "team_worker_spawn_batch" -> "세션 작업자 교체"
+  | "team_stop" -> "세션 중지"
+  | "keeper_message" -> "키퍼 메시지"
+  | "keeper_probe" -> "키퍼 점검"
+  | "keeper_recover" -> "키퍼 복구"
+  | "review_resolve" -> "검토 해결"
+  | "review_defer" -> "검토 보류"
+  | other -> other

--- a/lib/operator/operator_digest_review_types.ml
+++ b/lib/operator/operator_digest_review_types.ml
@@ -5,9 +5,11 @@
     [severity], [target_type], [target_id]. Modules that include
     Operator_digest_types would see ambiguous field resolution. *)
 
-module U = Yojson.Safe.Util
 open Operator_pending_confirm
 open Operator_digest_types
+
+(* Local alias — not leaked when this module is included/re-exported. *)
+module U_ = Yojson.Safe.Util
 
 type review_item = {
   id : string;
@@ -45,17 +47,17 @@ let review_truth_ref_json ~target_type ~target_id =
     ]
 
 let json_string_opt json key =
-  json |> U.member key |> U.to_string_option
+  json |> U_.member key |> U_.to_string_option
 
 let json_float_opt json key =
-  match json |> U.member key with
+  match json |> U_.member key with
   | `Float value -> Some value
   | `Int value -> Some (float_of_int value)
   | `Intlit raw -> (try Some (float_of_string raw) with Failure _ -> None)
   | _ -> None
 
 let json_bool_opt json key =
-  match json |> U.member key with
+  match json |> U_.member key with
   | `Bool value -> Some value
   | _ -> None
 

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -473,3 +473,7 @@ let normalize_digest_target_type value =
       | "team_session" -> Ok "team_session"
       | _ -> Error "target_type must be one of: room, team_session")
   | None -> Ok "room"
+
+(* review_item type + helpers are in Operator_digest_review_types
+   to avoid field name collision with attention_item in modules
+   that include Operator_digest_types *)


### PR DESCRIPTION
review_item record + helpers를 operator_digest_review_types.ml로 분리. attention_item과 field name collision 방지. operator_digest.ml 1005→935줄. Closes #4546.