### PR TITLE
feat(command-plane): enforce unit policy in routing

### DIFF
--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -736,18 +736,18 @@ let dispatch_plan_json config json =
                  ("routing_reason", `String candidate.routing_reason);
                ])
     else
+      let workload_profile =
+        match operation with
+        | Some op -> operation_workload_profile op
+        | None -> "coding_task"
+      in
+      let stage =
+        match operation with
+        | Some op -> op.stage
+        | None -> None
+      in
       candidate_units_for_operation units operations current_unit_id
       |> List.filter_map (fun (unit : unit_record) ->
-             let workload_profile =
-               match operation with
-               | Some op -> operation_workload_profile op
-               | None -> "coding_task"
-             in
-             let stage =
-               match operation with
-               | Some op -> op.stage
-               | None -> None
-             in
              match
                operation_assignment_guard_json config unit.unit_id
                  ~workload_profile ~stage

--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -314,7 +314,11 @@ let check_blocked_intents config =
 
 let apply_operation_assignment config ~(actor : string) (operation : operation_record)
     ~target_unit_id ~note ~event_type =
-  match unit_guard_json config target_unit_id with
+  match
+    operation_assignment_guard_json config target_unit_id
+      ~workload_profile:(operation_workload_profile operation)
+      ~stage:operation.stage
+  with
   | Error message -> Error message
   | Ok _ ->
       let updated =
@@ -453,141 +457,143 @@ let start_operation config ~(actor : string) json =
     | Some value -> value
     | None -> invalid_arg "objective is required"
   in
-  match unit_guard_json config assigned_unit_id with
-  | Error message -> Error message
-  | Ok _ ->
-      let workload_template =
-        match get_string_opt json "workload_template" with
-        | Some value ->
-            let* validated = validate_workload_template value in
-            Ok (Some validated)
-        | None -> Ok None
-      in
-      let* workload_template = workload_template in
-      let inferred_workload_profile, inferred_stage =
-        match workload_template with
-        | Some template -> (
-            match workload_template_defaults template with
-            | Some defaults -> defaults
-            | None -> ("coding_task", None))
-        | None -> ("coding_task", None)
-      in
-      let explicit_workload_profile = get_string_opt json "workload_profile" in
-      let* () =
-        match workload_template, explicit_workload_profile with
-        | Some template, Some explicit_profile -> (
-            let expected_profile, _ =
-              match workload_template_defaults template with
-              | Some defaults -> defaults
-              | None -> ("coding_task", None)
-            in
-            let* normalized_explicit = validate_workload_profile explicit_profile in
-            if String.equal normalized_explicit expected_profile then
-              Ok ()
-            else
+  let workload_template =
+    match get_string_opt json "workload_template" with
+    | Some value ->
+        let* validated = validate_workload_template value in
+        Ok (Some validated)
+    | None -> Ok None
+  in
+  let* workload_template = workload_template in
+  let inferred_workload_profile, inferred_stage =
+    match workload_template with
+    | Some template -> (
+        match workload_template_defaults template with
+        | Some defaults -> defaults
+        | None -> ("coding_task", None))
+    | None -> ("coding_task", None)
+  in
+  let explicit_workload_profile = get_string_opt json "workload_profile" in
+  let* () =
+    match workload_template, explicit_workload_profile with
+    | Some template, Some explicit_profile -> (
+        let expected_profile, _ =
+          match workload_template_defaults template with
+          | Some defaults -> defaults
+          | None -> ("coding_task", None)
+        in
+        let* normalized_explicit = validate_workload_profile explicit_profile in
+        if String.equal normalized_explicit expected_profile then
+          Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "workload_template %s requires workload_profile=%s"
+               template expected_profile))
+    | _ -> Ok ()
+  in
+  let workload_profile_raw =
+    match explicit_workload_profile with
+    | Some value -> value
+    | None -> inferred_workload_profile
+  in
+  let requested_stage =
+    match get_string_opt json "stage" with
+    | Some value -> Some value
+    | None -> inferred_stage
+  in
+  let search_strategy_raw =
+    get_string_default json "search_strategy" (room_search_strategy_default config)
+  in
+  let depends_on_operation_ids = get_string_list json "depends_on_operation_ids" in
+  let requested_intent_id = get_string_opt json "intent_id" in
+  let raw_artifact_scope = get_string_list json "artifact_scope" in
+  let* workload_profile = validate_workload_profile workload_profile_raw in
+  let* stage =
+    validate_stage_for_workload ~workload_profile requested_stage
+  in
+  let* () =
+    operation_assignment_guard_json config assigned_unit_id ~workload_profile
+      ~stage
+    |> Result.map ignore
+  in
+  let* search_strategy = validate_search_strategy search_strategy_raw in
+  let* intent_binding =
+    match requested_intent_id with
+    | None -> Ok None
+    | Some intent_id ->
+        with_intent config intent_id (fun _ intent ->
+            if not (String.equal intent.workload_profile workload_profile) then
               Error
                 (Printf.sprintf
-                   "workload_template %s requires workload_profile=%s"
-                   template expected_profile))
-        | _ -> Ok ()
-      in
-      let workload_profile_raw =
-        match explicit_workload_profile with
+                   "intent workload_profile mismatch: intent=%s operation=%s"
+                   intent.workload_profile workload_profile)
+            else
+              Ok (Some intent))
+  in
+  let artifact_scope =
+    match intent_binding with
+    | Some intent when raw_artifact_scope = [] -> intent.artifact_priors
+    | _ -> raw_artifact_scope
+  in
+  let* () =
+    match workload_profile, stage with
+    | "coding_task", Some ("verify" | "review" as stage_name) ->
+        validate_coding_dependency_requirement ~stage:stage_name
+          ~depends_on_operation_ids
+    | _ -> Ok ()
+  in
+  let checkpoint_ref =
+    option_first_some (get_string_opt json "checkpoint_ref")
+      (legacy_chain_run_id json)
+  in
+  let operation =
+    {
+      operation_id = next_operation_id ();
+      objective;
+      intent_id = Option.map (fun (intent : intent_record) -> intent.intent_id) intent_binding;
+      assigned_unit_id;
+      policy_class = get_string_default json "policy_class" "strict";
+      budget_class = get_string_default json "budget_class" "standard";
+      workload_template;
+      workload_profile;
+      stage;
+      artifact_scope;
+      depends_on_operation_ids;
+      search_strategy;
+      detachment_session_id = get_string_opt json "detachment_session_id";
+      trace_id = next_trace_id ();
+      checkpoint_ref;
+      active_goal_ids = get_string_list json "active_goal_ids";
+      note = get_string_opt json "note";
+      created_by = actor;
+      source = "managed";
+      status =
+        (match
+           (match get_string_opt json "status" with
+           | Some value -> operation_status_of_string value
+           | None -> None)
+         with
         | Some value -> value
-        | None -> inferred_workload_profile
-      in
-      let requested_stage =
-        match get_string_opt json "stage" with
-        | Some value -> Some value
-        | None -> inferred_stage
-      in
-      let search_strategy_raw =
-        get_string_default json "search_strategy" (room_search_strategy_default config)
-      in
-      let depends_on_operation_ids = get_string_list json "depends_on_operation_ids" in
-      let requested_intent_id = get_string_opt json "intent_id" in
-      let raw_artifact_scope = get_string_list json "artifact_scope" in
-      let* workload_profile = validate_workload_profile workload_profile_raw in
-      let* stage =
-        validate_stage_for_workload ~workload_profile requested_stage
-      in
-      let* search_strategy = validate_search_strategy search_strategy_raw in
-      let* intent_binding =
-        match requested_intent_id with
-        | None -> Ok None
-        | Some intent_id ->
-            with_intent config intent_id (fun _ intent ->
-                if not (String.equal intent.workload_profile workload_profile) then
-                  Error
-                    (Printf.sprintf
-                       "intent workload_profile mismatch: intent=%s operation=%s"
-                       intent.workload_profile workload_profile)
-                else
-                  Ok (Some intent))
-      in
-      let artifact_scope =
-        match intent_binding with
-        | Some intent when raw_artifact_scope = [] -> intent.artifact_priors
-        | _ -> raw_artifact_scope
-      in
-      let* () =
-        match workload_profile, stage with
-        | "coding_task", Some ("verify" | "review" as stage_name) ->
-            validate_coding_dependency_requirement ~stage:stage_name
-              ~depends_on_operation_ids
-        | _ -> Ok ()
-      in
-      let checkpoint_ref =
-        option_first_some (get_string_opt json "checkpoint_ref")
-          (legacy_chain_run_id json)
-      in
-      let operation =
-        {
-          operation_id = next_operation_id ();
-          objective;
-          intent_id = Option.map (fun (intent : intent_record) -> intent.intent_id) intent_binding;
-          assigned_unit_id;
-          policy_class = get_string_default json "policy_class" "strict";
-          budget_class = get_string_default json "budget_class" "standard";
-          workload_template;
-          workload_profile;
-          stage;
-          artifact_scope;
-          depends_on_operation_ids;
-          search_strategy;
-          detachment_session_id = get_string_opt json "detachment_session_id";
-          trace_id = next_trace_id ();
-          checkpoint_ref;
-          active_goal_ids = get_string_list json "active_goal_ids";
-          note = get_string_opt json "note";
-          created_by = actor;
-          source = "managed";
-          status =
-            (match
-               (match get_string_opt json "status" with
-               | Some value -> operation_status_of_string value
-               | None -> None)
-             with
-            | Some value -> value
-            | None -> Active);
-          created_at = Types.now_iso ();
-          updated_at = Types.now_iso ();
-        }
-      in
-      let operations = read_operations config in
-      write_operations config (operation :: operations);
-      let _, _, units, _ = topology_units config in
-      let _ =
-        match operation_search_strategy operation with
-        | Cp_search_fabric.Legacy -> sync_managed_detachments config units operation
-        | Cp_search_fabric.Best_first_v1 -> []
-      in
-      touch_intent_from_operation config ~actor operation ~state:Active_intent;
-      append_cp_event config ~trace_id:operation.trace_id ~event_type:"operation_started"
-        ~operation_id:operation.operation_id ~unit_id:operation.assigned_unit_id ~actor
-        (`Assoc
-          [
-            ("objective", `String operation.objective);
+        | None -> Active);
+      created_at = Types.now_iso ();
+      updated_at = Types.now_iso ();
+    }
+  in
+  let operations = read_operations config in
+  write_operations config (operation :: operations);
+  let _, _, units, _ = topology_units config in
+  let _ =
+    match operation_search_strategy operation with
+    | Cp_search_fabric.Legacy -> sync_managed_detachments config units operation
+    | Cp_search_fabric.Best_first_v1 -> []
+  in
+  touch_intent_from_operation config ~actor operation ~state:Active_intent;
+  append_cp_event config ~trace_id:operation.trace_id ~event_type:"operation_started"
+    ~operation_id:operation.operation_id ~unit_id:operation.assigned_unit_id ~actor
+    (`Assoc
+      [
+        ("objective", `String operation.objective);
             ("intent_id", Json_util.string_opt_to_json operation.intent_id);
             ("policy_class", `String operation.policy_class);
             ("workload_template", Json_util.string_opt_to_json operation.workload_template);
@@ -732,7 +738,20 @@ let dispatch_plan_json config json =
     else
       candidate_units_for_operation units operations current_unit_id
       |> List.filter_map (fun (unit : unit_record) ->
-             match unit_guard_json config unit.unit_id with
+             let workload_profile =
+               match operation with
+               | Some op -> operation_workload_profile op
+               | None -> "coding_task"
+             in
+             let stage =
+               match operation with
+               | Some op -> op.stage
+               | None -> None
+             in
+             match
+               operation_assignment_guard_json config unit.unit_id
+                 ~workload_profile ~stage
+             with
              | Ok guard ->
                  Some
                    (`Assoc

--- a/lib/command_plane/cp_lifecycle_search.ml
+++ b/lib/command_plane/cp_lifecycle_search.ml
@@ -1,5 +1,75 @@
 include Cp_snapshot
 
+let normalized_allowlist_value raw =
+  String.trim raw |> String.lowercase_ascii
+
+let allowlist_allows_value allowlist value =
+  let allowlist =
+    allowlist
+    |> List.map normalized_allowlist_value
+    |> List.filter (fun item -> item <> "")
+  in
+  allowlist = []
+  || List.mem (normalized_allowlist_value value) allowlist
+
+let effective_capability_profile (unit : unit_record) =
+  unit.capability_profile
+  |> List.filter (fun raw ->
+         match Cp_search_fabric.extract_tag_value "tool" raw with
+         | Some tool_name ->
+             allowlist_allows_value unit.policy.tool_allowlist tool_name
+         | None -> (
+             match Cp_search_fabric.extract_tag_value "model" raw with
+             | Some model_name ->
+                 allowlist_allows_value unit.policy.model_allowlist model_name
+             | None -> true))
+
+let operation_policy_scope_label ~workload_profile ~stage =
+  let stage_label =
+    normalize_stage stage |> Option.value ~default:"generic"
+  in
+  Printf.sprintf "%s/%s" workload_profile stage_label
+
+let operation_requires_allowed_tools ~workload_profile ~stage =
+  match workload_profile, normalize_stage stage with
+  | "coding_task", Some ("implement" | "verify") -> true
+  | _ -> false
+
+let operation_requires_allowed_models ~workload_profile ~stage =
+  match workload_profile, normalize_stage stage with
+  | "research_pipeline", _ -> true
+  | "coding_task", Some ("inspect" | "review") -> true
+  | _ -> false
+
+let unit_policy_blocker (unit : unit_record) ~workload_profile ~stage =
+  let scope = operation_policy_scope_label ~workload_profile ~stage in
+  let effective_capabilities = effective_capability_profile unit in
+  let effective_tool_tags =
+    Cp_search_fabric.tag_values "tool" effective_capabilities
+  in
+  let effective_model_tags =
+    Cp_search_fabric.tag_values "model" effective_capabilities
+  in
+  if
+    operation_requires_allowed_tools ~workload_profile ~stage
+    && unit.policy.tool_allowlist <> []
+    && effective_tool_tags = []
+  then
+    Some
+      (Printf.sprintf
+         "assigned unit policy blocks %s: no allowed tool capability remains for unit %s"
+         scope unit.unit_id)
+  else if
+    operation_requires_allowed_models ~workload_profile ~stage
+    && unit.policy.model_allowlist <> []
+    && effective_model_tags = []
+  then
+    Some
+      (Printf.sprintf
+         "assigned unit policy blocks %s: no allowed model capability remains for unit %s"
+         scope unit.unit_id)
+  else
+    None
 
 let unit_guard_json config unit_id =
   let agents, _, units, _ = topology_units config in
@@ -39,6 +109,28 @@ let unit_guard_json config unit_id =
               ("active_operations", `Int active_count);
               ("active_operation_cap", `Int unit.budget.active_operation_cap);
             ])
+
+let operation_assignment_guard_json config unit_id ~workload_profile ~stage =
+  let _, _, units, _ = topology_units config in
+  match unit_guard_json config unit_id with
+  | Error _ as error -> error
+  | Ok guard -> (
+      match lookup_unit units unit_id with
+      | None -> Error (Printf.sprintf "assigned unit not found: %s" unit_id)
+      | Some unit -> (
+          match unit_policy_blocker unit ~workload_profile ~stage with
+          | Some message -> Error message
+          | None -> (
+              match guard with
+              | `Assoc fields ->
+                  Ok
+                    (`Assoc
+                      ( fields
+                      @ [
+                          ( "effective_capability_profile",
+                            json_list_of_strings (effective_capability_profile unit) );
+                        ] ))
+              | _ -> Ok guard)))
 
 let replace_operation operations (updated : operation_record) =
   updated
@@ -585,19 +677,24 @@ let operation_active_count operations unit_id =
 let search_candidates_for_operation config units operations
     (operation : operation_record) =
   let current_unit_id = Some operation.assigned_unit_id in
+  let workload_profile = operation_workload_profile operation in
+  let stage = operation.stage in
   candidate_units_for_operation units operations current_unit_id
   |> List.filter_map (fun (unit : unit_record) ->
-         match unit_guard_json config unit.unit_id with
+         match
+           operation_assignment_guard_json config unit.unit_id ~workload_profile
+             ~stage
+         with
          | Error _ -> None
          | Ok _ ->
              if decision_requires_approval units current_unit_id unit.unit_id then
                None
              else
-               Some
-                 {
+                Some
+                  {
                    Cp_search_fabric.unit_id = unit.unit_id;
                    label = unit.label;
-                   capability_profile = unit.capability_profile;
+                   capability_profile = effective_capability_profile unit;
                    active_operation_cap = unit.budget.active_operation_cap;
                    active_operations = operation_active_count operations unit.unit_id;
                    current_assignment = String.equal unit.unit_id operation.assigned_unit_id;

--- a/lib/command_plane/cp_lifecycle_search.ml
+++ b/lib/command_plane/cp_lifecycle_search.ml
@@ -3,12 +3,13 @@ include Cp_snapshot
 let normalized_allowlist_value raw =
   String.trim raw |> String.lowercase_ascii
 
+let normalize_allowlist raw =
+  raw
+  |> List.map normalized_allowlist_value
+  |> List.filter (fun item -> item <> "")
+
 let allowlist_allows_value allowlist value =
-  let allowlist =
-    allowlist
-    |> List.map normalized_allowlist_value
-    |> List.filter (fun item -> item <> "")
-  in
+  let allowlist = normalize_allowlist allowlist in
   allowlist = []
   || List.mem (normalized_allowlist_value value) allowlist
 
@@ -52,7 +53,7 @@ let unit_policy_blocker (unit : unit_record) ~workload_profile ~stage =
   in
   if
     operation_requires_allowed_tools ~workload_profile ~stage
-    && unit.policy.tool_allowlist <> []
+    && normalize_allowlist unit.policy.tool_allowlist <> []
     && effective_tool_tags = []
   then
     Some
@@ -61,7 +62,7 @@ let unit_policy_blocker (unit : unit_record) ~workload_profile ~stage =
          scope unit.unit_id)
   else if
     operation_requires_allowed_models ~workload_profile ~stage
-    && unit.policy.model_allowlist <> []
+    && normalize_allowlist unit.policy.model_allowlist <> []
     && effective_model_tags = []
   then
     Some
@@ -71,8 +72,7 @@ let unit_policy_blocker (unit : unit_record) ~workload_profile ~stage =
   else
     None
 
-let unit_guard_json config unit_id =
-  let agents, _, units, _ = topology_units config in
+let unit_guard_json_with ~agents ~units config unit_id =
   match lookup_unit units unit_id with
   | None -> Error (Printf.sprintf "assigned unit not found: %s" unit_id)
   | Some unit ->
@@ -110,9 +110,13 @@ let unit_guard_json config unit_id =
               ("active_operation_cap", `Int unit.budget.active_operation_cap);
             ])
 
+let unit_guard_json config unit_id =
+  let agents, _, units, _ = topology_units config in
+  unit_guard_json_with ~agents ~units config unit_id
+
 let operation_assignment_guard_json config unit_id ~workload_profile ~stage =
-  let _, _, units, _ = topology_units config in
-  match unit_guard_json config unit_id with
+  let agents, _, units, _ = topology_units config in
+  match unit_guard_json_with ~agents ~units config unit_id with
   | Error _ as error -> error
   | Ok guard -> (
       match lookup_unit units unit_id with

--- a/lib/command_plane/cp_lifecycle_search.ml
+++ b/lib/command_plane/cp_lifecycle_search.ml
@@ -102,39 +102,38 @@ let unit_guard_json_with ~agents ~units config unit_id =
              unit.budget.active_operation_cap)
       else
         Ok
-          (`Assoc
-            [
-              ("unit_id", `String unit.unit_id);
-              ("live_roster", `Int live_count);
-              ("active_operations", `Int active_count);
-              ("active_operation_cap", `Int unit.budget.active_operation_cap);
-            ])
+          ( unit,
+            `Assoc
+              [
+                ("unit_id", `String unit.unit_id);
+                ("live_roster", `Int live_count);
+                ("active_operations", `Int active_count);
+                ("active_operation_cap", `Int unit.budget.active_operation_cap);
+              ] )
 
 let unit_guard_json config unit_id =
   let agents, _, units, _ = topology_units config in
   unit_guard_json_with ~agents ~units config unit_id
+  |> Result.map snd
 
 let operation_assignment_guard_json config unit_id ~workload_profile ~stage =
   let agents, _, units, _ = topology_units config in
   match unit_guard_json_with ~agents ~units config unit_id with
   | Error _ as error -> error
-  | Ok guard -> (
-      match lookup_unit units unit_id with
-      | None -> Error (Printf.sprintf "assigned unit not found: %s" unit_id)
-      | Some unit -> (
-          match unit_policy_blocker unit ~workload_profile ~stage with
-          | Some message -> Error message
-          | None -> (
-              match guard with
-              | `Assoc fields ->
-                  Ok
-                    (`Assoc
-                      ( fields
-                      @ [
-                          ( "effective_capability_profile",
-                            json_list_of_strings (effective_capability_profile unit) );
-                        ] ))
-              | _ -> Ok guard)))
+  | Ok (unit, guard) -> (
+      match unit_policy_blocker unit ~workload_profile ~stage with
+      | Some message -> Error message
+      | None -> (
+          match guard with
+          | `Assoc fields ->
+              Ok
+                (`Assoc
+                  ( fields
+                  @ [
+                      ( "effective_capability_profile",
+                        json_list_of_strings (effective_capability_profile unit) );
+                    ] ))
+          | _ -> Ok guard))
 
 let replace_operation operations (updated : operation_record) =
   updated

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -236,7 +236,7 @@ let manual_help_entry name =
           key_constraints =
             [
               "Tool catalog visibility metadata is read-only in this snapshot.";
-              "Command-plane tool/model allowlists are reported as advisory until runtime enforcement is wired.";
+              "Command-plane tool/model allowlists now constrain unit routing and assignment via tagged capabilities, but they do not yet hard-stop every per-tool worker invocation.";
             ];
           details_markdown =
             "Provides a room-scoped control snapshot: auth config and credentials, command-plane policy topology, and the full tool inventory with metadata and permission hints.";
@@ -261,10 +261,10 @@ let manual_help_entry name =
           key_constraints =
             [
               "Section must be one of: auth | unit_policy.";
-              "Unit tool/model allowlists are stored and surfaced, but remain advisory until runtime enforcement is added.";
+              "Unit tool/model allowlists now affect command-plane routing and assignment when capability tags are present; worker-runtime per-tool enforcement is still a follow-up slice.";
             ];
           details_markdown =
-            "Delegates to the existing truthful write paths: Config mode updates, Auth config persistence, CPv2 unit policy updates, and keeper meta policy updates. Returns warnings for advisory-only fields.";
+            "Delegates to the existing truthful write paths: Config mode updates, Auth config persistence, CPv2 unit policy updates, and keeper meta policy updates. Command-plane unit policy now feeds routing/assignment gates; deeper worker-runtime enforcement remains a separate step.";
           doc_refs =
             [
               "docs/COMMAND-PLANE-RUNBOOK.md";

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -68,6 +68,10 @@ let () =
           Alcotest.test_case "best first search blocks and routes research pipeline"
             `Quick
             Test_command_plane_v2_search.test_best_first_search_blocks_and_routes_research_pipeline;
+          Alcotest.test_case
+            "best first search skips units blocked by tool allowlist"
+            `Quick
+            Test_command_plane_v2_search.test_best_first_search_skips_units_blocked_by_tool_allowlist;
           Alcotest.test_case "invalid search strategy is rejected" `Quick
             Test_command_plane_v2_search.test_invalid_search_strategy_is_rejected;
           Alcotest.test_case
@@ -87,5 +91,9 @@ let () =
             Test_command_plane_v2_policy_inputs.test_unit_reparent_requires_unit_id;
           Alcotest.test_case "policy update requires unit_id" `Quick
             Test_command_plane_v2_policy_inputs.test_policy_update_requires_unit_id;
+          Alcotest.test_case
+            "start operation rejects unit policy model mismatch"
+            `Quick
+            Test_command_plane_v2_policy_inputs.test_start_operation_rejects_unit_policy_model_mismatch;
         ] );
     ]

--- a/test/test_command_plane_v2_policy_inputs.ml
+++ b/test/test_command_plane_v2_policy_inputs.ml
@@ -40,3 +40,61 @@ let test_policy_update_requires_unit_id () =
     ~expected:"unit_id is required"
     (Command_plane_v2.policy_update_json config ~actor:"owner"
        (`Assoc [ ("policy", `Assoc []); ("budget", `Assoc []) ]))
+
+let test_start_operation_rejects_unit_policy_model_mismatch () =
+  with_test_config @@ fun config ->
+  let owner = "owner-root-node" in
+  let alpha_lead = "alpha-lead-node" in
+  let alpha_two = "alpha-two-node" in
+  let research_lead = "research-lead-node" in
+  Test_command_plane_v2_support.setup_company_and_platoon config ~owner
+    ~alpha_lead ~alpha_two;
+  ignore (Room.join config ~agent_name:research_lead ~capabilities:[] ());
+  ignore
+    (Test_command_plane_v2_support.unwrap_ok
+       (Command_plane_v2.unit_update_json config ~actor:"owner"
+          (`Assoc
+            [
+              ("unit_id", `String "platoon-alpha");
+              ("kind", `String "platoon");
+              ("label", `String "Alpha Platoon");
+              ("parent_unit_id", `String "company-main");
+              ("leader_id", `String alpha_lead);
+              ( "roster",
+                `List
+                  [
+                    `String alpha_lead;
+                    `String alpha_two;
+                    `String research_lead;
+                  ] );
+            ])));
+  ignore
+    (Test_command_plane_v2_support.unwrap_ok
+       (Command_plane_v2.unit_update_json config ~actor:"owner"
+          (`Assoc
+            [
+              ("unit_id", `String "squad-research");
+              ("kind", `String "squad");
+              ("label", `String "Research Squad");
+              ("parent_unit_id", `String "platoon-alpha");
+              ("leader_id", `String research_lead);
+              ("roster", `List [ `String research_lead ]);
+              ( "capability_profile",
+                `List [ `String "model:glm"; `String "runtime:codex" ] );
+              ( "policy",
+                `Assoc
+                  [ ("model_allowlist", `List [ `String "qwen" ]) ] );
+            ])));
+  expect_error
+    ~label:"start_operation policy model mismatch"
+    ~expected:
+      "assigned unit policy blocks research_pipeline/normalize: no allowed model capability remains for unit squad-research"
+    (Command_plane_v2.start_operation config ~actor:"owner"
+       (`Assoc
+         [
+           ("assigned_unit_id", `String "squad-research");
+           ("objective", `String "Normalize research artifacts");
+           ("workload_profile", `String "research_pipeline");
+           ("stage", `String "normalize");
+           ("search_strategy", `String "best_first_v1");
+         ]))

