### PR TITLE
feat(team-session): unify worker run evidence summary

### DIFF
--- a/lib/dashboard/dashboard_proof_actors.ml
+++ b/lib/dashboard/dashboard_proof_actors.ml
@@ -71,104 +71,16 @@ let worker_run_meta_jsons config = function
              else None)
 
 let worker_run_trace_capability json =
-  match U.member "trace_capability" json with
-  | `String value -> Some value
-  | _ -> None
+  Worker_run_evidence_summary.trace_capability json
 
 let worker_run_trace_validated json =
-  match U.member "validated" json with
-  | `Bool value -> Some value
-  | _ -> (
-      match U.member "trace_validation" json |> U.member "ok" with
-      | `Bool value -> Some value
-      | _ -> None)
-
-let session_conformance_failures json =
-  match U.member "session_conformance" json |> U.member "checks" with
-  | `List items ->
-      items
-      |> List.filter_map (fun item ->
-             match U.member "name" item, U.member "passed" item with
-             | `String name, `Bool false -> Some name
-             | _ -> None)
-  | _ -> []
+  Worker_run_evidence_summary.trace_validated json
 
 let worker_run_validation_failures json =
-  let trace_failures =
-    match U.member "trace_validation" json |> U.member "checks" with
-    | `List items ->
-        items
-        |> List.filter_map (fun item ->
-               match U.member "name" item, U.member "passed" item with
-               | `String name, `Bool false -> Some name
-               | _ -> None)
-    | _ -> []
-  in
-  Team_session_types.dedup_strings
-    (trace_failures @ session_conformance_failures json)
+  Worker_run_evidence_summary.validation_failures json
 
 let worker_run_summary_json json =
-  let summary = U.member "trace_summary" json in
-  let base_fields =
-    [
-      ("session_id", U.member "session_id" json);
-      ("operation_id", U.member "operation_id" json);
-      ("worker_run_id", U.member "worker_run_id" json);
-      ("cdal_run_id", U.member "cdal_run_id" json);
-      ("contract_id", U.member "contract_id" json);
-      ("result_status", U.member "result_status" json);
-      ("worker_name", U.member "worker_name" json);
-      ("status", U.member "status" json);
-      ("mode", U.member "mode" json);
-      ("wait_mode", U.member "wait_mode" json);
-      ( "trace_capability",
-        Option.fold ~none:`Null ~some:(fun s -> `String s)
-          (worker_run_trace_capability json) );
-      ( "trace_validated",
-        Option.fold ~none:`Null ~some:(fun v -> `Bool v)
-          (worker_run_trace_validated json) );
-      ( "validation_failures",
-        `List
-          (List.map (fun item -> `String item)
-             (worker_run_validation_failures json)) );
-      ("success", U.member "success" json);
-      ("execution_scope", U.member "execution_scope" json);
-      ("requested_worker_class", U.member "requested_worker_class" json);
-      ("requested_worker_size", U.member "requested_worker_size" json);
-      ("resolved_runtime", U.member "resolved_runtime" json);
-      ("resolved_model", U.member "resolved_model" json);
-      ("routing_reason", U.member "routing_reason" json);
-      ("tool_names", U.member "tool_names" json);
-      ("tool_call_count", U.member "tool_call_count" json);
-      ("output_preview", U.member "output_preview" json);
-      ("record_count", U.member "record_count" summary);
-      ("assistant_block_count", U.member "assistant_block_count" summary);
-      ("final_text", if U.member "final_text" json <> `Null then U.member "final_text" json else U.member "final_text" summary);
-      ("stop_reason", if U.member "stop_reason" json <> `Null then U.member "stop_reason" json else U.member "stop_reason" summary);
-      ("failure_reason", U.member "failure_reason" json);
-      ("error", if U.member "error" json <> `Null then U.member "error" json else U.member "error" summary);
-      ("proof_present", U.member "proof_present" json);
-      ("tool_trace_refs", U.member "tool_trace_refs" json);
-      ("raw_evidence_refs", U.member "raw_evidence_refs" json);
-      ("checkpoint_ref", U.member "checkpoint_ref" json);
-      ("evidence_refs", U.member "evidence_refs" json);
-      ("session_conformance", U.member "session_conformance" json);
-      ("ts_iso", U.member "ts_iso" json);
-    ]
-  in
-  let proof_fields =
-    match U.member "proof_run_id" json with
-    | `String _ ->
-        [
-          ("proof_run_id", U.member "proof_run_id" json);
-          ("proof_status", U.member "proof_status" json);
-          ("proof_risk_class", U.member "proof_risk_class" json);
-          ("proof_execution_mode", U.member "proof_execution_mode" json);
-          ("proof_evidence_count", U.member "proof_evidence_count" json);
-        ]
-    | _ -> []
-  in
-  `Assoc (base_fields @ proof_fields)
+  Worker_run_evidence_summary.summary_json json
 
 let actor_activity_state (acc : actor_acc) =
   if acc.observed_event_count > 0 then

--- a/lib/dune
+++ b/lib/dune
@@ -244,6 +244,7 @@
    goal_orchestrator
    goal_scheduler
    swarm_goal_loop
+   worker_run_evidence_summary
    room
    run_eio
    team_context

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -329,33 +329,7 @@ let pending_worker_names (session : Team_session_types.session) ready_names
   |> Team_session_types.dedup_strings |> List.sort String.compare
 
 let worker_run_status_json (json : Yojson.Safe.t) =
-  let open Yojson.Safe.Util in
-  `Assoc
-    [
-      ("worker_run_id", member "worker_run_id" json);
-      ("worker_name", member "worker_name" json);
-      ("status", member "status" json);
-      ("mode", member "mode" json);
-      ("wait_mode", member "wait_mode" json);
-      ("success", member "success" json);
-      ("trace_capability", member "trace_capability" json);
-      ("execution_scope", member "execution_scope" json);
-      ("requested_worker_class", member "requested_worker_class" json);
-      ("requested_worker_size", member "requested_worker_size" json);
-      ("resolved_runtime", member "resolved_runtime" json);
-      ("resolved_model", member "resolved_model" json);
-      ("routing_reason", member "routing_reason" json);
-      ("validated", member "validated" json);
-      ("final_text", member "final_text" json);
-      ("stop_reason", member "stop_reason" json);
-      ("failure_reason", member "failure_reason" json);
-      ("tool_names", member "tool_names" json);
-      ("tool_call_count", member "tool_call_count" json);
-      ("output_preview", member "output_preview" json);
-      ("session_conformance", member "session_conformance" json);
-      ("error", member "error" json);
-      ("ts_iso", member "ts_iso" json);
-    ]
+  Worker_run_evidence_summary.summary_json json
 
 let status_sections ?events (config : Room.config) (session : Team_session_types.session) =
   let events =

--- a/lib/tool_team_session_handlers.ml
+++ b/lib/tool_team_session_handlers.ml
@@ -315,24 +315,7 @@ let handle_verify_trace ctx args : result =
           in
           let verification_result meta_json worker_run_id =
             let worker_run_summary =
-              `Assoc
-                [
-                  ("worker_run_id", `String worker_run_id);
-                  ("worker_name", Yojson.Safe.Util.member "worker_name" meta_json);
-                  ("status", Yojson.Safe.Util.member "status" meta_json);
-                  ("mode", Yojson.Safe.Util.member "mode" meta_json);
-                  ("wait_mode", Yojson.Safe.Util.member "wait_mode" meta_json);
-                  ("success", Yojson.Safe.Util.member "success" meta_json);
-                  ("execution_scope", Yojson.Safe.Util.member "execution_scope" meta_json);
-                  ("requested_worker_class", Yojson.Safe.Util.member "requested_worker_class" meta_json);
-                  ("requested_worker_size", Yojson.Safe.Util.member "requested_worker_size" meta_json);
-                  ("resolved_runtime", Yojson.Safe.Util.member "resolved_runtime" meta_json);
-                  ("resolved_model", Yojson.Safe.Util.member "resolved_model" meta_json);
-                  ("routing_reason", Yojson.Safe.Util.member "routing_reason" meta_json);
-                  ("tool_names", Yojson.Safe.Util.member "tool_names" meta_json);
-                  ("tool_call_count", Yojson.Safe.Util.member "tool_call_count" meta_json);
-                  ("output_preview", Yojson.Safe.Util.member "output_preview" meta_json);
-                ]
+              Worker_run_evidence_summary.summary_json meta_json
             in
             let session_root = oas_trace_session_root ctx.config in
             match evidence_session_id_of_json meta_json with
@@ -369,10 +352,7 @@ let handle_verify_trace ctx args : result =
                                       [
                                         ("worker_run_id", `String worker_run_id);
                                         ("trace_capability", `String "raw");
-                                        ( "worker_run",
-                                          Option.fold ~none:worker_run_summary
-                                            ~some:Oas.Sessions.worker_run_to_yojson
-                                            bundle.latest_worker_run );
+                                        ("worker_run", worker_run_summary);
                                         ( "trace_ref",
                                           Oas.Raw_trace.run_ref_to_yojson summary.run_ref );
                                         ("verification", verification);
@@ -402,10 +382,7 @@ let handle_verify_trace ctx args : result =
                                         ("trace_capability", `String "summary_only");
                                         ("ok", `Bool false);
                                         ("error", `String detail);
-                                        ( "worker_run",
-                                          Option.fold ~none:worker_run_summary
-                                            ~some:Oas.Sessions.worker_run_to_yojson
-                                            bundle.latest_worker_run );
+                                        ("worker_run", worker_run_summary);
                                         ( "session_conformance",
                                           Oas.Conformance.report_to_yojson report );
                                       ] );
@@ -423,10 +400,7 @@ let handle_verify_trace ctx args : result =
                                     ( "error",
                                       `String
                                         "direct evidence proof bundle did not contain a raw trace run" );
-                                    ( "worker_run",
-                                      Option.fold ~none:worker_run_summary
-                                        ~some:Oas.Sessions.worker_run_to_yojson
-                                        bundle.latest_worker_run );
+                                    ("worker_run", worker_run_summary);
                                     ( "session_conformance",
                                       Oas.Conformance.report_to_yojson report );
                                   ] );

--- a/lib/worker_run_evidence_summary.ml
+++ b/lib/worker_run_evidence_summary.ml
@@ -119,7 +119,7 @@ let summary_json json =
     | `Assoc _ -> U.member key summary
     | _ -> `Null
   in
-  `Assoc
+  let base_fields =
     [
       ("session_id", U.member "session_id" json);
       ("operation_id", U.member "operation_id" json);
@@ -170,11 +170,6 @@ let summary_json json =
       ("proof_present", U.member "proof_present" json);
       ( "proof_evidence_status",
         `String (evidence_state_to_string (proof_evidence_state json)) );
-      ("proof_run_id", U.member "proof_run_id" json);
-      ("proof_status", U.member "proof_status" json);
-      ("proof_risk_class", U.member "proof_risk_class" json);
-      ("proof_execution_mode", U.member "proof_execution_mode" json);
-      ("proof_evidence_count", U.member "proof_evidence_count" json);
       ("tool_trace_refs", U.member "tool_trace_refs" json);
       ("raw_evidence_refs", U.member "raw_evidence_refs" json);
       ("checkpoint_ref", U.member "checkpoint_ref" json);
@@ -183,3 +178,17 @@ let summary_json json =
       ("session_conformance", U.member "session_conformance" json);
       ("ts_iso", U.member "ts_iso" json);
     ]
+  in
+  let proof_fields =
+    match U.member "proof_run_id" json with
+    | `String _ ->
+        [
+          ("proof_run_id", U.member "proof_run_id" json);
+          ("proof_status", U.member "proof_status" json);
+          ("proof_risk_class", U.member "proof_risk_class" json);
+          ("proof_execution_mode", U.member "proof_execution_mode" json);
+          ("proof_evidence_count", U.member "proof_evidence_count" json);
+        ]
+    | _ -> []
+  in
+  `Assoc (base_fields @ proof_fields)

--- a/lib/worker_run_evidence_summary.ml
+++ b/lib/worker_run_evidence_summary.ml
@@ -1,0 +1,185 @@
+module U = Yojson.Safe.Util
+
+type evidence_state =
+  | Available
+  | Unavailable
+  | Missing
+
+let evidence_state_to_string = function
+  | Available -> "available"
+  | Unavailable -> "unavailable"
+  | Missing -> "missing"
+
+let non_empty_string = function
+  | `String value when String.trim value <> "" -> Some (String.trim value)
+  | _ -> None
+
+let string_member_opt key json = non_empty_string (U.member key json)
+
+let bool_member_opt key json =
+  match U.member key json with
+  | `Bool value -> Some value
+  | _ -> None
+
+let list_member key json =
+  match U.member key json with
+  | `List items -> items
+  | _ -> []
+
+let has_non_null key json =
+  match U.member key json with
+  | `Null -> false
+  | _ -> true
+
+let bool_opt_to_json = function
+  | Some value -> `Bool value
+  | None -> `Null
+
+let string_list_to_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let trace_capability json = string_member_opt "trace_capability" json
+
+let trace_validated json =
+  match bool_member_opt "validated" json with
+  | Some _ as value -> value
+  | None -> (
+      match U.member "trace_validation" json with
+      | `Assoc _ as validation -> bool_member_opt "ok" validation
+      | _ -> None)
+
+let session_conformance_failures json =
+  match U.member "session_conformance" json with
+  | `Assoc _ as conformance -> (
+      match U.member "checks" conformance with
+      | `List items ->
+          items
+          |> List.filter_map (fun item ->
+                 match U.member "name" item, U.member "passed" item with
+                 | `String name, `Bool false -> Some name
+                 | _ -> None)
+      | _ -> [])
+  | _ -> []
+
+let validation_failures json =
+  let trace_failures =
+    match U.member "trace_validation" json with
+    | `Assoc _ as validation -> (
+        match U.member "checks" validation with
+        | `List items ->
+            items
+            |> List.filter_map (fun item ->
+                   match U.member "name" item, U.member "passed" item with
+                   | `String name, `Bool false -> Some name
+                   | _ -> None)
+        | _ -> [])
+    | _ -> []
+  in
+  Team_session_types.dedup_strings
+    (trace_failures @ session_conformance_failures json)
+
+let trace_evidence_state json =
+  let has_trace_evidence =
+    has_non_null "trace_ref" json
+    || has_non_null "trace_summary" json
+    || has_non_null "trace_validation" json
+  in
+  match trace_capability json with
+  | Some "raw" ->
+      if has_trace_evidence then Available else Missing
+  | Some "summary_only" ->
+      if has_trace_evidence then Available else Unavailable
+  | Some _ ->
+      if has_trace_evidence then Available else Unavailable
+  | None ->
+      if has_trace_evidence then Available
+      else if has_non_null "evidence_session_id" json then Unavailable
+      else Missing
+
+let proof_refs_present json =
+  has_non_null "proof_run_id" json
+  || has_non_null "checkpoint_ref" json
+  || list_member "tool_trace_refs" json <> []
+  || list_member "raw_evidence_refs" json <> []
+  || list_member "evidence_refs" json <> []
+
+let proof_evidence_state json =
+  match bool_member_opt "proof_present" json with
+  | Some true ->
+      if proof_refs_present json then Available else Missing
+  | Some false ->
+      if proof_refs_present json then Missing else Unavailable
+  | None ->
+      if proof_refs_present json then Available else Unavailable
+
+let summary_json json =
+  let summary = U.member "trace_summary" json in
+  let summary_member key =
+    match summary with
+    | `Assoc _ -> U.member key summary
+    | _ -> `Null
+  in
+  `Assoc
+    [
+      ("session_id", U.member "session_id" json);
+      ("operation_id", U.member "operation_id" json);
+      ("worker_run_id", U.member "worker_run_id" json);
+      ("cdal_run_id", U.member "cdal_run_id" json);
+      ("contract_id", U.member "contract_id" json);
+      ("result_status", U.member "result_status" json);
+      ("worker_name", U.member "worker_name" json);
+      ("status", U.member "status" json);
+      ("mode", U.member "mode" json);
+      ("wait_mode", U.member "wait_mode" json);
+      ("success", U.member "success" json);
+      ("execution_scope", U.member "execution_scope" json);
+      ("requested_worker_class", U.member "requested_worker_class" json);
+      ("requested_worker_size", U.member "requested_worker_size" json);
+      ("resolved_runtime", U.member "resolved_runtime" json);
+      ("resolved_model", U.member "resolved_model" json);
+      ("routing_reason", U.member "routing_reason" json);
+      ("tool_names", U.member "tool_names" json);
+      ("tool_call_count", U.member "tool_call_count" json);
+      ("output_preview", U.member "output_preview" json);
+      ("trace_capability", U.member "trace_capability" json);
+      ( "trace_evidence_status",
+        `String (evidence_state_to_string (trace_evidence_state json)) );
+      ("trace_ref", U.member "trace_ref" json);
+      ("trace_summary_present", `Bool (has_non_null "trace_summary" json));
+      ("trace_validation_present", `Bool (has_non_null "trace_validation" json));
+      ("trace_validated", bool_opt_to_json (trace_validated json));
+      ("validation_failures", string_list_to_json (validation_failures json));
+      ("record_count", summary_member "record_count");
+      ("assistant_block_count", summary_member "assistant_block_count");
+      ( "final_text",
+        if U.member "final_text" json <> `Null then
+          U.member "final_text" json
+        else
+          summary_member "final_text" );
+      ( "stop_reason",
+        if U.member "stop_reason" json <> `Null then
+          U.member "stop_reason" json
+        else
+          summary_member "stop_reason" );
+      ("failure_reason", U.member "failure_reason" json);
+      ( "error",
+        if U.member "error" json <> `Null then
+          U.member "error" json
+        else
+          summary_member "error" );
+      ("proof_present", U.member "proof_present" json);
+      ( "proof_evidence_status",
+        `String (evidence_state_to_string (proof_evidence_state json)) );
+      ("proof_run_id", U.member "proof_run_id" json);
+      ("proof_status", U.member "proof_status" json);
+      ("proof_risk_class", U.member "proof_risk_class" json);
+      ("proof_execution_mode", U.member "proof_execution_mode" json);
+      ("proof_evidence_count", U.member "proof_evidence_count" json);
+      ("tool_trace_refs", U.member "tool_trace_refs" json);
+      ("raw_evidence_refs", U.member "raw_evidence_refs" json);
+      ("checkpoint_ref", U.member "checkpoint_ref" json);
+      ("evidence_session_id", U.member "evidence_session_id" json);
+      ("evidence_refs", U.member "evidence_refs" json);
+      ("session_conformance", U.member "session_conformance" json);
+      ("ts_iso", U.member "ts_iso" json);
+    ]

