### PR TITLE
[codex] Fix keeper exec audit and dual .masc root resolution

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
+import { resolveKeeperCurrentTaskLabel } from './keeper-detail-runtime'
 import {
   resolveKeeperObservedToolAudit,
   resolveKeeperToolPolicy,
@@ -163,5 +164,59 @@ describe('resolveKeeperObservedToolAudit', () => {
       toolAuditSource: null,
       toolAuditAt: null,
     })
+  })
+})
+
+describe('resolveKeeperCurrentTaskLabel', () => {
+  it('shows the active task when one is bound', () => {
+    const keeper: Keeper = {
+      name: 'config-provenance',
+      status: 'busy',
+      agent: {
+        name: 'keeper-config-provenance-agent',
+        current_task: 'task-046',
+      },
+    }
+
+    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('task-046')
+  })
+
+  it('shows unassigned when the runtime reported no bound task', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      agent: {
+        name: 'keeper-sangsu-agent',
+        current_task: null,
+      },
+    }
+
+    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('unassigned')
+  })
+
+  it('treats an empty current task string as unassigned', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      agent: {
+        name: 'keeper-sangsu-agent',
+        current_task: '   ',
+      },
+    }
+
+    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('unassigned')
+  })
+
+  it('returns unlinked when no keeper payload is available', () => {
+    expect(resolveKeeperCurrentTaskLabel(null)).toBe('unlinked')
+  })
+
+  it('keeps not_collected for online keepers without linked agent payload', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+    }
+
+    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('not_collected')
   })
 })

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -71,6 +71,19 @@ function keeperTopTools(keeper: Keeper): string[] {
     .filter((item): item is string => item !== null)
 }
 
