### PR TITLE
[codex] Unify keeper tool policy schema

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -2,6 +2,50 @@
 
 open Types
 
+let string_array_schema =
+  `Assoc [
+    ("type", `String "array");
+    ("items", `Assoc [ ("type", `String "string") ]);
+  ]
+
+let tool_access_schema description =
+  let preset_shape =
+    `Assoc [
+      ("type", `String "object");
+      ("description", `String "Preset-based tool policy.");
+      ("properties", `Assoc [
+        ("kind", `Assoc [ ("const", `String "preset") ]);
+        ("preset", `Assoc [
+          ("type", `String "string");
+          ("enum",
+            `List
+              [ `String "minimal"; `String "messaging"; `String "coding";
+                `String "research"; `String "full" ]);
+        ]);
+        ("also_allow", string_array_schema);
+      ]);
+      ("required", `List [ `String "kind"; `String "preset" ]);
+      ("additionalProperties", `Bool false);
+    ]
+  in
+  let custom_shape =
+    `Assoc [
+      ("type", `String "object");
+      ("description", `String "Custom tool allowlist policy.");
+      ("properties", `Assoc [
+        ("kind", `Assoc [ ("const", `String "custom") ]);
+        ("tools", string_array_schema);
+      ]);
+      ("required", `List [ `String "kind"; `String "tools" ]);
+      ("additionalProperties", `Bool false);
+    ]
+  in
+  `Assoc [
+    ("type", `String "object");
+    ("description", `String description);
+    ("oneOf", `List [ preset_shape; custom_shape ]);
+  ]
+
 let keeper_schemas : tool_schema list = [
   {
     name = "masc_persona_list";
@@ -68,10 +112,9 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
         ]);
-        ("tool_access", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
-        ]);
+        ("tool_access",
+          tool_access_schema
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("description", `String "Compatibility field. Use tool_access.kind='preset' for new callers.");
@@ -211,10 +254,9 @@ let keeper_schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Restrict file writes to these path prefixes. Empty list uses computed defaults based on execution_scope. Use [\"*\"] for explicit full access.");
         ]);
-        ("tool_access", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
-        ]);
+        ("tool_access",
+          tool_access_schema
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "minimal"; `String "messaging"; `String "coding"; `String "research"; `String "full"]);

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -68,13 +68,24 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
         ]);
+        ("tool_access", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
+        ]);
         ("tool_preset", `Assoc [
           ("type", `String "string");
+          ("description", `String "Compatibility field. Use tool_access.kind='preset' for new callers.");
           ("enum", `List [`String "minimal"; `String "messaging"; `String "coding"; `String "research"; `String "full"]);
+        ]);
+        ("tool_custom_allowlist", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Compatibility field for custom allowlists. Use tool_access.kind='custom' for new callers.");
         ]);
         ("tool_also_allow", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Compatibility field. Adds tools on top of tool_preset.");
         ]);
         ("tool_denylist", `Assoc [
           ("type", `String "array");
@@ -200,15 +211,24 @@ let keeper_schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Restrict file writes to these path prefixes. Empty list uses computed defaults based on execution_scope. Use [\"*\"] for explicit full access.");
         ]);
