### PR TITLE
fix(keeper): detect context overflow and retry with forced compaction

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -860,7 +860,17 @@ let recover_latest_checkpoint_for_overflow_retry
              Log.Keeper.error
                "keeper:%s overflow retry legacy checkpoint restore failed: %s"
                meta.runtime.trace_id (Printexc.to_string exn);
-             None)
+             (match oas_checkpoint with
+              | Some checkpoint ->
+                  let turn_generation =
+                    checkpoint_generation checkpoint
+                      ~fallback:meta.runtime.generation
+                  in
+                  Some
+                    ( context_of_oas_checkpoint checkpoint
+                        ~primary_model_max_tokens,
+                      turn_generation )
+              | None -> None))
     | _ -> None
   in
   match selected with

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -849,9 +849,18 @@ let recover_latest_checkpoint_for_overflow_retry
           ( context_of_oas_checkpoint checkpoint ~primary_model_max_tokens,
             turn_generation )
     | _, _, Some checkpoint ->
-        Some
-          ( context_of_legacy_checkpoint checkpoint ~primary_model_max_tokens,
-            checkpoint.generation )
+        (try
+           Some
+             ( context_of_legacy_checkpoint checkpoint
+                 ~primary_model_max_tokens,
+               checkpoint.generation )
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn ->
+             Log.Keeper.error
+               "keeper:%s overflow retry legacy checkpoint restore failed: %s"
+               meta.runtime.trace_id (Printexc.to_string exn);
+             None)
     | _ -> None
   in
   match selected with
@@ -871,9 +880,10 @@ let recover_latest_checkpoint_for_overflow_retry
       let compaction_applied =
         String.starts_with ~prefix:"applied:" decision
       in
-      if not compaction_applied then None
+      let after_tokens = token_count compacted_ctx in
+      let meaningful_reduction = after_tokens < before_tokens in
+      if not (compaction_applied && meaningful_reduction) then None
       else
