### PR TITLE
[codex] Canonicalize loopback dashboard host

### DIFF
--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -272,13 +272,17 @@ let command_plane_error_json message =
 let parse_host_port host_header default_host default_port =
   match host_header with
   | None -> (default_host, default_port)
-  | Some host_value ->
-      (match String.split_on_char ':' host_value with
-       | [host] -> (host, default_port)
-       | host :: port_str :: _ ->
-           let port = try int_of_string port_str with Failure _ -> default_port in
-           (host, port)
-       | _ -> (default_host, default_port))
+  | Some host_value -> (
+      let trimmed = String.trim host_value in
+      if trimmed = "" then
+        (default_host, default_port)
+      else
+        try
+          let uri = Uri.of_string ("http://" ^ trimmed) in
+          let host = Uri.host uri |> Option.value ~default:default_host in
+          let port = Uri.port uri |> Option.value ~default:default_port in
+          (host, port)
+        with _ -> (default_host, default_port))
 
 (** Utility: string prefix check *)
 let starts_with ~prefix s =

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -269,12 +269,36 @@ let command_plane_help_http_json () =
 
 let command_plane_error_json message =
   Server_command_plane_http.command_plane_error_json message
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  needle_len > 0 && loop 0
+
+let host_header_has_forbidden_authority_chars value =
+  let has_forbidden_char =
+    String.exists
+      (function
+        | '/' | '@' | '?' | '#' | '%' | ' ' | '\t' -> true
+        | _ -> false)
+      value
+  in
+  has_forbidden_char || contains_substring ~needle:"://" value
+
 let parse_host_port host_header default_host default_port =
   match host_header with
   | None -> (default_host, default_port)
   | Some host_value -> (
       let trimmed = String.trim host_value in
-      if trimmed = "" then
+      if trimmed = "" || host_header_has_forbidden_authority_chars trimmed then
         (default_host, default_port)
       else
         try

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -34,6 +34,18 @@ let canonical_loopback_location ~default_port request =
   else
     Some (Printf.sprintf "http://%s:%d%s" canonical_host port request.target)
 
+let canonical_root_dashboard_location ~default_port request =
+  let (host, port) =
+    parse_host_port
+      (Httpun.Headers.get request.Httpun.Request.headers "host")
+      "127.0.0.1" default_port
+  in
+  let canonical_host = Transport_read_model.normalize_advertised_host host in
+  if String.equal canonical_host host then
+    None
+  else
+    Some (Printf.sprintf "http://%s:%d/dashboard" canonical_host port)
+
 let with_canonical_loopback_host ~port handler request reqd =
   match canonical_loopback_location ~default_port:port request with
   | Some location -> respond_redirect ~location reqd
@@ -169,9 +181,9 @@ let add_routes ~port ~host router =
          Http.Response.json ~status (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/" (fun request reqd ->
-       with_canonical_loopback_host ~port
-         (fun _req reqd -> redirect_to_dashboard reqd)
-         request reqd)
+       match canonical_root_dashboard_location ~default_port:port request with
+       | Some location -> respond_redirect ~location reqd
+       | None -> redirect_to_dashboard reqd)
   |> Http.Router.get "/static/css/middleware.css"
        (serve_playground_asset "static/css/middleware.css")
   |> Http.Router.get "/static/js/middleware.js"

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -11,16 +11,36 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 
-let redirect_to_dashboard reqd =
+let respond_redirect ~location reqd =
   let response =
     Httpun.Response.create
       ~headers:(Httpun.Headers.of_list [
-        ("location", "/dashboard");
+        ("location", location);
         ("content-length", "0");
       ])
       `Found
   in
   Httpun.Reqd.respond_with_string reqd response ""
+
+let canonical_loopback_location ~default_port request =
+  let (host, port) =
+    parse_host_port
+      (Httpun.Headers.get request.Httpun.Request.headers "host")
+      "127.0.0.1" default_port
+  in
+  let canonical_host = Transport_read_model.normalize_advertised_host host in
+  if String.equal canonical_host host then
+    None
+  else
+    Some (Printf.sprintf "http://%s:%d%s" canonical_host port request.target)
+
+let with_canonical_loopback_host ~port handler request reqd =
+  match canonical_loopback_location ~default_port:port request with
+  | Some location -> respond_redirect ~location reqd
+  | None -> handler request reqd
+
+let redirect_to_dashboard reqd =
+  respond_redirect ~location:"/dashboard" reqd
 
 let is_dashboard_observer_stream request =
   match Server_utils.query_param request "sse_kind" with
@@ -71,9 +91,12 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/ag-ui/events" handle_ag_ui_events
   (* Dashboard sub-routes: must come before the SPA catchall *)
   |> Http.Router.get "/dashboard/credits" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
-         Http.Response.html (Credits_dashboard.html ()) reqd
-       ) request reqd)
+       with_canonical_loopback_host ~port
+         (fun request reqd ->
+           with_public_read (fun _state _req reqd ->
+             Http.Response.html (Credits_dashboard.html ()) reqd
+           ) request reqd)
+         request reqd)
   |> Http.Router.get "/favicon.ico" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          serve_favicon req reqd
@@ -94,22 +117,31 @@ let add_routes ~port ~host router =
            Http.Response.not_found reqd)
   (* Dashboard SPA: index.html *)
   |> Http.Router.get "/dashboard" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         serve_dashboard_index req reqd
-       ) request reqd)
+       with_canonical_loopback_host ~port
+         (fun request reqd ->
+           with_public_read (fun _state req reqd ->
+             serve_dashboard_index req reqd
+           ) request reqd)
+         request reqd)
   |> Http.Router.get "/dashboard/" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         serve_dashboard_index req reqd
-       ) request reqd)
+       with_canonical_loopback_host ~port
+         (fun request reqd ->
+           with_public_read (fun _state req reqd ->
+             serve_dashboard_index req reqd
+           ) request reqd)
+         request reqd)
   |> Http.Router.prefix_get "/dashboard/"
        (fun request reqd ->
-         with_public_read (fun _state req reqd ->
-           let req_path = Http.Request.path req in
-           if is_dashboard_spa_deep_link req_path then
-             serve_dashboard_index req reqd
-           else
-             Http.Response.not_found reqd
-         ) request reqd)
+         with_canonical_loopback_host ~port
+           (fun request reqd ->
+             with_public_read (fun _state req reqd ->
+               let req_path = Http.Request.path req in
+               if is_dashboard_spa_deep_link req_path then
+                 serve_dashboard_index req reqd
+               else
+                 Http.Response.not_found reqd
+             ) request reqd)
+           request reqd)
   |> Http.Router.get "/api/v1/credits" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
          Http.Response.json (Credits_dashboard.json_api ()) reqd
@@ -136,7 +168,10 @@ let add_routes ~port ~host router =
          in
          Http.Response.json ~status (Yojson.Safe.to_string json) reqd
        ) request reqd)
-  |> Http.Router.get "/" (fun _req reqd -> redirect_to_dashboard reqd)
+  |> Http.Router.get "/" (fun request reqd ->
+       with_canonical_loopback_host ~port
+         (fun _req reqd -> redirect_to_dashboard reqd)
+         request reqd)
   |> Http.Router.get "/static/css/middleware.css"
        (serve_playground_asset "static/css/middleware.css")
   |> Http.Router.get "/static/js/middleware.js"

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -44,7 +44,8 @@ let is_canonical_loopback_alias host =
   | "localhost" -> true
   | _ -> (
       match Ipaddr.of_string normalized with
-      | Ok ip -> ipaddr_is_loopback ip && not (String.equal normalized "127.0.0.1")
+      | Ok (Ipaddr.V6 addr) -> Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+      | Ok (Ipaddr.V4 _) -> false
       | Error _ -> false)
 
 let normalize_advertised_host host =
@@ -54,10 +55,23 @@ let normalize_advertised_host host =
   else
     trimmed
 
+let normalize_loopback_base_url base_url =
+  let trimmed = trim_trailing_slashes base_url in
+  let uri = Uri.of_string trimmed in
+  match Uri.host uri with
+  | Some host ->
+      let normalized_host = normalize_advertised_host host in
+      if String.equal normalized_host host then
+        trimmed
+      else
+        Uri.with_host uri (Some normalized_host) |> Uri.to_string
+        |> trim_trailing_slashes
+  | None -> trimmed
+
 let make_http_context ?(include_configured = false) ~base_url ~host
     ~allow_legacy_accept () =
   {
-    base_url = trim_trailing_slashes base_url;
+    base_url = normalize_loopback_base_url base_url;
     host = normalize_advertised_host host;
     allow_legacy_accept;
     include_configured;
@@ -72,7 +86,7 @@ let context_from_env ?(include_configured = false) ~allow_legacy_accept () =
     match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
     | Some raw -> (
         match trim_nonempty raw with
-        | Some value -> trim_trailing_slashes value
+        | Some value -> normalize_loopback_base_url value
         | None -> default_base_url)
     | None -> default_base_url
   in

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -26,13 +26,33 @@ let ipaddr_is_unspecified = function
   | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0
   | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
 
+let ipaddr_is_loopback = function
+  | Ipaddr.V4 addr ->
+      let octets = Ipaddr.V4.to_octets addr in
+      String.length octets = 4 && Char.code octets.[0] = 127
+  | Ipaddr.V6 addr ->
+      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+
 let is_unspecified_host host =
   match Ipaddr.of_string (String.trim host) with
   | Ok ip -> ipaddr_is_unspecified ip
   | Error _ -> false
 
+let is_canonical_loopback_alias host =
+  let normalized = String.trim host |> String.lowercase_ascii in
+  match normalized with
+  | "localhost" -> true
+  | _ -> (
+      match Ipaddr.of_string normalized with
+      | Ok ip -> ipaddr_is_loopback ip && not (String.equal normalized "127.0.0.1")
+      | Error _ -> false)
+
 let normalize_advertised_host host =
-  if is_unspecified_host host then "127.0.0.1" else host
+  let trimmed = String.trim host in
+  if is_unspecified_host trimmed || is_canonical_loopback_alias trimmed then
+    "127.0.0.1"
+  else
+    trimmed
 
 let make_http_context ?(include_configured = false) ~base_url ~host
     ~allow_legacy_accept () =

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -236,12 +236,15 @@ let test_room_current_validation_contracts () =
        "dashboard_room_truth_http_json")
 
 let test_root_redirect_contracts () =
+  check bool "frontend canonicalizes loopback aliases" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       "let with_canonical_loopback_host ~port handler request reqd =");
   check bool "http root redirects to dashboard" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
-       {|Http.Router.get "/" (fun _req reqd -> redirect_to_dashboard reqd)|});
+       {|redirect_to_dashboard reqd|});
   check bool "http redirect sets dashboard location" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
-       {|("location", "/dashboard")|});
+       {|~location:"/dashboard"|});
   check bool "h2 root responds with server identity" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|h2_respond_text h2_reqd "MASC MCP Server (HTTP/2)"|})

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -74,6 +74,38 @@ let test_frontend_transport_routes_present () =
   Alcotest.(check bool) "POST /webrtc/answer route" true
     (has_route `POST "/webrtc/answer")
 
