### PR TITLE
chore(tools): remove masc_config_snapshot (strict subset of masc_config)

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -36,7 +36,7 @@ The front-door promise is level 1. Levels 2-4 are real, but they are not the fir
 | Remote-safe operator | Working | Supporting | `docs/REMOTE-MCP-OPERATOR.md` | auth and release posture still need tightening | keep surface reduced and explicit |
 | Multi-transport matrix | Working but not front-door | Experimental | implementation status appendix, live transport issues | reachable state and reported state can diverge | fix health truth before promotion |
 | Auth and API contract posture | Not done for product promise | Advanced / supporting | `docs/PRODUCT-REVIEW.md` | non-local default is still too weak, REST contract is not crisp | design + narrow hardening slices |
-| Config introspection | Working but split | Supporting | `masc_config`, `masc_config_snapshot`, `/api/v1/dashboard/config`, open issues `#3364`, `#3365`, `#3363` | read contract is duplicated and not yet centralized enough to promise as SSOT | centralize config and expose one canonical read-only snapshot |
+| Config introspection | Working but split | Supporting | `masc_config`, `/api/v1/dashboard/config`, open issues `#3364`, `#3365`, `#3363` | read contract is duplicated and not yet centralized enough to promise as SSOT | centralize config and expose one canonical read-only snapshot |
 | Release and doc truth | Not done for product promise | Front door | stale roadmap/version drift | package, roadmap, changelog, and release lane drift | enforce version truth in docs and workflow |
 | Research and legacy surfaces | Deferred | Experimental | archived docs, implementation appendix | merged surface area is wider than product promise | keep clearly labeled and avoid front-door promotion |
 

--- a/docs/design/inventory-gap-analysis-rfc.md
+++ b/docs/design/inventory-gap-analysis-rfc.md
@@ -511,7 +511,7 @@ Wave 1 완료 조건: `scripts/check-version-truth.sh` green + dead handler 0개
 | 순서 | 갭 | 노력 | 산출물 |
 |------|-----|------|--------|
 | 5 | C1: Keeper Memory | 5-7일 | tool-based memory + post-turn fallback + E2E 테스트 (I1 해소) |
-| 6 | C2: Config Introspection | 2-3일 | `masc_config_snapshot` read-only 도구 |
+| 6 | C2: Config Introspection | 2-3일 | `masc_config` read-only consolidation |
 | 7 | M6: Transport Health | 2-3일 | gRPC listening 상태 수정 |
 
 Wave 2 완료 조건: `find .masc/keepers -name "memory.jsonl" | wc -l` > 0 + config 도구 등록 확인

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -418,7 +418,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_keeper_tool_catalog" -> Some (handle_keeper_tool_catalog ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)
-  | "masc_config_snapshot" -> Some (Tool_misc_admin.handle_config_snapshot args)
   | "masc_feature_flags" -> Some (Tool_misc_admin.handle_feature_flags args)
   | _ -> None
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -200,10 +200,6 @@ let enforcement_summary_json () =
 (* Handlers                                                         *)
 (* ================================================================ *)
 
-let handle_config_snapshot _args : result =
-  let json = Env_config_introspect.to_json () in
-  (true, Yojson.Safe.pretty_to_string json)
-
 let handle_feature_flags args : result =
   let category_filter =
     match U.member "category" args with

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -291,16 +291,6 @@ After masc_tool_admin_snapshot to review current state before making changes.";
     ];
   };
   {
-    name = "masc_config_snapshot";
-    description = "Return a read-only snapshot of the current runtime configuration. \
-Env vars are categorized (server, storage, transport, inference, keeper, dashboard) \
-with source (env or default) and sensitivity flags. Sensitive values are masked.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc []);
-    ];
-  };
-  {
     name = "masc_feature_flags";
     description = "List all boolean feature flags with their canonical defaults, runtime values, \
 lifecycle state, and source (env or default). Flags are grouped by category: transport, tool, \

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -106,7 +106,6 @@ let all_known_tool_names =
     "masc_collaboration_evidence";
     "masc_collaboration_graph";
     "masc_config";
-    "masc_config_snapshot";
     "masc_consolidate_learning";
     "masc_dashboard";
     "masc_deliver";


### PR DESCRIPTION
## Summary
- `masc_config_snapshot`은 `masc_config`(category 미지정)과 동일 출력. 스키마, 핸들러(3줄), dispatch 엔트리 제거.
- 참고: `masc_transport_status`/`masc_websocket_discovery`는 MCP Resources 전환 후보 (별도 이슈)

Closes #4702