### PR TITLE
[codex] Add docker worker runtime backend

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -1,0 +1,22 @@
+FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+
+WORKDIR /src
+
+COPY . .
+
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends pkg-config libssl-dev libsqlite3-dev zlib1g-dev curl git \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test -y && dune build @install"
+
+FROM debian:12-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl git \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/_build/install/default/bin/masc-worker-run /usr/local/bin/masc-worker-run
+COPY --from=build /src/_build/install/default/bin/masc-mcp /usr/local/bin/masc-mcp
+
+ENTRYPOINT ["/usr/local/bin/masc-worker-run"]

--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -10,7 +10,7 @@ RUN sudo apt-get update \
 
 RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test -y && dune build @install"
 
-FROM debian:12-slim
+FROM ocaml/opam:debian-12-ocaml-5.4 AS runtime
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl git libsqlite3-0 libssl3 zlib1g \

--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -13,7 +13,7 @@ RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . -
 FROM debian:12-slim
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl git \
+ && apt-get install -y --no-install-recommends ca-certificates curl git libsqlite3-0 libssl3 zlib1g \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /src/_build/install/default/bin/masc-worker-run /usr/local/bin/masc-worker-run

--- a/bin/dune
+++ b/bin/dune
@@ -41,3 +41,10 @@
  (public_name cdal-label)
  (package masc_mcp)
  (libraries masc_mcp cmdliner yojson unix masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str eio_main eio mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm))
+
+(executable
+ (name masc_worker_run)
+ (modules masc_worker_run)
+ (public_name masc-worker-run)
+ (package masc_mcp)
+ (libraries masc_mcp yojson unix eio_main eio masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider agent_sdk.swarm))

--- a/bin/masc_worker_run.ml
+++ b/bin/masc_worker_run.ml
@@ -10,60 +10,77 @@ let emit_json json =
 let has_spec_stdin_flag () =
   Array.exists (String.equal "--spec-stdin") Sys.argv
 
-let main () =
-  if not (has_spec_stdin_flag ()) then (
-    emit_json
-      (Lib.Worker_runtime_helper_protocol.error_json
-         {
-            message = "masc-worker-run requires --spec-stdin";
-            kind = Lib.Worker_runtime_helper_protocol.Spec_parse;
-         });
-    exit 2);
-  let stdin_text = read_stdin_all () in
-  match Yojson.Safe.from_string stdin_text |> Lib.Worker_execution_spec.of_yojson with
-  | exception Yojson.Json_error msg ->
-      emit_json
-        (Lib.Worker_runtime_helper_protocol.error_json
-           { message = "invalid worker spec JSON: " ^ msg; kind = Lib.Worker_runtime_helper_protocol.Spec_parse })
-  | Error msg ->
-      emit_json
-        (Lib.Worker_runtime_helper_protocol.error_json
-           { message = msg; kind = Lib.Worker_runtime_helper_protocol.Spec_parse })
-  | Ok spec ->
-      Eio_main.run @@ fun env ->
-      Eio_guard.enable ();
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Time_compat.set_clock (Eio.Stdenv.clock env);
-      Process_eio.reset_for_testing ();
-      Process_eio.init
-        ~cwd_default:(Eio.Stdenv.fs env)
-        ~proc_mgr:(Eio.Stdenv.process_mgr env)
-        ~clock:(Eio.Stdenv.clock env);
-      Eio.Switch.run @@ fun sw ->
-      Eio_context.with_test_env
-        ~net:(Eio.Stdenv.net env)
-        ~clock:(Eio.Stdenv.clock env)
-        ~mono_clock:(Eio.Stdenv.mono_clock env)
-        ~sw
-        (fun () ->
-          Fun.protect
-            ~finally:(fun () ->
-              Process_eio.reset_for_testing ();
-              Time_compat.clear_clock ();
-              Eio_guard.disable ())
-            (fun () ->
-              match Lib.Worker_run_once.execute_spec ~sw ~room_config:None spec with
-              | Ok run_result ->
-                  emit_json
-                    (Lib.Worker_runtime_helper_protocol.success_json run_result)
-              | Error msg ->
-                  emit_json
-                    (Lib.Worker_runtime_helper_protocol.error_json
-                       { message = msg; kind = Lib.Worker_runtime_helper_protocol.Runtime })))
+let main_result () =
+  if not (has_spec_stdin_flag ()) then
+    ( Lib.Worker_runtime_helper_protocol.error_json
+        {
+          message = "masc-worker-run requires --spec-stdin";
+          kind = Lib.Worker_runtime_helper_protocol.Spec_parse;
+        },
+      2 )
+  else
+    let stdin_text = read_stdin_all () in
+    match
+      Yojson.Safe.from_string stdin_text |> Lib.Worker_execution_spec.of_yojson
+    with
+    | exception Yojson.Json_error msg ->
+        ( Lib.Worker_runtime_helper_protocol.error_json
+            {
+              message = "invalid worker spec JSON: " ^ msg;
+              kind = Lib.Worker_runtime_helper_protocol.Spec_parse;
+            },
+          1 )
+    | Error msg ->
+        ( Lib.Worker_runtime_helper_protocol.error_json
+            {
+              message = msg;
+              kind = Lib.Worker_runtime_helper_protocol.Spec_parse;
+            },
+          1 )
+    | Ok spec ->
+        Eio_main.run @@ fun env ->
+        Eio_guard.enable ();
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Time_compat.set_clock (Eio.Stdenv.clock env);
+        Process_eio.reset_for_testing ();
+        Process_eio.init
+          ~cwd_default:(Eio.Stdenv.fs env)
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env);
+        Eio.Switch.run @@ fun sw ->
+        Eio_context.with_test_env
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          ~sw
+          (fun () ->
+            Fun.protect
+              ~finally:(fun () ->
+                Process_eio.reset_for_testing ();
+                Time_compat.clear_clock ();
+                Eio_guard.disable ())
+              (fun () ->
+                match
+                  Lib.Worker_run_once.execute_spec ~sw ~room_config:None spec
+                with
+                | Ok run_result ->
+                    ( Lib.Worker_runtime_helper_protocol.success_json run_result,
+                      0 )
+                | Error msg ->
+                    ( Lib.Worker_runtime_helper_protocol.error_json
+                        {
+                          message = msg;
+                          kind = Lib.Worker_runtime_helper_protocol.Runtime;
+                        },
+                      1 )))
 
 let () =
-  try main ()
+  try
+    let json, exit_code = main_result () in
+    emit_json json;
+    exit exit_code
   with exn ->
     emit_json
       (Lib.Worker_runtime_helper_protocol.error_json
-         { message = Printexc.to_string exn; kind = Lib.Worker_runtime_helper_protocol.Internal })
+         { message = Printexc.to_string exn; kind = Lib.Worker_runtime_helper_protocol.Internal });
+    exit 1

--- a/bin/masc_worker_run.ml
+++ b/bin/masc_worker_run.ml
@@ -1,0 +1,69 @@
+module Lib = Masc_mcp
+
+let read_stdin_all () =
+  In_channel.input_all In_channel.stdin
+
+let emit_json json =
+  Yojson.Safe.to_string json |> print_endline;
+  flush stdout
+
+let has_spec_stdin_flag () =
+  Array.exists (String.equal "--spec-stdin") Sys.argv
+
+let main () =
+  if not (has_spec_stdin_flag ()) then (
+    emit_json
+      (Lib.Worker_runtime_helper_protocol.error_json
+         {
+            message = "masc-worker-run requires --spec-stdin";
+            kind = Lib.Worker_runtime_helper_protocol.Spec_parse;
+         });
+    exit 2);
+  let stdin_text = read_stdin_all () in
+  match Yojson.Safe.from_string stdin_text |> Lib.Worker_execution_spec.of_yojson with
+  | exception Yojson.Json_error msg ->
+      emit_json
+        (Lib.Worker_runtime_helper_protocol.error_json
+           { message = "invalid worker spec JSON: " ^ msg; kind = Lib.Worker_runtime_helper_protocol.Spec_parse })
+  | Error msg ->
+      emit_json
+        (Lib.Worker_runtime_helper_protocol.error_json
+           { message = msg; kind = Lib.Worker_runtime_helper_protocol.Spec_parse })
+  | Ok spec ->
+      Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Time_compat.set_clock (Eio.Stdenv.clock env);
+      Process_eio.reset_for_testing ();
+      Process_eio.init
+        ~cwd_default:(Eio.Stdenv.fs env)
+        ~proc_mgr:(Eio.Stdenv.process_mgr env)
+        ~clock:(Eio.Stdenv.clock env);
+      Eio.Switch.run @@ fun sw ->
+      Eio_context.with_test_env
+        ~net:(Eio.Stdenv.net env)
+        ~clock:(Eio.Stdenv.clock env)
+        ~mono_clock:(Eio.Stdenv.mono_clock env)
+        ~sw
+        (fun () ->
+          Fun.protect
+            ~finally:(fun () ->
+              Process_eio.reset_for_testing ();
+              Time_compat.clear_clock ();
+              Eio_guard.disable ())
+            (fun () ->
+              match Lib.Worker_run_once.execute_spec ~sw ~room_config:None spec with
+              | Ok run_result ->
+                  emit_json
+                    (Lib.Worker_runtime_helper_protocol.success_json run_result)
+              | Error msg ->
+                  emit_json
+                    (Lib.Worker_runtime_helper_protocol.error_json
+                       { message = msg; kind = Lib.Worker_runtime_helper_protocol.Runtime })))
+
+let () =
+  try main ()
+  with exn ->
+    emit_json
+      (Lib.Worker_runtime_helper_protocol.error_json
+         { message = Printexc.to_string exn; kind = Lib.Worker_runtime_helper_protocol.Internal })

--- a/docs/TEAM-SESSION-WORKER-RUNTIME.md
+++ b/docs/TEAM-SESSION-WORKER-RUNTIME.md
@@ -1,0 +1,66 @@
+# Team-Session Worker Runtime
+
+`masc_team_session_step` spawned workers now support an optional Docker-backed
+runtime backend.
+
+## Scope
+
+- v1 applies only to team-session spawned workers.
+- `observe_only` workers stay local.
+- `limited_code_change` and `autonomous` workers can resolve to Docker when the
+  backend is enabled.
+- This is runtime isolation and reproducibility, not a hostile-code sandbox.
+
+## Config
+
+Config file path:
+
+- `<resolved-config-root>/worker-runtime.json`
+
+Example:
+
+```json
+{
+  "team_session_spawn": {
+    "backend": "docker",
+    "docker_scopes": ["limited_code_change", "autonomous"],
+    "docker": {
+      "image": "masc-worker-runtime:local-<git-sha>",
+      "host_mcp_base_url": "http://host.docker.internal:8935"
+    }
+  }
+}
+```
+
+Environment overrides:
+
+- `MASC_WORKER_RUNTIME_BACKEND=local|docker`
+- `MASC_WORKER_RUNTIME_DOCKER_IMAGE=<image>`
+- `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL=<url>`
+
+## Image Build
+
+```bash
+./scripts/build-worker-runtime-image.sh
+```
+
+Or pin a tag explicitly:
+
+```bash
+./scripts/build-worker-runtime-image.sh masc-worker-runtime:local-my-tag
+```
+
+## Runtime Behavior
+
+- Docker preflight runs once per spawn batch before the first Docker-backed
+  worker starts.
+- Preflight checks Docker daemon availability and the configured image.
+- If Docker preflight fails, the entire spawn batch is rejected.
+- Worker run metadata now includes `worker_backend=local|docker`.
+
+## Notes
+
+- `masc-worker-run --spec-stdin` is the internal container entrypoint.
+- Host loopback URLs used by the worker runtime are rewritten to
+  `host.docker.internal`.
+- `Docker-in-Docker` is not supported in v1.

--- a/lib/dune
+++ b/lib/dune
@@ -170,10 +170,16 @@
    sdk_tool_contract
    tool_schema_dsl
    worker_oas
+   worker_execution_backend
+   worker_execution_spec
    worker_runtime
+   worker_runtime_config
+   worker_runtime_docker
+   worker_runtime_helper_protocol
    worker_container_types
    worker_container
    worker_container_runners
+   worker_run_once
    worker_dev_tools
    worker_tool_input
    worker_verification

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -13,166 +13,44 @@ let resolve_net ?net () =
       | Some net -> Ok net
       | None -> Error "Eio net not initialized")
 
