### PR TITLE
[codex] Gate keeper board context injection

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -353,22 +353,28 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
                 }
               in
               let matched = board_signal_match ~continuity_summary ~meta ~signal in
-              Some
-                {
+              if matched.explicit_mention then
+                Some
+                  {
+                    post_id;
+                    author = Board.Agent_id.to_string p.author;
+                    title = p.title;
+                    preview = short_preview ~max_len:80 p.content;
+                    hearth = p.hearth;
+                    post_kind = p.post_kind;
+                    updated_at = p.updated_at;
+                    explicit_mention = matched.explicit_mention;
+                    matched_targets = matched.matched_targets;
+                    self_commented = false;
+                    new_external_since = 0;
+                    latest_external_author = None;
+                    latest_external_preview = None;
+                  }
+              else (
+                Log.Keeper.debug
+                  "board dedup: skipping post_id=%s (no mention and no prior keeper participation)"
                   post_id;
-                  author = Board.Agent_id.to_string p.author;
-                  title = p.title;
-                  preview = short_preview ~max_len:80 p.content;
-                  hearth = p.hearth;
-                  post_kind = p.post_kind;
-                  updated_at = p.updated_at;
-                  explicit_mention = matched.explicit_mention;
-                  matched_targets = matched.matched_targets;
-                  self_commented = false;
-                  new_external_since = 0;
-                  latest_external_author = None;
-                  latest_external_preview = None;
-                }
+                None)
           | `New_external (count, ext_author, ext_preview) ->
               let signal : Board_dispatch.keeper_board_signal =
                 {

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -176,7 +176,7 @@ let test_observe_uses_precollected_board_events () =
       check bool "board event schedules turn" true
         (WO.should_run_unified_turn ~meta:minimal_meta obs))
 
-let test_collect_board_events_keeps_non_mentions () =
+let test_collect_board_events_skips_non_mentions_without_followup () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -201,14 +201,62 @@ let test_collect_board_events_keeps_non_mentions () =
           ~continuity_summary:"goal test-keeper"
           ~meta:minimal_meta
       in
-      check int "collects non-mention events" 1 (List.length events);
+      check int "skips non-mention events" 0 (List.length events);
       check int "new count includes non-mention" 1 new_count;
+      check int "mention count stays zero" 0 mention_count)
+
+let test_collect_board_events_keeps_external_replies_after_self_comment () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
+      let post_id =
+        match
+          Masc_mcp.Board_dispatch.create_post ~author:"alice"
+            ~title:"General update" ~content:"No direct mention here"
+            ~post_kind:Masc_mcp.Board.Human_post ()
+        with
+        | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+      in
+      (match
+         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"test-keeper"
+           ~content:"I am following this thread."
+           ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+      Unix.sleepf 0.02;
+      (match
+         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"bob"
+           ~content:"Thanks, there is a new question for you."
+           ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+      let events, new_count, mention_count =
+        WO.collect_board_events ~base_path:base_dir
+          ~continuity_summary:"goal test-keeper"
+          ~meta:minimal_meta
+      in
+      check int "new count still tracks recent post" 1 new_count;
       check int "mention count stays zero" 0 mention_count;
       match events with
       | [ event ] ->
-          check bool "explicit mention false" false event.explicit_mention;
-          check (list string) "matched targets empty" [] event.matched_targets
-      | _ -> fail "expected exactly one board event")
+          check bool "follow-up marks self commented" true event.self_commented;
+          check int "external reply count" 1 event.new_external_since;
+          check bool "no explicit mention required" false event.explicit_mention;
+          check string "latest external author" "bob"
+            (Option.value ~default:"" event.latest_external_author)
+      | _ -> fail "expected one follow-up board event")
 
 let test_observe_collects_room_signal_when_enabled () =
   let base_dir = temp_dir () in
@@ -1043,8 +1091,10 @@ let () =
           test_case "with mentions" `Quick test_observation_with_mentions;
           test_case "uses precollected board events" `Quick
             test_observe_uses_precollected_board_events;
-          test_case "collects non-mention board events" `Quick
-            test_collect_board_events_keeps_non_mentions;
+          test_case "skips non-mention board events without follow-up" `Quick
+            test_collect_board_events_skips_non_mentions_without_followup;
+          test_case "keeps external replies after self comment" `Quick
+            test_collect_board_events_keeps_external_replies_after_self_comment;
           test_case "collects room signal when enabled" `Quick
             test_observe_collects_room_signal_when_enabled;
           test_case "scheduled turn uses cooldown only" `Quick


### PR DESCRIPTION
## Summary
Keeper keepalive was treating any fresh non-self board post as actionable `pending_board_events`, even when the keeper had no explicit mention and had never participated in the thread.

## Product impact
- reduces unrelated keeper turn triggers on general board traffic
- preserves follow-up reactions for threads a keeper has already joined
- lowers persona drift and cross-thread context pollution in board-heavy rooms

## Evidence
- Root cause: `collect_board_events` promoted recent non-self posts into `pending_board_events` without requiring a mention or prior keeper participation
- Reproduction: recent board traffic on the `sleepers` thread caused unrelated keepers to react as if the thread were part of their active context
- Fix: gate new thread injection to explicit mentions, while still allowing re-entry when there are new external replies after a keeper comment

## Review evidence
- GLM-5.1 via direct `sb glm-text` at 2026-04-02 19:23:45Z returned `No findings.` for correctness-only review of the PR diff

## Linked issue
Fixes #4686

## What changed
- gate keeper board event injection so non-mention posts do not immediately become actionable keeper context
- keep follow-up reactions enabled when a keeper already commented and a new external reply arrives
- add regression tests for both the skip path and the follow-up path

## Why
A recent board post was being injected into multiple keepers even without an explicit mention or prior participation. That made keepers react to unrelated threads and looked like context continuity was broken, even though checkpoint and memory state were intact.

## Impact
- keepers should stop treating arbitrary fresh board posts as direct contextual interrupts
- board-driven follow-up behavior still works for threads a keeper has already entered
- reduces cross-thread noise and persona drift from unrelated board traffic

## Root cause
`collect_board_events` promoted recent non-self board posts into `pending_board_events` even when `board_signal_match` found no explicit mention and the keeper had never participated in the thread. `should_run_unified_turn` then treated those events as external triggers and ran a new turn.

## Validation
- `./_build/default/test/test_keeper_unified.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-board-context-gating`
- manual local verification on `http://127.0.0.1:8935/dashboard/?agent=sleepers#workspace?section=board&post=p-d9b2a7fc7f1450945d58a31d8c76d58c`