+let test_frontend_canonical_loopback_location_localhost () =
+  let headers = Httpun.Headers.of_list [ ("host", "localhost:8935") ] in
+  let request =
+    Httpun.Request.create ~headers `GET "/dashboard?agent=codex"
+  in
+  let location =
+    Masc_mcp.Server_routes_http_routes_frontend.canonical_loopback_location
+      ~default_port:8935 request
+  in
+  Alcotest.(check (option string)) "localhost redirects to canonical loopback"
+    (Some "http://127.0.0.1:8935/dashboard?agent=codex") location
+
+let test_frontend_canonical_loopback_location_ipv6 () =
+  let headers = Httpun.Headers.of_list [ ("host", "[::1]:8935") ] in
+  let request = Httpun.Request.create ~headers `GET "/dashboard" in
+  let location =
+    Masc_mcp.Server_routes_http_routes_frontend.canonical_loopback_location
+      ~default_port:8935 request
+  in
+  Alcotest.(check (option string)) "::1 redirects to canonical loopback"
+    (Some "http://127.0.0.1:8935/dashboard") location
+
+let test_frontend_canonical_loopback_location_canonical_host () =
+  let headers = Httpun.Headers.of_list [ ("host", "127.0.0.1:8935") ] in
+  let request = Httpun.Request.create ~headers `GET "/dashboard" in
+  let location =
+    Masc_mcp.Server_routes_http_routes_frontend.canonical_loopback_location
+      ~default_port:8935 request
+  in
+  Alcotest.(check (option string)) "canonical loopback host does not redirect"
+    None location
+
 (* ===== Unit Tests for Config ===== *)
 
 let test_default_config () =
@@ -170,6 +202,12 @@ let router_tests = [
   "add multiple routes", `Quick, test_router_add_multiple;
   "prefix specificity", `Quick, test_router_prefix_specificity;
   "frontend transport routes present", `Quick, test_frontend_transport_routes_present;
