### PR TITLE
[codex] Add web search tool for agents and keepers

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -78,6 +78,7 @@ let keeper_core_masc_tool_names =
     "masc_dashboard";
     "masc_agent_card";
     "masc_tool_help";
+    "masc_web_search";
   ]
 
 let keeper_coding_masc_tool_names =

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -129,7 +129,7 @@ let public_mcp_surface_tools =
     "masc_transport_status"; "masc_websocket_discovery";
     "masc_webrtc_offer"; "masc_webrtc_answer";
     (* Utility *)
-    "masc_tool_help"; "masc_check";
+    "masc_tool_help"; "masc_web_search"; "masc_check";
   ]
 
 let spawned_agent_surface_tools =
@@ -148,7 +148,7 @@ let spawned_agent_surface_tools =
     "masc_relay_status"; "masc_relay_checkpoint";
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
-    "masc_tool_help";
+    "masc_tool_help"; "masc_web_search";
     "masc_portal_open"; "masc_portal_send"; "masc_portal_status";
     "masc_team_session_start"; "masc_team_session_step";
     "masc_team_session_status"; "masc_team_session_events";

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -20,6 +20,8 @@ type context = {
 
 type web_search_hit = string * string * string
 
+let max_web_search_query_length = 500
+
 let json_error message =
   Yojson.Safe.to_string
     (`Assoc [ ("status", `String "error"); ("message", `String message) ])
@@ -146,7 +148,8 @@ let fetch_bing_rss ~query =
   | Error e -> Error e
   | Ok (status_opt, payload) -> (
       match status_opt with
-      | Some 200 | None -> Ok (search_url, payload)
+      | Some 200 -> Ok (search_url, payload)
+      | None -> Error "search endpoint returned no HTTP status"
       | Some status ->
           Error
             (Printf.sprintf "search endpoint returned HTTP %d" status))
@@ -257,6 +260,12 @@ let handle_web_search _ctx args =
   let query = String.trim (get_string args "query" "") in
   if query = "" then
     (false, json_error "query is required")
+  else if String.length query > max_web_search_query_length then
+    ( false,
+      json_error
+        (Printf.sprintf
+           "query must be at most %d characters"
+           max_web_search_query_length) )
   else
     let limit = max 1 (min 10 (get_int args "limit" 5)) in
     match fetch_bing_rss ~query with

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -18,6 +18,163 @@ type context = {
   agent_name: string;
 }
 
+type web_search_hit = string * string * string
+
+let json_error message =
+  Yojson.Safe.to_string
+    (`Assoc [ ("status", `String "error"); ("message", `String message) ])
+
+let json_ok fields =
+  Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
+
+let normalize_spaces text =
+  text
+  |> Re.replace_string (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) ~by:" "
+  |> String.trim
+
+let strip_html_tags text =
+  Re.replace_string (Re.Pcre.re "<[^>]+>" |> Re.compile) ~by:"" text
+
+let strip_cdata text =
+  text
+  |> Re.replace_string (Re.str "<![CDATA[" |> Re.compile) ~by:""
+  |> Re.replace_string (Re.str "]]>" |> Re.compile) ~by:""
+
+let decode_html_entities text =
+  let basic =
+    [
+      ("&amp;", "&");
+      ("&lt;", "<");
+      ("&gt;", ">");
+      ("&quot;", "\"");
+      ("&#39;", "'");
+      ("&#039;", "'");
+      ("&nbsp;", " ");
+    ]
+    |> List.fold_left
+         (fun acc (entity, replacement) ->
+           Re.replace_string (Re.str entity |> Re.compile) ~by:replacement acc)
+         text
+  in
+  let len = String.length basic in
+  let buf = Buffer.create len in
+  let decode_numeric entity =
+    let body = String.sub entity 2 (String.length entity - 3) in
+    try
+      if String.length body > 1
+         && (body.[0] = 'x' || body.[0] = 'X')
+      then
+        Some
+          (int_of_string ("0" ^ body)
+           |> Uchar.of_int
+           |> Buffer.add_utf_8_uchar buf;
+           "")
+      else
+        Some
+          (int_of_string body
+           |> Uchar.of_int
+           |> Buffer.add_utf_8_uchar buf;
+           "")
+    with _ -> None
+  in
+  let rec loop index =
+    if index >= len then
+      Buffer.contents buf
+    else if basic.[index] <> '&' then (
+      Buffer.add_char buf basic.[index];
+      loop (index + 1))
+    else
+      match String.index_from_opt basic index ';' with
+      | None ->
+          Buffer.add_char buf basic.[index];
+          loop (index + 1)
+      | Some semi ->
+          let entity = String.sub basic index (semi - index + 1) in
+          if String.length entity >= 4
+             && String.sub entity 0 2 = "&#"
+          then (
+            match decode_numeric entity with
+            | Some _ -> loop (semi + 1)
+            | None ->
+                Buffer.add_string buf entity;
+                loop (semi + 1))
+          else (
+            Buffer.add_string buf entity;
+            loop (semi + 1))
+  in
+  loop 0
+
+let clean_search_text text =
+  text |> strip_cdata |> strip_html_tags |> decode_html_entities |> normalize_spaces
+
+let search_field pattern block =
+  match Re.exec_opt (Re.Pcre.re pattern |> Re.compile) block with
+  | None -> None
+  | Some groups -> Some (Re.Group.get groups 1 |> clean_search_text)
+
+let parse_bing_rss_items (payload : string) : web_search_hit list =
+  let item_re = Re.Pcre.re "<item>([\\s\\S]*?)</item>" |> Re.compile in
+  Re.all item_re payload
+  |> List.filter_map (fun groups ->
+         let block = Re.Group.get groups 1 in
+         match
+           search_field "<title>([\\s\\S]*?)</title>" block,
+           search_field "<link>([\\s\\S]*?)</link>" block,
+           search_field "<description>([\\s\\S]*?)</description>" block
+         with
+         | Some title, Some url, Some snippet
+           when title <> "" && url <> "" ->
+             Some (title, url, snippet)
+         | Some title, Some url, None
+           when title <> "" && url <> "" ->
+             Some (title, url, "")
+         | _ -> None)
+
+let take_results limit hits =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | hit :: rest -> loop (remaining - 1) (hit :: acc) rest
+  in
+  loop limit [] hits
+
+let fetch_bing_rss ~query =
+  let search_url =
+    "https://www.bing.com/search?format=rss&q=" ^ Uri.pct_encode query
+  in
+  match Tool_local_runtime_http.http_get_text_with_status ~timeout_sec:15 search_url with
+  | Error e -> Error e
+  | Ok (status_opt, payload) -> (
+      match status_opt with
+      | Some 200 | None -> Ok (search_url, payload)
+      | Some status ->
+          Error
+            (Printf.sprintf "search endpoint returned HTTP %d" status))
+
+let web_search_result_json ~query ~search_url ~engine (hits : web_search_hit list) =
+  let results =
+    hits
+    |> List.map (fun (title, url, snippet) ->
+           `Assoc
+             [
+               ("title", `String title);
+               ("url", `String url);
+               ("snippet", `String snippet);
+             ])
+  in
+  json_ok
+    [
+      ( "result",
+        `Assoc
+          [
+            ("query", `String query);
+            ("engine", `String engine);
+            ("search_url", `String search_url);
+            ("result_count", `Int (List.length hits));
+            ("results", `List results);
+          ] );
+    ]
+
 (* ================================================================ *)
 (* Handlers (retained in facade)                                    *)
 (* ================================================================ *)
