### PR TITLE
fix(keeper): recover from context overflow

### DIFF
--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -49,18 +49,25 @@ let timed (f : unit -> 'a) : 'a * int =
 (* UTF-8 Sanitization                                               *)
 (* ================================================================ *)
 
+let is_disallowed_control_char (c : char) : bool =
+  let code = Char.code c in
+  (code < 32 && c <> '\n' && c <> '\r' && c <> '\t') || code = 127
+
 let sanitize_text_utf8 (s : string) : string =
   let len = String.length s in
-  (* Fast path: scan for invalid UTF-8 without allocating *)
-  let rec has_invalid i =
+  (* Fast path: scan for invalid UTF-8 or prompt-breaking control chars
+     without allocating. Keep LF/CR/TAB because prompts rely on them. *)
+  let rec has_invalid_or_control i =
     if i >= len then false
     else
       let dec = String.get_utf_8_uchar s i in
       let dlen = Uchar.utf_decode_length dec in
-      if dlen > 0 && Uchar.utf_decode_is_valid dec then has_invalid (i + dlen)
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then
+        if dlen = 1 && is_disallowed_control_char s.[i] then true
+        else has_invalid_or_control (i + dlen)
       else true
   in
-  if not (has_invalid 0) then s
+  if not (has_invalid_or_control 0) then s
   else
     let buf = Buffer.create len in
     let rec loop i =
@@ -69,7 +76,10 @@ let sanitize_text_utf8 (s : string) : string =
         let dec = String.get_utf_8_uchar s i in
         let dlen = Uchar.utf_decode_length dec in
         if dlen > 0 && Uchar.utf_decode_is_valid dec then (
-          Buffer.add_substring buf s i dlen;
+          if dlen = 1 && is_disallowed_control_char s.[i] then
+            Buffer.add_char buf ' '
+          else
+            Buffer.add_substring buf s i dlen;
           loop (i + dlen))
         else (
           Buffer.add_string buf "\xEF\xBF\xBD";

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -88,22 +88,50 @@ let sanitize_text_utf8 (s : string) : string =
     loop 0;
     Buffer.contents buf
 
+let rec sanitize_content_blocks_utf8
+    (blocks : Agent_sdk.Types.content_block list)
+  : Agent_sdk.Types.content_block list =
+  match blocks with
+  | [] -> blocks
+  | block :: rest ->
+      let sanitized_block =
+        match block with
+        | Agent_sdk.Types.Text s ->
+            let sanitized = sanitize_text_utf8 s in
+            if sanitized == s then block else Agent_sdk.Types.Text sanitized
+        | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error } ->
+            let sanitized_tool_use_id = sanitize_text_utf8 tool_use_id in
+            let sanitized_content = sanitize_text_utf8 content in
+            if sanitized_tool_use_id == tool_use_id && sanitized_content == content
+            then block
+            else
+              Agent_sdk.Types.ToolResult {
+                tool_use_id = sanitized_tool_use_id;
+                content = sanitized_content;
+                is_error;
+              }
+        | _ -> block
+      in
+      let sanitized_rest = sanitize_content_blocks_utf8 rest in
+      if sanitized_block == block && sanitized_rest == rest then blocks
+      else sanitized_block :: sanitized_rest
+
 let sanitize_message_utf8 (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
-  { m with
-    content = List.map (fun block ->
-      match block with
-      | Agent_sdk.Types.Text s -> Agent_sdk.Types.Text (sanitize_text_utf8 s)
-      | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error } ->
-          Agent_sdk.Types.ToolResult {
-            tool_use_id = sanitize_text_utf8 tool_use_id;
-            content = sanitize_text_utf8 content;
-            is_error }
-      | other -> other
-    ) m.content;
-  }
+  let sanitized_content = sanitize_content_blocks_utf8 m.content in
+  if sanitized_content == m.content then m
+  else { m with content = sanitized_content }
 
 let sanitize_messages_utf8 (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  List.map sanitize_message_utf8 msgs
+  let rec loop messages =
+    match messages with
+    | [] -> messages
+    | msg :: rest ->
+        let sanitized_msg = sanitize_message_utf8 msg in
+        let sanitized_rest = loop rest in
+        if sanitized_msg == msg && sanitized_rest == rest then messages
+        else sanitized_msg :: sanitized_rest
+  in
+  loop msgs
 
 (* ================================================================ *)
 (* Concurrency diagnostics (observability only, no throttling)       *)

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -20,8 +20,8 @@ val usage_of_response : Oas_response.api_response -> Agent_sdk.Types.api_usage
 (** Measure wall-clock latency of a thunk in milliseconds. *)
 val timed : (unit -> 'a) -> 'a * int
 
-(** Replace invalid UTF-8 bytes with U+FFFD and strip disallowed ASCII
-    control characters (except LF/CR/TAB). *)
+(** Replace invalid UTF-8 bytes with U+FFFD and replace disallowed ASCII
+    control characters with spaces (except LF/CR/TAB). *)
 val sanitize_text_utf8 : string -> string
 
 (** Sanitize text content blocks in a message. *)

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -20,7 +20,8 @@ val usage_of_response : Oas_response.api_response -> Agent_sdk.Types.api_usage
 (** Measure wall-clock latency of a thunk in milliseconds. *)
 val timed : (unit -> 'a) -> 'a * int
 
-(** Replace invalid UTF-8 bytes with U+FFFD. *)
+(** Replace invalid UTF-8 bytes with U+FFFD and strip disallowed ASCII
+    control characters (except LF/CR/TAB). *)
 val sanitize_text_utf8 : string -> string
 
 (** Sanitize text content blocks in a message. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -270,6 +270,10 @@ let run_turn
       ~base_system_prompt
       ~messages:ctx_work.messages
   in
+  let turn_system_prompt =
+    Inference_utils.sanitize_text_utf8 turn_system_prompt
+  in
+  let user_message = Inference_utils.sanitize_text_utf8 user_message in
   (* 6. Append user message and persist.
      On retry (is_retry=true), the user message was already persisted by the
      first attempt.  Checkpoint reload does not include it (checkpoint is
@@ -279,7 +283,7 @@ let run_turn
   (* Capture history BEFORE appending the current user_msg.
      OAS Agent.run appends user_msg from ~goal internally, so passing it
      in initial_messages would cause duplication. *)
-  let history_messages = ctx_work.messages in
+  let history_messages = Inference_utils.sanitize_messages_utf8 ctx_work.messages in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   if not is_retry then
     Keeper_exec_context.persist_message ~source:history_user_source session user_msg;

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -270,6 +270,10 @@ let run_turn
       ~base_system_prompt
       ~messages:ctx_work.messages
   in
+  (* Defense in depth: unified prompt builders sanitize their own output,
+     but run_turn is shared by other callers and is the final boundary before
+     handing prompts/history to OAS. Keep this sanitization here even when
+     upstream builders already cleaned their strings. *)
   let turn_system_prompt =
     Inference_utils.sanitize_text_utf8 turn_system_prompt
   in
@@ -283,7 +287,9 @@ let run_turn
   (* Capture history BEFORE appending the current user_msg.
      OAS Agent.run appends user_msg from ~goal internally, so passing it
      in initial_messages would cause duplication. *)
-  let history_messages = Inference_utils.sanitize_messages_utf8 ctx_work.messages in
+  let history_messages =
+    Inference_utils.sanitize_messages_utf8 ctx_work.messages
+  in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   if not is_retry then
     Keeper_exec_context.persist_message ~source:history_user_source session user_msg;

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -348,6 +348,12 @@ type post_turn_lifecycle = {
   message_count : int;
 }
 
+type overflow_retry_recovery = {
+  checkpoint : Agent_sdk.Checkpoint.t;
+  compaction : compaction_event;
+  turn_generation : int;
+}
+
 let maybe_rollover_oas_handoff
     ~(base_dir : string)
     ~(meta : keeper_meta)
@@ -763,6 +769,133 @@ let apply_post_turn_lifecycle
         context_max = rollover.context_max;
         message_count = rollover.message_count;
       }
+
+let clamp_context_max_tokens
+    (ctx : working_context)
+    ~(primary_model_max_tokens : int) : working_context =
+  let clamped =
+    if primary_model_max_tokens <= 0 then ctx.max_tokens
+    else min ctx.max_tokens primary_model_max_tokens
+  in
+  if clamped = ctx.max_tokens then ctx
+  else sync_oas_context { ctx with max_tokens = clamped }
+
+let forced_overflow_retry_meta
+    (meta : keeper_meta)
+    ~(turn_generation : int)
+    ~(now_ts : float) : keeper_meta =
+  let base_meta =
+    if turn_generation = meta.runtime.generation then meta
+    else
+      map_runtime
+        (fun rt -> { rt with generation = turn_generation })
+        meta
+  in
+  {
+    (map_runtime
+       (fun rt ->
+         let last_continuity_update_ts =
+           if rt.last_continuity_update_ts > 0.0
+           then rt.last_continuity_update_ts
+           else now_ts
+         in
+         let proactive_rt =
+           if rt.proactive_rt.last_ts > 0.0
+           then rt.proactive_rt
+           else { rt.proactive_rt with last_ts = now_ts }
+         in
+         { rt with last_continuity_update_ts; proactive_rt })
+       base_meta)
+    with
+    compaction =
+      {
+        base_meta.compaction with
+        ratio_gate = 0.0;
+        message_gate = 0;
+        token_gate = 0;
+        cooldown_sec = 0;
+      };
+  }
+
+let recover_latest_checkpoint_for_overflow_retry
+    ~(base_dir : string)
+    ~(meta : keeper_meta)
+    ~(model : string)
+    ~(primary_model_max_tokens : int) : overflow_retry_recovery option =
+  let session = create_session ~session_id:meta.runtime.trace_id ~base_dir in
+  let oas_checkpoint =
+    Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
+      ~session_id:meta.runtime.trace_id
+  in
+  let legacy_checkpoint =
+    try load_latest_checkpoint session
+    with exn ->
+      Log.Keeper.error "keeper:%s overflow retry checkpoint load failed: %s"
+        meta.runtime.trace_id (Printexc.to_string exn);
+      None
+  in
+  let prefer_legacy =
+    match oas_checkpoint, legacy_checkpoint with
+    | Some oas, Some legacy -> legacy.timestamp > oas.created_at
+    | _ -> false
+  in
+  let selected =
+    match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
+    | false, Some checkpoint, _ ->
+        let turn_generation =
+          checkpoint_generation checkpoint ~fallback:meta.runtime.generation
+        in
+        Some
+          ( context_of_oas_checkpoint checkpoint ~primary_model_max_tokens,
+            turn_generation )
+    | _, _, Some checkpoint ->
+        Some
+          ( context_of_legacy_checkpoint checkpoint ~primary_model_max_tokens,
+            checkpoint.generation )
+    | _ -> None
+  in
+  match selected with
+  | None -> None
+  | Some (ctx, turn_generation) ->
+      let now_ts = Time_compat.now () in
+      let ctx = clamp_context_max_tokens ctx ~primary_model_max_tokens in
+      let before_tokens = token_count ctx in
+      let retry_meta =
+        forced_overflow_retry_meta meta ~turn_generation ~now_ts
+      in
+      let compacted_ctx, trigger, decision =
+        compact_if_needed ~meta:retry_meta ~now_ts ctx
+      in
+      let compaction_applied =
+        String.starts_with ~prefix:"applied:" decision
+      in
+      if not compaction_applied then None
+      else
+        let after_tokens = token_count compacted_ctx in
+        let compaction =
+          {
+            applied = true;
+            trigger;
+            decision;
+            before_tokens;
+            after_tokens;
+            saved_tokens = max 0 (before_tokens - after_tokens);
+          }
+        in
+        try
+          let checkpoint =
+            save_oas_checkpoint ~session
+              ~agent_name:retry_meta.agent_name
+              ~model ~ctx:compacted_ctx ~generation:turn_generation
+          in
+          Some { checkpoint; compaction; turn_generation }
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+            log_keeper_exn
+              ~label:"overflow retry checkpoint save failed"
+              exn;
+            None
 
 let generate_trace_id = Keeper_identity.generate_trace_id
 

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -113,6 +113,12 @@ type post_turn_lifecycle = {
   message_count : int;
 }
 
+type overflow_retry_recovery = {
+  checkpoint : Agent_sdk.Checkpoint.t;
+  compaction : compaction_event;
+  turn_generation : int;
+}
+
 val maybe_rollover_oas_handoff :
   base_dir:string ->
   meta:keeper_meta ->
@@ -149,6 +155,13 @@ val apply_post_turn_lifecycle :
   primary_model_max_tokens:int ->
   checkpoint:Agent_sdk.Checkpoint.t option ->
   post_turn_lifecycle
+
+val recover_latest_checkpoint_for_overflow_retry :
+  base_dir:string ->
+  meta:keeper_meta ->
+  model:string ->
+  primary_model_max_tokens:int ->
+  overflow_retry_recovery option
 
 (** {1 Trace and Board Utilities} *)
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -142,6 +142,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
   in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block
+    |> Inference_utils.sanitize_text_utf8
   in
   (* User message: structured world observation *)
   let ubuf = Buffer.create 1024 in
@@ -256,5 +257,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
        Buffer.add_string ubuf summary;
        Buffer.add_string ubuf "\n"
    | _ -> ());
-  let user_message = Buffer.contents ubuf in
+  let user_message =
+    Buffer.contents ubuf |> Inference_utils.sanitize_text_utf8
+  in
   (system_prompt, user_message)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -28,6 +28,17 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
+let find_substring ~(needle : string) (haystack : string) : int option =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  let rec loop i =
+    if needle_len = 0 then Some 0
+    else if i + needle_len > hay_len then None
+    else if String.sub haystack i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop 0
+
 (** Detect transient TCP/TLS errors that warrant retry with backoff.
     These patterns match OAS cascade error messages for connection-level failures.
     See #4523: Connection_reset/Broken_pipe/EOF from idle TCP teardown. *)
@@ -50,6 +61,58 @@ let max_transient_retries = 2
     Delays: 1s, 2s — total wait 3s before giving up. *)
 let transient_backoff_sec (attempt : int) : float =
   Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
+
+let context_overflow_anchor = "available context size ("
+
+let context_overflow_limit (msg : string) : int option =
+  let lowered = String.lowercase_ascii msg in
+  match find_substring ~needle:context_overflow_anchor lowered with
+  | None -> None
+  | Some anchor_idx ->
+      let start_idx = anchor_idx + String.length context_overflow_anchor in
+      let rec consume_digits idx =
+        if idx >= String.length lowered then idx
+        else
+          match lowered.[idx] with
+          | '0' .. '9' -> consume_digits (idx + 1)
+          | _ -> idx
+      in
+      let end_idx = consume_digits start_idx in
+      if end_idx = start_idx then None
+      else
+        String.sub lowered start_idx (end_idx - start_idx)
+        |> int_of_string_opt
+
+let recover_context_overflow_retry
+    ~(meta : keeper_meta)
+    ~(base_dir : string)
+    ~(primary_max_context : int)
+    ~(error : string) : int option =
+  match context_overflow_limit error with
+  | None -> None
+  | Some actual_limit ->
+      let retry_max_context =
+        if primary_max_context <= 0 then actual_limit
+        else min primary_max_context actual_limit
+      in
+      let model = Keeper_exec_context.checkpoint_model_of_meta meta in
+      match
+        Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+          ~base_dir ~meta ~model
+          ~primary_model_max_tokens:retry_max_context
+      with
+      | Some recovery ->
+          Log.Keeper.warn
+            "%s: context overflow retry prepared with compacted checkpoint (%d->%d tokens, max_context=%d, generation=%d)"
+            meta.name recovery.compaction.before_tokens
+            recovery.compaction.after_tokens
+            retry_max_context recovery.turn_generation;
+          Some retry_max_context
+      | None ->
+          Log.Keeper.warn
+            "%s: context overflow detected but checkpoint recovery was unavailable: %s"
+            meta.name (short_preview error);
+          None
 
 let decision_channel_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
@@ -608,9 +671,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          across all providers).  See #4523. *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run ?(is_retry = false) () =
+          let do_run ?(is_retry = false) ~max_context () =
             Keeper_agent_run.run_turn ~config ~meta ~base_dir
-              ~max_context:primary_max_context ~build_turn_prompt
+              ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
               ~history_user_source:"world_state_prompt"
@@ -621,7 +684,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ()
           in
           let rec retry_loop attempt =
-            match do_run ~is_retry:(attempt > 1) () with
+            match do_run ~is_retry:(attempt > 1)
+                    ~max_context:primary_max_context () with
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
                            && attempt <= max_transient_retries ->
@@ -632,7 +696,15 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   (short_preview e);
                 Eio.Time.sleep (Eio_context.get_clock ()) delay;
                 retry_loop (attempt + 1)
-            | result -> result
+            | Error e -> (
+                match
+                  recover_context_overflow_retry ~meta ~base_dir
+                    ~primary_max_context ~error:e
+                with
+                | Some retry_max_context ->
+                    Eio.Fiber.yield ();
+                    do_run ~is_retry:true ~max_context:retry_max_context ()
+                | None -> Error e)
           in
           retry_loop 1)
       in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -10,34 +10,32 @@ open Keeper_types
 open Keeper_exec_context
 module Social = Keeper_social_model
 
-let string_contains_substring ~(needle : string) (haystack : string) : bool =
+let find_substring ~(needle : string) (haystack : string) : int option =
   let needle_len = String.length needle in
   let hay_len = String.length haystack in
-  if needle_len = 0 then true
-  else if needle_len > hay_len then false
-  else
-    let rec loop i =
-      if i + needle_len > hay_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else loop (i + 1)
+  let matches_at start_idx =
+    let rec loop offset =
+      if offset = needle_len then true
+      else if haystack.[start_idx + offset] <> needle.[offset] then false
+      else loop (offset + 1)
     in
     loop 0
+  in
+  let rec loop i =
+    if needle_len = 0 then Some 0
+    else if i + needle_len > hay_len then None
+    else if matches_at i then Some i
+    else loop (i + 1)
+  in
+  loop 0
+
+let string_contains_substring ~(needle : string) (haystack : string) : bool =
+  String_util.contains_substring haystack needle
 
 let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
   string_contains_substring
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
-
-let find_substring ~(needle : string) (haystack : string) : int option =
-  let needle_len = String.length needle in
-  let hay_len = String.length haystack in
-  let rec loop i =
-    if needle_len = 0 then Some 0
-    else if i + needle_len > hay_len then None
-    else if String.sub haystack i needle_len = needle then Some i
-    else loop (i + 1)
-  in
-  loop 0
 
 (** Detect transient TCP/TLS errors that warrant retry with backoff.
     These patterns match OAS cascade error messages for connection-level failures.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -64,6 +64,11 @@ let transient_backoff_sec (attempt : int) : float =
 
 let context_overflow_anchor = "available context size ("
 
+type overflow_retry_plan = {
+  retry_max_context : int;
+  retry_generation : int;
+}
+
 let context_overflow_limit (msg : string) : int option =
   let lowered = String.lowercase_ascii msg in
   match find_substring ~needle:context_overflow_anchor lowered with
@@ -83,11 +88,15 @@ let context_overflow_limit (msg : string) : int option =
         String.sub lowered start_idx (end_idx - start_idx)
         |> int_of_string_opt
 
+let meta_with_generation (meta : keeper_meta) ~(generation : int) : keeper_meta =
+  if generation = meta.runtime.generation then meta
+  else map_runtime (fun rt -> { rt with generation }) meta
+
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
     ~(primary_max_context : int)
-    ~(error : string) : int option =
+    ~(error : string) : overflow_retry_plan option =
   match context_overflow_limit error with
   | None -> None
   | Some actual_limit ->
@@ -107,7 +116,11 @@ let recover_context_overflow_retry
             meta.name recovery.compaction.before_tokens
             recovery.compaction.after_tokens
             retry_max_context recovery.turn_generation;
-          Some retry_max_context
+          Some
+            {
+              retry_max_context;
+              retry_generation = recovery.turn_generation;
+            }
       | None ->
           Log.Keeper.warn
             "%s: context overflow detected but checkpoint recovery was unavailable: %s"
@@ -671,8 +684,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          across all providers).  See #4523. *)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
-          let do_run ?(is_retry = false) ~max_context () =
-            Keeper_agent_run.run_turn ~config ~meta ~base_dir
+          let do_run ?(is_retry = false) ~(turn_meta : keeper_meta) ~generation
+              ~max_context () =
+            Keeper_agent_run.run_turn ~config ~meta:turn_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
@@ -683,8 +697,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_retry
               ()
           in
-          let rec retry_loop attempt =
-            match do_run ~is_retry:(attempt > 1)
+          let rec retry_loop attempt ~(turn_meta : keeper_meta) ~generation =
+            match do_run ~is_retry:(attempt > 1) ~turn_meta ~generation
                     ~max_context:primary_max_context () with
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
@@ -695,18 +709,24 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   meta.name attempt max_transient_retries delay
                   (short_preview e);
                 Eio.Time.sleep (Eio_context.get_clock ()) delay;
-                retry_loop (attempt + 1)
+                retry_loop (attempt + 1) ~turn_meta ~generation
             | Error e -> (
                 match
-                  recover_context_overflow_retry ~meta ~base_dir
+                  recover_context_overflow_retry ~meta:turn_meta ~base_dir
                     ~primary_max_context ~error:e
                 with
-                | Some retry_max_context ->
+                | Some retry_plan ->
+                    let retry_meta =
+                      meta_with_generation turn_meta
+                        ~generation:retry_plan.retry_generation
+                    in
                     Eio.Fiber.yield ();
-                    do_run ~is_retry:true ~max_context:retry_max_context ()
+                    do_run ~is_retry:true ~turn_meta:retry_meta
+                      ~generation:retry_plan.retry_generation
+                      ~max_context:retry_plan.retry_max_context ()
                 | None -> Error e)
           in
-          retry_loop 1)
+          retry_loop 1 ~turn_meta:meta ~generation)
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -30,7 +30,9 @@ let find_substring ~(needle : string) (haystack : string) : int option =
   loop 0
 
 let string_contains_substring ~(needle : string) (haystack : string) : bool =
-  String_util.contains_substring haystack needle
+  match find_substring ~needle haystack with
+  | Some _ -> true
+  | None -> false
 
 let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
   string_contains_substring
@@ -695,9 +697,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_retry
               ()
           in
-          let rec retry_loop attempt ~(turn_meta : keeper_meta) ~generation =
+          let rec retry_loop attempt ~(turn_meta : keeper_meta) ~generation
+              ~max_context ~allow_overflow_retry =
             match do_run ~is_retry:(attempt > 1) ~turn_meta ~generation
-                    ~max_context:primary_max_context () with
+                    ~max_context () with
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
                            && attempt <= max_transient_retries ->
@@ -708,23 +711,29 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   (short_preview e);
                 Eio.Time.sleep (Eio_context.get_clock ()) delay;
                 retry_loop (attempt + 1) ~turn_meta ~generation
+                  ~max_context ~allow_overflow_retry
             | Error e -> (
-                match
-                  recover_context_overflow_retry ~meta:turn_meta ~base_dir
-                    ~primary_max_context ~error:e
-                with
-                | Some retry_plan ->
-                    let retry_meta =
-                      meta_with_generation turn_meta
+                if not allow_overflow_retry then Error e
+                else
+                  match
+                    recover_context_overflow_retry ~meta:turn_meta ~base_dir
+                      ~primary_max_context:max_context ~error:e
+                  with
+                  | Some retry_plan ->
+                      let retry_meta =
+                        meta_with_generation turn_meta
+                          ~generation:retry_plan.retry_generation
+                      in
+                      Eio.Fiber.yield ();
+                      retry_loop 1 ~turn_meta:retry_meta
                         ~generation:retry_plan.retry_generation
-                    in
-                    Eio.Fiber.yield ();
-                    do_run ~is_retry:true ~turn_meta:retry_meta
-                      ~generation:retry_plan.retry_generation
-                      ~max_context:retry_plan.retry_max_context ()
-                | None -> Error e)
+                        ~max_context:retry_plan.retry_max_context
+                        ~allow_overflow_retry:false
+                  | None -> Error e)
           in
