### PR TITLE
[codex] Fix keeper detail source ownership

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -102,7 +102,7 @@ vi.mock('../api/dashboard', () => ({
   patchKeeperConfig: mocks.patchKeeperConfig,
 }))
 
-import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
+import { KeeperConfigPanel, loadKeeperConfig, resetKeeperConfig } from './keeper-config-panel'
 
 async function flush() {
   await new Promise(resolve => setTimeout(resolve, 0))
@@ -145,5 +145,13 @@ describe('KeeperConfigPanel', () => {
     const textareas = Array.from(container.querySelectorAll('textarea'))
     expect(textareas.length).toBeGreaterThan(0)
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
+  })
+
+  it('supports forced config refresh for already-loaded keepers', async () => {
+    await loadKeeperConfig('keeper-sangsu')
+    await loadKeeperConfig('keeper-sangsu')
+    await loadKeeperConfig('keeper-sangsu', { force: true })
+
+    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(2)
   })
 })

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -145,6 +145,20 @@ export function resetKeeperConfig(): void {
   runtimeSaving.value = false
 }
 
+export function peekLoadedKeeperConfig(name: string): KeeperConfig | null {
+  const state = configState.value
+  if (configKeeperName.value !== name || state.status !== 'loaded') return null
+  return state.data
+}
+
+export function peekKeeperConfigLoadStatus(
+  name: string,
+): 'idle' | 'loading' | 'loaded' | 'error' | 'other' {
+  const state = configState.value
+  if (configKeeperName.value !== name) return 'other'
+  return state.status
+}
+
 // ── Helpers ──────────────────────────────────────────────
 
 function ConfigRow({ label, value }: { label: string; value: string }) {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -126,9 +126,13 @@ function updateRuntimeDraft(field: keyof RuntimeDraft, value: boolean | number |
   runtimeDraft.value = { ...d, [field]: value }
 }
 
-export async function loadKeeperConfig(name: string): Promise<void> {
-  if (configKeeperName.value === name && configState.value.status === 'loaded') return
-  if (configKeeperName.value !== name) {
+export async function loadKeeperConfig(
+  name: string,
+  options?: { force?: boolean },
+): Promise<void> {
+  const force = options?.force === true
+  if (!force && configKeeperName.value === name && configState.value.status === 'loaded') return
+  if (configKeeperName.value !== name || force) {
     configResource.reset()
   }
   configKeeperName.value = name

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -57,6 +57,18 @@ describe('resolveKeeperToolPolicy', () => {
       resolvedAllowlist: [],
     })
   })
+
+  it('preserves an explicit config error state', () => {
+    expect(resolveKeeperToolPolicy(null, 'error')).toEqual({
+      source: 'error',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    })
+  })
 })
 
 describe('resolveKeeperObservedToolAudit', () => {

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
+import {
+  resolveKeeperObservedToolAudit,
+  resolveKeeperToolPolicy,
+} from './keeper-detail-runtime'
+
+describe('resolveKeeperToolPolicy', () => {
+  it('uses keeper config as the authoritative policy source', () => {
+    const keeperConfig = {
+      tools: {
+        tool_access: {},
+        tool_policy_mode: 'custom',
+        tool_preset: null,
+        tool_also_allow: ['mcp__masc__masc_join'],
+        tool_custom_allowlist: ['mcp__masc__masc_board_post'],
+        resolved_allowlist: ['mcp__masc__masc_board_post'],
+        tool_denylist: ['mcp__masc__masc_board_delete'],
+        active_masc_tool_count: 1,
+        active_keeper_tool_count: 0,
+        total_active: 1,
+      },
+    } satisfies Pick<KeeperConfig, 'tools'>
+
+    expect(resolveKeeperToolPolicy(keeperConfig, 'loaded')).toEqual({
+      source: 'keeper_config',
+      mode: 'custom',
+      preset: null,
+      alsoAllow: ['mcp__masc__masc_join'],
+      customAllowlist: ['mcp__masc__masc_board_post'],
+      denylist: ['mcp__masc__masc_board_delete'],
+      resolvedAllowlist: ['mcp__masc__masc_board_post'],
+    })
+  })
+
+  it('reports loading instead of inventing defaults before config arrives', () => {
+    expect(resolveKeeperToolPolicy(null, 'loading')).toEqual({
+      source: 'loading',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    })
+  })
+
+  it('reports none after config load when no policy payload is available', () => {
+    expect(resolveKeeperToolPolicy(null, 'loaded')).toEqual({
+      source: 'none',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    })
+  })
+})
+
+describe('resolveKeeperObservedToolAudit', () => {
+  it('prefers mission brief audit over dashboard summary fallback', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      latest_tool_names: ['dashboard_summary_tool'],
+      latest_tool_call_count: 1,
+      tool_audit_source: 'keeper_metrics',
+      tool_audit_at: '2026-04-01T12:00:00Z',
+    }
+
+    const missionBrief: DashboardMissionKeeperBrief = {
+      name: 'sangsu',
+      agent_name: 'sangsu',
+      status: 'active',
+      latest_tool_names: ['mission_brief_tool'],
+      latest_tool_call_count: 3,
+      tool_audit_source: 'heartbeat_result',
+      tool_audit_at: '2026-04-02T09:30:00Z',
+    }
+
+    expect(resolveKeeperObservedToolAudit(keeper, missionBrief)).toEqual({
+      source: 'mission_brief',
+      latestToolNames: ['mission_brief_tool'],
+      latestToolCallCount: 3,
+      toolAuditSource: 'heartbeat_result',
+      toolAuditAt: '2026-04-02T09:30:00Z',
+    })
+  })
+
+  it('falls back to dashboard summary audit when mission has no audit payload', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      latest_tool_names: ['dashboard_summary_tool'],
+      latest_tool_call_count: 1,
+      tool_audit_source: 'keeper_metrics',
+      tool_audit_at: '2026-04-01T12:00:00Z',
+    }
+
+    const missionBrief: DashboardMissionKeeperBrief = {
+      name: 'sangsu',
+      agent_name: 'sangsu',
+      status: 'active',
+    }
+
+    expect(resolveKeeperObservedToolAudit(keeper, missionBrief)).toEqual({
+      source: 'dashboard_summary',
+      latestToolNames: ['dashboard_summary_tool'],
+      latestToolCallCount: 1,
+      toolAuditSource: 'keeper_metrics',
+      toolAuditAt: '2026-04-01T12:00:00Z',
+    })
+  })
+
+  it('reports none when neither projection carries observed audit data', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+    }
+
+    expect(resolveKeeperObservedToolAudit(keeper, null)).toEqual({
+      source: 'none',
+      latestToolNames: [],
+      latestToolCallCount: null,
+      toolAuditSource: null,
+      toolAuditAt: null,
+    })
+  })
+})

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -7,7 +7,7 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
 import { missionSnapshot } from '../mission-store'
