### PR TITLE
[codex] Upgrade connector operations surfaces

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -1,0 +1,109 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { signal } from '@preact/signals'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    channels: [
+      {
+        channel: 'discord',
+        message_count: 12,
+        success_count: 10,
+        error_count: 2,
+        duplicate_count: 1,
+        validation_error_count: 0,
+        keeper_error_count: 2,
+        dispatch_unavailable_count: 0,
+        internal_error_count: 0,
+        last_activity: '2026-04-03T00:00:00Z',
+        last_success: '2026-04-03T00:00:00Z',
+        last_error_at: '2026-04-03T00:00:00Z',
+        last_keeper: 'luna',
+        last_room_id: '123456',
+        last_error: 'upstream timeout',
+        last_error_kind: 'keeper',
+        last_outcome: 'keeper_error',
+        avg_duration_ms: 1400,
+        max_duration_ms: 4800,
+        slow_count: 3,
+        slow_rate_pct: 25,
+        success_rate_pct: 91,
+        room_count: 2,
+        health: 'degraded',
+      },
+    ],
+    total_messages: 12,
+    total_success: 10,
+    total_errors: 2,
+    total_duplicates: 1,
+    success_rate_pct: 91,
+    dedup_table_size: 4,
+    uptime_seconds: 3600,
+    ...overrides,
+  }
+}
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+async function loadComponentWithApi(api: {
+  get: (path: string) => Promise<unknown>
+  lastEvent: { value: unknown }
+}) {
+  vi.resetModules()
+  vi.doMock('../api/core', () => ({
+    get: api.get,
+  }))
+  vi.doMock('../sse', () => ({
+    lastEvent: api.lastEvent,
+  }))
+  const module = await import('./connector-status')
+  module.resetConnectorStatusState()
+  return module
+}
+
+describe('ConnectorStatusPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    const { resetConnectorStatusState } = await import('./connector-status')
+    resetConnectorStatusState()
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../api/core')
+    vi.doUnmock('../sse')
+  })
+
+  it('renders enriched connector health details from gate status', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockResolvedValue(
+      sampleResponse(),
+    )
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      get,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    expect(get).toHaveBeenCalledWith('/api/v1/gate/status')
+    expect(container.textContent).toContain('Channel Gate')
+    expect(container.textContent).toContain('success 91%')
+    expect(container.textContent).toContain('duplicates')
+    expect(container.textContent).toContain('upstream timeout')
+    expect(container.innerHTML).toContain('degraded')
+  })
+})

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1,5 +1,5 @@
-// Connector Status — Channel Gate per-channel metrics panel.
-// Shows connected channels, message counts, last activity, avg latency.
+// Connector Status — Channel Gate per-channel diagnostics panel.
+// Shows connector health, success rate, duplicates, and latest failure context.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -11,15 +11,37 @@ import { StatCard } from './common/stat-card'
 interface ChannelInfo {
   channel: string
   message_count: number
+  success_count: number
   error_count: number
+  duplicate_count: number
+  validation_error_count: number
+  keeper_error_count: number
+  dispatch_unavailable_count: number
+  internal_error_count: number
   last_activity: string
+  last_success: string
+  last_error_at: string
   last_keeper: string
+  last_room_id: string
+  last_error: string
+  last_error_kind: string
+  last_outcome: string
   avg_duration_ms: number
+  max_duration_ms: number
+  slow_count: number
+  slow_rate_pct: number
+  success_rate_pct: number
+  room_count: number
+  health: 'idle' | 'healthy' | 'degraded' | 'failing' | string
 }
 
 interface GateStatusData {
   channels: ChannelInfo[]
   total_messages: number
+  total_success: number
+  total_errors: number
+  total_duplicates: number
+  success_rate_pct: number
   dedup_table_size: number
   uptime_seconds: number
 }
@@ -49,17 +71,17 @@ async function refresh() {
 }
 
 const CHANNEL_ICONS: Record<string, string> = {
-  discord: '\u{1F3AE}',   // game controller
-  telegram: '\u{2708}',    // airplane (paper plane)
-  slack: '\u{1F4AC}',      // speech bubble
-  signal: '\u{1F512}',     // lock
-  webchat: '\u{1F310}',    // globe
-  api: '\u{26A1}',         // zap
-  internal: '\u{2699}',    // gear
+  discord: '\u{1F3AE}',
+  telegram: '\u{2708}',
+  slack: '\u{1F4AC}',
+  signal: '\u{1F512}',
+  webchat: '\u{1F310}',
+  api: '\u{26A1}',
+  internal: '\u{2699}',
 }
 
 function channelIcon(ch: string): string {
-  return CHANNEL_ICONS[ch] ?? '\u{1F517}' // link
+  return CHANNEL_ICONS[ch] ?? '\u{1F517}'
 }
 
 function formatUptime(seconds: number): string {
@@ -79,42 +101,122 @@ function timeAgo(iso: string): string {
   return `${Math.floor(diff / 86400)}d ago`
 }
 
+function healthTone(health: string): { dot: string; badge: string; label: string } {
+  switch (health) {
+    case 'healthy':
+      return {
+        dot: 'var(--green)',
+        badge: 'border border-emerald-400/30 bg-emerald-500/12 text-emerald-100',
+        label: 'healthy',
+      }
+    case 'degraded':
+      return {
+        dot: 'var(--yellow)',
+        badge: 'border border-amber-400/30 bg-amber-500/12 text-amber-100',
+        label: 'degraded',
+      }
+    case 'failing':
+      return {
+        dot: 'var(--red)',
+        badge: 'border border-rose-400/35 bg-rose-500/12 text-rose-100',
+        label: 'failing',
+      }
+    default:
+      return {
+        dot: 'var(--text-dim)',
+        badge: 'border border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]',
+        label: health || 'idle',
+      }
+  }
+}
+
+function shortText(value: string, limit = 96): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  if (trimmed.length <= limit) return trimmed
+  return `${trimmed.slice(0, limit - 1)}…`
+}
+
 function ChannelCard({ ch }: { ch: ChannelInfo }) {
-  const errorRate = ch.message_count > 0
-    ? Math.round((ch.error_count / ch.message_count) * 100)
-    : 0
-  const statusColor = errorRate > 20 ? 'var(--red)' : errorRate > 5 ? 'var(--yellow)' : 'var(--green)'
+  const tone = healthTone(ch.health)
+  const lastError = shortText(ch.last_error)
 
   return html`
     <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-      <div class="flex items-center justify-between mb-2">
+      <div class="mb-3 flex items-start justify-between gap-3">
         <div class="flex items-center gap-2">
           <span class="text-lg">${channelIcon(ch.channel)}</span>
-          <span class="text-sm font-medium text-[var(--text-body)]">${ch.channel}</span>
+          <div>
+            <div class="text-sm font-medium text-[var(--text-body)]">${ch.channel}</div>
+            <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-dim)]">
+              ${ch.last_keeper ? `keeper ${ch.last_keeper}` : 'no keeper yet'}
+            </div>
+          </div>
         </div>
-        <div class="w-2 h-2 rounded-full" style="background: ${statusColor}"></div>
+        <div class="flex items-center gap-2">
+          <div class="h-2 w-2 rounded-full" style="background: ${tone.dot}"></div>
+          <span class=${`rounded-full px-2 py-1 text-[10px] uppercase tracking-[0.16em] ${tone.badge}`}>
+            ${tone.label}
+          </span>
+        </div>
       </div>
-      <div class="grid grid-cols-2 gap-2 text-xs">
+
+      <div class="grid grid-cols-3 gap-2 text-xs">
         <div>
           <div class="text-[var(--text-dim)]">messages</div>
           <div class="font-mono text-[var(--text-body)]">${ch.message_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">errors</div>
-          <div class="font-mono" style="color: ${ch.error_count > 0 ? 'var(--red)' : 'var(--text-body)'}">${ch.error_count}</div>
+          <div class="text-[var(--text-dim)]">success</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.success_rate_pct}%</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">avg latency</div>
-          <div class="font-mono text-[var(--text-body)]">${ch.avg_duration_ms > 0 ? `${(ch.avg_duration_ms / 1000).toFixed(1)}s` : '-'}</div>
+          <div class="text-[var(--text-dim)]">errors</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.error_count}</div>
+        </div>
+        <div>
+          <div class="text-[var(--text-dim)]">duplicates</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.duplicate_count}</div>
+        </div>
+        <div>
+          <div class="text-[var(--text-dim)]">rooms</div>
+          <div class="font-mono text-[var(--text-body)]">${ch.room_count}</div>
         </div>
         <div>
           <div class="text-[var(--text-dim)]">last active</div>
           <div class="font-mono text-[var(--text-body)]">${timeAgo(ch.last_activity)}</div>
         </div>
       </div>
-      ${ch.last_keeper ? html`
-        <div class="mt-2 text-[10px] text-[var(--text-dim)]">keeper: ${ch.last_keeper}</div>
-      ` : null}
+
+      <div class="mt-3 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)]">
+        <div>
+          avg ${(ch.avg_duration_ms / 1000).toFixed(1)}s
+          <span class="text-[var(--text-dim)]"> / max ${(ch.max_duration_ms / 1000).toFixed(1)}s</span>
+        </div>
+        <div>
+          slow ${ch.slow_count}
+          <span class="text-[var(--text-dim)]"> (${ch.slow_rate_pct}%)</span>
+        </div>
+        <div>
+          last outcome
+          <span class="font-mono text-[var(--text-body)]"> ${ch.last_outcome}</span>
+        </div>
+        <div>
+          last room
+          <span class="font-mono text-[var(--text-body)]"> ${ch.last_room_id || '-'}</span>
+        </div>
+      </div>
+
+      ${lastError
+        ? html`
+            <div class="mt-3 rounded-md border border-rose-400/20 bg-rose-500/8 px-3 py-2 text-[11px] text-rose-100">
+              <div class="mb-1 uppercase tracking-[0.16em] text-rose-200/80">
+                ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
+              </div>
+              <div>${lastError}</div>
+            </div>
+          `
+        : null}
     </div>
   `
 }
@@ -124,10 +226,9 @@ export function ConnectorStatusPanel() {
     refresh()
   }, [])
 