-        let after_tokens = token_count compacted_ctx in
         let compaction =
           {
             applied = true;

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -858,7 +858,9 @@ let recover_latest_checkpoint_for_overflow_retry
   | None -> None
   | Some (ctx, turn_generation) ->
       let now_ts = Time_compat.now () in
-      let ctx = clamp_context_max_tokens ctx ~primary_model_max_tokens in
+      let ctx =
+        clamp_context_max_tokens ctx ~primary_model_max_tokens
+      in
       let before_tokens = token_count ctx in
       let retry_meta =
         forced_overflow_retry_meta meta ~turn_generation ~now_ts

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -10,6 +10,15 @@ open Keeper_types
 open Keeper_exec_context
 module Social = Keeper_social_model
 
+let substring_matches_at ~(needle : string) (haystack : string) start_idx =
+  let needle_len = String.length needle in
+  let rec loop offset =
+    if offset = needle_len then true
+    else if haystack.[start_idx + offset] <> needle.[offset] then false
+    else loop (offset + 1)
+  in
+  loop 0
+
 let string_contains_substring ~(needle : string) (haystack : string) : bool =
   let needle_len = String.length needle in
   let hay_len = String.length haystack in
@@ -18,7 +27,7 @@ let string_contains_substring ~(needle : string) (haystack : string) : bool =
   else
     let rec loop i =
       if i + needle_len > hay_len then false
-      else if String.sub haystack i needle_len = needle then true
+      else if substring_matches_at ~needle haystack i then true
       else loop (i + 1)
     in
     loop 0
@@ -34,7 +43,7 @@ let find_substring ~(needle : string) (haystack : string) : int option =
   let rec loop i =
     if needle_len = 0 then Some 0
     else if i + needle_len > hay_len then None
-    else if String.sub haystack i needle_len = needle then Some i
+    else if substring_matches_at ~needle haystack i then Some i
     else loop (i + 1)
   in
   loop 0
@@ -85,11 +94,16 @@ let context_overflow_limit (msg : string) : int option =
 let should_attempt_context_overflow_retry (msg : string) : bool =
   Option.is_some (context_overflow_limit msg)
 
+type overflow_retry_plan = {
+  retry_max_context : int;
+  retry_generation : int;
+}
+
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
     ~(primary_max_context : int)
-    ~(error : string) : int option =
+    ~(error : string) : overflow_retry_plan option =
   match context_overflow_limit error with
   | None -> None
   | Some actual_limit ->
@@ -109,7 +123,11 @@ let recover_context_overflow_retry
             meta.name recovery.compaction.before_tokens
             recovery.compaction.after_tokens
             retry_max_context recovery.turn_generation;
-          Some retry_max_context
+          Some
+            {
+              retry_max_context;
+              retry_generation = recovery.turn_generation;
+            }
       | None ->
           Log.Keeper.warn
             "%s: context overflow detected but checkpoint recovery was unavailable: %s"
@@ -651,11 +669,11 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run ~max_context ~is_retry =
-            Keeper_agent_run.run_turn ~config ~meta ~base_dir
+          let do_run ~run_meta ~max_context ~run_generation ~is_retry =
+            Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
-              ~generation ~max_turns
+              ~generation:run_generation ~max_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
@@ -663,9 +681,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_retry
               ()
           in
-          let rec retry_loop ~max_context ~attempt ~is_retry
+          let rec retry_loop ~run_meta ~max_context ~run_generation
+              ~attempt ~is_retry
               ~overflow_retry_used =
-            match do_run ~max_context ~is_retry with
+            match do_run ~run_meta ~max_context ~run_generation ~is_retry with
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
                            && attempt <= max_transient_retries ->
@@ -675,7 +694,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   meta.name attempt max_transient_retries delay
                   (short_preview e);
                 Eio.Time.sleep (Eio_context.get_clock ()) delay;
-                retry_loop ~max_context ~attempt:(attempt + 1)
+                retry_loop ~run_meta ~max_context ~run_generation
+                  ~attempt:(attempt + 1)
                   ~is_retry:true ~overflow_retry_used
             | Error e when (not overflow_retry_used)
                            && should_attempt_context_overflow_retry e -> (
@@ -683,14 +703,26 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   recover_context_overflow_retry ~meta ~base_dir
                     ~primary_max_context ~error:e
                 with
-                | Some retry_max_context ->
+                | Some retry_plan ->
+                    let retry_meta =
+                      if retry_plan.retry_generation = run_meta.runtime.generation
+                      then run_meta
+                      else
+                        map_runtime
+                          (fun rt ->
+                            { rt with generation = retry_plan.retry_generation })
+                          run_meta
+                    in
                     Eio.Fiber.yield ();
-                    retry_loop ~max_context:retry_max_context ~attempt:1
+                    retry_loop ~run_meta:retry_meta
+                      ~max_context:retry_plan.retry_max_context
+                      ~run_generation:retry_plan.retry_generation ~attempt:1
                       ~is_retry:true ~overflow_retry_used:true
                 | None -> Error e)
             | Error e -> Error e
           in
-          retry_loop ~max_context:primary_max_context ~attempt:1
+          retry_loop ~run_meta:meta ~max_context:primary_max_context
+            ~run_generation:generation ~attempt:1
             ~is_retry:false ~overflow_retry_used:false)
       in
       match run_result with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -39,7 +39,7 @@ let find_substring ~(needle : string) (haystack : string) : int option =
   in
   loop 0
 
