### PR TITLE
fix(ci): detect superseded sweep PRs when linked issues are already closed (#4744)

### DIFF
--- a/.github/workflows/sweep-supersede-check.yml
+++ b/.github/workflows/sweep-supersede-check.yml
@@ -1,0 +1,128 @@
+name: Sweep Supersede Check
+
+# Detect when a PR's linked issues are already closed by other PRs.
+# Warns sweep PRs that their changes may be partially redundant.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  sweep-supersede-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for superseded linked issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const stickyMarker = '<!-- sweep-supersede-check -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Extract issue references: Closes #N, Fixes #N, Resolves #N
+            const issuePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const linkedIssues = [];
+            let match;
+            while ((match = issuePattern.exec(body)) !== null) {
+              linkedIssues.push(parseInt(match[1], 10));
+            }
+
+            if (linkedIssues.length === 0) {
+              core.info('No linked issues found. Skipping supersede check.');
+              return;
+            }
+
+            // Check each linked issue
+            const superseded = [];
+            for (const issueNumber of linkedIssues) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: issueNumber
+                });
+                if (issue.state === 'closed') {
+                  // Find which PR closed it
+                  const timeline = await github.paginate(
+                    github.rest.issues.listEventsForTimeline,
+                    { owner, repo, issue_number: issueNumber, per_page: 100 }
+                  );
+                  const closeEvent = timeline
+                    .filter(e => e.event === 'closed' && e.commit_id)
+                    .pop();
+                  const closedBy = closeEvent?.commit_id?.substring(0, 7) || 'unknown';
+
+                  superseded.push({
+                    issue: issueNumber,
+                    title: issue.title,
+                    closedAt: issue.closed_at,
+                    closedBy
+                  });
+                }
+              } catch (err) {
+                core.warning(`Could not check issue #${issueNumber}: ${err.message}`);
+              }
+            }
+
+            // Upsert sticky comment
+            async function upsertStickyComment(message) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: pr.number, per_page: 100 }
+              );
+              const existing = comments.find(c =>
+                c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes(stickyMarker)
+              );
+
+              if (!message) {
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    owner, repo, comment_id: existing.id
+                  });
+                }
+                return;
+              }
+
+              const commentBody = `${stickyMarker}\n${message}`;
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body: commentBody
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pr.number, body: commentBody
+                });
+              }
+            }
+
+            if (superseded.length === 0) {
+              await upsertStickyComment('');
+              core.info(`All ${linkedIssues.length} linked issue(s) are still open.`);
+              return;
+            }
+
+            const ratio = superseded.length / linkedIssues.length;
+            const severity = ratio >= 0.5 ? 'may be fully superseded' : 'partially superseded';
+
+            const lines = superseded.map(s =>
+              `| #${s.issue} | ${s.title.substring(0, 60)} | ${new Date(s.closedAt).toISOString().split('T')[0]} | \`${s.closedBy}\` |`
+            );
+
+            const msg = [
+              `**Sweep supersede warning** — ${superseded.length}/${linkedIssues.length} linked issue(s) are already closed. This PR ${severity}.`,
+              '',
+              '| Issue | Title | Closed | By |',
+              '|-------|-------|--------|----|',
+              ...lines,
+              '',
+              'Consider rebasing to drop redundant commits, or closing this PR if fully superseded.'
+            ].join('\n');
+
+            await upsertStickyComment(msg);
+            core.warning(`${superseded.length}/${linkedIssues.length} linked issues already closed.`);


### PR DESCRIPTION
## Summary
- New workflow `sweep-supersede-check.yml` detects when a PR's linked issues are already closed
- Posts a sticky warning with a table of superseded issues, closing dates, and commits
- Calculates supersede ratio to classify as "partially" or "fully" superseded

## How it works
1. Extracts `Closes #N` / `Fixes #N` / `Resolves #N` from PR body
2. Checks each issue's state via GitHub API
3. For closed issues, traces the closing commit via timeline events
4. Posts/updates a sticky comment (same pattern as planning-hygiene.yml)

## Product impact
Prevents wasted rebase effort on sweep PRs. In the 2026-04-03 session, PR #4689 (14-commit sweep) had 7 commits dropped because individual PRs resolved the same issues first.

## Evidence
Workflow syntax validated. Functional testing requires a live PR with superseded issue references.

## Review evidence
Pending CI + cross-model review

## Linked issue
Closes #4744