### PR TITLE
fix(keeper): exponential backoff for transient network errors (#4523)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -28,8 +28,9 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
-(** Detect transient TCP/TLS errors that warrant a single immediate retry.
-    These patterns match OAS cascade error messages for connection-level failures. *)
+(** Detect transient TCP/TLS errors that warrant retry with backoff.
+    These patterns match OAS cascade error messages for connection-level failures.
+    See #4523: Connection_reset/Broken_pipe/EOF from idle TCP teardown. *)
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
     "connection closed"; "Connection refused" ]
@@ -38,6 +39,16 @@ let is_transient_network_error (msg : string) : bool =
   List.exists
     (fun needle -> string_contains_substring ~needle msg)
     transient_error_patterns
+
+(** Max transient retries before giving up.  OAS internal retry is 3 per
+    provider; this outer retry covers cases where all providers fail transiently
+    (e.g. TCP keepalive expiry across all backends simultaneously). *)
+let max_transient_retries = 3
+
+(** Exponential backoff delay for transient retry attempt [n] (0-indexed).
+    Delays: 1s, 2s, 4s — matches OAS internal backoff progression. *)
+let transient_backoff_sec (attempt : int) : float =
+  Float.min 4.0 (1.0 *. Float.of_int (1 lsl attempt))
 
 let decision_channel_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
@@ -589,7 +600,11 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            No dynamic_context needed here. *)
         { system_prompt; dynamic_context = "" }
       in
-      (* 5. Run via OAS Agent.run() with transient-error retry *)
+      (* 5. Run via OAS Agent.run() with transient-error retry.
+         Exponential backoff (1s, 2s, 4s) up to max_transient_retries.
+         OAS already retries 3x per provider internally; this outer loop
+         covers simultaneous backend failures (e.g. TCP keepalive expiry
+         across all providers).  See #4523. *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
           let do_run ?(is_retry = false) () =
@@ -604,14 +619,22 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_retry
               ()
           in
-          match do_run () with
-          | Ok _ as ok -> ok
-          | Error e when is_transient_network_error e ->
-              Log.Keeper.warn "%s: transient network error, retrying once: %s"
-                meta.name (short_preview e);
-              Eio.Fiber.yield ();
-              do_run ~is_retry:true ()
-          | Error _ as err -> err)
+          let rec retry_loop attempt =
+            match do_run ~is_retry:(attempt > 0) () with
+            | Ok _ as ok -> ok
+            | Error e when is_transient_network_error e
+                           && attempt < max_transient_retries ->
+                let delay = transient_backoff_sec attempt in
+                Log.Keeper.warn
+                  "%s: transient network error (attempt %d/%d), backoff %.0fs: %s"
+                  meta.name (attempt + 1) max_transient_retries delay
+                  (short_preview e);
+                Eio.Fiber.yield ();
+                Unix.sleepf delay;
+                retry_loop (attempt + 1)
+            | result -> result
+          in
+          retry_loop 0)
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -630,7 +630,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   "%s: transient network error (retry %d/%d), backoff %.0fs: %s"
                   meta.name attempt max_transient_retries delay
                   (short_preview e);
-                Eio_unix.sleep delay;
+                Eio.Time.sleep (Eio_context.get_clock ()) delay;
                 retry_loop (attempt + 1)
             | result -> result
           in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -40,15 +40,16 @@ let is_transient_network_error (msg : string) : bool =
     (fun needle -> string_contains_substring ~needle msg)
     transient_error_patterns
 
-(** Max transient retries before giving up.  OAS internal retry is 3 per
-    provider; this outer retry covers cases where all providers fail transiently
-    (e.g. TCP keepalive expiry across all backends simultaneously). *)
-let max_transient_retries = 3
+(** Max transient retries (excluding the initial attempt).  Total attempts
+    = 1 initial + max_transient_retries.  OAS internal retry is 3 per
+    provider; this outer retry covers cases where all providers fail
+    transiently (e.g. TCP keepalive expiry across all backends). *)
+let max_transient_retries = 2
 
-(** Exponential backoff delay for transient retry attempt [n] (0-indexed).
-    Delays: 1s, 2s, 4s — matches OAS internal backoff progression. *)
+(** Exponential backoff delay for transient retry [attempt] (1-indexed).
+    Delays: 1s, 2s — total wait 3s before giving up. *)
 let transient_backoff_sec (attempt : int) : float =
-  Float.min 4.0 (1.0 *. Float.of_int (1 lsl attempt))
+  Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
 
 let decision_channel_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
@@ -620,21 +621,20 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ()
           in
           let rec retry_loop attempt =
-            match do_run ~is_retry:(attempt > 0) () with
+            match do_run ~is_retry:(attempt > 1) () with
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
-                           && attempt < max_transient_retries ->
+                           && attempt <= max_transient_retries ->
                 let delay = transient_backoff_sec attempt in
                 Log.Keeper.warn
-                  "%s: transient network error (attempt %d/%d), backoff %.0fs: %s"
-                  meta.name (attempt + 1) max_transient_retries delay
+                  "%s: transient network error (retry %d/%d), backoff %.0fs: %s"
+                  meta.name attempt max_transient_retries delay
                   (short_preview e);
-                Eio.Fiber.yield ();
-                Unix.sleepf delay;
+                Eio_unix.sleep delay;
                 retry_loop (attempt + 1)
             | result -> result
           in
-          retry_loop 0)
+          retry_loop 1)
       in
       match run_result with
       | Error e ->


### PR DESCRIPTION
## Summary
- Replace single-retry with 3-attempt exponential backoff (1s, 2s) for transient TCP errors
- Covers Connection_reset, Broken_pipe, End_of_file, connection closed, Connection refused

## Product impact
- repo coordination: keeper unified turns no longer fail immediately on TCP keepalive expiry
- Before: 1 retry with no delay → same error repeats → turn fail counter increments
- After: 3 total attempts (1 initial + 2 retries with 1s/2s backoff) → connection re-establishes → turn succeeds

## Evidence
- Build passes
- 1 file, +34/-11 lines
- Backoff values align with OAS internal retry progression (1s base, 2x multiplier)
- Uses Eio.Time.sleep for cooperative scheduling (not Unix.sleepf)

## Review evidence
- Copilot review: 2 issues raised (retry count off-by-one, Unix.sleepf blocking) — both addressed

## Linked issue
- Fixes #4523