### PR TITLE
fix(keeper): add context overflow guard for tool count

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -510,6 +510,29 @@ let run_turn
           Log.Keeper.info
             "keeper:%s turn_budget turn=%d/%d last_turn=%b"
             meta.name turn max_turns is_last_turn;
+        (* Context overflow guard: cap tool count to prevent exceeding
+           small model context windows (e.g. 8K).  ~118 tokens/tool schema,
+           so 40 tools ≈ 4700 tokens — safe for 8K models.  Beyond 40,
+           truncate to always_include_tools + top BM25 results.
+           Configurable via MASC_KEEPER_MAX_TOOLS_PER_TURN. *)
+        let max_tools =
+          Keeper_config.int_of_env_default
+            "MASC_KEEPER_MAX_TOOLS_PER_TURN" ~default:40 ~min_v:5 ~max_v:200
+        in
+        let all_allowed =
+          if List.length all_allowed > max_tools then begin
+            Log.Keeper.info
+              "context overflow guard: %d tools > max %d, truncating"
+              (List.length all_allowed) max_tools;
+            let essential = List.filter
+              (fun name -> List.mem name always_include_tools) all_allowed in
+            let non_essential = List.filter
+              (fun name -> not (List.mem name always_include_tools)) all_allowed in
+            let budget = max_tools - List.length essential in
+            essential @ (List.filteri (fun i _ -> i < budget) non_essential)
+          end else
+            all_allowed
+        in
         let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
         Agent_sdk.Hooks.AdjustParams
           { current_params with


### PR DESCRIPTION
## Summary
8K context 모델에 345 tool schema (~39K tokens) 전송 시 100% 실패하는 문제에 대한 defensive guard.

**Fix**: `before_turn_hook`에서 allowed tool count가 cap(기본 40)을 초과하면 truncation.
- Essential tools (always_include) 보존
- BM25 retrieved tools에서 순서대로 trim
- `MASC_KEEPER_MAX_TOOLS_PER_TURN` env로 조정 가능 (5-200)

40 tools × ~118 tokens/tool ≈ 4700 tokens — 8K 모델에서도 안전.

Closes #4592

## Test plan
- [x] `dune build` passes
- [ ] Integration: 8K 모델 라우팅 시 context overflow 미발생 확인
- [ ] Integration: 40개 초과 시 truncation 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)