### PR TITLE
fix(dashboard): null checks + activeFilter ownership (#4610 followup)

### DIFF
--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -2,16 +2,11 @@
 // Independent from global traceSlots (avoids keeper-detail overlay collision).
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
 import type { UnifiedTraceEvent, TraceEventKind } from '../session-trace/session-trace-state'
-
-export type ActivityFilter = 'all' | 'tool_call' | 'broadcast' | 'task'
-
-/** Exported so task-detail-state.ts resetState() can clear it. */
-export const activeFilter = signal<ActivityFilter>('all')
+import { activeFilter, type ActivityFilter } from './task-detail-state'
 
 function kindIcon(kind: TraceEventKind): string {
   switch (kind) {
@@ -43,7 +38,7 @@ function durationColor(ms: number | undefined): string {
 }
 
 function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
-  const hasDetail = event.toolArgs || event.toolResult || (event.detail && Object.keys(event.detail).length > 0)
+  const hasDetail = event.toolArgs != null || event.toolResult != null || (event.detail && Object.keys(event.detail).length > 0)
 
   if (!hasDetail) {
     return html`
@@ -66,20 +61,20 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <span class="text-[10px] text-text-dim">\u25B8</span>
       </summary>
       <div class="px-3 pb-2 pt-1 ml-7">
-        ${event.toolArgs ? html`
+        ${event.toolArgs != null ? html`
           <div class="mb-1">
             <div class="text-[10px] text-text-dim mb-0.5">args</div>
             <pre class="text-[11px] text-text-body whitespace-pre-wrap break-all bg-[var(--white-3)] rounded p-2 max-h-[200px] overflow-y-auto">${typeof event.toolArgs === 'string' ? event.toolArgs : JSON.stringify(event.toolArgs, null, 2)}</pre>
           </div>
         ` : null}
-        ${event.toolResult ? html`
+        ${event.toolResult != null ? html`
           <div>
             <div class="text-[10px] text-text-dim mb-0.5">result</div>
             <pre class="text-[11px] text-text-body whitespace-pre-wrap break-all bg-[var(--white-3)] rounded p-2 max-h-[200px] overflow-y-auto">${typeof event.toolResult === 'string' ? event.toolResult : JSON.stringify(event.toolResult, null, 2)}</pre>
           </div>
         ` : null}
         ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}
-        ${event.cost_usd ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
+        ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
       </div>
     </details>
   `

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -4,9 +4,13 @@ import { signal } from '@preact/signals'
 import { fetchTaskHistory } from '../../api/actions'
 import { fetchAgentTimeline, fetchKeeperTrajectory } from '../../api/dashboard'
 import { buildTraceEvents, type UnifiedTraceEvent } from '../session-trace/session-trace-state'
-import { activeFilter } from './task-activity-list'
 import { findKeeper } from '../../lib/keeper-utils'
 import type { Task } from '../../types'
+
+// -- Activity filter (owned here, consumed by task-activity-list) ---
+
+export type ActivityFilter = 'all' | 'tool_call' | 'broadcast' | 'task'
+export const activeFilter = signal<ActivityFilter>('all')
 
 // -- Normalized task event (from masc_task_history raw JSON) --------
 


### PR DESCRIPTION
## Summary
#4610 Copilot 리뷰 followup: truthiness → != null (toolArgs/toolResult/cost_usd), activeFilter를 state 모듈로 이동.

## Product impact
빈 문자열 args/result, cost_usd=0 이 정상 표시됨.

## Evidence
vite build 통과.

## Linked issue
Refs #4610
