### PR TITLE
perf(keeper): change default tool preset from Full to Research

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -104,7 +104,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let handoff_threshold = Option.value ~default:0.85 p.handoff_threshold_opt in
     let handoff_cooldown_sec = Option.value ~default:300 p.handoff_cooldown_sec_opt in
     let tool_preset =
-      Option.value ~default:Full
+      Option.value ~default:Research
         (first_some p.tool_preset_opt (preset_of_defaults p.profile_defaults))
     in
     let tool_also_allow =


### PR DESCRIPTION
## Summary
- Default tool preset for new keepers: Full (345 tools, ~158KB) -> Research (~60-80 tools)
- 7x reduction in schemas sent per turn, eliminates 150 warnings/1h38m
- BM25 universe still indexes all tools for progressive disclosure

## Test plan
- [ ] Create new keeper without explicit preset -> verify Research tools loaded
- [ ] Create keeper with tool_preset=Full -> verify all 345 tools
- [ ] Verify tool budget warning count drops to near-zero

Closes #4522

Generated with Claude Code