### PR TITLE
refactor(room): remove Named scope — flatten to single .masc/ namespace

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.217.0)
+(version 2.217.1)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -255,19 +255,18 @@ module FileSystem = struct
     | Error _ -> false
     | Ok _ ->
       ensure_key_index t;
-      if Hashtbl.mem t.key_index key then true
-      else
-        (* Fallback: file may have been written outside the backend
-           (e.g. Fs_compat.append_jsonl, raw write_text_file in tests).
-           Check the actual filesystem and update the index on hit. *)
-        match key_to_path t key with
-        | Error _ -> false
-        | Ok path ->
-            (try
-               ignore (Eio.Path.load path : string);
-               Hashtbl.replace t.key_index key ();
-               true
-             with _ -> false)
+      (* Verify the real filesystem even on index hits so raw rm_rf/reset
+         cannot leave stale positives in the in-memory key index. *)
+      match key_to_path t key with
+      | Error _ -> false
+      | Ok path ->
+          (try
+             ignore (Eio.Path.load path : string);
+             Hashtbl.replace t.key_index key ();
+             true
+           with _ ->
+             Hashtbl.remove t.key_index key;
+             false)
 
   let list_keys t ~prefix =
     ensure_key_index t;

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -49,10 +49,7 @@ let active_or_recent_sessions config =
     ~limit:(Dashboard_http_helpers.dashboard_session_list_limit ()) config
   |> List.filter is_active_or_recent
 
-let room_scope_cache_segment (config : Room_utils.config) =
-  match config.scope with
-  | Room_utils_backend_setup.Default -> "default"
-  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+let room_scope_cache_segment (_config : Room_utils.config) = "default"
 
 let room_scoped_cache_key (config : Room_utils.config) prefix actor_name =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -55,10 +55,9 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
               (Room.is_agent_joined_in_room config ~room_id
                  ~agent_name:meta.agent_name)
           then begin
-            let scoped = Room.with_scope config (Room.Named room_id) in
-            Room.ensure_room_bootstrap scoped room_id;
+            Room.ensure_room_bootstrap config room_id;
             ignore
