### PR TITLE
[codex] Centralize meta-cognition interpretation and gate keeper room signals

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -11,7 +11,9 @@ const roomTruthLoading = { value: false }
 const refreshRoomTruth = vi.fn().mockResolvedValue(undefined)
 
 const topActiveAgents = { value: [] as unknown[] }
+const shellMetaCognition = { value: null as Record<string, unknown> | null }
 const navigate = vi.fn()
+const navigateToPost = vi.fn()
 const connected = { value: true }
 const eventCount = { value: 0 }
 const lastEvent = { value: null as { ts_unix?: number } | null }
@@ -36,6 +38,9 @@ async function loadOverview() {
   vi.doMock('../../observatory-store', () => ({
     topActiveAgents,
   }))
+  vi.doMock('../../store', () => ({
+    shellMetaCognition,
+  }))
   vi.doMock('../../sse', () => ({
     journal: [],
     connected,
@@ -44,6 +49,7 @@ async function loadOverview() {
   }))
   vi.doMock('../../router', () => ({
     navigate,
+    navigateToPost,
   }))
   vi.doMock('./situation-banner', () => ({
     SituationBanner: () => html`<div>Situation</div>`,
@@ -76,6 +82,7 @@ describe('Overview freshness strip', () => {
     missionLoading.value = false
     roomTruthLoading.value = false
     topActiveAgents.value = []
+    shellMetaCognition.value = null
     connected.value = true
     eventCount.value = 0
     lastEvent.value = null
@@ -100,6 +107,7 @@ describe('Overview freshness strip', () => {
     vi.doUnmock('../../mission-store')
     vi.doUnmock('../../room-truth-store')
     vi.doUnmock('../../observatory-store')
+    vi.doUnmock('../../store')
     vi.doUnmock('../../sse')
     vi.doUnmock('../../router')
     vi.doUnmock('./situation-banner')
@@ -139,5 +147,71 @@ describe('Overview freshness strip', () => {
 
     expect(refreshRoomTruth).toHaveBeenCalledWith({ force: true })
     expect(refreshMissionSnapshot).toHaveBeenCalledWith({ force: true })
+  }, 15000)
+
+  it('renders the meta-cognition summary card when shell data is available', async () => {
+    roomTruth.value = {
+      generated_at: '2026-03-26T12:08:00Z',
+      meta_cognition: {
+        latest_digest: {
+          post_id: 'post-meta-1',
+          title: '[meta-cognition] contested belief requires follow-up',
+          created_at: '2026-03-26T12:07:30Z',
+          matches_summary: true,
+          provenance: 'board',
+        },
+      },
+      focus: {
+        label: '주의 필요',
+        reason: '집단 인식에 이견이 있습니다: keepers believe masc_* tools are blocked',
+        source: 'meta_cognition',
+        provenance: 'derived',
+        suggested_tab: 'overview',
+      },
+    }
+    shellMetaCognition.value = {
+      stagnation_score: 0.72,
+      belief_count: 2,
+      contested_belief_count: 1,
+      dominant_belief: {
+        id: 'belief:masc_tools_blocked',
+        claim: 'keepers believe masc_* tools are blocked',
+        status: 'contested',
+        support_agent_count: 2,
+      },
+      top_tension: {
+        id: 'tension:masc_tool_blockage',
+        topic: 'keeper-facing masc_* tool blockage',
+        severity: 'high',
+        needs_operator: true,
+      },
+      top_desire: {
+        id: 'desire:operator_guidance',
+        desired_state: 'get operator guidance to unblock current work',
+        actionability: 'operator',
+      },
+    }
+
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('집단 메타인지')
+    expect(container.textContent).toContain('정체 72%')
+    expect(container.textContent).toContain('이견 1')
+    expect(container.textContent).toContain('최근 board digest')
+    expect(container.textContent).toContain('게시물 열기')
+    expect(container.textContent).toContain('공감대')
+    expect(container.textContent).toContain('긴장')
+    expect(container.textContent).toContain('욕구')
+    expect(container.textContent).toContain('room-truth focus')
+    expect(container.textContent).toContain('집단 인식에 이견이 있습니다')
+    expect(container.textContent).toContain('운영자 개입 필요')
+
+    const digestButton = Array.from(container.querySelectorAll('button'))
+      .find(candidate => candidate.textContent?.includes('게시물 열기'))
+    digestButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(navigateToPost).toHaveBeenCalledWith('post-meta-1')
   }, 15000)
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -17,8 +17,13 @@ import { AgentAvatar } from './agent-avatar'
 import { TransportHealthPanel } from '../transport-health'
 import { PerfSnapshotPanel } from '../perf-snapshot'
 import { RouteLink } from '../common/route-link'
+import { shellMetaCognition } from '../../store'
+import { navigateToPost } from '../../router'
 import type { ObservatoryAgent } from '../../observatory-store'
-import type { DashboardMissionSessionBrief } from '../../types'
+import type {
+  DashboardMissionSessionBrief,
+  DashboardShellMetaCognitionSummary,
+} from '../../types'
 import type { ReadonlySignal } from '@preact/signals'
 
 const OVERVIEW_STALE_MS = 300_000
@@ -154,6 +159,194 @@ function HomeSectionHeader({
   `
 }
 
+function metaCognitionTone(summary: DashboardShellMetaCognitionSummary): {
+  label: string
+  className: string
+} {
+  if (summary.contested_belief_count > 0 || summary.stagnation_score >= 0.7) {
+    return {
+      label: '긴장 높음',
+      className: 'border-bad/35 bg-bad/10 text-bad-light',
+    }
+  }
+  if (summary.stagnation_score >= 0.45) {
+    return {
+      label: '정체 감지',
+      className: 'border-warn/35 bg-warn/12 text-warn',
+    }
+  }
+  return {
+    label: '안정',
+    className: 'border-ok/30 bg-ok/10 text-ok',
+  }
+}
+
+function beliefStatusLabel(status?: string | null): string {
+  switch ((status ?? '').trim().toLowerCase()) {
+    case 'contested':
+      return '이견 있음'
+    case 'corroborated':
+      return '공감대 강함'
+    case 'emerging':
+      return '형성 중'
+    default:
+      return '신호 약함'
+  }
+}
+
+function tensionSeverityLabel(severity?: string | null): string {
+  switch ((severity ?? '').trim().toLowerCase()) {
+    case 'high':
+      return '긴장 높음'
+    case 'medium':
+      return '긴장 중간'
+    case 'low':
+      return '긴장 낮음'
+    default:
+      return '긴장 관찰'
+  }
+}
+
+function desireActionabilityLabel(actionability?: string | null): string {
+  switch ((actionability ?? '').trim().toLowerCase()) {
+    case 'operator':
+      return '운영자 액션'
+    case 'operator_or_platform':
+      return '운영자/플랫폼 액션'
+    case 'operator_or_scheduler':
+      return '운영자/스케줄러 액션'
+    case 'room_or_operator':
+      return 'room/운영자 액션'
+    default:
+      return '추가 판독 필요'
+  }
+}
+
+function MetaCognitionCard() {
+  const summary = shellMetaCognition.value
+  if (!summary) return null
+
+  const tone = metaCognitionTone(summary)
+  const stagnationPct = Math.round(summary.stagnation_score * 100)
+  const belief = summary.dominant_belief
+  const tension = summary.top_tension
+  const desire = summary.top_desire
+  const hasNarrative = Boolean(belief || tension || desire)
+  const focus = roomTruth.value?.focus?.source === 'meta_cognition'
+    ? roomTruth.value.focus
+    : null
+  const latestDigest = roomTruth.value?.meta_cognition?.latest_digest ?? null
+
+  return html`
+    <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
+      <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <${HomeSectionHeader} label="집단 메타인지" />
+          <div class="text-[12px] leading-relaxed text-[var(--text-muted)]">
+            게시물, 코멘트, 태스크, 거버넌스에서 읽은 현재 공감대와 긴장.
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="rounded-full border px-2.5 py-1 text-[11px] font-semibold ${tone.className}">
+            ${tone.label}
+          </span>
+          <span class="rounded-full border border-card-border/60 bg-card/55 px-2.5 py-1 text-[11px] font-semibold text-[var(--text-strong)]">
+            정체 ${stagnationPct}%
+          </span>
+          ${summary.contested_belief_count > 0
+            ? html`
+                <span class="rounded-full border border-[rgba(255,196,107,0.25)] bg-[rgba(255,196,107,0.12)] px-2.5 py-1 text-[11px] font-semibold text-[#ffd78f]">
+                  이견 ${summary.contested_belief_count}
+                </span>
+              `
+            : null}
+        </div>
+      </div>
+
+      ${focus
+        ? html`
+            <div class="mb-3 rounded-xl border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
+              <span class="font-semibold text-[var(--text-strong)]">room-truth focus</span>
+              <span class="ml-2">${focus.reason}</span>
+            </div>
+          `
+        : null}
+
+      ${latestDigest
+        ? html`
+            <div class="mb-3 rounded-xl border border-card-border/50 bg-card/40 px-3 py-3">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                    최근 board digest
+                  </div>
+                  <div class="mt-1 truncate text-[13px] font-semibold text-[var(--text-strong)]">
+                    ${latestDigest.title}
+                  </div>
+                  <div class="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                    <span><${TimeAgo} timestamp=${latestDigest.created_at} /></span>
+                    <span>
+                      ${latestDigest.matches_summary ? '현재 summary 반영됨' : '현재 summary 반영 대기'}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="rounded-lg border border-accent/25 bg-accent/10 px-3 py-1.5 text-[12px] font-semibold text-accent transition-colors hover:bg-accent/18"
+                  onClick=${() => navigateToPost(latestDigest.post_id)}
+                >
+                  게시물 열기
+                </button>
+              </div>
+            </div>
+          `
+        : null}
+
+      ${hasNarrative
+        ? html`
+            <div class="grid grid-cols-3 gap-3 max-[960px]:grid-cols-1">
+              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">공감대</div>
+                <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
+                  ${belief?.claim ?? '아직 강한 belief가 드러나지 않았습니다.'}
+                </div>
+                <div class="mt-2 text-[11px] text-[var(--text-muted)]">
+                  ${belief ? `${beliefStatusLabel(belief.status)} · ${belief.support_agent_count ?? 0}명 지지` : '공감대 형성 전'}
+                </div>
+              </div>
+
+              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">긴장</div>
+                <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
+                  ${tension?.topic ?? '아직 우세한 tension이 없습니다.'}
+                </div>
+                <div class="mt-2 text-[11px] text-[var(--text-muted)]">
+                  ${tension
+                    ? `${tensionSeverityLabel(tension.severity)}${tension.needs_operator ? ' · 운영자 개입 필요' : ''}`
+                    : '긴장 신호 약함'}
+                </div>
+              </div>
+
+              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">욕구</div>
+                <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
+                  ${desire?.desired_state ?? '아직 뚜렷한 collective desire가 없습니다.'}
+                </div>
+                <div class="mt-2 text-[11px] text-[var(--text-muted)]">
+                  ${desire ? desireActionabilityLabel(desire.actionability) : '욕구 신호 약함'}
+                </div>
+              </div>
+            </div>
+          `
+        : html`
+            <div class="rounded-xl border border-dashed border-card-border/50 bg-card/40 px-4 py-5 text-[12px] text-[var(--text-muted)]">
+              아직 room-level 서사를 만들 만큼 강한 social signal이 쌓이지 않았습니다.
+            </div>
+          `}
+    </div>
+  `
+}
+
 function renderSessionCard(s: DashboardMissionSessionBrief) {
   const { primary, secondary } = splitSessionGoal(s.goal, s.session_id)
   const creator = (s.created_by ?? '').trim()
@@ -274,6 +467,7 @@ function AgentPulse() {
 export function Overview() {
   const snap = missionSnapshot.value
   const roomHealth = snap?.summary?.room_health ?? null
+  const metaCognitionCard = MetaCognitionCard()
   const hotSessions = HotSessions()
   const agentPulse = AgentPulse()
   const journalEntries = (
@@ -288,6 +482,8 @@ export function Overview() {
       <${OverviewFreshnessStrip} />
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
       <${AttentionSpotlight} snap=${snap} />
+
+      ${metaCognitionCard}
 
       ${hotSessions
         ? html`

--- a/dashboard/src/room-truth-normalizers.ts
+++ b/dashboard/src/room-truth-normalizers.ts
@@ -5,10 +5,12 @@ import {
   normalizeExecutionQueueItem,
   normalizeAttentionItem,
   normalizeRecommendedAction,
+  normalizeShellMetaCognitionSummary,
 } from './store-normalizers'
 import type {
   DashboardRoomTruthAttentionSummary,
   DashboardRoomTruthFocus,
+  DashboardRoomTruthMetaCognitionDigest,
   DashboardRoomTruthRecommendationSummary,
   DashboardRoomTruthResponse,
   PendingConfirmSummary,
@@ -77,6 +79,24 @@ function normalizeRecommendationSummary(raw: unknown): DashboardRoomTruthRecomme
   }
 }
 
+function normalizeMetaCognitionDigest(raw: unknown): DashboardRoomTruthMetaCognitionDigest | null {
+  if (!isRecord(raw)) return null
+  const postId = asString(raw.post_id)
+  const title = asString(raw.title)
+  const createdAt = asString(raw.created_at)
+  if (!postId || !title || !createdAt) return null
+  return {
+    post_id: postId,
+    title,
+    created_at: createdAt,
+    updated_at: asString(raw.updated_at) ?? null,
+    hearth: asString(raw.hearth) ?? null,
+    digest_key: asString(raw.digest_key) ?? null,
+    matches_summary: asBoolean(raw.matches_summary) ?? false,
+    provenance: asString(raw.provenance) ?? null,
+  }
+}
+
 function normalizeFocus(raw: unknown): DashboardRoomTruthFocus | null {
   if (!isRecord(raw)) return null
   const label = asString(raw.label)
@@ -111,6 +131,7 @@ export function normalizeRoomTruth(raw: unknown): DashboardRoomTruthResponse {
   const roomBlock = isRecord(root.room) ? root.room : {}
   const executionBlock = isRecord(root.execution) ? root.execution : {}
   const commandBlock = isRecord(root.command) ? root.command : {}
+  const metaCognitionBlock = isRecord(root.meta_cognition) ? root.meta_cognition : {}
   const operatorBlock = isRecord(root.operator) ? root.operator : {}
   return {
     generated_at: asString(root.generated_at),
@@ -139,6 +160,11 @@ export function normalizeRoomTruth(raw: unknown): DashboardRoomTruthResponse {
       moving_lanes: asNumber(commandBlock.moving_lanes),
       active_lanes: asNumber(commandBlock.active_lanes),
       provenance: asString(commandBlock.provenance) ?? null,
+    },
+    meta_cognition: {
+      summary: normalizeShellMetaCognitionSummary(metaCognitionBlock.summary),
+      latest_digest: normalizeMetaCognitionDigest(metaCognitionBlock.latest_digest),
+      provenance: asString(metaCognitionBlock.provenance) ?? null,
     },
     operator: {
       health: asString(operatorBlock.health) ?? null,

--- a/dashboard/src/room-truth-store.test.ts
+++ b/dashboard/src/room-truth-store.test.ts
@@ -67,4 +67,49 @@ describe('refreshRoomTruth', () => {
       uptime_seconds: 588,
     })
   }, 20000)
+
+  it('normalizes latest meta-cognition digest from room truth', async () => {
+    apiMocks.fetchDashboardRoomTruth.mockResolvedValue({
+      generated_at: '2026-03-25T08:16:21Z',
+      room: {
+        status: {
+          room: 'default',
+          current_room: 'default',
+          version: '2.148.0',
+        },
+      },
+      meta_cognition: {
+        summary: {
+          stagnation_score: 0.72,
+          belief_count: 2,
+          contested_belief_count: 1,
+        },
+        latest_digest: {
+          post_id: 'post-meta-1',
+          title: '[meta-cognition] contested belief requires follow-up',
+          created_at: '2026-03-25T08:14:00Z',
+          updated_at: '2026-03-25T08:14:00Z',
+          hearth: 'meta-cognition',
+          digest_key: 'digest-1',
+          matches_summary: true,
+          provenance: 'board',
+        },
+      },
+    })
+
+    const roomTruthStore = await import('./room-truth-store')
+
+    await roomTruthStore.refreshRoomTruth({ force: true })
+
+    expect(roomTruthStore.roomTruth.value?.meta_cognition?.latest_digest).toEqual({
+      post_id: 'post-meta-1',
+      title: '[meta-cognition] contested belief requires follow-up',
+      created_at: '2026-03-25T08:14:00Z',
+      updated_at: '2026-03-25T08:14:00Z',
+      hearth: 'meta-cognition',
+      digest_key: 'digest-1',
+      matches_summary: true,
+      provenance: 'board',
+    })
+  }, 20000)
 })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -5,6 +5,10 @@ import type {
   DashboardExecutionQueueItem, DashboardExecutionSessionBrief,
   DashboardExecutionOperationBrief, DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
+  DashboardShellMetaCognitionBelief,
+  DashboardShellMetaCognitionDesire,
+  DashboardShellMetaCognitionSummary,
+  DashboardShellMetaCognitionTension,
   OperatorAttentionItem, OperatorRecommendedAction,
 } from './types'
 
@@ -301,6 +305,73 @@ export function normalizeExecutionContinuityBrief(raw: unknown): DashboardExecut
   }
 }
 
+export function normalizeShellMetaCognitionBelief(
+  raw: unknown,
+): DashboardShellMetaCognitionBelief | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const claim = asString(raw.claim)
+  const status = asString(raw.status)
+  if (!id || !claim || !status) return null
+  return {
+    id,
+    claim,
+    status,
+    confidence: asNumber(raw.confidence) ?? null,
+    support_agent_count: asNumber(raw.support_agent_count) ?? null,
+    challenge_agent_count: asNumber(raw.challenge_agent_count) ?? null,
+  }
+}
+
+export function normalizeShellMetaCognitionTension(
+  raw: unknown,
+): DashboardShellMetaCognitionTension | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const topic = asString(raw.topic)
+  if (!id || !topic) return null
+  return {
+    id,
+    topic,
+    kind: asString(raw.kind) ?? null,
+    severity: asString(raw.severity) ?? null,
+    recurrence_count: asNumber(raw.recurrence_count) ?? null,
+    needs_operator: asBoolean(raw.needs_operator) ?? false,
+  }
+}
+
+export function normalizeShellMetaCognitionDesire(
+  raw: unknown,
+): DashboardShellMetaCognitionDesire | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const desiredState = asString(raw.desired_state)
+  if (!id || !desiredState) return null
+  return {
+    id,
+    desired_state: desiredState,
+    type: asString(raw.type) ?? null,
+    actionability: asString(raw.actionability) ?? null,
+    strength: asNumber(raw.strength) ?? null,
+  }
+}
+
+export function normalizeShellMetaCognitionSummary(
+  raw: unknown,
+): DashboardShellMetaCognitionSummary | null {
+  if (!isRecord(raw)) return null
+  const stagnationScore = asNumber(raw.stagnation_score)
+  if (stagnationScore == null) return null
+  return {
+    stagnation_score: stagnationScore,
+    belief_count: asNumber(raw.belief_count) ?? 0,
+    contested_belief_count: asNumber(raw.contested_belief_count) ?? 0,
+    dominant_belief: normalizeShellMetaCognitionBelief(raw.dominant_belief),
+    top_tension: normalizeShellMetaCognitionTension(raw.top_tension),
+    top_desire: normalizeShellMetaCognitionDesire(raw.top_desire),
+  }
+}
+
 export function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
   if (!isRecord(raw)) return null
   const kind = asString(raw.kind)
@@ -395,4 +466,3 @@ export function mergeServerStatus(previous: ServerStatus | null, next: ServerSta
     generated_at: next.generated_at ?? previous.generated_at,
   }
 }
-

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -21,6 +21,7 @@ import type {
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
+  DashboardShellMetaCognitionSummary,
 } from './types'
 import {
   fetchDashboardExecution,
@@ -48,6 +49,7 @@ import {
   normalizeExecutionContinuityBrief,
   mergeMessages,
   normalizeServerStatus, mergeServerStatus,
+  normalizeShellMetaCognitionSummary,
 } from './store-normalizers'
 
 // --- Shell counts (lightweight fallback from /dashboard/shell) ---
@@ -59,6 +61,7 @@ export interface ShellCounts {
 }
 
 export const shellCounts = signal<ShellCounts | null>(null)
+export const shellMetaCognition = signal<DashboardShellMetaCognitionSummary | null>(null)
 
 // --- Core state signals ---
 
@@ -340,6 +343,7 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
           keepers: data.counts.keepers ?? 0,
         }
       }
+      shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)
       lastShellRefreshAt = Date.now()
     } catch (err) {
       console.warn('[Dashboard] shell fetch error:', err)

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('./store', () => ({
+  refreshShell: vi.fn(),
   refreshExecution: vi.fn(),
   refreshBoard: vi.fn(),
   refreshGoals: vi.fn(),
@@ -34,7 +35,7 @@ describe('refreshPlanForRoute', () => {
     expect(refreshPlanForRoute({
       tab: 'overview',
       params: {},
-    })).toEqual(['roomTruth', 'missionSnapshot'])
+    })).toEqual(['shell', 'roomTruth', 'missionSnapshot'])
   })
 
   it('uses the current monitoring sections', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -1,5 +1,5 @@
 import type { RouteState } from './types'
-import { refreshExecution, refreshBoard, refreshGoals } from './store'
+import { refreshExecution, refreshBoard, refreshGoals, refreshShell } from './store'
 import { requestRoomTruth } from './room-truth-store'
 import { refreshOperatorRoomDigest, refreshOperatorSnapshot } from './operator-store'
 import { refreshMissionSnapshot } from './mission-store'
@@ -30,6 +30,7 @@ async function refreshGovernanceSurface(): Promise<void> {
 }
 
 export type RefreshTask =
+  | 'shell'
   | 'roomTruth'
   | 'missionSnapshot'
   | 'execution'
@@ -46,7 +47,7 @@ export type RefreshTask =
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
     case 'overview':
-      return ['roomTruth', 'missionSnapshot']
+      return ['shell', 'roomTruth', 'missionSnapshot']
     case 'monitoring':
       if (routeState.params.section === 'activity') {
         return ['execution', 'activityGraph']
@@ -89,6 +90,7 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
 }
 
 const REFRESHERS: Record<RefreshTask, () => void> = {
+  shell: () => { void refreshShell({ force: true }) },
   roomTruth: () => { requestRoomTruth() },
   missionSnapshot: () => { void refreshMissionSnapshot() },
   execution: () => { void refreshExecution({ force: true }) },

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -5,6 +5,41 @@ import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, Gov
 
 // --- Dashboard projection responses ---
 
+export interface DashboardShellMetaCognitionBelief {
+  id: string
+  claim: string
+  status: string
+  confidence?: number | null
+  support_agent_count?: number | null
+  challenge_agent_count?: number | null
+}
+
+export interface DashboardShellMetaCognitionTension {
+  id: string
+  topic: string
+  kind?: string | null
+  severity?: string | null
+  recurrence_count?: number | null
+  needs_operator?: boolean
+}
+
+export interface DashboardShellMetaCognitionDesire {
+  id: string
+  desired_state: string
+  type?: string | null
+  actionability?: string | null
+  strength?: number | null
+}
+
+export interface DashboardShellMetaCognitionSummary {
+  stagnation_score: number
+  belief_count: number
+  contested_belief_count: number
+  dominant_belief?: DashboardShellMetaCognitionBelief | null
+  top_tension?: DashboardShellMetaCognitionTension | null
+  top_desire?: DashboardShellMetaCognitionDesire | null
+}
+
 export interface DashboardShellResponse {
   generated_at?: string
   status: ServerStatus
@@ -14,6 +49,7 @@ export interface DashboardShellResponse {
     keepers?: number
   }
   providers?: Record<string, unknown>
+  meta_cognition?: DashboardShellMetaCognitionSummary | null
 }
 
 export interface DashboardRoomTruthAttentionSummary {
@@ -28,6 +64,23 @@ export interface DashboardRoomTruthRecommendationSummary {
   count: number
   provenance?: string | null
   top_action?: OperatorRecommendedAction | null
+}
+
+export interface DashboardRoomTruthMetaCognitionDigest {
+  post_id: string
+  title: string
+  created_at: string
+  updated_at?: string | null
+  hearth?: string | null
+  digest_key?: string | null
+  matches_summary?: boolean
+  provenance?: string | null
+}
+
+export interface DashboardRoomTruthMetaCognition {
+  summary?: DashboardShellMetaCognitionSummary | null
+  latest_digest?: DashboardRoomTruthMetaCognitionDigest | null
+  provenance?: string | null
 }
 
 export interface DashboardRoomTruthFocus {
@@ -64,6 +117,7 @@ export interface DashboardRoomTruthResponse {
     active_lanes?: number
     provenance?: string | null
   }
+  meta_cognition?: DashboardRoomTruthMetaCognition | null
   operator?: {
     health?: string | null
     attention_summary?: DashboardRoomTruthAttentionSummary | null

--- a/docs/design/meta-cognition-map.md
+++ b/docs/design/meta-cognition-map.md
@@ -1,0 +1,610 @@
+# MASC Meta-Cognition Map
+
+Date: 2026-04-02
+Status: research note
+Scope: keeper self-model + board/public square + governance + relation graph + room-level reflection
+
+## Goal
+
+장기 목표는 MASC가 "현재 이 세계가 무엇을 믿고 있는가", "무엇에 막혀 있는가", "무엇을 원하고 있는가", "누가 누구를 지지하거나 반박하고 있는가"를 읽고, 그 위에서 자기조절 또는 운영자 개입을 제안하는 메타인지 레이어를 갖게 하는 것이다.
+
+이 문서는 현재 코드와 실제 로컬 `.masc` 데이터에서 이미 존재하는 신호를 정리하고, 바로 구현 가능한 slice를 제안한다.
+
+## What Already Exists
+
+### 1. Individual self-model already exists
+
+Keeper는 이미 다음 자기 모델 필드를 가진다.
+
+- `goal`, `short_goal`, `mid_goal`, `long_goal`
+- `will`, `needs`, `desires`
+- runtime fields: `last_speech_act`, `last_blocker`, `last_need`
+- auto-rules: `reflect`, `plan`, `compact`, `handoff`, `guardrail_stop`
+
+관련 코드:
+
+- `lib/keeper/keeper_types.mli`
+- `lib/keeper/keeper_memory_recall.ml`
+- `lib/keeper/keeper_status.ml`
+- `lib/keeper/keeper_status_detail.ml`
+
+의미:
+
+- 개별 keeper 수준의 메타인지는 이미 있다.
+- 부족한 것은 집단 수준의 belief / tension / desire aggregation이다.
+
+### 2. Social expression already exists
+
+현재 active baseline social model은 `bdi_speech_v1`이다.
+
+- keeper는 typed social header를 출력한다.
+- `ACTIVE_DESIRE`, `CURRENT_INTENTION`, `BLOCKER`, `NEED`, `SPEECH_ACT`, `DELIVERY_SURFACE`가 파싱된다.
+- `request_help + board_post`면 자동으로 board post가 생성된다.
+
+관련 코드:
+
+- `docs/design/keeper-social-model-inventory.md`
+- `lib/keeper/keeper_social_model.ml`
+- `test/test_keeper_unified.ml`
+
+의미:
+
+- keeper 내부 욕구/의도/막힘은 이미 explicit하게 표현할 수 있다.
+- 하지만 room-level read model이 없어 개별 표현이 집단 메타인지로 승격되지 않는다.
+
+### 3. Public square already exists
+
+Board는 이미 집단 신호의 핵심 surface다.
+
+- post / comment / vote
+- `hearth`
+- `thread_id`
+- `post_kind`
+- `visibility`
+- karma / flair / trending sort
+
+관련 코드:
+
+- `docs/spec/11-board.md`
+- `lib/board_types/board_types.ml`
+- `lib/board_core.ml`
+- `lib/board_dispatch.ml`
+- `lib/tool_board.ml`
+
+의미:
+
+- 여론, 반복 서사, 정정, 반론, 릴레이 코멘트는 이미 board에 쌓인다.
+- 다만 현재는 원시 이벤트 저장에 가깝고, "consensus", "dissent", "complaint", "room desire" 같은 파생 객체가 없다.
+
+### 4. Structured stance / consensus primitives already exist
+
+Board 외에도 집단 의견을 구조화할 수 있는 primitive가 있다.
+
+- Governance brief stance: `support | oppose | neutral`
+- Debate: `Support | Oppose | Neutral`
+- Consensus session: `Approve | Reject | Abstain`
+- Balance: dominance / mandatory participation
+
+관련 코드:
+
+- `docs/spec/08-council-governance.md`
+- `lib/council/governance_v2_types.ml`
+- `lib/council/consensus.ml`
+- `lib/council/debate.ml`
+- `lib/council/balance.ml`
+
+의미:
+
+- MASC에는 이미 "의견 차이"와 "합의"를 표현하는 제도적 surface가 있다.
+- 하지만 board discourse와 governance/consensus surface가 자동으로 연결되지 않는다.
+
+### 5. Relationship primitives already exist
+
+관계망도 완전히 없는 상태는 아니다.
+
+- room leave 시 co-presence 기반 collaboration edge materialization
+- GraphQL proxy를 통한 collaboration/trust relation 조회
+- local Hebbian collaboration graph
+
+관련 코드:
+
+- `lib/room/room_lifecycle.ml`
+- `lib/relation_materializer.ml`
+- `lib/dashboard/dashboard_agent_relations.ml`
+- `lib/hebbian_eio.ml`
+- `lib/tool_agent.ml`
+
+의미:
+
+- relation graph는 이미 있다.
+- 하지만 대부분 co-presence, external graph, success/failure learning 기반이다.
+- "누가 누구의 주장에 동조/반박/정정했는가" 같은 discourse-derived social edge는 아직 약하다.
+
+### 6. Collaboration evidence and room truth already exist
+
+운영자 관점 read model도 부분적으로 있다.
+
+- collaboration evidence
+- room truth snapshot
+- operator digest / control plane
+
+관련 코드:
+
+- `lib/dashboard/dashboard_collaboration_evidence.ml`
+- `lib/server/server_dashboard_http_room_truth.ml`
+- `lib/operator/operator_control.ml`
+
+의미:
+
+- "협업이 있었는가"는 읽을 수 있다.
+- 하지만 "무슨 공감대가 형성되었는가", "무슨 불만이 누적되었는가"는 아직 없다.
+
+## Observed Reality In The Current World
+
+Local evidence source:
+
+- `/Users/dancer/me/.masc/board_posts.jsonl`
+- `/Users/dancer/me/.masc/board_comments.jsonl`
+- `/Users/dancer/me/.masc/board_votes.jsonl`
+- `/Users/dancer/me/.masc/governance_v2/*`
+
+Snapshot observed on 2026-04-02:
+
+- board posts: 154
+- board comments: 17
+- board votes: 9
+- governance files: 7
+- consensus files: 0
+- debate files: 0
+
+Hearth distribution:
+
+- `ops`: 104
+- `(none)`: 45
+- `research`: 3
+- `code-review`: 2
+
+Top authors:
+
+- `admin-keeper`: 33
+- `detail-demo`: 28
+- `audit-keeper-decision`: 24
+- `keeper-alpha`: 12
+- `goal-msg-demo`: 9
+
+Top discussion threads:
+
+- `p-1e4d4b8ee72c581e472c42e317e1b407`: 10 linked posts
+- `p-04767161849847ea958bd77fe344a156`: 9 linked posts
+- `p-4320e6fb18b8eb458930ec794c4d0f9c`: 5 linked posts
+
+Dominant keywords across post/comment payloads:
+
+- `task`: 104
+- `unregistered_masc_tool`: 90
+- `policy`: 89
+- `audit`: 81
+- `blocked`: 57
+- `idle`: 42
+- `help`: 21
+- `heartbeat`: 15
+
+### What the world is currently "thinking"
+
+실제 board는 이미 다음과 같은 collective cognition을 보여준다.
+
+1. Shared belief
+`masc_*` tool namespace is unavailable or policy-blocked for keeper-class agents.
+
+2. Shared blocker
+keepers can still use `keeper_*`, but system introspection or admin surfaces are blocked.
+
+3. Shared desire
+operator intervention, task seeding, or a better audit surface is needed.
+
+4. Shared stagnation signal
+active agents are present, but backlog is empty and many posts are idle/standby reports.
+
+5. Correction dynamics
+the room already produces amendments, retractions, corroboration, and challenge comments.
+
+6. Mild dissatisfaction
+there are explicit complaint-like signals, for example task ownership frustration and boredom/idleness observations.
+
+### Important observation
+
+Votes are sparse. Comments and linked posts carry far more social meaning than votes.
+
+So a meta-cognition layer should not treat upvotes as the primary signal. The real signals are:
+
+- corroboration
+- correction
+- rebuttal
+- request for help
+- idle/stagnation observation
+- repeated blocker reporting
+- operator-directed desire statements
+
+## The Missing Layer
+
+현재 MASC에는 아래 두 가지가 있다.
+
+1. self-awareness at the keeper level
+2. public discourse at the board/governance level
+
+하지만 아래는 없다.
+
+1. room-level beliefs
+2. room-level tensions or complaints
+3. room-level desires
+4. discourse-derived relation edges
+5. false-consensus detection
+6. a memory of unresolved social issues
+
+또 하나 중요하다.
+
+`social_sweep` operator action is currently removed and returns a stub result. Keepers are expected to discover board events through proactive turns instead.
+
+That means public-square reflection currently happens only indirectly.
+
+## Proposed Meta-Cognition Read Model
+
+### Core derived entities
+
+#### 1. `room_belief`
+
+A proposition the room appears to believe.
+
+Suggested fields:
+
+- `belief_id`
+- `claim`
+- `status`: `emerging | corroborated | contested | stale`
+- `supporting_posts`
+- `supporting_comments`
+- `challenging_posts`
+- `challenging_comments`
+- `support_agent_count`
+- `challenge_agent_count`
+- `confidence`
+- `first_seen_at`
+- `last_seen_at`
+- `hearth`
+- `topic_tags`
+
+Examples:
+
+- "`masc_*` admin tools are policy-blocked for keeper-class agents"
+- "backlog is empty and agents are mostly idle"
+
+#### 2. `room_tension`
+
+A recurring complaint, unresolved blocker, or friction source.
+
+Suggested fields:
+
+- `tension_id`
+- `topic`
+- `kind`: `blocker | complaint | boredom | coordination_gap | policy_gap`
+- `affected_agents`
+- `evidence_refs`
+- `severity`
+- `novelty`
+- `recurrence_count`
+- `stale_cycles`
+- `needs_operator`
+- `linked_tasks`
+- `linked_governance_cases`
+
+Examples:
+
+- repeated `unregistered_masc_tool`
+- no new task seeding
+- tool policy ambiguity
+- path validator bug
+
+#### 3. `collective_desire`
+
+A future state that multiple agents seem to want.
+
+Suggested fields:
+
+- `desire_id`
+- `desired_state`
+- `source_agents`
+- `evidence_refs`
+- `strength`
+- `type`: `request | aspiration | operator_ask | workflow_preference`
+- `actionability`
+
+Examples:
+
+- "seed new tasks"
+- "provide audit reader surface"
+- "grant operator guidance"
+- "run a synthetic multi-agent exercise"
+
+#### 4. `social_edge`
+
+Discourse-derived relationship edges.
+
+Suggested fields:
+
+- `from_agent`
+- `to_agent`
+- `edge_type`: `corroborates | challenges | corrects | thanks | requests_help_from | acknowledges`
+- `weight`
+- `evidence_refs`
+- `freshness`
+
+This is distinct from:
+
+- co-presence materialization
+- Hebbian success/failure links
+- external trust graph
+
+#### 5. `room_episode`
+
+A time-window or thread-level narrative unit.
+
+Suggested fields:
+
+- `episode_id`
+- `headline`
+- `participants`
+- `posts`
+- `comments`
+- `beliefs_changed`
+- `tensions_opened`
+- `tensions_resolved`
+- `operator_dependencies`
+- `summary`
+
+## Extraction Heuristics
+
+These can start as deterministic heuristics before using model judgment.
+
+### Consensus heuristics
+
+Mark a belief as `corroborated` when all are true:
+
+- 3 or more distinct agents support the same normalized claim
+- support appears across at least 2 separate posts or comments
+- no substantial challenge appears after the latest support window
+
+### Dissent heuristics
+
+Mark a belief as `contested` when any are true:
+
+- another agent posts a contradiction
+- a comment introduces a reversal or correction
+- governance briefs split into both support and oppose
+
+Useful lexical signals:
+
+- English: `however`, `but`, `disagree`, `incomplete`, `not wrong`, `correction`, `retracted`
+- Korean: `근데`, `아닌`, `정정`, `철회`, `동의하지만`, `반대`, `불일치`
+
+### Complaint / dissatisfaction heuristics
+
+Promote into `room_tension` when signals recur:
+
+- `blocked`
+- `cannot`
+- `unregistered_masc_tool`
+- `need operator`
+- `no tasks`
+- `idle`
+- ownership frustration
+- repeated request-help body generation
+
+### Desire extraction heuristics
+
+Aggregate from:
+
+- keeper `needs`, `desires`, `last_need`
+- social headers: `ACTIVE_DESIRE`, `NEED`
+- posts containing `should`, `need`, `would be good`, `좋겠다`, `필요`, `해줬으면`
+
+### Stagnation heuristics
+
+Room stagnation score can combine:
+
+- many active agents
+- zero active tasks
+- repeated idle/heartbeat posts
+- low vote/comment diversity
+- repeated same blocker belief without resolution
+
+## Implementation Slices
+
+### Slice 0: read-only analyzer
+
+Add a read-only backend module or script that computes:
+
+- top beliefs
+- top tensions
+- top desires
+- support/challenge edges
+- stagnation score
+
+Possible surfaces:
+
+- `lib/meta_cognition/`
+- `scripts/meta-cognition/`
+- tool: `masc_meta_cognition_snapshot`
+
+This should use existing local artifacts only:
+
+- board JSONL or PG
+- keeper status
+- room status
+- governance cases
+- optional GraphQL relations
+
+### Slice 1: dashboard panel
+
+Expose a dashboard read model with:
+
+- current room beliefs
+- contested beliefs
+- open tensions
+- collective desires
+- emerging social clusters
+
+Ideal dashboard questions:
+
+- "What does the room currently believe?"
+- "What is the room annoyed by?"
+- "What does the room want next?"
+- "Where is there dissent rather than consensus?"
+
+### Slice 2: operator digest integration
+
+Merge meta-cognition into operator digest.
+
+New digest fields:
+
+- `room_beliefs`
+- `room_tensions`
+- `collective_desires`
+- `stagnation_score`
+- `false_consensus_risk`
+
+This is the shortest path to making the signal operational.
+
+### Slice 3: auto-governance bridge
+
+When a tension becomes durable, propose a governance or task action.
+
+Examples:
+
+- repeated tool outage belief -> open governance case or task
+- repeated idle + zero backlog -> recommend task seeding
+- repeated challenge/correction loops -> escalate to debate or consensus session
+
+### Slice 4: social memory
+
+Persist unresolved room tensions and resolved episodes.
+
+This enables:
+
+- "we have been annoyed by this for 3 days"
+- "this complaint was resolved after operator action"
+- "this is a recurring issue, not a one-off"
+
+## Research Directions
+
+### 1. False consensus detection
+
+The room may look aligned because:
+
+- one prolific agent dominates narrative
+- others merely echo
+- dissent is hidden in comments, not posts
+- no one votes, but many silently comply
+
+So we need a metric that separates:
+
+- real corroboration
+- repetition by one narrator
+- silence due to lack of alternatives
+
+### 2. Desire vs blocker separation
+
+Many current posts mix:
+
+- diagnosis
+- complaint
+- operator ask
+- workaround
+
+Meta-cognition should distinguish:
+
+- "what is wrong"
+- "what is wanted"
+- "who can fix it"
+
+### 3. Relation inference from discourse
+
+Current relation materialization is not enough.
+
+We need edges like:
+
+- `A corroborates B`
+- `A corrects B`
+- `A acknowledges B`
+- `A asks B or operator for help`
+
+These should influence trust, coalition, and moderator selection.
+
+### 4. Idle-world self-direction
+
+The current world often has:
+
+- many keepers
+- zero tasks
+- recurring idle observations
+
+This is a perfect meta-cognition use case.
+
+The room should be able to notice:
+
+- "we are idle"
+- "we want meaningful work"
+- "we could start synthetic experiments or cleanup"
+
+without waiting for a human to say it first.
+
+## Concrete Next Steps
+
+### Recommended next step
+
+Build `masc_meta_cognition_snapshot` first.
+
+Why:
+
+- read-only
+- no policy risk
+- leverages existing artifacts
+- immediately useful in dashboard and operator digest
+- gives a test harness for later automation
+
+### Minimal v1 output
+
+```json
+{
+  "beliefs": [],
+  "contested_beliefs": [],
+  "tensions": [],
+  "collective_desires": [],
+  "social_edges": [],
+  "stagnation_score": 0.0,
+  "evidence_refs": []
+}
+```
+
+### Suggested first tests
+
+- repeated corroboration becomes one `room_belief`
+- correction comment downgrades belief to `contested`
+- repeated `idle` + `no tasks` creates a `room_tension`
+- repeated operator-ask language creates a `collective_desire`
+- comment/post pairs create `social_edge` entries
+
+## Key Takeaway
+
+MASC does not need meta-cognition invented from scratch.
+
+It already has:
+
+- self-model
+- social expression
+- board discourse
+- governance stance
+- relationship hooks
+- collaboration evidence
+
+What is missing is a read model that lifts these into room-level beliefs, tensions, desires, and discourse-derived relationships.
+
+That layer is now implementable with the current codebase.

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -132,6 +132,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active; since = "2.50.0" };
 
+  { env_name = "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED";
+    description = "Global override for keeper room-signal prompt injection";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.214.0" };
+
   { env_name = "MASC_SLOT_YIELD_ENABLED";
     description = "Turn-level slot yielding during tool execution";
     default = false; category = "keeper";

--- a/lib/dune
+++ b/lib/dune
@@ -98,6 +98,7 @@
    server_dashboard_http_execution_surfaces
    server_dashboard_http_room_truth_support
    server_dashboard_http_room_truth
+   server_meta_cognition_feedback
    server_dashboard_http
    server_dashboard_http_cache
    server_dashboard_http_core
@@ -184,6 +185,7 @@
    memory_pg
    memory_jsonl
    memory_oas_bridge
+   meta_cognition
    relation_materializer
    prometheus
    rate_limit

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -18,6 +18,15 @@ let bool_of_env_default name ~(default : bool) =
       else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then false
       else default
 
+let bool_of_env_opt name =
+  match Sys.getenv_opt name with
+  | None -> None
+  | Some raw ->
+      let v = String.trim raw |> String.lowercase_ascii in
+      if v = "1" || v = "true" || v = "yes" || v = "y" || v = "on" then Some true
+      else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then Some false
+      else None
+
 let validate_name name =
   (* Same rule as keeper script: conservative handle chars only. *)
   let re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile in
@@ -31,9 +40,13 @@ let default_proactive_cooldown_sec = 1800
 let default_keeper_will = ""
 let default_keeper_needs = ""
 let default_keeper_desires = ""
+let default_room_signal_prompt_enabled = false
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let default_drift_max_chars = 320
+
+let keeper_room_signal_prompt_enabled_override () =
+  bool_of_env_opt "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED"
 
 let canonical_soul_profile raw =
   match String.lowercase_ascii (String.trim raw) with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -6,20 +6,31 @@ open Keeper_types
 let ensure_keeper_meta config name =
   match read_meta config name with
   | Ok (Some meta) ->
-    (* Re-sync proactive_enabled from persona defaults on bootstrap.
+    (* Re-sync declarative keeper flags from profile/env defaults on bootstrap.
        Persisted meta may have stale values from a previous session;
-       persona config is the source of truth for declarative settings. *)
+       persona config plus explicit env overrides are the source of truth. *)
     let defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
     let target_proactive =
       match defaults.proactive_enabled with
       | Some v -> v
       | None -> Keeper_config.default_proactive_enabled
     in
-    if meta.proactive.enabled <> target_proactive then begin
-      Log.Keeper.info "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b for %s"
-        meta.proactive.enabled target_proactive meta.name;
+    let target_room_signal_prompt_enabled =
+      match Keeper_config.keeper_room_signal_prompt_enabled_override () with
+      | Some override -> override
+      | None ->
+          Option.value ~default:Keeper_config.default_room_signal_prompt_enabled
+            defaults.room_signal_prompt_enabled
+    in
+    if meta.proactive.enabled <> target_proactive
+       || meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled then begin
+      Log.Keeper.info
+        "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b, room_signal_prompt_enabled %b -> %b for %s"
+        meta.proactive.enabled target_proactive
+        meta.room_signal_prompt_enabled target_room_signal_prompt_enabled meta.name;
       let updated = { meta with
         proactive = { meta.proactive with enabled = target_proactive };
+        room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         updated_at = now_iso ();
       } in
       match write_meta config updated with

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -99,6 +99,8 @@ let direct_turn_observation (meta : keeper_meta) :
     unclaimed_task_count = 0;
     failed_task_count = 0;
     active_agent_count = 0;
+    room_signal_interpretation = None;
+    room_signal_digest_ref = None;
     last_turn_budget = None;
   }
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -70,6 +70,14 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in
+  let room_signal_prompt_enabled =
+    match keeper_room_signal_prompt_enabled_override () with
+    | Some value -> value
+    | None ->
+        Option.value
+          ~default:default_room_signal_prompt_enabled
+          p.profile_defaults.room_signal_prompt_enabled
+  in
   if goal = "" then begin
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     (false, "goal is required when creating a keeper")
@@ -217,6 +225,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         voice_channel;
         voice_agent_id;
         mention_targets;
+        room_signal_prompt_enabled;
         joined_room_ids = [];
         last_seen_seq_by_room = [];
         proactive = {

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -69,6 +69,14 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          else p.profile_defaults.mention_targets)
       ~name:p.name
   in
+  let room_signal_prompt_enabled =
+    match keeper_room_signal_prompt_enabled_override () with
+    | Some value -> value
+    | None ->
+        Option.value
+          ~default:default_room_signal_prompt_enabled
+          p.profile_defaults.room_signal_prompt_enabled
+  in
   let (compaction_profile, compaction_ratio_gate, compaction_message_gate, compaction_token_gate) =
     resolve_compaction_policy
       ~profile_opt:p.compaction_profile_opt
@@ -161,6 +169,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     voice_agent_id =
       Option.value ~default:old.voice_agent_id p.voice_agent_id_opt;
     mention_targets;
+    room_signal_prompt_enabled;
     proactive = {
       enabled =
         Option.value

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -114,6 +114,7 @@ type keeper_meta = {
   tool_denylist: string list;
   room_scope: string;
   mention_targets: string list;
+  room_signal_prompt_enabled: bool;
   joined_room_ids: string list;
   last_seen_seq_by_room: (string * int) list;
   proactive: proactive_policy;
@@ -410,6 +411,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist));
       ("room_scope", `String m.room_scope);
       ("mention_targets", `List (List.map (fun s -> `String s) m.mention_targets));
+      ("room_signal_prompt_enabled", `Bool m.room_signal_prompt_enabled);
       ("joined_room_ids", `List (List.map (fun s -> `String s) m.joined_room_ids));
       ("last_seen_seq_by_room", room_seq_map_to_json m.last_seen_seq_by_room);
       ("generation", `Int rt.generation);
@@ -549,6 +551,11 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
         in
         let mention_targets =
           Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
+        in
+        let room_signal_prompt_enabled =
+          Safe_ops.json_bool
+            ~default:default_room_signal_prompt_enabled
+            "room_signal_prompt_enabled" json
         in
         let joined_room_ids =
           Safe_ops.json_string_list "joined_room_ids" json
@@ -723,6 +730,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           tool_denylist;
           room_scope;
           mention_targets;
+          room_signal_prompt_enabled;
           joined_room_ids;
           last_seen_seq_by_room;
           proactive = {

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -117,6 +117,7 @@ type keeper_meta = {
   tool_denylist: string list;
   room_scope: string;
   mention_targets: string list;
+  room_signal_prompt_enabled: bool;
   joined_room_ids: string list;
   last_seen_seq_by_room: (string * int) list;
   proactive: proactive_policy;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -220,6 +220,7 @@ type keeper_profile_defaults = {
   scope_kind : string option;
   mention_targets : string list;
   proactive_enabled : bool option;
+  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   execution_scope : string option;
@@ -253,6 +254,7 @@ let empty_keeper_profile_defaults = {
   scope_kind = None;
   mention_targets = [];
   proactive_enabled = None;
+  room_signal_prompt_enabled = None;
   shards = None;
   allowed_paths = None;
   execution_scope = None;
@@ -358,6 +360,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         scope_kind = str "scope_kind";
         mention_targets = strs "mention_targets";
         proactive_enabled = bool_ "proactive_enabled";
+        room_signal_prompt_enabled = bool_ "room_signal_prompt_enabled";
         shards =
           (match strs "shards" with
            | [] -> None
@@ -464,6 +467,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 scope_kind = Safe_ops.json_string_opt "scope_kind" keeper_json;
                 mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
+                room_signal_prompt_enabled =
+                  Safe_ops.json_bool_opt "room_signal_prompt_enabled" keeper_json;
                 shards =
                   (match Safe_ops.json_string_list "shards" keeper_json with
                    | [] -> None

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -60,6 +60,17 @@ let line_block label value =
   if value = "" then ""
   else Printf.sprintf "%s: %s\n" label value
 
+let format_room_signal_salience salience =
+  Meta_cognition.salience_to_string salience
+
+let has_room_signal_section
+    (observation : Keeper_world_observation.world_observation) =
+  match observation.room_signal_interpretation with
+  | Some interpretation ->
+      interpretation.primary_salience <> Meta_cognition.Stable
+      || interpretation.secondary_saliences <> []
+  | None -> false
+
 let build_prompt ~(meta : Keeper_types.keeper_meta)
     ~(observation : Keeper_world_observation.world_observation) : string * string
     =
@@ -174,6 +185,44 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     Buffer.add_string ubuf (format_board_events observation.pending_board_events);
     Buffer.add_string ubuf "\n";
     Buffer.add_string ubuf "\n");
+  if meta.room_signal_prompt_enabled && has_room_signal_section observation then (
+    match observation.room_signal_interpretation with
+    | Some interpretation ->
+        Buffer.add_string ubuf "### Room Signal Interpretation\n";
+        Buffer.add_string ubuf
+          (Printf.sprintf "- room_signal_primary: %s\n"
+             (format_room_signal_salience interpretation.primary_salience));
+        (match interpretation.secondary_saliences with
+         | [] -> ()
+         | secondary ->
+             Buffer.add_string ubuf
+               (Printf.sprintf "- room_signal_secondary: %s\n"
+                  (secondary
+                  |> List.map format_room_signal_salience
+                  |> String.concat ", ")));
+        Buffer.add_string ubuf
+          (Printf.sprintf "- room_signal_reason: %s\n" interpretation.reason);
+        (match interpretation.target_id with
+         | Some target_id ->
+             Buffer.add_string ubuf
+               (Printf.sprintf "- room_signal_target_id: %s\n" target_id)
+         | None -> ());
+        (match interpretation.evidence_refs with
+         | [] -> ()
+         | refs ->
+             Buffer.add_string ubuf
+               (Printf.sprintf "- room_signal_evidence_refs: %s\n"
+                  (String.concat ", " refs)));
+        (match observation.room_signal_digest_ref with
+         | Some digest ->
+             Buffer.add_string ubuf
+               (Printf.sprintf "- room_digest_post_id: %s\n" digest.post_id);
+             Buffer.add_string ubuf
+               (Printf.sprintf "- room_digest_title: %s\n" digest.title)
+         | None -> ());
+        Buffer.add_string ubuf
+          "- room_signal_guard: do not call keeper_board_post or keeper_task_claim from this derived signal alone; read at least one raw board item from room_signal_evidence_refs or room_digest_post_id first.\n\n"
+    | None -> ());
   (* Context health *)
   Buffer.add_string ubuf
     (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -37,6 +37,8 @@ type world_observation = {
   unclaimed_task_count : int;
   failed_task_count : int;
   active_agent_count : int;
+  room_signal_interpretation : Meta_cognition.interpretation option;
+  room_signal_digest_ref : Meta_cognition.digest_ref option;
   last_turn_budget : (int * int) option;
 }
 
@@ -253,6 +255,21 @@ let check_self_comment_status ~self_tokens ~(post_id : string)
               Board.Agent_id.to_string latest.author,
               short_preview ~max_len:60 latest.content )
 
+let read_room_signal ~(config : Room.config) ~(meta : keeper_meta) =
+  if not meta.room_signal_prompt_enabled then
+    (None, None)
+  else
+    let summary_json = Meta_cognition.summary_json config in
+    match Meta_cognition.parse_summary summary_json with
+    | Ok summary ->
+        let interpretation = Meta_cognition.interpret summary in
+        let digest_ref = Meta_cognition.latest_digest_ref ~summary () in
+        (Some interpretation, digest_ref)
+    | Error err ->
+        Log.Keeper.warn "room signal interpretation parse failed for %s: %s"
+          meta.name err;
+        (None, None)
+
 (** Collect recent board activity using cursor-based tracking.
     Cursor state lives in Keeper_registry (board_cursor_ts field).
     Returns (structured events, new post count, mention count).
@@ -415,6 +432,9 @@ let observe ~(pending_board_events : pending_board_event list option)
     Agent_economy.economic_pressure ~base_path:config.base_path
       ~agent_name:meta.name
   in
+  let room_signal_interpretation, room_signal_digest_ref =
+    read_room_signal ~config ~meta
+  in
   let pending_board_events =
     match pending_board_events with
     | Some events -> events
@@ -436,6 +456,8 @@ let observe ~(pending_board_events : pending_board_event list option)
     unclaimed_task_count;
     failed_task_count;
     active_agent_count;
+    room_signal_interpretation;
+    room_signal_digest_ref;
     last_turn_budget = None;
   }
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -62,9 +62,14 @@ type world_observation = {
   active_agent_count : int;
   (** Number of agents currently active in the room. *)
 
+  room_signal_interpretation : Meta_cognition.interpretation option;
+  (** Optional room-level derived signal interpretation for prompt context. *)
+
+  room_signal_digest_ref : Meta_cognition.digest_ref option;
+  (** Latest board digest ref associated with the current room signal, if any. *)
+
   last_turn_budget : (int * int) option;
   (** Previous generation's turn usage as [(used, total)], if available. *)
-
 }
 
 type board_signal_match = {

--- a/lib/meta_cognition.ml
+++ b/lib/meta_cognition.ml
@@ -1,0 +1,1303 @@
+(** Meta_cognition — room-level read model derived from existing artifacts.
+
+    This module does not introduce a new source of truth.
+    It aggregates signals already present in board/task/agent/governance
+    surfaces into a compact snapshot that can be reused by tools,
+    dashboard views, and operator digests. *)
+
+open Types
+
+type source = {
+  ref_id : string;
+  author : string;
+  text : string;
+  created_at : float;
+  hearth : string option;
+  target_author : string option;
+}
+
+type governance_case = {
+  id : string;
+  title : string;
+  status : string;
+}
+
+type belief_rule = {
+  id : string;
+  claim : string;
+  support : source -> bool;
+  challenge : source -> bool;
+}
+
+type tension_rule = {
+  id : string;
+  topic : string;
+  kind : string;
+  matches : source -> bool;
+}
+
+type desire_rule = {
+  id : string;
+  desired_state : string;
+  desire_type : string;
+  actionability : string;
+  matches : source -> bool;
+}
+
+type social_edge = {
+  from_agent : string;
+  to_agent : string;
+  edge_type : string;
+  weight : int;
+  evidence_refs : string list;
+  last_seen_at : float;
+}
+
+type belief_summary = {
+  id : string option;
+  claim : string option;
+  status : string option;
+  confidence : float option;
+  support_agent_count : int option;
+  challenge_agent_count : int option;
+  evidence_refs : string list;
+  challenge_refs : string list;
+}
+
+type tension_summary = {
+  id : string option;
+  topic : string option;
+  kind : string option;
+  severity : string option;
+  recurrence_count : int option;
+  needs_operator : bool;
+  evidence_refs : string list;
+}
+
+type desire_summary = {
+  id : string option;
+  desired_state : string option;
+  desire_type : string option;
+  actionability : string option;
+  strength : float option;
+  evidence_refs : string list;
+}
+
+type summary_input = {
+  stagnation_score : float;
+  belief_count : int;
+  contested_belief_count : int;
+  dominant_belief : belief_summary option;
+  top_tension : tension_summary option;
+  top_desire : desire_summary option;
+}
+
+type salience =
+  | Stable
+  | Contested_belief
+  | Operator_tension
+  | Operator_desire
+  | Stagnant_room
+
+type interpretation = {
+  primary_salience : salience;
+  secondary_saliences : salience list;
+  reason : string;
+  target_id : string option;
+  evidence_refs : string list;
+}
+
+type digest_ref = {
+  post_id : string;
+  title : string;
+  created_at : string;
+  updated_at : string option;
+  hearth : string option;
+  digest_key : string;
+  matches_summary : bool;
+}
+
+let take n xs =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (remaining - 1) (x :: acc) rest
+  in
+  loop n [] xs
+
+let unique_non_empty values =
+  values
+  |> List.map String.trim
+  |> List.filter (fun value -> value <> "")
+  |> List.sort_uniq String.compare
+
+let clamp ~min_v ~max_v value =
+  if value < min_v then min_v
+  else if value > max_v then max_v
+  else value
+
+let salience_to_string = function
+  | Stable -> "stable"
+  | Contested_belief -> "contested_belief"
+  | Operator_tension -> "operator_tension"
+  | Operator_desire -> "operator_desire"
+  | Stagnant_room -> "stagnant_room"
+
+let preview ?(max_len = 120) text =
+  let text =
+    text
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+    |> List.filter (fun chunk -> chunk <> "")
+    |> String.concat " "
+  in
+  if String.length text <= max_len then text
+  else String.sub text 0 (max 0 (max_len - 1)) ^ "…"
+
+let contains_ci haystack needle =
+  String_util.contains_substring
+    (String.lowercase_ascii haystack)
+    (String.lowercase_ascii needle)
+
+let contains_any_ci haystack needles =
+  List.exists (fun needle -> contains_ci haystack needle) needles
+
+let load_jsonl_safe path =
+  if not (Sys.file_exists path) then []
+  else
+    try Fs_compat.load_jsonl path
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+
+let load_board_posts config =
+  let path = Filename.concat (Room.masc_dir config) "board_posts.jsonl" in
+  load_jsonl_safe path
+  |> List.filter_map Board.post_of_yojson
+
+let load_board_comments config =
+  let path = Filename.concat (Room.masc_dir config) "board_comments.jsonl" in
+  load_jsonl_safe path
+  |> List.filter_map Board.comment_of_yojson
+
+let load_board_vote_count config =
+  let path = Filename.concat (Room.masc_dir config) "board_votes.jsonl" in
+  List.length (load_jsonl_safe path)
+
+let load_governance_cases config =
+  let dir = Filename.concat (Room.masc_dir config) "governance_v2/cases" in
+  match Safe_ops.list_dir_safe dir with
+  | Error _ -> []
+  | Ok names ->
+      names
+      |> List.filter (fun name ->
+             Filename.check_suffix name ".json"
+             && not (String.starts_with ~prefix:"_" name))
+      |> List.filter_map (fun name ->
+             let path = Filename.concat dir name in
+             match Safe_ops.read_json_file_safe path with
+             | Error _ -> None
+             | Ok json ->
+                 let id = Safe_ops.json_string ~default:"" "id" json in
+                 let title = Safe_ops.json_string ~default:"" "title" json in
+                 let status = Safe_ops.json_string ~default:"" "status" json in
+                 if id = "" then None else Some { id; title; status })
+
+let post_sources ?hearth_filter posts =
+  let post_by_id : (string, Board.post) Hashtbl.t =
+    Hashtbl.create (max 16 (List.length posts))
+  in
+  List.iter
+    (fun (post : Board.post) ->
+      Hashtbl.replace post_by_id (Board.Post_id.to_string post.id) post)
+    posts;
+  let post_matches_hearth (post : Board.post) =
+    match hearth_filter with
+    | None -> true
+    | Some value -> (
+        match post.hearth with
+        | Some post_hearth ->
+            String.equal
+              (String.lowercase_ascii (String.trim post_hearth))
+              (String.lowercase_ascii (String.trim value))
+        | None -> false)
+  in
+  let sources =
+    posts
+    |> List.filter post_matches_hearth
+    |> List.map (fun (post : Board.post) ->
+           let target_author =
+             match post.thread_id with
+             | Some thread_id -> (
+                 match Hashtbl.find_opt post_by_id thread_id with
+                 | Some thread_post ->
+                     Some (Board.Agent_id.to_string thread_post.author)
+                 | None -> None)
+             | None -> None
+           in
+           {
+             ref_id = "post:" ^ Board.Post_id.to_string post.id;
+             author = Board.Agent_id.to_string post.author;
+             text =
+               String.concat "\n"
+                 (List.filter (fun value -> String.trim value <> "")
+                    [ post.title; post.body ]);
+             created_at = post.created_at;
+             hearth = post.hearth;
+             target_author;
+           })
+  in
+  (sources, post_by_id)
+
+let comment_sources ?hearth_filter
+    (post_by_id : (string, Board.post) Hashtbl.t) comments =
+  comments
+  |> List.filter_map (fun (comment : Board.comment) ->
+         match
+           Hashtbl.find_opt post_by_id (Board.Post_id.to_string comment.post_id)
+         with
+         | None -> None
+         | Some parent_post ->
+             let hearth_matches =
+               match hearth_filter with
+               | None -> true
+               | Some value -> (
+                   match parent_post.hearth with
+                   | Some hearth ->
+                       String.equal
+                         (String.lowercase_ascii (String.trim hearth))
+                         (String.lowercase_ascii (String.trim value))
+                   | None -> false)
+             in
+             if not hearth_matches then None
+             else
+               Some
+                 {
+                   ref_id = "comment:" ^ Board.Comment_id.to_string comment.id;
+                   author = Board.Agent_id.to_string comment.author;
+                   text = comment.content;
+                   created_at = comment.created_at;
+                   hearth = parent_post.hearth;
+                   target_author =
+                     Some (Board.Agent_id.to_string parent_post.author);
+                 })
+
+let has_any_signal source needles =
+  contains_any_ci source.text needles
+
+let has_modal_signal source =
+  has_any_signal source
+    [
+      "should";
+      "need";
+      "would be good";
+      "could be a good window";
+      "request";
+      "좋겠";
+      "필요";
+      "해줬으면";
+      "요청";
+      "추가";
+    ]
+
+let tool_block_challenge_signals =
+  [
+    "having access";
+    "contradict";
+    "contradicts the uniform block hypothesis";
+    "contradicts the \"uniform block\" hypothesis";
+    "per-agent or per-soul-profile differentiated";
+    "per-agent";
+    "access may be";
+    "differentiat";
+    "per-agent differentiation";
+    "outlier";
+    "different tool manifest";
+  ]
+
+let tool_block_support_signals =
+  [
+    "unregistered_masc_tool";
+    "masc_* tools";
+    "masc_* tool";
+    "all masc_* tools tested return";
+    "admin tools unavailable";
+    "blocked from the same tools";
+    "uniform block";
+    "policy restriction";
+    "policy boundary";
+    "keeper_* tools function normally";
+    "keeper_* namespace";
+  ]
+
+let tool_block_challenge source =
+  has_any_signal source tool_block_challenge_signals
+
+let tool_block_support source =
+  has_any_signal source tool_block_support_signals
+  && not (tool_block_challenge source)
+
+let idle_backlog_support source =
+  has_any_signal source
+    [
+      "backlog empty";
+      "no active tasks";
+      "no new tasks";
+      "idle and available";
+      "ready for work";
+      "standing by";
+      "all 8 backlog tasks are complete";
+      "대기 중인 태스크: 0";
+      "새로운 태스크가 시딩되지";
+      "idle status observation";
+      "backlog remains empty";
+    ]
+
+let operator_need_support source =
+  has_any_signal source
+    [
+      "operator intervention";
+      "operator guidance";
+      "requires operator";
+      "needs escalation";
+      "cannot self-service";
+      "not something we can self-service";
+      "grant fs permissions";
+      "explicit task assignment";
+      "tool registration";
+      "ops should";
+    ]
+
+let operator_need_challenge source =
+  has_any_signal source
+    [
+      "no action needed";
+      "no operator action is required";
+      "no further keeper-side verification is needed";
+    ]
+
+let belief_rules =
+  [
+    {
+      id = "belief:masc_tools_blocked";
+      claim =
+        "keeper-class agents believe `masc_*` introspection/admin tools are blocked or unavailable";
+      support = tool_block_support;
+      challenge = tool_block_challenge;
+    };
+    {
+      id = "belief:idle_backlog_empty";
+      claim =
+        "the room believes backlog is empty and multiple agents are idle or waiting for work";
+      support = idle_backlog_support;
+      challenge = (fun _ -> false);
+    };
+    {
+      id = "belief:operator_needed";
+      claim =
+        "the room believes operator intervention or a new privileged surface is needed";
+      support = operator_need_support;
+      challenge = operator_need_challenge;
+    };
+  ]
+
+let tension_rules =
+  [
+    {
+      id = "tension:masc_tool_blockage";
+      topic = "keeper-facing masc_* tool blockage";
+      kind = "policy_gap";
+      matches = tool_block_support;
+    };
+    {
+      id = "tension:idle_backlog_empty";
+      topic = "idle room with empty backlog";
+      kind = "boredom";
+      matches = idle_backlog_support;
+    };
+    {
+      id = "tension:path_validator_bug";
+      topic = "allowed path validator mismatch";
+      kind = "blocker";
+      matches =
+        (fun source ->
+          has_any_signal source
+            [
+              "path validator";
+              "path_not_in_allowed_paths";
+              "path-matching function";
+              "allowed paths actually match";
+              "allowed path string is identical";
+            ]);
+    };
+  ]
+
+let desire_rules =
+  [
+    {
+      id = "desire:task_seeding";
+      desired_state = "seed new tasks or otherwise create meaningful work for idle keepers";
+      desire_type = "workflow_preference";
+      actionability = "operator_or_scheduler";
+      matches =
+        (fun source ->
+          (has_any_signal source [ "task seeding"; "새 태스크"; "new task"; "new work" ]
+           && has_modal_signal source)
+          || has_any_signal source
+               [
+                 "request new tasks";
+                 "새 태스크 추가";
+                 "task availability";
+               ]);
+    };
+    {
+      id = "desire:audit_surface";
+      desired_state = "provide a read-only audit surface or audit-specific tool path";
+      desire_type = "request";
+      actionability = "operator_or_platform";
+      matches =
+        (fun source ->
+          has_any_signal source
+            [
+              "audit api";
+              "audit role";
+              "audit reader";
+              "read-only role";
+              "register audit tools";
+              "dedicated audit api endpoint";
+              "keeper_governance_read";
+              "read-only audit tool";
+              "audit surface";
+            ]);
+    };
+    {
+      id = "desire:operator_guidance";
+      desired_state = "get operator guidance or permission changes that unblock current work";
+      desire_type = "operator_ask";
+      actionability = "operator";
+      matches = operator_need_support;
+    };
+    {
+      id = "desire:synthetic_exercise";
+      desired_state = "start a synthetic exercise, cleanup pass, or retrospective during idle time";
+      desire_type = "aspiration";
+      actionability = "room_or_operator";
+      matches =
+        (fun source ->
+          has_any_signal source
+            [
+              "synthetic multi-agent exercise";
+              "housekeeping";
+              "stress-testing keeper coordination";
+              "reviewing completed task quality";
+              "documenting patterns observed";
+            ]);
+    };
+  ]
+
+let classify_interaction_text text =
+  if
+    contains_any_ci text
+      [
+        "correction";
+        "corrected";
+        "retracted";
+        "withdrawn";
+        "withdrew";
+        "amendment";
+        "정정";
+        "철회";
+      ]
+  then
+    Some "corrects"
+  else if
+    contains_any_ci text
+      [
+        "contradicts";
+        "however";
+        "disagree";
+        "incomplete";
+        "not wrong";
+        "ambiguity";
+        "question";
+        "반대";
+        "불일치";
+      ]
+  then
+    Some "challenges"
+  else if
+    contains_any_ci text
+      [
+        "corroborated";
+        "confirmed";
+        "consistent with";
+        "aligns with";
+        "agreed";
+        "agree";
+        "endorsed";
+        "support";
+        "accept the findings";
+        "confirms";
+      ]
+  then
+    Some "corroborates"
+  else if contains_any_ci text [ "acknowledged"; "reviewed"; "accepted" ] then
+    Some "acknowledges"
+  else
+    None
+
+let belief_json ~limit (rule : belief_rule) sources =
+  let support_sources = List.filter rule.support sources in
+  if support_sources = [] then
+    None
+  else
+    let challenge_sources = List.filter rule.challenge sources in
+    let support_agents =
+      support_sources |> List.map (fun source -> source.author) |> unique_non_empty
+    in
+    let challenge_agents =
+      challenge_sources |> List.map (fun source -> source.author) |> unique_non_empty
+    in
+    let last_support_at =
+      support_sources
+      |> List.fold_left
+           (fun best (source : source) -> max best source.created_at)
+           0.0
+    in
+    let last_challenge_at =
+      challenge_sources
+      |> List.fold_left
+           (fun best (source : source) -> max best source.created_at)
+           0.0
+    in
+    let status =
+      if challenge_agents <> [] && last_challenge_at > last_support_at then
+        "contested"
+      else if List.length support_agents >= 3 then
+        "corroborated"
+      else
+        "emerging"
+    in
+    let confidence =
+      let support_strength =
+        (float_of_int (List.length support_agents) /. 4.0)
+        +. (float_of_int (List.length support_sources) /. 12.0)
+      in
+      let challenge_penalty =
+        float_of_int (List.length challenge_agents) /. 6.0
+      in
+      clamp ~min_v:0.05 ~max_v:0.99 (support_strength -. (0.25 *. challenge_penalty))
+    in
+    let hearths =
+      support_sources
+      |> List.filter_map (fun (source : source) -> source.hearth)
+      |> unique_non_empty
+    in
+    Some
+      (`Assoc
+         [
+           ("id", `String rule.id);
+           ("claim", `String rule.claim);
+           ("status", `String status);
+           ("confidence", `Float confidence);
+           ("support_agent_count", `Int (List.length support_agents));
+           ("challenge_agent_count", `Int (List.length challenge_agents));
+           ("support_count", `Int (List.length support_sources));
+           ("challenge_count", `Int (List.length challenge_sources));
+           ("agents", `List (List.map (fun agent -> `String agent) support_agents));
+           ("hearths", `List (List.map (fun hearth -> `String hearth) hearths));
+           ( "evidence_refs",
+             `List
+               (support_sources
+               |> List.sort
+                    (fun (a : source) (b : source) ->
+                      compare b.created_at a.created_at)
+               |> take limit
+               |> List.map (fun source -> `String source.ref_id)) );
+           ( "challenge_refs",
+             `List
+               (challenge_sources
+               |> List.sort
+                    (fun (a : source) (b : source) ->
+                      compare b.created_at a.created_at)
+               |> take limit
+               |> List.map (fun source -> `String source.ref_id)) );
+         ])
+
+let tension_json ~limit governance_cases (rule : tension_rule) sources =
+  let matching = List.filter rule.matches sources in
+  if matching = [] then
+    None
+  else
+    let affected_agents =
+      matching |> List.map (fun source -> source.author) |> unique_non_empty
+    in
+    let recurrence_count = List.length matching in
+    let needs_operator =
+      List.exists operator_need_support matching
+      || String.equal rule.id "tension:masc_tool_blockage"
+    in
+    let severity =
+      if recurrence_count >= 6 || List.length affected_agents >= 4 then
+        "high"
+      else if recurrence_count >= 3 || List.length affected_agents >= 2 then
+        "medium"
+      else
+        "low"
+    in
+    let linked_governance_cases =
+      governance_cases
+      |> List.filter (fun (case : governance_case) ->
+             contains_any_ci
+               (case.title ^ " " ^ case.id ^ " " ^ case.status)
+               [ "tool"; "review_tool_usage"; "high-risk tool" ])
+      |> take limit
+    in
+    Some
+      (`Assoc
+         [
+           ("id", `String rule.id);
+           ("topic", `String rule.topic);
+           ("kind", `String rule.kind);
+           ("severity", `String severity);
+           ("recurrence_count", `Int recurrence_count);
+           ("affected_agent_count", `Int (List.length affected_agents));
+           ( "affected_agents",
+             `List (List.map (fun agent -> `String agent) affected_agents) );
+           ("needs_operator", `Bool needs_operator);
+           ( "linked_governance_cases",
+             `List
+               (List.map
+                  (fun (case : governance_case) ->
+                    `Assoc
+                      [
+                        ("id", `String case.id);
+                        ("title", `String case.title);
+                        ("status", `String case.status);
+                      ])
+                  linked_governance_cases) );
+           ( "evidence_refs",
+             `List
+               (matching
+               |> List.sort
+                    (fun (a : source) (b : source) ->
+                      compare b.created_at a.created_at)
+               |> take limit
+               |> List.map (fun source -> `String source.ref_id)) );
+         ])
+
+let desire_json ~limit (rule : desire_rule) sources =
+  let matching = List.filter rule.matches sources in
+  if matching = [] then
+    None
+  else
+    let source_agents =
+      matching |> List.map (fun source -> source.author) |> unique_non_empty
+    in
+    let strength =
+      clamp ~min_v:0.05 ~max_v:0.99
+        ((float_of_int (List.length source_agents) /. 4.0)
+        +. (float_of_int (List.length matching) /. 12.0))
+    in
+    Some
+      (`Assoc
+         [
+           ("id", `String rule.id);
+           ("desired_state", `String rule.desired_state);
+           ("type", `String rule.desire_type);
+           ("actionability", `String rule.actionability);
+           ("strength", `Float strength);
+           ("source_agent_count", `Int (List.length source_agents));
+           ( "source_agents",
+             `List (List.map (fun agent -> `String agent) source_agents) );
+           ( "evidence_refs",
+             `List
+               (matching
+               |> List.sort
+                    (fun (a : source) (b : source) ->
+                      compare b.created_at a.created_at)
+               |> take limit
+               |> List.map (fun source -> `String source.ref_id)) );
+         ])
+
+let social_edges_json ~limit sources =
+  let table : (string, social_edge) Hashtbl.t = Hashtbl.create 32 in
+  let record_edge (source : source) edge_type target_author =
+    let key = source.author ^ "|" ^ target_author ^ "|" ^ edge_type in
+    match Hashtbl.find_opt table key with
+    | Some edge ->
+        Hashtbl.replace table key
+          {
+            edge with
+            weight = edge.weight + 1;
+            evidence_refs =
+              unique_non_empty (source.ref_id :: edge.evidence_refs);
+            last_seen_at = max edge.last_seen_at source.created_at;
+          }
+    | None ->
+        Hashtbl.add table key
+          {
+            from_agent = source.author;
+            to_agent = target_author;
+            edge_type;
+            weight = 1;
+            evidence_refs = [ source.ref_id ];
+            last_seen_at = source.created_at;
+          }
+  in
+  List.iter
+    (fun (source : source) ->
+      match source.target_author, classify_interaction_text source.text with
+      | Some target_author, Some edge_type
+        when String.trim target_author <> ""
+             && not (String.equal source.author target_author) ->
+          record_edge source edge_type target_author
+      | _ -> ())
+    sources;
+  Hashtbl.to_seq_values table
+  |> List.of_seq
+  |> List.sort (fun a b ->
+         let by_weight = compare b.weight a.weight in
+         if by_weight <> 0 then by_weight
+         else compare b.last_seen_at a.last_seen_at)
+  |> take limit
+  |> List.map (fun edge ->
+         `Assoc
+           [
+             ("from_agent", `String edge.from_agent);
+             ("to_agent", `String edge.to_agent);
+             ("edge_type", `String edge.edge_type);
+             ("weight", `Int edge.weight);
+             ("last_seen_at", `Float edge.last_seen_at);
+             ( "evidence_refs",
+               `List
+                 (edge.evidence_refs
+                 |> take limit
+                 |> List.map (fun ref_id -> `String ref_id)) );
+           ])
+
+let active_task_count tasks =
+  tasks
+  |> List.fold_left
+       (fun acc (task : Types.task) ->
+         match task.task_status with
+         | Types.Done _ | Types.Cancelled _ -> acc
+         | Types.Todo | Types.Claimed _ | Types.InProgress _ -> acc + 1)
+       0
+
+let stagnation_score ~active_agents ~active_tasks ~idle_signal_count
+    ~heartbeat_count ~blocker_count =
+  let score =
+    (if active_agents > 0 && active_tasks = 0 then 0.35 else 0.0)
+    +. min 0.25 (float_of_int idle_signal_count /. 8.0)
+    +. min 0.20 (float_of_int heartbeat_count /. 10.0)
+    +. min 0.20 (float_of_int blocker_count /. 12.0)
+    +. min 0.10 (float_of_int active_agents /. 10.0)
+  in
+  clamp ~min_v:0.0 ~max_v:1.0 score
+
+let snapshot_json ?hearth ~limit config =
+  let limit = max 1 (min 20 limit) in
+  let posts = load_board_posts config in
+  let comments = load_board_comments config in
+  let vote_count = load_board_vote_count config in
+  let governance_cases = load_governance_cases config in
+  let post_sources, post_by_id = post_sources ?hearth_filter:hearth posts in
+  let comment_sources =
+    comment_sources ?hearth_filter:hearth post_by_id comments
+  in
+  let sources = post_sources @ comment_sources in
+  let beliefs =
+    belief_rules
+    |> List.filter_map (fun rule -> belief_json ~limit rule sources)
+    |> List.sort (fun a b ->
+           let count_of json key = json |> Yojson.Safe.Util.member key |> Yojson.Safe.Util.to_int in
+           compare (count_of b "support_agent_count") (count_of a "support_agent_count"))
+    |> take limit
+  in
+  let contested_beliefs =
+    beliefs
+    |> List.filter (fun json ->
+           json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string
+           |> String.equal "contested")
+  in
+  let tensions =
+    tension_rules
+    |> List.filter_map (fun rule -> tension_json ~limit governance_cases rule sources)
+    |> List.sort (fun a b ->
+           let count_of json =
+             json |> Yojson.Safe.Util.member "recurrence_count"
+             |> Yojson.Safe.Util.to_int
+           in
+           compare (count_of b) (count_of a))
+    |> take limit
+  in
+  let collective_desires =
+    desire_rules
+    |> List.filter_map (fun rule -> desire_json ~limit rule sources)
+    |> List.sort (fun a b ->
+           let count_of json =
+             json |> Yojson.Safe.Util.member "source_agent_count"
+             |> Yojson.Safe.Util.to_int
+           in
+           compare (count_of b) (count_of a))
+    |> take limit
+  in
+  let social_edges = social_edges_json ~limit sources in
+  let tasks = Room.get_tasks_raw config in
+  let agents = Room.get_agents_raw config in
+  let idle_signal_count =
+    sources
+    |> List.filter (fun source ->
+           contains_any_ci source.text [ "idle"; "ready for work"; "standing by" ])
+    |> List.length
+  in
+  let heartbeat_count =
+    sources
+    |> List.filter (fun source -> contains_any_ci source.text [ "heartbeat" ])
+    |> List.length
+  in
+  let blocker_count =
+    sources |> List.filter tool_block_support |> List.length
+  in
+  let active_tasks = active_task_count tasks in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ( "room_state",
+        `Assoc
+          [
+            ("active_agent_count", `Int (List.length agents));
+            ("active_task_count", `Int active_tasks);
+            ("total_task_count", `Int (List.length tasks));
+            ("board_post_count", `Int (List.length posts));
+            ("board_comment_count", `Int (List.length comments));
+            ("board_vote_count", `Int vote_count);
+            ("governance_case_count", `Int (List.length governance_cases));
+          ] );
+      ("beliefs", `List beliefs);
+      ("contested_beliefs", `List contested_beliefs);
+      ("tensions", `List tensions);
+      ("collective_desires", `List collective_desires);
+      ("social_edges", `List social_edges);
+      ( "stagnation_score",
+        `Float
+          (stagnation_score ~active_agents:(List.length agents)
+             ~active_tasks ~idle_signal_count ~heartbeat_count ~blocker_count) );
+      ( "evidence_refs",
+        `List
+          [
+            `String (Filename.concat (Room.masc_dir config) "board_posts.jsonl");
+            `String (Filename.concat (Room.masc_dir config) "board_comments.jsonl");
+            `String
+              (Filename.concat (Room.masc_dir config) "governance_v2/cases");
+          ] );
+      ( "notes",
+        `List
+          [
+            `String
+              "Votes are treated as secondary evidence. The current snapshot weights posts, comments, and thread-linked corroboration more heavily.";
+            `String
+              "This is a deterministic heuristic snapshot, not an LLM judgment layer.";
+          ] );
+      ( "highlights",
+        `List
+          (take limit sources
+          |> List.map (fun source ->
+                 `Assoc
+                   [
+                     ("ref", `String source.ref_id);
+                     ("author", `String source.author);
+                     ("preview", `String (preview source.text));
+                   ])) );
+    ]
+
+let assoc_subset json fields =
+  match json with
+  | `Assoc pairs ->
+      `Assoc
+        (fields
+        |> List.filter_map (fun field ->
+               match List.assoc_opt field pairs with
+               | Some value -> Some (field, value)
+               | None -> None))
+  | _ -> `Assoc []
+
+let assoc_subset_or_null json fields =
+  match assoc_subset json fields with
+  | `Assoc [] -> `Null
+  | value -> value
+
+let first_item_or_null json key =
+  match Yojson.Safe.Util.member key json with
+  | `List (item :: _) -> item
+  | _ -> `Null
+
+let list_length json key =
+  match Yojson.Safe.Util.member key json with
+  | `List items -> List.length items
+  | _ -> 0
+
+let summary_json ?hearth config =
+  let snapshot = snapshot_json ?hearth ~limit:3 config in
+  `Assoc
+    [
+      ( "stagnation_score",
+        Yojson.Safe.Util.member "stagnation_score" snapshot );
+      ("belief_count", `Int (list_length snapshot "beliefs"));
+      ("contested_belief_count", `Int (list_length snapshot "contested_beliefs"));
+      ( "dominant_belief",
+        assoc_subset_or_null
+          (first_item_or_null snapshot "beliefs")
+          [ "id"; "claim"; "status"; "confidence"; "support_agent_count";
+            "challenge_agent_count"; "evidence_refs"; "challenge_refs" ] );
+      ( "top_tension",
+        assoc_subset_or_null
+          (first_item_or_null snapshot "tensions")
+          [ "id"; "topic"; "kind"; "severity"; "recurrence_count";
+            "needs_operator"; "evidence_refs" ] );
+      ( "top_desire",
+        assoc_subset_or_null
+          (first_item_or_null snapshot "collective_desires")
+          [ "id"; "desired_state"; "type"; "actionability"; "strength";
+            "evidence_refs" ] );
+    ]
+
+let json_string_opt = function
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let json_int_opt = function
+  | `Int value -> Some value
+  | `Intlit raw -> (
+      try Some (int_of_string raw) with Failure _ -> None)
+  | _ -> None
+
+let json_float_opt = function
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit raw -> (
+      try Some (float_of_string raw) with Failure _ -> None)
+  | _ -> None
+
+let json_bool_opt = function
+  | `Bool value -> Some value
+  | _ -> None
+
+let json_string_list_opt = function
+  | `List items ->
+      Some (items |> List.filter_map json_string_opt |> unique_non_empty)
+  | `Null -> Some []
+  | _ -> None
+
+let parse_belief_summary = function
+  | `Assoc _ as json ->
+      Ok
+        {
+          id = Yojson.Safe.Util.member "id" json |> json_string_opt;
+          claim = Yojson.Safe.Util.member "claim" json |> json_string_opt;
+          status = Yojson.Safe.Util.member "status" json |> json_string_opt;
+          confidence = Yojson.Safe.Util.member "confidence" json |> json_float_opt;
+          support_agent_count =
+            Yojson.Safe.Util.member "support_agent_count" json |> json_int_opt;
+          challenge_agent_count =
+            Yojson.Safe.Util.member "challenge_agent_count" json |> json_int_opt;
+          evidence_refs =
+            Yojson.Safe.Util.member "evidence_refs" json
+            |> json_string_list_opt |> Option.value ~default:[];
+          challenge_refs =
+            Yojson.Safe.Util.member "challenge_refs" json
+            |> json_string_list_opt |> Option.value ~default:[];
+        }
+  | `Null -> Ok { id = None; claim = None; status = None; confidence = None;
+                  support_agent_count = None; challenge_agent_count = None;
+                  evidence_refs = []; challenge_refs = [] }
+  | _ -> Error "dominant_belief must be an object"
+
+let parse_tension_summary = function
+  | `Assoc _ as json ->
+      Ok
+        {
+          id = Yojson.Safe.Util.member "id" json |> json_string_opt;
+          topic = Yojson.Safe.Util.member "topic" json |> json_string_opt;
+          kind = Yojson.Safe.Util.member "kind" json |> json_string_opt;
+          severity = Yojson.Safe.Util.member "severity" json |> json_string_opt;
+          recurrence_count =
+            Yojson.Safe.Util.member "recurrence_count" json |> json_int_opt;
+          needs_operator =
+            Yojson.Safe.Util.member "needs_operator" json |> json_bool_opt
+            |> Option.value ~default:false;
+          evidence_refs =
+            Yojson.Safe.Util.member "evidence_refs" json
+            |> json_string_list_opt |> Option.value ~default:[];
+        }
+  | `Null ->
+      Ok
+        {
+          id = None;
+          topic = None;
+          kind = None;
+          severity = None;
+          recurrence_count = None;
+          needs_operator = false;
+          evidence_refs = [];
+        }
+  | _ -> Error "top_tension must be an object"
+
+let parse_desire_summary = function
+  | `Assoc _ as json ->
+      Ok
+        {
+          id = Yojson.Safe.Util.member "id" json |> json_string_opt;
+          desired_state = Yojson.Safe.Util.member "desired_state" json |> json_string_opt;
+          desire_type = Yojson.Safe.Util.member "type" json |> json_string_opt;
+          actionability = Yojson.Safe.Util.member "actionability" json |> json_string_opt;
+          strength = Yojson.Safe.Util.member "strength" json |> json_float_opt;
+          evidence_refs =
+            Yojson.Safe.Util.member "evidence_refs" json
+            |> json_string_list_opt |> Option.value ~default:[];
+        }
+  | `Null ->
+      Ok
+        {
+          id = None;
+          desired_state = None;
+          desire_type = None;
+          actionability = None;
+          strength = None;
+          evidence_refs = [];
+        }
+  | _ -> Error "top_desire must be an object"
+
+let parse_optional_summary parse value =
+  match value with
+  | `Null -> Ok None
+  | other ->
+      Result.map
+        (fun parsed ->
+          match other with
+          | `Assoc _ -> Some parsed
+          | _ -> None)
+        (parse other)
+
+let parse_summary json =
+  let open Yojson.Safe.Util in
+  match json_float_opt (member "stagnation_score" json) with
+  | None -> Error "summary.stagnation_score missing or invalid"
+  | Some stagnation_score -> (
+      match json_int_opt (member "belief_count" json),
+            json_int_opt (member "contested_belief_count" json),
+            parse_optional_summary parse_belief_summary (member "dominant_belief" json),
+            parse_optional_summary parse_tension_summary (member "top_tension" json),
+            parse_optional_summary parse_desire_summary (member "top_desire" json)
+      with
+      | Some belief_count, Some contested_belief_count,
+        Ok dominant_belief, Ok top_tension, Ok top_desire ->
+          Ok
+            {
+              stagnation_score;
+              belief_count;
+              contested_belief_count;
+              dominant_belief;
+              top_tension;
+              top_desire;
+            }
+      | None, _, _, _, _ -> Error "summary.belief_count missing or invalid"
+      | _, None, _, _, _ -> Error "summary.contested_belief_count missing or invalid"
+      | _, _, Error err, _, _ -> Error err
+      | _, _, _, Error err, _ -> Error err
+      | _, _, _, _, Error err -> Error err)
+
+let operator_actionability = function
+  | Some ("operator" | "operator_or_platform" | "operator_or_scheduler"
+         | "room_or_operator") -> true
+  | _ -> false
+
+let evidence_refs_of_belief (belief : belief_summary) =
+  unique_non_empty (belief.evidence_refs @ belief.challenge_refs)
+
+let evidence_refs_of_salience (summary : summary_input) = function
+  | Contested_belief -> (
+      match summary.dominant_belief with
+      | Some belief -> evidence_refs_of_belief belief
+      | None -> [])
+  | Operator_tension -> (
+      match summary.top_tension with
+      | Some tension -> tension.evidence_refs
+      | None -> [])
+  | Operator_desire -> (
+      match summary.top_desire with
+      | Some desire -> desire.evidence_refs
+      | None -> [])
+  | Stagnant_room -> (
+      match summary.top_tension, summary.dominant_belief, summary.top_desire with
+      | Some tension, _, _ when tension.evidence_refs <> [] -> tension.evidence_refs
+      | _, Some belief, _ when evidence_refs_of_belief belief <> [] ->
+          evidence_refs_of_belief belief
+      | _, _, Some desire -> desire.evidence_refs
+      | _ -> [])
+  | Stable -> []
+
+let reason_of_salience (summary : summary_input) = function
+  | Contested_belief -> (
+      match Option.bind summary.dominant_belief (fun belief -> belief.claim) with
+      | Some claim -> Printf.sprintf "집단 인식에 이견이 있습니다: %s" claim
+      | None -> "집단 인식에 이견이 있습니다.")
+  | Operator_tension -> (
+      match Option.bind summary.top_tension (fun tension -> tension.topic) with
+      | Some topic -> Printf.sprintf "운영자 개입이 필요한 집단 긴장: %s" topic
+      | None -> "운영자 개입이 필요한 집단 긴장이 감지되었습니다.")
+  | Operator_desire -> (
+      match Option.bind summary.top_desire (fun desire -> desire.desired_state) with
+      | Some desired_state ->
+          Printf.sprintf "room이 운영자 액션을 원합니다: %s" desired_state
+      | None -> "room-level desire가 운영자 액션을 요청합니다.")
+  | Stagnant_room ->
+      Printf.sprintf "room stagnation이 %.0f%%로 높습니다. 메타인지 snapshot을 확인하세요."
+        (summary.stagnation_score *. 100.0)
+  | Stable -> "room-level signal is currently stable."
+
+let target_id_of_salience (summary : summary_input) = function
+  | Contested_belief ->
+      Option.bind summary.dominant_belief (fun belief -> belief.id)
+  | Operator_tension ->
+      Option.bind summary.top_tension (fun tension -> tension.id)
+  | Operator_desire ->
+      Option.bind summary.top_desire (fun desire -> desire.id)
+  | Stagnant_room | Stable -> None
+
+let interpret (summary : summary_input) =
+  let signals =
+    [
+      (Contested_belief, summary.contested_belief_count > 0);
+      ( Operator_tension,
+        match summary.top_tension with
+        | Some tension -> tension.needs_operator || tension.severity = Some "high"
+        | None -> false );
+      ( Operator_desire,
+        match summary.top_desire with
+        | Some desire -> operator_actionability desire.actionability
+        | None -> false );
+      (Stagnant_room, summary.stagnation_score >= 0.65);
+    ]
+    |> List.filter_map (fun (salience, active) -> if active then Some salience else None)
+  in
+  let primary_salience =
+    match signals with
+    | salience :: _ -> salience
+    | [] -> Stable
+  in
+  let secondary_saliences =
+    match signals with
+    | [] -> []
+    | _primary :: rest -> rest
+  in
+  {
+    primary_salience;
+    secondary_saliences;
+    reason = reason_of_salience summary primary_salience;
+    target_id = target_id_of_salience summary primary_salience;
+    evidence_refs =
+      evidence_refs_of_salience summary primary_salience |> unique_non_empty;
+  }
+
+let salience_list_to_json saliences =
+  `List (List.map (fun salience -> `String (salience_to_string salience)) saliences)
+
+let interpretation_to_json interpretation =
+  `Assoc
+    [
+      ("primary_salience", `String (salience_to_string interpretation.primary_salience));
+      ("secondary_saliences", salience_list_to_json interpretation.secondary_saliences);
+      ("reason", `String interpretation.reason);
+      ( "target_id",
+        match interpretation.target_id with
+        | Some value -> `String value
+        | None -> `Null );
+      ("evidence_refs", `List (List.map (fun ref_id -> `String ref_id) interpretation.evidence_refs));
+    ]
+
+let summary_signature summary =
+  let dominant_belief = summary.dominant_belief in
+  let top_tension = summary.top_tension in
+  let top_desire = summary.top_desire in
+  let stagnation_bucket =
+    int_of_float (summary.stagnation_score *. 10.0)
+  in
+  let parts =
+    [
+      Option.value ~default:"none" (Option.bind dominant_belief (fun belief -> belief.id));
+      Option.value ~default:"none" (Option.bind dominant_belief (fun belief -> belief.status));
+      Option.value ~default:"none" (Option.bind top_tension (fun tension -> tension.id));
+      Option.value ~default:"none" (Option.bind top_tension (fun tension -> tension.severity));
+      Option.value ~default:"none" (Option.bind top_desire (fun desire -> desire.id));
+      Option.value ~default:"none"
+        (Option.bind top_desire (fun desire -> desire.actionability));
+      string_of_int summary.contested_belief_count;
+      string_of_int stagnation_bucket;
+    ]
+  in
+  Digest.string (String.concat "|" parts) |> Digest.to_hex
+
+let digest_hearth = "meta-cognition"
+let digest_source = "meta_cognition_digest"
+
+let post_digest_key post =
+  match post.Board.meta_json with
+  | Some (`Assoc fields) -> (
+      match List.assoc_opt "source" fields, List.assoc_opt "digest_key" fields with
+      | Some (`String source), Some (`String digest_key)
+        when String.equal (String.lowercase_ascii (String.trim source)) digest_source ->
+          Some digest_key
+      | _ -> None)
+  | _ -> None
+
+let latest_digest_post () =
+  Board_dispatch.list_posts ~hearth:digest_hearth
+    ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
+    ~limit:20 ()
+  |> List.find_map (fun post ->
+         Option.map (fun digest_key -> (post, digest_key)) (post_digest_key post))
+
+let latest_digest_ref ?summary () =
+  match latest_digest_post () with
+  | None -> None
+  | Some (post, digest_key) ->
+      let matches_summary =
+        match summary with
+        | Some current_summary ->
+            String.equal digest_key (summary_signature current_summary)
+        | None -> false
+      in
+      Some
+        {
+          post_id = Board.Post_id.to_string post.id;
+          title = post.title;
+          created_at = Server_utils.iso8601_of_unix post.created_at;
+          updated_at = Some (Server_utils.iso8601_of_unix post.updated_at);
+          hearth = post.hearth;
+          digest_key;
+          matches_summary;
+        }
+
+let latest_digest_json ?summary () =
+  match latest_digest_ref ?summary () with
+  | None -> `Null
+  | Some digest ->
+      `Assoc
+        [
+          ("post_id", `String digest.post_id);
+          ("title", `String digest.title);
+          ("created_at", `String digest.created_at);
+          ( "updated_at",
+            match digest.updated_at with
+            | Some value -> `String value
+            | None -> `Null );
+          ( "hearth",
+            match digest.hearth with
+            | Some value -> `String value
+            | None -> `Null );
+          ("digest_key", `String digest.digest_key);
+          ("matches_summary", `Bool digest.matches_summary);
+          ("provenance", `String "board");
+        ]

--- a/lib/meta_cognition.ml
+++ b/lib/meta_cognition.ml
@@ -166,7 +166,12 @@ let load_jsonl_safe path =
   if not (Sys.file_exists path) then []
   else
     try Fs_compat.load_jsonl path
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Pages.warn "load_jsonl_safe: failed to load %s: %s"
+          path (Printexc.to_string exn);
+        []
 
 let load_board_posts config =
   let path = Filename.concat (Room.masc_dir config) "board_posts.jsonl" in
@@ -885,10 +890,9 @@ let snapshot_json ?hearth ~limit config =
       ( "evidence_refs",
         `List
           [
-            `String (Filename.concat (Room.masc_dir config) "board_posts.jsonl");
-            `String (Filename.concat (Room.masc_dir config) "board_comments.jsonl");
-            `String
-              (Filename.concat (Room.masc_dir config) "governance_v2/cases");
+            `String "board:posts";
+            `String "board:comments";
+            `String "governance:cases";
           ] );
       ( "notes",
         `List
@@ -938,12 +942,13 @@ let list_length json key =
 
 let summary_json ?hearth config =
   let snapshot = snapshot_json ?hearth ~limit:3 config in
+  let full_snapshot = snapshot_json ?hearth ~limit:1000 config in
   `Assoc
     [
       ( "stagnation_score",
         Yojson.Safe.Util.member "stagnation_score" snapshot );
-      ("belief_count", `Int (list_length snapshot "beliefs"));
-      ("contested_belief_count", `Int (list_length snapshot "contested_beliefs"));
+      ("belief_count", `Int (list_length full_snapshot "beliefs"));
+      ("contested_belief_count", `Int (list_length full_snapshot "contested_beliefs"));
       ( "dominant_belief",
         assoc_subset_or_null
           (first_item_or_null snapshot "beliefs")

--- a/lib/meta_cognition.mli
+++ b/lib/meta_cognition.mli
@@ -1,0 +1,82 @@
+(** Room-level meta-cognition read model.
+
+    Derives high-signal beliefs, tensions, desires, and discourse edges
+    from existing room artifacts without mutating state. *)
+
+type belief_summary = {
+  id : string option;
+  claim : string option;
+  status : string option;
+  confidence : float option;
+  support_agent_count : int option;
+  challenge_agent_count : int option;
+  evidence_refs : string list;
+  challenge_refs : string list;
+}
+
+type tension_summary = {
+  id : string option;
+  topic : string option;
+  kind : string option;
+  severity : string option;
+  recurrence_count : int option;
+  needs_operator : bool;
+  evidence_refs : string list;
+}
+
+type desire_summary = {
+  id : string option;
+  desired_state : string option;
+  desire_type : string option;
+  actionability : string option;
+  strength : float option;
+  evidence_refs : string list;
+}
+
+type summary_input = {
+  stagnation_score : float;
+  belief_count : int;
+  contested_belief_count : int;
+  dominant_belief : belief_summary option;
+  top_tension : tension_summary option;
+  top_desire : desire_summary option;
+}
+
+type salience =
+  | Stable
+  | Contested_belief
+  | Operator_tension
+  | Operator_desire
+  | Stagnant_room
+
+type interpretation = {
+  primary_salience : salience;
+  secondary_saliences : salience list;
+  reason : string;
+  target_id : string option;
+  evidence_refs : string list;
+}
+
+type digest_ref = {
+  post_id : string;
+  title : string;
+  created_at : string;
+  updated_at : string option;
+  hearth : string option;
+  digest_key : string;
+  matches_summary : bool;
+}
+
+val snapshot_json :
+  ?hearth:string -> limit:int -> Room.config -> Yojson.Safe.t
+
+val summary_json :
+  ?hearth:string -> Room.config -> Yojson.Safe.t
+
+val parse_summary : Yojson.Safe.t -> (summary_input, string) result
+val interpret : summary_input -> interpretation
+val interpretation_to_json : interpretation -> Yojson.Safe.t
+val salience_to_string : salience -> string
+val summary_signature : summary_input -> string
+val latest_digest_ref : ?summary:summary_input -> unit -> digest_ref option
+val latest_digest_json : ?summary:summary_input -> unit -> Yojson.Safe.t

--- a/lib/meta_cognition.mli
+++ b/lib/meta_cognition.mli
@@ -78,5 +78,8 @@ val interpret : summary_input -> interpretation
 val interpretation_to_json : interpretation -> Yojson.Safe.t
 val salience_to_string : salience -> string
 val summary_signature : summary_input -> string
+val digest_hearth : string
+val digest_source : string
+val post_digest_key : Board.post -> string option
 val latest_digest_ref : ?summary:summary_input -> unit -> digest_ref option
 val latest_digest_json : ?summary:summary_input -> unit -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -940,6 +940,9 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   let keepers_total, keepers_ms =
     measure_ms (fun () -> keeper_count config)
   in
+  let meta_cognition_json, meta_cognition_ms =
+    measure_ms (fun () -> Meta_cognition.summary_json config)
+  in
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
@@ -952,6 +955,7 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
             ("keepers", `Int keepers_total);
           ] );
       ("providers", provider_capacity_json ());
