### PR TITLE
fix(server): log unhandled exceptions before exit (#4795)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -281,6 +281,7 @@ let acquire_pid_lock port =
       exit 1
 
 let run_cmd host port base_path =
+  Printexc.record_backtrace true;
   acquire_pid_lock port;
   Log.init_from_env ();
   Unix.putenv "MASC_BASE_PATH" base_path;
@@ -405,6 +406,11 @@ let run_cmd host port base_path =
         exit 1
     | Unix.Unix_error (Unix.EACCES, _, _) ->
         Log.Server.error "[FATAL] Permission denied binding to port %d" port;
+        exit 1
+    | exn ->
+        let bt = Printexc.get_backtrace () in
+        Log.Server.error "[FATAL] Unhandled exception: %s" (Printexc.to_string exn);
+        if bt <> "" then Log.Server.error "[FATAL] Backtrace:\n%s" bt;
         exit 1)
   in
   try_start 0;

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -407,6 +407,12 @@ let run_cmd host port base_path =
     | Unix.Unix_error (Unix.EACCES, _, _) ->
         Log.Server.error "[FATAL] Permission denied binding to port %d" port;
         exit 1
+    | Out_of_memory ->
+        Printf.eprintf "[FATAL] Out_of_memory\n%!";
+        exit 1
+    | Stack_overflow ->
+        Printf.eprintf "[FATAL] Stack_overflow\n%!";
+        exit 1
     | exn ->
         let bt = Printexc.get_backtrace () in
         Log.Server.error "[FATAL] Unhandled exception: %s" (Printexc.to_string exn);


### PR DESCRIPTION
## Summary
- try 블록에 catch-all 추가 — 미처리 예외 시 로그 + backtrace 기록 후 exit
- Printexc.record_backtrace 활성화

## 문제
서버가 로그 없이 죽음. EADDRINUSE/EACCES/Cancelled 외 예외가 catch되지 않아 silent exit.

## Linked issue
Closes #4795

## Test plan
- [x] dune build clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>