+export function resolveKeeperCurrentTaskLabel(
+  keeper: Keeper | null | undefined,
+): string {
+  const runtimeState = linkedRuntimeState(keeper)
+  if (!keeper) return 'unlinked'
+  if (runtimeState === 'offline') return 'offline'
+  if (!keeper.agent) return 'not_collected'
+  if (typeof keeper.agent.current_task === 'string' && keeper.agent.current_task.trim() !== '') {
+    return keeper.agent.current_task
+  }
+  return 'unassigned'
+}
+
 // ── Shared row component ─────────────────────────────────
 
 function SignalRow({ label, value }: { label: string; value: string | number }) {
@@ -237,7 +250,10 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
 // ── Neighborhood & Tool Audit ────────────────────────────
 
 export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
-  useEffect(() => { showAllowlistEditor.value = false }, [keeper.name])
+  useEffect(() => {
+    showAllowlistEditor.value = false
+    void loadKeeperConfig(keeper.name)
+  }, [keeper.name])
 
   const keeperConfig = peekLoadedKeeperConfig(keeper.name)
   const configLoadStatus = peekKeeperConfigLoadStatus(keeper.name)
@@ -265,9 +281,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const metadataFallback = toolAuditStateLabel(auditMetadataState(keeper, auditSource))
   const linkedRecentFallback = toolAuditStateLabel(linkedRecentToolsEmptyState(keeper))
   const runtimeState = linkedRuntimeState(keeper)
-  const currentTaskLabel =
-    keeper.agent?.current_task
-    ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
+  const currentTaskLabel = resolveKeeperCurrentTaskLabel(keeper)
   const skillRouteLabel =
     keeper.skill_primary
     ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -140,14 +140,45 @@ let rec find_git_root path =
 
 let bool_env name = Env_config_core.get_bool ~default:false name
 
+let normalize_base_path path =
+  let trimmed = String.trim path in
+  if trimmed = "" then ""
+  else if Filename.is_relative trimmed then Filename.concat (Sys.getcwd ()) trimmed
+  else trimmed
+
+let canonical_base_path path =
+  let normalized = normalize_base_path path in
+  match find_git_root normalized with
+  | Some git_root -> git_root
+  | None -> normalized
+  | exception _ -> normalized
+
+let path_has_masc_dir path =
+  let masc_dir = Filename.concat path ".masc" in
+  Sys.file_exists masc_dir && Sys.is_directory masc_dir
+
 let running_under_test_executable () =
   let executable =
     Sys.executable_name |> Filename.basename |> String.lowercase_ascii
   in
   String.starts_with ~prefix:"test_" executable
 
+let should_ignore_inherited_base_path ~requested_path ~explicit_path =
+  not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
+  && String.trim requested_path <> ""
+  && not (String.equal requested_path ".")
+  &&
+  let requested = canonical_base_path requested_path in
+  let explicit = canonical_base_path explicit_path in
+  requested <> ""
+  && explicit <> ""
+  && not (String.equal requested explicit)
+  && path_has_masc_dir requested
+  && path_has_masc_dir explicit
+
 let should_ignore_inherited_test_base_path ~requested_path ~explicit_path =
   running_under_test_executable ()
+  && not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
   && not (bool_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
   && String.trim requested_path <> ""
   && not (String.equal requested_path ".")
@@ -181,6 +212,14 @@ let resolve_requested_base_path path =
     the intended base path. *)
 let resolve_masc_base_path path =
   match Env_config_core.base_path_opt () with
+  | Some explicit
+    when should_ignore_inherited_base_path ~requested_path:path
+           ~explicit_path:explicit ->
+      let resolved = resolve_requested_base_path path in
+      Log.Room.warn
+        "Ignoring inherited MASC_BASE_PATH=%s because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
+        explicit (canonical_base_path path) (canonical_base_path explicit) resolved;
+      resolved
   | Some explicit
     when should_ignore_inherited_test_base_path ~requested_path:path
            ~explicit_path:explicit ->

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -67,6 +67,13 @@ release_build_lock() {
     _masc_cleanup_lock
 }
 
+is_truthy() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|y|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 build_dashboard_spa() {
     local dashboard_dir="$SCRIPT_DIR/dashboard"
     local log_file=""
@@ -369,28 +376,21 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Guard against worktree env inheritance: when a worktree child inherits
-# MASC_BASE_PATH pointing to its own repo root, both paths have .masc/
-# and using the parent path would silently operate on the wrong room state.
-#
-# Exception: if BASE_PATH is a genuinely different project (not this repo's
-# root), the user intentionally configured a parent project as MASC root
-# (e.g. MASC_BASE_PATH=~/me in .zshenv while running from ~/me/workspace/*/masc-mcp).
-# REPO_ENV_ROOT (git common dir) identifies the repo boundary.
+# Guard against inherited MASC_BASE_PATH ambiguity. When the caller shell
+# exports a parent project root and both that root and this checkout have
+# their own .masc directories, the server can silently read/write the wrong
+# state tree. Explicit --base-path must still win; inherited env needs an
+# opt-in to survive this ambiguity.
 if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
    [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && \
    [ -n "$BASE_PATH" ] && \
-   [ "$BASE_PATH" != "$SCRIPT_DIR" ]; then
-    RESOLVED_ENV_ROOT="$(cd "$REPO_ENV_ROOT" && pwd)"
+   [ "$BASE_PATH" != "$SCRIPT_DIR" ] && \
+   ! is_truthy "${MASC_ALLOW_INHERITED_BASE_PATH:-0}"; then
     RESOLVED_BASE="$(cd "$BASE_PATH" 2>/dev/null && pwd || echo "$BASE_PATH")"
-    if [ "$RESOLVED_BASE" = "$RESOLVED_ENV_ROOT" ]; then
-        # BASE_PATH is this repo's own root — worktree inheritance. Guard applies.
-        if [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$BASE_PATH/.masc" ]; then
-            echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH (same repo root). Using $SCRIPT_DIR for server state." >&2
-            BASE_PATH="$SCRIPT_DIR"
-        fi
+    if [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$RESOLVED_BASE/.masc" ]; then
+        echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH because both $SCRIPT_DIR and $RESOLVED_BASE have .masc. Use --base-path or MASC_ALLOW_INHERITED_BASE_PATH=1 to keep the inherited root." >&2
+        BASE_PATH="$SCRIPT_DIR"
     fi
-    # If BASE_PATH is a different project, honor the env var unconditionally.
 fi
 
 if [ "$PORT_EXPLICIT" != "1" ]; then

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -74,6 +74,46 @@ is_truthy() {
     esac
 }
 
+# Resolve a path to its git-root equivalent (worktree-aware).
+# Used both by the ambiguity guard and the final MASC_BASE_PATH export
+# so both see the same effective base path.
+resolve_base_path() {
+    local path="$1"
+
+    if [ -f "$path/.git" ]; then
+        local gitdir
+        gitdir="$(sed -n 's/^gitdir: //p' "$path/.git")"
+        if [ -n "$gitdir" ]; then
+            case "$gitdir" in
+                */.git/worktrees/*)
+                    echo "${gitdir%/.git/worktrees/*}"
+                    return
+                    ;;
+                */.git)
+                    echo "${gitdir%/.git}"
+                    return
+                    ;;
+            esac
+        fi
+    fi
+
+    if [ -d "$path/.git" ]; then
+        echo "$path"
+        return
+    fi
+
+    if command -v git >/dev/null 2>&1; then
+        local git_root
+        git_root="$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)"
+        if [ -n "$git_root" ]; then
+            echo "$git_root"
+            return
+        fi
+    fi
+
+    echo "$path"
+}
+
 build_dashboard_spa() {
     local dashboard_dir="$SCRIPT_DIR/dashboard"
     local log_file=""
@@ -386,7 +426,9 @@ if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
    [ -n "$BASE_PATH" ] && \
    [ "$BASE_PATH" != "$SCRIPT_DIR" ] && \
    ! is_truthy "${MASC_ALLOW_INHERITED_BASE_PATH:-0}"; then
-    RESOLVED_BASE="$(cd "$BASE_PATH" 2>/dev/null && pwd || echo "$BASE_PATH")"
+    # Use the same git-root-aware resolution that will be used for the
+    # final MASC_BASE_PATH export so this guard sees the effective path.
+    RESOLVED_BASE="$(resolve_base_path "$BASE_PATH")"
     if [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$RESOLVED_BASE/.masc" ]; then
         echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH because both $SCRIPT_DIR and $RESOLVED_BASE have .masc. Use --base-path or MASC_ALLOW_INHERITED_BASE_PATH=1 to keep the inherited root." >&2
         BASE_PATH="$SCRIPT_DIR"
@@ -529,43 +571,6 @@ if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
         fi
     fi
 fi
-
-resolve_base_path() {
-    local path="$1"
-
-    if [ -f "$path/.git" ]; then
-        local gitdir
-        gitdir="$(sed -n 's/^gitdir: //p' "$path/.git")"
-        if [ -n "$gitdir" ]; then
-            case "$gitdir" in
-                */.git/worktrees/*)
-                    echo "${gitdir%/.git/worktrees/*}"
-                    return
-                    ;;
-                */.git)
-                    echo "${gitdir%/.git}"
-                    return
-                    ;;
-            esac
-        fi
-    fi
-
-    if [ -d "$path/.git" ]; then
-        echo "$path"
-        return
-    fi
-
-    if command -v git >/dev/null 2>&1; then
-        local git_root
-        git_root="$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)"
-        if [ -n "$git_root" ]; then
-            echo "$git_root"
-            return
-        fi
-    fi
-
-    echo "$path"
-}
 
 RESOLVED_BASE_PATH="$(resolve_base_path "$BASE_PATH")"
 export MASC_BASE_PATH="$RESOLVED_BASE_PATH"

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -82,6 +82,15 @@ let write_file path contents =
     ~finally:(fun () -> close_out oc)
     (fun () -> output_string oc contents)
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
 let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in
   let repo_root = Filename.concat scratch "repo" in
@@ -136,6 +145,45 @@ let test_resolve_masc_base_path_allows_test_opt_in () =
     (fun () ->
       check string "opt-in preserves inherited env" explicit
         (Room_utils.resolve_masc_base_path requested))
+
+let test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override ()
+    =
+  let scratch = Filename.temp_dir "room-utils-dual-roots" "" in
+  let requested = Filename.concat scratch "repo" in
+  let explicit = Filename.concat scratch "parent-root" in
+  Unix.mkdir requested 0o755;
+  Unix.mkdir explicit 0o755;
+  Unix.mkdir (Filename.concat requested ".masc") 0o755;
+  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      with_envs
+        [ ("MASC_BASE_PATH", Some explicit);
+          ("MASC_ALLOW_INHERITED_BASE_PATH", None);
+          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+        (fun () ->
+          check string "dual roots prefer requested path" requested
+            (Room_utils.resolve_masc_base_path requested)))
+
+let test_resolve_masc_base_path_allows_dual_root_opt_in () =
+  let scratch = Filename.temp_dir "room-utils-dual-opt-in" "" in
+  let requested = Filename.concat scratch "repo" in
+  let explicit = Filename.concat scratch "parent-root" in
+  Unix.mkdir requested 0o755;
+  Unix.mkdir explicit 0o755;
+  Unix.mkdir (Filename.concat requested ".masc") 0o755;
+  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      with_envs
+        [ ("MASC_BASE_PATH", Some explicit);
+          ("MASC_ALLOW_INHERITED_BASE_PATH", Some "true");
+          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+        (fun () ->
+          check string "opt-in preserves explicit dual-root env" explicit
+            (Room_utils.resolve_masc_base_path requested)))
 
 let test_default_config_syncs_test_base_path_env () =
   let requested =
@@ -561,6 +609,10 @@ let () =
         test_resolve_masc_base_path_keeps_matching_explicit_env;
       test_case "allows explicit opt-in to inherited env" `Quick
         test_resolve_masc_base_path_allows_test_opt_in;
+      test_case "ignores dual .masc roots by default" `Quick
+        test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override;
+      test_case "allows dual-root opt-in" `Quick
+        test_resolve_masc_base_path_allows_dual_root_opt_in;
       test_case "default config syncs test base env" `Quick
         test_default_config_syncs_test_base_path_env;
     ];

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -238,14 +238,17 @@ let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
       copy_script (script_path ()) script;
       make_fake_eio_exe dir;
       let stale_root = Filename.concat dir "stale-root" in
+      let home_dir = Filename.concat dir "empty-home" in
       mkdir_p (Filename.concat dir ".masc");
       mkdir_p (Filename.concat stale_root ".masc");
+      mkdir_p home_dir;
       let capture = Filename.concat dir "captured-sanitized.txt" in
       let code, stdout, stderr =
         run_shell ~cwd:dir
           ~env:
             [
               ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
               ("MASC_BASE_PATH", stale_root);
               ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
@@ -295,14 +298,17 @@ let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
       copy_script (script_path ()) script;
       make_fake_eio_exe dir;
       let inherited_root = Filename.concat dir "shared-root" in
+      let home_dir = Filename.concat dir "empty-home" in
       mkdir_p (Filename.concat dir ".masc");
       mkdir_p (Filename.concat inherited_root ".masc");
+      mkdir_p home_dir;
       let capture = Filename.concat dir "captured-opt-in.txt" in
       let code, stdout, stderr =
         run_shell ~cwd:dir
           ~env:
             [
               ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
               ("MASC_BASE_PATH", inherited_root);
               ("MASC_ALLOW_INHERITED_BASE_PATH", "1");
             ]

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -164,6 +164,7 @@ let test_realtime_transports_default_enabled_and_preserve_override () =
               ("FAKE_CAPTURE_FILE", capture_default);
               ("HOME", home_dir);
               ("MASC_BASE_PATH", dir);
+              ("MASC_CONFIG_DIR", "");
             ]
           (Printf.sprintf "%s --http --port 9956 --base-path %s"
              (quote script) (quote dir))
@@ -218,6 +219,7 @@ let test_realtime_transports_fall_back_to_repo_config_when_home_missing () =
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", Filename.concat dir "empty-home");
               ("MASC_BASE_PATH", dir);
+              ("MASC_CONFIG_DIR", "");
             ]
           (Printf.sprintf "%s --http --port 9959 --base-path %s"
              (quote script) (quote dir))
@@ -245,6 +247,7 @@ let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
             [
               ("FAKE_CAPTURE_FILE", capture);
               ("MASC_BASE_PATH", stale_root);
+              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
           (Printf.sprintf "%s --http --port 9960" (quote script))
       in
@@ -254,6 +257,63 @@ let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
       let captured = read_file capture in
       check bool "inherited base path corrected to script root" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ dir)))
+
+let test_parent_project_base_path_with_dual_masc_roots_is_sanitized () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let parent = Filename.concat dir "parent-root" in
+      let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
+      let home_dir = Filename.concat dir "empty-home" in
+      mkdir_p repo;
+      mkdir_p home_dir;
+      mkdir_p (Filename.concat parent ".masc");
+      mkdir_p (Filename.concat repo ".masc");
+      let script = Filename.concat repo "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe repo;
+      let capture = Filename.concat dir "captured-parent-sanitized.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
+              ("MASC_BASE_PATH", parent);
+              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
+            ]
+          (Printf.sprintf "%s --http --port 9963" (quote script))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "parent root inheritance corrected to repo root" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ repo)))
+
+let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe dir;
+      let inherited_root = Filename.concat dir "shared-root" in
+      mkdir_p (Filename.concat dir ".masc");
+      mkdir_p (Filename.concat inherited_root ".masc");
+      let capture = Filename.concat dir "captured-opt-in.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", inherited_root);
+              ("MASC_ALLOW_INHERITED_BASE_PATH", "1");
+            ]
+          (Printf.sprintf "%s --http --port 9964" (quote script))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "opt-in preserves inherited base path" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ inherited_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -305,7 +365,12 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
       let capture_default = Filename.concat dir "captured-loopback-default.txt" in
       let code_default, stdout_default, stderr_default =
         run_shell ~cwd:repo_root