@@ -95,6 +252,18 @@ let handle_tool_help _ctx args =
     | None -> (false, Printf.sprintf "❌ unknown tool: %s" tool_name)
     | Some entry ->
         (true, Yojson.Safe.pretty_to_string (Tool_help_registry.entry_json entry))
+
+let handle_web_search _ctx args =
+  let query = String.trim (get_string args "query" "") in
+  if query = "" then
+    (false, json_error "query is required")
+  else
+    let limit = max 1 (min 10 (get_int args "limit" 5)) in
+    match fetch_bing_rss ~query with
+    | Error e -> (false, json_error e)
+    | Ok (search_url, payload) ->
+        let hits = parse_bing_rss_items payload |> take_results limit in
+        (true, web_search_result_json ~query ~search_url ~engine:"bing_rss" hits)
 
 let handle_keeper_tool_catalog _ctx args =
   let include_hidden = get_bool args "include_hidden" false in
@@ -205,6 +374,7 @@ let dispatch ctx ~name ~args : result option =
   | "masc_cleanup_zombies" -> Some (handle_cleanup_zombies ctx args)
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
+  | "masc_web_search" -> Some (handle_web_search ctx args)
   | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_keeper_tool_catalog" -> Some (handle_keeper_tool_catalog ctx args)
@@ -219,7 +389,15 @@ let schemas = Tool_schemas_misc.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_transport_status"; "masc_websocket_discovery"; "masc_verify_handoff"; "masc_tool_help"; "masc_dashboard" ]
+let _tool_spec_read_only =
+  [
+    "masc_transport_status";
+    "masc_websocket_discovery";
+    "masc_verify_handoff";
+    "masc_tool_help";
+    "masc_web_search";
+    "masc_dashboard";
+  ]
 
 let () =
   List.iter

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -109,13 +109,29 @@ let decode_html_entities text =
 let clean_search_text text =
   text |> strip_cdata |> strip_html_tags |> decode_html_entities |> normalize_spaces
 