+        ("tool_access", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
+        ]);
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "minimal"; `String "messaging"; `String "coding"; `String "research"; `String "full"]);
-          ("description", `String "Base keeper tools preset. Default: full.");
+          ("description", `String "Compatibility field. Use tool_access.kind='preset' for new callers.");
+        ]);
+        ("tool_custom_allowlist", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Compatibility field for custom allowlists. Use tool_access.kind='custom' for new callers.");
         ]);
         ("tool_also_allow", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Additional tool names to add on top of the selected preset.");
+          ("description", `String "Compatibility field. Adds tools on top of tool_preset.");
         ]);
         ("tool_denylist", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -31,6 +31,7 @@ type parsed_args = {
   compaction_message_gate_opt : int option;
   compaction_token_gate_opt : int option;
   continuity_compaction_cooldown_sec_opt : int option;
+  tool_access_opt : tool_access option;
   tool_preset_opt : tool_preset option;
   tool_also_allow_opt : string list option;
   tool_denylist_opt : string list option;
@@ -56,10 +57,68 @@ let get_present_tool_name_list_opt args key =
   | `Null -> None
   | _ -> Some (normalize_tool_name_list (get_string_list args key))
 
+let json_member_present key (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> false
+  | _ -> true
+
 let resolve_tool_name_list ~preferred ~fallback =
   first_some preferred fallback
   |> Option.value ~default:[]
   |> normalize_tool_name_list
+
+let parse_tool_access_input (args : Yojson.Safe.t) :
+    (tool_access option * tool_preset option * string list option, string) result =
+  let tool_access_present = json_member_present "tool_access" args in
+  let tool_preset_present = json_member_present "tool_preset" args in
+  let tool_also_allow_present = json_member_present "tool_also_allow" args in
+  let tool_custom_allowlist_present = json_member_present "tool_custom_allowlist" args in
+  if tool_access_present
+     && (tool_preset_present || tool_also_allow_present || tool_custom_allowlist_present)
+  then
+    Error
+      "tool_access cannot be combined with tool_preset, tool_also_allow, or tool_custom_allowlist"
+  else if tool_custom_allowlist_present && (tool_preset_present || tool_also_allow_present) then
+    Error
+      "tool_custom_allowlist cannot be combined with tool_preset or tool_also_allow"
+  else
+    let tool_access_opt =
+      if tool_access_present then
+        let access_json = Yojson.Safe.Util.member "tool_access" args in
+        match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
+        | Ok access -> Ok (Some access)
+        | Error msg -> Error msg
+      else if tool_custom_allowlist_present then
+        Ok
+          (Some
+             (Custom
+                (get_present_tool_name_list_opt args "tool_custom_allowlist"
+                 |> Option.value ~default:[])))
+      else
+        Ok None
+    in
+    match tool_access_opt with
+    | Error msg -> Error msg
+    | Ok tool_access_opt ->
+        let tool_preset_opt =
+          match get_string_opt args "tool_preset" with
+          | None -> Ok None
+          | Some raw -> (
+              match tool_preset_of_string raw with
+              | Some preset -> Ok (Some preset)
+              | None ->
+                  Error
+                    (Printf.sprintf
+                       "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
+                       raw))
+        in
+        (match tool_preset_opt with
+        | Error msg -> Error msg
+        | Ok tool_preset_opt ->
+            Ok
+              ( tool_access_opt,
+                tool_preset_opt,
+                get_present_tool_name_list_opt args "tool_also_allow" ))
 
 let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) result =
   let name = get_string args "name" "" in
@@ -76,25 +135,12 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let compaction_profile_opt_res =
       parse_compaction_profile_opt args "compaction_profile"
     in
-    match soul_profile_opt_res, compaction_profile_opt_res with
-    | Error e, _ | _, Error e -> Error (false, e)
-    | Ok soul_profile_opt, Ok compaction_profile_opt ->
-    let tool_preset_opt =
-      match get_string_opt args "tool_preset" with
-      | None -> Ok None
-      | Some raw -> (
-          match tool_preset_of_string raw with
-          | Some preset -> Ok (Some preset)
-          | None ->
-              Error
-                (false,
-                 Printf.sprintf
-                   "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
-                   raw))
-    in
-    match tool_preset_opt with
-    | Error e -> Error e
-    | Ok tool_preset_opt ->
+    let tool_access_input_res = parse_tool_access_input args in
+    match soul_profile_opt_res, compaction_profile_opt_res, tool_access_input_res with
+    | Error e, _, _ | _, Error e, _ -> Error (false, e)
+    | _, _, Error e -> Error (false, e)
+    | Ok soul_profile_opt, Ok compaction_profile_opt,
+      Ok (tool_access_opt, tool_preset_opt, tool_also_allow_opt) ->
     let goal_opt = get_string_opt args "goal" in
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
@@ -120,7 +166,6 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let continuity_compaction_cooldown_sec_opt =
       Safe_ops.json_int_opt "continuity_compaction_cooldown_sec" args
     in
-    let tool_also_allow_opt = get_present_tool_name_list_opt args "tool_also_allow" in
     let tool_denylist_opt = get_present_tool_name_list_opt args "tool_denylist" in
     let auto_handoff_opt = get_bool_opt args "auto_handoff" in
     let handoff_threshold_opt = Safe_ops.json_float_opt "handoff_threshold" args in
@@ -186,6 +231,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       compaction_message_gate_opt;
       compaction_token_gate_opt;
       continuity_compaction_cooldown_sec_opt;
+      tool_access_opt;
       tool_preset_opt;
       tool_also_allow_opt;
       tool_denylist_opt;

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -52,15 +52,29 @@ let normalize_tool_name_list names =
   |> List.filter (fun name -> name <> "")
   |> dedupe_keep_order
 
-let get_present_tool_name_list_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `Null -> None
-  | _ -> Some (normalize_tool_name_list (get_string_list args key))
+let json_assoc_member_opt key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
 
 let json_member_present key (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member key json with
-  | `Null -> false
-  | _ -> true
+  match json with
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+
+let parse_present_tool_name_list_opt args key =
+  match json_assoc_member_opt key args with
+  | None -> Ok None
+  | Some (`List items) ->
+      let rec collect acc index = function
+        | [] -> Ok (Some (normalize_tool_name_list (List.rev acc)))
+        | `String value :: rest -> collect (value :: acc) (index + 1) rest
+        | _ :: _ ->
+            Error (Printf.sprintf "%s[%d] must be a string" key index)
+      in
+      collect [] 0 items
+  | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
+  | Some _ -> Error (Printf.sprintf "%s must be an array of strings" key)
 
 let resolve_tool_name_list ~preferred ~fallback =
   first_some preferred fallback
@@ -84,16 +98,19 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
   else
     let tool_access_opt =
       if tool_access_present then
-        let access_json = Yojson.Safe.Util.member "tool_access" args in
-        match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
-        | Ok access -> Ok (Some access)
-        | Error msg -> Error msg
-      else if tool_custom_allowlist_present then
-        Ok
-          (Some
-             (Custom
-                (get_present_tool_name_list_opt args "tool_custom_allowlist"
-                 |> Option.value ~default:[])))
+        match json_assoc_member_opt "tool_access" args with
+        | Some ((`Assoc _) as access_json) -> (
+            match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
+            | Ok access -> Ok (Some access)
+            | Error msg -> Error msg)
+        | Some `Null -> Error "tool_access must not be null"
+        | Some _ -> Error "tool_access must be an object"
+        | None -> Ok None
+      else if tool_custom_allowlist_present then (
+        match parse_present_tool_name_list_opt args "tool_custom_allowlist" with
+        | Ok (Some names) -> Ok (Some (Custom names))
+        | Ok None -> Ok None
+        | Error msg -> Error msg)
       else
         Ok None
     in
@@ -101,9 +118,9 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
     | Error msg -> Error msg
     | Ok tool_access_opt ->
         let tool_preset_opt =
-          match get_string_opt args "tool_preset" with
+          match json_assoc_member_opt "tool_preset" args with
           | None -> Ok None
-          | Some raw -> (
+          | Some (`String raw) -> (
               match tool_preset_of_string raw with
               | Some preset -> Ok (Some preset)
               | None ->
@@ -111,14 +128,16 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
                     (Printf.sprintf
                        "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
                        raw))
+          | Some `Null -> Error "tool_preset must not be null"
+          | Some _ -> Error "tool_preset must be a string"
         in
-        (match tool_preset_opt with
-        | Error msg -> Error msg
-        | Ok tool_preset_opt ->
-            Ok
-              ( tool_access_opt,
-                tool_preset_opt,
-                get_present_tool_name_list_opt args "tool_also_allow" ))
+        let tool_also_allow_opt =
+          parse_present_tool_name_list_opt args "tool_also_allow"
+        in
+        (match tool_preset_opt, tool_also_allow_opt with
+        | Error msg, _ | _, Error msg -> Error msg
+        | Ok tool_preset_opt, Ok tool_also_allow_opt ->
+            Ok (tool_access_opt, tool_preset_opt, tool_also_allow_opt))
 
 let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) result =
   let name = get_string args "name" "" in
@@ -166,7 +185,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let continuity_compaction_cooldown_sec_opt =
       Safe_ops.json_int_opt "continuity_compaction_cooldown_sec" args
     in
-    let tool_denylist_opt = get_present_tool_name_list_opt args "tool_denylist" in
+    let tool_denylist_opt_res = parse_present_tool_name_list_opt args "tool_denylist" in
     let auto_handoff_opt = get_bool_opt args "auto_handoff" in
     let handoff_threshold_opt = Safe_ops.json_float_opt "handoff_threshold" args in
     let handoff_cooldown_sec_opt = Safe_ops.json_int_opt "handoff_cooldown_sec" args in
@@ -207,6 +226,9 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in
     let desires_opt = parse_self_model_opt args "desires" in
+    match tool_denylist_opt_res with
+    | Error msg -> Error (false, msg)
+    | Ok tool_denylist_opt ->
     Ok {
       name;
       soul_profile_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -111,14 +111,20 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
     let handoff_threshold = Option.value ~default:0.85 p.handoff_threshold_opt in
     let handoff_cooldown_sec = Option.value ~default:300 p.handoff_cooldown_sec_opt in
-    let tool_preset =
-      Option.value ~default:Research
-        (first_some p.tool_preset_opt (preset_of_defaults p.profile_defaults))
-    in
-    let tool_also_allow =
-      resolve_tool_name_list
-        ~preferred:p.tool_also_allow_opt
-        ~fallback:p.profile_defaults.tool_also_allow
+    let tool_access =
+      match p.tool_access_opt with
+      | Some access -> access
+      | None ->
+          let tool_preset =
+            Option.value ~default:Research
+              (first_some p.tool_preset_opt (preset_of_defaults p.profile_defaults))
+          in
+          let tool_also_allow =
+            resolve_tool_name_list
+              ~preferred:p.tool_also_allow_opt
+              ~fallback:p.profile_defaults.tool_also_allow
+          in
+          Preset { preset = tool_preset; also_allow = tool_also_allow }
     in
     let tool_denylist =
       resolve_tool_name_list
@@ -218,7 +224,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         execution_scope;
         allowed_paths;
         scope_kind;
-        tool_access = Preset { preset = tool_preset; also_allow = tool_also_allow };
+        tool_access;
         tool_denylist;
         room_scope;
         voice_enabled;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -9,8 +9,8 @@ open Keeper_keepalive
 open Keeper_turn_up_args
 
 let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result =
-  match old.tool_access, p.tool_preset_opt, p.tool_also_allow_opt with
-  | Custom _, None, Some _ ->
+  match p.tool_access_opt, old.tool_access, p.tool_preset_opt, p.tool_also_allow_opt with
+  | None, Custom _, None, Some _ ->
       (false, "tool_also_allow requires a preset-based keeper policy; set tool_preset first")
   | _ ->
   let goal_provided = Option.is_some p.goal_opt in
@@ -89,25 +89,28 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       ~fallback_token:old.compaction.token_gate
   in
   let tool_access =
-    match old.tool_access with
-    | Preset current ->
-        let preset = Option.value ~default:current.preset p.tool_preset_opt in
-        let also_allow =
-          resolve_tool_name_list
-            ~preferred:p.tool_also_allow_opt
-            ~fallback:(Some current.also_allow)
-        in
-        Preset { preset; also_allow }
-    | Custom names -> (
-        match p.tool_preset_opt with
-        | Some preset ->
+    match p.tool_access_opt with
+    | Some access -> access
+    | None ->
+        match old.tool_access with
+        | Preset current ->
+            let preset = Option.value ~default:current.preset p.tool_preset_opt in
             let also_allow =
               resolve_tool_name_list
                 ~preferred:p.tool_also_allow_opt
-                ~fallback:p.profile_defaults.tool_also_allow
+                ~fallback:(Some current.also_allow)
             in
             Preset { preset; also_allow }
-        | None -> Custom names)
+        | Custom names -> (
+            match p.tool_preset_opt with
+            | Some preset ->
+                let also_allow =
+                  resolve_tool_name_list
+                    ~preferred:p.tool_also_allow_opt
+                    ~fallback:p.profile_defaults.tool_also_allow
+                in
+                Preset { preset; also_allow }
+            | None -> Custom names)
   in
   let tool_denylist =
     resolve_tool_name_list

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -214,6 +214,11 @@ let json_member_present key (json : Yojson.Safe.t) =
   | `Assoc fields -> List.mem_assoc key fields
   | _ -> false
 
+let json_object_member_present key (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member key json with
+  | `Assoc _ -> true
+  | _ -> false
+
 let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
   let label = Option.value ~default:field_name label in
   match Yojson.Safe.Util.member field_name json with
@@ -443,7 +448,7 @@ let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
   match compat_present with
   | [] -> ()
   | fields ->
-      if json_member_present "tool_access" json then
+      if json_object_member_present "tool_access" json then
         Log.Keeper.warn
           "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
           path (String.concat ", " fields)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -209,47 +209,86 @@ let tool_access_to_json access =
           ("tools", `List (List.map (fun s -> `String s) names));
         ]
 
+let json_member_present key (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> false
+  | _ -> true
+
+let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
+  let label = Option.value ~default:field_name label in
+  match Yojson.Safe.Util.member field_name json with
+  | `List items ->
+      let rec collect acc index = function
+        | [] -> Ok (List.rev acc)
+        | `String value :: rest -> collect (value :: acc) (index + 1) rest
+        | _ :: _ ->
+            Error
+              (Printf.sprintf
+                 "keeper %s[%d] must be a string"
+                 label index)
+      in
+      collect [] 0 items
+  | `Null ->
+      Error (Printf.sprintf "keeper %s must be an array of strings" label)
+  | _ ->
+      Error (Printf.sprintf "keeper %s must be an array of strings" label)
+
+let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member field_name json with
+  | `Null -> Ok []
+  | _ -> string_list_field_result ?label ~field_name json
+
+let parse_tool_preset_projection (json : Yojson.Safe.t) =
+  let preset_member = Yojson.Safe.Util.member "tool_preset" json in
+  match preset_member with
+  | `String raw -> (
+      match tool_preset_of_string raw with
+      | Some preset -> Ok preset
+      | None ->
+          Error
+            (Printf.sprintf "invalid keeper tool_preset: %s" raw))
+  | `Null -> Error "keeper tool_preset required"
+  | _ -> Error "keeper tool_preset must be a string"
+
+let tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
+  let custom_present = json_member_present "tool_custom_allowlist" json in
+  let preset_present = json_member_present "tool_preset" json in
+  let also_allow_present = json_member_present "tool_also_allow" json in
+  let legacy_allowlist_present = json_member_present "tool_allowlist" json in
+  if custom_present then
+    match string_list_field_result ~field_name:"tool_custom_allowlist" json with
+    | Ok tools -> Ok (normalize_tool_access (Custom tools))
+    | Error msg -> Error msg
+  else if preset_present || also_allow_present then
+    match parse_tool_preset_projection json with
+    | Error msg -> Error msg
+    | Ok preset -> (
+        match string_list_field_opt_result ~field_name:"tool_also_allow" json with
+        | Ok also_allow ->
+            Ok (normalize_tool_access (Preset { preset; also_allow }))
+        | Error msg -> Error msg)
+  else if legacy_allowlist_present then
+    match string_list_field_result ~field_name:"tool_allowlist" json with
+    | Ok names -> Ok (migrate_legacy_restricted_tools names)
+    | Error msg -> Error msg
+  else
+    Ok (migrate_legacy_restricted_tools legacy_standard_tool_names)
+
 let tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member "tool_access" json with
   | `Null ->
-      let legacy_allowlist =
-        match Safe_ops.json_string_list "tool_allowlist" json with
-        | [] -> legacy_standard_tool_names
-        | names -> names
-      in
-      Ok (migrate_legacy_restricted_tools legacy_allowlist)
+      tool_access_projection_of_meta_json json
   | `Assoc _ as access_json -> (
       let kind =
         Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
-      in
-      let string_list_field field_name =
-        match Yojson.Safe.Util.member field_name access_json with
-        | `List items ->
-            let rec collect acc index = function
-              | [] -> Ok (List.rev acc)
-              | `String value :: rest -> collect (value :: acc) (index + 1) rest
-              | _ :: _ ->
-                  Error
-                    (Printf.sprintf
-                       "keeper tool_access.%s[%d] must be a string"
-                       field_name index)
-            in
-            collect [] 0 items
-        | `Null ->
-            Error (Printf.sprintf "keeper tool_access.%s must be an array of strings" field_name)
-        | _ ->
-            Error (Printf.sprintf "keeper tool_access.%s must be an array of strings" field_name)
-      in
-      let string_list_field_opt field_name =
-        match Yojson.Safe.Util.member field_name access_json with
-        | `Null -> Ok []
-        | _ -> string_list_field field_name
       in
       match kind with
       | Some "unrestricted" ->
           Ok (Preset { preset = Full; also_allow = [] } |> normalize_tool_access)
       | Some "restricted" -> (
-          match string_list_field_opt "tools" with
+          match string_list_field_opt_result
+                  ~field_name:"tools" ~label:"tool_access.tools" access_json
+          with
           | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
           | Error msg -> Error msg)
       | Some "preset" -> (
@@ -267,20 +306,151 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
                        "invalid keeper tool_access.preset: %s"
                        raw)
               | Some preset -> (
-                  match string_list_field_opt "also_allow" with
+                  match string_list_field_opt_result
+                          ~field_name:"also_allow" ~label:"tool_access.also_allow" access_json
+                  with
                   | Ok also_allow ->
                       Ok
                         (normalize_tool_access
                            (Preset { preset; also_allow }))
                   | Error msg -> Error msg)))
       | Some "custom" -> (
-          match string_list_field "tools" with
+          match string_list_field_result
+                  ~field_name:"tools" ~label:"tool_access.tools" access_json
+          with
           | Ok tools -> Ok (normalize_tool_access (Custom tools))
           | Error msg -> Error msg)
       | Some other ->
           Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
       | None -> Error "keeper tool_access.kind required")
   | _ -> Error "keeper tool_access must be an object"
+
+let canonical_keeper_meta_key_names =
+  [
+    "name";
+    "agent_name";
+    "trace_id";
+    "trace_history";
+    "goal";
+    "short_goal";
+    "mid_goal";
+    "long_goal";
+    "soul_profile";
+    "social_model";
+    "cascade_name";
+    "will";
+    "needs";
+    "desires";
+    "instructions";
+    "policy_voice_enabled";
+    "execution_scope";
+    "allowed_paths";
+    "scope_kind";
+    "tool_access";
+    "tool_denylist";
+    "room_scope";
+    "mention_targets";
+    "room_signal_prompt_enabled";
+    "joined_room_ids";
+    "last_seen_seq_by_room";
+    "generation";
+    "proactive_enabled";
+    "proactive_idle_sec";
+    "proactive_cooldown_sec";
+    "compaction_profile";
+    "compaction_ratio_gate";
+    "compaction_message_gate";
+    "compaction_token_gate";
+    "continuity_compaction_cooldown_sec";
+    "auto_handoff";
+    "handoff_threshold";
+    "handoff_cooldown_sec";
+    "voice_enabled";
+    "voice_channel";
+    "voice_agent_id";
+    "last_handoff_ts";
+    "created_at";
+    "updated_at";
+    "total_turns";
+    "total_input_tokens";
+    "total_output_tokens";
+    "total_tokens";
+    "total_cost_usd";
+    "last_turn_ts";
+    "last_model_used";
+    "last_input_tokens";
+    "last_output_tokens";
+    "last_total_tokens";
+    "last_latency_ms";
+    "compaction_count";
+    "last_compaction_ts";
+    "last_compaction_before_tokens";
+    "last_compaction_after_tokens";
+    "proactive_count_total";
+    "last_proactive_ts";
+    "last_proactive_reason";
+    "last_proactive_preview";
+    "last_compaction_check_ts";
+    "last_compaction_decision";
+    "last_continuity_update_ts";
+    "continuity_summary";
+    "active_goal_ids";
+    "active_team_session_id";
+    "last_team_session_started_at";
+    "team_session_start_count_total";
+    "last_autonomous_action_at";
+    "autonomous_action_count";
+    "autonomous_turn_count";
+    "autonomous_text_turn_count";
+    "autonomous_tool_turn_count";
+    "board_reactive_turn_count";
+    "mention_reactive_turn_count";
+    "noop_turn_count";
+    "last_speech_act";
+    "last_blocker";
+    "last_need";
+    "paused";
+    "current_task_id";
+  ]
+
+let compatibility_keeper_meta_key_names =
+  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+
+let known_keeper_meta_key_names =
+  canonical_keeper_meta_key_names
+  @ compatibility_keeper_meta_key_names
+
+let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+      let unknown =
+        fields
+        |> List.filter_map (fun (key, _) ->
+               if List.mem key known_keeper_meta_key_names then None else Some key)
+        |> dedupe_keep_order
+      in
+      if unknown <> [] then
+        Log.Keeper.warn
+          "keeper meta %s has unknown keys: %s"
+          path (String.concat ", " unknown)
+  | _ -> ()
+
+let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
+  let compat_present =
+    compatibility_keeper_meta_key_names
+    |> List.filter (fun key -> json_member_present key json)
+  in
+  match compat_present with
+  | [] -> ()
+  | fields ->
+      if json_member_present "tool_access" json then
+        Log.Keeper.warn
+          "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
+          path (String.concat ", " fields)
+      else
+        Log.Keeper.warn
+          "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
+          path (String.concat ", " fields)
 
 (* -- Updater helpers for nested record updates -- *)
 
@@ -818,9 +988,13 @@ let read_meta_file_path path : (keeper_meta option, string) result =
         let json, _scrubbed =
           scrub_persisted_keeper_meta_json ~path json
         in
+        warn_unknown_keeper_meta_keys ~path json;
+        warn_tool_access_compat_keys ~path json;
         (match meta_of_json json with
          | Ok meta -> Ok (Some meta)
-         | Error e -> Error e)
+         | Error e ->
+             Log.Keeper.warn "keeper meta parse failed for %s: %s" path e;
+             Error e)
 
 let keeper_names config =
   let dir = keeper_dir config in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -210,9 +210,9 @@ let tool_access_to_json access =
         ]
 
 let json_member_present key (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member key json with
-  | `Null -> false
-  | _ -> true
+  match json with
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
 
 let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
   let label = Option.value ~default:field_name label in

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -195,6 +195,67 @@ let test_tool_access_legacy_restricted_keeps_internal_and_listed_tools () =
   Alcotest.(check bool) "restricted does not unlock unrelated masc tool" false
     (List.mem "masc_autoresearch_cycle" names)
 
+let test_tool_access_projection_preset_keys_loaded () =
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "compat-preset");
+          ("agent_name", `String "compat-preset");
+          ("trace_id", `String "compat-preset-trace");
+          ("tool_preset", `String "coding");
+          ("tool_also_allow", `List [ `String "masc_governance_status" ]);
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  match meta.Masc_mcp.Keeper_types.tool_access with
+  | Masc_mcp.Keeper_types.Preset
+      { preset = Masc_mcp.Keeper_types.Coding; also_allow } ->
+      Alcotest.(check (list string))
+        "compat preset keeps also_allow"
+        [ "masc_governance_status" ] also_allow
+  | _ -> Alcotest.fail "expected coding preset from compatibility keys"
+
+let test_tool_access_projection_custom_allowlist_loaded () =
+  let meta =
+    match Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "compat-custom");
+          ("agent_name", `String "compat-custom");
+          ("trace_id", `String "compat-custom-trace");
+          ("tool_custom_allowlist", `List [ `String "masc_status" ]);
+        ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith e
+  in
+  match meta.Masc_mcp.Keeper_types.tool_access with
+  | Masc_mcp.Keeper_types.Custom names ->
+      Alcotest.(check (list string))
+        "compat custom allowlist preserved"
+        [ "masc_status" ] names
+  | _ -> Alcotest.fail "expected Custom allowlist from compatibility keys"
+
+let test_tool_access_projection_invalid_preset_rejected () =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc
+      [
+        ("name", `String "compat-invalid-preset");
+        ("agent_name", `String "compat-invalid-preset");
+        ("trace_id", `String "compat-invalid-preset-trace");
+        ("tool_preset", `String "bogus");
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected invalid compatibility preset to fail"
+  | Error e ->
+      Alcotest.(check string)
+        "invalid compatibility preset error"
+        "meta parse error: invalid keeper tool_preset: bogus"
+        e
+
 let test_tool_access_preset_empty_json_preserved () =
   let meta =
     match Masc_mcp.Keeper_types.meta_of_json
@@ -476,6 +537,12 @@ let () =
             test_tool_access_legacy_unrestricted_maps_to_full;
           Alcotest.test_case "legacy restricted keeps internal tools" `Quick
             test_tool_access_legacy_restricted_keeps_internal_and_listed_tools;
+          Alcotest.test_case "compat preset keys load preset policy" `Quick
+            test_tool_access_projection_preset_keys_loaded;
+          Alcotest.test_case "compat custom allowlist loads custom policy" `Quick
+            test_tool_access_projection_custom_allowlist_loaded;
+          Alcotest.test_case "compat invalid preset rejected" `Quick
+            test_tool_access_projection_invalid_preset_rejected;
           Alcotest.test_case "preset empty json preserved" `Quick
             test_tool_access_preset_empty_json_preserved;
           Alcotest.test_case "custom empty json preserved" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1445,6 +1445,57 @@ let test_keeper_up_update_allows_canonical_tool_access_override () =
             [ "masc_status" ] names
       | _ -> fail "expected canonical tool_access override to produce custom policy")
 
+let test_keeper_up_update_accepts_tool_custom_allowlist_compat () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "tool-custom-update";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, create_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-custom-update");
+              ("goal", `String "Create preset keeper before compat custom update");
+              ("tool_preset", `String "minimal");
+            ])
+      in
+      if not ok then fail ("initial keeper up failed: " ^ create_body);
+      let ok, update_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-custom-update");
+              ("goal", `String "Override with compat custom allowlist");
+              ("tool_custom_allowlist", `List [ `String "masc_status"; `String "masc_board_list" ]);
+            ])
+      in
+      if not ok then fail ("compat custom update failed: " ^ update_body);
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "tool-custom-update" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after compat custom update"
+        | Error e -> fail e
+      in
+      match meta.Masc_mcp.Keeper_types.tool_access with
+      | Masc_mcp.Keeper_types.Custom names ->
+          check (list string) "compat custom update wins"
+            [ "masc_status"; "masc_board_list" ] names
+      | _ -> fail "expected compat custom allowlist update to produce custom policy")
+
 let test_keeper_up_rejects_mixed_tool_access_inputs () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1474,6 +1525,31 @@ let test_keeper_up_rejects_mixed_tool_access_inputs () =
       check bool "keeper up rejects mixed tool inputs" false ok;
       check bool "mixed input error surfaced" true
         (contains_substring body "tool_access cannot be combined"))
+
+let test_keeper_up_rejects_tool_custom_allowlist_with_also_allow () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "mixed-custom-compat");
+              ("goal", `String "Reject mixed compat tool inputs");
+              ("tool_custom_allowlist", `List [ `String "masc_status" ]);
+              ("tool_also_allow", `List [ `String "masc_board_list" ]);
+            ])
+      in
+      check bool "keeper up rejects compat mixed tool inputs" false ok;
+      check bool "compat mixed input error surfaced" true
+        (contains_substring body "tool_custom_allowlist cannot be combined"))
 
 let test_keeper_up_persists_explicit_goal_horizons () =
   Eio_main.run @@ fun env ->