-import type { DashboardMissionKeeperBrief, Keeper } from '../types'
+import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
 import { serverStatus } from '../store'
 import { operatorSnapshot } from '../operator-store'
 import {
@@ -21,6 +21,10 @@ import {
 } from './common/tool-audit'
 import { ToolAllowlistEditor } from './tools/tool-allowlist-editor'
 import { loadTools } from './tools/tool-state'
+import {
+  peekKeeperConfigLoadStatus,
+  peekLoadedKeeperConfig,
+} from './keeper-config-panel'
 
 const showAllowlistEditor = signal(false)
 
@@ -69,6 +73,113 @@ function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null 
     brief.name === keeper.name
       || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
     ?? null
+}
+
+type KeeperConfigLoadStatus = 'idle' | 'loading' | 'loaded' | 'error' | 'other'
+
+export interface KeeperToolPolicySnapshot {
+  source: 'keeper_config' | 'loading' | 'none'
+  mode: 'preset' | 'custom' | string
+  preset: Keeper['tool_preset']
+  alsoAllow: string[]
+  customAllowlist: string[]
+  denylist: string[]
+  resolvedAllowlist: string[]
+}
+
+export function resolveKeeperToolPolicy(
+  keeperConfig: Pick<KeeperConfig, 'tools'> | null,
+  loadStatus: KeeperConfigLoadStatus,
+): KeeperToolPolicySnapshot {
+  const tools = keeperConfig?.tools
+  if (tools) {
+    return {
+      source: 'keeper_config',
+      mode: tools.tool_policy_mode,
+      preset: tools.tool_preset ?? null,
+      alsoAllow: tools.tool_also_allow ?? [],
+      customAllowlist: tools.tool_custom_allowlist ?? [],
+      denylist: tools.tool_denylist ?? [],
+      resolvedAllowlist: tools.resolved_allowlist ?? [],
+    }
+  }
+
+  if (loadStatus === 'idle' || loadStatus === 'loading') {
+    return {
+      source: 'loading',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    }
+  }
+
+  return {
+    source: 'none',
+    mode: 'preset',
+    preset: null,
+    alsoAllow: [],
+    customAllowlist: [],
+    denylist: [],
+    resolvedAllowlist: [],
+  }
+}
+
+export interface KeeperObservedToolAuditSnapshot {
+  source: 'mission_brief' | 'dashboard_summary' | 'none'
+  latestToolNames: string[]
+  latestToolCallCount: number | null
+  toolAuditSource: string | null
+  toolAuditAt: string | null
+}
+
+export function resolveKeeperObservedToolAudit(
+  keeper: Keeper,
+  missionBrief: DashboardMissionKeeperBrief | null,
+): KeeperObservedToolAuditSnapshot {
+  const hasMissionAudit =
+    missionBrief != null && (
+      (missionBrief.latest_tool_names?.length ?? 0) > 0
+      || missionBrief.latest_tool_call_count != null
+      || !!missionBrief.tool_audit_source?.trim()
+      || !!missionBrief.tool_audit_at?.trim()
+    )
+
+  if (hasMissionAudit && missionBrief) {
+    return {
+      source: 'mission_brief',
+      latestToolNames: missionBrief.latest_tool_names ?? [],
+      latestToolCallCount: missionBrief.latest_tool_call_count ?? null,
+      toolAuditSource: missionBrief.tool_audit_source ?? null,
+      toolAuditAt: missionBrief.tool_audit_at ?? null,
+    }
+  }
+
+  const hasDashboardAudit =
+    (keeper.latest_tool_names?.length ?? 0) > 0
+    || keeper.latest_tool_call_count != null
+    || !!keeper.tool_audit_source?.trim()
+    || !!keeper.tool_audit_at?.trim()
+
+  if (hasDashboardAudit) {
+    return {
+      source: 'dashboard_summary',
+      latestToolNames: keeper.latest_tool_names ?? [],
+      latestToolCallCount: keeper.latest_tool_call_count ?? null,
+      toolAuditSource: keeper.tool_audit_source ?? null,
+      toolAuditAt: keeper.tool_audit_at ?? null,
+    }
+  }
+
+  return {
+    source: 'none',
+    latestToolNames: [],
+    latestToolCallCount: null,
+    toolAuditSource: null,
+    toolAuditAt: null,
+  }
 }
 
 // ── Shared row component ─────────────────────────────────
