### PR TITLE
revert: undo base-path drift fix (#4605) — wrong premise

### DIFF
--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -14,58 +14,10 @@ let mcp_profile_by_session : (string, Server_mcp_transport_http_types.tool_profi
     Concurrent HTTP request fibers can race on Hashtbl read/write. *)
 let session_mutex = Eio.Mutex.create ()
 
-(** Infer the repo root from a binary's path.
-    Typical layout: [<repo>/_build/default/bin/main_eio.exe].
-    Returns [Some repo_root] when the binary lives under a [_build/] tree
-    and the inferred root contains a [.masc/] directory.
-
-    [?exe_path] overrides [Sys.executable_name] for testing. *)
-let infer_repo_root_from_exe ?(exe_path = Sys.executable_name) () =
-  let exe =
-    try Unix.realpath exe_path
-    with Unix.Unix_error _ -> exe_path
-  in
-  (* Walk up from exe dir looking for a _build/ ancestor, then take its parent *)
-  let rec walk dir =
-    if dir = "/" || dir = "." then None
-    else if Filename.basename dir = "_build" then
-      let candidate = Filename.dirname dir in
-      if Sys.file_exists (Filename.concat candidate ".masc") then
-        Some candidate
-      else
-        None
-    else walk (Filename.dirname dir)
-  in
-  walk (Filename.dirname exe)
-
 let default_base_path () =
-  let env_candidate =
-    match Env_config_core.base_path_opt () with
-    | Some _ as bp -> bp
-    | None -> Env_config_core.me_root_opt ()
-  in
-  let repo_root = infer_repo_root_from_exe () in
-  match env_candidate with
-  | Some path ->
-    (* Guard: if the binary lives in a different repo than the env-provided
-       path, prefer the binary's repo root.  This prevents base-path drift
-       when MCP clients auto-restart the binary and inherit a stale
-       MASC_BASE_PATH or ME_ROOT pointing to a parent project. *)
-    (match repo_root with
-     | Some root ->
-       let norm p = try Unix.realpath p with Unix.Unix_error _ -> p in
-       if String.equal (norm root) (norm path) then path
-       else begin
-         Printf.eprintf
-           "WARN: env base-path (%s) differs from binary repo root (%s); using repo root.\n%!"
-           path root;
-         root
-       end
-     | None -> path)
-  | None ->
-    (match repo_root with
-     | Some root -> root
-     | None -> Sys.getcwd ())
+  match Env_config_core.me_root_opt () with
+  | Some path -> path
+  | None -> Sys.getcwd ()
 
 let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -369,24 +369,28 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Guard against env inheritance: when the process inherits MASC_BASE_PATH
-# pointing to a different directory (same repo worktree OR a parent project),
-# both paths may have .masc/ and using the inherited path would silently
-# operate on the wrong room state.
+# Guard against worktree env inheritance: when a worktree child inherits
+# MASC_BASE_PATH pointing to its own repo root, both paths have .masc/
+# and using the parent path would silently operate on the wrong room state.
 #
-# When --base-path was not explicitly provided and the script's own directory
-# has .masc/, prefer SCRIPT_DIR over the inherited env value.  This covers:
-#   - Worktree inheritance (MASC_BASE_PATH = repo root, script runs in worktree)
-#   - Cross-project inheritance (MASC_BASE_PATH = ~/me, script runs in ~/me/.../masc-mcp)
-#   - MCP auto-restart (client re-launches binary with stale env)
+# Exception: if BASE_PATH is a genuinely different project (not this repo's
+# root), the user intentionally configured a parent project as MASC root
+# (e.g. MASC_BASE_PATH=~/me in .zshenv while running from ~/me/workspace/*/masc-mcp).
+# REPO_ENV_ROOT (git common dir) identifies the repo boundary.
 if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
    [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && \
    [ -n "$BASE_PATH" ] && \
    [ "$BASE_PATH" != "$SCRIPT_DIR" ]; then
-    if [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$BASE_PATH/.masc" ]; then
-        echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH (script dir has its own .masc/). Using $SCRIPT_DIR for server state." >&2
-        BASE_PATH="$SCRIPT_DIR"
+    RESOLVED_ENV_ROOT="$(cd "$REPO_ENV_ROOT" && pwd)"
+    RESOLVED_BASE="$(cd "$BASE_PATH" 2>/dev/null && pwd || echo "$BASE_PATH")"
+    if [ "$RESOLVED_BASE" = "$RESOLVED_ENV_ROOT" ]; then
+        # BASE_PATH is this repo's own root — worktree inheritance. Guard applies.
+        if [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$BASE_PATH/.masc" ]; then
+            echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH (same repo root). Using $SCRIPT_DIR for server state." >&2
+            BASE_PATH="$SCRIPT_DIR"
+        fi
     fi
+    # If BASE_PATH is a different project, honor the env var unconditionally.
 fi
 
 if [ "$PORT_EXPLICIT" != "1" ]; then

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -88,51 +88,6 @@ let test_to_yojson_exposes_effective_paths () =
   Alcotest.(check bool) "roots diverge field" true
     (json |> member "roots_diverge" |> to_bool)
 
-let rec mkdir_p path =
-  if path = "" || path = "." || path = "/" then ()
-  else if Sys.file_exists path then ()
-  else begin
-    mkdir_p (Filename.dirname path);
-    Unix.mkdir path 0o755
-  end
-
-let realpath p = try Unix.realpath p with Unix.Unix_error _ -> p
-
-let test_infer_repo_root_finds_build_ancestor () =
-  with_temp_dir "infer-repo" @@ fun root ->
-  let repo = Filename.concat root "my-repo" in
-  let exe = Filename.concat repo "_build/default/bin/main_eio.exe" in
-  mkdir_p (Filename.concat repo ".masc");
-  mkdir_p (Filename.dirname exe);
-  (* Create a dummy executable so realpath works *)
-  let oc = open_out exe in
-  close_out oc;
-  let result =
-    Server_mcp_transport_http_session.infer_repo_root_from_exe ~exe_path:exe ()
-  in
-  (* Normalize both sides: macOS /var -> /private/var symlink *)
-  Alcotest.(check (option string)) "finds repo root"
-    (Some (realpath repo)) result
-
-let test_infer_repo_root_returns_none_without_masc () =
-  with_temp_dir "infer-repo-no-masc" @@ fun root ->
-  let repo = Filename.concat root "bare-repo" in
-  let exe = Filename.concat repo "_build/default/bin/main_eio.exe" in
-  mkdir_p (Filename.dirname exe);
-  let oc = open_out exe in
-  close_out oc;
-  let result =
-    Server_mcp_transport_http_session.infer_repo_root_from_exe ~exe_path:exe ()
-  in
-  Alcotest.(check (option string)) "returns None without .masc" None result
-
-let test_infer_repo_root_returns_none_for_installed_binary () =
-  let result =
-    Server_mcp_transport_http_session.infer_repo_root_from_exe
-      ~exe_path:"/usr/local/bin/masc-mcp" ()
-  in
-  Alcotest.(check (option string)) "returns None for installed binary" None result
-
 let () =
   Alcotest.run "Server_base_path_diagnostics"
     [
@@ -144,14 +99,5 @@ let () =
             test_strict_violation_respects_env;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
-        ] );
-      ( "infer_repo_root",
-        [
-          Alcotest.test_case "finds repo root from _build path" `Quick
-            test_infer_repo_root_finds_build_ancestor;
-          Alcotest.test_case "returns None without .masc dir" `Quick
-            test_infer_repo_root_returns_none_without_masc;
-          Alcotest.test_case "returns None for installed binary" `Quick
-            test_infer_repo_root_returns_none_for_installed_binary;
         ] );
     ]

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -231,16 +231,11 @@ let test_realtime_transports_fall_back_to_repo_config_when_home_missing () =
            ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
 
 let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
-  with_temp_dir "start-masc-script" (fun parent ->
-      (* Use sibling dirs so the stale path is NOT a prefix/child of script dir.
-         Previous version used a child dir which made contains_substring a false positive. *)
-      let dir = Filename.concat parent "repo" in
-      let stale_root = Filename.concat parent "stale-root" in
-      mkdir_p dir;
-      mkdir_p stale_root;
+  with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
       make_fake_eio_exe dir;
+      let stale_root = Filename.concat dir "stale-root" in
       mkdir_p (Filename.concat dir ".masc");
       mkdir_p (Filename.concat stale_root ".masc");
       let capture = Filename.concat dir "captured-sanitized.txt" in
@@ -258,10 +253,7 @@ let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
           stderr;
       let captured = read_file capture in
       check bool "inherited base path corrected to script root" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ dir));
-      (* Verify the stale root is NOT present in the resolved path *)
-      check bool "stale root is not used" false
-        (contains_substring captured ("MASC_BASE_PATH=" ^ stale_root)))
+        (contains_substring captured ("MASC_BASE_PATH=" ^ dir)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->


### PR DESCRIPTION
## Summary\n\nReverts #4605. The base-path drift diagnosis was wrong — `MASC_BASE_PATH=~/me` is the intended configuration where state (`~/me/.masc/`) is separate from binary (`masc-mcp/`).\n\n## Product impact\n\n- Promise affected: keeper runtime\n- User-visible change: keepers and their state are visible in dashboard again\n\n## Evidence\n\n- `~/me/.masc/keepers/` contains 59 files (real keeper data)\n- `masc-mcp/.masc/keepers/` is empty (CI/test scaffold)\n- With #4605, server used empty dir → keepers invisible\n\n## Review evidence\n\nSelf-identified regression from incorrect premise.\n\n## Linked issue\n\nRefs #4568 (closed as wrong diagnosis)