@@ -2341,8 +2417,12 @@ let () =
            test_keeper_up_accepts_tool_custom_allowlist_compat;
          test_case "keeper up update allows canonical tool_access override" `Quick
            test_keeper_up_update_allows_canonical_tool_access_override;
+         test_case "keeper up update accepts tool_custom_allowlist compat" `Quick
+           test_keeper_up_update_accepts_tool_custom_allowlist_compat;
          test_case "keeper up rejects mixed tool_access inputs" `Quick
            test_keeper_up_rejects_mixed_tool_access_inputs;
+         test_case "keeper up rejects tool_custom_allowlist with also_allow" `Quick
+           test_keeper_up_rejects_tool_custom_allowlist_with_also_allow;
          test_case "write_meta syncs registry meta" `Quick
            test_write_meta_syncs_registry_meta;
          test_case "keeper up persists allowed paths" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1347,6 +1347,134 @@ let test_keeper_up_accepts_canonical_tool_access () =
             [ "masc_status"; "masc_board_list" ] names
       | _ -> fail "expected custom tool_access")
 
+let test_keeper_up_accepts_tool_custom_allowlist_compat () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "tool-custom-compat";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-custom-compat");
+              ("goal", `String "Exercise compat custom allowlist input");
+              ("tool_custom_allowlist", `List [ `String "masc_status"; `String "masc_board_list" ]);
+            ])
+      in
+      if not ok then fail ("keeper up failed: " ^ body);
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "tool-custom-compat" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after compat custom allowlist create"
+        | Error e -> fail e
+      in
+      match meta.Masc_mcp.Keeper_types.tool_access with
+      | Masc_mcp.Keeper_types.Custom names ->
+          check (list string) "compat custom allowlist preserved"
+            [ "masc_status"; "masc_board_list" ] names
+      | _ -> fail "expected custom tool_access from tool_custom_allowlist")
+
+let test_keeper_up_update_allows_canonical_tool_access_override () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "tool-access-override";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, create_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-access-override");
+              ("goal", `String "Create preset keeper before override");
+              ("tool_preset", `String "minimal");
+              ("tool_also_allow", `List [ `String "masc_governance_status" ]);
+            ])
+      in
+      if not ok then fail ("initial keeper up failed: " ^ create_body);
+      let ok, update_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-access-override");
+              ("goal", `String "Override with canonical tool_access");
+              ( "tool_access",
+                `Assoc
+                  [
+                    ("kind", `String "custom");
+                    ("tools", `List [ `String "masc_status" ]);
+                  ] );
+            ])
+      in
+      if not ok then fail ("override keeper up failed: " ^ update_body);
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "tool-access-override" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after canonical override update"
+        | Error e -> fail e
+      in
+      match meta.Masc_mcp.Keeper_types.tool_access with
+      | Masc_mcp.Keeper_types.Custom names ->
+          check (list string) "canonical override wins"
+            [ "masc_status" ] names
+      | _ -> fail "expected canonical tool_access override to produce custom policy")
+
+let test_keeper_up_rejects_mixed_tool_access_inputs () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "mixed-tool-input");
+              ("goal", `String "Reject mixed tool policy inputs");
+              ("tool_preset", `String "minimal");
+              ( "tool_access",
+                `Assoc
+                  [
+                    ("kind", `String "custom");
+                    ("tools", `List [ `String "masc_status" ]);
+                  ] );
+            ])
+      in
+      check bool "keeper up rejects mixed tool inputs" false ok;
+      check bool "mixed input error surfaced" true
+        (contains_substring body "tool_access cannot be combined"))
+
 let test_keeper_up_persists_explicit_goal_horizons () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1978,6 +2106,66 @@ let test_read_meta_warns_on_unknown_keys () =
            (fun message -> contains_substring message "unknown keys: mystery_key")
            messages))
 