@@ -239,6 +350,8 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
 export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   useEffect(() => { showAllowlistEditor.value = false }, [keeper.name])
 
+  const keeperConfig = peekLoadedKeeperConfig(keeper.name)
+  const configLoadStatus = peekKeeperConfigLoadStatus(keeper.name)
   const room = operatorSnapshot.value?.room ?? {}
   const actions = (operatorSnapshot.value?.available_actions ?? [])
     .filter(action => action.target_type === 'keeper' || action.target_type === 'room')
@@ -246,17 +359,13 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const recentTools = keeperRecentTools(keeper)
   const topTools = keeperTopTools(keeper)
   const missionBrief = missionKeeperBrief(keeper)
-  const allowedTools =
-    missionBrief?.allowed_tool_names && missionBrief.allowed_tool_names.length > 0
-      ? missionBrief.allowed_tool_names
-      : keeper.allowed_tool_names ?? []
-  const observedTools =
-    missionBrief?.latest_tool_names && missionBrief.latest_tool_names.length > 0
-      ? missionBrief.latest_tool_names
-      : keeper.latest_tool_names ?? []
-  const toolCallCount = missionBrief?.latest_tool_call_count ?? keeper.latest_tool_call_count
-  const auditSource = missionBrief?.tool_audit_source ?? keeper.tool_audit_source
-  const auditAt = missionBrief?.tool_audit_at ?? keeper.tool_audit_at
+  const toolPolicy = resolveKeeperToolPolicy(keeperConfig, configLoadStatus)
+  const observedAudit = resolveKeeperObservedToolAudit(keeper, missionBrief)
+  const allowedTools = toolPolicy.resolvedAllowlist
+  const observedTools = observedAudit.latestToolNames
+  const toolCallCount = observedAudit.latestToolCallCount
+  const auditSource = observedAudit.toolAuditSource
+  const auditAt = observedAudit.toolAuditAt
   const capabilities = keeper.agent?.capabilities ?? []
   const roomName = room.current_room ?? room.room_id ?? serverStatus.value?.room ?? 'default'
   const project = room.project ?? serverStatus.value?.project ?? 'N/A'
@@ -273,8 +382,20 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const skillRouteLabel =
     keeper.skill_primary
     ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
+  const policyLoading = toolPolicy.source === 'loading'
+  const policyEditable = toolPolicy.source === 'keeper_config'
+  const toolPolicyLabel =
+    policyLoading
+      ? 'loading'
+      : toolPolicy.mode === 'custom'
+        ? 'custom'
+        : toolPolicy.preset ?? 'unset'
   const allowedToolCountLabel =
