### PR TITLE
sec(keeper): add masc_reset to keeper_denied_set (#4780)

### DIFF
--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -200,6 +200,7 @@ let keeper_denied_surface_tools =
     "masc_force_leave"; "masc_force_remove_agent";
     "masc_admin_reset"; "masc_admin_cleanup";
     "masc_gc_force"; "masc_config_set"; "masc_config_reset";
+    "masc_reset";
     "masc_spawn";
     "masc_operator_action"; "masc_operator_confirm";
     "masc_operator_judgment_write";


### PR DESCRIPTION
## Summary
- `masc_reset`을 `keeper_denied_surface_tools`에 추가
- keeper LLM이 `.masc/` 삭제 도구에 접근하지 못하도록 차단

## 위험
`masc_reset`은 `.masc/` 전체를 삭제하는 파괴적 도구. confirm 가드가 있지만, LLM hallucination으로 `confirm=true` 호출 가능성 존재.

## Linked issue
Closes #4780

## Test plan
- [x] dune build clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>