### PR TITLE
fix(keeper): change default tool preset from Full to Research

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -228,8 +228,9 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     let count = List.length result in
     if count > 100 then
       Log.Keeper.warn
-        "tool budget exceeded: %d schemas in LLM context (~%dKB estimated). \
-         Consider using a narrower preset or custom allowlist."
+        "tool policy allows %d schemas (~%dKB). Progressive disclosure \
+         limits actual LLM context to ~20-40, but universe build cost scales \
+         with policy size. Consider a narrower preset or custom allowlist."
         count (count * 470 / 1024);
     result
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -104,7 +104,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let handoff_threshold = Option.value ~default:0.85 p.handoff_threshold_opt in
     let handoff_cooldown_sec = Option.value ~default:300 p.handoff_cooldown_sec_opt in
     let tool_preset =
-      Option.value ~default:Full
+      Option.value ~default:Research
         (first_some p.tool_preset_opt (preset_of_defaults p.profile_defaults))
     in
     let tool_also_allow =


### PR DESCRIPTION
## Summary
- 기본 tool preset을 `Full`(345개) → `Research`(~100개)로 변경
- 경고 메시지를 정확하게 수정 (progressive disclosure가 실제 LLM context를 ~20-40으로 제한함을 명시)
- 기존 keeper meta에 명시적 preset이 있으면 영향 없음 (새 keeper만 해당)

Closes #4522

## Test plan
- [x] `dune build` passes
- [x] test_keeper_tools_oas (20 tests) pass
- [x] test_keeper_tool_exposure (37 tests) pass
- [ ] Integration: 새 keeper 생성 시 Research preset 확인
- [ ] Integration: 기존 Full preset keeper가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)