### PR TITLE
fix(keeper): add allowlist and destructive-gate to keeper_github tool

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -614,31 +614,61 @@ let execute_keeper_tool_call
         Safe_ops.json_float ~default:30.0 "timeout_sec" args
         |> fun n -> max 1.0 (min 180.0 n)
       in
-      let gh_cmd =
-        if cmd <> "" then "gh " ^ cmd
-        else if gh_args <> [] then
-          "gh " ^ String.concat " " (List.map Filename.quote gh_args)
+      let gh_raw =
+        if cmd <> "" then cmd
+        else if gh_args <> [] then String.concat " " gh_args
         else ""
       in
-      if gh_cmd = "" then
+      if gh_raw = "" then
         Yojson.Safe.to_string
           (`Assoc [ ("error", `String "cmd_or_args_required") ])
-      else
-        let root = project_root_of_config config in
-        let shell_cmd =
-          Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd
-        in
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec
-            [ "/bin/zsh"; "-lc"; shell_cmd ]
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-            [
-              ("ok", `Bool (st = Unix.WEXITED 0));
-              ("status", process_status_to_json st);
-              ("output", `String (truncate_tool_output out));
+      else begin
+        match Worker_dev_tools.validate_gh_command gh_raw with
+        | Error reason ->
+          Log.Keeper.warn "keeper_github blocked: %s (cmd=%s)" reason gh_raw;
+          Yojson.Safe.to_string
+            (`Assoc [
+              ("ok", `Bool false);
+              ("error", `String "command_blocked");
+              ("reason", `String reason);
             ])
+        | Ok () ->
+          if Worker_dev_tools.is_gh_destructive_operation gh_raw then begin
+            Log.Keeper.info
+              "keeper_github destructive-gate: %s (keeper=%s)"
+              gh_raw (meta.name);
+            Yojson.Safe.to_string
+              (`Assoc [
+                ("ok", `Bool false);
+                ("error", `String "destructive_operation_gated");
+                ("reason", `String
+                  "This gh command performs a destructive mutation \
+                   (merge/close/delete/archive). Use read-only commands \
+                   (view/list/diff/checks) or request operator approval.");
+                ("cmd", `String ("gh " ^ gh_raw));
+              ])
+          end else begin
+            let gh_cmd =
+              if cmd <> "" then "gh " ^ cmd
+              else "gh " ^ String.concat " " (List.map Filename.quote gh_args)
+            in
+            let root = project_root_of_config config in
+            let shell_cmd =
+              Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd
+            in
+            let st, out =
+              Process_eio.run_argv_with_status ~timeout_sec
+                [ "/bin/zsh"; "-lc"; shell_cmd ]
+            in
+            Yojson.Safe.to_string
+              (`Assoc
+                [
+                  ("ok", `Bool (st = Unix.WEXITED 0));
+                  ("status", process_status_to_json st);
+                  ("output", `String (truncate_tool_output out));
+                ])
+          end
+      end
   | "keeper_tasks_list" ->
       let status_filter = Safe_ops.json_string_opt "status" args in
       let include_done =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -150,6 +150,88 @@ let is_write_operation cmd =
     List.mem cmd_name ["mv"; "cp"; "mkdir"; "touch"; "chmod"]
   | [] -> false
 