+let test_read_meta_warns_on_compat_tool_keys () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "compat-key-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "compat-key-demo");
+              ("goal", `String "Warn on compat tool keys");
+              ("tool_preset", `String "coding");
+              ("tool_also_allow", `List [ `String "masc_status" ]);
+            ])
+      in
+      if not ok then fail ("keeper up failed: " ^ body);
+      let meta_path =
+        Masc_mcp.Keeper_types.keeper_meta_path config "compat-key-demo"
+      in
+      let original_json = Yojson.Safe.from_file meta_path in
+      let compat_json =
+        match original_json with
+        | `Assoc fields ->
+            `Assoc
+              ( ("tool_preset", `String "coding")
+              :: ("tool_also_allow", `List [ `String "masc_status" ])
+              :: List.remove_assoc "tool_access" fields )
+        | _ -> fail "expected keeper meta object"
+      in
+      let oc = open_out meta_path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc (Yojson.Safe.pretty_to_string compat_json));
+      let baseline = latest_log_seq () in
+      let _ =
+        match Masc_mcp.Keeper_types.read_meta config "compat-key-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after compat key warning read"
+        | Error e -> fail e
+      in
+      let messages = recent_keeper_log_messages ~since_seq:baseline in
+      check bool "compat key warning emitted" true
+        (List.exists
+           (fun message -> contains_substring message "uses compatibility tool keys")
+           messages))
+
 let test_keeper_up_recreates_cached_keeper_dir_after_base_reset () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2149,6 +2337,12 @@ let () =
            test_keeper_up_update_clears_explicit_tool_lists;
          test_case "keeper up accepts canonical tool_access" `Quick
            test_keeper_up_accepts_canonical_tool_access;
+         test_case "keeper up accepts tool_custom_allowlist compat" `Quick
+           test_keeper_up_accepts_tool_custom_allowlist_compat;
+         test_case "keeper up update allows canonical tool_access override" `Quick
+           test_keeper_up_update_allows_canonical_tool_access_override;
+         test_case "keeper up rejects mixed tool_access inputs" `Quick
+           test_keeper_up_rejects_mixed_tool_access_inputs;
          test_case "write_meta syncs registry meta" `Quick
            test_write_meta_syncs_registry_meta;
          test_case "keeper up persists allowed paths" `Quick
@@ -2163,6 +2357,8 @@ let () =
            test_legacy_presence_keepalive_false_migrates_to_paused;
          test_case "read_meta warns on unknown keys" `Quick
            test_read_meta_warns_on_unknown_keys;
+         test_case "read_meta warns on compat tool keys" `Quick
+           test_read_meta_warns_on_compat_tool_keys;
          test_case "keeper repair passes with provided source_text" `Quick
            test_keeper_repair_passes_with_provided_source_text;
          test_case "keeper up recreates cached keeper dir after base reset (issue #3710)" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1526,6 +1526,31 @@ let test_keeper_up_rejects_mixed_tool_access_inputs () =
       check bool "mixed input error surfaced" true
         (contains_substring body "tool_access cannot be combined"))
 
+let test_keeper_up_rejects_null_tool_access_field () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "null-tool-access");
+              ("goal", `String "Reject null canonical tool_access");
+              ("tool_access", `Null);
+              ("tool_preset", `String "minimal");
+            ])
+      in
+      check bool "keeper up rejects null tool_access field" false ok;
+      check bool "null tool_access error surfaced" true
+        (contains_substring body "tool_access cannot be combined"))
+
 let test_keeper_up_rejects_tool_custom_allowlist_with_also_allow () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -2421,6 +2446,8 @@ let () =
            test_keeper_up_update_accepts_tool_custom_allowlist_compat;
          test_case "keeper up rejects mixed tool_access inputs" `Quick
            test_keeper_up_rejects_mixed_tool_access_inputs;
+         test_case "keeper up rejects null tool_access field" `Quick
+           test_keeper_up_rejects_null_tool_access_field;
          test_case "keeper up rejects tool_custom_allowlist with also_allow" `Quick
            test_keeper_up_rejects_tool_custom_allowlist_with_also_allow;
          test_case "write_meta syncs registry meta" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -2267,6 +2267,76 @@ let test_read_meta_warns_on_compat_tool_keys () =
            (fun message -> contains_substring message "uses compatibility tool keys")
            messages))
 
