### PR TITLE
feat(gate): connector status dashboard panel

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1,0 +1,174 @@
+// Connector Status — Channel Gate per-channel metrics panel.
+// Shows connected channels, message counts, last activity, avg latency.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { get } from '../api/core'
+import { lastEvent } from '../sse'
+import { StatCard } from './common/stat-card'
+
+interface ChannelInfo {
+  channel: string
+  message_count: number
+  error_count: number
+  last_activity: string
+  last_keeper: string
+  avg_duration_ms: number
+}
+
+interface GateStatusData {
+  channels: ChannelInfo[]
+  total_messages: number
+  dedup_table_size: number
+  uptime_seconds: number
+}
+
+const data = signal<GateStatusData | null>(null)
+const loading = signal(false)
+const error = signal<string | null>(null)
+
+let inflightRequest: Promise<void> | null = null
+
+async function refresh() {
+  if (inflightRequest) return
+  loading.value = true
+  inflightRequest = (async () => {
+    try {
+      const result = await get<GateStatusData>('/api/v1/gate/status')
+      data.value = result
+      error.value = null
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'fetch failed'
+    } finally {
+      loading.value = false
+      inflightRequest = null
+    }
+  })()
+  return inflightRequest
+}
+
+const CHANNEL_ICONS: Record<string, string> = {
+  discord: '\u{1F3AE}',   // game controller
+  telegram: '\u{2708}',    // airplane (paper plane)
+  slack: '\u{1F4AC}',      // speech bubble
+  signal: '\u{1F512}',     // lock
+  webchat: '\u{1F310}',    // globe
+  api: '\u{26A1}',         // zap
+  internal: '\u{2699}',    // gear
+}
+
+function channelIcon(ch: string): string {
+  return CHANNEL_ICONS[ch] ?? '\u{1F517}' // link
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}
+
+function timeAgo(iso: string): string {
+  if (iso === 'never') return 'never'
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function ChannelCard({ ch }: { ch: ChannelInfo }) {
+  const errorRate = ch.message_count > 0
+    ? Math.round((ch.error_count / ch.message_count) * 100)
+    : 0
+  const statusColor = errorRate > 20 ? 'var(--red)' : errorRate > 5 ? 'var(--yellow)' : 'var(--green)'
+
+  return html`
+    <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+      <div class="flex items-center justify-between mb-2">
+        <div class="flex items-center gap-2">
+          <span class="text-lg">${channelIcon(ch.channel)}</span>
+          <span class="text-sm font-medium text-[var(--text-body)]">${ch.channel}</span>
+        </div>
+        <div class="w-2 h-2 rounded-full" style="background: ${statusColor}"></div>
+      </div>
+      <div class="grid grid-cols-2 gap-2 text-xs">
+        <div>
+          <div class="text-[var(--text-dim)]">messages</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.message_count}</div>
+        </div>
+        <div>
+          <div class="text-[var(--text-dim)]">errors</div>
+          <div class="font-mono" style="color: ${ch.error_count > 0 ? 'var(--red)' : 'var(--text-body)'}">${ch.error_count}</div>
+        </div>
+        <div>
+          <div class="text-[var(--text-dim)]">avg latency</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.avg_duration_ms > 0 ? `${(ch.avg_duration_ms / 1000).toFixed(1)}s` : '-'}</div>
+        </div>
+        <div>
+          <div class="text-[var(--text-dim)]">last active</div>
+          <div class="font-mono text-[var(--text-body)]">${timeAgo(ch.last_activity)}</div>
+        </div>
+      </div>
+      ${ch.last_keeper ? html`
+        <div class="mt-2 text-[10px] text-[var(--text-dim)]">keeper: ${ch.last_keeper}</div>
+      ` : null}
+    </div>
+  `
+}
+
+export function ConnectorStatusPanel() {
+  useEffect(() => {
+    refresh()
+  }, [])
+
+  // Refresh on SSE events (debounced by sse-store)
+  useEffect(() => {
+    const _event = lastEvent.value
+    if (_event && data.value) {
+      const timer = setTimeout(refresh, 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [lastEvent.value])
+
+  const d = data.value
+
+  if (loading.value && !d) {
+    return html`<div class="text-xs text-[var(--text-dim)]">Loading connector status...</div>`
+  }
+
+  if (error.value && !d) {
+    return html`<div class="text-xs text-[var(--red)]">Gate: ${error.value}</div>`
+  }
+
+  if (!d) return null
+
+  return html`
+    <div>
+      <h3 class="text-sm font-semibold text-[var(--text-body)] mb-3">Channel Gate</h3>
+
+      <div class="grid grid-cols-3 gap-2 mb-3">
+        <${StatCard} label="Messages" value=${d.total_messages} />
+        <${StatCard} label="Dedup Keys" value=${d.dedup_table_size} />
+        <${StatCard} label="Uptime" value=${formatUptime(d.uptime_seconds)} />
+      </div>
+
+      ${d.channels.length === 0
+        ? html`<div class="text-xs text-[var(--text-dim)] text-center py-4">No active connectors</div>`
+        : html`
+          <div class="grid grid-cols-2 gap-2 max-[600px]:grid-cols-1">
+            ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
+          </div>
+        `}
+    </div>
+  `
+}
+
+export function resetConnectorStatusState() {
+  data.value = null
+  loading.value = false
+  error.value = null
+  inflightRequest = null
+}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -15,6 +15,7 @@ import { AttentionSpotlight } from './attention-spotlight'
 import { NarrativeTimeline } from './narrative-timeline'
 import { AgentAvatar } from './agent-avatar'
 import { TransportHealthPanel } from '../transport-health'
+import { ConnectorStatusPanel } from '../connector-status'
 import { PerfSnapshotPanel } from '../perf-snapshot'
 import { RouteLink } from '../common/route-link'
 import { shellMetaCognition } from '../../store'
@@ -508,6 +509,10 @@ export function Overview() {
         <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
           <${PerfSnapshotPanel} />
         </div>
+      </div>
+
+      <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
+        <${ConnectorStatusPanel} />
       </div>
 
       ${hasJournal

--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -93,6 +93,12 @@ let dedup_cleanup ~now =
     in
     List.iter (Hashtbl.remove dedup_table) to_remove)
 
+let dedup_table_size () =
+  with_dedup_lock (fun () -> Hashtbl.length dedup_table)
+
+(* Register dedup_table_size callback to break cycle *)
+let () = Channel_gate_metrics.register_dedup_size_fn dedup_table_size
+
 (* ── Validation (pure) ──────────────────────────────────────── *)
 
 let validation_error_to_string = function
@@ -192,16 +198,30 @@ let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
           let duration_ms =
             int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
           in
+          let ch = Agent_identity.string_of_channel msg.channel in
+          let keeper = String.trim msg.keeper_name in
+          Channel_gate_metrics.record_message
+            ~channel:ch ~keeper ~duration_ms ~success:true;
           let reply = extract_reply_text body in
           let stats = match extract_turn_stats body with
             | Some s -> Some { s with duration_ms }
             | None -> Some { model_used = ""; duration_ms; tokens_used = 0 }
           in
-          Ok { keeper_name = String.trim msg.keeper_name;
-               content = reply; turn_stats = stats }
+          Ok { keeper_name = keeper; content = reply; turn_stats = stats }
       | Some (false, err) ->
+          let duration_ms =
+            int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
+          in
+          Channel_gate_metrics.record_message
+            ~channel:(Agent_identity.string_of_channel msg.channel)
+            ~keeper:(String.trim msg.keeper_name)
+            ~duration_ms ~success:false;
           Error (Keeper_error err)
       | None ->
+          Channel_gate_metrics.record_message
+            ~channel:(Agent_identity.string_of_channel msg.channel)
+            ~keeper:(String.trim msg.keeper_name)
+            ~duration_ms:0 ~success:false;
           Error Dispatch_unavailable
 
 (* ── JSON helpers ───────────────────────────────────────────── *)

--- a/lib/channel_gate.mli
+++ b/lib/channel_gate.mli
@@ -62,6 +62,9 @@ val dedup_check : string -> bool
 val dedup_cleanup : now:float -> unit
 (** Evict expired entries.  Called periodically. *)
 
+val dedup_table_size : unit -> int
+(** Current number of entries in the dedup table.  For metrics. *)
+
 (** {1 Dispatch} *)
 
 (** {1 Dispatch errors (typed, not string)} *)

--- a/lib/channel_gate_metrics.ml
+++ b/lib/channel_gate_metrics.ml
@@ -1,0 +1,99 @@
+(** Channel_gate_metrics -- per-channel message counters and status.
+    See [channel_gate_metrics.mli]. *)
+
+type channel_stats = {
+  channel : string;
+  message_count : int;
+  error_count : int;
+  last_activity_ts : float;
+  last_keeper : string;
+  total_duration_ms : int;
+}
+
+(* Mutable internal record for accumulation. *)
+type stats_acc = {
+  mutable msg_count : int;
+  mutable err_count : int;
+  mutable last_ts : float;
+  mutable last_keeper : string;
+  mutable total_dur_ms : int;
+}
+
+let table : (string, stats_acc) Hashtbl.t = Hashtbl.create 16
+let mu = Eio.Mutex.create ()
+let start_time = Unix.gettimeofday ()
+
+let record_message ~channel ~keeper ~duration_ms ~success =
+  Eio_guard.with_mutex mu (fun () ->
+    let acc =
+      match Hashtbl.find_opt table channel with
+      | Some a -> a
+      | None ->
+          let a = {
+            msg_count = 0; err_count = 0;
+            last_ts = 0.0; last_keeper = ""; total_dur_ms = 0;
+          } in
+          Hashtbl.replace table channel a;
+          a
+    in
+    acc.msg_count <- acc.msg_count + 1;
+    acc.last_ts <- Unix.gettimeofday ();
+    acc.last_keeper <- keeper;
+    acc.total_dur_ms <- acc.total_dur_ms + duration_ms;
+    if not success then acc.err_count <- acc.err_count + 1)
+
+let snapshot () =
+  Eio_guard.with_mutex_ro mu (fun () ->
+    Hashtbl.fold (fun ch acc lst ->
+      { channel = ch;
+        message_count = acc.msg_count;
+        error_count = acc.err_count;
+        last_activity_ts = acc.last_ts;
+        last_keeper = acc.last_keeper;
+        total_duration_ms = acc.total_dur_ms;
+      } :: lst
+    ) table [])
+  |> List.sort (fun a b -> compare b.message_count a.message_count)
+
+let total_messages () =
+  Eio_guard.with_mutex_ro mu (fun () ->
+    Hashtbl.fold (fun _ acc sum -> sum + acc.msg_count) table 0)
+
+(** Callback for dedup table size.  Set by channel_gate at init
+    to break the module dependency cycle. *)
+let dedup_size_fn : (unit -> int) ref = ref (fun () -> 0)
+
+let register_dedup_size_fn f = dedup_size_fn := f
+
+let dedup_table_size () = !dedup_size_fn ()
+
+let iso_of_ts ts =
+  if ts <= 0.0 then "never"
+  else
+    let t = Unix.gmtime ts in
+    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+      (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday
+      t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
+
+let snapshot_json () =
+  let channels = snapshot () in
+  let total = List.fold_left (fun s c -> s + c.message_count) 0 channels in
+  let channel_json c =
+    let avg_dur =
+      if c.message_count > 0 then c.total_duration_ms / c.message_count else 0
+    in
+    `Assoc [
+      ("channel", `String c.channel);
+      ("message_count", `Int c.message_count);
+      ("error_count", `Int c.error_count);
+      ("last_activity", `String (iso_of_ts c.last_activity_ts));
+      ("last_keeper", `String c.last_keeper);
+      ("avg_duration_ms", `Int avg_dur);
+    ]
+  in
+  `Assoc [
+    ("channels", `List (List.map channel_json channels));
+    ("total_messages", `Int total);
+    ("dedup_table_size", `Int (dedup_table_size ()));
+    ("uptime_seconds", `Int (int_of_float (Unix.gettimeofday () -. start_time)));
+  ]

--- a/lib/channel_gate_metrics.mli
+++ b/lib/channel_gate_metrics.mli
@@ -1,0 +1,36 @@
+(** Channel_gate_metrics -- per-channel message counters and status.
+
+    Thread-safe via [Eio_guard.with_mutex].  Call [record_message]
+    after each gate dispatch; read state via [snapshot_json].
+
+    @since 2.218.0 *)
+
+(** Per-channel statistics snapshot (immutable). *)
+type channel_stats = {
+  channel : string;
+  message_count : int;
+  error_count : int;
+  last_activity_ts : float;
+  last_keeper : string;
+  total_duration_ms : int;
+}
+
+val record_message :
+  channel:string -> keeper:string -> duration_ms:int -> success:bool -> unit
+(** Record one gate message.  Thread-safe. *)
+
+val snapshot : unit -> channel_stats list
+(** Return a list of per-channel stats, sorted by message_count desc. *)
+
+val snapshot_json : unit -> Yojson.Safe.t
+(** Full status JSON for the [/api/v1/gate/status] endpoint. *)
+
+val total_messages : unit -> int
+(** Sum of all channels' message counts. *)
+
+val dedup_table_size : unit -> int
+(** Current dedup hashtable occupancy. *)
+
+val register_dedup_size_fn : (unit -> int) -> unit
+(** Register the dedup table size callback.  Called by [Channel_gate]
+    at module init to break the dependency cycle. *)

--- a/lib/dune
+++ b/lib/dune
@@ -29,6 +29,7 @@
    cascade_inference
    cancellation
    channel_gate
+   channel_gate_metrics
    command_plane_v2
    command_plane_orchestra
    cp_types

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -310,6 +310,7 @@ let is_public_read_path path =
   || String.equal path "/health/live"
   || String.equal path "/health/ready"
   || String.equal path "/api/v1/gate/health"
+  || String.equal path "/api/v1/gate/status"
   || String.equal path "/"
   || String.equal path "/dashboard"
   || String.equal path "/dashboard/"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -109,6 +109,15 @@ let handle_gate_health _state request reqd =
   respond_json_with_cors ~status:`OK request reqd
     {|{"ok":true,"service":"channel_gate"}|}
 
+(** GET /api/v1/gate/status
+
+    Per-channel connector metrics: message counts, last activity,
+    average latency, error counts.  Public read. *)
+let handle_gate_status _state request reqd =
+  let json = Channel_gate_metrics.snapshot_json () in
+  respond_json_with_cors ~status:`OK request reqd
+    (Yojson.Safe.to_string json)
+
 (** Register all gate routes on the router. *)
 let add_routes ~sw ~clock router =
   router
@@ -120,4 +129,9 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/gate/health" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          handle_gate_health state request reqd
+       ) request reqd)
+
+  |> Http.Router.get "/api/v1/gate/status" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         handle_gate_status state request reqd
        ) request reqd)


### PR DESCRIPTION
## Summary

Channel Gate 커넥터 상태를 대시보드에서 확인할 수 있는 패널 추가.

- **OCaml**: `channel_gate_metrics.ml` — per-channel 메시지/에러/지연 추적
- **API**: `GET /api/v1/gate/status` — JSON 스냅샷 (public read)
- **Dashboard**: `ConnectorStatusPanel` — overview 페이지에 배치
  - StatCard 3개 (total messages, dedup keys, uptime)
  - Per-channel 카드 (상태 표시등, 메시지/에러 수, 평균 지연, 마지막 활동)

### Architecture

```
channel_gate.ml → record_message() → channel_gate_metrics.ml
                                           ↓
                        GET /api/v1/gate/status → JSON
                                           ↓
                     dashboard ConnectorStatusPanel (Preact)
```

## Test plan

- [x] OCaml `dune build` 통과
- [x] TypeScript `tsc --noEmit` 통과
- [ ] CI checks green
- [ ] `curl /api/v1/gate/status` 응답 확인
- [ ] 대시보드에서 패널 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)