### PR TITLE
fix(dashboard): resolve CI test timeouts by enforcing serial execution and mocking lucide icons

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,7 +12,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:serial": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest"
   },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run --no-file-parallelism --maxWorkers=1",
-    "test:serial": "vitest run --no-file-parallelism --maxWorkers=1",
+    "test:serial": "pnpm test",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -5,15 +5,12 @@ import { html } from 'htm/preact'
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {
   const actual = await importOriginal<typeof import('lucide-preact')>()
-  const mocked: any = Object.create(
-    Object.getPrototypeOf(actual),
-    Object.getOwnPropertyDescriptors(actual),
-  )
+  const mocked: Record<string, unknown> = { ...actual }
 
   for (const key of Object.getOwnPropertyNames(actual)) {
     if (key === '__esModule' || key === 'createLucideIcon' || key === 'default')
       continue
-    if (typeof mocked[key] !== 'function') continue
+    if (typeof actual[key as keyof typeof actual] !== 'function') continue
 
     mocked[key] = ({ size, className, ...props }: any) =>
       html`<span data-icon=${key} width=${size} height=${size} class=${className} ...${props}></span>`

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -5,13 +5,19 @@ import { html } from 'htm/preact'
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {
   const actual = await importOriginal<typeof import('lucide-preact')>()
-  const mocked: any = { __esModule: true }
-  
-  for (const key in actual) {
-    if (key === 'createLucideIcon' || key === 'default') continue
-    mocked[key] = ({ size, className, ...props }: any) => 
+  const mocked: any = Object.create(
+    Object.getPrototypeOf(actual),
+    Object.getOwnPropertyDescriptors(actual),
+  )
+
+  for (const key of Object.getOwnPropertyNames(actual)) {
+    if (key === '__esModule' || key === 'createLucideIcon' || key === 'default')
+      continue
+    if (typeof mocked[key] !== 'function') continue
+
+    mocked[key] = ({ size, className, ...props }: any) =>
       html`<span data-icon=${key} width=${size} height=${size} class=${className} ...${props}></span>`
   }
-  
+
   return mocked
 })

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -5,15 +5,23 @@ import { html } from 'htm/preact'
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {
   const actual = await importOriginal<typeof import('lucide-preact')>()
-  const mocked: Record<string, unknown> = { ...actual }
+  const mocked: Record<string, unknown> = Object.create(
+    Object.getPrototypeOf(actual),
+    Object.getOwnPropertyDescriptors(actual),
+  )
 
   for (const key of Object.getOwnPropertyNames(actual)) {
     if (key === '__esModule' || key === 'createLucideIcon' || key === 'default')
       continue
     if (typeof actual[key as keyof typeof actual] !== 'function') continue
 
-    mocked[key] = ({ size, className, ...props }: any) =>
-      html`<span data-icon=${key} width=${size} height=${size} class=${className} ...${props}></span>`
+    Object.defineProperty(mocked, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: ({ size, className, ...props }: any) =>
+        html`<span data-icon=${key} width=${size} height=${size} class=${className} ...${props}></span>`,
+    })
   }
 
   return mocked

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest'
+import { html } from 'htm/preact'
+
+// Mock all lucide-preact icons to a lightweight span to avoid happy-dom timeout issues
+// This drastically reduces mounting time during parallel test runs.
+vi.mock('lucide-preact', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('lucide-preact')>()
+  const mocked: any = { __esModule: true }
+  
+  for (const key in actual) {
+    if (key === 'createLucideIcon' || key === 'default') continue
+    mocked[key] = ({ size, className, ...props }: any) => 
+      html`<span data-icon=${key} width=${size} height=${size} class=${className} ...${props}></span>`
+  }
+  
+  return mocked
+})

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'happy-dom',
     include: ['src/**/*.test.ts'],
     globals: true,
+    setupFiles: ['./vitest-setup.ts'],
   },
 })


### PR DESCRIPTION
## Overview
- Fixed the issue where `pnpm test` would randomly time out in CI or local environments due to `lucide-preact` icons monopolizing CPU/memory during parallel `happy-dom` mounting.
- Created `vitest-setup.ts` to mock all `lucide-preact` imports with a lightweight `<span>` component, drastically reducing mount overhead.
- Changed the default `test` script to execute serially (`--no-file-parallelism --maxWorkers=1`) to guarantee 100% stability across environments.