### PR TITLE
chore(server): skip legacy_trace_dir_migration when already migrated

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -407,6 +407,10 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           Server_startup_state.fail_lazy_task ~task:task_name ~error
     in
     let start_lazy_startup state =
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let has_legacy_traces =
+        Sys.file_exists (Filename.concat masc_root "perpetual")
+      in
       let tasks =
         [
           ("restore_sessions", fun () -> restore_persisted_sessions state);
@@ -431,7 +435,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("prompt_bootstrap", fun () -> bootstrap_prompt_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
           ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);
-          ("legacy_trace_dir_migration", fun () -> migrate_legacy_trace_dirs state);
+        ]
+        @ (if has_legacy_traces then
+             [("legacy_trace_dir_migration", fun () ->
+                 migrate_legacy_trace_dirs state)]
+           else [])
+        @ [
           ("jsonl_prune", fun () -> startup_prune_jsonl state);
           ( "keeper_checkpoint_prune",
             fun () -> startup_prune_keeper_checkpoints state );


### PR DESCRIPTION
## Summary
- `perpetual` 디렉토리가 존재하지 않으면 `legacy_trace_dir_migration` 태스크를 startup 목록에서 제외
- 매 재시작마다 불필요한 `lazy_task: starting/finished legacy_trace_dir_migration` info 로그 제거

## Changes
- `server_runtime_bootstrap.ml`: 태스크 리스트 구성 시 `Sys.file_exists` 가드 추가

## Test plan
- [ ] `perpetual` 디렉토리 없는 상태에서 서버 시작 → `legacy_trace_dir_migration` 로그 없음 확인
- [ ] `perpetual` 디렉토리 있는 상태에서 서버 시작 → 정상 마이그레이션 수행 확인

Closes #4554

🤖 Generated with [Claude Code](https://claude.com/claude-code)