-let run_worker_oas ~sw ?net ~base_path ~worker_name
-    ~(provider : Agent_sdk.Provider.config) ~(model_id : string)
-    ~team_session_id
-    ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id
-    ?contract
-    ~role
-    ~selection_note
-    ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
-    unit -> (run_result, string) result =
-  fun () ->
-    let mcp_session_id =
-      resolved_mcp_session_id ~base_path ~team_session_id ~worker_name
-    in
-    let execution_scope =
-      resolve_execution_scope ~base_path ~team_session_id ?execution_scope ()
-    in
-    let workspace_path =
-      match working_dir with
-      | Some dir when String.trim dir <> "" -> dir
-      | _ -> base_path
-    in
-    let meta =
-      make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
-        ~mcp_session_id ~role ~selection_note ~execution_scope ~worker_class
-        ~worker_size ~effective_model:model_id
-        ~thinking_enabled ~max_turns_override:max_turns
-        ~timeout_seconds:(Some timeout_sec)
-    in
-    match worker_auth_token ~base_path ~worker_name with
-    | Error e -> Error e
-    | Ok auth_token ->
-        let evidence_session_id =
-          evidence_session_id_of_worker_run worker_run_id
-        in
-        let system_prompt =
-          default_system_prompt ~worker_name ~model_id
-            ?session_id:team_session_id ?role ?selection_note ()
-        in
-        let prompt =
-          let tool_contract =
-            "Tool contract reminder: if you call masc_team_session_step with \
-             turn_kind=\"note\", you must include a non-empty message field. \
-             Calls missing message fail."
-          in
-          match execution_scope with
-          | Team_session_types.Autonomous ->
-              let resolvable =
-                Agent_tool_surfaces.local_worker_resolvable_tool_names ()
-              in
-              let tool_names =
-                Agent_tool_surfaces.build_tool_catalog ~role:"autonomous" ()
-                |> List.filter (fun name -> List.mem name resolvable)
-              in
-              let team_ctx =
-                match team_session_id with
-                | Some sid -> Team_context.build ~base_path ~team_session_id:sid
-                | None -> Team_context.empty
-              in
-              Prompt_composer.compose
-                [
-                  Identity
-                    {
-                      name = worker_name;
-                      role =
-                        (match role with
-                        | Some r -> r
-                        | None -> "autonomous");
-                      model = model_id;
-                    };
-                  TeamContext team_ctx;
-                  AvailableTools tool_names;
-                  Guidelines
-                    [
-                      tool_contract;
-                      "You have full read and write access. Choose the \
-                       approach that best accomplishes your task. Use tools to \
-                       verify your work. Prefer reading code before modifying \
-                       it, and run tests or builds to confirm changes are \
-                       correct.";
-                    ];
-                  Task prompt;
-                ]
-          | _ ->
-              let workflow_contract =
-                match execution_scope with
-                | Team_session_types.Limited_code_change ->
-                    "Coding worker protocol: you must use tools before \
-                     answering. If the task requires a code change, the \
-                     expected loop is file_read -> shell_exec -> file_write \
-                     -> shell_exec, and you should not finish until the \
-                     verification shell_exec succeeds. If the task is \
-                     inspection-only, do not modify files."
-                | Team_session_types.Observe_only ->
-                    "Readonly worker protocol: use file_read and shell_exec \
-                     for inspection, but do not modify files."
-                | Team_session_types.Autonomous ->
-                    (* Handled above; unreachable *)
-                    ""
-              in
-              let team_ctx_section =
-                match team_session_id with
-                | Some sid ->
-                    let ctx =
-                      Team_context.build ~base_path ~team_session_id:sid
-                    in
-                    let section = Team_context.to_prompt_section ctx in
-                    if section = "" then "" else "\n\n" ^ section
-                | None -> ""
-              in
-              String.concat "\n\n"
-                [ tool_contract; workflow_contract; prompt ]
-              ^ team_ctx_section
-        in
-        let* () =
-          save_worker_meta ~base_path ~team_session_id ~worker_name meta
-        in
-        let* mcp_tools =
-          build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
-            ~worker_name ~prompt ~allowed_tools
-        in
-        let mcp_tools =
-          List.map (Oas.Tool.with_defaults
-            [("agent_name", `String worker_name)]) mcp_tools
-        in
-        let* shell_tools =
-          build_local_shell_tools ~room_config ~worker_name ~execution_scope
-            ~workdir:workspace_path
-        in
-        let tools = mcp_tools @ shell_tools in
-        let* raw_trace =
-          match evidence_session_id with
-          | Some trace_session_id ->
-              Oas.Raw_trace.create_for_session
-                ~session_root:(oas_trace_session_root ~base_path)
-                ~session_id:trace_session_id ~agent_name:worker_name ()
-              |> Result.map_error Oas.Error.to_string
-          | None -> (
-              match team_session_id with
-              | Some trace_session_id ->
-                  Oas.Raw_trace.create_for_session
-                    ~session_root:(oas_trace_session_root ~base_path)
-                    ~session_id:trace_session_id ~agent_name:worker_name ()
-                  |> Result.map_error Oas.Error.to_string
-              | None ->
-                  Oas.Raw_trace.create ~session_id:mcp_session_id
-                    ~path:
-                      (worker_raw_trace_path ~base_path
-                         ~team_session_id
-                         ~worker_name)
-                    ()
-                  |> Result.map_error Oas.Error.to_string)
-        in
-        let gate_config =
-          Worker_oas.gate_config_of_execution_scope meta.execution_scope
-        in
-        let* net = resolve_net ?net () in
-        Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~meta ~provider
-          ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
-          ?contract ?worker_run_id ()
+let default_shell_tool_names execution_scope =
+  match execution_scope with
+  | Some Team_session_types.Observe_only ->
+      [ "file_read"; "shell_exec" ]
+  | _ ->
+      [ "file_read"; "file_write"; "shell_exec" ]
+
+let build_execution_spec ~base_path ~worker_name ~model_label ~team_session_id
+    ?working_dir ?worker_class ?worker_size ?execution_scope
+    ?thinking_enabled ~max_turns ?worker_run_id ?delivery_contract
+    ?allowed_shell_tools ~role ~selection_note
+    ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) () =
+  {
+    Worker_execution_spec.base_path;
+    worker_name;
+    model_label;
+    team_session_id;
+    working_dir;
+    worker_class;
+    worker_size;
+    execution_scope;
+    thinking_enabled;
+    max_turns;
+    worker_run_id;
+    role;
+    selection_note;
+    prompt;
+    allowed_tools;
+    allowed_shell_tools =
+      Option.value ~default:(default_shell_tool_names execution_scope)
+        allowed_shell_tools;
+    timeout_sec;
+    delivery_contract;
+  }
+
+let run_worker_oas ~sw ?net ~room_config
+    (spec : Worker_execution_spec.t) : unit -> (run_result, string) result =
+  fun () -> Worker_run_once.execute_spec ~sw ?net ~room_config spec
 
 let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~worker_name
     ~(team_session_id : string) ~(prompt : string) :
@@ -307,19 +185,43 @@ let continue_worker ?worker_run_id ?contract ~sw ?net ~base_path ~room_config ~w
               Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~meta ~checkpoint
                 ~prompt ~tools ~raw_trace ?contract ?worker_run_id ()))
 
-let run_worker ~sw ?net ~base_path ~worker_name ~model_label ~team_session_id
-    ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
-    ~selection_note
+let preflight_spawn_batch ?clock_opt specs =
+  let docker_specs =
+    specs
+    |> List.filter (fun (spec : Worker_execution_spec.t) ->
+           match spec.execution_scope with
+           | Some scope ->
+               Worker_runtime_config.backend_for_scope scope
+               = Worker_execution_backend.Docker
+           | None -> false)
+    |> List.map (fun (spec : Worker_execution_spec.t) ->
+           {
+             Worker_runtime_docker.worker_name = spec.worker_name;
+             model_label = spec.model_label;
+           })
+  in
+  match docker_specs with
+  | [] -> Ok ()
+  | _ -> Worker_runtime_docker.preflight_batch ?clock_opt docker_specs
+
+let run_worker ~sw ?net ~backend ~base_path ~worker_name ~model_label
+    ~team_session_id ~room_config ?working_dir ?worker_class ?worker_size
+    ?execution_scope ?thinking_enabled ?allowed_shell_tools ?max_turns
+    ?worker_run_id ?delivery_contract ~role ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
-  let provider = oas_provider_of_label model_label in
-  let model_id = match Llm_provider.Cascade_config.parse_model_string model_label with
-    | Some cfg -> cfg.Llm_provider.Provider_config.model_id
-    | None -> model_label
+  let max_turns = Option.value ~default:10 max_turns in
+  let spec =
+    build_execution_spec ~base_path ~worker_name ~model_label
+      ~team_session_id ?working_dir ?worker_class ?worker_size
+      ?execution_scope ?thinking_enabled ~max_turns ?worker_run_id
+      ?delivery_contract ?allowed_shell_tools ~role ~selection_note ~prompt
+      ~allowed_tools ~timeout_sec ()
   in
-  run_worker_oas ~sw ?net ~base_path ~worker_name ~provider ~model_id
-    ~team_session_id
-    ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
-    ?thinking_enabled ?max_turns ?worker_run_id ?contract ~role
-    ~selection_note ~prompt ~allowed_tools ~timeout_sec
+  match backend with
+  | Worker_execution_backend.Local ->
+      run_worker_oas ~sw ?net ~room_config spec
+  | Worker_execution_backend.Docker ->
+      let spec = Worker_runtime_docker.rewrite_spec_for_container spec in
+      let clock_opt = Eio_context.get_clock_opt () in
+      fun () -> Worker_runtime_docker.run_worker_spec ?clock_opt spec

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -93,6 +93,15 @@ let tail_text ?(max_chars = 4000) text =
   if len <= max_chars then text
   else String.sub text (len - max_chars) max_chars
 
+let close_fd_quietly fd =
+  try Unix.close fd with
+  | Unix.Unix_error _ -> ()
+
+let remove_path_quietly path =
+  try Sys.remove path with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> ()
+
 let swarm_live_run_dir config run_id =
   Filename.concat
     (Filename.concat (Cp_paths.control_plane_root_dir config) "swarm-live")
@@ -161,31 +170,65 @@ let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
   loop ()
 
 let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv ~env () =
-  let stdin_path_opt, stdin_fd =
-    match stdin_content with
-    | None -> (None, Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0)
-    | Some content ->
-        let stdin_path = Filename.temp_file "masc_cp_stdin_" ".log" in
-        Out_channel.with_open_bin stdin_path (fun oc -> Out_channel.output_string oc content);
-        (Some stdin_path, Unix.openfile stdin_path [ Unix.O_RDONLY ] 0)
-  in
+  let stdin_path_opt = ref None in
+  let stdin_fd_opt = ref None in
+  let stdout_fd_opt = ref None in
+  let stderr_fd_opt = ref None in
   let stdout_path = Filename.temp_file "masc_cp_stdout_" ".log" in
   let stderr_path = Filename.temp_file "masc_cp_stderr_" ".log" in
-  let stdout_fd =
-    Unix.openfile stdout_path
-      [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
-  in
-  let stderr_fd =
-    Unix.openfile stderr_path
-      [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
+  let cleanup_setup () =
+    Option.iter close_fd_quietly !stdin_fd_opt;
+    stdin_fd_opt := None;
+    Option.iter close_fd_quietly !stdout_fd_opt;
+    stdout_fd_opt := None;
+    Option.iter close_fd_quietly !stderr_fd_opt;
+    stderr_fd_opt := None;
+    Option.iter remove_path_quietly !stdin_path_opt;
+    stdin_path_opt := None;
+    remove_path_quietly stdout_path;
+    remove_path_quietly stderr_path
   in
   let pid =
-    Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd
-      stderr_fd
+    try
+      let stdin_fd =
+        match stdin_content with
+        | None -> Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0
+        | Some content ->
+            let stdin_path, oc =
+              Filename.open_temp_file ~mode:[ Open_wronly; Open_creat; Open_trunc; Open_binary ]
+                ~perms:0o600 "masc_cp_stdin_" ".log"
+            in
+            stdin_path_opt := Some stdin_path;
+            Out_channel.output_string oc content;
+            close_out oc;
+            Unix.openfile stdin_path [ Unix.O_RDONLY ] 0
+      in
+      stdin_fd_opt := Some stdin_fd;
+      let stdout_fd =
+        Unix.openfile stdout_path
+          [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
+      in
+      stdout_fd_opt := Some stdout_fd;
+      let stderr_fd =
+        Unix.openfile stderr_path
+          [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
+      in
+      stderr_fd_opt := Some stderr_fd;
+      let pid =
+        Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd
+          stderr_fd
+      in
+      close_fd_quietly stdin_fd;
+      stdin_fd_opt := None;
+      close_fd_quietly stdout_fd;
+      stdout_fd_opt := None;
+      close_fd_quietly stderr_fd;
+      stderr_fd_opt := None;
+      pid
+    with exn ->
+      cleanup_setup ();
+      raise exn
   in
-  Unix.close stdin_fd;
-  Unix.close stdout_fd;
-  Unix.close stderr_fd;
   let finalize exit_code =
     let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
     let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -161,15 +161,16 @@ let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
   loop ()
 
 let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv ~env () =
+  let stdin_path_opt, stdin_fd =
+    match stdin_content with
+    | None -> (None, Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0)
+    | Some content ->
+        let stdin_path = Filename.temp_file "masc_cp_stdin_" ".log" in
+        Out_channel.with_open_bin stdin_path (fun oc -> Out_channel.output_string oc content);
+        (Some stdin_path, Unix.openfile stdin_path [ Unix.O_RDONLY ] 0)
+  in
   let stdout_path = Filename.temp_file "masc_cp_stdout_" ".log" in
   let stderr_path = Filename.temp_file "masc_cp_stderr_" ".log" in
-  let stdin_fd, stdin_writer =
-    match stdin_content with
-    | None -> (Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0, None)
-    | Some _ ->
-        let read_fd, write_fd = Unix.pipe ~cloexec:true () in
-        (read_fd, Some write_fd)
-  in
   let stdout_fd =
     Unix.openfile stdout_path
       [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
@@ -183,25 +184,19 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
       stderr_fd
   in
   Unix.close stdin_fd;
-  (match stdin_content, stdin_writer with
-  | Some content, Some write_fd ->
-      let rec write_all offset =
-        if offset < String.length content then
-          let written =
-            Unix.write_substring write_fd content offset
-              (String.length content - offset)
-          in
-          write_all (offset + written)
-      in
-      (try write_all 0 with
-      | Unix.Unix_error _ -> ());
-      Unix.close write_fd
-  | _ -> ());
   Unix.close stdout_fd;
   Unix.close stderr_fd;
   let finalize exit_code =
     let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
     let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in
+    (match stdin_path_opt with
+    | Some stdin_path -> (
+        try Sys.remove stdin_path
+        with Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.CmdPlane.warn "failed to remove stdin tmpfile %s: %s" stdin_path
+               (Printexc.to_string exn))
+    | None -> ());
     (try Sys.remove stdout_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.CmdPlane.warn "failed to remove stdout tmpfile %s: %s" stdout_path (Printexc.to_string exn));
     (try Sys.remove stderr_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -232,7 +232,7 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
   let finalize exit_code =
     let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
     let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in
-    (match stdin_path_opt with
+    (match !stdin_path_opt with
     | Some stdin_path -> (
         try Sys.remove stdin_path
         with Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -160,10 +160,16 @@ let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
   in
   loop ()
 
-let run_process_with_timeout ~clock_opt ~timeout_sec ~prog ~argv ~env =
+let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv ~env () =
   let stdout_path = Filename.temp_file "masc_cp_stdout_" ".log" in
   let stderr_path = Filename.temp_file "masc_cp_stderr_" ".log" in
-  let stdin_fd = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let stdin_fd, stdin_writer =
+    match stdin_content with
+    | None -> (Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0, None)
+    | Some _ ->
+        let read_fd, write_fd = Unix.pipe ~cloexec:true () in
+        (read_fd, Some write_fd)
+  in
   let stdout_fd =
     Unix.openfile stdout_path
       [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
@@ -177,6 +183,20 @@ let run_process_with_timeout ~clock_opt ~timeout_sec ~prog ~argv ~env =
       stderr_fd
   in
   Unix.close stdin_fd;
+  (match stdin_content, stdin_writer with
+  | Some content, Some write_fd ->
+      let rec write_all offset =
+        if offset < String.length content then
+          let written =
+            Unix.write_substring write_fd content offset
+              (String.length content - offset)
+          in
+          write_all (offset + written)
+      in
+      (try write_all 0 with
+      | Unix.Unix_error _ -> ());
+      Unix.close write_fd
+  | _ -> ());
   Unix.close stdout_fd;
   Unix.close stderr_fd;
   let finalize exit_code =

--- a/lib/tool_repair_loop_ocaml.ml
+++ b/lib/tool_repair_loop_ocaml.ml
@@ -113,7 +113,7 @@ let run_validator ?clock ~(cwd : string) ~(timeout_sec : int) argv :
     | prog :: _ ->
         Tool_command_plane_support.run_process_with_timeout
           ~clock_opt:clock ~timeout_sec ~prog ~argv
-          ~env:(Unix.environment ())
+          ~env:(Unix.environment ()) ()
   in
   {
     command = argv;

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -45,6 +45,15 @@ type prepared_spawn = {
   mutable lease_released : bool;
 }
 
+type prepared_execution = {
+  prepared : prepared_spawn;
+  execution_scope : Team_session_types.execution_scope;
+  local_worker_tool_names : string list;
+  local_shell_tool_names : string list;
+  delivery_contract : Team_session_types.delivery_contract option;
+  worker_backend : Worker_execution_backend.t;
+}
+
 (** OAS worker evidence payload for trace integration. *)
 type oas_worker_evidence = {
   trace_ref : Oas.Raw_trace.run_ref option;

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -336,7 +336,12 @@ let append_delegate_event (env : _ step_env) ~worker_run_id ~worker_name ~delega
           ("ts_iso", `String (Types.now_iso ()));
         ])
 
-let append_spawn_requested_event (env : _ step_env) ~worker_run_id prepared =
+let rec append_spawn_requested_event (env : _ step_env) ~worker_run_id prepared =
+  append_spawn_requested_event_with_backend env ~worker_run_id prepared
+    ~worker_backend:None
+
+and append_spawn_requested_event_with_backend (env : _ step_env) ~worker_run_id
+    prepared ~worker_backend =
   Team_session_store.append_event env.ctx.config env.session_id
     ~event_type:"team_step_spawn_requested"
     ~detail:
@@ -349,7 +354,14 @@ let append_spawn_requested_event (env : _ step_env) ~worker_run_id prepared =
               ~some:(fun s -> `String s)
               prepared.runtime_actor_name );
           ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
-          ("worker_backend", if env.deps.is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
+          ( "worker_backend",
+            match worker_backend with
+            | Some backend ->
+                `String (Worker_execution_backend.to_string backend)
+            | None ->
+                if env.deps.is_local_spawn_agent prepared.spec.spawn_agent then
+                  `String "local"
+                else `Null );
           ("wait_mode", `String (Team_session_types.wait_mode_to_string env.wait_mode));
           ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.assigned_runtime);
           ("resolved_model", `String prepared.runtime_model_label);
@@ -651,3 +663,60 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
           assigned_runtime;
           lease_released = false;
         }
+
+let local_worker_tool_names_of_scope scope =
+  match scope with
+  | Team_session_types.Observe_only ->
+      Tool_access_policy.resolve
+        {
+          allow = Surface Tool_catalog.Local_worker;
+          deny =
+            Names
+              [
+                "masc_claim_next";
+                "masc_transition";
+                "masc_add_task";
+                "masc_heartbeat";
+                "masc_board_post";
+                "masc_board_comment";
+                "masc_board_vote";
+                "masc_worktree_create";
+                "masc_worktree_remove";
+                "masc_run_init";
+                "masc_run_plan";
+                "masc_run_log";
+                "masc_run_deliverable";
+                "masc_repair_loop_start";
+                "masc_repair_loop_iterate";
+                "masc_repair_loop_stop";
+              ];
+        }
+  | _ ->
+      Team_session_oas_bridge.supported_local_worker_tool_names
+
+let local_shell_tool_names_of_scope = function
+  | Team_session_types.Observe_only ->
+      [ "file_read"; "shell_exec" ]
+  | _ ->
+      [ "file_read"; "file_write"; "shell_exec" ]
+
+let materialize_prepared_execution (env : _ step_env) (prepared : prepared_spawn)
+    : prepared_execution =
+  let execution_scope =
+    match env.deps.effective_execution_scope_of_spec prepared.spec with
+    | Some scope -> scope
+    | None ->
+        Team_session_types.effective_execution_scope
+          ~worker_class:prepared.spec.worker_class
+          prepared.spec.execution_scope
+  in
+  {
+    prepared;
+    execution_scope;
+    local_worker_tool_names = local_worker_tool_names_of_scope execution_scope;
+    local_shell_tool_names = local_shell_tool_names_of_scope execution_scope;
+    delivery_contract =
+      delivery_contract_for_session env.ctx.config env.session_id;
+    worker_backend =
+      Worker_runtime_config.backend_for_scope execution_scope;
+  }

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -31,6 +31,8 @@ let execute_spawn_pipeline
     List.iter
       (fun (execution : prepared_execution) ->
         let prepared = execution.prepared in
+        append_spawn_requested_event_with_backend ~worker_run_id:prepared.worker_run_id
+          prepared ~worker_backend:(Some execution.worker_backend);
         release_prepared_runtime prepared ~success:false ~error ();
         append_spawn_event
           ~worker_run_id:prepared.worker_run_id
@@ -174,7 +176,8 @@ let execute_spawn_pipeline
                    | Ok () ->
                        (match ensure_all prepared_spawns_for_actors with
                        | Error msg ->
-                           fail_all_prepared prepared_spawns ~error:msg;
+                           fail_all_prepared_executions prepared_executions
+                             ~error:msg;
                            Some (`Assoc [ ("error", `String msg) ])
                        | Ok () ->
                        let execute_spawn ~run_sw index

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -122,7 +122,8 @@ let execute_spawn_pipeline
                in
                    let docker_specs =
                      prepared_executions
-                     |> List.filter_map (fun (execution : prepared_execution) ->
+                     |> List.mapi (fun i execution -> (i, execution))
+                     |> List.filter_map (fun (i, (execution : prepared_execution)) ->
                             match execution.worker_backend with
                             | Worker_execution_backend.Local -> None
                             | Worker_execution_backend.Docker ->
@@ -130,7 +131,7 @@ let execute_spawn_pipeline
                                 let worker_name =
                                   Option.value
                                     ~default:
-                                      (Printf.sprintf "spawn-%d-%s" 0
+                                      (Printf.sprintf "spawn-%d-%s" i
                                          prepared.worker_run_id)
                                     prepared.runtime_actor_name
                                 in

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -14,8 +14,9 @@ let execute_spawn_pipeline
   let session_id = env.session_id in
   let wait_mode = env.wait_mode in
   let append_spawn_event = Tool_team_session_step_exec.append_spawn_event env in
-  let append_spawn_requested_event =
-    Tool_team_session_step_exec.append_spawn_requested_event env
+  let append_spawn_requested_event_with_backend =
+    Tool_team_session_step_exec.append_spawn_requested_event_with_backend
+      env
   in
   let persist_worker_run_snapshot =
     Tool_team_session_step_exec.persist_worker_run_snapshot env
@@ -25,6 +26,40 @@ let execute_spawn_pipeline
   in
   let fail_all_prepared =
     Tool_team_session_step_exec.fail_all_prepared env
+  in
+  let fail_all_prepared_executions prepared_executions ~error =
+    List.iter
+      (fun (execution : prepared_execution) ->
+        let prepared = execution.prepared in
+        release_prepared_runtime prepared ~success:false ~error ();
+        append_spawn_event
+          ~worker_run_id:prepared.worker_run_id
+          ~spawn_agent:prepared.spec.spawn_agent
+          ?runtime_actor:prepared.runtime_actor_name
+          ?spawn_role:prepared.spec.spawn_role
+          ?spawn_model:prepared.spec.spawn_model
+          ~execution_scope:execution.execution_scope
+          ?worker_class:prepared.spec.worker_class
+          ?worker_size:(deps.worker_size_of_spec prepared.spec)
+          ~worker_backend:
+            (Worker_execution_backend.to_string execution.worker_backend)
+          ?parent_actor:prepared.spec.parent_actor
+          ?capsule_mode:prepared.spec.capsule_mode
+          ?runtime_pool:prepared.spec.runtime_pool
+          ?lane_id:prepared.spec.lane_id
+          ?controller_level:
+            (deps.inferred_controller_level_of_spec prepared.spec)
+          ?control_domain:prepared.spec.control_domain
+          ?supervisor_actor:prepared.spec.supervisor_actor
+          ?model_tier:prepared.spec.model_tier
+          ?task_profile:prepared.spec.task_profile
+          ?risk_level:prepared.spec.risk_level
+          ?routing_confidence:prepared.spec.routing_confidence
+          ?routing_reason:prepared.spec.routing_reason
+          ?assigned_runtime:prepared.assigned_runtime
+          ?spawn_selection_note:prepared.spec.spawn_selection_note
+          ~success:false ~error ())
+      prepared_executions
   in
   match prepared_spawns_result with
   | Error msg -> Some (`Assoc [ ("error", `String msg) ])
@@ -60,6 +95,12 @@ let execute_spawn_pipeline
               fail_all_prepared prepared_spawns ~error:msg;
               Some (`Assoc [ ("error", `String msg) ])
           | Some _pm ->
