### PR TITLE
perf(dashboard): skip expensive per-keeper I/O in keepers_json

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -190,7 +190,7 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
         fallback_snapshot.tool_audit_source,
         fallback_snapshot.tool_audit_at )
 
-let keepers_json ?keeper_names ?(include_recent_activity = true)
+let keepers_json ?keeper_names ?(include_recent_activity = false)
     ?(lightweight = false) config =
   let names = match keeper_names with
     | Some n -> n
@@ -242,7 +242,8 @@ let keepers_json ?keeper_names ?(include_recent_activity = true)
             in
             let allowed_tool_names, latest_tool_names, latest_tool_call_count,
                 tool_audit_source, tool_audit_at =
-              keeper_tool_audit_fields config meta
+              if lightweight then ([], [], None, None, None)
+              else keeper_tool_audit_fields config meta
             in
             let agent_status =
               if not agent_exists then "offline"


### PR DESCRIPTION
## Summary
- keepers_json caused 2-38s Eio blocking with 23 keepers (sequential file I/O)
- Default include_recent_activity to false (eliminates Dated_jsonl scans per keeper)
- Skip tool_audit_fields in lightweight mode (eliminates decision/metrics JSONL reads)
- Reduces per-keeper I/O from ~6 ops to ~2 in common dashboard path

## Test plan
- [ ] Dashboard loads without timeout (previously 60s+ timeout with 12+ keepers)
- [ ] Keeper detail view still shows recent_activity when requested
- [ ] operator_snapshot lightweight path completes in <2s with 23 keepers

Closes #4521

Generated with Claude Code