### PR TITLE
fix(command-plane): use deterministic hash for failover leader selection

### DIFF
--- a/lib/command_plane/cp_lifecycle_policy.ml
+++ b/lib/command_plane/cp_lifecycle_policy.ml
@@ -582,10 +582,13 @@ let pick_failover_leader live_agents (detachment : detachment_record) =
   | [] -> None
   | [single] -> Some single
   | _ ->
-      (* Pick based on hash of current time to distribute without needing Random.self_init *)
-      let arr = Array.of_list eligible in
+      (* Deterministic selection: hash detachment id + sorted roster to get
+         a stable index that is replayable and testable. *)
+      let sorted = List.sort String.compare eligible in
+      let arr = Array.of_list sorted in
       let n = Array.length arr in
-      let idx = abs (Hashtbl.hash (Unix.gettimeofday ())) mod n in
+      let seed = Hashtbl.hash (detachment.detachment_id, sorted) in
+      let idx = abs seed mod n in
       Some arr.(idx)
 
 let maybe_escalation_target units (detachment : detachment_record) =

--- a/lib/command_plane/cp_lifecycle_policy.ml
+++ b/lib/command_plane/cp_lifecycle_policy.ml
@@ -566,7 +566,7 @@ let stalled_or_quiet_detachment now (detachment : detachment_record) =
       |> Option.map (fun ts -> now -. ts > 1800.0)
       |> Option.value ~default:false
 
-(** Pick failover leader using shuffle to distribute load evenly.
+(** Pick failover leader using deterministic hash-based selection.
     BUG-006: List.find_opt always returned the first eligible agent,
     causing failover to concentrate on a single keeper. *)
 let pick_failover_leader live_agents (detachment : detachment_record) =
@@ -588,7 +588,7 @@ let pick_failover_leader live_agents (detachment : detachment_record) =
       let arr = Array.of_list sorted in
       let n = Array.length arr in
       let seed = Hashtbl.hash (detachment.detachment_id, sorted) in
-      let idx = abs seed mod n in
+      let idx = (seed land max_int) mod n in
       Some arr.(idx)
 
 let maybe_escalation_target units (detachment : detachment_record) =

--- a/lib/command_plane/cp_lifecycle_policy.mli
+++ b/lib/command_plane/cp_lifecycle_policy.mli
@@ -65,3 +65,7 @@ val dispatch_tick_json :
 val observe_operations_json : Room.config -> Yojson.Safe.t
 
 val observe_capacity_json : Room.config -> Yojson.Safe.t
+
+(** {1 Failover} *)
+
+val pick_failover_leader : string list -> Cp_types.detachment_record -> string option

--- a/test/dune
+++ b/test/dune
@@ -599,6 +599,12 @@
  (modules test_normalized_actor)
  (libraries masc_test_deps))
 
+; Failover leader deterministic selection
+(test
+ (name test_failover_leader)
+ (modules test_failover_leader)
+ (libraries masc_test_deps))
+
 ; Dashboard Collaboration Evidence (2 modules)
 (test
  (name test_dashboard_collaboration_evidence)

--- a/test/test_failover_leader.ml
+++ b/test/test_failover_leader.ml
@@ -1,0 +1,47 @@
+open Alcotest
+
+module Cp = Masc_mcp.Cp_lifecycle_policy
+module Cp_types = Masc_mcp.Cp_types
+
+let make_detachment ?(leader = None) ~id roster : Cp_types.detachment_record =
+  { detachment_id = id; operation_id = "op-1"; assigned_unit_id = "u-1";
+    leader_id = leader; roster; session_id = None; checkpoint_ref = None;
+    runtime_kind = None; runtime_ref = None; source = "test"; status = "active";
+    last_event_at = None; last_progress_at = None; heartbeat_deadline = None;
+    created_at = "2026-01-01T00:00:00Z"; updated_at = "2026-01-01T00:00:00Z" }
+
+let test_deterministic () =
+  let d = make_detachment ~id:"det-1" ["alice"; "bob"; "carol"] in
+  let live = ["alice"; "bob"; "carol"] in
+  let r1 = Cp.pick_failover_leader live d in
+  let r2 = Cp.pick_failover_leader live d in
+  check (option string) "same inputs same output" r1 r2
+
+let test_excludes_current_leader () =
+  let d = make_detachment ~id:"det-2" ~leader:(Some "alice") ["alice"; "bob"] in
+  let live = ["alice"; "bob"] in
+  check (option string) "picks non-leader" (Some "bob")
+    (Cp.pick_failover_leader live d)
+
+let test_empty_eligible () =
+  let d = make_detachment ~id:"det-3" ~leader:(Some "alice") ["alice"] in
+  let live = ["alice"] in
+  check (option string) "none when only leader" None
+    (Cp.pick_failover_leader live d)
+
+let test_roster_order_irrelevant () =
+  let d1 = make_detachment ~id:"det-4" ["bob"; "alice"; "carol"] in
+  let d2 = make_detachment ~id:"det-4" ["carol"; "alice"; "bob"] in
+  let live = ["alice"; "bob"; "carol"] in
+  check (option string) "order does not affect result"
+    (Cp.pick_failover_leader live d1)
+    (Cp.pick_failover_leader live d2)
+
+let () =
+  run "pick_failover_leader"
+    [ "failover",
+      [ test_case "deterministic" `Quick test_deterministic;
+        test_case "excludes current leader" `Quick test_excludes_current_leader;
+        test_case "empty eligible returns none" `Quick test_empty_eligible;
+        test_case "roster order irrelevant" `Quick test_roster_order_irrelevant;
+      ] ]


### PR DESCRIPTION
## Summary
`pick_failover_leader`가 `Unix.gettimeofday()` 해시로 leader를 선택하여 비결정적이던 문제를 수정.

### Before
```ocaml
abs (Hashtbl.hash (Unix.gettimeofday ())) mod n
```
동일 상태에서 replay/retry 시 다른 leader 선택 가능. 테스트 불가.

### After
```ocaml
let sorted = List.sort String.compare eligible in
let seed = Hashtbl.hash (detachment.detachment_id, sorted) in
let idx = (seed land max_int) mod n in
```
동일 roster + detachment에서 항상 동일한 leader. Replayable, testable.

## Product impact
Failover leader selection becomes deterministic. Same detachment + roster always elects the same leader, enabling replay and testing.

## Evidence
- Before: `Unix.gettimeofday()` hash — non-deterministic
- After: `(detachment_id, sorted roster)` hash — deterministic
- `abs min_int` crash fixed with `land max_int` pattern

## Review evidence
- Copilot: 2 issues (abs min_int crash, docstring mismatch) — both addressed in 1dc19a4
- GLM-5.1 cross-model review: confirmed abs min_int fix required, clean after fix
- Claude Opus 4.6: clean after fix

## Test plan
- [x] `dune build @check` 통과
- [x] CI 빌드 확인

## Linked issue
Closes #4698