### PR TITLE
fix(board): classify anonymous author posts as Automation_post

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -114,9 +114,18 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
        | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
       let author_lc = String.lowercase_ascii (String.trim author) in
-      if author_lc = "" || author_lc = "anonymous" then
+      if author_lc = "" then
+        Error "missing author"
+      else if author_lc = "anonymous" then
+        (* "anonymous" is the MCP/internal path default when the caller
+           omits _agent_name.  These are programmatic calls, not human
+           posts, so classify as automation to prevent misleading
+           attribution on people-facing board surfaces. *)
         Ok Board.Automation_post
       else
+        (* Auto-classify only when registry hook is available.
+           Without a registry, default to Human_post to avoid
+           false positives from the name-shape heuristic. *)
         (match !agent_lookup_hook with
          | Some _ when is_agent author_lc -> Ok Board.Automation_post
          | _ -> Ok Board.Human_post)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -113,13 +113,13 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
        | Some kind -> Ok kind
        | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
-      (* Auto-classify only when registry hook is available.
-         Without a registry, default to Human_post to avoid
-         false positives from the name-shape heuristic. *)
       let author_lc = String.lowercase_ascii (String.trim author) in
-      (match !agent_lookup_hook with
-       | Some _ when is_agent author_lc -> Ok Board.Automation_post
-       | _ -> Ok Board.Human_post)
+      if author_lc = "" || author_lc = "anonymous" then
+        Ok Board.Automation_post
+      else
+        (match !agent_lookup_hook with
+         | Some _ when is_agent author_lc -> Ok Board.Automation_post
+         | _ -> Ok Board.Human_post)
 
 (** {1 Formatters} *)
 


### PR DESCRIPTION
anonymous 또는 빈 author의 board post가 Human_post로 분류되는 문제 수정. resolve_board_post_kind에서 anonymous/empty author를 Automation_post로 분류하여 사람 게시물로 오인되는 것을 방지. Closes #4604