-(** Detect transient TCP/TLS errors that warrant a single immediate retry.
+(** Detect transient TCP/TLS errors that warrant retry with short backoff.
     These patterns match OAS cascade error messages for connection-level failures. *)
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
@@ -49,6 +49,17 @@ let is_transient_network_error (msg : string) : bool =
   List.exists
     (fun needle -> string_contains_substring ~needle msg)
     transient_error_patterns
+
+(** Max transient retries (excluding the initial attempt).  Total attempts
+    = 1 initial + max_transient_retries.  OAS internal retry is 3 per
+    provider; this outer retry covers cases where all providers fail
+    transiently (e.g. TCP keepalive expiry across all backends). *)
+let max_transient_retries = 2
+
+(** Exponential backoff delay for transient retry [attempt] (1-indexed).
+    Delays: 1s, 2s — total wait 3s before giving up. *)
+let transient_backoff_sec (attempt : int) : float =
+  Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
 
 let context_overflow_anchor = "available context size ("
 
@@ -70,6 +81,9 @@ let context_overflow_limit (msg : string) : int option =
       else
         String.sub lowered start_idx (end_idx - start_idx)
         |> int_of_string_opt
+
+let should_attempt_context_overflow_retry (msg : string) : bool =
+  Option.is_some (context_overflow_limit msg)
 
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
@@ -464,6 +478,10 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("work_kind", `String work_kind);
         ("tool_call_count", `Int result.tool_calls_made);
         ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
+        ("cascade",
+         match result.cascade_observation with
+         | Some observation -> Oas_worker.cascade_observation_to_json observation
+         | None -> `Null);
         ("snapshot_source", `String snapshot_source);
         ("memory_check", memory_check_default_json ());
         ("handoff_performed",
@@ -633,7 +651,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run ~max_context =
+          let do_run ~max_context ~is_retry =
             Keeper_agent_run.run_turn ~config ~meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
@@ -642,24 +660,38 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
               ~max_cost_usd
+              ~is_retry
               ()
           in
-          match do_run ~max_context:primary_max_context with
-          | Ok _ as ok -> ok
-          | Error e when is_transient_network_error e ->
-              Log.Keeper.warn "%s: transient network error, retrying once: %s"
-                meta.name (short_preview e);
-              Eio.Fiber.yield ();
-              do_run ~max_context:primary_max_context
-          | Error e -> (
-              match
-                recover_context_overflow_retry ~meta ~base_dir
-                  ~primary_max_context ~error:e
-              with
-              | Some retry_max_context ->
-                  Eio.Fiber.yield ();
-                  do_run ~max_context:retry_max_context
-              | None -> Error e))
+          let rec retry_loop ~max_context ~attempt ~is_retry
+              ~overflow_retry_used =
+            match do_run ~max_context ~is_retry with
+            | Ok _ as ok -> ok
+            | Error e when is_transient_network_error e
+                           && attempt <= max_transient_retries ->
+                let delay = transient_backoff_sec attempt in
+                Log.Keeper.warn
+                  "%s: transient network error (retry %d/%d), backoff %.0fs: %s"
+                  meta.name attempt max_transient_retries delay
+                  (short_preview e);
+                Eio.Time.sleep (Eio_context.get_clock ()) delay;
+                retry_loop ~max_context ~attempt:(attempt + 1)
+                  ~is_retry:true ~overflow_retry_used
+            | Error e when (not overflow_retry_used)
+                           && should_attempt_context_overflow_retry e -> (
+                match
+                  recover_context_overflow_retry ~meta ~base_dir
+                    ~primary_max_context ~error:e
+                with
+                | Some retry_max_context ->
+                    Eio.Fiber.yield ();
+                    retry_loop ~max_context:retry_max_context ~attempt:1
+                      ~is_retry:true ~overflow_retry_used:true
+                | None -> Error e)
+            | Error e -> Error e
+          in
+          retry_loop ~max_context:primary_max_context ~attempt:1
+            ~is_retry:false ~overflow_retry_used:false)
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -10,38 +10,37 @@ open Keeper_types
 open Keeper_exec_context
 module Social = Keeper_social_model
 
-let find_substring ~(needle : string) (haystack : string) : int option =
+let string_contains_substring ~(needle : string) (haystack : string) : bool =
   let needle_len = String.length needle in
   let hay_len = String.length haystack in
-  let matches_at start_idx =
-    let rec loop offset =
-      if offset = needle_len then true
-      else if haystack.[start_idx + offset] <> needle.[offset] then false
-      else loop (offset + 1)
+  if needle_len = 0 then true
+  else if needle_len > hay_len then false
+  else
+    let rec loop i =
+      if i + needle_len > hay_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
     in
     loop 0
-  in
-  let rec loop i =
-    if needle_len = 0 then Some 0
-    else if i + needle_len > hay_len then None
-    else if matches_at i then Some i
-    else loop (i + 1)
-  in
-  loop 0
-
-let string_contains_substring ~(needle : string) (haystack : string) : bool =
-  match find_substring ~needle haystack with
-  | Some _ -> true
-  | None -> false
 
 let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
   string_contains_substring
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
-(** Detect transient TCP/TLS errors that warrant retry with backoff.
-    These patterns match OAS cascade error messages for connection-level failures.
-    See #4523: Connection_reset/Broken_pipe/EOF from idle TCP teardown. *)
+let find_substring ~(needle : string) (haystack : string) : int option =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  let rec loop i =
+    if needle_len = 0 then Some 0
+    else if i + needle_len > hay_len then None
+    else if String.sub haystack i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop 0
+
+(** Detect transient TCP/TLS errors that warrant a single immediate retry.
+    These patterns match OAS cascade error messages for connection-level failures. *)
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
     "connection closed"; "Connection refused" ]
