### PR TITLE
chore(tools): remove 10 ghost tool entries (no dispatch, no schema)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -266,7 +266,7 @@ let legacy_permission_for_tool = function
   | "masc_status" | "masc_who" | "masc_tasks" | "masc_messages"
   | "masc_transport_status" | "masc_websocket_discovery"
   | "masc_agents" | "masc_portal_status" | "masc_pending_interrupts"
-  | "masc_votes" | "masc_vote_status" | "masc_worktree_list"
+  | "masc_worktree_list"
   | "masc_task_history" | "masc_operator_snapshot"
   | "masc_operator_digest" | "masc_surface_audit"
   | "masc_collaboration_evidence"
@@ -322,7 +322,6 @@ let legacy_permission_for_tool = function
   | "masc_portal_send" -> Some CanSendPortal
   | "masc_worktree_create" -> Some CanCreateWorktree
   | "masc_worktree_remove" -> Some CanRemoveWorktree
-  | "masc_vote_create" | "masc_vote_cast" -> Some CanVote
   | "masc_interrupt" | "masc_branch" -> Some CanInterrupt
   | "masc_approve" | "masc_reject" -> Some CanApprove
   | "masc_cleanup_zombies" -> Some CanBroadcast (* Worker level *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -76,11 +76,11 @@ let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
 
 let read_only_tools_inline =
   ["masc_status"; "masc_who"; "masc_messages";
-   "masc_votes"; "masc_vote_status"; "masc_pending_interrupts"]
+   "masc_pending_interrupts"]
 
 let requires_join_tools_inline =
   ["masc_broadcast"; "masc_listen"; "masc_leave";
-   "masc_vote_cast"; "masc_vote_revoke"]
+   "masc_vote_revoke"]
 
 let mcp_context_required_tools_inline =
   Tool_schemas_inline.schemas

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -5,7 +5,7 @@
     - Reader tier: CanReadState, CanJoin, CanLeave
     - Worker tier: CanAddTask, CanClaimTask, CanCompleteTask, CanBroadcast,
                    CanOpenPortal, CanSendPortal, CanCreateWorktree,
-                   CanRemoveWorktree, CanVote
+                   CanRemoveWorktree
     - Admin tier:  CanInit, CanReset, CanInterrupt, CanApprove, CanAdmin
 
     @since 2.204.0 *)
@@ -131,9 +131,6 @@ let worker_only_tools =
     "masc_worktree_create";
     (* CanRemoveWorktree *)
     "masc_worktree_remove";
