### PR TITLE
[codex] Fix keeper context fallback and direct chat auth state

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -13,6 +13,8 @@ import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import type { KeeperConversationEntry } from '../types'
+import { shellAuthSummary } from '../store'
+import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -155,6 +157,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
   const buffer = streamBuffer.value
   const isStreaming = streaming.value
   const entries = messages.map((msg, index) => toConversationEntry(name, msg, index))
+  const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
   const transcriptEntries =
     isStreaming && buffer
       ? [
@@ -192,6 +195,9 @@ export function KeeperChatPanel({ name }: { name: string }) {
       </div>
 
       <div class="px-4 py-4">
+        ${chatAccess.message
+          ? html`<div class="mb-4 rounded-[18px] border border-[rgba(245,158,11,0.18)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#f4d79e]">${chatAccess.message}</div>`
+          : null}
         <${ChatTranscript}
           entries=${transcriptEntries}
           emptyText="직접 프롬프트를 보내 키퍼 대화를 시작하세요."
@@ -206,12 +212,18 @@ export function KeeperChatPanel({ name }: { name: string }) {
       <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
         <${ChatComposer}
           draft=${chatInput.value}
-          placeholder="메시지 입력..."
-          disabled=${false}
+          placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : '메시지 입력...'}
+          disabled=${chatAccess.blocked}
           streaming=${isStreaming}
           streamStartedAt=${streamStartedAt.value}
           onDraftChange=${(value: string) => { chatInput.value = value }}
-          onSend=${() => { void sendChat(name) }}
+          onSend=${() => {
+            if (chatAccess.blocked) {
+              showToast(chatAccess.message ?? '직접 통신 권한이 없습니다.', 'error')
+              return
+            }
+            void sendChat(name)
+          }}
           onAbort=${cancelStream}
         />
       </div>

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -218,7 +218,7 @@ function formatDuration(sec: number): string {
 export function ContextChart({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) {
-    const pct = ((keeper.context?.context_ratio ?? 0) * 100)
+    const pct = ((keeper.context_ratio ?? keeper.context?.context_ratio ?? 0) * 100)
     const color = ctxColor(pct)
     return html`
       <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -38,10 +38,14 @@ vi.mock('../api/keeper', () => ({
   shutdownKeeper,
 }))
 
-vi.mock('../store', () => ({
-  invalidateDashboardCache,
-  refreshDashboard,
-}))
+vi.mock('../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store')>()
+  return {
+    ...actual,
+    invalidateDashboardCache,
+    refreshDashboard,
+  }
+})
 
 vi.mock('./common/toast', () => ({
   showToast: vi.fn(),
@@ -49,6 +53,7 @@ vi.mock('./common/toast', () => ({
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
 import { hydrateKeeperStatus } from '../keeper-runtime'
+import { shellAuthSummary } from '../store'
 import { showToast } from './common/toast'
 import { KeeperConversationPanel, KeeperRuntimeActions } from './keeper-shared'
 
@@ -69,6 +74,7 @@ describe('KeeperConversationPanel', () => {
     keeperHydrating.value = {}
     keeperActionErrors.value = {}
     keeperStreamStartedAt.value = {}
+    shellAuthSummary.value = null
   })
 
   afterEach(() => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
 import { isOfflineStatus } from '../lib/status-utils'
+import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -23,7 +24,7 @@ import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 import { signal } from '@preact/signals'
-import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { invalidateDashboardCache, refreshDashboard, shellAuthSummary } from '../store'
 
 const keeperBooting = signal<Record<string, boolean>>({})
 const keeperShuttingDown = signal<Record<string, boolean>>({})
@@ -265,6 +266,8 @@ export function KeeperConversationPanel({
   const sending = keeperSending.value[keeperName] ?? false
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
+  const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
+  const composerDisabled = !keeperName || chatAccess.blocked
 
   const expandHistory = async () => {
     setHistoryExpanded(true)
@@ -273,6 +276,10 @@ export function KeeperConversationPanel({
 
   const submit = async () => {
     const prompt = draft.trim()
+    if (chatAccess.blocked) {
+      showToast(chatAccess.message ?? '직접 통신 권한이 없습니다.', 'error')
+      return
+    }
     if (!keeperName || !prompt) return
     setDraft('')
     try {
@@ -335,6 +342,13 @@ export function KeeperConversationPanel({
         </div>
 
         <div class="px-4 py-4">
+          ${chatAccess.message
+            ? html`
+                <div class="mb-4 rounded-[16px] border border-[rgba(245,158,11,0.18)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#f4d79e]">
+                  ${chatAccess.message}
+                </div>
+              `
+            : null}
           <${ChatTranscript}
             entries=${thread}
             emptyText="아직 직접 대화가 없습니다. 내부 키퍼 프롬프트와 도구 호출은 숨김 처리됩니다."
@@ -354,8 +368,8 @@ export function KeeperConversationPanel({
         <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
           <${ChatComposer}
             draft=${draft}
-            placeholder=${placeholder}
-            disabled=${!keeperName}
+            placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : placeholder}
+            disabled=${composerDisabled}
             streaming=${sending}
             streamStartedAt=${keeperStreamStartedAt.value[keeperName] ?? null}
             onDraftChange=${setDraft}

--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -9,16 +9,13 @@ import { route } from '../router'
 import '@testing-library/jest-dom'
 
 // Mock dependencies
-vi.mock('../store', () => ({
-  boardPosts: { value: [] },
-  boardLoading: { value: false },
-  boardSortMode: { value: 'recent' },
-  boardExcludeSystem: { value: true },
-  boardExcludeAutomation: { value: false },
-  boardAuthorFilter: { value: '' },
-  lastBoardRefreshAt: { value: 0 },
-  refreshBoard: vi.fn(),
-}))
+vi.mock('../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store')>()
+  return {
+    ...actual,
+    refreshBoard: vi.fn(),
+  }
+})
 
 vi.mock('../router', () => ({
   route: { value: { params: {} } },

--- a/dashboard/src/lib/keeper-chat-access.test.ts
+++ b/dashboard/src/lib/keeper-chat-access.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardShellAuthSummary } from '../types'
+import { keeperDirectChatAccess } from './keeper-chat-access'
+
+function makeSummary(
+  overrides: Partial<DashboardShellAuthSummary> = {},
+): DashboardShellAuthSummary {
+  return {
+    enabled: true,
+    require_token: false,
+    default_role: 'reader',
+    token_present: false,
+    requested_agent: null,
+    effective_agent: 'dashboard',
+    effective_role: 'reader',
+    can_keeper_msg: false,
+    keeper_msg_error: null,
+    ...overrides,
+  }
+}
+
+describe('keeperDirectChatAccess', () => {
+  it('allows access when summary is null', () => {
+    expect(keeperDirectChatAccess(null)).toEqual({ blocked: false, message: null })
+  })
+
+  it('allows access when keeper messaging is authorized', () => {
+    const result = keeperDirectChatAccess(
+      makeSummary({ can_keeper_msg: true }),
+    )
+
+    expect(result).toEqual({ blocked: false, message: null })
+  })
+
+  it('builds a default denial message with role context', () => {
+    const result = keeperDirectChatAccess(
+      makeSummary({
+        effective_agent: 'alice',
+        effective_role: 'worker',
+        token_present: true,
+      }),
+    )
+
+    expect(result.blocked).toBe(true)
+    expect(result.message).toContain('@alice는 masc_keeper_msg 권한이 없습니다.')
+    expect(result.message).toContain('현재 역할은 worker입니다.')
+    expect(result.message).not.toContain('Bearer token이 없어')
+    expect(result.message).not.toContain('public read fallback')
+  })
+
+  it('includes the require-token hint when the bearer token is missing', () => {
+    const result = keeperDirectChatAccess(
+      makeSummary({
+        effective_agent: 'bob',
+        effective_role: 'worker',
+        default_role: 'worker',
+        require_token: true,
+        token_present: false,
+      }),
+    )
+
+    expect(result.blocked).toBe(true)
+    expect(result.message).toContain('Bearer token이 없어 direct keeper chat이 차단됩니다.')
+  })
+
+  it('includes the public-read fallback hint for reader sessions without a token', () => {
+    const result = keeperDirectChatAccess(
+      makeSummary({
+        effective_agent: 'carol',
+        effective_role: 'reader',
+        require_token: false,
+        token_present: false,
+      }),
+    )
+
+    expect(result.blocked).toBe(true)
+    expect(result.message).toContain('현재 public read fallback으로 동작 중입니다.')
+  })
+
+  it('sanitizes noisy keeper_msg_error values', () => {
+    const result = keeperDirectChatAccess(
+      makeSummary({
+        keeper_msg_error: '   !!!   에러 메시지 상세 설명 ',
+        token_present: true,
+      }),
+    )
+
+    expect(result.blocked).toBe(true)
+    expect(result.message).toContain('에러 메시지 상세 설명')
+    expect(result.message).not.toContain('!!!')
+  })
+})

--- a/dashboard/src/lib/keeper-chat-access.ts
+++ b/dashboard/src/lib/keeper-chat-access.ts
@@ -1,0 +1,42 @@
+import type { DashboardShellAuthSummary } from '../types'
+
+export interface KeeperDirectChatAccess {
+  blocked: boolean
+  message: string | null
+}
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function cleanErrorMessage(value: string | null | undefined): string | null {
+  if (!value) return null
+  return value.replace(/^[^\w가-힣@]+/u, '').trim() || null
+}
+
+export function keeperDirectChatAccess(
+  summary: DashboardShellAuthSummary | null | undefined,
+): KeeperDirectChatAccess {
+  if (!summary || summary.can_keeper_msg) {
+    return { blocked: false, message: null }
+  }
+
+  const actor = summary.effective_agent ?? summary.requested_agent ?? 'dashboard'
+  const role = summary.effective_role ?? summary.default_role ?? null
+  const reason = cleanErrorMessage(summary.keeper_msg_error)
+    ?? `@${actor}는 masc_keeper_msg 권한이 없습니다.`
+  const roleHint = role ? ` 현재 역할은 ${role}입니다.` : ''
+  const tokenHint =
+    summary.require_token && !summary.token_present
+      ? ' Bearer token이 없어 direct keeper chat이 차단됩니다.'
+      : !summary.require_token && !summary.token_present && role === 'reader'
+        ? ' 현재 public read fallback으로 동작 중입니다.'
+        : ''
+
+  return {
+    blocked: true,
+    message: compactWhitespace(
+      `직접 통신 비활성화: ${reason}.${roleHint}${tokenHint} worker/admin 권한 토큰을 사용하거나 room 기본 권한을 올린 뒤 다시 시도하세요.`,
+    ),
+  }
+}

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -21,6 +21,7 @@ import type {
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
+  DashboardShellAuthSummary,
   DashboardShellMetaCognitionSummary,
 } from './types'
 import {
@@ -62,6 +63,7 @@ export interface ShellCounts {
 
 export const shellCounts = signal<ShellCounts | null>(null)
 export const shellMetaCognition = signal<DashboardShellMetaCognitionSummary | null>(null)
+export const shellAuthSummary = signal<DashboardShellAuthSummary | null>(null)
 
 // --- Core state signals ---
 
@@ -325,6 +327,21 @@ function applyPlanningEnvelope(data: {
     .filter((row): row is Goal => row !== null)
 }
 
+function normalizeShellAuthSummary(raw: unknown): DashboardShellAuthSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    enabled: raw.enabled === true,
+    require_token: raw.require_token === true,
+    default_role: asString(raw.default_role) ?? null,
+    token_present: raw.token_present === true,
+    requested_agent: asString(raw.requested_agent) ?? null,
+    effective_agent: asString(raw.effective_agent) ?? null,
+    effective_role: asString(raw.effective_role) ?? null,
+    can_keeper_msg: raw.can_keeper_msg === true,
+    keeper_msg_error: asString(raw.keeper_msg_error) ?? null,
+  }
+}
+
 export async function refreshShell(opts?: RefreshOptions): Promise<void> {
   if (inflightShellRefresh) return inflightShellRefresh
   if (!opts?.force && Date.now() - lastShellRefreshAt < SHELL_TTL_MS) return
@@ -344,6 +361,7 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
         }
       }
       shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)
+      shellAuthSummary.value = normalizeShellAuthSummary(data.auth)
       lastShellRefreshAt = Date.now()
     } catch (err) {
       console.warn('[Dashboard] shell fetch error:', err)

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('./store', () => ({
-  refreshShell: vi.fn(),
-  refreshExecution: vi.fn(),
-  refreshBoard: vi.fn(),
-  refreshGoals: vi.fn(),
-}))
+vi.mock('./store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./store')>()
+  return {
+    ...actual,
+    refreshShell: vi.fn(),
+    refreshExecution: vi.fn(),
+    refreshBoard: vi.fn(),
+    refreshGoals: vi.fn(),
+  }
+})
 
 vi.mock('./room-truth-store', () => ({
   requestRoomTruth: vi.fn(),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -40,6 +40,18 @@ export interface DashboardShellMetaCognitionSummary {
   top_desire?: DashboardShellMetaCognitionDesire | null
 }
 
+export interface DashboardShellAuthSummary {
+  enabled: boolean
+  require_token: boolean
+  default_role?: string | null
+  token_present: boolean
+  requested_agent?: string | null
+  effective_agent?: string | null
+  effective_role?: string | null
+  can_keeper_msg: boolean
+  keeper_msg_error?: string | null
+}
+
 export interface DashboardShellResponse {
   generated_at?: string
   status: ServerStatus
@@ -50,6 +62,7 @@ export interface DashboardShellResponse {
   }
   providers?: Record<string, unknown>
   meta_cognition?: DashboardShellMetaCognitionSummary | null
+  auth?: DashboardShellAuthSummary | null
 }
 
 export interface DashboardRoomTruthAttentionSummary {

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -381,8 +381,8 @@ let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) res
 
 (** Resolve the effective role for an agent from auth context.
     Returns Error for invalid tokens (no silent downgrade). *)
-let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
-  let auth_cfg = load_auth_config config in
+let resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token :
+    (agent_role, masc_error) result =
   if not auth_cfg.enabled then
     Ok Admin  (* Auth disabled = full access *)
   else if (match read_initial_admin config with
@@ -399,6 +399,35 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
         else
           Ok auth_cfg.default_role
 
+let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
+  let auth_cfg = load_auth_config config in
+  resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token
+
+let authorize_tool_for_role ~agent_name ~role ~tool_name :
+    (unit, masc_error) result =
+  let policy = Tool_access_role.policy_for_role role in
+  if not (Tool_access_policy.allows_name policy tool_name) then
+    Error (Forbidden { agent = agent_name; action = tool_name })
+  else if not (is_tool_auth_strict_enabled ()) then
+    Ok ()  (* Non-strict: policy check is sufficient *)
+  else
+    (* Strict mode: additional gate for unmapped tools *)
+    match permission_for_tool tool_name with
+    | Some _ -> Ok ()  (* Mapped tool — policy already checked *)
+    | None ->
+        if is_masc_tool_name tool_name
+           || is_protocol_canonical_tool_name tool_name then
+          (* Unmapped internal tool: require at least Worker *)
+          if has_permission role CanBroadcast then Ok ()
+          else Error (Forbidden { agent = agent_name; action = tool_name })
+        else
+          Error
+            (Forbidden
+               {
+                 agent = agent_name;
+                 action = "use unknown non-masc tool: " ^ tool_name;
+               })
+
 (** Policy-based tool authorization.
     Replaces authorize_tool with a single Tool_access_policy check.
     Invalid/expired tokens are rejected (not silently downgraded).
@@ -410,27 +439,7 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
 let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match resolve_role config ~agent_name ~token with
   | Error e -> Error e
-  | Ok role ->
-      let policy = Tool_access_role.policy_for_role role in
-      if not (Tool_access_policy.allows_name policy tool_name) then
-        Error (Forbidden { agent = agent_name; action = tool_name })
-      else if not (is_tool_auth_strict_enabled ()) then
-        Ok ()  (* Non-strict: policy check is sufficient *)
-      else
-        (* Strict mode: additional gate for unmapped tools *)
-        match permission_for_tool tool_name with
-        | Some _ -> Ok ()  (* Mapped tool — policy already checked *)
-        | None ->
-            if is_masc_tool_name tool_name
-               || is_protocol_canonical_tool_name tool_name then
-              (* Unmapped internal tool: require at least Worker *)
-              if has_permission role CanBroadcast then Ok ()
-              else Error (Forbidden { agent = agent_name; action = tool_name })
-            else
-              Error (Forbidden {
-                agent = agent_name;
-                action = "use unknown non-masc tool: " ^ tool_name
-              })
+  | Ok role -> authorize_tool_for_role ~agent_name ~role ~tool_name
 
 (* ============================================ *)
 (* Room secret (for room-level auth)            *)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -986,29 +986,59 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Room.confi
   let resolved_agent_result =
     resolve_agent_name_for_auth ~base_path:config.base_path request ~token
   in
-  let effective_agent =
+  let resolved_agent_name_result =
     match resolved_agent_result with
-    | Ok agent_name_opt -> Some (Option.value ~default:"dashboard" agent_name_opt)
+    | Error err -> Error err
+    | Ok agent_name_opt ->
+        if auth_cfg.enabled && auth_cfg.require_token && token_present
+           && Option.is_none agent_name_opt
+        then
+          Error
+            (Types.Unauthorized
+               "Agent name required (X-MASC-Agent or token-bound credential)")
+        else
+          Ok (Option.value ~default:"dashboard" agent_name_opt)
+  in
+  let effective_agent =
+    match resolved_agent_name_result with
+    | Ok agent_name -> Some agent_name
     | Error _ -> requested_agent
   in
   let effective_role_result =
-    match resolved_agent_result, effective_agent with
-    | Error err, _ -> Error err
-    | Ok _, Some agent_name ->
-        Auth.resolve_role config.base_path ~agent_name ~token
-    | Ok _, None -> Ok auth_cfg.default_role
+    match resolved_agent_name_result with
+    | Error err -> Error err
+    | Ok agent_name ->
+        Auth.resolve_role_with_auth_config config.base_path ~auth_cfg
+          ~agent_name ~token
+  in
+  let endpoint_gate_result =
+    match
+      if token_present then Ok ()
+      else ensure_same_origin_browser_request request
+    with
+    | Error err -> Error err
+    | Ok () -> (
+        match
+          ensure_strict_http_token_auth
+            ~endpoint:"HTTP tool access for masc_keeper_msg" auth_cfg
+        with
+        | Ok _ -> Ok ()
+        | Error msg -> Error (Types.Unauthorized msg))
   in
   let can_keeper_msg, keeper_msg_error =
-    match resolved_agent_result, effective_agent with
-    | Error err, _ -> (false, Some (Types.masc_error_to_string err))
-    | Ok _, Some agent_name -> (
-        match
-          Auth.authorize_tool_v2 config.base_path ~agent_name ~token
-            ~tool_name:"masc_keeper_msg"
-        with
-        | Ok () -> (true, None)
-        | Error err -> (false, Some (Types.masc_error_to_string err)))
-    | Ok _, None -> (false, Some "Agent resolution failed for masc_keeper_msg")
+    match endpoint_gate_result with
+    | Error err -> (false, Some (Types.masc_error_to_string err))
+    | Ok () -> (
+        match resolved_agent_name_result, effective_role_result with
+        | Error err, _ | _, Error err ->
+            (false, Some (Types.masc_error_to_string err))
+        | Ok agent_name, Ok role -> (
+            match
+              Auth.authorize_tool_for_role ~agent_name ~role
+                ~tool_name:"masc_keeper_msg"
+            with
+            | Ok () -> (true, None)
+            | Error err -> (false, Some (Types.masc_error_to_string err))))
   in
   let effective_role =
     match effective_role_result with

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -971,7 +971,64 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
            ("meta_cognition_ms", `Int meta_cognition_ms);
          ]
 
-let dashboard_shell_http_json ?clock (config : Room.config) : Yojson.Safe.t =
+let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Room.config) :
+    Yojson.Safe.t =
+  let auth_cfg = Auth.load_auth_config config.base_path in
+  let token = auth_token_from_request request in
+  let requested_agent =
+    match agent_from_request request with
+    | Some raw ->
+        let value = String.trim raw in
+        if String.equal value "" then None else Some value
+    | None -> None
+  in
+  let token_present = Option.is_some token in
+  let resolved_agent_result =
+    resolve_agent_name_for_auth ~base_path:config.base_path request ~token
+  in
+  let effective_agent =
+    match resolved_agent_result with
+    | Ok agent_name_opt -> Some (Option.value ~default:"dashboard" agent_name_opt)
+    | Error _ -> requested_agent
+  in
+  let effective_role_result =
+    match resolved_agent_result, effective_agent with
+    | Error err, _ -> Error err
+    | Ok _, Some agent_name ->
+        Auth.resolve_role config.base_path ~agent_name ~token
+    | Ok _, None -> Ok auth_cfg.default_role
+  in
+  let can_keeper_msg, keeper_msg_error =
+    match resolved_agent_result, effective_agent with
+    | Error err, _ -> (false, Some (Types.masc_error_to_string err))
+    | Ok _, Some agent_name -> (
+        match
+          Auth.authorize_tool_v2 config.base_path ~agent_name ~token
+            ~tool_name:"masc_keeper_msg"
+        with
+        | Ok () -> (true, None)
+        | Error err -> (false, Some (Types.masc_error_to_string err)))
+    | Ok _, None -> (false, Some "Agent resolution failed for masc_keeper_msg")
+  in
+  let effective_role =
+    match effective_role_result with
+    | Ok role -> Some (Types.agent_role_to_string role)
+    | Error _ -> None
+  in
+  `Assoc
+    [
+      ("enabled", `Bool auth_cfg.enabled);
+      ("require_token", `Bool auth_cfg.require_token);
+      ("default_role", `String (Types.agent_role_to_string auth_cfg.default_role));
+      ("token_present", `Bool token_present);
+      ("requested_agent", Json_util.string_opt_to_json requested_agent);
+      ("effective_agent", Json_util.string_opt_to_json effective_agent);
+      ("effective_role", Json_util.string_opt_to_json effective_role);
+      ("can_keeper_msg", `Bool can_keeper_msg);
+      ("keeper_msg_error", Json_util.string_opt_to_json keeper_msg_error);
+    ]
+
+let dashboard_shell_http_json ?clock ?request (config : Room.config) : Yojson.Safe.t =
   let current_room = dashboard_current_room_id config in
   let cache_key =
     Printf.sprintf "shell:coord=%s:workspace=%s:room=%s"