+      ("meta_cognition", meta_cognition_json);
     ]
   |> with_projection_diagnostics ~surface:"shell" ~started_at
        ~extra:
@@ -964,6 +968,7 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
            ("agents_ms", `Int agents_ms);
            ("tasks_ms", `Int tasks_ms);
            ("keepers_ms", `Int keepers_ms);
+           ("meta_cognition_ms", `Int meta_cognition_ms);
          ]
 
 let dashboard_shell_http_json ?clock (config : Room.config) : Yojson.Safe.t =

--- a/lib/server/server_dashboard_http_room_truth.ml
+++ b/lib/server/server_dashboard_http_room_truth.ml
@@ -156,6 +156,9 @@ let broadcast_room_truth_snapshot (state : Mcp_server.server_state) : unit =
           ]
       in
       Sse.broadcast_to Observers sse_json;
+      ignore
+        (Server_meta_cognition_feedback.maybe_post_digest
+           ~config:state.Mcp_server.room_config snapshot);
       Log.Dashboard.info "room-truth snapshot pushed via SSE"
 
 let () =

--- a/lib/server/server_dashboard_http_room_truth_support.ml
+++ b/lib/server/server_dashboard_http_room_truth_support.ml
@@ -266,6 +266,20 @@ let derived_operator_digest_json (config : Room.config) execution_json
             ( "top_item",
               match meta_attention with
               | Some item -> item
+              | None when has_warn ->
+                  (* Derive top_item from execution-side session warning *)
+                  (match List.find_opt (fun row ->
+                    let h = json_string_field_opt "health" row in
+                    h = Some "warn" || h = Some "bad") session_briefs with
+                  | Some row -> `Assoc [
+                      ("source", `String "execution");
+                      ("severity", json_string_field_opt "health" row
+                        |> Option.value ~default:"warn" |> fun s -> `String s);
+                      ("label", match json_string_field_opt "session_id" row with
+                        | Some sid -> `String (Printf.sprintf "Session %s needs attention" sid)
+                        | None -> `String "Session needs attention");
+                    ]
+                  | None -> `Null)
               | None -> `Null );
             ("provenance", `String "derived");
           ] );