+  "frontend canonical localhost redirect", `Quick,
+  test_frontend_canonical_loopback_location_localhost;
+  "frontend canonical ipv6 redirect", `Quick,
+  test_frontend_canonical_loopback_location_ipv6;
+  "frontend canonical host stays put", `Quick,
+  test_frontend_canonical_loopback_location_canonical_host;
 ]
 
 let config_tests = [

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -106,6 +106,32 @@ let test_frontend_canonical_loopback_location_canonical_host () =
   Alcotest.(check (option string)) "canonical loopback host does not redirect"
     None location
 
+let test_frontend_canonical_root_dashboard_location_localhost () =
+  let headers = Httpun.Headers.of_list [ ("host", "localhost:8935") ] in
+  let request = Httpun.Request.create ~headers `GET "/" in
+  let location =
+    Masc_mcp.Server_routes_http_routes_frontend.canonical_root_dashboard_location
+      ~default_port:8935 request
+  in
+  Alcotest.(check (option string)) "localhost root redirects directly to dashboard"
+    (Some "http://127.0.0.1:8935/dashboard") location
+
+let test_parse_host_port_rejects_scheme_in_host_header () =
+  let parsed =
+    Masc_mcp.Server_routes_http_common.parse_host_port
+      (Some "http://localhost:8935") "127.0.0.1" 8935
+  in
+  Alcotest.(check (pair string int)) "scheme-bearing host header falls back"
+    ("127.0.0.1", 8935) parsed
+
+let test_parse_host_port_rejects_userinfo_in_host_header () =
+  let parsed =
+    Masc_mcp.Server_routes_http_common.parse_host_port
+      (Some "user@localhost:8935") "127.0.0.1" 8935
+  in
+  Alcotest.(check (pair string int)) "userinfo-bearing host header falls back"
+    ("127.0.0.1", 8935) parsed
+
 (* ===== Unit Tests for Config ===== *)
 
 let test_default_config () =
