### PR TITLE
keeper: emit entropy/source markers in deliberation evidence

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -255,6 +255,10 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     (if keeper_tools <> [] then keeper_tools else audit.latest_tool_names)
     |> cap_string_list
   in
+  let latest_action_source =
+    trim_to_option (string_field "latest_action_source" keeper)
+    |> option_or_else (fun () -> audit.latest_action_source)
+  in
   let skill_route_summary = skill_route_summary_of_keeper keeper in
   let (emoji, korean_name) = get_agent_identity name in
   {
@@ -287,6 +291,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
         @ tool_preview_fields "allowed_tool" allowed_tool_names
         @ [
             ("latest_tool_call_count", option_to_json (fun value -> `Int value) audit.latest_tool_call_count);
+            ("latest_action_source", json_string_option latest_action_source);
             ("tool_audit_source", json_string_option audit.tool_audit_source);
             ("tool_audit_at", json_string_option audit.tool_audit_at);
             ("autonomous_action_count", `Int autonomous_action_count);

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -65,6 +65,7 @@ type tool_audit_snapshot = {
   allowed_tool_names : string list;
   latest_tool_names : string list;
   latest_tool_call_count : int option;
+  latest_action_source : string option;
   tool_audit_source : string option;
   tool_audit_at : string option;
 }
@@ -166,6 +167,7 @@ let tool_audit_snapshot agent_name =
         allowed_tool_names = task.allowed_tools;
         latest_tool_names = [];
         latest_tool_call_count = None;
+        latest_action_source = None;
         tool_audit_source = Some "heartbeat_task";
         tool_audit_at = Some task.created_at;
       }
@@ -174,6 +176,7 @@ let tool_audit_snapshot agent_name =
         allowed_tool_names = task.allowed_tools;
         latest_tool_names = result.tool_names;
         latest_tool_call_count = Some result.tool_call_count;
+        latest_action_source = None;
         tool_audit_source = Some "heartbeat_result";
         tool_audit_at = Some result.updated_at;
       }
@@ -182,6 +185,7 @@ let tool_audit_snapshot agent_name =
         allowed_tool_names = task.allowed_tools;
         latest_tool_names = [];
         latest_tool_call_count = None;
+        latest_action_source = None;
         tool_audit_source = Some "heartbeat_task";
         tool_audit_at = Some task.created_at;
       }
@@ -190,6 +194,7 @@ let tool_audit_snapshot agent_name =
         allowed_tool_names = [];
         latest_tool_names = result.tool_names;
         latest_tool_call_count = Some result.tool_call_count;
+        latest_action_source = None;
         tool_audit_source = Some "heartbeat_result";
         tool_audit_at = Some result.updated_at;
       }
@@ -198,6 +203,7 @@ let tool_audit_snapshot agent_name =
         allowed_tool_names = [];
         latest_tool_names = [];
         latest_tool_call_count = None;
+        latest_action_source = None;
         tool_audit_source = None;
         tool_audit_at = None;
       }

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -53,6 +53,14 @@ let keeper_tool_audit_json_fields config keeper agent_name =
           }
     | None -> None
   in
+  let fallback_latest_action_source =
+    match file_snapshot with
+    | Some snapshot -> (
+        match snapshot.latest_action_source with
+        | Some _ as value -> value
+        | None -> fallback_action_source)
+    | None -> fallback_action_source
+  in
   let allowed_tool_names, latest_tool_names, latest_tool_call_count,
       latest_action_source, tool_audit_source, tool_audit_at =
     match A2a_tools.latest_heartbeat_task agent_name,
@@ -62,23 +70,28 @@ let keeper_tool_audit_json_fields config keeper agent_name =
           ( task.allowed_tools,
             result.tool_names,
             Some result.tool_call_count,
-            None,
+            fallback_latest_action_source,
             Some "heartbeat_task_pending_result",
             Some task.created_at )
         else
           ( task.allowed_tools,
             result.tool_names,
             Some result.tool_call_count,
-            None,
+            fallback_latest_action_source,
             Some "heartbeat_result",
             Some result.updated_at )
     | Some task, None ->
-        (task.allowed_tools, [], None, None, Some "heartbeat_task", Some task.created_at)
+        ( task.allowed_tools,
+          [],
+          None,
+          fallback_latest_action_source,
+          Some "heartbeat_task",
+          Some task.created_at )
     | None, Some result ->
         ( fallback_allowed,
           result.tool_names,
           Some result.tool_call_count,
-          None,
+          fallback_latest_action_source,
           Some "heartbeat_result",
           Some result.updated_at )
     | None, None ->

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -25,6 +25,9 @@ let keeper_tool_audit_json_fields config keeper agent_name =
     | Some _ as value -> value
     | None -> None
   in
+  let fallback_action_source =
+    trim_to_option (string_field "latest_action_source" keeper)
+  in
   let fallback_at =
     trim_to_option (string_field "tool_audit_at" keeper)
   in