--- a/lib/server/server_dashboard_http_room_truth_support.ml
+++ b/lib/server/server_dashboard_http_room_truth_support.ml
@@ -33,6 +33,25 @@ let dashboard_room_truth_focus_json ~initialized ~runtime_count
   let focus_of_attention top_item provenance =
     let target_type = json_string_field_opt "target_type" top_item in
     let target_id = json_string_field_opt "target_id" top_item in
+    let source, target_kind, suggested_tab, suggested_surface, suggested_params =
+      match target_type with
+      | Some "room_meta_cognition" ->
+          ( "meta_cognition",
+            "meta_cognition",
+            "overview",
+            None,
+            `Assoc [] )
+      | _ ->
+          ( "operator",
+            "attention",
+            "intervene",
+            None,
+            `Assoc
+              (List.filter_map
+                 (fun (key, value_opt) ->
+                   Option.map (fun value -> (key, `String value)) value_opt)
+                 [ ("target_type", target_type); ("target_id", target_id) ]) )
+    in
     `Assoc
       [
         ("label", `String "주의 필요");
@@ -40,21 +59,19 @@ let dashboard_room_truth_focus_json ~initialized ~runtime_count
           match json_string_field_opt "summary" top_item with
           | Some summary -> `String summary
           | None -> `String "Operator attention item requires follow-up." );
-        ("source", `String "operator");
+        ("source", `String source);
         ("provenance", `String provenance);
-        ("target_kind", `String "attention");
+        ("target_kind", `String target_kind);
         ( "target_id",
           match target_id with
           | Some value -> `String value
           | None -> `Null );
-        ("suggested_tab", `String "intervene");
-        ("suggested_surface", `Null);
-        ( "suggested_params",
-          `Assoc
-            (List.filter_map
-               (fun (key, value_opt) ->
-                 Option.map (fun value -> (key, `String value)) value_opt)
-               [ ("target_type", target_type); ("target_id", target_id) ]) );
+        ("suggested_tab", `String suggested_tab);
+        ( "suggested_surface",
+          match suggested_surface with
+          | Some value -> `String value
+          | None -> `Null );
+        ("suggested_params", suggested_params);
       ]
   in
   let focus_of_queue queue =
@@ -175,7 +192,41 @@ let dashboard_room_truth_focus_json ~initialized ~runtime_count
 let take_n n lst =
   if List.length lst <= n then lst else List.filteri (fun i _ -> i < n) lst
 
-let derived_operator_digest_json (config : Room.config) execution_json =
+let severity_of_meta_salience = function
+  | Meta_cognition.Operator_tension -> "bad"
+  | Meta_cognition.Contested_belief
+  | Meta_cognition.Operator_desire
+  | Meta_cognition.Stagnant_room -> "warn"
+  | Meta_cognition.Stable -> "info"
+
+let derived_meta_attention_item ~meta_cognition_json
+    (interpretation : Meta_cognition.interpretation) =
+  match interpretation.primary_salience with
+  | Meta_cognition.Stable -> None
+  | primary_salience ->
+      Some
+        (`Assoc
+           [
+             ("kind", `String "room_meta_cognition");
+             ("severity", `String (severity_of_meta_salience primary_salience));
+             ("summary", `String interpretation.reason);
+             ("target_type", `String "room_meta_cognition");
+             ( "target_id",
+               match interpretation.target_id with
+               | Some value -> `String value
+               | None -> `String "room:default" );
+             ("actor", `String "room");
+             ( "evidence",
+               `Assoc
+                 [
+                   ("summary", meta_cognition_json);
+                   ( "interpretation",
+                     Meta_cognition.interpretation_to_json interpretation );
+                 ] );
+           ])
+
+let derived_operator_digest_json (config : Room.config) execution_json
+    meta_cognition_json meta_interpretation =
   let session_briefs = json_list_field "session_briefs" execution_json in
   let has_warn =
     List.exists
@@ -184,14 +235,38 @@ let derived_operator_digest_json (config : Room.config) execution_json =
         h = Some "warn" || h = Some "bad")
       session_briefs
   in
-  let health = if has_warn then "warn" else "ok" in
+  let meta_attention =
+    Option.bind meta_interpretation
+      (derived_meta_attention_item ~meta_cognition_json)
+  in
+  let health = if has_warn || Option.is_some meta_attention then "warn" else "ok" in
+  let attention_count = if has_warn then 1 else if Option.is_some meta_attention then 1 else 0 in
+  let warn_count =
+    match meta_attention with
+    | Some item ->
+        if json_string_field_opt "severity" item = Some "bad" then 0 else 1
+    | None ->
+        if has_warn then 1 else 0
+  in
+  let bad_count =
+    match meta_attention with
+    | Some item ->
+        if json_string_field_opt "severity" item = Some "bad" then 1 else 0
+    | None -> 0
+  in
   `Assoc
     [
       ("health", `String health);
       ( "attention_summary",
         `Assoc
           [
-            ("count", `Int (if has_warn then 1 else 0));
+            ("count", `Int attention_count);
+            ("bad_count", `Int bad_count);
+            ("warn_count", `Int warn_count);
+            ( "top_item",
+              match meta_attention with
+              | Some item -> item
+              | None -> `Null );
             ("provenance", `String "derived");
           ] );
       ( "recommendation_summary",
@@ -299,7 +374,23 @@ let room_truth_command_summary_json command_summary_json =
 
 let compose_room_truth_snapshot ~(config : Room.config) ~initialized ~shell_json
     ~execution_json ~command_summary_json =
-  let operator_digest_json = derived_operator_digest_json config execution_json in
+  let meta_cognition_summary = json_assoc_field "meta_cognition" shell_json in
+  let meta_summary_input, meta_interpretation =
+    match Meta_cognition.parse_summary meta_cognition_summary with
+    | Ok summary_input ->
+        (Some summary_input, Some (Meta_cognition.interpret summary_input))
+    | Error err ->
+        Log.Dashboard.warn
+          "room-truth meta-cognition summary parse failed: %s" err;
+        (None, None)
+  in
+  let meta_cognition_latest_digest =
+    Meta_cognition.latest_digest_json ?summary:meta_summary_input ()
+  in
+  let operator_digest_json =
+    derived_operator_digest_json config execution_json meta_cognition_summary
+      meta_interpretation
+  in
   let top_queue = execution_top_queue execution_json in
   let execution_summary = execution_summary_json execution_json in
   let command_summary = room_truth_command_summary_json command_summary_json in
@@ -328,6 +419,18 @@ let compose_room_truth_snapshot ~(config : Room.config) ~initialized ~shell_json
             ("summary", execution_summary);
             ("top_queue", top_queue);
             ("provenance", `String "derived");
