### PR TITLE
fix(tools): add 9 shadow tools to schema assembly (tools/list visibility)

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -25,6 +25,18 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
     @ Tool_autoresearch.schemas
+    (* Tool_spec-registered modules missing from prior schema assembly.
+       Without these, the tools dispatch correctly but are invisible
+       in tools/list responses.  See #4724. *)
+    @ Tool_agent_timeline.schemas
+    @ Tool_audit.schemas
+    @ Tool_compact.schemas
+    @ Tool_cost.schemas
+    @ Tool_fire_task.schemas
+    @ Tool_model_catalog.schemas
+    @ Tool_rate_limit.schemas
+    @ Tool_repair_loop.schemas
+    @ Tool_tempo.schemas
     )
 
 (** Validate tool schemas at module initialization time.

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -48,6 +48,7 @@ let all_known_tool_names =
     "masc_agent_card";
     "masc_agent_fitness";
     "masc_agent_relations";
+    "masc_agent_timeline";
     "masc_agent_update";
     "masc_agents";
     "masc_approve";
@@ -59,6 +60,9 @@ let all_known_tool_names =
     "masc_auth_refresh";
     "masc_auth_revoke";
     "masc_auth_status";
+    "masc_audit_query";
+    "masc_audit_stats";
+    "masc_audit_trail";
     "masc_autoresearch_cycle";
     "masc_autoresearch_inject";
     "masc_autoresearch_record_finding";
@@ -105,8 +109,11 @@ let all_known_tool_names =
     "masc_code_write";
     "masc_collaboration_evidence";
     "masc_collaboration_graph";
+    "masc_compact_context";
     "masc_config";
     "masc_consolidate_learning";
+    "masc_cost_log";
+    "masc_cost_report";
     "masc_dashboard";
     "masc_deliver";
     "masc_detachment_list";
@@ -123,6 +130,7 @@ let all_known_tool_names =
     "masc_error_resolve";
     "masc_feature_flags";
     "masc_find_by_capability";
+    "masc_fire_task";
     "masc_gc";
     "masc_get_metrics";
     "masc_goal_dispatch";
@@ -131,6 +139,7 @@ let all_known_tool_names =
     "masc_goal_review";
     "masc_goal_snapshot";
     "masc_goal_upsert";
+    "masc_governance_report";
     "masc_governance_set";
     "masc_handover_claim";
     "masc_handover_create";
@@ -185,6 +194,7 @@ let all_known_tool_names =
     "masc_mcp_session";
     "masc_messages";
     "masc_meta_cognition_snapshot";
+    "masc_model_catalog";
     "masc_note_add";
     "masc_observe_alerts";
     "masc_observe_capacity";
@@ -227,6 +237,8 @@ let all_known_tool_names =
     "masc_portal_send";
     "masc_portal_status";
     "masc_progress";
+    "masc_rate_limit_config";
+    "masc_rate_limit_status";
     "masc_recall_search";
     "masc_register_capabilities";
     "masc_reject";
@@ -234,6 +246,10 @@ let all_known_tool_names =
     "masc_relay_now";
     "masc_relay_smart_check";
     "masc_relay_status";
+    "masc_repair_loop_iterate";
+    "masc_repair_loop_start";
+    "masc_repair_loop_status";
+    "masc_repair_loop_stop";
     "masc_repo_synthesis_swarm_start";
     "masc_reset";
     "masc_resume";
@@ -267,6 +283,11 @@ let all_known_tool_names =
     "masc_team_session_step";
     "masc_team_session_stop";
     "masc_team_session_verify_trace";
+    "masc_tempo";
+    "masc_tempo_adjust";
+    "masc_tempo_get";
+    "masc_tempo_reset";
+    "masc_tempo_set";
     "masc_tool_admin_snapshot";
     "masc_tool_admin_update";
     "masc_tool_help";


### PR DESCRIPTION
## Summary
9 modules registered tools via `Tool_spec.register` but were not included in `Config.raw_all_tool_schemas`. This made them dispatchable (tools/call works) but invisible (tools/list omits them).

**Added to config.ml schema assembly:**
- `Tool_agent_timeline` — was in essential tier but invisible
- `Tool_audit` (4 tools)
- `Tool_compact` (masc_compact_context)
- `Tool_cost` (2 tools)
- `Tool_fire_task` (masc_fire_task)
- `Tool_model_catalog` (masc_model_catalog)
- `Tool_rate_limit` (2 tools)
- `Tool_repair_loop` (4 tools)
- `Tool_tempo` (5 tools)

## Root cause
`Tool_spec.register` feeds `Tool_dispatch.schema_registry` (used for input validation at call time) but does NOT feed `Config.raw_all_tool_schemas` (used for tools/list). When modules migrated to the newer Tool_spec pattern, the manual schema list in config.ml was not updated.

## Test plan
- [x] `dune build` passes
- [x] No duplicate schema warnings in test output
- [x] Pre-existing `voice agent` test failure is unrelated

Fixes #4724
