### PR TITLE
fix(keeper): normalize trailing slash in allowed_paths check (#4693)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -8,6 +8,10 @@ let starts_with ~(prefix : string) (s : string) : bool =
   let lp = String.length prefix in
   String.length s >= lp && String.sub s 0 lp = prefix
 
+let strip_trailing_slash s =
+  let len = String.length s in
+  if len > 0 && s.[len - 1] = '/' then String.sub s 0 (len - 1) else s
+
 let normalize_path_for_check (path : string) : string =
   try Unix.realpath path
   with Unix.Unix_error _ ->
@@ -49,7 +53,10 @@ let resolve_keeper_target_path ~(config : Room.config)
         else ""
       in
       let matches_any =
-        List.exists (fun ap -> starts_with ~prefix:ap rel) allowed_paths
+        List.exists (fun ap ->
+          let ap' = strip_trailing_slash ap in
+          rel = ap' || starts_with ~prefix:(ap' ^ "/") rel
+        ) allowed_paths
       in
       if matches_any then Ok candidate
       else

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -9,8 +9,12 @@ let starts_with ~(prefix : string) (s : string) : bool =
   String.length s >= lp && String.sub s 0 lp = prefix
 
 let strip_trailing_slash s =
+  let rec find_end i =
+    if i > 0 && s.[i - 1] = '/' then find_end (i - 1) else i
+  in
   let len = String.length s in
-  if len > 0 && s.[len - 1] = '/' then String.sub s 0 (len - 1) else s
+  let end_pos = find_end len in
+  if end_pos = len then s else String.sub s 0 end_pos
 
 let normalize_path_for_check (path : string) : string =
   try Unix.realpath path

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -335,6 +335,17 @@ let test_path_allowed_paths_filter () =
         (Str.regexp_string "path_not_in_allowed_paths") err 0 in true
        with Not_found -> false))
 
+let test_path_allowed_paths_filter_strips_all_trailing_slashes () =
+  let dir = make_path_test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let ok_result = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:["lib//"] ~raw_path:"lib/foo.ml" in
+    check bool "lib path allowed with repeated trailing slash" true
+      (Result.is_ok ok_result))
+
 let test_path_empty_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
@@ -427,6 +438,8 @@ let () =
       test_case "absolute outside root" `Quick test_path_absolute_outside_root;
       test_case "traversal attack" `Quick test_path_traversal_attack;
       test_case "allowed_paths filter" `Quick test_path_allowed_paths_filter;
+      test_case "allowed_paths strip all trailing slashes" `Quick
+        test_path_allowed_paths_filter_strips_all_trailing_slashes;
       test_case "empty path rejected" `Quick test_path_empty_rejected;
       test_case "whitespace only rejected" `Quick test_path_whitespace_only_rejected;
       test_case "empty allowed permits all" `Quick test_path_empty_allowed_permits_all_within_root;


### PR DESCRIPTION
## Summary
- `Unix.realpath`가 trailing slash를 제거하지만, `allowed_paths` 항목에는 trailing slash가 포함
- `starts_with` 비교 시 prefix가 더 길어서 항상 false → 허용된 경로도 거부
- `strip_trailing_slash` 헬퍼 추가 + exact match 체크 추가로 해결

## 증상
```
WARN: tool keeper_shell_readonly returned error result:
  {"error":"path_not_in_allowed_paths: .masc/keepers/config-provenance/ (allowed: [.masc/keepers/config-provenance/, .masc/traces/])"}
```

## Product impact
- keeper의 `keeper_shell_readonly` 도구가 trailing slash가 포함된 allowed_paths를 정상 인식
- 기존에 거부되던 합법적 경로 접근이 복구됨

## Evidence
- 재현: allowed_paths에 trailing slash 포함 시 항상 `path_not_in_allowed_paths` 에러
- 수정 후: `test_keeper_tool_exposure.exe` 37 tests pass (trailing slash 포함 케이스 추가)

## Review evidence
- Copilot 리뷰 2건 → 코드에 반영 (recursive strip + regression test) → 스레드 resolved
- Cross-model review: Claude Opus 4.6 (2026-04-03)

## Test plan
- [x] `test_tool_keeper.exe` 54 tests pass
- [x] `test_keeper_tool_exposure.exe` 37 tests pass (trailing slash 케이스 포함)
- [x] `dune build` clean
- [x] CI green (11/11 checks)

Closes #4693

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>