### PR TITLE
[codex] Add cascade attempt observability

### DIFF
--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -147,6 +147,7 @@ type run_result = {
   session_id : string;
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
+  cascade_observation : cascade_observation option;
 }
 ```
 
@@ -159,6 +160,12 @@ type run_result = {
 3. 첫 번째 available provider를 primary로 Agent 구성
 4. OAS `named_cascade`가 내부적으로 fallback 처리
 5. `accept` 콜백으로 응답 유효성 검증
+
+관측 경계:
+- MASC는 configured labels, resolved candidate models, 최종 selected model은 관측 가능
+- `Llm_provider.Metrics` callback을 통해 actual request attempt와 cascade fallback event는 관측 가능하다
+- `raw_trace`에는 아직 provider attempt record가 없으므로 raw-trace만으로는 opaque 하다
+- 따라서 attempt details source는 `oas_metrics_callbacks` 또는 `no_oas_observation`처럼 경계를 명시한다
 
 Hardcoded fallback (cascade.json 없을 때):
 - `llama:{MASC_DEFAULT_MODEL}` (로컬)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -25,6 +25,7 @@ type turn_prompt = {
 type run_result = {
   response_text : string;
   model_used : string;
+  cascade_observation : Oas_worker.cascade_observation option;
   turn_count : int;
   tool_calls_made : int;
   usage : Agent_sdk.Types.api_usage;
@@ -800,6 +801,7 @@ let run_turn
          Ok {
            response_text;
            model_used = model;
+           cascade_observation = result.cascade_observation;
            turn_count = result.turns;
            tool_calls_made = List.length tool_names;
            usage;

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -86,6 +86,18 @@ let handle_keeper_status ctx args : tool_result =
          let trace_history_count = List.length m.runtime.trace_history in
          let active_model = active_model_of_meta m in
          let next_model_hint = next_model_hint_of_meta m in
+         let runtime_cascade_metrics =
+           match Oas_worker.cascade_metrics_json () with
+           | `List entries ->
+               entries
+               |> List.find_opt (function
+                    | `Assoc fields ->
+                        List.assoc_opt "cascade_name" fields
+                        = Some (`String m.cascade_name)
+                    | _ -> false)
+               |> Option.value ~default:`Null
+           | _ -> `Null
+         in
          let last_compaction_saved_tokens =
            max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
          in
@@ -442,6 +454,7 @@ let handle_keeper_status ctx args : tool_result =
            ("last_proactive_ago_s", `Float last_proactive_ago_s);
            ("active_model", `String active_model);
            ("next_model_hint", Json_util.string_opt_to_json next_model_hint);
+           ("runtime_cascade_metrics", runtime_cascade_metrics);
            ("trace_history_count", `Int trace_history_count);
            ("handoff_count_total", `Int trace_history_count);
            ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -363,6 +363,27 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
     else "noop"
   in
   let metrics_store = keeper_metrics_store config meta.name in
+  let cascade_json =
+    match result.cascade_observation with
+    | Some obs -> Oas_worker.cascade_observation_to_json obs
+    | None ->
+        `Assoc
+          [
+            ("cascade_name", `String meta.cascade_name);
+            ("configured_labels", `List []);
+            ("candidate_models", `List []);
+            ("primary_model", `Null);
+            ("selected_model", `String result.model_used);
+            ("selected_model_raw", `String result.model_used);
+            ("selected_index", `Null);
+            ("fallback_hops", `Null);
+            ("fallback_applied", `Bool false);
+            ("attempts", `List []);
+            ("fallback_events", `List []);
+            ("attempt_details_available", `Bool false);
+            ("attempt_details_source", `String "no_oas_observation");
+          ]
+  in
   let snapshot =
     `Assoc
       [
@@ -374,6 +395,7 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("trace_id", `String meta.runtime.trace_id);
         ("generation", `Int turn_generation);
         ("model_used", `String result.model_used);
