### PR TITLE
fix(keeper): review followup for #4651 and #4643

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Guard pending release tag on main PRs
         if: github.event_name == 'pull_request' && github.base_ref == 'main'
@@ -58,7 +59,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/check-release-train-guard.sh
-          git fetch origin "${{ github.base_ref }}" --depth=100
+          git fetch origin "${{ github.base_ref }}" --depth=100 --tags
           scripts/check-release-train-guard.sh \
             --base "$BASE_REF" \
             --head "$HEAD_REF"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -169,7 +169,10 @@ let log_keeper_memory_write
     @param temperature MODEL temperature override; when omitted, resolved
            from [Cascade_inference] with a 0.3 fallback
     @param max_tokens Maximum output tokens override; when omitted, resolved
-           from [Cascade_inference] with a 4096 fallback *)
+           from [Cascade_inference] with a 4096 fallback
+    @param is_retry When [true], replays the current user message into the
+           working context without persisting it again, so transient retry
+           attempts do not duplicate the user entry in session history *)
 let run_turn
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -193,6 +193,7 @@ let run_turn
     ?(trajectory_acc : Trajectory.accumulator option)
     ?(tool_overlay : Agent_sdk.Tool_op.t ref option)
     ?_priority
+    ?(is_retry = false)
     ()
   : (run_result, string) result =
   (* 0. Resolve inference parameters via Cascade_inference *)
@@ -265,14 +266,19 @@ let run_turn
       ~base_system_prompt
       ~messages:ctx_work.messages
   in
-  (* 6. Append user message and persist *)
+  (* 6. Append user message and persist.
+     On retry (is_retry=true), the user message was already persisted by the
+     first attempt.  Checkpoint reload does not include it (checkpoint is
+     written only on success), so we still append to ctx — but skip persist
+     to avoid duplicate entries in the session history file. *)
   let user_msg = Agent_sdk.Types.user_msg user_message in
   (* Capture history BEFORE appending the current user_msg.
      OAS Agent.run appends user_msg from ~goal internally, so passing it
      in initial_messages would cause duplication. *)
   let history_messages = ctx_work.messages in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
-  Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
+  if not is_retry then
+    Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
   (* 7. Set up agent *)
   let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -164,12 +164,12 @@ let log_keeper_memory_write
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
     @param generation Current generation counter
-    @param max_turns Maximum agent turns (default 3)
+    @param max_turns Maximum agent turns (default 50)
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature MODEL temperature override; when omitted, resolved
            from [Cascade_inference] with a 0.3 fallback
     @param max_tokens Maximum output tokens override; when omitted, resolved
-           from [Cascade_inference] with a 4096 fallback
+           from [Cascade_inference] with a 2048 fallback
     @param is_retry When [true], replays the current user message into the
            working context without persisting it again, so transient retry
            attempts do not duplicate the user entry in session history *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -570,7 +570,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run () =
+          let do_run ?(is_retry = false) () =
             Keeper_agent_run.run_turn ~config ~meta ~base_dir
               ~max_context:primary_max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
@@ -579,6 +579,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
               ~max_cost_usd
+              ~is_retry
               ()
           in
           match do_run () with
@@ -587,7 +588,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               Log.Keeper.warn "%s: transient network error, retrying once: %s"
                 meta.name (short_preview e);
               Eio.Fiber.yield ();
-              do_run ()
+              do_run ~is_retry:true ()
           | Error _ as err -> err)
       in
       match run_result with

--- a/lib/worker_run_evidence_summary.ml
+++ b/lib/worker_run_evidence_summary.ml
@@ -101,7 +101,6 @@ let proof_refs_present json =
   || has_non_null "checkpoint_ref" json
   || list_member "tool_trace_refs" json <> []
   || list_member "raw_evidence_refs" json <> []
-  || list_member "evidence_refs" json <> []
 
 let proof_evidence_state json =
   match bool_member_opt "proof_present" json with

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -170,7 +170,7 @@ let test_step_spawn_batch_applies_hybrid_routing () =
           (fun worker -> worker.Team_session_types.spawn_role = Some "normalizer")
           session.planned_workers
       in
