### PR TITLE
feat(dashboard): replace native confirm with custom ConfirmDialog modal

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -21,6 +21,7 @@ import { KeeperDetailOverlay } from './components/keeper-detail'
 import { AgentDetailOverlay } from './components/agent-detail'
 import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
 import { ToastContainer } from './components/common/toast'
+import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
@@ -131,6 +132,7 @@ export function App() {
       <${AgentDetailOverlay} />
       <${TaskDetailOverlay} />
       <${ToastContainer} />
+      <${ConfirmDialogOverlay} />
     </div>
   `
 }

--- a/dashboard/src/components/autoresearch-state.ts
+++ b/dashboard/src/components/autoresearch-state.ts
@@ -2,6 +2,7 @@
 // Extracted from autoresearch.ts to separate state from UI.
 
 import { signal, computed } from '@preact/signals'
+import { requestConfirm } from './common/confirm-dialog'
 import { createAsyncResource } from '../lib/async-state'
 import {
   deleteAutoresearchLoop,
@@ -131,12 +132,12 @@ export async function retrySelectedLoop() {
 export async function deleteSelectedLoop() {
   const loop = selectedLoop.value
   if (!loop?.loop_id) return
-  if (typeof globalThis.confirm === 'function') {
-    const confirmed = globalThis.confirm(
-      `루프 ${loop.loop_id}와 연결된 worktree/branch/results를 삭제합니다. 계속할까요?`,
-    )
-    if (!confirmed) return
-  }
+  const confirmed = await requestConfirm({
+    title: '루프 삭제',
+    message: `루프 ${loop.loop_id}와 연결된 worktree/branch/results를 삭제합니다. 계속할까요?`,
+    tone: 'danger'
+  })
+  if (!confirmed) return
   await runLoopAction(() => deleteAutoresearchLoop(loop.loop_id))
 }
 

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -103,8 +103,8 @@ describe('Autoresearch surface refresh', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    confirmMock = vi.fn(() => true)
-    vi.stubGlobal('confirm', confirmMock)
+    confirmMock = vi.fn(() => Promise.resolve(true))
+    vi.doMock('./common/confirm-dialog', () => ({ requestConfirm: confirmMock }))
   })
 
   afterEach(async () => {
@@ -321,7 +321,7 @@ describe('Autoresearch surface refresh', () => {
   })
 
   it('does not delete when the confirmation is cancelled', async () => {
-    confirmMock.mockReturnValueOnce(false)
+    confirmMock.mockReturnValueOnce(Promise.resolve(false))
     const erroredLoop = loopSummary('loop-del1', {
       status: 'error',
       live: false,

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -1,0 +1,115 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { AlertTriangle, AlertCircle, Info } from 'lucide-preact'
+
+export type ConfirmTone = 'danger' | 'warning' | 'info'
+
+interface ConfirmState {
+  isOpen: boolean
+  title: string
+  message: string
+  confirmText: string
+  cancelText: string
+  tone: ConfirmTone
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const confirmState = signal<ConfirmState>({
+  isOpen: false,
+  title: '',
+  message: '',
+  confirmText: '확인',
+  cancelText: '취소',
+  tone: 'warning',
+  onConfirm: () => {},
+  onCancel: () => {}
+})
+
+export function requestConfirm({
+  title,
+  message,
+  confirmText = '확인',
+  cancelText = '취소',
+  tone = 'warning'
+}: {
+  title: string
+  message: string
+  confirmText?: string
+  cancelText?: string
+  tone?: ConfirmTone
+}): Promise<boolean> {
+  return new Promise((resolve) => {
+    confirmState.value = {
+      isOpen: true,
+      title,
+      message,
+      confirmText,
+      cancelText,
+      tone,
+      onConfirm: () => {
+        confirmState.value = { ...confirmState.value, isOpen: false }
+        resolve(true)
+      },
+      onCancel: () => {
+        confirmState.value = { ...confirmState.value, isOpen: false }
+        resolve(false)
+      }
+    }
+  })
+}
+
+export function ConfirmDialogOverlay() {
+  const state = confirmState.value
+  if (!state.isOpen) return null
+
+  const handleClose = () => state.onCancel()
+  
+  // Prevent clicks inside the modal from bubbling to the overlay backdrop
+  const stopPropagation = (e: Event) => e.stopPropagation()
+
+  let iconColor = 'text-warn'
+  let iconBg = 'bg-warn/10 border-warn/20'
+  let confirmBtnClass = 'bg-[var(--warn)] text-[var(--bg-0)] hover:bg-[var(--warn)]/90'
+  let IconComponent = AlertTriangle
+
+  if (state.tone === 'danger') {
+    iconColor = 'text-bad'
+    iconBg = 'bg-bad/10 border-bad/20'
+    confirmBtnClass = 'bg-[var(--bad)] text-white hover:bg-[var(--bad)]/90'
+    IconComponent = AlertCircle
+  } else if (state.tone === 'info') {
+    iconColor = 'text-accent'
+    iconBg = 'bg-accent/10 border-accent/20'
+    confirmBtnClass = 'bg-[var(--accent)] text-[var(--bg-0)] hover:bg-[var(--accent)]/90'
+    IconComponent = Info
+  }
+
+  return html`
+    <div class="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm isolate flex items-center justify-center p-4 animate-in fade-in duration-200" onClick=${handleClose}>
+      <div class="w-full max-w-[400px] bg-[rgba(13,21,38,0.98)] rounded-xl border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+        <div class="p-5">
+          <div class="flex items-start gap-4">
+            <div class="shrink-0 size-10 rounded-full border flex items-center justify-center ${iconBg} ${iconColor}">
+              <${IconComponent} size=${20} />
+            </div>
+            <div class="flex-1 min-w-0 pt-0.5">
+              <h2 id="confirm-dialog-title" class="text-[16px] font-semibold text-text-strong mb-1 leading-snug">${state.title}</h2>
+              <p class="text-[13px] text-text-body leading-relaxed opacity-90 whitespace-pre-wrap">${state.message}</p>
+            </div>
+          </div>
+          <div class="mt-6 flex items-center justify-end gap-2">
+            <button type="button"
+              class="px-4 py-2 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
+              onClick=${state.onCancel}
+            >${state.cancelText}</button>
+            <button type="button"
+              class="px-4 py-2 rounded-lg text-[13px] font-medium border border-transparent transition-colors cursor-pointer ${confirmBtnClass}"
+              onClick=${state.onConfirm}
+            >${state.confirmText}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
+import { requestConfirm } from '../common/confirm-dialog'
 import { SurfaceCard } from '../common/card'
 import { ActionButton } from '../common/button'
 import { TextInput } from '../common/input'
@@ -82,10 +83,16 @@ export function FlowControlPanel() {
         <summary class="cursor-pointer text-[13px] text-[var(--text-strong)] font-medium select-none py-1">유지보수</summary>
         <div class="mt-3 flex flex-wrap gap-2">
           <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value}
-            onClick=${() => { if (confirm('GC를 실행합니까?')) void runGarbageCollection() }}>
+            onClick=${async () => {
+              const confirmed = await requestConfirm({ title: '유지보수', message: 'GC를 실행합니까?' })
+              if (confirmed) void runGarbageCollection()
+            }}>
             ${maintenanceLoading.value ? '...' : 'GC 실행'}<//>
           <${ActionButton} variant="danger" size="md" disabled=${maintenanceLoading.value}
-            onClick=${() => { if (confirm('좀비 에이전트를 정리합니까?')) void cleanupZombies() }}>
+            onClick=${async () => {
+              const confirmed = await requestConfirm({ title: '유지보수', message: '좀비 에이전트를 정리합니까?', tone: 'danger' })
+              if (confirmed) void cleanupZombies()
+            }}>
             ${maintenanceLoading.value ? '...' : '좀비 정리'}<//>
         </div>
         ${maintenanceResult.value ? html`

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -6,6 +6,7 @@ import { StatusBadge } from '../common/status-badge'
 import { TimeAgo } from '../common/time-ago'
 import { FilterChips } from '../common/filter-chips'
 import { showToast } from '../common/toast'
+import { requestConfirm } from '../common/confirm-dialog'
 import { goals, refreshGoals } from '../../store'
 import { deleteGoal } from '../../api/actions'
 import type { Goal } from '../../types'
@@ -28,7 +29,12 @@ export function GoalRow({ goal }: { goal: Goal }) {
 
   async function handleDelete(e: Event) {
     e.stopPropagation()
-    if (!confirm(`"${goal.title}" 목표를 삭제하시겠습니까?`)) return
+    const confirmed = await requestConfirm({
+      title: '목표 삭제',
+      message: `"${goal.title}" 목표를 삭제하시겠습니까?`,
+      tone: 'danger'
+    })
+    if (!confirmed) return
     deletingGoalId.value = goal.id
     try {
       await deleteGoal(goal.id)

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -9,6 +9,7 @@ import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
+import { requestConfirm } from '../common/confirm-dialog'
 import { tasksByStatus, refreshExecution, executionLoading, executionLoaded, executionError } from '../../store'
 import { deleteTask } from '../../api/actions'
 import type { Task } from '../../types'
@@ -70,7 +71,12 @@ export function KanbanCard({ task }: { task: Task }) {
 
   async function handleDelete(e: Event) {
     e.stopPropagation()
-    if (!confirm(`"${task.title}" 태스크를 삭제하시겠습니까?`)) return
+    const confirmed = await requestConfirm({
+      title: '태스크 삭제',
+      message: `"${task.title}" 태스크를 삭제하시겠습니까?`,
+      tone: 'danger'
+    })
+    if (!confirmed) return
     deletingTaskId.value = task.id
     try {
       await deleteTask(task.id)

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { isOfflineStatus } from '../lib/status-utils'
 import { signal } from '@preact/signals'
 import { useRef } from 'preact/hooks'
+import { requestConfirm } from './common/confirm-dialog'
 import { currentDashboardActor, runOperatorAction } from '../api'
 import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
@@ -373,8 +374,13 @@ export function KeeperDetailOverlay() {
                 <button type="button"
                   class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
                   onClick=${() => {
-                    if (confirm(keeper.name + ' 키퍼를 종료합니까?')) {
-                      void (async () => {
+                    void (async () => {
+                      const confirmed = await requestConfirm({
+                        title: '키퍼 종료',
+                        message: keeper.name + ' 키퍼를 종료합니까?',
+                        tone: 'danger'
+                      })
+                      if (confirmed) {
                         try {
                           const res = await shutdownKeeper(keeper.name)
                           if (res.ok) {
@@ -386,8 +392,8 @@ export function KeeperDetailOverlay() {
                         } catch {
                           showToast('종료 실패', 'error')
                         }
-                      })()
-                    }
+                      }
+                    })()
                   }}
                 >종료</button>`
               return null

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
+import { requestConfirm } from './common/confirm-dialog'
 import { isOfflineStatus } from '../lib/status-utils'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import type { Keeper, KeeperDiagnostic } from '../types'
@@ -425,7 +426,12 @@ export function KeeperRuntimeActions({
     }
   }
   const runShutdown = async () => {
-    if (!confirm(`${keeper.name} 키퍼를 종료합니까?`)) return
+    const confirmed = await requestConfirm({
+      title: '키퍼 종료',
+      message: `${keeper.name} 키퍼를 종료합니까?`,
+      tone: 'danger'
+    })
+    if (!confirmed) return
     keeperShuttingDown.value = { ...keeperShuttingDown.value, [keeper.name]: true }
     try {
       const response = await shutdownKeeper(keeper.name)

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -1,5 +1,6 @@
 import { signal } from '@preact/signals'
 import { showToast } from './common/toast'
+import { requestConfirm } from './common/confirm-dialog'
 import {
   boardPosts,
   boardSortMode,
@@ -305,7 +306,12 @@ export function togglePostSelection(postId: string, event: Event) {
 export async function bulkDeleteSelected() {
   const ids = Array.from(selectedPostIds.value)
   if (ids.length === 0) return
-  if (!confirm(`${ids.length}개의 글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`)) return
+  const confirmed = await requestConfirm({
+    title: '선택 삭제',
+    message: `${ids.length}개의 글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`,
+    tone: 'danger'
+  })
+  if (!confirmed) return
   bulkDeleting.value = true
   const results = await Promise.allSettled(ids.map(id => deleteBoardPost(id)))
   const deleted = results.filter(r => r.status === 'fulfilled').length

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
+import { requestConfirm } from './common/confirm-dialog'
 import { EmptyState } from './common/empty-state'
 import { Markdown } from './common/markdown'
 import { TextInput, TextArea } from './common/input'
@@ -285,7 +286,12 @@ function PostCard({ post }: { post: BoardPost }) {
 
   const handleDelete = async (event: Event) => {
     event.stopPropagation()
-    if (!confirm(`"${post.title}" 게시글을 삭제하시겠습니까?`)) return
+    const confirmed = await requestConfirm({
+      title: '게시글 삭제',
+      message: `"${post.title}" 게시글을 삭제하시겠습니까?`,
+      tone: 'danger'
+    })
+    if (!confirmed) return
     deletingPostId.value = post.id
     try {
       await deleteBoardPost(post.id)


### PR DESCRIPTION
## Overview
- Replaced the rigid, browser-native `confirm()` alerts with a beautifully styled, custom `ConfirmDialogOverlay` component.
- The new modal provides a much more integrated and professional UX (e.g., customized icons, tone colors like danger/warning, and a backdrop blur).
- Applied across all destructive or high-risk actions (Task deletion, Memory deletion, Keeper shutdown, Autoresearch loop termination, GC/Zombie Cleanup).