### PR TITLE
fix(keeper): use keeper-prefixed agent name in tag dispatch, block MCP-only tools

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -848,14 +848,23 @@ let execute_keeper_tool_call
         | Some (false, msg) ->
             Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
         | None ->
-            (* Phase 2: Handler returned None — try tag-based dispatch.
+            (* Phase 2: Block MCP-session-only tools early — keepers lack
+               MCP session context so these always fail. #4775 *)
+            if Tool_dispatch.is_mcp_context_required name then
+              Yojson.Safe.to_string
+                (`Assoc [ ("error",
+                           `String (Printf.sprintf
+                              "tool '%s' requires MCP session (use keeper_* equivalent)" name)) ])
+            else
+            (* Phase 3: Handler returned None — try tag-based dispatch.
                Most masc_* tools are only in tag_registry, not handler_registry.
                tag_dispatch_fn is set to Keeper_tag_dispatch.dispatch at server
                init (mcp_server_eio.ml) to break the dependency cycle. #4579 *)
             (match Tool_dispatch.lookup_tag name with
              | Some tag ->
+                 let keeper_agent = Printf.sprintf "keeper-%s" meta.name in
                  (match !tag_dispatch_fn
-                          ~config ~agent_name:meta.name ~tag ~name ~args with
+                          ~config ~agent_name:keeper_agent ~tag ~name ~args with
                   | Some (true, msg) -> msg
                   | Some (false, msg) ->
                       Yojson.Safe.to_string


### PR DESCRIPTION
## Summary

- tag dispatch에서 agent name prefix 불일치 수정 (cheolsu → keeper-cheolsu)
- MCP-session-only tool 호출을 실행 시점에서 조기 차단

## Product impact

- heartbeat "Agent not found" 72건/일 해소
- MCP-session tool 에러 153건/일 해소 (masc_messages 104 + masc_who 33 + masc_broadcast 16)
- keeper가 room에 정상적으로 heartbeat를 기록하게 됨

## Evidence

2026-04-03 system_log에서:
- `masc_heartbeat returned error: "Agent cheolsu not found"` 72건
- `tool 'masc_messages' requires MCP session context` 104건

## Review evidence

- 빌드 성공, test_lifecycle 7/7 PASS
- 기존 keeper_task_claim(708), keeper_task_done(735), keeper_broadcast(757)이 이미 `keeper-%s` 패턴 사용 → 일관성 확보

## Linked issue

Closes #4775, closes #4776

## Test plan

- [x] `dune build --root .` 성공
- [x] `test_lifecycle.exe` 7/7 PASS
- [ ] CI Build and Test
- [ ] 서버 재시작 후 heartbeat 에러 0건 확인

Generated with [Claude Code](https://claude.com/claude-code)
