### PR TITLE
fix(shutdown): cancel background fibers on SIGTERM (#4563)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -233,9 +233,16 @@ let make_extended_handler routes =
       Http.Response.internal_error msg reqd
 
 (** Main server loop *)
-let run_server ~sw ~env ~host ~port ~base_path =
+let run_server ~sw:_ ~env ~host ~port ~base_path =
+  (* Use a dedicated sub-switch so that ALL fibers spawned by
+     Server_runtime_bootstrap (background maintenance, keeper loops,
+     dashboard refresh, etc.) are children of this switch.  When
+     Eio.Fiber.first cancels the run_server fiber on SIGTERM, the
+     sub-switch is cancelled too, which propagates Cancel to every
+     child fiber — preventing the 10s force-exit timeout. *)
+  Eio.Switch.run @@ fun server_sw ->
   try
-    Server_runtime_bootstrap.run ~sw ~env ~host ~port ~base_path ~make_routes
+    Server_runtime_bootstrap.run ~sw:server_sw ~env ~host ~port ~base_path ~make_routes
       ~make_request_handler:make_extended_handler
       ~make_h2_request_handler:Server_h2_gateway.make_request_handler
       ~make_h2_error_handler:Server_h2_gateway.make_error_handler
@@ -313,7 +320,6 @@ let run_cmd host port base_path =
   let rec try_start attempt =
     (try
       Eio.Switch.run @@ fun sw ->
-      Masc_mcp.Dashboard_cache.set_sw sw;
       let clock = Eio.Stdenv.clock env in
       let rec await_shutdown_signal () =
         match Atomic.exchange pending_shutdown_signal None with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -30,6 +30,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;
+  Dashboard_cache.set_sw sw;
   Eio_context.set_net net;
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;


### PR DESCRIPTION
## Summary

- Wraps `run_server` body in a dedicated `Eio.Switch.run` sub-switch so all background fibers (SSE eviction, session reaper, keeper loops, dashboard refresh) are cancelled when `Eio.Fiber.first` cancels the server fiber on SIGTERM
- Moves `Dashboard_cache.set_sw` from the top-level switch into `server_runtime_bootstrap.ml` so dashboard revalidation fibers also terminate on shutdown
- Eliminates the 10s force-exit timeout that fired because orphaned fibers held the parent switch open after "Shutdown complete"

Closes #4563

## Test plan

- [ ] `dune build` compiles without errors
- [ ] Start server, send SIGTERM, verify "Shutdown complete" appears without the 10s timeout error
- [ ] Verify no "Evicted expired SSE buffer events" or "reaped stale sessions" logs appear after "Shutdown complete"
- [ ] SSE clients receive shutdown notification before disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)