### PR TITLE
refactor: remove hardcoded model tier inference from model names

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -103,31 +103,8 @@ let execution_scope_or_default = function
   | Some scope -> scope
   | None -> Team_session_types.Limited_code_change
 
-let infer_model_tier_from_model_name model_name =
-  let model_name = String.trim model_name in
-  let haystack = String.lowercase_ascii model_name in
-  let contains needle =
-    let needle = String.lowercase_ascii needle in
-    let needle_len = String.length needle in
-    let haystack_len = String.length haystack in
-    let rec loop idx =
-      if needle_len = 0 then true
-      else if idx + needle_len > haystack_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-  in
-  if model_name = "" then
-    None
-  else if contains "35b" then
-      Some Team_session_types.Tier_35b
-  else if contains "27b" then
-      Some Team_session_types.Tier_27b
-  else if contains "9b" then
-      Some Team_session_types.Tier_9b
-  else
-    None
+(* Model tier inference removed (#4505). Cascade handles model selection
+   without hardcoded name→tier mapping. *)
 
 let worker_profiles_of_scope scope =
   match scope with
@@ -138,18 +115,13 @@ let worker_profiles_of_scope scope =
   | Team_session_types.Autonomous ->
       (Profile_session_dev, Shell_dev)
 
-let derive_effective_tier worker_size model_id =
+let derive_effective_tier worker_size _model_id =
   match worker_size with
   | Some size -> Team_session_types.model_tier_of_worker_size size
-  | None -> infer_model_tier_from_model_name model_id
+  | None -> None
 
-let effective_worker_size worker_size model_id =
-  match worker_size with
-  | Some _ as explicit -> explicit
-  | None ->
-      Option.bind
-        (infer_model_tier_from_model_name model_id)
-        Team_session_types.worker_size_of_model_tier
+let effective_worker_size worker_size _model_id =
+  worker_size
 
 let worker_meta_to_yojson (meta : worker_container_meta) =
   `Assoc

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -203,26 +203,8 @@ let inferred_worker_model () =
       runtime_inventory_models ()
       |> List.find_opt (fun model -> contains_size_token_ci model "9b")
 
-let infer_model_tier_from_model_name model_name =
-  match trim_opt model_name with
-  | None -> None
-  | Some model_name -> (
-      match
-        (inferred_worker_model (), inferred_middle_model (), inferred_lead_model ())
-      with
-      | Some worker_model, _, _ when String.equal worker_model model_name ->
-          Some Team_session_types.Tier_9b
-      | _, Some middle_model, _ when String.equal middle_model model_name ->
-          Some Team_session_types.Tier_27b
-      | _, _, Some lead_model when String.equal lead_model model_name ->
-          Some Team_session_types.Tier_35b
-      | _ when contains_size_token_ci model_name "35b" ->
-          Some Team_session_types.Tier_35b
-      | _ when contains_size_token_ci model_name "27b" ->
-          Some Team_session_types.Tier_27b
-      | _ when contains_size_token_ci model_name "9b" ->
-          Some Team_session_types.Tier_9b
-      | _ -> None)
+(* Model tier inference removed (#4505). Cascade handles model selection. *)
+let infer_model_tier_from_model_name _model_name = None
 
 let default_risk_for_profile = function
   | Team_session_types.Profile_extract

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -531,12 +531,12 @@ let test_runtime_inventory_uses_token_boundaries_for_model_tiers () =
       Alcotest.(check (option string)) "worker runtime inferred from 9b token"
         (Some "qwen2.5-9b-instruct")
         (Tool_team_session_routing.inferred_worker_model ());
-      Alcotest.(check (option string)) "109b does not infer as 9b tier" None
+      (* #4505: tier inference removed — always returns None *)
+      Alcotest.(check (option string)) "tier inference disabled (109b)" None
         (Tool_team_session_routing.infer_model_tier_from_model_name
            (Some "llama-109b-instruct")
         |> Option.map Team_session_types.model_tier_to_string);
-      Alcotest.(check (option string)) "35b token still infers exact tier"
-        (Some "35b")
+      Alcotest.(check (option string)) "tier inference disabled (35b)" None
         (Tool_team_session_routing.infer_model_tier_from_model_name
            (Some "qwen3.5-35b-a3b-ud-q8-xl")
         |> Option.map Team_session_types.model_tier_to_string))


### PR DESCRIPTION
## Summary
- Remove infer_model_tier_from_model_name (2 copies, -54 lines)
- Cascade handles model selection without hardcoded name→tier mapping
- Phase 1: inference removed, model_tier type stays for Phase 2

## Test plan
- [ ] Worker spawn without explicit worker_size: no tier inferred (None)
- [ ] Worker spawn with explicit worker_size: tier derived from size
- [ ] Team session routing works without tier inference

Closes #4505

Generated with Claude Code