### PR TITLE
fix(auth,keeper): map 30 read-only tools to CanReadState + keeper tool fixes

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -283,7 +283,20 @@ let legacy_permission_for_tool = function
   | "masc_observe_swarm" | "masc_observe_capacity" | "masc_observe_alerts"
   | "masc_observe_traces"
   | "masc_voice_sessions" | "masc_voice_agent"
-  | "masc_agent_card" | "masc_agent_fitness" ->
+  | "masc_agent_card" | "masc_agent_fitness"
+  | "masc_agent_relations" | "masc_a2a_discover" | "masc_a2a_query_skill"
+  | "masc_dashboard" | "masc_check" | "masc_config_snapshot"
+  | "masc_collaboration_graph" | "masc_episode_list"
+  | "masc_feature_flags" | "masc_get_metrics"
+  | "masc_meta_cognition_snapshot" | "masc_poll_events"
+  | "masc_recall_search" | "masc_room_strategy_get"
+  | "masc_select_agent" | "masc_auth_list"
+  | "masc_verify_auto" | "masc_verify_handoff"
+  | "masc_verify_pending" | "masc_verify_request"
+  | "masc_verify_status" | "masc_verify_submit"
+  | "masc_heartbeat_list" | "masc_heartbeat_result"
+  | "masc_plan_get_task" | "masc_plan_get"
+  | "masc_pause_status" | "masc_workflow_guide" ->
       Some CanReadState
   | "masc_autoresearch_status" | "masc_config" -> Some CanReadState
   | "masc_add_task" -> Some CanAddTask

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -386,10 +386,9 @@ let run_turn
     "masc_tasks", "태스크 목록 할일 작업";
     "masc_add_task", "태스크 추가 등록 생성";
     "masc_status", "상태 현황 방 룸 요약";
-    "masc_broadcast", "브로드캐스트 방송 알림 공지";
     "masc_heartbeat", "하트비트 살아있음 생존";
-    "masc_who", "누구 참여자 에이전트 목록";
-    "masc_messages", "메시지 대화 채팅 로그";
+    (* masc_broadcast, masc_who, masc_messages require MCP session context
+       and fail in keeper. Use keeper_broadcast instead. (#4694) *)
   ] in
   let tool_entries = List.map (fun (t : Agent_sdk.Tool.t) ->
     let name = t.schema.name in

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -98,6 +98,7 @@ let keeper_coding_masc_tool_names =
     These are the survival-critical tools. *)
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";
+    "keeper_tools_list"; "keeper_tasks_list";
     "masc_status"; "masc_heartbeat"; "masc_tool_help";
     "extend_turns" ]
 


### PR DESCRIPTION
## Summary

**Auth mapping** — 30개 read-only 도구를 CanReadState로 매핑. Strict auth 모드에서 미매핑 masc_* 도구는 CanBroadcast(Worker+)가 기본값이라 대시보드 Reader 세션에서 Forbidden 발생. 등가 테스트 15/15 green.

**#4695** — keeper_tools_list/keeper_tasks_list를 core_always_tools에 추가. Minimal preset에서도 self-introspection 가능.

**#4694** — BM25 도구 검색 인덱스에서 masc_broadcast/masc_who/masc_messages 제거. MCP session context 없이 실행 불가한 도구가 keeper에게 추천되어 턴 낭비.

Closes #4695 #4694