-          retry_loop 1 ~turn_meta:meta ~generation)
+          retry_loop 1 ~turn_meta:meta ~generation
+            ~max_context:primary_max_context
+            ~allow_overflow_retry:true)
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -68,6 +68,18 @@ val broadcast_lifecycle_events :
 (** Detect transient TCP/TLS errors eligible for retry. Exposed for testing. *)
 val is_transient_network_error : string -> bool
 
+type overflow_retry_plan = {
+  retry_max_context : int;
+  retry_generation : int;
+}
+
+val recover_context_overflow_retry :
+  meta:Keeper_types.keeper_meta ->
+  base_dir:string ->
+  primary_max_context:int ->
+  error:string ->
+  overflow_retry_plan option
+
 val run_unified_turn :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -242,6 +242,75 @@ let test_apply_post_turn_lifecycle_handoffs_after_compaction () =
             (List.length loaded.messages > 0)
       | None -> fail "expected rollover checkpoint in new trace")
 
+let test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint () =
+  let base_dir = temp_dir "keeper_lifecycle_overflow_retry_oas" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-retry-oas" () in
+      let original_ctx =
+        build_dense_context ~turns:22 ~max_tokens:4096
+          ~state_reply:
+            "done\n\n[STATE]\nGoal: retry after overflow\nProgress: ready\n[/STATE]"
+      in
+      let original_message_count = List.length original_ctx.messages in
+      ignore (save_checkpoint ~base_dir ~meta ~ctx:original_ctx);
+      match
+        KEC.recover_latest_checkpoint_for_overflow_retry ~base_dir ~meta
+          ~model:"llama:auto" ~primary_model_max_tokens:256
+      with
+      | Some recovery ->
+          check bool "compaction applied" true recovery.compaction.applied;
+          check bool "saved tokens positive" true
+            (recovery.compaction.saved_tokens > 0);
+          (match
+             load_context ~base_dir ~trace_id:meta.runtime.trace_id
+               ~max_tokens:256
+           with
+          | Some loaded ->
+              check int "checkpoint max tokens clamped" 256 loaded.max_tokens;
+              check bool "message count reduced" true
+                (List.length loaded.messages < original_message_count)
+          | None -> fail "expected compacted OAS checkpoint")
+      | None -> fail "expected overflow retry recovery from OAS checkpoint")
+
+let test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint () =
+  let base_dir = temp_dir "keeper_lifecycle_overflow_retry_legacy" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-retry-legacy" () in
+      let session =
+        KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let legacy_ctx =
+        build_dense_context ~turns:18 ~max_tokens:2048
+          ~state_reply:
+            "done\n\n[STATE]\nGoal: recover legacy checkpoint\nProgress: ready\n[/STATE]"
+      in
+      ignore (KEC.save_checkpoint session legacy_ctx ~generation:3);
+      match
+        KEC.recover_latest_checkpoint_for_overflow_retry ~base_dir ~meta
+          ~model:"llama:auto" ~primary_model_max_tokens:192
+      with
+      | Some recovery ->
+          check int "legacy generation preserved" 3 recovery.turn_generation;
+          check bool "legacy recovery compacts" true recovery.compaction.applied;
+          (match
+             load_context ~base_dir ~trace_id:meta.runtime.trace_id
+               ~max_tokens:192
+           with
+          | Some loaded ->
+              check int "legacy retry max tokens clamped" 192 loaded.max_tokens
+          | None -> fail "expected compacted checkpoint after legacy recovery")
+      | None -> fail "expected overflow retry recovery from legacy checkpoint")
+
 let () =
   run "keeper_lifecycle"
     [
@@ -253,5 +322,9 @@ let () =
             test_apply_post_turn_lifecycle_compacts_and_updates_continuity;
           test_case "handoff runs after compaction" `Quick
             test_apply_post_turn_lifecycle_handoffs_after_compaction;
+          test_case "overflow retry compacts OAS checkpoint" `Quick
+            test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint;
+          test_case "overflow retry falls back to legacy checkpoint" `Quick
+            test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -56,6 +56,17 @@ let contains_substring haystack needle =
   in
   needle_len = 0 || loop 0
 
+let contains_disallowed_control_char s =
+  let rec loop i =
+    if i >= String.length s then false
+    else
+      let code = Char.code s.[i] in
+      if (code < 32 && s.[i] <> '\n' && s.[i] <> '\r' && s.[i] <> '\t') || code = 127
+      then true
+      else loop (i + 1)
+  in
+  loop 0
+
 (* ---------- World Observation type tests ---------- *)
 
 let base_observation : WO.world_observation =
@@ -926,6 +937,41 @@ let test_prompt_prefers_silence_guidance () =
      in
      found)
 
+let test_sanitize_text_utf8_replaces_control_chars () =
+  let raw = "alpha\000beta\001gamma\n\tomega" in
+  let sanitized = Masc_mcp.Inference_utils.sanitize_text_utf8 raw in
+  check bool "no disallowed control chars" false
+    (contains_disallowed_control_char sanitized);
+  check string "content preserved with spaces" "alpha beta gamma\n\tomega"
+    sanitized
+
+let test_prompt_sanitizes_control_chars () =
+  let meta =
+    { minimal_meta with
+      instructions = "watch\000this";
+    }
+  in
+  let obs =
+    { base_observation with
+      pending_mentions = [ ("alice", "ping\001pong") ];
+      pending_board_events =
+        [
+          { sample_board_event with
+            preview = "bad\127preview";
+          };
+        ];
+    }
+  in
+  let sys, user = UP.build_prompt ~meta ~observation:obs in
+  check bool "system prompt sanitized" false
+    (contains_disallowed_control_char sys);
+  check bool "user prompt sanitized" false
+    (contains_disallowed_control_char user);
+  check bool "mention text preserved" true
+    (contains_substring user "ping pong");
+  check bool "board preview preserved" true
+    (contains_substring user "bad preview")
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -1253,6 +1299,10 @@ let () =
             test_prompt_includes_room_signal_when_flag_enabled;
           test_case "prefers silence guidance" `Quick
             test_prompt_prefers_silence_guidance;
+          test_case "sanitize_text_utf8 replaces control chars" `Quick
+            test_sanitize_text_utf8_replaces_control_chars;
+          test_case "prompt sanitizes control chars" `Quick
+            test_prompt_sanitizes_control_chars;
         ] );
       ( "config",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4,6 +4,7 @@ module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
 module KAR = Masc_mcp.Keeper_agent_run
+module KEC = Masc_mcp.Keeper_exec_context
 module KSM = Masc_mcp.Keeper_social_model
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
@@ -66,6 +67,28 @@ let contains_disallowed_control_char s =
       else loop (i + 1)
   in
   loop 0
+
+let append_dense_turn ctx idx =
+  let payload = String.make 160 'x' in
+  KEC.append ctx
+    (Agent_sdk.Types.user_msg
+       (Printf.sprintf "turn %02d user %s" idx payload))
+  |> fun next ->
+  KEC.append next
+    (Agent_sdk.Types.assistant_msg
+       (Printf.sprintf "turn %02d assistant %s" idx payload))
+
+let build_dense_retry_context ~turns ~max_tokens =
+  let rec loop idx ctx =
+    if idx > turns then ctx else loop (idx + 1) (append_dense_turn ctx idx)
+  in
+  let ctx =
+    loop 1 (KEC.create ~system_prompt:"keeper unified" ~max_tokens)
+  in
+  KEC.append ctx
+    (Agent_sdk.Types.assistant_msg
+       "done\n\n[STATE]\nGoal: retry after overflow\nProgress: ready\n[/STATE]")
+  |> KEC.sync_oas_context
 
 (* ---------- World Observation type tests ---------- *)
 
@@ -1014,6 +1037,45 @@ let test_sanitize_messages_utf8_cleans_history_path () =
        | _ -> fail "expected sanitized tool result")
   | _ -> fail "expected two sanitized messages"
 