@@ -208,6 +234,12 @@ let router_tests = [
   test_frontend_canonical_loopback_location_ipv6;
   "frontend canonical host stays put", `Quick,
   test_frontend_canonical_loopback_location_canonical_host;
+  "frontend canonical root goes direct to dashboard", `Quick,
+  test_frontend_canonical_root_dashboard_location_localhost;
+  "parse_host_port rejects scheme host header", `Quick,
+  test_parse_host_port_rejects_scheme_in_host_header;
+  "parse_host_port rejects userinfo host header", `Quick,
+  test_parse_host_port_rejects_userinfo_in_host_header;
 ]
 
 let config_tests = [

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -89,6 +89,13 @@ let test_context_from_env_trims_explicit_base_url () =
       check string "base_url trimmed" "https://example.com/root" ctx.base_url;
       check bool "allow_legacy_accept carried" true ctx.allow_legacy_accept)
 
+let test_context_from_env_normalizes_loopback_alias_base_url () =
+  with_env "MASC_HTTP_BASE_URL" (Some "http://localhost:8935/root/") (fun () ->
+      let ctx = TRM.context_from_env ~allow_legacy_accept:false () in
+      check string "loopback alias host canonicalized" "127.0.0.1" ctx.host;
+      check string "loopback alias base_url canonicalized"
+        "http://127.0.0.1:8935/root" ctx.base_url)
+
 let test_normalize_advertised_host_canonicalizes_localhost () =
   check string "localhost normalizes to loopback" "127.0.0.1"
     (TRM.normalize_advertised_host "localhost")
