### PR TITLE
fix(server): add per-phase timeouts to graceful shutdown sequence

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -346,17 +346,34 @@ let run_cmd host port base_path =
             Log.Server.info
               "[MASC] Sent shutdown notification to %d SSE clients"
               (Sse.client_count ());
-            Eio.Time.sleep clock 0.2;
-            Masc_mcp.Shutdown_hooks.run_all ();
-            (try Board_dispatch.flush ()
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | _ ->
-               Log.Server.warn
-                 "[Shutdown] Board flush skipped (not initialized)");
-            (* Return normally — Eio.Fiber.first will cancel run_server
-               cleanly via Eio.Cancel.Cancelled, avoiding "Multiple
-               exceptions" from raising Shutdown + Cancelled together. *)
+            Eio.Time.sleep clock shutdown_cfg.notify_delay_s;
+            (* Phase 2: Run shutdown hooks with cleanup timeout *)
+            Log.Server.info "[Shutdown] Phase: hooks (timeout=%.1fs)"
+              shutdown_cfg.cleanup_timeout_s;
+            (try
+              Eio.Time.with_timeout_exn clock shutdown_cfg.cleanup_timeout_s
+                (fun () -> Masc_mcp.Shutdown_hooks.run_all ())
+            with
+            | Eio.Time.Timeout ->
+                Log.Server.warn
+                  "[Shutdown] hooks timeout after %.1fs, proceeding"
+                  shutdown_cfg.cleanup_timeout_s
+            | Eio.Cancel.Cancelled _ as e -> raise e);
+            (* Phase 3: Board flush with 2s timeout *)
+            Log.Server.info "[Shutdown] Phase: board flush (timeout=2.0s)";
+            (try
+              Eio.Time.with_timeout_exn clock 2.0
+                (fun () -> Board_dispatch.flush ())
+            with
+            | Eio.Time.Timeout ->
+                Log.Server.warn "[Shutdown] Board flush timeout, skipping"
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ ->
+                Log.Server.warn
+                  "[Shutdown] Board flush skipped (not initialized)");
+            (* Phase 4: Return normally — Eio.Fiber.first will cancel
+               run_server cleanly via Eio.Cancel.Cancelled. *)
+            Log.Server.info "[Shutdown] Phase: server cancel";
             ()
       in
       Eio.Fiber.first

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -358,7 +358,11 @@ let run_cmd host port base_path =
                 Log.Server.warn
                   "[Shutdown] hooks timeout after %.1fs, proceeding"
                   shutdown_cfg.cleanup_timeout_s
-            | Eio.Cancel.Cancelled _ as e -> raise e);
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Server.warn
+                  "[Shutdown] hooks failed, proceeding: %s"
+                  (Printexc.to_string exn));
             (* Phase 3: Board flush with 2s timeout *)
             Log.Server.info "[Shutdown] Phase: board flush (timeout=2.0s)";
             (try
@@ -368,9 +372,10 @@ let run_cmd host port base_path =
             | Eio.Time.Timeout ->
                 Log.Server.warn "[Shutdown] Board flush timeout, skipping"
             | Eio.Cancel.Cancelled _ as e -> raise e
-            | _ ->
+            | exn ->
                 Log.Server.warn
-                  "[Shutdown] Board flush skipped (not initialized)");
+                  "[Shutdown] Board flush skipped: %s"
+                  (Printexc.to_string exn));
             (* Phase 4: Return normally — Eio.Fiber.first will cancel
                run_server cleanly via Eio.Cancel.Cancelled. *)
             Log.Server.info "[Shutdown] Phase: server cancel";


### PR DESCRIPTION
## Summary

- Graceful shutdown이 100% 타임아웃으로 강제 종료되는 문제 수정
- `Shutdown_hooks.run_all()`과 `Board_dispatch.flush()`에 개별 타임아웃 추가
- 각 shutdown phase마다 로깅 추가로 hang 지점 진단 가능

## 변경 내용

| Phase | Before | After |
|-------|--------|-------|
| Hooks | 타임아웃 없음 | `cleanup_timeout_s` (기본 3s) |
| Board flush | 타임아웃 없음 | 2s |
| Notify delay | 하드코딩 0.2s | `shutdown_cfg.notify_delay_s` |
| Phase logging | 없음 | 각 단계 시작 시 로깅 |

10s force-exit 내 예산: notify 0.2s + hooks 3s + flush 2s + server cancel ~4.8s

## Product impact

서버 재시작/배포 시 매번 dirty exit(강제 종료)로 상태 파일 손상 위험 제거. crash-restart loop의 근본 원인 중 하나 해소.

## Evidence

system_log_2026-04-02.jsonl에서 4/4 shutdown이 모두 10s 타임아웃으로 종료 확인.
SSE client 0인 상태에서도 타임아웃 발생 → hooks/flush 블로킹이 원인.

## Review evidence

- GLM-5.1 cross-model review 완료: catch-all 예외 누락(Phase 2) + 에러 메시지 로깅(Phase 3) 2건 지적 → 반영 완료
- test_lifecycle.exe 7/7 PASS

## Linked issue

Closes #4763

## Test plan

- [x] `test_lifecycle.exe` 7/7 PASS
- [x] `dune build --root .` 성공
- [x] GLM cross-model review 반영
- [ ] 서버 시작 후 `kill -TERM` → phase 로그 + 정상 종료 확인

Generated with [Claude Code](https://claude.com/claude-code)
