### PR TITLE
chore(tools): deprecate 11 dead-feature tools (hat, encryption, tempo)

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -160,6 +160,41 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_judgment_latest",
       hidden_active
         "Internal operator-judge read path hidden from the default tool list; use for operator judgment experiments and keeper automation." );
+    (* Dead features: no surface, no external callers. Deprecated 2026-04-03.
+       Physical removal after 4-week telemetry confirms 0 calls. See #4709. *)
+    ("masc_hat_wear",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Role-hat feature unused since introduction.");
+    ("masc_hat_status",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Role-hat feature unused since introduction.");
+    ("masc_encryption_enable",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Room encryption feature never integrated.");
+    ("masc_encryption_disable",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Room encryption feature never integrated.");
+    ("masc_encryption_status",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Room encryption feature never integrated.");
+    ("masc_generate_key",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Room encryption feature never integrated.");
+    ("masc_tempo",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Tempo feature never integrated into workflows.");
+    ("masc_tempo_get",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Tempo feature never integrated into workflows.");
+    ("masc_tempo_set",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Tempo feature never integrated into workflows.");
+    ("masc_tempo_adjust",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Tempo feature never integrated into workflows.");
+    ("masc_tempo_reset",
+     deprecated ~implementation_status:Real
+       "No surface, no external callers. Tempo feature never integrated into workflows.");
     (* Semantic annotations for governance risk classification. *)
     ("masc_status", readonly_tool);
     ("masc_tasks", readonly_tool);


### PR DESCRIPTION
## Summary
Deprecate 11 dead-feature tools that have full dispatch wiring but zero external callers and no surface membership.

**Hat (2):** masc_hat_wear, masc_hat_status — agent role-hat system, never used
**Encryption (4):** masc_encryption_enable/disable/status, masc_generate_key — room encryption, never integrated
**Tempo (5):** masc_tempo, masc_tempo_get/set/adjust/reset — work tempo control, never integrated

This is the first use of the `deprecated()` metadata constructor, which existed but had zero consumers.

## Evidence
- `Hat.wear`, `Hat.list_all`, `Hat.of_string` — only called from `tool_hat.ml`
- `Encryption.*` — only called from `tool_encryption.ml`  
- `Tool_tempo.*` — only called from `tool_tempo.ml` and `keeper_tag_dispatch.ml` (dispatch only)
- None of these tools appear in any surface list (public_mcp, spawned_agent, etc.)

## Deprecation lifecycle
- Deprecated tools are fully blocked: hidden from tools/list AND blocked from tools/call direct invocation (`deprecated()` sets `visibility=Hidden`, `allow_direct_call_when_hidden=false`)
- This is intentional for dead tools with zero callers — no grace period needed
- Zero-caller audit (grep evidence above) is the primary safety gate
- Physical removal (module deletion) after 4-week confirmation period

## Product impact
None. All 11 tools have zero external callers and no surface membership. No user-facing behavior changes.

## Review evidence
- Copilot inline review: visibility/callability concern resolved (full blocking is intentional)
- GLM-5.1 cross-model review: HIGH finding (PR body mismatch) corrected, code approved

## Linked issue
Ref #4709, #3890

## Test plan
- [x] `dune build` passes
- [x] Inventory test passes (deprecated tools stay in raw_all_tool_schemas)