### PR TITLE
[codex] block PRs while release tag is pending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,41 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
+  release-train:
+    name: Release Train
+    runs-on: ubuntu-latest
+    needs: [pr-sync-check]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Guard pending release tag on main PRs
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        run: |
+          chmod +x scripts/check-release-train-guard.sh
+          git fetch origin "${{ github.base_ref }}" --depth=100
+          scripts/check-release-train-guard.sh \
+            --base "$BASE_REF" \
+            --head "$HEAD_REF"
+
+      - name: Skip outside main PRs
+        if: github.event_name != 'pull_request' || github.base_ref != 'main'
+        run: echo "::notice::Release train guard only applies to PRs targeting main"
+
   health:
     name: Health
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, release-train]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -132,8 +161,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, release-train]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -222,8 +251,8 @@ jobs:
     name: Contract Harness
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, release-train]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
 
     steps:
       - name: Checkout

--- a/scripts/check-release-train-guard.sh
+++ b/scripts/check-release-train-guard.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-release-train-guard.sh [--base REF] [--head REF]
+EOF
+}
+
+base_ref=""
+head_ref="HEAD"
+
+while (($# > 0)); do
+  case "$1" in
+    --base)
+      shift
+      (($# > 0)) || { usage >&2; exit 1; }
+      base_ref="$1"
+      ;;
+    --head)
+      shift
+      (($# > 0)) || { usage >&2; exit 1; }
+      head_ref="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fail() {
+  printf 'release train guard failed: %s\n' "$1" >&2
+  exit 1
+}
+
+version_from_stream() {
+  sed -n 's/^(version \([^)]*\)).*/\1/p' | head -n1
+}
+
+version_from_ref() {
+  git show "$1:dune-project" 2>/dev/null | version_from_stream
+}
+
+version_gt() {
+  local left="$1"
+  local right="$2"
+  [[ "$left" != "$right" ]] && [[ "$(printf '%s\n%s\n' "$left" "$right" | sort -V | tail -n1)" == "$left" ]]
+}
+
+head_package_version="$(version_from_ref "$head_ref")"
+[[ -n "$head_package_version" ]] || fail "missing package version in $head_ref:dune-project"
+
+latest_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
+if [[ -z "$latest_tag" ]]; then
+  printf 'Release train guard OK: no release tags found, head=%s\n' "$head_package_version"
+  exit 0
+fi
+latest_tag_version="${latest_tag#v}"
+
+if [[ -z "$base_ref" ]]; then
+  printf 'Release train guard OK: no base ref provided, head=%s latest_tag=%s\n' \
+    "$head_package_version" "$latest_tag_version"
+  exit 0
+fi
+
+base_package_version="$(version_from_ref "$base_ref")"
+[[ -n "$base_package_version" ]] || fail "missing package version in $base_ref:dune-project"
+
+if [[ "$base_package_version" == "$latest_tag_version" ]]; then
+  printf 'Release train guard OK: base=%s head=%s latest_tag=%s\n' \
+    "$base_package_version" "$head_package_version" "$latest_tag_version"
+  exit 0
+fi
+
+if version_gt "$base_package_version" "$latest_tag_version"; then
+  if [[ "$head_package_version" == "$base_package_version" ]]; then
+    fail "base ref $base_ref advertises unreleased package version $base_package_version while latest tag is v$latest_tag_version; publish/tag v$base_package_version before merging further PRs into main"
+  fi
+  fail "base ref $base_ref advertises unreleased package version $base_package_version while latest tag is v$latest_tag_version, and head changes package version to $head_package_version; publish/tag v$base_package_version before widening the release train"
+fi
+
+fail "base ref $base_ref has package version $base_package_version, which is older than latest tag v$latest_tag_version; sync version truth before merging"


### PR DESCRIPTION
## Summary
- add a lightweight `release-train` CI job for PRs targeting `main`
- block follow-up PRs when the base branch advertises a package version ahead of the latest release tag
- gate heavy CI jobs behind the release-train guard so the failure happens early and cheaply

## Product impact
- prevents `main` from silently widening a release train after a bump PR merges but before the corresponding tag is pushed
- keeps changelog and tag honesty aligned by requiring the pending release to be published before more PRs land on `main`
- saves CI time because `Health`, `Build and Test`, and `Contract Harness` no longer run when the branch is already blocked by release drift

## Evidence
- `bash -n scripts/check-release-train-guard.sh`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD`
- `bash scripts/check-release-train-guard.sh --base origin/main --head origin/chore/bump-2.216.0`
- `bash scripts/check-release-train-guard.sh --base origin/chore/bump-2.216.0 --head origin/chore/bump-2.216.0` (expected failure)

## Review evidence
- reviewer: GLM-5.1 via `sb glm-text`
- timestamp: 2026-04-02 12:28:24 KST
- scope: `main...192626383`
- result: No findings.

## Linked issue
- Closes #4572
