### PR TITLE
fix(keeper): add category anchor tools to always-include list

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -364,7 +364,16 @@ let run_turn
     Keeper_exec_tools.core_always_tools
     @ [ "keeper_broadcast"; "keeper_task_claim"; "keeper_task_done";
         "keeper_tasks_list"; "keeper_fs_read"; "keeper_shell_readonly";
-        "keeper_board_get"; "keeper_board_post" ]
+        "keeper_board_get"; "keeper_board_post";
+        (* Category anchors: one representative per major tool category
+           so the LLM knows these capabilities exist even when BM25
+           retrieval favours keeper_* internal tools.  See #4520. *)
+        "masc_governance_status";    (* governance *)
+        "masc_code_search";          (* coding shard *)
+        "masc_plan_get";             (* planning *)
+        "masc_tasks";                (* task management *)
+        "masc_agent_card";           (* agent introspection *)
+      ]
     |> Keeper_exec_tools.dedupe_tool_names
   in
   (* Layer 2: Universe — all tool names that the dispatch can handle.


### PR DESCRIPTION
## Summary
masc_* tools가 BM25 progressive disclosure에서 체계적으로 밀려 LLM에 도달하지 않는 문제 수정.

**Root cause**: keeper_* 내부 도구가 keeper context와 더 잘 매칭되어 항상 top_k=20 안에 들고, masc_* (governance, coding, planning)는 밀림.

**Fix**: 주요 카테고리별 대표 tool 5개를 `always_include_tools`에 추가:
- `masc_governance_status` (거버넌스)
- `masc_code_search` (코딩)
- `masc_plan_get` (플래닝)
- `masc_tasks` (태스크)
- `masc_agent_card` (에이전트)

max_tools=40 guard (#4609) 범위 내. 1파일, 10줄 변경.

Partially addresses #4520

## Test plan
- [x] `dune build` passes
- [ ] Integration: keeper turn 로그에서 category anchor tools가 항상 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)