### PR TITLE
fix(keeper): remove masc_agent_fitness from BM25 search index

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -370,7 +370,6 @@ let run_turn
     "masc_agent_card", "에이전트 카드 프로필 정보";
     "masc_agents", "에이전트 목록 현황 누구";
     "masc_agent_update", "에이전트 업데이트 상태변경";
-    "masc_agent_fitness", "에이전트 적합도 평가";
     "masc_keeper_up", "키퍼 시작 기동 생성";
     "masc_keeper_down", "키퍼 중지 종료";
     "masc_keeper_list", "키퍼 목록 현황";


### PR DESCRIPTION
## Summary
Keeper가 BM25 검색으로 `masc_agent_fitness`를 발견하지만, keeper dispatch에 핸들러가 없어 `tool_not_allowed` 에러 발생. 검색 인덱스에서 제거하여 불필요한 턴 낭비 방지.

## Root Cause
`keeper_agent_run.ml`의 BM25 인덱스에 `masc_agent_fitness`가 등록되어 있었으나, `keeper_tag_dispatch.ml`에는 이 도구의 dispatch 경로가 없음. Keeper가 도구를 "발견"하지만 "실행"할 수 없는 불일치.

## Product impact
- Keeper 턴 낭비 제거 (fitness 도구 호출 시도 → 실패 → 재시도 루프 방지)
- 사용자 체감: keeper 응답 지연 감소

## Evidence
- Issue #4707 재현: keeper BM25 검색 → `masc_agent_fitness` 발견 → `tool_not_allowed` 에러
- 변경: `lib/keeper/keeper_agent_run.ml`에서 1줄 삭제

## Review evidence
- Copilot review: 2 threads (scope limitation + test sync) — addressed, resolved
- Cross-model review (GLM-5.1): Approve. Correct and safe fix, structural guard follow-up recommended

## Linked issue
Closes #4707
Follow-up: #4637 Phase 3b (Korean alias SSOT module)

## Test plan
- [x] 1줄 삭제만, 빌드 영향 없음
- [x] CI all green (Build and Test, Lint, Contract Harness, Health)