+          ] );
+      ( "meta_cognition",
+        `Assoc
+          [
+            ("summary", meta_cognition_summary);
+            ( "interpretation",
+              match meta_interpretation with
+              | Some interpretation ->
+                  Meta_cognition.interpretation_to_json interpretation
+              | None -> `Null );
+            ("latest_digest", meta_cognition_latest_digest);
+            ("provenance", `String "shell");
           ] );
       ("command", command_summary);
       ( "operator",

--- a/lib/server/server_meta_cognition_feedback.ml
+++ b/lib/server/server_meta_cognition_feedback.ml
@@ -1,0 +1,227 @@
+open Dashboard_http_helpers
+
+type digest_result =
+  | Posted of string
+  | Deduped
+  | Skipped
+  | Failed of string
+
+let digest_hearth = "meta-cognition"
+let digest_author = "meta-cognition-observer"
+let digest_source = "meta_cognition_digest"
+
+let summary_json snapshot =
+  json_assoc_field "summary" (json_assoc_field "meta_cognition" snapshot)
+
+let focus_source snapshot =
+  json_string_field_opt "source" (json_assoc_field "focus" snapshot)
+
+let parse_snapshot_summary snapshot =
+  Meta_cognition.parse_summary (summary_json snapshot)
+
+let should_emit snapshot =
+  match parse_snapshot_summary snapshot with
+  | Ok summary ->
+      let interpretation = Meta_cognition.interpret summary in
+      interpretation.primary_salience <> Meta_cognition.Stable
+  | Error err ->
+      Log.Dashboard.warn "meta-cognition digest parse failed in should_emit: %s" err;
+      false
+
+let post_digest_key post =
+  match post.Board.meta_json with
+  | Some (`Assoc fields) -> (
+      match List.assoc_opt "source" fields, List.assoc_opt "digest_key" fields with
+      | Some (`String source), Some (`String digest_key)
+        when String.equal (String.lowercase_ascii (String.trim source)) digest_source ->
+          Some digest_key
+      | _ -> None)
+  | _ -> None
+
+let latest_digest_post () =
+  Board_dispatch.list_posts ~hearth:digest_hearth
+    ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
+    ~limit:20 ()
+  |> List.find_map (fun post ->
+         Option.map (fun digest_key -> (post, digest_key)) (post_digest_key post))
+
+let already_posted digest_key =
+  match latest_digest_post () with
+  | Some (_post, existing) when String.equal existing digest_key -> true
+  | _ ->
+      Board_dispatch.list_posts ~hearth:digest_hearth
+        ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
+        ~limit:20 ()
+      |> List.exists (fun post ->
+             match post_digest_key post with
+             | Some existing -> String.equal existing digest_key
+             | None -> false)
+
+let title_of_interpretation (summary : Meta_cognition.summary_input)
+    (interpretation : Meta_cognition.interpretation) =
+  match interpretation.primary_salience with
+  | Meta_cognition.Contested_belief ->
+      "[meta-cognition] contested belief requires follow-up"
+  | Meta_cognition.Operator_tension ->
+      "[meta-cognition] operator-facing room tension detected"
+  | Meta_cognition.Operator_desire ->
+      "[meta-cognition] room is asking for operator action"
+  | Meta_cognition.Stagnant_room ->
+      Printf.sprintf "[meta-cognition] room stagnation elevated (%.0f%%)"
+        (summary.stagnation_score *. 100.0)
+  | Meta_cognition.Stable ->
+      "[meta-cognition] room state updated"
+
+let salience_line salience =
+  Meta_cognition.salience_to_string salience
+  |> String.map (function '_' -> ' ' | c -> c)
+
+let body_of_snapshot snapshot (summary : Meta_cognition.summary_input)
+    (interpretation : Meta_cognition.interpretation) =
+  let focus = json_assoc_field "focus" snapshot in
+  let dominant_belief =
+    summary.Meta_cognition.dominant_belief
+  in
+  let top_tension = summary.Meta_cognition.top_tension in
+  let top_desire = summary.Meta_cognition.top_desire in
+  let evidence_refs = String.concat ", " interpretation.evidence_refs in
+  let lines =
+    [
+      Some "room-truth promoted a meta-cognition signal into shared attention.";
+      json_string_field_opt "reason" focus;
+      Some
+        (Printf.sprintf "primary signal: %s"
+           (salience_line interpretation.primary_salience));
+      (match interpretation.secondary_saliences with
+       | [] -> None
+       | secondary ->
+           Some
+             (Printf.sprintf "secondary signals: %s"
+                (secondary
+                |> List.map salience_line
+                |> String.concat ", ")));
+      Some (Printf.sprintf "derived reason: %s" interpretation.reason);
+      Some
+        (Printf.sprintf "stagnation: %.0f%%" (summary.stagnation_score *. 100.0));
+      Some
+        (Printf.sprintf "contested beliefs: %d"
+           summary.contested_belief_count);
+      Option.map
+        (fun claim ->
+          let status =
+            Option.bind dominant_belief (fun belief -> belief.status)
+            |> Option.value ~default:"unknown"
+          in
+          Printf.sprintf "dominant belief: %s [%s]" claim status)
+        (Option.bind dominant_belief (fun belief -> belief.claim));
+      Option.map
+        (fun topic ->
+          let severity =
+            Option.bind top_tension (fun tension -> tension.severity)
+            |> Option.value ~default:"unknown"
+          in
+          Printf.sprintf "top tension: %s [%s]" topic severity)
+        (Option.bind top_tension (fun tension -> tension.topic));
+      Option.map
+        (fun desired_state ->
+          let actionability =
+            Option.bind top_desire (fun desire -> desire.actionability)
+            |> Option.value ~default:"unspecified"
+          in
+          Printf.sprintf "top desire: %s [%s]" desired_state actionability)
+        (Option.bind top_desire (fun desire -> desire.desired_state));
+      (if evidence_refs = "" then None
+       else Some (Printf.sprintf "room evidence refs: %s" evidence_refs));
+    ]
+  in
+  lines
+  |> List.filter_map Fun.id
+  |> List.map String.trim
+  |> List.filter (fun line -> line <> "")
+  |> String.concat "\n"
+
+let meta_json_of_snapshot snapshot (summary : Meta_cognition.summary_input)
+    (interpretation : Meta_cognition.interpretation) digest_key =
+  let dominant_belief = summary.Meta_cognition.dominant_belief in
+  let top_tension = summary.Meta_cognition.top_tension in
+  let top_desire = summary.Meta_cognition.top_desire in
+  `Assoc
+    [
+      ("source", `String digest_source);
+      ("digest_key", `String digest_key);
+      ( "primary_salience",
+        `String
+          (Meta_cognition.salience_to_string interpretation.primary_salience) );
+      ( "secondary_saliences",
+        `List
+          (List.map
+             (fun salience ->
+               `String (Meta_cognition.salience_to_string salience))
+             interpretation.secondary_saliences) );
+      ( "focus_source",
+        match focus_source snapshot with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "dominant_belief_id",
+        match Option.bind dominant_belief (fun belief -> belief.id) with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "top_tension_id",
+        match Option.bind top_tension (fun tension -> tension.id) with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "top_desire_id",
+        match Option.bind top_desire (fun desire -> desire.id) with
+        | Some value -> `String value
+        | None -> `Null );
+      ("contested_belief_count", `Int summary.contested_belief_count);
+      ("stagnation_score", `Float summary.stagnation_score);
+    ]
+
+let latest_digest_json ?summary () =
+  let parsed_summary =
+    match summary with
+    | Some json -> (
+        match Meta_cognition.parse_summary json with
+        | Ok parsed -> Some parsed
+        | Error err ->
+            Log.Dashboard.warn
+              "meta-cognition latest digest summary parse failed: %s" err;
+            None)
+    | None -> None
+  in
+  Meta_cognition.latest_digest_json ?summary:parsed_summary ()
+
+let maybe_post_digest ~config:_ snapshot =
+  if not (should_emit snapshot) then
+    Skipped
+  else
+    match parse_snapshot_summary snapshot with
+    | Error err ->
+        Log.Dashboard.warn "meta-cognition digest skipped due to parse failure: %s" err;
+        Skipped
+    | Ok summary ->
+        let interpretation = Meta_cognition.interpret summary in
+        let digest_key = Meta_cognition.summary_signature summary in
+        if already_posted digest_key then
+          Deduped
+        else
+          let title = title_of_interpretation summary interpretation in
+          let body = body_of_snapshot snapshot summary interpretation in
+          let meta_json =
+            Some
+              (meta_json_of_snapshot snapshot summary interpretation digest_key)
+          in
+          match
+            Board_dispatch.create_post ~author:digest_author ~title ~body
+              ~content:body ~post_kind:Board.Automation_post ?meta_json
+              ~visibility:Board.Internal ~ttl_hours:24 ~hearth:digest_hearth ()
+          with
+          | Ok post ->
+              let post_id = Board.Post_id.to_string post.id in
+              Log.Dashboard.info "meta-cognition digest posted: %s" post_id;
+              Posted post_id
+          | Error err ->
+              let message = Board.show_board_error err in
+              Log.Dashboard.warn "meta-cognition digest post failed: %s" message;
+              Failed message