+let looks_like_rss_payload payload =
+  let normalized = String.lowercase_ascii payload in
+  String.contains normalized '<'
+  && (Re.execp (Re.Pcre.re "<rss\\b" |> Re.compile) normalized
+      || Re.execp (Re.Pcre.re "<channel\\b" |> Re.compile) normalized)
+
+let valid_search_result_url url =
+  let trimmed = String.trim url in
+  if trimmed = "" then
+    false
+  else
+    let uri = Uri.of_string trimmed in
+    match Uri.scheme uri |> Option.map String.lowercase_ascii with
+    | Some "http" | Some "https" -> true
+    | _ -> false
+
 let search_field pattern block =
   match Re.exec_opt (Re.Pcre.re pattern |> Re.compile) block with
   | None -> None
   | Some groups -> Some (Re.Group.get groups 1 |> clean_search_text)
 
 let parse_bing_rss_items (payload : string) : web_search_hit list =
-  let item_re = Re.Pcre.re "<item>([\\s\\S]*?)</item>" |> Re.compile in
+  let item_re = Re.Pcre.re "<item\\b[^>]*>([\\s\\S]*?)</item>" |> Re.compile in
   Re.all item_re payload
   |> List.filter_map (fun groups ->
          let block = Re.Group.get groups 1 in
@@ -125,10 +141,10 @@ let parse_bing_rss_items (payload : string) : web_search_hit list =
            search_field "<description>([\\s\\S]*?)</description>" block
          with
          | Some title, Some url, Some snippet
-           when title <> "" && url <> "" ->
+           when title <> "" && valid_search_result_url url ->
              Some (title, url, snippet)
          | Some title, Some url, None
-           when title <> "" && url <> "" ->
+           when title <> "" && valid_search_result_url url ->
              Some (title, url, "")
          | _ -> None)
 
@@ -270,6 +286,8 @@ let handle_web_search _ctx args =
     let limit = max 1 (min 10 (get_int args "limit" 5)) in
     match fetch_bing_rss ~query with
     | Error e -> (false, json_error e)
+    | Ok (_search_url, payload) when not (looks_like_rss_payload payload) ->
+        (false, json_error "search endpoint returned a non-RSS payload")
     | Ok (search_url, payload) ->
         let hits = parse_bing_rss_items payload |> take_results limit in
         (true, web_search_result_json ~query ~search_url ~engine:"bing_rss" hits)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -22,6 +22,30 @@ type web_search_hit = string * string * string
 
 let max_web_search_query_length = 500
 
