### PR TITLE
[codex] Align keeper tool policy defaults and runtime allowlist

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -250,7 +250,7 @@ let resolved_keeper_args_from_persona args :
                  let tool_preset =
                    match Option.bind defaults.tool_preset tool_preset_of_string with
                    | Some preset -> preset
-                   | None -> Full
+                   | None -> Research
                  in
                  let tool_also_allow =
                    match get_string_list args "tool_also_allow" with

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -29,10 +29,29 @@ let is_keeper_mcp_context_required name =
   || Tool_dispatch.is_mcp_context_required name
 
 let inject_masc_schemas (schemas : Types.tool_schema list) =
+  let supported_in_keeper name =
+    if Tool_dispatch.is_registered name then
+      true
+    else if not (Tool_dispatch.is_tag_registry_initialized ()) then
+      true
+    else
+      match Tool_dispatch.lookup_tag name with
+      | Some Tool_dispatch.Mod_inline
+      | Some Tool_dispatch.Mod_encryption
+      | Some Tool_dispatch.Mod_rate_limit
+      | Some Tool_dispatch.Mod_compact
+      | Some Tool_dispatch.Mod_keeper
+      | Some Tool_dispatch.Mod_operator
+      | Some Tool_dispatch.Mod_control ->
+          false
+      | Some _ -> true
+      | None -> false
+  in
   masc_schemas_ref :=
     List.filter (fun (s : Types.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name
       && not (is_keeper_mcp_context_required s.name)
+      && supported_in_keeper s.name
       && not (is_keeper_denied s.name))
       schemas
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -93,7 +93,7 @@ let keeper_coding_masc_tool_names =
 (* ── Layer 0: Core tools (always executable, always visible) ───── *)
 
 (** Tools that bypass policy restrictions.  A keeper with Minimal
-    preset still needs masc_status/broadcast/heartbeat to function.
+    preset still needs masc_status/heartbeat/help to function.
     These are the survival-critical tools. *)
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -40,6 +40,7 @@
    (re_export masc_mcp.prompt_registry)
    (re_export masc_mcp.response)
    (re_export masc_mcp.team_session_types)
+   (re_export masc_mcp.tool_schemas)
    (re_export masc_process)
    (re_export masc_room)
    (re_export masc_types)

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -1,3 +1,7 @@
 (* Shared dependency re-export for MASC test suite.
-   This module contains no code — it exists to centralise the library
-   dependency list so individual test stanzas in dune do not repeat it. *)
+   Also hosts tiny test helpers that need a single SSOT across files. *)
+
+let init_keeper_tool_registry () =
+  if not (Masc_mcp.Tool_dispatch.is_tag_registry_initialized ()) then
+    let _ = Masc_mcp.Mcp_server_eio.governance_defaults in
+    ()

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -3,13 +3,15 @@
 module KET = Masc_mcp.Keeper_exec_tools
 
 let init_keeper_tool_registry () =
-  let open Masc_mcp in
-  Tool_dispatch.register_module_tag
-    ~schemas:Tool_schemas_inline.schemas
-    ~tag:Tool_dispatch.Mod_inline;
-  Tool_tag_init.register_all ();
-  Tool_board.register ();
-  Tool_dispatch.mark_tag_registry_initialized ()
+  if not Masc_mcp.Tool_dispatch.(is_tag_registry_initialized ()) then begin
+    let open Masc_mcp in
+    Tool_dispatch.register_module_tag
+      ~schemas:Tool_schemas_inline.schemas
+      ~tag:Tool_dispatch.Mod_inline;
+    Tool_tag_init.register_all ();
+    Tool_board.register ();
+    Tool_dispatch.mark_tag_registry_initialized ()
+  end
 
 let prime_keeper_bridge () =
   init_keeper_tool_registry ();

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -3,15 +3,7 @@
 module KET = Masc_mcp.Keeper_exec_tools
 
 let init_keeper_tool_registry () =
