### PR TITLE
fix(connector): add gate bot compatibility aliases

### DIFF
--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -130,14 +130,22 @@ class GateClient:
     def _note_transport_failure(self, reason: str) -> None:
         self._consecutive_failures += 1
         self._last_failure = reason
-        if self._breaker_enabled() and self._consecutive_failures >= self._breaker_failure_threshold:
+        breaker_enabled = self._breaker_enabled()
+        if breaker_enabled and self._consecutive_failures >= self._breaker_failure_threshold:
             self._breaker_open_until = self._now() + self._breaker_reset_sec
-        logger.warning(
-            "Gate transport failure %d/%d: %s",
-            self._consecutive_failures,
-            self._breaker_failure_threshold,
-            reason,
-        )
+        if breaker_enabled:
+            logger.warning(
+                "Gate transport failure %d/%d: %s",
+                self._consecutive_failures,
+                self._breaker_failure_threshold,
+                reason,
+            )
+        else:
+            logger.warning(
+                "Gate transport failure %d (breaker disabled): %s",
+                self._consecutive_failures,
+                reason,
+            )
 
     def breaker_snapshot(self) -> BreakerSnapshot:
         remaining = max(0, int(round(self._breaker_open_until - self._now())))
@@ -371,4 +379,3 @@ class GateClient:
             return None
         self._keeper_status_cache[normalized] = (self._now(), data)
         return data
-

--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -134,18 +134,19 @@ class GateClient:
         if breaker_enabled and self._consecutive_failures >= self._breaker_failure_threshold:
             self._breaker_open_until = self._now() + self._breaker_reset_sec
         if breaker_enabled:
-            logger.warning(
-                "Gate transport failure %d/%d: %s",
+            msg = "Gate transport failure %d/%d: %s"
+            args = (
                 self._consecutive_failures,
                 self._breaker_failure_threshold,
                 reason,
             )
         else:
-            logger.warning(
-                "Gate transport failure %d (breaker disabled): %s",
+            msg = "Gate transport failure %d (breaker disabled): %s"
+            args = (
                 self._consecutive_failures,
                 reason,
             )
+        logger.warning(msg, *args)
 
     def breaker_snapshot(self) -> BreakerSnapshot:
         remaining = max(0, int(round(self._breaker_open_until - self._now())))

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -163,19 +163,6 @@ def test_legacy_env_aliases_still_work(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.masc_mcp_url == "http://legacy.example"
 
 
-def test_legacy_constructor_aliases_still_work() -> None:
-    cfg = BotConfig(
-        discord_bot_token="test-token",
-        masc_api_token="legacy-api-token",
-        masc_mcp_url="http://legacy.example",
-    )
-
-    assert cfg.gate_api_token == "legacy-api-token"
-    assert cfg.gate_base_url == "http://legacy.example"
-    assert cfg.masc_api_token == "legacy-api-token"
-    assert cfg.masc_mcp_url == "http://legacy.example"
-
-
 def test_legacy_import_shim_reexports_gate_client_surface() -> None:
     assert MascGateClient is GateClient
     response = GateResponse.from_error("timeout")

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -163,6 +163,19 @@ def test_legacy_env_aliases_still_work(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.masc_mcp_url == "http://legacy.example"
 
 
+def test_legacy_constructor_aliases_still_work() -> None:
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        masc_api_token="legacy-api-token",
+        masc_mcp_url="http://legacy.example",
+    )
+
+    assert cfg.gate_api_token == "legacy-api-token"
+    assert cfg.gate_base_url == "http://legacy.example"
+    assert cfg.masc_api_token == "legacy-api-token"
+    assert cfg.masc_mcp_url == "http://legacy.example"
+
+
 def test_legacy_import_shim_reexports_gate_client_surface() -> None:
     assert MascGateClient is GateClient
     response = GateResponse.from_error("timeout")


### PR DESCRIPTION
## Summary
- normalize channel labels before recording gate error metrics
- switch Discord bot/docs/env naming to GATE_* while keeping MASC_* compatibility aliases
- replace sidecars/discord-bot/src/masc_client.py with a compatibility shim over gate_client
- update sidecar imports/tests to use the canonical gate client surface

## Verification
- opam exec -- dune build --root . lib/server/server_routes_http_routes_channel_gate.ml
- python3 -m compileall sidecars/discord-bot/src sidecars/discord-bot/tests
- local pytest collection is blocked in this environment because pydantic_settings and discord are not installed

## Review evidence
- direct sb glm-text --no-thinking review on the patch returned No findings.
