### PR TITLE
refactor(http-client): return Result.t instead of failwith

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -203,8 +203,10 @@ let masc_call ~sw:_ ~tool_name ~(args : Yojson.Safe.t) : (string, string) result
           ("Accept", "application/json, text/event-stream");
         ] in
         let code, body_str =
-          Masc_http_client.post_sync ~net ~url:(Uri.to_string uri)
-            ~headers ~body ()
+          match Masc_http_client.post_sync ~net ~url:(Uri.to_string uri)
+            ~headers ~body () with
+          | Ok v -> v
+          | Error e -> raise (Failure e)
         in
         if not (Cohttp.Code.is_success code) then
           Error (Printf.sprintf "MASC HTTP %d" code)

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -151,7 +151,5 @@ let get_https_connector_result () =
           Ok c
       | Error _ as error -> error)
 
-let get_https_connector () =
-  match get_https_connector_result () with
-  | Ok connector -> connector
-  | Error message -> failwith message
+(* get_https_connector (failwith variant) removed — all callers use
+   get_https_connector_result which returns (connector, string) result. *)

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -55,12 +55,7 @@ val get_switch : unit -> Eio.Switch.t
 (** Get the Eio switch.
     @raise Invalid_argument if not initialized. *)
 
-val get_https_connector :
-  unit ->
-  (Uri.t ->
-   [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
-   [ `Close | `Flow | `R | `Shutdown | `Tls | `W ] Eio.Resource.t)
-(** TLS connector for Cohttp_eio HTTPS support. *)
+(** [get_https_connector] removed — use [get_https_connector_result] instead. *)
 
 val get_https_connector_result :
   unit ->

--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -130,13 +130,13 @@ let request ?(timeout_sec=10.0) ?(fallback=true) body : (string, string) result 
         | Error _ as error -> error
         | Ok https ->
             let header_list = Cohttp.Header.to_list headers in
-            let code, body_str =
-              Masc_http_client.post_sync ~net ~https ~url ~headers:header_list
-                ~body ()
-            in
-            if not (Cohttp.Code.is_success code) then
-              Error (Printf.sprintf "HTTP %d" code)
-            else ensure_json_response body_str
+            (match Masc_http_client.post_sync ~net ~https ~url ~headers:header_list
+                ~body () with
+            | Error e -> Error (Printf.sprintf "HTTP request failed: %s" e)
+            | Ok (code, body_str) ->
+                if not (Cohttp.Code.is_success code) then
+                  Error (Printf.sprintf "HTTP %d" code)
+                else ensure_json_response body_str)
       in
       match Eio_context.get_clock_opt () with
       | Some clock ->

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -196,11 +196,11 @@ let post_json_via_eio ~sw:_ ~(auth_token : string option) ~session_id
             | _ -> [])
         in
         let url = mcp_endpoint_url ~auth_token in
-        let status, raw_body =
-          Masc_http_client.post_sync ~net ~url ~headers ~body:request_body ()
-        in
-        if Cohttp.Code.is_success status then Ok raw_body
-        else Error (sprintf "MASC HTTP %d: %s" status raw_body)
+        (match Masc_http_client.post_sync ~net ~url ~headers ~body:request_body () with
+        | Error e -> Error (sprintf "MASC HTTP request failed: %s" e)
+        | Ok (status, raw_body) ->
+            if Cohttp.Code.is_success status then Ok raw_body
+            else Error (sprintf "MASC HTTP %d: %s" status raw_body))
       with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : string)

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -51,39 +51,50 @@ let make_closing_client ~sw ~net ~https =
         (try Eio.Net.close sock with _ -> ()));
   client
 
+(** POST with structured error handling.
+    DNS resolution, TLS, and I/O errors return Error instead of crashing the fiber. *)
 let post_sync ~net ?(https = None) ~url ~headers ~body () =
-  Eio.Switch.run @@ fun sw ->
-  let client = make_closing_client ~sw ~net ~https in
-  let uri = Uri.of_string url in
-  let hdr =
-    Cohttp.Header.of_list (("connection", "close") :: headers)
-  in
-  let body_content = Eio.Flow.string_source body in
-  let resp, resp_body =
-    Cohttp_eio.Client.post client ~sw uri ~headers:hdr ~body:body_content
-  in
-  let code =
-    Cohttp.Response.status resp |> Cohttp.Code.code_of_status
-  in
-  let body_str =
-    Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
-  in
-  (code, body_str)
+  try
+    Eio.Switch.run @@ fun sw ->
+    let client = make_closing_client ~sw ~net ~https in
+    let uri = Uri.of_string url in
+    let hdr =
+      Cohttp.Header.of_list (("connection", "close") :: headers)
+    in
+    let body_content = Eio.Flow.string_source body in
+    let resp, resp_body =
+      Cohttp_eio.Client.post client ~sw uri ~headers:hdr ~body:body_content
+    in
+    let code =
+      Cohttp.Response.status resp |> Cohttp.Code.code_of_status
+    in
+    let body_str =
+      Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
+    in
+    Ok (code, body_str)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
 
+(** GET with structured error handling. *)
 let get_sync ~net ?(https = None) ~url ~headers () =
-  Eio.Switch.run @@ fun sw ->
-  let client = make_closing_client ~sw ~net ~https in
-  let uri = Uri.of_string url in
-  let hdr =
-    Cohttp.Header.of_list (("connection", "close") :: headers)
-  in
-  let resp, resp_body =
-    Cohttp_eio.Client.get client ~sw ~headers:hdr uri
-  in
-  let code =
-    Cohttp.Response.status resp |> Cohttp.Code.code_of_status
-  in
-  let body_str =
-    Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
-  in
-  (code, body_str)
+  try
+    Eio.Switch.run @@ fun sw ->
+    let client = make_closing_client ~sw ~net ~https in
+    let uri = Uri.of_string url in
+    let hdr =
+      Cohttp.Header.of_list (("connection", "close") :: headers)
+    in
+    let resp, resp_body =
+      Cohttp_eio.Client.get client ~sw ~headers:hdr uri
+    in
+    let code =
+      Cohttp.Response.status resp |> Cohttp.Code.code_of_status
+    in
+    let body_str =
+      Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
+    in
+    Ok (code, body_str)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)


### PR DESCRIPTION
## Summary

`Masc_http_client.post_sync`와 `get_sync`가 DNS 실패/TLS 에러 시 `failwith`로 fiber를 crash하던 것을 `(int * string, string) result` 반환으로 전환.

- **Before**: `failwith "failed to resolve hostname"` → fiber crash, 복구 불가
- **After**: `Error "failed to resolve hostname"` → caller가 결정

`Eio.Cancel.Cancelled`는 재발생 (절대 삼키지 않음).

## Motivation

#4518 (Tech Debt: Code Smells) 카테고리 1 — "Excessive failwith for Expected Domain Errors."
DNS 해석 실패, HTTPS 미설정은 예상 가능한 런타임 에러이므로 `Result.t`로 모델링해야 함.

## Changed Files

| 파일 | 변경 |
|------|------|
| `masc_http_client.ml` | `post_sync`/`get_sync` → `Result.t` 반환 |
| `auto_responder.ml` | `match ... Ok v` unwrap (기존 try-with가 catch) |
| `graphql_client.ml` | pattern match into existing Error path |
| `worker_container_types.ml` | pattern match into existing Error path |

## Test plan

- [x] `dune build` 통과
- [ ] auto_responder model mode @mention 테스트
- [ ] graphql_client 통합 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)