### PR TITLE
fix(harness): distinguish skip from pass in observability smoke scripts

### DIFF
--- a/scripts/harness/lib/obs_smoke_common.sh
+++ b/scripts/harness/lib/obs_smoke_common.sh
@@ -7,8 +7,12 @@ FAIL_COUNT=0
 
 # Exit code 2 = skipped (distinct from 0=pass, 1=fail).
 # Set OBS_PERMISSIVE=1 to treat skips as exit 0 for local dev convenience.
-OBS_SKIP_EXIT=${OBS_PERMISSIVE:+0}
-OBS_SKIP_EXIT=${OBS_SKIP_EXIT:-2}
+OBS_SKIP_EXIT=2
+case "${OBS_PERMISSIVE:-}" in
+  1|true|TRUE|yes|YES)
+    OBS_SKIP_EXIT=0
+    ;;
+esac
 
 obs_skip() {
   echo "SKIP: $1"

--- a/scripts/harness/lib/obs_smoke_common.sh
+++ b/scripts/harness/lib/obs_smoke_common.sh
@@ -5,10 +5,20 @@
 PASS_COUNT=0
 FAIL_COUNT=0
 
+# Exit code 2 = skipped (distinct from 0=pass, 1=fail).
+# Set OBS_PERMISSIVE=1 to treat skips as exit 0 for local dev convenience.
+OBS_SKIP_EXIT=${OBS_PERMISSIVE:+0}
+OBS_SKIP_EXIT=${OBS_SKIP_EXIT:-2}
+
+obs_skip() {
+  echo "SKIP: $1"
+  exit "$OBS_SKIP_EXIT"
+}
+
 obs_require_commands() {
   for cmd in jq curl python3; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
-      echo "SKIP: $cmd not found" && exit 0
+      obs_skip "$cmd not found"
     fi
   done
 }
@@ -17,8 +27,7 @@ obs_require_server_exe() {
   local root_dir="$1"
   local exe
   exe="$(harness_find_server_exe "$root_dir" "${SERVER_EXE:-}")" || {
-    echo "SKIP: server executable not found (run: dune build)"
-    exit 0
+    obs_skip "server executable not found (run: dune build)"
   }
   printf '%s\n' "$exe"
 }

--- a/scripts/harness/workload/observability_smoke_coding.sh
+++ b/scripts/harness/workload/observability_smoke_coding.sh
@@ -87,8 +87,7 @@ else
 fi
 
 if ! obs_wait_for_ready "$PORT" "$HEALTH_TIMEOUT_SEC"; then
-  echo "SKIP: server did not become healthy (not running or build missing)"
-  exit 0
+  obs_skip "server did not become healthy (not running or build missing)"
 fi
 
 # ── step 2: bootstrap room ──
@@ -150,8 +149,7 @@ proof_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
   "http://127.0.0.1:${PORT}/api/v1/dashboard/proof?session_id=${TEAM_SESSION_ID}" 2>/dev/null || true)"
 
 if [ -z "$proof_json" ]; then
-  echo "SKIP: proof endpoint returned empty"
-  exit 0
+  obs_skip "proof endpoint returned empty"
 fi
 
 # Extract all tool_input_preview values and check lengths

--- a/scripts/harness/workload/observability_smoke_coding.sh
+++ b/scripts/harness/workload/observability_smoke_coding.sh
@@ -22,7 +22,8 @@
 #   - No raw API key patterns in any preview field
 #
 # Exit codes:
-#   0 - PASS (or graceful skip if server unavailable)
+#   0 - PASS (or graceful skip when OBS_PERMISSIVE=1)
+#   2 - SKIP (default when a prerequisite/environment is unavailable)
 #   1 - FAIL
 
 set -euo pipefail

--- a/scripts/harness/workload/observability_smoke_supervisor.sh
+++ b/scripts/harness/workload/observability_smoke_supervisor.sh
@@ -82,8 +82,7 @@ else
 fi
 
 if ! obs_wait_for_ready "$PORT" "$HEALTH_TIMEOUT_SEC"; then