@@ -987,9 +1044,20 @@ let dashboard_shell_http_json ?clock (config : Room.config) : Yojson.Safe.t =
     | Some clock -> Some clock
     | None -> Eio_context.get_clock_opt ()
   in
-  match clock_opt with
-  | Some clock ->
-      Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0 ~clock
-        ~timeout_sec:dashboard_shell_timeout_s compute
-  | None ->
-      Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+  let payload =
+    match clock_opt with
+    | Some clock ->
+        Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0 ~clock
+          ~timeout_sec:dashboard_shell_timeout_s compute
+    | None ->
+        Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+  in
+  match request with
+  | None -> payload
+  | Some request -> (
+      match payload with
+      | `Assoc fields ->
+          `Assoc
+            (("auth", dashboard_shell_auth_json ~request config)
+            :: List.remove_assoc "auth" fields)
+      | other -> other)

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -161,6 +161,7 @@ val dashboard_messages_safe :
 val provider_capacity_json : unit -> Yojson.Safe.t
 val dashboard_shell_http_json :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?request:Httpun.Request.t ->
   Room.config ->
   Yojson.Safe.t
 

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -492,6 +492,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let state = get_server_state () in
           let json =
             dashboard_shell_http_json ?clock:state.Mcp_server.clock
+              ~request:httpun_request
               state.Mcp_server.room_config
           in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -210,7 +210,7 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/shell" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           dashboard_shell_http_json ?clock:state.Mcp_server.clock
