### PR TITLE
[codex] Fix auth subject resolution for transient actors

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -18,6 +18,9 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join 
 let is_ephemeral_agent_name name =
   String.length name >= 6 && String.sub name 0 6 = "agent-"
 
+let is_transient_agent_name name =
+  is_ephemeral_agent_name name || Nickname.is_generated_nickname name
+
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
   (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name
 
@@ -194,7 +197,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   let agent_name =
     match token with
-    | Some t when is_ephemeral_agent_name agent_name ->
+    (* Generated dashboard/session aliases should not outrank the
+       credential owner encoded by the bearer token. *)
+    | Some t when is_transient_agent_name agent_name ->
         (match Auth.resolve_agent_from_token config.base_path ~token:t with
          | Ok resolved -> resolved
          | Error _ -> agent_name)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -126,6 +126,12 @@ let agent_from_request request =
   first_some [ hdr "x-masc-agent"; hdr "x-masc-agent-name"; qp "agent"; qp "agent_name" ]
   |> Option.map Uri.pct_decode
 
+let is_transient_actor_name name =
+  let normalized = String.trim name in
+  normalized <> ""
+  && (String.starts_with ~prefix:"agent-" normalized
+      || Nickname.is_generated_nickname normalized)
+
 (** Extract host and explicit port only.
     Host header carries no scheme, so inferring a default port from scheme
     (80 for http, 443 for https) causes mismatches when the browser Origin
@@ -315,7 +321,19 @@ let is_public_read_path path =
 let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Types.masc_error) result =
   match agent_from_request request with
-  | Some raw when String.trim raw <> "" -> Ok (Some (String.trim raw))
+  | Some raw when String.trim raw <> "" ->
+      let agent_name = String.trim raw in
+      if is_transient_actor_name agent_name then
+        (match token with
+         | Some t ->
+             (match Auth.resolve_agent_from_token base_path ~token:t with
+              | Ok resolved -> Ok (Some resolved)
+              | Error (Types.InvalidToken _ as e) -> Error e
+              | Error (Types.TokenExpired _ as e) -> Error e
+              | Error _ -> Ok (Some agent_name))
+         | None -> Ok (Some agent_name))
+      else
+        Ok (Some agent_name)
   | _ ->
       (match token with
        | None -> Ok None

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -9,6 +9,11 @@ type context = {
 
 type result = bool * string
 
+let target_agent_name ctx args =
+  match get_string args "agent_name" ctx.agent_name |> String.trim with
+  | "" -> ctx.agent_name
+  | name -> name
+
 let handle_auth_enable ctx args =
   let require_token = get_bool args "require_token" false in
   let (secret, bootstrap_token) =
@@ -61,12 +66,13 @@ Bind Host: %s (%s)
   (true, msg)
 
 let handle_auth_create_token ctx args =
+  let target_agent = target_agent_name ctx args in
   let role_str = get_string args "role" "worker" in
   let role = match Types.agent_role_of_string role_str with
     | Ok r -> r
     | Error _ -> Types.Worker
   in
-  match Auth.create_token ctx.config.base_path ~agent_name:ctx.agent_name ~role with
+  match Auth.create_token ctx.config.base_path ~agent_name:target_agent ~role with
   | Ok (raw_token, cred) ->
       let expires = match cred.expires_at with
         | Some exp -> exp
@@ -81,14 +87,15 @@ Role: %s
 Expires: %s
 
 Pass this token in requests to authenticate.
-|} ctx.agent_name raw_token (Types.agent_role_to_string role) expires in
+|} target_agent raw_token (Types.agent_role_to_string role) expires in
       (true, msg)
   | Error e ->
       (false, Types.masc_error_to_string e)
 
 let handle_auth_refresh ctx args =
+  let target_agent = target_agent_name ctx args in
   let token = get_string args "token" "" in
-  match Auth.refresh_token ctx.config.base_path ~agent_name:ctx.agent_name ~old_token:token with
+  match Auth.refresh_token ctx.config.base_path ~agent_name:target_agent ~old_token:token with
   | Ok (new_token, cred) ->
       let expires = match cred.expires_at with
         | Some exp -> exp
@@ -100,14 +107,15 @@ New Token:
 `%s`
 
 Expires: %s
-|} ctx.agent_name new_token expires in
+|} target_agent new_token expires in
       (true, msg)
   | Error e ->
       (false, Types.masc_error_to_string e)
 
