### PR TITLE
fix(board): classify anonymous/empty author as Automation_post

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -113,13 +113,15 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
        | Some kind -> Ok kind
        | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
-      (* Auto-classify only when registry hook is available.
-         Without a registry, default to Human_post to avoid
-         false positives from the name-shape heuristic. *)
       let author_lc = String.lowercase_ascii (String.trim author) in
-      (match !agent_lookup_hook with
-       | Some _ when is_agent author_lc -> Ok Board.Automation_post
-       | _ -> Ok Board.Human_post)
+      if author_lc = "" || author_lc = "anonymous" then
+        (* Missing or default author is never human — classify as automation
+           to prevent misleading human-attributed posts (#4604). *)
+        Ok Board.Automation_post
+      else
+        (match !agent_lookup_hook with
+         | Some _ when is_agent author_lc -> Ok Board.Automation_post
+         | _ -> Ok Board.Human_post)
 
 (** {1 Formatters} *)
 


### PR DESCRIPTION
## Summary
- Anonymous or empty board post authors were classified as Human_post
- Now classified as Automation_post to prevent misleading human attribution
- 23 existing board tests pass

## Test plan
- [ ] Post without author -> classified as automation, not human
- [ ] Post with real agent name -> still classified as Automation_post
- [ ] Post with human name (spaces, mixed case) -> still Human_post

Closes #4604

Generated with Claude Code