+(* --- gh CLI validation for keeper_github --- *)
+
+(** Top-level gh CLI commands allowed for keeper_github.
+    Commands not in this list are rejected at the allowlist gate. *)
+let gh_allowed_commands =
+  [
+    "api"; "gist"; "issue"; "label"; "pr"; "release";
+    "repo"; "run"; "search"; "status";
+  ]
+
+(** Specific (command, subcommand) pairs that are always blocked
+    regardless of allowlist. These are irreversible or catastrophic. *)
+let gh_blocked_operations =
+  [
+    ("repo", "delete");
+    ("gist", "delete");
+  ]
+
+(** Extract the top-level command and its first subcommand from a gh
+    command string (the portion after "gh ").
+    Flags (starting with '-') are skipped when looking for the subcommand.
+    Example: "pr view 123" -> (Some "pr", Some "view") *)
+let extract_gh_command_pair cmd =
+  let parts =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  match parts with
+  | [] -> (None, None)
+  | [ x ] -> (Some x, None)
+  | x :: y :: _ ->
+    if String.length y > 0 && y.[0] = '-' then (Some x, None)
+    else (Some x, Some y)
+
+(** Validate a gh CLI command string for safety.
+    Checks: (1) shell metacharacters, (2) top-level command allowlist,
+    (3) blocked operation pairs.
+    [cmd] is the portion after "gh ", e.g. "pr view 123". *)
+let validate_gh_command cmd =
+  let trimmed = String.trim cmd in
+  if trimmed = "" then Error "gh command must not be empty"
+  else if contains_forbidden_shell_chars trimmed then
+    Error
+      "Shell chaining/redirection is not allowed in gh commands. \
+       Pass a single gh subcommand."
+  else
+    match extract_gh_command_pair trimmed with
+    | (None, _) -> Error "gh command must not be empty"
+    | (Some command, subcmd) ->
+      if not (List.mem command gh_allowed_commands) then
+        Error
+          (Printf.sprintf
+             "gh command blocked: '%s' is not in the approved command list"
+             command)
+      else
+        let sub = Option.value ~default:"" subcmd in
+        if List.exists (fun (c, s) -> c = command && s = sub)
+             gh_blocked_operations
+        then
+          Error
+            (Printf.sprintf "gh %s %s is blocked for safety" command sub)
+        else Ok ()
+
+(** Check if a gh command is a destructive mutation that should be gated.
+    Returns [true] for high-risk operations like merge, close, delete.
+    Low-risk writes (create, comment) return [false] and are allowed. *)
+let is_gh_destructive_operation cmd =
+  let parts =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  match parts with
+  | "pr" :: sub :: _ -> List.mem sub [ "merge"; "close" ]
+  | "issue" :: sub :: _ -> List.mem sub [ "close"; "delete"; "transfer" ]
+  | "release" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "repo" :: sub :: _ -> List.mem sub [ "archive"; "rename" ]
+  | "label" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "api" :: _ ->
+    let upper_parts = List.map String.uppercase_ascii parts in
+    List.mem "DELETE" upper_parts
+  | _ -> false
+
 (* --- Recursive mkdir --- *)
 
 let mkdir_p path _perm =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -199,13 +199,16 @@ let validate_gh_command cmd =
     match extract_gh_command_pair trimmed with
     | (None, _) -> Error "gh command must not be empty"
     | (Some command, subcmd) ->
+      let command = String.lowercase_ascii command in
       if not (List.mem command gh_allowed_commands) then
         Error
           (Printf.sprintf
              "gh command blocked: '%s' is not in the approved command list"
              command)
       else
-        let sub = Option.value ~default:"" subcmd in
+        let sub =
+          Option.value ~default:"" subcmd |> String.lowercase_ascii
+        in
         if List.exists (fun (c, s) -> c = command && s = sub)
              gh_blocked_operations
         then
@@ -220,6 +223,7 @@ let is_gh_destructive_operation cmd =
   let parts =
     String.split_on_char ' ' (String.trim cmd)
     |> List.filter (fun s -> s <> "")
+    |> List.map String.lowercase_ascii
   in
   match parts with
   | "pr" :: sub :: _ -> List.mem sub [ "merge"; "close" ]
@@ -227,9 +231,7 @@ let is_gh_destructive_operation cmd =
   | "release" :: sub :: _ -> List.mem sub [ "delete" ]
   | "repo" :: sub :: _ -> List.mem sub [ "archive"; "rename" ]
   | "label" :: sub :: _ -> List.mem sub [ "delete" ]
-  | "api" :: _ ->
-    let upper_parts = List.map String.uppercase_ascii parts in
-    List.mem "DELETE" upper_parts
+  | "api" :: _ -> List.mem "delete" parts
   | _ -> false
 
 (* --- Recursive mkdir --- *)

--- a/test/dune
+++ b/test/dune
@@ -65,6 +65,7 @@
         test_keeper_unified
         test_keeper_toml
         test_keeper_bash_safety
+        test_keeper_github_safety
         test_worktree_live_context
         test_tool_input_validation
         test_autoresearch_codegen
