### PR TITLE
refactor(dashboard): deduplicate KeeperConfigLoadStatus type

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -7,6 +7,7 @@ import { signal } from '@preact/signals'
 import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig } from '../types'
+import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens } from '../lib/format-number'
 import { showToast } from './common/toast'
 import { createAsyncResource, loaded } from '../lib/async-state'
@@ -157,7 +158,7 @@ export function peekLoadedKeeperConfig(name: string): KeeperConfig | null {
 
 export function peekKeeperConfigLoadStatus(
   name: string,
-): 'idle' | 'loading' | 'loaded' | 'error' | 'other' {
+): KeeperConfigLoadStatus {
   const state = configState.value
   if (configKeeperName.value !== name) return 'other'
   return state.status


### PR DESCRIPTION
## Summary

- Import `KeeperConfigLoadStatus` from `keeper-detail-source.ts` in `keeper-config-panel.ts` instead of redeclaring the same union type inline as the return type of `peekKeeperConfigLoadStatus`.
- Eliminates drift risk where one definition could be updated without the other.
- Addresses unresolved review feedback from #4672.

## Test plan

- [x] `tsc --noEmit` passes (exit 0)
- [x] `vitest run` passes (58 files, 263 tests)
- [ ] CI green

Refs #4672

Generated with [Claude Code](https://claude.com/claude-code)