### PR TITLE
fix(mcp): trim readonly timeout overshoot hot paths

### DIFF
--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -177,6 +177,39 @@ let read_metrics_file file : task_metric list =
         None
     ) lines
 
+let safe_yield () =
+  try Eio.Fiber.yield () with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+
+let month_key ~year ~month =
+  (year * 12) + (month - 1)
+
+let month_key_of_unix timestamp =
+  let tm = Unix.gmtime timestamp in
+  month_key ~year:(tm.Unix.tm_year + 1900) ~month:(tm.Unix.tm_mon + 1)
+
+let parse_month_key_from_filename filename =
+  if not (Filename.check_suffix filename ".jsonl") then
+    None
+  else
+    match String.split_on_char '-' (Filename.chop_suffix filename ".jsonl") with
+    | [ year_s; month_s ] -> (
+        match int_of_string_opt year_s, int_of_string_opt month_s with
+        | Some year, Some month when month >= 1 && month <= 12 ->
+            Some (month_key ~year ~month)
+        | _ -> None)
+    | _ -> None
+
+let filter_recent_month_filenames ~now ~days filenames =
+  let cutoff = now -. (float_of_int days *. 86400.0) in
+  let min_month = month_key_of_unix cutoff in
+  let max_month = month_key_of_unix now in
+  List.filter
+    (fun filename ->
+      match parse_month_key_from_filename filename with
+      | Some key -> key >= min_month && key <= max_month
+      | None -> true)
+    filenames
+
 (** Get recent metrics for an agent - synchronous *)
 let get_recent config ~agent_id ~days : task_metric list =
   let now = Time_compat.now () in
@@ -185,10 +218,19 @@ let get_recent config ~agent_id ~days : task_metric list =
   if not (Sys.file_exists dir) then
     []
   else
-    let files = Sys.readdir dir |> Array.to_list
+    let files =
+      Sys.readdir dir |> Array.to_list
       |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
-      |> List.map (fun f -> Filename.concat dir f) in
-    let all_metrics = List.concat_map read_metrics_file files in
+      |> filter_recent_month_filenames ~now ~days
+      |> List.map (fun f -> Filename.concat dir f)
+    in
+    let all_metrics =
+      List.concat_map
+        (fun file ->
+          safe_yield ();
+          read_metrics_file file)
+        files
+    in
     List.filter (fun m -> m.started_at >= cutoff) all_metrics
 
 (** Calculate aggregated metrics for fitness - synchronous *)

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -184,6 +184,24 @@ let extract_seq_from_filename name =
   | None -> 0
   | Some idx -> Safe_ops.int_of_string_with_default ~default:0 (String.sub name 0 idx)
 
+let select_recent_message_names ~since_seq ~limit names =
+  let insert_candidate acc name =
+    let seq = extract_seq_from_filename name in
+    if limit <= 0 || seq <= since_seq then
+      acc
+    else
+      (seq, name) :: acc
+      |> List.sort (fun (a, _) (b, _) -> compare b a)
+      |> take_first limit
+  in
+  names
+  |> List.fold_left
+       (fun acc name ->
+         safe_yield ();
+         insert_candidate acc name)
+       []
+  |> List.map snd
+
 let message_name_from_key key =
   match List.rev (String.split_on_char ':' key) with
   | name :: _ -> name
@@ -243,7 +261,7 @@ let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
           Sys.readdir msgs_path
           |> Array.to_list
           |> List.filter is_valid_filename
-          |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
+          |> select_recent_message_names ~since_seq ~limit
         in
         let rec loop remaining acc = function
           | _ when remaining <= 0 -> List.rev acc

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -190,9 +190,15 @@ let select_recent_message_names ~since_seq ~limit names =
     if limit <= 0 || seq <= since_seq then
       acc
     else