--- a/test/test_command_plane_v2_search.ml
+++ b/test/test_command_plane_v2_search.ml
@@ -220,3 +220,114 @@ let test_invalid_search_strategy_is_rejected () =
           Alcotest.(check string) "validation error"
             "unsupported search_strategy: made_up_strategy" message)
 
+let test_best_first_search_skips_units_blocked_by_tool_allowlist () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let approved_lead = "approved-lead-node" in
+      let blocked_lead = "blocked-lead-node" in
+      with_eio_test base_dir @@ fun config ->
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      ignore (Room.join config ~agent_name:approved_lead ~capabilities:[] ());
+      ignore (Room.join config ~agent_name:blocked_lead ~capabilities:[] ());
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "platoon-alpha");
+            ("kind", `String "platoon");
+            ("label", `String "Alpha Platoon");
+            ("parent_unit_id", `String "company-main");
+            ("leader_id", `String alpha_lead);
+            ( "roster",
+              `List
+                [
+                  `String alpha_lead;
+                  `String alpha_two;
+                  `String approved_lead;
+                  `String blocked_lead;
+                ] );
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "squad-approved");
+            ("kind", `String "squad");
+            ("label", `String "Approved Squad");
+            ("parent_unit_id", `String "platoon-alpha");
+            ("leader_id", `String approved_lead);
+            ("roster", `List [ `String approved_lead ]);
+            ( "capability_profile",
+              `List
+                [
+                  `String "tool:approved_tool";
+                  `String "model:qwen";
+                  `String "runtime:codex";
+                ] );
+            ( "policy",
+              `Assoc
+                [ ("tool_allowlist", `List [ `String "approved_tool" ]) ] );
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "squad-blocked");
+            ("kind", `String "squad");
+            ("label", `String "Blocked Squad");
+            ("parent_unit_id", `String "platoon-alpha");
+            ("leader_id", `String blocked_lead);
+            ("roster", `List [ `String blocked_lead ]);
+            ( "capability_profile",
+              `List
+                [
+                  `String "tool:code_write";
+                  `String "model:qwen";
+                  `String "runtime:codex";
+                ] );
+            ( "policy",
+              `Assoc
+                [ ("tool_allowlist", `List [ `String "approved_tool" ]) ] );
+          ]);
+      let op =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "platoon-alpha");
+              ("objective", `String "Implement approved tool change");
+              ("workload_profile", `String "coding_task");
+              ("stage", `String "implement");
+              ("search_strategy", `String "best_first_v1");
+            ])
+      in
+      let plan =
+        Command_plane_v2.dispatch_plan_json config
+          (`Assoc [ ("operation_id", `String op.operation_id) ])
+      in
+      let recommended =
+        plan |> Yojson.Safe.Util.member "recommended_units"
+        |> Yojson.Safe.Util.to_list
+      in
+      Alcotest.(check int) "only one recommended unit survives policy gate" 1
+        (List.length recommended);
+      Alcotest.(check string) "approved squad is recommended"
+        "squad-approved"
+        (recommended |> List.hd |> Yojson.Safe.Util.member "unit"
+       |> Yojson.Safe.Util.member "unit_id"
+       |> Yojson.Safe.Util.to_string);
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.dispatch_tick_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String op.operation_id) ])));
+      let op_json =
+        Command_plane_v2.operation_status_json config ~operation_id:op.operation_id
+          ()
+      in
+      Alcotest.(check string) "tick assigns approved squad" "squad-approved"
+        (op_json |> Yojson.Safe.Util.member "operations"
+       |> Yojson.Safe.Util.index 0
+       |> Yojson.Safe.Util.member "operation"
+       |> Yojson.Safe.Util.member "assigned_unit_id"
+       |> Yojson.Safe.Util.to_string))


### PR DESCRIPTION
## Summary

- make command-plane unit `tool_allowlist` and `model_allowlist` affect real routing and assignment decisions
- gate `start_operation`, `dispatch_assign`, and best-first candidate selection on the unit's effective capability profile
- add regression tests covering tool-allowlist candidate filtering and model-allowlist rejection at operation start

## Product impact

- Promise affected: `none/internal`
- User-visible change: command-plane policy becomes materially more trustworthy for supervised routing, but only at the routing/assignment layer

## Evidence

- `./_build/default/test/test_command_plane_v2.exe`
- Result: `27` tests passed after rebase onto `origin/main`
- Added regression coverage for:
  - best-first routing skipping units blocked by `tool_allowlist`
  - `start_operation` rejecting unit/model policy mismatch

## Review evidence

- Cross-model review: direct `sb glm-text` (GLM-5.1)
- Status: completed. No high/critical issues found. 3 false positives explained in PR comment.
- Copilot review: 3 threads addressed and resolved (double lookup, normalize consistency, loop-invariant hoist)
- Fix commits: c982f6f59 (normalize + hoist), 0e488ec1b (redundant lookup_unit elimination)

## Linked issue

- Refs #4794
- Refs #4793