### PR TITLE
feat(mcp): register masc_clear_param and masc_prompt_override tools

### DIFF
--- a/lib/tool_council_feed.ml
+++ b/lib/tool_council_feed.ml
@@ -176,3 +176,94 @@ let handle_set_param ~submit_petition ctx args =
                Printf.sprintf "Set %s = %s (low-risk, applied immediately)"
                  param_key (Yojson.Safe.to_string value))
         end
+
+let handle_clear_param ~submit_petition ctx args =
+  let param_key = get_string args "param_key" "" |> String.trim in
+  let reason = get_string args "reason" "" in
+  if param_key = "" then (false, "param_key is required")
+  else
+    let risk =
+      Governance_registry.surfaces
+      |> List.find_opt (fun (s : Governance_registry.surface) ->
+           List.mem param_key s.param_keys)
+      |> Option.map (fun (s : Governance_registry.surface) -> s.risk)
+      |> Option.value ~default:"low"
+    in
+    if risk = "high" then
+      let title =
+        Printf.sprintf "Clear %s to default%s" param_key
+          (if reason <> "" then " (" ^ reason ^ ")" else "")
+      in
+      let petition_args =
+        `Assoc [
+          ("title", `String title);
+          ("origin", `String "agent");
+          ("subject_type", `String "param_change");
+          ("risk_class", `String "high");
+          ("requested_action", `Assoc [
+            ("action_type", `String "clear_param");
+            ("payload", `Assoc [("param_key", `String param_key)]);
+          ]);
+          ("source_refs", `List [`String param_key]);
+        ]
+      in
+      let (ok, msg) = submit_petition ctx petition_args in
+      if ok then
+        (true, Printf.sprintf "High-risk parameter. Governance petition created.\n%s" msg)
+      else
+        (false, Printf.sprintf "Failed to create governance petition: %s" msg)
+    else begin
+      let old_value =
+        match Runtime_params.registry ()
+              |> List.find_opt (fun (k, _, _, _, _) -> k = param_key) with
+        | Some (_, current, _, _, _) -> current
+        | None -> `Null
+      in
+      match Runtime_params.clear_by_key param_key with
+      | Error msg -> (false, Printf.sprintf "clear_param failed: %s" msg)
+      | Ok () ->
+          let new_value =
+            match Runtime_params.registry ()
+                  |> List.find_opt (fun (k, _, _, _, _) -> k = param_key) with
+            | Some (_, _, default, _, _) -> default
+            | None -> `Null
+          in
+          Runtime_params.persist ~base_path:ctx.base_path;
+          Runtime_params.record_audit ~base_path:ctx.base_path
+            ~key:param_key ~old_value ~new_value ~actor:ctx.agent_name ();
+          Sse.broadcast
+            (`Assoc [
+              ("type", `String "governance_param_changed");
+              ("param_key", `String param_key);
+              ("old_value", old_value);
+              ("new_value", new_value);
+              ("actor", `String ctx.agent_name);
+            ]);
+          (true, Printf.sprintf "Cleared %s to default (low-risk, applied immediately)" param_key)
+    end
+
+let handle_prompt_override ctx args =
+  let key = get_string args "key" "" |> String.trim in
+  let action = get_string args "action" "set" in
+  if key = "" then (false, "key is required")
+  else
+    match action with
+    | "clear" ->
+      Prompt_registry.clear_prompt_override key;
+      (try Prompt_registry.persist_overrides ctx.base_path
+       with exn ->
+         Log.Pages.warn "prompt override persist (clear) failed: %s"
+           (Printexc.to_string exn));
+      (true, Printf.sprintf "Prompt override cleared for %s" key)
+    | "set" | _ ->
+      let value = get_string args "value" "" in
+      if value = "" then (false, "value is required when action is 'set'")
+      else
+        match Prompt_registry.set_override key value with
+        | Error msg -> (false, msg)
+        | Ok () ->
+          (try Prompt_registry.persist_overrides ctx.base_path
+           with exn ->
+             Log.Pages.warn "prompt override persist (set) failed: %s"
+               (Printexc.to_string exn));
+          (true, Printf.sprintf "Prompt override set for %s" key)

--- a/lib/tool_council_internal_schemas.ml
+++ b/lib/tool_council_internal_schemas.ml
@@ -256,4 +256,49 @@ Use masc_runtime_params to list available keys and their risk class.";
       ("required", `List [`String "param_key"; `String "value"]);
     ];
   };
+  {
+    name = "masc_clear_param";
+    description = "Reset a runtime parameter to its default value. Low-risk params clear immediately. \
+High-risk params create a governance petition requiring council approval. \
+Use masc_runtime_params to list available keys and current overrides.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("param_key", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Parameter key to reset to default. Use masc_runtime_params to list available keys.");
+        ]);
+        ("reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Why this reset is needed (recorded in audit log)");
+        ]);
+      ]);
+      ("required", `List [`String "param_key"]);
+    ];
+  };
+  {
+    name = "masc_prompt_override";
+    description = "Set or clear a prompt template override. Action 'set' overrides the template with the given value. \
+Action 'clear' removes the override, restoring the default. Changes are persisted to .masc/prompt_overrides.json. \
+Use GET /api/v1/prompts to see available prompt keys and current values.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("key", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Prompt template key to override or clear");
+        ]);
+        ("action", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "set"; `String "clear"]);
+          ("description", `String "Action to perform: 'set' to override, 'clear' to restore default");
+        ]);
+        ("value", `Assoc [
+          ("type", `String "string");
+          ("description", `String "New prompt template value (required when action is 'set')");
+        ]);
+      ]);
+      ("required", `List [`String "key"; `String "action"]);
+    ];
+  };
 ]

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -262,7 +262,30 @@ let feed_ctx_of (ctx : context) : Tool_council_feed.context =
 let handle_clear_param ctx args =
   let fctx = feed_ctx_of ctx in
   let submit_petition _ctx petition_args =