+let whitespace_re = Re.Pcre.re "[ \t\r\n]+" |> Re.compile
+let html_tag_re = Re.Pcre.re "<[^>]+>" |> Re.compile
+let cdata_start_re = Re.str "<![CDATA[" |> Re.compile
+let cdata_end_re = Re.str "]]>" |> Re.compile
+let rss_re = Re.Pcre.re "<rss\\b" |> Re.compile
+let channel_re = Re.Pcre.re "<channel\\b" |> Re.compile
+let item_re = Re.Pcre.re "<item\\b[^>]*>([\\s\\S]*?)</item>" |> Re.compile
+let title_re = Re.Pcre.re "<title>([\\s\\S]*?)</title>" |> Re.compile
+let link_re = Re.Pcre.re "<link>([\\s\\S]*?)</link>" |> Re.compile
+let description_re = Re.Pcre.re "<description>([\\s\\S]*?)</description>" |> Re.compile
+
+let html_entity_replacements =
+  [
+    ("&amp;", "&");
+    ("&lt;", "<");
+    ("&gt;", ">");
+    ("&quot;", "\"");
+    ("&#39;", "'");
+    ("&#039;", "'");
+    ("&nbsp;", " ");
+  ]
+  |> List.map (fun (entity, replacement) ->
+         (Re.str entity |> Re.compile, replacement))
+
 let json_error message =
   Yojson.Safe.to_string
     (`Assoc [ ("status", `String "error"); ("message", `String message) ])
@@ -30,32 +54,22 @@ let json_ok fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
 let normalize_spaces text =
-  text
-  |> Re.replace_string (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) ~by:" "
-  |> String.trim
+  text |> Re.replace_string whitespace_re ~by:" " |> String.trim
 
 let strip_html_tags text =
-  Re.replace_string (Re.Pcre.re "<[^>]+>" |> Re.compile) ~by:"" text
+  Re.replace_string html_tag_re ~by:"" text
 
 let strip_cdata text =
   text
-  |> Re.replace_string (Re.str "<![CDATA[" |> Re.compile) ~by:""
-  |> Re.replace_string (Re.str "]]>" |> Re.compile) ~by:""
+  |> Re.replace_string cdata_start_re ~by:""
+  |> Re.replace_string cdata_end_re ~by:""
 
 let decode_html_entities text =
   let basic =
-    [
-      ("&amp;", "&");
-      ("&lt;", "<");
-      ("&gt;", ">");
-      ("&quot;", "\"");
-      ("&#39;", "'");
-      ("&#039;", "'");
-      ("&nbsp;", " ");
-    ]
+    html_entity_replacements
     |> List.fold_left
-         (fun acc (entity, replacement) ->
-           Re.replace_string (Re.str entity |> Re.compile) ~by:replacement acc)
+         (fun acc (entity_re, replacement) ->
+           Re.replace_string entity_re ~by:replacement acc)
          text
   in
   let len = String.length basic in
@@ -112,8 +126,7 @@ let clean_search_text text =
 let looks_like_rss_payload payload =
   let normalized = String.lowercase_ascii payload in
   String.contains normalized '<'
-  && (Re.execp (Re.Pcre.re "<rss\\b" |> Re.compile) normalized
-      || Re.execp (Re.Pcre.re "<channel\\b" |> Re.compile) normalized)
+  && (Re.execp rss_re normalized || Re.execp channel_re normalized)
 
 let valid_search_result_url url =
   let trimmed = String.trim url in
@@ -125,20 +138,19 @@ let valid_search_result_url url =
     | Some "http" | Some "https" -> true
     | _ -> false
 
-let search_field pattern block =
-  match Re.exec_opt (Re.Pcre.re pattern |> Re.compile) block with
+let search_field field_re block =
+  match Re.exec_opt field_re block with
   | None -> None
   | Some groups -> Some (Re.Group.get groups 1 |> clean_search_text)
 
 let parse_bing_rss_items (payload : string) : web_search_hit list =
-  let item_re = Re.Pcre.re "<item\\b[^>]*>([\\s\\S]*?)</item>" |> Re.compile in
   Re.all item_re payload
   |> List.filter_map (fun groups ->
          let block = Re.Group.get groups 1 in
          match
-           search_field "<title>([\\s\\S]*?)</title>" block,
-           search_field "<link>([\\s\\S]*?)</link>" block,
-           search_field "<description>([\\s\\S]*?)</description>" block
+           search_field title_re block,
+           search_field link_re block,
+           search_field description_re block
          with
          | Some title, Some url, Some snippet
            when title <> "" && valid_search_result_url url ->

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -13,6 +13,7 @@ type context = {
 
 val schemas : Types.tool_schema list
 
+val looks_like_rss_payload : string -> bool
 val parse_bing_rss_items : string -> (string * string * string) list
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -13,6 +13,8 @@ type context = {
 
 val schemas : Types.tool_schema list
 
+val parse_bing_rss_items : string -> (string * string * string) list
+
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
 
 val tool_inventory_json :

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -178,6 +178,27 @@ Use from the answering side after a prior masc_webrtc_offer call.";
     ];
   };
   {
+    name = "masc_web_search";
+    description = "Search the public web and return top result titles, URLs, and snippets. \
+Read-only helper for current-information lookups before deeper file or repo work. \
+Uses a public RSS-backed search endpoint and returns structured JSON.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Search query text");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum number of results to return (default 5, max 10)");
+          ("default", `Int 5);
+        ]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  };
+  {
     name = "masc_tool_admin_snapshot";
     description = "Return a unified admin snapshot of tool inventory, auth/RBAC, and command-plane surfaces.";
     input_schema = `Assoc [

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -187,7 +187,8 @@ let test_research_preset_has_read_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   (* keeper_read removed: dead alias with no schema, keeper_fs_read is the actual tool *)
   check bool "has keeper_fs_read" true (has_tool "keeper_fs_read" tools);
-  check bool "has keeper_library_search" true (has_tool "keeper_library_search" tools)
+  check bool "has keeper_library_search" true (has_tool "keeper_library_search" tools);
+  check bool "has masc_web_search" true (has_tool "masc_web_search" tools)
 
 let test_coding_preset_has_coordination_tools () =
   let meta = make_meta ~preset:Keeper_types.Coding () in

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -271,6 +271,7 @@ let all_known_tool_names =
     "masc_tool_admin_snapshot";
     "masc_tool_admin_update";
     "masc_tool_help";
+    "masc_web_search";
     "masc_tool_stats";
     "masc_transition";
     "masc_transport_status";
@@ -1046,8 +1047,20 @@ let git_guard_fragments =
     "path traversal";
   ]
 
+let web_search_guard_fragments =
+  [
+    "curl exit code";
+    "curl signal";
+    "curl stopped";
+    "search endpoint returned no http status";
+    "search endpoint returned http";
+    "search endpoint returned a non-rss payload";
+  ]
+
 let guard_fragments_for_name name =
-  if
+  if String.equal name "masc_web_search" then
+    web_search_guard_fragments
+  else if
     List.exists
       (fun prefix -> string_starts_with ~prefix name)
       [

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -244,6 +244,28 @@ let () = test "parse_bing_rss_items" (fun () ->
   | _ -> failwith "expected two parsed items"
 )
 
+let () = test "looks_like_rss_payload" (fun () ->
+  assert (Tool_misc.looks_like_rss_payload "<rss><channel></channel></rss>");
+  assert (Tool_misc.looks_like_rss_payload "<?xml version=\"1.0\"?><rss version=\"2.0\"></rss>");
+  assert (not (Tool_misc.looks_like_rss_payload "<html><body>captcha</body></html>"))
+)
+
+let () = test "parse_bing_rss_items_drops_non_http_links" (fun () ->
+  let payload =
+    {|<rss><channel>
+    <item><title>safe</title><link>https://example.com/</link><description>ok</description></item>
+    <item><title>bad</title><link>javascript:alert(1)</link><description>bad</description></item>
+    </channel></rss>|}
+  in
+  let items = Tool_misc.parse_bing_rss_items payload in
+  assert (List.length items = 1);
+  match items with
+  | [ (title, url, _snippet) ] ->
+      assert (title = "safe");
+      assert (url = "https://example.com/")
+  | _ -> failwith "expected one safe parsed item"
+)
+
 let () = test "dispatch_webrtc_offer" (fun () ->
   let ctx = make_test_ctx () in
   let args =

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -186,6 +186,49 @@ let () = test "dispatch_websocket_discovery" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_web_search_requires_query" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [] in
+  match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
+  | Some (success, result) ->
+      assert (not success);
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.member "status" json = `String "error");
+      assert (Yojson.Safe.Util.member "message" json = `String "query is required")
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "parse_bing_rss_items" (fun () ->
+  let payload =
+    {|<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>OpenAI &amp; ChatGPT</title>
+      <link>https://openai.com/</link>
+      <description>OpenAI&#39;s <b>latest</b> updates.</description>
+    </item>
+    <item>
+      <title><![CDATA[Example Result]]></title>
+      <link>https://example.com/hello?a=1&amp;b=2</link>
+      <description><![CDATA[Snippet with <b>markup</b> &amp; detail]]></description>
+    </item>
+  </channel>
+</rss>|}
+  in
+  let items = Tool_misc.parse_bing_rss_items payload in
+  assert (List.length items = 2);
+  match items with
+  | (title1, url1, snippet1) :: (title2, url2, snippet2) :: _ ->
+      assert (title1 = "OpenAI & ChatGPT");
+      assert (url1 = "https://openai.com/");
+      assert (snippet1 = "OpenAI's latest updates.");
+      assert (title2 = "Example Result");
+      assert (url2 = "https://example.com/hello?a=1&b=2");
+      assert (snippet2 = "Snippet with markup & detail")
+  | _ -> failwith "expected two parsed items"
+)
+
 let () = test "dispatch_webrtc_offer" (fun () ->
   let ctx = make_test_ctx () in
   let args =

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -198,6 +198,21 @@ let () = test "dispatch_web_search_requires_query" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_web_search_rejects_long_query" (fun () ->
+  let ctx = make_test_ctx () in
+  let query = String.make 501 'a' in
+  let args = `Assoc [ ("query", `String query) ] in
+  match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
+  | Some (success, result) ->
+      assert (not success);
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.member "status" json = `String "error");
+      assert
+        (Yojson.Safe.Util.member "message" json
+         = `String "query must be at most 500 characters")
+  | None -> failwith "dispatch returned None"
+)
+
 let () = test "parse_bing_rss_items" (fun () ->
   let payload =
     {|<?xml version="1.0" encoding="utf-8" ?>


### PR DESCRIPTION
## What changed

This adds a new read-only MCP tool, `masc_web_search`, to fetch public web search results as structured JSON (`title`, `url`, `snippet`).

The implementation lives in `tool_misc` and uses a Bing RSS search endpoint so agents and keepers can retrieve current web results without shelling out through privileged keeper paths.

## Why it changed

`masc-mcp` exposed no dedicated web search capability for spawned agents or keepers. Keepers could inspect local files and repo state, but there was no safe, first-class tool for current web lookups.

This closes that gap with a scoped search surface instead of expanding `keeper_bash` or relying on ad hoc network commands.

## Impact

- Public MCP clients can call `masc_web_search` directly.
- Spawned agents now see `masc_web_search` on their surface.
- Keeper research-capable presets can use `masc_web_search` without opening broader shell/network access.
- Surface and exposure tests now cover the new tool.

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/web-search-tool test/test_tool_misc_coverage.exe test/test_keeper_tool_exposure.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/web-search-tool test/test_tool_surface_ssot.exe test/test_tool_exposure.exe`
- `_build/default/test/test_tool_misc_coverage.exe`
- `_build/default/test/test_tool_misc_coverage.exe`
- `_build/default/test/test_keeper_tool_exposure.exe`
- `_build/default/test/test_tool_surface_ssot.exe`
- `_build/default/test/test_tool_exposure.exe`

---

## Summary

- Adds `masc_web_search` MCP tool: read-only structured web search via Bing RSS.
- Changes span 8 files: tool handler, JSON schema, surface registration, keeper registry, and tests.
- Agents and keepers can now retrieve web search results as first-class tool calls without shelling out.

## Product impact

Agents and keepers gain a scoped, read-only web search capability. This removes the need for `keeper_bash` or ad hoc network commands for web lookups, keeping the security surface minimal.

## Evidence

- All CI checks pass (Build and Test, Contract Harness, Health, Lint, PR Hygiene, Dashboard, Release Train).
- Unit tests cover tool dispatch, RSS parsing, surface registration, and keeper exposure.

## Review evidence

- Cross-model review: GLM-5.1 via direct `sb glm-text` (2026-04-03). No blockers identified.
- 5 Copilot review threads addressed and resolved (regex precompilation, HTTP status handling, public interface scope).

## Linked issue

No linked issue.