### PR TITLE
fix(keeper): null-safe tool policy mutual-exclusion + legacy kind rejection

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -114,7 +114,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("description", `String "Compatibility field. Use tool_access.kind='preset' for new callers.");
@@ -256,7 +256,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "minimal"; `String "messaging"; `String "coding"; `String "research"; `String "full"]);

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -57,9 +57,12 @@ let json_assoc_member_opt key (json : Yojson.Safe.t) =
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
 
-let json_member_present key (json : Yojson.Safe.t) =
+let json_non_null_member_present key (json : Yojson.Safe.t) =
   match json with
-  | `Assoc fields -> List.mem_assoc key fields
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some `Null | None -> false
+      | Some _ -> true)
   | _ -> false
 
 let parse_present_tool_name_list_opt args key =
@@ -81,12 +84,22 @@ let resolve_tool_name_list ~preferred ~fallback =
   |> Option.value ~default:[]
   |> normalize_tool_name_list
 
+let reject_legacy_tool_access_kind access_json =
+  match json_assoc_member_opt "kind" access_json with
+  | Some (`String ("restricted" | "unrestricted")) ->
+      Error
+        "tool_access.kind must be \"preset\" or \"custom\"; legacy kinds \
+         \"restricted\" and \"unrestricted\" are not supported for this endpoint"
+  | _ -> Ok ()
+
 let parse_tool_access_input (args : Yojson.Safe.t) :
     (tool_access option * tool_preset option * string list option, string) result =
-  let tool_access_present = json_member_present "tool_access" args in
-  let tool_preset_present = json_member_present "tool_preset" args in
-  let tool_also_allow_present = json_member_present "tool_also_allow" args in
-  let tool_custom_allowlist_present = json_member_present "tool_custom_allowlist" args in
+  let tool_access_present = json_non_null_member_present "tool_access" args in
+  let tool_preset_present = json_non_null_member_present "tool_preset" args in
+  let tool_also_allow_present = json_non_null_member_present "tool_also_allow" args in
+  let tool_custom_allowlist_present =
+    json_non_null_member_present "tool_custom_allowlist" args
+  in
   if tool_access_present
      && (tool_preset_present || tool_also_allow_present || tool_custom_allowlist_present)
   then
@@ -100,9 +113,14 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
       if tool_access_present then
         match json_assoc_member_opt "tool_access" args with
         | Some ((`Assoc _) as access_json) -> (
-            match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
-            | Ok access -> Ok (Some access)
-            | Error msg -> Error msg)
+            match reject_legacy_tool_access_kind access_json with
+            | Error msg -> Error msg
+            | Ok () -> (
+                match
+                  tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ])
+                with
+                | Ok access -> Ok (Some access)
+                | Error msg -> Error msg))
         | Some `Null -> Error "tool_access must not be null"
         | Some _ -> Error "tool_access must be an object"
         | None -> Ok None


### PR DESCRIPTION
## Summary

Follow-up to #4633 (merged). Addresses Copilot review comments.

- Explicit null fields (`"tool_access": null`) no longer trigger mutual-exclusion errors — treated as absent
- Legacy tool_access kinds (`restricted`/`unrestricted`) rejected at API input level with actionable error
- Trailing whitespace trimmed in tool_access schema descriptions

## Review comment mapping

| Comment | File | Response |
|---------|------|----------|
| `json_member_present` null handling | `keeper_turn_up_args.ml:97` | Replaced with `json_non_null_member_present` |
| tool_access schema bare object | `keeper_schema.ml:73` | Already fixed in #4633 (47c64eee8) |
| Legacy kind not in published schema | `keeper_turn_up_args.ml:105` | Added `reject_legacy_tool_access_kind` |
| canonical_keeper_meta_key_names drift | `keeper_types.ml:337` | Acknowledged — test coverage suggested for follow-up |
| Trailing whitespace | `keeper_schema.ml:259` | Fixed |

## Test plan

- [x] `dune build` passes
- [ ] CI green

Refs #4633