-      Alcotest.(check (option string)) "normalizer model" (Some "qwen9-worker")
+      Alcotest.(check (option string)) "normalizer model" (Some "qwen35-lead")
         normalizer.spawn_model;
       Alcotest.(check (option string)) "normalizer profile" (Some "normalize")
         (Option.map Team_session_types.task_profile_to_string

--- a/test/test_worker_run_evidence_summary.ml
+++ b/test/test_worker_run_evidence_summary.ml
@@ -148,6 +148,16 @@ let test_summary_distinguishes_missing_vs_unavailable_evidence () =
   in
   check string "proof absent without refs is unavailable" "unavailable"
     U.(unavailable_proof |> member "proof_evidence_status" |> to_string);
+  let trace_only_evidence_refs =
+    Worker_run_evidence_summary.summary_json
+      (sample_meta ~proof_present:(`Bool false) ~proof_run_id:`Null
+         ~tool_trace_refs:(`List []) ~raw_evidence_refs:(`List [])
+         ~checkpoint_ref:`Null
+         ~evidence_refs:(`List [ `String "traces/wr-evidence-1.jsonl" ]) ())
+  in
+  check string "trace-only evidence refs do not imply proof availability"
+    "unavailable"
+    U.(trace_only_evidence_refs |> member "proof_evidence_status" |> to_string);
   check bool "proof fields stay absent when no proof_run_id" false
     (has_key "proof_run_id" unavailable_proof);
   check bool "proof status stays absent when no proof_run_id" false


### PR DESCRIPTION
## Summary
- #4651 review: `proof_refs_present`에서 `evidence_refs` 제거 — trace-only run의 정규화 evidence list가 proof evidence로 오분류되던 문제 수정
- #4643 review: `run_turn`에 `is_retry` 파라미터 추가 — transient error retry 시 user message 이중 persist 방지
- CI follow-up: `test/test_tool_team_session_step_routing.ml` 기대값을 post-#4658 routing 동작에 맞게 정렬 (`normalizer`는 명시적 `spawn_model`이 없으면 lead model로 해석)
- CI follow-up: release-train guard가 최신 tag를 확실히 보도록 Actions checkout/fetch에서 tag fetch를 명시

## Product impact
- team session worker run summary가 trace-only evidence를 proof evidence로 잘못 표시하지 않음
- keeper retry 경로의 의도와 문서가 일치해 후속 유지보수 시 중복 persist 회귀를 줄임
- routing test alignment와 release-train fetch 보강은 CI/test-only 변경으로 런타임 동작을 새로 바꾸지 않음

## Root Cause
1. `evidence_refs`는 trace + proof를 합친 정규화 리스트라 proof 판별 근거로 쓰면 false positive가 발생함.
2. unified keeper retry는 동일 user message를 working context에 재주입해야 하지만, session history file에는 다시 persist하면 안 됨.
3. PR 업데이트 과정에서 CI가 post-#4658 routing 기대값과 release-train tag fetch 전제를 그대로 물고 있어 unrelated red가 발생함.

## Evidence
- Copilot review on #4651: proof_refs_present misclassification
- Copilot review on #4643: retry wraps entire `run_turn` causing duplicate persist
- follow-up patch `36fd31604` adds the missing regression test and parameter doc
- cherry-picked upstream test alignment from `39ccec956` to keep this PR green against current `main`
- release-train failure reproduced in GitHub Actions because the job did not fetch tags before comparing against `latest_tag`
- repo search confirms `proof_evidence_status` is only produced in `lib/worker_run_evidence_summary.ml` and asserted in its dedicated test, so the semantic change does not fan out to other in-repo consumers

## Test plan
- [x] `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/test/test_worker_run_evidence_summary.exe`
- [x] local team-session regression suite pass (57 tests, 1.7s)
- [ ] CI Build and Test
- [ ] CI Contract Harness
- [ ] CI Health
- [ ] CI Lint

## Review evidence
- 2026-04-02 18:50:49 KST: direct `sb glm-text` cross-model review on commit `36fd31604` for correctness/regressions -> `No findings.`
- 2026-04-03 00:37:19 KST: direct `sb glm-text` cross-model review on current head `515595084` -> semantic change is intentional/contained, doc defaults match runtime after `98773702c`, no new blocking correctness or CI-scope issues beyond those already addressed

## Linked issue
Relates #4651
Relates #4643