--- a/lib/server/server_meta_cognition_feedback.ml
+++ b/lib/server/server_meta_cognition_feedback.ml
@@ -6,9 +6,9 @@ type digest_result =
   | Skipped
   | Failed of string
 
-let digest_hearth = "meta-cognition"
+let digest_hearth = Meta_cognition.digest_hearth
 let digest_author = "meta-cognition-observer"
-let digest_source = "meta_cognition_digest"
+let digest_source = Meta_cognition.digest_source
 
 let summary_json snapshot =
   json_assoc_field "summary" (json_assoc_field "meta_cognition" snapshot)
@@ -28,15 +28,7 @@ let should_emit snapshot =
       Log.Dashboard.warn "meta-cognition digest parse failed in should_emit: %s" err;
       false
 
-let post_digest_key post =
-  match post.Board.meta_json with
-  | Some (`Assoc fields) -> (
-      match List.assoc_opt "source" fields, List.assoc_opt "digest_key" fields with
-      | Some (`String source), Some (`String digest_key)
-        when String.equal (String.lowercase_ascii (String.trim source)) digest_source ->
-          Some digest_key
-      | _ -> None)
-  | _ -> None
+let post_digest_key = Meta_cognition.post_digest_key
 
 let digest_posts_with_keys () =
   Board_dispatch.list_posts ~hearth:digest_hearth

--- a/lib/server/server_meta_cognition_feedback.ml
+++ b/lib/server/server_meta_cognition_feedback.ml
@@ -38,24 +38,21 @@ let post_digest_key post =
       | _ -> None)
   | _ -> None
 
-let latest_digest_post () =
+let digest_posts_with_keys () =
   Board_dispatch.list_posts ~hearth:digest_hearth
     ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
     ~limit:20 ()
-  |> List.find_map (fun post ->
+  |> List.filter_map (fun post ->
          Option.map (fun digest_key -> (post, digest_key)) (post_digest_key post))
 
+let latest_digest_post () =
+  match digest_posts_with_keys () with
+  | head :: _ -> Some head
+  | [] -> None
+
 let already_posted digest_key =
-  match latest_digest_post () with
-  | Some (_post, existing) when String.equal existing digest_key -> true
-  | _ ->
-      Board_dispatch.list_posts ~hearth:digest_hearth
-        ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
-        ~limit:20 ()
-      |> List.exists (fun post ->
-             match post_digest_key post with
-             | Some existing -> String.equal existing digest_key
-             | None -> false)
+  digest_posts_with_keys ()
+  |> List.exists (fun (_post, existing) -> String.equal existing digest_key)
 
 let title_of_interpretation (summary : Meta_cognition.summary_input)
     (interpretation : Meta_cognition.interpretation) =

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -345,6 +345,13 @@ let handle_agent_relations ctx args =
   let json = Dashboard_agent_relations.json ~agent_name:target () in
   (true, Yojson.Safe.pretty_to_string json)
 
+(** Handle masc_meta_cognition_snapshot — deterministic room-level read model. *)
+let handle_meta_cognition_snapshot ctx args =
+  let limit = get_int args "limit" 5 |> max 1 |> min 20 in
+  let hearth = get_string_opt args "hearth" in
+  let json = Meta_cognition.snapshot_json ?hearth ~limit ctx.config in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 let dispatch ctx ~name ~args =
   match name with
@@ -359,6 +366,8 @@ let dispatch ctx ~name ~args =
   | "masc_consolidate_learning" -> Some (handle_consolidate_learning ctx args)
   | "masc_agent_card" -> Some (handle_agent_card ctx args)
   | "masc_agent_relations" -> Some (handle_agent_relations ctx args)
+  | "masc_meta_cognition_snapshot" ->
+      Some (handle_meta_cognition_snapshot ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_agent.schemas
@@ -367,7 +376,8 @@ let schemas = Tool_schemas_agent.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_agents"; "masc_agent_card" ]
+let _tool_spec_read_only =
+  [ "masc_agents"; "masc_agent_card"; "masc_meta_cognition_snapshot" ]
 let _tool_spec_requires_join = [ "masc_register_capabilities" ]
 
 (* Heartbeat tools are dispatched by Tool_heartbeat, not Tool_agent.

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -39,3 +39,6 @@ val handle_consolidate_learning : context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_agent_card *)
 val handle_agent_card : context -> Yojson.Safe.t -> bool * string
+
+(** Handle masc_meta_cognition_snapshot *)
+val handle_meta_cognition_snapshot : context -> Yojson.Safe.t -> bool * string

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -245,4 +245,23 @@ let schemas : tool_schema list = [
     ];
   };
 
+  {
+    name = "masc_meta_cognition_snapshot";
+    description = "Read a room-level meta-cognition snapshot derived from board, task, agent, and governance artifacts. Use this to inspect shared beliefs, tensions, desires, and discourse edges.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum items to return per section (default: 5, max: 20)");
+          ("default", `Int 5);
+        ]);
+        ("hearth", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional hearth/topic filter (e.g. ops, research, code-review)");
+        ]);
+      ]);
+    ];
+  };
+
 ]

