### PR TITLE
fix(harness): mark dry-run artifacts as simulated, use DRY_RUN classification

### DIFF
--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -387,6 +387,8 @@ phase_report_string() {
   local value="$2"
   if ! phase_enabled "$phase"; then
     printf 'skipped'
+  elif [[ "$value" == "2" ]]; then
+    printf 'simulated'
   elif [[ "$value" == "1" ]]; then
     printf 'pass'
   else
@@ -405,12 +407,12 @@ run_dry_run() {
     write_text "$heartbeat_file" "[simulated] Active heartbeats:\n  • dry-run: agent=keeper-dry-run-agent interval=5s message=\"dry-run\" uptime=1s"
     append_phase "$phase" "simulated" "dry-run synthetic (not runtime proof)" "$snapshot_file" "$heartbeat_file"
   done
-  BOOTSTRAP_PASS=1
-  LIVENESS_PASS=1
-  CONTINUITY_PASS=1
-  COMPACTION_PASS=1
-  HANDOFF_PASS=1
-  RECOVERY_PASS=1
+  BOOTSTRAP_PASS=2
+  LIVENESS_PASS=2
+  CONTINUITY_PASS=2
+  COMPACTION_PASS=2
+  HANDOFF_PASS=2
+  RECOVERY_PASS=2
   LATEST_INPUT_PREVIEW="[simulated] dry-run validation input"
   LATEST_OUTPUT_PREVIEW="[simulated] dry-run validation output"
   LATEST_TRACE_ID="trace-dry-run-simulated"

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -401,9 +401,9 @@ run_dry_run() {
     [[ -n "$TARGET_PHASES" ]] && ! phase_enabled "$phase" && continue
     snapshot_file="$SNAP_DIR/${phase}-keeper-status.json"
     heartbeat_file="$SNAP_DIR/${phase}-heartbeat.txt"
-    write_json_pretty "$snapshot_file" "$(jq -nc --arg phase "$phase" --arg run_id "$RUN_ID" '{dry_run:true,phase:$phase,run_id:$run_id}')"
-    write_text "$heartbeat_file" "Active heartbeats:\n  • dry-run: agent=keeper-dry-run-agent interval=5s message=\"dry-run\" uptime=1s"
-    append_phase "$phase" "pass" "dry-run synthetic success" "$snapshot_file" "$heartbeat_file"
+    write_json_pretty "$snapshot_file" "$(jq -nc --arg phase "$phase" --arg run_id "$RUN_ID" '{simulated:true,dry_run:true,phase:$phase,run_id:$run_id}')"
+    write_text "$heartbeat_file" "[simulated] Active heartbeats:\n  • dry-run: agent=keeper-dry-run-agent interval=5s message=\"dry-run\" uptime=1s"
+    append_phase "$phase" "simulated" "dry-run synthetic (not runtime proof)" "$snapshot_file" "$heartbeat_file"
   done
   BOOTSTRAP_PASS=1
   LIVENESS_PASS=1
@@ -411,14 +411,14 @@ run_dry_run() {
   COMPACTION_PASS=1
   HANDOFF_PASS=1
   RECOVERY_PASS=1
-  LATEST_INPUT_PREVIEW="dry-run validation input"
-  LATEST_OUTPUT_PREVIEW="dry-run validation output"
-  LATEST_TRACE_ID="trace-dry-run"
-  LATEST_GENERATION="1"
-  LATEST_COMPACTIONS="1"
-  LATEST_HANDOFFS="1"
-  LATEST_HEALTH="healthy"
-  LATEST_HEARTBEAT="active"
+  LATEST_INPUT_PREVIEW="[simulated] dry-run validation input"
+  LATEST_OUTPUT_PREVIEW="[simulated] dry-run validation output"
+  LATEST_TRACE_ID="trace-dry-run-simulated"
+  LATEST_GENERATION="0"
+  LATEST_COMPACTIONS="0"
+  LATEST_HANDOFFS="0"
+  LATEST_HEALTH="simulated"
+  LATEST_HEARTBEAT="simulated"
 }
 
 cleanup() {
@@ -449,7 +449,10 @@ finalize_report() {
   if ! phase_enabled handoff; then handoff_ok=1; fi
   if ! phase_enabled recovery; then recovery_ok=1; fi
 
-  if [[ $bootstrap_ok -eq 1 && $liveness_ok -eq 1 && $continuity_ok -eq 1 ]]; then
+  if [[ "$(normalize_bool "$DRY_RUN")" == "1" ]]; then
+    classification="DRY_RUN"
+    VALIDATION_EXIT_CODE=2
+  elif [[ $bootstrap_ok -eq 1 && $liveness_ok -eq 1 && $continuity_ok -eq 1 ]]; then
     if [[ $compaction_ok -eq 1 && $handoff_ok -eq 1 && $recovery_ok -eq 1 ]]; then
       classification="PASS"
       VALIDATION_EXIT_CODE=0

--- a/scripts/harness/workload/keeper_social_experiment.sh
+++ b/scripts/harness/workload/keeper_social_experiment.sh
@@ -56,7 +56,7 @@ mcp_call() {
         local n
         n="$(echo "$args_json" | jq -r '.name // "unknown"')"
         jq -cn --arg n "$n" \
-          '{jsonrpc:"2.0",id:1,result:{content:[{type:"text",text:("{\"name\":\""+$n+"\",\"ok\":true}")}]}}'
+          '{jsonrpc:"2.0",id:1,result:{content:[{type:"text",text:("{\"simulated\":true,\"name\":\""+$n+"\",\"ok\":true}")}]}}'
         ;;
       masc_keeper_msg)
         DRY_TICK=$((DRY_TICK + 1))
@@ -83,9 +83,10 @@ mcp_call() {
           --argjson handoff "$handoff" \
           '{
              jsonrpc:"2.0",id:1,result:{content:[{type:"text",text:( {
+               simulated:true,
                name:$n,
                generation:0,
-               model_used:"dry-run:model",
+               model_used:"simulated:dry-run",
                latency_ms:$latency,
                context_ratio:$ratio,
                compacted:($compacted==1),

--- a/scripts/harness/workload/keeper_social_experiment.sh
+++ b/scripts/harness/workload/keeper_social_experiment.sh
@@ -56,7 +56,7 @@ mcp_call() {
         local n
         n="$(echo "$args_json" | jq -r '.name // "unknown"')"
         jq -cn --arg n "$n" \
-          '{jsonrpc:"2.0",id:1,result:{content:[{type:"text",text:("{\"simulated\":true,\"name\":\""+$n+"\",\"ok\":true}")}]}}'
+          '{jsonrpc:"2.0",id:1,result:{content:[{type:"text",text:({simulated:true,name:$n,ok:true}|tojson)}]}}'
         ;;
       masc_keeper_msg)
         DRY_TICK=$((DRY_TICK + 1))


### PR DESCRIPTION
## Summary
Harness dry-run 경로가 `classification="PASS"` + `exit 0`으로 실제 런타임 증명과 구별 불가능한 결과를 생성하던 문제 수정.

### keeper_continuity_validation.sh
- classification: `PASS` → `DRY_RUN`
- exit code: `0` → `2` (skip convention, #4666과 동일)
- 합성 아티팩트에 `simulated:true` 추가
- phase result: `"pass"` → `"simulated"`
- evidence 수치: `"1"` → `"0"`, `"healthy"` → `"simulated"`

### keeper_social_experiment.sh
- dry-run 응답에 `simulated:true` 필드 추가
- `model_used`: `"dry-run:model"` → `"simulated:dry-run"`

## Test plan
- [x] bash syntax check 통과
- [x] `runtime_truth_proven` 필드는 이미 `$dry_run | not` 체크가 있어 영향 없음
- [ ] CI 빌드 확인

Closes #4665