### PR TITLE
fix(keeper): include error detail in retry log + check stop before turn

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -486,7 +486,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                        ~pending_board_events:(Some pending_board_events)
                        ~config:ctx.config ~meta:meta_after_triage
                     in
-                   if
+                   if Atomic.get stop then
+                     meta_after_triage
+                   else if
                      Keeper_world_observation.should_run_unified_turn
                        ~meta:meta_after_triage
                        obs

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -199,14 +199,14 @@ let make_tools
                 Hashtbl.replace failure_counts key count;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
-                let preview =
+                let detail =
                   let s = String.trim result in
-                  if String.length s <= 120 then s
-                  else String.sub s 0 120 ^ "..."
+                  if String.length s <= 300 then s
+                  else String.sub s 0 300 ^ "..."
                 in
                 Log.Keeper.warn
-                  "tool %s returned error result (%d/%d) for same args: %s"
-                  td.name count max_consecutive_failures preview;
+                  "tool %s returned error result (%d/%d): %s"
+                  td.name count max_consecutive_failures detail;
                 (false, normalize_tool_result ~success:false result)
               end else begin
                 Hashtbl.remove failure_counts key;


### PR DESCRIPTION
## Summary
- #4543: Retry log expanded from 120 to 300 chars, shows actual error instead of \"for same args\"
- #4532: Stop flag checked before run_unified_turn to prevent zombie keepers from starting new turns

## Test plan
- [ ] Tool retry logs now show full error content
- [ ] Zombie-cleaned keeper does not start new unified turns

Closes #4543, #4532

Generated with Claude Code