+        ("cascade", cascade_json);
         ( "usage",
           `Assoc
             [

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -26,28 +26,398 @@ let default_max_tokens = 4096
 (* Cascade metrics                                                   *)
 (* ================================================================ *)
 
+type cascade_observation = {
+  cascade_name : string;
+  configured_labels : string list;
+  candidate_models : string list;
+  primary_model : string option;
+  selected_model : string option;
+  selected_model_raw : string option;
+  selected_index : int option;
+  fallback_hops : int option;
+  fallback_applied : bool;
+  attempts : cascade_attempt list;
+  fallback_events : cascade_fallback_event list;
+  attempt_details_available : bool;
+  attempt_details_source : string;
+}
+
+and cascade_attempt = {
+  attempt_index : int;
+  model_id : string;
+  model_label : string option;
+  latency_ms : int option;
+  error : string option;
+}
+
+and cascade_fallback_event = {
+  from_model_id : string;
+  from_model_label : string option;
+  to_model_id : string;
+  to_model_label : string option;
+  reason : string;
+}
+
 type cascade_counter = {
   mutable calls : int;
   mutable successes : int;
   mutable failures : int;
   mutable rejected : int;
+  mutable fallback_calls : int;
+  mutable total_attempts : int;
+  mutable total_fallback_events : int;
+  mutable last_selected_model : string option;
+  mutable last_selected_index : int option;
+  mutable last_candidate_models : string list;
+  mutable last_attempts : cascade_attempt list;
+  mutable last_fallback_events : cascade_fallback_event list;
+  mutable last_attempt_details_available : bool;
+  mutable last_attempt_details_source : string option;
+  selected_models : (string, int) Hashtbl.t;
+  attempted_models : (string, int) Hashtbl.t;
+  errored_models : (string, int) Hashtbl.t;
 }
 
 let cascade_counters : (string, cascade_counter) Hashtbl.t = Hashtbl.create 8
 let cascade_max_keys = 256
 
-let record_cascade ~cascade_name ~outcome =
+let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
+  match cfg.kind with
+  | Llm_provider.Provider_config.Anthropic -> "claude"
+  | Llm_provider.Provider_config.OpenAI_compat -> "openai"
+  | Llm_provider.Provider_config.Gemini -> "gemini"
+  | Llm_provider.Provider_config.Glm -> "glm"
+  | Llm_provider.Provider_config.Claude_code -> "claude_code"
+
+let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf "%s:%s" (provider_name_of_config cfg) cfg.model_id
+
+let model_label_option_of_model_id
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    (model_id : string) =
+  let matches =
+    candidate_cfgs
+    |> List.filter (fun (cfg : Llm_provider.Provider_config.t) ->
+           String.equal cfg.model_id model_id)
+    |> List.map model_label_of_config
+    |> List.sort_uniq String.compare
+  in
+  match matches with
+  | [ label ] -> Some label
+  | _ -> None
+
+let strip_latest_suffix s =
+  let trimmed = String.trim s in
+  if String.length trimmed > 7
+     && String.sub trimmed (String.length trimmed - 7) 7 = ":latest"
+  then String.sub trimmed 0 (String.length trimmed - 7)
+  else trimmed
+
+let selected_index_of_model ~(selected_model_raw : string option)
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list) =
+  match selected_model_raw with
+  | None -> None
+  | Some raw ->
+      let selected = strip_latest_suffix raw in
+      let rec loop idx = function
+        | [] -> None
+        | cfg :: rest ->
+            let candidate_label = model_label_of_config cfg |> strip_latest_suffix in
+            let candidate_model = strip_latest_suffix cfg.model_id in
+            if selected = candidate_label || selected = candidate_model then Some idx
+            else loop (idx + 1) rest
+      in
+      loop 0 candidate_cfgs
+
+let cascade_observation_of_candidates ~cascade_name ~configured_labels
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    ~(selected_model_raw : string option)
+    ?(attempts = [])
+    ?(fallback_events = [])
+    ?(attempt_details_available = false)
+    ?(attempt_details_source = "opaque_named_cascade")
+    () : cascade_observation =
+  let candidate_models = List.map model_label_of_config candidate_cfgs in
+  let primary_model = match candidate_models with first :: _ -> Some first | [] -> None in
+  let selected_index =
+    selected_index_of_model ~selected_model_raw ~candidate_cfgs
+  in
+  let selected_model =
+    match selected_index with
+    | Some idx -> List.nth_opt candidate_models idx
+    | None -> Option.map String.trim selected_model_raw
+  in
+  let fallback_hops = Option.map (fun idx -> max 0 idx) selected_index in
+  let fallback_applied =
+    match fallback_hops with
+    | Some hops -> hops > 0
+    | None -> false
+  in
+  {
+    cascade_name;
+    configured_labels;
+    candidate_models;
+    primary_model;
+    selected_model;
+    selected_model_raw;
+    selected_index;
+    fallback_hops;
+    fallback_applied;
+    attempts;
+    fallback_events;
+    attempt_details_available;
+    attempt_details_source;
+  }
+
+type cascade_metrics_capture = {
+  mutable next_attempt_index : int;
+  mutable attempts_rev : cascade_attempt list;
+  mutable fallback_events_rev : cascade_fallback_event list;
+}
+
+let cascade_attempt_to_json (attempt : cascade_attempt) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("attempt_index", `Int attempt.attempt_index);
+      ("model_id", `String attempt.model_id);
+      ("model_label", Json_util.string_opt_to_json attempt.model_label);
+      ("latency_ms", Json_util.int_opt_to_json attempt.latency_ms);
+      ("error", Json_util.string_opt_to_json attempt.error);
+    ]
+
+let cascade_fallback_event_to_json (event : cascade_fallback_event) :
+    Yojson.Safe.t =
+  `Assoc
+    [
+      ("from_model_id", `String event.from_model_id);
+      ("from_model_label", Json_util.string_opt_to_json event.from_model_label);
+      ("to_model_id", `String event.to_model_id);
+      ("to_model_label", Json_util.string_opt_to_json event.to_model_label);
+      ("reason", `String event.reason);
+    ]
+
+let update_first_attempt_if ~predicate ~update attempts_rev =
+  let rec loop = function
+    | [] -> None
+    | attempt :: rest ->
+        if predicate attempt then Some (update attempt :: rest)
+        else Option.map (fun rest' -> attempt :: rest') (loop rest)
+  in
+  loop attempts_rev
+
+let record_attempt_start (capture : cascade_metrics_capture)
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list) ~(model_id : string) =
+  let attempt_index = capture.next_attempt_index in
+  capture.next_attempt_index <- capture.next_attempt_index + 1;
+  capture.attempts_rev <-
+    {
+      attempt_index;
+      model_id;
+      model_label = model_label_option_of_model_id ~candidate_cfgs model_id;
+      latency_ms = None;
+      error = None;
+    }
+    :: capture.attempts_rev
+
+let ensure_terminal_attempt (capture : cascade_metrics_capture)
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    ~(model_id : string) ~(latency_ms : int option) ~(error : string option) =
+  let is_open attempt =
+    String.equal attempt.model_id model_id
+    && Option.is_none attempt.latency_ms
+    && Option.is_none attempt.error
+  in
+  let update attempt = { attempt with latency_ms; error } in
+  match update_first_attempt_if ~predicate:is_open ~update capture.attempts_rev with
+  | Some attempts_rev -> capture.attempts_rev <- attempts_rev
+  | None ->
+      let attempt_index = capture.next_attempt_index in
+      capture.next_attempt_index <- capture.next_attempt_index + 1;
+      capture.attempts_rev <-
+        {
+          attempt_index;
+          model_id;
+          model_label = model_label_option_of_model_id ~candidate_cfgs model_id;
+          latency_ms;
+          error;
+        }
+        :: capture.attempts_rev
+
+let record_fallback_event (capture : cascade_metrics_capture)
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    ~(from_model : string) ~(to_model : string) ~(reason : string) =
+  capture.fallback_events_rev <-
+    {
+      from_model_id = from_model;
+      from_model_label =
+        model_label_option_of_model_id ~candidate_cfgs from_model;
+      to_model_id = to_model;
+      to_model_label = model_label_option_of_model_id ~candidate_cfgs to_model;
+      reason;
+    }
+    :: capture.fallback_events_rev
+
+let cascade_metrics_for_candidates
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list) () =
+  let capture =
+    { next_attempt_index = 0; attempts_rev = []; fallback_events_rev = [] }
+  in
+  let metrics : Llm_provider.Metrics.t =
+    {
+      on_cache_hit = (fun ~model_id:_ -> ());
+      on_cache_miss = (fun ~model_id:_ -> ());
+      on_request_start =
+        (fun ~model_id ->
+          record_attempt_start capture ~candidate_cfgs ~model_id);
+      on_request_end =
+        (fun ~model_id ~latency_ms ->
+          ensure_terminal_attempt capture ~candidate_cfgs ~model_id
+            ~latency_ms:(Some latency_ms) ~error:None);
+      on_error =
+        (fun ~model_id ~error ->
+          ensure_terminal_attempt capture ~candidate_cfgs ~model_id
+            ~latency_ms:None ~error:(Some error));
+      on_cascade_fallback =
+        (fun ~from_model ~to_model ~reason ->
+          record_fallback_event capture ~candidate_cfgs ~from_model ~to_model
+            ~reason);
+    }
+  in
+  (capture, metrics)
+
+let cascade_observation_with_metrics ~cascade_name ~configured_labels
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture) =
+  cascade_observation_of_candidates ~cascade_name ~configured_labels
+    ~candidate_cfgs ~selected_model_raw
+    ~attempts:(List.rev capture.attempts_rev)
+    ~fallback_events:(List.rev capture.fallback_events_rev)
+    ~attempt_details_available:true
+    ~attempt_details_source:"oas_metrics_callbacks"
+    ()
+
+let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("cascade_name", `String obs.cascade_name);
+      ( "configured_labels",
+        `List (List.map (fun label -> `String label) obs.configured_labels) );
+      ( "candidate_models",
+        `List (List.map (fun label -> `String label) obs.candidate_models) );
+      ("primary_model", Json_util.string_opt_to_json obs.primary_model);
+      ("selected_model", Json_util.string_opt_to_json obs.selected_model);
+      ("selected_model_raw", Json_util.string_opt_to_json obs.selected_model_raw);
+      ("selected_index", Json_util.int_opt_to_json obs.selected_index);
+      ("fallback_hops", Json_util.int_opt_to_json obs.fallback_hops);
+      ("fallback_applied", `Bool obs.fallback_applied);
+      ( "attempts",
+        `List (List.map cascade_attempt_to_json obs.attempts) );
+      ( "fallback_events",
+        `List
+          (List.map cascade_fallback_event_to_json obs.fallback_events) );
+      ("attempt_details_available", `Bool obs.attempt_details_available);
+      ("attempt_details_source", `String obs.attempt_details_source);
+    ]
+
+let increment_counter table key =
+  let count = Option.value ~default:0 (Hashtbl.find_opt table key) in
+  Hashtbl.replace table key (count + 1)
+
+let distribution_json table =
+  Hashtbl.fold
+    (fun model count acc ->
+      `Assoc [ ("model", `String model); ("count", `Int count) ] :: acc)
+    table []
+  |> List.sort (fun left right ->
+         let count_of = function
+           | `Assoc fields ->
+               (match List.assoc_opt "count" fields with
+               | Some (`Int count) -> count
+               | _ -> 0)
+           | _ -> 0
+         in
+         Int.compare (count_of right) (count_of left))
+
+let attempt_model_display (attempt : cascade_attempt) =
+  match attempt.model_label with
+  | Some label when String.trim label <> "" -> label
+  | _ -> attempt.model_id
+
+let record_cascade ~observation ~cascade_name ~outcome =
   let c = match Hashtbl.find_opt cascade_counters cascade_name with
     | Some c -> c
     | None ->
       if Hashtbl.length cascade_counters >= cascade_max_keys then