@@ -51,7 +54,7 @@ let keeper_tool_audit_json_fields config keeper agent_name =
     | None -> None
   in
   let allowed_tool_names, latest_tool_names, latest_tool_call_count,
-      tool_audit_source, tool_audit_at =
+      latest_action_source, tool_audit_source, tool_audit_at =
     match A2a_tools.latest_heartbeat_task agent_name,
           A2a_tools.latest_heartbeat_result agent_name with
     | Some task, Some result ->
@@ -59,20 +62,23 @@ let keeper_tool_audit_json_fields config keeper agent_name =
           ( task.allowed_tools,
             result.tool_names,
             Some result.tool_call_count,
+            None,
             Some "heartbeat_task_pending_result",
             Some task.created_at )
         else
           ( task.allowed_tools,
             result.tool_names,
             Some result.tool_call_count,
+            None,
             Some "heartbeat_result",
             Some result.updated_at )
     | Some task, None ->
-        (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+        (task.allowed_tools, [], None, None, Some "heartbeat_task", Some task.created_at)
     | None, Some result ->
         ( fallback_allowed,
           result.tool_names,
           Some result.tool_call_count,
+          None,
           Some "heartbeat_result",
           Some result.updated_at )
     | None, None ->
@@ -81,6 +87,7 @@ let keeper_tool_audit_json_fields config keeper agent_name =
             ( fallback_allowed,
               snapshot.latest_tool_names,
               snapshot.latest_tool_call_count,
+              snapshot.latest_action_source,
               snapshot.tool_audit_source,
               snapshot.tool_audit_at )
         | None ->
@@ -93,15 +100,21 @@ let keeper_tool_audit_json_fields config keeper agent_name =
                 max acc e.Keeper_tools_oas.last_used_at) 0.0 tracked in
               let at_str = if latest_at > 0.0
                 then Some (Dashboard_utils.iso_of_unix latest_at) else None in
-              (fallback_allowed, names, Some total, Some "keeper_dispatch", at_str)
+              (fallback_allowed, names, Some total, None, Some "keeper_dispatch", at_str)
             else
