### PR TITLE
fix(backend): log warning on unknown task status instead of silent fallback

### DIFF
--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -138,7 +138,9 @@ let status_of_db ~status ~assignee ~claimed_at ~started_at ~completed_at ~cancel
         cancelled_at = Option.value cancelled_at ~default:"";
         reason;
       }
-  | _ -> Todo  (* fallback *)
+  | unknown ->
+      Log.Backend.warn "status_of_db: unknown task status %S, falling back to Todo" unknown;
+      Todo
 
 (** {1 Queries} *)
 


### PR DESCRIPTION
## Summary
- `task_pg.ml`의 `status_of_db`가 알 수 없는 DB status를 조용히 `Todo`로 변환하던 문제 수정
- 이제 `Log.Backend.warn`으로 알 수 없는 값을 기록한 뒤 fallback
- 데이터 손상이나 스키마 drift를 대시보드 로그에서 감지 가능

## Change
`| _ -> Todo` → `| unknown -> Log.Backend.warn ... ; Todo`

## Test plan
- [x] `dune build @check` 통과
- [x] 기존 동작 유지 (정상 status 처리 변경 없음)
- [ ] CI 빌드 확인

Closes #4671