### PR TITLE
fix(test): replace vacuous assertions with behavioral checks

### DIFF
--- a/test/test_agent_registry_eio.ml
+++ b/test/test_agent_registry_eio.ml
@@ -9,7 +9,7 @@ let test_init () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
-  check bool "total count >= 0" true (Agent_registry_eio.total_count () >= 0)
+  check int "total count after reset is 0" 0 (Agent_registry_eio.total_count ())
 
 let test_get_or_create_new () =
   Eio_main.run @@ fun env ->
@@ -90,9 +90,9 @@ let test_cleanup_stale () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
-  (* This should not fail even with nothing to clean *)
+  (* After reset, no sessions exist so cleanup should return 0 *)
   let cleaned = Agent_registry_eio.cleanup_stale_sessions () in
-  check bool "cleanup returned count" true (cleaned >= 0)
+  check int "cleanup after reset returns 0" 0 cleaned
 
 let test_reset_clears_cached_session_mappings () =
   Eio_main.run @@ fun env ->

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -150,21 +150,25 @@ let test_html_contains_stylesheet () =
       (contains_re "rel=\"stylesheet\"" html
        || contains_substr "<style>" html)
   else
-    check bool "fallback ok" true true
+    check bool "fallback has no stylesheet" true
+      (not (contains_re "rel=\"stylesheet\"" html)
+       && not (contains_substr "<style>" html))
 
 let test_html_contains_script () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
     check bool "has script" true (contains_re "<script" html)
   else
-    check bool "fallback ok" true true
+    check bool "fallback has no script" true
+      (not (contains_re "<script" html))
 
 let test_html_contains_app_mount () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
     check bool "has app mount div" true (contains_substr "id=\"app\"" html)
   else
-    check bool "fallback ok" true true
+    check bool "fallback has no app mount" true
+      (not (contains_substr "id=\"app\"" html))
 
 let test_html_ends_with_html_tag () =
   let html = Web_dashboard.html () in


### PR DESCRIPTION
## Summary
Vacuous assertion 5개를 실제 행동 검증으로 교체.

### test_agent_registry_eio.ml
- `total_count >= 0` (항상 참) → `total_count == 0` (reset 후 정확한 값)
- `cleaned >= 0` (항상 참) → `cleaned == 0` (reset 직후 stale 없음)

### test_web_dashboard_coverage.ml
- `"fallback ok" true true` 3건 → fallback HTML에 해당 요소(stylesheet/script/app mount)가 **없는지** 검증
- fallback은 `<html><body>Dashboard build not found...</body></html>`이므로 빌드 아티팩트가 없어야 정상

## Product impact
테스트 품질 개선. 기존 vacuous assertion은 regression을 감지하지 못했음. 이제 실제 post-condition 위반 시 테스트가 실패함.

## Evidence
- Issue #4670 에서 식별된 5개 vacuous assertion
- `check bool "fallback ok" true true` 패턴은 조건 불문 항상 pass

## Review evidence
- Copilot review: LGTM (no comments generated)
- GLM-5.1 cross-model review: LGTM (De Morgan correctness confirmed, no false positive risk)

## Linked issue
Closes #4670

## Test plan
- [x] CI `dune test` 통과 확인 (Build and Test green)