### PR TITLE
fix(dashboard): unicode-safe title truncation on board

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -17,14 +17,17 @@ Knowledge lookup:
 - Research docs and references: keeper_library_search first, then keeper_library_read for full text
 
 Board and communication:
-- Read/write board posts: keeper_board_get, keeper_board_post, keeper_board_comment, keeper_board_vote
+- Read/write board posts: keeper_board_get, keeper_board_post (hearth required), keeper_board_comment, keeper_board_vote
 - List recent posts: keeper_board_list
+- When posting to the board, always set hearth to your keeper name (e.g. hearth="sangsu"). Never post without hearth.
 - Broadcast to all agents: keeper_broadcast
 - Speak aloud: keeper_voice_speak (use when you have opinions, moods, greetings, or anything worth saying)
 
 Task management:
 - View tasks: keeper_tasks_list
-- Claim and complete: keeper_task_claim, keeper_task_done
+- Create tasks: masc_add_task (single), masc_batch_add_tasks (multiple)
+- Claim next available: masc_claim_next
+- Claim specific and complete: keeper_task_claim, keeper_task_done
 
 Context:
 - Current time: keeper_time_now

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -280,8 +280,9 @@ export function normalizeGovernanceJudgeSummary(raw: unknown): GovernanceJudgeSu
 }
 
 function truncatePostTitle(title: string): string {
-  if (title.length <= 96) return title
-  return `${title.slice(0, 93)}...`
+  const chars = Array.from(title)
+  if (chars.length <= 96) return title
+  return `${chars.slice(0, 93).join('')}...`
 }
 
 function stripTitleMarkdown(line: string): string {

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -65,10 +65,11 @@ function CommentItem({
   depth?: number
   childrenMap: Map<string, BoardComment[]>
 }) {
-  const needsTruncation = (comment.content?.length ?? 0) > 300
+  const contentChars = Array.from(comment.content ?? '')
+  const needsTruncation = contentChars.length > 300
   const [expanded, setExpanded] = useState(false)
   const displayText = needsTruncation && !expanded
-    ? `${comment.content.slice(0, 297)}...`
+    ? `${contentChars.slice(0, 297).join('')}...`
     : comment.content
   const isReplying = replyingTo.value === comment.id
   const indent = depth > 0 ? `ml-${Math.min(depth * 4, 12)}` : ''

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -56,6 +56,19 @@ let ensure_keeper_board_post_args ~author ~source = function
           (fun (k, _) -> k <> "author" && k <> "post_kind" && k <> "meta")
           fields
       in
+      let has_hearth =
+        List.exists
+          (fun (k, v) ->
+            k = "hearth"
+            && (match v with `String s -> String.trim s <> "" | _ -> false))
+          fields
+      in
+      let fields =
+        if has_hearth then fields
+        else
+          ("hearth", `String author)
+          :: List.filter (fun (k, _) -> k <> "hearth") fields
+      in
       `Assoc
         ([
            ("author", `String author);


### PR DESCRIPTION
## Summary
3가지 keeper 동작 버그 수정:

1. **게시판 제목 이모지 깨짐** — `String.slice`가 surrogate pair를 중간에서 자름. `Array.from()`으로 code point 단위 슬라이싱 전환
2. **keeper가 태스크를 안 만들고 claim 안 함** — `keeper.capabilities.md`에 `masc_add_task`, `masc_batch_add_tasks`, `masc_claim_next`가 누락. BM25 top_k=20 검색에서 프롬프트에 없는 도구는 매칭 불가
3. **사람 게시판에 keeper가 글 올림** — `keeper_board_post`의 hearth가 optional이고 기본값 없음. hearth=None → 범용 게시판에 게시. 코드 가드로 keeper 이름을 기본 hearth로 주입

## Changed
- `dashboard/src/api/board.ts` — `truncatePostTitle()` unicode-safe 전환
- `dashboard/src/components/memory-post-detail.ts` — 댓글 본문 truncation 동일 수정
- `config/prompts/keeper.capabilities.md` — task 생성/claim 도구 추가, hearth 필수 안내
- `lib/keeper/keeper_exec_tools.ml` — `ensure_keeper_board_post_args`에 기본 hearth 주입

## Test plan
- [ ] 이모지 포함 제목 게시글이 목록에서 깨지지 않고 표시
- [ ] keeper가 `masc_add_task`로 태스크 생성 가능 확인
- [ ] keeper가 `masc_claim_next`로 태스크 자동 claim 확인
- [ ] keeper 게시글이 사람 게시판이 아닌 keeper 이름 hearth에 게시되는지 확인
- [ ] hearth를 명시적으로 지정한 게시글은 해당 hearth에 정상 게시

🤖 Generated with [Claude Code](https://claude.com/claude-code)