-              (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at))
+              ( fallback_allowed,
+                fallback_latest,
+                fallback_count,
+                fallback_action_source,
+                fallback_source,
+                fallback_at ))
   in
   [
     ("allowed_tool_names", string_list_json allowed_tool_names);
     ("latest_tool_names", string_list_json latest_tool_names);
     ( "latest_tool_call_count",
       option_to_json (fun value -> `Int value) latest_tool_call_count );
+    ("latest_action_source", json_string_option latest_action_source);
     ("tool_audit_source", json_string_option tool_audit_source);
     ("tool_audit_at", json_string_option tool_audit_at);
   ]

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -383,6 +383,19 @@ type structured_result = {
   confidence: float;
 }
 
+type action_source =
+  | Baseline
+  | Structured_model
+  | Fallback_after_validation_failure
+
+let action_source_to_string = function
+  | Baseline -> "baseline"
+  | Structured_model -> "structured_model"
+  | Fallback_after_validation_failure -> "fallback_after_validation_failure"
+
+let action_source_to_json source =
+  `String (action_source_to_string source)
+
 type legality_verdict =
   | Legal
   | Illegal of string
@@ -390,6 +403,7 @@ type legality_verdict =
 type execution_result = {
   proposed_action: deliberation_action;
   selected_action: deliberation_action;
+  action_source: action_source;
   fallback_used: bool;
   fallback_reason: string option;
   policy_labels: string list;
@@ -472,14 +486,46 @@ let legality_verdict obs action =
   | None -> Legal
   | Some reason -> Illegal reason
 
+let baseline_execution_result (obs : world_observation) : execution_result =
+  let action = deterministic_baseline_action obs in
+  {
+    proposed_action = action;
+    selected_action = action;
+    action_source = Baseline;
+    fallback_used = false;
+    fallback_reason = None;
+    policy_labels = policy_labels_of_action action;
+    reasoning = "deterministic_baseline";
+    confidence = 1.0;
+  }
+
+let action_source_of_execution_result (result : execution_result) =
+  result.action_source
+
+let execution_result_to_json (result : execution_result) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("proposed_action", deliberation_action_to_json result.proposed_action);
+      ("selected_action", deliberation_action_to_json result.selected_action);
+      ("action_source", action_source_to_json result.action_source);
+      ("fallback_used", `Bool result.fallback_used);
+      ( "fallback_reason",
+        match result.fallback_reason with
+        | Some reason -> `String reason
+        | None -> `Null );
+      ("policy_labels", `List (List.map (fun label -> `String label) result.policy_labels));
+      ("reasoning", `String result.reasoning);
+      ("confidence", `Float result.confidence);
+    ]
+
 let execute_structured_result (obs : world_observation)
     (result : structured_result) : execution_result =
-  let baseline_action = deterministic_baseline_action obs in
   match legality_verdict obs result.action with
   | Legal ->
       {
         proposed_action = result.action;
         selected_action = result.action;
+        action_source = Structured_model;
         fallback_used = false;
         fallback_reason = None;
         policy_labels = policy_labels_of_action result.action;
@@ -487,12 +533,14 @@ let execute_structured_result (obs : world_observation)
         confidence = result.confidence;
       }
   | Illegal reason ->
+      let baseline = baseline_execution_result obs in
       {
         proposed_action = result.action;
-        selected_action = baseline_action;
+        selected_action = baseline.selected_action;
+        action_source = Fallback_after_validation_failure;
         fallback_used = true;
         fallback_reason = Some reason;
-        policy_labels = policy_labels_of_action baseline_action;
+        policy_labels = baseline.policy_labels;
         reasoning = result.reasoning;
         confidence = result.confidence;
       }

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -73,6 +73,14 @@ val world_observation_to_json : world_observation -> Yojson.Safe.t
 
 (** {1 Deterministic execution} *)
 
+type action_source =
+  | Baseline
+  | Structured_model
+  | Fallback_after_validation_failure
+
+val action_source_to_string : action_source -> string
+val action_source_to_json : action_source -> Yojson.Safe.t
+
 type legality_verdict =
   | Legal
   | Illegal of string
@@ -80,6 +88,7 @@ type legality_verdict =
 type execution_result = {
   proposed_action: deliberation_action;
   selected_action: deliberation_action;
+  action_source: action_source;
   fallback_used: bool;
   fallback_reason: string option;
   policy_labels: string list;
@@ -87,6 +96,9 @@ type execution_result = {
   confidence: float;
 }
 
+val baseline_execution_result : world_observation -> execution_result
+val action_source_of_execution_result : execution_result -> action_source
+val execution_result_to_json : execution_result -> Yojson.Safe.t
 val policy_labels_of_action : deliberation_action -> string list
 val legality_verdict : world_observation -> deliberation_action -> legality_verdict
 val execute_structured_result :

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -485,65 +485,118 @@ let read_recent_metrics_lines config keeper_name =
     let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
     Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
 
+let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
+  let ordered = List.rev lines in
+  match List.find_map parse_snapshot ordered with
+  | Some _ as snapshot -> snapshot
+  | None ->
+      List.find_map
+        (fun line ->
+          try
+            let json = Yojson.Safe.from_string line in
+            match parse_snapshot line with
+            | Some _ as snapshot -> snapshot
+            | None ->
+                if has_legacy_shape json then
+                  Some
+                    {
+                      latest_tool_names = [];
+                      latest_tool_call_count = Some 0;
+                      latest_action_source = None;
+                      tool_audit_source = None;
+                      tool_audit_at = json_iso_opt json;
+                    }
+                else None
+          with Yojson.Json_error _ -> None)
+        ordered
+
 let latest_tool_audit_snapshot_from_decisions config keeper_name =
   let path = Keeper_types.keeper_decision_log_path config keeper_name in
   if not (Sys.file_exists path) then None
   else
-    Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12
-    |> List.rev
-    |> List.find_map (fun line ->
-           try
-             let json = Yojson.Safe.from_string line in
-             let tools = json_string_list_member "tools_used" json in
-             let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
-           let tool_call_count =
-             match raw_tool_call_count with
-             | Some _ as value -> value
-             | None -> Some (List.length tools)
-           in
-            let action_source = action_source_opt_member json in
-            if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
-            then None
-            else
-              Some
-                {
-                  latest_tool_names = List.sort_uniq String.compare tools;
-                  latest_tool_call_count = tool_call_count;
-                  latest_action_source = action_source;
-                  tool_audit_source = Some "keeper_decision_log";
-                  tool_audit_at = json_iso_opt json;
-                }
-           with Yojson.Json_error _ -> None)
+    let lines = Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12 in
+    let parse_snapshot line =
+      try
+        let json = Yojson.Safe.from_string line in
+        let tools = json_string_list_member "tools_used" json in
+        let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+        let tool_call_count =
+          match raw_tool_call_count with
+          | Some _ as value -> value
+          | None -> Some (List.length tools)
+        in
+        let action_source = action_source_opt_member json in
+        if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+        then None
+        else
+          Some
+            {
+              latest_tool_names = List.sort_uniq String.compare tools;
+              latest_tool_call_count = tool_call_count;
+              latest_action_source = action_source;
+              tool_audit_source = Some "keeper_decision_log";
+              tool_audit_at = json_iso_opt json;
+            }
+      with Yojson.Json_error _ -> None
+    in
+    latest_snapshot_of_lines lines
+      ~parse_snapshot
+      ~has_legacy_shape:(fun json ->
+        Option.is_some (json_iso_opt json)
+        || Option.is_some (Safe_ops.json_string_opt "selected_mode" json)
+        || Option.is_some (Safe_ops.json_string_opt "outcome" json))
+    |> Option.map (fun snapshot ->
+           {
+             snapshot with
+             tool_audit_source =
+               Some
+                 (Option.value ~default:"keeper_decision_log"
+                    snapshot.tool_audit_source);
+           })
 
 let latest_tool_audit_snapshot_from_metrics config keeper_name =
-  read_recent_metrics_lines config keeper_name
-  |> List.rev
-  |> List.find_map (fun line ->
-         try
-           let json = Yojson.Safe.from_string line in
-           let tools =
-             json_string_list_member "tools_used" json
-             |> List.sort_uniq String.compare
-           in
-           let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
-           let tool_call_count =
-             match raw_tool_call_count with
-             | Some _ as value -> value
-             | None -> Some (List.length tools)
-           in
-           let action_source = action_source_opt_member json in
-           if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
-           then None
-           else
+  let lines = read_recent_metrics_lines config keeper_name in
+  let parse_snapshot line =
+    try
+      let json = Yojson.Safe.from_string line in
+      let tools =
+        json_string_list_member "tools_used" json
+        |> List.sort_uniq String.compare
+      in
+      let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+      let tool_call_count =
+        match raw_tool_call_count with
+        | Some _ as value -> value
+        | None -> Some (List.length tools)
+      in
+      let action_source = action_source_opt_member json in
+      if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+      then None
+      else
+        Some
+          {
+            latest_tool_names = tools;
+            latest_tool_call_count = tool_call_count;
+            latest_action_source = action_source;
+            tool_audit_source = Some "keeper_metrics";
+            tool_audit_at = json_iso_opt json;
+          }
+    with Yojson.Json_error _ -> None
+  in
+  latest_snapshot_of_lines lines
+    ~parse_snapshot
+    ~has_legacy_shape:(fun json ->
+      Option.is_some (json_iso_opt json)
+      || Option.is_some (Safe_ops.json_string_opt "channel" json)
+      || Option.is_some (Safe_ops.json_string_opt "work_kind" json))
+  |> Option.map (fun snapshot ->
+         {
+           snapshot with
+           tool_audit_source =
              Some
-               {
-                 latest_tool_names = tools;
-                 latest_tool_call_count = tool_call_count;
-                 latest_action_source = action_source;
-                 tool_audit_source = Some "keeper_metrics";
-                 tool_audit_at = json_iso_opt json;
-               }
-         with Yojson.Json_error _ -> None)
+               (Option.value ~default:"keeper_metrics"
+                  snapshot.tool_audit_source);
+         })
 
 let latest_tool_audit_snapshot_from_files config ~keeper_name =
   match latest_tool_audit_snapshot_from_decisions config keeper_name with

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -42,6 +42,7 @@ type metrics_summary = {
 type tool_audit_snapshot = {
   latest_tool_names : string list;
   latest_tool_call_count : int option;
+  latest_action_source : string option;
   tool_audit_source : string option;
   tool_audit_at : string option;
 }
@@ -89,6 +90,7 @@ let empty_tool_audit_snapshot =
   {
     latest_tool_names = [];
     latest_tool_call_count = None;
+    latest_action_source = None;
     tool_audit_source = None;
     tool_audit_at = None;
   }
@@ -456,6 +458,18 @@ let json_int_opt_member key json =
   | `Float value -> Some (int_of_float value)
   | _ -> None
 
+let action_source_opt_member json =
+  match Safe_ops.json_string_opt "action_source" json with
+  | Some _ as value -> value
+  | None -> (
+      match Yojson.Safe.Util.member "deliberation_execution" json with
+      | `Assoc _ as nested ->
+          Safe_ops.json_string_opt "action_source" nested
+      | _ -> None)
+
+let has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source =
+  tools <> [] || Option.is_some raw_tool_call_count || Option.is_some action_source
+
 let json_iso_opt json =
   match Safe_ops.json_string_opt "ts" json with
   | Some text when String.trim text <> "" -> Some (String.trim text)
@@ -482,27 +496,23 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
              let json = Yojson.Safe.from_string line in
              let tools = json_string_list_member "tools_used" json in
              let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
-             let tool_call_count =
-               match raw_tool_call_count with
-               | Some _ as value -> value
-               | None -> Some (List.length tools)
-             in
-             let has_decision_shape =
-               Option.is_some (json_iso_opt json)
-               || Option.is_some (Safe_ops.json_string_opt "selected_mode" json)
-               || Option.is_some (Safe_ops.json_string_opt "outcome" json)
-               || tools <> []
-               || Option.is_some raw_tool_call_count
-             in
-             if not has_decision_shape then None
-             else
-               Some
-                 {
-                   latest_tool_names = List.sort_uniq String.compare tools;
-                   latest_tool_call_count = tool_call_count;
-                   tool_audit_source = Some "keeper_decision_log";
-                   tool_audit_at = json_iso_opt json;
-                 }
+           let tool_call_count =
+             match raw_tool_call_count with
+             | Some _ as value -> value
+             | None -> Some (List.length tools)
+           in
+            let action_source = action_source_opt_member json in
+            if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+            then None
+            else
+              Some
+                {
+                  latest_tool_names = List.sort_uniq String.compare tools;
+                  latest_tool_call_count = tool_call_count;
+                  latest_action_source = action_source;
+                  tool_audit_source = Some "keeper_decision_log";
+                  tool_audit_at = json_iso_opt json;
+                }
            with Yojson.Json_error _ -> None)
 
 let latest_tool_audit_snapshot_from_metrics config keeper_name =
@@ -521,19 +531,15 @@ let latest_tool_audit_snapshot_from_metrics config keeper_name =
              | Some _ as value -> value
              | None -> Some (List.length tools)
            in
-           let has_metric_shape =
-             Option.is_some (json_iso_opt json)
-             || Option.is_some (Safe_ops.json_string_opt "channel" json)
-             || Option.is_some (Safe_ops.json_string_opt "work_kind" json)
-             || tools <> []
-             || Option.is_some raw_tool_call_count
-           in
-           if not has_metric_shape then None
+           let action_source = action_source_opt_member json in
+           if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+           then None
            else
              Some
                {
                  latest_tool_names = tools;
                  latest_tool_call_count = tool_call_count;
+                 latest_action_source = action_source;
                  tool_audit_source = Some "keeper_metrics";
                  tool_audit_at = json_iso_opt json;
                }

--- a/lib/keeper/keeper_exec_status_metrics.mli
+++ b/lib/keeper/keeper_exec_status_metrics.mli
@@ -3,6 +3,7 @@ type metrics_summary
 type tool_audit_snapshot = {
   latest_tool_names : string list;
   latest_tool_call_count : int option;
+  latest_action_source : string option;
   tool_audit_source : string option;
   tool_audit_at : string option;
 }

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -405,6 +405,7 @@ let handle_keeper_status ctx args : tool_result =
                 empty_tool_audit_snapshot with
                 latest_tool_call_count =
                   (if has_runtime_activity then Some 0 else None);
+                latest_action_source = None;
                 tool_audit_source =
                   (if has_runtime_activity then Some "keeper_runtime_meta" else None);
                 tool_audit_at =
@@ -477,6 +478,8 @@ let handle_keeper_status ctx args : tool_result =
              string_list_to_json tool_audit_snapshot.latest_tool_names);
            ("latest_tool_call_count",
              Json_util.int_opt_to_json tool_audit_snapshot.latest_tool_call_count);
+           ("latest_action_source",
+             Json_util.string_opt_to_json tool_audit_snapshot.latest_action_source);
            ("tool_audit_source",
              Json_util.string_opt_to_json tool_audit_snapshot.tool_audit_source);
            ("tool_audit_at",

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -201,6 +201,7 @@ let append_decision_record
     ~(outcome : string)
     ~(selected_mode : string)
     ?social_state
+    ?deliberation_execution
     ?(result : Keeper_agent_run.run_result option = None)
     ?error
     () : unit =
@@ -286,6 +287,17 @@ let append_decision_record
         ("tools_used", `List (List.map (fun s -> `String s) tools_used));
         ("claim_was_available", `Bool (observation.unclaimed_task_count > 0));
         ("claim_executed", `Bool claim_executed);
+        ( "action_source",
+          match deliberation_execution with
+          | Some execution ->
+              Keeper_deliberation.action_source_of_execution_result execution
+              |> Keeper_deliberation.action_source_to_json
+          | None -> `Null );
+        ( "deliberation_execution",
+          match deliberation_execution with
+          | Some execution ->
+              Keeper_deliberation.execution_result_to_json execution
+          | None -> `Null );
         ( "response_preview",
           match response_preview with
           | Some preview -> `String preview
@@ -449,7 +461,8 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
     ~(context_max : int)
     ~(message_count : int)
     ~(compaction : Keeper_exec_context.compaction_event)
-    ~(handoff_json : Yojson.Safe.t option) () : unit =
+    ~(handoff_json : Yojson.Safe.t option)
+    ?deliberation_execution () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let work_kind =
@@ -496,6 +509,17 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("work_kind", `String work_kind);
         ("tool_call_count", `Int result.tool_calls_made);
         ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
+        ( "action_source",
+          match deliberation_execution with
+          | Some execution ->
+              Keeper_deliberation.action_source_of_execution_result execution
+              |> Keeper_deliberation.action_source_to_json
+          | None -> `Null );
+        ( "deliberation_execution",
+          match deliberation_execution with
+          | Some execution ->
+              Keeper_deliberation.execution_result_to_json execution
+          | None -> `Null );
         ("cascade",
          match result.cascade_observation with
          | Some observation -> Oas_worker.cascade_observation_to_json observation

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -55,6 +55,7 @@ val append_metrics_snapshot :
   message_count:int ->
   compaction:Keeper_exec_context.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
+  ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit
 

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -167,26 +167,30 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
         ( task.allowed_tools,
           result.tool_names,
           Some result.tool_call_count,
+          None,
           Some "heartbeat_task_pending_result",
           Some task.created_at )
       else
         ( task.allowed_tools,
           result.tool_names,
           Some result.tool_call_count,
+          None,
           Some "heartbeat_result",
           Some result.updated_at )
   | Some task, None ->
-      (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+      (task.allowed_tools, [], None, None, Some "heartbeat_task", Some task.created_at)
   | None, Some result ->
       ( fallback_allowed,
         result.tool_names,
         Some result.tool_call_count,
+        None,
         Some "heartbeat_result",
         Some result.updated_at )
   | None, None ->
       ( fallback_allowed,
         fallback_snapshot.latest_tool_names,
         fallback_snapshot.latest_tool_call_count,
+        fallback_snapshot.latest_action_source,
         fallback_snapshot.tool_audit_source,
         fallback_snapshot.tool_audit_at )
 
@@ -241,8 +245,8 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    ~meta ~keepalive_running ~keepalive_started_at ~now_ts
             in
             let allowed_tool_names, latest_tool_names, latest_tool_call_count,
-                tool_audit_source, tool_audit_at =
-              if lightweight then ([], [], None, None, None)
+                latest_action_source, tool_audit_source, tool_audit_at =
+              if lightweight then ([], [], None, None, None, None)
               else keeper_tool_audit_fields config meta
             in
             let agent_status =
@@ -297,6 +301,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                   ("latest_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
                   ("recent_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
                   ("latest_tool_call_count", option_to_json (fun value -> `Int value) latest_tool_call_count);
+                  ("latest_action_source", string_option_to_json latest_action_source);
                   ("tool_audit_source", string_option_to_json tool_audit_source);
                   ("tool_audit_at", string_option_to_json tool_audit_at);
                   ("updated_at", `String meta.updated_at);

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -645,6 +645,7 @@ let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
                 ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_vote" ]);
                 ("latest_tool_names", `List []);
                 ("latest_tool_call_count", `Null);
+                ("latest_action_source", `String "structured_model");
                 ("tool_audit_source", `Null);
                 ("tool_audit_at", `Null);
               ];
@@ -658,6 +659,8 @@ let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
         ((brief |> member "allowed_tool_names" |> to_list) <> []);
       check string "heartbeat task source wins in keeper brief" "heartbeat_task"
         (brief |> member "tool_audit_source" |> to_string);
+      check string "heartbeat task preserves fallback action source" "structured_model"
+        (brief |> member "latest_action_source" |> to_string);
       check bool "no observed tools without evidence" true
         ((brief |> member "latest_tool_names" |> to_list) = []))
 

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -678,6 +678,7 @@ let test_dashboard_mission_keeper_tool_audit_uses_decision_log () =
           [
             ("ts", `String (Types.now_iso ()));
             ("selected_mode", `String "text_response");
+            ("action_source", `String "structured_model");
             ("tool_call_count", `Int 0);
             ("tools_used", `List []);
           ]);
@@ -704,6 +705,9 @@ let test_dashboard_mission_keeper_tool_audit_uses_decision_log () =
       in
       check string "decision log source present in keeper brief" "keeper_decision_log"
         (brief |> member "tool_audit_source" |> to_string);
+      check string "decision log action source present in keeper brief"
+        "structured_model"
+        (brief |> member "latest_action_source" |> to_string);
       check int "decision log zero tool count preserved" 0
         (brief |> member "latest_tool_call_count" |> to_int);
       check bool "decision log still reports empty tool list" true

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -182,6 +182,12 @@ let test_baseline_no_mention_returns_noop () =
   | D.Noop _ -> ()
   | _ -> fail "expected Noop for no mention"
 
+let test_baseline_execution_result_emits_baseline_source () =
+  let result = D.baseline_execution_result base_obs in
+  check string "baseline source" "baseline"
+    (D.action_source_to_string result.action_source);
+  check bool "baseline fallback not used" false result.fallback_used
+
 (* ---------- Deliberation meta tests ---------- *)
 
 let test_deliberation_meta_json_roundtrip () =
@@ -477,6 +483,8 @@ let test_execute_structured_result_keeps_legal_action () =
       }
   in
   let result = D.execute_structured_result obs structured in
+  check string "legal action source" "structured_model"
+    (D.action_source_to_string result.action_source);
   check bool "fallback not used" false result.fallback_used;
   check (option string) "no fallback reason" None result.fallback_reason;
   check (list string) "policy labels" [ "task_claim" ] result.policy_labels;
@@ -496,6 +504,8 @@ let test_execute_structured_result_falls_back_to_baseline () =
       }
   in
   let result = D.execute_structured_result obs structured in
+  check string "fallback action source" "fallback_after_validation_failure"
+    (D.action_source_to_string result.action_source);
   check bool "fallback used" true result.fallback_used;
   check bool "fallback reason present" true (Option.is_some result.fallback_reason);
   check (list string) "policy labels" [ "noop" ] result.policy_labels;
@@ -911,6 +921,8 @@ let () =
             test_baseline_mention_returns_reply;
           test_case "no mention returns Noop" `Quick
             test_baseline_no_mention_returns_noop;
+          test_case "baseline execution emits baseline source" `Quick
+            test_baseline_execution_result_emits_baseline_source;
         ] );
       ( "deliberation_meta",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6,6 +6,7 @@ module UT = Masc_mcp.Keeper_unified_turn
 module KAR = Masc_mcp.Keeper_agent_run
 module KEC = Masc_mcp.Keeper_exec_context
 module KSM = Masc_mcp.Keeper_social_model
+module KD = Masc_mcp.Keeper_deliberation
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
 module HK = Masc_mcp.Keeper_hooks_oas
@@ -798,6 +799,10 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
               };
         }
       in
+      let deliberation_execution =
+        KD.baseline_execution_result
+          (KD.empty_world_observation ~keeper_name:minimal_meta.name)
+      in
       UT.append_metrics_snapshot
         ~config
         ~meta:minimal_meta
@@ -822,6 +827,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
             saved_tokens = 0;
           }
         ~handoff_json:None
+        ~deliberation_execution
         ();
       let metrics_store =
         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
@@ -849,7 +855,13 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
           json |> member "cascade" |> member "attempt_details_available" |> to_bool);
       check string "attempt detail boundary persisted" "oas_metrics_callbacks"
         Yojson.Safe.Util.(
-          json |> member "cascade" |> member "attempt_details_source" |> to_string))
+          json |> member "cascade" |> member "attempt_details_source" |> to_string);
+      check string "action source persisted" "baseline"
+        Yojson.Safe.Util.(json |> member "action_source" |> to_string);
+      check string "nested deliberation execution source persisted" "baseline"
+        Yojson.Safe.Util.(
+          json |> member "deliberation_execution" |> member "action_source"
+          |> to_string))
 
 let test_context_overflow_limit_parses_common_oas_errors () =
   check (option int) "available context size extracted" (Some 159671)

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -434,6 +434,7 @@ let test_snapshot_keeper_tool_audit_uses_decision_log () =
           [
             ("ts", `String (Types.now_iso ()));
             ("selected_mode", `String "text_response");
+            ("action_source", `String "fallback_after_validation_failure");
             ("tool_call_count", `Int 0);
             ("tools_used", `List []);
           ]);
@@ -459,6 +460,9 @@ let test_snapshot_keeper_tool_audit_uses_decision_log () =
       let keeper = load_keeper_snapshot 10 in
       Alcotest.(check string) "decision log source exposed" "keeper_decision_log"
         (keeper |> member "tool_audit_source" |> to_string);
+      Alcotest.(check string) "decision log action source exposed"
+        "fallback_after_validation_failure"
+        (keeper |> member "latest_action_source" |> to_string);
       Alcotest.(check int) "decision log zero tool count exposed" 0
         (keeper |> member "latest_tool_call_count" |> to_int);
       Alcotest.(check bool) "decision log names remain empty" true

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1081,6 +1081,68 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
       in
       check string "detailed list skill route primary" "masc-heartbeat"
         Yojson.Safe.Util.(keeper_row |> member "skill_route" |> member "primary" |> to_string))
+
+let test_keeper_status_detailed_preserves_legacy_metrics_fallback () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "legacy-detail-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "legacy-detail-demo");
+              ("goal", `String "Inspect legacy status");
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "keeper up ok" true ok;
+      (match Masc_mcp.Keeper_registry.find_by_name "legacy-detail-demo" with
+       | Some entry -> Atomic.set entry.fiber_stop true
+       | None -> ());
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "legacy-detail-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta"
+        | Error e -> fail e
+      in
+      let metrics_store = Masc_mcp.Keeper_types.keeper_metrics_store config meta.name in
+      let legacy_metrics_json = Yojson.Safe.from_string
+          {|{"channel":"turn","generation":0,"trace_id":"trace-legacy","context_ratio":0.33,"context_tokens":80,"context_max":512,"message_count":2}|}
+      in
+      Dated_jsonl.append metrics_store legacy_metrics_json;
+      let ok, body =
+        dispatch "masc_keeper_status"
+          (`Assoc
+            [
+              ("name", `String "legacy-detail-demo");
+              ("fast", `Bool false);
+              ("include_context", `Bool false);
+              ("include_metrics_overview", `Bool true);
+            ])
+      in
+      check bool "status ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      check string "tool audit source from legacy metrics fallback" "keeper_metrics"
+        Yojson.Safe.Util.(json |> member "tool_audit_source" |> to_string);
+      check bool "legacy metrics fallback keeps null action source" true
+        Yojson.Safe.Util.(json |> member "latest_action_source" = `Null);
+      check int "legacy metrics fallback keeps zero tool calls" 0
+        Yojson.Safe.Util.(json |> member "latest_tool_call_count" |> to_int))
 (* test_keeper_policy_tools_roundtrip: removed — keeper policy tools return stubs *)
 (* test_keeper_policy_set_rejects_invalid_mode: removed — keeper policy_mode system removed *)
 
@@ -2588,6 +2650,8 @@ let () =
            test_keeper_dispatch_auxiliary_surfaces_smoke;
          test_case "keeper status detailed reads metrics/history/memory" `Quick
            test_keeper_status_detailed_reads_metrics_history_and_memory;
+         test_case "keeper status detailed preserves legacy metrics fallback" `Quick
+           test_keeper_status_detailed_preserves_legacy_metrics_fallback;
          test_case "shell tool policy gates" `Quick
            test_keeper_shell_tool_policy_gates;
          test_case "shell readonly enforces allowed paths" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -994,7 +994,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
       let memory_bank_path = Masc_mcp.Keeper_types.keeper_memory_bank_path config meta.name in
       let decision_log_path = Masc_mcp.Keeper_types.keeper_decision_log_path config meta.name in
       let turn_json = Yojson.Safe.from_string
-          {|{"channel":"turn","generation":0,"trace_id":"trace-1","context_ratio":0.41,"context_tokens":120,"context_max":1024,"message_count":4,"memory_check":{"performed":true,"passed":true,"final_score":0.9},"skill_primary":"masc-heartbeat","skill_secondary":["masc-keeper-autonomy"],"skill_reason":"stateful routing","skill_selection_mode":"agent","skill_provenance":"judgment"}|}
+          {|{"channel":"turn","generation":0,"trace_id":"trace-1","context_ratio":0.41,"context_tokens":120,"context_max":1024,"message_count":4,"memory_check":{"performed":true,"passed":true,"final_score":0.9},"skill_primary":"masc-heartbeat","skill_secondary":["masc-keeper-autonomy"],"skill_reason":"stateful routing","skill_selection_mode":"agent","skill_provenance":"judgment","action_source":"structured_model"}|}
       in
       let compaction_json = Yojson.Safe.from_string
           {|{"channel":"proactive","generation":0,"trace_id":"trace-1","compacted":true,"compaction_before_tokens":180,"compaction_after_tokens":120,"memory_compaction_performed":true,"memory_compaction_before_notes":4,"memory_compaction_after_notes":2,"memory_compaction_dropped_notes":2,"memory_compaction_invalid_dropped":1,"memory_compaction_reason":"dedupe"}|}
@@ -1051,6 +1051,8 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         Yojson.Safe.Util.(json |> member "storage_paths" |> member "decisions" |> to_string);
       check string "tool audit source from metrics fallback" "keeper_metrics"
         Yojson.Safe.Util.(json |> member "tool_audit_source" |> to_string);
+      check string "action source from metrics fallback" "structured_model"
+        Yojson.Safe.Util.(json |> member "latest_action_source" |> to_string);
       check int "tool audit count falls back to zero" 0
         Yojson.Safe.Util.(json |> member "latest_tool_call_count" |> to_int);
       check bool "tool audit names remain empty without tool use" true


### PR DESCRIPTION
## Summary
- add `action_source` markers to keeper deliberation execution evidence and downstream report surfaces
- keep marker assignment runtime-owned at the executor boundary while surfacing it in status, operator, and dashboard read models
- preserve legacy metrics/decision fallback behavior and keep fallback `latest_action_source` visible in dashboard heartbeat paths

## Testing
- `dune build --root . --build-dir /tmp/masc-4749-build-clean --display=short test/test_keeper_deliberation.exe test/test_keeper_unified.exe test/test_tool_keeper.exe test/test_dashboard_mission.exe test/test_operator_control.exe`
- `/tmp/masc-4749-build-clean/default/test/test_keeper_deliberation.exe`
- `/tmp/masc-4749-build-clean/default/test/test_keeper_unified.exe`
- `/tmp/masc-4749-build-clean/default/test/test_tool_keeper.exe`
- `/tmp/masc-4749-build-clean/default/test/test_dashboard_mission.exe`
- `/tmp/masc-4749-build-clean/default/test/test_operator_control.exe`
- `scripts/check-version-truth.sh`

## Links
- Closes #4749
- Related: #4738