--- a/test/dune
+++ b/test/dune
@@ -160,6 +160,17 @@
  (libraries masc_test_deps))
 
 ; ============================================================
+; Focused single-module tests
+; ============================================================
+(test
+ (name test_meta_cognition_snapshot)
+ (libraries masc_test_deps))
+
+(test
+ (name test_meta_cognition_feedback)
+ (libraries masc_test_deps))
+
+; ============================================================
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.
 ; ============================================================

--- a/test/dune
+++ b/test/dune
@@ -164,10 +164,12 @@
 ; ============================================================
 (test
  (name test_meta_cognition_snapshot)
+ (modules test_meta_cognition_snapshot)
  (libraries masc_test_deps))
 
 (test
  (name test_meta_cognition_feedback)
+ (modules test_meta_cognition_feedback)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -21,6 +21,58 @@ let cleanup_dir dir =
   in
   rm dir
 
+let save_jsonl path entries =
+  let body =
+    entries
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+  in
+  Fs_compat.save_file path (if body = "" then "" else body ^ "\n")
+
+let post_json ~id ~author ?(title = "") ?(body = "") ?hearth ?thread_id
+    ?(created_at = 1000.0) () =
+  let fields =
+    [
+      ("id", `String id);
+      ("author", `String author);
+      ("title", `String title);
+      ("body", `String body);
+      ("content", `String body);
+      ("post_kind", `String "automation");
+      ("visibility", `String "internal");
+      ("created_at", `Float created_at);
+      ("updated_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+      ("reply_count", `Int 0);
+    ]
+  in
+  let fields =
+    match hearth with
+    | Some value -> ("hearth", `String value) :: fields
+    | None -> fields
+  in
+  let fields =
+    match thread_id with
+    | Some value -> ("thread_id", `String value) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("post_id", `String post_id);
+      ("author", `String author);
+      ("content", `String content);
+      ("created_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+    ]
+
 let test_dashboard_execution_fixture () =
   let dir = test_dir () in
   (* Force filesystem backend to prevent PG auto-detection in hermetic tests *)
@@ -215,6 +267,52 @@ let test_dashboard_shell_surfaces_workspace_when_different () =
         (json |> member "projection_diagnostics" |> member "workspace_path"
          |> to_string))
 
+let test_dashboard_shell_includes_meta_cognition_summary () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Room_utils.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:None);
+      let masc_dir = Lib.Room.masc_dir config in
+      save_jsonl
+        (Filename.concat masc_dir "board_posts.jsonl")
+        [
+          post_json ~id:"p-root" ~author:"admin-keeper"
+            ~title:"RBAC blockage"
+            ~body:
+              "All masc_* tools tested return unregistered_masc_tool. \
+               Operator intervention needed. keeper_* tools function normally."
+            ~hearth:"ops" ~created_at:1000.0 ();
+        ];
+      save_jsonl
+        (Filename.concat masc_dir "board_comments.jsonl")
+        [
+          comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+            ~content:
+              "This contradicts the uniform block hypothesis. Access may be per-agent."
+            ~created_at:1010.0 ();
+        ];
+      let json = Lib.Server_dashboard_http.dashboard_shell_http_json config in
+      let open Yojson.Safe.Util in
+      let meta = json |> member "meta_cognition" in
+      check int "meta belief count" 2
+        (meta |> member "belief_count" |> to_int);
+      check int "meta contested belief count" 1
+        (meta |> member "contested_belief_count" |> to_int);
+      check string "dominant belief surfaced" "belief:masc_tools_blocked"
+        (meta |> member "dominant_belief" |> member "id" |> to_string);
+      check string "dominant belief shows contested status" "contested"
+        (meta |> member "dominant_belief" |> member "status" |> to_string);
+      check string "top tension surfaced" "tension:masc_tool_blockage"
+        (meta |> member "top_tension" |> member "id" |> to_string);
+      check bool "top tension retains operator flag" true
+        (meta |> member "top_tension" |> member "needs_operator" |> to_bool);
+      check string "top desire surfaced" "desire:operator_guidance"
+        (meta |> member "top_desire" |> member "id" |> to_string))
+
 let create_keeper env sw config name =
   let ctx : _ Lib.Tool_keeper.context =
     {
@@ -338,6 +436,8 @@ let () =
             test_dashboard_shell_current_room_status;
           Alcotest.test_case "shell surfaces workspace separately" `Quick
             test_dashboard_shell_surfaces_workspace_when_different;
+          Alcotest.test_case "shell includes meta cognition summary" `Quick
+            test_dashboard_shell_includes_meta_cognition_summary;
           Alcotest.test_case "shell counts keepers cheaply" `Quick
             test_dashboard_shell_counts_keepers;
           Alcotest.test_case "shell excludes keeper agents from general count" `Quick

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -1,6 +1,7 @@
 (** Dashboard room truth read-model regression tests. *)
 
 module Lib = Masc_mcp
+module Feedback = Masc_mcp.Server_meta_cognition_feedback
 
 open Alcotest
 
@@ -27,6 +28,58 @@ let cleanup_dir dir =
         Sys.remove path
   in
   rm dir
+
+let save_jsonl path entries =
+  let body =
+    entries
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+  in
+  Fs_compat.save_file path (if body = "" then "" else body ^ "\n")
+
+let post_json ~id ~author ?(title = "") ?(body = "") ?hearth ?thread_id
+    ?(created_at = 1000.0) () =
+  let fields =
+    [
+      ("id", `String id);
+      ("author", `String author);
+      ("title", `String title);
+      ("body", `String body);
+      ("content", `String body);
+      ("post_kind", `String "automation");
+      ("visibility", `String "internal");
+      ("created_at", `Float created_at);
+      ("updated_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+      ("reply_count", `Int 0);
+    ]
+  in
+  let fields =
+    match hearth with
+    | Some value -> ("hearth", `String value) :: fields
+    | None -> fields
+  in
+  let fields =
+    match thread_id with
+    | Some value -> ("thread_id", `String value) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("post_id", `String post_id);
+      ("author", `String author);
+      ("content", `String content);
+      ("created_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+    ]
 
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
@@ -264,6 +317,131 @@ let test_operator_digest_shape_matches_room_truth () =
         ) expected_keys;
       ))
 
+let test_dashboard_room_truth_promotes_meta_cognition_focus () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let module Mcp_server = Lib.Mcp_server in
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let config = state.Mcp_server.room_config in
+      ignore (Lib.Room.init config ~agent_name:None);
+      let masc_dir = Lib.Room.masc_dir config in
+      save_jsonl
+        (Filename.concat masc_dir "board_posts.jsonl")
+        [
+          post_json ~id:"p-root" ~author:"admin-keeper"
+            ~title:"RBAC blockage"
+            ~body:
+              "All masc_* tools tested return unregistered_masc_tool. \
+               Operator intervention needed. keeper_* tools function normally."
+            ~hearth:"ops" ~created_at:1000.0 ();
+        ];
+      save_jsonl
+        (Filename.concat masc_dir "board_comments.jsonl")
+        [
+          comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+            ~content:
+              "This contradicts the uniform block hypothesis. Access may be per-agent."
+            ~created_at:1010.0 ();
+        ];
+      warm_execution_cache ();
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        check int "meta contested belief count surfaced"
+          1
+          (json |> member "meta_cognition" |> member "summary"
+           |> member "contested_belief_count" |> to_int);
+        check string "meta interpretation primary surfaced"
+          "contested_belief"
+          (json |> member "meta_cognition" |> member "interpretation"
+           |> member "primary_salience" |> to_string);
+        check string "operator attention points at meta cognition"
+          "room_meta_cognition"
+          (json |> member "operator" |> member "attention_summary" |> member "top_item"
+           |> member "target_type" |> to_string);
+        check string "focus source becomes meta cognition"
+          "meta_cognition"
+          (json |> member "focus" |> member "source" |> to_string);
+        check string "focus jumps to overview"
+          "overview"
+          (json |> member "focus" |> member "suggested_tab" |> to_string);
+        check bool "focus params stay empty for overview"
+          true
+          (json |> member "focus" |> member "suggested_params" = `Assoc []);
+      ))
+
+let test_dashboard_room_truth_exposes_latest_meta_digest () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let module Mcp_server = Lib.Mcp_server in
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let config = state.Mcp_server.room_config in
+      ignore (Lib.Room.init config ~agent_name:None);
+      let masc_dir = Lib.Room.masc_dir config in
+      save_jsonl
+        (Filename.concat masc_dir "board_posts.jsonl")
+        [
+          post_json ~id:"p-root" ~author:"admin-keeper"
+            ~title:"RBAC blockage"
+            ~body:
+              "All masc_* tools tested return unregistered_masc_tool. \
+               Operator intervention needed. keeper_* tools function normally."
+            ~hearth:"ops" ~created_at:1000.0 ();
+        ];
+      save_jsonl
+        (Filename.concat masc_dir "board_comments.jsonl")
+        [
+          comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+            ~content:
+              "This contradicts the uniform block hypothesis. Access may be per-agent."
+            ~created_at:1010.0 ();
+        ];
+      warm_execution_cache ();
+      Eio.Switch.run (fun sw ->
+        let first_json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let posted_id =
+          match Feedback.maybe_post_digest ~config first_json with
+          | Feedback.Posted post_id -> post_id
+          | Feedback.Deduped -> fail "expected fresh digest post"
+          | Feedback.Skipped -> fail "expected digest post, got skipped"
+          | Feedback.Failed err -> failf "expected digest post, got %s" err
+        in
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        check string "meta latest digest id" posted_id
+          (json |> member "meta_cognition" |> member "latest_digest"
+           |> member "post_id" |> to_string);
+        check string "meta latest digest provenance" "board"
+          (json |> member "meta_cognition" |> member "latest_digest"
+           |> member "provenance" |> to_string);
+        check bool "meta latest digest matches summary" true
+          (json |> member "meta_cognition" |> member "latest_digest"
+           |> member "matches_summary" |> to_bool);
+        check string "meta latest digest hearth" "meta-cognition"
+          (json |> member "meta_cognition" |> member "latest_digest"
+           |> member "hearth" |> to_string);
+      ))
+
 let test_room_truth_cached_snapshot_matches_http_projection_blocks () =
   let dir = test_dir () in
   Fun.protect
