### PR TITLE
[codex] fix keeper persona auth flow

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,15 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { fetchWithTimeout, reportToolHostFailure, authHeaders } = vi.hoisted(() => ({
+const { fetchWithTimeout, reportToolHostFailure, authHeaders, currentDashboardActor } = vi.hoisted(() => ({
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
   authHeaders: vi.fn().mockReturnValue({}),
+  currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
 }))
 
 vi.mock('./core', () => ({
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
   authHeaders,
+  currentDashboardActor,
 }))
 
 vi.mock('./dashboard', () => ({
@@ -85,6 +87,35 @@ describe('mcpHeaders auth integration', () => {
 })
 
 describe('callMcpTool', () => {
+  it('injects the dashboard actor into MCP tool arguments', async () => {
+    setupMcpSessionMocks('sess-actor')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_keeper_create_from_persona', { persona_name: 'sonsukku' })
+
+    const toolCall = findCallByMethod('tools/call')
+    expect(toolCall).toBeDefined()
+    const body = JSON.parse(toolCall![1].body as string)
+    expect(body.params.arguments).toEqual({
+      persona_name: 'sonsukku',
+      _agent_name: 'dashboard',
+    })
+  })
+
+  it('preserves an explicit agent_name field when the caller already set one', async () => {
+    setupMcpSessionMocks('sess-explicit')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_join', { agent_name: 'codex-tool-matrix' })
+
+    const toolCall = findCallByMethod('tools/call')
+    expect(toolCall).toBeDefined()
+    const body = JSON.parse(toolCall![1].body as string)
+    expect(body.params.arguments).toEqual({
+      agent_name: 'codex-tool-matrix',
+    })
+  })
+
   it('reports tool-host failures after the MCP session is established', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — MCP-over-HTTP client with session lifecycle
 
-import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS, authHeaders } from './core'
+import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS, authHeaders, currentDashboardActor } from './core'
 import {
   MCP_INIT_COOLDOWN_MS,
   MCP_INITIALIZE_TIMEOUT_MS,
@@ -194,12 +194,17 @@ export async function callMcpTool(toolName: string, args: Record<string, unknown
   try {
     await ensureSession()
     phase = 'tools/call'
+    const actor = currentDashboardActor()
+    const toolArgs =
+      args._agent_name == null && args.agent_name == null && actor
+        ? { ...args, _agent_name: actor }
+        : args
     const text = await mcpPost({
       jsonrpc: '2.0',
       method: 'tools/call',
       params: {
         name: toolName,
-        arguments: args,
+        arguments: toolArgs,
       },
       id: Number.parseInt(requestId, 10),
     })

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
@@ -1,8 +1,29 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { callMcpTool, showToast } = vi.hoisted(() => ({
+  callMcpTool: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('../../api/mcp', () => ({
+  callMcpTool,
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast,
+}))
+
 import {
   normalizePersonaSummaries,
   normalizePersonaSummary,
+  spawnKeeperFromPersona,
+  spawnResult,
 } from './keeper-spawn-state'
+
+afterEach(() => {
+  spawnResult.value = null
+  vi.clearAllMocks()
+})
 
 describe('normalizePersonaSummary', () => {
   it('accepts backend persona summary fields and keeps the handle for spawning', () => {
@@ -59,5 +80,25 @@ describe('normalizePersonaSummaries', () => {
         description: undefined,
       },
     ])
+  })
+})
+
+describe('spawnKeeperFromPersona', () => {
+  it('turns raw forbidden keeper-spawn errors into actionable auth guidance', async () => {
+    callMcpTool.mockRejectedValueOnce(
+      new Error('🚫 Forbidden: agent-3a9df104 cannot masc_keeper_create_from_persona'),
+    )
+
+    await spawnKeeperFromPersona('sonsukku')
+
+    expect(spawnResult.value).toEqual({
+      success: false,
+      message:
+        'agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.',
+    })
+    expect(showToast).toHaveBeenCalledWith(
+      '키퍼 생성 실패: agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.',
+      'error',
+    )
   })
 })

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -55,6 +55,14 @@ export const spawning = signal(false)
 export const spawnResult = signal<{ success: boolean; message: string } | null>(null)
 export const showSpawnPanel = signal(false)
 
+function formatKeeperSpawnError(message: string): string {
+  const forbiddenMatch = message.match(/Forbidden:\s+([^\s]+)\s+cannot\s+masc_keeper_create_from_persona/i)
+  if (!forbiddenMatch) return message
+
+  const actor = forbiddenMatch[1]
+  return `${actor} 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.`
+}
+
 export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRun?: boolean; roomScope?: string }): Promise<void> {
   spawning.value = true
   spawnResult.value = null
@@ -66,7 +74,7 @@ export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRu
     spawnResult.value = { success: true, message: result }
     if (!opts?.dryRun) showToast(`${personaName} 키퍼 생성 완료`, 'success')
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = formatKeeperSpawnError(err instanceof Error ? err.message : String(err))
     spawnResult.value = { success: false, message }
     showToast(`키퍼 생성 실패: ${message}`, 'error')
   } finally {

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -215,6 +215,15 @@ let refresh_token config ~agent_name ~old_token : (string * agent_credential, ma
 (* ============================================ *)
 
 (** Check if agent has permission for an action *)
+let verify_optional_token config ~agent_name ~token :
+    (agent_credential option, masc_error) result =
+  match token with
+  | None -> Ok None
+  | Some raw ->
+      match verify_token config ~agent_name ~token:raw with
+      | Ok cred -> Ok (Some cred)
+      | Error e -> Error e
+
 let check_permission config ~agent_name ~token ~permission : (unit, masc_error) result =
   let auth_cfg = load_auth_config config in
   if not auth_cfg.enabled then
@@ -225,24 +234,24 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
            | None -> false) then
     (* Bootstrap grace: the agent who enabled auth always has full access *)
     (ignore permission; Ok ())
-  else if not auth_cfg.require_token then
-    (* Token not required - use default role *)
-    if has_permission auth_cfg.default_role permission then
-      Ok ()
-    else
-      Error (Forbidden { agent = agent_name; action = show_permission permission })
   else
-    (* Token required - verify and check role *)
-    match token with
-    | None -> Error (Unauthorized "Token required")
-    | Some t ->
-        match verify_token config ~agent_name ~token:t with
-        | Error e -> Error e
-        | Ok cred ->
-            if has_permission cred.role permission then
-              Ok ()
-            else
-              Error (Forbidden { agent = agent_name; action = show_permission permission })
+    match verify_optional_token config ~agent_name ~token with
+    | Error e -> Error e
+    | Ok (Some cred) ->
+        if has_permission cred.role permission then
+          Ok ()
+        else
+          Error (Forbidden { agent = agent_name; action = show_permission permission })
+    | Ok None ->
+        if not auth_cfg.require_token then
+          (* Optional-token mode: fall back to the room's default role only
+             when no token was presented. *)
+          if has_permission auth_cfg.default_role permission then
+            Ok ()
+          else
+            Error (Forbidden { agent = agent_name; action = show_permission permission })
+        else
+          Error (Unauthorized "Token required")
 
 (** Tool_spec / Tool_catalog-declared permission, when present. *)
 let declared_permission_for_tool tool_name =
@@ -380,15 +389,15 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
            | Some admin -> String.equal agent_name admin
            | None -> false) then
     Ok Admin  (* Bootstrap admin = full access *)
-  else if not auth_cfg.require_token then
-    Ok auth_cfg.default_role
   else
-    match token with
-    | None -> Error (Unauthorized "Token required")
-    | Some t ->
-        (match verify_token config ~agent_name ~token:t with
-        | Ok cred -> Ok cred.role
-        | Error e -> Error e)
+    match verify_optional_token config ~agent_name ~token with
+    | Error e -> Error e
+    | Ok (Some cred) -> Ok cred.role
+    | Ok None ->
+        if auth_cfg.require_token then
+          Error (Unauthorized "Token required")
+        else
+          Ok auth_cfg.default_role
 
 (** Policy-based tool authorization.
     Replaces authorize_tool with a single Tool_access_policy check.

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -191,6 +191,7 @@ let handle_post_create args =
   let body = get_string_opt args "body" |> Option.map strip_state_blocks_text in
   let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
   let content = strip_state_blocks_text raw_content in
+  let author = get_string_opt args "author" |> Option.map String.trim in
   let title_is_empty =
     match title with
     | Some value -> String.trim value = ""
@@ -198,11 +199,13 @@ let handle_post_create args =
   in
   if title_is_empty then
     (false, "❌ title is required")
+  else if author = None || author = Some "" || author = Some "anonymous" then
+    (false, "❌ author is required")
   else if String.length content > Board.Limits.max_content_length then
     (false, Printf.sprintf "Content exceeds max length (%d > %d chars)"
        (String.length content) Board.Limits.max_content_length)
   else
-  let author = get_string args "author" "anonymous" in
+  let author = Option.value author ~default:"" in
   let ttl_hours = get_int args "ttl_hours" Board.Limits.default_ttl_hours in
   let visibility_str = get_string args "visibility" "internal" in
   let hearth = get_string_opt args "hearth" in
@@ -379,18 +382,21 @@ let handle_post_get args =
 let handle_comment_add args =
   let post_id = get_string args "post_id" "" in
   let content = get_string args "content" "" in
-  let author = get_string args "author" "anonymous" in
+  let author = get_string_opt args "author" |> Option.map String.trim in
   let parent_id = get_string_opt args "parent_id" in
   let ttl_hours = get_int args "ttl_hours" Board.Limits.default_ttl_hours in
   if String.trim post_id = "" then
     (false, "post_id is required")
   else if String.trim content = "" then
     (false, "Content must not be empty")
+  else if author = None || author = Some "" || author = Some "anonymous" then
+    (false, "author is required")
   else if String.length content > Board.Limits.max_content_length then
     (false, Printf.sprintf "Content exceeds max length (%d > %d chars)"
        (String.length content) Board.Limits.max_content_length)
   else
-  match Board_dispatch.add_comment ~post_id ~author ~content ?parent_id ~ttl_hours () with
+  match Board_dispatch.add_comment ~post_id ~author:(Option.value author ~default:"")
+          ~content ?parent_id ~ttl_hours () with
   | Ok comment ->
       let json = Board.comment_to_yojson comment in
       (true, Printf.sprintf "✅ Comment added:\n%s" (Yojson.Safe.pretty_to_string json))
@@ -518,7 +524,7 @@ let tool_post_create : Types.tool_schema = {
       ("hearth", `Assoc [("type", `String "string"); ("description", `String "Topic hearth name (e.g. webrtc, code-review)")]);
       ("thread_id", `Assoc [("type", `String "string"); ("description", `String "Linked conversation thread ID")]);
     ]);
-    ("required", `List [`String "content"]);
+    ("required", `List [`String "content"; `String "author"]);
   ];
 }
 
@@ -566,7 +572,7 @@ let tool_comment_add : Types.tool_schema = {
       ("parent_id", `Assoc [("type", `String "string"); ("description", `String "Parent comment ID for replies (optional)")]);
       ("ttl_hours", `Assoc [("type", `String "integer"); ("description", `String "Time-to-live in hours")]);
     ]);
-    ("required", `List [`String "post_id"; `String "content"]);
+    ("required", `List [`String "post_id"; `String "content"; `String "author"]);
   ];
 }
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -249,6 +249,49 @@ let test_permission_denied_for_reader () =
   | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
+let test_optional_token_overrides_reader_default_role () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:false ~agent_name:"test-admin" in
+  let cfg = Auth.load_auth_config dir in
+  Auth.save_auth_config dir { cfg with default_role = Types.Reader };
+  let result =
+    match Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker with
+    | Ok (raw_token, _) ->
+        Auth.check_permission dir ~agent_name:"worker_agent"
+          ~token:(Some raw_token) ~permission:Types.CanClaimTask
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> ()
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "optional worker token should override reader default_role: %s"
+           (Types.masc_error_to_string e))
+
+let test_optional_token_authorizes_keeper_tool_when_default_role_reader () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:false ~agent_name:"test-admin" in
+  let cfg = Auth.load_auth_config dir in
+  Auth.save_auth_config dir { cfg with default_role = Types.Reader };
+  let result =
+    match Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker with
+    | Ok (raw_token, _) ->
+        Auth.authorize_tool_v2 dir ~agent_name:"worker_agent"
+          ~token:(Some raw_token)
+          ~tool_name:"masc_keeper_create_from_persona"
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> ()
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "optional worker token should authorize keeper spawn tool: %s"
+           (Types.masc_error_to_string e))
+
 let test_authorize_unknown_masc_tool_strict_worker_allowed () =
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
@@ -383,6 +426,10 @@ let () =
       test_case "auth enabled requires token" `Quick test_auth_enabled_requires_token;
       test_case "auth enabled with valid token" `Quick test_auth_enabled_with_valid_token;
       test_case "permission denied for reader" `Quick test_permission_denied_for_reader;
+      test_case "optional token overrides reader default role"
+        `Quick test_optional_token_overrides_reader_default_role;
+      test_case "optional token authorizes keeper tool"
+        `Quick test_optional_token_authorizes_keeper_tool_when_default_role_reader;
       test_case "strict unknown masc tool allows worker"
         `Quick test_authorize_unknown_masc_tool_strict_worker_allowed;
       test_case "strict unknown masc tool denies reader"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -261,6 +261,26 @@ let test_post_create_empty_title_rejected () =
   Alcotest.(check bool) "error mentions title" true
     (contains_substring body "title" || contains_substring body "Title")
 
+let test_post_create_missing_author_rejected () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body = dispatch "masc_board_post"
+    (make_args [("content", `String "Hello board")]) in
+  Alcotest.(check bool) "missing author rejected" false ok;
+  Alcotest.(check bool) "error mentions author" true
+    (contains_substring body "author")
+
+let test_post_create_anonymous_author_rejected () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body = dispatch "masc_board_post"
+    (make_args [("content", `String "Hello board"); ("author", `String "anonymous")]) in
+  Alcotest.(check bool) "anonymous author rejected" false ok;
+  Alcotest.(check bool) "error mentions author" true
+    (contains_substring body "author")
+
 let test_post_list_empty () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -495,6 +515,27 @@ let test_comment_add_missing_post () =
   Alcotest.(check bool) "comment on missing post fails" false ok;
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
+let test_comment_add_missing_author_rejected () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body = dispatch "masc_board_comment"
+    (make_args [("post_id", `String "missing"); ("content", `String "hi")]) in
+  Alcotest.(check bool) "missing author rejected" false ok;
+  Alcotest.(check bool) "error mentions author" true
+    (contains_substring body "author")
+
+let test_comment_add_anonymous_author_rejected () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body = dispatch "masc_board_comment"
+    (make_args
+       [("post_id", `String "missing"); ("content", `String "hi"); ("author", `String "anonymous")]) in
+  Alcotest.(check bool) "anonymous author rejected" false ok;
+  Alcotest.(check bool) "error mentions author" true
+    (contains_substring body "author")
+
 let test_comment_vote_missing () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -640,6 +681,10 @@ let () =
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;
           Alcotest.test_case "create empty title rejected" `Quick
             test_post_create_empty_title_rejected;
+          Alcotest.test_case "create missing author rejected" `Quick
+            test_post_create_missing_author_rejected;
+          Alcotest.test_case "create anonymous author rejected" `Quick
+            test_post_create_anonymous_author_rejected;
           Alcotest.test_case "list empty" `Quick test_post_list_empty;
           Alcotest.test_case "cleanup clears persisted jsonl" `Quick
             test_cleanup_clears_persisted_jsonl;
@@ -660,6 +705,10 @@ let () =
       ( "comments",
         [
           Alcotest.test_case "comment missing post" `Quick test_comment_add_missing_post;
+          Alcotest.test_case "comment missing author rejected" `Quick
+            test_comment_add_missing_author_rejected;
+          Alcotest.test_case "comment anonymous author rejected" `Quick
+            test_comment_add_anonymous_author_rejected;
           Alcotest.test_case "comment vote missing" `Quick test_comment_vote_missing;
         ] );
       ( "search_stats",


### PR DESCRIPTION
## Summary
- fixed auth optional-token handling so `require_token=false` rooms still honor a presented bearer token role instead of always falling back to `default_role`
- injected the dashboard actor into MCP tool arguments so HTTP header actor and MCP session identity stay aligned for dashboard tool calls
- translated keeper persona spawn `Forbidden` failures into actionable auth guidance in the dashboard UI
- rejected `masc_board_post` and `masc_board_comment` calls that omit `author` or try to use `anonymous`, so anonymous writes can no longer land in the human board lane
- added OCaml and dashboard regression coverage for auth, MCP actor propagation, and explicit board-author enforcement

## Product impact
- dashboard keeper persona spawn now uses the intended actor identity
- optional worker/admin tokens work again in rooms configured with `require_token=false`
- users now get an auth-specific error instead of a raw `Forbidden: agent-...` string
- future board posts/comments must carry an explicit author, which prevents misleading `anonymous` human posts from being created through MCP/internal write paths

## Evidence
- reproduced the original keeper persona failure on the live server as `🚫 Forbidden: agent-... cannot masc_keeper_create_from_persona`
- identified the live auth config on the running 8935 server as `enabled=true`, `require_token=false`, `default_role=reader` under `~/me/.masc/auth/config.json`
- inspected board write paths and confirmed dashboard HTTP routes and keeper adapters already inject `author`; the unsafe fallback was in `Tool_board.handle_post_create` / `handle_comment_add`
- validation commands:
  - `dune build --root . test/test_auth.exe`
  - `_build/default/test/test_auth.exe`
  - `dune build --root . test/test_tool_board_coverage.exe`
  - `./_build/default/test/test_tool_board_coverage.exe`
  - `./node_modules/.bin/vitest run src/api/mcp.test.ts src/components/keeper-spawn/keeper-spawn-state.test.ts --reporter=dot`
  - `npm run build`

## Review evidence
- external review via `sb glm-text` on commit `ad4188a61` at 2026-04-02 returned: `No findings.`
- external review via `sb glm-text --no-thinking` on commit `2c5251f8d` at 2026-04-02 returned: `No findings.`

## Linked issue
- Refs #4597
- Refs #4604
