### PR TITLE
chore(keeper): demote routine audit logs from info to debug

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -127,9 +127,6 @@ let log_keeper_friction
     Log.Keeper.warn "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
       keeper_name blocked groups tripwires
   else if blocked > 0 || groups > 0 then
-    Log.Keeper.info "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-      keeper_name blocked groups tripwires
-  else if Keeper_types_profile.keeper_debug then
     Log.Keeper.debug "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
       keeper_name blocked groups tripwires
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -232,7 +232,7 @@ let make_hooks
               Log.Keeper.error "keeper:%s on_tool_executed callback failed for %s: %s"
                 (!meta_ref).name tool_name (Printexc.to_string exn));
         if List.mem tool_name board_write_tools then
-          Log.Keeper.info "keeper:%s social_event tool=%s"
+          Log.Keeper.debug "keeper:%s social_event tool=%s"
             (!meta_ref).name tool_name;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
@@ -290,7 +290,7 @@ let make_hooks
     on_idle = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; _ } ->
-        Log.Keeper.info "keeper:%s idle_turns=%d"
+        Log.Keeper.debug "keeper:%s idle_turns=%d"
           (!meta_ref).name consecutive_idle_turns;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);


### PR DESCRIPTION
## Summary
- keeper 성공 경로의 루틴 audit 로그 3곳을 `info` → `debug` 레벨로 변경
  - `social_event` (board write tool 사용 시)
  - `idle_turns` (매 idle cycle)
  - `friction blocked/groups` (tripwire 없는 경우)
- 이상 감지 로그(tripwires, cost gate, deny list)는 `warn` 유지
- 턴 요약(model/tokens)은 운영 가시성을 위해 `info` 유지

## Changes
- `keeper_hooks_oas.ml`: social_event, idle_turns 로그 → debug
- `keeper_agent_run.ml`: friction (blocked > 0, no tripwires) → debug, keeper_debug guard 제거 (항상 debug)

## Test plan
- [ ] keeper 정상 턴 실행 후 info 로그에 social_event/idle_turns/friction 없음 확인
- [ ] tripwire 발생 시 warn 로그 정상 출력 확인
- [ ] `MASC_KEEPER_DEBUG=1` 설정 시 debug 로그 출력 확인

Closes #4501

🤖 Generated with [Claude Code](https://claude.com/claude-code)