### PR TITLE
fix(dashboard): mark synthetic agent entries and fallback judge target

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -176,6 +176,7 @@ function synthesizeAgentFromKeeper(source: Keeper | DashboardMissionKeeperBrief)
     traits: typed.traits,
     activityLevel: typed.activityLevel,
     primaryValue: typed.primaryValue,
+    synthetic: true,
   }
 }
 
@@ -476,6 +477,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   <div class="flex items-center gap-1.5 flex-wrap mt-1">
                     <span class="roster-badge ${statusBadgeClass(agent.status)}" title=${statusDescription(agent.status)}>${statusLabel(agent.status)}</span>
                     <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼 런타임' : '일반 에이전트'}</span>
+                    ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
                     ${keeper?.model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${keeper.model}</span>` : null}
                     ${keeper?.generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[rgba(71,184,255,0.15)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${keeper.generation}</span>` : null}
                   </div>

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -275,7 +275,7 @@ export function MissionBriefingCard() {
                 <strong class="text-[var(--text-strong)]">실제 판단 대상</strong>
                 <div class="flex gap-2 flex-wrap">
                   <${StatusChip}
-                    label=${liveJudge.source === 'judge_runtime' ? 'judge runtime' : 'live keeper'}
+                    label=${liveJudge.source === 'judge_runtime' ? 'judge runtime' : 'live keeper (fallback)'}
                     tone=${liveJudgeTone}
                   />
                   <${StatusChip}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -21,6 +21,7 @@ export interface Agent {
   peakHour?: number
   primaryValue?: string
   personalityHint?: string
+  synthetic?: boolean
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary
- 키퍼에서 파생된 합성(synthetic) agent 엔트리에 provenance 마커 추가
- 합성 엔트리는 Agent 카드에 "파생" 배지로 시각적 구별
- `operator_judge_runtime` 부재 시 keeper fallback 대상을 "(fallback)"으로 명시

## Product impact
대시보드 사용자가 실제 agent와 키퍼에서 합성된 agent를 시각적으로 구분할 수 있게 되어, 판단 대상(judge target) 출처의 투명성이 향상됨.

## Evidence
- 합성 엔트리에 `synthetic: true` 마킹 확인 (agent-roster.ts)
- "(fallback)" 라벨 표시 확인 (mission-briefing-card.ts)

## Changed files
- `dashboard/src/types/core.ts` — `synthetic?: boolean` 필드 추가
- `dashboard/src/components/agent-roster.ts` — `synthesizeAgentFromKeeper`에 `synthetic: true`, UI 배지
- `dashboard/src/components/mission-briefing-card.ts` — keeper source 라벨에 "(fallback)"

## Review evidence
- Copilot review: 2 comments (test coverage), author acknowledged
- Cross-model review (GLM-5.1): 2 medium, 3 low findings posted

## Linked issue
Closes #4669

## Scope note
이슈에서 언급된 `operator_digest_guidance.ml`, `ops-room-column.ts`, `ops-session-column.ts`는 이번 PR에서 다루지 않음. 후속 PR에서 guidance layer provenance 분리 예정.

## Test plan
- [ ] CI 빌드 확인 (Dashboard job)
- [ ] 합성 엔트리에 "파생" 배지 표시 확인
- [ ] `synthesizeAgentFromKeeper` unit test: `synthetic === true` 검증
- [ ] mission-briefing-card render test: "(fallback)" label 검증