-  echo "SKIP: server did not become healthy (not running or build missing)"
-  exit 0
+  obs_skip "server did not become healthy (not running or build missing)"
 fi
 
 # ── step 2: initialize room and join ──
@@ -152,8 +151,7 @@ proof_json="$(curl -fsS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" \
   "http://127.0.0.1:${PORT}/api/v1/dashboard/proof?session_id=${TEAM_SESSION_ID}" 2>/dev/null || true)"
 
 if [ -z "$proof_json" ]; then
-  echo "SKIP: proof endpoint returned empty (endpoint may not exist yet)"
-  exit 0
+  obs_skip "proof endpoint returned empty (endpoint may not exist yet)"
 fi
 
 # Assert: trace_ref presence in worker run entries

--- a/scripts/harness/workload/observability_smoke_supervisor.sh
+++ b/scripts/harness/workload/observability_smoke_supervisor.sh
@@ -17,7 +17,8 @@
 #   HEALTH_TIMEOUT_SEC   - server health check timeout (default: 30)
 #
 # Exit codes:
-#   0 - PASS (or graceful skip if server unavailable)
+#   0 - PASS (or graceful skip when OBS_PERMISSIVE=1)
+#   2 - SKIP (default when a prerequisite/environment is unavailable)
 #   1 - FAIL
 
 set -euo pipefail

--- a/scripts/harness/workload/observability_smoke_swarm.sh
+++ b/scripts/harness/workload/observability_smoke_swarm.sh
@@ -102,8 +102,7 @@ else
 fi
 
 if ! obs_wait_for_ready "$PORT" "$HEALTH_TIMEOUT_SEC"; then
-  echo "SKIP: server did not become healthy (not running or build missing)"
-  exit 0
+  obs_skip "server did not become healthy (not running or build missing)"
 fi
 
 # ── step 2: bootstrap room ──

--- a/scripts/harness/workload/observability_smoke_swarm.sh
+++ b/scripts/harness/workload/observability_smoke_swarm.sh
@@ -25,7 +25,8 @@
 #   4. Assert: distinct cascade_name values and visible model/cascade evidence across keepers
 #
 # Exit codes:
-#   0 - PASS (or graceful skip if server unavailable)
+#   0 - PASS (or graceful skip when OBS_PERMISSIVE=1)
+#   2 - SKIP (default when a prerequisite/environment is unavailable)
 #   1 - FAIL
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Observability smoke 스크립트가 prerequisite 미충족(커맨드 없음, 빌드 없음, 서버 미응답, proof 비어있음) 시 `exit 0`으로 성공을 위장하던 문제 수정
- 새로운 `obs_skip()` 함수: exit code 2 (skip)로 "실행 안 됨"과 "통과"를 구별
- `OBS_PERMISSIVE=1` 환경변수로 로컬 개발 시 기존 exit 0 동작 유지 가능

## Changed files
- `scripts/harness/lib/obs_smoke_common.sh` — `obs_skip()`, `OBS_SKIP_EXIT`, `OBS_PERMISSIVE` 추가
- `scripts/harness/workload/observability_smoke_{coding,supervisor,swarm}.sh` — `exit 0` → `obs_skip`

## Product impact
- Observability smoke suite의 신뢰도 향상: skip과 pass가 구별되어 CI 결과 해석이 정확해짐
- 기존 로컬 개발 워크플로에 영향 없음 (`OBS_PERMISSIVE=1`로 이전 동작 유지 가능)

## Evidence
- `bash -n` syntax check 통과
- 3개 workload 스크립트 모두 `obs_skip` 호출로 전환 확인
- CI 체크 전체 green (Build and Test, Contract Harness, Lint, Dashboard, Health, PR Hygiene)

## Review evidence
- Copilot review: 4 threads — OBS_PERMISSIVE parsing 개선, exit code 문서 업데이트 피드백 반영 완료
- Cross-model review: GLM-5.1 via `sb glm-text` — no blocking issues, approved

## Linked issue
Closes #4666

## Test plan
- [x] bash syntax check 통과
- [x] CI에서 직접 호출되지 않음 확인 (optional env-gated suite)
- [x] CI 빌드 확인