### PR TITLE
refactor: remove infer_model_tier_from_model_name stub and dead call sites

### DIFF
--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -203,9 +203,6 @@ let inferred_worker_model () =
       runtime_inventory_models ()
       |> List.find_opt (fun model -> contains_size_token_ci model "9b")
 
-(* Model tier inference removed (#4505). Cascade handles model selection. *)
-let infer_model_tier_from_model_name _model_name = None
-
 let default_risk_for_profile = function
   | Team_session_types.Profile_extract
   | Team_session_types.Profile_normalize
@@ -495,12 +492,7 @@ let finalize_routing_decision ~spawn_model ~(decision : routing_decision) =
     | None -> resolved_model
   in
   let resolved_tier =
-    match trim_opt spawn_model with
-    | Some explicit ->
-        Option.value ~default:decision.model_tier
-          (infer_model_tier_from_model_name (Some explicit))
-    | None ->
-        if escalated then Team_session_types.Tier_35b else decision.model_tier
+    if escalated then Team_session_types.Tier_35b else decision.model_tier
   in
   (resolved_model, resolved_tier, escalated, reason)
 
@@ -512,9 +504,7 @@ let resolve_routing_for_spec (spec : spawn_spec) =
       match spec.worker_size with
       | Some size -> Team_session_types.model_tier_of_worker_size size
       | None -> (
-          match spec.model_tier with
-          | Some tier -> Some tier
-          | None -> infer_model_tier_from_model_name spec.spawn_model)
+          spec.model_tier)
     in
     let heuristic =
       heuristic_routing ~spawn_prompt:spec.spawn_prompt ~spawn_role:spec.spawn_role

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -531,12 +531,5 @@ let test_runtime_inventory_uses_token_boundaries_for_model_tiers () =
       Alcotest.(check (option string)) "worker runtime inferred from 9b token"
         (Some "qwen2.5-9b-instruct")
         (Tool_team_session_routing.inferred_worker_model ());
-      (* #4505: tier inference removed — always returns None *)
-      Alcotest.(check (option string)) "tier inference disabled (109b)" None
-        (Tool_team_session_routing.infer_model_tier_from_model_name
-           (Some "llama-109b-instruct")
-        |> Option.map Team_session_types.model_tier_to_string);
-      Alcotest.(check (option string)) "tier inference disabled (35b)" None
-        (Tool_team_session_routing.infer_model_tier_from_model_name
-           (Some "qwen3.5-35b-a3b-ud-q8-xl")
-        |> Option.map Team_session_types.model_tier_to_string))
+      (* #4505: infer_model_tier_from_model_name removed entirely. *)
+      ())


### PR DESCRIPTION
## Summary
- `infer_model_tier_from_model_name` stub 함수 제거 (PR #4625에서 `_model_name -> None`으로 비활성화됨)
- 2개 call site 단순화: None 분기 제거
- 관련 테스트 assertions 제거

## Evidence
- `dune build` 통과
- 59/59 team session 테스트 통과
- -21줄 / +4줄 (net -17)

## Linked issue
- Closes #4505

🤖 Generated with [Claude Code](https://claude.com/claude-code)