+let test_overflow_retry_plan_preserves_recovered_generation () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let meta =
+        {
+          minimal_meta with
+          runtime =
+            {
+              minimal_meta.runtime with
+              trace_id = "trace-overflow-plan";
+              generation = 0;
+            };
+        }
+      in
+      let session =
+        KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
+      in
+      let legacy_ctx =
+        build_dense_retry_context ~turns:18 ~max_tokens:2048
+      in
+      ignore (KEC.save_checkpoint session legacy_ctx ~generation:3);
+      match
+        UT.recover_context_overflow_retry ~meta ~base_dir
+          ~primary_max_context:192
+          ~error:
+            "HTTP 400: prompt exceeds available context size (192) for this model"
+      with
+      | Some retry_plan ->
+          check int "retry generation preserved" 3
+            retry_plan.UT.retry_generation;
+          check int "retry max_context clamped" 192
+            retry_plan.retry_max_context
+      | None -> fail "expected overflow retry plan")
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -1430,5 +1492,7 @@ let () =
           test_case "empty string not transient" `Quick (fun () ->
             check bool "empty" false
               (UT.is_transient_network_error ""));
+          test_case "overflow retry plan preserves generation" `Quick
+            test_overflow_retry_plan_preserves_recovered_generation;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1037,6 +1037,16 @@ let test_sanitize_messages_utf8_cleans_history_path () =
        | _ -> fail "expected sanitized tool result")
   | _ -> fail "expected two sanitized messages"
 
