### PR TITLE
[codex] Surface worker run tool visibility

### DIFF
--- a/dashboard/src/components/proof-helpers.test.ts
+++ b/dashboard/src/components/proof-helpers.test.ts
@@ -14,6 +14,7 @@ describe('workerRunEvidence helpers', () => {
       trace_validated: true,
       resolved_runtime: 'local',
       resolved_model: 'qwen',
+      tool_surface_names: ['file_read', 'file_write', 'shell_exec'],
       tool_call_count: 3,
     }
 
@@ -21,7 +22,17 @@ describe('workerRunEvidence helpers', () => {
     expect(workerRunEvidenceLabel(item)).toBe('검증됨')
     expect(workerRunEvidenceMeta(item)).toContain('local')
     expect(workerRunEvidenceMeta(item)).toContain('qwen')
+    expect(workerRunEvidenceMeta(item)).toContain('surface 3')
     expect(workerRunEvidenceMeta(item)).toContain('도구 3')
+  })
+
+  it('marks missing tool surface explicitly in meta', () => {
+    const item = {
+      worker_run_id: 'worker-surface-missing',
+      tool_surface_status: 'missing',
+    }
+
+    expect(workerRunEvidenceMeta(item)).toContain('surface missing')
   })
 
   it('prefers final text preview, then falls back to errors', () => {

--- a/dashboard/src/components/proof-helpers.ts
+++ b/dashboard/src/components/proof-helpers.ts
@@ -176,10 +176,21 @@ export function workerRunEvidenceLabel(item: DashboardProofWorkerRunEvidence): s
 }
 
 export function workerRunEvidenceMeta(item: DashboardProofWorkerRunEvidence): string {
+  const toolSurfaceCount =
+    typeof item.tool_surface_count === 'number'
+      ? item.tool_surface_count
+      : Array.isArray(item.tool_surface_names)
+        ? item.tool_surface_names.length
+        : null
   const parts = [
     item.resolved_runtime ?? null,
     item.resolved_model ?? null,
     item.mode ?? null,
+    item.tool_surface_status === 'missing'
+      ? 'surface missing'
+      : typeof toolSurfaceCount === 'number'
+        ? `surface ${toolSurfaceCount}`
+        : null,
     typeof item.tool_call_count === 'number' ? `도구 ${item.tool_call_count}` : null,
     typeof item.record_count === 'number' ? `레코드 ${item.record_count}` : null,
   ].filter((value): value is string => Boolean(value))

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -89,6 +89,7 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
 export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEvidence }) {
   const preview = workerRunEvidencePreview(item)
   const validationFailures = Array.isArray(item.validation_failures) ? item.validation_failures : []
+  const toolSurfaceNames = Array.isArray(item.tool_surface_names) ? item.tool_surface_names : []
   const toolNames = Array.isArray(item.tool_names) ? item.tool_names : []
   return html`
     <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm hover:border-accent/30 transition-all duration-200 flex flex-col gap-3">
@@ -120,9 +121,20 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
             <span class="text-[12px] text-text-body leading-relaxed whitespace-pre-wrap">${validationFailures.join(' · ')}</span>
           </div>`
         : null}
+      ${toolSurfaceNames.length > 0
+        ? html`<div class="flex flex-col gap-2 mt-2 pt-3 border-t border-card-border/50">
+            <strong class="text-[11px] font-semibold uppercase tracking-widest text-text-muted">사용 가능 도구</strong>
+            <div class="flex flex-wrap gap-2">
+              ${toolSurfaceNames.map(name => html`<span class="px-2 py-1 rounded-md text-[10px] font-medium bg-white/5 text-text-body border border-white/10 shadow-sm">${name}</span>`)}
+            </div>
+          </div>`
+        : null}
       ${toolNames.length > 0
-        ? html`<div class="flex flex-wrap gap-2 mt-2 pt-3 border-t border-card-border/50">
-            ${toolNames.map(name => html`<span class="px-2 py-1 rounded-md text-[10px] font-medium bg-accent/10 text-accent border border-accent/20 shadow-sm">${name}</span>`)}
+        ? html`<div class="flex flex-col gap-2 mt-2 pt-3 border-t border-card-border/50">
+            <strong class="text-[11px] font-semibold uppercase tracking-widest text-text-muted">실행 도구</strong>
+            <div class="flex flex-wrap gap-2">
+              ${toolNames.map(name => html`<span class="px-2 py-1 rounded-md text-[10px] font-medium bg-accent/10 text-accent border border-accent/20 shadow-sm">${name}</span>`)}
+            </div>
           </div>`
         : null}
     </article>

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -332,6 +332,12 @@ export interface DashboardProofWorkerRunEvidence {
   execution_scope?: string | null
   requested_worker_class?: string | null
   requested_worker_size?: string | null
+  tool_surface_status?: string | null
+  tool_surface_source?: string | null
+  tool_surface_names?: string[]
+  tool_surface_masc_names?: string[]
+  tool_surface_shell_names?: string[]
+  tool_surface_count?: number | null
   resolved_runtime?: string | null
   resolved_model?: string | null
   routing_reason?: string | null

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -420,6 +420,12 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
             (proof.capability_snapshot.tools @ tool_surface_masc_names)
           |> List.sort String.compare
         in
+        let tool_surface_status =
+          if tool_surface_names <> [] then `String "available" else `String "missing"
+        in
+        let tool_surface_source =
+          if tool_surface_names <> [] then `String "swarm_masc_tools" else `Null
+        in
         let worker_run_id = proof.run_id in
         let worker_name =
           worker_name_of_planned_worker ~fallback:fallback_name planned_worker
@@ -449,8 +455,8 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
                     `String
                       (Team_session_types.execution_scope_to_string scope))
                   planned_worker.execution_scope );
