### PR TITLE
fix(keeper): add Korean BM25 keywords for masc_* tools (#4520)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -347,7 +347,7 @@ let run_turn
     "masc_autoresearch_stop", "자동연구 리서치 중지";
     "masc_autoresearch_cycle", "자동연구 리서치 사이클 실행";
     "masc_autoresearch_search_findings", "자동연구 결과 검색 발견";
-    "masc_plan_get", "계획 플랜 조회 현재";
+    "masc_plan_get", "계획 플랜 마일스톤 로드맵 프로젝트 전략";
     "masc_plan_update", "계획 플랜 수정 업데이트";
     "masc_plan_init", "계획 플랜 초기화 생성";
     "masc_plan_set_task", "계획 태스크 설정 할당";
@@ -361,7 +361,7 @@ let run_turn
     "masc_keeper_list", "키퍼 목록 현황";
     "masc_keeper_msg", "키퍼 메시지 전달 대화";
     "masc_keeper_status", "키퍼 상태 확인";
-    "masc_team_session_start", "팀세션 시작 스웜";
+    "masc_team_session_start", "팀 세션 병렬 작업 스웜 멀티 에이전트 시작";
     "masc_team_session_status", "팀세션 상태 현황";
     "masc_team_session_stop", "팀세션 중지 종료";
     "masc_team_session_step", "팀세션 단계 스텝 실행";

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -327,6 +327,54 @@ let run_turn
     "keeper_voice_sessions", "음성 세션 목록";
     "keeper_voice_session_start", "음성 세션 시작";
     "keeper_voice_session_end", "음성 세션 종료";
+    (* masc_* tools: Korean keywords for cross-language BM25 retrieval.
+       Without these, Korean queries like "코드 검색" only match keeper_*
+       tools that have Korean aliases, systematically deprioritizing
+       masc_* tools.  See #4520. *)
+    "masc_code_search", "코드 검색 소스코드 찾기 심볼";
+    "masc_code_read", "코드 읽기 파일 소스코드";
+    "masc_code_edit", "코드 편집 수정 파일 변경";
+    "masc_code_write", "코드 작성 파일 생성 쓰기";
+    "masc_code_symbols", "코드 심볼 함수 클래스 정의";
+    "masc_code_shell", "코드 명령어 쉘 실행";
+    "masc_code_git", "깃 커밋 브랜치 로그 이력";
+    "masc_governance_status", "거버넌스 상태 규칙 정책";
+    "masc_governance_feed", "거버넌스 피드 이벤트 로그";
+    "masc_governance_report", "거버넌스 보고서 리포트";
+    "masc_governance_set", "거버넌스 설정 규칙 변경";
+    "masc_autoresearch_start", "자동연구 리서치 시작";
+    "masc_autoresearch_status", "자동연구 리서치 상태";
+    "masc_autoresearch_stop", "자동연구 리서치 중지";
+    "masc_autoresearch_cycle", "자동연구 리서치 사이클 실행";
+    "masc_autoresearch_search_findings", "자동연구 결과 검색 발견";
+    "masc_plan_get", "계획 플랜 조회 현재";
+    "masc_plan_update", "계획 플랜 수정 업데이트";
+    "masc_plan_init", "계획 플랜 초기화 생성";
+    "masc_plan_set_task", "계획 태스크 설정 할당";
+    "masc_plan_get_task", "계획 태스크 조회";
+    "masc_agent_card", "에이전트 카드 프로필 정보";
+    "masc_agents", "에이전트 목록 현황 누구";
+    "masc_agent_update", "에이전트 업데이트 상태변경";
+    "masc_agent_fitness", "에이전트 적합도 평가";
+    "masc_keeper_up", "키퍼 시작 기동 생성";
+    "masc_keeper_down", "키퍼 중지 종료";
+    "masc_keeper_list", "키퍼 목록 현황";
+    "masc_keeper_msg", "키퍼 메시지 전달 대화";
+    "masc_keeper_status", "키퍼 상태 확인";
+    "masc_team_session_start", "팀세션 시작 스웜";
+    "masc_team_session_status", "팀세션 상태 현황";
+    "masc_team_session_stop", "팀세션 중지 종료";
+    "masc_team_session_step", "팀세션 단계 스텝 실행";
+    "masc_worktree_create", "워크트리 생성 브랜치";
+    "masc_worktree_list", "워크트리 목록 현황";
+    "masc_worktree_remove", "워크트리 삭제 정리";
+    "masc_tasks", "태스크 목록 할일 작업";
+    "masc_add_task", "태스크 추가 등록 생성";
+    "masc_status", "상태 현황 방 룸 요약";
+    "masc_broadcast", "브로드캐스트 방송 알림 공지";
+    "masc_heartbeat", "하트비트 살아있음 생존";
+    "masc_who", "누구 참여자 에이전트 목록";
+    "masc_messages", "메시지 대화 채팅 로그";
   ] in
   let tool_entries = List.map (fun (t : Agent_sdk.Tool.t) ->
     let name = t.schema.name in

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -26,7 +26,7 @@ let make_meta () =
     Uses the same Korean keywords, groups, and config. *)
 let build_keeper_index () =
   let meta = make_meta () in
-  let tool_schemas = Keeper_exec_tools.keeper_allowed_model_tools meta in
+  let tool_schemas = Keeper_exec_tools.keeper_universe_model_tools meta in
   let tool_index_config =
     { Agent_sdk.Tool_index.default_config with top_k = 20 } in
   let korean_keywords = [
@@ -57,6 +57,50 @@ let build_keeper_index () =
     "keeper_voice_sessions", "음성 세션 목록";
     "keeper_voice_session_start", "음성 세션 시작";
     "keeper_voice_session_end", "음성 세션 종료";
+    "masc_code_search", "코드 검색 소스코드 찾기 심볼";
+    "masc_code_read", "코드 읽기 파일 소스코드";
+    "masc_code_edit", "코드 편집 수정 파일 변경";
+    "masc_code_write", "코드 작성 파일 생성 쓰기";
+    "masc_code_symbols", "코드 심볼 함수 클래스 정의";
+    "masc_code_shell", "코드 명령어 쉘 실행";
+    "masc_code_git", "깃 커밋 브랜치 로그 이력";
+    "masc_governance_status", "거버넌스 상태 규칙 정책";
+    "masc_governance_feed", "거버넌스 피드 이벤트 로그";
+    "masc_governance_report", "거버넌스 보고서 리포트";
+    "masc_governance_set", "거버넌스 설정 규칙 변경";
+    "masc_autoresearch_start", "자동연구 리서치 시작";
+    "masc_autoresearch_status", "자동연구 리서치 상태";
+    "masc_autoresearch_stop", "자동연구 리서치 중지";
+    "masc_autoresearch_cycle", "자동연구 리서치 사이클 실행";
+    "masc_autoresearch_search_findings", "자동연구 결과 검색 발견";
+    "masc_plan_get", "계획 플랜 마일스톤 로드맵 프로젝트 전략";
+    "masc_plan_update", "계획 플랜 수정 업데이트";
+    "masc_plan_init", "계획 플랜 초기화 생성";
+    "masc_plan_set_task", "계획 태스크 설정 할당";
+    "masc_plan_get_task", "계획 태스크 조회";
+    "masc_agent_card", "에이전트 카드 프로필 정보";
+    "masc_agents", "에이전트 목록 현황 누구";
+    "masc_agent_update", "에이전트 업데이트 상태변경";
+    "masc_agent_fitness", "에이전트 적합도 평가";
+    "masc_keeper_up", "키퍼 시작 기동 생성";
+    "masc_keeper_down", "키퍼 중지 종료";
+    "masc_keeper_list", "키퍼 목록 현황";
+    "masc_keeper_msg", "키퍼 메시지 전달 대화";
+    "masc_keeper_status", "키퍼 상태 확인";
+    "masc_team_session_start", "팀 세션 병렬 작업 스웜 멀티 에이전트 시작";
+    "masc_team_session_status", "팀세션 상태 현황";
+    "masc_team_session_stop", "팀세션 중지 종료";
+    "masc_team_session_step", "팀세션 단계 스텝 실행";
+    "masc_worktree_create", "워크트리 생성 브랜치";
+    "masc_worktree_list", "워크트리 목록 현황";
+    "masc_worktree_remove", "워크트리 삭제 정리";
+    "masc_tasks", "태스크 목록 할일 작업";
+    "masc_add_task", "태스크 추가 등록 생성";
+    "masc_status", "상태 현황 방 룸 요약";
+    "masc_broadcast", "브로드캐스트 방송 알림 공지";
+    "masc_heartbeat", "하트비트 살아있음 생존";
+    "masc_who", "누구 참여자 에이전트 목록";
+    "masc_messages", "메시지 대화 채팅 로그";
   ] in
   let tool_entries = List.map (fun (t : Types.tool_schema) ->
     let name = t.name in
@@ -68,7 +112,16 @@ let build_keeper_index () =
       else if String.starts_with ~prefix:"keeper_voice_" name then Some "voice"
       else if String.starts_with ~prefix:"keeper_fs_" name
            || name = "keeper_shell_readonly"
-           || name = "keeper_bash" then Some "filesystem"
+           || name = "keeper_bash"
+           || name = "keeper_write" then Some "filesystem"
+      else if name = "keeper_github" then Some "vcs"
+      else if String.starts_with ~prefix:"masc_board_" name then Some "masc_board"
+      else if String.starts_with ~prefix:"masc_keeper_" name then Some "masc_keeper"
+      else if String.starts_with ~prefix:"masc_plan_" name then Some "masc_plan"
+      else if String.starts_with ~prefix:"masc_team_session_" name then Some "masc_session"
+      else if String.starts_with ~prefix:"masc_worktree_" name then Some "masc_worktree"
+      else if String.starts_with ~prefix:"masc_code_" name then Some "masc_code"
+      else if String.starts_with ~prefix:"masc_" name then Some "masc_core"
       else None
     in
     let kr_kw = match List.assoc_opt name korean_keywords with
@@ -233,6 +286,37 @@ let test_github_issue_kr () =
     "깃허브 이슈 풀리퀘스트" "keeper_github")
 
 (* ================================================================ *)
+(* Scenarios: masc_* tools (Korean BM25 retrieval — #4520)          *)
+(* ================================================================ *)
+
+let test_masc_code_search_kr () =
+  let idx = build_keeper_index () in
+  ignore (assert_retrieves ~label:"masc_code_kr" idx
+    "코드 검색 소스코드" "masc_code_search")
+
+let test_masc_code_search_en () =
+  let idx = build_keeper_index () in
+  ignore (assert_retrieves ~label:"masc_code_en" idx
+    "search the codebase for function definitions" "masc_code_search")
+
+let test_masc_governance_kr () =
+  let idx = build_keeper_index () in
+  ignore (assert_retrieves ~label:"governance_kr" idx
+    "거버넌스 상태 규칙" "masc_governance_status")
+
+(* masc_plan_get and masc_team_session_start are not retrievable via BM25
+   with Korean queries: "계획", "플랜", "팀", "세션" are common terms that
+   produce no BM25 match against 350+ tool descriptions, even with Korean
+   aliases. Needs embedding-based retrieval — tracked in #4331.
+   These tools ARE always-included via category anchors, so they remain
+   accessible regardless of BM25 ranking. *)
+
+let test_masc_worktree_kr () =
+  let idx = build_keeper_index () in
+  ignore (assert_retrieves ~label:"worktree_kr" idx
+    "워크트리 생성 브랜치" "masc_worktree_create")
+
+(* ================================================================ *)
 (* Discrimination: fs_edit vs bash for file writes                  *)
 (* ================================================================ *)
 
@@ -311,6 +395,13 @@ let () =
         [
           Alcotest.test_case "github PR (en)" `Quick test_github_pr_en;
           Alcotest.test_case "github issue (kr)" `Quick test_github_issue_kr;
+        ] );
+      ( "masc_tools",
+        [
+          Alcotest.test_case "masc code search (kr)" `Quick test_masc_code_search_kr;
+          Alcotest.test_case "masc code search (en)" `Quick test_masc_code_search_en;
+          Alcotest.test_case "masc governance (kr)" `Quick test_masc_governance_kr;
+          Alcotest.test_case "masc worktree (kr)" `Quick test_masc_worktree_kr;
         ] );
       ( "discrimination",
         [


### PR DESCRIPTION
## Summary
- Add Korean keyword aliases for 44 masc_* tools in BM25 progressive disclosure index
- Sync retrieval quality test with production index scope (universe, not policy)
- Add 4 masc_* retrieval test scenarios; document BM25 limitations for plan/team-session categories

## Product impact
- repo coordination: masc_* tools now match Korean queries in BM25 ranking, closing the systematic deprioritization gap reported in #4520
- Previously, "코드 검색해줘" matched keeper_fs_read but not masc_code_search because only keeper_* tools had Korean aliases

## Evidence
- Build passes, 26 retrieval quality tests pass (22 existing + 4 new masc_* scenarios)
- Korean keywords follow the same pattern established for keeper_* tools

## Review evidence
- Copilot review addressed: count corrected to 44, test synced with production index

## Linked issue
- Closes #4520 (partially — Korean keyword gap is the primary addressable root cause; remaining BM25 scoring limitations tracked in #4331)