### PR TITLE
[codex] Align discord package metadata with gate naming

### DIFF
--- a/sidecars/discord-bot/pyproject.toml
+++ b/sidecars/discord-bot/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "masc-discord-bot"
 version = "0.1.0"
-description = "Discord bot consumer for MASC Channel Gate"
+description = "Discord bot consumer for the Channel Gate"
 requires-python = ">=3.11"
 dependencies = [
     "discord.py>=2.4.0",


### PR DESCRIPTION
## Summary
- rename the Discord sidecar package description to refer to the Channel Gate instead of `MASC Channel Gate`

## Why
The connector boundary cleanup in #4789 moved user-facing naming to the Gate contract, but the Python package metadata still exposed the older name.

## Impact
- keeps published/package metadata aligned with the Gate-centered boundary language
- no runtime behavior changes

## Validation
- `python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('sidecars/discord-bot/pyproject.toml').read_text())"`
- `rg -n "MASC Channel Gate" sidecars/discord-bot`

Refs #4789