@@ -51,23 +50,7 @@ let is_transient_network_error (msg : string) : bool =
     (fun needle -> string_contains_substring ~needle msg)
     transient_error_patterns
 
-(** Max transient retries (excluding the initial attempt).  Total attempts
-    = 1 initial + max_transient_retries.  OAS internal retry is 3 per
-    provider; this outer retry covers cases where all providers fail
-    transiently (e.g. TCP keepalive expiry across all backends). *)
-let max_transient_retries = 2
-
-(** Exponential backoff delay for transient retry [attempt] (1-indexed).
-    Delays: 1s, 2s — total wait 3s before giving up. *)
-let transient_backoff_sec (attempt : int) : float =
-  Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
-
 let context_overflow_anchor = "available context size ("
-
-type overflow_retry_plan = {
-  retry_max_context : int;
-  retry_generation : int;
-}
 
 let context_overflow_limit (msg : string) : int option =
   let lowered = String.lowercase_ascii msg in
@@ -88,15 +71,11 @@ let context_overflow_limit (msg : string) : int option =
         String.sub lowered start_idx (end_idx - start_idx)
         |> int_of_string_opt
 
-let meta_with_generation (meta : keeper_meta) ~(generation : int) : keeper_meta =
-  if generation = meta.runtime.generation then meta
-  else map_runtime (fun rt -> { rt with generation }) meta
-
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
     ~(primary_max_context : int)
-    ~(error : string) : overflow_retry_plan option =
+    ~(error : string) : int option =
   match context_overflow_limit error with
   | None -> None
   | Some actual_limit ->
@@ -116,11 +95,7 @@ let recover_context_overflow_retry
             meta.name recovery.compaction.before_tokens
             recovery.compaction.after_tokens
             retry_max_context recovery.turn_generation;
-          Some
-            {
-              retry_max_context;
-              retry_generation = recovery.turn_generation;
-            }
+          Some retry_max_context
       | None ->
           Log.Keeper.warn
             "%s: context overflow detected but checkpoint recovery was unavailable: %s"
@@ -451,27 +426,6 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
     else "noop"
   in
   let metrics_store = keeper_metrics_store config meta.name in
-  let cascade_json =
-    match result.cascade_observation with
-    | Some obs -> Oas_worker.cascade_observation_to_json obs
-    | None ->
-        `Assoc
-          [
-            ("cascade_name", `String meta.cascade_name);
-            ("configured_labels", `List []);
-            ("candidate_models", `List []);
-            ("primary_model", `Null);
-            ("selected_model", `String result.model_used);
-            ("selected_model_raw", `String result.model_used);
-            ("selected_index", `Null);
-            ("fallback_hops", `Null);
-            ("fallback_applied", `Bool false);
-            ("attempts", `List []);
-            ("fallback_events", `List []);
-            ("attempt_details_available", `Bool false);
-            ("attempt_details_source", `String "no_oas_observation");
-          ]
-  in
   let snapshot =
     `Assoc
       [
@@ -483,7 +437,6 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("trace_id", `String meta.runtime.trace_id);
         ("generation", `Int turn_generation);
         ("model_used", `String result.model_used);