+let test_read_meta_treats_null_tool_access_as_compat_warning () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "null-tool-access-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "null-tool-access-demo");
+              ("goal", `String "Warn on null canonical tool_access");
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      if not ok then fail ("keeper up failed: " ^ body);
+      let meta_path =
+        Masc_mcp.Keeper_types.keeper_meta_path config "null-tool-access-demo"
+      in
+      let original_json = Yojson.Safe.from_file meta_path in
+      let compat_json =
+        match original_json with
+        | `Assoc fields ->
+            `Assoc
+              ( ("tool_access", `Null)
+              :: ("tool_preset", `String "coding")
+              :: ("tool_also_allow", `List [ `String "masc_status" ])
+              :: List.remove_assoc "tool_access" fields )
+        | _ -> fail "expected keeper meta object"
+      in
+      let oc = open_out meta_path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc (Yojson.Safe.pretty_to_string compat_json));
+      let baseline = latest_log_seq () in
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "null-tool-access-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after null tool_access warning read"
+        | Error e -> fail e
+      in
+      let messages = recent_keeper_log_messages ~since_seq:baseline in
+      check bool "compat warning emitted for null tool_access" true
+        (List.exists
+           (fun message -> contains_substring message "uses compatibility tool keys")
+           messages);
+      check bool "ignore warning not emitted for null tool_access" false
+        (List.exists
+           (fun message -> contains_substring message "has tool_access plus compatibility tool keys")
+           messages);
+      check bool "tool access projected from compat fields" true
+        (match meta.tool_access with
+         | Masc_mcp.Keeper_types.Preset
+             { preset = Masc_mcp.Keeper_types.Coding; also_allow } ->
+             List.mem "masc_status" also_allow
+         | _ -> false))
+
 let test_keeper_up_recreates_cached_keeper_dir_after_base_reset () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2466,6 +2536,8 @@ let () =
            test_read_meta_warns_on_unknown_keys;
          test_case "read_meta warns on compat tool keys" `Quick
            test_read_meta_warns_on_compat_tool_keys;
+         test_case "read_meta treats null tool_access as compat warning" `Quick
+           test_read_meta_treats_null_tool_access_as_compat_warning;
          test_case "keeper repair passes with provided source_text" `Quick
            test_keeper_repair_passes_with_provided_source_text;
          test_case "keeper up recreates cached keeper dir after base reset (issue #3710)" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -98,6 +98,16 @@ let contains_substring s needle =
     else loop (i + 1)
   in
   if n_len = 0 then true else loop 0
+
+let latest_log_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | (entry : Log.Ring.entry) :: _ -> entry.seq
+  | [] -> -1
+
+let recent_keeper_log_messages ~since_seq =
+  Log.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq ()
+  |> List.map (fun (entry : Log.Ring.entry) -> entry.message)
+
 let string_is_valid_utf8 s =
   let len = String.length s in
   let rec loop i =
@@ -1235,10 +1245,19 @@ let test_keeper_up_update_clears_explicit_tool_lists () =
         | Ok parsed -> parsed
         | Error (_, msg) -> fail ("failed to parse create args: " ^ msg)
       in
-      let ok, _ =
+      check (option (list string)) "parsed also_allow before create"
+        (Some [ "masc_governance_status" ]) create_parsed.tool_also_allow_opt;
+      let ok, create_body =
         Masc_mcp.Keeper_turn_up_create.create_keeper keeper_ctx create_parsed
       in
-      check bool "initial keeper create ok" true ok;
+      if not ok then fail ("initial keeper create failed: " ^ create_body);
+      let created_json =
+        Yojson.Safe.from_file (Masc_mcp.Keeper_types.keeper_meta_path config "tool-policy-demo")
+      in
+      check (list string) "persisted tool_access also_allow after create"
+        [ "masc_governance_status" ]
+        Yojson.Safe.Util.(
+          created_json |> member "tool_access" |> member "also_allow" |> to_list |> filter_string);
       let old_meta =
         match Masc_mcp.Keeper_types.read_meta config "tool-policy-demo" with
         | Ok (Some meta) -> meta
@@ -1281,6 +1300,52 @@ let test_keeper_up_update_clears_explicit_tool_lists () =
           check (list string) "update clears also_allow" [] also_allow
       | _ -> fail "expected minimal preset after update");
       check (list string) "update clears denylist" [] updated_meta.tool_denylist)
