### PR TITLE
feat(keeper): add keeper_list_my_tools for self-discovery

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -304,6 +304,7 @@ let run_turn
      Appending Korean keywords gives BM25 term overlap across languages.
      Keys must match actual tool names from keeper_tools. *)
   let korean_keywords = [
+    "keeper_list_my_tools", "도구 목록 능력 뭐 할 수 있어 기능";
     "keeper_board_post", "게시판 글 작성 올리기 포스트";
     "keeper_board_get", "게시판 글 읽기 조회 확인";
     "keeper_board_list", "게시판 목록 최근글";

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -105,6 +105,60 @@ let execute_keeper_tool_call
                 ("tool", `String name) ])
   else
   match name with
+  | "keeper_list_my_tools" ->
+      let allowed = keeper_allowed_tool_names meta in
+      let all_schemas = keeper_universe_model_tools meta in
+      let categorize name =
+        if String.starts_with ~prefix:"keeper_board_" name then "board"
+        else if String.starts_with ~prefix:"keeper_memory_" name
+             || String.starts_with ~prefix:"keeper_library_" name then "knowledge"
+        else if String.starts_with ~prefix:"keeper_task" name then "tasks"
+        else if String.starts_with ~prefix:"keeper_voice_" name then "voice"
+        else if String.starts_with ~prefix:"keeper_fs_" name
+             || name = "keeper_shell_readonly"
+             || name = "keeper_bash"
+             || name = "keeper_write" then "filesystem"
+        else if name = "keeper_github" then "vcs"
+        else if String.starts_with ~prefix:"masc_code_" name then "masc_code"
+        else if String.starts_with ~prefix:"masc_board_" name then "masc_board"
+        else if String.starts_with ~prefix:"masc_keeper_" name then "masc_keeper"
+        else if String.starts_with ~prefix:"masc_plan_" name then "masc_plan"
+        else if String.starts_with ~prefix:"masc_team_session_" name then "masc_team_session"
+        else if String.starts_with ~prefix:"masc_worktree_" name then "masc_worktree"
+        else if String.starts_with ~prefix:"masc_governance_" name then "masc_governance"
+        else if String.starts_with ~prefix:"masc_autoresearch_" name then "masc_autoresearch"
+        else if String.starts_with ~prefix:"masc_agent_" name
+             || name = "masc_agents" then "masc_agent"
+        else if String.starts_with ~prefix:"masc_" name then "masc_core"
+        else if String.starts_with ~prefix:"keeper_" name then "keeper_core"
+        else "other"
+      in
+      let groups : (string, (string * string) list) Hashtbl.t = Hashtbl.create 16 in
+      List.iter (fun name ->
+        let cat = categorize name in
+        let desc = match List.find_opt (fun (s : Types.tool_schema) -> s.name = name) all_schemas with
+          | Some s -> s.description
+          | None -> ""
+        in
+        let desc_short = if String.length desc > 80 then String.sub desc 0 80 ^ "..." else desc in
+        let existing = match Hashtbl.find_opt groups cat with Some l -> l | None -> [] in
+        Hashtbl.replace groups cat ((name, desc_short) :: existing)
+      ) allowed;
+      let entries = Hashtbl.fold (fun cat tools acc ->
+        let tools_json = List.rev_map (fun (n, d) ->
+          `Assoc [("name", `String n); ("description", `String d)]
+        ) tools in
+        `Assoc [("category", `String cat); ("tools", `List tools_json)] :: acc
+      ) groups [] in
+      Yojson.Safe.to_string
+        (`Assoc [
+          ("total_tools", `Int (List.length allowed));
+          ("groups", `List (List.sort (fun a b ->
+            compare
+              (Yojson.Safe.Util.to_string (Yojson.Safe.Util.member "category" a))
+              (Yojson.Safe.Util.to_string (Yojson.Safe.Util.member "category" b))
+          ) entries));
+        ])
   | "keeper_time_now" ->
       Yojson.Safe.to_string
         (`Assoc

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -60,7 +60,8 @@ let keeper_voice_tool_schemas =
   | None -> []
 
 let keeper_base_tool_names =
-  [ "keeper_time_now"; "keeper_context_status"; "keeper_memory_search" ]
+  [ "keeper_time_now"; "keeper_context_status"; "keeper_list_my_tools";
+    "keeper_memory_search" ]
 
 let keeper_filesystem_tool_names = [ "keeper_fs_read" ]
 let keeper_library_tool_names = [ "keeper_library_search"; "keeper_library_read" ]

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -102,6 +102,7 @@ let keeper_coding_masc_tool_names =
     These are the survival-critical tools. *)
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";
+    "keeper_list_my_tools";
     "masc_status"; "masc_broadcast"; "masc_heartbeat";
     "masc_messages"; "masc_who"; "masc_tool_help";
     "extend_turns" ]

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -26,6 +26,7 @@ let keeper_internal_tools =
     "keeper_library_read";
     "keeper_time_now";
     "keeper_context_status";
+    "keeper_list_my_tools";
     "keeper_tasks_list";
     "keeper_tasks_audit";
     "keeper_task_claim";

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -26,6 +26,18 @@ Use to timestamp events, check elapsed time, or include current time in reports.
       ("properties", `Assoc []);
     ];
   };
