### PR TITLE
fix(dashboard): unify shell padding to 8px/16px token scale

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -70,9 +70,9 @@ export function App() {
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
-      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.44)] px-3 py-2 backdrop-blur-xl lg:px-4 lg:py-2.5">
+      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.44)] px-4 py-2 backdrop-blur-xl">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
-        <div class="mx-auto flex w-full max-w-[1680px] items-center justify-between gap-4 max-[860px]:flex-col max-[860px]:items-stretch">
+        <div class="mx-auto flex w-full max-w-[1600px] items-center justify-between gap-4 max-[860px]:flex-col max-[860px]:items-stretch">
           <div class="min-w-0">
             <div class="flex items-center gap-4">
               <button type="button"
@@ -113,13 +113,13 @@ export function App() {
 
       <${RemoteWarningBanner} />
 
-      <div class="flex flex-1 gap-2.5 overflow-hidden p-2.5 max-[1100px]:flex-col max-[1100px]:gap-2 max-[1100px]:p-2">
+      <div class="flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col">
         <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 
         <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(10,15,26,0.68)] backdrop-blur-lg max-[1100px]:min-h-0">
-          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-3 lg:p-4">
+          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-4">
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -168,7 +168,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
   return html`
     <nav class="flex flex-col h-full" aria-label="Dashboard navigation">
-      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2.5 pt-2.5 pb-1">
+      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
             <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">내비게이션</div>
@@ -185,7 +185,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </button>
       </div>
 
-      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1.5' : 'px-2.5'} py-1.5">
+      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1' : 'px-2'} py-1.5">
         <div class="flex flex-col gap-2">
           ${DASHBOARD_SURFACES.map(surface => {
             const isSurfaceActive = surface.id === currentTab
@@ -210,7 +210,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center gap-2.5 w-full rounded-lg border px-2.5 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.18)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)]'}"
+                  class="flex items-center gap-2 w-full rounded-lg border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.18)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
                   <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.03)] text-[14px]">
@@ -222,14 +222,14 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <//>
 
                 ${sections.length > 0 ? html`
-                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[rgba(255,255,255,0.05)] pl-10 pr-1" role="list">
+                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[rgba(255,255,255,0.05)] pl-3" role="list">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
                         <${RouteLink}
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded-lg border px-2.5 py-1.5 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.14)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.14)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded-lg border px-2 py-1 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.14)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.14)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)]'}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>
@@ -244,7 +244,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </div>
       </div>
 
-      <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] ${collapsed ? 'px-1.5 py-2' : 'px-2.5 py-2'}">
+      <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] ${collapsed ? 'px-1 py-2' : 'px-2 py-2'}">
         <${HealthIndicator} collapsed=${collapsed} />
       </div>
     </nav>
@@ -297,16 +297,14 @@ function SurfaceLead() {
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
 
+  const description = currentSection?.description ?? currentView?.description ?? null
+
   return html`
-    <div class="mb-5 flex flex-wrap items-end justify-between gap-3">
-      <div class="min-w-0">
-        <h2 class="flex items-center gap-2.5 text-[28px] font-bold tracking-tight text-[var(--text-strong)]">
-          ${currentSection?.label ?? currentView?.label ?? '홈'}
-        </h2>
-        <p class="mt-1.5 max-w-[680px] text-[13px] leading-relaxed text-[rgba(255,255,255,0.54)]">
-          ${currentSection?.description ?? currentView?.description ?? '지금 필요한 신호를 가장 안정적으로 읽을 수 있는 기본 화면입니다.'}
-        </p>
-      </div>
+    <div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+      <h2 class="flex items-center gap-2 text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
+        ${currentSection?.label ?? currentView?.label ?? '홈'}
+        ${description ? html`<span class="text-[13px] font-normal text-[rgba(255,255,255,0.44)]">${description}</span>` : null}
+      </h2>
     </div>
   `
 }
@@ -327,7 +325,7 @@ export function DashboardMain() {
 
   return html`
     ${roomTruthInitializing.value ? html`
-      <div class="mb-3 shrink-0 rounded-xl border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-3.5 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
+      <div class="mb-3 shrink-0 rounded-xl border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-3 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
     <${SurfaceLead} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>


### PR DESCRIPTION
## Summary

- Shell 레이어 3종 패딩(10/12/16px) → 2종(8/16px) 토큰 기반으로 통일
- SurfaceLead 수직 공간 ~80px → ~40px 절감 (제목 축소 + 설명 인라인)
- Sidebar sub-nav `pl-10`(40px) → `pl-3`(12px), 220px 폭에서 공간 회복
- Header/content max-width 1680/1600 불일치 → 1600px 통일

## Before/After 패딩 맵

| 레이어 | Before | After |
|--------|--------|-------|
| Header | px-3/py-2 lg:px-4/py-2.5 | px-4/py-2 |
| Body container | p-2.5 gap-2.5 | p-2 gap-2 |
| Content | p-3 lg:p-4 | p-4 |
| Sidebar internal | px-2.5 | px-2 |
| Sub-nav indent | pl-10 | pl-3 |

## Test plan

- [ ] `npx vite build` 통과 확인
- [ ] Overview/모니터링/작업 탭 전환 시 레이아웃 깨짐 없음
- [ ] 사이드바 접기/펼치기 정상
- [ ] 1100px 이하 반응형 확인
- [ ] 768px 이하 모바일 메뉴 정상

Generated with [Claude Code](https://claude.com/claude-code)
