### PR TITLE
fix(auth): remove stale masc_config_snapshot from permission map

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -285,7 +285,7 @@ let legacy_permission_for_tool = function
   | "masc_voice_sessions" | "masc_voice_agent"
   | "masc_agent_card" | "masc_agent_fitness"
   | "masc_agent_relations" | "masc_a2a_discover" | "masc_a2a_query_skill"
-  | "masc_dashboard" | "masc_check" | "masc_config_snapshot"
+  | "masc_dashboard" | "masc_check"
   | "masc_collaboration_graph" | "masc_episode_list"
   | "masc_feature_flags" | "masc_get_metrics"
   | "masc_meta_cognition_snapshot" | "masc_poll_events"


### PR DESCRIPTION
## Summary
- masc_config_snapshot was removed in #4705
- #4712 accidentally re-added it to legacy_permission_for_tool during bulk CanReadState mapping
- This removes the stale auth reference (the only remaining trace)

## Product impact
None. Internal auth table cleanup only. No user-facing behavior change.

## Evidence
- `masc_config_snapshot` removed in #4705, stale re-addition in #4712
- Single-line removal from string pattern match in `lib/auth.ml`

## Review evidence
- Copilot: no issues
- GLM-5.1 cross-model review: clean
- Claude Opus 4.6: clean

## Linked issue
Closes #4702