### PR TITLE
chore(tools): deprecate broken cost tools (masc-cost CLI missing)

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -195,6 +195,13 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tempo_reset",
      deprecated ~implementation_status:Real
        "No surface, no external callers. Tempo feature never integrated into workflows.");
+    (* Broken tools: shell out to non-existent CLI. Deprecated 2026-04-03. See #4709. *)
+    ("masc_cost_log",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
+    ("masc_cost_report",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
     (* Semantic annotations for governance risk classification. *)
     ("masc_status", readonly_tool);
     ("masc_tasks", readonly_tool);

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -196,15 +196,16 @@ let explicit_metadata : (string * metadata) list =
      deprecated ~implementation_status:Real
        "No surface, no external callers. Tempo feature never integrated into workflows.");
     (* Broken tools: shell out to CLI binaries unavailable at runtime.
-       masc-cost: buildable from bin/masc_cost.ml but not deployed in container image.
+       masc-cost: buildable from bin/masc_cost.ml but not guaranteed to be
+       present in runtime images or on PATH.
        masc-checkpoint: removed from codebase (refactor #102).
        Deprecated 2026-04-03. See #4709, #4734. *)
     ("masc_cost_log",
      deprecated ~implementation_status:Real
-       "Shells out to masc-cost CLI which is not deployed in the runtime container image. Fails in containerized environments.");
+       "Shells out to masc-cost CLI which may be unavailable in the runtime environment or missing from PATH.");
     ("masc_cost_report",
      deprecated ~implementation_status:Real
-       "Shells out to masc-cost CLI which is not deployed in the runtime container image. Fails in containerized environments.");
+       "Shells out to masc-cost CLI which may be unavailable in the runtime environment or missing from PATH.");
     ("masc_interrupt",
      deprecated ~implementation_status:Real
        "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -195,13 +195,29 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tempo_reset",
      deprecated ~implementation_status:Real
        "No surface, no external callers. Tempo feature never integrated into workflows.");
-    (* Broken tools: shell out to non-existent CLI. Deprecated 2026-04-03. See #4709. *)
+    (* Broken tools: shell out to non-existent CLI. Deprecated 2026-04-03.
+       See #4709, #4734. *)
     ("masc_cost_log",
      deprecated ~implementation_status:Real
        "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
     ("masc_cost_report",
      deprecated ~implementation_status:Real
        "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
+    ("masc_interrupt",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+    ("masc_approve",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+    ("masc_reject",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+    ("masc_pending_interrupts",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+    ("masc_branch",
+     deprecated ~implementation_status:Real
+       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
     (* Semantic annotations for governance risk classification. *)
     ("masc_status", readonly_tool);
     ("masc_tasks", readonly_tool);

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -195,29 +195,31 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tempo_reset",
      deprecated ~implementation_status:Real
        "No surface, no external callers. Tempo feature never integrated into workflows.");
-    (* Broken tools: shell out to non-existent CLI. Deprecated 2026-04-03.
-       See #4709, #4734. *)
+    (* Broken tools: shell out to CLI binaries unavailable at runtime.
+       masc-cost: buildable from bin/masc_cost.ml but not deployed in container image.
+       masc-checkpoint: removed from codebase (refactor #102).
+       Deprecated 2026-04-03. See #4709, #4734. *)
     ("masc_cost_log",
      deprecated ~implementation_status:Real
-       "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-cost CLI which is not deployed in the runtime container image. Fails in containerized environments.");
     ("masc_cost_report",
      deprecated ~implementation_status:Real
-       "Shells out to masc-cost CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-cost CLI which is not deployed in the runtime container image. Fails in containerized environments.");
     ("masc_interrupt",
      deprecated ~implementation_status:Real
-       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");
     ("masc_approve",
      deprecated ~implementation_status:Real
-       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");
     ("masc_reject",
      deprecated ~implementation_status:Real
-       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");
     ("masc_pending_interrupts",
      deprecated ~implementation_status:Real
-       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");
     ("masc_branch",
      deprecated ~implementation_status:Real
-       "Shells out to masc-checkpoint CLI which does not exist. Always fails at runtime.");
+       "Shells out to masc-checkpoint CLI which was removed from the codebase. Always fails at runtime.");
     (* Semantic annotations for governance risk classification. *)
     ("masc_status", readonly_tool);
     ("masc_tasks", readonly_tool);


### PR DESCRIPTION
## Summary

Deprecate `masc_cost_log` and `masc_cost_report` MCP tools by adding explicit deprecation metadata in `tool_catalog.ml`. These tools shell out to `masc-cost` CLI which, while buildable from source (`bin/masc_cost.ml`), is not included in the runtime Docker image (`Dockerfile.worker-runtime`).

## Product impact

No user-facing impact. These tools already fail in deployed environments. Deprecation hides them from tool discovery.

## Evidence

- `bin/dune` defines `(public_name masc-cost)` for `masc_cost.ml`
- `Dockerfile.worker-runtime` copies only `masc-mcp` and `masc-worker-run`
- Part of dead/broken tool cleanup tracked in #4709, alongside #4732

## Review evidence

- Copilot PR review: flagged inaccurate deprecation reason (CLI exists but is missing from runtime image)
- Owner acknowledged: "Valid. Will correct the deprecation rationale or reconsider the deprecation."
- Cross-model review (GLM-5.1 + Claude Opus 4.6): confirmed finding, syntax correct, awaiting reason text fix

## Linked issue

Ref #4709