-  if not Masc_mcp.Tool_dispatch.(is_tag_registry_initialized ()) then begin
-    let open Masc_mcp in
-    Tool_dispatch.register_module_tag
-      ~schemas:Tool_schemas_inline.schemas
-      ~tag:Tool_dispatch.Mod_inline;
-    Tool_tag_init.register_all ();
-    Tool_board.register ();
-    Tool_dispatch.mark_tag_registry_initialized ()
-  end
+  Masc_test_deps.init_keeper_tool_registry ()
 
 let prime_keeper_bridge () =
   init_keeper_tool_registry ();

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -2,9 +2,20 @@
 
 module KET = Masc_mcp.Keeper_exec_tools
 
+let init_keeper_tool_registry () =
+  let open Masc_mcp in
+  Tool_dispatch.register_module_tag
+    ~schemas:Tool_schemas_inline.schemas
+    ~tag:Tool_dispatch.Mod_inline;
+  Tool_tag_init.register_all ();
+  Tool_board.register ();
+  Tool_dispatch.mark_tag_registry_initialized ()
+
 let prime_keeper_bridge () =
+  init_keeper_tool_registry ();
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
+
 
 let make_meta ?tool_access ?(tool_denylist = []) () =
   let tool_access =
@@ -34,6 +45,7 @@ let allowed_names_of_json json =
   | Error e -> failwith e
 
 let test_inject_stores_filtered_masc () =
