### PR TITLE
fix(room): patch flat-scope follow-up regressions

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -261,9 +261,13 @@ module FileSystem = struct
       | Error _ -> false
       | Ok path ->
           (try
-             ignore (Eio.Path.load path : string);
-             Hashtbl.replace t.key_index key ();
-             true
+             match Eio.Path.kind ~follow:true path with
+             | `Regular_file ->
+                 Hashtbl.replace t.key_index key ();
+                 true
+             | _ ->
+                 Hashtbl.remove t.key_index key;
+                 false
            with _ ->
              Hashtbl.remove t.key_index key;
              false)

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -9,6 +9,11 @@ open Room_state
 
 let room_id_of_config (_config : Room_utils_backend_setup.config) = "default"
 
+let compat_room_id config room_id =
+  match validate_room_id room_id with
+  | Ok valid_room_id -> valid_room_id
+  | Error _ -> room_id_of_config config
+
 (** Join room - with auto-generated nickname and metadata *)
 let join config ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
@@ -161,11 +166,13 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   end
 
 (** @deprecated Since #4638 storage is flattened to the default scope.
-    This compat helper still accepts [room_id] and preserves it in legacy
-    messages/log entries, but agent state is shared with [join]. *)
+    This compat helper still accepts [room_id], normalizes invalid values to
+    the default label for legacy messages/log entries, and shares state with
+    [join]. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
   ensure_room_bootstrap config room_id;
+  let legacy_room_id = compat_room_id config room_id in
 
   let agent_type = match agent_type_override with
     | Some t -> t
@@ -213,15 +220,23 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
         { s with active_agents = agents }
       ) in
       let _ = broadcast config ~from_agent:nickname
-                ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname room_id) in
-      log_event config (Printf.sprintf
-        "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
-        room_id nickname (now_iso ()));
-      !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname ~room_id
+                ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname legacy_room_id) in
+      log_event config
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("type", `String "agent_join");
+               ("room_id", `String legacy_room_id);
+               ("agent", `String nickname);
+               ("rejoin", `Bool true);
+               ("ts", `String (now_iso ()));
+             ]));
+      !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+        ~room_id:legacy_room_id
         ~event_kind:"rejoin"
         ~details:(`Assoc [ ("rejoin", `Bool true) ]);
     end;