+let test_sanitize_messages_utf8_reuses_clean_history_list () =
+  let msgs =
+    [
+      Agent_sdk.Types.user_msg "already clean";
+      Agent_sdk.Types.assistant_msg "still clean";
+    ]
+  in
+  let sanitized = Masc_mcp.Inference_utils.sanitize_messages_utf8 msgs in
+  check bool "same list reused" true (sanitized == msgs)
+
 let test_overflow_retry_plan_preserves_recovered_generation () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1409,6 +1419,8 @@ let () =
             test_prompt_sanitizes_control_chars;
           test_case "sanitize_messages_utf8 cleans history path" `Quick
             test_sanitize_messages_utf8_cleans_history_path;
+          test_case "sanitize_messages_utf8 reuses clean history list" `Quick
+            test_sanitize_messages_utf8_reuses_clean_history_list;
         ] );
       ( "config",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -938,11 +938,12 @@ let test_prompt_prefers_silence_guidance () =
      found)
 
 let test_sanitize_text_utf8_replaces_control_chars () =
-  let raw = "alpha\000beta\001gamma\n\tomega" in
+  let raw = "alpha\000beta\001gamma\127delta\n\tomega" in
   let sanitized = Masc_mcp.Inference_utils.sanitize_text_utf8 raw in
   check bool "no disallowed control chars" false
     (contains_disallowed_control_char sanitized);
