### PR TITLE
[codex] filter MCP-runtime-only tools from keeper surface

### DIFF
--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -1,6 +1,8 @@
 # Keeper Capability Matrix
 
-All keepers receive the full tool surface unconditionally.
+Keepers do not receive the full public MCP surface.
+They get keeper-native tools plus `masc_*` tools that are executable without
+MCP runtime/session context.
 Triage and trigger detection run on each heartbeat using the proactive idle/cooldown settings.
 
 Research profile (`soul_profile = "research"`) adds autoresearch/research tools.
@@ -30,6 +32,11 @@ Notes:
 All keepers receive: base + board + fs + shell + library + taskboard + governance + coding shards.
 Voice tools are added when `policy_voice_enabled = true`.
 `write_done = true` returns empty tool list (session terminated).
+
+Excluded from keeper exposure:
+- inline MCP-runtime tools such as `masc_start`, `masc_join`, `masc_leave`,
+  `masc_broadcast`, `masc_messages`, `masc_listen`, and `masc_who`
+- other tools that depend on MCP runtime-only context rather than keeper context
 
 ## Continuity Positioning
 

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -25,7 +25,7 @@ val keeper_preset_universe_tool_names : keeper_meta -> string list
 val keeper_preset_universe_model_tools : keeper_meta -> Types.tool_schema list
 
 (** Core tools that are always executable and visible regardless of preset.
-    E.g. masc_status, masc_broadcast, masc_heartbeat, extend_turns. *)
+    E.g. masc_status, masc_heartbeat, masc_tool_help, extend_turns. *)
 val core_always_tools : string list
 
 (** [is_core_always_tool name] — true if [name] bypasses policy restrictions. *)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -20,10 +20,19 @@ let is_keeper_denied (name : string) : bool =
 
 (* ── Schema injection filter ──────────────────────────────────── *)
 