+
+let test_keeper_up_accepts_canonical_tool_access () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "tool-access-canonical";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "tool-access-canonical");
+              ("goal", `String "Exercise canonical tool_access input");
+              ( "tool_access",
+                `Assoc
+                  [
+                    ("kind", `String "custom");
+                    ("tools", `List [ `String "masc_status"; `String "masc_board_list" ]);
+                  ] );
+            ])
+      in
+      if not ok then fail ("keeper up failed: " ^ body);
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "tool-access-canonical" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after canonical tool_access create"
+        | Error e -> fail e
+      in
+      match meta.Masc_mcp.Keeper_types.tool_access with
+      | Masc_mcp.Keeper_types.Custom names ->
+          check (list string) "custom tool_access preserved"
+            [ "masc_status"; "masc_board_list" ] names
+      | _ -> fail "expected custom tool_access")
 
 let test_keeper_up_persists_explicit_goal_horizons () =
   Eio_main.run @@ fun env ->
@@ -1858,6 +1923,61 @@ let test_legacy_presence_keepalive_false_migrates_to_paused () =
       check bool "paused persisted after scrub" true
         Yojson.Safe.Util.(scrubbed_json |> member "paused" = `Bool true))
 
+let test_read_meta_warns_on_unknown_keys () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "unknown-key-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "unknown-key-demo");
+              ("goal", `String "Warn on unknown keeper meta keys");
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "keeper up ok" true ok;
+      let meta_path =
+        Masc_mcp.Keeper_types.keeper_meta_path config "unknown-key-demo"
+      in
+      let original_json = Yojson.Safe.from_file meta_path in
+      let mutated_json =
+        match original_json with
+        | `Assoc fields -> `Assoc (("mystery_key", `String "surprise") :: fields)
+        | _ -> fail "expected keeper meta object"
+      in
+      let oc = open_out meta_path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc (Yojson.Safe.pretty_to_string mutated_json));
+      let baseline = latest_log_seq () in
+      let _ =
+        match Masc_mcp.Keeper_types.read_meta config "unknown-key-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after unknown key warning read"
+        | Error e -> fail e
+      in
+      let messages = recent_keeper_log_messages ~since_seq:baseline in
+      check bool "unknown key warning emitted" true
+        (List.exists
+           (fun message -> contains_substring message "unknown keys: mystery_key")
+           messages))
+
 let test_keeper_up_recreates_cached_keeper_dir_after_base_reset () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2027,6 +2147,8 @@ let () =
            test_keeper_up_update_preserves_proactive_when_omitted;
          test_case "keeper up update clears explicit tool lists" `Quick
            test_keeper_up_update_clears_explicit_tool_lists;
+         test_case "keeper up accepts canonical tool_access" `Quick
+           test_keeper_up_accepts_canonical_tool_access;
          test_case "write_meta syncs registry meta" `Quick
            test_write_meta_syncs_registry_meta;
          test_case "keeper up persists allowed paths" `Quick
@@ -2039,6 +2161,8 @@ let () =
            test_keeper_supervisor_recovers_missing_desired_keeper;
          test_case "legacy presence_keepalive false migrates to paused" `Quick
            test_legacy_presence_keepalive_false_migrates_to_paused;
+         test_case "read_meta warns on unknown keys" `Quick
+           test_read_meta_warns_on_unknown_keys;
          test_case "keeper repair passes with provided source_text" `Quick
            test_keeper_repair_passes_with_provided_source_text;
          test_case "keeper up recreates cached keeper dir after base reset (issue #3710)" `Quick


### PR DESCRIPTION
## Summary
Unify keeper tool policy handling around canonical `tool_access` while preserving compatibility with existing flat/projection fields.

## Product impact
Operators and keeper authors can pass canonical `tool_access` directly to `masc_keeper_up`, while existing keeper meta and compatibility fields continue to load. Persisted keeper meta with stale or unknown keys now emits keeper warnings instead of failing silently.

## What changed
- made `tool_access` the canonical keeper tool policy input/output shape across persisted meta loading and `masc_keeper_up`
- kept compatibility for legacy/projection fields like `tool_preset`, `tool_also_allow`, `tool_custom_allowlist`, and `tool_allowlist`
- tightened tool-policy input validation so explicit nulls and mixed canonical/compat inputs are rejected instead of being silently treated as absent
- structured the `tool_access` schema in keeper tool definitions so callers can validate preset/custom shapes earlier
- added keeper meta warnings when persisted JSON contains unknown top-level keys or compatibility tool-policy keys
- expanded keeper tests for canonical create/update paths, compatibility inputs, mixed-input rejection, and warning behavior

## Root cause
Keeper tool policy handling had drifted across persisted JSON, runtime parsing, tool schemas, and editor/API entry points after the move from flat allowlist fields to the structured `tool_access` ADT.

## Evidence
- `dune build --root . ./test/test_tool_keeper.exe`
- `./_build/default/test/test_keeper_masc_bridge.exe`
- `./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 31-38,45-46 --color=never`

## Review evidence
- direct `sb glm-text` (`GLM-5.1`) cross-model review run on 2026-04-02T06:42:32Z
- follow-up review comments were patched in `47c64eee8`
- review evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4633#issuecomment-4175048591

## Linked issue
Refs #4130