-              ("tool_surface_status", `String "available");
-              ("tool_surface_source", `String "swarm_masc_tools");
+              ("tool_surface_status", tool_surface_status);
+              ("tool_surface_source", tool_surface_source);
               ( "tool_surface_names",
                 `List
                   (List.map (fun value -> `String value) tool_surface_names)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -406,6 +406,20 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
           "team_session_oas_bridge: skipping proof persistence for unsafe worker run id %S"
           proof.run_id
       else
+        let effective_execution_scope =
+          Team_session_types.effective_execution_scope_of_planned_worker
+            planned_worker
+        in
+        let tool_surface_masc_names =
+          supported_local_worker_tool_names_for_scope
+            (Some effective_execution_scope)
+          |> Team_session_types.dedup_strings |> List.sort String.compare
+        in
+        let tool_surface_names =
+          Team_session_types.dedup_strings
+            (proof.capability_snapshot.tools @ tool_surface_masc_names)
+          |> List.sort String.compare
+        in
         let worker_run_id = proof.run_id in
         let worker_name =
           worker_name_of_planned_worker ~fallback:fallback_name planned_worker
@@ -435,6 +449,18 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
                     `String
                       (Team_session_types.execution_scope_to_string scope))
                   planned_worker.execution_scope );
+              ("tool_surface_status", `String "available");
+              ("tool_surface_source", `String "swarm_masc_tools");
+              ( "tool_surface_names",
+                `List
+                  (List.map (fun value -> `String value) tool_surface_names)
+              );
+              ( "tool_surface_masc_names",
+                `List
+                  (List.map
+                     (fun value -> `String value)
+                     tool_surface_masc_names) );
+              ("tool_surface_shell_names", `List []);
               ( "requested_worker_class",
                 Option.fold ~none:`Null
                   ~some:(fun kind ->

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -42,6 +42,89 @@ let proof_result_status_to_string = function
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)
 
+let local_worker_tool_names_of_scope scope =
+  match scope with
+  | Team_session_types.Observe_only ->
+      Tool_access_policy.resolve
+        {
+          allow = Surface Tool_catalog.Local_worker;
+          deny =
+            Names
+              [
+                "masc_claim_next";
+                "masc_transition";
+                "masc_add_task";
+                "masc_heartbeat";
+                "masc_board_post";
+                "masc_board_comment";
+                "masc_board_vote";
+                "masc_worktree_create";
+                "masc_worktree_remove";
+                "masc_run_init";
+                "masc_run_plan";
+                "masc_run_log";
+                "masc_run_deliverable";
+                "masc_repair_loop_start";
+                "masc_repair_loop_iterate";
+                "masc_repair_loop_stop";
+              ];
+        }
+  | _ ->
+      Team_session_oas_bridge.supported_local_worker_tool_names
+
+let local_shell_tool_names_of_scope = function
+  | Team_session_types.Observe_only ->
+      [ "file_read"; "shell_exec" ]
+  | _ ->
+      [ "file_read"; "file_write"; "shell_exec" ]
+
+let tool_surface_source_of_mode = function
+  | "swarm" -> Some "swarm_masc_tools"
+  | "spawn" | "delegate" -> Some "local_worker_tools"
+  | _ -> None
+
+let dedup_tool_names values =
+  Team_session_types.dedup_strings values |> List.sort String.compare
+
+let tool_surface_fields ~mode ?execution_scope ?(proof : Oas.Cdal_proof.t option)
+    () =
+  let tool_surface_masc_names =
+    match mode, execution_scope with
+    | "swarm", Some scope ->
+        Team_session_oas_bridge.supported_local_worker_tool_names_for_scope
+          (Some scope)
+    | ("spawn" | "delegate"), Some scope ->
+        local_worker_tool_names_of_scope scope
+    | _ -> []
+  in
+  let tool_surface_shell_names =
+    match mode, execution_scope with
+    | ("spawn" | "delegate"), Some scope ->
+        local_shell_tool_names_of_scope scope
+    | _ -> []
+  in
+  let tool_surface_names =
+    let proof_tool_names =
+      match proof with
+      | Some proof -> proof.capability_snapshot.tools
+      | None -> []
+    in
+    dedup_tool_names
+      (proof_tool_names @ tool_surface_masc_names @ tool_surface_shell_names)
+  in
+  [
+    ( "tool_surface_status",
+      `String
+        (if tool_surface_names <> [] then "available" else "missing") );
+    ( "tool_surface_source",
+      Option.fold ~none:`Null ~some:(fun value -> `String value)
+        (if tool_surface_names <> [] then tool_surface_source_of_mode mode
+         else None) );
+    ("tool_surface_names", json_string_list tool_surface_names);
+    ("tool_surface_masc_names", json_string_list tool_surface_masc_names);
+    ("tool_surface_shell_names", json_string_list tool_surface_shell_names);
+  ]
+
 let proof_summary_fields ~(worker_run_id : string)
     ?(proof : Oas.Cdal_proof.t option) () =
   let null_fields =
@@ -492,6 +575,9 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
   let proof_fields =
     proof_summary_fields ~worker_run_id ?proof ()
   in
+  let tool_surface_fields =
+    tool_surface_fields ~mode ?execution_scope ?proof ()
+  in
   if Room_utils.path_exists env.ctx.config checkpoint_path then
     Team_session_store.save_worker_run_checkpoint_text env.ctx.config
       env.session_id worker_run_id
@@ -527,7 +613,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         ("stop_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.stop_reason) oas_worker);
         ("failure_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.failure_reason) oas_worker);
         ("ts_iso", `String (Types.now_iso ()));
-      ] @ proof_fields))
+      ] @ tool_surface_fields @ proof_fields))
 
 let release_prepared_runtime (prepared : prepared_spawn) ~success
     ?error ?latency_ms () =
@@ -654,42 +740,6 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
           assigned_runtime;
           lease_released = false;
         }
-
-let local_worker_tool_names_of_scope scope =
-  match scope with
-  | Team_session_types.Observe_only ->
-      Tool_access_policy.resolve
-        {
-          allow = Surface Tool_catalog.Local_worker;
-          deny =
-            Names
-              [
-                "masc_claim_next";
-                "masc_transition";
-                "masc_add_task";
-                "masc_heartbeat";
-                "masc_board_post";
-                "masc_board_comment";
-                "masc_board_vote";
-                "masc_worktree_create";
-                "masc_worktree_remove";
-                "masc_run_init";
-                "masc_run_plan";
-                "masc_run_log";
-                "masc_run_deliverable";
-                "masc_repair_loop_start";
-                "masc_repair_loop_iterate";
-                "masc_repair_loop_stop";
-              ];
-        }
-  | _ ->
-      Team_session_oas_bridge.supported_local_worker_tool_names
-
-let local_shell_tool_names_of_scope = function
-  | Team_session_types.Observe_only ->
-      [ "file_read"; "shell_exec" ]
-  | _ ->
-      [ "file_read"; "file_write"; "shell_exec" ]
 
 let materialize_prepared_execution (env : _ step_env) (prepared : prepared_spawn)
     : prepared_execution =

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -43,34 +43,8 @@ let json_string_list values =
   `List (List.map (fun value -> `String value) values)
 
 let local_worker_tool_names_of_scope scope =
-  match scope with
-  | Team_session_types.Observe_only ->
-      Tool_access_policy.resolve
-        {
-          allow = Surface Tool_catalog.Local_worker;
-          deny =
-            Names
-              [
-                "masc_claim_next";
-                "masc_transition";
-                "masc_add_task";
-                "masc_heartbeat";
-                "masc_board_post";
-                "masc_board_comment";
-                "masc_board_vote";
-                "masc_worktree_create";
-                "masc_worktree_remove";
-                "masc_run_init";
-                "masc_run_plan";
-                "masc_run_log";
-                "masc_run_deliverable";
-                "masc_repair_loop_start";
-                "masc_repair_loop_iterate";
-                "masc_repair_loop_stop";
-              ];
-        }
-  | _ ->
-      Team_session_oas_bridge.supported_local_worker_tool_names
+  Team_session_oas_bridge.supported_local_worker_tool_names_for_scope
+    (Some scope)
 
 let local_shell_tool_names_of_scope = function
   | Team_session_types.Observe_only ->

--- a/lib/worker_run_evidence_summary.ml
+++ b/lib/worker_run_evidence_summary.ml
@@ -62,6 +62,12 @@ let tool_surface_status json =
       Some
         (if tool_surface_names json <> [] then "available" else "missing")
 
+let tool_surface_status_with_names ~names json =
+  match string_member_opt "tool_surface_status" json with
+  | Some _ as value -> value
+  | None ->
+      Some (if names <> [] then "available" else "missing")
+
 let trace_validated json =
   match bool_member_opt "validated" json with
   | Some _ as value -> value
@@ -135,6 +141,10 @@ let proof_evidence_state json =
 
 let summary_json json =
   let summary = U.member "trace_summary" json in
+  let normalized_tool_surface_names = tool_surface_names json in
+  let normalized_tool_surface_status =
+    tool_surface_status_with_names ~names:normalized_tool_surface_names json
+  in
   let summary_member key =
     match summary with
     | `Assoc _ -> U.member key summary
@@ -161,16 +171,16 @@ let summary_json json =
       ("routing_reason", U.member "routing_reason" json);
       ( "tool_surface_status",
         Option.fold ~none:`Null ~some:(fun value -> `String value)
-          (tool_surface_status json) );
+          normalized_tool_surface_status );
       ("tool_surface_source", U.member "tool_surface_source" json);
-      ("tool_surface_names", string_list_to_json (tool_surface_names json));
+      ("tool_surface_names", string_list_to_json normalized_tool_surface_names);
       ( "tool_surface_masc_names",
         string_list_to_json (string_list_member "tool_surface_masc_names" json)
       );
       ( "tool_surface_shell_names",
         string_list_to_json
           (string_list_member "tool_surface_shell_names" json) );
-      ("tool_surface_count", `Int (List.length (tool_surface_names json)));
+      ("tool_surface_count", `Int (List.length normalized_tool_surface_names));
       ("tool_names", U.member "tool_names" json);
       ("tool_call_count", U.member "tool_call_count" json);
       ("output_preview", U.member "output_preview" json);

--- a/lib/worker_run_evidence_summary.ml
+++ b/lib/worker_run_evidence_summary.ml
@@ -26,6 +26,12 @@ let list_member key json =
   | `List items -> items
   | _ -> []
 
+let string_list_member key json =
+  list_member key json
+  |> List.filter_map (function
+       | `String value when String.trim value <> "" -> Some (String.trim value)
+       | _ -> None)
+
 let has_non_null key json =
   match U.member key json with
   | `Null -> false
@@ -39,6 +45,22 @@ let string_list_to_json values =
   `List (List.map (fun value -> `String value) values)
 
 let trace_capability json = string_member_opt "trace_capability" json
+
+let tool_surface_names json =
+  let explicit = string_list_member "tool_surface_names" json in
+  if explicit <> [] then
+    Team_session_types.dedup_strings explicit
+  else
+    Team_session_types.dedup_strings
+      (string_list_member "tool_surface_masc_names" json
+      @ string_list_member "tool_surface_shell_names" json)
+
+let tool_surface_status json =
+  match string_member_opt "tool_surface_status" json with
+  | Some _ as value -> value
+  | None ->
+      Some
+        (if tool_surface_names json <> [] then "available" else "missing")
 
 let trace_validated json =
   match bool_member_opt "validated" json with
@@ -137,6 +159,18 @@ let summary_json json =
       ("resolved_runtime", U.member "resolved_runtime" json);
       ("resolved_model", U.member "resolved_model" json);
       ("routing_reason", U.member "routing_reason" json);
+      ( "tool_surface_status",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          (tool_surface_status json) );
+      ("tool_surface_source", U.member "tool_surface_source" json);
+      ("tool_surface_names", string_list_to_json (tool_surface_names json));
+      ( "tool_surface_masc_names",
+        string_list_to_json (string_list_member "tool_surface_masc_names" json)
+      );
+      ( "tool_surface_shell_names",
+        string_list_to_json
+          (string_list_member "tool_surface_shell_names" json) );
+      ("tool_surface_count", `Int (List.length (tool_surface_names json)));
       ("tool_names", U.member "tool_names" json);
       ("tool_call_count", U.member "tool_call_count" json);
       ("output_preview", U.member "output_preview" json);

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -227,6 +227,21 @@ let seed_worker_run_meta config session_id =
         ("execution_scope", `String "limited_code_change");
         ("requested_worker_class", `String "executor");
         ("requested_worker_size", `String "lg");
+        ("tool_surface_status", `String "available");
+        ("tool_surface_source", `String "local_worker_tools");
+        ( "tool_surface_names",
+          `List
+            [
+              `String "file_read";
+              `String "file_write";
+              `String "shell_exec";
+              `String "masc_status";
+              `String "masc_team_session_step";
+            ] );
+        ( "tool_surface_masc_names",
+          `List [ `String "masc_status"; `String "masc_team_session_step" ] );
+        ( "tool_surface_shell_names",
+          `List [ `String "file_read"; `String "file_write"; `String "shell_exec" ] );
         ("resolved_runtime", `String "llama-8085");
         ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
         ("routing_reason", `String "explicit_task_profile");
@@ -359,6 +374,14 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "resolved_runtime" |> U.to_string);
       check string "worker resolved model" "qwen3.5-35b-a3b-ud-q8-xl"
         (worker |> U.member "resolved_model" |> U.to_string);
+      check string "worker tool surface status" "available"
+        (worker |> U.member "tool_surface_status" |> U.to_string);
+      check int "worker tool surface count" 5
+        (worker |> U.member "tool_surface_count" |> U.to_int);
+      check (list string) "worker tool surface names"
+        [ "file_read"; "file_write"; "shell_exec"; "masc_status"; "masc_team_session_step" ]
+        (worker |> U.member "tool_surface_names" |> U.to_list
+       |> List.map U.to_string);
       check string "worker result_status" "completed"
         (worker |> U.member "result_status" |> U.to_string);
       check string "worker proof run id" "proof-run-123"

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -44,7 +44,8 @@ let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
       };
     capability_snapshot =
       {
-        Oas.Cdal_proof.tools = [];
+        Oas.Cdal_proof.tools =
+          [ "file_read"; "file_write"; "shell_exec"; "masc_team_session_step" ];
         mcp_servers = [];
         max_turns = 10;
         max_tokens = Some 4096;
@@ -159,6 +160,7 @@ let persist_snapshot ?proof step_env =
     ~worker_name:"worker-proof"
     ~mode:"spawn"
     ~wait_mode:Team_session_types.Wait_blocking
+    ~execution_scope:Team_session_types.Limited_code_change
     ~status:`Completed
     ~resolved_runtime:"llama-8085"
     ~resolved_model:"glm-5"
@@ -188,7 +190,15 @@ let test_persist_worker_run_snapshot_with_proof () =
   check string "proof execution mode" "execute"
     (json |> U.member "proof_execution_mode" |> U.to_string);
   check int "proof evidence count" 2
-    (json |> U.member "proof_evidence_count" |> U.to_int)
+    (json |> U.member "proof_evidence_count" |> U.to_int);
+  check string "tool surface status" "available"
+    (json |> U.member "tool_surface_status" |> U.to_string);
+  check string "tool surface source" "local_worker_tools"
+    (json |> U.member "tool_surface_source" |> U.to_string);
+  check (list string) "tool surface shell names"
+    [ "file_read"; "file_write"; "shell_exec" ]
+    (json |> U.member "tool_surface_shell_names" |> U.to_list
+   |> List.map U.to_string)
 
 let test_persist_worker_run_snapshot_without_proof () =
   with_snapshot_env @@ fun config step_env ->
@@ -205,7 +215,9 @@ let test_persist_worker_run_snapshot_without_proof () =
   check bool "proof_execution_mode null" true
     (json |> U.member "proof_execution_mode" = `Null);
   check bool "proof_evidence_count null" true
-    (json |> U.member "proof_evidence_count" = `Null)
+    (json |> U.member "proof_evidence_count" = `Null);
+  check string "tool surface status without proof" "available"
+    (json |> U.member "tool_surface_status" |> U.to_string)
 
 let test_persist_worker_run_snapshot_rejects_invalid_run_id () =
   with_snapshot_env @@ fun config step_env ->

--- a/test/test_worker_run_evidence_summary.ml
+++ b/test/test_worker_run_evidence_summary.ml
@@ -72,6 +72,21 @@ let sample_meta ?(trace_capability = `String "raw")
       ("execution_scope", `String "limited_code_change");
       ("requested_worker_class", `String "executor");
       ("requested_worker_size", `String "lg");
+      ("tool_surface_status", `String "available");
+      ("tool_surface_source", `String "local_worker_tools");
+      ( "tool_surface_names",
+        `List
+          [
+            `String "file_read";
+            `String "file_write";
+            `String "shell_exec";
+            `String "masc_status";
+            `String "masc_team_session_step";
+          ] );
+      ( "tool_surface_masc_names",
+        `List [ `String "masc_status"; `String "masc_team_session_step" ] );
+      ( "tool_surface_shell_names",
+        `List [ `String "file_read"; `String "file_write"; `String "shell_exec" ] );
       ("resolved_runtime", `String "llama-8085");
       ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
       ("routing_reason", `String "explicit_task_profile");
@@ -117,6 +132,19 @@ let test_status_and_dashboard_use_canonical_summary () =
   check bool "status equals canonical" true (Yojson.Safe.equal canonical status_json);
   check bool "dashboard equals canonical" true
     (Yojson.Safe.equal canonical dashboard_json)
+
+let test_summary_projects_tool_surface_visibility () =
+  let meta_json = sample_meta () in
+  let summary = Worker_run_evidence_summary.summary_json meta_json in
+  check string "tool surface status" "available"
+    U.(summary |> member "tool_surface_status" |> to_string);
+  check string "tool surface source" "local_worker_tools"
+    U.(summary |> member "tool_surface_source" |> to_string);
+  check int "tool surface count" 5
+    U.(summary |> member "tool_surface_count" |> to_int);
+  check (list string) "tool surface names"
+    [ "file_read"; "file_write"; "shell_exec"; "masc_status"; "masc_team_session_step" ]
+    U.(summary |> member "tool_surface_names" |> to_list |> List.map to_string)
 
 let test_summary_distinguishes_missing_vs_unavailable_evidence () =
   let missing_trace =
@@ -213,6 +241,8 @@ let () =
         [
           test_case "status and dashboard use canonical summary" `Quick
             test_status_and_dashboard_use_canonical_summary;
+          test_case "projects tool surface visibility" `Quick
+            test_summary_projects_tool_surface_visibility;
           test_case "distinguishes missing vs unavailable evidence" `Quick
             test_summary_distinguishes_missing_vs_unavailable_evidence;
           test_case "verify_trace returns canonical worker run summary" `Quick


### PR DESCRIPTION
## Summary
- persist worker-run tool surface metadata alongside resolved runtime/model in local worker snapshots and OAS swarm proof snapshots
- project the same canonical worker-run visibility fields into status, verify-trace, and dashboard proof surfaces
- distinguish available tool surface from actually executed tools in the dashboard proof UI

## Why
Operators could already see some worker-run evidence, but runtime/model/tool visibility was still split across raw metadata, proof artifacts, and dashboard rendering. That made it harder to answer which runtime ran a worker, which model was resolved, and which tool surface was available without reading raw logs.

## Product impact
- team-session worker runs now expose `tool_surface_*` fields through the canonical summary used by status, dashboard proof, and verify-trace
- dashboard proof rows now show both available tool surface and executed tools, reducing ambiguity during swarm debugging
- missing tool-surface projection becomes explicit instead of silently dropping visibility context

## Root cause
Worker-run metadata persisted `resolved_runtime` and `resolved_model`, but not a canonical tool-surface snapshot. Downstream projections therefore had no stable source of truth for the tool universe that was available to the worker at execution time.

## Evidence
- local worker snapshots now persist `tool_surface_status`, `tool_surface_source`, `tool_surface_names`, `tool_surface_masc_names`, and `tool_surface_shell_names`
- OAS swarm proof snapshots persist the same tool-surface fields so worker proof and worker run evidence stay aligned
- dashboard proof rows separate available tool surface from executed `tool_names`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/4529-worker-run-visibility`
- `./_build/default/test/test_worker_run_evidence_summary.exe`
- `./_build/default/test/test_persist_worker_run_snapshot.exe`
- `./_build/default/test/test_dashboard_proof.exe`
- `dashboard`: `vitest run src/components/proof-helpers.test.ts`
- `dashboard`: `tsc --noEmit --pretty`

## Review evidence
- `2026-04-02 18:23:35 KST` direct `sb glm-text --no-thinking` diff review on PR #4663: `No findings.`

## Linked issue
- Closes #4529