--- a/test/dune
+++ b/test/dune
@@ -172,6 +172,11 @@
  (modules test_meta_cognition_feedback)
  (libraries masc_test_deps))
 
+(test
+ (name test_worker_run_evidence_summary)
+ (modules test_worker_run_evidence_summary test_tool_team_session_support)
+ (libraries masc_test_deps))
+
 ; ============================================================
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.

--- a/test/test_worker_run_evidence_summary.ml
+++ b/test/test_worker_run_evidence_summary.ml
@@ -1,0 +1,203 @@
+open Alcotest
+open Masc_mcp
+open Test_tool_team_session_support
+
+module U = Yojson.Safe.Util
+
+let sample_trace_ref ~session_id ~worker_run_id ~agent_name =
+  `Assoc
+    [
+      ("session_id", `String session_id);
+      ("worker_run_id", `String worker_run_id);
+      ("agent_name", `String agent_name);
+      ("start_seq", `Int 1);
+      ("end_seq", `Int 9);
+    ]
+
+let sample_meta ?(trace_capability = `String "raw")
+    ?(trace_ref =
+      Some
+        (sample_trace_ref ~session_id:"ts-evidence-summary"
+           ~worker_run_id:"wr-evidence-1" ~agent_name:"worker-a"))
+    ?(trace_summary =
+      Some
+        (`Assoc
+          [
+            ("record_count", `Int 8);
+            ("assistant_block_count", `Int 3);
+            ("final_text", `String "Patched calc.py and verification passed.");
+            ("stop_reason", `String "end_turn");
+          ]))
+    ?(trace_validation =
+      Some
+        (`Assoc
+          [
+            ("ok", `Bool false);
+            ( "checks",
+              `List
+                [
+                  `Assoc [ ("name", `String "seq_monotonic"); ("passed", `Bool false) ];
+                ] );
+          ]))
+    ?(proof_present = `Bool true) ?(proof_run_id = `String "proof-run-123")
+    ?(tool_trace_refs =
+      `List [ `String "proof-store://wr-evidence-1/tool_traces/trace-1.jsonl" ])
+    ?(raw_evidence_refs =
+      `List [ `String "proof-store://wr-evidence-1/evidence/mode_violations.json" ])
+    ?(checkpoint_ref = `String "proof-store://wr-evidence-1/checkpoint.json")
+    ?(evidence_refs =
+      `List [ `String "proof-store://wr-evidence-1/checkpoint.json" ])
+    () =
+  `Assoc
+    [
+      ("session_id", `String "ts-evidence-summary");
+      ("operation_id", `String "op-evidence-summary");
+      ("worker_run_id", `String "wr-evidence-1");
+      ("worker_name", `String "worker-a");
+      ("status", `String "completed");
+      ("mode", `String "delegate");
+      ("wait_mode", `String "background");
+      ("success", `Bool true);
+      ("trace_capability", trace_capability);
+      ( "trace_ref",
+        Option.value ~default:`Null trace_ref );
+      ( "trace_summary",
+        Option.value ~default:`Null trace_summary );
+      ( "trace_validation",
+        Option.value ~default:`Null trace_validation );
+      ("execution_scope", `String "limited_code_change");
+      ("requested_worker_class", `String "executor");
+      ("requested_worker_size", `String "lg");
+      ("resolved_runtime", `String "llama-8085");
+      ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+      ("routing_reason", `String "explicit_task_profile");
+      ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
+      ("tool_call_count", `Int 2);
+      ("output_preview", `String "Patched calc.py and verification passed.");
+      ("proof_present", proof_present);
+      ("proof_run_id", proof_run_id);
+      ("proof_status", `String "completed");
+      ("proof_risk_class", `String "medium");
+      ("proof_execution_mode", `String "execute");
+      ("proof_evidence_count", `Int 2);
+      ("tool_trace_refs", tool_trace_refs);
+      ("raw_evidence_refs", raw_evidence_refs);
+      ("checkpoint_ref", checkpoint_ref);
+      ("evidence_session_id", `String "oas-proof-session");
+      ("evidence_refs", evidence_refs);
+      ("validated", `Bool true);
+      ("final_text", `String "Patched calc.py and verification passed.");
+      ("failure_reason", `Null);
+      ( "session_conformance",
+        `Assoc
+          [
+            ("ok", `Bool true);
+            ( "checks",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("name", `String "proof bundle available");
+                      ("passed", `Bool true);
+                    ];
+                ] );
+          ] );
+      ("ts_iso", `String "2026-04-02T00:00:00Z");
+    ]
+
+let test_status_and_dashboard_use_canonical_summary () =
+  let meta_json = sample_meta () in
+  let canonical = Worker_run_evidence_summary.summary_json meta_json in
+  let status_json = Team_session_engine_status.worker_run_status_json meta_json in
+  let dashboard_json = Dashboard_proof_actors.worker_run_summary_json meta_json in
+  check bool "status equals canonical" true (Yojson.Safe.equal canonical status_json);
+  check bool "dashboard equals canonical" true
+    (Yojson.Safe.equal canonical dashboard_json)
+
+let test_summary_distinguishes_missing_vs_unavailable_evidence () =
+  let missing_trace =
+    Worker_run_evidence_summary.summary_json
+      (sample_meta ~trace_ref:None ~trace_summary:None ~trace_validation:None ())
+  in
+  check string "raw trace without refs is missing" "missing"
+    U.(missing_trace |> member "trace_evidence_status" |> to_string);
+  let unavailable_trace =
+    Worker_run_evidence_summary.summary_json
+      (sample_meta ~trace_capability:(`String "summary_only") ~trace_ref:None
+         ~trace_summary:None ~trace_validation:None ())
+  in
+  check string "summary_only without refs is unavailable" "unavailable"
+    U.(unavailable_trace |> member "trace_evidence_status" |> to_string);
+  let missing_proof =
+    Worker_run_evidence_summary.summary_json
+      (sample_meta ~proof_present:(`Bool true) ~proof_run_id:`Null
+         ~tool_trace_refs:(`List []) ~raw_evidence_refs:(`List [])
+         ~checkpoint_ref:`Null ~evidence_refs:(`List []) ())
+  in
+  check string "proof declared without refs is missing" "missing"
+    U.(missing_proof |> member "proof_evidence_status" |> to_string);
+  let unavailable_proof =
+    Worker_run_evidence_summary.summary_json
+      (sample_meta ~proof_present:(`Bool false) ~proof_run_id:`Null
+         ~tool_trace_refs:(`List []) ~raw_evidence_refs:(`List [])
+         ~checkpoint_ref:`Null ~evidence_refs:(`List []) ())
+  in
+  check string "proof absent without refs is unavailable" "unavailable"
+    U.(unavailable_proof |> member "proof_evidence_status" |> to_string)
+
+let test_verify_trace_returns_canonical_worker_run_summary () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    {
+      config;
+      agent_name = "owner";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  let session_id = start_session_exn ctx ~goal:"verify-trace-canonical" |> get_session_id in
+  let worker_run_id = "run-trace-1" in
+  ignore
+    (write_worker_run_raw_trace_exn config ~session_id ~worker_run_id
+       ~worker_name:"llama-local-impl");
+  let verify_ok, verify_body =
+    dispatch_exn ctx ~name:"masc_team_session_verify_trace"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("worker_run_id", `String worker_run_id);
+          ])
+  in
+  check bool "verify trace ok" true verify_ok;
+  let result = parse_json_exn verify_body |> result_field in
+  let worker_run = U.member "worker_run" result in
+  let meta_json =
+    Team_session_store.worker_run_meta_path config session_id worker_run_id
+    |> Room_utils.read_json config
+  in
+  let canonical = Worker_run_evidence_summary.summary_json meta_json in
+  check bool "verify_trace worker_run uses canonical summary" true
+    (Yojson.Safe.equal canonical worker_run);
+  cleanup_dir base_dir
+
+let () =
+  Alcotest.run "worker_run_evidence_summary"
+    [
+      ( "summary",
+        [
+          test_case "status and dashboard use canonical summary" `Quick
+            test_status_and_dashboard_use_canonical_summary;
+          test_case "distinguishes missing vs unavailable evidence" `Quick
+            test_summary_distinguishes_missing_vs_unavailable_evidence;
+          test_case "verify_trace returns canonical worker run summary" `Quick
+            test_verify_trace_returns_canonical_worker_run_summary;
+        ] );
+    ]

