### PR TITLE
fix(backend,room): task status diagnostic + Printf JSON injection fix

### DIFF
--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -138,7 +138,9 @@ let status_of_db ~status ~assignee ~claimed_at ~started_at ~completed_at ~cancel
         cancelled_at = Option.value cancelled_at ~default:"";
         reason;
       }
-  | _ -> Todo  (* fallback *)
+  | unknown ->
+      Log.Backend.warn "[task_pg] unknown task status %S in DB, defaulting to Todo" unknown;
+      Todo
 
 (** {1 Queries} *)
 

--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -113,7 +113,7 @@ let status_to_db (status : task_status) : string * string option * string option
       ("cancelled", None, None, None, None, Some cancelled_at, Some cancelled_by, reason)
 
 (** Convert DB representation to task_status *)
-let status_of_db ~status ~assignee ~claimed_at ~started_at ~completed_at ~cancelled_at ~cancelled_by ~notes ~reason : task_status =
+let status_of_db ~id ~status ~assignee ~claimed_at ~started_at ~completed_at ~cancelled_at ~cancelled_by ~notes ~reason : task_status =
   match status with
   | "todo" -> Todo
   | "claimed" ->
@@ -139,7 +139,7 @@ let status_of_db ~status ~assignee ~claimed_at ~started_at ~completed_at ~cancel
         reason;
       }
   | unknown ->
-      Log.Backend.warn "[task_pg] unknown task status %S in DB, defaulting to Todo" unknown;
+      Log.Backend.warn "[task_pg] unknown task status %S for task %S in DB, defaulting to Todo" unknown id;
       Todo
 
 (** {1 Queries} *)
@@ -245,7 +245,7 @@ let row_to_task (((id, title, description), (priority, status, assignee),
     worktree = None;  (* Worktree loaded separately if needed *)
     required_role;
     stage = None;
-    task_status = status_of_db ~status ~assignee ~claimed_at ~started_at
+    task_status = status_of_db ~id ~status ~assignee ~claimed_at ~started_at
                     ~completed_at ~cancelled_at:None ~cancelled_by:None ~notes ~reason:None;
   }
 

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -451,12 +451,13 @@ let gc config ?(days=7) () =
   else
     results := "✅ No stale CP data" :: !results;
   (* Log event *)
-  let cp_json =
-    Printf.sprintf "{\"dead_units\":%d,\"orphan_units\":%d,\"ops_archived\":%d,\"orphan_dets\":%d,\"dropped_intents\":%d}"
-      cp_result.dead_units_removed cp_result.orphaned_units_removed
-      cp_result.operations_archived cp_result.detachments_removed
-      cp_result.intents_removed
-  in
+  let cp_json = Yojson.Safe.to_string (`Assoc [
+    ("dead_units", `Int cp_result.dead_units_removed);
+    ("orphan_units", `Int cp_result.orphaned_units_removed);
+    ("ops_archived", `Int cp_result.operations_archived);
+    ("orphan_dets", `Int cp_result.detachments_removed);
+    ("dropped_intents", `Int cp_result.intents_removed);
+  ]) in
   (* 9. Archive stale room directories (no file modified in N days).
          Prevents .masc/rooms/ from growing unbounded and slowing down
          snapshot computation (each room adds hundreds of JSON files). *)

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -585,11 +585,13 @@ let complete_task config ~agent_name ~task_id ~notes =
                     ("task_id", `String task_id);
                     ("notes", if notes = "" then `Null else `String notes);
                   ]);
-            log_event config (Printf.sprintf
-              "{\"type\":\"task_done\",\"agent\":\"%s\",\"task\":\"%s\",\"notes\":%s,\"ts\":\"%s\"}"
-              agent_name task_id
-              (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes)
-              (now_iso ()));
+            log_event config (Yojson.Safe.to_string (`Assoc [
+              ("type", `String "task_done");
+              ("agent", `String agent_name);
+              ("task", `String task_id);
+              ("notes", if notes = "" then `Null else `String notes);
+              ("ts", `String (now_iso ()));
+            ]));
             observe_task_transition config ~agent_name ~task_id
               ~transition:"done"
               ~details:


### PR DESCRIPTION
## Summary

**#4671** — `status_of_db`의 catch-all `| _ -> Todo`를 제거. 미지 상태값에 대해 `Log.Backend.warn`으로 진단 로그(task ID 포함)를 남기도록 변경. JSON parser(`types_core.ml`)는 이미 Error를 반환하지만 PG backend만 silent fallback이었음.

**#4429 (partial)** — `room_task.ml`에서 agent_name/task_id/notes를 이스케이프 없이 JSON에 직접 삽입하던 코드를 `Yojson.Safe`로 전환 (injection 위험 제거). `room_gc.ml`도 같은 패턴 수정.

Closes #4671
Partial fix for #4429