-          ~env:[ ("FAKE_CAPTURE_FILE", capture_default); ("HOME", home_dir) ]
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture_default);
+              ("HOME", home_dir);
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "");
+            ]
           (Printf.sprintf "%s --port 9961 --base-path %s"
              (quote loopback_script) (quote repo_root))
       in
@@ -351,6 +416,10 @@ let () =
             test_realtime_transports_fall_back_to_repo_config_when_home_missing;
           test_case "inherited base path with dual .masc roots is sanitized" `Quick
             test_inherited_base_path_with_dual_masc_roots_is_sanitized;
+          test_case "parent project inherited base path is sanitized" `Quick
+            test_parent_project_base_path_with_dual_masc_roots_is_sanitized;
+          test_case "dual roots opt-in preserves inherited base path" `Quick
+            test_dual_masc_roots_opt_in_preserves_inherited_base_path;
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
           test_case


### PR DESCRIPTION
## Summary
- fix keeper detail so the allowlist loads from keeper config when the panel opens
- show `unassigned` instead of `not_collected` when an online keeper has no bound task
- block inherited `MASC_BASE_PATH` when both the inherited root and the current checkout have their own `.masc` trees
- preserve the inherited root only when `--base-path` is passed explicitly or `MASC_ALLOW_INHERITED_BASE_PATH=1` is set

## Root Cause
- the dashboard treated keeper config as authoritative for tool policy, but did not actually load that config when the detail panel opened
- the runtime and launcher both accepted inherited `MASC_BASE_PATH` values even when they pointed at a different `.masc` root than the active checkout, which let the server inspect stale state
- test coverage around inherited env defaults was also too sensitive to the caller shell environment

## Impact
- keeper detail now reports tool policy and current task state more accurately
- local server startup no longer silently binds to the wrong `.masc` root in dual-root setups such as `~/me` and `~/me/workspace/.../masc-mcp`
- the new opt-in keeps the old behavior available for intentional shared-root setups

## Validation
- `npx tsc --noEmit --pretty`
- `npm test -- src/components/keeper-detail-runtime.test.ts`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-exec-audit ./test/test_start_masc_mcp_script.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-exec-audit ./test/test_room_utils_coverage.exe`