-  check string "content preserved with spaces" "alpha beta gamma\n\tomega"
+  check string "content preserved with spaces"
+    "alpha beta gamma delta\n\tomega"
     sanitized
 
 let test_prompt_sanitizes_control_chars () =
@@ -971,6 +972,47 @@ let test_prompt_sanitizes_control_chars () =
     (contains_substring user "ping pong");
   check bool "board preview preserved" true
     (contains_substring user "bad preview")
+
+let test_sanitize_messages_utf8_cleans_history_path () =
+  let user_msg =
+    Agent_sdk.Types.
+      {
+        role = User;
+        content = [ Text "hist\000ory\127entry" ];
+        name = None;
+        tool_call_id = None;
+      }
+  in
+  let tool_msg =
+    Agent_sdk.Types.
+      {
+        role = Tool;
+        content =
+          [
+            ToolResult
+              {
+                tool_use_id = "tool\001id";
+                content = "result\127payload";
+                is_error = false;
+              };
+          ];
+        name = None;
+        tool_call_id = None;
+      }
+  in
+  let sanitized =
+    Masc_mcp.Inference_utils.sanitize_messages_utf8 [ user_msg; tool_msg ]
+  in
+  match sanitized with
+  | [ user_msg; tool_msg ] ->
+      check string "user history content sanitized" "hist ory entry"
+        (Agent_sdk.Types.text_of_message user_msg);
+      (match tool_msg.Agent_sdk.Types.content with
+       | [ Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ] ->
+           check string "tool id sanitized" "tool id" tool_use_id;
+           check string "tool payload sanitized" "result payload" content
+       | _ -> fail "expected sanitized tool result")
+  | _ -> fail "expected two sanitized messages"
 
 let test_metrics_mixed_response () =
   let result =
