### PR TITLE
[codex] Normalize timeout exit handling

### DIFF
--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -261,23 +261,13 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
       (match clock_opt with
       | Some clock -> Eio.Time.sleep clock 1.0
       | None -> Time_compat.sleep 1.0);
-      let _exit_code =
-        match waitpid_nointr [ Unix.WNOHANG ] pid with
-        | 0, _ ->
-            (try Unix.kill pid Sys.sigkill with
-             | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
-             | exn -> Log.CmdPlane.warn "sigkill pid %d: %s" pid (Printexc.to_string exn));
-            let _, status = waitpid_nointr [] pid in
-            (match status with
-            | Unix.WEXITED code -> code
-            | Unix.WSIGNALED code -> 128 + code
-            | Unix.WSTOPPED code -> 256 + code)
-        | _, status -> (
-            match status with
-            | Unix.WEXITED code -> code
-            | Unix.WSIGNALED code -> 128 + code
-            | Unix.WSTOPPED code -> 256 + code)
-      in
+      (match waitpid_nointr [ Unix.WNOHANG ] pid with
+      | 0, _ ->
+          (try Unix.kill pid Sys.sigkill with
+           | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
+           | exn -> Log.CmdPlane.warn "sigkill pid %d: %s" pid (Printexc.to_string exn));
+          ignore (waitpid_nointr [] pid)
+      | _, _ -> ());
       finalize 124
 
 let json_with_process_metadata json ({ exit_code; stdout; stderr } : process_result) =

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -153,10 +153,14 @@ let run_process ~prog ~argv ~env =
   in
   Eio_guard.run_in_systhread f
 
+let rec waitpid_nointr flags pid =
+  try Unix.waitpid flags pid with
+  | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_nointr flags pid
+
 let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
   let start = Unix.gettimeofday () in
   let rec loop () =
-    match Unix.waitpid [ Unix.WNOHANG ] pid with
+    match waitpid_nointr [ Unix.WNOHANG ] pid with
     | 0, _ ->
         if Unix.gettimeofday () -. start >= float_of_int timeout_sec then
           `Timeout
@@ -257,13 +261,13 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
       (match clock_opt with
       | Some clock -> Eio.Time.sleep clock 1.0
       | None -> Time_compat.sleep 1.0);
-      let exit_code =
-        match Unix.waitpid [ Unix.WNOHANG ] pid with
+      let _exit_code =
+        match waitpid_nointr [ Unix.WNOHANG ] pid with
         | 0, _ ->
             (try Unix.kill pid Sys.sigkill with
              | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
              | exn -> Log.CmdPlane.warn "sigkill pid %d: %s" pid (Printexc.to_string exn));
-            let _, status = Unix.waitpid [] pid in
+            let _, status = waitpid_nointr [] pid in
             (match status with
             | Unix.WEXITED code -> code
             | Unix.WSIGNALED code -> 128 + code
@@ -274,8 +278,7 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
             | Unix.WSIGNALED code -> 128 + code
             | Unix.WSTOPPED code -> 256 + code)
       in
-      finalize
-        (if exit_code = 0 then 124 else exit_code)
+      finalize 124
 
 let json_with_process_metadata json ({ exit_code; stdout; stderr } : process_result) =
   match json with

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -25,6 +25,13 @@ let rec mkdir_p dir =
     Unix.mkdir dir 0o755
   end
 
+let with_eio f =
+  Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
+  Fun.protect
+    ~finally:(fun () -> Time_compat.clear_clock ())
+    (fun () -> f env)
+
 let write_file path content =
   let oc = open_out path in
   output_string oc content;
@@ -169,6 +176,16 @@ let test_rewrite_custom_model_label_for_container () =
   check string "loopback custom label rewritten to host alias"
     "custom:qwen-test@http://host.docker.internal:8085" rewritten
 
+let test_run_process_with_timeout_returns_124_on_timeout () =
+  with_eio @@ fun env ->
+  let result =
+    Lib.Tool_command_plane_support.run_process_with_timeout
+      ~clock_opt:(Some (Eio.Stdenv.clock env)) ~timeout_sec:1
+      ~prog:"/bin/sh" ~argv:[ "/bin/sh"; "-c"; "trap '' TERM; sleep 5" ]
+      ~env:(Unix.environment ()) ()
+  in
+  check int "timeout exit code" 124 result.exit_code
+
 let () =
   Alcotest.run "worker_runtime"
     [
@@ -187,4 +204,7 @@ let () =
       ( "rewrites",
         [ test_case "custom loopback model label rewritten for container" `Quick
             test_rewrite_custom_model_label_for_container ] );
+      ( "process_timeout",
+        [ test_case "timeout maps to exit code 124" `Quick
+            test_run_process_with_timeout_returns_124_on_timeout ] );
     ]

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -181,7 +181,7 @@ let test_run_process_with_timeout_returns_124_on_timeout () =
   let result =
     Lib.Tool_command_plane_support.run_process_with_timeout
       ~clock_opt:(Some (Eio.Stdenv.clock env)) ~timeout_sec:1
-      ~prog:"/bin/sh" ~argv:[ "/bin/sh"; "-c"; "trap '' TERM; sleep 5" ]
+      ~prog:"/bin/sh" ~argv:[ "/bin/sh"; "-c"; "trap '' TERM; kill -STOP $$" ]
       ~env:(Unix.environment ()) ()
   in
   check int "timeout exit code" 124 result.exit_code


### PR DESCRIPTION
## Summary
- normalize timeout handling in the shared command-plane subprocess helper
- make timeout cleanup resilient to `EINTR`
- lock the behavior with a regression test that exercises a timed-out subprocess

## What Changed
- `Tool_command_plane_support.run_process_with_timeout` now always returns exit code `124` when the helper timeout path fires
- added `waitpid_nointr` and reused it in timeout wait/cleanup paths
- added a `worker_runtime` regression test that verifies timed-out subprocesses resolve to `124`

## Why
The merged Docker worker runtime PR expected the shared subprocess helper to surface timeouts as `124`, but the helper could return signal-derived exit codes after SIGTERM/SIGKILL cleanup. That made Docker worker timeouts look like generic docker failures. The same cleanup path could also raise `Unix.EINTR` while waiting on the child.

## Product impact
- Docker-backed worker timeouts are classified consistently as timeouts
- existing timeout consumers that already key off `124` now see deterministic behavior
- no MCP schema or config changes

## Evidence
- `dune build --root . test/test_worker_runtime.exe test/test_tool_team_session.exe`
- `./_build/default/test/test_worker_runtime.exe`
- `./_build/default/test/test_tool_team_session.exe`

## Review evidence
- review evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4640#issuecomment-4175422991
- attempted direct `sb glm-text`, local `scripts/review/local-review.sh`, and `sb glm-cascade --simple`; all reviewer paths were unavailable from this host, so the fallback reason is recorded in the comment above

## Linked issue
- Closes #4639

## Follow-up context
- follow-up to merged PR #4622
