### PR TITLE
[codex] clarify allow_legacy_accept binding in transport runtime

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -66,7 +66,7 @@ let websocket_discovery_json request =
   let (host, port) = advertised_host_port request in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~allow_legacy_accept ~host
+      ~allow_legacy_accept:Server_routes_http_common.allow_legacy_accept ~host
       ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
   in
   Transport_read_model.websocket_discovery_json ctx
@@ -75,7 +75,7 @@ let transport_json request =
   let (host, port) = advertised_host_port request in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~allow_legacy_accept ~host
+      ~allow_legacy_accept:Server_routes_http_common.allow_legacy_accept ~host
       ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
   in
   Transport_read_model.transport_status_json ctx


### PR DESCRIPTION
## Summary
- make the `allow_legacy_accept` binding explicit in `server_routes_http_runtime`
- remove ambiguity around where the value comes from when building the shared transport read model context

## Root Cause
The original transport-truth change relied on `open Server_routes_http_common` for `allow_legacy_accept`. That is valid OCaml, but the implicit binding was easy to misread in review and triggered repeated compile-scope comments.

## Product impact
No behavior change. This is a review follow-up that makes the source of `allow_legacy_accept` explicit in the HTTP runtime transport JSON path, so the runtime read-model construction is easier to audit.

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/transport-truth-review-followup lib/.masc_mcp.objs/native/masc_mcp__Server_routes_http_runtime.cmx`
- follow-up diff is limited to [server_routes_http_runtime.ml](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/transport-truth-review-followup/lib/server/server_routes_http_runtime.ml)

## Review evidence
- local cross-model review via `./scripts/review/local-review.sh --base origin/main --head HEAD --format markdown`
- reviewer: local `llama-server` target `qwen3.5-35b-a3b-ud-q4-xl`
- result: no findings

## Linked issue
- Refs #4536
