### PR TITLE
fix(test): skip governance BM25 test when schemas absent

### DIFF
--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -299,10 +299,22 @@ let test_masc_code_search_en () =
   ignore (assert_retrieves ~label:"masc_code_en" idx
     "search the codebase for function definitions" "masc_code_search")
 
+(* masc_governance_status is not retrievable via offline BM25: governance
+   tool schemas were removed with the council module (#4620).
+   governance_tools in tool_shard.ml returns [] so masc_governance_status
+   is excluded from the keeper candidate universe.
+   Re-enable when governance schemas are available via MCP injection
+   or a replacement module.  Tracked in #4520. *)
 let test_masc_governance_kr () =
   let idx = build_keeper_index () in
-  ignore (assert_retrieves ~label:"governance_kr" idx
-    "거버넌스 상태 규칙" "masc_governance_status")
+  let retrieved = Agent_sdk.Tool_index.retrieve idx "거버넌스 상태 규칙" in
+  let names = List.map fst retrieved in
+  if List.mem "masc_governance_status" names then
+    ignore (assert_retrieves ~label:"governance_kr" idx
+      "거버넌스 상태 규칙" "masc_governance_status")
+  else
+    (* governance schemas absent — skip rather than fail *)
+    Alcotest.(check pass) "governance_kr: skipped (no offline governance schemas)" () ()
 
 (* masc_plan_get and masc_team_session_start are not retrievable via BM25
    with Korean queries: "계획", "플랜", "팀", "세션" are common terms that


### PR DESCRIPTION
## Summary
- governance_tools가 council 모듈 제거(#4620) 이후 빈 리스트를 반환하여 masc_governance_status가 BM25 인덱스에서 제외됨
- keeper_retrieval_quality 테스트가 전체 open PR 6개를 차단 중
- governance schemas 부재 시 graceful skip으로 변경

## Root Cause
`lib/tool_shard.ml:501-504`에서 `governance_tools = []` (council 제거 후). `keeper_governance_tool_names`가 빈 리스트 → `keeper_all_candidate_tool_names`에서 governance 도구 누락 → BM25 universe 미포함.

## Test plan
- [ ] CI Build and Test 통과 (현재 6개 PR 차단 해제)
- [ ] governance_kr 테스트가 skip으로 처리되는지 확인

Generated with [Claude Code](https://claude.com/claude-code)