### PR TITLE
chore(oas): bump pin to 574bfcc (Lenient_json + Tool_input_validation)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="40e09715551dd89b0e98bac050f99ceaee17f6ef"
+readonly OAS_AGENT_SDK_SHA="574bfcc5607e0f60ccacca97bbff81d1a404fdf8"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.0"


### PR DESCRIPTION
## Summary
- OAS pin update: `40e0971` → `574bfcc` (oas#552 squash merge)
- No masc-mcp code changes — features apply automatically via `Agent.run`

### What's new in OAS
- **Lenient_json**: 5-transform recovery pipeline (markdown fence, double-stringify, trailing comma, keyword completion, unclosed brackets)
- **Tool_input_validation**: schema-based deterministic validation + type coercion
- **Validation gate**: automatic in `agent_tools.ml` before `Tool.execute`

### Boundary check
- OAS contains zero MASC references
- Dependency direction: MASC → OAS (unchanged)

## Test plan
- [ ] CI build with new pin
- [ ] Existing masc-mcp tests pass

Generated with [Claude Code](https://claude.com/claude-code)