-  // Refresh on SSE events (debounced by sse-store)
   useEffect(() => {
-    const _event = lastEvent.value
-    if (_event && data.value) {
+    const event = lastEvent.value
+    if (event && data.value) {
       const timer = setTimeout(refresh, 2000)
       return () => clearTimeout(timer)
     }
@@ -147,21 +248,38 @@ export function ConnectorStatusPanel() {
 
   return html`
     <div>
-      <h3 class="text-sm font-semibold text-[var(--text-body)] mb-3">Channel Gate</h3>
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <h3 class="text-sm font-semibold text-[var(--text-body)]">Channel Gate</h3>
+        <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+          success ${d.success_rate_pct}% · uptime ${formatUptime(d.uptime_seconds)}
+        </div>
+      </div>
 
-      <div class="grid grid-cols-3 gap-2 mb-3">
+      <div class="mb-3 grid grid-cols-4 gap-2 max-[720px]:grid-cols-2">
         <${StatCard} label="Messages" value=${d.total_messages} />
+        <${StatCard} label="Success" value=${d.total_success} />
+        <${StatCard} label="Errors" value=${d.total_errors} />
         <${StatCard} label="Dedup Keys" value=${d.dedup_table_size} />
-        <${StatCard} label="Uptime" value=${formatUptime(d.uptime_seconds)} />
+      </div>
+
+      <div class="mb-4 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)] max-[720px]:grid-cols-1">
+        <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
+          duplicate suppressions
+          <span class="ml-2 font-mono text-[var(--text-body)]">${d.total_duplicates}</span>
+        </div>
+        <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
+          active connectors
+          <span class="ml-2 font-mono text-[var(--text-body)]">${d.channels.length}</span>
+        </div>
       </div>
 
       ${d.channels.length === 0
-        ? html`<div class="text-xs text-[var(--text-dim)] text-center py-4">No active connectors</div>`
+        ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">No active connectors</div>`
         : html`
-          <div class="grid grid-cols-2 gap-2 max-[600px]:grid-cols-1">
-            ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
-          </div>
-        `}
+            <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
+              ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
+            </div>
+          `}
     </div>
   `
 }

--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -173,7 +173,18 @@ let extract_reply_text (body : string) : string =
 
 let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
   match validate msg with
-  | Error e -> Error (Validation e)
+  | Error e ->
+      Channel_gate_metrics.record_attempt
+        ~channel:(Agent_identity.string_of_channel msg.channel)
+        ~room_id:msg.channel_room_id
+        ~keeper:(String.trim msg.keeper_name)
+        ~duration_ms:0
+        (match e with
+         | Duplicate_message _ -> Channel_gate_metrics.Duplicate
+         | _ ->
+             Channel_gate_metrics.Validation_error
+               (validation_error_to_string e));
+      Error (Validation e)
   | Ok () ->
       let args =
         `Assoc [
@@ -200,8 +211,12 @@ let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
           in
           let ch = Agent_identity.string_of_channel msg.channel in
           let keeper = String.trim msg.keeper_name in
-          Channel_gate_metrics.record_message
-            ~channel:ch ~keeper ~duration_ms ~success:true;
+          Channel_gate_metrics.record_attempt
+            ~channel:ch
+            ~room_id:msg.channel_room_id
+            ~keeper
+            ~duration_ms
+            Channel_gate_metrics.Success;
           let reply = extract_reply_text body in
           let stats = match extract_turn_stats body with
             | Some s -> Some { s with duration_ms }
@@ -212,16 +227,20 @@ let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
           let duration_ms =
             int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
           in
-          Channel_gate_metrics.record_message
+          Channel_gate_metrics.record_attempt
             ~channel:(Agent_identity.string_of_channel msg.channel)
+            ~room_id:msg.channel_room_id
             ~keeper:(String.trim msg.keeper_name)
-            ~duration_ms ~success:false;
+            ~duration_ms
+            (Channel_gate_metrics.Keeper_error err);
           Error (Keeper_error err)
       | None ->
-          Channel_gate_metrics.record_message
+          Channel_gate_metrics.record_attempt
             ~channel:(Agent_identity.string_of_channel msg.channel)
+            ~room_id:msg.channel_room_id
             ~keeper:(String.trim msg.keeper_name)
-            ~duration_ms:0 ~success:false;
+            ~duration_ms:0
+            Channel_gate_metrics.Dispatch_unavailable;
           Error Dispatch_unavailable
 
 (* ── JSON helpers ───────────────────────────────────────────── *)

--- a/lib/channel_gate_metrics.ml
+++ b/lib/channel_gate_metrics.ml
@@ -1,71 +1,202 @@
-(** Channel_gate_metrics -- per-channel message counters and status.
+(** Channel_gate_metrics -- per-channel connector diagnostics.
     See [channel_gate_metrics.mli]. *)
+
+type outcome =
+  | Success
+  | Duplicate
+  | Validation_error of string
+  | Keeper_error of string
+  | Dispatch_unavailable
+  | Internal_error of string
 
 type channel_stats = {
   channel : string;
   message_count : int;
+  success_count : int;
   error_count : int;
+  duplicate_count : int;
+  validation_error_count : int;
+  keeper_error_count : int;
+  dispatch_unavailable_count : int;
+  internal_error_count : int;
   last_activity_ts : float;
+  last_success_ts : float;
+  last_error_ts : float;
   last_keeper : string;
+  last_room_id : string;
+  last_error : string;
+  last_error_kind : string;
+  last_outcome : string;
   total_duration_ms : int;
+  timed_count : int;
+  max_duration_ms : int;
+  slow_count : int;
+  room_count : int;
 }
 
-(* Mutable internal record for accumulation. *)
 type stats_acc = {
   mutable msg_count : int;
+  mutable success_count : int;
   mutable err_count : int;
+  mutable duplicate_count : int;
+  mutable validation_error_count : int;
+  mutable keeper_error_count : int;
+  mutable dispatch_unavailable_count : int;
+  mutable internal_error_count : int;
   mutable last_ts : float;
+  mutable last_success_ts : float;
+  mutable last_error_ts : float;
   mutable last_keeper : string;
+  mutable last_room_id : string;
+  mutable last_error : string;
+  mutable last_error_kind : string;
+  mutable last_outcome : string;
   mutable total_dur_ms : int;
+  mutable timed_count : int;
+  mutable max_dur_ms : int;
+  mutable slow_count : int;
+  rooms : (string, unit) Hashtbl.t;
 }
+
+let slow_threshold_ms () =
+  match Sys.getenv_opt "MASC_CHANNEL_GATE_SLOW_MS" with
+  | Some s -> (try max 250 (min 120_000 (int_of_string (String.trim s))) with _ -> 10_000)
+  | None -> 10_000
+
+let make_acc () =
+  {
+    msg_count = 0;
+    success_count = 0;
+    err_count = 0;
+    duplicate_count = 0;
+    validation_error_count = 0;
+    keeper_error_count = 0;
+    dispatch_unavailable_count = 0;
+    internal_error_count = 0;
+    last_ts = 0.0;
+    last_success_ts = 0.0;
+    last_error_ts = 0.0;
+    last_keeper = "";
+    last_room_id = "";
+    last_error = "";
+    last_error_kind = "";
+    last_outcome = "idle";
+    total_dur_ms = 0;
+    timed_count = 0;
+    max_dur_ms = 0;
+    slow_count = 0;
+    rooms = Hashtbl.create 8;
+  }
 
 let table : (string, stats_acc) Hashtbl.t = Hashtbl.create 16
 let mu = Eio.Mutex.create ()
 let start_time = Unix.gettimeofday ()
 
-let record_message ~channel ~keeper ~duration_ms ~success =
-  Eio_guard.with_mutex mu (fun () ->
-    let acc =
-      match Hashtbl.find_opt table channel with
-      | Some a -> a
-      | None ->
-          let a = {
-            msg_count = 0; err_count = 0;
-            last_ts = 0.0; last_keeper = ""; total_dur_ms = 0;
-          } in
-          Hashtbl.replace table channel a;
-          a
-    in
-    acc.msg_count <- acc.msg_count + 1;
-    acc.last_ts <- Unix.gettimeofday ();
-    acc.last_keeper <- keeper;
-    acc.total_dur_ms <- acc.total_dur_ms + duration_ms;
-    if not success then acc.err_count <- acc.err_count + 1)
-
-let snapshot () =
-  Eio_guard.with_mutex_ro mu (fun () ->
-    Hashtbl.fold (fun ch acc lst ->
-      { channel = ch;
-        message_count = acc.msg_count;
-        error_count = acc.err_count;
-        last_activity_ts = acc.last_ts;
-        last_keeper = acc.last_keeper;
-        total_duration_ms = acc.total_dur_ms;
-      } :: lst
-    ) table [])
-  |> List.sort (fun a b -> compare b.message_count a.message_count)
-
-let total_messages () =
-  Eio_guard.with_mutex_ro mu (fun () ->
-    Hashtbl.fold (fun _ acc sum -> sum + acc.msg_count) table 0)
-
-(** Callback for dedup table size.  Set by channel_gate at init
-    to break the module dependency cycle. *)
 let dedup_size_fn : (unit -> int) ref = ref (fun () -> 0)
 
 let register_dedup_size_fn f = dedup_size_fn := f
-
 let dedup_table_size () = !dedup_size_fn ()
+
+let get_or_create_acc channel =
+  match Hashtbl.find_opt table channel with
+  | Some acc -> acc
+  | None ->
+      let acc = make_acc () in
+      Hashtbl.replace table channel acc;
+      acc
+
+let outcome_name = function
+  | Success -> "success"
+  | Duplicate -> "duplicate"
+  | Validation_error _ -> "validation_error"
+  | Keeper_error _ -> "keeper_error"
+  | Dispatch_unavailable -> "dispatch_unavailable"
+  | Internal_error _ -> "internal_error"
+
+let update_error_fields acc ~now ~kind ~message =
+  acc.err_count <- acc.err_count + 1;
+  acc.last_error_ts <- now;
+  acc.last_error_kind <- kind;
+  acc.last_error <- message
+
+let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
+  Eio_guard.with_mutex mu (fun () ->
+      let acc = get_or_create_acc channel in
+      let now = Unix.gettimeofday () in
+      acc.msg_count <- acc.msg_count + 1;
+      acc.last_ts <- now;
+      acc.last_outcome <- outcome_name outcome;
+      if String.trim keeper <> "" then acc.last_keeper <- keeper;
+      let trimmed_room = String.trim room_id in
+      if trimmed_room <> "" then begin
+        acc.last_room_id <- trimmed_room;
+        Hashtbl.replace acc.rooms trimmed_room ()
+      end;
+      if duration_ms > 0 then begin
+        acc.total_dur_ms <- acc.total_dur_ms + duration_ms;
+        acc.timed_count <- acc.timed_count + 1;
+        acc.max_dur_ms <- max acc.max_dur_ms duration_ms;
+        if duration_ms >= slow_threshold_ms () then
+          acc.slow_count <- acc.slow_count + 1
+      end;
+      match outcome with
+      | Success ->
+          acc.success_count <- acc.success_count + 1;
+          acc.last_success_ts <- now
+      | Duplicate ->
+          acc.duplicate_count <- acc.duplicate_count + 1
+      | Validation_error message ->
+          acc.validation_error_count <- acc.validation_error_count + 1;
+          update_error_fields acc ~now ~kind:"validation" ~message
+      | Keeper_error message ->
+          acc.keeper_error_count <- acc.keeper_error_count + 1;
+          update_error_fields acc ~now ~kind:"keeper" ~message
+      | Dispatch_unavailable ->
+          acc.dispatch_unavailable_count <- acc.dispatch_unavailable_count + 1;
+          update_error_fields acc ~now ~kind:"dispatch_unavailable"
+            ~message:"keeper dispatch unavailable"
+      | Internal_error message ->
+          acc.internal_error_count <- acc.internal_error_count + 1;
+          update_error_fields acc ~now ~kind:"internal" ~message)
+
+let snapshot () =
+  Eio_guard.with_mutex_ro mu (fun () ->
+      Hashtbl.fold
+        (fun channel acc rows ->
+          {
+            channel;
+            message_count = acc.msg_count;
+            success_count = acc.success_count;
+            error_count = acc.err_count;
+            duplicate_count = acc.duplicate_count;
+            validation_error_count = acc.validation_error_count;
+            keeper_error_count = acc.keeper_error_count;
+            dispatch_unavailable_count = acc.dispatch_unavailable_count;
+            internal_error_count = acc.internal_error_count;
+            last_activity_ts = acc.last_ts;
+            last_success_ts = acc.last_success_ts;
+            last_error_ts = acc.last_error_ts;
+            last_keeper = acc.last_keeper;
+            last_room_id = acc.last_room_id;
+            last_error = acc.last_error;
+            last_error_kind = acc.last_error_kind;
+            last_outcome = acc.last_outcome;
+            total_duration_ms = acc.total_dur_ms;
+            timed_count = acc.timed_count;
+            max_duration_ms = acc.max_dur_ms;
+            slow_count = acc.slow_count;
+            room_count = Hashtbl.length acc.rooms;
+          }
+          :: rows)
+        table [])
+  |> List.sort (fun a b ->
+         let by_messages = compare b.message_count a.message_count in
+         if by_messages <> 0 then by_messages
+         else String.compare a.channel b.channel)
+
+let total_messages () =
+  Eio_guard.with_mutex_ro mu (fun () ->
+      Hashtbl.fold (fun _ acc sum -> sum + acc.msg_count) table 0)
 
 let iso_of_ts ts =
   if ts <= 0.0 then "never"
@@ -75,25 +206,99 @@ let iso_of_ts ts =
       (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday
       t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
 
+let percent numerator denominator =
+  if denominator <= 0 then 0
+  else
+    int_of_float
+      (Float.round
+         ((float_of_int numerator *. 100.0) /. float_of_int denominator))
+
+let effective_attempt_count (stats : channel_stats) =
+  max 0 (stats.message_count - stats.duplicate_count)
+
+let success_rate_pct (stats : channel_stats) =
+  percent stats.success_count (effective_attempt_count stats)
+
+let slow_rate_pct (stats : channel_stats) =
+  percent stats.slow_count stats.timed_count
+
+let health_of_stats (stats : channel_stats) =
+  if stats.message_count = 0 then "idle"
+  else if stats.error_count = 0 then "healthy"
+  else if stats.success_count = 0 then "failing"
+  else
+    let err_rate = percent stats.error_count (effective_attempt_count stats) in
+    let slow_rate = slow_rate_pct stats in
+    if err_rate >= 50 then "failing"
+    else if err_rate >= 10 || slow_rate >= 25 then "degraded"
+    else "healthy"
+
 let snapshot_json () =
   let channels = snapshot () in
-  let total = List.fold_left (fun s c -> s + c.message_count) 0 channels in
-  let channel_json c =
-    let avg_dur =
-      if c.message_count > 0 then c.total_duration_ms / c.message_count else 0
-    in
-    `Assoc [
-      ("channel", `String c.channel);
-      ("message_count", `Int c.message_count);
-      ("error_count", `Int c.error_count);
-      ("last_activity", `String (iso_of_ts c.last_activity_ts));
-      ("last_keeper", `String c.last_keeper);
-      ("avg_duration_ms", `Int avg_dur);
-    ]
+  let total =
+    List.fold_left
+      (fun sum (stats : channel_stats) -> sum + stats.message_count)
+      0 channels
   in
-  `Assoc [
-    ("channels", `List (List.map channel_json channels));
-    ("total_messages", `Int total);
-    ("dedup_table_size", `Int (dedup_table_size ()));
-    ("uptime_seconds", `Int (int_of_float (Unix.gettimeofday () -. start_time)));
-  ]
+  let total_success =
+    List.fold_left
+      (fun sum (stats : channel_stats) -> sum + stats.success_count)
+      0 channels
+  in
+  let total_errors =
+    List.fold_left
+      (fun sum (stats : channel_stats) -> sum + stats.error_count)
+      0 channels
+  in
+  let total_duplicates =
+    List.fold_left
+      (fun sum (stats : channel_stats) -> sum + stats.duplicate_count)
+      0 channels
+  in
+  let channel_json (stats : channel_stats) =
+    let avg_dur =
+      if stats.timed_count > 0 then stats.total_duration_ms / stats.timed_count
+      else 0
+    in
+    `Assoc
+      [
+        ("channel", `String stats.channel);
+        ("message_count", `Int stats.message_count);
+        ("success_count", `Int stats.success_count);
+        ("error_count", `Int stats.error_count);
+        ("duplicate_count", `Int stats.duplicate_count);
+        ("validation_error_count", `Int stats.validation_error_count);
+        ("keeper_error_count", `Int stats.keeper_error_count);
+        ("dispatch_unavailable_count", `Int stats.dispatch_unavailable_count);
+        ("internal_error_count", `Int stats.internal_error_count);
+        ("last_activity", `String (iso_of_ts stats.last_activity_ts));
+        ("last_success", `String (iso_of_ts stats.last_success_ts));
+        ("last_error_at", `String (iso_of_ts stats.last_error_ts));
+        ("last_keeper", `String stats.last_keeper);
+        ("last_room_id", `String stats.last_room_id);
+        ("last_error", `String stats.last_error);
+        ("last_error_kind", `String stats.last_error_kind);
+        ("last_outcome", `String stats.last_outcome);
+        ("avg_duration_ms", `Int avg_dur);
+        ("max_duration_ms", `Int stats.max_duration_ms);
+        ("slow_count", `Int stats.slow_count);
+        ("slow_rate_pct", `Int (slow_rate_pct stats));
+        ("success_rate_pct", `Int (success_rate_pct stats));
+        ("room_count", `Int stats.room_count);
+        ("health", `String (health_of_stats stats));
+      ]
+  in
+  `Assoc
+    [
+      ("channels", `List (List.map channel_json channels));
+      ("total_messages", `Int total);
+      ("total_success", `Int total_success);
+      ("total_errors", `Int total_errors);
+      ("total_duplicates", `Int total_duplicates);
+      ( "success_rate_pct",
+        `Int
+          (percent total_success
+             (max 0 (total - total_duplicates))) );
+      ("dedup_table_size", `Int (dedup_table_size ()));
+      ("uptime_seconds", `Int (int_of_float (Unix.gettimeofday () -. start_time)));
+    ]

--- a/lib/channel_gate_metrics.ml
+++ b/lib/channel_gate_metrics.ml
@@ -56,12 +56,21 @@ type stats_acc = {
   mutable max_dur_ms : int;
   mutable slow_count : int;
   rooms : (string, unit) Hashtbl.t;
+  room_order : string Queue.t;
 }
 
-let slow_threshold_ms () =
+let parse_slow_threshold_ms value =
+  try max 250 (min 120_000 (int_of_string (String.trim value))) with _ -> 10_000
+
+let cached_slow_threshold_ms =
   match Sys.getenv_opt "MASC_CHANNEL_GATE_SLOW_MS" with
-  | Some s -> (try max 250 (min 120_000 (int_of_string (String.trim s))) with _ -> 10_000)
+  | Some value -> parse_slow_threshold_ms value
   | None -> 10_000
+
+let slow_threshold_ms () =
+  cached_slow_threshold_ms
+
+let max_tracked_rooms = 256
 
 let make_acc () =
   {
@@ -86,6 +95,7 @@ let make_acc () =
     max_dur_ms = 0;
     slow_count = 0;
     rooms = Hashtbl.create 8;
+    room_order = Queue.create ();
   }
 
 let table : (string, stats_acc) Hashtbl.t = Hashtbl.create 16
@@ -119,6 +129,19 @@ let update_error_fields acc ~now ~kind ~message =
   acc.last_error_kind <- kind;
   acc.last_error <- message
 
+let remember_room acc room_id =
+  acc.last_room_id <- room_id;
+  if not (Hashtbl.mem acc.rooms room_id) then begin
+    if Hashtbl.length acc.rooms >= max_tracked_rooms
+       && not (Queue.is_empty acc.room_order)
+    then begin
+      let evicted = Queue.take acc.room_order in
+      Hashtbl.remove acc.rooms evicted
+    end;
+    Hashtbl.replace acc.rooms room_id ();
+    Queue.add room_id acc.room_order
+  end
+
 let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
   Eio_guard.with_mutex mu (fun () ->
       let trimmed_channel = String.trim channel in
@@ -131,10 +154,7 @@ let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
       acc.last_outcome <- outcome_name outcome;
       if trimmed_keeper <> "" then acc.last_keeper <- trimmed_keeper;
       let trimmed_room = String.trim room_id in
-      if trimmed_room <> "" then begin
-        acc.last_room_id <- trimmed_room;
-        Hashtbl.replace acc.rooms trimmed_room ()
-      end;
+      if trimmed_room <> "" then remember_room acc trimmed_room;
       if duration_ms > 0 then begin
         acc.total_dur_ms <- acc.total_dur_ms + duration_ms;
         acc.timed_count <- acc.timed_count + 1;
@@ -162,9 +182,9 @@ let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
           acc.internal_error_count <- acc.internal_error_count + 1;
           update_error_fields acc ~now ~kind:"internal" ~message)
 
-let record_internal_error_exn ~channel ~room_id ~keeper ~duration_ms exn =
+let record_internal_error_exn ~channel ~room_id ~keeper ~duration_ms _exn =
   record_attempt ~channel ~room_id ~keeper ~duration_ms
-    (Internal_error (Printexc.to_string exn))
+    (Internal_error "internal error")
 
 let snapshot () =
   Eio_guard.with_mutex_ro mu (fun () ->

--- a/lib/channel_gate_metrics.ml
+++ b/lib/channel_gate_metrics.ml
@@ -121,12 +121,15 @@ let update_error_fields acc ~now ~kind ~message =
 
 let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
   Eio_guard.with_mutex mu (fun () ->
-      let acc = get_or_create_acc channel in
+      let trimmed_channel = String.trim channel in
+      let channel_key = if trimmed_channel = "" then "unknown" else trimmed_channel in
+      let acc = get_or_create_acc channel_key in
       let now = Unix.gettimeofday () in
+      let trimmed_keeper = String.trim keeper in
       acc.msg_count <- acc.msg_count + 1;
       acc.last_ts <- now;
       acc.last_outcome <- outcome_name outcome;
-      if String.trim keeper <> "" then acc.last_keeper <- keeper;
+      if trimmed_keeper <> "" then acc.last_keeper <- trimmed_keeper;
       let trimmed_room = String.trim room_id in
       if trimmed_room <> "" then begin
         acc.last_room_id <- trimmed_room;
@@ -158,6 +161,10 @@ let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
       | Internal_error message ->
           acc.internal_error_count <- acc.internal_error_count + 1;
           update_error_fields acc ~now ~kind:"internal" ~message)
+
+let record_internal_error_exn ~channel ~room_id ~keeper ~duration_ms exn =
+  record_attempt ~channel ~room_id ~keeper ~duration_ms
+    (Internal_error (Printexc.to_string exn))
 
 let snapshot () =
   Eio_guard.with_mutex_ro mu (fun () ->

--- a/lib/channel_gate_metrics.mli
+++ b/lib/channel_gate_metrics.mli
@@ -1,23 +1,54 @@
 (** Channel_gate_metrics -- per-channel message counters and status.
 
-    Thread-safe via [Eio_guard.with_mutex].  Call [record_message]
-    after each gate dispatch; read state via [snapshot_json].
+    Thread-safe via [Eio_guard.with_mutex]. Call [record_attempt]
+    for every gate ingress, including validation failures and duplicates,
+    then read state via [snapshot_json].
 
     @since 2.218.0 *)
+
+(** Ingress outcome classification for connector diagnostics. *)
+type outcome =
+  | Success
+  | Duplicate
+  | Validation_error of string
+  | Keeper_error of string
+  | Dispatch_unavailable
+  | Internal_error of string
 
 (** Per-channel statistics snapshot (immutable). *)
 type channel_stats = {
   channel : string;
   message_count : int;
+  success_count : int;
   error_count : int;
+  duplicate_count : int;
+  validation_error_count : int;
+  keeper_error_count : int;
+  dispatch_unavailable_count : int;
+  internal_error_count : int;
   last_activity_ts : float;
+  last_success_ts : float;
+  last_error_ts : float;
   last_keeper : string;
+  last_room_id : string;
+  last_error : string;
+  last_error_kind : string;
+  last_outcome : string;
   total_duration_ms : int;
+  timed_count : int;
+  max_duration_ms : int;
+  slow_count : int;
+  room_count : int;
 }
 
-val record_message :
-  channel:string -> keeper:string -> duration_ms:int -> success:bool -> unit
-(** Record one gate message.  Thread-safe. *)
+val record_attempt :
+  channel:string ->
+  room_id:string ->
+  keeper:string ->
+  duration_ms:int ->
+  outcome ->
+  unit
+(** Record one gate attempt. Thread-safe. *)
 
 val snapshot : unit -> channel_stats list
 (** Return a list of per-channel stats, sorted by message_count desc. *)

--- a/lib/channel_gate_metrics.mli
+++ b/lib/channel_gate_metrics.mli
@@ -50,6 +50,15 @@ val record_attempt :
   unit
 (** Record one gate attempt. Thread-safe. *)
 
+val record_internal_error_exn :
+  channel:string ->
+  room_id:string ->
+  keeper:string ->
+  duration_ms:int ->
+  exn ->
+  unit
+(** Record an unexpected gate exception with the same channel metadata. *)
+
 val snapshot : unit -> channel_stats list
 (** Return a list of per-channel stats, sorted by message_count desc. *)
 

--- a/lib/channel_gate_metrics.mli
+++ b/lib/channel_gate_metrics.mli
@@ -57,7 +57,8 @@ val record_internal_error_exn :
   duration_ms:int ->
   exn ->
   unit
-(** Record an unexpected gate exception with the same channel metadata. *)
+(** Record an unexpected gate exception with the same channel metadata.
+    The public status surface receives a redacted internal error string. *)
 
 val snapshot : unit -> channel_stats list
 (** Return a list of per-channel stats, sorted by message_count desc. *)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -9,6 +9,7 @@
     @since 2.217.0 *)
 
 open Server_auth
+open Server_utils
 
 module Http = Http_server_eio
 
@@ -118,6 +119,79 @@ let handle_gate_status _state request reqd =
   respond_json_with_cors ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
+let gate_keeper_ctx ~sw ~clock state =
+  {
+    Tool_keeper.config = state.Mcp_server.room_config;
+    agent_name = "gate:connector";
+    sw;
+    clock;
+    proc_mgr = state.Mcp_server.proc_mgr;
+    net = state.Mcp_server.net;
+  }
+
+let respond_keeper_tool_json ~sw ~clock state request reqd ~tool_name ~args =
+  match
+    Tool_keeper.dispatch (gate_keeper_ctx ~sw ~clock state) ~name:tool_name ~args
+  with
+  | Some (true, body) -> (
+      try
+        ignore (Yojson.Safe.from_string body);
+        respond_json_with_cors ~status:`OK request reqd body
+      with
+      | Yojson.Json_error err ->
+          Log.Misc.error "channel_gate %s returned invalid json: %s"
+            tool_name err;
+          respond_json_with_cors ~status:`Internal_server_error request reqd
+            (Yojson.Safe.to_string
+               (Channel_gate.error_json "internal error")) )
+  | Some (false, err) ->
+      let lower = String.lowercase_ascii err in
+      let status =
+        if String_util.contains_substring lower "keeper not found" then `Not_found
+        else `Bad_gateway
+      in
+      respond_json_with_cors ~status request reqd
+        (Yojson.Safe.to_string (Channel_gate.error_json err))
+  | None ->
+      respond_json_with_cors ~status:`Service_unavailable request reqd
+        (Yojson.Safe.to_string
+           (Channel_gate.error_json "keeper dispatch unavailable"))
+
+(** GET /api/v1/gate/keepers?limit=100&detailed=true
+
+    Authenticated keeper discovery for channel-side connectors. *)
+let handle_gate_keepers ~sw ~clock state request reqd =
+  let limit =
+    int_query_param request "limit" ~default:100
+    |> fun value -> max 1 (min 200 value)
+  in
+  let detailed = bool_query_param request "detailed" ~default:true in
+  let args =
+    `Assoc [ ("limit", `Int limit); ("detailed", `Bool detailed) ]
+  in
+  respond_keeper_tool_json ~sw ~clock state request reqd
+    ~tool_name:"masc_keeper_list" ~args
+
+(** GET /api/v1/gate/keeper-status?name=<keeper>
+
+    Authenticated single-keeper status for connector admin surfaces. *)
+let handle_gate_keeper_status ~sw ~clock state request reqd =
+  match query_param request "name" with
+  | Some raw_name ->
+      let name = String.trim raw_name in
+      if name = "" then
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json "name is required"))
+      else
+        let args = `Assoc [ ("name", `String name) ] in
+        respond_keeper_tool_json ~sw ~clock state request reqd
+          ~tool_name:"masc_keeper_status" ~args
+  | None ->
+      respond_json_with_cors ~status:`Bad_request request reqd
+        (Yojson.Safe.to_string
+           (Channel_gate.error_json "name is required"))
+
 (** Register all gate routes on the router. *)
 let add_routes ~sw ~clock router =
   router
@@ -134,4 +208,14 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/gate/status" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          handle_gate_status state request reqd
+       ) request reqd)
+
+  |> Http.Router.get "/api/v1/gate/keepers" (fun request reqd ->
+       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+         handle_gate_keepers ~sw ~clock state request reqd
+       ) request reqd)
+
+  |> Http.Router.get "/api/v1/gate/keeper-status" (fun request reqd ->
+       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+         handle_gate_keeper_status ~sw ~clock state request reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -53,8 +53,30 @@ let http_status_of_gate_error : Channel_gate.gate_error -> Httpun.Status.t = fun
   | Dispatch_unavailable -> `Service_unavailable
   | Internal _ -> `Internal_server_error
 
+let record_internal_error_metric ~duration_ms body_str exn =
+  let fallback () =
+    Channel_gate_metrics.record_internal_error_exn
+      ~channel:"unknown"
+      ~room_id:""
+      ~keeper:""
+      ~duration_ms exn
+  in
+  try
+    let json = Yojson.Safe.from_string body_str in
+    match Channel_gate.inbound_of_json json with
+    | Ok msg ->
+        Channel_gate_metrics.record_internal_error_exn
+          ~channel:(Agent_identity.string_of_channel msg.channel)
+          ~room_id:msg.channel_room_id
+          ~keeper:msg.keeper_name
+          ~duration_ms exn
+    | Error _ -> fallback ()
+  with
+  | Yojson.Json_error _ -> fallback ()
+
 let handle_gate_message ~sw ~clock state request reqd =
   Http.Request.read_body_async reqd (fun body_str ->
+    let request_started = Unix.gettimeofday () in
     let result =
       try
         let json = Yojson.Safe.from_string body_str in
@@ -77,6 +99,10 @@ let handle_gate_message ~sw ~clock state request reqd =
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
           (* Log details server-side, return generic message to client *)
+          let duration_ms =
+            int_of_float ((Unix.gettimeofday () -. request_started) *. 1000.0)
+          in
+          record_internal_error_metric ~duration_ms body_str exn;
           Log.Misc.error "channel_gate internal error: %s" (Printexc.to_string exn);
           Error (Channel_gate.Internal "", "internal error")
     in

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -14,3 +14,11 @@ DISCORD_KEEPER_MAP={"1234567890": "luna"}
 
 # Discord role ID for admin commands (optional)
 DISCORD_ADMIN_ROLE_ID=
+
+# Cache TTLs for gate status + keeper discovery
+STATUS_CACHE_TTL_SEC=15
+KEEPER_CACHE_TTL_SEC=30
+
+# Transport breaker: opens after repeated 5xx/timeout failures
+GATE_BREAKER_FAILURE_THRESHOLD=3
+GATE_BREAKER_RESET_SEC=30

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -61,3 +61,18 @@ The `DISCORD_KEEPER_MAP` environment variable maps Discord channel IDs to keeper
 
 Messages in mapped channels are automatically forwarded to the corresponding keeper.
 Use the `/keeper-ask` slash command to talk to any keeper from any channel.
+
+## Operations Upgrades
+
+- `/keeper-status [keeper]`: connector health snapshot or single-keeper status
+- `/keeper-bind <keeper>`: runtime bind current channel to a keeper
+- `/keeper-unbind`: remove the current runtime binding
+- `/keeper-map`: inspect resolved binding + loaded runtime map
+- Keeper names support slash-command autocomplete via `/api/v1/gate/keepers`
+- The bot now forwards attachment-only messages by synthesizing a deterministic
+  `Attachments:` block instead of dropping them as empty content
+- A lightweight transport circuit breaker prevents repeated timeouts / 5xx
+  storms from hammering the gate while still serving cached status data
+
+Runtime binds are in-memory only. They override the initial `DISCORD_KEEPER_MAP`
+for the current process and reset on bot restart.

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -12,19 +12,53 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from typing import Any, cast
 
 import discord
 from discord import app_commands
 
 from .config import get_config
-from .formatters import chunk_text, format_error_embed, format_keeper_embed
-from .masc_client import GateResponse, MascGateClient
+from .formatters import (
+    chunk_text,
+    compose_gate_content,
+    format_error_embed,
+    format_keeper_embed,
+)
+from .masc_client import BreakerSnapshot, GateResponse, MascGateClient
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
 )
 logger = logging.getLogger("masc-discord-bot")
+
+
+def attachment_lines(message: discord.Message) -> list[str]:
+    """Render Discord attachments into deterministic plain text."""
+    lines: list[str] = []
+    visible = message.attachments[:5]
+    for attachment in visible:
+        filename = attachment.filename.strip() or "attachment"
+        lines.append(f"- {filename}: {attachment.url}")
+    extra = len(message.attachments) - len(visible)
+    if extra > 0:
+        lines.append(f"- ... {extra} more attachment(s)")
+    return lines
+
+
+def channel_stats_for(status: dict[str, Any] | None, channel_name: str) -> dict[str, Any] | None:
+    """Extract one connector row from gate status."""
+    if status is None:
+        return None
+    rows = status.get("channels")
+    if not isinstance(rows, list):
+        return None
+    for item in cast(list[object], rows):
+        if isinstance(item, dict):
+            row = cast(dict[str, Any], item)
+            if row.get("channel") == channel_name:
+                return row
+    return None
 
 
 class MascBot(discord.Client):
@@ -37,12 +71,15 @@ class MascBot(discord.Client):
         self.tree = app_commands.CommandTree(self)
         self.gate = MascGateClient()
         self.cfg = get_config()
-        self._keeper_map = self.cfg.keeper_map()
+        self.keeper_bindings = self.cfg.keeper_map()
 
     async def setup_hook(self) -> None:
         """Register slash commands on startup."""
-        self.tree.add_command(keeper_ask)
-        self.tree.add_command(keeper_status)
+        self.tree.add_command(keeper_ask)  # pyright: ignore[reportUnknownArgumentType]
+        self.tree.add_command(keeper_status)  # pyright: ignore[reportUnknownArgumentType]
+        self.tree.add_command(keeper_bind)  # pyright: ignore[reportUnknownArgumentType]
+        self.tree.add_command(keeper_unbind)  # pyright: ignore[reportUnknownArgumentType]
+        self.tree.add_command(keeper_map)  # pyright: ignore[reportUnknownArgumentType]
         await self.tree.sync()
         logger.info("Slash commands synced")
 
@@ -54,42 +91,53 @@ class MascBot(discord.Client):
     async def on_ready(self) -> None:
         assert self.user is not None
         logger.info("Bot ready: %s (id=%s)", self.user.name, self.user.id)
-        logger.info("Keeper map: %s", self._keeper_map)
+        logger.info("Keeper map: %s", self.keeper_bindings)
 
-        # Health check on startup
         healthy = await self.gate.health_check()
         if healthy:
             logger.info("Gate health check: OK")
         else:
             logger.warning("Gate health check: FAILED (bot will retry on messages)")
 
-    async def on_message(self, message: discord.Message) -> None:
-        """Route channel messages to the mapped keeper."""
-        # Ignore own messages
-        if message.author == self.user:
-            return
-        # Ignore DMs for now
-        if not message.guild:
-            return
+    def _resolve_keeper_for_channel(self, channel: discord.abc.Snowflake) -> str | None:
+        channel_id = str(channel.id)
+        direct = self.keeper_bindings.get(channel_id)
+        if direct is not None:
+            return direct
+        if isinstance(channel, discord.Thread) and channel.parent is not None:
+            return self.keeper_bindings.get(str(channel.parent.id))
+        return None
 
-        channel_id = str(message.channel.id)
-        keeper_name = self._keeper_map.get(channel_id)
+    def channel_binding_debug(self, channel: discord.abc.Snowflake) -> tuple[str | None, str]:
+        channel_id = str(channel.id)
+        direct = self.keeper_bindings.get(channel_id)
+        if direct is not None:
+            return direct, "direct"
+        if isinstance(channel, discord.Thread) and channel.parent is not None:
+            inherited = self.keeper_bindings.get(str(channel.parent.id))
+            if inherited is not None:
+                return inherited, "thread-parent"
+        return None, "unmapped"
 
-        if keeper_name is None:
-            return  # Channel not mapped to any keeper
+    def set_channel_binding(self, channel_id: str, keeper_name: str) -> None:
+        self.keeper_bindings[channel_id] = keeper_name
 
-        # Show typing while waiting for keeper response
-        async with message.channel.typing():
-            response = await self.gate.send_message(
-                keeper_name=keeper_name,
-                content=message.content,
-                channel_user_id=str(message.author.id),
-                channel_user_name=str(message.author),
-                channel_room_id=channel_id,
-                message_id=str(message.id),
-            )
+    def remove_channel_binding(self, channel_id: str) -> str | None:
+        return self.keeper_bindings.pop(channel_id, None)
 
-        await self._send_response(message.channel, response)
+    def _compose_gate_content(self, message: discord.Message) -> str:
+        return compose_gate_content(message.content, attachment_lines(message))
+
+    def is_admin(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            return False
+        if member.guild_permissions.administrator or member.guild_permissions.manage_guild:
+            return True
+        role_id = self.cfg.discord_admin_role_id.strip()
+        if not role_id:
+            return False
+        return any(str(role.id) == role_id for role in member.roles)
 
     async def _send_response(
         self,
@@ -99,7 +147,7 @@ class MascBot(discord.Client):
         """Send a gate response to a Discord channel."""
         if not response.ok:
             if response.error == "duplicate message":
-                return  # Silently skip duplicates
+                return
             embed = format_error_embed(response.error)
             await channel.send(embed=embed)
             return
@@ -109,17 +157,159 @@ class MascBot(discord.Client):
                 await channel.send(chunk)
             return
 
-        # Short replies: plain text. Medium replies or replies with stats: embed.
         if len(response.reply) <= 500 and not response.model_used:
-            chunks = chunk_text(response.reply)
-            for chunk in chunks:
+            for chunk in chunk_text(response.reply):
                 await channel.send(chunk)
         else:
             embed = format_keeper_embed(response)
             await channel.send(embed=embed)
 
+    async def on_message(self, message: discord.Message) -> None:
+        """Route channel messages to the mapped keeper."""
+        if message.author == self.user or message.author.bot:
+            return
+        if not message.guild:
+            return
+
+        keeper_name = self._resolve_keeper_for_channel(message.channel)
+        if keeper_name is None:
+            return
+
+        content = self._compose_gate_content(message)
+        if not content:
+            logger.info("Skipping empty Discord message %s", message.id)
+            return
+
+        async with message.channel.typing():
+            response = await self.gate.send_message(
+                keeper_name=keeper_name,
+                content=content,
+                channel_user_id=str(message.author.id),
+                channel_user_name=str(message.author),
+                channel_room_id=str(message.channel.id),
+                message_id=str(message.id),
+            )
+
+        await self._send_response(message.channel, response)
+
+
+def breaker_summary(snapshot: BreakerSnapshot) -> str:
+    if snapshot.open:
+        return f"open ({snapshot.remaining_sec}s)"
+    if snapshot.consecutive_failures > 0 and snapshot.last_failure:
+        return f"closed, last failure: {snapshot.last_failure}"
+    return "closed"
+
+
+def keeper_status_embed(keeper_name: str, data: dict[str, Any]) -> discord.Embed:
+    """Build a compact embed from masc_keeper_status JSON."""
+    embed = discord.Embed(
+        title=f"Keeper: {keeper_name}",
+        color=0x5865F2,
+    )
+
+    active_model = str(data.get("active_model", "-"))
+    running = "yes" if bool(data.get("keepalive_running", False)) else "no"
+    last_turn_ago = data.get("last_turn_ago_s")
+    last_turn_value = "-"
+    if isinstance(last_turn_ago, (int, float)):
+        last_turn_value = f"{last_turn_ago:.0f}s ago"
+
+    embed.add_field(name="Model", value=active_model or "-", inline=True)
+    embed.add_field(name="Keepalive", value=running, inline=True)
+    embed.add_field(name="Last Turn", value=last_turn_value, inline=True)
+
+    goal = data.get("goal")
+    if isinstance(goal, str) and goal.strip():
+        embed.add_field(name="Goal", value=goal[:1024], inline=False)
+
+    blocker = data.get("last_blocker")
+    if isinstance(blocker, str) and blocker.strip():
+        embed.add_field(name="Last Blocker", value=blocker[:1024], inline=False)
+
+    return embed
+
+
+def connector_status_embed(
+    *,
+    channel_id: str | None,
+    channel_binding: tuple[str | None, str],
+    gate_status: dict[str, Any] | None,
+    breaker: BreakerSnapshot,
+) -> discord.Embed:
+    """Build connector status embed for Discord operators."""
+    embed = discord.Embed(
+        title="Discord Connector Status",
+        color=0x57F287 if not breaker.open else 0xFEE75C,
+    )
+
+    binding_name, binding_source = channel_binding
+    embed.add_field(
+        name="Current Channel",
+        value=f"{channel_id or 'n/a'}\nkeeper: {binding_name or 'unmapped'} ({binding_source})",
+        inline=False,
+    )
+    embed.add_field(name="Breaker", value=breaker_summary(breaker), inline=False)
+
+    if gate_status is None:
+        embed.description = "Gate status unavailable"
+        return embed
+
+    discord_row = channel_stats_for(gate_status, "discord")
+    if discord_row is None:
+        embed.description = "No Discord traffic recorded yet"
+        return embed
+
+    health = str(discord_row.get("health", "unknown"))
+    success_rate = discord_row.get("success_rate_pct", 0)
+    errors = discord_row.get("error_count", 0)
+    duplicates = discord_row.get("duplicate_count", 0)
+    rooms = discord_row.get("room_count", 0)
+    avg_duration_ms = discord_row.get("avg_duration_ms", 0)
+    max_duration_ms = discord_row.get("max_duration_ms", 0)
+    last_error = str(discord_row.get("last_error", "")).strip()
+
+    embed.add_field(
+        name="Connector",
+        value=(
+            f"health: {health}\n"
+            f"success: {success_rate}%\n"
+            f"errors: {errors} | duplicates: {duplicates}\n"
+            f"rooms: {rooms}"
+        ),
+        inline=True,
+    )
+    embed.add_field(
+        name="Latency",
+        value=(
+            f"avg: {int(avg_duration_ms) / 1000:.1f}s\n"
+            f"max: {int(max_duration_ms) / 1000:.1f}s"
+        ),
+        inline=True,
+    )
+
+    if last_error:
+        embed.add_field(name="Last Error", value=last_error[:1024], inline=False)
+
+    return embed
+
+
+async def keeper_name_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    bot = interaction.client
+    assert isinstance(bot, MascBot)
+    names = await bot.gate.list_keepers()
+    needle = current.strip().lower()
+    matches = [
+        name for name in names if not needle or needle in name.lower()
+    ][:25]
+    return [app_commands.Choice(name=name, value=name) for name in matches]
+
 
 # ── Slash Commands ──────────────────────────────────────────
+
 
 @app_commands.command(name="keeper-ask", description="Send a message to a specific keeper")
 @app_commands.describe(
@@ -139,10 +329,10 @@ async def keeper_ask(
 
     response = await bot.gate.send_message(
         keeper_name=keeper,
-        content=message,
+        content=message.strip(),
         channel_user_id=str(interaction.user.id),
         channel_user_name=str(interaction.user),
-        channel_room_id=str(interaction.channel_id),
+        channel_room_id=str(interaction.channel_id or "unknown"),
         message_id=f"slash-{interaction.id}",
     )
 
@@ -155,25 +345,180 @@ async def keeper_ask(
             await interaction.followup.send(embed=embed)
     else:
         embed = format_error_embed(response.error)
-        await interaction.followup.send(embed=embed)
+        await interaction.followup.send(embed=embed, ephemeral=True)
 
 
-@app_commands.command(name="keeper-status", description="Check gate connection status")
-async def keeper_status(interaction: discord.Interaction) -> None:
-    """Check if the gate is reachable."""
-    await interaction.response.defer(thinking=True)
+@keeper_ask.autocomplete("keeper")
+async def keeper_ask_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    return await keeper_name_autocomplete(interaction, current)
+
+
+@app_commands.command(
+    name="keeper-status",
+    description="Show connector health or a single keeper status",
+)
+@app_commands.describe(
+    keeper="Optional keeper name",
+)
+async def keeper_status(
+    interaction: discord.Interaction,
+    keeper: str | None = None,
+) -> None:
+    """Check gate + connector health, or inspect one keeper."""
+    await interaction.response.defer(thinking=True, ephemeral=True)
 
     bot = interaction.client
     assert isinstance(bot, MascBot)
 
-    healthy = await bot.gate.health_check()
-    if healthy:
-        await interaction.followup.send("Gate: connected")
-    else:
-        await interaction.followup.send("Gate: unreachable")
+    if keeper is not None and keeper.strip():
+        data = await bot.gate.keeper_status(keeper)
+        if data is None:
+            embed = format_error_embed(f"keeper status unavailable: {keeper}")
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+        embed = keeper_status_embed(keeper.strip(), data)
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        return
+
+    channel_binding = (
+        bot.channel_binding_debug(interaction.channel)
+        if interaction.channel is not None
+        else (None, "no-channel")
+    )
+    embed = connector_status_embed(
+        channel_id=str(interaction.channel_id) if interaction.channel_id is not None else None,
+        channel_binding=channel_binding,
+        gate_status=await bot.gate.gate_status(),
+        breaker=bot.gate.breaker_snapshot(),
+    )
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+@keeper_status.autocomplete("keeper")
+async def keeper_status_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    return await keeper_name_autocomplete(interaction, current)
+
+
+@app_commands.command(
+    name="keeper-bind",
+    description="Bind the current Discord channel to a keeper",
+)
+@app_commands.describe(keeper="Keeper name")
+async def keeper_bind(
+    interaction: discord.Interaction,
+    keeper: str,
+) -> None:
+    """Bind the current channel to a keeper in runtime memory."""
+    bot = interaction.client
+    assert isinstance(bot, MascBot)
+
+    if not bot.is_admin(interaction):
+        await interaction.response.send_message(
+            "Admin role or Manage Server permission required.",
+            ephemeral=True,
+        )
+        return
+
+    if interaction.channel is None:
+        await interaction.response.send_message("Channel context required.", ephemeral=True)
+        return
+
+    await interaction.response.defer(thinking=True, ephemeral=True)
+
+    keeper_name = keeper.strip()
+    known = await bot.gate.list_keepers()
+    if keeper_name not in known:
+        status = await bot.gate.keeper_status(keeper_name)
+        if status is None:
+            embed = format_error_embed(f"unknown keeper: {keeper_name}")
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            return
+
+    channel_id = str(interaction.channel.id)
+    bot.set_channel_binding(channel_id, keeper_name)
+    await interaction.followup.send(
+        f"Bound channel `{channel_id}` to keeper `{keeper_name}`.",
+        ephemeral=True,
+    )
+
+
+@keeper_bind.autocomplete("keeper")
+async def keeper_bind_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    return await keeper_name_autocomplete(interaction, current)
+
+
+@app_commands.command(
+    name="keeper-unbind",
+    description="Remove the current Discord channel binding",
+)
+async def keeper_unbind(interaction: discord.Interaction) -> None:
+    """Remove channel -> keeper binding from runtime memory."""
+    bot = interaction.client
+    assert isinstance(bot, MascBot)
+
+    if not bot.is_admin(interaction):
+        await interaction.response.send_message(
+            "Admin role or Manage Server permission required.",
+            ephemeral=True,
+        )
+        return
+
+    if interaction.channel is None:
+        await interaction.response.send_message("Channel context required.", ephemeral=True)
+        return
+
+    channel_id = str(interaction.channel.id)
+    removed = bot.remove_channel_binding(channel_id)
+    if removed is None:
+        await interaction.response.send_message(
+            f"Channel `{channel_id}` is not currently bound.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        f"Removed binding `{channel_id}` -> `{removed}`.",
+        ephemeral=True,
+    )
+
+
+@app_commands.command(
+    name="keeper-map",
+    description="Show runtime Discord channel bindings",
+)
+async def keeper_map(interaction: discord.Interaction) -> None:
+    """Show current runtime bindings."""
+    bot = interaction.client
+    assert isinstance(bot, MascBot)
+
+    binding = (
+        bot.channel_binding_debug(interaction.channel)
+        if interaction.channel is not None
+        else (None, "no-channel")
+    )
+    lines = [
+        f"current channel: {interaction.channel_id or 'n/a'}",
+        f"resolved keeper: {binding[0] or 'unmapped'} ({binding[1]})",
+        f"runtime bindings: {len(bot.keeper_bindings)}",
+    ]
+
+    for channel_id, keeper_name in sorted(bot.keeper_bindings.items())[:10]:
+        lines.append(f"- {channel_id} -> {keeper_name}")
+
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
 
 # ── Entry point ─────────────────────────────────────────────
+
 
 def main() -> None:
     """Run the bot."""

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -7,9 +7,9 @@ Fails fast at startup if any required config is missing.
 from __future__ import annotations
 
 import json
-from typing import Final
+from typing import Final, cast
 
-from pydantic import field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -19,19 +19,60 @@ class BotConfig(BaseSettings):
     model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
 
     # Required
-    discord_bot_token: str
-    masc_mcp_url: str = "http://localhost:8935"
-    masc_api_token: str
+    discord_bot_token: str = Field(
+        validation_alias=AliasChoices("DISCORD_BOT_TOKEN", "discord_bot_token")
+    )
+    masc_mcp_url: str = Field(
+        default="http://localhost:8935",
+        validation_alias=AliasChoices("MASC_MCP_URL", "masc_mcp_url"),
+    )
+    masc_api_token: str = Field(
+        validation_alias=AliasChoices("MASC_API_TOKEN", "masc_api_token")
+    )
 
     # Channel-to-keeper mapping: {"channel_id": "keeper_name"}
-    discord_keeper_map: str = "{}"
+    discord_keeper_map: str = Field(
+        default="{}",
+        validation_alias=AliasChoices("DISCORD_KEEPER_MAP", "discord_keeper_map"),
+    )
 
     # Optional
-    discord_admin_role_id: str = ""
+    discord_admin_role_id: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "DISCORD_ADMIN_ROLE_ID",
+            "discord_admin_role_id",
+        ),
+    )
 
     # Timeouts
-    gate_timeout_sec: int = 120
-    gate_max_retries: int = 2
+    gate_timeout_sec: int = Field(
+        default=120,
+        validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
+    )
+    gate_max_retries: int = Field(
+        default=2,
+        validation_alias=AliasChoices("GATE_MAX_RETRIES", "gate_max_retries"),
+    )
+    status_cache_ttl_sec: int = Field(
+        default=15,
+        validation_alias=AliasChoices("STATUS_CACHE_TTL_SEC", "status_cache_ttl_sec"),
+    )
+    keeper_cache_ttl_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("KEEPER_CACHE_TTL_SEC", "keeper_cache_ttl_sec"),
+    )
+    gate_breaker_failure_threshold: int = Field(
+        default=3,
+        validation_alias=AliasChoices(
+            "GATE_BREAKER_FAILURE_THRESHOLD",
+            "gate_breaker_failure_threshold",
+        ),
+    )
+    gate_breaker_reset_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
+    )
 
     @field_validator("discord_bot_token")
     @classmethod
@@ -63,6 +104,20 @@ class BotConfig(BaseSettings):
             raise ValueError(f"DISCORD_KEEPER_MAP is not valid JSON: {e}") from e
         return v
 
+    @field_validator(
+        "gate_timeout_sec",
+        "gate_max_retries",
+        "status_cache_ttl_sec",
+        "keeper_cache_ttl_sec",
+        "gate_breaker_failure_threshold",
+        "gate_breaker_reset_sec",
+    )
+    @classmethod
+    def validate_positive_ints(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("connector timing values must be positive")
+        return v
+
     def keeper_map(self) -> dict[str, str]:
         """Parse DISCORD_KEEPER_MAP JSON into dict.
 
@@ -72,7 +127,8 @@ class BotConfig(BaseSettings):
         raw: object = json.loads(self.discord_keeper_map)
         if not isinstance(raw, dict):
             return {}
-        return {str(k): str(v) for k, v in raw.items()}
+        typed_raw = cast(dict[object, object], raw)
+        return {str(key): str(value) for key, value in typed_raw.items()}
 
     def gate_message_url(self) -> str:
         base = self.masc_mcp_url.rstrip("/")
@@ -96,3 +152,9 @@ def get_config() -> BotConfig:
     if _config is None:
         _config = BotConfig()  # type: ignore[call-arg]
     return _config
+
+
+def reset_config_cache() -> None:
+    """Clear the cached settings object. Used by tests."""
+    global _config  # noqa: PLW0603
+    _config = None

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -104,8 +104,14 @@ class BotConfig(BaseSettings):
             raise ValueError(f"DISCORD_KEEPER_MAP is not valid JSON: {e}") from e
         return v
 
+    @field_validator("gate_timeout_sec")
+    @classmethod
+    def validate_positive_timeout(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("gate_timeout_sec must be positive")
+        return v
+
     @field_validator(
-        "gate_timeout_sec",
         "gate_max_retries",
         "status_cache_ttl_sec",
         "keeper_cache_ttl_sec",
@@ -113,9 +119,9 @@ class BotConfig(BaseSettings):
         "gate_breaker_reset_sec",
     )
     @classmethod
-    def validate_positive_ints(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("connector timing values must be positive")
+    def validate_non_negative_ints(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("connector timing values must be non-negative")
         return v
 
     def keeper_map(self) -> dict[str, str]:

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -50,6 +50,7 @@ class BotConfig(BaseSettings):
         default=120,
         validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
     )
+    # Retries after the first attempt; 0 disables retries.
     gate_max_retries: int = Field(
         default=2,
         validation_alias=AliasChoices("GATE_MAX_RETRIES", "gate_max_retries"),

--- a/sidecars/discord-bot/src/formatters.py
+++ b/sidecars/discord-bot/src/formatters.py
@@ -5,6 +5,8 @@ Converts GateResponse objects into Discord embeds and chunked messages.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import discord
 
 from .config import DISCORD_EMBED_LIMIT, DISCORD_MESSAGE_LIMIT
@@ -46,6 +48,17 @@ def format_error_embed(error_msg: str) -> discord.Embed:
         description=error_msg,
         color=0xED4245,  # Discord red
     )
+
+
+def compose_gate_content(text: str, attachment_lines: Sequence[str]) -> str:
+    """Build deterministic gate content from text + Discord attachments."""
+    parts: list[str] = []
+    body = text.strip()
+    if body:
+        parts.append(body)
+    if attachment_lines:
+        parts.append("Attachments:\n" + "\n".join(attachment_lines))
+    return "\n\n".join(parts).strip()
 
 
 def chunk_text(text: str, limit: int = DISCORD_MESSAGE_LIMIT) -> list[str]:

--- a/sidecars/discord-bot/src/masc_client.py
+++ b/sidecars/discord-bot/src/masc_client.py
@@ -6,9 +6,11 @@ The gate is the only interface -- no direct keeper access.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -31,7 +33,8 @@ class GateResponse:
 
     @staticmethod
     def from_json(data: dict[str, Any]) -> GateResponse:
-        stats = data.get("turn_stats") or {}
+        raw_stats = data.get("turn_stats")
+        stats = cast(dict[str, Any], raw_stats) if isinstance(raw_stats, dict) else {}
         return GateResponse(
             ok=bool(data.get("ok", False)),
             keeper_name=str(data.get("keeper_name", "")),
@@ -55,6 +58,16 @@ class GateResponse:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class BreakerSnapshot:
+    """Current transport breaker state."""
+
+    open: bool
+    remaining_sec: int
+    consecutive_failures: int
+    last_failure: str
+
+
 class MascGateClient:
     """HTTP client for the Channel Gate API.
 
@@ -64,15 +77,73 @@ class MascGateClient:
 
     def __init__(self) -> None:
         cfg = get_config()
+        base = cfg.masc_mcp_url.rstrip("/")
         self._url = cfg.gate_message_url()
         self._health_url = cfg.gate_health_url()
+        self._status_url = f"{base}/api/v1/gate/status"
+        self._keepers_url = f"{base}/api/v1/gate/keepers"
+        self._keeper_status_url = f"{base}/api/v1/gate/keeper-status"
         self._timeout = cfg.gate_timeout_sec
         self._max_retries = cfg.gate_max_retries
+        self._status_cache_ttl = cfg.status_cache_ttl_sec
+        self._keeper_cache_ttl = cfg.keeper_cache_ttl_sec
+        self._breaker_failure_threshold = cfg.gate_breaker_failure_threshold
+        self._breaker_reset_sec = cfg.gate_breaker_reset_sec
         self._headers = {
             "Authorization": f"Bearer {cfg.masc_api_token}",
             "Content-Type": "application/json",
         }
         self._client: httpx.AsyncClient | None = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._last_failure = ""
+        self._status_cache: tuple[float, dict[str, Any]] | None = None
+        self._keeper_names_cache: tuple[float, list[str]] | None = None
+        self._keeper_status_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _breaker_is_open(self) -> bool:
+        return self._breaker_open_until > self._now()
+
+    def _breaker_error(self) -> str:
+        remaining = max(1, int(round(self._breaker_open_until - self._now())))
+        if self._last_failure:
+            return (
+                f"connector circuit open for {remaining}s after transport failures: "
+                f"{self._last_failure}"
+            )
+        return f"connector circuit open for {remaining}s after transport failures"
+
+    def _note_success(self) -> None:
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._last_failure = ""
+
+    def _note_transport_failure(self, reason: str) -> None:
+        self._consecutive_failures += 1
+        self._last_failure = reason
+        if self._consecutive_failures >= self._breaker_failure_threshold:
+            self._breaker_open_until = self._now() + self._breaker_reset_sec
+        logger.warning(
+            "Gate transport failure %d/%d: %s",
+            self._consecutive_failures,
+            self._breaker_failure_threshold,
+            reason,
+        )
+
+    def breaker_snapshot(self) -> BreakerSnapshot:
+        remaining = max(0, int(round(self._breaker_open_until - self._now())))
+        return BreakerSnapshot(
+            open=self._breaker_is_open(),
+            remaining_sec=remaining,
+            consecutive_failures=self._consecutive_failures,
+            last_failure=self._last_failure,
+        )
+
+    def _cache_fresh(self, cache: tuple[float, Any] | None, ttl: int) -> bool:
+        return cache is not None and (self._now() - cache[0]) < ttl
 
     def _get_client(self) -> httpx.AsyncClient:
         """Return the shared client, lazily creating it on first use."""
@@ -89,6 +160,52 @@ class MascGateClient:
             await self._client.aclose()
             self._client = None
 
+    async def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+        allow_breaker_cache: tuple[float, dict[str, Any]] | None = None,
+    ) -> dict[str, Any] | None:
+        if self._breaker_is_open():
+            if allow_breaker_cache is not None and self._cache_fresh(
+                allow_breaker_cache,
+                self._status_cache_ttl,
+            ):
+                return allow_breaker_cache[1]
+            logger.warning("Gate request short-circuited: %s", self._breaker_error())
+            return None
+
+        client = self._get_client()
+        try:
+            response = await client.request(method, url, json=json_body, params=params)
+            if response.status_code >= 500:
+                self._note_transport_failure(f"gate returned {response.status_code}")
+                return None
+            if response.status_code >= 400:
+                logger.info("Gate returned %d for %s %s", response.status_code, method, url)
+                self._note_success()
+                return None
+            raw_data = response.json()
+            if not isinstance(raw_data, dict):
+                logger.warning("Gate returned non-object JSON from %s %s", method, url)
+                self._note_success()
+                return None
+            data = cast(dict[str, Any], raw_data)
+            self._note_success()
+            return data
+        except httpx.TimeoutException:
+            self._note_transport_failure(f"gate timeout after {self._timeout}s")
+            return None
+        except httpx.HTTPError as e:
+            self._note_transport_failure(f"gate http error: {e}")
+            return None
+        except Exception as e:  # pragma: no cover - defensive logging
+            self._note_transport_failure(f"gate error: {e}")
+            return None
+
     async def send_message(
         self,
         *,
@@ -99,19 +216,10 @@ class MascGateClient:
         channel_room_id: str,
         message_id: str,
     ) -> GateResponse:
-        """Send a message to a keeper via the gate.
+        """Send a message to a keeper via the gate."""
+        if self._breaker_is_open():
+            return GateResponse.from_error(self._breaker_error())
 
-        Args:
-            keeper_name: Target keeper name.
-            content: Message text.
-            channel_user_id: Discord user snowflake.
-            channel_user_name: Discord display name.
-            channel_room_id: Discord channel snowflake.
-            message_id: Discord message ID (used as idempotency key).
-
-        Returns:
-            GateResponse with keeper's reply or error.
-        """
         payload = {
             "channel": "discord",
             "channel_user_id": channel_user_id,
@@ -126,50 +234,131 @@ class MascGateClient:
         for attempt in range(1, self._max_retries + 1):
             try:
                 resp = await client.post(self._url, json=payload)
-
-                data: dict[str, Any] = resp.json()
-
                 if resp.status_code == 409:
-                    # Duplicate message -- not an error, just skip.
+                    self._note_success()
                     logger.info("Duplicate message (idempotency): %s", message_id)
                     return GateResponse.from_error("duplicate message")
 
-                if resp.status_code >= 500 and attempt < self._max_retries:
-                    logger.warning(
-                        "Gate returned %d, retry %d/%d",
-                        resp.status_code,
-                        attempt,
-                        self._max_retries,
-                    )
-                    continue
+                if resp.status_code >= 500:
+                    if attempt < self._max_retries:
+                        await asyncio.sleep(min(0.25 * attempt, 1.0))
+                        continue
+                    self._note_transport_failure(f"gate returned {resp.status_code}")
+                    return GateResponse.from_error(f"gate returned {resp.status_code}")
 
+                raw_data = resp.json()
+                if not isinstance(raw_data, dict):
+                    self._note_success()
+                    return GateResponse.from_error("gate returned invalid json")
+                data = cast(dict[str, Any], raw_data)
+
+                self._note_success()
                 return GateResponse.from_json(data)
 
             except httpx.TimeoutException:
-                logger.warning(
-                    "Gate timeout (%ds), attempt %d/%d",
-                    self._timeout,
-                    attempt,
-                    self._max_retries,
-                )
-                if attempt >= self._max_retries:
-                    return GateResponse.from_error(
-                        f"gate timeout after {self._timeout}s"
-                    )
+                if attempt < self._max_retries:
+                    await asyncio.sleep(min(0.25 * attempt, 1.0))
+                    continue
+                self._note_transport_failure(f"gate timeout after {self._timeout}s")
+                return GateResponse.from_error(f"gate timeout after {self._timeout}s")
             except httpx.HTTPError as e:
-                logger.error("Gate HTTP error: %s", e)
+                self._note_transport_failure(f"gate http error: {e}")
                 return GateResponse.from_error(f"gate http error: {e}")
-            except Exception as e:
-                logger.error("Gate unexpected error: %s", e)
+            except Exception as e:  # pragma: no cover - defensive logging
+                self._note_transport_failure(f"gate error: {e}")
                 return GateResponse.from_error(f"gate error: {e}")
 
         return GateResponse.from_error("max retries exceeded")
 
     async def health_check(self) -> bool:
         """Check if the gate is reachable."""
-        try:
-            client = self._get_client()
-            resp = await client.get(self._health_url)
-            return resp.status_code == 200
-        except Exception:
+        cached: dict[str, Any] | None = None
+        if self._status_cache is not None and self._cache_fresh(
+            self._status_cache,
+            self._status_cache_ttl,
+        ):
+            cached = self._status_cache[1]
+        if cached is not None:
+            return True
+        if self._breaker_is_open():
             return False
+        data = await self._request_json("GET", self._health_url)
+        return data is not None
+
+    async def gate_status(self, *, force: bool = False) -> dict[str, Any] | None:
+        """Fetch the enriched connector status snapshot."""
+        if not force and self._cache_fresh(self._status_cache, self._status_cache_ttl):
+            assert self._status_cache is not None
+            return self._status_cache[1]
+        data = await self._request_json(
+            "GET",
+            self._status_url,
+            allow_breaker_cache=self._status_cache,
+        )
+        if data is None:
+            if self._cache_fresh(self._status_cache, self._status_cache_ttl):
+                assert self._status_cache is not None
+                return self._status_cache[1]
+            return None
+        self._status_cache = (self._now(), data)
+        return data
+
+    async def list_keepers(self, *, force: bool = False) -> list[str]:
+        """Return keeper names for autocomplete and binding validation."""
+        if not force and self._cache_fresh(self._keeper_names_cache, self._keeper_cache_ttl):
+            assert self._keeper_names_cache is not None
+            return self._keeper_names_cache[1]
+
+        data = await self._request_json(
+            "GET",
+            self._keepers_url,
+            params={"limit": "200", "detailed": "true"},
+        )
+        if data is None:
+            if self._cache_fresh(self._keeper_names_cache, self._keeper_cache_ttl):
+                assert self._keeper_names_cache is not None
+                return self._keeper_names_cache[1]
+            return []
+
+        rows = data.get("keepers", [])
+        names: list[str] = []
+        if isinstance(rows, list):
+            for item in cast(list[object], rows):
+                if isinstance(item, dict):
+                    row = cast(dict[str, Any], item)
+                    name = row.get("name")
+                    if isinstance(name, str) and name.strip():
+                        names.append(name.strip())
+                elif isinstance(item, str) and item.strip():
+                    names.append(item.strip())
+        self._keeper_names_cache = (self._now(), names)
+        return names
+
+    async def keeper_status(
+        self,
+        keeper_name: str,
+        *,
+        force: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch status for a single keeper."""
+        normalized = keeper_name.strip()
+        if not normalized:
+            return None
+
+        cached = self._keeper_status_cache.get(normalized)
+        if not force and self._cache_fresh(cached, self._keeper_cache_ttl):
+            assert cached is not None
+            return cached[1]
+
+        data = await self._request_json(
+            "GET",
+            self._keeper_status_url,
+            params={"name": normalized},
+        )
+        if data is None:
+            if self._cache_fresh(cached, self._keeper_cache_ttl):
+                assert cached is not None
+                return cached[1]
+            return None
+        self._keeper_status_cache[normalized] = (self._now(), data)
+        return data

--- a/sidecars/discord-bot/src/masc_client.py
+++ b/sidecars/discord-bot/src/masc_client.py
@@ -107,6 +107,12 @@ class MascGateClient:
     def _breaker_is_open(self) -> bool:
         return self._breaker_open_until > self._now()
 
+    def _breaker_enabled(self) -> bool:
+        return self._breaker_failure_threshold > 0 and self._breaker_reset_sec > 0
+
+    def _max_attempts(self) -> int:
+        return max(1, self._max_retries)
+
     def _breaker_error(self) -> str:
         remaining = max(1, int(round(self._breaker_open_until - self._now())))
         if self._last_failure:
@@ -124,7 +130,7 @@ class MascGateClient:
     def _note_transport_failure(self, reason: str) -> None:
         self._consecutive_failures += 1
         self._last_failure = reason
-        if self._consecutive_failures >= self._breaker_failure_threshold:
+        if self._breaker_enabled() and self._consecutive_failures >= self._breaker_failure_threshold:
             self._breaker_open_until = self._now() + self._breaker_reset_sec
         logger.warning(
             "Gate transport failure %d/%d: %s",
@@ -231,7 +237,8 @@ class MascGateClient:
         }
 
         client = self._get_client()
-        for attempt in range(1, self._max_retries + 1):
+        max_attempts = self._max_attempts()
+        for attempt in range(1, max_attempts + 1):
             try:
                 resp = await client.post(self._url, json=payload)
                 if resp.status_code == 409:
@@ -240,7 +247,7 @@ class MascGateClient:
                     return GateResponse.from_error("duplicate message")
 
                 if resp.status_code >= 500:
-                    if attempt < self._max_retries:
+                    if attempt < max_attempts:
                         await asyncio.sleep(min(0.25 * attempt, 1.0))
                         continue
                     self._note_transport_failure(f"gate returned {resp.status_code}")
@@ -256,7 +263,7 @@ class MascGateClient:
                 return GateResponse.from_json(data)
 
             except httpx.TimeoutException:
-                if attempt < self._max_retries:
+                if attempt < max_attempts:
                     await asyncio.sleep(min(0.25 * attempt, 1.0))
                     continue
                 self._note_transport_failure(f"gate timeout after {self._timeout}s")

--- a/sidecars/discord-bot/src/masc_client.py
+++ b/sidecars/discord-bot/src/masc_client.py
@@ -111,7 +111,7 @@ class MascGateClient:
         return self._breaker_failure_threshold > 0 and self._breaker_reset_sec > 0
 
     def _max_attempts(self) -> int:
-        return max(1, self._max_retries)
+        return 1 + max(0, self._max_retries)
 
     def _breaker_error(self) -> str:
         remaining = max(1, int(round(self._breaker_open_until - self._now())))
@@ -275,7 +275,9 @@ class MascGateClient:
                 self._note_transport_failure(f"gate error: {e}")
                 return GateResponse.from_error(f"gate error: {e}")
 
-        return GateResponse.from_error("max retries exceeded")
+        return GateResponse.from_error(
+            f"gate retries exhausted after {max_attempts} attempts"
+        )
 
     async def health_check(self) -> bool:
         """Check if the gate is reachable."""

--- a/sidecars/discord-bot/tests/test_formatters.py
+++ b/sidecars/discord-bot/tests/test_formatters.py
@@ -1,6 +1,6 @@
 """Tests for Discord message formatting."""
 
-from src.formatters import chunk_text
+from src.formatters import chunk_text, compose_gate_content
 from src.masc_client import GateResponse
 
 
@@ -58,3 +58,21 @@ def test_gate_response_from_error() -> None:
     assert resp.ok is False
     assert resp.error == "timeout"
     assert resp.reply == ""
+
+
+def test_compose_gate_content_includes_attachments() -> None:
+    result = compose_gate_content(
+        "hello",
+        ["- image.png: https://cdn.example/image.png"],
+    )
+    assert "hello" in result
+    assert "Attachments:" in result
+    assert "image.png" in result
+
+
+def test_compose_gate_content_handles_attachment_only_messages() -> None:
+    result = compose_gate_content(
+        "   ",
+        ["- image.png: https://cdn.example/image.png"],
+    )
+    assert result.startswith("Attachments:")

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -93,6 +93,34 @@ async def test_list_keepers_uses_cached_names_when_breaker_is_open() -> None:
     await client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_send_message_uses_retry_count_after_first_attempt() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(503, json={"ok": False, "error": "down"})
+
+    client = make_client(httpx.MockTransport(handler))
+    client._max_retries = 2  # pyright: ignore[reportPrivateUsage]
+
+    response = await client.send_message(
+        keeper_name="luna",
+        content="hello",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="m4",
+    )
+
+    assert response.ok is False
+    assert response.error == "gate returned 503"
+    assert attempts == 3
+
+    await client.aclose()
+
+
 def test_config_allows_zero_disable_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GATE_MAX_RETRIES", raising=False)
     monkeypatch.delenv("STATUS_CACHE_TTL_SEC", raising=False)

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from src import config as config_module
+from src.config import BotConfig
 from src.masc_client import MascGateClient
 
 
@@ -90,3 +91,27 @@ async def test_list_keepers_uses_cached_names_when_breaker_is_open() -> None:
     assert cached == ["luna", "sangsu"]
 
     await client.aclose()
+
+
+def test_config_allows_zero_disable_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GATE_MAX_RETRIES", raising=False)
+    monkeypatch.delenv("STATUS_CACHE_TTL_SEC", raising=False)
+    monkeypatch.delenv("KEEPER_CACHE_TTL_SEC", raising=False)
+    monkeypatch.delenv("GATE_BREAKER_FAILURE_THRESHOLD", raising=False)
+    monkeypatch.delenv("GATE_BREAKER_RESET_SEC", raising=False)
+
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        masc_api_token="test-api-token",
+        gate_max_retries=0,
+        status_cache_ttl_sec=0,
+        keeper_cache_ttl_sec=0,
+        gate_breaker_failure_threshold=0,
+        gate_breaker_reset_sec=0,
+    )
+
+    assert cfg.gate_max_retries == 0
+    assert cfg.status_cache_ttl_sec == 0
+    assert cfg.keeper_cache_ttl_sec == 0
+    assert cfg.gate_breaker_failure_threshold == 0
+    assert cfg.gate_breaker_reset_sec == 0

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -1,0 +1,92 @@
+"""Tests for the Discord Channel Gate client."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from src import config as config_module
+from src.masc_client import MascGateClient
+
+
+@pytest.fixture(autouse=True)
+def reset_config(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("MASC_API_TOKEN", "test-api-token")
+    monkeypatch.setenv("MASC_MCP_URL", "http://localhost:8935")
+    config_module.reset_config_cache()
+    yield
+    config_module.reset_config_cache()
+
+
+def make_client(handler: httpx.MockTransport) -> MascGateClient:
+    client = MascGateClient()
+    client._client = httpx.AsyncClient(transport=handler, headers=client._headers)  # pyright: ignore[reportPrivateUsage]
+    client._max_retries = 1  # pyright: ignore[reportPrivateUsage]
+    client._breaker_failure_threshold = 2  # pyright: ignore[reportPrivateUsage]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_breaker_opens_after_repeated_server_failures() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(503, json={"ok": False, "error": "down"})
+    )
+    client = make_client(transport)
+
+    first = await client.send_message(
+        keeper_name="luna",
+        content="hello",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="m1",
+    )
+    second = await client.send_message(
+        keeper_name="luna",
+        content="hello again",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="m2",
+    )
+    third = await client.send_message(
+        keeper_name="luna",
+        content="still there?",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="m3",
+    )
+
+    assert first.ok is False
+    assert second.ok is False
+    assert client.breaker_snapshot().open is True
+    assert "circuit open" in third.error
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_list_keepers_uses_cached_names_when_breaker_is_open() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "count": 2,
+                "keepers": [{"name": "luna"}, {"name": "sangsu"}],
+            },
+        )
+    )
+    client = make_client(transport)
+
+    keepers = await client.list_keepers(force=True)
+    assert keepers == ["luna", "sangsu"]
+
+    client._breaker_open_until = client._now() + 30  # pyright: ignore[reportPrivateUsage]
+    cached = await client.list_keepers()
+    assert cached == ["luna", "sangsu"]
+
+    await client.aclose()

--- a/test/dune
+++ b/test/dune
@@ -678,6 +678,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_channel_gate_metrics)
+ (modules test_channel_gate_metrics)
+ (libraries masc_test_deps))
+
+(test
  (name test_local_review_script)
  (modules test_local_review_script)
  (libraries alcotest unix yojson))

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -1,0 +1,98 @@
+open Alcotest
+
+module Metrics = Masc_mcp.Channel_gate_metrics
+module U = Yojson.Safe.Util
+
+let unique_channel prefix =
+  Printf.sprintf "%s-%d-%.0f" prefix (Unix.getpid ())
+    (Unix.gettimeofday () *. 1_000_000.)
+
+let with_eio f =
+  Eio_main.run @@ fun _env ->
+  Eio_guard.enable ();
+  Fun.protect ~finally:Eio_guard.disable f
+
+let find_channel_json channel json =
+  json
+  |> U.member "channels"
+  |> U.to_list
+  |> List.find (fun item ->
+         String.equal (item |> U.member "channel" |> U.to_string) channel)
+
+let with_env name value_opt f =
+  let original = Sys.getenv_opt name in
+  let restore () =
+    match original with
+    | Some value -> Unix.putenv name value
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect
+    ~finally:restore
+    (fun () ->
+      (match value_opt with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "");
+      f ())
+
+let test_record_attempt_tracks_connector_diagnostics () =
+  with_eio (fun () ->
+      let channel = unique_channel "discord-metrics" in
+      Metrics.record_attempt ~channel ~room_id:"room-a" ~keeper:"luna"
+        ~duration_ms:1200 Metrics.Success;
+      Metrics.record_attempt ~channel ~room_id:"room-b" ~keeper:"luna"
+        ~duration_ms:0
+        (Metrics.Validation_error "content is required");
+      Metrics.record_attempt ~channel ~room_id:"room-b" ~keeper:"luna"
+        ~duration_ms:0 Metrics.Duplicate;
+      let stats =
+        Metrics.snapshot ()
+        |> List.find (fun (row : Metrics.channel_stats) ->
+               String.equal row.channel channel)
+      in
+      check int "message_count includes duplicates" 3 stats.message_count;
+      check int "success_count" 1 stats.success_count;
+      check int "error_count excludes duplicates" 1 stats.error_count;
+      check int "duplicate_count" 1 stats.duplicate_count;
+      check int "validation_error_count" 1 stats.validation_error_count;
+      check int "room_count counts unique rooms" 2 stats.room_count;
+      check string "last_error_kind" "validation" stats.last_error_kind;
+      check string "last_outcome" "duplicate" stats.last_outcome;
+      check string "last_room_id" "room-b" stats.last_room_id)
+
+let test_snapshot_json_reports_health_and_latency () =
+  with_env "MASC_CHANNEL_GATE_SLOW_MS" (Some "250") (fun () ->
+      with_eio (fun () ->
+          let channel = unique_channel "discord-json" in
+          Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
+            ~duration_ms:280 Metrics.Success;
+          Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
+            ~duration_ms:320
+            (Metrics.Keeper_error "upstream timeout");
+          let json = Metrics.snapshot_json () in
+          let row = find_channel_json channel json in
+          check int "avg_duration_ms uses timed attempts" 300
+            (row |> U.member "avg_duration_ms" |> U.to_int);
+          check int "max_duration_ms" 320
+            (row |> U.member "max_duration_ms" |> U.to_int);
+          check int "slow_count" 2
+            (row |> U.member "slow_count" |> U.to_int);
+          check int "slow_rate_pct" 100
+            (row |> U.member "slow_rate_pct" |> U.to_int);
+          check int "success_rate_pct ignores duplicates" 50
+            (row |> U.member "success_rate_pct" |> U.to_int);
+          check string "health" "failing"
+            (row |> U.member "health" |> U.to_string);
+          check string "last_error" "upstream timeout"
+            (row |> U.member "last_error" |> U.to_string)))
+
+let () =
+  Alcotest.run "Channel_gate_metrics"
+    [
+      ( "metrics",
+        [
+          test_case "records connector diagnostics" `Quick
+            test_record_attempt_tracks_connector_diagnostics;
+          test_case "serializes health and latency" `Quick
+            test_snapshot_json_reports_health_and_latency;
+        ] );
+    ]

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -37,7 +37,7 @@ let with_env name value_opt f =
 let test_record_attempt_tracks_connector_diagnostics () =
   with_eio (fun () ->
       let channel = unique_channel "discord-metrics" in
-      Metrics.record_attempt ~channel ~room_id:"room-a" ~keeper:"luna"
+      Metrics.record_attempt ~channel:("  " ^ channel ^ "  ") ~room_id:"room-a" ~keeper:"  luna  "
         ~duration_ms:1200 Metrics.Success;
       Metrics.record_attempt ~channel ~room_id:"room-b" ~keeper:"luna"
         ~duration_ms:0
@@ -55,9 +55,31 @@ let test_record_attempt_tracks_connector_diagnostics () =
       check int "duplicate_count" 1 stats.duplicate_count;
       check int "validation_error_count" 1 stats.validation_error_count;
       check int "room_count counts unique rooms" 2 stats.room_count;
+      check string "last_keeper trimmed" "luna" stats.last_keeper;
       check string "last_error_kind" "validation" stats.last_error_kind;
       check string "last_outcome" "duplicate" stats.last_outcome;
       check string "last_room_id" "room-b" stats.last_room_id)