+  init_keeper_tool_registry ();
   let schemas : Types.tool_schema list =
     [
       { name = "masc_status"; description = ""; input_schema = `Assoc [] };
@@ -72,7 +84,9 @@ let test_full_preset_exposes_masc () =
   Alcotest.(check bool) "no masc_governance_status" false
     (List.mem "masc_governance_status" names);
   Alcotest.(check bool) "has masc_autoresearch_cycle" true
-    (List.mem "masc_autoresearch_cycle" names)
+    (List.mem "masc_autoresearch_cycle" names);
+  Alcotest.(check bool) "filters unsupported inline tool" false
+    (List.mem "masc_who" names)
 
 let test_messaging_preset_exposes_board () =
   prime_keeper_bridge ();
@@ -154,6 +168,22 @@ let test_preset_with_also_allow_opens_extra_tool () =
     (List.mem "masc_tasks" names);
   Alcotest.(check bool) "minimal omits board post" false
     (List.mem "keeper_board_post" names)
+
+let test_custom_keeps_registered_inline_board_tool () =
+  init_keeper_tool_registry ();
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  let meta =
+    make_meta
+      ~tool_access:
+        (Masc_mcp.Keeper_types.Custom
+           [ "masc_board_post"; "masc_who" ])
+      ()
+  in
+  let names = KET.keeper_masc_tool_names meta in
+  Alcotest.(check bool) "keeps board handler tool" true
+    (List.mem "masc_board_post" names);
+  Alcotest.(check bool) "drops unsupported inline tool" false
+    (List.mem "masc_who" names)
 
 let test_tool_access_missing_migrates_legacy_standard_policy () =
   let names =
@@ -533,6 +563,8 @@ let () =
             test_messaging_preset_exposes_board;
           Alcotest.test_case "preset also_allow opens extra tool" `Quick
             test_preset_with_also_allow_opens_extra_tool;
+          Alcotest.test_case "custom keeps registered inline board tool" `Quick
+            test_custom_keeps_registered_inline_board_tool;
         ] );
       ( "custom_policy",
         [

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -454,6 +454,30 @@ let test_persona_profile_ignores_invalid_soul_profile () =
   let defaults = KTP.load_keeper_profile_defaults_from_persona "probe" in
   check (option string) "invalid soul_profile dropped" None defaults.soul_profile
 
+let test_persona_resolver_defaults_to_research_tool_preset () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper"
+  }
+}
+|};
+  match
+    Masc_mcp.Keeper_exec_persona.resolved_keeper_args_from_persona
+      (`Assoc [ ("persona_name", `String "probe") ])
+  with
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      let tool_preset = Yojson.Safe.Util.member "tool_preset" resolved in
+      check string "persona default tool_preset" "research"
+        (Yojson.Safe.Util.to_string tool_preset)
+
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -504,5 +528,7 @@ let () =
             test_persona_profile_canonicalizes_soul_profile;
           test_case "persona profile ignores invalid soul_profile" `Quick
             test_persona_profile_ignores_invalid_soul_profile;
+          test_case "persona resolver defaults to research tool_preset" `Quick
+            test_persona_resolver_defaults_to_research_tool_preset;
         ] );
     ]

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -8,14 +8,7 @@ open Alcotest
 open Masc_mcp
 
 let init_keeper_tool_registry () =
-  if not Tool_dispatch.is_tag_registry_initialized () then begin
-    Tool_dispatch.register_module_tag
-      ~schemas:Tool_schemas_inline.schemas
-      ~tag:Tool_dispatch.Mod_inline;
-    Tool_tag_init.register_all ();
-    Tool_board.register ();
-    Tool_dispatch.mark_tag_registry_initialized ()
-  end
+  Masc_test_deps.init_keeper_tool_registry ()
 
 (* ================================================================ *)
 (* Selector basics                                                   *)

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -7,6 +7,14 @@
 open Alcotest
 open Masc_mcp
 
+let init_keeper_tool_registry () =
+  Tool_dispatch.register_module_tag
+    ~schemas:Tool_schemas_inline.schemas
+    ~tag:Tool_dispatch.Mod_inline;
+  Tool_tag_init.register_all ();
+  Tool_board.register ();
+  Tool_dispatch.mark_tag_registry_initialized ()
+
 (* ================================================================ *)
 (* Selector basics                                                   *)
 (* ================================================================ *)
@@ -475,9 +483,12 @@ let make_gate_test_meta ?(name = "test-gate") () : Keeper_types.keeper_meta =
   | Error e -> failwith (Printf.sprintf "make_gate_test_meta failed: %s" e)
 
 let test_core_tools_are_core () =
+  init_keeper_tool_registry ();
   let core = Keeper_exec_tools.core_always_tools in
   check bool "masc_status is core" true
     (List.mem "masc_status" core);
+  check bool "masc_broadcast is not core" false
+    (List.mem "masc_broadcast" core);
   check bool "masc_heartbeat is core" true
     (List.mem "masc_heartbeat" core);
   check bool "masc_tool_help is core" true
@@ -490,6 +501,7 @@ let test_core_tools_are_core () =
     (Keeper_exec_tools.is_core_always_tool "keeper_bash")
 
 let test_universe_superset_of_policy () =
+  init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
     tool_access = Preset { preset = Minimal; also_allow = [] };
@@ -505,6 +517,7 @@ let test_universe_superset_of_policy () =
     (List.length universe >= List.length policy)
 
 let test_minimal_preset_includes_core_masc () =
+  init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-minimal" () in
   let meta = { base with
     tool_access = Preset { preset = Minimal; also_allow = [] };
@@ -525,6 +538,7 @@ let test_minimal_preset_includes_core_masc () =
 (* ================================================================ *)
 
 let test_preset_universe_subset_of_global () =
+  init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
     tool_access = Preset { preset = Coding; also_allow = [] };
@@ -540,6 +554,7 @@ let test_preset_universe_subset_of_global () =
     (List.length scoped < List.length global)
 
 let test_preset_universe_includes_core () =
+  init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-scoped" () in
   let meta = { base with
     tool_access = Preset { preset = Minimal; also_allow = [] };
@@ -556,6 +571,7 @@ let test_preset_universe_includes_core () =
     (List.mem "masc_broadcast" scoped)
 
 let test_preset_universe_sizes () =
+  init_keeper_tool_registry ();
   let make preset =
     let base = make_gate_test_meta () in
     { base with
@@ -578,6 +594,7 @@ let test_preset_universe_sizes () =
     true (coding_size <= full_size)
 
 let test_preset_universe_superset_of_policy () =
+  init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
     tool_access = Preset { preset = Coding; also_allow = [] };
@@ -589,6 +606,20 @@ let test_preset_universe_superset_of_policy () =
     List.filter (fun name -> not (List.mem name scoped)) policy
   in
   check (list string) "all policy tools in preset universe" [] missing
+
+let test_registered_inline_board_tool_survives_filter () =
+  init_keeper_tool_registry ();
+  Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
+  let base = make_gate_test_meta ~name:"test-board-inline" () in
+  let meta = { base with
+    tool_access = Custom [ "masc_board_post"; "masc_who" ];
+    tool_denylist = [];
+  } in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "board handler tool survives" true
+    (List.mem "masc_board_post" allowed);
+  check bool "unsupported inline tool removed" false
+    (List.mem "masc_who" allowed)
 
 (* ================================================================ *)
 (* Runner                                                            *)
@@ -729,6 +760,8 @@ let () =
             test_universe_superset_of_policy;
           test_case "minimal preset includes core masc" `Quick
             test_minimal_preset_includes_core_masc;
+          test_case "registered inline board tool survives filter" `Quick
+            test_registered_inline_board_tool_survives_filter;
         ] );
       (* ======================================================== *)
       (* Preset-scoped universe (#4637)                            *)

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -8,12 +8,14 @@ open Alcotest
 open Masc_mcp
 
 let init_keeper_tool_registry () =
-  Tool_dispatch.register_module_tag
-    ~schemas:Tool_schemas_inline.schemas
-    ~tag:Tool_dispatch.Mod_inline;
-  Tool_tag_init.register_all ();
-  Tool_board.register ();
-  Tool_dispatch.mark_tag_registry_initialized ()
+  if not Tool_dispatch.is_tag_registry_initialized () then begin
+    Tool_dispatch.register_module_tag
+      ~schemas:Tool_schemas_inline.schemas
+      ~tag:Tool_dispatch.Mod_inline;
+    Tool_tag_init.register_all ();
+    Tool_board.register ();
+    Tool_dispatch.mark_tag_registry_initialized ()
+  end
 
 (* ================================================================ *)
 (* Selector basics                                                   *)


### PR DESCRIPTION
## Summary
- align persona-backed keeper creation with the standard `masc_keeper_up` default by using the `research` preset instead of silently falling back to `full`
- exclude `masc_*` tools that are not actually callable from keeper context from the injected allowlist candidates while preserving registered board handlers
- add regression coverage for empty custom allowlists, supported inline board tools, persona default resolution, and repeated test-side registry initialization

## Root Cause
- keeper creation had diverged: `masc_keeper_up` defaulted to `research`, but `masc_keeper_create_from_persona` still defaulted to `full`, which inflated keeper allowlists unexpectedly
- the keeper bridge injected `masc_*` schemas without checking whether the tool was actually dispatchable in keeper context, so tools like `masc_who` could appear in the effective allowlist and then fail at runtime with MCP session context errors

## Product impact
- persona-created keepers no longer get a broad tool policy unless the preset is explicitly requested
- keepers stop advertising unsupported inline/operator/session-context tools in their effective allowlist
- `Custom []` semantics remain unchanged: no tools are allowed

## Evidence
- runtime symptom observed from keeper logs: oversized allowlists (`226 tools > max 40`) followed by unsupported tool failures such as `tool 'masc_who' requires MCP session context (not available in keeper)`
- code path alignment:
  - `masc_keeper_up` already defaulted to `research`
  - persona-backed keeper creation still defaulted to `full`
- local validation:
  - `./_build/default/test/test_keeper_masc_bridge.exe`
  - `./_build/default/test/test_tool_access_policy.exe`
  - `./_build/default/test/test_keeper_toml.exe`

## Review evidence
- External review: GLM-5.1 via `sb glm-text` on 2026-04-02 18:56:14 KST
- Review evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4674#issuecomment-4176066937
- Follow-up patch applied from review: guarded repeated test-side tool registry initialization to avoid double-registration risk

## Linked issue
- Refs #4678