-    Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname room_id
+    Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname legacy_room_id
   end else begin
     let session_id = generate_session_id () in
     let meta : agent_meta = {
@@ -255,15 +270,21 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       broadcast config ~from_agent:nickname
         ~content:(Printf.sprintf "👋 %s joined the room" nickname)
     in
-    log_event config (Printf.sprintf
-      "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
-      room_id
-      nickname
-      agent_type
-      session_id
-      (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
-      (now_iso ()));
-    !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname ~room_id
+    log_event config
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("type", `String "agent_join");
+             ("room_id", `String legacy_room_id);
+             ("agent", `String nickname);
+             ("agent_type", `String agent_type);
+             ("session_id", `String session_id);
+             ( "capabilities",
+               `List (List.map (fun s -> `String s) capabilities) );
+             ("ts", `String (now_iso ()));
+           ]));
+    !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+      ~room_id:legacy_room_id
       ~event_kind:"join"
       ~details:
         (`Assoc
@@ -273,7 +294,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
             ( "capabilities",
               `List (List.map (fun s -> `String s) capabilities) );
           ]);
-    Printf.sprintf "✅ %s joined room %s" nickname room_id
+    Printf.sprintf "✅ %s joined room %s" nickname legacy_room_id
   end
 
 (** Leave room *)

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -171,8 +171,8 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     [join]. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
-  ensure_room_bootstrap config room_id;
   let legacy_room_id = compat_room_id config room_id in
+  ensure_room_bootstrap config legacy_room_id;
 
   let agent_type = match agent_type_override with
     | Some t -> t

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -69,22 +69,20 @@ let legacy_room_dirs_exist config =
     if exists then cache_legacy_room_root masc_root;
     exists
 
+(* Validation logic mirrors Room_utils_ops.validate_room_id but returns
+   Option instead of Result.  Cannot call validate_room_id directly due to
+   cyclic dependency (paths_backend <-> ops).  Keep in sync. *)
+let room_id_re =
+  Re.compile Re.(whole_string (rep1 (alt [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-'])))
+
 let normalize_current_room_label room_id =
   let room_id = String.trim room_id in
   if room_id = "" then None
   else if room_id = "." || room_id = ".." then None
   else if String.contains room_id '/' || String.contains room_id '\\' then None
   else if String_util.contains_substring room_id ".." then None
-  else if
-    not
-      (Re.execp
-         (Re.compile
-            Re.(whole_string (rep1 (alt [ rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-' ]))))
-         room_id)
-  then
-    None
-  else
-    Some room_id
+  else if not (Re.execp room_id_re room_id) then None
+  else Some room_id
 
 let warn_if_legacy_room_state_exists config =
   let legacy_current_room =

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -17,6 +17,7 @@ let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.js
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"
 
 let warned_legacy_room_roots = Atomic.make []
+let cached_legacy_room_roots = Atomic.make []
 
 let rec mark_legacy_room_warning_emitted masc_root =
   let warned = Atomic.get warned_legacy_room_roots in
@@ -42,13 +43,31 @@ let read_legacy_current_room config =
   else
     None
 
-let legacy_room_dirs_exist config =
+let rec cache_legacy_room_root masc_root =
+  let cached = Atomic.get cached_legacy_room_roots in
+  if List.mem masc_root cached then
+    ()
+  else if Atomic.compare_and_set cached_legacy_room_roots cached (masc_root :: cached) then
+    ()
+  else
+    cache_legacy_room_root masc_root
+
+let legacy_room_dirs_exist_uncached config =
   let path = rooms_root_dir config in
   Sys.file_exists path
   &&
   try
     Sys.is_directory path && Array.length (Sys.readdir path) > 0
   with _ -> false
+
+let legacy_room_dirs_exist config =
+  let masc_root = masc_root_dir config in
+  if List.mem masc_root (Atomic.get cached_legacy_room_roots) then
+    true
+  else
+    let exists = legacy_room_dirs_exist_uncached config in
+    if exists then cache_legacy_room_root masc_root;
+    exists
 
 let normalize_current_room_label room_id =
   let room_id = String.trim room_id in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -176,7 +176,11 @@ let legacy_room_candidates rooms_dir =
            if Sys.is_directory room_path then
              match Room.validate_room_id room_id with
              | Ok valid_room_id -> Some valid_room_id
-             | Error _ -> None
+             | Error msg ->
+                 Log.Misc.warn
+                   "migrate: ignoring invalid legacy room dir %s (%s)" room_id
+                   msg;
+                 None
            else
              None)
     with _ -> []

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -164,39 +164,78 @@ let migrate_legacy_keeper_dirs_blocking (state : Mcp_server.server_state) =
 
 let default_room_for_flat_migration = "focus-room"
 
-let load_current_room_or_default masc_root =
+let legacy_room_candidates rooms_dir =
+  if not (Sys.file_exists rooms_dir) then
+    []
+  else
+    try
+      Sys.readdir rooms_dir
+      |> Array.to_list
+      |> List.filter_map (fun room_id ->
+           let room_path = Filename.concat rooms_dir room_id in
+           if Sys.is_directory room_path then
+             match Room.validate_room_id room_id with
+             | Ok valid_room_id -> Some valid_room_id
+             | Error _ -> None
+           else
+             None)
+    with _ -> []
+
+let infer_current_room_from_legacy_dirs rooms_dir =
+  match legacy_room_candidates rooms_dir with
+  | [ room_id ] ->
+      Log.Misc.info
+        "migrate: current_room unavailable; using only legacy room %s" room_id;
+      Some room_id
+  | room_ids when List.mem default_room_for_flat_migration room_ids ->
+      Log.Misc.info
+        "migrate: current_room unavailable; using legacy room %s"
+        default_room_for_flat_migration;
+      Some default_room_for_flat_migration
+  | [] -> None
+  | room_ids ->
+      Log.Misc.warn
+        "migrate: current_room unavailable and multiple legacy rooms exist (%s); skipping room flatten"
+        (String.concat ", " room_ids);
+      None
+
+let load_current_room_or_default masc_root rooms_dir =
   let path = Filename.concat masc_root "current_room" in
   if not (Sys.file_exists path) then
-    default_room_for_flat_migration
+    infer_current_room_from_legacy_dirs rooms_dir
   else
     match Safe_ops.read_file_safe path with
     | Error msg ->
         Log.Misc.warn
-          "migrate: failed to read %s (%s); falling back to %s"
-          path msg default_room_for_flat_migration;
-        default_room_for_flat_migration
+          "migrate: failed to read %s (%s); probing legacy room dirs instead"
+          path msg;
+        infer_current_room_from_legacy_dirs rooms_dir
     | Ok raw -> (
         match Room.validate_room_id (String.trim raw) with
-        | Ok room_id -> room_id
+        | Ok room_id -> Some room_id
         | Error msg ->
             Log.Misc.warn
-              "migrate: ignoring invalid current_room in %s (%s); falling back to %s"
-              path msg default_room_for_flat_migration;
-            default_room_for_flat_migration)
+              "migrate: ignoring invalid current_room in %s (%s); probing legacy room dirs instead"
+              path msg;
+            infer_current_room_from_legacy_dirs rooms_dir)
 
 let migrate_room_to_flat (state : Mcp_server.server_state) =
   let masc_root = Room.masc_root_dir state.room_config in
   let rooms_dir = Filename.concat masc_root "rooms" in
   if not (Sys.file_exists rooms_dir) then ()
   else begin
-    let current_room = load_current_room_or_default masc_root in
-    let room_dir = Filename.concat rooms_dir current_room in
-    if Sys.file_exists room_dir && Sys.is_directory room_dir then begin
-      Log.Misc.info "migrate: flattening room %s to .masc/ root" current_room;
-      migrate_legacy_dirs_with_renames state
-        [ (Filename.concat "rooms" current_room, ".") ]
-    end else
-      Log.Misc.warn "migrate: rooms/ exists but active room %s not found" current_room
+    match load_current_room_or_default masc_root rooms_dir with
+    | Some current_room ->
+        let room_dir = Filename.concat rooms_dir current_room in
+        if Sys.file_exists room_dir && Sys.is_directory room_dir then begin
+          Log.Misc.info "migrate: flattening room %s to .masc/ root" current_room;
+          migrate_legacy_dirs_with_renames state
+            [ (Filename.concat "rooms" current_room, ".") ]
+        end else
+          Log.Misc.warn "migrate: rooms/ exists but active room %s not found" current_room
+    | None ->
+        Log.Misc.warn
+          "migrate: rooms/ exists but no safe current room could be inferred; leaving legacy room dirs untouched"
   end
 
 let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -174,13 +174,20 @@ let legacy_room_candidates rooms_dir =
       |> List.filter_map (fun room_id ->
            let room_path = Filename.concat rooms_dir room_id in
            if Sys.is_directory room_path then
-             match Room.validate_room_id room_id with
-             | Ok valid_room_id -> Some valid_room_id
-             | Error msg ->
+             let trimmed_room_id = String.trim room_id in
+             if not (String.equal room_id trimmed_room_id) then begin
+               Log.Misc.warn
+                 "migrate: ignoring invalid legacy room dir %S (must not have leading/trailing whitespace)"
+                 room_id;
+               None
+             end else
+               match Room.validate_room_id room_id with
+               | Ok valid_room_id -> Some valid_room_id
+               | Error msg ->
                  Log.Misc.warn
                    "migrate: ignoring invalid legacy room dir %s (%s)" room_id
                    msg;
-                 None
+                   None
            else
              None)
     with _ -> []

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -62,13 +62,25 @@ let read_lines path =
       in
       loop [])
 
-let current_event_log_path config =
-  let tm = Unix.gmtime (Unix.gettimeofday ()) in
-  Filename.concat
-    (Filename.concat
-       (Filename.concat (Room.masc_dir config) "events")
-       (Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)))
-    (Printf.sprintf "%02d.jsonl" tm.tm_mday)
+(* Find the most recent .jsonl event file under .masc/events/ rather than
+   computing the path from wall-clock time, which is racy around UTC
+   day/month boundaries (#4792 review). *)
+let find_latest_event_log config =
+  let events_dir = Filename.concat (Room.masc_dir config) "events" in
+  let rec collect_jsonl dir =
+    if not (Sys.file_exists dir) then []
+    else
+      Sys.readdir dir |> Array.to_list
+      |> List.concat_map (fun name ->
+           let path = Filename.concat dir name in
+           if Sys.is_directory path then collect_jsonl path
+           else if Filename.check_suffix name ".jsonl" then [ path ]
+           else [])
+  in
+  let files = collect_jsonl events_dir in
+  match List.sort (fun a b -> compare b a) files with
+  | latest :: _ -> Some latest
+  | [] -> None
 
 let test_join_in_room_sanitizes_invalid_room_id () =
   with_config (fun config ->
@@ -88,7 +100,11 @@ let test_join_in_room_sanitizes_invalid_room_id () =
             (str_contains result "room default");
           check (option string) "hook sees sanitized room label" (Some "default")
             !captured_room_id;
-          let event_log = current_event_log_path config in
+          let event_log =
+            match find_latest_event_log config with
+            | Some path -> path
+            | None -> fail "expected event log file under .masc/events/"
+          in
           let last_event =
             match read_lines event_log |> List.rev with
             | last_event :: _ -> last_event

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -89,7 +89,11 @@ let test_join_in_room_sanitizes_invalid_room_id () =
           check (option string) "hook sees sanitized room label" (Some "default")
             !captured_room_id;
           let event_log = current_event_log_path config in
-          let last_event = read_lines event_log |> List.rev |> List.hd in
+          let last_event =
+            match read_lines event_log |> List.rev with
+            | last_event :: _ -> last_event
+            | [] -> fail "expected agent join event in log"
+          in
           let room_id =
             Yojson.Safe.from_string last_event
             |> Yojson.Safe.Util.member "room_id"

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -3,6 +3,18 @@
 open Alcotest
 open Masc_mcp
 
+let str_contains s substring =
+  let len_s = String.length s in
+  let len_sub = String.length substring in
+  if len_sub > len_s then false
+  else
+    let rec loop i =
+      if i > len_s - len_sub then false
+      else if String.sub s i len_sub = substring then true
+      else loop (i + 1)
+    in
+    loop 0
+
 let with_config f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -38,6 +50,53 @@ let test_write_current_room_updates_label () =
       check (option string) "current room label updated" (Some "focus-room")
         (Room.read_current_room config))
 
+let read_lines path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+
+let current_event_log_path config =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  Filename.concat
+    (Filename.concat
+       (Filename.concat (Room.masc_dir config) "events")
+       (Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)))
+    (Printf.sprintf "%02d.jsonl" tm.tm_mday)
+
+let test_join_in_room_sanitizes_invalid_room_id () =
+  with_config (fun config ->
+      let captured_room_id = ref None in
+      let previous_hook = !Room_hooks.observe_agent_lifecycle_fn in
+      Fun.protect
+        ~finally:(fun () -> Room_hooks.observe_agent_lifecycle_fn := previous_hook)
+        (fun () ->
+          Room_hooks.observe_agent_lifecycle_fn :=
+            (fun _config ~agent_id:_ ~room_id ~event_kind:_ ~details:_ ->
+              captured_room_id := Some room_id);
+          let result =
+            Room.join_in_room config ~room_id:"bad\"\nroom" ~agent_name:"claude"
+              ~capabilities:[ "debug" ] ()
+          in
+          check bool "result uses sanitized room label" true
+            (str_contains result "room default");
+          check (option string) "hook sees sanitized room label" (Some "default")
+            !captured_room_id;
+          let event_log = current_event_log_path config in
+          let last_event = read_lines event_log |> List.rev |> List.hd in
+          let room_id =
+            Yojson.Safe.from_string last_event
+            |> Yojson.Safe.Util.member "room_id"
+            |> Yojson.Safe.Util.to_string
+          in
+          check string "event room_id sanitized" "default" room_id))
+
 let () =
   run "current_room_compat"
     [
@@ -47,5 +106,7 @@ let () =
             test_current_room_defaults_to_default;
           test_case "write updates label" `Quick
             test_write_current_room_updates_label;
+          test_case "join_in_room sanitizes invalid room id" `Quick
+            test_join_in_room_sanitizes_invalid_room_id;
         ] );
     ]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -91,10 +91,28 @@ let rec rm_rf path =
     end else
       Sys.remove path
 
-let latest_ring_seq () =
-  match Log.Ring.recent ~limit:1 () with
-  | entry :: _ -> entry.seq
-  | [] -> 0
+let capture_stderr f =
+  let (pipe_read, pipe_write) = Unix.pipe () in
+  let saved_stderr = Unix.dup Unix.stderr in
+  Unix.dup2 pipe_write Unix.stderr;
+  Unix.close pipe_write;
+  (try f () with _ -> ());
+  flush stderr;
+  Unix.dup2 saved_stderr Unix.stderr;
+  Unix.close saved_stderr;
+  Unix.set_nonblock pipe_read;
+  let buf = Buffer.create 256 in
+  let tmp = Bytes.create 256 in
+  let rec read_all () =
+    match Unix.read pipe_read tmp 0 256 with
+    | 0 -> ()
+    | n -> Buffer.add_subbytes buf tmp 0 n; read_all ()
+    | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> ()
+    | exception _ -> ()
+  in
+  read_all ();
+  Unix.close pipe_read;
+  Buffer.contents buf
 
 let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in
@@ -605,25 +623,38 @@ let test_read_current_room_warns_once_for_legacy_state () =
       Unix.mkdir rooms_dir 0o755;
       write_file (Filename.concat rooms_dir "state.json") "{}";
       write_file (Room_utils.current_room_root_path cfg) "legacy-room\n";
-      let before_seq = latest_ring_seq () in
-      check (option string) "current room still defaults" (Some "default")
-        (Room_utils.read_current_room cfg);
-      let entries =
-        Log.Ring.recent ~limit:20 ~module_filter:"Room" ~since_seq:before_seq ()
+      let stderr_first =
+        capture_stderr (fun () ->
+            check (option string) "current room still defaults" (Some "default")
+              (Room_utils.read_current_room cfg))
       in
       check bool "legacy warning emitted"
         true
-        (List.exists
-           (fun (entry : Log.Ring.entry) ->
-             Room_utils.contains_substring entry.message
-               "Legacy room-scoped state detected")
-           entries);
-      let after_first_seq = latest_ring_seq () in
-      ignore (Room_utils.read_current_room cfg);
-      let follow_up =
-        Log.Ring.recent ~limit:20 ~module_filter:"Room" ~since_seq:after_first_seq ()
-      in
-      check int "warning logged once" 0 (List.length follow_up))
+        (Room_utils.contains_substring stderr_first
+           "Legacy room-scoped state detected");
+      let stderr_second = capture_stderr (fun () -> ignore (Room_utils.read_current_room cfg)) in
+      check bool "warning logged once" false
+        (Room_utils.contains_substring stderr_second
+           "Legacy room-scoped state detected"))
+
+let test_read_current_room_keeps_default_after_legacy_rooms_cached () =
+  let scratch = Filename.temp_dir "room-utils-legacy-cache" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      let cfg = make_test_config ~base_path:scratch ~cluster_name:"default" in
+      let masc_dir = Room_utils.masc_root_dir cfg in
+      let rooms_dir = Room_utils.rooms_root_dir cfg in
+      Unix.mkdir masc_dir 0o755;
+      Unix.mkdir rooms_dir 0o755;
+      write_file (Filename.concat rooms_dir "state.json") "{}";
+      write_file (Room_utils.current_room_root_path cfg) "legacy-room\n";
+      check (option string) "legacy rooms force default once" (Some "default")
+        (Room_utils.read_current_room cfg);
+      Unix.unlink (Filename.concat rooms_dir "state.json");
+      Unix.rmdir rooms_dir;
+      check (option string) "cached legacy rooms keep default label" (Some "default")
+        (Room_utils.read_current_room cfg))
 
 (* ============================================================
    Test Runners
@@ -751,5 +782,7 @@ let () =
       test_case "rooms_root_dir with cluster" `Quick test_rooms_root_dir_with_cluster;
       test_case "read_current_room warns once for legacy state" `Quick
         test_read_current_room_warns_once_for_legacy_state;
+      test_case "read_current_room caches legacy rooms" `Quick
+        test_read_current_room_keeps_default_after_legacy_rooms_cached;
     ];
   ]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -94,25 +94,38 @@ let rec rm_rf path =
 let capture_stderr f =
   let (pipe_read, pipe_write) = Unix.pipe () in
   let saved_stderr = Unix.dup Unix.stderr in
-  Unix.dup2 pipe_write Unix.stderr;
-  Unix.close pipe_write;
-  (try f () with _ -> ());
-  flush stderr;
-  Unix.dup2 saved_stderr Unix.stderr;
-  Unix.close saved_stderr;
-  Unix.set_nonblock pipe_read;
-  let buf = Buffer.create 256 in
-  let tmp = Bytes.create 256 in
-  let rec read_all () =
-    match Unix.read pipe_read tmp 0 256 with
-    | 0 -> ()
-    | n -> Buffer.add_subbytes buf tmp 0 n; read_all ()
-    | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> ()
-    | exception _ -> ()
+  let exn_opt = ref None in
+  let restored = ref false in
+  let restore_stderr () =
+    if not !restored then begin
+      flush stderr;
+      Unix.dup2 saved_stderr Unix.stderr;
+      restored := true
+    end
   in
-  read_all ();
-  Unix.close pipe_read;
-  Buffer.contents buf
+  Fun.protect
+    ~finally:(fun () ->
+      restore_stderr ();
+      Unix.close saved_stderr;
+      Unix.close pipe_read)
+    (fun () ->
+      Unix.dup2 pipe_write Unix.stderr;
+      Unix.close pipe_write;
+      (try f () with e -> exn_opt := Some e);
+      restore_stderr ();
+      Unix.set_nonblock pipe_read;
+      let buf = Buffer.create 256 in
+      let tmp = Bytes.create 256 in
+      let rec read_all () =
+        match Unix.read pipe_read tmp 0 256 with
+        | 0 -> ()
+        | n -> Buffer.add_subbytes buf tmp 0 n; read_all ()
+        | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> ()
+        | exception _ -> ()
+      in
+      read_all ();
+      (match !exn_opt with Some e -> raise e | None -> ());
+      Buffer.contents buf)
 
 let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -404,6 +404,29 @@ let test_blocking_bootstrap_flattens_room_with_safe_current_room_fallback () =
            (Filename.concat masc_root
               "_quarantine/rooms/focus-room/tasks/backlog.json")))
 