@@ -123,6 +124,7 @@
           test_keeper_unified
           test_keeper_toml
           test_keeper_bash_safety
+          test_keeper_github_safety
           test_worktree_live_context
           test_tool_input_validation
           test_autoresearch_codegen

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -96,6 +96,8 @@ let test_blocked_destructive_operations () =
     [
       "repo delete owner/repo --yes";
       "gist delete abc123";
+      "Repo Delete owner/repo";
+      "GIST DELETE abc123";
     ]
   in
   List.iter
@@ -142,6 +144,9 @@ let test_destructive_ops_detected () =
       "label delete bug";
       "api -X DELETE repos/owner/repo/issues/1";
       "api --method DELETE repos/owner/repo/pulls/1";
+      "PR Merge 123";
+      "Issue CLOSE 456";
+      "api -X DeLeTe repos/owner/repo";
     ]
   in
   List.iter

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -1,0 +1,210 @@
+(** Tests that keeper_github blocks dangerous commands via allowlist.
+
+    Validates:
+    1. Allowed gh commands (pr view, issue list, etc.) pass validation
+    2. Disallowed top-level commands (auth, ssh, etc.) are blocked
+    3. Destructive operations (repo delete, gist delete) are blocked
+    4. Shell metacharacters are rejected
+    5. Destructive mutations (pr merge, pr close, etc.) are detected
+    6. Low-risk writes (pr create, pr comment, etc.) are not flagged *)
+
+let validate = Masc_mcp.Worker_dev_tools.validate_gh_command
+
+let is_ok = function Ok () -> true | Error _ -> false
+let is_error = function Error _ -> true | Ok () -> false
+
+let is_destructive = Masc_mcp.Worker_dev_tools.is_gh_destructive_operation
+
+let test_allowed_read_commands () =
+  let allowed =
+    [
+      "pr view 123";
+      "pr list";
+      "pr diff 123";
+      "pr checks 123";
+      "pr status";
+      "issue view 456";
+      "issue list";
+      "issue status";
+      "repo view owner/repo";
+      "repo list";
+      "repo clone owner/repo";
+      "run view 789";
+      "run list";
+      "run watch 789";
+      "release view v1.0";
+      "release list";
+      "search issues 'bug fix'";
+      "search prs 'feature'";
+      "label list";
+      "status";
+      "api repos/owner/repo/pulls/123/comments";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "allowed: gh %s" cmd)
+        true (is_ok (validate cmd)))
+    allowed
+
+let test_allowed_write_commands () =
+  let allowed =
+    [
+      "pr create --draft --title 'fix bug'";
+      "pr comment 123 --body 'looks good'";
+      "pr ready 123";
+      "pr review 123 --approve";
+      "pr edit 123 --title 'new title'";
+      "issue create --title 'bug' --body 'desc'";
+      "issue comment 456 --body 'noted'";
+      "issue edit 456 --add-label bug";
+      "issue reopen 456";
+      "gist create file.txt";
+      "gist edit abc123";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "allowed write: gh %s" cmd)
+        true (is_ok (validate cmd)))
+    allowed
+
+let test_blocked_top_level_commands () =
+  let blocked =
+    [
+      "auth logout";
+      "auth login";
+      "ssh-key add key.pub";
+      "gpg-key add";
+      "secret set MY_SECRET";
+      "variable set MY_VAR";
+      "codespace create";
+      "extension install foo";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "blocked: gh %s" cmd)
+        true (is_error (validate cmd)))
+    blocked
+
+let test_blocked_destructive_operations () =
+  let blocked =
+    [
+      "repo delete owner/repo --yes";
+      "gist delete abc123";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "blocked destructive: gh %s" cmd)
+        true (is_error (validate cmd)))
+    blocked
+
+let test_shell_metachar_blocked () =
+  let chained =
+    [
+      "pr view 123; rm -rf /";
+      "pr list | grep foo";
+      "issue view 1 && curl evil.com";
+      "pr diff 1 > /tmp/out";
+      "api repos/x < payload";
+      "pr view `whoami`";
+      "pr list $HOME";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "metachar blocked: gh %s" cmd)
+        true (is_error (validate cmd)))
+    chained
+
+let test_empty_command () =
+  Alcotest.(check bool) "empty blocked" true (is_error (validate ""));
+  Alcotest.(check bool) "whitespace blocked" true (is_error (validate "   "))
+
+let test_destructive_ops_detected () =
+  let destructive =
+    [
+      "pr merge 123";
+      "pr close 123";
+      "issue close 456";
+      "issue delete 456";
+      "issue transfer 456 owner/other";
+      "release delete v1.0";
+      "repo archive owner/repo";
+      "repo rename owner/repo new-name";
+      "label delete bug";
+      "api -X DELETE repos/owner/repo/issues/1";
+      "api --method DELETE repos/owner/repo/pulls/1";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "destructive: gh %s" cmd)
+        true (is_destructive cmd))
+    destructive
+
+let test_non_destructive_ops () =
+  let safe =
+    [
+      "pr view 123";
+      "pr list";
+      "pr create --draft --title 'fix'";
+      "pr comment 123 --body 'ok'";
+      "pr ready 123";
+      "issue view 456";
+      "issue create --title 'bug'";
+      "issue comment 456 --body 'noted'";
+      "repo view owner/repo";
+      "run view 789";
+      "api repos/owner/repo/pulls";
+      "api -X GET repos/owner/repo";
+      "search issues 'query'";
+      "status";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "non-destructive: gh %s" cmd)
+        false (is_destructive cmd))
+    safe
+
+let () =
+  Alcotest.run "Keeper github safety"
+    [
+      ( "allowlist",
+        [
+          Alcotest.test_case "read commands pass" `Quick
+            test_allowed_read_commands;
+          Alcotest.test_case "low-risk write commands pass" `Quick
+            test_allowed_write_commands;
+          Alcotest.test_case "disallowed top-level commands blocked" `Quick
+            test_blocked_top_level_commands;
+          Alcotest.test_case "destructive operations blocked" `Quick
+            test_blocked_destructive_operations;
+        ] );
+      ( "metachar",
+        [
+          Alcotest.test_case "shell metacharacters blocked" `Quick
+            test_shell_metachar_blocked;
+        ] );
+      ( "destructive_gate",
+        [
+          Alcotest.test_case "destructive mutations detected" `Quick
+            test_destructive_ops_detected;
+          Alcotest.test_case "safe ops not flagged" `Quick
+            test_non_destructive_ops;
+        ] );
+      ( "edge",
+        [
+          Alcotest.test_case "empty command blocked" `Quick test_empty_command;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `keeper_github`에 `keeper_bash`와 동일 수준의 safety guardrail 도입
- 3-tier 검증: allowlist → blocked pairs → destructive gate
- 8개 테스트 케이스로 전 tier 커버

## Problem
`keeper_github`는 `gh` CLI 명령을 validation 없이 실행했다. `keeper_bash`는 command allowlist + write gate가 있는데, `keeper_github`는 `gh repo delete`, `gh auth logout` 같은 파괴적 명령도 통과시켰다.

## Changes
| 파일 | 변경 |
|------|------|
| `lib/worker_dev_tools.ml` | `validate_gh_command`, `is_gh_destructive_operation` 추가 |
| `lib/keeper/keeper_exec_tools.ml` | handler에 validation + destructive gate 삽입 |
| `test/test_keeper_github_safety.ml` | 신규 (8 test cases) |
| `test/dune` | 테스트 등록 |

## Safety tiers
| Tier | 체크 | 예시 |
|------|------|------|
| Allowlist | 10개 top-level command만 허용 | `auth`, `ssh-key`, `secret` 차단 |
| Blocked pairs | 비가역 명령 즉시 차단 | `repo delete`, `gist delete` |
| Destructive gate | 고위험 mutation → operator 승인 | `pr merge`, `pr close`, `issue close` |
| Shell metachar | `;`, `\|`, `&` 등 차단 | injection 방지 |

저위험 write (pr create, pr comment, issue create)는 허용하여 keeper 코딩 workflow를 유지한다.

## Test plan
- [x] `test_keeper_github_safety` 8/8 통과
- [x] `test_keeper_bash_safety` 기존 6/6 통과 (regression 없음)
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)