### PR TITLE
fix(keeper): add diagnostic logging to autoboot for path debugging

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -206,6 +206,15 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
     Eio.Time.sleep clock 5.0;
     let config = state.room_config in
+    let masc_root = Room.masc_root_dir config in
+    let keeper_path = Filename.concat masc_root "keepers" in
+    let all_count =
+      match Safe_ops.list_dir_safe keeper_path with
+      | Ok files -> List.length (List.filter (fun f -> Filename.check_suffix f ".json") files)
+      | Error _ -> -1
+    in
+    Log.Keeper.info "autoboot: base_path=%s masc_root=%s keeper_json_count=%d"
+      config.base_path masc_root all_count;
     let names = Keeper_types.keepalive_keeper_names config in
     Log.Keeper.info "autoboot: %d keeper(s) to boot: [%s]"
       (List.length names) (String.concat ", " names);

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -203,23 +203,25 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     if not Env_config.KeeperBootstrap.enabled then
       Log.Keeper.info "autoboot: disabled via MASC_KEEPER_BOOTSTRAP_ENABLED=false"
     else begin
-	    (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
-	    Eio.Time.sleep clock 5.0;
-	    let config = state.room_config in
-	    let masc_root = Room.masc_root_dir config in
-	    let keeper_dir = Keeper_fs.keeper_dir config in
-	    let all_count =
-	      match Safe_ops.list_dir_safe keeper_dir with
-	      | Ok files -> List.length (List.filter (fun f -> Filename.check_suffix f ".json") files)
-	      | Error msg ->
-	          Log.Keeper.warn "autoboot: failed to list keeper dir %s: %s"
-	            keeper_dir msg;
-	          0
-	    in
-	    Log.Keeper.info
-	      "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
-	      config.base_path masc_root keeper_dir all_count;
-	    let names = Keeper_types.keepalive_keeper_names config in
+      (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
+      Eio.Time.sleep clock 5.0;
+      let config = state.room_config in
+      let masc_root = Room.masc_root_dir config in
+      let keeper_dir = Keeper_fs.keeper_dir config in
+      let all_count =
+        match Safe_ops.list_dir_safe keeper_dir with
+        | Ok files ->
+            List.length
+              (List.filter (fun f -> Filename.check_suffix f ".json") files)
+        | Error msg ->
+            Log.Keeper.warn "autoboot: failed to list keeper dir %s: %s"
+              keeper_dir msg;
+            0
+      in
+      Log.Keeper.info
+        "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
+        config.base_path masc_root keeper_dir all_count;
+      let names = Keeper_types.keepalive_keeper_names config in
     Log.Keeper.info "autoboot: %d keeper(s) to boot: [%s]"
       (List.length names) (String.concat ", " names);
     let booted = ref 0 in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -203,19 +203,23 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     if not Env_config.KeeperBootstrap.enabled then
       Log.Keeper.info "autoboot: disabled via MASC_KEEPER_BOOTSTRAP_ENABLED=false"
     else begin
-    (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
-    Eio.Time.sleep clock 5.0;
-    let config = state.room_config in
-    let masc_root = Room.masc_root_dir config in
-    let keeper_path = Filename.concat masc_root "keepers" in
-    let all_count =
-      match Safe_ops.list_dir_safe keeper_path with
-      | Ok files -> List.length (List.filter (fun f -> Filename.check_suffix f ".json") files)
-      | Error _ -> -1
-    in
-    Log.Keeper.info "autoboot: base_path=%s masc_root=%s keeper_json_count=%d"
-      config.base_path masc_root all_count;
-    let names = Keeper_types.keepalive_keeper_names config in
+	    (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
+	    Eio.Time.sleep clock 5.0;
+	    let config = state.room_config in
+	    let masc_root = Room.masc_root_dir config in
+	    let keeper_dir = Keeper_fs.keeper_dir config in
+	    let all_count =
+	      match Safe_ops.list_dir_safe keeper_dir with
+	      | Ok files -> List.length (List.filter (fun f -> Filename.check_suffix f ".json") files)
+	      | Error msg ->
+	          Log.Keeper.warn "autoboot: failed to list keeper dir %s: %s"
+	            keeper_dir msg;
+	          0
+	    in
+	    Log.Keeper.info
+	      "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
+	      config.base_path masc_root keeper_dir all_count;
+	    let names = Keeper_types.keepalive_keeper_names config in
     Log.Keeper.info "autoboot: %d keeper(s) to boot: [%s]"
       (List.length names) (String.concat ", " names);
     let booted = ref 0 in


### PR DESCRIPTION
## Summary
- Autoboot 시작 시 `base_path`, `masc_root`, `keeper_json_count`를 로그에 출력
- #4660에서 보고된 "0 keeper(s) to boot" 문제의 근본 원인 파악용

## Root cause (추정)
`keeper_dir`이 올바른 `.masc/keepers/`를 참조하지 않거나, 서버 시작 시점에 keeper JSON이 아직 생성되지 않았을 가능성. 이 로그로 다음 서버 재시작 시 정확한 경로와 파일 수를 확인 가능.

## Evidence
- `dune build` 통과
- +9 lines, 기존 동작 변경 없음

## Linked issue
- Refs #4660

🤖 Generated with [Claude Code](https://claude.com/claude-code)