+           dashboard_shell_http_json ?clock:state.Mcp_server.clock ~request:req
              state.Mcp_server.room_config
          in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary
- fix the keeper detail fallback context bar so it uses the top-level `context_ratio` when nested `context` and metrics series are absent
- add request-scoped auth metadata to `/api/v1/dashboard/shell`
- surface direct keeper chat denial state in the dashboard before the user attempts a send

## Product impact
- operators no longer see a contradictory `7%` KPI and `0.0%` fallback bar for the same keeper state
- direct chat panels now explain when the current actor only has `reader` access and disable the composer instead of failing opaquely

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-context-chat-auth-warning`
- `/opt/homebrew/bin/node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/typescript/bin/tsc --noEmit -p /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-context-chat-auth-warning/dashboard/tsconfig.json`
- `/opt/homebrew/bin/node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/vite/bin/vite.js build`
- live check on `http://127.0.0.1:8935`: `/health`, `/api/v1/dashboard/shell`, `/dashboard`, and browser spot-check of the `cheolsu` overlay

## Review evidence
- GLM-5.1 cross-model review via `sb glm-text`: no findings
- review record: https://github.com/jeong-sik/masc-mcp/pull/4647#issuecomment-4175528085
- residual risk recorded in the review comment: `/api/v1/dashboard/shell` auth state can remain stale until the 15s shell cache TTL rolls over after a role or token change

## Linked issue
- Refs #4648
