### PR TITLE
fix(keeper): add tag-based dispatch for masc_* tools

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -434,6 +434,7 @@
    keeper_alerting_path
    keeper_tool_registry
    keeper_tool_policy
+   keeper_tag_dispatch
    keeper_exec_tools
    keeper_voice_local
    keeper_voice_loop

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -27,6 +27,20 @@ let on_keeper_tool_call :
   (tool_name:string -> success:bool -> duration_ms:int -> unit) ref =
   ref (fun ~tool_name:_ ~success:_ ~duration_ms:_ -> ())
 
+(** Tag-based dispatch callback for masc_* tools.
+    Set at server initialization to Keeper_tag_dispatch.dispatch.
+    Breaks the dependency cycle: keeper_exec_tools cannot import Tool_*
+    modules directly because Config -> Operator_control -> Keeper_exec_tools
+    creates a cycle with any Tool_* that depends on Config.
+
+    Default: returns None (falls through to "unregistered" error).
+    See: mcp_server_eio.ml initialization, #4579. *)
+let tag_dispatch_fn :
+  (config:Room.config -> agent_name:string ->
+   tag:Tool_dispatch.module_tag -> name:string ->
+   args:Yojson.Safe.t -> (bool * string) option) ref =
+  ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
+
 (** Estimate total token count for a working context (system prompt + messages).
     Mirrors [Keeper_exec_context.token_count] but avoids a dependency cycle. *)
 let count_context_tokens (ctx : working_context) =
@@ -744,6 +758,10 @@ let execute_keeper_tool_call
       | Some err ->
           Yojson.Safe.to_string (`Assoc [ ("error", `String err) ])
       | None ->
+      (* Phase 1: Try handler registry first.
+         Preserves masc_board_* which is registered in both tag_registry
+         (as Mod_inline) and handler_registry (via Tool_board.register).
+         Without this priority, Mod_inline would fail for keepers. *)
       (match Tool_dispatch.mint_token ~name with
        | Error reason ->
            Yojson.Safe.to_string
@@ -751,15 +769,31 @@ let execute_keeper_tool_call
                        ("tool", `String name);
                        ("reason", `String reason) ])
        | Ok token ->