+              let prepared_executions =
+                List.map
+                  (Tool_team_session_step_exec
+                   .materialize_prepared_execution env)
+                  prepared_spawns
+              in
               let rec ensure_all = function
                 | [] -> Ok ()
                 | prepared :: rest -> (
@@ -73,560 +114,694 @@ let execute_spawn_pipeline
                         | Ok () -> ensure_all rest
                         | Error msg -> Error msg))
               in
-              (match ensure_all prepared_spawns with
-               | Error msg ->
-                   fail_all_prepared prepared_spawns ~error:msg;
-                   Some (`Assoc [ ("error", `String msg) ])
-               | Ok () ->
-                   let execute_spawn ~run_sw index prepared =
-                    let start_time = Time_compat.now () in
-                    let worker_name =
-                      Option.value
-                        ~default:(Printf.sprintf "spawn-%d-%s" index prepared.worker_run_id)
-                        prepared.runtime_actor_name
-                    in
-                    let execution_scope =
-                      deps.effective_execution_scope_of_spec prepared.spec
-                    in
-                    let local_worker_tool_names =
-                      match execution_scope with
-                      | Some Team_session_types.Observe_only ->
-                          (* Includes masc_heartbeat in deny — spawned workers
-                             should not heartbeat on behalf of the session. *)
-                          Tool_access_policy.resolve {
-                            allow = Surface Tool_catalog.Local_worker;
-                            deny = Names [
-                              "masc_claim_next";
-                              "masc_transition";
-                              "masc_add_task";
-                              "masc_heartbeat";
-                              "masc_board_post";
-                              "masc_board_comment";
-                              "masc_board_vote";
-                              "masc_worktree_create";
-                              "masc_worktree_remove";
-                              "masc_run_init";
-                              "masc_run_plan";
-                              "masc_run_log";
-                              "masc_run_deliverable";
-                              "masc_repair_loop_start";
-                              "masc_repair_loop_iterate";
-                              "masc_repair_loop_stop";
-                            ];
-                          }
-                      | _ ->
-                          Team_session_oas_bridge.supported_local_worker_tool_names
-                    in
-                    let local_shell_tool_names =
-                      match execution_scope with
-                      | Some Team_session_types.Observe_only ->
-                          [ "file_read"; "shell_exec" ]
-                      | _ -> [ "file_read"; "file_write"; "shell_exec" ]
-                    in
-                    let delivery_contract =
-                      Tool_team_session_step_exec.delivery_contract_for_session
-                        ctx.config session_id
-                    in
-                    let contract =
-                      Option.map
-                        (fun delivery_contract ->
-                          Contract_composer.compose ~delivery_contract
-                            ~execution_scope
-                            ~tool_names:
-                              (List.sort_uniq String.compare
-                                 (local_worker_tool_names @ local_shell_tool_names)))
-                        delivery_contract
-                    in
-                    let worker_backend =
-                      if deps.is_local_spawn_agent prepared.spec.spawn_agent
-                      then Some "local"
-                      else None
-                    in
-                    let unexpected_failure ~elapsed_ms error =
-                      let output_preview = deps.truncate_for_event error in
-                      Log.Spawn.error
-                        "spawn worker failed (worker_run_id=%s, agent=%s): %s"
-                        prepared.worker_run_id worker_name error;
-                      release_prepared_runtime prepared ~success:false ~error
-                        ~latency_ms:elapsed_ms ();
-                      persist_worker_run_snapshot
-                        ~worker_run_id:prepared.worker_run_id
-                        ~worker_name
-                        ~mode:"spawn" ~wait_mode
-                        ~status:`Failed
-                        ?execution_scope
-                        ?requested_worker_class:prepared.spec.worker_class
-                        ?requested_worker_size:
-                          (deps.worker_size_of_spec prepared.spec)
-                        ?resolved_runtime:prepared.assigned_runtime
-                        ~resolved_model:prepared.runtime_model_label
-                        ?routing_reason:prepared.spec.routing_reason
-                        ~tool_names:[]
-                        ~tool_call_count:0
-                        ~success:false
-                        ~output_preview
-                        ~evidence_session_id:
-                          (Worker_runtime.oas_worker_evidence_session_id
-                             ~worker_run_id:prepared.worker_run_id)
-                        ~trace_capability:"summary_only"
-                        ();
-                      append_spawn_event
-                        ~worker_run_id:prepared.worker_run_id
-                        ~spawn_agent:prepared.spec.spawn_agent
-                        ?runtime_actor:prepared.runtime_actor_name
-                        ?spawn_role:prepared.spec.spawn_role
-                        ?spawn_model:prepared.spec.spawn_model
-                        ?execution_scope
-                        ?worker_class:prepared.spec.worker_class
-                        ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                        ?worker_backend
-                        ~wait_mode:
-                          (Team_session_types.wait_mode_to_string wait_mode)
-                        ~trace_capability:"summary_only"
-                        ?parent_actor:prepared.spec.parent_actor
-                        ?capsule_mode:prepared.spec.capsule_mode
-                        ?runtime_pool:prepared.spec.runtime_pool
-                        ?lane_id:prepared.spec.lane_id
-                        ?controller_level:
-                          (deps.inferred_controller_level_of_spec prepared.spec)
-                        ?control_domain:prepared.spec.control_domain
-                        ?supervisor_actor:prepared.spec.supervisor_actor
-                        ?model_tier:prepared.spec.model_tier
-                        ?task_profile:prepared.spec.task_profile
-                        ?risk_level:prepared.spec.risk_level
-                        ?routing_confidence:prepared.spec.routing_confidence
-                        ?routing_reason:prepared.spec.routing_reason
-                        ?assigned_runtime:prepared.assigned_runtime
-                        ?spawn_selection_note:prepared.spec.spawn_selection_note
-                        ~tool_names:[]
-                        ~tool_call_count:0
-                        ~success:false
-                        ~exit_code:1
-                        ~elapsed_ms
-                        ~output_preview
-                        ~error
-                        ();
-                      (match prepared.runtime_actor_name with
-                      | Some worker_actor ->
-                          ignore
-                            (deps.reconcile_failed_spawn_actor ctx.config
-                               session_id worker_actor)
-                      | None -> ());
-                      `Assoc
-                        [
-                          ("worker_run_id", `String prepared.worker_run_id);
-                          ( "runtime_actor",
-                            Option.fold ~none:`Null
-                              ~some:(fun s -> `String s)
-                              prepared.runtime_actor_name );
-                          ( "spawn_role",
-                            Option.fold ~none:`Null
-                              ~some:(fun s -> `String s)
-                              prepared.spec.spawn_role );
-                          ( "execution_scope",
-                            Option.fold ~none:`Null
-                              ~some:(fun scope ->
-                                `String
-                                  (Team_session_types
-                                   .execution_scope_to_string scope))
-                              execution_scope );
-                          ( "thinking_enabled",
-                            Option.fold ~none:`Null
-                              ~some:(fun v -> `Bool v)
-                              prepared.spec.thinking_enabled );
-                          ( "max_turns",
-                            Option.fold ~none:`Null
-                              ~some:(fun n -> `Int n)
-                              prepared.spec.max_turns );
-                          ( "worker_class",
-                            Option.fold ~none:`Null
-                              ~some:(fun kind ->
-                                `String
-                                  (Team_session_types
-                                   .worker_class_to_string kind))
-                              prepared.spec.worker_class );
-                          ( "worker_size",
-                            Option.fold ~none:`Null
-                              ~some:(fun size ->
-                                `String
-                                  (Team_session_types
-                                   .worker_size_to_string size))
-                              (deps.worker_size_of_spec prepared.spec) );
-                          ( "worker_backend",
-                            Option.fold ~none:`Null
-                              ~some:(fun s -> `String s)
-                              worker_backend );
-                          ( "wait_mode",
-                            `String
-                              (Team_session_types.wait_mode_to_string wait_mode)
-                          );
-                          ("status", `String "failed");
-                          ("trace_capability", `String "summary_only");
-                          ( "resolved_runtime",
-                            Option.fold ~none:`Null
-                              ~some:(fun s -> `String s)
-                              prepared.assigned_runtime );
-                          ("resolved_model", `String prepared.runtime_model_label);
-                          ( "routing_reason",
-                            Option.fold ~none:`Null
-                              ~some:(fun s -> `String s)
-                              prepared.spec.routing_reason );
-                          ("tool_call_count", `Int 0);
-                          ("tool_names", `List []);
-                          ("success", `Bool false);
-                          ("error", `String error);
-                          ("exit_code", `Int 1);
-                          ("elapsed_ms", `Int elapsed_ms);
-                          ("output_preview", `String output_preview);
-                        ]
-                    in
-                    try
-                      let worker_result =
-                        Worker_runtime.run_worker ~sw:run_sw ?net:ctx.net
-                          ~base_path:ctx.config.base_path ~worker_name
-                          ~model_label:prepared.runtime_model_label
-                          ~team_session_id:(Some session_id)
-                          ~room_config:(Some ctx.config)
-                          ?worker_class:prepared.spec.worker_class
-                          ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                          ?execution_scope
-                          ?thinking_enabled:prepared.spec.thinking_enabled
-                          ~max_turns:(Option.value ~default:10 prepared.spec.max_turns)
-                          ~worker_run_id:prepared.worker_run_id
-                          ~role:prepared.spec.spawn_role
-                          ~selection_note:prepared.spec.spawn_selection_note
-                          ~prompt:prepared.spec.spawn_prompt
-                          ~allowed_tools:local_worker_tool_names
-                          ~timeout_sec:prepared.spec.spawn_timeout_seconds
-                          ?contract
-                          ()
-                      in
-                      let elapsed_ms =
-                        int_of_float
-                          ((Time_compat.now () -. start_time) *. 1000.0)
-                      in
-                      let spawn_result, run_result =
-                        match worker_result with
-                        | Ok run_result ->
-                            ( { Spawn.success = true;
-                                output = run_result.output;
-                                exit_code = 0;
-                                elapsed_ms;
-                                input_tokens = run_result.input_tokens;
-                                output_tokens = run_result.output_tokens;
-                                cache_creation_tokens = None;
-                                cache_read_tokens = None;
-                                cost_usd = run_result.cost_usd;
-                              },
-                              Some run_result )
-                        | Error e ->
-                            ( { Spawn.success = false;
-                                output = e;
-                                exit_code = 1;
-                                elapsed_ms;
-                                input_tokens = None;
-                                output_tokens = None;
-                                cache_creation_tokens = None;
-                                cache_read_tokens = None;
-                                cost_usd = None;
-                              },
-                              None )
-                      in
-                    let output_preview =
-                      deps.truncate_for_event spawn_result.output
-                    in
-                    let oas_trace_ref =
-                      Option.bind run_result
-                        (fun (result : Worker_container_types.run_result) ->
-                          result.raw_trace_run)
-                    in
-                    let oas_tool_names =
-                      Option.value ~default:[]
-                        (Option.map
-                           (fun (result : Worker_container_types.run_result) ->
-                             result.tool_names)
-                           run_result)
-                    in
-                    let oas_tool_call_count =
-                      Option.value ~default:0
-                        (Option.map
-                           (fun (result : Worker_container_types.run_result) ->
-                             result.tool_call_count)
-                           run_result)
-                    in
-                    let resolved_model =
-                      Option.value ~default:prepared.runtime_model_label
-                        (Option.map
-                           (fun (result : Worker_container_types.run_result) ->
-                             result.model_used)
-                           run_result)
-                    in
-                    let trace_summary_json, trace_validation_json =
-                      match oas_trace_ref with
-                      | Some run_ref -> (
-                          match
-                            deps.raw_trace_session_payloads
-                              ~config:ctx.config
-                              ~fallback_session_id:session_id run_ref
-                          with
-                          | Some pair -> (Some (fst pair), Some (snd pair))
-                          | None -> (None, None))
-                      | None -> (None, None)
-                    in
-                      let proof =
-                      Option.bind run_result
-                        (fun (result : Worker_container_types.run_result) ->
-                          result.proof)
-                    in
-                      let verification_outcome =
-                      match run_result with
-                      | Some run_result ->
-                          let goal =
-                            match
-                              Team_session_store.load_session ctx.config
-                                session_id
-                            with
-                            | Some session -> session.goal
-                            | None -> prepared.spec.spawn_prompt
-                          in
-                          Some
-                            (Worker_verification.verify_worker_result
-                               ?delivery_contract
-                               ~goal run_result)
-                      | None -> None
-                      in
-                      let trace_capability =
-                        if Option.is_some oas_trace_ref then "raw"
-                        else "summary_only"
-                      in
-                     Option.iter
-                       (Tool_team_session_step_exec
-                        .record_delivery_verdict_for_worker_run
-                          ~config:ctx.config ~session_id
-                          ~worker_run_id:prepared.worker_run_id)
-                       verification_outcome;
-                     let delivery_verdict_json =
-                       Tool_team_session_step_exec
-                       .latest_delivery_verdict_json_for_session ctx.config
-                         session_id
-                     in
-                     (match spawn_result.success with
-                     | true ->
-                         release_prepared_runtime prepared
-                           ~success:true
-                           ~latency_ms:spawn_result.elapsed_ms ()
-                     | false ->
-                         release_prepared_runtime prepared
-                           ~success:false
-                           ~error:spawn_result.output
-                           ~latency_ms:spawn_result.elapsed_ms ());
-                     persist_worker_run_snapshot
-                       ~worker_run_id:prepared.worker_run_id
-                       ~worker_name
-                       ~mode:"spawn" ~wait_mode
-                       ~status:
-                         (if spawn_result.success then `Completed else `Failed)
-                       ?execution_scope
-                       ?requested_worker_class:prepared.spec.worker_class
-                       ?requested_worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?resolved_runtime:prepared.assigned_runtime
-                       ~resolved_model
-                       ?routing_reason:prepared.spec.routing_reason
-                       ~tool_names:oas_tool_names
-                       ~tool_call_count:oas_tool_call_count
-                       ~success:spawn_result.success
-                       ~output_preview
-                       ~evidence_session_id:
-                         (Worker_runtime
-                          .oas_worker_evidence_session_id
-                            ~worker_run_id:
-                              prepared.worker_run_id)
-                       ?trace_ref:oas_trace_ref
-                       ?trace_summary:trace_summary_json
-                       ?trace_validation:trace_validation_json
-                       ?proof
-                        ~trace_capability
-                       ();
-                     append_spawn_event
-                       ~worker_run_id:prepared.worker_run_id
-                       ~spawn_agent:prepared.spec.spawn_agent
-                       ?runtime_actor:prepared.runtime_actor_name
-                       ?spawn_role:prepared.spec.spawn_role
-                       ?spawn_model:prepared.spec.spawn_model
-                       ?execution_scope
-                       ?worker_class:prepared.spec.worker_class
-                       ?worker_size:(deps.worker_size_of_spec prepared.spec)
-                       ?worker_backend
-                       ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
-                       ~trace_capability
-                       ?parent_actor:prepared.spec.parent_actor
-                       ?capsule_mode:prepared.spec.capsule_mode
-                       ?runtime_pool:prepared.spec.runtime_pool
-                       ?lane_id:prepared.spec.lane_id
-                       ?controller_level:(deps.inferred_controller_level_of_spec prepared.spec)
-                       ?control_domain:prepared.spec.control_domain
-                       ?supervisor_actor:prepared.spec.supervisor_actor
-                       ?model_tier:prepared.spec.model_tier
-                       ?task_profile:prepared.spec.task_profile
-                       ?risk_level:prepared.spec.risk_level
-                       ?routing_confidence:prepared.spec.routing_confidence
-                       ?routing_reason:prepared.spec.routing_reason
-                       ?assigned_runtime:prepared.assigned_runtime
-                       ?spawn_selection_note:
-                         prepared.spec.spawn_selection_note
-                       ~tool_names:oas_tool_names
-                       ~tool_call_count:oas_tool_call_count
-                       ~success:spawn_result.success
-                       ~exit_code:spawn_result.exit_code
-                       ~elapsed_ms:spawn_result.elapsed_ms
-                       ~output_preview ();
-                     (match
-                        ( spawn_result.success,
-                          prepared.runtime_actor_name,
-                          deps.auto_note_message_of_spawn_output
-                            spawn_result.output )
-                      with
-                     | true, Some worker_actor, Some auto_note
-                       when not
-                              (deps.session_has_turn_for_actor
-                                 ctx.config session_id worker_actor) ->
-                         ignore
-                           (deps.record_session_turn_json
-                              ~config:ctx.config ~session_id
-                              ~actor:worker_actor
-                              ~turn_kind:Team_session_types.Turn_note
-                              ~message:(Some auto_note)
-                              ~target_agent:None
-                              ~task_title:None
-                              ~task_description:None
-                              ~task_priority:3)
-                     | _ -> ());
-                     (* Record finding for successful spawns so
-                        subsequent workers see prior results *)
-                     (if spawn_result.success
-                         && String.length spawn_result.output > 0
-                      then
-                        let finding_preview =
-                          let len =
-                            String.length spawn_result.output
-                          in
-                          if len <= 200 then spawn_result.output
-                          else
-                            String.sub spawn_result.output 0 200
-                        in
-                        let worker_name =
-                          Option.value
-                            ~default:
-                              (Printf.sprintf "spawn-%d" index)
-                            prepared.runtime_actor_name
-                        in
-                        Team_context.add_finding
-                          ~base_path:
-                            ctx.config.Room_utils.base_path
-                          ~team_session_id:session_id
-                          ~worker_name ~finding:finding_preview);
-                     (match (spawn_result.success, prepared.runtime_actor_name) with
-                     | false, Some worker_actor ->
-                         ignore
-                           (deps.reconcile_failed_spawn_actor
-                              ctx.config session_id worker_actor)
-                     | _ -> ());
-                     `Assoc
-                       [
-                         ("worker_run_id", `String prepared.worker_run_id);
-                         ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
-                         ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
-                         ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) (deps.effective_execution_scope_of_spec prepared.spec));
-                         ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) prepared.spec.thinking_enabled);
-                         ("max_turns", Option.fold ~none:`Null ~some:(fun n -> `Int n) prepared.spec.max_turns);
-                         ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
-                         ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (deps.worker_size_of_spec prepared.spec));
-                         ("worker_backend", if deps.is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
-                         ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
-                         ("status", `String "completed");
-                         ("trace_capability", `String (if Option.is_some oas_trace_ref then "raw" else "summary_only"));
-                         ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.assigned_runtime);
-                         ("resolved_model", `String resolved_model);
-                         ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.routing_reason);
-                         ("tool_call_count", `Int oas_tool_call_count);
-                         ("tool_names", `List (List.map (fun name -> `String name) oas_tool_names));
-                         ("success", `Bool spawn_result.success);
-                         ("elapsed_ms", `Int spawn_result.elapsed_ms);
-                         ("output_preview", `String output_preview);
-                         ("delivery_verdict", Option.value ~default:`Null delivery_verdict_json);
-                       ]
+              (let prepared_spawns_for_actors =
+                 List.map (fun (execution : prepared_execution) -> execution.prepared)
+                   prepared_executions
+               in
+                   let docker_specs =
+                     prepared_executions
+                     |> List.filter_map (fun (execution : prepared_execution) ->
+                            match execution.worker_backend with
+                            | Worker_execution_backend.Local -> None
+                            | Worker_execution_backend.Docker ->
+                                let prepared = execution.prepared in
+                                let worker_name =
+                                  Option.value
+                                    ~default:
+                                      (Printf.sprintf "spawn-%d-%s" 0
+                                         prepared.worker_run_id)
+                                    prepared.runtime_actor_name
+                                in
+                                Some
+                                  (Worker_runtime.build_execution_spec
+                                     ~base_path:ctx.config.base_path
+                                     ~worker_name
+                                     ~model_label:prepared.runtime_model_label
+                                     ~team_session_id:(Some session_id)
+                                     ?worker_class:prepared.spec.worker_class
+                                     ?worker_size:
+                                       (deps.worker_size_of_spec prepared.spec)
+                                     ~execution_scope:
+                                       execution.execution_scope
+                                     ?thinking_enabled:
+                                       prepared.spec.thinking_enabled
+                                     ?allowed_shell_tools:
+                                       (Some execution.local_shell_tool_names)
+                                     ~max_turns:
+                                       (Option.value ~default:10
+                                          prepared.spec.max_turns)
+                                     ~worker_run_id:prepared.worker_run_id
+                                     ?delivery_contract:
+                                       execution.delivery_contract
+                                     ~role:prepared.spec.spawn_role
+                                     ~selection_note:
+                                       prepared.spec.spawn_selection_note
+                                     ~prompt:prepared.spec.spawn_prompt
+                                     ~allowed_tools:
+                                       execution.local_worker_tool_names
+                                     ~timeout_sec:
+                                       prepared.spec.spawn_timeout_seconds
+                                     ()))
+                   in
+                   (match
+                      Worker_runtime.preflight_spawn_batch
+                        ?clock_opt:(Some ctx.clock) docker_specs
                     with
-                    | Eio.Cancel.Cancelled _ as exn -> raise exn
-                    | exn ->
-                        let elapsed_ms =
-                          int_of_float
-                            ((Time_compat.now () -. start_time) *. 1000.0)
-                        in
-                        unexpected_failure ~elapsed_ms
-                          (Printexc.to_string exn)
-                  in
-                   (match wait_mode with
-                   | Team_session_types.Wait_background ->
-                       let sw_bg =
-                         Option.value ~default:ctx.sw
-                           (Eio_context.get_switch_opt ())
-                       in
-                       List.iteri
-                         (fun index prepared ->
-                           append_spawn_requested_event
+                   | Error msg ->
+                       fail_all_prepared_executions prepared_executions
+                         ~error:msg;
+                       Some (`Assoc [ ("error", `String msg) ])
+                   | Ok () ->
+                       (match ensure_all prepared_spawns_for_actors with
+                       | Error msg ->
+                           fail_all_prepared prepared_spawns ~error:msg;
+                           Some (`Assoc [ ("error", `String msg) ])
+                       | Ok () ->
+                       let execute_spawn ~run_sw index
+                           (execution : prepared_execution) =
+                         let prepared = execution.prepared in
+                         let start_time = Time_compat.now () in
+                         let worker_name =
+                           Option.value
+                             ~default:
+                               (Printf.sprintf "spawn-%d-%s" index
+                                  prepared.worker_run_id)
+                             prepared.runtime_actor_name
+                         in
+                         let execution_scope = Some execution.execution_scope in
+                         let delivery_contract = execution.delivery_contract in
+                         let worker_backend =
+                           Some
+                             (Worker_execution_backend.to_string
+                                execution.worker_backend)
+                         in
+                         let unexpected_failure ~elapsed_ms error =
+                           let output_preview = deps.truncate_for_event error in
+                           Log.Spawn.error
+                             "spawn worker failed (worker_run_id=%s, agent=%s): %s"
+                             prepared.worker_run_id worker_name error;
+                           release_prepared_runtime prepared ~success:false
+                             ~error ~latency_ms:elapsed_ms ();
+                           persist_worker_run_snapshot
                              ~worker_run_id:prepared.worker_run_id
-                             prepared;
-                           Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                             ignore (execute_spawn ~run_sw:sw_bg index prepared)))
-                         prepared_spawns;
-                       let accepted =
-                         prepared_spawns
-                         |> List.map (fun prepared ->
-                                `Assoc
-                                  [
-                                    ("worker_run_id", `String prepared.worker_run_id);
-                                    ("status", `String "accepted");
-                                    ("wait_mode", `String "background");
-                                    ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
-                                    ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
-                                    ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
-                                    ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (deps.worker_size_of_spec prepared.spec));
-                                    ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.assigned_runtime);
-                                    ("resolved_model", `String prepared.runtime_model_label);
-                                    ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.routing_reason);
-                                    ("ready", `Bool false);
-                                  ])
+                             ~worker_name ~mode:"spawn" ~wait_mode
+                             ~status:`Failed ?execution_scope
+                             ?requested_worker_class:
+                               prepared.spec.worker_class
+                             ?requested_worker_size:
+                               (deps.worker_size_of_spec prepared.spec)
+                             ?resolved_runtime:prepared.assigned_runtime
+                             ~resolved_model:prepared.runtime_model_label
+                             ?routing_reason:prepared.spec.routing_reason
+                             ~tool_names:[] ~tool_call_count:0
+                             ~success:false ~output_preview
+                             ~evidence_session_id:
+                               (Worker_runtime
+                                .oas_worker_evidence_session_id
+                                  ~worker_run_id:prepared.worker_run_id)
+                             ~trace_capability:"summary_only" ();
+                           append_spawn_event
+                             ~worker_run_id:prepared.worker_run_id
+                             ~spawn_agent:prepared.spec.spawn_agent
+                             ?runtime_actor:prepared.runtime_actor_name
+                             ?spawn_role:prepared.spec.spawn_role
+                             ?spawn_model:prepared.spec.spawn_model
+                             ?execution_scope
+                             ?worker_class:prepared.spec.worker_class
+                             ?worker_size:
+                               (deps.worker_size_of_spec prepared.spec)
+                             ?worker_backend
+                             ~wait_mode:
+                               (Team_session_types.wait_mode_to_string
+                                  wait_mode)
+                             ~trace_capability:"summary_only"
+                             ?parent_actor:prepared.spec.parent_actor
+                             ?capsule_mode:prepared.spec.capsule_mode
+                             ?runtime_pool:prepared.spec.runtime_pool
+                             ?lane_id:prepared.spec.lane_id
+                             ?controller_level:
+                               (deps.inferred_controller_level_of_spec
+                                  prepared.spec)
+                             ?control_domain:prepared.spec.control_domain
+                             ?supervisor_actor:
+                               prepared.spec.supervisor_actor
+                             ?model_tier:prepared.spec.model_tier
+                             ?task_profile:prepared.spec.task_profile
+                             ?risk_level:prepared.spec.risk_level
+                             ?routing_confidence:
+                               prepared.spec.routing_confidence
+                             ?routing_reason:prepared.spec.routing_reason
+                             ?assigned_runtime:prepared.assigned_runtime
+                             ?spawn_selection_note:
+                               prepared.spec.spawn_selection_note
+                             ~tool_names:[] ~tool_call_count:0
+                             ~success:false ~exit_code:1 ~elapsed_ms
+                             ~output_preview ~error ();
+                           (match prepared.runtime_actor_name with
+                           | Some worker_actor ->
+                               ignore
+                                 (deps.reconcile_failed_spawn_actor
+                                    ctx.config session_id worker_actor)
+                           | None -> ());
+                           `Assoc
+                             [
+                               ( "worker_run_id",
+                                 `String prepared.worker_run_id );
+                               ( "runtime_actor",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.runtime_actor_name );
+                               ( "spawn_role",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.spec.spawn_role );
+                               ( "execution_scope",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun scope ->
+                                     `String
+                                       (Team_session_types
+                                        .execution_scope_to_string scope))
+                                   execution_scope );
+                               ( "thinking_enabled",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun v -> `Bool v)
+                                   prepared.spec.thinking_enabled );
+                               ( "max_turns",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun n -> `Int n)
+                                   prepared.spec.max_turns );
+                               ( "worker_class",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun kind ->
+                                     `String
+                                       (Team_session_types
+                                        .worker_class_to_string kind))
+                                   prepared.spec.worker_class );
+                               ( "worker_size",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun size ->
+                                     `String
+                                       (Team_session_types
+                                        .worker_size_to_string size))
+                                   (deps.worker_size_of_spec prepared.spec) );
+                               ( "worker_backend",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   worker_backend );
+                               ( "wait_mode",
+                                 `String
+                                   (Team_session_types.wait_mode_to_string
+                                      wait_mode) );
+                               ("status", `String "failed");
+                               ("trace_capability", `String "summary_only");
+                               ( "resolved_runtime",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.assigned_runtime );
+                               ( "resolved_model",
+                                 `String prepared.runtime_model_label );
+                               ( "routing_reason",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.spec.routing_reason );
+                               ("tool_call_count", `Int 0);
+                               ("tool_names", `List []);
+                               ("success", `Bool false);
+                               ("error", `String error);
+                               ("exit_code", `Int 1);
+                               ("elapsed_ms", `Int elapsed_ms);
+                               ("output_preview", `String output_preview);
+                             ]
+                         in
+                         try
+                           let worker_result =
+                             Worker_runtime.run_worker ~sw:run_sw ?net:ctx.net
+                               ~backend:execution.worker_backend
+                               ~base_path:ctx.config.base_path ~worker_name
+                               ~model_label:prepared.runtime_model_label
+                               ~team_session_id:(Some session_id)
+                               ~room_config:(Some ctx.config)
+                               ?worker_class:prepared.spec.worker_class
+                               ?worker_size:
+                                 (deps.worker_size_of_spec prepared.spec)
+                               ?execution_scope
+                               ?thinking_enabled:
+                                 prepared.spec.thinking_enabled
+                               ?allowed_shell_tools:
+                                 (Some execution.local_shell_tool_names)
+                               ~max_turns:
+                                 (Option.value ~default:10
+                                    prepared.spec.max_turns)
+                               ~worker_run_id:prepared.worker_run_id
+                               ?delivery_contract ~role:prepared.spec.spawn_role
+                               ~selection_note:
+                                 prepared.spec.spawn_selection_note
+                               ~prompt:prepared.spec.spawn_prompt
+                               ~allowed_tools:
+                                 execution.local_worker_tool_names
+                               ~timeout_sec:
+                                 prepared.spec.spawn_timeout_seconds
+                               ()
+                           in
+                           let elapsed_ms =
+                             int_of_float
+                               ((Time_compat.now () -. start_time) *. 1000.0)
+                           in
+                           let spawn_result, run_result =
+                             match worker_result with
+                             | Ok run_result ->
+                                 ( {
+                                     Spawn.success = true;
+                                     output = run_result.output;
+                                     exit_code = 0;
+                                     elapsed_ms;
+                                     input_tokens = run_result.input_tokens;
+                                     output_tokens = run_result.output_tokens;
+                                     cache_creation_tokens = None;
+                                     cache_read_tokens = None;
+                                     cost_usd = run_result.cost_usd;
+                                   },
+                                   Some run_result )
+                             | Error e ->
+                                 ( {
+                                     Spawn.success = false;
+                                     output = e;
+                                     exit_code = 1;
+                                     elapsed_ms;
+                                     input_tokens = None;
+                                     output_tokens = None;
+                                     cache_creation_tokens = None;
+                                     cache_read_tokens = None;
+                                     cost_usd = None;
+                                   },
+                                   None )
+                           in
+                           let output_preview =
+                             deps.truncate_for_event spawn_result.output
+                           in
+                           let oas_trace_ref =
+                             Option.bind run_result
+                               (fun
+                                    (result :
+                                      Worker_container_types.run_result) ->
+                                 result.raw_trace_run)
+                           in
+                           let oas_tool_names =
+                             Option.value ~default:[]
+                               (Option.map
+                                  (fun
+                                       (result :
+                                         Worker_container_types.run_result)
+                                     -> result.tool_names)
+                                  run_result)
+                           in
+                           let oas_tool_call_count =
+                             Option.value ~default:0
+                               (Option.map
+                                  (fun
+                                       (result :
+                                         Worker_container_types.run_result)
+                                     -> result.tool_call_count)
+                                  run_result)
+                           in
+                           let resolved_model =
+                             Option.value
+                               ~default:prepared.runtime_model_label
+                               (Option.map
+                                  (fun
+                                       (result :
+                                         Worker_container_types.run_result)
+                                     -> result.model_used)
+                                  run_result)
+                           in
+                           let trace_summary_json, trace_validation_json =
+                             match oas_trace_ref with
+                             | Some run_ref -> (
+                                 match
+                                   deps.raw_trace_session_payloads
+                                     ~config:ctx.config
+                                     ~fallback_session_id:session_id
+                                     run_ref
+                                 with
+                                 | Some pair ->
+                                     (Some (fst pair), Some (snd pair))
+                                 | None -> (None, None))
+                             | None -> (None, None)
+                           in
+                           let proof =
+                             Option.bind run_result
+                               (fun
+                                    (result :
+                                      Worker_container_types.run_result) ->
+                                 result.proof)
+                           in
+                           let verification_outcome =
+                             match run_result with
+                             | Some run_result ->
+                                 let goal =
+                                   match
+                                     Team_session_store.load_session
+                                       ctx.config session_id
+                                   with
+                                   | Some session -> session.goal
+                                   | None -> prepared.spec.spawn_prompt
+                                 in
+                                 Some
+                                   (Worker_verification.verify_worker_result
+                                      ?delivery_contract ~goal run_result)
+                             | None -> None
+                           in
+                           let trace_capability =
+                             if Option.is_some oas_trace_ref then "raw"
+                             else "summary_only"
+                           in
+                           Option.iter
+                             (Tool_team_session_step_exec
+                              .record_delivery_verdict_for_worker_run
+                                ~config:ctx.config ~session_id
+                                ~worker_run_id:prepared.worker_run_id)
+                             verification_outcome;
+                           let delivery_verdict_json =
+                             Tool_team_session_step_exec
+                             .latest_delivery_verdict_json_for_session
+                               ctx.config session_id
+                           in
+                           (match spawn_result.success with
+                           | true ->
+                               release_prepared_runtime prepared
+                                 ~success:true
+                                 ~latency_ms:spawn_result.elapsed_ms ()
+                           | false ->
+                               release_prepared_runtime prepared
+                                 ~success:false
+                                 ~error:spawn_result.output
+                                 ~latency_ms:spawn_result.elapsed_ms ());
+                           persist_worker_run_snapshot
+                             ~worker_run_id:prepared.worker_run_id
+                             ~worker_name ~mode:"spawn" ~wait_mode
+                             ~status:
+                               (if spawn_result.success then `Completed
+                                else `Failed)
+                             ?execution_scope
+                             ?requested_worker_class:
+                               prepared.spec.worker_class
+                             ?requested_worker_size:
+                               (deps.worker_size_of_spec prepared.spec)
+                             ?resolved_runtime:prepared.assigned_runtime
+                             ~resolved_model
+                             ?routing_reason:prepared.spec.routing_reason
+                             ~tool_names:oas_tool_names
+                             ~tool_call_count:oas_tool_call_count
+                             ~success:spawn_result.success
+                             ~output_preview
+                             ~evidence_session_id:
+                               (Worker_runtime
+                                .oas_worker_evidence_session_id
+                                  ~worker_run_id:prepared.worker_run_id)
+                             ?trace_ref:oas_trace_ref
+                             ?trace_summary:trace_summary_json
+                             ?trace_validation:trace_validation_json ?proof
+                             ~trace_capability ();
+                           append_spawn_event
+                             ~worker_run_id:prepared.worker_run_id
+                             ~spawn_agent:prepared.spec.spawn_agent
+                             ?runtime_actor:prepared.runtime_actor_name
+                             ?spawn_role:prepared.spec.spawn_role
+                             ?spawn_model:prepared.spec.spawn_model
+                             ?execution_scope
+                             ?worker_class:prepared.spec.worker_class
+                             ?worker_size:
+                               (deps.worker_size_of_spec prepared.spec)
+                             ?worker_backend
+                             ~wait_mode:
+                               (Team_session_types.wait_mode_to_string
+                                  wait_mode)
+                             ~trace_capability
+                             ?parent_actor:prepared.spec.parent_actor
+                             ?capsule_mode:prepared.spec.capsule_mode
+                             ?runtime_pool:prepared.spec.runtime_pool
+                             ?lane_id:prepared.spec.lane_id
+                             ?controller_level:
+                               (deps.inferred_controller_level_of_spec
+                                  prepared.spec)
+                             ?control_domain:prepared.spec.control_domain
+                             ?supervisor_actor:
+                               prepared.spec.supervisor_actor
+                             ?model_tier:prepared.spec.model_tier
+                             ?task_profile:prepared.spec.task_profile
+                             ?risk_level:prepared.spec.risk_level
+                             ?routing_confidence:
+                               prepared.spec.routing_confidence
+                             ?routing_reason:prepared.spec.routing_reason
+                             ?assigned_runtime:prepared.assigned_runtime
+                             ?spawn_selection_note:
+                               prepared.spec.spawn_selection_note
+                             ~tool_names:oas_tool_names
+                             ~tool_call_count:oas_tool_call_count
+                             ~success:spawn_result.success
+                             ~exit_code:spawn_result.exit_code
+                             ~elapsed_ms:spawn_result.elapsed_ms
+                             ~output_preview ();
+                           (match
+                              ( spawn_result.success,
+                                prepared.runtime_actor_name,
+                                deps.auto_note_message_of_spawn_output
+                                  spawn_result.output )
+                            with
+                           | true, Some worker_actor, Some auto_note
+                             when
+                               not
+                                 (deps.session_has_turn_for_actor
+                                    ctx.config session_id worker_actor) ->
+                               ignore
+                                 (deps.record_session_turn_json
+                                    ~config:ctx.config ~session_id
+                                    ~actor:worker_actor
+                                    ~turn_kind:
+                                      Team_session_types.Turn_note
+                                    ~message:(Some auto_note)
+                                    ~target_agent:None ~task_title:None
+                                    ~task_description:None
+                                    ~task_priority:3)
+                           | _ -> ());
+                           if spawn_result.success
+                              && String.length spawn_result.output > 0
+                           then (
+                             let finding_preview =
+                               let len = String.length spawn_result.output in
+                               if len <= 200 then spawn_result.output
+                               else String.sub spawn_result.output 0 200
+                             in
+                             let worker_name =
+                               Option.value
+                                 ~default:(Printf.sprintf "spawn-%d" index)
+                                 prepared.runtime_actor_name
+                             in
+                             Team_context.add_finding
+                               ~base_path:ctx.config.Room_utils.base_path
+                               ~team_session_id:session_id ~worker_name
+                               ~finding:finding_preview)
+                           else ();
+                           (match
+                              (spawn_result.success, prepared.runtime_actor_name)
+                            with
+                           | false, Some worker_actor ->
+                               ignore
+                                 (deps.reconcile_failed_spawn_actor
+                                    ctx.config session_id worker_actor)
+                           | _ -> ());
+                           `Assoc
+                             [
+                               ( "worker_run_id",
+                                 `String prepared.worker_run_id );
+                               ( "runtime_actor",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.runtime_actor_name );
+                               ( "spawn_role",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.spec.spawn_role );
+                               ( "execution_scope",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun scope ->
+                                     `String
+                                       (Team_session_types
+                                        .execution_scope_to_string scope))
+                                   execution_scope );
+                               ( "thinking_enabled",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun v -> `Bool v)
+                                   prepared.spec.thinking_enabled );
+                               ( "max_turns",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun n -> `Int n)
+                                   prepared.spec.max_turns );
+                               ( "worker_class",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun kind ->
+                                     `String
+                                       (Team_session_types
+                                        .worker_class_to_string kind))
+                                   prepared.spec.worker_class );
+                               ( "worker_size",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun size ->
+                                     `String
+                                       (Team_session_types
+                                        .worker_size_to_string size))
+                                   (deps.worker_size_of_spec prepared.spec) );
+                               ( "worker_backend",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   worker_backend );
+                               ( "wait_mode",
+                                 `String
+                                   (Team_session_types.wait_mode_to_string
+                                      wait_mode) );
+                               ("status", `String "completed");
+                               ("trace_capability", `String trace_capability);
+                               ( "resolved_runtime",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.assigned_runtime );
+                               ("resolved_model", `String resolved_model);
+                               ( "routing_reason",
+                                 Option.fold ~none:`Null
+                                   ~some:(fun s -> `String s)
+                                   prepared.spec.routing_reason );
+                               ("tool_call_count", `Int oas_tool_call_count);
+                               ( "tool_names",
+                                 `List
+                                   (List.map
+                                      (fun name -> `String name)
+                                      oas_tool_names) );
+                               ("success", `Bool spawn_result.success);
+                               ("elapsed_ms", `Int spawn_result.elapsed_ms);
+                               ("output_preview", `String output_preview);
+                               ( "delivery_verdict",
+                                 Option.value ~default:`Null
+                                   delivery_verdict_json );
+                             ]
+                         with
+                         | Eio.Cancel.Cancelled _ as exn -> raise exn
+                         | exn ->
+                             let elapsed_ms =
+                               int_of_float
+                                 ((Time_compat.now () -. start_time)
+                                 *. 1000.0)
+                             in
+                             unexpected_failure ~elapsed_ms
+                               (Printexc.to_string exn)
                        in
-                       Some
-                         (match accepted with
-                          | [single] -> single
-                          | _ ->
-                            `Assoc
-                              [
-                                ("mode", `String "batch");
-                                ("count", `Int (List.length accepted));
-                                ("results", `List accepted);
-                              ])
-                   | Team_session_types.Wait_blocking ->
-                      let results =
-                        Array.make (List.length prepared_spawns) None
-                      in
-                      Eio.Fiber.all
-                         (List.mapi
-                            (fun index prepared () ->
-                              results.(index) <- Some (execute_spawn ~run_sw:ctx.sw index prepared))
-                            prepared_spawns);
-                       let spawn_results =
-                         results |> Array.to_list
-                         |> List.filter_map (fun item -> item)
-                       in
-                       Some
-                         (match spawn_results with
-                          | [single] -> single
-                          | _ ->
-                            `Assoc
-                              [
-                                ("mode", `String "batch");
-                                ("count", `Int (List.length spawn_results));
-                                ("results", `List spawn_results);
-                              ]))))
+                       match wait_mode with
+                       | Team_session_types.Wait_background ->
+                           let sw_bg =
+                             Option.value ~default:ctx.sw
+                               (Eio_context.get_switch_opt ())
+                           in
+                           List.iteri
+                             (fun index (execution : prepared_execution) ->
+                               let prepared = execution.prepared in
+                               append_spawn_requested_event_with_backend
+                                 ~worker_run_id:prepared.worker_run_id
+                                 prepared
+                                 ~worker_backend:
+                                   (Some execution.worker_backend);
+                               Eio.Fiber.fork ~sw:sw_bg (fun () ->
+                                   ignore
+                                     (execute_spawn ~run_sw:sw_bg index
+                                        execution)))
+                             prepared_executions;
+                           let accepted =
+                             prepared_executions
+                             |> List.map
+                                  (fun (execution : prepared_execution) ->
+                                    let prepared = execution.prepared in
+                                    `Assoc
+                                      [
+                                        ( "worker_run_id",
+                                          `String prepared.worker_run_id );
+                                        ("status", `String "accepted");
+                                        ("wait_mode", `String "background");
+                                        ( "runtime_actor",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun s -> `String s)
+                                            prepared.runtime_actor_name );
+                                        ( "spawn_role",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun s -> `String s)
+                                            prepared.spec.spawn_role );
+                                        ( "worker_class",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun kind ->
+                                              `String
+                                                (Team_session_types
+                                                 .worker_class_to_string
+                                                   kind))
+                                            prepared.spec.worker_class );
+                                        ( "worker_size",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun size ->
+                                              `String
+                                                (Team_session_types
+                                                 .worker_size_to_string size))
+                                            (deps.worker_size_of_spec
+                                               prepared.spec) );
+                                        ( "worker_backend",
+                                          `String
+                                            (Worker_execution_backend
+                                             .to_string
+                                               execution.worker_backend) );
+                                        ( "resolved_runtime",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun s -> `String s)
+                                            prepared.assigned_runtime );
+                                        ( "resolved_model",
+                                          `String
+                                            prepared.runtime_model_label );
+                                        ( "routing_reason",
+                                          Option.fold ~none:`Null
+                                            ~some:(fun s -> `String s)
+                                            prepared.spec.routing_reason );
+                                        ("ready", `Bool false);
+                                      ])
+                           in
+                           Some
+                             (match accepted with
+                             | [ single ] -> single
+                             | _ ->
+                                 `Assoc
+                                   [
+                                     ("mode", `String "batch");
+                                     ( "count",
+                                       `Int (List.length accepted) );
+                                     ("results", `List accepted);
+                                   ])
+                       | Team_session_types.Wait_blocking ->
+                           let results =
+                             Array.make (List.length prepared_executions) None
+                           in
+                           Eio.Fiber.all
+                             (List.mapi
+                                (fun index execution () ->
+                                  results.(index) <-
+                                    Some
+                                      (execute_spawn ~run_sw:ctx.sw index
+                                         execution))
+                                prepared_executions);
+                           let spawn_results =
+                             results |> Array.to_list
+                             |> List.filter_map (fun item -> item)
+                           in
+                           Some
+                             (match spawn_results with
+                             | [ single ] -> single
+                             | _ ->
+                                 `Assoc
+                                   [
+                                     ("mode", `String "batch");
+                                     ( "count",
+                                       `Int (List.length spawn_results) );
+                                     ("results", `List spawn_results);
+                                   ])))))

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -49,6 +49,15 @@ type prepared_spawn = {
   mutable lease_released : bool;
 }
 
+type prepared_execution = {
+  prepared : prepared_spawn;
+  execution_scope : Team_session_types.execution_scope;
+  local_worker_tool_names : string list;
+  local_shell_tool_names : string list;
+  delivery_contract : Team_session_types.delivery_contract option;
+  worker_backend : Worker_execution_backend.t;
+}
+
 (** OAS worker evidence payload for trace integration. *)
 type oas_worker_evidence = {
   trace_ref : Oas.Raw_trace.run_ref option;
@@ -146,4 +155,3 @@ type step_deps = {
     Oas.Raw_trace.run_ref ->
     (Yojson.Safe.t * Yojson.Safe.t) option;
 }
-

--- a/lib/worker_execution_backend.ml
+++ b/lib/worker_execution_backend.ml
@@ -1,0 +1,25 @@
+type t =
+  | Local
+  | Docker
+
+let to_string = function
+  | Local -> "local"
+  | Docker -> "docker"
+
+let of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "local" -> Some Local
+  | "docker" -> Some Docker
+  | _ -> None
+
+let to_yojson backend =
+  `String (to_string backend)
+
+let of_yojson = function
+  | `String value -> (
+      match of_string value with
+      | Some backend -> Ok backend
+      | None ->
+          Error
+            (Printf.sprintf "unknown worker execution backend: %s" value))
+  | _ -> Error "worker execution backend must be a string"

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -1,0 +1,153 @@
+module Oas = Agent_sdk
+
+type t = {
+  base_path : string;
+  worker_name : string;
+  model_label : string;
+  team_session_id : string option;
+  working_dir : string option;
+  worker_class : Team_session_types.worker_class option;
+  worker_size : Team_session_types.worker_size option;
+  execution_scope : Team_session_types.execution_scope option;
+  thinking_enabled : bool option;
+  max_turns : int;
+  worker_run_id : string option;
+  role : string option;
+  selection_note : string option;
+  prompt : string;
+  allowed_tools : string list;
+  allowed_shell_tools : string list;
+  timeout_sec : int;
+  delivery_contract : Team_session_types.delivery_contract option;
+}
+
+let option_to_yojson to_json = function
+  | Some value -> to_json value
+  | None -> `Null
+
+let option_string json =
+  match json with
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | `Null -> None
+  | _ -> None
+
+let string_list_of_yojson = function
+  | `List values ->
+      values
+      |> List.filter_map (function
+           | `String value ->
+               let trimmed = String.trim value in
+               if trimmed = "" then None else Some trimmed
+           | _ -> None)
+  | _ -> []
+
+let execution_scope_to_yojson = function
+  | Some scope ->
+      `String (Team_session_types.execution_scope_to_string scope)
+  | None -> `Null
+
+let execution_scope_of_yojson = function
+  | `String value ->
+      Some
+        (Team_session_types.execution_scope_of_string
+           (String.lowercase_ascii (String.trim value)))
+  | `Null -> None
+  | _ -> None
+
+let worker_class_to_yojson = function
+  | Some worker_class ->
+      `String (Team_session_types.worker_class_to_string worker_class)
+  | None -> `Null
+
+let worker_class_of_yojson = function
+  | `String value ->
+      Team_session_types.worker_class_of_string
+        (String.lowercase_ascii (String.trim value))
+  | `Null -> None
+  | _ -> None
+
+let worker_size_to_yojson = function
+  | Some worker_size ->
+      `String (Team_session_types.worker_size_to_string worker_size)
+  | None -> `Null
+
+let worker_size_of_yojson = function
+  | `String value ->
+      Team_session_types.worker_size_of_string
+        (String.lowercase_ascii (String.trim value))
+  | `Null -> None
+  | _ -> None
+
+let to_yojson (spec : t) =
+  `Assoc
+    [
+      ("base_path", `String spec.base_path);
+      ("worker_name", `String spec.worker_name);
+      ("model_label", `String spec.model_label);
+      ("team_session_id", option_to_yojson (fun s -> `String s) spec.team_session_id);
+      ("working_dir", option_to_yojson (fun s -> `String s) spec.working_dir);
+      ("worker_class", worker_class_to_yojson spec.worker_class);
+      ("worker_size", worker_size_to_yojson spec.worker_size);
+      ("execution_scope", execution_scope_to_yojson spec.execution_scope);
+      ("thinking_enabled", option_to_yojson (fun v -> `Bool v) spec.thinking_enabled);
+      ("max_turns", `Int spec.max_turns);
+      ("worker_run_id", option_to_yojson (fun s -> `String s) spec.worker_run_id);
+      ("role", option_to_yojson (fun s -> `String s) spec.role);
+      ("selection_note", option_to_yojson (fun s -> `String s) spec.selection_note);
+      ("prompt", `String spec.prompt);
+      ("allowed_tools", `List (List.map (fun value -> `String value) spec.allowed_tools));
+      ( "allowed_shell_tools",
+        `List
+          (List.map (fun value -> `String value) spec.allowed_shell_tools) );
+      ("timeout_sec", `Int spec.timeout_sec);
+      ( "delivery_contract",
+        option_to_yojson Team_session_types.delivery_contract_to_yojson
+          spec.delivery_contract );
+    ]
+
+let of_yojson (json : Yojson.Safe.t) =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Assoc _ ->
+      let base_path = json |> member "base_path" |> to_string in
+      let worker_name = json |> member "worker_name" |> to_string in
+      let model_label = json |> member "model_label" |> to_string in
+      let prompt = json |> member "prompt" |> to_string in
+      let max_turns = json |> member "max_turns" |> to_int in
+      let timeout_sec = json |> member "timeout_sec" |> to_int in
+      let delivery_contract =
+        match json |> member "delivery_contract" with
+        | `Null -> None
+        | contract_json ->
+            Team_session_types.delivery_contract_of_yojson contract_json
+      in
+      Ok
+        {
+          base_path;
+          worker_name;
+          model_label;
+          team_session_id = option_string (json |> member "team_session_id");
+          working_dir = option_string (json |> member "working_dir");
+          worker_class = worker_class_of_yojson (json |> member "worker_class");
+          worker_size = worker_size_of_yojson (json |> member "worker_size");
+          execution_scope =
+            execution_scope_of_yojson (json |> member "execution_scope");
+          thinking_enabled =
+            (match json |> member "thinking_enabled" with
+            | `Bool value -> Some value
+            | `Null -> None
+            | _ -> None);
+          max_turns;
+          worker_run_id = option_string (json |> member "worker_run_id");
+          role = option_string (json |> member "role");
+          selection_note = option_string (json |> member "selection_note");
+          prompt;
+          allowed_tools = string_list_of_yojson (json |> member "allowed_tools");
+          allowed_shell_tools =
+            string_list_of_yojson (json |> member "allowed_shell_tools");
+          timeout_sec;
+          delivery_contract;
+        }
+  | _ -> Error "worker execution spec must be a JSON object"

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -1,5 +1,7 @@
 module Oas = Agent_sdk
 
+let ( let* ) = Result.bind
+
 type t = {
   base_path : string;
   worker_name : string;
@@ -24,6 +26,12 @@ type t = {
 let option_to_yojson to_json = function
   | Some value -> to_json value
   | None -> `Null
+
+let required_trimmed_string field = function
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then Error (field ^ " must not be empty") else Ok trimmed
+  | _ -> Error (field ^ " must be a string")
 
 let option_string json =
   match json with
@@ -111,43 +119,56 @@ let of_yojson (json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
   match json with
   | `Assoc _ ->
-      let base_path = json |> member "base_path" |> to_string in
-      let worker_name = json |> member "worker_name" |> to_string in
-      let model_label = json |> member "model_label" |> to_string in
-      let prompt = json |> member "prompt" |> to_string in
-      let max_turns = json |> member "max_turns" |> to_int in
-      let timeout_sec = json |> member "timeout_sec" |> to_int in
-      let delivery_contract =
-        match json |> member "delivery_contract" with
-        | `Null -> None
-        | contract_json ->
-            Team_session_types.delivery_contract_of_yojson contract_json
-      in
-      Ok
-        {
-          base_path;
-          worker_name;
-          model_label;
-          team_session_id = option_string (json |> member "team_session_id");
-          working_dir = option_string (json |> member "working_dir");
-          worker_class = worker_class_of_yojson (json |> member "worker_class");
-          worker_size = worker_size_of_yojson (json |> member "worker_size");
-          execution_scope =
-            execution_scope_of_yojson (json |> member "execution_scope");
-          thinking_enabled =
-            (match json |> member "thinking_enabled" with
-            | `Bool value -> Some value
-            | `Null -> None
-            | _ -> None);
-          max_turns;
-          worker_run_id = option_string (json |> member "worker_run_id");
-          role = option_string (json |> member "role");
-          selection_note = option_string (json |> member "selection_note");
-          prompt;
-          allowed_tools = string_list_of_yojson (json |> member "allowed_tools");
-          allowed_shell_tools =
-            string_list_of_yojson (json |> member "allowed_shell_tools");
-          timeout_sec;
-          delivery_contract;
-        }
+      (try
+         let* base_path =
+           required_trimmed_string "base_path" (json |> member "base_path")
+         in
+         let* worker_name =
+           required_trimmed_string "worker_name" (json |> member "worker_name")
+         in
+         let* model_label =
+           required_trimmed_string "model_label" (json |> member "model_label")
+         in
+         let* prompt =
+           required_trimmed_string "prompt" (json |> member "prompt")
+         in
+         let max_turns = json |> member "max_turns" |> to_int in
+         let timeout_sec = json |> member "timeout_sec" |> to_int in
+         let delivery_contract =
+           match json |> member "delivery_contract" with
+           | `Null -> None
+           | contract_json ->
+               Team_session_types.delivery_contract_of_yojson contract_json
+         in
+         Ok
+           {
+             base_path;
+             worker_name;
+             model_label;
+             team_session_id = option_string (json |> member "team_session_id");
+             working_dir = option_string (json |> member "working_dir");
+             worker_class = worker_class_of_yojson (json |> member "worker_class");
+             worker_size = worker_size_of_yojson (json |> member "worker_size");
+             execution_scope =
+               execution_scope_of_yojson (json |> member "execution_scope");
+             thinking_enabled =
+               (match json |> member "thinking_enabled" with
+               | `Bool value -> Some value
+               | `Null -> None
+               | _ -> None);
+             max_turns;
+             worker_run_id = option_string (json |> member "worker_run_id");
+             role = option_string (json |> member "role");
+             selection_note = option_string (json |> member "selection_note");
+             prompt;
+             allowed_tools = string_list_of_yojson (json |> member "allowed_tools");
+             allowed_shell_tools =
+               string_list_of_yojson (json |> member "allowed_shell_tools");
+             timeout_sec;
+             delivery_contract;
+           }
+       with
+       | Yojson.Json_error msg -> Error ("worker execution spec JSON error: " ^ msg)
+       | Type_error (msg, _) -> Error ("worker execution spec type error: " ^ msg)
+       | Failure msg -> Error msg)
   | _ -> Error "worker execution spec must be a JSON object"

--- a/lib/worker_run_once.ml
+++ b/lib/worker_run_once.ml
@@ -1,0 +1,208 @@
+open Result_syntax
+
+module Oas = Agent_sdk
+
+let resolve_net ?net () =
+  match net with
+  | Some net -> Ok net
+  | None -> (
+      match Eio_context.get_net_opt () with
+      | Some net -> Ok net
+      | None -> Error "Eio net not initialized")
+
+let effective_execution_scope (spec : Worker_execution_spec.t) =
+  Worker_container.resolve_execution_scope ~base_path:spec.base_path
+    ~team_session_id:spec.team_session_id ?execution_scope:spec.execution_scope
+    ()
+
+let workspace_path_of_spec (spec : Worker_execution_spec.t) =
+  match spec.working_dir with
+  | Some dir when String.trim dir <> "" -> dir
+  | _ -> spec.base_path
+
+let contract_of_spec ~execution_scope (spec : Worker_execution_spec.t) =
+  Option.map
+    (fun delivery_contract ->
+      Contract_composer.compose ~delivery_contract ~execution_scope
+        ~tool_names:
+          (List.sort_uniq String.compare
+             (spec.allowed_tools @ spec.allowed_shell_tools)))
+    spec.delivery_contract
+
+let provider_and_model_id_of_label model_label =
+  let provider = Worker_container.oas_provider_of_label model_label in
+  let model_id =
+    match Llm_provider.Cascade_config.parse_model_string model_label with
+    | Some cfg -> cfg.Llm_provider.Provider_config.model_id
+    | None -> model_label
+  in
+  (provider, model_id)
+
+let execute_spec ~sw ?net ~room_config (spec : Worker_execution_spec.t) :
+    (Worker_container_types.run_result, string) result =
+  let execution_scope = effective_execution_scope spec in
+  let workspace_path = workspace_path_of_spec spec in
+  let mcp_session_id =
+    Worker_container.resolved_mcp_session_id ~base_path:spec.base_path
+      ~team_session_id:spec.team_session_id ~worker_name:spec.worker_name
+  in
+  let meta =
+    Worker_container.make_worker_meta ~base_path:spec.base_path
+      ~workspace_path ~team_session_id:spec.team_session_id
+      ~worker_name:spec.worker_name ~mcp_session_id ~role:spec.role
+      ~selection_note:spec.selection_note ~execution_scope
+      ~worker_class:spec.worker_class ~worker_size:spec.worker_size
+      ~effective_model:
+        (match provider_and_model_id_of_label spec.model_label with
+        | _provider, model_id -> model_id)
+      ~thinking_enabled:spec.thinking_enabled
+      ~max_turns_override:(Some spec.max_turns)
+      ~timeout_seconds:(Some spec.timeout_sec)
+  in
+  match
+    Worker_container.worker_auth_token ~base_path:spec.base_path
+      ~worker_name:spec.worker_name
+  with
+  | Error e -> Error e
+  | Ok auth_token ->
+      let evidence_session_id =
+        Worker_container.evidence_session_id_of_worker_run spec.worker_run_id
+      in
+      let _provider, model_id = provider_and_model_id_of_label spec.model_label in
+      let provider = Worker_container.oas_provider_of_label spec.model_label in
+      let system_prompt =
+        Worker_container.default_system_prompt ~worker_name:spec.worker_name
+          ~model_id ?session_id:spec.team_session_id ?role:spec.role
+          ?selection_note:spec.selection_note ()
+      in
+      let prompt =
+        let tool_contract =
+          "Tool contract reminder: if you call masc_team_session_step with \
+           turn_kind=\"note\", you must include a non-empty message field. Calls \
+           missing message fail."
+        in
+        match execution_scope with
+        | Team_session_types.Autonomous ->
+            let resolvable =
+              Agent_tool_surfaces.local_worker_resolvable_tool_names ()
+            in
+            let tool_names =
+              Agent_tool_surfaces.build_tool_catalog ~role:"autonomous" ()
+              |> List.filter (fun name -> List.mem name resolvable)
+            in
+            let team_ctx =
+              match spec.team_session_id with
+              | Some sid ->
+                  Team_context.build ~base_path:spec.base_path
+                    ~team_session_id:sid
+              | None -> Team_context.empty
+            in
+            Prompt_composer.compose
+              [
+                Identity
+                  {
+                    name = spec.worker_name;
+                    role =
+                      (match spec.role with
+                      | Some role -> role
+                      | None -> "autonomous");
+                    model = model_id;
+                  };
+                TeamContext team_ctx;
+                AvailableTools tool_names;
+                Guidelines
+                  [
+                    tool_contract;
+                    "You have full read and write access. Choose the approach \
+                     that best accomplishes your task. Use tools to verify \
+                     your work. Prefer reading code before modifying it, and \
+                     run tests or builds to confirm changes are correct.";
+                  ];
+                Task spec.prompt;
+              ]
+        | _ ->
+            let workflow_contract =
+              match execution_scope with
+              | Team_session_types.Limited_code_change ->
+                  "Coding worker protocol: you must use tools before answering. \
+                   If the task requires a code change, the expected loop is \
+                   file_read -> shell_exec -> file_write -> shell_exec, and you \
+                   should not finish until the verification shell_exec succeeds. \
+                   If the task is inspection-only, do not modify files."
+              | Team_session_types.Observe_only ->
+                  "Readonly worker protocol: use file_read and shell_exec for \
+                   inspection, but do not modify files."
+              | Team_session_types.Autonomous -> ""
+            in
+            let team_ctx_section =
+              match spec.team_session_id with
+              | Some sid ->
+                  let ctx =
+                    Team_context.build ~base_path:spec.base_path
+                      ~team_session_id:sid
+                  in
+                  let section = Team_context.to_prompt_section ctx in
+                  if section = "" then "" else "\n\n" ^ section
+              | None -> ""
+            in
+            String.concat "\n\n" [ tool_contract; workflow_contract; spec.prompt ]
+            ^ team_ctx_section
+      in
+      let* () =
+        Worker_container.save_worker_meta ~base_path:spec.base_path
+          ~team_session_id:spec.team_session_id ~worker_name:spec.worker_name
+          meta
+      in
+      let* mcp_tools =
+        Worker_container.build_oas_mcp_tools ~sw ~auth_token
+          ~session_id:mcp_session_id ~worker_name:spec.worker_name
+          ~prompt ~allowed_tools:spec.allowed_tools
+      in
+      let mcp_tools =
+        List.map
+          (Oas.Tool.with_defaults [ ("agent_name", `String spec.worker_name) ])
+          mcp_tools
+      in
+      let* shell_tools =
+        Worker_container.build_local_shell_tools ~room_config
+          ~worker_name:spec.worker_name ~execution_scope
+          ~workdir:workspace_path
+      in
+      let tools = mcp_tools @ shell_tools in
+      let* raw_trace =
+        match evidence_session_id with
+        | Some trace_session_id ->
+            Oas.Raw_trace.create_for_session
+              ~session_root:
+                (Worker_container.oas_trace_session_root
+                   ~base_path:spec.base_path)
+              ~session_id:trace_session_id ~agent_name:spec.worker_name ()
+            |> Result.map_error Oas.Error.to_string
+        | None -> (
+            match spec.team_session_id with
+            | Some trace_session_id ->
+                Oas.Raw_trace.create_for_session
+                  ~session_root:
+                    (Worker_container.oas_trace_session_root
+                       ~base_path:spec.base_path)
+                  ~session_id:trace_session_id
+                  ~agent_name:spec.worker_name ()
+                |> Result.map_error Oas.Error.to_string
+            | None ->
+                Oas.Raw_trace.create ~session_id:mcp_session_id
+                  ~path:
+                    (Worker_container.worker_raw_trace_path
+                       ~base_path:spec.base_path
+                       ~team_session_id:spec.team_session_id
+                       ~worker_name:spec.worker_name)
+                  ()
+                |> Result.map_error Oas.Error.to_string)
+      in
+      let gate_config =
+        Worker_oas.gate_config_of_execution_scope meta.execution_scope
+      in
+      let* net = resolve_net ?net () in
+      Worker_oas.run_worker_via_oas ~sw ~net ~base_path:spec.base_path ~meta
+        ~provider ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
+        ?contract:(contract_of_spec ~execution_scope:(Some execution_scope) spec)
+        ?worker_run_id:spec.worker_run_id ()

--- a/lib/worker_runtime_config.ml
+++ b/lib/worker_runtime_config.ml
@@ -123,7 +123,10 @@ let load_file_config path =
         }
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | _ -> malformed_fail_closed
+    | exn ->
+        Log.CmdPlane.warn "worker-runtime config malformed at %s: %s" path
+          (Printexc.to_string exn);
+        malformed_fail_closed
   else default
 
 let apply_env_overrides (config : t) =

--- a/lib/worker_runtime_config.ml
+++ b/lib/worker_runtime_config.ml
@@ -65,14 +65,19 @@ let env_image_opt () =
 let env_host_mcp_base_url_opt () =
   Sys.getenv_opt "MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL" |> trim_opt
 
+let execution_scope_of_string_opt value =
+  match String.lowercase_ascii (String.trim value) with
+  | "observe_only" -> Some Team_session_types.Observe_only
+  | "limited_code_change" -> Some Team_session_types.Limited_code_change
+  | "autonomous" -> Some Team_session_types.Autonomous
+  | _ -> None
+
 let scopes_of_json = function
   | `List values ->
       values
       |> List.filter_map (function
            | `String value ->
-               Some
-                 (Team_session_types.execution_scope_of_string
-                    (String.lowercase_ascii (String.trim value)))
+               execution_scope_of_string_opt value
            | _ -> None)
   | _ -> []
 
@@ -165,13 +170,17 @@ let reset () =
   cached := None
 
 let backend_for_scope scope =
-  let config = resolve () in
-  match config.team_session_spawn.backend with
-  | Worker_execution_backend.Local -> Worker_execution_backend.Local
-  | Worker_execution_backend.Docker ->
-      if List.mem scope config.team_session_spawn.docker_scopes then
-        Worker_execution_backend.Docker
-      else Worker_execution_backend.Local
+  match scope with
+  | Team_session_types.Observe_only ->
+      Worker_execution_backend.Local
+  | _ ->
+      let config = resolve () in
+      match config.team_session_spawn.backend with
+      | Worker_execution_backend.Local -> Worker_execution_backend.Local
+      | Worker_execution_backend.Docker ->
+          if List.mem scope config.team_session_spawn.docker_scopes then
+            Worker_execution_backend.Docker
+          else Worker_execution_backend.Local
 
 let docker_image () =
   (resolve ()).team_session_spawn.docker.image

--- a/lib/worker_runtime_config.ml
+++ b/lib/worker_runtime_config.ml
@@ -1,0 +1,180 @@
+type docker_config = {
+  image : string;
+  host_mcp_base_url : string option;
+}
+
+type team_session_spawn = {
+  backend : Worker_execution_backend.t;
+  docker_scopes : Team_session_types.execution_scope list;
+  docker : docker_config;
+}
+
+type t = {
+  team_session_spawn : team_session_spawn;
+}
+
+let default_docker_scopes =
+  [
+    Team_session_types.Limited_code_change;
+    Team_session_types.Autonomous;
+  ]
+
+let default =
+  {
+    team_session_spawn =
+      {
+        backend = Worker_execution_backend.Local;
+        docker_scopes = default_docker_scopes;
+        docker =
+          {
+            image = "masc-worker-runtime:dev";
+            host_mcp_base_url = None;
+          };
+      };
+  }
+
+let malformed_fail_closed =
+  {
+    team_session_spawn =
+      {
+        backend = Worker_execution_backend.Docker;
+        docker_scopes = default_docker_scopes;
+        docker =
+          {
+            image = "";
+            host_mcp_base_url = None;
+          };
+      };
+  }
+
+let trim_opt value =
+  match value with
+  | None -> None
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+
+let backend_of_env () =
+  match Sys.getenv_opt "MASC_WORKER_RUNTIME_BACKEND" |> trim_opt with
+  | Some raw -> Worker_execution_backend.of_string raw
+  | None -> None
+
+let env_image_opt () =
+  Sys.getenv_opt "MASC_WORKER_RUNTIME_DOCKER_IMAGE" |> trim_opt
+
+let env_host_mcp_base_url_opt () =
+  Sys.getenv_opt "MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL" |> trim_opt
+
+let scopes_of_json = function
+  | `List values ->
+      values
+      |> List.filter_map (function
+           | `String value ->
+               Some
+                 (Team_session_types.execution_scope_of_string
+                    (String.lowercase_ascii (String.trim value)))
+           | _ -> None)
+  | _ -> []
+
+let load_file_config path =
+  if Sys.file_exists path then
+    try
+      let json = Safe_ops.read_json_eio path in
+        let open Yojson.Safe.Util in
+        let spawn_json = member "team_session_spawn" json in
+        let backend =
+          match spawn_json |> member "backend" with
+          | `String value -> (
+              match Worker_execution_backend.of_string value with
+              | Some backend -> backend
+              | None -> default.team_session_spawn.backend)
+          | _ -> default.team_session_spawn.backend
+        in
+        let docker_scopes =
+          match spawn_json |> member "docker_scopes" |> scopes_of_json with
+          | [] -> default_docker_scopes
+          | scopes -> scopes
+        in
+        let docker_json = spawn_json |> member "docker" in
+        let image =
+          match docker_json |> member "image" with
+          | `String value when String.trim value <> "" -> value
+          | _ -> default.team_session_spawn.docker.image
+        in
+        let host_mcp_base_url =
+          match docker_json |> member "host_mcp_base_url" with
+          | `String value ->
+              let trimmed = String.trim value in
+              if trimmed = "" then None else Some trimmed
+          | _ -> None
+        in
+        {
+          team_session_spawn =
+            {
+              backend;
+              docker_scopes;
+              docker = { image; host_mcp_base_url };
+            };
+        }
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> malformed_fail_closed
+  else default
+
+let apply_env_overrides (config : t) =
+  let backend =
+    match backend_of_env () with
+    | Some backend -> backend
+    | None -> config.team_session_spawn.backend
+  in
+  let image =
+    match env_image_opt () with
+    | Some image -> image
+    | None -> config.team_session_spawn.docker.image
+  in
+  let host_mcp_base_url =
+    match env_host_mcp_base_url_opt () with
+    | Some value -> Some value
+    | None -> config.team_session_spawn.docker.host_mcp_base_url
+  in
+  {
+    team_session_spawn =
+      {
+        config.team_session_spawn with
+        backend;
+        docker = { image; host_mcp_base_url };
+      };
+  }
+
+let cached : t option ref = ref None
+
+let config_path resolution =
+  Filename.concat resolution.Config_dir_resolver.config_root.path
+    "worker-runtime.json"
+
+let resolve () =
+  match !cached with
+  | Some config -> config
+  | None ->
+      let resolution = Config_dir_resolver.resolve () in
+      let config = load_file_config (config_path resolution) |> apply_env_overrides in
+      cached := Some config;
+      config
+
+let reset () =
+  cached := None
+
+let backend_for_scope scope =
+  let config = resolve () in
+  match config.team_session_spawn.backend with
+  | Worker_execution_backend.Local -> Worker_execution_backend.Local
+  | Worker_execution_backend.Docker ->
+      if List.mem scope config.team_session_spawn.docker_scopes then
+        Worker_execution_backend.Docker
+      else Worker_execution_backend.Local
+
+let docker_image () =
+  (resolve ()).team_session_spawn.docker.image
+
+let host_mcp_base_url_opt () =
+  (resolve ()).team_session_spawn.docker.host_mcp_base_url

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -233,7 +233,7 @@ let preflight_batch ?clock_opt (subjects : preflight_subject list) =
         in
         check_auth subjects
 
-let docker_argv (spec : Worker_execution_spec.t) =
+let docker_argv ~container_name (spec : Worker_execution_spec.t) =
   let image = Worker_runtime_config.docker_image () in
   let env_flags =
     allowlisted_env_pairs ()
@@ -260,7 +260,7 @@ let docker_argv (spec : Worker_execution_spec.t) =
     "run";
     "--rm";
     "--name";
-    container_name spec;
+    container_name;
     "-i";
     "--cap-drop=ALL";
     "--security-opt";
@@ -290,7 +290,7 @@ let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t) :
       let result =
         Tool_command_plane_support.run_process_with_timeout ~clock_opt
           ~stdin_content ~timeout_sec:effective_timeout_sec
-          ~prog:"docker" ~argv:(docker_argv spec)
+          ~prog:"docker" ~argv:(docker_argv ~container_name:name spec)
           ~env:(Unix.environment ()) ()
       in
       persist_stderr_artifact spec result.stderr;

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -1,0 +1,328 @@
+module Oas = Agent_sdk
+
+type preflight_subject = {
+  worker_name : string;
+  model_label : string;
+}
+
+let helper_binary = "masc-worker-run"
+let docker_host_alias = "host.docker.internal"
+
+let path_within ~root path =
+  let root =
+    if String.ends_with ~suffix:"/" root then root
+    else root ^ "/"
+  in
+  path = String.sub root 0 (String.length root - 1)
+  || String.starts_with ~prefix:root path
+
+let host_is_linux () =
+  Sys.os_type = "Unix" && Sys.file_exists "/proc/version"
+
+let is_loopback_host = function
+  | Some "localhost" | Some "127.0.0.1" -> true
+  | Some host when String.starts_with ~prefix:"127." host -> true
+  | _ -> false
+
+let rewrite_loopback_url value =
+  let uri = Uri.of_string value in
+  if is_loopback_host (Uri.host uri) then
+    Uri.with_host uri (Some docker_host_alias) |> Uri.to_string
+  else value
+
+let docker_http_base_url () =
+  match Worker_runtime_config.host_mcp_base_url_opt () with
+  | Some url -> url
+  | None -> rewrite_loopback_url (Env_config.masc_http_base_url ())
+
+let docker_mcp_url () =
+  match Sys.getenv_opt "MASC_MCP_URL" with
+  | Some value when String.trim value <> "" -> rewrite_loopback_url value
+  | _ -> docker_http_base_url () ^ "/mcp"
+
+let docker_llama_server_url () =
+  rewrite_loopback_url Env_config.Local_runtime.server_url
+
+let rewrite_model_label_for_container model_label =
+  if String.starts_with ~prefix:"custom:" model_label then
+    match Llm_provider.Cascade_config.parse_model_string model_label with
+    | Some cfg ->
+        let rewritten = rewrite_loopback_url cfg.Llm_provider.Provider_config.base_url in
+        if String.equal rewritten cfg.Llm_provider.Provider_config.base_url then
+          model_label
+        else
+          Printf.sprintf "custom:%s@%s"
+            cfg.Llm_provider.Provider_config.model_id rewritten
+    | None -> model_label
+  else model_label
+
+let rewrite_spec_for_container (spec : Worker_execution_spec.t) =
+  { spec with model_label = rewrite_model_label_for_container spec.model_label }
+
+let allowlisted_env_pairs () =
+  let keys =
+    [
+      "ANTHROPIC_API_KEY";
+      "OPENAI_API_KEY";
+      "GEMINI_API_KEY";
+      "ZAI_API_KEY";
+      "OPENROUTER_API_KEY";
+      "GOOGLE_CLOUD_PROJECT";
+      "GOOGLE_CLOUD_LOCATION";
+      "MASC_STORAGE_TYPE";
+      "MASC_BASE_PATH";
+      "MASC_CONFIG_DIR";
+    ]
+  in
+  let inherited =
+    keys
+    |> List.filter_map (fun key ->
+           match Sys.getenv_opt key with
+           | Some value when String.trim value <> "" -> Some (key, value)
+           | _ -> None)
+  in
+  let overrides =
+    [
+      ("MASC_BASE_PATH", "");
+      ("MASC_HTTP_BASE_URL", docker_http_base_url ());
+      ("MASC_MCP_URL", docker_mcp_url ());
+      ("LLAMA_SERVER_URL", docker_llama_server_url ());
+    ]
+  in
+  let overrides =
+    overrides
+    |> List.filter_map (fun (key, value) ->
+           let trimmed = String.trim value in
+           if trimmed = "" then None else Some (key, trimmed))
+  in
+  Array.of_list (List.map (fun (key, value) -> key ^ "=" ^ value) (inherited @ overrides))
+
+let container_name (spec : Worker_execution_spec.t) =
+  let token =
+    match spec.worker_run_id with
+    | Some worker_run_id when String.trim worker_run_id <> "" ->
+        worker_run_id
+    | _ -> spec.worker_name
+  in
+  "masc-worker-" ^ String.lowercase_ascii (Room_utils.safe_filename token)
+
+let artifact_dir (spec : Worker_execution_spec.t) =
+  Worker_container.worker_container_dir ~base_path:spec.base_path
+    ~team_session_id:spec.team_session_id ~worker_name:spec.worker_name
+
+let stderr_artifact_path (spec : Worker_execution_spec.t) =
+  let suffix =
+    match spec.worker_run_id with
+    | Some worker_run_id when String.trim worker_run_id <> "" ->
+        Room_utils.safe_filename worker_run_id
+    | _ -> "latest"
+  in
+  Filename.concat (artifact_dir spec)
+    (Printf.sprintf "docker-stderr-%s.log" suffix)
+
+let persist_stderr_artifact (spec : Worker_execution_spec.t) stderr =
+  if String.trim stderr <> "" then (
+    Worker_container.ensure_worker_container_dirs ~base_path:spec.base_path
+      ~team_session_id:spec.team_session_id ~worker_name:spec.worker_name;
+    Team_session_store.write_text_file (stderr_artifact_path spec) stderr)
+
+let best_effort_remove_container ?clock_opt name =
+  ignore
+    (Tool_command_plane_support.run_process_with_timeout ~clock_opt
+       ~timeout_sec:10 ~prog:"docker"
+       ~argv:[ "docker"; "rm"; "-f"; name ]
+       ~env:(Unix.environment ()) ())
+
+let mount_args (spec : Worker_execution_spec.t) =
+  let base_mount = [ "-v"; spec.base_path ^ ":" ^ spec.base_path ^ ":rw" ] in
+  let config_mount =
+    let resolution = Config_dir_resolver.resolve () in
+    let config_root = resolution.Config_dir_resolver.config_root.path in
+    if path_within ~root:spec.base_path config_root then []
+    else [ "-v"; config_root ^ ":" ^ config_root ^ ":ro" ]
+  in
+  base_mount @ config_mount
+
+let auth_requirements_of_model_label model_label =
+  match Llm_provider.Cascade_config.parse_model_string model_label with
+  | None -> Ok []
+  | Some cfg -> (
+      match cfg.Llm_provider.Provider_config.kind with
+      | Llm_provider.Provider_config.Anthropic -> Ok [ "ANTHROPIC_API_KEY" ]
+      | Llm_provider.Provider_config.Glm -> Ok [ "ZAI_API_KEY" ]
+      | Llm_provider.Provider_config.OpenAI_compat ->
+          let base_url = cfg.Llm_provider.Provider_config.base_url in
+          let uri = Uri.of_string base_url in
+          if is_loopback_host (Uri.host uri) then Ok [] else Ok [ "OPENAI_API_KEY" ]
+      | Llm_provider.Provider_config.Gemini ->
+          if Sys.getenv_opt "GEMINI_API_KEY" |> Option.is_some then
+            Ok [ "GEMINI_API_KEY" ]
+          else
+            Error
+              "Gemini Docker workers currently require GEMINI_API_KEY; Vertex ADC is unsupported in v1"
+      | Llm_provider.Provider_config.Claude_code -> Ok [])
+
+let missing_required_envs keys =
+  keys
+  |> List.filter (fun key ->
+         match Sys.getenv_opt key with
+         | Some value -> String.trim value = ""
+         | None -> true)
+
+let preflight_batch ?clock_opt (subjects : preflight_subject list) =
+  let image = Worker_runtime_config.docker_image () in
+  if String.trim image = "" then
+    Error "worker runtime Docker image is not configured"
+  else
+      let info_result =
+        Tool_command_plane_support.run_process_with_timeout ~clock_opt
+          ~timeout_sec:20 ~prog:"docker"
+          ~argv:[ "docker"; "info" ]
+          ~env:(Unix.environment ()) ()
+    in
+    if info_result.exit_code <> 0 then
+      Error
+        (Printf.sprintf "docker info failed: %s"
+           (Tool_command_plane_support.tail_text info_result.stderr))
+    else
+        let image_result =
+          Tool_command_plane_support.run_process_with_timeout ~clock_opt
+            ~timeout_sec:20 ~prog:"docker"
+            ~argv:[ "docker"; "image"; "inspect"; image ]
+            ~env:(Unix.environment ()) ()
+      in
+      if image_result.exit_code <> 0 then
+        Error
+          (Printf.sprintf "docker image inspect failed for %s: %s" image
+             (Tool_command_plane_support.tail_text image_result.stderr))
+      else
+        let rec check_auth = function
+          | [] -> Ok ()
+          | subject :: rest -> (
+              match auth_requirements_of_model_label subject.model_label with
+              | Error msg ->
+                  Error
+                    (Printf.sprintf "%s (%s)" msg subject.worker_name)
+              | Ok keys -> (
+                  match missing_required_envs keys with
+                  | [] -> check_auth rest
+                  | missing ->
+                      Error
+                        (Printf.sprintf
+                           "missing env for Docker worker %s: %s"
+                           subject.worker_name
+                           (String.concat ", " missing))))
+        in
+        check_auth subjects
+
+let docker_argv (spec : Worker_execution_spec.t) =
+  let image = Worker_runtime_config.docker_image () in
+  let env_flags =
+    allowlisted_env_pairs ()
+    |> Array.to_list
+    |> List.filter_map (fun pair ->
+           match String.index_opt pair '=' with
+           | Some idx ->
+               let key = String.sub pair 0 idx in
+               let value =
+                 String.sub pair (idx + 1) (String.length pair - idx - 1)
+               in
+               if String.trim value = "" then None
+               else Some [ "-e"; key ^ "=" ^ value ]
+           | None -> None)
+    |> List.flatten
+  in
+  let linux_host_flags =
+    if host_is_linux () then
+      [ "--add-host"; docker_host_alias ^ ":host-gateway" ]
+    else []
+  in
+  [
+    "docker";
+    "run";
+    "--rm";
+    "--name";
+    container_name spec;
+    "-i";
+    "--cap-drop=ALL";
+    "--security-opt";
+    "no-new-privileges";
+    "--pids-limit";
+    "256";
+    "--memory";
+    "4g";
+    "--workdir";
+    (match spec.working_dir with
+    | Some dir when String.trim dir <> "" -> dir
+    | _ -> spec.base_path);
+  ]
+  @ linux_host_flags @ mount_args spec @ env_flags
+  @ [ "--entrypoint"; helper_binary; image; "--spec-stdin" ]
+
+let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t) :
+    (Worker_container_types.run_result, string) result =
+  let name = container_name spec in
+  best_effort_remove_container ?clock_opt name;
+  Fun.protect
+    ~finally:(fun () -> best_effort_remove_container ?clock_opt name)
+    (fun () ->
+      let stdin_content =
+        Worker_execution_spec.to_yojson spec |> Yojson.Safe.to_string
+      in
+      let result =
+        Tool_command_plane_support.run_process_with_timeout ~clock_opt
+          ~stdin_content ~timeout_sec:(max 10 spec.timeout_sec)
+          ~prog:"docker" ~argv:(docker_argv spec)
+          ~env:(Unix.environment ()) ()
+      in
+      persist_stderr_artifact spec result.stderr;
+      match result.exit_code with
+      | 0 -> (
+          match Worker_runtime_helper_protocol.parse_stdout result.stdout with
+          | Ok (Ok run_result) -> Ok run_result
+          | Ok (Error payload) ->
+              Error
+                (Printf.sprintf "Docker worker runtime error (%s): %s"
+                   (Worker_runtime_helper_protocol.error_kind_to_string
+                      payload.kind)
+                   payload.message)
+          | Error msg ->
+              Error
+                (Printf.sprintf
+                   "failed to decode Docker worker output: %s%s"
+                   msg
+                   (if String.trim result.stderr = "" then ""
+                    else
+                      "\n[stderr]\n"
+                      ^ Tool_command_plane_support.tail_text result.stderr)))
+      | 124 ->
+          Error
+            (Printf.sprintf "Docker worker timed out after %ds%s"
+               spec.timeout_sec
+               (if String.trim result.stderr = "" then ""
+                else
+                  "\n[stderr]\n"
+                  ^ Tool_command_plane_support.tail_text result.stderr))
+      | _ ->
+          let stderr_tail =
+            if String.trim result.stderr = "" then ""
+            else
+              "\n[stderr]\n"
+              ^ Tool_command_plane_support.tail_text result.stderr
+          in
+          (match Worker_runtime_helper_protocol.parse_stdout result.stdout with
+          | Ok (Ok _run_result) ->
+              Error
+                (Printf.sprintf
+                   "docker run exited with code %d after producing a success envelope%s"
+                   result.exit_code stderr_tail)
+          | Ok (Error payload) ->
+              Error
+                (Printf.sprintf "Docker worker failed (%s): %s%s"
+                   (Worker_runtime_helper_protocol.error_kind_to_string
+                      payload.kind)
+                   payload.message stderr_tail)
+          | Error _ ->
+              Error
+                (Printf.sprintf "docker run exited with code %d%s"
+                   result.exit_code stderr_tail)))

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -90,6 +90,16 @@ let allowlisted_env_pairs () =
       ("LLAMA_SERVER_URL", docker_llama_server_url ());
     ]
   in
+  (* Keys with empty override values signal removal from inherited env. *)
+  let cleared_keys =
+    overrides
+    |> List.filter_map (fun (key, value) ->
+           if String.trim value = "" then Some key else None)
+  in
+  let inherited =
+    inherited
+    |> List.filter (fun (key, _) -> not (List.mem key cleared_keys))
+  in
   let overrides =
     overrides
     |> List.filter_map (fun (key, value) ->
@@ -273,12 +283,13 @@ let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t) :
   Fun.protect
     ~finally:(fun () -> best_effort_remove_container ?clock_opt name)
     (fun () ->
+      let effective_timeout_sec = max 10 spec.timeout_sec in
       let stdin_content =
         Worker_execution_spec.to_yojson spec |> Yojson.Safe.to_string
       in
       let result =
         Tool_command_plane_support.run_process_with_timeout ~clock_opt
-          ~stdin_content ~timeout_sec:(max 10 spec.timeout_sec)
+          ~stdin_content ~timeout_sec:effective_timeout_sec
           ~prog:"docker" ~argv:(docker_argv spec)
           ~env:(Unix.environment ()) ()
       in
@@ -305,7 +316,7 @@ let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t) :
       | 124 ->
           Error
             (Printf.sprintf "Docker worker timed out after %ds%s"
-               spec.timeout_sec
+               effective_timeout_sec
                (if String.trim result.stderr = "" then ""
                 else
                   "\n[stderr]\n"

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -104,7 +104,13 @@ let container_name (spec : Worker_execution_spec.t) =
         worker_run_id
     | _ -> spec.worker_name
   in
-  "masc-worker-" ^ String.lowercase_ascii (Room_utils.safe_filename token)
+  let unique_suffix =
+    Printf.sprintf "%d-%d" (Unix.getpid ())
+      (int_of_float (Unix.gettimeofday () *. 1000.0))
+  in
+  Printf.sprintf "masc-worker-%s-%s"
+    (String.lowercase_ascii (Room_utils.safe_filename token))
+    unique_suffix
 
 let artifact_dir (spec : Worker_execution_spec.t) =
   Worker_container.worker_container_dir ~base_path:spec.base_path
@@ -262,7 +268,6 @@ let docker_argv (spec : Worker_execution_spec.t) =
 let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t) :
     (Worker_container_types.run_result, string) result =
   let name = container_name spec in
-  best_effort_remove_container ?clock_opt name;
   Fun.protect
     ~finally:(fun () -> best_effort_remove_container ?clock_opt name)
     (fun () ->

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -7,6 +7,7 @@ type preflight_subject = {
 
 let helper_binary = "masc-worker-run"
 let docker_host_alias = "host.docker.internal"
+let container_counter = Atomic.make 0
 
 let path_within ~root path =
   let root =
@@ -105,8 +106,9 @@ let container_name (spec : Worker_execution_spec.t) =
     | _ -> spec.worker_name
   in
   let unique_suffix =
-    Printf.sprintf "%d-%d" (Unix.getpid ())
+    Printf.sprintf "%d-%d-%d" (Unix.getpid ())
       (int_of_float (Unix.gettimeofday () *. 1000.0))
+      (Atomic.fetch_and_add container_counter 1)
   in
   Printf.sprintf "masc-worker-%s-%s"
     (String.lowercase_ascii (Room_utils.safe_filename token))

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -1,0 +1,115 @@
+module Oas = Agent_sdk
+
+type error_kind =
+  | Spec_parse
+  | Runtime
+  | Timeout
+  | Internal
+
+type error_payload = {
+  message : string;
+  kind : error_kind;
+}
+
+let error_kind_to_string = function
+  | Spec_parse -> "spec_parse"
+  | Runtime -> "runtime"
+  | Timeout -> "timeout"
+  | Internal -> "internal"
+
+let error_kind_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "spec_parse" -> Some Spec_parse
+  | "runtime" -> Some Runtime
+  | "timeout" -> Some Timeout
+  | "internal" -> Some Internal
+  | _ -> None
+
+let hex_char value =
+  if value < 10 then Char.chr (Char.code '0' + value)
+  else Char.chr (Char.code 'a' + value - 10)
+
+let hex_encode text =
+  let len = String.length text in
+  let bytes = Bytes.create (len * 2) in
+  for idx = 0 to len - 1 do
+    let code = Char.code text.[idx] in
+    Bytes.set bytes (idx * 2) (hex_char ((code lsr 4) land 0xF));
+    Bytes.set bytes ((idx * 2) + 1) (hex_char (code land 0xF))
+  done;
+  Bytes.unsafe_to_string bytes
+
+let hex_value = function
+  | '0' .. '9' as ch -> Char.code ch - Char.code '0'
+  | 'a' .. 'f' as ch -> 10 + Char.code ch - Char.code 'a'
+  | 'A' .. 'F' as ch -> 10 + Char.code ch - Char.code 'A'
+  | ch ->
+      invalid_arg
+        (Printf.sprintf "invalid hex character in worker helper payload: %c" ch)
+
+let hex_decode text =
+  let len = String.length text in
+  if len mod 2 <> 0 then invalid_arg "hex payload length must be even";
+  let bytes = Bytes.create (len / 2) in
+  let rec loop idx =
+    if idx >= len then ()
+    else
+      let hi = hex_value text.[idx] in
+      let lo = hex_value text.[idx + 1] in
+      Bytes.set bytes (idx / 2) (Char.chr ((hi lsl 4) lor lo));
+      loop (idx + 2)
+  in
+  loop 0;
+  Bytes.unsafe_to_string bytes
+
+let marshal_run_result (run_result : Worker_container_types.run_result) =
+  run_result |> fun value -> Marshal.to_string value [] |> hex_encode
+
+let unmarshal_run_result payload =
+  let raw = hex_decode payload in
+  Marshal.from_string raw 0
+
+let success_json (run_result : Worker_container_types.run_result) =
+  `Assoc [ ("ok_marshaled", `String (marshal_run_result run_result)) ]
+
+let error_json (payload : error_payload) =
+  `Assoc
+    [
+      ( "error",
+        `Assoc
+          [
+            ("message", `String payload.message);
+            ("kind", `String (error_kind_to_string payload.kind));
+          ] );
+    ]
+
+let parse_stdout (stdout : string) :
+    ((Worker_container_types.run_result, error_payload) result, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let json = Yojson.Safe.from_string stdout in
+    match json |> member "ok_marshaled" with
+    | `String payload ->
+        Ok (Ok (unmarshal_run_result payload))
+    | _ -> (
+        match json |> member "error" with
+        | `Assoc fields ->
+            let message =
+              match List.assoc_opt "message" fields with
+              | Some (`String value) -> value
+              | _ -> "worker helper error"
+            in
+            let kind =
+              match List.assoc_opt "kind" fields with
+              | Some (`String value) -> (
+                  match error_kind_of_string value with
+                  | Some kind -> kind
+                  | None -> Internal)
+              | _ -> Internal
+            in
+            Ok (Error { message; kind })
+        | _ -> Error "worker helper stdout did not contain ok_marshaled or error")
+  with
+  | Invalid_argument msg -> Error msg
+  | Failure msg -> Error msg
+  | Yojson.Json_error msg -> Error ("invalid worker helper JSON: " ^ msg)

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -1,4 +1,5 @@
 module Oas = Agent_sdk
+module Llm_provider = Llm_provider
 
 type error_kind =
   | Spec_parse
@@ -25,52 +26,126 @@ let error_kind_of_string value =
   | "internal" -> Some Internal
   | _ -> None
 
-let hex_char value =
-  if value < 10 then Char.chr (Char.code '0' + value)
-  else Char.chr (Char.code 'a' + value - 10)
+let option_to_yojson to_json = function
+  | Some value -> to_json value
+  | None -> `Null
 
-let hex_encode text =
-  let len = String.length text in
-  let bytes = Bytes.create (len * 2) in
-  for idx = 0 to len - 1 do
-    let code = Char.code text.[idx] in
-    Bytes.set bytes (idx * 2) (hex_char ((code lsr 4) land 0xF));
-    Bytes.set bytes ((idx * 2) + 1) (hex_char (code land 0xF))
-  done;
-  Bytes.unsafe_to_string bytes
+let ( let* ) = Result.bind
 
-let hex_value = function
-  | '0' .. '9' as ch -> Char.code ch - Char.code '0'
-  | 'a' .. 'f' as ch -> 10 + Char.code ch - Char.code 'a'
-  | 'A' .. 'F' as ch -> 10 + Char.code ch - Char.code 'A'
-  | ch ->
-      invalid_arg
-        (Printf.sprintf "invalid hex character in worker helper payload: %c" ch)
+let int_option_of_yojson = function
+  | `Null -> Ok None
+  | `Int value -> Ok (Some value)
+  | `Intlit value -> (
+      try Ok (Some (int_of_string value))
+      with Failure _ -> Error "invalid int option in worker helper payload")
+  | _ -> Error "invalid int option in worker helper payload"
 
-let hex_decode text =
-  let len = String.length text in
-  if len mod 2 <> 0 then invalid_arg "hex payload length must be even";
-  let bytes = Bytes.create (len / 2) in
-  let rec loop idx =
-    if idx >= len then ()
-    else
-      let hi = hex_value text.[idx] in
-      let lo = hex_value text.[idx + 1] in
-      Bytes.set bytes (idx / 2) (Char.chr ((hi lsl 4) lor lo));
-      loop (idx + 2)
-  in
-  loop 0;
-  Bytes.unsafe_to_string bytes
+let float_option_of_yojson = function
+  | `Null -> Ok None
+  | `Float value -> Ok (Some value)
+  | `Int value -> Ok (Some (float_of_int value))
+  | `Intlit value -> (
+      try Ok (Some (float_of_string value))
+      with Failure _ -> Error "invalid float option in worker helper payload")
+  | `String value -> (
+      try Ok (Some (float_of_string value))
+      with Failure _ -> Error "invalid float option in worker helper payload")
+  | _ -> Error "invalid float option in worker helper payload"
 
-let marshal_run_result (run_result : Worker_container_types.run_result) =
-  run_result |> fun value -> Marshal.to_string value [] |> hex_encode
+let string_list_of_yojson = function
+  | `List values ->
+      List.fold_right
+        (fun value acc ->
+          match (value, acc) with
+          | `String s, Ok rest -> Ok (s :: rest)
+          | _, Ok _ -> Error "invalid string list in worker helper payload"
+          | _, Error msg -> Error msg)
+        values (Ok [])
+  | _ -> Error "invalid string list in worker helper payload"
 
-let unmarshal_run_result payload =
-  let raw = hex_decode payload in
-  Marshal.from_string raw 0
+let api_response_to_yojson =
+  option_to_yojson Llm_provider.Cache.response_to_json
+
+let api_response_of_yojson = function
+  | `Null -> Ok None
+  | json -> (
+      match Llm_provider.Cache.response_of_json json with
+      | Some response -> Ok (Some response)
+      | None -> Error "invalid api_response in worker helper payload")
+
+let proof_to_yojson =
+  option_to_yojson Oas.Cdal_proof.to_json
+
+let proof_of_yojson = function
+  | `Null -> Ok None
+  | json -> (
+      match Oas.Cdal_proof.of_json json with
+      | Ok proof -> Ok (Some proof)
+      | Error msg -> Error ("invalid proof in worker helper payload: " ^ msg))
+
+let run_result_to_yojson (run_result : Worker_container_types.run_result) =
+  `Assoc
+    [
+      ("output", `String run_result.output);
+      ("model_used", `String run_result.model_used);
+      ("input_tokens", option_to_yojson (fun v -> `Int v) run_result.input_tokens);
+      ("output_tokens", option_to_yojson (fun v -> `Int v) run_result.output_tokens);
+      ("cost_usd", option_to_yojson (fun v -> `Float v) run_result.cost_usd);
+      ("tool_call_count", `Int run_result.tool_call_count);
+      ("tool_names", `List (List.map (fun name -> `String name) run_result.tool_names));
+      ("session_id", `String run_result.session_id);
+      ( "raw_trace_run",
+        option_to_yojson Oas.Raw_trace.run_ref_to_yojson run_result.raw_trace_run );
+      ("api_response", api_response_to_yojson run_result.api_response);
+      ("proof", proof_to_yojson run_result.proof);
+    ]
+
+let run_result_of_yojson (json : Yojson.Safe.t) :
+    (Worker_container_types.run_result, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let output = json |> member "output" |> to_string in
+    let model_used = json |> member "model_used" |> to_string in
+    let tool_call_count = json |> member "tool_call_count" |> to_int in
+    let session_id = json |> member "session_id" |> to_string in
+    let* input_tokens = int_option_of_yojson (json |> member "input_tokens") in
+    let* output_tokens =
+      int_option_of_yojson (json |> member "output_tokens")
+    in
+    let* cost_usd = float_option_of_yojson (json |> member "cost_usd") in
+    let* tool_names = string_list_of_yojson (json |> member "tool_names") in
+    let* raw_trace_run =
+      match json |> member "raw_trace_run" with
+      | `Null -> Ok None
+      | value -> (
+          match Oas.Raw_trace.run_ref_of_yojson value with
+          | Ok run_ref -> Ok (Some run_ref)
+          | Error msg ->
+              Error ("invalid raw_trace_run in worker helper payload: " ^ msg))
+    in
+    let* api_response = api_response_of_yojson (json |> member "api_response") in
+    let* proof = proof_of_yojson (json |> member "proof") in
+    let run_result : Worker_container_types.run_result = {
+      output;
+      model_used;
+      input_tokens;
+      output_tokens;
+      cost_usd;
+      tool_call_count;
+      tool_names;
+      session_id;
+      raw_trace_run;
+      api_response;
+      proof;
+    } in
+    Ok run_result
+  with
+  | Yojson.Json_error msg -> Error ("invalid worker helper run_result JSON: " ^ msg)
+  | Type_error (msg, _) -> Error ("invalid worker helper run_result JSON: " ^ msg)
+  | Failure msg -> Error msg
 
 let success_json (run_result : Worker_container_types.run_result) =
-  `Assoc [ ("ok_marshaled", `String (marshal_run_result run_result)) ]
+  `Assoc [ ("ok", run_result_to_yojson run_result) ]
 
 let error_json (payload : error_payload) =
   `Assoc
@@ -88,9 +163,11 @@ let parse_stdout (stdout : string) :
   let open Yojson.Safe.Util in
   try
     let json = Yojson.Safe.from_string stdout in
-    match json |> member "ok_marshaled" with
-    | `String payload ->
-        Ok (Ok (unmarshal_run_result payload))
+    match json |> member "ok" with
+    | `Assoc _ as payload -> (
+        match run_result_of_yojson payload with
+        | Ok run_result -> Ok (Ok run_result)
+        | Error msg -> Error msg)
     | _ -> (
         match json |> member "error" with
         | `Assoc fields ->
@@ -108,8 +185,7 @@ let parse_stdout (stdout : string) :
               | _ -> Internal
             in
             Ok (Error { message; kind })
-        | _ -> Error "worker helper stdout did not contain ok_marshaled or error")
+        | _ -> Error "worker helper stdout did not contain ok or error")
   with
-  | Invalid_argument msg -> Error msg
   | Failure msg -> Error msg
   | Yojson.Json_error msg -> Error ("invalid worker helper JSON: " ^ msg)

--- a/scripts/build-worker-runtime-image.sh
+++ b/scripts/build-worker-runtime-image.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+git_sha="$(git -C "$repo_root" rev-parse --short HEAD)"
+image_tag="${1:-masc-worker-runtime:local-${git_sha}}"
+
+echo "Building ${image_tag}"
+docker build -f "${repo_root}/Dockerfile.worker-runtime" -t "${image_tag}" "${repo_root}"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -493,11 +493,11 @@ let test_team_session_spawn_tool_contracts () =
     (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
        "Worker_runtime.run_worker");
   check bool "team session spawn branches on local spawn agents" true
-    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
-       "if deps.is_local_spawn_agent prepared.spec.spawn_agent");
+    (file_contains_pattern "lib/tool_team_session_step_exec.ml"
+       "if env.deps.is_local_spawn_agent spec.spawn_agent then");
   check bool "team session spawn contract uses scoped tool names" true
-    (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
-       "supported_local_worker_tool_names");
+    (file_contains_pattern "lib/tool_team_session_step_exec.ml"
+       "local_worker_tool_names_of_scope");
   check bool "team session bridge exposes scoped local worker tools" true
     (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
        "supported_local_worker_tool_names_for_scope")

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -40,7 +40,8 @@ let make_config_root root =
 
 (* OCaml stdlib lacks Unix.unsetenv; putenv name "" is only an
    approximation. Code that treats [""] as missing is fine, but
-   Sys.getenv_opt still sees the variable as present. *)
+   Sys.getenv_opt (or Option.is_some checks on it) still sees the
+   variable as present, so tests must not assume true unset semantics. *)
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -38,6 +38,9 @@ let make_config_root root =
   write_file (Filename.concat config "cascade.json") "{}";
   config
 
+(* OCaml stdlib lacks Unix.unsetenv; putenv name "" is the closest
+   approximation.  Code under test guards with [value <> ""] so this
+   behaves like an unset for practical purposes. *)
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -38,9 +38,9 @@ let make_config_root root =
   write_file (Filename.concat config "cascade.json") "{}";
   config
 
-(* OCaml stdlib lacks Unix.unsetenv; putenv name "" is the closest
-   approximation.  Code under test guards with [value <> ""] so this
-   behaves like an unset for practical purposes. *)
+(* OCaml stdlib lacks Unix.unsetenv; putenv name "" is only an
+   approximation. Code that treats [""] as missing is fine, but
+   Sys.getenv_opt still sees the variable as present. *)
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -2,6 +2,54 @@ module Lib = Masc_mcp
 
 open Alcotest
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let make_config_root root =
+  let config = Filename.concat root "config" in
+  mkdir_p (Filename.concat config "prompts");
+  mkdir_p (Filename.concat config "keepers");
+  mkdir_p (Filename.concat config "personas");
+  write_file (Filename.concat config "cascade.json") "{}";
+  config
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+  | Some v -> Unix.putenv name v
+  | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let test_list_masc_tools_exposes_board_and_keeper_schemas () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -25,10 +73,114 @@ let test_list_masc_tools_exposes_board_and_keeper_schemas () =
             check bool "masc_board_list" true (List.mem "masc_board_list" names)
         | Error err -> failf "expected schema lookup to succeed: %s" err)
 
+let test_worker_runtime_config_prefers_env_override () =
+  with_temp_dir "worker-runtime-config" @@ fun root ->
+  let config_dir = make_config_root root in
+  write_file
+    (Filename.concat config_dir "worker-runtime.json")
+    {|{
+  "team_session_spawn": {
+    "backend": "docker",
+    "docker_scopes": ["limited_code_change", "autonomous"],
+    "docker": {
+      "image": "masc-worker-runtime:test"
+    }
+  }
+}|};
+  with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+  with_env "MASC_WORKER_RUNTIME_BACKEND" None @@ fun () ->
+  Lib.Config_dir_resolver.reset ();
+  Lib.Worker_runtime_config.reset ();
+  check string "file config enables docker for code-change scope" "docker"
+    (Lib.Worker_execution_backend.to_string
+       (Lib.Worker_runtime_config.backend_for_scope
+          Team_session_types.Limited_code_change));
+  check string "observe-only remains local" "local"
+    (Lib.Worker_execution_backend.to_string
+       (Lib.Worker_runtime_config.backend_for_scope
+          Team_session_types.Observe_only));
+  with_env "MASC_WORKER_RUNTIME_BACKEND" (Some "local") @@ fun () ->
+  Lib.Config_dir_resolver.reset ();
+  Lib.Worker_runtime_config.reset ();
+  check string "env override forces local backend" "local"
+    (Lib.Worker_execution_backend.to_string
+       (Lib.Worker_runtime_config.backend_for_scope
+          Team_session_types.Limited_code_change))
+
+let test_worker_runtime_helper_protocol_roundtrip () =
+  let run_result : Lib.Worker_container_types.run_result =
+    {
+      output = "ok";
+      model_used = "custom:test@http://127.0.0.1:8085";
+      input_tokens = Some 11;
+      output_tokens = Some 7;
+      cost_usd = Some 0.01;
+      tool_call_count = 2;
+      tool_names = [ "file_read"; "shell_exec" ];
+      session_id = "worker-session";
+      raw_trace_run = None;
+      api_response = None;
+      proof = None;
+    }
+  in
+  let encoded =
+    Lib.Worker_runtime_helper_protocol.success_json run_result
+    |> Yojson.Safe.to_string
+  in
+  match Lib.Worker_runtime_helper_protocol.parse_stdout encoded with
+  | Ok (Ok decoded) ->
+      check string "output" run_result.output decoded.output;
+      check string "model" run_result.model_used decoded.model_used;
+      check (option int) "input_tokens" run_result.input_tokens
+        decoded.input_tokens;
+      check (list string) "tool_names" run_result.tool_names
+        decoded.tool_names
+  | Ok (Error payload) ->
+      failf "expected success envelope, got helper error: %s" payload.message
+  | Error err ->
+      failf "expected helper envelope decode to succeed: %s" err
+
+let test_worker_runtime_invalid_config_fails_closed () =
+  with_temp_dir "worker-runtime-invalid" @@ fun root ->
+  let config_dir = make_config_root root in
+  write_file
+    (Filename.concat config_dir "worker-runtime.json")
+    {|{ "team_session_spawn": { "backend": "docker", |};
+  with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+  with_env "MASC_WORKER_RUNTIME_BACKEND" None @@ fun () ->
+  Lib.Config_dir_resolver.reset ();
+  Lib.Worker_runtime_config.reset ();
+  check string "malformed config resolves to fail-closed docker backend" "docker"
+    (Lib.Worker_execution_backend.to_string
+       (Lib.Worker_runtime_config.backend_for_scope
+          Team_session_types.Limited_code_change));
+  check string "malformed config clears docker image" ""
+    (Lib.Worker_runtime_config.docker_image ())
+
+let test_rewrite_custom_model_label_for_container () =
+  let rewritten =
+    Lib.Worker_runtime_docker.rewrite_model_label_for_container
+      "custom:qwen-test@http://127.0.0.1:8085"
+  in
+  check string "loopback custom label rewritten to host alias"
+    "custom:qwen-test@http://host.docker.internal:8085" rewritten
+
 let () =
   Alcotest.run "worker_runtime"
     [
       ( "tool_schemas",
         [ test_case "includes board and keeper tools for local workers" `Quick
             test_list_masc_tools_exposes_board_and_keeper_schemas ] );
+      ( "config",
+        [ test_case "worker runtime config env override" `Quick
+            test_worker_runtime_config_prefers_env_override ] );
+      ( "helper_protocol",
+        [ test_case "worker helper envelope roundtrip" `Quick
+            test_worker_runtime_helper_protocol_roundtrip ] );
+      ( "fail_closed",
+        [ test_case "malformed worker runtime config fails closed" `Quick
+            test_worker_runtime_invalid_config_fails_closed ] );
+      ( "rewrites",
+        [ test_case "custom loopback model label rewritten for container" `Quick
+            test_rewrite_custom_model_label_for_container ] );
     ]


### PR DESCRIPTION
## Summary
- add an optional Docker-backed worker runtime backend for team-session spawned workers
- keep the MCP schema and main `masc-mcp` CLI shape unchanged by introducing `masc-worker-run`
- add config, preflight, observability, docs, and regression coverage for the new backend

## What Changed
- added `prepared_execution` materialization and backend resolution before worker execution
- added shared `Worker_execution_spec`, helper stdout envelope protocol, and `masc-worker-run --spec-stdin`
- added Docker preflight, fail-closed config handling, loopback URL/model-label rewrites, and stderr artifact capture
- added `worker-runtime.json` support, `Dockerfile.worker-runtime`, and the image build script
- updated team-session tests and added dedicated `worker_runtime` tests

## Why
Team-session spawned workers needed an opt-in runtime isolation path for Docker without changing the public spawn API. The implementation keeps the existing local path as default while allowing Docker-backed execution for write-capable worker scopes.

## Product impact
- no MCP request schema changes in v1
- local execution remains the default backend
- Docker-backed workers are opt-in through config/env and restricted to team-session spawned workers

## Evidence
- `dune build --root .`
- `./_build/default/test/test_worker_runtime.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_tool_team_session.exe`

## Review evidence
- direct `sb glm-text` cross-model review was run and follow-up findings were patched in helper protocol transport, Docker packaging, timeout/stdin handling, config parsing, and spawn/runtime diagnostics
- review evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4622#issuecomment-4174900644

## Linked issue
- Closes #4584

## Known Gap
- Docker daemon smoke was not run on this machine because `docker info` currently fails with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`.
