### PR TITLE
[codex] normalize failure envelope ids

### DIFF
--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -52,6 +52,9 @@ let trim_to_option value =
   let trimmed = String.trim value in
   if trimmed = "" then None else Some trimmed
 
+let first_non_empty values =
+  List.find_map (fun value -> Option.bind value trim_to_option) values
+
 let tool_host_cause_code ?timeout_ms message =
   let lower = String.lowercase_ascii message in
   if Option.is_some timeout_ms
@@ -82,10 +85,7 @@ let tool_host_failure ~agent_name ~client_name ~tool_name ~transport ?phase
   {
     surface = "tool_host";
     entity_kind = "tool_call";
-    entity_id =
-      (match request_id with
-       | Some _ -> request_id
-       | None -> (match session_id with Some _ -> session_id | None -> trace_id));
+    entity_id = first_non_empty [ request_id; session_id; trace_id ];
     cause_code;
     severity = Bad;
     summary = summary_for_tool_host ~client_name ~tool_name ~transport phase;

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -83,6 +83,7 @@ let planned_worker_turn_grace_sec = 180.0
 let room_digest_session_limit = 10
 
 let severity_rank = function
+  | "critical" -> 3
   | "bad" -> 2
   | "warn" -> 1
   | _ -> 0
@@ -472,4 +473,3 @@ let normalize_digest_target_type value =
       | "team_session" -> Ok "team_session"
       | _ -> Error "target_type must be one of: room, team_session")
   | None -> Ok "room"
-

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -157,6 +157,32 @@ let test_generic_failure_envelope_is_retryable_without_operator_action () =
   check bool "generic operator action omitted" true
     Yojson.Safe.Util.(failure_envelope |> member "operator_action" = `Null)
 
+let test_blank_entity_id_is_normalized_out () =
+  let details =
+    Dashboard_tool_host_events.details_json
+      {
+        agent_name = "codex";
+        client_name = "codex";
+        tool_name = "masc_keeper_msg";
+        transport = "mcp_http";
+        phase = Some "tools/call";
+        message = "upstream returned malformed payload";
+        request_id = Some "   ";
+        session_id = Some "";
+        trace_id = Some "trace-7";
+        timeout_ms = None;
+      }
+  in
+  let failure_envelope = Yojson.Safe.Util.member "failure_envelope" details in
+  check string "normalized entity_id uses first non-empty id" "trace-7"
+    Yojson.Safe.Util.(failure_envelope |> member "entity_id" |> to_string);
+  check bool "blank request_id omitted from evidence" true
+    Yojson.Safe.Util.
+      (failure_envelope |> member "evidence_ref" |> member "request_id" = `Null);
+  check bool "blank session_id omitted from evidence" true
+    Yojson.Safe.Util.
+      (failure_envelope |> member "evidence_ref" |> member "session_id" = `Null)
+
 let () =
   run "Dashboard_tool_host_events"
     [
@@ -169,5 +195,7 @@ let () =
             test_record_writes_audit_ring_and_telemetry;
           test_case "generic failure envelope stays retryable" `Quick
             test_generic_failure_envelope_is_retryable_without_operator_action;
+          test_case "blank entity_id is normalized out" `Quick
+            test_blank_entity_id_is_normalized_out;
         ] );
     ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -30,6 +30,10 @@ let () =
           Alcotest.test_case "digest room tool host attention" `Quick
             Test_operator_control_snapshot
             .test_digest_room_includes_tool_host_failure_attention;
+          Alcotest.test_case "operator digest severity rank supports critical"
+            `Quick
+            Test_operator_control_snapshot
+            .test_operator_digest_severity_rank_supports_critical;
           Alcotest.test_case "digest room prefers fresh operator judgment"
             `Quick
             Test_operator_control_judgment

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -457,6 +457,13 @@ let test_digest_room_includes_tool_host_failure_attention () =
           (item |> member "evidence" |> member "failure_envelope"
          |> member "operator_action" |> to_string))
 
+let test_operator_digest_severity_rank_supports_critical () =
+  Alcotest.(check int) "critical rank" 3
+    (Operator_digest.severity_rank "critical");
+  Alcotest.(check bool) "critical outranks bad" true
+    (Operator_digest.severity_rank "critical"
+    > Operator_digest.severity_rank "bad")
+
 let test_digest_team_session_can_skip_workers () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary
- normalize `failure_envelope.entity_id` by selecting the first non-empty trimmed id across `request_id`, `session_id`, and `trace_id`
- teach `Operator_digest.severity_rank` to recognize `critical`
- add regression coverage for blank id normalization and critical severity ordering

## Product impact
- tool-host failures no longer emit `entity_id = ""` while omitting the same ids from `evidence_ref`
- future `critical` failure envelopes will not be sorted below `bad` or `warn` attention items in operator digest surfaces

## Evidence
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope ./test/test_dashboard_tool_host_events.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope ./test/test_operator_control.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope/_build/default/test/test_operator_control.exe test --color=never operator 8`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/codex-unified-failure-envelope/_build/default/test/test_operator_control.exe test --color=never operator 9`

## Review evidence
- reviewer: GLM-5.1 via `sb glm-text`
- timestamp: 2026-04-02 09:42:49 KST
- scope: `origin/main...3a3770f7e`
- result: No findings.

## Linked issue
- Refs #1009
- Follow-up to #4526 (merged on 2026-04-02 KST; this PR carries the post-merge review fixes only)