@@ -1303,6 +1345,8 @@ let () =
             test_sanitize_text_utf8_replaces_control_chars;
           test_case "prompt sanitizes control chars" `Quick
             test_prompt_sanitizes_control_chars;
+          test_case "sanitize_messages_utf8 cleans history path" `Quick
+            test_sanitize_messages_utf8_cleans_history_path;
         ] );
       ( "config",
         [


### PR DESCRIPTION
## Summary
- Detect keeper unified-turn failures caused by provider context overflow errors such as `request ... exceeds the available context size (8192 tokens)`.
- Recover the latest keeper checkpoint, clamp it to the provider-reported context limit, force one compaction pass, and save a compacted checkpoint for retry.
- Retry the unified turn once with the compacted checkpoint instead of repeatedly failing the same oversized request.

## Product impact
- Keepers should recover from transient context-overflow failures without manual intervention when a recent checkpoint can be compacted.
- Avoids blindly increasing context budgets beyond what the selected model/provider actually supports.

## Evidence
- Production log showed repeated failures: `Invalid request: request (8275/8513 tokens) exceeds the available context size (8192 tokens)`.
- The previous code retried transient network failures but had no dedicated recovery path for context overflow, so the same oversized checkpoint state kept failing.

## Test plan
- [x] `test/test_keeper_lifecycle.exe` overflow retry compacts OAS checkpoint
- [x] `test/test_keeper_lifecycle.exe` overflow retry falls back to legacy checkpoint
- [x] `test/test_keeper_lifecycle.exe` existing lifecycle cases `0,1,2`
- [ ] CI green

## Review evidence
- Local targeted lifecycle regression tests passed after adding overflow-recovery coverage.
- No GitHub review threads were present at PR creation time.

## Linked issue
- Fixes #4735
- Related: #4736
