### PR TITLE
fix(keeper): include error detail in tool retry log

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -199,9 +199,14 @@ let make_tools
                 Hashtbl.replace failure_counts key count;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
+                let preview =
+                  let s = String.trim result in
+                  if String.length s <= 120 then s
+                  else String.sub s 0 120 ^ "..."
+                in
                 Log.Keeper.warn
-                  "tool %s returned error result (%d/%d) for same args"
-                  td.name count max_consecutive_failures;
+                  "tool %s returned error result (%d/%d) for same args: %s"
+                  td.name count max_consecutive_failures preview;
                 (false, normalize_tool_result ~success:false result)
               end else begin
                 Hashtbl.remove failure_counts key;


### PR DESCRIPTION
## Summary
Tool failure retry 로그에 실제 error content가 누락되어 353건의 first-attempt 실패 원인을 진단할 수 없었던 문제 수정.

**Before**: `tool masc_tasks returned error result (1/3) for same args`
**After**: `tool masc_tasks returned error result (1/3) for same args: {"error":"lock contention on .masc/state.json..."}`

1파일, 7줄 변경. Error result의 첫 120자를 preview로 포함.

Partially addresses #4543

## Test plan
- [x] `dune build` passes
- [ ] Integration: keeper 가동 후 retry 로그에 error detail 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)