+let test_blocking_bootstrap_flattens_single_legacy_room_without_current_room () =
+  with_temp_dir "startup-blocking-room-single-fallback" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let legacy_tasks = Filename.concat masc_root "rooms/team-room/tasks" in
+      Fs_compat.mkdir_p legacy_tasks;
+      write_file
+        (Filename.concat legacy_tasks "backlog.json")
+        (Yojson.Safe.to_string
+           (Types.backlog_to_yojson
+              { tasks = []; last_updated = Types.now_iso (); version = 11 }));
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      let root_backlog =
+        Yojson.Safe.from_string
+          (read_file (Filename.concat masc_root "tasks/backlog.json"))
+      in
+      Alcotest.(check int) "single legacy room promoted without current_room" 11
+        Yojson.Safe.Util.(root_backlog |> member "version" |> to_int);
+      Alcotest.(check bool) "single legacy backlog not quarantined" false
+        (Sys.file_exists
+           (Filename.concat masc_root
+              "_quarantine/rooms/team-room/tasks/backlog.json")))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -578,6 +601,10 @@ let () =
             "blocking bootstrap flattens room with safe current_room fallback"
             `Quick
             test_blocking_bootstrap_flattens_room_with_safe_current_room_fallback;
+          Alcotest.test_case
+            "blocking bootstrap flattens single legacy room without current_room"
+            `Quick
+            test_blocking_bootstrap_flattens_single_legacy_room_without_current_room;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -427,6 +427,42 @@ let test_blocking_bootstrap_flattens_single_legacy_room_without_current_room () 
            (Filename.concat masc_root
               "_quarantine/rooms/team-room/tasks/backlog.json")))
 
