### PR TITLE
chore(tools): remove last ghost vote tool references

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -79,8 +79,7 @@ let read_only_tools_inline =
    "masc_pending_interrupts"]
 
 let requires_join_tools_inline =
-  ["masc_broadcast"; "masc_listen"; "masc_leave";
-   "masc_vote_revoke"]
+  ["masc_broadcast"; "masc_listen"; "masc_leave"]
 
 let mcp_context_required_tools_inline =
   Tool_schemas_inline.schemas

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -80,10 +80,10 @@ let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param 
 
     {[
       let oas_tool = oas_tool_of_masc
-        ~name:"masc_vote_create"
-        ~description:"Create a vote..."
+        ~name:"masc_board_post"
+        ~description:"Post to the board..."
         ~input_schema:schema_json
-        (fun args -> handle_vote_create ctx args)
+        (fun args -> handle_board_post ctx args)
     ]} *)
 let oas_tool_of_masc ~name ~description ~input_schema
     handler : Agent_sdk.Tool.t =


### PR DESCRIPTION
## Summary
- Remove `masc_vote_revoke` from `requires_join_tools_inline` — tool was removed but this reference remained
- Update `tool_bridge.ml` docstring example from removed `masc_vote_create` to existing `masc_board_post`

The ghost vote/post/comment tools were bulk-removed in a prior cleanup. These are the last two straggling references.

## Test plan
- [x] `dune build` passes
- [x] Pre-existing `voice agent` test failure is unrelated (confirmed on clean main)

Ref #4704