-let handle_auth_revoke ctx _args =
-  Auth.delete_credential ctx.config.base_path ctx.agent_name;
-  (true, Printf.sprintf "🗑️ Token revoked for %s" ctx.agent_name)
+let handle_auth_revoke ctx args =
+  let target_agent = target_agent_name ctx args in
+  Auth.delete_credential ctx.config.base_path target_agent;
+  (true, Printf.sprintf "🗑️ Token revoked for %s" target_agent)
 
 let handle_auth_list ctx _args =
   let creds = Auth.list_credentials ctx.config.base_path in

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -114,8 +114,12 @@ Expires: %s
 
 let handle_auth_revoke ctx args =
   let target_agent = target_agent_name ctx args in
-  Auth.delete_credential ctx.config.base_path target_agent;
-  (true, Printf.sprintf "🗑️ Token revoked for %s" target_agent)
+  match Auth.load_credential ctx.config.base_path target_agent with
+  | None ->
+      (false, Printf.sprintf "No credential found for %s" target_agent)
+  | Some _ ->
+      Auth.delete_credential ctx.config.base_path target_agent;
+      (true, Printf.sprintf "🗑️ Token revoked for %s" target_agent)
 
 let handle_auth_list ctx _args =
   let creds = Auth.list_credentials ctx.config.base_path in

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -94,23 +94,26 @@ Pass this token in requests to authenticate.
 
 let handle_auth_refresh ctx args =
   let target_agent = target_agent_name ctx args in
-  let token = get_string args "token" "" in
-  match Auth.refresh_token ctx.config.base_path ~agent_name:target_agent ~old_token:token with
-  | Ok (new_token, cred) ->
-      let expires = match cred.expires_at with
-        | Some exp -> exp
-        | None -> "never"
-      in
-      let msg = Printf.sprintf {|🔄 **Token Refreshed for %s**
+  if target_agent <> ctx.agent_name then
+    (false, "agent_name must match the authenticated agent for refresh")
+  else
+    let token = get_string args "token" "" in
+    match Auth.refresh_token ctx.config.base_path ~agent_name:target_agent ~old_token:token with
+    | Ok (new_token, cred) ->
+        let expires = match cred.expires_at with
+          | Some exp -> exp
+          | None -> "never"
+        in
+        let msg = Printf.sprintf {|🔄 **Token Refreshed for %s**
 
 New Token:
 `%s`
 
 Expires: %s
 |} target_agent new_token expires in
-      (true, msg)
-  | Error e ->
-      (false, Types.masc_error_to_string e)
+        (true, msg)
+    | Error e ->
+        (false, Types.masc_error_to_string e)
 
 let handle_auth_revoke ctx args =
   let target_agent = target_agent_name ctx args in

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -39,6 +39,27 @@ let test_generate_token_unique () =
   let t2 = Auth.generate_token () in
   check bool "unique" true (t1 <> t2)
 
+let setup_test_room () =
+  let unique_id =
+    Printf.sprintf "masc-auth-coverage-%d-%d"
+      (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))
+  in
+  let tmp = Filename.concat (Filename.get_temp_dir_name ()) unique_id in
+  Unix.mkdir tmp 0o755;
+  let masc_dir = Filename.concat tmp ".masc" in
+  Unix.mkdir masc_dir 0o755;
+  tmp
+
+let cleanup_test_room dir =
+  let rec rm_rf path =
+    if Sys.is_directory path then begin
+      Array.iter (fun f -> rm_rf (Filename.concat path f)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
+
 (* ============================================================
    sha256_hash Tests
    ============================================================ *)
@@ -610,6 +631,58 @@ let test_permission_for_tool_empty () =
   | None -> ()
   | Some _ -> fail "expected None for empty string"
 
+let test_resolve_agent_name_prefers_token_for_generated_actor () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard-eager-manta");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `POST "/mcp" in
+      match SA.resolve_agent_name_for_auth ~base_path:dir request ~token:(Some raw_token) with
+      | Ok (Some agent_name) ->
+          check string "token subject wins for generated actor" "stable-admin" agent_name
+      | Ok None -> fail "expected resolved agent name"
+      | Error e -> fail (Types.masc_error_to_string e))
+
+let test_resolve_agent_name_preserves_explicit_stable_actor () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard-admin");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `POST "/mcp" in
+      match SA.resolve_agent_name_for_auth ~base_path:dir request ~token:(Some raw_token) with
+      | Ok (Some agent_name) ->
+          check string "stable actor preserved" "dashboard-admin" agent_name
+      | Ok None -> fail "expected explicit stable actor"
+      | Error e -> fail (Types.masc_error_to_string e))
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -721,6 +794,10 @@ let () =
       test_case "header token only" `Quick test_http_auth_token_from_header_only;
       test_case "reject query token fallback" `Quick
         test_http_auth_rejects_query_token_fallback;