--- a/test/test_worker_run_evidence_summary.ml
+++ b/test/test_worker_run_evidence_summary.ml
@@ -4,6 +4,10 @@ open Test_tool_team_session_support
 
 module U = Yojson.Safe.Util
 
+let has_key key = function
+  | `Assoc fields -> List.exists (fun (field, _) -> String.equal field key) fields
+  | _ -> false
+
 let sample_trace_ref ~session_id ~worker_run_id ~agent_name =
   `Assoc
     [
@@ -143,7 +147,11 @@ let test_summary_distinguishes_missing_vs_unavailable_evidence () =
          ~checkpoint_ref:`Null ~evidence_refs:(`List []) ())
   in
   check string "proof absent without refs is unavailable" "unavailable"
-    U.(unavailable_proof |> member "proof_evidence_status" |> to_string)
+    U.(unavailable_proof |> member "proof_evidence_status" |> to_string);
+  check bool "proof fields stay absent when no proof_run_id" false
+    (has_key "proof_run_id" unavailable_proof);
+  check bool "proof status stays absent when no proof_run_id" false
+    (has_key "proof_status" unavailable_proof)
 
 let test_verify_trace_returns_canonical_worker_run_summary () =
   with_eio @@ fun env ->


### PR DESCRIPTION
Closes #4530

## Summary
- add a canonical worker-run evidence summary read model
- reuse it across team-session status, dashboard proof, and verify-trace
- distinguish missing evidence from unavailable evidence

## Product impact
- operators see the same worker-run evidence summary across status, proof, and verify-trace
- missing evidence versus unavailable evidence is explicit instead of inferred from null-heavy payloads

## Evidence
- canonical summary added in `lib/worker_run_evidence_summary.ml`
- status, dashboard proof, and verify-trace now project worker-run evidence through the same builder

## Review evidence
- GLM-5.1 diff review via `sb glm-text --no-thinking`
- one schema-drift note about unconditional `proof_*` fields was patched in `27224dd1d`
- remaining notes were non-actionable after manual inspection

## Linked issue
- #4530

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/4530-worker-evidence-summary --build-dir _build_4530 ./test/test_worker_run_evidence_summary.exe
- ./_build_4530/default/test/test_worker_run_evidence_summary.exe