### PR TITLE
fix(keeper): filter masc_board_* tools that have keeper_board_* wrappers

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -47,12 +47,22 @@ let inject_masc_schemas (schemas : Types.tool_schema list) =
       | Some _ -> true
       | None -> false
   in
+  (* masc_board_* tools that have keeper_board_* wrappers with auto-injected
+     author/voter fields. Exposing both leads to the LLM calling the raw
+     masc_* variant without the required author, causing "author is required". *)
+  let has_keeper_board_wrapper name =
+    match name with
+    | "masc_board_comment" | "masc_board_post"
+    | "masc_board_vote" | "masc_board_delete" -> true
+    | _ -> false
+  in
   masc_schemas_ref :=
     List.filter (fun (s : Types.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name
       && not (is_keeper_mcp_context_required s.name)
       && supported_in_keeper s.name
-      && not (is_keeper_denied s.name))
+      && not (is_keeper_denied s.name)
+      && not (has_keeper_board_wrapper s.name))
       schemas
 
 let select_existing_masc_tool_names names =

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -170,11 +170,13 @@ let test_custom_keeps_registered_inline_board_tool () =
     make_meta
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
-           [ "masc_board_post"; "masc_who" ])
+           [ "keeper_board_post"; "masc_who" ])
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check bool) "keeps board handler tool" true
+  (* keeper_board_post is a keeper-internal tool, not a masc_ schema;
+     it won't appear in masc tool names but will be in the full allowed set *)
+  Alcotest.(check bool) "raw masc_board_post filtered out" false
     (List.mem "masc_board_post" names);
   Alcotest.(check bool) "drops unsupported inline tool" false
     (List.mem "masc_who" names)
@@ -557,7 +559,7 @@ let () =
             test_messaging_preset_exposes_board;
           Alcotest.test_case "preset also_allow opens extra tool" `Quick
             test_preset_with_also_allow_opens_extra_tool;
-          Alcotest.test_case "custom keeps registered inline board tool" `Quick
+          Alcotest.test_case "custom filters board tools with keeper wrappers" `Quick
             test_custom_keeps_registered_inline_board_tool;
         ] );
       ( "custom_policy",

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -607,11 +607,13 @@ let test_registered_inline_board_tool_survives_filter () =
   Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
   let base = make_gate_test_meta ~name:"test-board-inline" () in
   let meta = { base with
-    tool_access = Custom [ "masc_board_post"; "masc_who" ];
+    tool_access = Custom [ "keeper_board_post"; "masc_who" ];
     tool_denylist = [];
   } in
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "board handler tool survives" true
+  check bool "keeper board wrapper tool survives" true
+    (List.mem "keeper_board_post" allowed);
+  check bool "raw masc_board_post filtered out" false
     (List.mem "masc_board_post" allowed);
   check bool "unsupported inline tool removed" false
     (List.mem "masc_who" allowed)


### PR DESCRIPTION
## Summary
Keeper에게 `masc_board_comment`와 `keeper_board_comment`가 동시에 노출되면, LLM이 raw `masc_*` 버전을 선택하여 author 자동 주입 없이 호출 → `"author is required"` 에러.

## Fix
`inject_masc_schemas`에서 `keeper_board_*` 래퍼가 있는 `masc_board_{comment,post,vote,delete}`를 필터링. Keeper는 `keeper_board_*`만 사용하게 됨.

## Root Cause
`keeper_exec_tools.ml`의 `keeper_board_comment` 핸들러가 `meta.name`으로 author를 자동 주입하지만, `inject_masc_schemas`가 `masc_board_comment`도 같이 주입하여 LLM이 래퍼를 우회.

## Test plan
- [x] `dune build @check` 통과
- [x] CI all green (Build and Test, Lint, Contract Harness, Health)

Closes #4729
