### PR TITLE
fix(keeper): core tools bypass candidate_set, add task_claim/broadcast to core (#4695)

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -180,11 +180,11 @@ let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
 (** Execution gate: core tools bypass policy, others require policy allowlist.
     All tools must exist in candidate_set — rejects hallucinated tool names. *)
 let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
-  if not (Hashtbl.mem lookup.candidate_set name
-          || Keeper_tool_registry.is_core_always_tool name) then
+  if Keeper_tool_registry.is_core_always_tool name then
+    (* Core tools bypass candidate_set — only deny_set blocks them *)
+    not (Hashtbl.mem lookup.deny_set name)
+  else if not (Hashtbl.mem lookup.candidate_set name) then
     false
-  else if Keeper_tool_registry.is_core_always_tool name then
-    filter_by_universe ~lookup name
   else
     filter_by_access ~lookup name
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -95,6 +95,7 @@ let keeper_coding_masc_tool_names =
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";
     "keeper_tools_list"; "keeper_tasks_list";
+    "keeper_task_claim"; "keeper_broadcast";
     "masc_status"; "masc_heartbeat"; "masc_tool_help";
     "extend_turns" ]
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -95,7 +95,6 @@ let keeper_coding_masc_tool_names =
 let core_always_tools =
   [ "keeper_time_now"; "keeper_context_status";
     "keeper_tools_list"; "keeper_tasks_list";
-    "keeper_task_claim"; "keeper_broadcast";
     "masc_status"; "masc_heartbeat"; "masc_tool_help";
     "extend_turns" ]
 


### PR DESCRIPTION
## Summary
- `can_execute`에서 core_always_tools가 `candidate_set` 검사를 우회하도록 수정 (deny만 확인)
- `keeper_task_claim`, `keeper_broadcast`를 core_always_tools에 추가

## 문제
- core tools(keeper_tools_list 등)가 `filter_by_universe`를 통과할 때 `candidate_set` 멤버십을 요구
- Custom preset keeper에서 candidate_set 구성 타이밍/누락으로 core tools가 차단
- keeper_task_claim, keeper_broadcast가 preset-dependent여서 Minimal keeper에서 사용 불가

## 변경
1. `keeper_tool_policy.ml:can_execute` — core tools는 deny_set만 확인
2. `keeper_tool_registry.ml:core_always_tools` — +keeper_task_claim, +keeper_broadcast

## Linked issue
Closes #4695, partially addresses #4694

## Test plan
- [x] test_tool_keeper.exe 54 tests pass
- [x] test_keeper_tool_exposure.exe 39 tests pass
- [x] dune build clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>