+let keeper_mcp_context_required_tools =
+  Tool_schemas_inline.schemas
+  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+
+let is_keeper_mcp_context_required name =
+  List.mem name keeper_mcp_context_required_tools
+  || Tool_dispatch.is_mcp_context_required name
+
 let inject_masc_schemas (schemas : Types.tool_schema list) =
   masc_schemas_ref :=
     List.filter (fun (s : Types.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name
+      && not (is_keeper_mcp_context_required s.name)
       && not (is_keeper_denied s.name))
       schemas
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -68,11 +68,6 @@ let keeper_library_tool_names = [ "keeper_library_search"; "keeper_library_read"
 let keeper_core_masc_tool_names =
   [
     "masc_status";
-    "masc_messages";
-    "masc_broadcast";
-    "masc_join";
-    "masc_leave";
-    "masc_who";
     "masc_heartbeat";
     "masc_tasks";
     "masc_claim_next";
@@ -102,8 +97,7 @@ let keeper_coding_masc_tool_names =
     These are the survival-critical tools. *)
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";
-    "masc_status"; "masc_broadcast"; "masc_heartbeat";
-    "masc_messages"; "masc_who"; "masc_tool_help";
+    "masc_status"; "masc_heartbeat"; "masc_tool_help";
     "extend_turns" ]
 
 let core_always_set : (string, unit) Hashtbl.t =

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -82,8 +82,13 @@ let requires_join_tools_inline =
   ["masc_broadcast"; "masc_listen"; "masc_leave";
    "masc_vote_cast"; "masc_vote_revoke"]
 
+let mcp_context_required_tools_inline =
+  Tool_schemas_inline.schemas
+  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+
 let () = Tool_dispatch.init_read_only_set read_only_tools_inline
 let () = Tool_dispatch.init_requires_join_set requires_join_tools_inline
+let () = Tool_dispatch.init_mcp_context_required_set mcp_context_required_tools_inline
 
 (* Tag registry initialization.
    Most modules register via Tool_spec.register at module load time.

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -129,10 +129,11 @@ let registered_count () = Hashtbl.length registry
 (** Check whether a tool name is registered. *)
 let is_registered name = Hashtbl.mem registry name
 
-(** --- Hashtbl sets for read_only and requires_join checks --- *)
+(** --- Hashtbl sets for dispatch capability checks --- *)
 
 let read_only_set : (string, unit) Hashtbl.t = Hashtbl.create 32
 let requires_join_set : (string, unit) Hashtbl.t = Hashtbl.create 64
+let mcp_context_required_set : (string, unit) Hashtbl.t = Hashtbl.create 64
 
 let init_read_only_set (names : string list) =
   with_dispatch_rw (fun () ->
@@ -142,8 +143,14 @@ let init_requires_join_set (names : string list) =
   with_dispatch_rw (fun () ->
     List.iter (fun name -> Hashtbl.replace requires_join_set name ()) names)
 
+let init_mcp_context_required_set (names : string list) =
+  with_dispatch_rw (fun () ->
+    List.iter (fun name -> Hashtbl.replace mcp_context_required_set name ()) names)
+
 let is_read_only name = with_dispatch_ro (fun () -> Hashtbl.mem read_only_set name)
 let is_join_required name = with_dispatch_ro (fun () -> Hashtbl.mem requires_join_set name)
+let is_mcp_context_required name =
+  with_dispatch_ro (fun () -> Hashtbl.mem mcp_context_required_set name)
 
 (** {2 Module Tag Dispatch — O(1) two-level dispatch}
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -74,8 +74,10 @@ val is_registered : string -> bool
 
 val init_read_only_set : string list -> unit
 val init_requires_join_set : string list -> unit
+val init_mcp_context_required_set : string list -> unit
 val is_read_only : string -> bool
 val is_join_required : string -> bool
+val is_mcp_context_required : string -> bool
 
 (** {2 Module Tag Dispatch - O(1) two-level dispatch}
 

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -2,6 +2,10 @@
 
 module KET = Masc_mcp.Keeper_exec_tools
 
+let prime_keeper_bridge () =
+  ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
+
 let make_meta ?tool_access ?(tool_denylist = []) () =
   let tool_access =
     match tool_access with
@@ -24,7 +28,7 @@ let make_meta ?tool_access ?(tool_denylist = []) () =
   | Error e -> failwith e
 
 let allowed_names_of_json json =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   match Masc_mcp.Keeper_types.meta_of_json json with
   | Ok meta -> KET.keeper_allowed_tool_names meta
   | Error e -> failwith e
@@ -38,6 +42,7 @@ let test_inject_stores_filtered_masc () =
       { name = "keeper_time_now"; description = ""; input_schema = `Assoc [] };
     ]
   in
+  ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
   KET.inject_masc_schemas schemas;
   let meta =
     make_meta
@@ -47,12 +52,19 @@ let test_inject_stores_filtered_masc () =
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "3 masc tools" 3 (List.length names);
+  Alcotest.(check int) "only keeper-compatible masc tools remain" 1
+    (List.length names);
+  Alcotest.(check bool) "keeps masc_status" true
+    (List.mem "masc_status" names);
+  Alcotest.(check bool) "filters masc_broadcast" false
+    (List.mem "masc_broadcast" names);
+  Alcotest.(check bool) "filters masc_messages" false
+    (List.mem "masc_messages" names);
   Alcotest.(check bool) "no keeper_time_now" false
     (List.mem "keeper_time_now" names)
 
 let test_full_preset_exposes_masc () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
@@ -63,7 +75,7 @@ let test_full_preset_exposes_masc () =
     (List.mem "masc_autoresearch_cycle" names)
 
 let test_messaging_preset_exposes_board () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
@@ -81,40 +93,42 @@ let test_messaging_preset_exposes_board () =
     (List.mem "keeper_shell_readonly" names)
 
 let test_custom_opens_specific_tools_only () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
-           [ "masc_status"; "masc_broadcast"; "masc_join" ])
+           [ "masc_status"; "masc_tasks"; "masc_join" ])
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "3 allowed" 3 (List.length names);
+  Alcotest.(check int) "only keeper-compatible tools allowed" 2
+    (List.length names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
-  Alcotest.(check bool) "has masc_broadcast" true
-    (List.mem "masc_broadcast" names);
-  Alcotest.(check bool) "has masc_join" true (List.mem "masc_join" names);
+  Alcotest.(check bool) "has masc_tasks" true
+    (List.mem "masc_tasks" names);
+  Alcotest.(check bool) "filters masc_join" false
+    (List.mem "masc_join" names);
   Alcotest.(check bool) "no masc_board_post" false
     (List.mem "masc_board_post" names)
 
 let test_deny_overrides_allow () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
-           [ "masc_status"; "masc_broadcast"; "masc_join" ])
-      ~tool_denylist:[ "masc_broadcast" ] ()
+           [ "masc_status"; "masc_tasks"; "masc_join" ])
+      ~tool_denylist:[ "masc_tasks" ] ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "2 after deny" 2 (List.length names);
+  Alcotest.(check int) "1 after deny" 1 (List.length names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
-  Alcotest.(check bool) "no masc_broadcast (denied)" false
-    (List.mem "masc_broadcast" names)
+  Alcotest.(check bool) "no masc_tasks (denied)" false
+    (List.mem "masc_tasks" names)
 
 let test_custom_empty_blocks_all () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta ~tool_access:(Masc_mcp.Keeper_types.Custom []) ()
   in
@@ -122,22 +136,22 @@ let test_custom_empty_blocks_all () =
   Alcotest.(check int) "no tools" 0 (List.length names)
 
 let test_preset_with_also_allow_opens_extra_tool () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Preset
            {
              preset = Masc_mcp.Keeper_types.Minimal;
-             also_allow = [ "masc_broadcast" ];
+             also_allow = [ "masc_tasks" ];
            })
       ()
   in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check bool) "minimal keeps base tool" true
     (List.mem "keeper_time_now" names);
-  Alcotest.(check bool) "also_allow adds broadcast" true
-    (List.mem "masc_broadcast" names);
+  Alcotest.(check bool) "also_allow adds tasks" true
+    (List.mem "masc_tasks" names);
   Alcotest.(check bool) "minimal omits board post" false
     (List.mem "keeper_board_post" names)
 
@@ -421,18 +435,18 @@ let test_tool_access_invalid_tool_member_rejected () =
         e
 
 let test_allowlist_gates_shard_tools () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
-           [ "masc_status"; "masc_broadcast" ])
+           [ "masc_status"; "masc_tasks" ])
       ()
   in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
-  Alcotest.(check bool) "has masc_broadcast" true
-    (List.mem "masc_broadcast" names);
+  Alcotest.(check bool) "has masc_tasks" true
+    (List.mem "masc_tasks" names);
   Alcotest.(check bool) "masc_autoresearch_cycle blocked by custom policy" false
     (List.mem "masc_autoresearch_cycle" names)
 
@@ -443,12 +457,12 @@ let test_dispatch_unregistered () =
   Alcotest.(check bool) "unregistered mint_token returns Error" true (Result.is_error result)
 
 let test_schemas_match_names () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
-           [ "masc_status"; "masc_join"; "masc_broadcast" ])
+           [ "masc_status"; "masc_join"; "masc_tasks" ])
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
@@ -462,7 +476,7 @@ let test_schemas_match_names () =
     schemas
 
 let test_denied_tools_excluded_from_injection () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
   let denied =
@@ -486,7 +500,7 @@ let test_is_keeper_denied () =
     (KET.is_keeper_denied "keeper_time_now")
 
 let test_denied_excluded_from_allowed_names () =
-  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  prime_keeper_bridge ();
   let meta = make_meta () in
   let names = KET.keeper_allowed_tool_names meta in
   let denied =

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -478,10 +478,10 @@ let test_core_tools_are_core () =
   let core = Keeper_exec_tools.core_always_tools in
   check bool "masc_status is core" true
     (List.mem "masc_status" core);
-  check bool "masc_broadcast is core" true
-    (List.mem "masc_broadcast" core);
   check bool "masc_heartbeat is core" true
     (List.mem "masc_heartbeat" core);
+  check bool "masc_tool_help is core" true
+    (List.mem "masc_tool_help" core);
   check bool "extend_turns is core" true
     (List.mem "extend_turns" core);
   check bool "is_core_always_tool masc_status" true
@@ -513,10 +513,12 @@ let test_minimal_preset_includes_core_masc () =
   let universe = Keeper_exec_tools.keeper_universe_tool_names meta in
   check bool "masc_status in universe" true
     (List.mem "masc_status" universe);
-  check bool "masc_broadcast in universe" true
-    (List.mem "masc_broadcast" universe);
   check bool "masc_heartbeat in universe" true
-    (List.mem "masc_heartbeat" universe)
+    (List.mem "masc_heartbeat" universe);
+  check bool "masc_tool_help in universe" true
+    (List.mem "masc_tool_help" universe);
+  check bool "masc_broadcast excluded from universe" false
+    (List.mem "masc_broadcast" universe)
 
 (* ================================================================ *)
 (* Preset-scoped universe (#4637)                                    *)
@@ -546,10 +548,12 @@ let test_preset_universe_includes_core () =
   let scoped = Keeper_exec_tools.keeper_preset_universe_tool_names meta in
   check bool "masc_status in scoped" true
     (List.mem "masc_status" scoped);
-  check bool "masc_broadcast in scoped" true
-    (List.mem "masc_broadcast" scoped);
   check bool "masc_heartbeat in scoped" true
-    (List.mem "masc_heartbeat" scoped)
+    (List.mem "masc_heartbeat" scoped);
+  check bool "masc_tool_help in scoped" true
+    (List.mem "masc_tool_help" scoped);
+  check bool "masc_broadcast excluded from scoped" false
+    (List.mem "masc_broadcast" scoped)
 
 let test_preset_universe_sizes () =
   let make preset =

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -134,6 +134,21 @@ let () =
               check bool "masc_worktree_list not join_required" false
                 (Tool_dispatch.is_join_required "masc_worktree_list"));
         ] );
+      ( "mcp_context_required_set",
+        [
+          test_case "inline tools can be marked as requiring mcp context" `Quick (fun () ->
+              Tool_dispatch.init_mcp_context_required_set
+                [ "masc_join"; "masc_messages" ];
+              check bool "masc_join" true
+                (Tool_dispatch.is_mcp_context_required "masc_join");
+              check bool "masc_messages" true
+                (Tool_dispatch.is_mcp_context_required "masc_messages"));
+          test_case "non-inline tool returns false" `Quick (fun () ->
+              check bool "masc_status" false
+                (Tool_dispatch.is_mcp_context_required "masc_status");
+              check bool "masc_board_list" false
+                (Tool_dispatch.is_mcp_context_required "masc_board_list"));
+        ] );
       ( "handler_receives_args",
         [
           test_case "args are passed through" `Quick (fun () ->


### PR DESCRIPTION
## Summary
Keeper tool exposure and keeper execution were using different rules. Public inline `masc_*` tools such as `masc_messages` could be surfaced to keepers even though keeper dispatch rejects those tools without MCP session context.

This change adds a keeper-side runtime capability flag for MCP-session-dependent inline tools, filters keeper `masc_*` schema injection so MCP-runtime-only tools are not exposed to keepers, removes inline communication tools from keeper core/core-always exposure, and updates the keeper capability docs and tests to match the actual execution contract.

## Product impact
- keepers no longer attempt MCP-session-only inline tools such as `masc_join`, `masc_leave`, `masc_broadcast`, `masc_messages`, `masc_listen`, and `masc_who`
- keeper tool disclosure is closer to the actually executable surface, so the overflow guard should trigger less often
- keeper capability docs now describe the real contract instead of the old full-surface assumption

## Evidence
- Root cause: keeper schema injection accepted public `masc_*` tools without checking whether they require MCP runtime/session state
- User-visible symptom: repeated keeper errors like `tool 'masc_messages' requires MCP session context (not available in keeper)`
- Local validation:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-mcp-context`
  - `./_build/default/test/test_tool_dispatch.exe`
  - `./_build/default/test/test_tool_access_policy.exe`
  - `./_build/default/test/test_keeper_masc_bridge.exe`

## Review evidence
- Cross-model review: `GLM-5.1` via `sb glm-text`
- Scope: HEAD patch for this PR
- Result: `No findings.`
- Evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4675#issuecomment-4176058210

## Linked issue
Closes #4677
