### PR TITLE
fix(keeper): review followup for #4696 — reuse shared helper, add single-slash test

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -8,13 +8,7 @@ let starts_with ~(prefix : string) (s : string) : bool =
   let lp = String.length prefix in
   String.length s >= lp && String.sub s 0 lp = prefix
 
-let strip_trailing_slash s =
-  let rec find_end i =
-    if i > 0 && s.[i - 1] = '/' then find_end (i - 1) else i
-  in
-  let len = String.length s in
-  let end_pos = find_end len in
-  if end_pos = len then s else String.sub s 0 end_pos
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let normalize_path_for_check (path : string) : string =
   try Unix.realpath path
@@ -58,7 +52,7 @@ let resolve_keeper_target_path ~(config : Room.config)
       in
       let matches_any =
         List.exists (fun ap ->
-          let ap' = strip_trailing_slash ap in
+          let ap' = strip_trailing_slashes ap in
           rel = ap' || starts_with ~prefix:(ap' ^ "/") rel
         ) allowed_paths
       in

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -347,6 +347,21 @@ let test_path_allowed_paths_filter_strips_all_trailing_slashes () =
     check bool "lib path allowed with repeated trailing slash" true
       (Result.is_ok ok_result))
 
+let test_path_allowed_paths_single_trailing_slash () =
+  let dir = make_path_test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let exact_match = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:["lib/"] ~raw_path:"lib" in
+    check bool "exact dir match with single trailing slash" true
+      (Result.is_ok exact_match);
+    let subpath_match = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:["lib/"] ~raw_path:"lib/foo.ml" in
+    check bool "subpath match with single trailing slash" true
+      (Result.is_ok subpath_match))
+
 let test_path_empty_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
@@ -441,6 +456,8 @@ let () =
       test_case "allowed_paths filter" `Quick test_path_allowed_paths_filter;
       test_case "allowed_paths strip all trailing slashes" `Quick
         test_path_allowed_paths_filter_strips_all_trailing_slashes;
+      test_case "allowed_paths single trailing slash" `Quick
+        test_path_allowed_paths_single_trailing_slash;
       test_case "empty path rejected" `Quick test_path_empty_rejected;
       test_case "whitespace only rejected" `Quick test_path_whitespace_only_rejected;
       test_case "empty allowed permits all" `Quick test_path_empty_allowed_permits_all_within_root;


### PR DESCRIPTION
## Summary
- `strip_trailing_slash` 로컬 구현을 `Env_config_core.strip_trailing_slashes`로 교체 (중복 제거)
- 단일 trailing slash 테스트 추가 (원래 버그 케이스: `"lib/"` → `"lib"` 매칭)

## Review feedback addressed
- Copilot: "duplicates existing shared helpers" → `Env_config_core.strip_trailing_slashes` 재사용
- Copilot: "no regression test for single trailing slash" → `test_path_allowed_paths_single_trailing_slash` 추가

## Linked issue
Followup to #4696 (merged), addresses #4693

## Test plan
- [x] `test_keeper_tool_exposure.exe` 39 tests pass
- [x] `dune build` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>