### PR TITLE
fix(keeper): restore keeper_debug guard for zero-friction debug log

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -129,6 +129,9 @@ let log_keeper_friction
   else if blocked > 0 || groups > 0 then
     Log.Keeper.debug "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
       keeper_name blocked groups tripwires
+  else if Keeper_types_profile.keeper_debug then
+    Log.Keeper.debug "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name blocked groups tripwires
 
 let log_keeper_memory_write
     ~(keeper_name : string)


### PR DESCRIPTION
Follow-up to #4586. The keeper_debug-gated debug branch for blocked=0/groups=0 was dropped during squash merge. Restores MASC_KEEPER_DEBUG=1 friction diagnostics when no friction events occurred.