+
+let test_record_internal_error_exn_tracks_internal_failures () =
+  with_eio (fun () ->
+      let channel = unique_channel "discord-internal" in
+      Metrics.record_internal_error_exn
+        ~channel
+        ~room_id:"room-z"
+        ~keeper:"  sangsu  "
+        ~duration_ms:42
+        (Failure "boom");
+      let stats =
+        Metrics.snapshot ()
+        |> List.find (fun (row : Metrics.channel_stats) ->
+               String.equal row.channel channel)
+      in
+      check int "message_count" 1 stats.message_count;
+      check int "error_count" 1 stats.error_count;
+      check int "internal_error_count" 1 stats.internal_error_count;
+      check string "last_keeper trimmed" "sangsu" stats.last_keeper;
+      check string "last_error_kind" "internal" stats.last_error_kind;
+      check string "last_outcome" "internal_error" stats.last_outcome)
 
 let test_snapshot_json_reports_health_and_latency () =
   with_env "MASC_CHANNEL_GATE_SLOW_MS" (Some "250") (fun () ->
@@ -92,6 +114,8 @@ let () =
         [
           test_case "records connector diagnostics" `Quick
             test_record_attempt_tracks_connector_diagnostics;
+          test_case "records internal exception diagnostics" `Quick
+            test_record_internal_error_exn_tracks_internal_failures;
           test_case "serializes health and latency" `Quick
             test_snapshot_json_reports_health_and_latency;
         ] );

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -19,21 +19,6 @@ let find_channel_json channel json =
   |> List.find (fun item ->
          String.equal (item |> U.member "channel" |> U.to_string) channel)
 
-let with_env name value_opt f =
-  let original = Sys.getenv_opt name in
-  let restore () =
-    match original with
-    | Some value -> Unix.putenv name value
-    | None -> Unix.putenv name ""
-  in
-  Fun.protect
-    ~finally:restore
-    (fun () ->
-      (match value_opt with
-      | Some value -> Unix.putenv name value
-      | None -> Unix.putenv name "");
-      f ())
-
 let test_record_attempt_tracks_connector_diagnostics () =
   with_eio (fun () ->
       let channel = unique_channel "discord-metrics" in
@@ -78,34 +63,50 @@ let test_record_internal_error_exn_tracks_internal_failures () =
       check int "error_count" 1 stats.error_count;
       check int "internal_error_count" 1 stats.internal_error_count;
       check string "last_keeper trimmed" "sangsu" stats.last_keeper;
+      check string "last_error redacted" "internal error" stats.last_error;
       check string "last_error_kind" "internal" stats.last_error_kind;
       check string "last_outcome" "internal_error" stats.last_outcome)
 
 let test_snapshot_json_reports_health_and_latency () =
-  with_env "MASC_CHANNEL_GATE_SLOW_MS" (Some "250") (fun () ->
-      with_eio (fun () ->
-          let channel = unique_channel "discord-json" in
-          Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
-            ~duration_ms:280 Metrics.Success;
-          Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
-            ~duration_ms:320
-            (Metrics.Keeper_error "upstream timeout");
-          let json = Metrics.snapshot_json () in
-          let row = find_channel_json channel json in
-          check int "avg_duration_ms uses timed attempts" 300
-            (row |> U.member "avg_duration_ms" |> U.to_int);
-          check int "max_duration_ms" 320
-            (row |> U.member "max_duration_ms" |> U.to_int);
-          check int "slow_count" 2
-            (row |> U.member "slow_count" |> U.to_int);
-          check int "slow_rate_pct" 100
-            (row |> U.member "slow_rate_pct" |> U.to_int);
-          check int "success_rate_pct ignores duplicates" 50
-            (row |> U.member "success_rate_pct" |> U.to_int);
-          check string "health" "failing"
-            (row |> U.member "health" |> U.to_string);
-          check string "last_error" "upstream timeout"
-            (row |> U.member "last_error" |> U.to_string)))
+  with_eio (fun () ->
+      let channel = unique_channel "discord-json" in
+      Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
+        ~duration_ms:10_500 Metrics.Success;
+      Metrics.record_attempt ~channel ~room_id:"room-1" ~keeper:"sangsu"
+        ~duration_ms:11_500
+        (Metrics.Keeper_error "upstream timeout");
+      let json = Metrics.snapshot_json () in
+      let row = find_channel_json channel json in
+      check int "avg_duration_ms uses timed attempts" 11_000
+        (row |> U.member "avg_duration_ms" |> U.to_int);
+      check int "max_duration_ms" 11_500
+        (row |> U.member "max_duration_ms" |> U.to_int);
+      check int "slow_count" 2
+        (row |> U.member "slow_count" |> U.to_int);
+      check int "slow_rate_pct" 100
+        (row |> U.member "slow_rate_pct" |> U.to_int);
+      check int "success_rate_pct ignores duplicates" 50
+        (row |> U.member "success_rate_pct" |> U.to_int);
+      check string "health" "failing"
+        (row |> U.member "health" |> U.to_string);
+      check string "last_error" "upstream timeout"
+        (row |> U.member "last_error" |> U.to_string))
+
+let test_room_tracking_is_bounded () =
+  with_eio (fun () ->
+      let channel = unique_channel "discord-rooms" in
+      for i = 1 to 300 do
+        Metrics.record_attempt ~channel
+          ~room_id:(Printf.sprintf "room-%03d" i)
+          ~keeper:"luna" ~duration_ms:0 Metrics.Success
+      done;
+      let stats =
+        Metrics.snapshot ()
+        |> List.find (fun (row : Metrics.channel_stats) ->
+               String.equal row.channel channel)
+      in
+      check int "room_count capped" 256 stats.room_count;
+      check string "last_room_id still updates" "room-300" stats.last_room_id)
 
 let () =
   Alcotest.run "Channel_gate_metrics"
@@ -118,5 +119,7 @@ let () =
             test_record_internal_error_exn_tracks_internal_failures;
           test_case "serializes health and latency" `Quick
             test_snapshot_json_reports_health_and_latency;
+          test_case "bounds tracked rooms" `Quick
+            test_room_tracking_is_bounded;
         ] );
     ]


### PR DESCRIPTION
## Summary
Upgrade the connector operations layer around Channel Gate and the Discord sidecar so connector surfaces are observable, operable, and safer under transport failures.

## What changed
- expanded Channel Gate metrics/status payloads with success/error/duplicate breakdowns, latency, room coverage, and last-error context
- added authenticated `/api/v1/gate/keepers` and `/api/v1/gate/keeper-status` endpoints for connector-side keeper discovery and status lookup
- upgraded the Discord sidecar with runtime bind/unbind/map commands, keeper autocomplete, attachment forwarding, caching, and a transport circuit breaker
- refreshed the dashboard connector panel to render the richer connector diagnostics
- added focused OCaml, dashboard, and Python coverage for the new connector surfaces

## Why
The connector layer was previously a thin request/response bridge. That made Discord and similar adapters hard to operate because they could not discover keepers, inspect connector health, or degrade safely when the gate failed.

## Product impact
- external channel adapters can inspect keeper inventory and per-connector health through Channel Gate APIs
- Discord operators can bind channels at runtime and inspect connector/keeper health from slash commands
- dashboard users can see degradation, duplicate suppression, latency, and last failure context instead of raw counters only

## Root cause
Connector tooling was underpowered because the gate only exposed coarse counters and the Discord adapter only supported static env-based mappings.

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/connector-ops-upgrade`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/connector-ops-upgrade test/test_channel_gate_metrics.exe`
- `pnpm typecheck`
- `pnpm exec vitest run src/components/connector-status.test.ts`
- `.venv/bin/pytest tests/test_formatters.py tests/test_masc_client.py`
- `.venv/bin/pyright --pythonpath .venv/bin/python --outputjson src/config.py src/formatters.py src/masc_client.py src/bot.py tests/test_formatters.py tests/test_masc_client.py`
- `ruff check src tests`

## Review evidence
- `GLM-5.1` via `sb glm-text`, 2026-04-03 13:50 KST, high-risk connector subset review, no material findings after triage

## Linked issue
- Refs #4751
