### PR TITLE
fix(auto-responder): propagate Result.t directly instead of raise-catch

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -197,17 +197,14 @@ let masc_call ~sw:_ ~tool_name ~(args : Yojson.Safe.t) : (string, string) result
   match Eio_context.get_net_opt () with
   | None -> Error "Eio net not initialized"
   | Some net ->
-      try
-        let headers = [
-          ("Content-Type", "application/json");
-          ("Accept", "application/json, text/event-stream");
-        ] in
-        let code, body_str =
-          match Masc_http_client.post_sync ~net ~url:(Uri.to_string uri)
-            ~headers ~body () with
-          | Ok v -> v
-          | Error e -> raise (Failure e)
-        in
+      let headers = [
+        ("Content-Type", "application/json");
+        ("Accept", "application/json, text/event-stream");
+      ] in
+      (match Masc_http_client.post_sync ~net ~url:(Uri.to_string uri)
+          ~headers ~body () with
+      | Error e -> Error e
+      | Ok (code, body_str) ->
         if not (Cohttp.Code.is_success code) then
           Error (Printf.sprintf "MASC HTTP %d" code)
         else
@@ -224,11 +221,7 @@ let masc_call ~sw:_ ~tool_name ~(args : Yojson.Safe.t) : (string, string) result
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
             Log.Misc.warn "auto_responder: MCP response parse failed: %s" (Printexc.to_string exn);
-            Ok body_str
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Error (Printexc.to_string exn)
+            Ok body_str)
 
 let extract_nickname (response_text : string) : string option =
   let prefix = "Nickname:" in


### PR DESCRIPTION
## Summary

- Addresses Copilot review comment 3 on #4621: `auto_responder.ml` was unwrapping `Masc_http_client.post_sync` Result by `raise (Failure e)` only to immediately catch it in the surrounding `try...with exn` handler
- Replaced with direct pattern matching: `Error e -> Error e` propagates the transport error cleanly without exception-driven control flow
- Removes the now-unnecessary outer `try...with` block (JSON parse exceptions in the inner block are still handled)

## Linked issue

Refs #4621

## Review evidence

Copilot review comment on #4621:
> `Masc_http_client.post_sync` now returns a `result`, but on `Error e` this code raises `Failure e` only to immediately catch it in the surrounding `try ... with exn -> Error (Printexc.to_string exn)`. This loses the original error message (it becomes `Failure("...")`) and reintroduces exception-driven control flow.

## Test plan

- [x] `dune build` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)