### PR TITLE
[codex] Follow up keeper review fixes

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -114,7 +114,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("description", `String "Compatibility field. Use tool_access.kind='preset' for new callers.");
@@ -256,7 +256,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}."); 
+            "Canonical tool policy. Prefer this over tool_preset/tool_also_allow. Example preset: {kind: 'preset', preset: 'research', also_allow: ['masc_status']}. Example custom: {kind: 'custom', tools: ['masc_status']}.");
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "minimal"; `String "messaging"; `String "coding"; `String "research"; `String "full"]);

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -119,7 +119,7 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
         | Some `Null -> Error "tool_access must not be null"
         | Some _ -> Error "tool_access must be an object"
         | None -> Ok None
-      else if tool_custom_allowlist_present then (
+      else if json_assoc_member_opt "tool_custom_allowlist" args <> None then (
         match parse_present_tool_name_list_opt args "tool_custom_allowlist" with
         | Ok (Some names) -> Ok (Some (Custom names))
         | Ok None -> Ok None

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -107,25 +107,22 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
       "tool_custom_allowlist cannot be combined with tool_preset or tool_also_allow"
   else
     let tool_access_opt =
-      if tool_access_present then
-        match json_assoc_member_opt "tool_access" args with
-        | Some ((`Assoc _) as access_json) -> (
-            match reject_legacy_tool_access_kind access_json with
-            | Error msg -> Error msg
-            | Ok () -> (
-                match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
-                | Ok access -> Ok (Some access)
-                | Error msg -> Error msg))
-        | Some `Null -> Error "tool_access must not be null"
-        | Some _ -> Error "tool_access must be an object"
-        | None -> Ok None
-      else if json_assoc_member_opt "tool_custom_allowlist" args <> None then (
-        match parse_present_tool_name_list_opt args "tool_custom_allowlist" with
-        | Ok (Some names) -> Ok (Some (Custom names))
-        | Ok None -> Ok None
-        | Error msg -> Error msg)
-      else
-        Ok None
+      match json_assoc_member_opt "tool_access" args with
+      | Some ((`Assoc _) as access_json) -> (
+          match reject_legacy_tool_access_kind access_json with
+          | Error msg -> Error msg
+          | Ok () -> (
+              match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
+              | Ok access -> Ok (Some access)
+              | Error msg -> Error msg))
+      | Some `Null -> Ok None
+      | Some _ -> Error "tool_access must be an object"
+      | None when json_assoc_member_opt "tool_custom_allowlist" args <> None -> (
+          match parse_present_tool_name_list_opt args "tool_custom_allowlist" with
+          | Ok (Some names) -> Ok (Some (Custom names))
+          | Ok None -> Ok None
+          | Error msg -> Error msg)
+      | None -> Ok None
     in
     match tool_access_opt with
     | Error msg -> Error msg

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -57,9 +57,12 @@ let json_assoc_member_opt key (json : Yojson.Safe.t) =
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
 
-let json_member_present key (json : Yojson.Safe.t) =
+let json_non_null_member_present key (json : Yojson.Safe.t) =
   match json with
-  | `Assoc fields -> List.mem_assoc key fields
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some `Null | None -> false
+      | Some _ -> true)
   | _ -> false
 
 let parse_present_tool_name_list_opt args key =
@@ -83,10 +86,10 @@ let resolve_tool_name_list ~preferred ~fallback =
 
 let parse_tool_access_input (args : Yojson.Safe.t) :
     (tool_access option * tool_preset option * string list option, string) result =
-  let tool_access_present = json_member_present "tool_access" args in
-  let tool_preset_present = json_member_present "tool_preset" args in
-  let tool_also_allow_present = json_member_present "tool_also_allow" args in
-  let tool_custom_allowlist_present = json_member_present "tool_custom_allowlist" args in
+  let tool_access_present = json_non_null_member_present "tool_access" args in
+  let tool_preset_present = json_non_null_member_present "tool_preset" args in
+  let tool_also_allow_present = json_non_null_member_present "tool_also_allow" args in
+  let tool_custom_allowlist_present = json_non_null_member_present "tool_custom_allowlist" args in
   if tool_access_present
      && (tool_preset_present || tool_also_allow_present || tool_custom_allowlist_present)
   then

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -84,6 +84,13 @@ let resolve_tool_name_list ~preferred ~fallback =
   |> Option.value ~default:[]
   |> normalize_tool_name_list
 
+let reject_legacy_tool_access_kind access_json =
+  match json_assoc_member_opt "kind" access_json with
+  | Some (`String ("restricted" | "unrestricted")) ->
+      Error
+        "tool_access.kind must be \"preset\" or \"custom\"; legacy kinds \"restricted\" and \"unrestricted\" are not supported for this endpoint"
+  | _ -> Ok ()
+
 let parse_tool_access_input (args : Yojson.Safe.t) :
     (tool_access option * tool_preset option * string list option, string) result =
   let tool_access_present = json_non_null_member_present "tool_access" args in
@@ -103,9 +110,12 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
       if tool_access_present then
         match json_assoc_member_opt "tool_access" args with
         | Some ((`Assoc _) as access_json) -> (
-            match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
-            | Ok access -> Ok (Some access)
-            | Error msg -> Error msg)
+            match reject_legacy_tool_access_kind access_json with
+            | Error msg -> Error msg
+            | Ok () -> (
+                match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
+                | Ok access -> Ok (Some access)
+                | Error msg -> Error msg))
         | Some `Null -> Error "tool_access must not be null"
         | Some _ -> Error "tool_access must be an object"
         | None -> Ok None

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -330,133 +330,6 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
       | None -> Error "keeper tool_access.kind required")
   | _ -> Error "keeper tool_access must be an object"
 
-let canonical_keeper_meta_key_names =
-  [
-    "name";
-    "agent_name";
-    "trace_id";
-    "trace_history";
-    "goal";
-    "short_goal";
-    "mid_goal";
-    "long_goal";
-    "soul_profile";
-    "social_model";
-    "cascade_name";
-    "will";
-    "needs";
-    "desires";
-    "instructions";
-    "policy_voice_enabled";
-    "execution_scope";
-    "allowed_paths";
-    "scope_kind";
-    "tool_access";
-    "tool_denylist";
-    "room_scope";
-    "mention_targets";
-    "room_signal_prompt_enabled";
-    "joined_room_ids";
-    "last_seen_seq_by_room";
-    "generation";
-    "proactive_enabled";
-    "proactive_idle_sec";
-    "proactive_cooldown_sec";
-    "compaction_profile";
-    "compaction_ratio_gate";
-    "compaction_message_gate";
-    "compaction_token_gate";
-    "continuity_compaction_cooldown_sec";
-    "auto_handoff";
-    "handoff_threshold";
-    "handoff_cooldown_sec";
-    "voice_enabled";
-    "voice_channel";
-    "voice_agent_id";
-    "last_handoff_ts";
-    "created_at";
-    "updated_at";
-    "total_turns";
-    "total_input_tokens";
-    "total_output_tokens";
-    "total_tokens";
-    "total_cost_usd";
-    "last_turn_ts";
-    "last_model_used";
-    "last_input_tokens";
-    "last_output_tokens";
-    "last_total_tokens";
-    "last_latency_ms";
-    "compaction_count";
-    "last_compaction_ts";
-    "last_compaction_before_tokens";
-    "last_compaction_after_tokens";
-    "proactive_count_total";
-    "last_proactive_ts";
-    "last_proactive_reason";
-    "last_proactive_preview";
-    "last_compaction_check_ts";
-    "last_compaction_decision";
-    "last_continuity_update_ts";
-    "continuity_summary";
-    "active_goal_ids";
-    "active_team_session_id";
-    "last_team_session_started_at";
-    "team_session_start_count_total";
-    "last_autonomous_action_at";
-    "autonomous_action_count";
-    "autonomous_turn_count";
-    "autonomous_text_turn_count";
-    "autonomous_tool_turn_count";
-    "board_reactive_turn_count";
-    "mention_reactive_turn_count";
-    "noop_turn_count";
-    "last_speech_act";
-    "last_blocker";
-    "last_need";
-    "paused";
-    "current_task_id";
-  ]
-
-let compatibility_keeper_meta_key_names =
-  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
-
-let known_keeper_meta_key_names =
-  canonical_keeper_meta_key_names
-  @ compatibility_keeper_meta_key_names
-
-let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
-  match json with
-  | `Assoc fields ->
-      let unknown =
-        fields
-        |> List.filter_map (fun (key, _) ->
-               if List.mem key known_keeper_meta_key_names then None else Some key)
-        |> dedupe_keep_order
-      in
-      if unknown <> [] then
-        Log.Keeper.warn
-          "keeper meta %s has unknown keys: %s"
-          path (String.concat ", " unknown)
-  | _ -> ()
-
-let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
-  let compat_present =
-    compatibility_keeper_meta_key_names
-    |> List.filter (fun key -> json_member_present key json)
-  in
-  match compat_present with
-  | [] -> ()
-  | fields ->
-      if json_object_member_present "tool_access" json then
-        Log.Keeper.warn
-          "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
-          path (String.concat ", " fields)
-      else
-        Log.Keeper.warn
-          "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
-          path (String.concat ", " fields)
-
 (* -- Updater helpers for nested record updates -- *)
 
 let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta) : keeper_meta =
@@ -983,6 +856,67 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
+
+let canonical_keeper_meta_key_names =
+  let seed_json =
+    `Assoc
+      [
+        ("name", `String "__keeper-meta-key-seed__");
+        ("agent_name", `String "__keeper-meta-key-seed__");
+        ("trace_id", `String "__keeper-meta-key-seed__");
+      ]
+  in
+  let seed_meta =
+    match meta_of_json seed_json with
+    | Ok meta -> meta
+    | Error msg ->
+        failwith
+          (Printf.sprintf
+             "canonical_keeper_meta_key_names seed failed: %s"
+             msg)
+  in
+  match meta_to_json seed_meta with
+  | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
+  | _ -> []
+
+let compatibility_keeper_meta_key_names =
+  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+
+let known_keeper_meta_key_names =
+  canonical_keeper_meta_key_names
+  @ compatibility_keeper_meta_key_names
+
+let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+      let unknown =
+        fields
+        |> List.filter_map (fun (key, _) ->
+               if List.mem key known_keeper_meta_key_names then None else Some key)
+        |> dedupe_keep_order
+      in
+      if unknown <> [] then
+        Log.Keeper.warn
+          "keeper meta %s has unknown keys: %s"
+          path (String.concat ", " unknown)
+  | _ -> ()
+
+let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
+  let compat_present =
+    compatibility_keeper_meta_key_names
+    |> List.filter (fun key -> json_member_present key json)
+  in
+  match compat_present with
+  | [] -> ()
+  | fields ->
+      if json_object_member_present "tool_access" json then
+        Log.Keeper.warn
+          "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
+          path (String.concat ", " fields)
+      else
+        Log.Keeper.warn
+          "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
+          path (String.concat ", " fields)
 
 let read_meta_file_path path : (keeper_meta option, string) result =
   if not (Sys.file_exists path) then Ok None

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -857,38 +857,125 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
 
+let fallback_canonical_keeper_meta_key_names =
+  [
+    "name";
+    "agent_name";
+    "trace_id";
+    "trace_history";
+    "goal";
+    "short_goal";
+    "mid_goal";
+    "long_goal";
+    "soul_profile";
+    "social_model";
+    "cascade_name";
+    "will";
+    "needs";
+    "desires";
+    "instructions";
+    "policy_voice_enabled";
+    "execution_scope";
+    "allowed_paths";
+    "scope_kind";
+    "tool_access";
+    "tool_denylist";
+    "room_scope";
+    "mention_targets";
+    "room_signal_prompt_enabled";
+    "joined_room_ids";
+    "last_seen_seq_by_room";
+    "generation";
+    "proactive_enabled";
+    "proactive_idle_sec";
+    "proactive_cooldown_sec";
+    "compaction_profile";
+    "compaction_ratio_gate";
+    "compaction_message_gate";
+    "compaction_token_gate";
+    "continuity_compaction_cooldown_sec";
+    "auto_handoff";
+    "handoff_threshold";
+    "handoff_cooldown_sec";
+    "voice_enabled";
+    "voice_channel";
+    "voice_agent_id";
+    "last_handoff_ts";
+    "created_at";
+    "updated_at";
+    "total_turns";
+    "total_input_tokens";
+    "total_output_tokens";
+    "total_tokens";
+    "total_cost_usd";
+    "last_turn_ts";
+    "last_model_used";
+    "last_input_tokens";
+    "last_output_tokens";
+    "last_total_tokens";
+    "last_latency_ms";
+    "compaction_count";
+    "last_compaction_ts";
+    "last_compaction_before_tokens";
+    "last_compaction_after_tokens";
+    "proactive_count_total";
+    "last_proactive_ts";
+    "last_proactive_reason";
+    "last_proactive_preview";
+    "last_compaction_check_ts";
+    "last_compaction_decision";
+    "last_continuity_update_ts";
+    "continuity_summary";
+    "active_goal_ids";
+    "active_team_session_id";
+    "last_team_session_started_at";
+    "team_session_start_count_total";
+    "last_autonomous_action_at";
+    "autonomous_action_count";
+    "autonomous_turn_count";
+    "autonomous_text_turn_count";
+    "autonomous_tool_turn_count";
+    "board_reactive_turn_count";
+    "mention_reactive_turn_count";
+    "noop_turn_count";
+    "last_speech_act";
+    "last_blocker";
+    "last_need";
+    "paused";
+    "current_task_id";
+  ]
+
 let canonical_keeper_meta_key_names =
-  let seed_json =
-    `Assoc
-      [
-        ("name", `String "__keeper-meta-key-seed__");
-        ("agent_name", `String "__keeper-meta-key-seed__");
-        ("trace_id", `String "__keeper-meta-key-seed__");
-      ]
-  in
-  let seed_meta =
-    match meta_of_json seed_json with
-    | Ok meta -> meta
-    | Error msg ->
-        failwith
-          (Printf.sprintf
-             "canonical_keeper_meta_key_names seed failed: %s"
-             msg)
-  in
-  match meta_to_json seed_meta with
-  | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
-  | _ -> []
+  lazy
+    (let seed_json =
+       `Assoc
+         [
+           ("name", `String "__keeper-meta-key-seed__");
+           ("agent_name", `String "__keeper-meta-key-seed__");
+           ("trace_id", `String "__keeper-meta-key-seed__");
+         ]
+     in
+     match meta_of_json seed_json with
+     | Ok meta -> (
+         match meta_to_json meta with
+         | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
+         | _ -> fallback_canonical_keeper_meta_key_names)
+     | Error msg ->
+         Log.Keeper.warn
+           "canonical_keeper_meta_key_names seed failed: %s; falling back to static keys"
+           msg;
+         fallback_canonical_keeper_meta_key_names)
 
 let compatibility_keeper_meta_key_names =
   [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
 
-let known_keeper_meta_key_names =
-  canonical_keeper_meta_key_names
-  @ compatibility_keeper_meta_key_names
-
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
+      let known_keeper_meta_key_names =
+        Lazy.force canonical_keeper_meta_key_names
+        @ compatibility_keeper_meta_key_names
+      in
       let unknown =
         fields
         |> List.filter_map (fun (key, _) ->

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1616,6 +1616,30 @@ let test_keeper_up_rejects_tool_custom_allowlist_with_also_allow () =
       check bool "compat mixed input error surfaced" true
         (contains_substring body "tool_custom_allowlist cannot be combined"))
 
+let test_keeper_up_rejects_null_tool_custom_allowlist_field () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "null-tool-custom-allowlist");
+              ("goal", `String "Reject null compat custom allowlist");
+              ("tool_custom_allowlist", `Null);
+            ])
+      in
+      check bool "keeper up rejects null tool_custom_allowlist field" false ok;
+      check bool "null tool_custom_allowlist error surfaced" true
+        (contains_substring body "tool_custom_allowlist must not be null"))
+
 let test_keeper_up_persists_explicit_goal_horizons () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -2604,6 +2628,8 @@ let () =
            test_keeper_up_rejects_legacy_tool_access_kinds;
          test_case "keeper up rejects tool_custom_allowlist with also_allow" `Quick
            test_keeper_up_rejects_tool_custom_allowlist_with_also_allow;
+         test_case "keeper up rejects null tool_custom_allowlist field" `Quick
+           test_keeper_up_rejects_null_tool_custom_allowlist_field;
          test_case "write_meta syncs registry meta" `Quick
            test_write_meta_syncs_registry_meta;
          test_case "keeper up persists allowed paths" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1526,12 +1526,14 @@ let test_keeper_up_rejects_mixed_tool_access_inputs () =
       check bool "mixed input error surfaced" true
         (contains_substring body "tool_access cannot be combined"))
 
-let test_keeper_up_rejects_null_tool_access_field () =
+let test_keeper_up_treats_null_tool_access_as_absent () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> rm_rf base_dir)
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "null-tool-access";
+      rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
       let keeper_ctx : _ Masc_mcp.Keeper_types.context =
@@ -1547,9 +1549,47 @@ let test_keeper_up_rejects_null_tool_access_field () =
               ("tool_preset", `String "minimal");
             ])
       in
