### PR TITLE
[codex] harden keeper detail source contracts

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -4,7 +4,7 @@ import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types
 import {
   resolveKeeperObservedToolAudit,
   resolveKeeperToolPolicy,
-} from './keeper-detail-runtime'
+} from './keeper-detail-source'
 
 describe('resolveKeeperToolPolicy', () => {
   it('uses keeper config as the authoritative policy source', () => {
@@ -116,6 +116,30 @@ describe('resolveKeeperObservedToolAudit', () => {
       agent_name: 'sangsu',
       status: 'active',
     }
+
+    expect(resolveKeeperObservedToolAudit(keeper, missionBrief)).toEqual({
+      source: 'dashboard_summary',
+      latestToolNames: ['dashboard_summary_tool'],
+      latestToolCallCount: 1,
+      toolAuditSource: 'keeper_metrics',
+      toolAuditAt: '2026-04-01T12:00:00Z',
+    })
+  })
+
+  it('does not treat mission compatibility allowlists as observed audit freshness', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      latest_tool_names: ['dashboard_summary_tool'],
+      latest_tool_call_count: 1,
+      tool_audit_source: 'keeper_metrics',
+      tool_audit_at: '2026-04-01T12:00:00Z',
+    }
+
+    const missionBrief = {
+      name: 'sangsu',
+      allowed_tool_names: ['compat_only_allowlist'],
+    } as DashboardMissionKeeperBrief & { allowed_tool_names: string[] }
 
     expect(resolveKeeperObservedToolAudit(keeper, missionBrief)).toEqual({
       source: 'dashboard_summary',

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -6,8 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
-import { missionSnapshot } from '../mission-store'
-import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
+import type { Keeper } from '../types'
 import { serverStatus } from '../store'
 import { operatorSnapshot } from '../operator-store'
 import {
@@ -21,6 +20,11 @@ import {
 } from './common/tool-audit'
 import { ToolAllowlistEditor } from './tools/tool-allowlist-editor'
 import { loadTools } from './tools/tool-state'
+import {
+  resolveKeeperMissionBrief,
+  resolveKeeperObservedToolAudit,
+  resolveKeeperToolPolicy,
+} from './keeper-detail-source'
 import {
   loadKeeperConfig,
   peekKeeperConfigLoadStatus,
@@ -65,134 +69,6 @@ function keeperTopTools(keeper: Keeper): string[] {
   return topTools
     .map(item => (typeof item === 'object' && item !== null && 'tool' in item && typeof item.tool === 'string' ? item.tool : null))
     .filter((item): item is string => item !== null)
-}
-
-function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null {
-  const mission = missionSnapshot.value
-  if (!mission) return null
-  return mission.keeper_briefs.find(brief =>
-    brief.name === keeper.name
-      || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
-    ?? null
-}
-
-type KeeperConfigLoadStatus = 'idle' | 'loading' | 'loaded' | 'error' | 'other'
-
-export interface KeeperToolPolicySnapshot {
-  source: 'keeper_config' | 'loading' | 'error' | 'none'
-  mode: 'preset' | 'custom' | string
-  preset: Keeper['tool_preset']
-  alsoAllow: string[]
-  customAllowlist: string[]
-  denylist: string[]
-  resolvedAllowlist: string[]
-}
-
-export function resolveKeeperToolPolicy(
-  keeperConfig: Pick<KeeperConfig, 'tools'> | null,
-  loadStatus: KeeperConfigLoadStatus,
-): KeeperToolPolicySnapshot {
-  const tools = keeperConfig?.tools
-  if (tools) {
-    return {
-      source: 'keeper_config',
-      mode: tools.tool_policy_mode,
-      preset: tools.tool_preset ?? null,
-      alsoAllow: tools.tool_also_allow ?? [],
-      customAllowlist: tools.tool_custom_allowlist ?? [],
-      denylist: tools.tool_denylist ?? [],
-      resolvedAllowlist: tools.resolved_allowlist ?? [],
-    }
-  }
-
-  if (loadStatus === 'idle' || loadStatus === 'loading') {
-    return {
-      source: 'loading',
-      mode: 'preset',
-      preset: null,
-      alsoAllow: [],
-      customAllowlist: [],
-      denylist: [],
-      resolvedAllowlist: [],
-    }
-  }
-
-  if (loadStatus === 'error') {
-    return {
-      source: 'error',
-      mode: 'preset',
-      preset: null,
-      alsoAllow: [],
-      customAllowlist: [],
-      denylist: [],
-      resolvedAllowlist: [],
-    }
-  }
-
-  return {
-    source: 'none',
-    mode: 'preset',
-    preset: null,
-    alsoAllow: [],
-    customAllowlist: [],
-    denylist: [],
-    resolvedAllowlist: [],
-  }
-}
-
-export interface KeeperObservedToolAuditSnapshot {
-  source: 'mission_brief' | 'dashboard_summary' | 'none'
-  latestToolNames: string[]
-  latestToolCallCount: number | null
-  toolAuditSource: string | null
-  toolAuditAt: string | null
-}
-
-export function resolveKeeperObservedToolAudit(
-  keeper: Keeper,
-  missionBrief: DashboardMissionKeeperBrief | null,
-): KeeperObservedToolAuditSnapshot {
-  const hasMissionAudit =
-    missionBrief != null && (
-      (missionBrief.latest_tool_names?.length ?? 0) > 0
-      || missionBrief.latest_tool_call_count != null
-      || !!missionBrief.tool_audit_source?.trim()
-      || !!missionBrief.tool_audit_at?.trim()
-    )
-
-  if (hasMissionAudit && missionBrief) {
-    return {
-      source: 'mission_brief',
-      latestToolNames: missionBrief.latest_tool_names ?? [],
-      latestToolCallCount: missionBrief.latest_tool_call_count ?? null,
-      toolAuditSource: missionBrief.tool_audit_source ?? null,
-      toolAuditAt: missionBrief.tool_audit_at ?? null,
-    }
-  }
-
-  const hasDashboardAudit =
-    (keeper.latest_tool_names?.length ?? 0) > 0
-    || keeper.latest_tool_call_count != null
-    || !!keeper.tool_audit_source?.trim()
-    || !!keeper.tool_audit_at?.trim()
-
-  if (hasDashboardAudit) {
-    return {
-      source: 'dashboard_summary',
-      latestToolNames: keeper.latest_tool_names ?? [],
-      latestToolCallCount: keeper.latest_tool_call_count ?? null,
-      toolAuditSource: keeper.tool_audit_source ?? null,
-      toolAuditAt: keeper.tool_audit_at ?? null,
-    }
-  }
-
-  return {
-    source: 'none',
-    latestToolNames: [],
-    latestToolCallCount: null,
-    toolAuditSource: null,
-    toolAuditAt: null,
-  }
 }
 
 // ── Shared row component ─────────────────────────────────
@@ -371,7 +247,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
     .slice(0, 8)
   const recentTools = keeperRecentTools(keeper)
   const topTools = keeperTopTools(keeper)
-  const missionBrief = missionKeeperBrief(keeper)
+  const missionBrief = resolveKeeperMissionBrief(keeper)
   const toolPolicy = resolveKeeperToolPolicy(keeperConfig, configLoadStatus)
   const observedAudit = resolveKeeperObservedToolAudit(keeper, missionBrief)
   const allowedTools = toolPolicy.resolvedAllowlist

--- a/dashboard/src/components/keeper-detail-source.ts
+++ b/dashboard/src/components/keeper-detail-source.ts
@@ -1,0 +1,137 @@
+import { missionSnapshot } from '../mission-store'
+import type {
+  DashboardMissionKeeperBrief,
+  Keeper,
+  KeeperConfig,
+  KeeperConfigTools,
+} from '../types'
+
+export type KeeperConfigLoadStatus = 'idle' | 'loading' | 'loaded' | 'error' | 'other'
+
+export function resolveKeeperMissionBrief(
+  keeper: Pick<Keeper, 'name' | 'agent_name'>,
+): DashboardMissionKeeperBrief | null {
+  const mission = missionSnapshot.value
+  if (!mission) return null
+  return mission.keeper_briefs.find(brief =>
+    brief.name === keeper.name
+      || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
+    ?? null
+}
+
+export interface KeeperToolPolicySnapshot {
+  source: 'keeper_config' | 'loading' | 'error' | 'none'
+  mode: 'preset' | 'custom' | string
+  preset: KeeperConfigTools['tool_preset']
+  alsoAllow: string[]
+  customAllowlist: string[]
+  denylist: string[]
+  resolvedAllowlist: string[]
+}
+
+export function resolveKeeperToolPolicy(
+  keeperConfig: Pick<KeeperConfig, 'tools'> | null,
+  loadStatus: KeeperConfigLoadStatus,
+): KeeperToolPolicySnapshot {
+  const tools = keeperConfig?.tools
+  if (tools) {
+    return {
+      source: 'keeper_config',
+      mode: tools.tool_policy_mode,
+      preset: tools.tool_preset ?? null,
+      alsoAllow: tools.tool_also_allow ?? [],
+      customAllowlist: tools.tool_custom_allowlist ?? [],
+      denylist: tools.tool_denylist ?? [],
+      resolvedAllowlist: tools.resolved_allowlist ?? [],
+    }
+  }
+
+  if (loadStatus === 'idle' || loadStatus === 'loading') {
+    return {
+      source: 'loading',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    }
+  }
+
+  if (loadStatus === 'error') {
+    return {
+      source: 'error',
+      mode: 'preset',
+      preset: null,
+      alsoAllow: [],
+      customAllowlist: [],
+      denylist: [],
+      resolvedAllowlist: [],
+    }
+  }
+
+  return {
+    source: 'none',
+    mode: 'preset',
+    preset: null,
+    alsoAllow: [],
+    customAllowlist: [],
+    denylist: [],
+    resolvedAllowlist: [],
+  }
+}
+
+export interface KeeperObservedToolAuditSnapshot {
+  source: 'mission_brief' | 'dashboard_summary' | 'none'
+  latestToolNames: string[]
+  latestToolCallCount: number | null
+  toolAuditSource: string | null
+  toolAuditAt: string | null
+}
+
+export function resolveKeeperObservedToolAudit(
+  keeper: Pick<Keeper, 'latest_tool_names' | 'latest_tool_call_count' | 'tool_audit_source' | 'tool_audit_at'>,
+  missionBrief: DashboardMissionKeeperBrief | null,
+): KeeperObservedToolAuditSnapshot {
+  const hasMissionAudit =
+    missionBrief != null && (
+      (missionBrief.latest_tool_names?.length ?? 0) > 0
+      || missionBrief.latest_tool_call_count != null
+      || !!missionBrief.tool_audit_source?.trim()
+      || !!missionBrief.tool_audit_at?.trim()
+    )
+
+  if (hasMissionAudit && missionBrief) {
+    return {
+      source: 'mission_brief',
+      latestToolNames: missionBrief.latest_tool_names ?? [],
+      latestToolCallCount: missionBrief.latest_tool_call_count ?? null,
+      toolAuditSource: missionBrief.tool_audit_source ?? null,
+      toolAuditAt: missionBrief.tool_audit_at ?? null,
+    }
+  }
+
+  const hasDashboardAudit =
+    (keeper.latest_tool_names?.length ?? 0) > 0
+    || keeper.latest_tool_call_count != null
+    || !!keeper.tool_audit_source?.trim()
+    || !!keeper.tool_audit_at?.trim()
+
+  if (hasDashboardAudit) {
+    return {
+      source: 'dashboard_summary',
+      latestToolNames: keeper.latest_tool_names ?? [],
+      latestToolCallCount: keeper.latest_tool_call_count ?? null,
+      toolAuditSource: keeper.tool_audit_source ?? null,
+      toolAuditAt: keeper.tool_audit_at ?? null,
+    }
+  }
+
+  return {
+    source: 'none',
+    latestToolNames: [],
+    latestToolCallCount: null,
+    toolAuditSource: null,
+    toolAuditAt: null,
+  }
+}

--- a/dashboard/src/components/keeper-detail-source.ts
+++ b/dashboard/src/components/keeper-detail-source.ts
@@ -1,4 +1,4 @@
-import { missionSnapshot } from '../mission-store'
+import { missionKeeperBriefs } from '../mission-store'
 import type {
   DashboardMissionKeeperBrief,
   Keeper,
@@ -11,9 +11,7 @@ export type KeeperConfigLoadStatus = 'idle' | 'loading' | 'loaded' | 'error' | '
 export function resolveKeeperMissionBrief(
   keeper: Pick<Keeper, 'name' | 'agent_name'>,
 ): DashboardMissionKeeperBrief | null {
-  const mission = missionSnapshot.value
-  if (!mission) return null
-  return mission.keeper_briefs.find(brief =>
+  return missionKeeperBriefs.value.find(brief =>
     brief.name === keeper.name
       || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
     ?? null

--- a/dashboard/src/components/keeper-detail-source.ts
+++ b/dashboard/src/components/keeper-detail-source.ts
@@ -1,4 +1,4 @@
-import { missionKeeperBriefs } from '../mission-store'
+import { missionKeeperBriefs } from '../mission-signals'
 import type {
   DashboardMissionKeeperBrief,
   Keeper,

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Keeper } from '../types'
+
+const mocks = vi.hoisted(() => ({
+  loadKeeperConfig: vi.fn(async () => {}),
+  resetKeeperConfig: vi.fn(),
+  selectKeeper: vi.fn(),
+}))
+
+vi.mock('./keeper-config-panel', async () => {
+  const actual = await vi.importActual<typeof import('./keeper-config-panel')>('./keeper-config-panel')
+  return {
+    ...actual,
+    KeeperConfigPanel: () => null,
+    loadKeeperConfig: mocks.loadKeeperConfig,
+    resetKeeperConfig: mocks.resetKeeperConfig,
+  }
+})
+
+vi.mock('../keeper-runtime', () => ({
+  selectKeeper: mocks.selectKeeper,
+}))
+
+import {
+  closeKeeperDetail,
+  openKeeperDetail,
+  selectedKeeper,
+} from './keeper-detail'
+
+describe('openKeeperDetail', () => {
+  beforeEach(() => {
+    selectedKeeper.value = null
+    mocks.loadKeeperConfig.mockClear()
+    mocks.resetKeeperConfig.mockClear()
+    mocks.selectKeeper.mockClear()
+  })
+
+  it('selects the keeper and preloads config on modal open', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+    }
+
+    openKeeperDetail(keeper)
+
+    expect(selectedKeeper.value).toEqual(keeper)
+    expect(mocks.selectKeeper).toHaveBeenCalledWith('sangsu')
+    expect(mocks.loadKeeperConfig).toHaveBeenCalledWith('sangsu')
+  })
+
+  it('resets modal-local state on close', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+    }
+
+    openKeeperDetail(keeper)
+    closeKeeperDetail()
+
+    expect(selectedKeeper.value).toBeNull()
+    expect(mocks.resetKeeperConfig).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -109,4 +109,42 @@ describe('normalizeKeepers lifecycle metrics', () => {
     })
     expect(deriveLifecycleState(keeper!)).toBe('compacting')
   })
+
+  it('drops authored tool policy duplicates from shell rows while keeping runtime audit fields', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'delta',
+        status: 'active',
+        tool_policy_mode: 'custom',
+        tool_preset: 'full',
+        tool_also_allow: ['mcp__masc__masc_join'],
+        tool_custom_allowlist: ['mcp__masc__masc_board_post'],
+        tool_denylist: ['mcp__masc__masc_board_delete'],
+        allowed_tool_names: ['compat_only_allowlist'],
+        latest_tool_names: ['observed_tool'],
+        latest_tool_call_count: 2,
+        tool_audit_source: 'heartbeat_result',
+        tool_audit_at: '2026-04-02T08:30:00Z',
+        context_source: 'metrics_log',
+        recent_input_preview: 'operator asked for a refresh',
+        recent_output_preview: 'keeper acknowledged the request',
+      },
+    ])
+
+    expect(keeper).toMatchObject({
+      latest_tool_names: ['observed_tool'],
+      latest_tool_call_count: 2,
+      tool_audit_source: 'heartbeat_result',
+      tool_audit_at: '2026-04-02T08:30:00Z',
+      context_source: 'metrics_log',
+      recent_input_preview: 'operator asked for a refresh',
+      recent_output_preview: 'keeper acknowledged the request',
+    })
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('tool_policy_mode')
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('tool_preset')
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('tool_also_allow')
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('tool_custom_allowlist')
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('tool_denylist')
+    expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('allowed_tool_names')
+  })
 })

--- a/dashboard/src/mission-normalizers-entities.test.ts
+++ b/dashboard/src/mission-normalizers-entities.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeKeeperBrief } from './mission-normalizers-entities'
+
+describe('normalizeKeeperBrief', () => {
+  it('keeps observed audit fields and drops compatibility allowlists', () => {
+    const brief = normalizeKeeperBrief({
+      name: 'sangsu',
+      status: 'active',
+      allowed_tool_names: ['compat_only_allowlist'],
+      latest_tool_names: ['observed_tool'],
+      latest_tool_call_count: 3,
+      tool_audit_source: 'heartbeat_result',
+      tool_audit_at: '2026-04-02T09:30:00Z',
+    })
+
+    expect(brief).toEqual({
+      name: 'sangsu',
+      agent_name: null,
+      status: 'active',
+      generation: undefined,
+      context_ratio: null,
+      last_turn_ago_s: null,
+      current_work: null,
+      last_autonomous_action_at: null,
+      latest_tool_names: ['observed_tool'],
+      latest_tool_call_count: 3,
+      tool_audit_source: 'heartbeat_result',
+      tool_audit_at: '2026-04-02T09:30:00Z',
+    })
+    expect(brief as unknown as Record<string, unknown>).not.toHaveProperty('allowed_tool_names')
+  })
+})

--- a/dashboard/src/mission-normalizers-entities.ts
+++ b/dashboard/src/mission-normalizers-entities.ts
@@ -196,9 +196,6 @@ export function normalizeKeeperBrief(raw: unknown): DashboardMissionKeeperBrief 
     last_turn_ago_s: asNumber(raw.last_turn_ago_s) ?? null,
     current_work: asString(raw.current_work) ?? null,
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
-    allowed_tool_names: extractArray(raw.allowed_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
     latest_tool_names: extractArray(raw.latest_tool_names)
       .map(item => (typeof item === 'string' ? item.trim() : ''))
       .filter(Boolean),

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -2,6 +2,8 @@
 // Mission store is split into mission-signals, mission-normalizers, mission-actions.
 export {
   missionSnapshot,
+  missionAgentBriefs,
+  missionKeeperBriefs,
   missionLoading,
   missionError,
   missionBriefing,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -495,12 +495,7 @@ export interface Keeper {
   recent_input_preview?: string | null
   recent_output_preview?: string | null
   recent_tool_names?: string[]
-  tool_policy_mode?: 'preset' | 'custom' | string
-  tool_preset?: 'minimal' | 'messaging' | 'coding' | 'research' | 'full' | null
-  tool_also_allow?: string[]
-  tool_custom_allowlist?: string[]
-  tool_denylist?: string[]
-  allowed_tool_names?: string[]
+  // Observed audit fallback from the shell summary; not authored tool policy.
   latest_tool_names?: string[]
   latest_tool_call_count?: number | null
   tool_audit_source?: string | null

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -148,7 +148,7 @@ export interface DashboardMissionKeeperBrief {
   last_turn_ago_s?: number | null
   current_work?: string | null
   last_autonomous_action_at?: string | null
-  allowed_tool_names?: string[]
+  // Mission keeper briefs carry observed audit freshness, not authored policy.
   latest_tool_names?: string[]
   latest_tool_call_count?: number | null
   tool_audit_source?: string | null

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -6,6 +6,8 @@
 include Dashboard_mission_agents
 
 let keeper_tool_audit_json_fields config keeper agent_name =
+  (* Compatibility-only derived allowlist. Keeper detail SSOT must source
+     authored/effective policy from /api/v1/keepers/:name/config instead. *)
   let fallback_allowed =
     string_list_of_json (member_assoc "allowed_tool_names" keeper)
   in


### PR DESCRIPTION
## Summary
- move keeper detail source resolution into a dedicated selector layer
- harden dashboard types/normalizers so shell and mission compatibility fields are not treated as authored policy
- add tests for config preload, observed audit precedence, and duplicate field dropping

## Why
keeper detail had the main tool-policy boundary fixed, but type surfaces still allowed shell and mission projections to look like authoritative authored config. this kept the source contract partially implicit and easy to regress.

## Impact
- keeper detail keeps using `/api/v1/keepers/:name/config` as SSOT for authored/effective tool policy
- mission and shell projections remain wire-compatible, but the dashboard no longer promotes their compatibility fields into keeper-detail SSOT
- regressions are covered with focused dashboard tests

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/vitest run src/components/keeper-detail-runtime.test.ts src/components/keeper-detail.test.ts src/keeper-store-normalize.test.ts src/mission-normalizers-entities.test.ts src/components/keeper-config-panel.test.ts`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-detail-ssot-contracts`
