### PR TITLE
[codex] Genericize external channel serialization

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -43,14 +43,8 @@ let string_of_channel = function
 let channel_to_yojson = function
   | Api -> `String "Api"
   | Internal -> `String "Internal"
-  | External s -> (
-      match normalize_channel_label s with
-      | "telegram" -> `String "Telegram"
-      | "discord" -> `String "Discord"
-      | "slack" -> `String "Slack"
-      | "signal" -> `String "Signal"
-      | "webchat" -> `String "Webchat"
-      | other -> `List [ `String "External"; `String other ] )
+  | External s ->
+      `List [ `String "External"; `String (normalize_channel_label s) ]
 
 let channel_of_yojson = function
   | `String "Api" | `String "api" -> Ok Api

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -117,8 +117,8 @@ let test_channel_yojson_backward_compat () =
     (match Agent_identity.channel_of_yojson (`String "Discord") with
      | Ok channel -> Ok (Agent_identity.string_of_channel channel)
      | Error err -> Error err);
-  check string "known external serializes like legacy constructor"
-    "\"Discord\""
+  check string "known external serializes as tagged external"
+    "[\"External\",\"discord\"]"
     (Yojson.Safe.to_string
        (Agent_identity.channel_to_yojson (Agent_identity.External "DisCord")));
   check string "unknown external serializes as tagged external"

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -117,6 +117,13 @@ let test_channel_yojson_backward_compat () =
     (match Agent_identity.channel_of_yojson (`String "Discord") with
      | Ok channel -> Ok (Agent_identity.string_of_channel channel)
      | Error err -> Error err);
+  check (result string string) "tagged external Discord decodes"
+    (Ok "discord")
+    (match Agent_identity.channel_of_yojson
+             (`List [ `String "External"; `String "discord" ])
+     with
+     | Ok channel -> Ok (Agent_identity.string_of_channel channel)
+     | Error err -> Error err);
   check string "known external serializes as tagged external"
     "[\"External\",\"discord\"]"
     (Yojson.Safe.to_string


### PR DESCRIPTION
## Summary
- stop serializing known external channels as vendor-specific legacy constructor strings
- keep backward-compatible decoding for existing legacy payloads
- update identity tests to lock the new tagged-external write shape

## Why
After the connector boundary cleanup, `Agent_identity.channel_to_yojson` still hard-coded vendor names such as `Discord` and `Telegram` on the write path. That kept connector-specific knowledge in core serialization even though the core channel model is now `External of string`.

## Impact
- new serialized external channels use the generic tagged form like `["External","discord"]`
- legacy payloads like `"Discord"` still decode successfully
- boundary is tighter on the write path with no connector-specific branching in core

## Validation
- `env DUNE_BUILD_DIR=_build_gate_boundary_yojson dune build --root . ./test/test_agent_identity.exe`
- `env DUNE_BUILD_DIR=_build_gate_boundary_yojson dune build --root . ./test/test_identity_e2e.exe ./test/test_identity_edge_cases.exe ./test/test_mcp_full_cycle.exe`
- `./_build_gate_boundary_yojson/default/test/test_agent_identity.exe`
- `./_build_gate_boundary_yojson/default/test/test_identity_e2e.exe`
- `./_build_gate_boundary_yojson/default/test/test_identity_edge_cases.exe`
- `./_build_gate_boundary_yojson/default/test/test_mcp_full_cycle.exe`

Follow-up to #4789 and #4801.