-      check bool "keeper up rejects null tool_access field" false ok;
-      check bool "null tool_access error surfaced" true
-        (contains_substring body "tool_access cannot be combined"))
+      if not ok then fail body;
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "null-tool-access" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after null tool_access create"
+        | Error e -> fail e
+      in
+      check bool "keeper up accepts null tool_access field as absent" true ok;
+      match meta.Masc_mcp.Keeper_types.tool_access with
+      | Masc_mcp.Keeper_types.Preset
+          { preset = Masc_mcp.Keeper_types.Minimal; also_allow } ->
+          check (list string) "null tool_access preserves tool_preset fallback" [] also_allow
+      | _ -> fail "expected null tool_access to fall back to tool_preset")
+
+let test_keeper_up_rejects_legacy_tool_access_kinds () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let assert_kind_rejected kind =
+        let ok, body =
+          Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+            (`Assoc
+              [
+                ("name", `String ("legacy-tool-access-" ^ kind));
+                ("goal", `String "Reject legacy tool_access.kind in keeper_up");
+                ("tool_access", `Assoc [ ("kind", `String kind) ]);
+              ])
+        in
+        check bool ("legacy kind rejected: " ^ kind) false ok;
+        check bool ("legacy kind error surfaced: " ^ kind) true
+          (contains_substring body "tool_access.kind must be \"preset\" or \"custom\"")
+      in
+      assert_kind_rejected "restricted";
+      assert_kind_rejected "unrestricted")
 
 let test_keeper_up_rejects_tool_custom_allowlist_with_also_allow () =
   Eio_main.run @@ fun env ->
@@ -2207,6 +2247,48 @@ let test_read_meta_warns_on_unknown_keys () =
            (fun message -> contains_substring message "unknown keys: mystery_key")
            messages))
 
+let test_read_meta_on_fresh_writer_output_emits_no_unknown_key_warning () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "fresh-meta-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "fresh-meta-demo");
+              ("goal", `String "Read fresh writer output without schema drift warnings");
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      if not ok then fail ("keeper up failed: " ^ body);
+      let baseline = latest_log_seq () in
+      let _ =
+        match Masc_mcp.Keeper_types.read_meta config "fresh-meta-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after fresh read"
+        | Error e -> fail e
+      in
+      let messages = recent_keeper_log_messages ~since_seq:baseline in
+      check bool "fresh writer output emits no unknown key warning" false
+        (List.exists
+           (fun message -> contains_substring message "unknown keys:")
+           messages))
+
 let test_read_meta_warns_on_compat_tool_keys () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -2516,8 +2598,10 @@ let () =
            test_keeper_up_update_accepts_tool_custom_allowlist_compat;
          test_case "keeper up rejects mixed tool_access inputs" `Quick
            test_keeper_up_rejects_mixed_tool_access_inputs;
-         test_case "keeper up rejects null tool_access field" `Quick
-           test_keeper_up_rejects_null_tool_access_field;
+         test_case "keeper up treats null tool_access as absent" `Quick
+           test_keeper_up_treats_null_tool_access_as_absent;
+         test_case "keeper up rejects legacy tool_access kinds" `Quick
+           test_keeper_up_rejects_legacy_tool_access_kinds;
          test_case "keeper up rejects tool_custom_allowlist with also_allow" `Quick
            test_keeper_up_rejects_tool_custom_allowlist_with_also_allow;
          test_case "write_meta syncs registry meta" `Quick
@@ -2534,6 +2618,8 @@ let () =
            test_legacy_presence_keepalive_false_migrates_to_paused;
          test_case "read_meta warns on unknown keys" `Quick
            test_read_meta_warns_on_unknown_keys;
+         test_case "read_meta on fresh writer output emits no unknown key warning" `Quick
+           test_read_meta_on_fresh_writer_output_emits_no_unknown_key_warning;
          test_case "read_meta warns on compat tool keys" `Quick
            test_read_meta_warns_on_compat_tool_keys;
          test_case "read_meta treats null tool_access as compat warning" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1544,7 +1544,7 @@ let test_keeper_up_treats_null_tool_access_as_absent () =
           (`Assoc
             [
               ("name", `String "null-tool-access");
-              ("goal", `String "Reject null canonical tool_access");
+              ("goal", `String "Treat null canonical tool_access as absent");
               ("tool_access", `Null);
               ("tool_preset", `String "minimal");
             ])


### PR DESCRIPTION
Summary
- reject legacy tool_access kinds for masc_keeper_up so endpoint validation matches the published schema
- derive canonical keeper meta warning keys from meta_to_json to remove encoder/warning drift
- align compatibility field null handling so tool_custom_allowlist=null is rejected instead of being silently treated as absent
- add regression coverage for null-as-absent canonical handling, compatibility null rejection, and fresh-writer unknown-key warnings

Product impact
- follow-up fixes after merged PR #4633
- reduces schema/runtime drift and prevents silent acceptance of malformed compatibility inputs

Evidence
- dune build --root . ./test/test_tool_keeper.exe ./test/test_keeper_masc_bridge.exe
- ./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 31-51 --color=never
- ./_build/default/test/test_keeper_masc_bridge.exe

Review evidence
- Copilot follow-up review on PR #4652 surfaced null-handling consistency and schema/runtime alignment concerns; addressed in follow-up commits on this PR
- prior merged PR discussion on #4633 identified the legacy kind/runtime drift and canonical warning drift that this PR isolates as post-merge fixes

Linked issue
- Refs #4633