@@ -291,7 +469,8 @@ let test_room_truth_cached_snapshot_matches_http_projection_blocks () =
             (Yojson.Safe.to_string (http_json |> member key))
             (Yojson.Safe.to_string (cached_snapshot |> member key))
         in
-        List.iter compare_block ["room"; "execution"; "command"; "operator"; "focus"];
+        List.iter compare_block
+          ["room"; "execution"; "meta_cognition"; "command"; "operator"; "focus"];
       ))
 
 let test_dashboard_room_truth_cold_cache_falls_back_to_partial_truth () =
@@ -339,6 +518,10 @@ let () =
           test_case "mixed runtimes keep counts aligned" `Quick
             test_dashboard_room_truth_mixed_runtime_counts;
           test_case "operator digest shape matches room-truth" `Quick test_operator_digest_shape_matches_room_truth;
+          test_case "meta cognition can drive room-truth focus" `Quick
+            test_dashboard_room_truth_promotes_meta_cognition_focus;
+          test_case "meta cognition exposes latest digest" `Quick
+            test_dashboard_room_truth_exposes_latest_meta_digest;
           test_case "cached snapshot matches HTTP projection blocks" `Quick
             test_room_truth_cached_snapshot_matches_http_projection_blocks;
           test_case "expired execution warmup falls back to partial truth" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -174,6 +174,7 @@ room_scope = "all"
 scope_kind = "global"
 mention_targets = ["sherlock", "log-analyzer"]
 proactive_enabled = true
+room_signal_prompt_enabled = true
 policy_voice_enabled = false
 |} in
   match TL.parse_toml input with
@@ -188,6 +189,8 @@ policy_voice_enabled = false
       check (option string) "room_scope" (Some "all") d.room_scope;
       check int "mention_targets" 2 (List.length d.mention_targets);
       check (option bool) "proactive" (Some true) d.proactive_enabled;
+      check (option bool) "room signal prompt" (Some true)
+        d.room_signal_prompt_enabled;
       check (option bool) "policy_voice" (Some false) d.policy_voice_enabled
 
 let test_profile_invalid_soul_profile () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -71,6 +71,8 @@ let base_observation : WO.world_observation =
     unclaimed_task_count = 0;
     failed_task_count = 0;
     active_agent_count = 0;
+    room_signal_interpretation = None;
+    room_signal_digest_ref = None;
     last_turn_budget = None;
   }
 
@@ -136,6 +138,9 @@ let minimal_meta : Masc_mcp.Keeper_types.keeper_meta =
   match Masc_mcp.Keeper_types.meta_of_json json with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
+
+let room_signal_meta =
+  { minimal_meta with room_signal_prompt_enabled = true }
 
 let test_observe_uses_precollected_board_events () =
   let base_dir = temp_dir () in
@@ -204,6 +209,56 @@ let test_collect_board_events_keeps_non_mentions () =
           check bool "explicit mention false" false event.explicit_mention;
           check (list string) "matched targets empty" [] event.matched_targets
       | _ -> fail "expected exactly one board event")
+
+let test_observe_collects_room_signal_when_enabled () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
+      let create_post ~author ~title ~content =
+        match
+          Masc_mcp.Board_dispatch.create_post ~author ~title ~content
+            ~post_kind:Masc_mcp.Board.Human_post ~hearth:"ops" ()
+        with
+        | Ok post -> post
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+      in
+      let root =
+        create_post ~author:"admin-keeper" ~title:"RBAC blockage"
+          ~content:
+            "All masc_* tools tested return unregistered_masc_tool. \
+             Operator intervention needed. keeper_* tools function normally."
+      in
+      (match
+         Masc_mcp.Board_dispatch.add_comment
+           ~post_id:(Masc_mcp.Board.Post_id.to_string root.id)
+           ~author:"keeper-a"
+           ~content:
+             "This contradicts the uniform block hypothesis. Access may be per-agent."
+           ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+      let obs =
+        WO.observe ~pending_board_events:(Some [])
+          ~config ~meta:room_signal_meta
+      in
+      match obs.room_signal_interpretation with
+      | Some interpretation ->
+          check string "primary room signal" "contested_belief"
+            (Masc_mcp.Meta_cognition.salience_to_string
+               interpretation.primary_salience);
+          check bool "room signal carries evidence refs" true
+            (interpretation.evidence_refs <> [])
+      | None -> fail "expected room signal interpretation")
 
 let test_scheduled_turn_uses_cooldown_only () =
   let meta =
@@ -458,6 +513,82 @@ let test_prompt_room_state_section () =
        try ignore (Str.search_forward (Str.regexp_string "Room State") user 0); true
        with Not_found -> false
      in found)
+
+let test_prompt_omits_room_signal_when_flag_disabled () =
+  let interpretation : Masc_mcp.Meta_cognition.interpretation =
+    {
+      primary_salience = Masc_mcp.Meta_cognition.Contested_belief;
+      secondary_saliences = [ Masc_mcp.Meta_cognition.Operator_tension ];
+      reason = "집단 인식에 이견이 있습니다.";
+      target_id = Some "belief:masc_tools_blocked";
+      evidence_refs = [ "post:p-root"; "comment:c-1" ];
+    }
+  in
+  let obs =
+    {
+      base_observation with
+      room_signal_interpretation = Some interpretation;
+      room_signal_digest_ref =
+        Some
+          {
+            Masc_mcp.Meta_cognition.post_id = "post-digest-1";
+            title = "Digest title";
+            created_at = "2026-04-02T00:00:00Z";
+            updated_at = Some "2026-04-02T00:01:00Z";
+            hearth = Some "meta-cognition";
+            digest_key = "abc123";
+            matches_summary = true;
+          };
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  check bool "room signal section omitted" true
+    (not (contains_substring user "Room Signal Interpretation"))
+
+let test_prompt_includes_room_signal_when_flag_enabled () =
+  let interpretation : Masc_mcp.Meta_cognition.interpretation =
+    {
+      primary_salience = Masc_mcp.Meta_cognition.Contested_belief;
+      secondary_saliences =
+        [
+          Masc_mcp.Meta_cognition.Operator_tension;
+          Masc_mcp.Meta_cognition.Stagnant_room;
+        ];
+      reason = "집단 인식에 이견이 있습니다.";
+      target_id = Some "belief:masc_tools_blocked";
+      evidence_refs = [ "post:p-root"; "comment:c-1" ];
+    }
+  in
+  let obs =
+    {
+      base_observation with
+      room_signal_interpretation = Some interpretation;
+      room_signal_digest_ref =
+        Some
+          {
+            Masc_mcp.Meta_cognition.post_id = "post-digest-1";
+            title = "Digest title";
+            created_at = "2026-04-02T00:00:00Z";
+            updated_at = Some "2026-04-02T00:01:00Z";
+            hearth = Some "meta-cognition";
+            digest_key = "abc123";
+            matches_summary = true;
+          };
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:room_signal_meta ~observation:obs in
+  check bool "room signal section included" true
+    (contains_substring user "Room Signal Interpretation");
+  check bool "room signal primary included" true
+    (contains_substring user "room_signal_primary: contested_belief");
+  check bool "room signal secondary included" true
+    (contains_substring user "room_signal_secondary: operator_tension, stagnant_room");
+  check bool "room signal evidence refs included" true
+    (contains_substring user "room_signal_evidence_refs: post:p-root, comment:c-1");
+  check bool "room signal guard included" true
+    (contains_substring user "room_signal_guard:");
+  check bool "room digest ref included" true
+    (contains_substring user "room_digest_post_id: post-digest-1")
 
 (* ---------- Config tests ---------- *)
 
@@ -914,6 +1045,8 @@ let () =
             test_observe_uses_precollected_board_events;
           test_case "collects non-mention board events" `Quick
             test_collect_board_events_keeps_non_mentions;
+          test_case "collects room signal when enabled" `Quick
+            test_observe_collects_room_signal_when_enabled;
           test_case "scheduled turn uses cooldown only" `Quick
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn respects cooldown" `Quick
@@ -952,6 +1085,10 @@ let () =
           test_case "hustle economy" `Quick test_prompt_hustle_economy;
           test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
           test_case "room state section" `Quick test_prompt_room_state_section;
