### PR TITLE
fix(gate): public health path + invalid JSON 400

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -309,6 +309,7 @@ let is_public_read_path path =
   String.equal path "/health"
   || String.equal path "/health/live"
   || String.equal path "/health/ready"
+  || String.equal path "/api/v1/gate/health"
   || String.equal path "/"
   || String.equal path "/dashboard"
   || String.equal path "/dashboard/"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -71,7 +71,8 @@ let handle_gate_message ~sw ~clock state request reqd =
             | Error gate_err ->
                 Error (gate_err, Channel_gate.gate_error_to_string gate_err))
       with
-      | Yojson.Json_error e -> Error (Channel_gate.Internal e, "invalid json")
+      | Yojson.Json_error _e ->
+          Error (Channel_gate.Validation Channel_gate.Empty_content, "invalid json")
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
           (* Log details server-side, return generic message to client *)


### PR DESCRIPTION
## Summary

Copilot review 대응 (#4623 후속).

- `/api/v1/gate/health`를 `is_public_read_path`에 등록 — strict HTTP auth에서 public 유지
- Invalid JSON 요청 시 500 → 400 반환 (클라이언트 에러)

## Test plan

- [x] `dune build` 통과
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)