### PR TITLE
fix(keeper): cap fallback tools to 30 to prevent context overflow (#4592)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -376,16 +376,36 @@ let run_turn
     :: List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) keeper_tools
   in
   (* Layer 1: Policy fallback — when BM25 confidence is low, fall back
-     to the preset/custom-allowed set (not the full universe).
-     This prevents overwhelming the LLM with 80+ tools on every turn. *)
+     to a capped subset of the preset-allowed tools.
+     Full-preset keepers can have 300+ policy-allowed tools; sending all
+     of them as fallback produces ~39K tokens which exceeds 8K model
+     context windows.  Cap to max_fallback_tools, prioritizing keeper_*
+     tools (preset-scoped, always relevant) then standard-tier MASC
+     tools (coordination essentials).  See #4592. *)
   let policy_allowed =
     Keeper_exec_tools.keeper_allowed_tool_names !meta_ref
   in
+  let max_fallback_tools = 30 in
   let fallback_tools =
-    List.filter (fun name ->
-      not (List.mem name always_include_tools)
-      && List.mem name policy_allowed
-    ) all_tool_names
+    let candidates =
+      List.filter (fun name ->
+        not (List.mem name always_include_tools)
+        && List.mem name policy_allowed
+      ) all_tool_names
+    in
+    if List.length candidates <= max_fallback_tools then
+      candidates
+    else
+      let keeper = List.filter (fun n ->
+        String.starts_with ~prefix:"keeper_" n) candidates in
+      let masc_std = List.filter (fun n ->
+        String.starts_with ~prefix:"masc_" n
+        && Tool_catalog_tiers.is_in_tier Standard n
+      ) candidates in
+      let merged = keeper @ masc_std in
+      if List.length merged > max_fallback_tools then
+        List.filteri (fun i _ -> i < max_fallback_tools) merged
+      else merged
   in
   let confidence_threshold = 0.5 in
   (* Runtime tool overlay: external callers (masc_tool_grant/revoke)


### PR DESCRIPTION
## Summary
- BM25 confidence가 낮을 때(한국어 쿼리 등) fallback이 policy-allowed 전체(~300 tools, ~39K tokens)를 추가하여 8K 모델에서 context overflow 발생
- `fallback_tools`를 최대 30개로 제한 (keeper_* 우선, 그 다음 standard-tier MASC tools)
- 변경 후 fallback 모드 총 ~67 tools (17 always + 20 BM25 + 30 fallback) ≈ 7.6K tokens

## Before / After

| 모드 | Before | After |
|------|--------|-------|
| 정상 (BM25 confident) | ~37 tools | ~37 tools (변동 없음) |
| Fallback (BM25 low confidence) | **~337 tools (~39K tokens)** | **~67 tools (~7.6K tokens)** |
| 8K 모델 호환 | 불가 | 가능 |

## 근거
- 시스템 로그 관찰: 39K tokens → 8K context overflow가 keeper fiber 사망의 직접 원인
- 12→9 keeper fiber 감소가 context overflow 반복으로 발생
- 22차 감시에서 7건의 context overflow ERROR 확인

## Test plan
- [x] `dune build --root .` 통과
- [x] `test_keeper_lifecycle` 3/3 통과
- [x] `test_keeper_agent_isolation` 11/11 통과
- [ ] 로컬 서버 재시작 후 8K 모델 keeper turn 성공 확인
- [ ] fallback 모드에서 tool count 로그 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)