### PR TITLE
perf(dashboard): tune CP refresh loops to reduce CPU pressure

### DIFF
--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -58,7 +58,10 @@ let tool_command_plane_http_json ~deps ~state request ~name ~args =
 let _cp_summary_ref : Yojson.Safe.t ref =
   ref (`Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")])
 
-let _cp_summary_refresh_interval_s = 120.0
+let _cp_summary_refresh_interval_s =
+  Dashboard_http_helpers.float_of_env_default
+    "MASC_CP_SUMMARY_REFRESH_INTERVAL_S"
+    ~default:120.0 ~min_v:30.0 ~max_v:600.0
 
 let compute_cp_summary ~state =
   let config = state.Mcp_server.room_config in
@@ -71,22 +74,20 @@ let compute_cp_summary ~state =
   assoc_add "swarm_status" swarm_status summary
 
 let start_cp_summary_refresh_loop ~state ~sw ~clock =
-  Eio.Fiber.fork ~sw (fun () ->
-    Log.CmdPlane.info "starting cp-summary proactive refresh loop";
-    let rec loop () =
-      let t0 = Time_compat.now () in
-      (try
-        _cp_summary_ref := compute_cp_summary ~state;
-        let dt = Time_compat.now () -. t0 in
-        Log.CmdPlane.info "cp-summary refreshed (%.1fs)" dt
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        let dt = Time_compat.now () -. t0 in
-        Log.CmdPlane.warn "cp-summary refresh failed (%.1fs): %s"
-          dt (Printexc.to_string exn));
-      Eio.Time.sleep clock _cp_summary_refresh_interval_s;
-      loop ()
-    in
-    loop ())
+  Proactive_refresh.start ~sw ~clock
+    ~config:{ (Proactive_refresh.default_config
+                 ~label:"cp-summary"
+                 ~interval_s:_cp_summary_refresh_interval_s)
+              with timeout_s =
+                     Dashboard_http_helpers.float_of_env_default
+                       "MASC_CP_SUMMARY_TIMEOUT_S"
+                       ~default:60.0 ~min_v:10.0 ~max_v:120.0;
+                   warm_delay_s =
+                     Dashboard_http_helpers.float_of_env_default
+                       "MASC_WARM_DELAY_CP_SUMMARY_S"
+                       ~default:30.0 ~min_v:0.0 ~max_v:300.0 }
+    ~compute:(fun () -> compute_cp_summary ~state)
+    ~on_result:(fun json -> _cp_summary_ref := json)
 
 let command_plane_summary_http_json ~state:_ =
   (* Always return the proactively cached ref.  Never compute synchronously —
@@ -104,7 +105,10 @@ let command_plane_summary_http_json ~state:_ =
 let _cp_snapshot_ref : Yojson.Safe.t ref =
   ref (`Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")])
 
-let _cp_snapshot_refresh_interval_s = 30.0
+let _cp_snapshot_refresh_interval_s =
+  Dashboard_http_helpers.float_of_env_default
+    "MASC_CP_SNAPSHOT_REFRESH_INTERVAL_S"
+    ~default:120.0 ~min_v:30.0 ~max_v:600.0
 
 let compute_cp_snapshot ~state =
   let config = state.Mcp_server.room_config in
@@ -121,11 +125,14 @@ let start_cp_snapshot_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"cp-snapshot"
                  ~interval_s:_cp_snapshot_refresh_interval_s)
-              with timeout_s = 30.0;
+              with timeout_s =
+                     Dashboard_http_helpers.float_of_env_default
+                       "MASC_CP_SNAPSHOT_TIMEOUT_S"
+                       ~default:60.0 ~min_v:10.0 ~max_v:120.0;
                    warm_delay_s =
                      Dashboard_http_helpers.float_of_env_default
                        "MASC_WARM_DELAY_CP_SNAPSHOT_S"
-                       ~default:60.0 ~min_v:0.0 ~max_v:300.0 }
+                       ~default:90.0 ~min_v:0.0 ~max_v:300.0 }
     ~compute:(fun () -> compute_cp_snapshot ~state)
     ~on_result:(fun snapshot -> _cp_snapshot_ref := snapshot)
 


### PR DESCRIPTION
## Summary

- cp_snapshot 간격 30s -> 120s: 가장 무거운 루프. 9개 keeper 활동 시 mtime 기반 section cache가 매 사이클 무효화되어 전체 재계산 발생
- cp_summary 수동 루프 -> Proactive_refresh: timeout 없는 수동 루프는 I/O 블로킹 시 fiber 영구 정지. timeout(60s) + exponential backoff + jitter 추가
- warm_delay 스태거링: cp_summary=30s, cp_snapshot=90s로 서버 기동 시 동시 계산 방지

모든 간격/타임아웃은 env var로 조정 가능.

## Product impact

- keeper가 많은 방에서 command-plane background refresh가 CPU를 과도하게 점유하는 빈도를 낮춤
- cp_summary refresh가 파일시스템 I/O 등에 막혀도 fiber가 영구 정지하지 않도록 timeout/backoff 경로를 확보함
- 서버 기동 직후 cp_summary와 cp_snapshot의 무거운 계산이 겹치는 startup contention을 줄임

## 변경 전후 비교

| Loop | Before | After |
|------|--------|-------|
| cp_summary interval | 120s (hardcoded) | 120s (env var) |
| cp_summary timeout | **없음** | 60s |
| cp_summary warm_delay | 0s (즉시 계산) | 30s |
| cp_snapshot interval | **30s** | **120s** (env var) |
| cp_snapshot timeout | 30s (hardcoded) | 60s (env var) |
| cp_snapshot warm_delay | 60s | 90s |

## Evidence

- GitHub PR checks currently pass: `Build and Test`, `Contract Harness`, `Dashboard`, `Health`, `Lint`, `Release Train`, `PR Hygiene`, `PR Sync Check`, `label-and-review`, `pr-hygiene`, `sweep-supersede-check`
- CI evidence confirmed via `gh pr checks 4787 --repo jeong-sik/masc-mcp` on 2026-04-03 KST

## Review evidence

- Attempted external Codex review on 2026-04-03, but the review bot returned a usage-limit response instead of findings
- Additional non-self cross-model review is still recommended before merge

## Linked issue

- Refs #4706

## Test plan

- [ ] `dune build @check` 통과
- [ ] 서버 시작 후 로그에서 cp-summary/cp-snapshot refresh 정상 동작 확인
- [ ] CPU 사용량이 이전 대비 감소 확인 (9 keeper 활성 환경)
- [ ] `MASC_CP_SNAPSHOT_REFRESH_INTERVAL_S=30` 설정 시 이전 동작으로 복귀 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