-      (seq, name) :: acc
-      |> List.sort (fun (a, _) (b, _) -> compare b a)
-      |> take_first limit
+      let rec insert prefix = function
+        | [] -> List.rev_append prefix [ (seq, name) ]
+        | ((existing_seq, _) as existing) :: rest ->
+            if seq >= existing_seq then
+              List.rev_append prefix ((seq, name) :: existing :: rest)
+            else
+              insert (existing :: prefix) rest
+      in
+      insert [] acc |> take_first limit
   in
   names
   |> List.fold_left

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -206,6 +206,7 @@ let status_summary_string (ctx : context) =
   let agents_with_state =
     List.map
       (fun (agent : Types.agent) ->
+        Room_query.safe_yield ();
         let is_zombie =
           safe_is_zombie_agent ~agent_name:agent.name agent.last_seen
         in
@@ -225,6 +226,7 @@ let status_summary_string (ctx : context) =
       (fun
          (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt)
          (task : Types.task) ->
+        Room_query.safe_yield ();
         match task.task_status with
         | Types.Todo ->
             (task :: active, todo_cnt + 1, claimed_cnt, in_progress_cnt,
@@ -328,6 +330,7 @@ let status_summary_string (ctx : context) =
   | _ ->
       List.iter
         (fun ((agent : Types.agent), is_zombie) ->
+          Room_query.safe_yield ();
           let icon = agent_status_icon ~is_zombie agent.status in
           let you_marker =
             if String.equal agent.name actual_name then " (you)" else ""
@@ -344,6 +347,7 @@ let status_summary_string (ctx : context) =
   Buffer.add_string buf "\n📋 Quest Board:\n";
   List.iter
     (fun (task : Types.task) ->
+      Room_query.safe_yield ();
       let (status_icon, status_label) = task_status_badge task.task_status in
       let assignee = task_assignee task.task_status in
       Buffer.add_string buf

--- a/test/test_metrics_store_eio.ml
+++ b/test/test_metrics_store_eio.ml
@@ -184,6 +184,27 @@ let test_generate_id () =
   assert (String.length (List.hd ids) > 10);
   print_endline "✓ test_generate_id passed"
 
+let test_filter_recent_month_filenames () =
+  let filenames =
+    [
+      "2025-12.jsonl";
+      "2026-01.jsonl";
+      "2026-02.jsonl";
+      "2026-03.jsonl";
+      "2026-04.jsonl";
+      "notes.jsonl";
+    ]
+  in
+  let filtered =
+    Metrics_store_eio.filter_recent_month_filenames
+      ~now:1_775_091_200.0
+      ~days:7
+      filenames
+  in
+  let expected = [ "2026-03.jsonl"; "2026-04.jsonl"; "notes.jsonl" ] in
+  assert (filtered = expected);
+  print_endline "✓ test_filter_recent_month_filenames passed"
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -196,4 +217,5 @@ let () =
   test_collaborators ();
   test_handoff_tracking ();
   test_generate_id ();
-  print_endline "\n✅ All 8 Metrics_store_eio tests passed!\n"
+  test_filter_recent_month_filenames ();
+  print_endline "\n✅ All 9 Metrics_store_eio tests passed!\n"

--- a/test/test_room_messages_raw.ml
+++ b/test/test_room_messages_raw.ml
@@ -47,6 +47,21 @@ let test_get_messages_raw_since_seq_stops_early () =
       ["Message 3"] contents
   )
 
+let test_get_messages_raw_large_history_keeps_newest_window () =
+  with_test_env (fun config ->
+    for i = 1 to 20 do
+      let _ =
+        Room.broadcast config ~from_agent:"claude"
+          ~content:(Printf.sprintf "Message %d" i)
+      in
+      ()
+    done;
+    let msgs = Room.get_messages_raw config ~since_seq:5 ~limit:3 in
+    let contents = List.map (fun (msg : Types.message) -> msg.content) msgs in
+    Alcotest.(check (list string)) "large history keeps newest 3"
+      [ "Message 20"; "Message 19"; "Message 18" ] contents
+  )
+
 let () =
   Alcotest.run "Room raw message regression" [
     ("messages_raw", [
@@ -54,5 +69,7 @@ let () =
         test_get_messages_raw_limit_and_order;
       Alcotest.test_case "since_seq filters older history" `Quick
         test_get_messages_raw_since_seq_stops_early;
+      Alcotest.test_case "large history keeps newest window" `Quick
+        test_get_messages_raw_large_history_keeps_newest_window;
     ]);
   ]


### PR DESCRIPTION
## Summary
- narrow `masc_agent_fitness` metrics scans to the relevant month files and yield between file reads
- keep `masc_messages` on a bounded newest-first filename window instead of sorting the whole directory
- add cooperative yields while rendering `masc_status` summaries so timeout fibers can run sooner on large rooms
- lock the new month-filter and large-history message-window behavior with regression tests

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/tool-timeout-overshoot-4533 ./test/test_room_messages_raw.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/tool-timeout-overshoot-4533 ./test/test_metrics_store_eio.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/tool-timeout-overshoot-4533 ./test/test_mcp_server_eio_call_tool.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/tool-timeout-overshoot-4533 ./test/test_mcp_server_eio.exe`

## Review
- `GLM-5.1` via `sb glm-text` on `2026-04-02 13:01 KST`
- review raised suspected issues around recent-message ordering and duplicated `safe_yield`; rechecked locally against the new large-history regression plus targeted builds, and no actionable finding remained

Refs #4533