-        { calls = 0; successes = 0; failures = 0; rejected = 0 }
+        {
+          calls = 0;
+          successes = 0;
+          failures = 0;
+          rejected = 0;
+          fallback_calls = 0;
+          total_attempts = 0;
+          total_fallback_events = 0;
+          last_selected_model = None;
+          last_selected_index = None;
+          last_candidate_models = [];
+          last_attempts = [];
+          last_fallback_events = [];
+          last_attempt_details_available = false;
+          last_attempt_details_source = None;
+          selected_models = Hashtbl.create 8;
+          attempted_models = Hashtbl.create 8;
+          errored_models = Hashtbl.create 8;
+        }
       else begin
-        let c = { calls = 0; successes = 0; failures = 0; rejected = 0 } in
+        let c =
+          {
+            calls = 0;
+            successes = 0;
+            failures = 0;
+            rejected = 0;
+            fallback_calls = 0;
+            total_attempts = 0;
+            total_fallback_events = 0;
+            last_selected_model = None;
+            last_selected_index = None;
+            last_candidate_models = [];
+            last_attempts = [];
+            last_fallback_events = [];
+            last_attempt_details_available = false;
+            last_attempt_details_source = None;
+            selected_models = Hashtbl.create 8;
+            attempted_models = Hashtbl.create 8;
+            errored_models = Hashtbl.create 8;
+          }
+        in
         Hashtbl.replace cascade_counters cascade_name c; c
       end
   in
   c.calls <- c.calls + 1;