-    allowedTools.length > 0 ? String(allowedTools.length) : allowlistFallback
+    allowedTools.length > 0
+      ? String(allowedTools.length)
+      : policyLoading
+        ? 'loading'
+        : allowlistFallback
   const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
 
   return html`
@@ -285,11 +406,14 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <${SignalRow} label="현재 태스크" value=${currentTaskLabel} />
       <${SignalRow} label="스킬 경로" value=${skillRouteLabel} />
       <${SignalRow} label="컨텍스트 출처" value=${keeper.context_source ?? keeper.context?.source ?? '-'} />
+      <${SignalRow} label="도구 정책" value=${toolPolicyLabel} />
+      <${SignalRow} label="정책 소스" value=${toolPolicy.source} />
       <${SignalRow} label="허용 도구 수" value=${allowedToolCountLabel} />
 
       <div class="flex justify-end mt-1">
         <button type="button"
-          class="py-1.5 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
+          class="py-1.5 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
+          disabled=${!openToolsQuery}
           onClick=${() => { openToolsInventory(openToolsQuery) }}
         >
           도구 패널 열기
@@ -299,31 +423,38 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center justify-between mt-3">
         <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">허용된 도구</span>
         <button type="button"
-          class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+          class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
+          disabled=${!policyEditable}
           onClick=${() => {
             showAllowlistEditor.value = !showAllowlistEditor.value
             if (showAllowlistEditor.value) loadTools()
           }}
-        >${showAllowlistEditor.value ? '닫기' : '편집'}</button>
+        >${policyLoading ? '로딩 중' : policyEditable ? (showAllowlistEditor.value ? '닫기' : '편집') : '설정 필요'}</button>
       </div>
 
-      ${showAllowlistEditor.value
+      ${showAllowlistEditor.value && policyEditable
         ? html`<${ToolAllowlistEditor}
             keeperName=${keeper.name}
-            currentMode=${keeper.tool_policy_mode ?? 'preset'}
-            currentPreset=${keeper.tool_preset ?? 'full'}
-            currentAlsoAllow=${keeper.tool_also_allow ?? []}
-            currentCustomAllowlist=${keeper.tool_custom_allowlist ?? []}
-            currentDenylist=${keeper.tool_denylist ?? []}
+            currentMode=${toolPolicy.mode}
+            currentPreset=${toolPolicy.preset ?? 'full'}
+            currentAlsoAllow=${toolPolicy.alsoAllow}
+            currentCustomAllowlist=${toolPolicy.customAllowlist}
+            currentDenylist=${toolPolicy.denylist}
             resolvedAllowlist=${allowedTools}
             onUpdated=${() => { showAllowlistEditor.value = false; loadTools() }}
           />`
         : html`
-          <span class="text-[11px] text-[var(--text-muted)] leading-snug">이 키퍼 런타임에 현재 허용된 도구.</span>
+          <span class="text-[11px] text-[var(--text-muted)] leading-snug">
+            ${policyLoading
+              ? '정적 도구 정책을 불러오는 중입니다.'
+              : policyEditable
+                ? '이 키퍼 정책에서 해석된 allowlist입니다.'
+                : '정적 도구 정책을 아직 확인할 수 없습니다.'}
+          </span>
           <div class="flex flex-wrap gap-1.5">
             ${allowedTools.length > 0
               ? allowedTools.map((tool: string) => html`<${ToolChip} name=${tool} />`)
-              : html`<span class="text-[11px] text-[var(--text-muted)] italic">${allowlistFallback}</span>`}
+              : html`<span class="text-[11px] text-[var(--text-muted)] italic">${policyLoading ? 'loading' : policyEditable ? allowlistFallback : 'config_unavailable'}</span>`}
           </div>
         `}
 
@@ -335,6 +466,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       />
 
       <${SignalRow} label="도구 호출" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
+      <${SignalRow} label="관측 계층" value=${observedAudit.source} />
       <${SignalRow} label="감사 출처" value=${auditSource ?? metadataFallback} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">관측 시점</span>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -22,6 +22,7 @@ import {
 import { ToolAllowlistEditor } from './tools/tool-allowlist-editor'
 import { loadTools } from './tools/tool-state'
 import {
+  loadKeeperConfig,
   peekKeeperConfigLoadStatus,
   peekLoadedKeeperConfig,
 } from './keeper-config-panel'
@@ -78,7 +79,7 @@ function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null 
 type KeeperConfigLoadStatus = 'idle' | 'loading' | 'loaded' | 'error' | 'other'
 
 export interface KeeperToolPolicySnapshot {
-  source: 'keeper_config' | 'loading' | 'none'
+  source: 'keeper_config' | 'loading' | 'error' | 'none'
   mode: 'preset' | 'custom' | string
   preset: Keeper['tool_preset']
   alsoAllow: string[]
@@ -107,6 +108,18 @@ export function resolveKeeperToolPolicy(
   if (loadStatus === 'idle' || loadStatus === 'loading') {
     return {
       source: 'loading',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    }
+  }
+
+  if (loadStatus === 'error') {
+    return {
+      source: 'error',
       mode: 'preset',
       preset: null,
       alsoAllow: [],
@@ -383,19 +396,25 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
     keeper.skill_primary
     ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
   const policyLoading = toolPolicy.source === 'loading'
+  const policyError = toolPolicy.source === 'error'
   const policyEditable = toolPolicy.source === 'keeper_config'
   const toolPolicyLabel =
     policyLoading
       ? 'loading'
+      : policyError
+        ? 'error'
       : toolPolicy.mode === 'custom'
         ? 'custom'
         : toolPolicy.preset ?? 'unset'
+  const unavailablePolicyLabel = policyError ? 'config_error' : 'config_unavailable'
   const allowedToolCountLabel =
     allowedTools.length > 0
       ? String(allowedTools.length)
       : policyLoading
         ? 'loading'
-        : allowlistFallback
+        : policyEditable
+          ? allowlistFallback
+          : unavailablePolicyLabel
   const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
 
   return html`
