### PR TITLE
fix(board): classify anonymous author as Automation_post

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -113,13 +113,19 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
        | Some kind -> Ok kind
        | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
-      (* Auto-classify only when registry hook is available.
-         Without a registry, default to Human_post to avoid
-         false positives from the name-shape heuristic. *)
       let author_lc = String.lowercase_ascii (String.trim author) in
-      (match !agent_lookup_hook with
-       | Some _ when is_agent author_lc -> Ok Board.Automation_post
-       | _ -> Ok Board.Human_post)
+      (* Missing or "anonymous" author is classified as Automation_post
+         to prevent misleading human-post attribution on the board.
+         See #4604: anonymous fallback was surfacing as human posts. *)
+      if author_lc = "" || author_lc = "anonymous" then
+        Ok Board.Automation_post
+      else
+        (* Auto-classify only when registry hook is available.
+           Without a registry, default to Human_post to avoid
+           false positives from the name-shape heuristic. *)
+        (match !agent_lookup_hook with
+         | Some _ when is_agent author_lc -> Ok Board.Automation_post
+         | _ -> Ok Board.Human_post)
 
 (** {1 Formatters} *)
 


### PR DESCRIPTION
## Summary
author가 없거나 "anonymous"인 board post가 Human_post로 분류되어 실제 사람이 쓴 것처럼 표시되는 문제 수정.

**Root cause**: `is_agent_heuristic`이 "anonymous"를 명시적으로 제외 → `resolve_board_post_kind` fallback이 `Human_post`

**Fix**: empty/anonymous author를 agent lookup 전에 `Automation_post`로 분류. 1파일, 12줄 변경.

Closes #4604

## Test plan
- [x] `dune build` passes
- [ ] Integration: anonymous author로 board post 생성 → Automation_post 분류 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)