-      let result = Tool_dispatch.dispatch ~token ~args in
-      (match result with
+      (match Tool_dispatch.dispatch ~token ~args with
         | Some (true, msg) -> msg
         | Some (false, msg) ->
             Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
         | None ->
-            Yojson.Safe.to_string
-              (`Assoc [ ("error", `String "unregistered_masc_tool");
-                        ("tool", `String name) ]))))
+            (* Phase 2: Handler returned None — try tag-based dispatch.
+               Most masc_* tools are only in tag_registry, not handler_registry.
+               tag_dispatch_fn is set to Keeper_tag_dispatch.dispatch at server
+               init (mcp_server_eio.ml) to break the dependency cycle. #4579 *)
+            (match Tool_dispatch.lookup_tag name with
+             | Some tag ->
+                 (match !tag_dispatch_fn
+                          ~config ~agent_name:meta.name ~tag ~name ~args with
+                  | Some (true, msg) -> msg
+                  | Some (false, msg) ->
+                      Yojson.Safe.to_string
+                        (`Assoc [ ("error", `String msg) ])
+                  | None ->
+                      Yojson.Safe.to_string
+                        (`Assoc [ ("error", `String "keeper_dispatch_none");
+                                  ("tool", `String name) ]))
+             | None ->
+                 Yojson.Safe.to_string
+                   (`Assoc [ ("error", `String "unregistered_masc_tool");
+                             ("tool", `String name) ])))))
   | other ->
       Yojson.Safe.to_string
         (`Assoc [ ("error", `String "unknown_tool"); ("tool", `String other) ])

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -41,6 +41,14 @@ val is_keeper_denied : string -> bool
 val on_keeper_tool_call :
   (tool_name:string -> success:bool -> duration_ms:int -> unit) ref
 
+(** Tag-based dispatch callback for masc_* tools without handler registry entries.
+    Set at server init to [Keeper_tag_dispatch.dispatch]. Default: returns None.
+    See #4579. *)
+val tag_dispatch_fn :
+  (config:Room.config -> agent_name:string ->
+   tag:Tool_dispatch.module_tag -> name:string ->
+   args:Yojson.Safe.t -> (bool * string) option) ref
+
 (** masc_* tool names available for a keeper (filtered by allowlist/denylist). *)
 val keeper_masc_tool_names : keeper_meta -> string list
 

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -1,0 +1,271 @@
+(** Keeper_tag_dispatch — Tag-based tool dispatch for keeper context.
+
+    Bridges the gap between keeper's available context (config, agent_name,
+    Eio globals) and the module-specific contexts needed by Tool_*.dispatch.
+
+    Handler registry dispatch (Tool_dispatch.dispatch) MUST be tried first
+    by the caller — this module is the fallback for tools only in tag_registry.
+
+    See: mcp_server_eio_execute.ml dispatch_by_tag for the MCP server version.
+    Issue: #4579 *)
+
+(** Helper: require Eio.Switch.t, return error if unavailable. *)
+let require_sw () =
+  match Eio_context.get_switch_opt () with
+  | Some sw -> Ok sw
+  | None -> Error "requires Eio switch (not available in keeper context)"
+
+(** Helper: require Eio clock, return error if unavailable. *)
+let require_clock () =
+  match Eio_context.get_clock_opt () with
+  | Some clock -> Ok clock
+  | None -> Error "requires Eio clock (not available in keeper context)"
+
+(** Helper: get optional proc_mgr via Process_eio fallback. *)
+let get_proc_mgr_opt () =
+  match Process_eio.get_proc_mgr () with
+  | Ok pm -> Some pm
+  | Error _ -> None
+
+(** Helper: get optional net. *)
+let get_net_opt () = Eio_context.get_net_opt ()
+
+(** Helper: get optional fs. *)
+let get_fs_opt () = Fs_compat.get_fs_opt ()
+
+(** Dispatch a tool by its module tag using keeper-available context.
+
+    @param config   Room configuration
+    @param agent_name  Keeper's agent name (meta.name)
+    @param tag      Module tag from [Tool_dispatch.lookup_tag]
+    @param name     Tool name
+    @param args     Tool arguments JSON
+
+    Returns [Some (success, message)] or [None] if module dispatch
+    does not recognize the tool name (should not happen when tag is correct). *)
+let dispatch
+    ~(config : Room.config)
+    ~(agent_name : string)
+    ~(tag : Tool_dispatch.module_tag)
+    ~(name : string)
+    ~(args : Yojson.Safe.t)
+  : (bool * string) option =
+  match tag with
+
+  (* ── Tier A: config + agent_name only ──────────────────────── *)
+
+  | Mod_plan ->
+      Tool_plan.dispatch { config } ~name ~args
+  | Mod_local_runtime ->
+      Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name }
+        ~name ~args
+  | Mod_portal ->
+      Tool_portal.dispatch { Tool_portal.config; agent_name } ~name ~args
+  | Mod_worktree ->
+      Tool_worktree.dispatch { Tool_worktree.config; agent_name } ~name ~args
+  | Mod_code ->
+      Tool_code.dispatch { Tool_code.config; agent_name } ~name ~args
+  | Mod_code_write ->
+      Tool_code_write.dispatch { Tool_code_write.config; agent_name }
+        ~name ~args
+  | Mod_a2a ->
+      Tool_a2a.dispatch { Tool_a2a.config; agent_name } ~name ~args
+  | Mod_auth ->
+      Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args
+  | Mod_audit ->
+      Tool_audit.dispatch { Tool_audit.config } ~name ~args
+  | Mod_cost ->
+      Tool_cost.dispatch { Tool_cost.agent_name } ~name ~args
+  | Mod_cache ->
+      Tool_cache.dispatch { Tool_cache.config } ~name ~args
+  | Mod_run ->
+      Tool_run.dispatch { Tool_run.config } ~name ~args
+  | Mod_tempo ->
+      Tool_tempo.dispatch { Tool_tempo.config; agent_name } ~name ~args
+  | Mod_agent ->
+      Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
+  | Mod_room ->
+      Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args
+  | Mod_control ->
+      Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args
+  | Mod_agent_timeline ->
+      Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name }
+        ~name ~args
+  | Mod_misc ->
+      Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args
+  | Mod_suspend ->
+      Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name }
+        ~name ~args
+  | Mod_library ->
+      Tool_library.dispatch { Tool_library.agent_name } ~name ~args
+  | Mod_hat ->
+      Tool_hat.dispatch { Tool_hat.config; agent_name } ~name ~args
+  | Mod_model_catalog ->
+      Tool_model_catalog.dispatch () ~name ~args
+  | Mod_goals ->
+      Tool_goals.dispatch { Tool_goals.config; agent_name;
+                            call_keeper_msg = None } ~name ~args
+
+  (* ── Tier A special: Tool_shard returns Yojson.Safe.t ──────── *)
+
+  | Mod_shard ->
+      let (ok, json) = Tool_shard.execute name args in
+      Some (ok, Yojson.Safe.to_string json)
+
+  (* ── Tier B: Eio-dependent ─────────────────────────────────── *)
+
+  | Mod_heartbeat ->
+      (match require_sw (), require_clock () with
+       | Ok sw, Ok clock ->
+           Tool_heartbeat.dispatch
+             { Tool_heartbeat.config; agent_name; sw; clock } ~name ~args
+       | Error e, _ | _, Error e -> Some (false, e))
+
+  | Mod_task ->
+      Tool_task.dispatch
+        { Tool_task.config; agent_name;
+          sw = Eio_context.get_switch_opt () }
+        ~name ~args
+
+  | Mod_fire_task ->
+      (match require_sw () with
+       | Ok sw ->
+           Tool_fire_task.dispatch
+             { Tool_fire_task.config; agent_name; sw } ~name ~args
+       | Error e -> Some (false, e))
+
+  | Mod_relay ->
+      (match require_sw () with
+       | Ok sw ->
+           Tool_relay.dispatch
+             { Tool_relay.config; agent_name; sw;
+               proc_mgr = get_proc_mgr_opt () } ~name ~args
+       | Error e -> Some (false, e))
+
+  | Mod_handover ->
+      Tool_handover.dispatch
+        { Tool_handover.config; agent_name;
+          fs = get_fs_opt (); proc_mgr = get_proc_mgr_opt ();
+          sw = Eio_context.get_switch_opt () }
+        ~name ~args
+
+  | Mod_improve_loop ->
+      Tool_improve_loop.dispatch
+        { Tool_improve_loop.config; agent_name;
+          sw = Eio_context.get_switch_opt ();
+          clock = Eio_context.get_clock_opt ();
+          proc_mgr = get_proc_mgr_opt ();
+          net = get_net_opt () }
+        ~name ~args
+
+  | Mod_repair_loop ->
+      let ctx : _ Tool_repair_loop_types.context =
+        { config; agent_name;
+          sw = Eio_context.get_switch_opt ();
+          clock = Eio_context.get_clock_opt ();
+          proc_mgr = get_proc_mgr_opt () }
+      in
+      Tool_repair_loop.dispatch ctx ~name ~args
+
+  | Mod_keeper ->
+      (* Tool_keeper depends on Keeper_exec_status — dispatching it here
+         creates a dependency cycle. Keeper already handles keeper_* tools
+         inline; masc_keeper_* tools route through the MCP server path. *)
+      Some (false,
+        Printf.sprintf
+          "tool '%s' is a keeper management tool (use MCP client)" name)
+
+  | Mod_operator ->
+      (* Tool_operator depends on Operator_control -> Keeper_exec_status.
+         Operator tools are admin-level and routed through MCP server. *)
+      Some (false,
+        Printf.sprintf
+          "tool '%s' is an operator tool (use MCP client)" name)
+
+  | Mod_team_session ->
+      (match require_sw (), require_clock () with
+       | Ok sw, Ok clock ->
+           Tool_team_session.dispatch
+             { Tool_team_session.config; agent_name; sw; clock;
+               proc_mgr = get_proc_mgr_opt ();
+               net = get_net_opt () }
+             ~name ~args
+       | Error e, _ | _, Error e -> Some (false, e))
+
+  | Mod_voice ->
+      (match require_sw (), require_clock () with
+       | Ok sw, Ok clock ->
+           Tool_voice.dispatch
+             { agent_name; sw; clock; net = get_net_opt () }
+             ~name ~args
+       | Error e, _ | _, Error e -> Some (false, e))
+
+  | Mod_research ->
+      (match require_sw (), require_clock (), get_net_opt () with
+       | Ok sw, Ok clock, Some net ->
+           Tool_research.dispatch
+             { Tool_research.base_path = config.base_path;
+               agent_name = Some agent_name; sw; net; clock }
+             ~name ~args
+       | _, _, _ ->
+           Some (false, "research tools require Eio sw/clock/net"))
+
+  | Mod_autoresearch ->
+      (* Keeper already handles masc_autoresearch_* before reaching this path.
+         If we get here, provide a minimal context without team session starter. *)
+      Tool_autoresearch.dispatch
+        { Tool_autoresearch.base_path = config.base_path;
+          agent_name = Some agent_name;
+          start_operation = None;
+          start_team_session = None;
+          config = Some config;
+          sw = Eio_context.get_switch_opt ();
+          clock = Eio_context.get_clock_opt () }
+        ~name ~args
+
+  (* ── Tier C: MCP-state-dependent ───────────────────────────── *)
+
+  | Mod_inline ->
+      (* Handler registry catches masc_board_* before we reach here.
+         Remaining Mod_inline tools need full MCP session context
+         (registry, state, SSE callbacks) that keepers do not have.
+         Return actionable error. *)
+      Some (false,
+        Printf.sprintf
+          "tool '%s' requires MCP session context (not available in keeper)" name)
+
+  | Mod_encryption ->
+      Some (false,
+        Printf.sprintf "tool '%s' requires MCP server state" name)
+
+  | Mod_rate_limit ->
+      Some (false,
+        Printf.sprintf "tool '%s' requires MCP session registry" name)
+
+  (* ── Tier D: Cycle-breaking — modules that back-reference Keeper_exec_* *)
+
+  | Mod_council ->
+      (* Tool_council_oas requires Operator_approval -> Operator_control
+         -> Keeper_exec_status, creating a dependency cycle.
+         Governance tools are accessible via MCP client path. *)
+      Some (false,
+        Printf.sprintf
+          "tool '%s' requires governance context (use MCP client)" name)
+
+  | Mod_compact ->
+      (* Tool_compact depends on Keeper_exec_context. *)
+      Some (false,
+        Printf.sprintf
+          "tool '%s' is an internal context tool (use MCP client)" name)
+
+  (* ── Tier E: Hybrid (option fields degrade gracefully) ─────── *)
+
+  | Mod_command_plane ->
+      let ctx : (_, _) Tool_command_plane.context =
+        { config; agent_name;
+          sw = Eio_context.get_switch_opt ();
+          clock = Eio_context.get_clock_opt ();
+          net = get_net_opt ();
+          mcp_state = None; mcp_session_id = None; auth_token = None }
+      in
+      Tool_command_plane.dispatch ctx ~name ~args

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -104,6 +104,11 @@ let () =
     (fun ~tool_name ~success ~duration_ms ->
        Tool_registry.record_call ~source:Keeper_internal
          ~tool_name ~success ~duration_ms ());
+  (* Wire tag-based dispatch for keeper masc_* tools.
+     Breaks the same Config dependency cycle as on_keeper_tool_call.
+     See #4579: keeper_exec_tools uses handler registry (Tool_Board only),
+     this callback adds tag-registry dispatch for ~190 more tools. *)
+  Keeper_exec_tools.tag_dispatch_fn := Keeper_tag_dispatch.dispatch;
   Log.Mcp.info "Tag registry initialized: %d tools registered" (tag_registry_count ());
   (* C-4: Register input schema validation pre-hook.
      Validates tool arguments against their declared input_schema


### PR DESCRIPTION
## Summary
Keeper가 200+ masc_* tools 중 ~13개만 사용 가능했던 근본 원인 수정.

**Root cause**: `keeper_exec_tools.ml`이 handler registry (Tool_Board 등 ~13개)만 사용. 나머지 ~190개 tool은 tag_registry에만 등록되어 있어 "unregistered_masc_tool" 반환.

**Fix**: `Keeper_tag_dispatch` 모듈 추가 — module tag 기반으로 keeper context (config, agent_name, Eio globals)를 각 Tool_*.dispatch에 연결. Callback ref로 wiring하여 dependency cycle 회피.

Dispatch 우선순위: handler registry → tag registry → error

Closes #4579, partially addresses #4543 (353 retries의 근본 원인)

## Test plan
- [x] `dune build` passes
- [ ] Integration: keeper에서 masc_status, masc_tasks 등 tag-only tools 정상 동작 확인
- [ ] Integration: 20분 관찰 후 "unregistered_masc_tool" 에러 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)