+  (* Tool self-discovery *)
+  {
+    name = "keeper_list_my_tools";
+    description = "List all tools available to you, grouped by category. \
+Call when asked about your capabilities, when planning multi-step operations, \
+or when you need to discover what actions you can take. Returns tool names \
+and descriptions organized by group (board, filesystem, tasks, voice, masc, etc).";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
   (* Context status *)
   {
     name = "keeper_context_status";

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -32,6 +32,7 @@ let build_keeper_index () =
   let tool_index_config =
     { Agent_sdk.Tool_index.default_config with top_k = 20 } in
   let korean_keywords = [
+    "keeper_list_my_tools", "도구 목록 능력 뭐 할 수 있어 기능";
     "keeper_board_post", "게시판 글 작성 올리기 포스트";
     "keeper_board_get", "게시판 글 읽기 조회 확인";
     "keeper_board_list", "게시판 목록 최근글";
@@ -403,6 +404,17 @@ let () =
         [
           Alcotest.test_case "github PR (en)" `Quick test_github_pr_en;
           Alcotest.test_case "github issue (kr)" `Quick test_github_issue_kr;
+        ] );
+      ( "self_discovery",
+        [
+          Alcotest.test_case "list tools (kr)" `Quick (fun () ->
+            let idx = build_keeper_index () in
+            ignore (assert_retrieves ~label:"list_tools_kr" idx
+              "도구 목록 뭐 할 수 있어" "keeper_list_my_tools"));
+          Alcotest.test_case "list tools (en)" `Quick (fun () ->
+            let idx = build_keeper_index () in
+            ignore (assert_retrieves ~label:"list_tools_en" idx
+              "list all my available tools and capabilities" "keeper_list_my_tools"));
         ] );
       ( "masc_tools",
         [


### PR DESCRIPTION
## Summary
- `keeper_list_my_tools`: keeper가 자신의 전체 도구 목록을 카테고리별로 조회하는 도구
- Always-included (core_always_tools) — BM25 순위와 무관하게 항상 사용 가능
- "뭐 할 수 있어?" 같은 범용 질문에 keeper가 전체 능력을 파악 가능

## Product impact
- 100+ 도구를 가진 keeper가 BM25 top_k=20 제한으로 자기 능력의 20%만 인식하던 문제 해결
- "뭐 할 수 있어?" → `keeper_list_my_tools` 호출 → 전체 카테고리별 도구 목록 반환

## Evidence
- `dune build` 통과
- BM25 retrieval: "도구 목록 뭐 할 수 있어" → rank 1
- BM25 retrieval: "list all my available tools" → rank 1

## Linked issue
- Refs #4519

🤖 Generated with [Claude Code](https://claude.com/claude-code)