### PR TITLE
chore: add Dockerfile and build script for masc-worker-runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+_build
+_opam
+.worktrees
+node_modules
+dashboard/node_modules
+logs
+.masc
+.env
+.env.*
+*.exe

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,37 @@
+# Dockerfile for masc-worker-runtime image.
+# Builds the masc-worker-run helper binary and packages it into a minimal
+# Alpine image. The binary reads a Worker_execution_spec from stdin (via
+# --spec-stdin) and writes the run_result to stdout.
+#
+# Build:  docker build -f Dockerfile.worker -t masc-worker-runtime:dev .
+# Usage:  echo '<spec-json>' | docker run -i masc-worker-runtime:dev
+
+# ── stage 1: build ──────────────────────────────────────────────────
+FROM ocaml/opam:alpine-5.4-flambda AS build
+
+USER opam
+WORKDIR /home/opam/src
+
+# Install system deps first (cache layer)
+RUN sudo apk add --no-cache \
+  gmp-dev libffi-dev openssl-dev linux-headers pkgconf m4 git
+
+# Copy opam files for dependency caching
+COPY --chown=opam:opam masc_mcp.opam dune-project ./
+RUN opam install . --deps-only --yes 2>&1 | tail -5
+
+# Copy full source
+COPY --chown=opam:opam . .
+
+# Build only the worker binary
+RUN opam exec -- dune build bin/masc_worker_run.exe
+
+# ── stage 2: runtime ────────────────────────────────────────────────
+FROM alpine:3.21 AS runtime
+
+RUN apk add --no-cache gmp libffi openssl
+
+COPY --from=build /home/opam/src/_build/default/bin/masc_worker_run.exe \
+     /usr/local/bin/masc-worker-run
+
+ENTRYPOINT ["/usr/local/bin/masc-worker-run", "--spec-stdin"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -18,7 +18,7 @@ RUN sudo apk add --no-cache \
 
 # Copy opam files for dependency caching
 COPY --chown=opam:opam masc_mcp.opam dune-project ./
-RUN opam install . --deps-only --yes 2>&1 | tail -5
+RUN opam install . --deps-only --yes
 
 # Copy full source
 COPY --chown=opam:opam . .

--- a/scripts/build-worker-image.sh
+++ b/scripts/build-worker-image.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the masc-worker-runtime Docker image.
+# Usage: scripts/build-worker-image.sh [TAG]
+#   TAG defaults to "dev".
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="${1:-dev}"
+IMAGE="masc-worker-runtime:${TAG}"
+
+echo "Building ${IMAGE} from ${REPO_ROOT}/Dockerfile.worker"
+docker build \
+  -f "${REPO_ROOT}/Dockerfile.worker" \
+  -t "${IMAGE}" \
+  "${REPO_ROOT}"
+
+echo "Built ${IMAGE}"
+echo "Verify: echo '{}' | docker run --rm -i ${IMAGE}"


### PR DESCRIPTION
## Summary
- `Dockerfile.worker`: multi-stage Alpine build (OCaml 5.4 flambda → minimal runtime)
- `scripts/build-worker-image.sh`: `docker build` 래퍼, 기본 태그 `dev`
- Entry point: `masc-worker-run --spec-stdin` (Worker_execution_spec JSON → run_result JSON)

## Context
PR #4622에서 Docker worker runtime backend가 머지됐지만 실제 이미지 빌드 파이프라인이 없었음. 이 PR로 `masc-worker-runtime:dev` 이미지를 로컬에서 빌드 가능.

## Product impact
- Docker worker runtime backend (#4622)의 보완 PR. 이미지 빌드 없이는 Docker backend가 동작하지 않음.
- 로컬 개발/테스트 환경에서 worker 이미지 빌드를 가능하게 함.

## Evidence
- 기존 `Dockerfile.worker-runtime` + `build-worker-runtime-image.sh`와의 중복 존재 확인됨. 통합 또는 차별화 필요.
- Copilot 6건 리뷰 코멘트 수신, 전건 owner ack. GLM-5.1 교차 리뷰 3건 추가 발견.

## Review evidence
- Copilot: 6 inline comments (all owner-acknowledged, all OPEN)
- GLM-5.1 cross-model review: 4 HIGH, 4 MEDIUM, 1 LOW (2026-04-03)
- Status: **fixes not yet pushed**

## Linked issue
Closes #4645

## Test plan
- [ ] `scripts/build-worker-image.sh` 로컬 빌드 확인
- [ ] `echo '{}' | docker run --rm -i masc-worker-runtime:dev` → spec parse error (expected)
- [ ] CI 빌드 확인