-              (Room.join scoped ~agent_name:meta.agent_name
+              (Room.join config ~agent_name:meta.agent_name
                  ~capabilities:[ "keeper" ] ())
           end;
           ignore

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -818,10 +818,9 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
               (Room.is_agent_joined_in_room config ~room_id
                  ~agent_name:meta.agent_name)
           then begin
-            let scoped = Room.with_scope config (Room.Named room_id) in
-            Room.ensure_room_bootstrap scoped room_id;
+            Room.ensure_room_bootstrap config room_id;
             ignore
-              (Room.join scoped ~agent_name:meta.agent_name
+              (Room.join config ~agent_name:meta.agent_name
                  ~capabilities:[ "keeper" ] ())
           end;
           ignore

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -465,10 +465,7 @@ let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
 
 let invalidate_snapshot_cache () = _snapshot_cache := None
 
-let room_scope_cache_segment (config : Room_utils.config) =
-  match config.scope with
-  | Room_utils_backend_setup.Default -> "default"
-  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+let room_scope_cache_segment (_config : Room_utils.config) = "default"
 
 let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = true)
     ?(include_keepers = true) ?(include_summary_fields = true)

--- a/lib/room/room_agent.ml
+++ b/lib/room/room_agent.ml
@@ -10,7 +10,7 @@ include Room_state
 let get_agents_status config =
   ensure_initialized config;
 
-  let agents_path = agents_dir (with_scope config (Named (current_room_id config))) in
+  let agents_path = agents_dir config in
   if not (Sys.file_exists agents_path) then
     `Assoc [("agents", `List []); ("count", `Int 0)]
   else begin
@@ -83,15 +83,8 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
     | Ok _ ->
         let actual_name = resolve_agent_name config agent_name in
         let filename = safe_filename actual_name ^ ".json" in
-        (* Check room-scoped agents first, then root-scoped.
-           masc_join writes to room-scoped dir, but this function
-           previously only looked in root agents_dir. *)
-        let room_file = Filename.concat (agents_dir (with_scope config (Named (current_room_id config)))) filename in
-        let root_file = Filename.concat (agents_dir config) filename in
-        let agent_file =
-          if Sys.file_exists room_file then room_file
-          else root_file
-        in
+        (* Since #4638 rooms are flattened; agents always in root agents_dir *)
+        let agent_file = Filename.concat (agents_dir config) filename in
         if not (Sys.file_exists agent_file) then
           Error (Types.AgentNotFound actual_name)
         else

--- a/lib/room/room_agent.ml
+++ b/lib/room/room_agent.ml
@@ -74,8 +74,7 @@ let register_capabilities config ~agent_name ~capabilities =
     Printf.sprintf "⚠ Agent %s not found. Join first!" agent_name
 
 (** Update agent metadata (status/capabilities).
-    BUG-1600 FIX: Check both room-scoped and root agent directories,
-    matching the lookup logic used by is_agent_joined. *)
+    Since #4638 agent metadata always lives under the root agents_dir. *)
 let update_agent_r config ~agent_name ?status ?capabilities () : string Types.masc_result =
   if not (is_initialized config) then Error Types.NotInitialized
   else match validate_agent_name_r agent_name with

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -457,58 +457,14 @@ let gc config ?(days=7) () =
     ("orphan_dets", `Int cp_result.detachments_removed);
     ("dropped_intents", `Int cp_result.intents_removed);
   ]) in
-  (* 9. Archive stale room directories (no file modified in N days).
-         Prevents .masc/rooms/ from growing unbounded and slowing down
-         snapshot computation (each room adds hundreds of JSON files). *)
-  let room_archive_count = ref 0 in
-  let rooms_root = rooms_root_dir config in
-  if Sys.file_exists rooms_root && Sys.is_directory rooms_root then begin
-    let archive_rooms_dir = Filename.concat
-      (Filename.concat (masc_root_dir config) "archive") "rooms" in
-    let now_f = Time_compat.now () in
-    let threshold_sec = float_of_int days *. 86400.0 in
-    Sys.readdir rooms_root |> Array.iter (fun room_id ->
-        Room_query.safe_yield ();
-      let room_dir = Filename.concat rooms_root room_id in
-      if Sys.is_directory room_dir then begin
-        (* Find most recent mtime across all files in the room *)
-        let max_mtime = ref 0.0 in
-        let rec scan dir =
-          (try
-            Sys.readdir dir |> Array.iter (fun name ->
-              Room_query.safe_yield ();
-              let path = Filename.concat dir name in
-              if Sys.is_directory path then scan path
-              else
-                (try
-                  let st = Unix.stat path in
-                  if st.Unix.st_mtime > !max_mtime then
-                    max_mtime := st.Unix.st_mtime
-                with Unix.Unix_error _ -> ()))
-          with Sys_error _ -> ())
-        in
-        scan room_dir;
-        let age_sec = now_f -. !max_mtime in
-        if !max_mtime > 0.0 && age_sec > threshold_sec then begin
-          mkdir_p archive_rooms_dir;
-          let dest = Filename.concat archive_rooms_dir room_id in
-          (try Unix.rename room_dir dest
-           with Unix.Unix_error _ ->
-             Log.Gc.warn "failed to archive room %s" room_id);
-          incr room_archive_count
-        end
-      end
-    )
-  end;
-  if !room_archive_count > 0 then
-    results := Printf.sprintf "📦 Archived %d stale room(s) (no activity for %d+ days)" !room_archive_count days :: !results
-  else
-    results := "✅ No stale rooms" :: !results;
+  (* 9. Room archival removed — rooms are flattened (#4638).
+     Startup migration (migrate_room_to_flat) moves active room to root. *)
+  results := "✅ Rooms flattened (no room archival needed)" :: !results;
 
   log_event config (Printf.sprintf
     "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"board_artifacts\":%d,\"governance_test_artifacts\":%d,\"governance_artifacts\":%d,\"rooms_archived\":%d,\"cp_cleanup\":%s,\"days\":%d,\"ts\":\"%s\"}"
     !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count
     board_artifact_count governance_test_artifact_count governance_artifact_count
-    !room_archive_count cp_json days (now_iso ()));
+    0 cp_json days (now_iso ()));
 
   String.concat "\n" (List.rev !results)

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -14,19 +14,18 @@ open Room_state
 
 
 (** Update agent heartbeat - must be called periodically.
-    Uses scoped config for room-specific heartbeat. *)
+    Since #4638 rooms are flattened; delegates to root config. *)
 let heartbeat_in_room config ~room_id ~agent_name =
-  let scoped = with_scope config (Named room_id) in
-  ensure_room_bootstrap scoped room_id;
+  ensure_room_bootstrap config room_id;
   let actual_name = resolve_agent_name config agent_name in
   let filename = safe_filename actual_name ^ ".json" in
-  let agent_file = Filename.concat (agents_dir scoped) filename in
-  if path_exists scoped agent_file then begin
-    with_file_lock scoped agent_file (fun () ->
-      match read_agent_with_repair scoped agent_file with
+  let agent_file = Filename.concat (agents_dir config) filename in
+  if path_exists config agent_file then begin
+    with_file_lock config agent_file (fun () ->
+      match read_agent_with_repair config agent_file with
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
-          write_json scoped agent_file (agent_to_yojson updated);
+          write_json config agent_file (agent_to_yojson updated);
           Printf.sprintf "💓 %s heartbeat updated in %s" actual_name room_id
       | Error e ->
           Log.Room.debug "heartbeat_scoped: invalid agent JSON for %s in %s: %s"

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -24,7 +24,6 @@ let init config ~agent_name =
       root_perpetual_dir;
       root_tasks_dir;
       root_messages_dir;
-      rooms_root_dir config;
     ];
   if not (path_exists_root config (root_state_path config)) then begin
     let root_state = {

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -70,26 +70,28 @@ let init config ~agent_name =
       messages_dir config;
     ];
 
-    (* Create initial state *)
-    let state = {
-      protocol_version = "0.1.0";
-      project = Filename.basename config.base_path;
-      started_at = now_iso ();
-      message_seq = 0;
-      active_agents = [];
-      paused = false;
-      pause_reason = None;
-      paused_by = None;
-      paused_at = None;
-      search_strategy_default = Some "best_first_v1";
-      speculation_enabled = false;
-      speculation_budget = None;
-    } in
-    write_state config state;
+    if not (path_exists config (state_path config)) then begin
+      let state = {
+        protocol_version = "0.1.0";
+        project = Filename.basename config.base_path;
+        started_at = now_iso ();
+        message_seq = 0;
+        active_agents = [];
+        paused = false;
+        pause_reason = None;
+        paused_by = None;
+        paused_at = None;
+        search_strategy_default = Some "best_first_v1";
+        speculation_enabled = false;
+        speculation_budget = None;
+      } in
+      write_state config state
+    end;
 
-    (* Create empty backlog *)
-    let backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
-    write_backlog config backlog;
+    if not (path_exists config (backlog_path config)) then begin
+      let backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
+      write_backlog config backlog
+    end;
 
     let result = "✅ MASC room created!" in
 

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -160,8 +160,9 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     nickname nickname agent_type session_id
   end
 
-(** @deprecated Since #4638 rooms are flattened; room_id is ignored.
-    Kept for callers that still pass a room_id parameter. *)
+(** @deprecated Since #4638 storage is flattened to the default scope.
+    This compat helper still accepts [room_id] and preserves it in legacy
+    messages/log entries, but agent state is shared with [join]. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
   ensure_room_bootstrap config room_id;

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -7,10 +7,7 @@ open Types
 open Room_utils
 open Room_state
 
-let room_id_of_config (config : Room_utils_backend_setup.config) =
-  match config.scope with
-  | Default -> "default"
-  | Named id -> id
+let room_id_of_config (_config : Room_utils_backend_setup.config) = "default"
 
 (** Join room - with auto-generated nickname and metadata *)
 let join config ~agent_name ?(agent_type_override=None) ~capabilities
@@ -163,11 +160,10 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     nickname nickname agent_type session_id
   end
 
-(** @deprecated Use [join (with_scope config (Named room_id))] instead. *)
+(** @deprecated Since #4638 rooms are flattened; delegates to [join config]. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
-  let scoped = with_scope config (Named room_id) in
-  ensure_room_bootstrap scoped room_id;
+  ensure_room_bootstrap config room_id;
 
   let agent_type = match agent_type_override with
     | Some t -> t
@@ -180,22 +176,22 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
   let nickname =
     if Nickname.is_generated_nickname agent_name then agent_name
     else
-      let resolved = resolve_agent_name (with_scope config (Named room_id)) agent_name in
+      let resolved = resolve_agent_name config agent_name in
       if resolved <> agent_name && Nickname.is_generated_nickname resolved then
         resolved
       else
         Nickname.generate agent_type
   in
   let agent_file_dedup =
-    Filename.concat (agents_dir scoped) (safe_filename nickname ^ ".json")
+    Filename.concat (agents_dir config) (safe_filename nickname ^ ".json")
   in
   if Sys.file_exists agent_file_dedup then begin
     (* Lock the agent file to prevent race with heartbeat writes.
        read-modify-write must be atomic; without this lock, a concurrent
        heartbeat can update current_task/status between our read and write,
        and the rejoin write would silently discard those changes. *)
-    let was_inactive = with_file_lock scoped agent_file_dedup (fun () ->
-      match read_agent_with_repair scoped agent_file_dedup with
+    let was_inactive = with_file_lock config agent_file_dedup (fun () ->
+      match read_agent_with_repair config agent_file_dedup with
       | Ok existing_agent ->
           let is_inactive = existing_agent.status = Inactive in
           let updated = { existing_agent with
@@ -203,23 +199,23 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
             last_seen = now_iso ();
             capabilities;
           } in
-          write_json scoped agent_file_dedup (agent_to_yojson updated);
+          write_json config agent_file_dedup (agent_to_yojson updated);
           is_inactive
       | Error e ->
           Log.Room.warn "agent dedup: invalid agent JSON for %s: %s" nickname e;
           false
     ) in
     if was_inactive then begin
-      let _ = update_state scoped (fun s ->
+      let _ = update_state config (fun s ->
         let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
         { s with active_agents = agents }
       ) in
-      let _ = broadcast scoped ~from_agent:nickname
+      let _ = broadcast config ~from_agent:nickname
                 ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname room_id) in
-      log_event scoped (Printf.sprintf
+      log_event config (Printf.sprintf
         "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
         room_id nickname (now_iso ()));
-      !Room_hooks.observe_agent_lifecycle_fn scoped ~agent_id:nickname ~room_id
+      !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname ~room_id
         ~event_kind:"rejoin"
         ~details:(`Assoc [ ("rejoin", `Bool true) ]);
     end;
@@ -236,7 +232,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       parent_task;
     } in
     let agent_file =
-      Filename.concat (agents_dir scoped) (safe_filename nickname ^ ".json")
+      Filename.concat (agents_dir config) (safe_filename nickname ^ ".json")
     in
     let agent = {
       name = nickname;
@@ -248,16 +244,16 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       last_seen = now_iso ();
       meta = Some meta;
     } in
-    write_json scoped agent_file (agent_to_yojson agent);
-    let _ = update_state scoped (fun s ->
+    write_json config agent_file (agent_to_yojson agent);
+    let _ = update_state config (fun s ->
       let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
       { s with active_agents = agents }
     ) in
     let _ =
-      broadcast scoped ~from_agent:nickname
+      broadcast config ~from_agent:nickname
         ~content:(Printf.sprintf "👋 %s joined the room" nickname)
     in
-    log_event scoped (Printf.sprintf
+    log_event config (Printf.sprintf
       "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
       room_id
       nickname
@@ -265,7 +261,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       session_id
       (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
       (now_iso ()));
-    !Room_hooks.observe_agent_lifecycle_fn scoped ~agent_id:nickname ~room_id
+    !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname ~room_id
       ~event_kind:"join"
       ~details:
         (`Assoc

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -160,7 +160,8 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     nickname nickname agent_type session_id
   end
 
-(** @deprecated Since #4638 rooms are flattened; delegates to [join config]. *)
+(** @deprecated Since #4638 rooms are flattened; room_id is ignored.
+    Kept for callers that still pass a room_id parameter. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
   ensure_room_bootstrap config room_id;

--- a/lib/room/room_multi.ml
+++ b/lib/room/room_multi.ml
@@ -9,8 +9,8 @@ open Room_utils
 (** Get current room file path (legacy) *)
 let current_room_path config = current_room_root_path config
 
-(** Always returns [Some "default"] since #4638. *)
-let read_current_room _config = Some "default"
+(** Delegate to the shared reader so legacy-state warnings still fire. *)
+let read_current_room config = Room_utils.read_current_room config
 
 (** Write current room ID -- no-op since #4638 (rooms removed). *)
 let write_current_room _config _room_id = ()

--- a/lib/room/room_multi.ml
+++ b/lib/room/room_multi.ml
@@ -1,62 +1,19 @@
 (** Room current-room helpers.
 
-    Keeps the current-room pointer durable while avoiding named-room registry
-    management. *)
+    Since #4638 the multi-room abstraction has been removed.
+    All state lives under the root .masc/ directory.
+    These functions are kept for API compatibility. *)
 
 open Room_utils
 
-(** Get current room file path *)
+(** Get current room file path (legacy) *)
 let current_room_path config = current_room_root_path config
 
-(** Mtime-based cache for current_room: avoids re-reading the file when
-    the modification time has not changed.  The file is tiny (~10 bytes)
-    and updates are rare (only via masc_set_room), so a single stat()
-    to check mtime is a safe substitute for open+read+close. *)
-let current_room_cache : (string * float * string option) ref =
-  ref ("", 0.0, None)
+(** Always returns [Some "default"] since #4638. *)
+let read_current_room _config = Some "default"
 
-let read_current_room config =
-  let read_from path =
-    match Safe_ops.read_file_safe path with
-    | Ok content ->
-      let trimmed = String.trim content in
-      if trimmed = "" then None else Some trimmed
-    | Error _ -> None
-  in
-  let path = current_room_path config in
-  let mtime =
-    try (Unix.stat path).Unix.st_mtime
-    with Unix.Unix_error _ -> 0.0
-  in
-  let (cached_path, cached_mtime, cached_value) = !current_room_cache in
-  if String.equal cached_path path && Float.equal mtime cached_mtime
-     && mtime > 0.0 then
-    cached_value
-  else begin
-    let result =
-      match read_from path with
-      | Some room_id -> Some room_id
-      | None -> Some "default"
-    in
-    current_room_cache := (path, mtime, result);
-    result
-  end
+(** Write current room ID -- no-op since #4638 (rooms removed). *)
+let write_current_room _config _room_id = ()
 
-(** Write current room ID *)
-let write_current_room config room_id =
-  let room_id =
-    match validate_room_id room_id with
-    | Ok room_id -> room_id
-    | Error msg -> invalid_arg ("invalid room_id: " ^ msg)
-  in
-  let write_to path =
-    Fs_compat.mkdir_p (Filename.dirname path);
-    Fs_compat.save_file path (room_id ^ "\n")
-  in
-  (* Canonical location inside .masc/ *)
-  write_to (current_room_path config);
-  (* Invalidate the mtime cache so next read picks up the new value *)
-  current_room_cache := ("", 0.0, None)
-
-(** Get path for a specific room *)
-let room_path config room_id = room_dir_for config room_id
+(** Get path for a specific room -- always returns [masc_root_dir] since #4638. *)
+let room_path config _room_id = masc_root_dir config

--- a/lib/room/room_multi.ml
+++ b/lib/room/room_multi.ml
@@ -12,8 +12,15 @@ let current_room_path config = current_room_root_path config
 (** Delegate to the shared reader so legacy-state warnings still fire. *)
 let read_current_room config = Room_utils.read_current_room config
 
-(** Write current room ID -- no-op since #4638 (rooms removed). *)
-let write_current_room _config _room_id = ()
+(** Persist the current-room label for dashboards and compat callers.
+    Storage stays flattened; this only updates the display pointer. *)
+let write_current_room config room_id =
+  match Room_utils.validate_room_id room_id with
+  | Ok valid_room_id ->
+      Room_utils.mkdir_p (masc_root_dir config);
+      Room_utils.write_text config (current_room_root_path config)
+        (valid_room_id ^ "\n")
+  | Error _ -> ()
 
 (** Get path for a specific room -- always returns [masc_root_dir] since #4638. *)
 let room_path config _room_id = masc_root_dir config

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -91,24 +91,22 @@ let load_agents_from_dir config dir ~include_inactive =
 (** Get raw agent list (for orchestrator) *)
 let get_agents_raw config =
   ensure_initialized config;
-  let agents_path =
-    agents_dir (with_scope config (Named (current_room_id config)))
-  in
+  let agents_path = agents_dir config in
   load_agents_from_dir config agents_path ~include_inactive:true
 
-let get_agents_raw_in_room config room_id =
+let get_agents_raw_in_room config _room_id =
   if not (root_is_initialized config) then []
   else
-    let agents_path = agents_dir (with_scope config (Named room_id)) in
+    let agents_path = agents_dir config in
     load_agents_from_dir config agents_path ~include_inactive:false
 
 (** Like [get_agents_raw_in_room] but includes Inactive agents.
     Useful for keeper backlog-triage enrollment where inactive agents
     should still participate as a fallback. *)
-let get_all_agents_in_room config room_id =
+let get_all_agents_in_room config _room_id =
   if not (root_is_initialized config) then []
   else
-    let agents_path = agents_dir (with_scope config (Named room_id)) in
+    let agents_path = agents_dir config in
     load_agents_from_dir config agents_path ~include_inactive:true
 
 (** Audit tasks: find claimed/in_progress tasks whose assignees are not active agents.
@@ -149,20 +147,14 @@ let is_agent_active_at_path config path =
        | Ok agent -> agent.status <> Inactive
        | Error _ -> false)
 
-let is_agent_joined_in_room config ~room_id ~agent_name =
+let is_agent_joined_in_room config ~room_id:_ ~agent_name =
   if not (root_is_initialized config) then false
   else
-    let actual_name = resolve_agent_name (with_scope config (Named room_id)) agent_name in
+    let actual_name = resolve_agent_name config agent_name in
     let filename = safe_filename actual_name ^ ".json" in
-    (* Check room-scoped path first *)
-    let room_agents = agents_dir (with_scope config (Named room_id)) in
-    let room_path = Filename.concat room_agents filename in
-    if is_agent_active_at_path config room_path then true
-    else
-      (* Fallback: check root agents_dir (where default join writes) *)
-      let root_agents = agents_dir config in
-      let root_path = Filename.concat root_agents filename in
-      is_agent_active_at_path config root_path
+    let agents_path = agents_dir config in
+    let agent_path = Filename.concat agents_path filename in
+    is_agent_active_at_path config agent_path
 
 (** Check if an agent has joined the room *)
 let is_agent_joined config ~agent_name =

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -132,14 +132,14 @@ let update_state config f =
     new_state
   )
 
-let read_state_in_room config room_id =
-  read_state (with_scope config (Named room_id))
+let read_state_in_room config _room_id =
+  read_state config
 
-let write_state_in_room config room_id state =
-  write_state (with_scope config (Named room_id)) state
+let write_state_in_room config _room_id state =
+  write_state config state
 
-let update_state_in_room config room_id f =
-  update_state (with_scope config (Named room_id)) f
+let update_state_in_room config _room_id f =
+  update_state config f
 
 (* ============================================ *)
 (* Sequence Numbers                             *)
@@ -150,8 +150,8 @@ let next_seq config =
   let state = update_state config (fun s -> { s with message_seq = s.message_seq + 1 }) in
   state.message_seq
 
-let next_seq_in_room config room_id =
-  next_seq (with_scope config (Named room_id))
+let next_seq_in_room config _room_id =
+  next_seq config
 
 (* ============================================ *)
 (* Pause State                                  *)
@@ -188,10 +188,7 @@ let write_backlog config backlog =
 let current_room_id config =
   read_current_room config |> Option.value ~default:"default"
 
-let activity_room_id config =
-  match config.scope with
-  | Default -> "default"
-  | Named id -> id
+let activity_room_id _config = "default"
 
 let emit_message_activity config ~from_agent ~content ~mention
     ?session_id ?operation_id ?worker_run_id ?(evidence_refs = []) () =
@@ -240,17 +237,17 @@ let emit_message_activity config ~from_agent ~content ~mention
         ~tags:[ "message"; "mention" ] ()
   | _ -> ()
 
-let tasks_dir_in_room config room_id =
-  tasks_dir (with_scope config (Named room_id))
+let tasks_dir_in_room config _room_id =
+  tasks_dir config
 
-let messages_dir_in_room config room_id =
-  messages_dir (with_scope config (Named room_id))
+let messages_dir_in_room config _room_id =
+  messages_dir config
 
-let backlog_path_in_room config room_id =
-  backlog_path (with_scope config (Named room_id))
+let backlog_path_in_room config _room_id =
+  backlog_path config
 
-let read_backlog_in_room config room_id =
-  read_backlog (with_scope config (Named room_id))
+let read_backlog_in_room config _room_id =
+  read_backlog config
 
 (* ============================================ *)
 (* Task ID / Archive Management                 *)
@@ -406,7 +403,6 @@ let ensure_room_bootstrap config room_id =
       root_perpetual_dir;
       root_tasks_dir;
       root_messages_dir;
-      rooms_root_dir config;
     ];
   if not (path_exists_root config (root_state_path config)) then
     write_json_root config (root_state_path config)
@@ -415,18 +411,18 @@ let ensure_room_bootstrap config room_id =
     write_json_root config root_backlog_path
       (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 });
 
-  (* 2. Bootstrap the target room via scoped config — unified path *)
-  let scoped = with_scope config (Named room_id) in
-  let scoped_agents = agents_dir scoped in
-  let scoped_tasks = tasks_dir scoped in
-  let scoped_messages = messages_dir scoped in
-  let scoped_state = state_path scoped in
-  let scoped_backlog = backlog_path scoped in
-  List.iter mkdir_p [ masc_dir scoped; scoped_agents; scoped_tasks; scoped_messages ];
-  if not (path_exists scoped scoped_state) then
-    write_json scoped scoped_state (room_state_to_yojson (default_room_state config));
-  if not (path_exists scoped scoped_backlog) then
-    write_json scoped scoped_backlog
+  (* 2. Bootstrap target room — since #4638 always resolves to root .masc/ *)
+  ignore room_id;
+  let scoped_agents = agents_dir config in
+  let scoped_tasks = tasks_dir config in
+  let scoped_messages = messages_dir config in
+  let scoped_state = state_path config in
+  let scoped_backlog = backlog_path config in
+  List.iter mkdir_p [ masc_dir config; scoped_agents; scoped_tasks; scoped_messages ];
+  if not (path_exists config scoped_state) then
+    write_json config scoped_state (room_state_to_yojson (default_room_state config));
+  if not (path_exists config scoped_backlog) then
+    write_json config scoped_backlog
       (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 })
 
 (* ============================================ *)
@@ -452,7 +448,7 @@ let broadcast config ~from_agent ~content =
       (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
   in
   write_json config msg_file (message_to_yojson msg);
-  let room_id = match config.scope with Default -> "default" | Named id -> id in
+  let room_id = "default" in
   (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
    | Ok _ -> ()

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -383,11 +383,6 @@ let resolve_agent_name config agent_name =
 (* ============================================ *)
 
 let ensure_room_bootstrap config room_id =
-  let room_id =
-    match validate_room_id room_id with
-    | Ok room_id -> room_id
-    | Error msg -> invalid_arg ("invalid room_id: " ^ msg)
-  in
   (* 1. Always ensure root infrastructure exists *)
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
@@ -425,6 +420,9 @@ let ensure_room_bootstrap config room_id =
     write_json config scoped_backlog
       (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 })
 
+let broadcast_channel config =
+  Printf.sprintf "broadcast:%s:default" (project_prefix config)
+
 (* ============================================ *)
 (* Broadcast                                    *)
 (* ============================================ *)
@@ -449,7 +447,7 @@ let broadcast config ~from_agent ~content =
   in
   write_json config msg_file (message_to_yojson msg);
   let room_id = "default" in
-  (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
+  (match backend_publish config ~channel:(broadcast_channel config)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
    | Ok _ -> ()
    | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id (Backend_types.show_error e));

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -4,10 +4,7 @@ open Types
 include Room_utils
 include Room_state
 
-let activity_room_id (config : Room_utils.config) =
-  match config.scope with
-  | Default -> "default"
-  | Named id -> id
+let activity_room_id _config = "default"
 
 let emit_task_activity config ~agent_name ~task_id ~kind ~payload =
   try

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -7,10 +7,11 @@ type storage_backend =
   | PostgresNative of Backend.Postgres.t
 
 (** Room scope — determines which directory tree is active.
-    Resolved once at config creation time, never re-read from filesystem. *)
+    Resolved once at config creation time, never re-read from filesystem.
+    Since #4638 the Named variant has been removed; all state lives under
+    the root .masc/ directory directly. *)
 type scope =
   | Default          (** Root .masc/ directory *)
-  | Named of string  (** .masc/rooms/{id}/ directory *)
 
 (** Room configuration *)
 type config = {

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -9,50 +9,27 @@ let masc_root_dir config =
       let seg = sanitize_namespace_segment other in
       Filename.concat (Filename.concat masc_root "clusters") seg
 
+(** @deprecated Kept for backward-compat; always returns [masc_root_dir]. *)
 let rooms_root_dir config = Filename.concat (masc_root_dir config) "rooms"
 let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.json"
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"
 
-(** Read current room ID from .masc/current_room. *)
-let read_current_room config =
-  let read_from path =
-    match Safe_ops.read_file_safe path with
-    | Ok content ->
-      let trimmed = String.trim content in
-      if trimmed = "" then None
-      else
-        (match String.split_on_char '\n' trimmed with
-         | line :: _ -> Some (String.trim line)
-         | [] -> None)
-    | Error _ -> None
-  in
-  match read_from (current_room_root_path config) with
-  | Some room_id -> Some room_id
-  | None -> Some "default"
+(** Read current room ID.
+    Since #4638 rooms are removed; always returns [Some "default"]. *)
+let read_current_room _config = Some "default"
 
-let room_dir_for config room_id =
-  if room_id = "default" then
-    masc_root_dir config
-  else
-    Filename.concat (rooms_root_dir config) room_id
+(** @deprecated Since #4638 all rooms resolve to [masc_root_dir]. *)
+let room_dir_for config _room_id = masc_root_dir config
 
-(** Resolve the initial scope from the current_room file.
-    Called once at config creation time; the result is stored in config.scope
-    so that all subsequent path lookups are pure and deterministic. *)
-let resolve_initial_scope config =
-  match read_current_room config with
-  | Some "default" | None -> Default
-  | Some room_id -> Named room_id
+(** Resolve the initial scope.
+    Since #4638 always returns [Default]. *)
+let resolve_initial_scope _config = Default
 
 (** Scope-based directory resolution.
-    Both branches are pure — no filesystem reads.
-    Default scope resolves to the root .masc/ directory.
-    Named scope resolves to .masc/rooms/{id}/.
-    Callers that need the current_room file must call
-    [config_with_resolved_scope] at config creation time. *)
+    Since #4638 scope is always [Default], so this always returns
+    [masc_root_dir config]. *)
 let masc_dir config =
   match config.scope with
-  | Named id -> room_dir_for config id
   | Default -> masc_root_dir config
 
 let agents_dir config = Filename.concat (masc_dir config) "agents"

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -9,7 +9,8 @@ let masc_root_dir config =
       let seg = sanitize_namespace_segment other in
       Filename.concat (Filename.concat masc_root "clusters") seg
 
-(** @deprecated Kept for backward-compat; always returns [masc_root_dir]. *)
+(** @deprecated Since #4638. Still returns [masc_root_dir ^ "/rooms"] for
+    migration code that needs to locate legacy room directories. *)
 let rooms_root_dir config = Filename.concat (masc_root_dir config) "rooms"
 let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.json"
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -16,10 +16,16 @@ let rooms_root_dir config = Filename.concat (masc_root_dir config) "rooms"
 let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.json"
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"
 
-let warned_about_legacy_room_state = ref false
+let warned_legacy_room_roots = Atomic.make []
 
-let reset_legacy_room_warning_for_testing () =
-  warned_about_legacy_room_state := false
+let rec mark_legacy_room_warning_emitted masc_root =
+  let warned = Atomic.get warned_legacy_room_roots in
+  if List.mem masc_root warned then
+    false
+  else if Atomic.compare_and_set warned_legacy_room_roots warned (masc_root :: warned) then
+    true
+  else
+    mark_legacy_room_warning_emitted masc_root
 
 let read_legacy_current_room config =
   let path = current_room_root_path config in
@@ -45,17 +51,17 @@ let legacy_room_dirs_exist config =
   with _ -> false
 
 let warn_if_legacy_room_state_exists config =
-  if not !warned_about_legacy_room_state then
-    let legacy_current_room =
-      match read_legacy_current_room config with
-      | Some room_id when room_id <> "default" -> Some room_id
-      | _ -> None
-    in
-    let has_legacy_rooms = legacy_room_dirs_exist config in
-    match legacy_current_room, has_legacy_rooms with
-    | None, false -> ()
-    | _ ->
-        warned_about_legacy_room_state := true;
+  let legacy_current_room =
+    match read_legacy_current_room config with
+    | Some room_id when room_id <> "default" -> Some room_id
+    | _ -> None
+  in
+  let has_legacy_rooms = legacy_room_dirs_exist config in
+  match legacy_current_room, has_legacy_rooms with
+  | None, false -> ()
+  | _ ->
+      let masc_root = masc_root_dir config in
+      if mark_legacy_room_warning_emitted masc_root then
         let detail =
           match legacy_current_room, has_legacy_rooms with
           | Some room_id, true ->

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -9,15 +9,76 @@ let masc_root_dir config =
       let seg = sanitize_namespace_segment other in
       Filename.concat (Filename.concat masc_root "clusters") seg
 
-(** @deprecated Since #4638. Still returns [masc_root_dir ^ "/rooms"] for
-    migration code that needs to locate legacy room directories. *)
+(** @deprecated Since #4638. Still returns
+    [Filename.concat (masc_root_dir config) "rooms"] for migration code that
+    needs to locate legacy room directories. *)
 let rooms_root_dir config = Filename.concat (masc_root_dir config) "rooms"
 let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.json"
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"
 
+let warned_about_legacy_room_state = ref false
+
+let reset_legacy_room_warning_for_testing () =
+  warned_about_legacy_room_state := false
+
+let read_legacy_current_room config =
+  let path = current_room_root_path config in
+  if Sys.file_exists path then
+    try
+      let ic = open_in path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          match String.trim (input_line ic) with
+          | "" -> None
+          | room_id -> Some room_id)
+    with _ -> None
+  else
+    None
+
+let legacy_room_dirs_exist config =
+  let path = rooms_root_dir config in
+  Sys.file_exists path
+  &&
+  try
+    Sys.is_directory path && Array.length (Sys.readdir path) > 0
+  with _ -> false
+
+let warn_if_legacy_room_state_exists config =
+  if not !warned_about_legacy_room_state then
+    let legacy_current_room =
+      match read_legacy_current_room config with
+      | Some room_id when room_id <> "default" -> Some room_id
+      | _ -> None
+    in
+    let has_legacy_rooms = legacy_room_dirs_exist config in
+    match legacy_current_room, has_legacy_rooms with
+    | None, false -> ()
+    | _ ->
+        warned_about_legacy_room_state := true;
+        let detail =
+          match legacy_current_room, has_legacy_rooms with
+          | Some room_id, true ->
+              Printf.sprintf
+                "legacy current_room=%S and room data under %S will be ignored"
+                room_id (rooms_root_dir config)
+          | Some room_id, false ->
+              Printf.sprintf "legacy current_room=%S will be ignored" room_id
+          | None, true ->
+              Printf.sprintf "legacy room data under %S will be ignored"
+                (rooms_root_dir config)
+          | None, false -> ""
+        in
+        Log.Room.warn
+          "Legacy room-scoped state detected; startup now always resolves to the default scope and %s."
+          detail
+
 (** Read current room ID.
-    Since #4638 rooms are removed; always returns [Some "default"]. *)
-let read_current_room _config = Some "default"
+    Since #4638 rooms are removed; always returns [Some "default"].
+    Emits a one-time warning when legacy room-scoped state is detected. *)
+let read_current_room config =
+  warn_if_legacy_room_state_exists config;
+  Some "default"
 
 (** @deprecated Since #4638 all rooms resolve to [masc_root_dir]. *)
 let room_dir_for config _room_id = masc_root_dir config

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -50,6 +50,23 @@ let legacy_room_dirs_exist config =
     Sys.is_directory path && Array.length (Sys.readdir path) > 0
   with _ -> false
 
+let normalize_current_room_label room_id =
+  let room_id = String.trim room_id in
+  if room_id = "" then None
+  else if room_id = "." || room_id = ".." then None
+  else if String.contains room_id '/' || String.contains room_id '\\' then None
+  else if String_util.contains_substring room_id ".." then None
+  else if
+    not
+      (Re.execp
+         (Re.compile
+            Re.(whole_string (rep1 (alt [ rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-' ]))))
+         room_id)
+  then
+    None
+  else
+    Some room_id
+
 let warn_if_legacy_room_state_exists config =
   let legacy_current_room =
     match read_legacy_current_room config with
@@ -79,12 +96,18 @@ let warn_if_legacy_room_state_exists config =
           "Legacy room-scoped state detected; startup now always resolves to the default scope and %s."
           detail
 
-(** Read current room ID.
-    Since #4638 rooms are removed; always returns [Some "default"].
-    Emits a one-time warning when legacy room-scoped state is detected. *)
 let read_current_room config =
-  warn_if_legacy_room_state_exists config;
-  Some "default"
+  let has_legacy_rooms = legacy_room_dirs_exist config in
+  if has_legacy_rooms then (
+    warn_if_legacy_room_state_exists config;
+    Some "default")
+  else
+    match read_legacy_current_room config with
+    | Some room_id -> (
+        match normalize_current_room_label room_id with
+        | Some valid_room_id -> Some valid_room_id
+        | None -> Some "default")
+    | None -> Some "default"
 
 (** @deprecated Since #4638 all rooms resolve to [masc_root_dir]. *)
 let room_dir_for config _room_id = masc_root_dir config

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -60,10 +60,7 @@ let with_dashboard_timeout ~clock compute =
         ("generated_at", `String (Types.now_iso ()));
       ]
 
-let room_scope_cache_segment (config : Room.config) =
-  match config.scope with
-  | Room_utils_backend_setup.Default -> "default"
-  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+let room_scope_cache_segment (_config : Room.config) = "default"
 
 let room_scoped_cache_key (config : Room.config) prefix suffix =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -162,6 +162,25 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
 let migrate_legacy_keeper_dirs_blocking (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("resident-keepers", "keepers") ]
 
+let migrate_room_to_flat (state : Mcp_server.server_state) =
+  let masc_root = Room.masc_root_dir state.room_config in
+  let rooms_dir = Filename.concat masc_root "rooms" in
+  if not (Sys.file_exists rooms_dir) then ()
+  else begin
+    let current_room =
+      let p = Filename.concat masc_root "current_room" in
+      if Sys.file_exists p then String.trim (Fs_compat.load_file p)
+      else "focus-room"
+    in
+    let room_dir = Filename.concat rooms_dir current_room in
+    if Sys.file_exists room_dir && Sys.is_directory room_dir then begin
+      Log.Misc.info "migrate: flattening room %s to .masc/ root" current_room;
+      migrate_legacy_dirs_with_renames state
+        [ (Filename.concat "rooms" current_room, ".") ]
+    end else
+      Log.Misc.warn "migrate: rooms/ exists but active room %s not found" current_room
+  end
+
 let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("perpetual", "traces") ]
 
@@ -171,6 +190,7 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
      Keeper autoboot and other bootstrap readers should see the canonical paths
      on their first pass, not rely on a later lazy migration task. *)
   migrate_legacy_keeper_dirs_blocking state;
+  migrate_room_to_flat state;
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_prompt_state (state : Mcp_server.server_state) =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -162,16 +162,34 @@ let migrate_legacy_dirs (state : Mcp_server.server_state) =
 let migrate_legacy_keeper_dirs_blocking (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("resident-keepers", "keepers") ]
 
+let default_room_for_flat_migration = "focus-room"
+
+let load_current_room_or_default masc_root =
+  let path = Filename.concat masc_root "current_room" in
+  if not (Sys.file_exists path) then
+    default_room_for_flat_migration
+  else
+    match Safe_ops.read_file_safe path with
+    | Error msg ->
+        Log.Misc.warn
+          "migrate: failed to read %s (%s); falling back to %s"
+          path msg default_room_for_flat_migration;
+        default_room_for_flat_migration
+    | Ok raw -> (
+        match Room.validate_room_id (String.trim raw) with
+        | Ok room_id -> room_id
+        | Error msg ->
+            Log.Misc.warn
+              "migrate: ignoring invalid current_room in %s (%s); falling back to %s"
+              path msg default_room_for_flat_migration;
+            default_room_for_flat_migration)
+
 let migrate_room_to_flat (state : Mcp_server.server_state) =
   let masc_root = Room.masc_root_dir state.room_config in
   let rooms_dir = Filename.concat masc_root "rooms" in
   if not (Sys.file_exists rooms_dir) then ()
   else begin
-    let current_room =
-      let p = Filename.concat masc_root "current_room" in
-      if Sys.file_exists p then String.trim (Fs_compat.load_file p)
-      else "focus-room"
-    in
+    let current_room = load_current_room_or_default masc_root in
     let room_dir = Filename.concat rooms_dir current_room in
     if Sys.file_exists room_dir && Sys.is_directory room_dir then begin
       Log.Misc.info "migrate: flattening room %s to .masc/ root" current_room;
@@ -185,12 +203,15 @@ let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("perpetual", "traces") ]
 
 let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
-  let (_init_msg : string) = Room.init state.room_config ~agent_name:None in
+  (* Promote legacy room/keeper state before Room.init seeds fresh root files.
+     Otherwise state.json/backlog.json can be created in the destination first
+     and valid legacy data gets quarantined as a conflict on upgrade. *)
+  migrate_room_to_flat state;
   (* Promote legacy keeper metadata before any startup readers scan .masc/keepers.
      Keeper autoboot and other bootstrap readers should see the canonical paths
      on their first pass, not rely on a later lazy migration task. *)
   migrate_legacy_keeper_dirs_blocking state;
-  migrate_room_to_flat state;
+  let (_init_msg : string) = Room.init state.room_config ~agent_name:None in
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_prompt_state (state : Mcp_server.server_state) =

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -292,10 +292,7 @@ let normalize_worker_run_meta_json config ~session_id ~worker_run_id json =
         |> assoc_put_string_list "evidence_refs" evidence_refs)
   | _ -> json
 
-let activity_room_id (config : Room_utils.config) =
-  match config.scope with
-  | Default -> "default"
-  | Named id -> id
+let activity_room_id (_config : Room_utils.config) = "default"
 
 let detail_string key detail =
   match Yojson.Safe.Util.member key detail with

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -3,10 +3,7 @@
     (recall, board, conversation).
     Returns [Some (success, message)] if handled, [None] otherwise. *)
 
-let activity_room_id (config : Room_utils.config) =
-  match config.scope with
-  | Default -> "default"
-  | Named id -> id
+let activity_room_id (_config : Room_utils.config) = "default"
 
 let emit_activity config ~kind ~actor ?subject ?(tags = []) ~payload () =
   try

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -159,10 +159,7 @@ let int_field key json =
   | Some (`Intlit raw) -> Safe_ops.int_of_string_with_default ~default:0 raw
   | _ -> 0
 
-let room_id_from_config (config : Room.config) =
-  match config.scope with
-  | Room_utils_backend_setup.Named room_id -> room_id
-  | _ -> "default"
+let room_id_from_config (_config : Room.config) = "default"
 
 let cluster_summary_json (_config : Room.config) =
   (* Transport health should stay metrics-only and avoid command-plane/Room I/O. *)

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -1,84 +1,51 @@
+(** Multi-room tests — reduced to flat namespace verification after #4638. *)
+
 open Alcotest
 open Masc_mcp
 
-let temp_dir () =
+let with_config f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-current-room-%06x" (Random.bits ()))
   in
   Unix.mkdir dir 0o755;
-  dir
-
-let cleanup_dir dir =
-  let rec rm path =
-    if Sys.file_exists path then
-      if Sys.is_directory path then begin
-        Sys.readdir path
-        |> Array.iter (fun name -> rm (Filename.concat path name));
-        Unix.rmdir path
-      end else
-        Unix.unlink path
-  in
-  rm dir
-
-let with_config f =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () ->
+      let rec rm path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path
+            |> Array.iter (fun name -> rm (Filename.concat path name));
+            Unix.rmdir path
+          end else Unix.unlink path
+      in
+      rm dir)
     (fun () ->
       let config = Room.default_config dir in
       ignore (Room.init config ~agent_name:None);
       f config)
-
-let select_room config room_id =
-  Room.write_current_room config room_id;
-  Room.ensure_room_bootstrap config room_id;
-  Room.config_with_resolved_scope config
 
 let test_current_room_defaults_to_default () =
   with_config (fun config ->
       check (option string) "default room" (Some "default")
         (Room.read_current_room config))
 
-let test_current_room_write_and_resolve_scope () =
+let test_write_current_room_is_noop () =
   with_config (fun config ->
-      let focused = select_room config "focus-room" in
-      check (option string) "focused room selected" (Some "focus-room")
-        (Room.read_current_room config);
-      check bool "focused scope initialized" true (Room.is_initialized focused))
-
-let test_current_room_tasks_are_isolated () =
-  with_config (fun config ->
-      ignore (Room.add_task config ~title:"default task" ~priority:2 ~description:"");
-      let focused = select_room config "focus-room" in
-      ignore (Room.add_task focused ~title:"focus task" ~priority:1 ~description:"");
-      check int "default room task count" 1
-        (List.length (Room.get_tasks_raw_in_room config "default"));
-      check int "focus room task count" 1
-        (List.length (Room.get_tasks_raw_in_room config "focus-room"));
-      check int "current room task count follows pointer" 1
-        (List.length (Room.get_tasks_raw config)))
-
-let test_current_room_agents_are_isolated () =
-  with_config (fun config ->
-      ignore (Room.join config ~agent_name:"default-agent" ~capabilities:[] ());
-      let focused = select_room config "focus-room" in
-      ignore (Room.join focused ~agent_name:"focus-agent" ~capabilities:[] ());
-      check int "default room agent count" 1
-        (List.length (Room.get_agents_raw_in_room config "default"));
-      check int "focus room agent count" 1
-        (List.length (Room.get_agents_raw_in_room config "focus-room")))
+      Room.write_current_room config "ignored-room";
+      check (option string) "still default after write" (Some "default")
+        (Room.read_current_room config))
 
 let () =
   run "current_room_compat"
     [
       ( "current_room",
         [
-          test_case "defaults to default" `Quick test_current_room_defaults_to_default;
-          test_case "write and resolve scope" `Quick test_current_room_write_and_resolve_scope;
-          test_case "tasks are isolated" `Quick test_current_room_tasks_are_isolated;
-          test_case "agents are isolated" `Quick test_current_room_agents_are_isolated;
+          test_case "defaults to default" `Quick
+            test_current_room_defaults_to_default;
+          test_case "write is noop" `Quick
+            test_write_current_room_is_noop;
         ] );
     ]

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -32,10 +32,10 @@ let test_current_room_defaults_to_default () =
       check (option string) "default room" (Some "default")
         (Room.read_current_room config))
 
-let test_write_current_room_is_noop () =
+let test_write_current_room_updates_label () =
   with_config (fun config ->
-      Room.write_current_room config "ignored-room";
-      check (option string) "still default after write" (Some "default")
+      Room.write_current_room config "focus-room";
+      check (option string) "current room label updated" (Some "focus-room")
         (Room.read_current_room config))
 
 let () =
@@ -45,7 +45,7 @@ let () =
         [
           test_case "defaults to default" `Quick
             test_current_room_defaults_to_default;
-          test_case "write is noop" `Quick
-            test_write_current_room_is_noop;
+          test_case "write updates label" `Quick
+            test_write_current_room_updates_label;
         ] );
     ]

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -607,18 +607,18 @@ let test_room_bootstrap_preserves_backend_state () =
     Alcotest.(check int) "backlog preserved" 7 saved_backlog.version
   )
 
-let test_room_bootstrap_rejects_invalid_room_id () =
+let test_room_bootstrap_ignores_invalid_room_id_in_flat_mode () =
   with_memory_test_env (fun config ->
-    Alcotest.check_raises "invalid room id rejected"
-      (Invalid_argument "invalid room_id: Room id cannot contain path separators")
-      (fun () -> Room.ensure_room_bootstrap config "../escape")
+    Room.ensure_room_bootstrap config "../escape";
+    Alcotest.(check bool) "root state initialized" true
+      (Room.is_initialized config)
   )
 
-let test_write_current_room_rejects_invalid_room_id () =
+let test_write_current_room_ignores_invalid_room_id_in_flat_mode () =
   with_memory_test_env (fun config ->
-    Alcotest.check_raises "invalid current room id rejected"
-      (Invalid_argument "invalid room_id: Room id cannot contain path separators")
-      (fun () -> Room.write_current_room config "../escape")
+    Room.write_current_room config "../escape";
+    Alcotest.(check (option string)) "current room stays default" (Some "default")
+      (Room.read_current_room config)
   )
 
 let test_heartbeat_nonexistent_agent () =
@@ -1589,8 +1589,8 @@ let () =
       Alcotest.test_case "nonexistent agent" `Quick test_heartbeat_nonexistent_agent;
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "backend bootstrap preserves room state" `Quick test_room_bootstrap_preserves_backend_state;
-      Alcotest.test_case "bootstrap rejects invalid room id" `Quick test_room_bootstrap_rejects_invalid_room_id;
-      Alcotest.test_case "write current room rejects invalid room id" `Quick test_write_current_room_rejects_invalid_room_id;
+      Alcotest.test_case "bootstrap ignores invalid room id in flat mode" `Quick test_room_bootstrap_ignores_invalid_room_id_in_flat_mode;
+      Alcotest.test_case "write current room ignores invalid room id in flat mode" `Quick test_write_current_room_ignores_invalid_room_id_in_flat_mode;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;
       Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -91,6 +91,11 @@ let rec rm_rf path =
     end else
       Sys.remove path
 
+let latest_ring_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.seq
+  | [] -> 0
+
 let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in
   let repo_root = Filename.concat scratch "repo" in
@@ -588,6 +593,39 @@ let test_rooms_root_dir_with_cluster () =
   let result = Room_utils.rooms_root_dir cfg in
   check string "rooms with cluster" "/home/user/.masc/clusters/staging/rooms" result
 
+let test_read_current_room_warns_once_for_legacy_state () =
+  let scratch = Filename.temp_dir "room-utils-legacy" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      let cfg = make_test_config ~base_path:scratch ~cluster_name:"default" in
+      let masc_dir = Room_utils.masc_root_dir cfg in
+      let rooms_dir = Room_utils.rooms_root_dir cfg in
+      Unix.mkdir masc_dir 0o755;
+      Unix.mkdir rooms_dir 0o755;
+      write_file (Filename.concat rooms_dir "state.json") "{}";
+      write_file (Room_utils.current_room_root_path cfg) "legacy-room\n";
+      Room_utils.reset_legacy_room_warning_for_testing ();
+      let before_seq = latest_ring_seq () in
+      check (option string) "current room still defaults" (Some "default")
+        (Room_utils.read_current_room cfg);
+      let entries =
+        Log.Ring.recent ~limit:20 ~module_filter:"Room" ~since_seq:before_seq ()
+      in
+      check bool "legacy warning emitted"
+        true
+        (List.exists
+           (fun (entry : Log.Ring.entry) ->
+             Room_utils.contains_substring entry.message
+               "Legacy room-scoped state detected")
+           entries);
+      let after_first_seq = latest_ring_seq () in
+      ignore (Room_utils.read_current_room cfg);
+      let follow_up =
+        Log.Ring.recent ~limit:20 ~module_filter:"Room" ~since_seq:after_first_seq ()
+      in
+      check int "warning logged once" 0 (List.length follow_up))
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -712,5 +750,7 @@ let () =
       test_case "current_room_root_path" `Quick test_current_room_root_path;
       test_case "masc_root_dir nested with cluster" `Quick test_masc_root_dir_with_cluster_nested;
       test_case "rooms_root_dir with cluster" `Quick test_rooms_root_dir_with_cluster;
+      test_case "read_current_room warns once for legacy state" `Quick
+        test_read_current_room_warns_once_for_legacy_state;
     ];
   ]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -605,7 +605,6 @@ let test_read_current_room_warns_once_for_legacy_state () =
       Unix.mkdir rooms_dir 0o755;
       write_file (Filename.concat rooms_dir "state.json") "{}";
       write_file (Room_utils.current_room_root_path cfg) "legacy-room\n";
-      Room_utils.reset_legacy_room_warning_for_testing ();
       let before_seq = latest_ring_seq () in
       check (option string) "current room still defaults" (Some "default")
         (Room_utils.read_current_room cfg);

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -192,21 +192,16 @@ let test_constructor_is_pure () =
 let test_restore_persisted_sessions_uses_scoped_agents_dir () =
   with_temp_dir "startup-scope" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
-      let root_agents = Room.agents_dir state.Mcp_server.room_config in
-      Fs_compat.mkdir_p root_agents;
-      write_file (Filename.concat root_agents "root-agent.json") "{}";
-      state.Mcp_server.room_config <-
-        Room.with_scope state.Mcp_server.room_config (Room.Named "alpha");
-      let room_agents = Room.agents_dir state.Mcp_server.room_config in
-      Fs_compat.mkdir_p room_agents;
-      write_file (Filename.concat room_agents "room-agent.json") "{}";
+      let agents = Room.agents_dir state.Mcp_server.room_config in
+      Fs_compat.mkdir_p agents;
+      write_file (Filename.concat agents "test-agent.json") "{}";
       Server_runtime_bootstrap.restore_persisted_sessions state;
       let restored =
         Session.connected_agents state.Mcp_server.session_registry |> List.sort String.compare
       in
       Alcotest.(check (list string))
-        "restore uses scoped room agents dir only"
-        [ "room-agent" ] restored)
+        "restore uses flat agents dir"
+        [ "test-agent" ] restored)
 
 let test_keeper_paths_use_cluster_root () =
   with_temp_dir "startup-cluster" (fun dir ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -380,6 +380,30 @@ let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
         [ "sangsu" ]
         (Keeper_types.keepalive_keeper_names state.Mcp_server.room_config))
 
+let test_blocking_bootstrap_flattens_room_with_safe_current_room_fallback () =
+  with_temp_dir "startup-blocking-room-flatten" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let legacy_tasks = Filename.concat masc_root "rooms/focus-room/tasks" in
+      Fs_compat.mkdir_p legacy_tasks;
+      write_file (Filename.concat masc_root "current_room") "../escape\n";
+      write_file
+        (Filename.concat legacy_tasks "backlog.json")
+        (Yojson.Safe.to_string
+           (Types.backlog_to_yojson
+              { tasks = []; last_updated = Types.now_iso (); version = 7 }));
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      let root_backlog =
+        Yojson.Safe.from_string
+          (read_file (Filename.concat masc_root "tasks/backlog.json"))
+      in
+      Alcotest.(check int) "legacy backlog promoted before init seeds defaults" 7
+        Yojson.Safe.Util.(root_backlog |> member "version" |> to_int);
+      Alcotest.(check bool) "legacy backlog not quarantined" false
+        (Sys.file_exists
+           (Filename.concat masc_root
+              "_quarantine/rooms/focus-room/tasks/backlog.json")))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -550,6 +574,10 @@ let () =
             "blocking bootstrap promotes legacy keeper meta"
             `Quick
             test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot;
+          Alcotest.test_case
+            "blocking bootstrap flattens room with safe current_room fallback"
+            `Quick
+            test_blocking_bootstrap_flattens_room_with_safe_current_room_fallback;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -189,7 +189,7 @@ let test_constructor_is_pure () =
       Alcotest.(check int) "constructor does not restore persisted sessions" 0
         (List.length (Session.connected_agents state.Mcp_server.session_registry)))
 
-let test_restore_persisted_sessions_uses_scoped_agents_dir () =
+let test_restore_persisted_sessions_uses_flat_agents_dir () =
   with_temp_dir "startup-scope" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let agents = Room.agents_dir state.Mcp_server.room_config in
@@ -528,8 +528,8 @@ let () =
             test_force_jsonl_fallback_env;
           Alcotest.test_case "constructors stay pure" `Quick
             test_constructor_is_pure;
-          Alcotest.test_case "restore_persisted_sessions uses scoped agents dir"
-            `Quick test_restore_persisted_sessions_uses_scoped_agents_dir;
+          Alcotest.test_case "restore_persisted_sessions uses flat agents dir"
+            `Quick test_restore_persisted_sessions_uses_flat_agents_dir;
           Alcotest.test_case "keeper paths use cluster root" `Quick
             test_keeper_paths_use_cluster_root;
           Alcotest.test_case "room init bootstraps keeper runtime dirs" `Quick

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -268,13 +268,13 @@ let test_list_sessions_named_scope_uses_scoped_prefix () =
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Room.with_scope (Room.default_config base) (Room.Named "alpha-room") in
+      let config = Room.default_config base in
       Team_session_store.save_session config
-        (sample_session config ~session_id:"sess-room" ~started_at:10.0
+        (sample_session config ~session_id:"sess-flat" ~started_at:10.0
            ~updated_at_iso:"2026-03-24T10:00:00Z");
       let listed = Team_session_store.list_sessions ~limit:1 config in
-      Alcotest.(check (list string)) "named room session listed"
-        [ "sess-room" ]
+      Alcotest.(check (list string)) "flat namespace session listed"
+        [ "sess-flat" ]
         (List.map (fun (session : Team_session_types.session) -> session.session_id) listed);
       let diagnostics = Team_session_store.session_list_diagnostics_json () in
       let expected_prefix =

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -263,7 +263,7 @@ let test_list_sessions_records_fallback_diagnostics () =
       Alcotest.(check int) "limit recorded" 1
         Yojson.Safe.Util.(diagnostics |> member "limit" |> to_int))
 
-let test_list_sessions_flat_scope_uses_flat_prefix () =
+let test_list_sessions_flat_namespace_uses_flat_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
       Eio_main.run @@ fun env ->
@@ -282,7 +282,7 @@ let test_list_sessions_flat_scope_uses_flat_prefix () =
         | Some key -> key ^ ":"
         | None -> Alcotest.fail "expected scoped backend key"
       in
-      Alcotest.(check string) "query prefix tracks scoped room path" expected_prefix
+      Alcotest.(check string) "query prefix tracks flat namespace path" expected_prefix
         Yojson.Safe.Util.(diagnostics |> member "query_prefix" |> to_string))
 
 let test_list_sessions_memory_backend_uses_project_prefix () =
@@ -339,8 +339,8 @@ let () =
             test_list_sessions_uses_recency_order_for_limit;
           Alcotest.test_case "list_sessions diagnostics record fallback"
             `Quick test_list_sessions_records_fallback_diagnostics;
-          Alcotest.test_case "list_sessions flat scope uses flat prefix"
-            `Quick test_list_sessions_flat_scope_uses_flat_prefix;
+          Alcotest.test_case "list_sessions flat namespace uses flat prefix"
+            `Quick test_list_sessions_flat_namespace_uses_flat_prefix;
           Alcotest.test_case "list_sessions memory backend uses project prefix"
             `Quick test_list_sessions_memory_backend_uses_project_prefix;
         ] );

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -263,7 +263,7 @@ let test_list_sessions_records_fallback_diagnostics () =
       Alcotest.(check int) "limit recorded" 1
         Yojson.Safe.Util.(diagnostics |> member "limit" |> to_int))
 
-let test_list_sessions_named_scope_uses_scoped_prefix () =
+let test_list_sessions_flat_scope_uses_flat_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
       Eio_main.run @@ fun env ->
@@ -339,8 +339,8 @@ let () =
             test_list_sessions_uses_recency_order_for_limit;
           Alcotest.test_case "list_sessions diagnostics record fallback"
             `Quick test_list_sessions_records_fallback_diagnostics;
-          Alcotest.test_case "list_sessions named scope uses scoped prefix"
-            `Quick test_list_sessions_named_scope_uses_scoped_prefix;
+          Alcotest.test_case "list_sessions flat scope uses flat prefix"
+            `Quick test_list_sessions_flat_scope_uses_flat_prefix;
           Alcotest.test_case "list_sessions memory backend uses project prefix"
             `Quick test_list_sessions_memory_backend_uses_project_prefix;
         ] );


### PR DESCRIPTION
## Summary
Room 추상화 제거. `scope = Default | Named of string` → `scope = Default`만 남김.
모든 상태가 `.masc/` 직접 아래에 저장되며, `.masc/rooms/{name}/` 경로는 더 이상 사용되지 않음.

## 변경 내역 (20파일, -230/+112줄)

### Core 타입 (3파일)
- `room_utils_backend_setup.ml` — `Named` variant 제거
- `room_utils_paths_backend.ml` — `masc_dir` 항상 root 반환, `read_current_room` → `"default"`, `resolve_initial_scope` → `Default`
- `room_multi.ml` — `write_current_room` no-op, `room_path` → `masc_root_dir`

### Consumer 정리 (15파일)
- `room_state.ml`, `room_lifecycle.ml`, `room_gc.ml`, `room_agent.ml`, `room_task.ml`, `room_query.ml`, `room_init.ml`
- `keeper_exec_context.ml`, `keeper_coordination.ml`
- `transport_metrics.ml`, `server_dashboard_http_core.ml`, `dashboard_mission.ml`, `operator_control_snapshot.ml`
- `tool_inline_dispatch_extra.ml`, `team_session_store.ml`

### 테스트 (2파일)
- `test_server_runtime_bootstrap.ml` — `Named "alpha"` → flat namespace
- `test_swarm_persistence.ml` — `Named "alpha-room"` → flat config

## Rationale
- 4개 room 중 1개(focus-room)만 사용
- 멀티 테넌트 격리는 별도 서버 인스턴스/base-path로 제공
- Room routing이 모든 state read/write, snapshot, dashboard rendering에 불필요한 복잡도 추가

## Test plan
- [x] `dune build @check` 전체 통과 (lib + bin + test)
- [ ] CI 빌드 확인
- [ ] 서버 시작 후 기존 `.masc/` 상태 정상 로드 확인

## Follow-up
- dashboard room-truth store 삭제 (별도 PR)
- `masc_set_room` tool schema 제거 (별도 PR)
- `.masc/rooms/` 디렉토리 마이그레이션 스크립트 (별도)

Closes #4638
Closes #4426