### PR TITLE
[codex] clarify board direct post kind

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -376,10 +376,10 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     post_kind:
       (() => {
         const rawKind = asString(raw.post_kind, '').trim().toLowerCase()
-        return rawKind === 'automation' || rawKind === 'system' || rawKind === 'human'
-          ? rawKind
-          : undefined
+        if (rawKind === 'human' || rawKind === 'direct') return 'direct'
+        return rawKind === 'automation' || rawKind === 'system' ? rawKind : undefined
       })(),
+    classification_reason: asString(raw.classification_reason, '').trim() || null,
     title,
     body,
     content,
@@ -446,7 +446,8 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
     const post = normalizeBoardPost(postRaw) ?? {
       id: postId,
       author: 'unknown',
-      post_kind: 'human',
+      post_kind: 'direct',
+      classification_reason: null,
       title: 'Post',
       body: '',
       content: '',

--- a/dashboard/src/components/memory-post-detail.test.ts
+++ b/dashboard/src/components/memory-post-detail.test.ts
@@ -46,14 +46,15 @@ vi.mock('./memory-state', () => ({
   submitComment: vi.fn(),
   authorAvatar: (author: string) => `@${author}`,
   kindBadgeColor: () => '',
+  kindLabel: (kind: string) => (kind === 'direct' ? '직접' : kind),
   visibilityLabel: () => '',
   visibilityBadgeColor: () => '',
-  boardPostKind: () => 'human',
+  boardPostKind: () => 'direct',
   votePost: vi.fn(),
   refreshBoard: vi.fn(),
 }))
 
-import { CommentThread } from './memory-post-detail'
+import { CommentThread, PostDetail } from './memory-post-detail'
 
 afterEach(() => {
   cleanup()
@@ -84,5 +85,30 @@ describe('CommentThread', () => {
 
     expect(screen.getByText('orphan reply still visible')).toBeInTheDocument()
     expect(screen.getByText(/댓글 1개/)).toBeInTheDocument()
+  })
+})
+
+describe('PostDetail', () => {
+  it('renders the classification reason when present', () => {
+    const post = {
+      id: 'post-1',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      classification_reason: 'Direct board post without automation provenance.',
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.getByText(/분류 근거:/)).toBeInTheDocument()
+    expect(screen.getByText(/Direct board post without automation provenance/)).toBeInTheDocument()
+    expect(screen.getByText('직접')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -19,6 +19,7 @@ import {
   submitComment,
   authorAvatar,
   kindBadgeColor,
+  kindLabel,
   visibilityLabel,
   visibilityBadgeColor,
   boardPostKind,
@@ -228,13 +229,18 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Badges -->
-          ${(post.hearth || post.visibility || post.expires_at)
+          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason)
             ? html`
-                <div class="flex gap-1.5 flex-wrap">
-                  ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
-                  ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
-                  <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(boardPostKind(post))}">${boardPostKind(post) === 'human' ? '사람' : boardPostKind(post)}</span>
-                  ${expiryChip(post)}
+                <div class="flex flex-col gap-2">
+                  <div class="flex gap-1.5 flex-wrap">
+                    ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
+                    ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
+                    ${expiryChip(post)}
+                  </div>
+                  ${post.classification_reason
+                    ? html`<div class="text-[11px] text-[var(--text-muted)]">분류 근거: ${post.classification_reason}</div>`
+                    : null}
                 </div>
               `
             : null}

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -97,15 +97,15 @@ export function isUpdated(post: BoardPost): boolean {
   return post.updated_at !== post.created_at
 }
 
-export function boardPostKind(post: BoardPost): 'human' | 'automation' | 'system' {
-  return post.post_kind ?? 'human'
+export function boardPostKind(post: BoardPost): 'direct' | 'automation' | 'system' {
+  return post.post_kind ?? 'direct'
 }
 
 export type VisibleBoardGroups = {
-  human: BoardPost[]
+  direct: BoardPost[]
   automation: BoardPost[]
   system: BoardPost[]
-  totalHuman: number
+  totalDirect: number
   totalAutomation: number
   totalSystem: number
   hiddenAutomation: number
@@ -113,19 +113,19 @@ export type VisibleBoardGroups = {
 }
 
 export function splitVisiblePosts(posts: BoardPost[]): VisibleBoardGroups {
-  const human: BoardPost[] = []
+  const direct: BoardPost[] = []
   const automation: BoardPost[] = []
   const system: BoardPost[] = []
-  let totalHuman = 0
+  let totalDirect = 0
   let totalAutomation = 0
   let totalSystem = 0
   let hiddenAutomation = 0
   let hiddenSystem = 0
   posts.forEach(post => {
     const kind = boardPostKind(post)
-    if (kind === 'human') {
-      totalHuman += 1
-      human.push(post)
+    if (kind === 'direct') {
+      totalDirect += 1
+      direct.push(post)
       return
     }
     if (kind === 'automation') {
@@ -145,10 +145,10 @@ export function splitVisiblePosts(posts: BoardPost[]): VisibleBoardGroups {
     system.push(post)
   })
   return {
-    human,
+    direct,
     automation,
     system,
-    totalHuman,
+    totalDirect,
     totalAutomation,
     totalSystem,
     hiddenAutomation,
@@ -157,8 +157,8 @@ export function splitVisiblePosts(posts: BoardPost[]): VisibleBoardGroups {
 }
 
 export function filterHint(grouped: VisibleBoardGroups): string | null {
-  if (grouped.totalAutomation === 0 && grouped.totalSystem === 0 && grouped.totalHuman > 0) {
-    return '현재 목록은 사람 글만 있어서 자동화·시스템 필터를 눌러도 보이는 글 수가 그대로일 수 있습니다.'
+  if (grouped.totalAutomation === 0 && grouped.totalSystem === 0 && grouped.totalDirect > 0) {
+    return '현재 목록은 직접 작성 글만 있어서 자동화·시스템 필터를 눌러도 보이는 글 수가 그대로일 수 있습니다.'
   }
   if (boardExcludeAutomation.value && grouped.hiddenAutomation > 0) {
     return `자동화 글 ${grouped.hiddenAutomation}건이 숨겨져 있습니다.`
@@ -180,7 +180,7 @@ export function authorAvatar(name: string): string {
 
 export function kindLabel(kind: string): string {
   switch (kind) {
-    case 'human': return '사람'
+    case 'direct': return '직접'
     case 'automation': return '자동화'
     case 'system': return '시스템'
     default: return kind
@@ -189,7 +189,7 @@ export function kindLabel(kind: string): string {
 
 export function kindBadgeColor(kind: string): string {
   switch (kind) {
-    case 'human': return 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)]'
+    case 'direct': return 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)]'
     case 'automation': return 'bg-[var(--cyan-16)] text-[#38bdf8] border-[rgba(34,211,238,0.3)]'
     case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
     default: return 'bg-[var(--white-8)] text-[var(--text-muted)] border-[var(--border-slate-16)]'

--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -73,23 +73,24 @@ describe('Memory Component', () => {
     expect(screen.getByText(/메모리 피드 불러오는 중/)).toBeInTheDocument()
   })
   
-  it('renders a list of human posts', () => {
+  it('renders a list of direct posts', () => {
     boardPosts.value = [
       {
         id: 'post-1',
         title: 'Test Post',
         body: 'Hello world',
-        author: 'human-agent',
+        author: 'direct-agent',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         comment_count: 0,
         votes: 0,
-        post_kind: 'human',
+        post_kind: 'direct',
       }
     ] as any
     render(h(Memory, null))
     expect(screen.getByText('Test Post')).toBeInTheDocument()
-    expect(screen.getByText(/현재 목록은 사람 글만 있어서/)).toBeInTheDocument()
+    expect(screen.getByText(/현재 목록은 직접 작성 글만 있어서/)).toBeInTheDocument()
+    expect(screen.getByText(/직접 작성 글 \(1\)/)).toBeInTheDocument()
   })
 
   it('separates automation posts into the autonomy section', () => {

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -228,7 +228,7 @@ function SortBar() {
 function MemorySummary() {
   const sortLabel = SORT_MODES.find(mode => mode.id === boardSortMode.value)?.label ?? boardSortMode.value
   const grouped = splitVisiblePosts(boardPosts.value)
-  const visibleCount = grouped.human.length + grouped.automation.length + grouped.system.length
+  const visibleCount = grouped.direct.length + grouped.automation.length + grouped.system.length
   const automationPolicy = grouped.totalAutomation === 0
     ? '자동화 글 없음'
     : boardExcludeAutomation.value
@@ -377,7 +377,7 @@ function PostCard({ post }: { post: BoardPost }) {
 export function Memory() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
   const grouped = splitVisiblePosts(boardPosts.value)
-  const posts = [...grouped.human, ...grouped.automation, ...grouped.system]
+  const posts = [...grouped.direct, ...grouped.automation, ...grouped.system]
   const hint = filterHint(grouped)
   const postId = route.value.params.post ?? null
   const post = postId
@@ -425,7 +425,7 @@ export function Memory() {
         : posts.length === 0
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`
-              ${renderSection('사람이 쓴 글', grouped.human, visibleLimit)}
+              ${renderSection('직접 작성 글', grouped.direct, visibleLimit)}
               ${renderSection('자율 글', grouped.automation, automationVisibleLimit)}
               ${renderSection('시스템 글', grouped.system, systemVisibleLimit)}
             `}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -147,7 +147,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'board',
       label: '작업 게시판',
-      description: '에이전트 간 지식 공유 게시판. 사람 글, 자동화 글(시스템 자동 생성), 시스템 글 구분.',
+      description: '에이전트 간 지식 공유 게시판. 직접 작성 글, 자동화 글, 시스템 글을 함께 보여줍니다.',
       params: { section: 'board' },
     },
     {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -48,7 +48,8 @@ export interface Message {
 export interface BoardPost {
   id: string
   author: string
-  post_kind?: 'human' | 'automation' | 'system'
+  post_kind?: 'direct' | 'automation' | 'system'
+  classification_reason?: string | null
   title: string
   body: string
   content: string

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -274,7 +274,7 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
 let classify_post_kind (p : post) = p.post_kind
 
 let post_classification_reason (p : post) =
-  let author = Agent_id.to_string p.author in
+  let author = String.lowercase_ascii (Agent_id.to_string p.author) in
   match p.post_kind, meta_source p.meta_json with
   | Human_post, Some "dashboard_board_post" ->
       "Direct board post created from the dashboard without automation override."

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -206,11 +206,12 @@ let visibility_of_string = function
   | _ -> None
 
 let post_kind_to_string = function
-  | Human_post -> "human"
+  | Human_post -> "direct"
   | Automation_post -> "automation"
   | System_post -> "system"
 
 let post_kind_of_string = function
+  | "direct" -> Some Human_post
   | "human" -> Some Human_post
   | "automation" -> Some Automation_post
   | "system" -> Some System_post
@@ -271,6 +272,29 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
     Human_post
 
 let classify_post_kind (p : post) = p.post_kind
+
+let post_classification_reason (p : post) =
+  let author = Agent_id.to_string p.author in
+  match p.post_kind, meta_source p.meta_json with
+  | Human_post, Some "dashboard_board_post" ->
+      "Direct board post created from the dashboard without automation override."
+  | Human_post, Some source ->
+      Printf.sprintf
+        "Direct board post without automation override (source=%s)." source
+  | Human_post, None ->
+      "Direct board post without automation provenance."
+  | Automation_post, Some "keeper_board_post" ->
+      "Keeper board adapter forced automation classification."
+  | Automation_post, Some "dashboard_board_post" ->
+      "Dashboard board post classified as automation for a joined agent author."
+  | Automation_post, Some source ->
+      Printf.sprintf "Automation provenance source: %s." source
+  | Automation_post, None when legacy_author_looks_automation author ->
+      "Legacy automation classification from author naming heuristic."
+  | Automation_post, None ->
+      "Automation post preserved by board post_kind contract."
+  | System_post, _ ->
+      "System post reserved for platform or operator authored messages."
 
 let post_matches_filters ~exclude_system ~exclude_automation (p : post) =
   let kind = p.post_kind in
@@ -390,6 +414,7 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
     ("title", `String p.title);
     ("body", `String p.body);
     ("post_kind", `String (post_kind_to_string p.post_kind));
+    ("classification_reason", `String (post_classification_reason p));
     ("content", `String p.content);
     ("visibility", `String (visibility_to_string p.visibility));
     ("created_at", `Float p.created_at);

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -575,6 +575,7 @@ let post_to_yojson_with_karma (p : post) ~author_karma : Yojson.Safe.t =
     ("title", `String p.title);
     ("body", `String p.body);
     ("post_kind", `String (post_kind_to_string p.post_kind));
+    ("classification_reason", `String (post_classification_reason p));
     ("content", `String p.body);
     ("flair", flair_json);
     ("visibility", `String (visibility_to_string p.visibility));

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -24,7 +24,7 @@ let format_board_events
        (fun (event : Keeper_world_observation.pending_board_event) ->
          let kind =
            match event.post_kind with
-           | Board.Human_post -> "human"
+           | Board.Human_post -> "direct"
            | Board.Automation_post -> "automation"
            | Board.System_post -> "system"
          in

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -45,10 +45,10 @@ let json_ensure_meta_source source = function
         | Some (`Assoc meta_fields as existing_meta) -> (
             match List.assoc_opt "source" meta_fields with
             | Some (`String current) when String.trim current <> "" -> existing_meta
-            | _ -> `Assoc (("source", `String source) :: List.remove_assoc "source" meta_fields))
+            | _ -> `Assoc (("source", `String source) :: List.filter (fun (k, _) -> k <> "source") meta_fields))
         | _ -> `Assoc [ ("source", `String source) ]
       in
-      let fields = ("meta", meta_json) :: List.remove_assoc "meta" fields in
+      let fields = ("meta", meta_json) :: List.filter (fun (k, _) -> k <> "meta") fields in
       `Assoc fields
   | _non_object ->
       failwith "json_ensure_meta_source: expected JSON object"

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -38,6 +38,21 @@ let json_upsert_string_field name value = function
   | _non_object ->
       failwith (Printf.sprintf "json_upsert_string_field: expected JSON object, got non-object for field %S" name)
 
+let json_ensure_meta_source source = function
+  | `Assoc fields ->
+      let meta_json =
+        match List.assoc_opt "meta" fields with
+        | Some (`Assoc meta_fields as existing_meta) -> (
+            match List.assoc_opt "source" meta_fields with
+            | Some (`String current) when String.trim current <> "" -> existing_meta
+            | _ -> `Assoc (("source", `String source) :: List.remove_assoc "source" meta_fields))
+        | _ -> `Assoc [ ("source", `String source) ]
+      in
+      let fields = ("meta", meta_json) :: List.remove_assoc "meta" fields in
+      `Assoc fields
+  | _non_object ->
+      failwith "json_ensure_meta_source: expected JSON object"
+
 let governance_surface_for_param_key param_key =
   Governance_registry.surfaces
   |> List.find_opt (fun (surface : Governance_registry.surface) ->
@@ -258,6 +273,7 @@ let add_routes ~sw ~clock router =
              let args =
                Yojson.Safe.from_string body_str
                |> json_upsert_string_field "author" agent_name
+               |> json_ensure_meta_source "dashboard_board_post"
              in
              let (ok, msg) = Tool_board.handle_tool "masc_board_post" args in
              let status = if ok then `Created else `Bad_request in

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -115,8 +115,8 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
   | None ->
       let author_lc = String.lowercase_ascii (String.trim author) in
       if author_lc = "" || author_lc = "anonymous" then
-        (* Missing or default author is never human — classify as automation
-           to prevent misleading human-attributed posts (#4604). *)
+        (* Missing or default author is never direct/manual — classify as
+           automation to prevent misleading direct-attributed posts (#4604). *)
         Ok Board.Automation_post
       else
         (match !agent_lookup_hook with
@@ -513,7 +513,7 @@ let handle_hearth_list _args =
 
 let tool_post_create : Types.tool_schema = {
   name = "masc_board_post";
-  description = "Create a human-authored post on the MASC internal board for sharing updates, questions, or knowledge with other agents. Keeper and internal automation surfaces use narrower adapters.";
+  description = "Create a direct/manual post on the MASC internal board for sharing updates, questions, or knowledge with other agents. Keeper and internal automation surfaces use narrower adapters.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -64,7 +64,7 @@ let () =
     Printf.printf "✓ Sweeper removed 0 permanent posts\n"
   in
 
-  let test_post_kind_human_default () =
+  let test_post_kind_direct_default () =
     let store = create_store () in
     match
       create_post store ~author:"test-agent" ~content:"Human post"
@@ -73,9 +73,14 @@ let () =
     | Ok post ->
         let json = post_to_yojson post in
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
-        assert (String.equal kind "human");
-        Printf.printf "✓ Default board post kind is human\n"
-    | Error e -> fail_board_test "Failed to create human post" e
+        let reason =
+          Yojson.Safe.Util.(json |> member "classification_reason" |> to_string)
+        in
+        assert (String.equal kind "direct");
+        assert
+          (String.equal reason "Direct board post without automation provenance.");
+        Printf.printf "✓ Default board post kind is direct\n"
+    | Error e -> fail_board_test "Failed to create direct post" e
   in
 
   let test_post_kind_automation_contract () =
@@ -114,7 +119,12 @@ let test_post_kind_keeper_provenance_upgrade () =
         assert (classify_post_kind post = Automation_post);
         let json = post_to_yojson post in
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
+        let reason =
+          Yojson.Safe.Util.(json |> member "classification_reason" |> to_string)
+        in
         assert (String.equal kind "automation");
+        assert
+          (String.equal reason "Keeper board adapter forced automation classification.");
         Printf.printf "✓ Keeper provenance preserves automation post kind\n"
   | Error e -> fail_board_test "Failed to create keeper provenance post" e
   in
@@ -123,7 +133,7 @@ let test_post_kind_keeper_provenance_upgrade () =
   test_permanent_post ();
   test_expiring_post ();
   test_sweeper_skips_permanent ();
-  test_post_kind_human_default ();
+  test_post_kind_direct_default ();
   test_post_kind_automation_contract ();
   test_post_kind_system_contract ();
   test_post_kind_keeper_provenance_upgrade ();

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -203,7 +203,7 @@ let test_post_create_structured_payload () =
     Yojson.Safe.Util.(json |> member "body" |> to_string);
   Alcotest.(check string) "content alias" "Visible answer"
     Yojson.Safe.Util.(json |> member "content" |> to_string);
-  Alcotest.(check string) "public posts stay human" "human"
+  Alcotest.(check string) "public posts stay direct" "direct"
     Yojson.Safe.Util.(json |> member "post_kind" |> to_string);
   Alcotest.(check string) "source meta kept" "keeper_autonomy"
     Yojson.Safe.Util.(json |> member "meta" |> member "source" |> to_string);
@@ -737,7 +737,7 @@ let () =
         ] );
       ( "post_kind_registry",
         [
-          Alcotest.test_case "no hook: defaults to human" `Quick (fun () ->
+          Alcotest.test_case "no hook: defaults to direct" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
             cleanup ();
@@ -747,8 +747,8 @@ let () =
               ("author", `String "claude-agent")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "classified as human" true
-              (contains_substring msg {|"post_kind": "human"|}));
+            Alcotest.(check bool) "classified as direct" true
+              (contains_substring msg {|"post_kind": "direct"|}));
           Alcotest.test_case "with hook: agent classified as automation" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -761,7 +761,7 @@ let () =
             Alcotest.(check bool) "post created" true ok;
             Alcotest.(check bool) "classified as automation" true
               (contains_substring msg {|"post_kind": "automation"|}));
-          Alcotest.test_case "with hook: non-agent stays human" `Quick (fun () ->
+          Alcotest.test_case "with hook: non-agent stays direct" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
             cleanup ();
@@ -771,9 +771,9 @@ let () =
               ("author", `String "sangsu")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "classified as human" true
-              (contains_substring msg {|"post_kind": "human"|}));
-          Alcotest.test_case "explicit override respected" `Quick (fun () ->
+            Alcotest.(check bool) "classified as direct" true
+              (contains_substring msg {|"post_kind": "direct"|}));
+          Alcotest.test_case "legacy human override normalizes to direct" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
             cleanup ();
@@ -784,7 +784,7 @@ let () =
               ("post_kind", `String "human")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "explicit human override" true
-              (contains_substring msg {|"post_kind": "human"|}));
+            Alcotest.(check bool) "legacy override normalized to direct" true
+              (contains_substring msg {|"post_kind": "direct"|}));
         ] );
     ]


### PR DESCRIPTION
## What changed

- Renamed the board post kind surface from `human` to `direct` while keeping legacy `human` input compatibility.
- Added `classification_reason` to board post payloads and showed it in the board post detail view.
- Updated dashboard labels from 사람 to 직접 so the UI matches the actual provenance semantics.

## Why

- `human` had been interpreted as a literal person tag, but the board logic really meant direct/manual posts without automation provenance.
- The mismatch made agent-authored direct posts look incorrectly human in the dashboard.

## Impact

- Board API consumers now receive `post_kind: "direct"` for direct/manual posts.
- Existing `human` payloads still parse and normalize to `direct`.
- Operators can inspect `classification_reason` in the post detail view to see why a post was classified as direct, automation, or system.

## Validation

- `pnpm -C dashboard exec tsc --noEmit --pretty false`
- `pnpm -C dashboard test -- --run src/components/memory.test.ts src/components/memory-post-detail.test.ts`
- `dune build`
- `./_build/default/test/test_tool_board_coverage.exe`