-        ("cascade", cascade_json);
         ( "usage",
           `Assoc
             [
@@ -677,16 +630,11 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            No dynamic_context needed here. *)
         { system_prompt; dynamic_context = "" }
       in
-      (* 5. Run via OAS Agent.run() with transient-error retry.
-         Exponential backoff (1s, 2s, 4s) up to max_transient_retries.
-         OAS already retries 3x per provider internally; this outer loop
-         covers simultaneous backend failures (e.g. TCP keepalive expiry
-         across all providers).  See #4523. *)
+      (* 5. Run via OAS Agent.run() with transient-error retry *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run ?(is_retry = false) ~(turn_meta : keeper_meta) ~generation
-              ~max_context () =
-            Keeper_agent_run.run_turn ~config ~meta:turn_meta ~base_dir
+          let do_run ~max_context =
+            Keeper_agent_run.run_turn ~config ~meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
@@ -694,46 +642,24 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
               ~max_cost_usd
-              ~is_retry
               ()
           in
-          let rec retry_loop attempt ~(turn_meta : keeper_meta) ~generation
-              ~max_context ~allow_overflow_retry =
-            match do_run ~is_retry:(attempt > 1) ~turn_meta ~generation
-                    ~max_context () with
-            | Ok _ as ok -> ok
-            | Error e when is_transient_network_error e
-                           && attempt <= max_transient_retries ->
-                let delay = transient_backoff_sec attempt in
-                Log.Keeper.warn
-                  "%s: transient network error (retry %d/%d), backoff %.0fs: %s"
-                  meta.name attempt max_transient_retries delay
-                  (short_preview e);
-                Eio.Time.sleep (Eio_context.get_clock ()) delay;
-                retry_loop (attempt + 1) ~turn_meta ~generation
-                  ~max_context ~allow_overflow_retry
-            | Error e -> (
-                if not allow_overflow_retry then Error e
-                else
-                  match
-                    recover_context_overflow_retry ~meta:turn_meta ~base_dir
-                      ~primary_max_context:max_context ~error:e
-                  with
-                  | Some retry_plan ->
-                      let retry_meta =
-                        meta_with_generation turn_meta
-                          ~generation:retry_plan.retry_generation
-                      in
-                      Eio.Fiber.yield ();
-                      retry_loop 1 ~turn_meta:retry_meta
-                        ~generation:retry_plan.retry_generation
-                        ~max_context:retry_plan.retry_max_context
-                        ~allow_overflow_retry:false
-                  | None -> Error e)
-          in
-          retry_loop 1 ~turn_meta:meta ~generation
-            ~max_context:primary_max_context
-            ~allow_overflow_retry:true)
+          match do_run ~max_context:primary_max_context with
+          | Ok _ as ok -> ok
+          | Error e when is_transient_network_error e ->
+              Log.Keeper.warn "%s: transient network error, retrying once: %s"
+                meta.name (short_preview e);
+              Eio.Fiber.yield ();
+              do_run ~max_context:primary_max_context
+          | Error e -> (
+              match
+                recover_context_overflow_retry ~meta ~base_dir
+                  ~primary_max_context ~error:e
+              with
+              | Some retry_max_context ->
+                  Eio.Fiber.yield ();
+                  do_run ~max_context:retry_max_context
+              | None -> Error e))
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -68,17 +68,11 @@ val broadcast_lifecycle_events :
 (** Detect transient TCP/TLS errors eligible for retry. Exposed for testing. *)
 val is_transient_network_error : string -> bool
 
-type overflow_retry_plan = {
-  retry_max_context : int;
-  retry_generation : int;
-}
+(** Parse the provider-reported available context limit from an overflow error. *)
+val context_overflow_limit : string -> int option
 
-val recover_context_overflow_retry :
-  meta:Keeper_types.keeper_meta ->
-  base_dir:string ->
-  primary_max_context:int ->
-  error:string ->
-  overflow_retry_plan option
+(** [true] when an error string should trigger overflow recovery handling. *)
+val should_attempt_context_overflow_retry : string -> bool
 
 val run_unified_turn :
   config:Room.config ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -873,6 +873,25 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
         Yojson.Safe.Util.(
           json |> member "cascade" |> member "attempt_details_source" |> to_string))
 
+let test_context_overflow_limit_parses_common_oas_errors () =
+  check (option int) "available context size extracted" (Some 159671)
+    (UT.context_overflow_limit
+       "OpenAI returned 400: This model's maximum context length is 128000 tokens. However, your messages resulted in 193217 tokens. available context size (159671)");
+  check (option int) "missing digits" None
+    (UT.context_overflow_limit
+       "available context size () but message malformed");
+  check (option int) "non-overflow message" None
+    (UT.context_overflow_limit
+       "HTTP error: 503 Service Unavailable")
+
+let test_should_attempt_context_overflow_retry_only_for_overflow_errors () =
+  check bool "overflow string retries" true
+    (UT.should_attempt_context_overflow_retry
+       "provider error: available context size (32768) exceeded");
+  check bool "non-overflow string skips retry" false
+    (UT.should_attempt_context_overflow_retry
+       "Network error: Connection_reset")
+
 let test_metrics_persist_social_state_fields () =
   let result =
     make_run_result
@@ -1506,5 +1525,12 @@ let () =
               (UT.is_transient_network_error ""));
           test_case "overflow retry plan preserves generation" `Quick
             test_overflow_retry_plan_preserves_recovered_generation;
+        ] );
+      ( "context_overflow",
+        [
+          test_case "parses common OAS overflow errors" `Quick
+            test_context_overflow_limit_parses_common_oas_errors;
+          test_case "overflow retry gate only opens for overflow errors" `Quick
+            test_should_attempt_context_overflow_retry_only_for_overflow_errors;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -68,28 +68,6 @@ let contains_disallowed_control_char s =
   in
   loop 0
 
-let append_dense_turn ctx idx =
-  let payload = String.make 160 'x' in
-  KEC.append ctx
-    (Agent_sdk.Types.user_msg
-       (Printf.sprintf "turn %02d user %s" idx payload))
-  |> fun next ->
-  KEC.append next
-    (Agent_sdk.Types.assistant_msg
-       (Printf.sprintf "turn %02d assistant %s" idx payload))
-
-let build_dense_retry_context ~turns ~max_tokens =
-  let rec loop idx ctx =
-    if idx > turns then ctx else loop (idx + 1) (append_dense_turn ctx idx)
-  in
-  let ctx =
-    loop 1 (KEC.create ~system_prompt:"keeper unified" ~max_tokens)
-  in
-  KEC.append ctx
-    (Agent_sdk.Types.assistant_msg
-       "done\n\n[STATE]\nGoal: retry after overflow\nProgress: ready\n[/STATE]")
-  |> KEC.sync_oas_context
-
 (* ---------- World Observation type tests ---------- *)
 
 let base_observation : WO.world_observation =
@@ -1066,44 +1044,16 @@ let test_sanitize_messages_utf8_reuses_clean_history_list () =
   let sanitized = Masc_mcp.Inference_utils.sanitize_messages_utf8 msgs in
   check bool "same list reused" true (sanitized == msgs)
 
-let test_overflow_retry_plan_preserves_recovered_generation () =
-  let base_dir = temp_dir () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
-    (fun () ->
-      Fs_compat.clear_fs ();
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let meta =
-        {
-          minimal_meta with
-          runtime =
-            {
-              minimal_meta.runtime with
-              trace_id = "trace-overflow-plan";
-              generation = 0;
-            };
-        }
-      in
-      let session =
-        KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
-      in
-      let legacy_ctx =
-        build_dense_retry_context ~turns:18 ~max_tokens:2048
-      in
-      ignore (KEC.save_checkpoint session legacy_ctx ~generation:3);
-      match
-        UT.recover_context_overflow_retry ~meta ~base_dir
-          ~primary_max_context:192
-          ~error:
-            "HTTP 400: prompt exceeds available context size (192) for this model"
-      with
-      | Some retry_plan ->
-          check int "retry generation preserved" 3
-            retry_plan.UT.retry_generation;
-          check int "retry max_context clamped" 192
-            retry_plan.retry_max_context
-      | None -> fail "expected overflow retry plan")
+let test_overflow_detection_and_limit_parsing () =
+  let msg = "HTTP 400: prompt exceeds available context size (8192 tokens)" in
+  check bool "should attempt overflow retry" true
+    (UT.should_attempt_context_overflow_retry msg);
+  check (option int) "parses limit" (Some 8192)
+    (UT.context_overflow_limit msg);
+  check (option int) "no limit in unrelated error" None
+    (UT.context_overflow_limit "Network error: connection reset");
+  check bool "unrelated error not overflow" false
+    (UT.should_attempt_context_overflow_retry "Network error: timeout")
 
 let test_metrics_mixed_response () =
   let result =
@@ -1523,8 +1473,8 @@ let () =
           test_case "empty string not transient" `Quick (fun () ->
             check bool "empty" false
               (UT.is_transient_network_error ""));
-          test_case "overflow retry plan preserves generation" `Quick
-            test_overflow_retry_plan_preserves_recovered_generation;
+          test_case "overflow detection and limit parsing" `Quick
+            test_overflow_detection_and_limit_parsing;
         ] );
       ( "context_overflow",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -654,13 +654,64 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
       Alcotest.(check bool) "handoff json absent" false
         (Option.is_some rollover.handoff_json))
 
-let test_overflow_retry_legacy_restore_failure_returns_none () =
-  let base_dir = temp_dir "keeper_overflow_retry_legacy_fail" in
+let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
+  let base_dir = temp_dir "keeper_overflow_retry_legacy_fallback" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
       Fs_compat.clear_fs ();
       let meta = make_keeper_meta ~trace_id:"trace-overflow-legacy-fail" () in
+      let session =
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let noisy_tool_output = String.make 4000 'x' in
+      let ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy")
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (tool_result_msg noisy_tool_output)
+        |> Keeper_exec_context.sync_oas_context
+      in
+      ignore
+        (Keeper_exec_context.save_oas_checkpoint ~session
+           ~agent_name:meta.agent_name
+           ~model:"llama:auto" ~ctx
+           ~generation:11);
+      let bad_legacy =
+        {
+          (Keeper_exec_context.create_checkpoint ctx ~generation:19) with
+          timestamp = Time_compat.now () +. 10.0;
+          serialized = "\"broken-context\"";
+        }
+      in
+      Keeper_exec_context.save_session_checkpoint session bad_legacy;
+      match
+        Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+          ~base_dir ~meta ~model:"llama:auto"
+          ~primary_model_max_tokens:256
+      with
+      | None ->
+          Alcotest.fail
+            "expected overflow retry recovery to fall back to OAS checkpoint"
+      | Some recovery ->
+          let recovered_ctx =
+            Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
+              ~primary_model_max_tokens:256
+          in
+          Alcotest.(check int) "fallback uses OAS generation" 11
+            recovery.turn_generation;
+          Alcotest.(check bool) "compacted from OAS fallback" true
+            (Keeper_exec_context.token_count recovered_ctx
+             < Keeper_exec_context.token_count ctx))
+
+let test_overflow_retry_legacy_restore_failure_returns_none_without_oas () =
+  let base_dir = temp_dir "keeper_overflow_retry_legacy_fail" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-legacy-only" () in
       let session =
         Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
       in
@@ -684,7 +735,7 @@ let test_overflow_retry_legacy_restore_failure_returns_none () =
       | None -> ()
       | Some _ ->
           Alcotest.fail
-            "expected overflow retry recovery to skip broken legacy checkpoint")
+            "expected overflow retry recovery to skip broken legacy checkpoint without OAS fallback")
 
 let test_overflow_retry_requires_meaningful_reduction () =
   let base_dir = temp_dir "keeper_overflow_retry_noop" in
@@ -939,8 +990,10 @@ let () =
         test_keeper_oas_handoff_rollover_increments_generation;
       Alcotest.test_case "OAS handoff rollover noops below threshold" `Quick
         test_keeper_oas_handoff_rollover_below_threshold_noop;
-      Alcotest.test_case "overflow retry skips broken legacy checkpoint" `Quick
-        test_overflow_retry_legacy_restore_failure_returns_none;
+      Alcotest.test_case "overflow retry falls back to OAS after broken legacy restore" `Quick
+        test_overflow_retry_legacy_restore_failure_falls_back_to_oas;
+      Alcotest.test_case "overflow retry skips broken legacy checkpoint without OAS" `Quick
+        test_overflow_retry_legacy_restore_failure_returns_none_without_oas;
       Alcotest.test_case "overflow retry requires meaningful reduction" `Quick
         test_overflow_retry_requires_meaningful_reduction;
       Alcotest.test_case "overflow retry saves compacted checkpoint" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -385,6 +385,18 @@ let make_oas_checkpoint
     working_context;
   }
 
+let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+    content =
+      [
+        Agent_sdk.Types.ToolResult
+          { tool_use_id = id; content = text; is_error = false };
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
 let test_keeper_checkpoint_store_oas_roundtrip () =
   let base_dir = temp_dir "keeper_oas_store" in
   Fun.protect
@@ -642,6 +654,109 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
       Alcotest.(check bool) "handoff json absent" false
         (Option.is_some rollover.handoff_json))
 
+let test_overflow_retry_legacy_restore_failure_returns_none () =
+  let base_dir = temp_dir "keeper_overflow_retry_legacy_fail" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-legacy-fail" () in
+      let session =
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy" ~max_tokens:1024
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy")
+      in
+      let bad_checkpoint =
+        {
+          (Keeper_exec_context.create_checkpoint ctx ~generation:7) with
+          serialized = "\"broken-context\"";
+        }
+      in
+      Keeper_exec_context.save_session_checkpoint session bad_checkpoint;
+      match
+        Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+          ~base_dir ~meta ~model:"llama:auto"
+          ~primary_model_max_tokens:512
+      with
+      | None -> ()
+      | Some _ ->
+          Alcotest.fail
+            "expected overflow retry recovery to skip broken legacy checkpoint")
+
+let test_overflow_retry_requires_meaningful_reduction () =
+  let base_dir = temp_dir "keeper_overflow_retry_noop" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-noop" () in
+      let session =
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let ctx =
+        Keeper_exec_context.create ~system_prompt:"noop" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "short")
+        |> Keeper_exec_context.sync_oas_context
+      in
+      ignore
+        (Keeper_exec_context.save_oas_checkpoint ~session
+           ~agent_name:meta.agent_name
+           ~model:"llama:auto" ~ctx
+           ~generation:meta.runtime.generation);
+      match
+        Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+          ~base_dir ~meta ~model:"llama:auto"
+          ~primary_model_max_tokens:1024
+      with
+      | None -> ()
+      | Some _ ->
+          Alcotest.fail
+            "expected overflow retry recovery to skip no-op compaction")
+
+let test_overflow_retry_saves_compacted_checkpoint () =
+  let base_dir = temp_dir "keeper_overflow_retry_compacts" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-compacts" () in
+      let session =
+        Keeper_exec_context.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let noisy_tool_output = String.make 4000 'x' in
+      let ctx =
+        Keeper_exec_context.create ~system_prompt:"overflow" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "please summarize")
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (tool_result_msg noisy_tool_output)
+        |> Keeper_exec_context.sync_oas_context
+      in
+      let before_tokens = Keeper_exec_context.token_count ctx in
+      ignore
+        (Keeper_exec_context.save_oas_checkpoint ~session
+           ~agent_name:meta.agent_name
+           ~model:"llama:auto" ~ctx
+           ~generation:meta.runtime.generation);
+      match
+        Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+          ~base_dir ~meta ~model:"llama:auto"
+          ~primary_model_max_tokens:256
+      with
+      | None -> Alcotest.fail "expected overflow retry recovery to compact"
+      | Some recovery ->
+          let recovered_ctx =
+            Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
+              ~primary_model_max_tokens:256
+          in
+          Alcotest.(check bool) "token count reduced" true
+            (Keeper_exec_context.token_count recovered_ctx < before_tokens);
+          Alcotest.(check int) "max tokens clamped" 256 recovered_ctx.max_tokens)
+
 (* ================================================================ *)
 (* Same-trace checkpoint continuity regression (OAS #467)            *)
 (* ================================================================ *)
@@ -824,6 +939,12 @@ let () =
         test_keeper_oas_handoff_rollover_increments_generation;
       Alcotest.test_case "OAS handoff rollover noops below threshold" `Quick
         test_keeper_oas_handoff_rollover_below_threshold_noop;
+      Alcotest.test_case "overflow retry skips broken legacy checkpoint" `Quick
+        test_overflow_retry_legacy_restore_failure_returns_none;
+      Alcotest.test_case "overflow retry requires meaningful reduction" `Quick
+        test_overflow_retry_requires_meaningful_reduction;
+      Alcotest.test_case "overflow retry saves compacted checkpoint" `Quick
+        test_overflow_retry_saves_compacted_checkpoint;
     ];
     "keeper_checkpoint_store", [
       Alcotest.test_case "OAS store roundtrip" `Quick


### PR DESCRIPTION
## Summary
Keeper unified turn이 context overflow (8192 token limit)로 실패할 때, 에러에서 실제 limit을 파싱하고 강제 compaction 후 재시도하는 로직 추가.

## Mechanism
1. OAS가 "request (8423 tokens) exceeds the available context size (8192 tokens)" 에러 반환
2. `context_overflow_limit`이 에러 메시지에서 실제 limit (8192) 파싱
3. `recover_context_overflow_retry`가 최신 checkpoint 로드 → 강제 compaction (ratio_gate=0) → 새 checkpoint 저장
4. 압축된 context로 재시도

## Changed files
- `keeper_unified_turn.ml` — overflow 감지 + retry 분기, `find_substring`/`context_overflow_limit` 헬퍼
- `keeper_exec_context.ml` — `recover_latest_checkpoint_for_overflow_retry`, `clamp_context_max_tokens`, `forced_overflow_retry_meta`
- `keeper_exec_context.mli` — 타입 + 함수 export

## Origin
`fix/keeper-context-overflow-retry` 브랜치(75fa29068)에서 cherry-pick. 해당 브랜치는 183파일 diverge로 직접 merge 불가하여 patch 방식으로 적용.

## Test plan
- [x] `dune build @check` 통과
- [ ] CI 빌드 확인
- [ ] 8192 context limit 환경에서 overflow → compaction → 재시도 동작 확인

Closes #4735