@@ -96,6 +103,10 @@ let test_normalize_advertised_host_canonicalizes_localhost () =
 let test_normalize_advertised_host_canonicalizes_ipv6_loopback () =
   check string "::1 normalizes to IPv4 loopback" "127.0.0.1"
     (TRM.normalize_advertised_host "::1")
+
+let test_normalize_advertised_host_preserves_noncanonical_127_alias () =
+  check string "127.0.1.1 stays explicit" "127.0.1.1"
+    (TRM.normalize_advertised_host "127.0.1.1")
 
 let () =
   run "Transport_read_model"
@@ -113,9 +124,13 @@ let () =
             test_context_from_env_uses_default_loopback_base_url;
           test_case "trim explicit base url" `Quick
             test_context_from_env_trims_explicit_base_url;
+          test_case "normalize loopback alias base url" `Quick
+            test_context_from_env_normalizes_loopback_alias_base_url;
           test_case "normalize localhost" `Quick
             test_normalize_advertised_host_canonicalizes_localhost;
           test_case "normalize ipv6 loopback" `Quick
             test_normalize_advertised_host_canonicalizes_ipv6_loopback;
+          test_case "preserve noncanonical 127 alias" `Quick
+            test_normalize_advertised_host_preserves_noncanonical_127_alias;
         ] );
     ]

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -89,6 +89,14 @@ let test_context_from_env_trims_explicit_base_url () =
       check string "base_url trimmed" "https://example.com/root" ctx.base_url;
       check bool "allow_legacy_accept carried" true ctx.allow_legacy_accept)
 
+let test_normalize_advertised_host_canonicalizes_localhost () =
+  check string "localhost normalizes to loopback" "127.0.0.1"
+    (TRM.normalize_advertised_host "localhost")
+
+let test_normalize_advertised_host_canonicalizes_ipv6_loopback () =
+  check string "::1 normalizes to IPv4 loopback" "127.0.0.1"
+    (TRM.normalize_advertised_host "::1")
+
 let () =
   run "Transport_read_model"
     [
@@ -105,5 +113,9 @@ let () =
             test_context_from_env_uses_default_loopback_base_url;
           test_case "trim explicit base url" `Quick
             test_context_from_env_trims_explicit_base_url;
+          test_case "normalize localhost" `Quick
+            test_normalize_advertised_host_canonicalizes_localhost;
+          test_case "normalize ipv6 loopback" `Quick
+            test_normalize_advertised_host_canonicalizes_ipv6_loopback;
         ] );
     ]


### PR DESCRIPTION
## Summary
- canonicalize loopback advertised hosts so `localhost` and `::1` are exposed as `127.0.0.1`
- redirect dashboard-facing loopback alias requests to the canonical `127.0.0.1` origin
- harden host-header parsing and add regression coverage for localhost and IPv6 loopback cases

## Product impact
- local dashboard users land on one canonical loopback origin instead of silently forking browser state
- dashboard agent identity, SSE session state, and other storage-backed state no longer diverge between `localhost` and `127.0.0.1`
- transport discovery reports consistent loopback URLs in local development

## Evidence
- `dune build --root . test/test_transport_read_model.exe test/test_http_server_eio.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_transport_read_model.exe`
- `./_build/default/test/test_http_server_eio.exe`
- `./_build/default/test/test_ci_hardening_source.exe`

## Review evidence
- direct `sb glm-text` review run using the default `GLM-5.1` path
- timestamp: `2026-04-03T05:30:39Z`
- outcome: no high/critical findings outstanding

## Linked issue
Closes #4760
