### PR TITLE
feat(dashboard): improve toast UI/UX with lucide-preact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 ## [2.217.1] - 2026-04-03
 
 ### Changed
-- TBD
+- **Dashboard toast/icon refresh** -- replace raw toast glyphs with lucide icons, icon close affordance, and tighter toast presentation for dashboard notifications.
 
 ### Deprecated
-- TBD
+- None.
 
 ## [2.217.0] - 2026-04-02
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,6 +21,7 @@
     "dompurify": "^3.3.3",
     "downshift": "^9.3.2",
     "htm": "^3.1.1",
+    "lucide-preact": "^1.7.0",
     "marked": "^17.0.5",
     "mermaid": "^11.12.0",
     "preact": "^10.25.4",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       htm:
         specifier: ^3.1.1
         version: 3.1.1
+      lucide-preact:
+        specifier: ^1.7.0
+        version: 1.7.0(preact@10.28.3)
       marked:
         specifier: ^17.0.5
         version: 17.0.5
@@ -1511,6 +1514,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-preact@1.7.0:
+    resolution: {integrity: sha512-gv743hfkCH2MeUmZQ9g4+Yd+/zZyAOLuXvxWo6CUY6kMrnnoDZnnwpSZqWsEveCC9LNp+NgHkeTfztObIue+SA==}
+    peerDependencies:
+      preact: ^10.27.2
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3372,6 +3380,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-preact@1.7.0(preact@10.28.3):
+    dependencies:
+      preact: 10.28.3
 
   lz-string@1.5.0: {}
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -23,6 +23,7 @@ import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
 import { ToastContainer } from './components/common/toast'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
+import { Menu, X, ChevronLeft, ChevronRight } from 'lucide-preact'
 
 export const sidebarCollapsed = signal(false)
 export const mobileMenuOpen = signal(false)
