### PR TITLE
fix(tools): rescue Tool_shard.schemas registration from orphan branch

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -33,6 +33,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_rate_limit.schemas
     @ Tool_repair_loop.schemas
     @ Tool_agent_timeline.schemas
+    @ Tool_shard.schemas
     )
 
 (** Validate tool schemas at module initialization time.


### PR DESCRIPTION
## Summary
- `Tool_shard.schemas` was added on orphan branch `chore/deprecate-dead-features` but never merged to main.
- Without this line in `raw_all_tool_schemas`, the shard management tools (`masc_tool_grant`, `masc_tool_revoke`, `masc_tool_list`) are invisible to the MCP tool registry.
- Single-line addition to `lib/config.ml`, appending `@ Tool_shard.schemas` to the schema composition list.

## Verification
- `dune build lib/config.ml` compiles clean.
- `tool_inventory_gen.exe` confirms `masc_tool_grant`, `masc_tool_revoke`, `masc_tool_list` appear in the inventory.
- `test_tool_shard_coverage.exe`: 50/50 tests pass.
- `test_tool_registry.exe`: 12/12 tests pass.

## Test plan
- [x] Compilation passes
- [x] Tool inventory includes shard tools
- [x] Shard coverage tests pass (50/50)
- [x] Tool registry tests pass (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)