### PR TITLE
[codex] disable keeper autoboot on loopback startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This path is the easiest default when you want local MCP development plus transp
 
 - shortcut script: `scripts/start-loopback.sh`
 - keep the server loopback-only with `--host 127.0.0.1`
+- keep keeper autoboot off by default on this shortcut path; override with `MASC_KEEPER_BOOTSTRAP_ENABLED=true scripts/start-loopback.sh` when you intentionally want bootstrap scan on local 8935
 - keep the fixed default ports when you are not juggling multiple instances:
   - HTTP / MCP: `127.0.0.1:8935`
   - gRPC: `127.0.0.1:8936`
@@ -98,7 +99,7 @@ Things to watch:
 - do not bind `0.0.0.0` or `::` for routine local development; that moves you onto the remote-exposure path and auth requirements become stricter
 - do not point `MASC_HTTP_BASE_URL` at a public host when you only want local development
 - if you only need target-scoped `.masc/` isolation and do not need gRPC / WS / WebRTC, use `scripts/run-local.sh` instead
-- `scripts/start-loopback.sh` is just a thin wrapper over `./start-masc-mcp.sh --http --host 127.0.0.1 --port 8935`; pass extra args after it only when you intentionally want to override the defaults
+- `scripts/start-loopback.sh` is a thin wrapper over `MASC_KEEPER_BOOTSTRAP_ENABLED=false ./start-masc-mcp.sh --http --host 127.0.0.1 --port 8935`; pass extra args after it only when you intentionally want to override the defaults
 
 ## MCP Client Setup
 

--- a/scripts/start-loopback.sh
+++ b/scripts/start-loopback.sh
@@ -4,4 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Local loopback is the safe single-user path; keepers can still be started
+# explicitly, but do not autoboot a whole keeper set on 8935 unless requested.
+export MASC_KEEPER_BOOTSTRAP_ENABLED="${MASC_KEEPER_BOOTSTRAP_ENABLED:-false}"
+
 exec "$REPO_ROOT/start-masc-mcp.sh" --http --host 127.0.0.1 --port 8935 "$@"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -216,6 +216,7 @@ for env_name in \
     DATABASE_URL \
     SUPABASE_DB_URL \
     SB_PG_URL \
+    MASC_KEEPER_BOOTSTRAP_ENABLED \
     MASC_MCP_PORT \
     MASC_HOST \
     MASC_BASE_PATH \
@@ -247,6 +248,7 @@ for env_name in \
     DATABASE_URL \
     SUPABASE_DB_URL \
     SB_PG_URL \
+    MASC_KEEPER_BOOTSTRAP_ENABLED \
     MASC_MCP_PORT \
     MASC_HOST \
     MASC_BASE_PATH \

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -8,6 +8,9 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "start-masc-mcp.sh"
 
+let loopback_script_path () =
+  Filename.concat (source_root ()) "scripts/start-loopback.sh"
+
 let quote = Filename.quote
 
 let read_file path =
@@ -95,6 +98,7 @@ capture="${FAKE_CAPTURE_FILE:?}"
   printf 'SUPABASE_DB_URL=%%s\n' "${SUPABASE_DB_URL:-}"
   printf 'MASC_BASE_PATH=%%s\n' "${MASC_BASE_PATH:-}"
   printf 'MASC_CONFIG_DIR=%%s\n' "${MASC_CONFIG_DIR:-}"
+  printf 'MASC_KEEPER_BOOTSTRAP_ENABLED=%%s\n' "${MASC_KEEPER_BOOTSTRAP_ENABLED:-}"
   printf 'MASC_WS_ENABLED=%%s\n' "${MASC_WS_ENABLED:-}"
   printf 'MASC_WEBRTC_ENABLED=%%s\n' "${MASC_WEBRTC_ENABLED:-}"
   printf 'ARGS=%%s\n' "$*"
@@ -284,6 +288,54 @@ let test_worktree_prefers_local_build_over_workspace_build () =
       check bool "local build wins in worktree" true
         (contains_substring captured "FAKE_EXE_MARKER=local"))
 
+let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
+    =
+  with_temp_dir "start-loopback-script" (fun dir ->
+      let repo_root = Filename.concat dir "repo-root" in
+      let scripts_dir = Filename.concat repo_root "scripts" in
+      mkdir_p scripts_dir;
+      let start_script = Filename.concat repo_root "start-masc-mcp.sh" in
+      let loopback_script = Filename.concat scripts_dir "start-loopback.sh" in
+      copy_script (script_path ()) start_script;
+      copy_script (loopback_script_path ()) loopback_script;
+      write_file (Filename.concat repo_root ".env.local")
+        "MASC_KEEPER_BOOTSTRAP_ENABLED=true\n";
+      make_fake_eio_exe repo_root;
+      let home_dir = Filename.concat dir "home" in
+      let capture_default = Filename.concat dir "captured-loopback-default.txt" in
+      let code_default, stdout_default, stderr_default =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture_default); ("HOME", home_dir) ]
+          (Printf.sprintf "%s --port 9961 --base-path %s"
+             (quote loopback_script) (quote repo_root))
+      in
+      if code_default <> 0 then
+        failf "loopback script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_default stdout_default stderr_default;
+      let captured_default = read_file capture_default in
+      check bool "loopback disables keeper autoboot by default" true
+        (contains_substring captured_default "MASC_KEEPER_BOOTSTRAP_ENABLED=false");
+      let capture_override =
+        Filename.concat dir "captured-loopback-override.txt"
+      in
+      let code_override, stdout_override, stderr_override =
+        run_shell ~cwd:repo_root
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture_override);
+              ("HOME", home_dir);
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "true");
+            ]
+          (Printf.sprintf "%s --port 9962 --base-path %s"
+             (quote loopback_script) (quote repo_root))
+      in
+      if code_override <> 0 then
+        failf "loopback script override failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_override stdout_override stderr_override;
+      let captured_override = read_file capture_override in
+      check bool "loopback preserves explicit keeper autoboot override" true
+        (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
+
 let () =
   run "start_masc_mcp_script"
     [
@@ -301,5 +353,9 @@ let () =
             test_inherited_base_path_with_dual_masc_roots_is_sanitized;
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
+          test_case
+            "loopback disables keeper autoboot by default and preserves override"
+            `Quick
+            test_loopback_disables_keeper_autoboot_by_default_and_preserves_override;
         ] );
     ]


### PR DESCRIPTION
## Summary
- disable keeper autoboot by default on the local `scripts/start-loopback.sh` path
- preserve `MASC_KEEPER_BOOTSTRAP_ENABLED` through `start-masc-mcp.sh` env-file loading so explicit caller intent wins
- add coverage for the loopback wrapper default and override behavior, and document the local-dev behavior in `README.md`

## Why
- the loopback `8935` path is the default single-user local runtime and should not restart a whole keeper set unless the caller explicitly opts in
- without preserving `MASC_KEEPER_BOOTSTRAP_ENABLED`, wrapper-level overrides can be silently reset by repo or shell env files

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-disable-loopback-keeper-autoboot`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-disable-loopback-keeper-autoboot -- test/test_start_masc_mcp_script.exe`
  - new loopback autoboot test passes
  - two pre-existing `MASC_CONFIG_DIR` assertions still fail, and the same failures reproduce on `main`