+  (match observation with
+  | Some obs ->
+      c.last_candidate_models <- obs.candidate_models;
+      c.last_selected_model <- obs.selected_model;
+      c.last_selected_index <- obs.selected_index;
+      c.last_attempts <- obs.attempts;
+      c.last_fallback_events <- obs.fallback_events;
+      c.last_attempt_details_available <- obs.attempt_details_available;
+      c.last_attempt_details_source <- Some obs.attempt_details_source;
+      if obs.fallback_applied then c.fallback_calls <- c.fallback_calls + 1;
+      c.total_attempts <- c.total_attempts + List.length obs.attempts;
+      c.total_fallback_events <-
+        c.total_fallback_events + List.length obs.fallback_events;
+      (match obs.selected_model with
+      | Some model when String.trim model <> "" ->
+          increment_counter c.selected_models model
+      | _ -> ());
+      List.iter
+        (fun attempt ->
+          increment_counter c.attempted_models (attempt_model_display attempt);
+          match attempt.error with
+          | Some _ -> increment_counter c.errored_models (attempt_model_display attempt)
+          | None -> ())
+        obs.attempts
+  | None -> ());
   (match outcome with
   | `Success -> c.successes <- c.successes + 1
   | `Failure -> c.failures <- c.failures + 1
@@ -64,7 +434,25 @@ let cascade_metrics_json () : Yojson.Safe.t =
       ("successes", `Int c.successes);
       ("failures", `Int c.failures);
       ("rejected", `Int c.rejected);
-        ("error_rate", `Float error_rate);
+      ("fallback_calls", `Int c.fallback_calls);
+      ("total_attempts", `Int c.total_attempts);
+      ("total_fallback_events", `Int c.total_fallback_events);
+      ("last_selected_model", Json_util.string_opt_to_json c.last_selected_model);
+      ("last_selected_index", Json_util.int_opt_to_json c.last_selected_index);
+      ( "last_candidate_models",
+        `List (List.map (fun model -> `String model) c.last_candidate_models) );
+      ( "last_attempts",
+        `List (List.map cascade_attempt_to_json c.last_attempts) );
+      ( "last_fallback_events",
+        `List
+          (List.map cascade_fallback_event_to_json c.last_fallback_events) );
+      ("last_attempt_details_available", `Bool c.last_attempt_details_available);
+      ( "last_attempt_details_source",
+        Json_util.string_opt_to_json c.last_attempt_details_source );
+      ("selected_models", `List (distribution_json c.selected_models));
+      ("attempted_models", `List (distribution_json c.attempted_models));
+      ("errored_models", `List (distribution_json c.errored_models));
+      ("error_rate", `Float error_rate);
       ] :: acc
     ) cascade_counters [] in
     `List (List.sort (fun a b ->
@@ -145,6 +533,7 @@ type run_result = {
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
   proof : Oas.Cdal_proof.t option;
+  cascade_observation : cascade_observation option;
   stop_reason : stop_reason;
 }
 
@@ -373,8 +762,18 @@ let run
     let trace_ref = Oas.Agent.last_raw_trace_run agent in
     Oas.Agent.close agent;
     (match result with
-    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref; proof;
-                          stop_reason = Completed }
+    | Ok response ->
+      Ok
+        {
+          response;
+          checkpoint;
+          session_id;
+          turns;
+          trace_ref;
+          proof;
+          cascade_observation = None;
+          stop_reason = Completed;
+        }
     | Error (Oas.Error.Agent (Oas.Error.MaxTurnsExceeded r)) ->
       (* Turn budget exhaustion is not a fatal error — the agent made progress.
          Return Ok with TurnBudgetExhausted so callers can checkpoint and resume
@@ -386,9 +785,17 @@ let run
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
         usage = None;
       } in
-      Ok { response = partial_response; checkpoint; session_id; turns;
-           trace_ref; proof;
-           stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit } }
+      Ok
+        {
+          response = partial_response;
+          checkpoint;
+          session_id;
+          turns;
+          trace_ref;
+          proof;
+          cascade_observation = None;
+          stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit };
+        }
     | Error err ->
       (match proof with
        | Some p ->
@@ -576,13 +983,19 @@ let run_named
   | Ok (sw, net) ->
   let defaults = default_model_strings ~cascade_name in
   let config_path = default_config_path () in
+  let configured_labels =
+    Llm_provider.Cascade_config.resolve_model_strings
+      ?config_path ~name:cascade_name ~defaults ()
+  in
+  let candidate_cfgs = resolve_cascade_providers ~cascade_name in
+  let capture, metrics = cascade_metrics_for_candidates ~candidate_cfgs () in
   let named_cascade = Oas.Api.named_cascade ?config_path
-    ~name:cascade_name ~defaults () in
+    ~metrics ~name:cascade_name ~defaults () in
   let name = Printf.sprintf "oas-%s" cascade_name in
   (* Use first available provider config as primary for Builder.
      OAS named_cascade handles actual fallback — this is just the
      initial provider for Agent construction. *)
-  let primary_provider = match resolve_cascade_providers ~cascade_name with
+  let primary_provider = match candidate_cfgs with
     | cfg :: _ -> cfg
     | [] ->
       Llm_provider.Provider_config.make
@@ -616,13 +1029,28 @@ let run_named
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in
   match run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?agent_ref ?proof_ref ?contract goal with
   | Ok result when accept result.response ->
-    record_cascade ~cascade_name ~outcome:`Success;
+    let observation =
+      cascade_observation_with_metrics ~cascade_name ~configured_labels
+        ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
+        ~capture
+    in
+    let result = { result with cascade_observation = Some observation } in
+    record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
     Ok result
-  | Ok _ ->
-    record_cascade ~cascade_name ~outcome:`Rejected;
+  | Ok result ->
+    let observation =
+      cascade_observation_with_metrics ~cascade_name ~configured_labels
+        ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
+        ~capture
+    in
+    record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
     Error (Printf.sprintf "cascade %s: response rejected by accept" cascade_name)
   | Error e ->
-    record_cascade ~cascade_name ~outcome:`Failure;
+    let observation =
+      cascade_observation_with_metrics ~cascade_name ~configured_labels
+        ~candidate_cfgs ~selected_model_raw:None ~capture
+    in
+    record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
     Error e
 
 (** Run a single Agent.run() using a model label string (e.g. "llama:qwen3.5").

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -129,6 +129,23 @@ let selected_index_of_model ~(selected_model_raw : string option)
       in
       loop 0 candidate_cfgs
 
+let normalized_selected_model ~(selected_model_raw : string option)
+    ~(candidate_cfgs : Llm_provider.Provider_config.t list)
+    ~(candidate_models : string list) ~(selected_index : int option) =
+  match selected_index with
+  | Some idx -> List.nth_opt candidate_models idx
+  | None ->
+      (match selected_model_raw with
+      | None -> None
+      | Some raw ->
+          let trimmed = String.trim raw in
+          if trimmed = "" then None
+          else
+            let stripped = strip_latest_suffix trimmed in
+            match model_label_option_of_model_id ~candidate_cfgs stripped with
+            | Some label -> Some label
+            | None -> Some trimmed)
+
 let cascade_observation_of_candidates ~cascade_name ~configured_labels
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)
     ~(selected_model_raw : string option)
@@ -143,9 +160,8 @@ let cascade_observation_of_candidates ~cascade_name ~configured_labels
     selected_index_of_model ~selected_model_raw ~candidate_cfgs
   in
   let selected_model =
-    match selected_index with
-    | Some idx -> List.nth_opt candidate_models idx
-    | None -> Option.map String.trim selected_model_raw
+    normalized_selected_model ~selected_model_raw ~candidate_cfgs
+      ~candidate_models ~selected_index
   in
   let fallback_hops = Option.map (fun idx -> max 0 idx) selected_index in
   let fallback_applied =

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -18,6 +18,38 @@
 
 module Oas = Agent_sdk
 
+type cascade_attempt = {
+  attempt_index : int;
+  model_id : string;
+  model_label : string option;
+  latency_ms : int option;
+  error : string option;
+}
+
+type cascade_fallback_event = {
+  from_model_id : string;
+  from_model_label : string option;
+  to_model_id : string;
+  to_model_label : string option;
+  reason : string;
+}
+
+type cascade_observation = {
+  cascade_name : string;
+  configured_labels : string list;
+  candidate_models : string list;
+  primary_model : string option;
+  selected_model : string option;
+  selected_model_raw : string option;
+  selected_index : int option;
+  fallback_hops : int option;
+  fallback_applied : bool;
+  attempts : cascade_attempt list;
+  fallback_events : cascade_fallback_event list;
+  attempt_details_available : bool;
+  attempt_details_source : string;
+}
+
 type stop_reason =
   | Completed
   | TurnBudgetExhausted of { turns_used : int; limit : int }
@@ -29,11 +61,13 @@ type run_result = {
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
   proof : Oas.Cdal_proof.t option;
+  cascade_observation : cascade_observation option;
   stop_reason : stop_reason;
 }
 
 (** Cascade call/error metrics as JSON array, sorted by call count. *)
 val cascade_metrics_json : unit -> Yojson.Safe.t
+val cascade_observation_to_json : cascade_observation -> Yojson.Safe.t
 
 (** Locate config/cascade.json via CWD or ME_ROOT.
     Delegates to {!Model_spec.cascade_config_path}. *)

--- a/lib/tool_model_catalog.ml
+++ b/lib/tool_model_catalog.ml
@@ -41,6 +41,7 @@ let handle_status _ctx _args : result =
     ("result", `Assoc [
       ("endpoints", `List (List.map D.endpoint_to_json endpoints));
       ("summary", summary);
+      ("cascade_metrics", Oas_worker.cascade_metrics_json ());
       ("masc_permits", `Assoc [
         ("available", `Int permits_available);
         ("in_use", `Int permits_in_use);
@@ -127,7 +128,7 @@ let schemas : tool_schema list = [
     description =
       "Query MODEL provider infrastructure status and get endpoint recommendations. \
        Actions: 'list' (enumerate endpoints), 'status' (slot utilization + \
-       MASC permit state), 'recommend' (pick best endpoint for task_type: \
+       MASC permit state + cascade runtime metrics), 'recommend' (pick best endpoint for task_type: \
        reasoning|analysis|planning|generation|general). Uses OAS Discovery \
        to probe OpenAI-compatible endpoints.";
     input_schema = `Assoc [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -623,6 +623,7 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
   {
     response_text = text;
     model_used = model;
+    cascade_observation = None;
     turn_count = 1;
     tool_calls_made = List.length tools;
     usage = { input_tokens = input_tok; output_tokens = output_tok; cache_creation_input_tokens = 0; cache_read_input_tokens = 0; cost_usd = None };
@@ -678,6 +679,117 @@ let test_metrics_noop_response () =
   check int "autonomous unchanged" minimal_meta.runtime.autonomous_action_count
     updated.runtime.autonomous_action_count;
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
+
+let test_append_metrics_snapshot_includes_cascade_observation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let result =
+        {
+          (make_run_result ~text:"Observed" ~tools:[]
+             ~model:"openai:qwen3.5-35b" ~input_tok:40 ~output_tok:20)
+          with
+          cascade_observation =
+            Some
+              {
+                Masc_mcp.Oas_worker.cascade_name = "keeper_unified";
+                configured_labels = [ "glm:auto"; "llama:auto" ];
+                candidate_models =
+                  [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
+                primary_model = Some "glm:glm-5.1";
+                selected_model = Some "openai:qwen3.5-35b";
+                selected_model_raw = Some "qwen3.5-35b";
+                selected_index = Some 1;
+                fallback_hops = Some 1;
+                fallback_applied = true;
+                attempts =
+                  [
+                    {
+                      Masc_mcp.Oas_worker.attempt_index = 0;
+                      model_id = "glm-5.1";
+                      model_label = Some "glm:glm-5.1";
+                      latency_ms = None;
+                      error = Some "HTTP 503";
+                    };
+                    {
+                      attempt_index = 1;
+                      model_id = "qwen3.5-35b";
+                      model_label = Some "openai:qwen3.5-35b";
+                      latency_ms = Some 187;
+                      error = None;
+                    };
+                  ];
+                fallback_events =
+                  [
+                    {
+                      from_model_id = "glm-5.1";
+                      from_model_label = Some "glm:glm-5.1";
+                      to_model_id = "qwen3.5-35b";
+                      to_model_label = Some "openai:qwen3.5-35b";
+                      reason = "HTTP 503";
+                    };
+                  ];
+                attempt_details_available = true;
+                attempt_details_source = "oas_metrics_callbacks";
+              };
+        }
+      in
+      UT.append_metrics_snapshot
+        ~config
+        ~meta:minimal_meta
+        ~observation:base_observation
+        ~result
+        ~latency_ms:123
+        ~turn_cost:0.01
+        ~turn_generation:1
+        ~channel:"turn"
+        ~snapshot_source:"test"
+        ~context_ratio:0.1
+        ~context_tokens:10
+        ~context_max:100
+        ~message_count:2
+        ~compaction:
+          {
+            Masc_mcp.Keeper_exec_context.applied = false;
+            trigger = None;
+            decision = "no_compaction";
+            before_tokens = 0;
+            after_tokens = 0;
+            saved_tokens = 0;
+          }
+        ~handoff_json:None
+        ();
+      let metrics_store =
+        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+      in
+      let line =
+        match Dated_jsonl.read_recent_lines metrics_store 1 with
+        | [ line ] -> line
+        | _ -> fail "expected one metrics line"
+      in
+      let json = Yojson.Safe.from_string line in
+      check bool "cascade field present" true
+        Yojson.Safe.Util.(json |> member "cascade" <> `Null);
+      check string "cascade name persisted" "keeper_unified"
+        Yojson.Safe.Util.(
+          json |> member "cascade" |> member "cascade_name" |> to_string);
+      check bool "fallback applied persisted" true
+        Yojson.Safe.Util.(
+          json |> member "cascade" |> member "fallback_applied" |> to_bool);
+      check int "attempts persisted" 2
+        Yojson.Safe.Util.(
+          json |> member "cascade" |> member "attempts" |> to_list
+          |> List.length);
+      check bool "attempt details available persisted" true
+        Yojson.Safe.Util.(
+          json |> member "cascade" |> member "attempt_details_available" |> to_bool);
+      check string "attempt detail boundary persisted" "oas_metrics_callbacks"
+        Yojson.Safe.Util.(
+          json |> member "cascade" |> member "attempt_details_source" |> to_string))
 
 let test_metrics_persist_social_state_fields () =
   let result =
@@ -1104,6 +1216,8 @@ let () =
           test_case "text response" `Quick test_metrics_text_response;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
+          test_case "snapshot includes cascade observation" `Quick
+            test_append_metrics_snapshot_includes_cascade_observation;
           test_case "social fields" `Quick
             test_metrics_persist_social_state_fields;
           test_case "failure response" `Quick test_metrics_failure_response;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -182,6 +182,84 @@ let test_cascade_names_produce_models () =
     Alcotest.(check bool) (name ^ " has models") true (models <> [])
   ) cascades
 
+let test_cascade_observation_json_includes_fallback_fields () =
+  let observation : Oas_worker.cascade_observation =
+    {
+      cascade_name = "keeper_unified";
+      configured_labels = [ "glm:auto"; "llama:auto" ];
+      candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
+      primary_model = Some "glm:glm-5.1";
+      selected_model = Some "openai:qwen3.5-35b";
+      selected_model_raw = Some "qwen3.5-35b";
+      selected_index = Some 1;
+      fallback_hops = Some 1;
+      fallback_applied = true;
+      attempts =
+        [
+          {
+            attempt_index = 0;
+            model_id = "glm-5.1";
+            model_label = Some "glm:glm-5.1";
+            latency_ms = None;
+            error = Some "HTTP 503";
+          };
+          {
+            attempt_index = 1;
+            model_id = "qwen3.5-35b";
+            model_label = Some "openai:qwen3.5-35b";
+            latency_ms = Some 212;
+            error = None;
+          };
+        ];
+      fallback_events =
+        [
+          {
+            from_model_id = "glm-5.1";
+            from_model_label = Some "glm:glm-5.1";
+            to_model_id = "qwen3.5-35b";
+            to_model_label = Some "openai:qwen3.5-35b";
+            reason = "HTTP 503";
+          };
+        ];
+      attempt_details_available = true;
+      attempt_details_source = "oas_metrics_callbacks";
+    }
+  in
+  let json = Oas_worker.cascade_observation_to_json observation in
+  Alcotest.(check string) "cascade name preserved" "keeper_unified"
+    Yojson.Safe.Util.(json |> member "cascade_name" |> to_string);
+  Alcotest.(check bool) "fallback applied preserved" true
+    Yojson.Safe.Util.(json |> member "fallback_applied" |> to_bool);
+  Alcotest.(check int) "fallback hops preserved" 1
+    Yojson.Safe.Util.(json |> member "fallback_hops" |> to_int);
+  Alcotest.(check string) "selected model preserved" "openai:qwen3.5-35b"
+    Yojson.Safe.Util.(json |> member "selected_model" |> to_string);
+  Alcotest.(check int) "attempt count preserved" 2
+    Yojson.Safe.Util.(json |> member "attempts" |> to_list |> List.length);
+  Alcotest.(check int) "fallback event count preserved" 1
+    Yojson.Safe.Util.(
+      json |> member "fallback_events" |> to_list |> List.length);
+  Alcotest.(check bool) "attempt details marked available" true
+    Yojson.Safe.Util.(json |> member "attempt_details_available" |> to_bool);
+  Alcotest.(check string) "attempt detail boundary preserved" "oas_metrics_callbacks"
+    Yojson.Safe.Util.(json |> member "attempt_details_source" |> to_string)
+
+let test_model_catalog_status_includes_cascade_metrics () =
+  let result =
+    Tool_model_catalog.dispatch () ~name:"masc_model_catalog"
+      ~args:(`Assoc [ ("action", `String "status") ])
+  in
+  match result with
+  | None -> Alcotest.fail "expected masc_model_catalog dispatch result"
+  | Some (ok, body) ->
+      Alcotest.(check bool) "status ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      let metrics =
+        Yojson.Safe.Util.(json |> member "result" |> member "cascade_metrics")
+      in
+      Alcotest.(check bool) "cascade_metrics is list" true
+        (match metrics with `List _ -> true | _ -> false)
+
 let make_worker_meta ?(effective_model = "local-qwen") () :
     Worker_container_types.worker_container_meta =
   {
@@ -726,6 +804,10 @@ let () =
         test_default_config_path;
       Alcotest.test_case "all cascade names produce models" `Quick
         test_cascade_names_produce_models;
+      Alcotest.test_case "cascade observation json includes fallback fields" `Quick
+        test_cascade_observation_json_includes_fallback_fields;
+      Alcotest.test_case "model catalog status includes cascade metrics" `Quick
+        test_model_catalog_status_includes_cascade_metrics;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -296,6 +296,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
       turns = 3;
       trace_ref = Some trace_ref;
       proof = None;
+      cascade_observation = None;
       stop_reason = Oas_worker.Completed;
     }
   in


### PR DESCRIPTION
## What Changed
- add authoritative cascade attempt observation to `Oas_worker` using OAS `Llm_provider.Metrics` callbacks
- expose per-run `attempts` and `fallback_events` plus aggregate distributions in `masc_model_catalog` and keeper status/metrics surfaces
- document the observability boundary: callback-backed attempt data is available, but `raw_trace` still does not encode provider attempts

## Why
Cascade selection was behaving as designed, but downstream surfaces only showed the final selected model. That made repeated selection of the primary healthy model look opaque and made fallback behavior hard to verify.

## Impact
- keepers and model catalog status now show which models were attempted, which model was selected, and which fallback transitions happened
- this does not change cascade ordering, balancing, or selection heuristics
- boundary remains explicit: no inferred attempt reasons, only callback-derived facts

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-observability`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-observability test/test_oas_worker.exe test/test_keeper_unified.exe test/test_team_session_oas_bridge.exe test/test_tool_keeper.exe`