+      test_case "generated actor prefers token subject" `Quick
+        test_resolve_agent_name_prefers_token_for_generated_actor;
+      test_case "stable actor preserved" `Quick
+        test_resolve_agent_name_preserves_explicit_stable_actor;
       test_case "same-origin rejects missing origin without token" `Quick
         test_same_origin_browser_request_rejects_missing_origin;
       test_case "same-origin allows matching origin" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1568,6 +1568,34 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
 
   cleanup_dir base_path
 
+let test_execute_tool_generated_agent_name_uses_token_identity () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+
+  let (ok_status, status_msg) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_auth_status"
+      ~arguments:(`Assoc [("agent_name", `String "dashboard-eager-manta")])
+  in
+  Alcotest.(check bool) "auth status succeeds" true ok_status;
+  Alcotest.(check bool) "auth status payload returned" true
+    (contains_substring status_msg "Authentication Status");
+
+  cleanup_dir base_path
+
 let test_execute_tool_mcp_session_ignores_term_persistence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2642,6 +2670,8 @@ let eio_tests = [
     test_should_read_legacy_persisted_agent_name;
   "explicit agent_name not overridden", `Quick, test_execute_tool_explicit_agent_name_not_overridden;
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
+  "generated agent_name uses token identity", `Quick,
+    test_execute_tool_generated_agent_name_uses_token_identity;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
   "convo start uses current room", `Quick, test_convo_start_uses_current_room;
 ]

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -134,6 +134,7 @@ let () = test "handle_auth_list_empty" (fun () ->
 (* Test auth_revoke dispatch *)
 let () = test "dispatch_auth_revoke" (fun () ->
   let ctx = make_test_ctx () in
+  ignore (Auth.create_token ctx.config.base_path ~agent_name:ctx.agent_name ~role:Types.Worker);
   let args = `Assoc [] in
   match Tool_auth.dispatch ctx ~name:"masc_auth_revoke" ~args with
   | Some (success, _result) -> assert success
@@ -160,15 +161,14 @@ let () = test "handle_auth_create_token_respects_agent_name" (fun () ->
 
 let () = test "handle_auth_refresh_respects_agent_name" (fun () ->
   let ctx = make_test_ctx () in
-  let target = "dashboard-eager-manta" in
   let old_token =
-    match Auth.create_token ctx.config.base_path ~agent_name:target ~role:Types.Worker with
+    match Auth.create_token ctx.config.base_path ~agent_name:ctx.agent_name ~role:Types.Worker with
     | Ok (raw_token, _cred) -> raw_token
     | Error e -> failwith (Types.masc_error_to_string e)
   in
   let args =
     `Assoc [
-      ("agent_name", `String target);
+      ("agent_name", `String ctx.agent_name);
       ("token", `String old_token);
     ]
   in
@@ -176,9 +176,22 @@ let () = test "handle_auth_refresh_respects_agent_name" (fun () ->
   assert success;
   let new_token = extract_first_backtick_value result in
   assert (new_token <> old_token);
-  match Auth.verify_token ctx.config.base_path ~agent_name:target ~token:new_token with
+  match Auth.verify_token ctx.config.base_path ~agent_name:ctx.agent_name ~token:new_token with
   | Ok _ -> ()
   | Error e -> failwith (Types.masc_error_to_string e)
+)
+
+let () = test "handle_auth_refresh_rejects_other_agent" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc [
+      ("agent_name", `String "dashboard-eager-manta");
+      ("token", `String "dummy-token");
+    ]
+  in
+  let (success, result) = Tool_auth.handle_auth_refresh ctx args in
+  assert (not success);
+  assert (contains_substring result "authenticated agent")
 )
 
 let () = test "handle_auth_revoke_respects_agent_name" (fun () ->

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -20,6 +20,14 @@ let contains_substring haystack needle =
   in
   needle_len = 0 || loop 0
 
+let extract_first_backtick_value text =
+  match String.index_opt text '`' with
+  | None -> failwith ("no backtick-delimited value found in: " ^ text)
+  | Some start ->
+      (match String.index_from_opt text (start + 1) '`' with
+       | None -> failwith ("unterminated backtick-delimited value in: " ^ text)
+       | Some stop -> String.sub text (start + 1) (stop - start - 1))
+
 (* Test helper — wraps in Eio context so dispatch paths that use
    Eio.Mutex or structured concurrency work correctly. *)
 let test name f =
@@ -130,6 +138,62 @@ let () = test "dispatch_auth_revoke" (fun () ->
   match Tool_auth.dispatch ctx ~name:"masc_auth_revoke" ~args with
   | Some (success, _result) -> assert success
   | None -> failwith "dispatch returned None"
+)
+
+let () = test "handle_auth_create_token_respects_agent_name" (fun () ->
+  let ctx = make_test_ctx () in
+  let target = "dashboard-eager-manta" in
+  let args =
+    `Assoc [
+      ("agent_name", `String target);
+      ("role", `String "worker");
+    ]
+  in
+  let (success, result) = Tool_auth.handle_auth_create_token ctx args in
+  assert success;
+  assert (contains_substring result target);
+  let raw_token = extract_first_backtick_value result in
+  match Auth.verify_token ctx.config.base_path ~agent_name:target ~token:raw_token with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e)
+)
+
+let () = test "handle_auth_refresh_respects_agent_name" (fun () ->
+  let ctx = make_test_ctx () in
+  let target = "dashboard-eager-manta" in
+  let old_token =
+    match Auth.create_token ctx.config.base_path ~agent_name:target ~role:Types.Worker with
+    | Ok (raw_token, _cred) -> raw_token
+    | Error e -> failwith (Types.masc_error_to_string e)
+  in
+  let args =
+    `Assoc [
+      ("agent_name", `String target);
+      ("token", `String old_token);
+    ]
+  in
+  let (success, result) = Tool_auth.handle_auth_refresh ctx args in
+  assert success;
+  let new_token = extract_first_backtick_value result in
+  assert (new_token <> old_token);
+  match Auth.verify_token ctx.config.base_path ~agent_name:target ~token:new_token with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e)
+)
+
+let () = test "handle_auth_revoke_respects_agent_name" (fun () ->
+  let ctx = make_test_ctx () in
+  let target = "dashboard-eager-manta" in
+  ignore (Auth.create_token ctx.config.base_path ~agent_name:target ~role:Types.Worker);
+  let args = `Assoc [("agent_name", `String target)] in
+  let (success, result) = Tool_auth.handle_auth_revoke ctx args in
+  assert success;
+  assert (contains_substring result target);
+  let remaining =
+    Auth.list_credentials ctx.config.base_path
+    |> List.filter (fun (cred : Types.agent_credential) -> cred.agent_name = target)
+  in
+  assert (remaining = [])
 )
 
 (* Test get_string helper *)

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -196,6 +196,15 @@ let () = test "handle_auth_revoke_respects_agent_name" (fun () ->
   assert (remaining = [])
 )
 
+let () = test "handle_auth_revoke_missing_agent_fails" (fun () ->
+  let ctx = make_test_ctx () in
+  let target = "missing-agent" in
+  let args = `Assoc [("agent_name", `String target)] in
+  let (success, result) = Tool_auth.handle_auth_revoke ctx args in
+  assert (not success);
+  assert (contains_substring result target)
+)
+
 (* Test get_string helper *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in


### PR DESCRIPTION
## Summary
Fix auth subject resolution when transient dashboard or MCP actor names are present, and align auth token tool behavior with the schema they already expose.

## Product impact
- bearer-authenticated dashboard and MCP requests no longer fail spuriously when a generated actor name like `dashboard-eager-manta` is sent for attribution
- explicit stable actor names still remain available for attribution
- auth token create/refresh/revoke now target the requested `agent_name` consistently, with refresh scoped back to the authenticated caller and revoke failing cleanly when the credential is missing

## Evidence
- root cause: auth resolution was conflating presentation-time actor names with the authenticated bearer subject, so transient aliases could outrank the credential owner
- fix: transient/generated actor names now resolve to the token subject for auth, while stable explicit actor names are preserved
- fix: auth token handlers now honor `agent_name` where intended, keep refresh self-scoped, and include regression coverage for HTTP auth resolution, auth tool targeting, and MCP execution

## Review evidence
- direct GLM-5.1 review completed on PR head `37591801f`: https://github.com/jeong-sik/masc-mcp/pull/4627#issuecomment-4174915383

## Linked issue
- Closes #4628