-    handle_petition_submit ctx petition_args
+    let open Yojson.Safe.Util in
+    let title = member "title" petition_args |> to_string_option
+      |> Option.value ~default:"Clear runtime parameter" in
+    let subject_type = member "subject_type" petition_args |> to_string_option
+      |> Option.value ~default:"param_change" in
+    let risk_class = match member "risk_class" petition_args |> to_string_option with
+      | Some s -> (match GV2.risk_class_of_string s with Ok r -> r | Error _ -> GV2.High)
+      | None -> GV2.High in
+    let requested_action = match member "requested_action" petition_args with
+      | `Null -> None
+      | ra ->
+        let at = member "action_type" ra |> to_string_option
+          |> Option.value ~default:"clear_param" in
+        let payload = match member "payload" ra with `Null -> None | p -> Some p in
+        Some ({ action_type = at; target_type = Some "param";
+                target_id = None; payload } : GV2.action_request) in
+    let source_refs = match member "source_refs" petition_args with
+      | `List items -> List.filter_map to_string_option items
+      | _ -> [] in
+    match GV2.submit_petition ctx.base_path ~title ~origin:ctx.agent_name
+      ~subject_type ~risk_class ~requested_action ~source_refs
+      ~created_by:ctx.agent_name with
+    | Ok result -> (true, Printf.sprintf "Petition created: case %s" result.case_.id)
+    | Error msg -> (false, msg)
   in
   Tool_council_feed.handle_clear_param ~submit_petition fctx args
 

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -254,6 +254,21 @@ let handle_set_param ctx args =
     ])
   end
 
+let feed_ctx_of (ctx : context) : Tool_council_feed.context =
+  { base_path = ctx.base_path;
+    agent_name = ctx.agent_name;
+    room_config = ctx.room_config; }
+
+let handle_clear_param ctx args =
+  let fctx = feed_ctx_of ctx in
+  let submit_petition _ctx petition_args =
+    handle_petition_submit ctx petition_args
+  in
+  Tool_council_feed.handle_clear_param ~submit_petition fctx args
+
+let handle_prompt_override ctx args =
+  Tool_council_feed.handle_prompt_override (feed_ctx_of ctx) args
+
 (* ================================================================ *)
 (* Execute/voting — delegate to Council.Executor                     *)
 (* ================================================================ *)
@@ -405,6 +420,8 @@ let dispatch (ctx : context) ~name ~args : result option =
     | "masc_execution_orders" -> Some handle_execution_orders
     | "masc_runtime_params" -> Some handle_runtime_params
     | "masc_set_param" -> Some handle_set_param
+    | "masc_clear_param" -> Some handle_clear_param
+    | "masc_prompt_override" -> Some handle_prompt_override
     | _ -> None
   in
   match handler with

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -98,6 +98,7 @@ let all_known_tool_names =
     "masc_circuit_status";
     "masc_claim_next";
     "masc_cleanup_zombies";
+    "masc_clear_param";
     "masc_code_delete";
     "masc_code_edit";
     "masc_code_git";
@@ -241,6 +242,7 @@ let all_known_tool_names =
     "masc_portal_send";
     "masc_portal_status";
     "masc_progress";
+    "masc_prompt_override";
     "masc_recall_search";
     "masc_register_capabilities";
     "masc_reject";

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -423,6 +423,100 @@ let () =
          (Str.regexp_string "petition") s 0); true with Not_found -> false))
   in
 
+  let test_handle_clear_param_low_risk () =
+    let tmp_dir = Filename.temp_dir "masc_clearparam_" "" in
+    let masc_dir = Filename.concat tmp_dir ".masc" in
+    (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+    let ctx =
+      Tool_council_feed.{ base_path = tmp_dir; agent_name = "test-agent";
+        room_config = None }
+    in
+    (* First set a medium-risk param to a non-default value *)
+    let set_args = `Assoc [
+      ("param_key", `String "keeper.max_consecutive_hb_failures");
+      ("value", `Int 15);
+    ] in
+    let submit_petition _ctx _args = (false, "unexpected petition") in
+    let (ok, _) =
+      Tool_council_feed.handle_set_param ~submit_petition ctx set_args
+    in
+    Alcotest.(check bool) "set succeeded" true ok;
+    Alcotest.(check int) "value overridden" 15
+      (Runtime_params.get Governance_registry.keeper_max_hb_failures);
+    (* Now clear it *)
+    let petition_called = ref false in
+    let submit_petition2 _ctx _args =
+      petition_called := true; (false, "unexpected petition")
+    in
+    let clear_args = `Assoc [
+      ("param_key", `String "keeper.max_consecutive_hb_failures");
+    ] in
+    let (ok2, _msg) =
+      Tool_council_feed.handle_clear_param ~submit_petition:submit_petition2 ctx clear_args
+    in
+    Alcotest.(check bool) "clear succeeded" true ok2;
+    Alcotest.(check bool) "no petition for low risk" false !petition_called;
+    (* Cleanup *)
+    rm_rf tmp_dir
+  in
+
+  let test_handle_clear_param_high_risk_triggers_petition () =
+    let ctx =
+      Tool_council_feed.{ base_path = "/tmp"; agent_name = "test-agent";
+        room_config = None }
+    in
+    let petition_called = ref false in
+    let submit_petition _ctx _args =
+      petition_called := true; (true, "petition-456")
+    in
+    let args = `Assoc [
+      ("param_key", `String "inference.default_model");
+    ] in
+    let (ok, msg) =
+      Tool_council_feed.handle_clear_param ~submit_petition ctx args
+    in
+    Alcotest.(check bool) "petition created" true !petition_called;
+    Alcotest.(check bool) "ok" true ok;
+    Alcotest.(check bool) "mentions petition" true
+      (try ignore (Str.search_forward
+         (Str.regexp_string "petition") (String.lowercase_ascii msg) 0); true
+       with Not_found -> false)
+  in
+
+  let test_handle_prompt_override_set_clear () =
+    let tmp_dir = Filename.temp_dir "masc_prompt_" "" in
+    let masc_dir = Filename.concat tmp_dir ".masc" in
+    (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+    let ctx =
+      Tool_council_feed.{ base_path = tmp_dir; agent_name = "test-agent";
+        room_config = None }
+    in
+    let key = "test_prompt_key_for_override" in
+    (* Register a default prompt so get_prompt works *)
+    Prompt_registry.register_default ~key ~default:"original" ~description:"test" ();
+    (* Set override *)
+    let set_args = `Assoc [
+      ("key", `String key);
+      ("action", `String "set");
+      ("value", `String "overridden");
+    ] in
+    let (ok, _msg) = Tool_council_feed.handle_prompt_override ctx set_args in
+    Alcotest.(check bool) "set succeeded" true ok;
+    Alcotest.(check string) "override applied"
+      "overridden" (Prompt_registry.get_prompt key);
+    (* Clear override *)
+    let clear_args = `Assoc [
+      ("key", `String key);
+      ("action", `String "clear");
+    ] in
+    let (ok2, _msg2) = Tool_council_feed.handle_prompt_override ctx clear_args in
+    Alcotest.(check bool) "clear succeeded" true ok2;
+    Alcotest.(check string) "default restored"
+      "original" (Prompt_registry.get_prompt key);
+    (* Cleanup *)
+    rm_rf tmp_dir
+  in
+
   let test_handle_runtime_params_includes_keeper () =
     let ctx =
       Tool_council_feed.{ base_path = "/tmp"; agent_name = "test-agent";
@@ -528,6 +622,18 @@ let () =
             test_handle_set_param_high_risk_triggers_petition;
           Alcotest.test_case "runtime params includes keeper" `Quick
             test_handle_runtime_params_includes_keeper;
+        ] );
+      ( "handle_clear_param",
+        [
+          Alcotest.test_case "low-risk param clear" `Quick
+            test_handle_clear_param_low_risk;
+          Alcotest.test_case "high-risk triggers petition" `Quick
+            test_handle_clear_param_high_risk_triggers_petition;
+        ] );
+      ( "handle_prompt_override",
+        [
+          Alcotest.test_case "set and clear" `Quick
+            test_handle_prompt_override_set_clear;
         ] );
       ( "crash_persistence",
         [


### PR DESCRIPTION
## Summary
- MCP agents could not clear governance params or manage prompt overrides (only dashboard HTTP API)
- Added `masc_clear_param` and `masc_prompt_override` MCP tools with full implementations

## Changes
- `tool_council_internal_schemas.ml`: Schema definitions for both tools
- `tool_council_feed.ml`: `handle_clear_param` (with petition for high-risk) and `handle_prompt_override` (set/clear with persist)
- `tool_council_oas.ml`: Dispatch entries + context conversion helper

## Test plan
- [ ] `masc_clear_param` with low-risk param: clears immediately
- [ ] `masc_clear_param` with high-risk param: creates governance petition
- [ ] `masc_prompt_override` with action=set: overrides prompt
- [ ] `masc_prompt_override` with action=clear: restores default
- [ ] Tools appear in `tools/list` MCP response

Closes #4516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