+let test_blocking_bootstrap_skips_flatten_with_multiple_legacy_rooms () =
+  with_temp_dir "startup-blocking-room-multi-fallback" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let alpha_tasks = Filename.concat masc_root "rooms/alpha-room/tasks" in
+      let beta_tasks = Filename.concat masc_root "rooms/beta-room/tasks" in
+      Fs_compat.mkdir_p alpha_tasks;
+      Fs_compat.mkdir_p beta_tasks;
+      write_file
+        (Filename.concat alpha_tasks "backlog.json")
+        (Yojson.Safe.to_string
+           (Types.backlog_to_yojson
+              { tasks = []; last_updated = Types.now_iso (); version = 7 }));
+      write_file
+        (Filename.concat beta_tasks "backlog.json")
+        (Yojson.Safe.to_string
+           (Types.backlog_to_yojson
+              { tasks = []; last_updated = Types.now_iso (); version = 11 }));
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      let root_backlog_path = Filename.concat masc_root "tasks/backlog.json" in
+      let root_backlog_promoted =
+        if Sys.file_exists root_backlog_path then
+          let root_backlog = Yojson.Safe.from_string (read_file root_backlog_path) in
+          let version = Yojson.Safe.Util.(root_backlog |> member "version" |> to_int) in
+          version = 7 || version = 11
+        else
+          false
+      in
+      Alcotest.(check bool)
+        "multiple legacy rooms do not promote a legacy backlog into root"
+        false root_backlog_promoted;
+      Alcotest.(check bool) "alpha-room backlog stays in legacy dir" true
+        (Sys.file_exists (Filename.concat alpha_tasks "backlog.json"));
+      Alcotest.(check bool) "beta-room backlog stays in legacy dir" true
+        (Sys.file_exists (Filename.concat beta_tasks "backlog.json")))
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -605,6 +641,10 @@ let () =
             "blocking bootstrap flattens single legacy room without current_room"
             `Quick
             test_blocking_bootstrap_flattens_single_legacy_room_without_current_room;
+          Alcotest.test_case
+            "blocking bootstrap skips flatten with multiple legacy rooms"
+            `Quick
+            test_blocking_bootstrap_skips_flatten_with_multiple_legacy_rooms;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -463,6 +463,33 @@ let test_blocking_bootstrap_skips_flatten_with_multiple_legacy_rooms () =
       Alcotest.(check bool) "beta-room backlog stays in legacy dir" true
         (Sys.file_exists (Filename.concat beta_tasks "backlog.json")))
 