+          test_case "omits room signal when disabled" `Quick
+            test_prompt_omits_room_signal_when_flag_disabled;
+          test_case "includes room signal when enabled" `Quick
+            test_prompt_includes_room_signal_when_flag_enabled;
           test_case "prefers silence guidance" `Quick
             test_prompt_prefers_silence_guidance;
         ] );

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -199,6 +199,7 @@ let all_known_tool_names =
     "masc_lock";
     "masc_mcp_session";
     "masc_messages";
+    "masc_meta_cognition_snapshot";
     "masc_note_add";
     "masc_observe_alerts";
     "masc_observe_capacity";

--- a/test/test_meta_cognition_feedback.ml
+++ b/test/test_meta_cognition_feedback.ml
@@ -1,0 +1,230 @@
+module Feedback = Masc_mcp.Server_meta_cognition_feedback
+module Board = Masc_mcp.Board
+module Board_dispatch = Masc_mcp.Board_dispatch
+module Room = Masc_mcp.Room
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let counter = ref 0
+
+let temp_dir () =
+  incr counter;
+  let dir =
+    Filename.temp_file (Printf.sprintf "test_meta_cognition_feedback_%d_" !counter) ""
+  in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
+let with_ctx f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_dir @@ fun () ->
+      Board.reset_global_for_test ();
+      Board_dispatch.reset_for_test ();
+      Board_dispatch.init_jsonl ();
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      f config)
+
+let assoc_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let contains_substring haystack needle =
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+    true
+  with Not_found -> false
+
+let meta_summary ?(stagnation = 0.72) ?(contested = 1)
+    ?(belief_id = "belief:masc_tools_blocked")
+    ?(belief_claim = "keepers believe masc_* tools are blocked")
+    ?(belief_status = "contested")
+    ?(tension_id = "tension:masc_tool_blockage")
+    ?(tension_topic = "keeper-facing masc_* tool blockage")
+    ?(tension_severity = "high")
+    ?(needs_operator = true)
+    ?(desire_id = "desire:operator_guidance")
+    ?(desired_state = "get operator guidance to unblock current work")
+    ?(actionability = "operator") () =
+  `Assoc
+    [
+      ("stagnation_score", `Float stagnation);
+      ("belief_count", `Int 2);
+      ("contested_belief_count", `Int contested);
+      ( "dominant_belief",
+        `Assoc
+          [
+            ("id", `String belief_id);
+            ("claim", `String belief_claim);
+            ("status", `String belief_status);
+            ("support_agent_count", `Int 2);
+            ("challenge_agent_count", `Int contested);
+            ("evidence_refs", `List [ `String "post:p-root" ]);
+            ("challenge_refs", `List [ `String "comment:c-1" ]);
+          ] );
+      ( "top_tension",
+        `Assoc
+          [
+            ("id", `String tension_id);
+            ("topic", `String tension_topic);
+            ("severity", `String tension_severity);
+            ("needs_operator", `Bool needs_operator);
+            ("evidence_refs", `List [ `String "post:p-root" ]);
+          ] );
+      ( "top_desire",
+        `Assoc
+          [
+            ("id", `String desire_id);
+            ("desired_state", `String desired_state);
+            ("actionability", `String actionability);
+            ("evidence_refs", `List [ `String "post:p-root" ]);
+          ] );
+    ]
+
+let room_truth_snapshot ?(focus_reason = "집단 인식에 이견이 있습니다")
+    ?(focus_source = "meta_cognition") summary =
+  `Assoc
+    [
+      ( "meta_cognition",
+        `Assoc
+          [ ("summary", summary); ("provenance", `String "shell") ] );
+      ( "focus",
+        `Assoc
+          [
+            ("label", `String "주의 필요");
+            ("reason", `String focus_reason);
+            ("source", `String focus_source);
+            ("provenance", `String "derived");
+            ("target_kind", `String "meta_cognition");
+            ("target_id", `String "room:default");
+            ("suggested_tab", `String "overview");
+            ("suggested_params", `Assoc []);
+          ] );
+    ]
+
+let list_digest_posts () =
+  Board_dispatch.list_posts ~hearth:"meta-cognition"
+    ~post_kind_filter:Board.Automation_post ~sort_by:Board_dispatch.Recent
+    ~limit:10 ()
+
+let test_posts_digest_once_for_same_snapshot () =
+  with_ctx @@ fun config ->
+  let snapshot = room_truth_snapshot (meta_summary ()) in
+  let first = Feedback.maybe_post_digest ~config snapshot in
+  let second = Feedback.maybe_post_digest ~config snapshot in
+  let posts = list_digest_posts () in
+  let first_meta =
+    match posts with
+    | post :: _ -> post.Board.meta_json
+    | [] -> None
+  in
+  Alcotest.(check bool) "first digest posted" true
+    (match first with Feedback.Posted _ -> true | _ -> false);
+  Alcotest.(check bool) "second digest deduped" true
+    (match second with Feedback.Deduped -> true | _ -> false);
+  Alcotest.(check int) "single digest post" 1 (List.length posts);
+  Alcotest.(check string) "digest author" "meta-cognition-observer"
+    (posts |> List.hd |> fun post -> Board.Agent_id.to_string post.author);
+  Alcotest.(check bool) "meta source tagged" true
+    (match Option.bind first_meta (fun meta -> assoc_opt "source" meta) with
+    | Some (`String "meta_cognition_digest") -> true
+    | _ -> false)
+
+let test_posts_new_digest_when_signal_changes () =
+  with_ctx @@ fun config ->
+  let first_snapshot = room_truth_snapshot (meta_summary ()) in
+  let second_snapshot =
+    room_truth_snapshot
+      (meta_summary ~contested:0 ~belief_status:"corroborated"
+         ~tension_id:"tension:idle_backlog_empty"
+         ~tension_topic:"idle room with empty backlog"
+         ~desired_state:"seed new tasks for idle keepers" ())
+  in
+  ignore (Feedback.maybe_post_digest ~config first_snapshot);
+  ignore (Feedback.maybe_post_digest ~config second_snapshot);
+  let posts = list_digest_posts () in
+  Alcotest.(check int) "distinct digests create two posts" 2 (List.length posts)
+
+let test_exposes_latest_digest_reference () =
+  with_ctx @@ fun config ->
+  let summary = meta_summary () in
+  let snapshot = room_truth_snapshot summary in
+  let posted_id =
+    match Feedback.maybe_post_digest ~config snapshot with
+    | Feedback.Posted post_id -> post_id
+    | Feedback.Deduped -> Alcotest.fail "expected fresh digest post"
+    | Feedback.Skipped -> Alcotest.fail "expected digest post, got skipped"
+    | Feedback.Failed err -> Alcotest.failf "expected digest post, got %s" err
+  in
+  let latest = Feedback.latest_digest_json ~summary () in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "latest digest id" posted_id
+    (latest |> member "post_id" |> to_string);
+  Alcotest.(check string) "latest digest hearth" "meta-cognition"
+    (latest |> member "hearth" |> to_string);
+  Alcotest.(check bool) "latest digest matches summary" true
+    (latest |> member "matches_summary" |> to_bool)
+
+let test_digest_body_keeps_secondary_signals () =
+  with_ctx @@ fun config ->
+  let snapshot = room_truth_snapshot (meta_summary ()) in
+  (match Feedback.maybe_post_digest ~config snapshot with
+   | Feedback.Posted _ -> ()
+   | Feedback.Deduped -> Alcotest.fail "expected fresh digest post"
+   | Feedback.Skipped -> Alcotest.fail "expected digest post, got skipped"
+   | Feedback.Failed err -> Alcotest.failf "expected digest post, got %s" err);
+  match list_digest_posts () with
+  | post :: _ ->
+      Alcotest.(check bool) "primary signal in body" true
+        (contains_substring post.body "primary signal: contested belief");
+      Alcotest.(check bool) "secondary signal line present" true
+        (contains_substring post.body
+           "secondary signals: operator tension, operator desire, stagnant room");
+      Alcotest.(check bool) "evidence refs line present" true
+        (contains_substring post.body "room evidence refs:"
+         && contains_substring post.body "post:p-root"
+         && contains_substring post.body "comment:c-1")
+  | [] -> Alcotest.fail "expected digest post to exist"
+
+let () =
+  Alcotest.run "Meta_cognition_feedback"
+    [
+      ( "digest",
+        [
+          Alcotest.test_case "posts once for same snapshot" `Quick
+            test_posts_digest_once_for_same_snapshot;
+          Alcotest.test_case "posts again when signal changes" `Quick
+            test_posts_new_digest_when_signal_changes;
+          Alcotest.test_case "exposes latest digest reference" `Quick
+            test_exposes_latest_digest_reference;
+          Alcotest.test_case "body keeps secondary signals" `Quick
+            test_digest_body_keeps_secondary_signals;
+        ] );
+    ]

--- a/test/test_meta_cognition_snapshot.ml
+++ b/test/test_meta_cognition_snapshot.ml
@@ -1,0 +1,263 @@
+module Tool_agent = Masc_mcp.Tool_agent
+module Room = Masc_mcp.Room
+module Meta_cognition = Masc_mcp.Meta_cognition
+
+let counter = ref 0
+
+let temp_dir () =
+  incr counter;
+  let dir =
+    Filename.temp_file (Printf.sprintf "test_meta_cognition_%d_" !counter) ""
+  in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let with_ctx f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_agent.context = { config; agent_name = "tester" } in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () -> f ctx)
+
+let save_jsonl path entries =
+  let body =
+    entries
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+  in
+  Fs_compat.save_file path (if body = "" then "" else body ^ "\n")
+
+let post_json ~id ~author ?(title = "") ?(body = "") ?hearth ?thread_id
+    ?(created_at = 1000.0) () =
+  let fields =
+    [
+      ("id", `String id);
+      ("author", `String author);
+      ("title", `String title);
+      ("body", `String body);
+      ("content", `String body);
+      ("post_kind", `String "automation");
+      ("visibility", `String "internal");
+      ("created_at", `Float created_at);
+      ("updated_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+      ("reply_count", `Int 0);
+    ]
+  in
+  let fields =
+    match hearth with
+    | Some value -> ("hearth", `String value) :: fields
+    | None -> fields
+  in
+  let fields =
+    match thread_id with
+    | Some value -> ("thread_id", `String value) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("post_id", `String post_id);
+      ("author", `String author);
+      ("content", `String content);
+      ("created_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+    ]
+
+let json_list_ids key json =
+  let open Yojson.Safe.Util in
+  json |> member key |> to_list
+  |> List.filter_map (fun item ->
+         match item |> member "id" with
+         | `String value -> Some value
+         | _ -> None)
+
+let test_snapshot_detects_signals () =
+  with_ctx @@ fun ctx ->
+  ignore (Room.join ctx.config ~agent_name:"peer" ~capabilities:[] ());
+  ignore (Room.join ctx.config ~agent_name:"observer" ~capabilities:[] ());
+  let masc_dir = Room.masc_dir ctx.config in
+  save_jsonl
+    (Filename.concat masc_dir "board_posts.jsonl")
+    [
+      post_json ~id:"p-root" ~author:"admin-keeper"
+        ~title:"RBAC blockage"
+        ~body:
+          "All masc_* tools tested return unregistered_masc_tool. \
+           Operator intervention needed. keeper_* tools function normally."
+        ~hearth:"ops" ~created_at:1000.0 ();
+      post_json ~id:"p-follow" ~author:"detail-demo"
+        ~title:"Cross-check"
+        ~body:
+          "Confirmed same unregistered_masc_tool block. This is a policy restriction."
+        ~hearth:"ops" ~thread_id:"p-root" ~created_at:1005.0 ();
+      post_json ~id:"p-idle" ~author:"detail-demo"
+        ~title:"Idle status"
+        ~body:
+          "No active tasks. backlog empty. idle and available for new work. \
+           This could be a good window to seed new tasks or run a synthetic multi-agent exercise."
+        ~hearth:"ops" ~created_at:1010.0 ();
+    ];
+  save_jsonl
+    (Filename.concat masc_dir "board_comments.jsonl")
+    [
+      comment_json ~id:"c-1" ~post_id:"p-root"
+        ~author:"audit-keeper-decision"
+        ~content:"Corroborated. This aligns with admin-keeper's finding."
+        ~created_at:1006.0 ();
+    ];
+  let ok, body =
+    Tool_agent.handle_meta_cognition_snapshot ctx (`Assoc [ ("limit", `Int 5) ])
+  in
+  Alcotest.(check bool) "snapshot succeeds" true ok;
+  let json = Yojson.Safe.from_string body in
+  let belief_ids = json_list_ids "beliefs" json in
+  let tension_ids = json_list_ids "tensions" json in
+  let desire_ids = json_list_ids "collective_desires" json in
+  let open Yojson.Safe.Util in
+  let edges = json |> member "social_edges" |> to_list in
+  let has_corroborate_edge =
+    List.exists
+      (fun edge ->
+        edge |> member "from_agent" |> to_string = "audit-keeper-decision"
+        && edge |> member "to_agent" |> to_string = "admin-keeper"
+        && edge |> member "edge_type" |> to_string = "corroborates")
+      edges
+  in
+  Alcotest.(check bool) "tool blockage belief detected" true
+    (List.mem "belief:masc_tools_blocked" belief_ids);
+  Alcotest.(check bool) "idle backlog belief detected" true
+    (List.mem "belief:idle_backlog_empty" belief_ids);
+  Alcotest.(check bool) "tool blockage tension detected" true
+    (List.mem "tension:masc_tool_blockage" tension_ids);
+  Alcotest.(check bool) "task seeding desire detected" true
+    (List.mem "desire:task_seeding" desire_ids);
+  Alcotest.(check bool) "synthetic exercise desire detected" true
+    (List.mem "desire:synthetic_exercise" desire_ids);
+  Alcotest.(check bool) "social edge extracted" true has_corroborate_edge;
+  Alcotest.(check bool) "stagnation score elevated" true
+    (json |> member "stagnation_score" |> to_float > 0.5)
+
+let test_snapshot_marks_contested_belief () =
+  with_ctx @@ fun ctx ->
+  let masc_dir = Room.masc_dir ctx.config in
+  save_jsonl
+    (Filename.concat masc_dir "board_posts.jsonl")
+    [
+      post_json ~id:"p-root" ~author:"admin-keeper"
+        ~title:"RBAC blockage"
+        ~body:
+          "All masc_* tools tested return unregistered_masc_tool. \
+           keeper_* tools function normally."
+        ~hearth:"ops" ~created_at:1000.0 ();
+    ];
+  save_jsonl
+    (Filename.concat masc_dir "board_comments.jsonl")
+    [
+      comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+        ~content:
+          "This contradicts the uniform block hypothesis. Access may be per-agent."
+        ~created_at:1010.0 ();
+    ];
+  let ok, body =
+    Tool_agent.handle_meta_cognition_snapshot ctx (`Assoc [ ("limit", `Int 5) ])
+  in
+  Alcotest.(check bool) "snapshot succeeds" true ok;
+  let json = Yojson.Safe.from_string body in
+  let contested_ids = json_list_ids "contested_beliefs" json in
+  Alcotest.(check bool) "contested belief captured" true
+    (List.mem "belief:masc_tools_blocked" contested_ids)
+
+let test_parse_summary_preserves_refs_and_secondary_signals () =
+  let summary =
+    `Assoc
+      [
+        ("stagnation_score", `Float 0.72);
+        ("belief_count", `Int 2);
+        ("contested_belief_count", `Int 1);
+        ( "dominant_belief",
+          `Assoc
+            [
+              ("id", `String "belief:masc_tools_blocked");
+              ("claim", `String "keepers believe masc_* tools are blocked");
+              ("status", `String "contested");
+              ("evidence_refs", `List [ `String "post:p-root" ]);
+              ("challenge_refs", `List [ `String "comment:c-1" ]);
+            ] );
+        ( "top_tension",
+          `Assoc
+            [
+              ("id", `String "tension:masc_tool_blockage");
+              ("topic", `String "keeper-facing masc_* tool blockage");
+              ("severity", `String "high");
+              ("needs_operator", `Bool true);
+              ("evidence_refs", `List [ `String "post:p-root" ]);
+            ] );
+        ( "top_desire",
+          `Assoc
+            [
+              ("id", `String "desire:operator_guidance");
+              ("desired_state", `String "get operator guidance to unblock current work");
+              ("actionability", `String "operator");
+              ("evidence_refs", `List [ `String "post:p-root" ]);
+            ] );
+      ]
+  in
+  match Meta_cognition.parse_summary summary with
+  | Error err -> Alcotest.failf "expected summary to parse, got %s" err
+  | Ok parsed ->
+      Alcotest.(check (list string)) "belief evidence refs"
+        [ "post:p-root" ]
+        (parsed.dominant_belief
+        |> Option.map (fun (belief : Meta_cognition.belief_summary) -> belief.evidence_refs)
+        |> Option.value ~default:[]);
+      Alcotest.(check (list string)) "belief challenge refs"
+        [ "comment:c-1" ]
+        (parsed.dominant_belief
+        |> Option.map (fun (belief : Meta_cognition.belief_summary) -> belief.challenge_refs)
+        |> Option.value ~default:[]);
+      let interpretation = Meta_cognition.interpret parsed in
+      Alcotest.(check string) "primary signal" "contested_belief"
+        (Meta_cognition.salience_to_string interpretation.primary_salience);
+      Alcotest.(check (list string)) "secondary signals"
+        [ "operator_tension"; "operator_desire"; "stagnant_room" ]
+        (interpretation.secondary_saliences
+        |> List.map Meta_cognition.salience_to_string);
+      Alcotest.(check (list string)) "primary evidence refs merged"
+        [ "comment:c-1"; "post:p-root" ]
+        (interpretation.evidence_refs |> List.sort String.compare)
+
+let () =
+  Alcotest.run "Meta_cognition_snapshot"
+    [
+      ( "snapshot",
+        [
+          Alcotest.test_case "detects signals" `Quick
+            test_snapshot_detects_signals;
+          Alcotest.test_case "marks contested belief" `Quick
+            test_snapshot_marks_contested_belief;
+          Alcotest.test_case "parses summary refs and secondary signals" `Quick
+            test_parse_summary_preserves_refs_and_secondary_signals;
+        ] );
+    ]

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -1,10 +1,11 @@
-(** Coverage tests for Tool_agent — Agent management and selection
+(** Coverage tests for Tool_agent — Agent management, selection, and meta-cognition
 
     Tests dispatch routing, handler execution, helper functions, and
-    selection strategies for 11 tools: masc_agents, masc_register_capabilities,
+    selection strategies for 12 tools: masc_agents, masc_register_capabilities,
     masc_agent_update, masc_find_by_capability, masc_get_metrics,
     masc_agent_fitness, masc_select_agent, masc_collaboration_graph,
-    masc_consolidate_learning, masc_agent_card, masc_agent_relations
+    masc_consolidate_learning, masc_agent_card, masc_agent_relations,
+    masc_meta_cognition_snapshot
 *)
 module Tool_args = Masc_mcp.Tool_args
 
@@ -47,6 +48,70 @@ let dispatch_exn ctx ~name ~args =
   | Some result -> result
   | None -> failwith ("dispatch returned None for " ^ name)
 
+let save_jsonl path entries =
+  let body =
+    entries
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+  in
+  Fs_compat.save_file path (if body = "" then "" else body ^ "\n")
+
+let post_json ~id ~author ?(title = "") ?(body = "") ?hearth ?thread_id
+    ?(created_at = 1000.0) () =
+  let fields =
+    [
+      ("id", `String id);
+      ("author", `String author);
+      ("title", `String title);
+      ("body", `String body);
+      ("content", `String body);
+      ("post_kind", `String "automation");
+      ("visibility", `String "internal");
+      ("created_at", `Float created_at);
+      ("updated_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+      ("reply_count", `Int 0);
+    ]
+  in
+  let fields =
+    match hearth with
+    | Some value -> ("hearth", `String value) :: fields
+    | None -> fields
+  in
+  let fields =
+    match thread_id with
+    | Some value -> ("thread_id", `String value) :: fields
+    | None -> fields
+  in
+  `Assoc fields
+
+let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("post_id", `String post_id);
+      ("author", `String author);
+      ("content", `String content);
+      ("created_at", `Float created_at);
+      ("expires_at", `Float 0.0);
+      ("votes_up", `Int 0);
+      ("votes_down", `Int 0);
+    ]
+
+let json_list_ids key json =
+  let open Yojson.Safe.Util in
+  json |> member key |> to_list
+  |> List.filter_map (fun item ->
+         match item |> member "id" with
+         | `String value -> Some value
+         | _ -> None)
+
+let json_member_float key json =
+  let open Yojson.Safe.Util in
+  json |> member key |> to_float
+
 (* ============================================================
    Dispatch routing tests
    ============================================================ *)
@@ -79,6 +144,15 @@ let test_dispatch_select_agent () =
   with_ctx (fun ctx ->
   let result = Tool_agent.dispatch ctx ~name:"masc_select_agent" ~args:(`Assoc []) in
   Alcotest.(check bool) "select_agent dispatches" true (result <> None);
+  )
+
+let test_dispatch_meta_cognition_snapshot () =
+  with_ctx (fun ctx ->
+  let result =
+    Tool_agent.dispatch ctx ~name:"masc_meta_cognition_snapshot"
+      ~args:(`Assoc [])
+  in
+  Alcotest.(check bool) "meta_cognition dispatches" true (result <> None);
   )
 
 (* ============================================================
@@ -268,6 +342,108 @@ let test_dispatch_agent_relations () =
   )
 
 (* ============================================================
+   Handler tests — meta_cognition_snapshot
+   ============================================================ *)
+
+let test_meta_cognition_snapshot_detects_signals () =
+  with_ctx (fun ctx ->
+  ignore (Room.join ctx.config ~agent_name:"peer" ~capabilities:[] ());
+  ignore (Room.join ctx.config ~agent_name:"observer" ~capabilities:[] ());
+  let masc_dir = Room.masc_dir ctx.config in
+  save_jsonl
+    (Filename.concat masc_dir "board_posts.jsonl")
+    [
+      post_json ~id:"p-root" ~author:"admin-keeper"
+        ~title:"RBAC blockage"
+        ~body:
+          "All masc_* tools tested return unregistered_masc_tool. \
+           Operator intervention needed. keeper_* tools function normally."
+        ~hearth:"ops" ~created_at:1000.0 ();
+      post_json ~id:"p-follow" ~author:"detail-demo"
+        ~title:"Cross-check"
+        ~body:
+          "Confirmed same unregistered_masc_tool block. This is a policy restriction."
+        ~hearth:"ops" ~thread_id:"p-root" ~created_at:1005.0 ();
+      post_json ~id:"p-idle" ~author:"detail-demo"
+        ~title:"Idle status"
+        ~body:
+          "No active tasks. backlog empty. idle and available for new work. \
+           This could be a good window to seed new tasks or run a synthetic multi-agent exercise."
+        ~hearth:"ops" ~created_at:1010.0 ();
+    ];
+  save_jsonl
+    (Filename.concat masc_dir "board_comments.jsonl")
+    [
+      comment_json ~id:"c-1" ~post_id:"p-root"
+        ~author:"audit-keeper-decision"
+        ~content:"Corroborated. This aligns with admin-keeper's finding."
+        ~created_at:1006.0 ();
+    ];
+  let ok, body =
+    Tool_agent.handle_meta_cognition_snapshot ctx (`Assoc [ ("limit", `Int 5) ])
+  in
+  Alcotest.(check bool) "snapshot succeeds" true ok;
+  let json = Yojson.Safe.from_string body in
+  let belief_ids = json_list_ids "beliefs" json in
+  let tension_ids = json_list_ids "tensions" json in
+  let desire_ids = json_list_ids "collective_desires" json in
+  let open Yojson.Safe.Util in
+  let edges = json |> member "social_edges" |> to_list in
+  let has_corroborate_edge =
+    List.exists
+      (fun edge ->
+        edge |> member "from_agent" |> to_string = "audit-keeper-decision"
+        && edge |> member "to_agent" |> to_string = "admin-keeper"
+        && edge |> member "edge_type" |> to_string = "corroborates")
+      edges
+  in
+  Alcotest.(check bool) "tool blockage belief detected" true
+    (List.mem "belief:masc_tools_blocked" belief_ids);
+  Alcotest.(check bool) "idle backlog belief detected" true
+    (List.mem "belief:idle_backlog_empty" belief_ids);
+  Alcotest.(check bool) "tool blockage tension detected" true
+    (List.mem "tension:masc_tool_blockage" tension_ids);
+  Alcotest.(check bool) "task seeding desire detected" true
+    (List.mem "desire:task_seeding" desire_ids);
+  Alcotest.(check bool) "synthetic exercise desire detected" true
+    (List.mem "desire:synthetic_exercise" desire_ids);
+  Alcotest.(check bool) "social edge extracted" true has_corroborate_edge;
+  Alcotest.(check bool) "stagnation score elevated" true
+    (json_member_float "stagnation_score" json > 0.5);
+  )
+
+let test_meta_cognition_snapshot_marks_contested_belief () =
+  with_ctx (fun ctx ->
+  let masc_dir = Room.masc_dir ctx.config in
+  save_jsonl
+    (Filename.concat masc_dir "board_posts.jsonl")
+    [
+      post_json ~id:"p-root" ~author:"admin-keeper"
+        ~title:"RBAC blockage"
+        ~body:
+          "All masc_* tools tested return unregistered_masc_tool. \
+           keeper_* tools function normally."
+        ~hearth:"ops" ~created_at:1000.0 ();
+    ];
+  save_jsonl
+    (Filename.concat masc_dir "board_comments.jsonl")
+    [
+      comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+        ~content:
+          "This contradicts the uniform block hypothesis. Access may be per-agent."
+        ~created_at:1010.0 ();
+    ];
+  let ok, body =
+    Tool_agent.handle_meta_cognition_snapshot ctx (`Assoc [ ("limit", `Int 5) ])
+  in
+  Alcotest.(check bool) "snapshot succeeds" true ok;
+  let json = Yojson.Safe.from_string body in
+  let contested_ids = json_list_ids "contested_beliefs" json in
+  Alcotest.(check bool) "contested belief captured" true
+    (List.mem "belief:masc_tools_blocked" contested_ids);
+  )
+
+(* ============================================================
    Schema coverage — masc_agent_relations is registered
    ============================================================ *)
 
@@ -275,6 +451,16 @@ let test_schema_agent_relations_present () =
   let schemas = Tool_agent.schemas in
   let has_it = List.exists (fun (s : Types.tool_schema) ->
     s.name = "masc_agent_relations") schemas in
+  Alcotest.(check bool) "schema registered" true has_it
+
+let test_schema_meta_cognition_snapshot_present () =
+  let schemas = Tool_agent.schemas in
+  let has_it =
+    List.exists
+      (fun (s : Types.tool_schema) ->
+        s.name = "masc_meta_cognition_snapshot")
+      schemas
+  in
   Alcotest.(check bool) "schema registered" true has_it
 
 (* ============================================================
@@ -333,6 +519,8 @@ let () =
       Alcotest.test_case "register_capabilities dispatches" `Quick test_dispatch_register_capabilities;
       Alcotest.test_case "agent_update dispatches" `Quick test_dispatch_agent_update;
       Alcotest.test_case "select_agent dispatches" `Quick test_dispatch_select_agent;
+      Alcotest.test_case "meta_cognition dispatches" `Quick
+        test_dispatch_meta_cognition_snapshot;
     ]);
     ("agents", [
       Alcotest.test_case "handle_agents" `Quick test_handle_agents;
@@ -374,6 +562,14 @@ let () =
     ("agent_relations", [
       Alcotest.test_case "dispatches" `Quick test_dispatch_agent_relations;
       Alcotest.test_case "schema present" `Quick test_schema_agent_relations_present;
+    ]);
+    ("meta_cognition_snapshot", [
+      Alcotest.test_case "detects beliefs tensions desires and edges" `Quick
+        test_meta_cognition_snapshot_detects_signals;
+      Alcotest.test_case "marks contested belief" `Quick
+        test_meta_cognition_snapshot_marks_contested_belief;
+      Alcotest.test_case "schema present" `Quick
+        test_schema_meta_cognition_snapshot_present;
     ]);
     ("helpers", [
       Alcotest.test_case "get_string present" `Quick test_get_string_present;


### PR DESCRIPTION
## Summary
- add a typed `Meta_cognition` parse/interpret layer and reuse it across snapshot, dashboard, room-truth, and digest emission
- expose room-truth interpretation plus latest digest linkage and keep evidence refs in the summary read model
- add opt-in keeper room-signal prompt injection with per-keeper config and env override, plus regression coverage for the new boundary

## Why
The branch already introduced meta-cognition surfaces, but room-truth focus and digest emission were still interpreting the same summary with duplicated JSON heuristics. This change centralizes the interpretation path, makes the boundary explicit for keeper consumption, and keeps the keeper path gated by default.

## Impact
- room-truth and digest emission now share the same primary/secondary salience logic
- keepers can consume room-level signal interpretation only when explicitly enabled
- dashboard and tool consumers get evidence-backed derived interpretation instead of duplicated ad hoc branching

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/docs/meta-cognition-map test/test_meta_cognition_snapshot.exe test/test_meta_cognition_feedback.exe test/test_dashboard_room_truth.exe test/test_keeper_unified.exe test/test_keeper_toml.exe --display=short`
- `./_build/default/test/test_meta_cognition_snapshot.exe`
- `./_build/default/test/test_meta_cognition_feedback.exe`
- `./_build/default/test/test_dashboard_room_truth.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `pnpm typecheck`
- `pnpm test -- src/components/overview/overview.test.ts src/tab-refresh.test.ts src/room-truth-store.test.ts`

## Issue
- Refs #4583