@@ -83,7 +84,7 @@ export function App() {
                 aria-controls="dashboard-side-rail"
                 onClick=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
               >
-                ${mobileMenuOpen.value ? '\u2715' : '\u2630'}
+                ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
               <div class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[15px] font-bold text-[#bfe7ff]">
                 ${currentView?.icon ?? 'M'}

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -23,7 +23,7 @@ import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
 import { ToastContainer } from './components/common/toast'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
-import { Menu, X, ChevronLeft, ChevronRight } from 'lucide-preact'
+import { Menu, X } from 'lucide-preact'
 
 export const sidebarCollapsed = signal(false)
 export const mobileMenuOpen = signal(false)

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { Component, type ComponentChildren } from 'preact'
+import { AlertOctagon, RefreshCcw } from 'lucide-preact'
 
 interface Props {
   label?: string
@@ -24,13 +25,21 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.error) {
       return html`
-        <div class="error-card rounded-xl my-3 rounded-lg border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-4">
-          <strong class="text-[var(--bad)]">${this.props.label ?? 'Component'} 렌더링 오류</strong>
-          <pre class="text-xs whitespace-pre-wrap mt-2 opacity-70">${this.state.error.message}</pre>
-          <button type="button"
-            class="mt-2 px-3 py-1 cursor-pointer rounded border border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-body)] text-sm hover:bg-[var(--white-10)]"
-            onClick=${() => this.setState({ error: null })}
-          >다시 시도</button>
+        <div class="error-card rounded-xl my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-md">
+          <div class="shrink-0 text-[var(--bad)] mt-0.5">
+            <${AlertOctagon} size=${24} />
+          </div>
+          <div class="flex-1 min-w-0">
+            <h3 class="text-base font-semibold text-[var(--bad)] tracking-tight mb-1">${this.props.label ?? 'Component'} 렌더링 오류</h3>
+            <pre class="text-[13px] whitespace-pre-wrap opacity-80 text-[var(--text-body)] overflow-x-auto bg-[rgba(0,0,0,0.2)] p-2 rounded">${this.state.error.message}</pre>
+            <button type="button"
+              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded-md border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--text-strong)] text-[13px] hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bad)]"
+              onClick=${() => this.setState({ error: null })}
+            >
+              <${RefreshCcw} size=${14} />
+              다시 시도
+            </button>
+          </div>
         </div>
       `
     }

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -1,14 +1,10 @@
-// Toast notification system — signal-based, auto-dismiss
-// Usage: showToast('Success message', 'success')
-//        showToast('Warning', 'warning')
-//        showToast('Error occurred', 'error')
-
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { CheckCircle2, AlertTriangle, XCircle, X } from 'lucide-preact'
 
-type ToastType = 'success' | 'warning' | 'error'
+export type ToastType = 'success' | 'warning' | 'error'
 
-interface ToastAction {
+export interface ToastAction {
   label: string
   onClick: () => void
 }
@@ -26,32 +22,34 @@ const toasts = signal<Toast[]>([])
 const BORDER_COLOR: Record<ToastType, string> = {
   success: 'border-l-[var(--ok)]',
   warning: 'border-l-[var(--warn)]',
-  error: 'border-l-[var(--bad)]',
-}
-
-const ICON: Record<ToastType, string> = {
-  success: '\u2713',
-  warning: '\u26A0',
-  error: '\u2715',
+  error: 'border-l-[var(--bad)]'
 }
 
 const ICON_COLOR: Record<ToastType, string> = {
   success: 'text-[var(--ok)]',
   warning: 'text-[var(--warn)]',
-  error: 'text-[var(--bad)]',
+  error: 'text-[var(--bad)]'
 }
 
-export function showToast(message: string, type: ToastType = 'success', durationMs = 4000): void {
+const ICON: Record<ToastType, any> = {
+  success: html`<${CheckCircle2} size=${14} />`,
+  warning: html`<${AlertTriangle} size=${14} />`,
+  error: html`<${XCircle} size=${14} />`
+}
+
+export function showToast(message: string, type: ToastType = 'success', durationMs = 4000) {
   const id = ++_nextId
   toasts.value = [...toasts.value, { id, message, type }]
+
   setTimeout(() => {
     toasts.value = toasts.value.filter(t => t.id !== id)
   }, durationMs)
 }
 
-export function showActionToast(message: string, action: ToastAction, type: ToastType = 'error', durationMs = 12000): void {
+export function showActionToast(message: string, action: ToastAction, type: ToastType = 'error', durationMs = 12000) {
   const id = ++_nextId
   toasts.value = [...toasts.value, { id, message, type, action }]
+
   setTimeout(() => {
     toasts.value = toasts.value.filter(t => t.id !== id)
   }, durationMs)
@@ -66,26 +64,36 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2" aria-live="polite" aria-atomic="true">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast)] flex flex-col gap-2 pointer-events-none">
       ${items.map(t => html`
-        <div
-          key=${t.id}
-          class="flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
-        >
-          <span class="text-xs shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
-          <span class="flex-1 text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+        <div key=${t.id} class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}">
+          <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
+          <span class="flex-1 text-[13px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
           ${t.action ? html`
-            <button type="button"
-              class="shrink-0 text-[11px] px-2 py-0.5 rounded border border-[var(--card-border)] bg-[var(--white-6)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
-              onClick=${(e: Event) => { e.stopPropagation(); t.action!.onClick(); dismissToast(t.id) }}
-            >${t.action.label}</button>
+            <button
+              type="button"
+              class="shrink-0 text-[11px] px-2 py-1 rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
+              onClick=${(e: Event) => {
+                e.stopPropagation()
+                t.action!.onClick()
+                dismissToast(t.id)
+              }}
+            >
+              ${t.action.label}
+            </button>
           ` : null}
-          <button type="button"
-            class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] p-0.5 transition-colors duration-150"
-            aria-label="알림 닫기"
-            onClick=${(e: Event) => { e.stopPropagation(); dismissToast(t.id) }}
+          <button
+            type="button"
+            class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-1 rounded hover:bg-[var(--white-5)] transition-colors duration-150 flex items-center justify-center"
+            aria-label="닫기"
             title="닫기"
-          >\u2715</button>
+            onClick=${(e: Event) => {
+              e.stopPropagation()
+              dismissToast(t.id)
+            }}
+          >
+            <${X} size=${14} />
+          </button>
         </div>
       `)}
     </div>

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -32,10 +32,10 @@ const ICON_COLOR: Record<ToastType, string> = {
   error: 'text-[var(--bad)]'
 }
 
-const ICON: Record<ToastType, ComponentChildren> = {
-  success: html`<${CheckCircle2} size=${14} />`,
-  warning: html`<${AlertTriangle} size=${14} />`,
-  error: html`<${XCircle} size=${14} />`
+const ICON: Record<ToastType, () => ComponentChildren> = {
+  success: () => html`<${CheckCircle2} size=${14} />`,
+  warning: () => html`<${AlertTriangle} size=${14} />`,
+  error: () => html`<${XCircle} size=${14} />`
 }
 
 export function showToast(message: string, type: ToastType = 'success', durationMs = 4000) {
@@ -76,7 +76,7 @@ export function ToastContainer() {
           role=${t.type === 'error' ? 'alert' : 'status'}
           class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
         >
-          <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
+          <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]()}</span>
           <span class="flex-1 text-[13px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
           ${t.action ? html`
             <button

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import type { ComponentChildren } from 'preact'
 import { CheckCircle2, AlertTriangle, XCircle, X } from 'lucide-preact'
 
 export type ToastType = 'success' | 'warning' | 'error'
@@ -31,7 +32,7 @@ const ICON_COLOR: Record<ToastType, string> = {
   error: 'text-[var(--bad)]'
 }
 
-const ICON: Record<ToastType, any> = {
+const ICON: Record<ToastType, ComponentChildren> = {
   success: html`<${CheckCircle2} size=${14} />`,
   warning: html`<${AlertTriangle} size=${14} />`,
   error: html`<${XCircle} size=${14} />`
@@ -64,9 +65,17 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast)] flex flex-col gap-2 pointer-events-none">
+    <div
+      class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2 pointer-events-none"
+      aria-live="polite"
+      aria-atomic="true"
+    >
       ${items.map(t => html`
-        <div key=${t.id} class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}">
+        <div
+          key=${t.id}
+          role=${t.type === 'error' ? 'alert' : 'status'}
+          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+        >
           <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
           <span class="flex-1 text-[13px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
           ${t.action ? html`

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -16,6 +16,7 @@ import {
   visibleSectionItemsForTab,
 } from '../config/navigation'
 import { RouteLink } from './common/route-link'
+import { ChevronRight, ChevronLeft } from 'lucide-preact'
 
 const buildIdentityOpen = signal(false)
 
@@ -181,7 +182,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
         >
-          ${collapsed ? '\u25B6' : '\u25C0'}
+          ${collapsed ? html`<${ChevronRight} size=${16} />` : html`<${ChevronLeft} size=${16} />`}
         </button>
       </div>
 

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { useRef } from 'preact/hooks'
+import { Check, X, ArrowRight, Dot, UserPlus } from 'lucide-preact'
 import { DialogOverlay } from '../common/dialog'
 import { StatusBadge } from '../common/status-badge'
 import { EmptyState } from '../common/empty-state'
@@ -30,16 +31,16 @@ import { goalById, priorityLabel } from './goal-helpers'
 
 // -- Event timeline (inline, NormalizedTaskEvent shape) --------------
 
-function eventBadge(label: string): { icon: string; color: string } {
+function eventBadge(label: string): { icon: any; color: string } {
   switch (label) {
     case 'claim':
-    case 'claimed': return { icon: 'C', color: 'text-accent' }
+    case 'claimed': return { icon: html`<${UserPlus} size=${14} />`, color: 'text-accent' }
     case 'done':
-    case 'completed': return { icon: '\u2713', color: 'text-ok' }
+    case 'completed': return { icon: html`<${Check} size=${14} />`, color: 'text-ok' }
     case 'cancel':
-    case 'cancelled': return { icon: '\u2715', color: 'text-bad' }
-    case 'transition': return { icon: '\u2192', color: 'text-warn' }
-    default: return { icon: '\u00B7', color: 'text-text-muted' }
+    case 'cancelled': return { icon: html`<${X} size=${14} />`, color: 'text-bad' }
+    case 'transition': return { icon: html`<${ArrowRight} size=${14} />`, color: 'text-warn' }
+    default: return { icon: html`<${Dot} size=${14} />`, color: 'text-text-muted' }
   }
 }
 
@@ -135,7 +136,7 @@ export function TaskDetailOverlay() {
           class="shrink-0 size-8 flex items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-5)] text-text-muted cursor-pointer transition-colors hover:bg-[var(--white-10)] hover:text-text-strong"
           onClick=${closeTaskDetail}
           aria-label="닫기"
-        >\u2715</button>
+        ><${X} size=${16} /></button>
       </div>
 
       ${'' /* Tab bar */}

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { AlertTriangle } from 'lucide-preact'
 import { ActionButton } from './common/button'
 import { TextArea } from './common/input'
 import { EmptyState } from './common/empty-state'
@@ -75,7 +76,7 @@ export function GuardrailPane({
               ${order?.status === 'needs_human_gate'
                 ? html`
                     <div class="mt-4 flex flex-col gap-3 rounded-xl border border-warn/30 bg-warn/10 p-4 shadow-inner">
-                      <h4 class="text-[12px] font-bold text-warn uppercase tracking-wider">⚠️ 관리자 승인 대기</h4>
+                      <h4 class="text-[12px] font-bold text-warn uppercase tracking-wider flex items-center gap-1.5"><${AlertTriangle} size=${14} /> 관리자 승인 대기</h4>
                       <div class="text-text-strong text-[13px] leading-relaxed">이 집행 명령은 고위험 작업으로 분류되어 승인이 필요합니다.</div>
                       <div class="mt-1.5 flex gap-2.5">
                         <button type="button" class="rounded-xl border border-ok/30 bg-ok/20 px-4 py-2 text-[13px] font-semibold text-ok transition-all duration-200 hover:bg-ok/30 disabled:opacity-50 shadow-sm shadow-black/15" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { AlertTriangle } from 'lucide-preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { KpiCard } from './common/stat-row'
@@ -50,7 +51,7 @@ function GovernanceSummaryStrip() {
   return html`
     ${isStale ? html`
       <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
-        <span class="text-lg">⚠️</span>
+        <div class="shrink-0"><${AlertTriangle} size=${18} /></div>
         <div>
           모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
           ${lastActivityAge != null ? html` 마지막 활동: ${formatAgeSummary(lastActivityAge)} 전.` : null}

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -2,6 +2,7 @@
 // Clean alert bar: icon + text hierarchy + severity indicator.
 
 import { html } from 'htm/preact'
+import { AlertCircle, AlertTriangle, CheckCircle2 } from 'lucide-preact'
 import { missionError, missionLoading } from '../../mission-store'
 import { roomTruthError } from '../../room-truth-store'
 import type {
@@ -148,10 +149,10 @@ const CATEGORY_LABELS: Record<string, string> = {
   incident: '인시던트',
 }
 
-function toneIcon(tone: SituationTone): string {
-  if (tone === 'bad') return '\u26A0'
-  if (tone === 'warn') return '\u25C9'
-  return '\u2713'
+function toneIcon(tone: SituationTone) {
+  if (tone === 'bad') return html`<${AlertCircle} size=${20} />`
+  if (tone === 'warn') return html`<${AlertTriangle} size=${20} />`
+  return html`<${CheckCircle2} size=${20} />`
 }
 
 function toneBorderClass(tone: SituationTone): string {

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -2,7 +2,7 @@
 
 > Current package version: v2.217.1
 > Latest release: v2.217.1 (2026-04-03)
-> Updated: 2026-04-02
+> Updated: 2026-04-03
 
 Execution companion for capsule-only coordination hardening:
 [design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,7 +2,7 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-02
+> Last Updated: 2026-04-03
 > Snapshot baseline: `dune-project` version `2.217.1`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.


### PR DESCRIPTION
## Overview
- Refactored the toast notification system to use `lucide-preact` icons instead of raw text symbols for a more modern and cohesive look.
- Replaced the simple text close button with an 'X' icon.
- Added `lucide-preact` dependency to `dashboard/package.json`.