### PR TITLE
fix(ci): release train guard warns instead of blocking version-neutral PRs

### DIFF
--- a/scripts/check-release-train-guard.sh
+++ b/scripts/check-release-train-guard.sh
@@ -83,7 +83,13 @@ fi
 
 if version_gt "$base_package_version" "$latest_tag_version"; then
   if [[ "$head_package_version" == "$base_package_version" ]]; then
-    fail "base ref $base_ref advertises unreleased package version $base_package_version while latest tag is v$latest_tag_version; publish/tag v$base_package_version before merging further PRs into main"
+    # PR does not change the package version — allow it through with a warning.
+    # The pending release tag is a repo-level concern, not this PR's responsibility.
+    printf '::warning::Release train: base %s is ahead of latest tag v%s. Tag v%s when ready.\n' \
+      "$base_package_version" "$latest_tag_version" "$base_package_version"
+    printf 'Release train guard OK (warn): base=%s head=%s latest_tag=%s (pending release)\n' \
+      "$base_package_version" "$head_package_version" "$latest_tag_version"
+    exit 0
   fi
   fail "base ref $base_ref advertises unreleased package version $base_package_version while latest tag is v$latest_tag_version, and head changes package version to $head_package_version; publish/tag v$base_package_version before widening the release train"
 fi


### PR DESCRIPTION
## Summary
- Release train guard가 base version > latest tag일 때 **버전을 변경하지 않는 PR**까지 차단하던 문제 수정
- 버전 미변경 PR: GitHub Actions warning annotation 출력 후 통과 (exit 0)
- 버전 변경 PR (release train 확장): 기존대로 차단 유지

## Root Cause
`main`의 `dune-project` 버전이 올라간 뒤 태그가 아직 안 붙으면, 모든 main 대상 PR이 CI에서 실패. PR 내용과 무관하게 repo-level 상태가 개별 PR을 차단하는 설계 결함.

## Test plan
- [x] `base_version > latest_tag`, `head == base` → warn + exit 0
- [x] `base_version > latest_tag`, `head != base` → fail (기존 동작 유지)
- [x] `base_version == latest_tag` → pass (기존 동작 유지)
- [x] bash syntax check 통과

Closes #4682