### PR TITLE
fix(orchestrator): stop keeper fibers during zombie cleanup

### DIFF
--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -127,7 +127,9 @@ let cleanup_zombies
            Without this, the keeper fiber continues running (fiber_stop stays
            false) and makes tool calls indefinitely after cleanup. *)
         (try !Room_hooks.stop_keeper_fn name
-         with _ -> ());
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> Log.Gc.warn "gc stop_keeper_fn error for %s: %s" name (Printexc.to_string exn));
         ()
       ) !zombie_entries;
 

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -109,7 +109,7 @@ let cleanup_zombies
     if !zombie_entries = [] then
       "✅ No zombie agents found"
     else begin
-      (* Phase 2: Transition status to Inactive + stop heartbeats.
+      (* Phase 2: Transition status to Inactive + stop heartbeats + stop keeper fibers.
          Note: If later phases fail (task release or file deletion), the agent
          remains in active_agents with an Inactive file. This is intentional:
          Inactive+in-list is self-healing (next GC cycle cleans up), whereas
@@ -123,6 +123,11 @@ let cleanup_zombies
           | Error err -> Log.Gc.warn "gc status update parse error for %s: %s" name err
         with Sys_error msg -> Log.Gc.warn "gc status update I/O error for %s: %s" name msg);
         let _stopped = Heartbeat.stop_by_agent ~agent_name:name in
+        (* Stop keeper fiber via hook to prevent zombie tool calls.
+           Without this, the keeper fiber continues running (fiber_stop stays
+           false) and makes tool calls indefinitely after cleanup. *)
+        (try !Room_hooks.stop_keeper_fn name
+         with _ -> ());
         ()
       ) !zombie_entries;
 

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -74,6 +74,13 @@ let agent_economy_earn_fn
   : (base_path:string -> agent_name:string -> reason:string -> unit) ref
   = ref (fun ~base_path:_ ~agent_name:_ ~reason:_ -> ())
 
+(** Stop keeper keepalive fiber — avoids Room_gc → Keeper_keepalive dep.
+    Called during zombie cleanup to terminate keeper fibers that would
+    otherwise continue making tool calls after agent removal. *)
+let stop_keeper_fn
+  : (string -> unit) ref
+  = ref (fun _name -> ())
+
 (** Relation materializer: agent leave — wraps Relation_materializer.on_agent_leave. *)
 let relation_on_leave_fn
   : (leaving_agent:string -> active_agents:string list -> unit) ref

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -12,6 +12,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =
   Progress.set_sse_callback Sse.broadcast;
   Sse.set_clock clock;
+  (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
+  Room_hooks.stop_keeper_fn := Keeper_keepalive.stop_keepalive;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Agent_sdk.Event_bus.create () in
   (* Eio fiber isolation: each subsystem runs in its own fiber.


### PR DESCRIPTION
## Summary
Zombie cleanup이 agent를 active_agents에서 제거하지만 keeper fiber의 `fiber_stop` flag를 설정하지 않아, zombie keeper가 cleanup 후에도 tool call을 계속 시도하는 문제 수정.

**Root cause**: `room_gc.ml`의 `cleanup_zombies`가 `Room_state`만 업데이트하고 `Keeper_registry`의 fiber lifecycle을 건드리지 않음.

**Fix**: `Room_hooks.stop_keeper_fn` hook을 추가하고, server bootstrap에서 `Keeper_keepalive.stop_keepalive`로 wiring. Zombie cleanup Phase 2에서 호출하여 keeper fiber의 `fiber_stop` Atomic을 true로 설정.

Closes #4532

## Test plan
- [x] `dune build` passes (no cycle, clean)
- [ ] Integration: zombie cleanup 후 keeper가 tool call을 멈추는지 확인
- [ ] Integration: 정상 keeper가 영향받지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)