+let test_blocking_bootstrap_ignores_whitespace_legacy_room_dirs () =
+  with_temp_dir "startup-blocking-room-whitespace" (fun dir ->
+      let state = Mcp_server.create_state ~base_path:dir in
+      let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
+      let spaced_tasks = Filename.concat masc_root "rooms/focus-room /tasks" in
+      Fs_compat.mkdir_p spaced_tasks;
+      write_file
+        (Filename.concat spaced_tasks "backlog.json")
+        (Yojson.Safe.to_string
+           (Types.backlog_to_yojson
+              { tasks = []; last_updated = Types.now_iso (); version = 13 }));
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      let root_backlog_path = Filename.concat masc_root "tasks/backlog.json" in
+      let root_backlog_promoted =
+        if Sys.file_exists root_backlog_path then
+          let root_backlog = Yojson.Safe.from_string (read_file root_backlog_path) in
+          let version = Yojson.Safe.Util.(root_backlog |> member "version" |> to_int) in
+          version = 13
+        else
+          false
+      in
+      Alcotest.(check bool) "whitespace room backlog stays in legacy dir" true
+        (Sys.file_exists (Filename.concat spaced_tasks "backlog.json"));
+      Alcotest.(check bool)
+        "whitespace room backlog does not promote into root" false
+        root_backlog_promoted)
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -645,6 +672,10 @@ let () =
             "blocking bootstrap skips flatten with multiple legacy rooms"
             `Quick
             test_blocking_bootstrap_skips_flatten_with_multiple_legacy_rooms;
+          Alcotest.test_case
+            "blocking bootstrap ignores whitespace legacy room dirs"
+            `Quick
+            test_blocking_bootstrap_ignores_whitespace_legacy_room_dirs;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case "liveness probe is always true" `Quick


### PR DESCRIPTION
## Summary
- follow up the already-merged #4756 flat-scope refactor with the remaining review fixes
- keep current-room compat writes observable while sanitizing invalid room labels in join_in_room logs/events
- infer a safe legacy room during startup migration, cache legacy-room detection, and make filesystem exists use metadata-only checks

## Product impact
- avoids skipping single-room legacy migrations when current_room is missing/invalid
- prevents invalid room labels from leaking into compat join logs/events
- removes repeated legacy room directory scans on read_current_room hot paths
- avoids loading whole files during filesystem exists checks

## Evidence
- `opam exec -- dune build --root . test/test_room_utils_coverage.exe test/test_server_runtime_bootstrap.exe test/test_multi_room.exe test/test_backend.exe`
- `./_build/default/test/test_room_utils_coverage.exe test path_helpers 8 --show-errors`
- `./_build/default/test/test_room_utils_coverage.exe test path_helpers 9 --show-errors`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 10 --show-errors`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 11 --show-errors`
- `./_build/default/test/test_multi_room.exe test current_room 2 --show-errors`
- `./_build/default/test/test_backend.exe test basic 1 --show-errors`

## Review evidence
- direct `sb glm-text --no-thinking` review on the staged diff returned `No findings.`

## Linked issue
- Refs #4638
- Follow-up for merged #4756