-    (* CanVote *)
-    "masc_vote_create";
-    "masc_vote_cast";
   ]
 
 (* ================================================================ *)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -154,36 +154,6 @@ let destructive_tool =
 
 let explicit_metadata : (string * metadata) list =
   [
-    ( "masc_post_create",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_post_list",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_post_get",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_comment_add",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_comment_list",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_vote",
-      hidden_active
-        "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );
-    ( "masc_vote_create",
-      hidden_active
-        "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
-    ( "masc_vote_cast",
-      hidden_active
-        "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
-    ( "masc_vote_status",
-      hidden_active
-        "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
-    ( "masc_votes",
-      hidden_active
-        "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
     ( "masc_operator_judgment_write",
       hidden_active
         "Internal operator-judge write path hidden from the default tool list; use for operator judgment experiments and keeper automation." );

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -595,13 +595,9 @@ let test_handle_request_tools_list () =
     false
     (List.mem "masc_room_enter" names);
   Alcotest.(check bool)
-    "low-usage social tool hidden from list"
+    "removed ghost tool absent from list"
     false
     (List.mem "masc_post_create" names);
-  Alcotest.(check bool)
-    "low-usage vote utility hidden from list"
-    false
-    (List.mem "masc_vote_create" names);
   Alcotest.(check bool) "first page non-empty" true (names <> []);
   let meta = tools_list_meta_exn first_page in
   let total_count = int_field_exn "tools/list _meta" meta "totalCount" in
@@ -1143,7 +1139,7 @@ let test_handle_request_tools_list_include_hidden_metadata () =
     (Yojson.Safe.Util.member "visibility" status_tool <> `Null);
   Alcotest.(check bool) "implementation status exposed" true
     (Yojson.Safe.Util.member "implementationStatus" status_tool <> `Null);
-  Alcotest.(check bool) "hidden utility omitted" false
+  Alcotest.(check bool) "removed ghost tool absent" false
     (List.exists
        (function
          | `Assoc fields -> List.assoc_opt "name" fields = Some (`String "masc_post_create")

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -116,8 +116,6 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_portal_send" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains a2a_delegate" true
     (List.mem "mcp__masc__masc_a2a_delegate" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "omits vote_create (hidden)" false
-    (List.mem "mcp__masc__masc_vote_create" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits run_deliverable" false
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains board_post" true

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -158,10 +158,6 @@ let test_masc_mcp_tools_has_a2a_delegate () =
   check bool "has a2a_delegate" true
     (List.mem "mcp__masc__masc_a2a_delegate" Spawn.masc_mcp_tools)
 
-let test_masc_mcp_tools_has_vote_create () =
-  check bool "omits vote_create (hidden)" false
-    (List.mem "mcp__masc__masc_vote_create" Spawn.masc_mcp_tools)
-
 let test_masc_mcp_tools_has_run_deliverable () =
   check bool "omits run_deliverable" false
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools)
@@ -734,7 +730,6 @@ let () =
       test_case "has team_session_step" `Quick test_masc_mcp_tools_has_team_session_step;
       test_case "has team_session_finalize" `Quick test_masc_mcp_tools_has_team_session_finalize;
       test_case "has a2a_delegate" `Quick test_masc_mcp_tools_has_a2a_delegate;
-      test_case "has vote_create" `Quick test_masc_mcp_tools_has_vote_create;
       test_case "has run_deliverable" `Quick test_masc_mcp_tools_has_run_deliverable;
       test_case "omits tool_stats" `Quick test_masc_mcp_tools_has_tool_stats;
       test_case "has tool_help" `Quick test_masc_mcp_tools_has_tool_help;

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -189,9 +189,9 @@ let test_admin_only_count () =
 let test_worker_only_count () =
   check bool "worker_only_tools is non-empty" true
     (List.length Tool_access_role.worker_only_tools > 0);
-  check bool "worker_only_tools has expected size (55)"
+  check bool "worker_only_tools has expected size (53)"
     true
-    (List.length Tool_access_role.worker_only_tools = 55)
+    (List.length Tool_access_role.worker_only_tools = 53)
 
 let test_no_overlap_admin_worker () =
   List.iter (fun tool_name ->

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -158,11 +158,8 @@ let () =
             (fun () ->
               let hidden_names =
                 [
-                  "masc_vote_create";
-                  "masc_vote_cast";
-                  "masc_vote_status";
-                  "masc_post_create";
-                  "masc_post_list";
+                  "masc_operator_judgment_write";
+                  "masc_operator_judgment_latest";
                 ]
               in
               List.iter
@@ -174,9 +171,8 @@ let () =
             (fun () ->
               let hidden_names =
                 [
-                  "masc_vote_create";
-                  "masc_vote_cast";
-                  "masc_vote_status";
+                  "masc_operator_judgment_write";
+                  "masc_operator_judgment_latest";
                 ]
               in
               List.iter


### PR DESCRIPTION
## Summary

10개 ghost tool 엔트리 제거 (9파일 -49줄):

**Group A** (5 complete phantom): masc_post_create/list/get, masc_comment_add/list — catalog metadata만 존재, 구현체 없음

**Group B** (5 unwired ghost): masc_vote/create/cast/status, masc_votes — catalog+auth 항목만 존재, MCP dispatch 없음. Room-level vote 로직(room_vote.ml)은 team_session에서 직접 사용하므로 보존.

테스트: tool_access_role 15/15, tool_exposure 19/19, spawn_coverage 87/87 green.

Closes #4704