### PR TITLE
fix(task): make done->done transition idempotent

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -402,6 +402,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                              completed_at = now;
                              notes = if notes = "" then None else Some notes;
                            }, None)
+                       | Types.Done_action, Types.Done _ ->
+                           (* Idempotent: already done, return current state unchanged *)
+                           Ok (task.task_status, None)
                        | Types.Cancel, Types.Todo ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -431,8 +431,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                      in
                      (match transition with
                       | Error e -> Error e
-                      | Ok (new_status, _) when new_status = task.task_status ->
-                          (* Idempotent no-op: status unchanged, skip write/events *)
+                      | Ok (new_status, None) when new_status = task.task_status ->
+                          (* Idempotent no-op: status unchanged, skip write/events.
+                             Match None explicitly so set_current=Some is never silently dropped. *)
                           Ok (Printf.sprintf "✅ %s already %s (no-op)" task_id
                                 (task_status_to_string task.task_status))
                       | Ok (new_status, set_current) ->

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -405,6 +405,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                        | Types.Done_action, Types.Done _ ->
                            (* Idempotent: already done, return current state unchanged *)
                            Ok (task.task_status, None)
+                       | Types.Cancel, Types.Cancelled _ ->
+                           (* Idempotent: already cancelled *)
+                           Ok (task.task_status, None)
                        | Types.Cancel, Types.Todo ->
                            Ok (Types.Cancelled {
                              cancelled_by = agent_name;
@@ -428,6 +431,10 @@ let transition_task_r config ~agent_name ~task_id ~action
                      in
                      (match transition with
                       | Error e -> Error e
+                      | Ok (new_status, _) when new_status = task.task_status ->
+                          (* Idempotent no-op: status unchanged, skip write/events *)
+                          Ok (Printf.sprintf "✅ %s already %s (no-op)" task_id
+                                (task_status_to_string task.task_status))
                       | Ok (new_status, set_current) ->
                           let new_tasks = List.map (fun t ->
                             if t.id = task_id then { t with task_status = new_status } else t

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -418,6 +418,30 @@ let test_transition_version_mismatch () =
     | _ -> Alcotest.fail "Expected TaskInvalidState for version mismatch"
   )
 
+let test_transition_done_idempotent () =
+  with_test_env (fun config ->
+    let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    let _ = Room.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
+    let _ = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Done_action () in
+    (* Second done call should succeed as no-op *)
+    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Done_action () in
+    match result with
+    | Ok msg -> Alcotest.(check bool) "done idempotent" true (str_contains msg "no-op")
+    | Error e -> Alcotest.failf "Expected Ok (no-op), got error: %s" (Types.masc_error_to_string e)
+  )
+
+let test_transition_cancel_idempotent () =
+  with_test_env (fun config ->
+    let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    (* Cancel from Todo (allowed) *)
+    let _ = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Cancel () in
+    (* Second cancel call should succeed as no-op *)
+    let result = Room.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Cancel () in
+    match result with
+    | Ok msg -> Alcotest.(check bool) "cancel idempotent" true (str_contains msg "no-op")
+    | Error e -> Alcotest.failf "Expected Ok (no-op), got error: %s" (Types.masc_error_to_string e)
+  )
+
 (* ============================================================ *)
 (* Observability Tests                                           *)
 (* ============================================================ *)
@@ -1011,6 +1035,8 @@ let () =
       Alcotest.test_case "release" `Quick test_transition_release;
       Alcotest.test_case "invalid" `Quick test_transition_invalid;
       Alcotest.test_case "version mismatch" `Quick test_transition_version_mismatch;
+      Alcotest.test_case "done idempotent" `Quick test_transition_done_idempotent;
+      Alcotest.test_case "cancel idempotent" `Quick test_transition_cancel_idempotent;
     ];
 
     (* === Observability === *)


### PR DESCRIPTION
## Summary
이미 완료된 task에 `Done_action`을 다시 호출하면 `Invalid transition: done -> done` 에러가 반환되던 문제 수정. 현재 상태를 변경 없이 반환하여 idempotent 동작 보장.

동일 패턴으로 `Cancel -> Cancelled` 도 idempotent 처리 추가.

## Root Cause
`room_task.ml`의 상태 전이 match에서 `Done_action, Done _` 케이스가 없어 catch-all `_` 분기로 빠짐.

## Changes
1. `Done_action, Done _` match arm 추가 (기존 상태 반환)
2. `Cancel, Cancelled _` match arm 추가 (대칭)
3. Post-transition `Ok (new_status, None) when new_status = task.task_status` guard로 write/events skip
4. Regression tests: `test_transition_done_idempotent`, `test_transition_cancel_idempotent`

## Review evidence
- Cross-model review: GLM-5.1 via `sb glm-text` (2026-04-03)
- Finding applied: narrowed wildcard guard to `None` to avoid silent `set_current` drop

## Test plan
- [x] `dune build @check` passes
- [x] `test_transition_done_idempotent` passes
- [x] `test_transition_cancel_idempotent` passes
- [x] All existing transition tests pass (claim/start/release/invalid/version_mismatch)

## Linked issue
Closes #4728