@@ -429,7 +448,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
             showAllowlistEditor.value = !showAllowlistEditor.value
             if (showAllowlistEditor.value) loadTools()
           }}
-        >${policyLoading ? '로딩 중' : policyEditable ? (showAllowlistEditor.value ? '닫기' : '편집') : '설정 필요'}</button>
+        >${policyLoading ? '로딩 중' : policyEditable ? (showAllowlistEditor.value ? '닫기' : '편집') : policyError ? '설정 오류' : '설정 필요'}</button>
       </div>
 
       ${showAllowlistEditor.value && policyEditable
@@ -441,7 +460,11 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
             currentCustomAllowlist=${toolPolicy.customAllowlist}
             currentDenylist=${toolPolicy.denylist}
             resolvedAllowlist=${allowedTools}
-            onUpdated=${() => { showAllowlistEditor.value = false; loadTools() }}
+            onUpdated=${() => {
+              showAllowlistEditor.value = false
+              void loadKeeperConfig(keeper.name, { force: true })
+              loadTools()
+            }}
           />`
         : html`
           <span class="text-[11px] text-[var(--text-muted)] leading-snug">
@@ -449,12 +472,14 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
               ? '정적 도구 정책을 불러오는 중입니다.'
               : policyEditable
                 ? '이 키퍼 정책에서 해석된 allowlist입니다.'
-                : '정적 도구 정책을 아직 확인할 수 없습니다.'}
+                : policyError
+                  ? '정적 도구 정책 로드에 실패했습니다.'
+                  : '정적 도구 정책을 아직 확인할 수 없습니다.'}
           </span>
           <div class="flex flex-wrap gap-1.5">
             ${allowedTools.length > 0
               ? allowedTools.map((tool: string) => html`<${ToolChip} name=${tool} />`)
-              : html`<span class="text-[11px] text-[var(--text-muted)] italic">${policyLoading ? 'loading' : policyEditable ? allowlistFallback : 'config_unavailable'}</span>`}
+              : html`<span class="text-[11px] text-[var(--text-muted)] italic">${policyLoading ? 'loading' : policyEditable ? allowlistFallback : unavailablePolicyLabel}</span>`}
           </div>
         `}
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -32,7 +32,11 @@ import {
   KeeperNeighborhood,
   RuntimeSignals,
 } from './keeper-detail-runtime'
-import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
+import {
+  KeeperConfigPanel,
+  loadKeeperConfig,
+  resetKeeperConfig,
+} from './keeper-config-panel'
 import { PipelineStageBar } from './keeper-pipeline-stage'
 import { AgentJournalStream } from './agent-detail-journal'
 import { KeeperTrajectoryTimeline } from './keeper-trajectory-timeline'
@@ -47,6 +51,7 @@ export const selectedKeeper = signal<Keeper | null>(null)
 export function openKeeperDetail(k: Keeper) {
   selectedKeeper.value = k
   selectKeeper(k.name)
+  void loadKeeperConfig(k.name)
 }
 
 export function closeKeeperDetail() {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -23,22 +23,6 @@ function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   return 'offline'
 }
 
-function normalizeToolPreset(
-  value: unknown,
-): Keeper['tool_preset'] {
-  const raw = typeof value === 'string' ? value : null
-  if (
-    raw === 'minimal'
-    || raw === 'messaging'
-    || raw === 'coding'
-    || raw === 'research'
-    || raw === 'full'
-  ) {
-    return raw
-  }
-  return null
-}
-
 export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   const status = keeper.status?.toLowerCase() ?? ''
   if (isOfflineStatus(status)) return 'offline'
@@ -271,12 +255,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         recent_input_preview: asString(row.recent_input_preview) ?? null,
         recent_output_preview: asString(row.recent_output_preview) ?? null,
         recent_tool_names: asStringArray(row.recent_tool_names) ?? [],
-        tool_policy_mode: asString(row.tool_policy_mode) ?? undefined,
-        tool_preset: normalizeToolPreset(row.tool_preset),
-        tool_also_allow: asStringArray(row.tool_also_allow) ?? [],
-        tool_custom_allowlist: asStringArray(row.tool_custom_allowlist) ?? [],
-        tool_denylist: asStringArray(row.tool_denylist) ?? [],
-        allowed_tool_names: asStringArray(row.allowed_tool_names) ?? [],
         latest_tool_names: asStringArray(row.latest_tool_names) ?? [],
         latest_tool_call_count: asNumber(row.latest_tool_call_count) ?? null,
         tool_audit_source: asString(row.tool_audit_source) ?? null,

--- a/docs/design/keeper-detail-source-ownership.md
+++ b/docs/design/keeper-detail-source-ownership.md
@@ -1,0 +1,106 @@
+# Keeper Detail Source Ownership
+
+**Status**: Draft  
+**Date**: 2026-04-02  
+**Scope**: Keeper detail modal and adjacent panels in the dashboard  
+**One sentence**: Separate authored keeper config, derived effective config, and live runtime observation so the detail modal does not map fields across the wrong source class.
+
+## Why This Exists
+
+Keeper detail currently reads from more than one projection:
+
+- `/api/v1/dashboard/shell` keeper summary
+- `/api/v1/dashboard/mission` keeper briefs
+- `/api/v1/keepers/:name/config`
+- keeper-scoped detail APIs such as chat history and trajectory
+
+Those projections do not carry the same truth class.
+
+- Some values are authored and should be stable until edited.
+- Some values are derived from authored config and registry state.
+- Some values are live runtime snapshots and can change every refresh.
+- Some values are observed audit signals and may be empty, stale, or missing even when config is valid.
+
+The detail modal must not treat those as interchangeable.
+
+## Source Classes
+
+| Source class | Meaning | Typical change cadence | Example fields |
+| --- | --- | --- | --- |
+| Authored config | Human-authored keeper intent and policy | On explicit edit only | `goal`, `tool_preset`, `tool_denylist` |
+| Derived effective config | Deterministic resolution of authored config | On config edit or registry/tool-policy logic change | `resolved_allowlist`, `active_model`, `effective_allowed_paths` |
+| Runtime summary | Live keeper/process state | Every refresh / heartbeat / turn | `status`, `context_ratio`, `last_turn_ago_s` |
+| Observed tool audit | What the keeper actually used recently | Event-driven, may be absent | `latest_tool_names`, `tool_audit_source`, `tool_audit_at` |
+| Detailed event/history | High-cardinality per-keeper drill-down data | Event-driven | trajectory, chat history |
+
+## Ownership Table
+
+| Field group | Example fields | Truth class | Authoritative HTTP surface | Backend producer | Durable / raw source | Primary dashboard consumer | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Keeper identity and header runtime | `name`, `emoji`, `koreanName`, `status`, `pipeline_stage`, `agent_name`, `trace_id`, `generation` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper.ml` via `keepers_dashboard_json` | live keeper meta, agent status, registry status | `dashboard/src/components/keeper-detail.ts` | Header and KPI shell should read from the keeper summary projection. |
+| Runtime freshness and continuity | `last_heartbeat`, `last_turn_ago_s`, `last_handoff_ago_s`, `last_compaction_ago_s`, `last_proactive_ago_s`, `handoff_count_total`, `compaction_count` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper.ml` | live keeper meta + metrics + trace history | `dashboard/src/components/keeper-detail.ts`, `dashboard/src/components/keeper-detail-panels.ts` | These are volatile and must not be cached as config. |
+| Runtime context | `context_ratio`, `context_tokens`, `context_max`, `context_source`, `context.*` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper.ml` | latest metrics line or checkpoint-derived context | `dashboard/src/components/keeper-detail.ts`, `dashboard/src/components/keeper-detail-runtime.ts` | `context_source` is runtime provenance, not authored config provenance. |
+| Runtime quality window | `metrics_window.*`, `metrics_series`, `metrics_24h_summary`, `recent_tool_names` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper_detail.ml` + `lib/dashboard/dashboard_http_keeper.ml` | metrics jsonl / dated jsonl | `dashboard/src/components/keeper-detail-runtime.ts`, `dashboard/src/components/keeper-detail-panels.ts` | Window aggregates are observational, not policy. |
+| Runtime conversation summary | `recent_input_preview`, `recent_output_preview`, `conversation_tail_count`, `k2k_count`, `k2k_mentions` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper.ml` | history jsonl | `dashboard/src/components/keeper-detail.ts`, `dashboard/src/components/keeper-detail-runtime.ts` | Preview emptiness does not imply keeper inactivity. |
+| Supervisor/process health | `registry_state`, `supervisor_diagnostics.*`, `keepalive_running`, `agent.*` | Runtime summary | `/api/v1/dashboard/shell` | `lib/dashboard/dashboard_http_keeper.ml` | registry state + crash persistence + agent status | `dashboard/src/components/keeper-detail.ts` | These are operational snapshots and must stay out of authored config. |
+| Authored prompt + persona | `goal`, `short_goal`, `mid_goal`, `long_goal`, `soul_profile`, `will`, `needs`, `desires`, `instructions` | Authored config | `/api/v1/keepers/:name/config` | `lib/dashboard/dashboard_http_keeper.ml` via `keeper_config_json` | keeper live meta + defaults/profile resolution | `dashboard/src/components/keeper-config-panel.ts` | Detail modal should show these through the config panel, not the shell summary. |
+| Authored execution/coordination | `execution_scope`, `allowed_paths`, `room_scope`, `scope_kind`, `mention_targets` | Authored config | `/api/v1/keepers/:name/config` | `lib/dashboard/dashboard_http_keeper.ml` via `keeper_config_json` | keeper live meta | `dashboard/src/components/keeper-config-panel.ts` | Stable until edited. |
+| Derived effective execution | `execution.models`, `execution.active_model`, `effective_allowed_paths` | Derived effective config | `/api/v1/keepers/:name/config` | `lib/dashboard/dashboard_http_keeper.ml` via `keeper_config_json` | resolved cascade config + path policy | `dashboard/src/components/keeper-config-panel.ts` | Derived from authored config, but should still be sourced from config API. |
+| Authored tool policy | `tools.tool_policy_mode`, `tools.tool_preset`, `tools.tool_also_allow`, `tools.tool_custom_allowlist`, `tools.tool_denylist` | Authored config | `/api/v1/keepers/:name/config` | `lib/dashboard/dashboard_http_keeper.ml` via `keeper_config_json` | `meta.tool_access`, `meta.tool_denylist` | `dashboard/src/components/keeper-config-panel.ts`, `dashboard/src/components/keeper-detail-runtime.ts` | This is the SSOT for editor seed values. |
+| Derived effective tool policy | `tools.resolved_allowlist`, `tools.active_masc_tool_count`, `tools.active_keeper_tool_count`, `tools.total_active` | Derived effective config | `/api/v1/keepers/:name/config` | `lib/dashboard/dashboard_http_keeper.ml` via `keeper_config_json` | `Keeper_exec_tools.keeper_allowed_tool_names` over meta | `dashboard/src/components/keeper-config-panel.ts`, `dashboard/src/components/keeper-detail-runtime.ts` | Derived allowlist is not the same thing as authored preset/custom lists. |
+| Observed tool audit | `latest_tool_names`, `latest_tool_call_count`, `tool_audit_source`, `tool_audit_at` | Observed tool audit | Prefer `/api/v1/dashboard/mission`; fallback `/api/v1/dashboard/shell` when parity exists | `lib/dashboard/dashboard_mission_assembly.ml` via `keeper_tool_audit_json_fields`; fallback `lib/keeper/keeper_exec_status_metrics.ml` | heartbeat task/result, decision log, metrics log | `dashboard/src/components/keeper-detail-runtime.ts` | Audit data answers “what recently happened”, not “what is allowed.” |
+| Trajectory detail | trajectory entries and gate/result rows | Detailed event/history | `/api/v1/keepers/:name/trajectory` | dashboard keeper trajectory API | trajectory / tool-call log | `dashboard/src/components/keeper-trajectory-timeline.ts` | High-cardinality detail view only. |
+| Direct chat history | chat thread history | Detailed event/history | `/api/v1/keepers/:name/chat/history` | dashboard keeper chat history route | history jsonl | `dashboard/src/components/keeper-chat-panel.ts` | Keep separate from summary previews. |
+
+## Non-Negotiable Rules
+
+1. `tool_preset`, `tool_also_allow`, `tool_custom_allowlist`, and `tool_denylist` must be seeded from `/api/v1/keepers/:name/config`.
+2. `allowed_tool_names` / `resolved_allowlist` must be treated as derived effective policy, not as authored policy.
+3. `latest_tool_names`, `latest_tool_call_count`, `tool_audit_source`, and `tool_audit_at` must be treated as observed runtime evidence only.
+4. `mission keeper brief` is an operations projection. It may override observed audit freshness, but it must not override authored tool policy.
+5. If authored config has not loaded yet, the UI should show `loading` for static policy rather than inventing a default such as `preset/full`.
+6. Empty observed audit data must not be interpreted as “no tools allowed”.
+7. Empty authored policy data must not be backfilled from mission or runtime audit projections.
+
+## Current Dashboard Touchpoints
+
+| Dashboard file | Role | Expected source class |
+| --- | --- | --- |
+| `dashboard/src/components/keeper-detail.ts` | modal shell, header, top-level sections | Runtime summary |
+| `dashboard/src/components/keeper-detail-runtime.ts` | neighborhood, tool audit, allowlist editor seed | Mixed: authored tool policy + observed audit + runtime summary |
+| `dashboard/src/components/keeper-config-panel.ts` | structured config view and editor | Authored config + derived effective config |
+| `dashboard/src/keeper-store-normalize.ts` | keeper summary normalization | Runtime summary only |
+| `dashboard/src/mission-normalizers-entities.ts` | mission keeper brief normalization | Observed audit / mission projection |
+
+## Backend Touchpoints
+
+| Backend file | Role | Exposes |
+| --- | --- | --- |
+| `lib/dashboard/dashboard_http_keeper.ml` | keeper shell summary + keeper config JSON | Runtime summary, config projection |
+| `lib/dashboard/dashboard_http_keeper_detail.ml` | metrics window aggregation | Runtime summary aggregates |
+| `lib/dashboard/dashboard_mission_assembly.ml` | mission keeper brief assembly | Observed tool audit and mission projection |
+| `lib/keeper/keeper_exec_status_metrics.ml` | latest tool audit snapshots from files | Observed tool audit fallback |
+| `lib/keeper/keeper_tool_policy.ml` | effective allowlist resolution | Derived effective tool policy |
+| `lib/server/server_routes_http_routes_dashboard.ml` | HTTP routing for shell/config/chat history | surface routing |
+
+## Known Anti-Patterns To Avoid
+
+- Seeding the tool editor from `keeper.tool_preset ?? 'full'` when config has not loaded.
+- Using `missionBrief.allowed_tool_names` as if it were authored policy.
+- Using `latest_tool_names` as if it were the allowlist.
+- Inferring `tool_policy_mode` from the presence or absence of recent audit data.
+- Treating `context_source` as keeper config provenance.
+
+## Recommended Cleanup Sequence
+
+1. Introduce explicit source-resolution helpers in the detail modal for:
+   - authored tool policy
+   - derived effective tool policy
+   - observed tool audit
+2. Preload `/api/v1/keepers/:name/config` when the detail modal opens.
+3. Render `loading` instead of fallback defaults for static policy fields until config resolves.
+4. Keep `dashboard/src/keeper-store-normalize.ts` limited to shell/runtime summary fields.
+5. Add unit tests that lock the precedence:
+   - config beats shell for authored policy
+   - mission beats shell for observed audit freshness
+   - loading state does not invent defaults


### PR DESCRIPTION
## Summary

- make keeper detail treat `/api/v1/keepers/:name/config` as the authoritative source for static tool policy
- keep mission/shell projections limited to observed runtime audit data
- document keeper detail source ownership and add precedence tests

## Root Cause

The detail modal mixed authored config, derived effective policy, and observed runtime audit fields from different projections. That let static fields fall back to shell/mission values or UI defaults such as `preset/full`, which broke source ownership and made the modal look inconsistent with the actual keeper config.

## Validation

- `node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/typescript/bin/tsc --noEmit --pretty false -p /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-detail-source-map/dashboard/tsconfig.json`
- `node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/vitest/vitest.mjs run src/components/keeper-detail-runtime.test.ts src/components/keeper-config-panel.test.ts`

## Impact

- static tool policy in keeper detail now comes only from config
- observed tool audit remains runtime-derived and can no longer override authored policy
- the source ownership contract is documented for future maintenance
