### PR TITLE
[codex] Fix board author filtering and reply threading

### DIFF
--- a/dashboard/src/components/memory-post-detail.test.ts
+++ b/dashboard/src/components/memory-post-detail.test.ts
@@ -1,0 +1,88 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+vi.mock('../router', () => ({
+  navigate: vi.fn(),
+}))
+
+vi.mock('../keeper-message', () => ({
+  stripStateBlocks: (value: string) => value,
+}))
+
+vi.mock('./common/card', () => ({
+  Card: ({ children }: { children?: any }) => h('div', {}, children),
+}))
+
+vi.mock('./common/time-ago', () => ({
+  TimeAgo: ({ timestamp }: { timestamp: string }) => h('span', {}, timestamp),
+}))
+
+vi.mock('./common/markdown', () => ({
+  Markdown: ({ text }: { text: string }) => h('div', {}, text),
+}))
+
+vi.mock('./common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+vi.mock('./common/empty-state', () => ({
+  EmptyState: ({ message }: { message: string }) => h('div', {}, message),
+}))
+
+vi.mock('./common/input', () => ({
+  TextInput: (props: Record<string, unknown>) => h('input', props),
+}))
+
+vi.mock('./memory-state', () => ({
+  detailComments: { value: [] },
+  detailLoading: { value: false },
+  detailPostId: { value: null },
+  commentText: { value: '' },
+  commentSubmitting: { value: false },
+  replyingTo: { value: null },
+  loadPostDetail: vi.fn(),
+  submitComment: vi.fn(),
+  authorAvatar: (author: string) => `@${author}`,
+  kindBadgeColor: () => '',
+  visibilityLabel: () => '',
+  visibilityBadgeColor: () => '',
+  boardPostKind: () => 'human',
+  votePost: vi.fn(),
+  refreshBoard: vi.fn(),
+}))
+
+import { CommentThread } from './memory-post-detail'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CommentThread', () => {
+  it('renders nested replies beyond one level', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'root-agent', content: 'root comment', created_at: '2026-04-02T00:00:00Z' },
+      { id: 'c2', post_id: 'post-1', parent_id: 'c1', author: 'child-agent', content: 'child reply', created_at: '2026-04-02T00:01:00Z' },
+      { id: 'c3', post_id: 'post-1', parent_id: 'c2', author: 'grandchild-agent', content: 'grandchild reply', created_at: '2026-04-02T00:02:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByText('root comment')).toBeInTheDocument()
+    expect(screen.getByText('child reply')).toBeInTheDocument()
+    expect(screen.getByText('grandchild reply')).toBeInTheDocument()
+  })
+
+  it('shows orphaned replies as root comments when the parent is missing', () => {
+    const comments = [
+      { id: 'c2', post_id: 'post-1', parent_id: 'missing-parent', author: 'orphan-agent', content: 'orphan reply still visible', created_at: '2026-04-02T00:01:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByText('orphan reply still visible')).toBeInTheDocument()
+    expect(screen.getByText(/댓글 1개/)).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -39,9 +39,10 @@ function expiryChip(post: BoardPost) {
 // ── Comment tree building ──────────────────────────────────────────
 function buildCommentTree(comments: BoardComment[]): { roots: BoardComment[]; childrenMap: Map<string, BoardComment[]> } {
   const childrenMap = new Map<string, BoardComment[]>()
+  const commentIds = new Set(comments.map((comment) => comment.id))
   const roots: BoardComment[] = []
   for (const c of comments) {
-    if (c.parent_id) {
+    if (c.parent_id && commentIds.has(c.parent_id)) {
       const siblings = childrenMap.get(c.parent_id) ?? []
       siblings.push(c)
       childrenMap.set(c.parent_id, siblings)
@@ -53,7 +54,17 @@ function buildCommentTree(comments: BoardComment[]): { roots: BoardComment[]; ch
 }
 
 // ── Comment item ───────────────────────────────────────────────────
-function CommentItem({ comment, postId, depth = 0, replies = [] }: { comment: BoardComment; postId: string; depth?: number; replies?: BoardComment[] }) {
+function CommentItem({
+  comment,
+  postId,
+  depth = 0,
+  childrenMap,
+}: {
+  comment: BoardComment
+  postId: string
+  depth?: number
+  childrenMap: Map<string, BoardComment[]>
+}) {
   const needsTruncation = (comment.content?.length ?? 0) > 300
   const [expanded, setExpanded] = useState(false)
   const displayText = needsTruncation && !expanded
@@ -61,6 +72,7 @@ function CommentItem({ comment, postId, depth = 0, replies = [] }: { comment: Bo
     : comment.content
   const isReplying = replyingTo.value === comment.id
   const indent = depth > 0 ? `ml-${Math.min(depth * 4, 12)}` : ''
+  const replies = childrenMap.get(comment.id) ?? []
 
   return html`
     <div class="${indent}">
@@ -107,7 +119,7 @@ function CommentItem({ comment, postId, depth = 0, replies = [] }: { comment: Bo
       </div>
       ${replies.length > 0 ? html`
         <div class="flex flex-col gap-1.5 mt-1.5">
-          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} replies=${[]} />`)}
+          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} />`)}
         </div>
       ` : null}
     </div>
@@ -115,7 +127,7 @@ function CommentItem({ comment, postId, depth = 0, replies = [] }: { comment: Bo
 }
 
 // ── Comment thread ─────────────────────────────────────────────────
-function CommentThread({ comments, postId }: { comments: BoardComment[]; postId: string }) {
+export function CommentThread({ comments, postId }: { comments: BoardComment[]; postId: string }) {
   if (comments.length === 0) return html`<${EmptyState} message="아직 댓글이 없습니다" compact />`
 
   const { roots, childrenMap } = buildCommentTree(comments)
@@ -133,7 +145,7 @@ function CommentThread({ comments, postId }: { comments: BoardComment[]; postId:
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기</button>
       ` : null}
-      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} replies=${childrenMap.get(comment.id) ?? []} />`)}
+      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${childrenMap} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <button type="button"
           class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -167,6 +167,23 @@ let sort_posts_in_memory ~sort_by (posts : Board.post list) =
         let cmp = compare b.reply_count a.reply_count in
         if cmp <> 0 then cmp else compare b.created_at a.created_at) posts
 
+let normalize_author_filter = function
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some (String.lowercase_ascii trimmed)
+  | None -> None
+
+let agent_matches_author_filter ~needle (agent_id : Board.Agent_id.t) =
+  let author = Board.Agent_id.to_string agent_id |> String.lowercase_ascii in
+  String_util.contains_substring author needle
+
+let post_matches_author_filter ~needle ~comments_for_post (post : Board.post) =
+  agent_matches_author_filter ~needle post.author
+  || List.exists
+       (fun (comment : Board.comment) ->
+         agent_matches_author_filter ~needle comment.author)
+       (comments_for_post post)
+
 (** {1 Dispatch Functions} *)
 
 let create_post ~author ~content ?title ?body ~post_kind ?meta_json
@@ -223,8 +240,22 @@ let get_post ~post_id =
   | Jsonl store -> Board.get_post store ~post_id
   | Postgres t -> Board_pg.get_post t ~post_id
 
-let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot)
+let list_posts ?(visibility_filter=None) ?hearth ?author_filter ?post_kind_filter ?(sort_by=Hot)
     ?(exclude_system=false) ?(exclude_automation=false) ?(limit=50) () =
+  let author_filter = normalize_author_filter author_filter in
+  let apply_visibility_and_hearth_filters posts =
+    let posts =
+      match visibility_filter with
+      | Some visibility ->
+          List.filter (fun (post : Board.post) -> post.visibility = visibility) posts
+      | None -> posts
+    in
+    match hearth with
+    | Some hearth_name ->
+        let hearth_name = String.lowercase_ascii (String.trim hearth_name) in
+        List.filter (fun (post : Board.post) -> post.hearth = Some hearth_name) posts
+    | None -> posts
+  in
   let apply_post_kind_filter posts =
     posts
     |> List.filter (fun (p : Board.post) ->
@@ -237,10 +268,35 @@ let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot
   in
   match backend () with
   | Jsonl store ->
-      let fetch_limit = max limit 200 in
-      let posts = Board.list_posts store ~visibility_filter ?hearth ~limit:fetch_limit () in
-      let sorted = sort_posts_in_memory ~sort_by posts in
+      let fetch_limit =
+        if Option.is_some author_filter then Board.Limits.max_posts
+        else max limit 200
+      in
+      let posts =
+        if Option.is_some author_filter then
+          Board.search_posts store ~predicate:(fun _ -> true) ~limit:fetch_limit
+        else
+          Board.list_posts store ~visibility_filter ?hearth ~limit:fetch_limit ()
+      in
+      let comments_for_post (post : Board.post) =
+        match Board.get_comments store ~post_id:(Board.Post_id.to_string post.id) with
+        | Ok comments -> comments
+        | Error _ -> []
+      in
+      let sorted =
+        posts
+        |> apply_visibility_and_hearth_filters
+        |> sort_posts_in_memory ~sort_by
+      in
       let filtered = apply_post_kind_filter sorted in
+      let filtered =
+        match author_filter with
+        | None -> filtered
+        | Some needle ->
+            List.filter
+              (post_matches_author_filter ~needle ~comments_for_post)
+              filtered
+      in
       Board.take limit filtered
   | Postgres t ->
       let pg_sort = match sort_by with
@@ -255,7 +311,10 @@ let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot
       in
       (* Over-fetch when post-query filtering is needed to avoid short results *)
       let fetch_limit = if needs_filter then max limit (limit * 3) else limit in
-      let posts = Board_pg.list_posts t ~visibility_filter ?hearth ~sort_by:pg_sort ~limit:fetch_limit () in
+      let posts =
+        Board_pg.list_posts t ~visibility_filter ?hearth ?author_filter
+          ~sort_by:pg_sort ~limit:fetch_limit ()
+      in
       let filtered = apply_post_kind_filter posts in
       Board.take limit filtered
 

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -184,6 +184,15 @@ let post_matches_author_filter ~needle ~comments_for_post (post : Board.post) =
          agent_matches_author_filter ~needle comment.author)
        (comments_for_post post)
 
+let matching_post_ids_for_comment_author_filter ~needle (comments : Board.comment list) =
+  let matches = Hashtbl.create 64 in
+  List.iter
+    (fun (comment : Board.comment) ->
+      if agent_matches_author_filter ~needle comment.author then
+        Hashtbl.replace matches (Board.Post_id.to_string comment.post_id) true)
+    comments;
+  matches
+
 (** {1 Dispatch Functions} *)
 
 let create_post ~author ~content ?title ?body ~post_kind ?meta_json
@@ -278,11 +287,6 @@ let list_posts ?(visibility_filter=None) ?hearth ?author_filter ?post_kind_filte
         else
           Board.list_posts store ~visibility_filter ?hearth ~limit:fetch_limit ()
       in
-      let comments_for_post (post : Board.post) =
-        match Board.get_comments store ~post_id:(Board.Post_id.to_string post.id) with
-        | Ok comments -> comments
-        | Error _ -> []
-      in
       let sorted =
         posts
         |> apply_visibility_and_hearth_filters
@@ -293,8 +297,15 @@ let list_posts ?(visibility_filter=None) ?hearth ?author_filter ?post_kind_filte
         match author_filter with
         | None -> filtered
         | Some needle ->
+            let matching_comment_post_ids =
+              Board.list_comments store ~limit:max_int ()
+              |> matching_post_ids_for_comment_author_filter ~needle
+            in
             List.filter
-              (post_matches_author_filter ~needle ~comments_for_post)
+              (fun (post : Board.post) ->
+                agent_matches_author_filter ~needle post.author
+                || Hashtbl.mem matching_comment_post_ids
+                     (Board.Post_id.to_string post.id))
               filtered
       in
       Board.take limit filtered

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -145,7 +145,13 @@ let get_pg_pool () =
 
 let sort_posts_in_memory ~sort_by (posts : Board.post list) =
   match sort_by with
-  | Hot -> posts  (* Board.list_posts already sorts by score *)
+  | Hot ->
+      List.sort (fun (a : Board.post) (b : Board.post) ->
+        let score_a = a.votes_up - a.votes_down in
+        let score_b = b.votes_up - b.votes_down in
+        let cmp = compare score_b score_a in
+        if cmp <> 0 then cmp
+        else compare b.created_at a.created_at) posts
   | Recent ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
         compare b.created_at a.created_at) posts

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -177,13 +177,6 @@ let agent_matches_author_filter ~needle (agent_id : Board.Agent_id.t) =
   let author = Board.Agent_id.to_string agent_id |> String.lowercase_ascii in
   String_util.contains_substring author needle
 
-let post_matches_author_filter ~needle ~comments_for_post (post : Board.post) =
-  agent_matches_author_filter ~needle post.author
-  || List.exists
-       (fun (comment : Board.comment) ->
-         agent_matches_author_filter ~needle comment.author)
-       (comments_for_post post)
-
 let matching_post_ids_for_comment_author_filter ~needle (comments : Board.comment list) =
   let matches = Hashtbl.create 64 in
   List.iter

--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -312,9 +312,16 @@ let get_post t ~post_id =
 
 type sort_order = Hot | Trending | Recent | Updated | Discussed
 
-let list_posts t ?(visibility_filter=None) ?hearth ?(sort_by=Hot) ?(limit=50) () =
+let list_posts t ?(visibility_filter=None) ?hearth ?author_filter ?(sort_by=Hot) ?(limit=50) () =
   let vis_str = Option.map visibility_to_string visibility_filter in
   let hearth_norm = Option.map (fun h -> String.lowercase_ascii (String.trim h)) hearth in
+  let author_norm =
+    match author_filter with
+    | Some raw ->
+        let trimmed = String.trim raw in
+        if trimmed = "" then None else Some trimmed
+    | None -> None
+  in
   let lim = max 1 (min limit 5200) in
   let q = match sort_by with
     | Hot -> list_hot_q
@@ -325,7 +332,7 @@ let list_posts t ?(visibility_filter=None) ?hearth ?(sort_by=Hot) ?(limit=50) ()
   in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
-    C.collect_list q (vis_str, hearth_norm, lim)
+    C.collect_list q (vis_str, hearth_norm, author_norm, lim)
   ) t.pool with
   | Ok rows -> List.filter_map post_of_row rows
   | Error err ->
@@ -579,7 +586,7 @@ let reclassify_posts t ?(limit = 5200) ?(dry_run = true) () =
       if scan_limit = 0 then
         Ok []
       else
-        C.collect_list list_recent_q (None, None, scan_limit)
+        C.collect_list list_recent_q (None, None, None, scan_limit)
     in
     let posts = List.filter_map post_of_row rows in
     let changed = ref 0 in

--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -319,7 +319,7 @@ let list_posts t ?(visibility_filter=None) ?hearth ?author_filter ?(sort_by=Hot)
     match author_filter with
     | Some raw ->
         let trimmed = String.trim raw in
-        if trimmed = "" then None else Some trimmed
+        if trimmed = "" then None else Some (String.lowercase_ascii trimmed)
     | None -> None
   in
   let lim = max 1 (min limit 5200) in

--- a/lib/board_pg_queries.ml
+++ b/lib/board_pg_queries.ml
@@ -4,6 +4,7 @@ open Board
 open Pg_infix
 
 let ttl_where = "(expires_at = 0 OR expires_at > extract(epoch from now()))"
+let comment_ttl_where = "(c.expires_at = 0 OR c.expires_at > extract(epoch from now()))"
 
 (* Post row: 16 fields packed as t4(t4, t4, t4, t4) *)
 let post_row_t = Caqti_type.(
@@ -125,15 +126,26 @@ let update_post_kind_q =
   (Caqti_type.(t2 string string) ->. Caqti_type.unit)
   "UPDATE masc_board_posts SET post_kind = $2 WHERE id = $1"
 
-(* Sort-order specific list queries. $1=visibility (NULL=any), $2=hearth (NULL=any), $3=limit.
+(* Sort-order specific list queries.
+   $1=visibility (NULL=any), $2=hearth (NULL=any),
+   $3=author filter (matches post author or visible comment author), $4=limit.
    NOTE: PostgreSQL cannot infer type from `$n IS NULL` alone, so explicit ::TEXT cast needed. *)
 let mk_list_q order_clause =
-  (Caqti_type.(t3 (option string) (option string) int) ->* post_row_t)
+  (Caqti_type.(t4 (option string) (option string) (option string) int) ->* post_row_t)
   (Printf.sprintf
     "SELECT %s FROM masc_board_posts \
-     WHERE %s AND ($1::TEXT IS NULL OR visibility = $1) AND ($2::TEXT IS NULL OR hearth = $2) \
-     ORDER BY %s LIMIT $3"
-    post_columns ttl_where order_clause)
+     WHERE %s \
+       AND ($1::TEXT IS NULL OR visibility = $1) \
+       AND ($2::TEXT IS NULL OR hearth = $2) \
+       AND ($3::TEXT IS NULL \
+         OR author ILIKE '%%' || $3 || '%%' \
+         OR EXISTS ( \
+           SELECT 1 FROM masc_board_comments c \
+           WHERE c.post_id = masc_board_posts.id \
+             AND %s \
+             AND c.author ILIKE '%%' || $3 || '%%')) \
+     ORDER BY %s LIMIT $4"
+    post_columns ttl_where comment_ttl_where order_clause)
 
 let list_hot_q = mk_list_q "(votes_up - votes_down) DESC, created_at DESC"
 let list_recent_q = mk_list_q "created_at DESC"

--- a/lib/board_pg_queries.ml
+++ b/lib/board_pg_queries.ml
@@ -138,12 +138,12 @@ let mk_list_q order_clause =
        AND ($1::TEXT IS NULL OR visibility = $1) \
        AND ($2::TEXT IS NULL OR hearth = $2) \
        AND ($3::TEXT IS NULL \
-         OR author ILIKE '%%' || $3 || '%%' \
+         OR position(lower($3) in lower(author)) > 0 \
          OR EXISTS ( \
            SELECT 1 FROM masc_board_comments c \
            WHERE c.post_id = masc_board_posts.id \
              AND %s \
-             AND c.author ILIKE '%%' || $3 || '%%')) \
+             AND position(lower($3) in lower(c.author)) > 0)) \
      ORDER BY %s LIMIT $4"
     post_columns ttl_where comment_ttl_where order_clause)
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -30,21 +30,9 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
   let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
-  let fetch_limit =
-    if Option.is_some author_filter then max 500 base_fetch
-    else base_fetch
-  in
   let posts =
     Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-      ~exclude_automation ~limit:fetch_limit ()
-  in
-  let posts = match author_filter with
-    | None -> posts
-    | Some needle ->
-        let needle_lc = String.lowercase_ascii needle in
-        List.filter (fun (p : Board.post) ->
-          let a = String.lowercase_ascii (Board.Agent_id.to_string p.author) in
-          Dashboard_utils.string_contains ~needle:needle_lc a) posts
+      ~exclude_automation ?author_filter ~limit:base_fetch ()
   in
   let karma_map = Board_dispatch.get_all_karma () in
   let get_karma author =

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -59,21 +59,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let limit = int_query_param httpun_request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
       let offset = int_query_param httpun_request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
       let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
-      let fetch_limit =
-        if Option.is_some author_filter then max 500 base_fetch
-        else base_fetch
-      in
       let posts =
         Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-          ~exclude_automation ~limit:fetch_limit ()
-      in
-      let posts = match author_filter with
-        | None -> posts
-        | Some needle ->
-            let needle_lc = String.lowercase_ascii needle in
-            List.filter (fun (p : Board.post) ->
-              let a = String.lowercase_ascii (Board.Agent_id.to_string p.author) in
-              Dashboard_utils.string_contains ~needle:needle_lc a) posts
+          ~exclude_automation ?author_filter ~limit:base_fetch ()
       in
       let karma_map = Board_dispatch.get_all_karma () in
       let get_karma author =

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -115,21 +115,9 @@ let add_routes ~sw ~clock router =
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
-         let fetch_limit =
-           if Option.is_some author_filter then max 500 base_fetch
-           else base_fetch
-         in
          let posts =
            Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-             ~exclude_automation ~limit:fetch_limit ()
-         in
-         let posts = match author_filter with
-           | None -> posts
-           | Some needle ->
-               let needle_lc = String.lowercase_ascii needle in
-               List.filter (fun (p : Board.post) ->
-                 let a = String.lowercase_ascii (Board.Agent_id.to_string p.author) in
-                 Dashboard_utils.string_contains ~needle:needle_lc a) posts
+             ~exclude_automation ?author_filter ~limit:base_fetch ()
          in
          let karma_map = Board_dispatch.get_all_karma () in
          let get_karma author =

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -161,13 +161,31 @@ let format_comment ?(indent=0) (c : Board.comment) =
 (** Format comments as a tree structure, grouping replies under parents.
     max_depth limits nesting (default 5). Beyond that, comments render flat. *)
 let format_comment_tree ?(max_depth=5) (comments : Board.comment list) =
-  let roots = List.filter (fun (c : Board.comment) -> c.parent_id = None) comments in
-  let children_of parent_id =
-    List.filter (fun (c : Board.comment) ->
-      match c.parent_id with
-      | Some pid -> Board.Comment_id.to_string pid = Board.Comment_id.to_string parent_id
-      | None -> false
+  let visible_comment_ids = Hashtbl.create (List.length comments) in
+  let children_map = Hashtbl.create (List.length comments) in
+  let comment_id = Board.Comment_id.to_string in
+  List.iter (fun (comment : Board.comment) ->
+    Hashtbl.replace visible_comment_ids (comment_id comment.id) true
+  ) comments;
+  List.iter (fun (comment : Board.comment) ->
+    match comment.parent_id with
+    | Some parent_id ->
+        let key = comment_id parent_id in
+        let existing = Hashtbl.find_opt children_map key |> Option.value ~default:[] in
+        Hashtbl.replace children_map key (comment :: existing)
+    | None -> ()
+  ) comments;
+  let roots =
+    List.filter (fun (comment : Board.comment) ->
+      match comment.parent_id with
+      | None -> true
+      | Some parent_id -> not (Hashtbl.mem visible_comment_ids (comment_id parent_id))
     ) comments
+  in
+  let children_of parent_id =
+    Hashtbl.find_opt children_map (comment_id parent_id)
+    |> Option.value ~default:[]
+    |> List.rev
   in
   let rec render depth indent (c : Board.comment) =
     let self = format_comment ~indent c in
@@ -293,28 +311,11 @@ let handle_post_list args =
   match sort_by_result with
   | Error msg -> (false, Printf.sprintf "❌ %s" msg)
   | Ok sort_by ->
-      let base_fetch = limit + offset + 100 in
-      let fetch_limit =
-        if Option.is_some author_filter then max 500 base_fetch
-        else base_fetch
-      in
-      let all_posts = Board_dispatch.list_posts ~visibility_filter ?hearth
-        ~exclude_system
-        ~exclude_automation
-        ~sort_by:(dispatch_sort_of sort_by) ~limit:fetch_limit () in
-
-      (* Sorting is already handled by Board_dispatch *)
-      let sorted_posts = all_posts in
-      (* Author filter: case-insensitive substring match *)
-      let sorted_posts = match author_filter with
-        | None -> sorted_posts
-        | Some needle ->
-            let needle_lower = String.lowercase_ascii needle in
-            List.filter (fun (p : Board.post) ->
-              let author_str = Board.Agent_id.to_string p.author in
-              let author_lower = String.lowercase_ascii author_str in
-              String_util.contains_substring author_lower needle_lower
-            ) sorted_posts
+      let fetch_limit = limit + offset + 100 in
+      let sorted_posts =
+        Board_dispatch.list_posts ~visibility_filter ?hearth ?author_filter
+          ~exclude_system ~exclude_automation
+          ~sort_by:(dispatch_sort_of sort_by) ~limit:fetch_limit ()
       in
 
       let posts =

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -219,6 +219,17 @@ let test_list_posts_matches_comment_author () =
   Alcotest.(check bool) "non matching comment author excluded" false
     (List.mem other_post_id ids)
 
+let test_author_filter_treats_wildcards_literally () =
+  ignore
+    (Board_dispatch.create_post ~author:"wildcard-alpha"
+       ~content:"literal wildcard filter" ~post_kind:Board.Human_post ());
+  let filtered =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
+      ~author_filter:"%" ~limit:20 ()
+  in
+  Alcotest.(check int) "percent does not match all authors" 0
+    (List.length filtered)
+
 let test_reclassify_posts_dry_run_and_apply () =
   let post_id = seed_legacy_keeper_post () in
   let dry_run = Board_dispatch.reclassify_posts ~dry_run:true () in
@@ -401,6 +412,8 @@ let () =
       Alcotest.test_case "filters" `Quick (with_eio test_list_posts_with_filters);
       Alcotest.test_case "comment author filter" `Quick
         (with_eio test_list_posts_matches_comment_author);
+      Alcotest.test_case "literal wildcard filter" `Quick
+        (with_eio test_author_filter_treats_wildcards_literally);
       Alcotest.test_case "reclassify dry-run and apply" `Quick
         (with_eio test_reclassify_posts_dry_run_and_apply);
     ];

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -174,6 +174,51 @@ let test_list_posts_with_filters () =
   Alcotest.(check string) "human remains" "filter-human"
     (human_only |> List.hd |> fun (p : Board.post) -> Board.Agent_id.to_string p.author)
 
+let test_list_posts_matches_comment_author () =
+  let matching_post =
+    match
+      Board_dispatch.create_post ~author:"post-owner-a"
+        ~content:"comment author should surface this post"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let other_post =
+    match
+      Board_dispatch.create_post ~author:"post-owner-b"
+        ~content:"different comment author"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let matching_post_id = Board.Post_id.to_string matching_post.id in
+  let other_post_id = Board.Post_id.to_string other_post.id in
+  (match
+     Board_dispatch.add_comment ~post_id:matching_post_id
+       ~author:"comment-match-agent" ~content:"I touched this thread" ()
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match
+     Board_dispatch.add_comment ~post_id:other_post_id
+       ~author:"comment-other-agent" ~content:"Different author" ()
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let filtered =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
+      ~author_filter:"MATCH-AGENT" ~limit:20 ()
+  in
+  let ids =
+    List.map (fun (post : Board.post) -> Board.Post_id.to_string post.id) filtered
+  in
+  Alcotest.(check bool) "matching comment author includes post" true
+    (List.mem matching_post_id ids);
+  Alcotest.(check bool) "non matching comment author excluded" false
+    (List.mem other_post_id ids)
+
 let test_reclassify_posts_dry_run_and_apply () =
   let post_id = seed_legacy_keeper_post () in
   let dry_run = Board_dispatch.reclassify_posts ~dry_run:true () in
@@ -354,6 +399,8 @@ let () =
       Alcotest.test_case "list" `Quick (with_eio test_list_posts);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);
       Alcotest.test_case "filters" `Quick (with_eio test_list_posts_with_filters);
+      Alcotest.test_case "comment author filter" `Quick
+        (with_eio test_list_posts_matches_comment_author);
       Alcotest.test_case "reclassify dry-run and apply" `Quick
         (with_eio test_reclassify_posts_dry_run_and_apply);
     ];

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -151,6 +151,52 @@ let test_add_and_get_comments = with_pg_backend (fun t ->
           Alcotest.(check bool) "has comment" true (List.length comments >= 1)
 )
 
+let test_list_posts_matches_comment_author = with_pg_backend (fun t ->
+  let matching_post =
+    match
+      Board_pg.create_post t ~author:"pg-test-owner-a"
+        ~content:"pg comment author filter match"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let other_post =
+    match
+      Board_pg.create_post t ~author:"pg-test-owner-b"
+        ~content:"pg comment author filter miss"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let matching_post_id = Board.Post_id.to_string matching_post.id in
+  let other_post_id = Board.Post_id.to_string other_post.id in
+  (match
+     Board_pg.add_comment t ~post_id:matching_post_id
+       ~author:"pg-test-comment-match" ~content:"visible author match" ()
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match
+     Board_pg.add_comment t ~post_id:other_post_id
+       ~author:"pg-test-comment-miss" ~content:"other author" ()
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let filtered =
+    Board_pg.list_posts t ~sort_by:Board_pg.Recent
+      ~author_filter:"COMMENT-MATCH" ~limit:10 ()
+  in
+  let ids =
+    List.map (fun (post : Board.post) -> Board.Post_id.to_string post.id) filtered
+  in
+  Alcotest.(check bool) "matching comment author includes post" true
+    (List.mem matching_post_id ids);
+  Alcotest.(check bool) "non matching comment author excluded" false
+    (List.mem other_post_id ids)
+)
+
 (** {1 Vote Operations} *)
 
 let test_vote_post = with_pg_backend (fun t ->
@@ -338,6 +384,8 @@ let () =
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick test_add_and_get_comments;
+      Alcotest.test_case "comment author filter" `Quick
+        test_list_posts_matches_comment_author;
     ];
     "votes", [
       Alcotest.test_case "upvote" `Quick test_vote_post;

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -197,6 +197,18 @@ let test_list_posts_matches_comment_author = with_pg_backend (fun t ->
     (List.mem other_post_id ids)
 )
 
+let test_author_filter_treats_wildcards_literally = with_pg_backend (fun t ->
+  ignore
+    (Board_pg.create_post t ~author:"pg-test-wildcard-alpha"
+       ~content:"pg literal wildcard filter" ~post_kind:Board.Human_post ());
+  let filtered =
+    Board_pg.list_posts t ~sort_by:Board_pg.Recent
+      ~author_filter:"%" ~limit:10 ()
+  in
+  Alcotest.(check int) "percent does not match all authors" 0
+    (List.length filtered)
+)
+
 (** {1 Vote Operations} *)
 
 let test_vote_post = with_pg_backend (fun t ->
@@ -386,6 +398,8 @@ let () =
       Alcotest.test_case "add and get" `Quick test_add_and_get_comments;
       Alcotest.test_case "comment author filter" `Quick
         test_list_posts_matches_comment_author;
+      Alcotest.test_case "literal wildcard filter" `Quick
+        test_author_filter_treats_wildcards_literally;
     ];
     "votes", [
       Alcotest.test_case "upvote" `Quick test_vote_post;


### PR DESCRIPTION
## Summary
- include board author filtering matches for comment authors, not only post authors
- route MCP and HTTP board listing surfaces through the shared backend author filter path
- fix nested reply rendering so deep replies recurse correctly and orphaned replies still appear in the thread

## Root Cause
- board author filtering was implemented as a post-level author substring check, so posts with matching comment authors were never returned
- comment thread rendering passed only one level of replies into the UI tree, so deeper replies disappeared

## Product impact
- board filters now return posts that participated in a matching discussion author, which makes author search usable for follow-up and moderation workflows
- reply threads in the dashboard no longer drop grandchildren or orphaned replies, so discussion context stays visible

## Evidence
- JSONL backend regression coverage added for comment-author matching
- PostgreSQL backend regression coverage added for comment-author matching
- dashboard component coverage added for nested replies and orphaned replies

## Review evidence
- GLM-5.1 direct review via `sb glm-text` on 2026-04-02T03:35:44Z (UTC)
- final result: `No findings.`
- review evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4603#issuecomment-4174403767

## Linked issue
- Closes #4606

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-board-comment-search ./bin/main_eio.exe`
- `./_build/default/test/test_board_dispatch.exe`
- `./_build/default/test/test_tool_board_coverage.exe`
- `pnpm --dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-board-comment-search/dashboard typecheck`
- `pnpm --dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-board-comment-search/dashboard test -- src/components/memory-post-detail.test.ts`
- `./_build/default/test/test_board_pg.exe` (`MASC_POSTGRES_URL` not set, so PG cases were skipped)
