### PR TITLE
[codex] Rename detail and transport wording to namespace

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -146,7 +146,7 @@ export async function refreshAgentDetail(): Promise<void> {
   agentFitness.value = null
 
   try {
-    // Fetch namespace messages, task histories, timeline, and fitness in parallel
+    // Fetch namespace (room) messages, task histories, timeline, and fitness in parallel
     const [lines, timelineResult, fitnessResult] = await Promise.all([
       fetchRoomMessages(80),
       fetchAgentTimeline(agentName, 24, 50).catch(() => null),

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -32,7 +32,7 @@ export type TaskHistoryRow = {
 export const selectedAgentName = signal<string | null>(null)
 export const loading = signal(false)
 export const detailError = signal('')
-export const roomActivity = signal<string[]>([])
+export const namespaceActivity = signal<string[]>([])
 export const taskHistories = signal<TaskHistoryRow[]>([])
 export const agentTimeline = signal<AgentTimelineResponse | null>(null)
 export const mentionText = signal('')
@@ -124,7 +124,7 @@ export function openAgentDetail(agentName: string): void {
 export function closeAgentDetail(): void {
   selectedAgentName.value = null
   detailError.value = ''
-  roomActivity.value = []
+  namespaceActivity.value = []
   taskHistories.value = []
   agentTimeline.value = null
   mentionText.value = ''
@@ -140,13 +140,13 @@ export async function refreshAgentDetail(): Promise<void> {
 
   loading.value = true
   detailError.value = ''
-  roomActivity.value = []
+  namespaceActivity.value = []
   taskHistories.value = []
   agentTimeline.value = null
   agentFitness.value = null
 
   try {
-    // Fetch room messages, task histories, timeline, and fitness in parallel
+    // Fetch namespace messages, task histories, timeline, and fitness in parallel
     const [lines, timelineResult, fitnessResult] = await Promise.all([
       fetchRoomMessages(80),
       fetchAgentTimeline(agentName, 24, 50).catch(() => null),
@@ -157,7 +157,7 @@ export async function refreshAgentDetail(): Promise<void> {
 
     const matchNames = agentMatchNames(agentName)
 
-    roomActivity.value = lines
+    namespaceActivity.value = lines
       .filter(line => {
         const lower = line.toLowerCase()
         return matchNames.some(name => lower.includes(name))

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -21,7 +21,7 @@ import {
   selectedAgentName,
   loading,
   detailError,
-  roomActivity,
+  namespaceActivity,
   taskHistories,
   mentionText,
   sendingMention,
@@ -86,7 +86,7 @@ export function AgentDetailOverlay() {
   const continuityBrief = continuityBriefForAgent(agentName)
   const missionBrief = missionAgentBrief(agentName)
   const ownedTasks = assignedTasks(agentName)
-  const lines = roomActivity.value
+  const lines = namespaceActivity.value
   const displayName = missionBrief?.display_name ?? keeper?.name ?? agentName
   const secondaryLabel = displayName !== agentName ? agentName : null
   const unified = resolveUnifiedStatus(keeper?.status, agent?.status, missionBrief?.signal_truth)

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -104,7 +104,7 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('Channel Gate')
     expect(text).toContain('success 91%')
     expect(text).toContain('duplicates')
-    expect(text).toContain('namespaces2')
+    expect(text).toMatch(/namespaces\s*2/)
     expect(text).toContain('last namespace 123456')
     expect(text).toContain('upstream timeout')
     expect(container.innerHTML).toContain('degraded')

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -98,14 +98,15 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(get).toHaveBeenCalledWith('/api/v1/gate/status')
-    expect(container.textContent).toContain('Channel Gate')
-    expect(container.textContent).toContain('success 91%')
-    expect(container.textContent).toContain('duplicates')
-    expect(container.textContent).toContain('namespaces')
-    expect(container.textContent).toContain('last namespace')
-    expect(container.textContent).toContain('upstream timeout')
+    expect(text).toContain('Channel Gate')
+    expect(text).toContain('success 91%')
+    expect(text).toContain('duplicates')
+    expect(text).toContain('namespaces2')
+    expect(text).toContain('last namespace 123456')
+    expect(text).toContain('upstream timeout')
     expect(container.innerHTML).toContain('degraded')
   })
 })

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -103,6 +103,8 @@ describe('ConnectorStatusPanel', () => {
     expect(container.textContent).toContain('Channel Gate')
     expect(container.textContent).toContain('success 91%')
     expect(container.textContent).toContain('duplicates')
+    expect(container.textContent).toContain('namespaces')
+    expect(container.textContent).toContain('last namespace')
     expect(container.textContent).toContain('upstream timeout')
     expect(container.innerHTML).toContain('degraded')
   })

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -179,7 +179,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
           <div class="font-mono text-[var(--text-body)]">${ch.duplicate_count}</div>
         </div>
         <div>
-          <div class="text-[var(--text-dim)]">rooms</div>
+          <div class="text-[var(--text-dim)]">namespaces</div>
           <div class="font-mono text-[var(--text-body)]">${ch.room_count}</div>
         </div>
         <div>
@@ -202,7 +202,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
           <span class="font-mono text-[var(--text-body)]"> ${ch.last_outcome}</span>
         </div>
         <div>
-          last room
+          last namespace
           <span class="font-mono text-[var(--text-body)]"> ${ch.last_room_id || '-'}</span>
         </div>
       </div>

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -167,4 +167,33 @@ describe('TransportHealthPanel', () => {
     expect(container.innerHTML).not.toContain('2 ICE')
     expect(container.textContent).toContain('namespace default')
   })
+
+  it('renders namespace chip with cluster prefix for non-default clusters', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockResolvedValue(
+      sampleResponse({
+        cluster: {
+          cluster: 'prod',
+          room_id: 'default',
+          topology_available: false,
+          topology_source: 'metrics_only',
+          total_units: null,
+          managed_units: null,
+          live_agents: null,
+          active_operations: null,
+          stale_units: null,
+        },
+      }),
+    )
+
+    const { TransportHealthPanel } = await loadComponentWithApi({
+      get,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${TransportHealthPanel} />`, container)
+    await flushUi()
+
+    expect(get).toHaveBeenCalledWith('/api/v1/dashboard/transport-health')
+    expect(container.textContent).toContain('prod / namespace default')
+  })
 })

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -165,5 +165,6 @@ describe('TransportHealthPanel', () => {
     expect(container.textContent).toContain('shared_http')
     expect(container.innerHTML).toContain('signaling down')
     expect(container.innerHTML).not.toContain('2 ICE')
+    expect(container.textContent).toContain('namespace default')
   })
 })

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -412,6 +412,10 @@ export function TransportHealthPanel() {
   const managedUnitsSub = data.cluster.topology_available
     ? `${formatMetricValue(data.cluster.total_units)} 전체`
     : `topology ${data.cluster.topology_source}`
+  const namespaceChip =
+    data.cluster.cluster && data.cluster.cluster !== 'unknown' && data.cluster.cluster !== 'default'
+      ? `${data.cluster.cluster} / namespace ${data.cluster.room_id}`
+      : `namespace ${data.cluster.room_id}`
 
   return html`
     <div class="space-y-4">
@@ -419,7 +423,7 @@ export function TransportHealthPanel() {
         <div>
           <div class="flex items-center gap-2">
             <span class="text-base text-text-strong">트랜스포트</span>
-            <span class="text-[10px] uppercase tracking-wider text-text-muted">${data.cluster.cluster && data.cluster.cluster !== 'unknown' && data.cluster.cluster !== 'default' ? `${data.cluster.cluster} / ` : ''}${data.cluster.room_id}</span>
+            <span class="text-[10px] uppercase tracking-wider text-text-muted">${namespaceChip}</span>
           </div>
           <div class="mt-1 text-sm text-text-body">
             primary path: <span class="font-mono text-text-strong">${data.summary.primary_path}</span>

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeExecutionSessionBrief } from './store-normalizers'
+
+describe('normalizeExecutionSessionBrief', () => {
+  it('promotes legacy room-only payloads to namespace while keeping the room alias', () => {
+    expect(normalizeExecutionSessionBrief({
+      session_id: 'session-1',
+      goal: 'legacy payload',
+      room: 'default',
+    })).toMatchObject({
+      session_id: 'session-1',
+      goal: 'legacy payload',
+      namespace: 'default',
+      room: 'default',
+    })
+  })
+
+  it('keeps namespace-only payloads canonical and mirrors the room alias', () => {
+    expect(normalizeExecutionSessionBrief({
+      session_id: 'session-2',
+      goal: 'flattened payload',
+      namespace: 'default',
+    })).toMatchObject({
+      session_id: 'session-2',
+      goal: 'flattened payload',
+      namespace: 'default',
+      room: 'default',
+    })
+  })
+
+  it('prefers namespace when both fields are present during rollout', () => {
+    expect(normalizeExecutionSessionBrief({
+      session_id: 'session-3',
+      goal: 'dual payload',
+      namespace: 'default',
+      room: 'legacy-room',
+    })).toMatchObject({
+      session_id: 'session-3',
+      goal: 'dual payload',
+      namespace: 'default',
+      room: 'default',
+    })
+  })
+})

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -174,7 +174,8 @@ export function normalizeExecutionSessionBrief(raw: unknown): DashboardExecution
   return {
     session_id: sessionId,
     goal,
-    room: asString(raw.room) ?? null,
+    namespace: asString(raw.namespace) ?? asString(raw.room) ?? null,
+    room: asString(raw.room) ?? asString(raw.namespace) ?? null,
     status: asString(raw.status),
     health: asString(raw.health),
     member_names: asStringArray(raw.member_names),

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -171,11 +171,13 @@ export function normalizeExecutionSessionBrief(raw: unknown): DashboardExecution
   const sessionId = asString(raw.session_id)
   const goal = asString(raw.goal)
   if (!sessionId || !goal) return null
+  const namespace = asString(raw.namespace) ?? asString(raw.room) ?? null
   return {
     session_id: sessionId,
     goal,
-    namespace: asString(raw.namespace) ?? asString(raw.room) ?? null,
-    room: asString(raw.room) ?? asString(raw.namespace) ?? null,
+    namespace,
+    // Keep `room` as a pure compatibility alias during namespace flattening.
+    room: namespace,
     status: asString(raw.status),
     health: asString(raw.health),
     member_names: asStringArray(raw.member_names),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -199,6 +199,7 @@ export interface DashboardExecutionQueueItem {
 export interface DashboardExecutionSessionBrief {
   session_id: string
   goal: string
+  namespace?: string | null
   room?: string | null
   status?: string
   health?: string

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -373,6 +373,7 @@ export interface DashboardProofBackingEvidence {
 export interface DashboardProofResponse {
   schema_version?: string
   generated_at?: string
+  namespace?: Record<string, unknown>
   room?: Record<string, unknown>
   selection?: DashboardProofSelection
   session_id?: string | null

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -178,7 +178,7 @@ let build_watch_section ~room_health ~incident_count ~recommended_action_count
   in
   let evidence =
     []
-    |> evidence_add_if risky_room (Printf.sprintf "Room health is %s" room_health)
+    |> evidence_add_if risky_room (Printf.sprintf "Namespace health is %s" room_health)
     |> evidence_add_if (incident_count > 0)
          (Printf.sprintf "Incident count is %d" incident_count)
     |> evidence_add_if (recommended_action_count > 0)

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -39,6 +39,9 @@ let execution_smoke_fixture_json () =
       ( "status",
         `Assoc
           [
+            ("namespace_id", `String "default");
+            ("namespace", `String "default");
+            ("namespace_mode", `String "flattened");
             ("room", `String "default");
             ("room_base_path", `String "/tmp/masc-execution-fixture");
             ("cluster", `String "fixture");
@@ -116,6 +119,7 @@ let execution_smoke_fixture_json () =
               [
                 ("session_id", `String "ts-execution-fixture-001");
                 ("goal", `String "Validate local64 swarm role coverage, runtime visibility, and operator census");
+                ("namespace", `String "default");
                 ("room", `String "default");
                 ("status", `String "interrupted");
                 ("health", `String "bad");
@@ -140,6 +144,7 @@ let execution_smoke_fixture_json () =
               [
                 ("session_id", `String "ts-execution-fixture-002");
                 ("goal", `String "Monitor runtime pressure without intervention");
+                ("namespace", `String "default");
                 ("room", `String "default");
                 ("status", `String "running");
                 ("health", `String "ok");

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -10,7 +10,7 @@ type queue_context = {
 type session_seed = {
   session_id : string;
   goal : string;
-  room : string option;
+  namespace : string option;
   status : string;
   health : string;
   member_names : string list;

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -289,6 +289,7 @@ let build_session_contexts seeds operation_contexts : session_context list =
                  ("session_id", `String seed.session_id);
                  ("goal", `String seed.goal);
                  ("namespace", json_string_option seed.namespace);
+                 (* Legacy room alias now mirrors the flattened namespace. *)
                  ("room", json_string_option seed.namespace);
                  ("status", `String seed.status);
                  ("health", `String seed.health);

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -175,7 +175,10 @@ let build_session_seed session_json session_cards =
         goal =
           trim_to_option (string_field "goal" meta)
           |> Option.value ~default:session_id;
-        room = trim_to_option (string_field "room_id" meta);
+        namespace =
+          (match trim_to_option (string_field "namespace_id" meta) with
+          | Some _ as value -> value
+          | None -> trim_to_option (string_field "room_id" meta));
         status = session_status_string session_json;
         health =
           (match session_card with
@@ -285,7 +288,8 @@ let build_session_contexts seeds operation_contexts : session_context list =
                [
                  ("session_id", `String seed.session_id);
                  ("goal", `String seed.goal);
-                 ("room", json_string_option seed.room);
+                 ("namespace", json_string_option seed.namespace);
+                 ("room", json_string_option seed.namespace);
                  ("status", `String seed.status);
                  ("health", `String seed.health);
                  ( "member_names",

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -550,7 +550,7 @@ type mission_projection = {
   generated_at : string;
   snapshot_json : Yojson.Safe.t;
   digest_json : Yojson.Safe.t;
-  room_json : Yojson.Safe.t;
+  namespace_json : Yojson.Safe.t;
   command_json : Yojson.Safe.t;
   incidents : Yojson.Safe.t list;
   recommended_actions : Yojson.Safe.t list;
@@ -629,7 +629,11 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
                 ("error", `String message);
               ])
   in
-  let room_json = member_assoc "room" snapshot_json in
+  let namespace_json =
+    match member_assoc "namespace" snapshot_json with
+    | `Assoc _ as value -> value
+    | _ -> member_assoc "room" snapshot_json
+  in
   let incidents =
     list_field "attention_items" digest_json
     |> List.sort (fun left right ->
@@ -653,7 +657,7 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
     | _ -> []
   in
   let agent_briefs =
-    Dashboard_mission_assembly.build_agent_briefs config sessions attention_queue room_json keeper_items
+    Dashboard_mission_assembly.build_agent_briefs config sessions attention_queue namespace_json keeper_items
   in
   let keeper_briefs = Dashboard_mission_assembly.build_keeper_briefs config keeper_items in
   let internal_signals = Dashboard_mission_assembly.build_internal_signals incidents recommended_actions in
@@ -661,7 +665,7 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
     generated_at = Types.now_iso ();
     snapshot_json;
     digest_json;
-    room_json;
+    namespace_json;
     command_json;
     incidents;
     recommended_actions;
@@ -690,9 +694,12 @@ let json ?actor ?command_plane_summary ?swarm_status ~config ~sw ~clock ~proc_mg
     `Assoc
       [
         ("room_health", `String (string_field ~default:"ok" "health" projection.digest_json));
-        ("cluster", json_string_option (Some (string_field "cluster" projection.room_json)));
-        ("project", json_string_option (Some (string_field "project" projection.room_json)));
-        ("current_room", member_assoc "current_room" projection.room_json);
+        ("cluster", json_string_option (Some (string_field "cluster" projection.namespace_json)));
+        ("project", json_string_option (Some (string_field "project" projection.namespace_json)));
+        ("namespace_id", json_string_option (Some (string_field "namespace_id" projection.namespace_json)));
+        ("namespace", json_string_option (Some (string_field "namespace" projection.namespace_json)));
+        ("namespace_mode", json_string_option (Some (string_field "namespace_mode" projection.namespace_json)));
+        ("current_room", member_assoc "current_room" projection.namespace_json);
       ]
   in
   let command_focus_json =

--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -239,6 +239,7 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
     [
       ("schema_version", `String "1.0.0");
       ("generated_at", `String (Types.now_iso ()));
+      ("namespace", Dashboard_proof_verdict.namespace_json config);
       ("room", Dashboard_proof_verdict.room_json config);
       ( "selection",
         Dashboard_proof_verdict.selection_json ~requested_session_id

--- a/lib/dashboard/dashboard_proof_verdict.ml
+++ b/lib/dashboard/dashboard_proof_verdict.ml
@@ -257,4 +257,15 @@ let namespace_json config =
       ("message_seq", `Int state.message_seq);
     ]
 
-let room_json config = namespace_json config
+let room_json config =
+  let state = Room.read_state config in
+  `Assoc
+    [
+      ("project", `String state.project);
+      ("current_room", Json_util.string_opt_to_json (Room.read_current_room config));
+      ("namespace_id", `String "default");
+      ("namespace", `String "default");
+      ("namespace_mode", `String "flattened");
+      ("paused", `Bool state.paused);
+      ("message_seq", `Int state.message_seq);
+    ]

--- a/lib/dashboard/dashboard_proof_verdict.ml
+++ b/lib/dashboard/dashboard_proof_verdict.ml
@@ -245,12 +245,16 @@ let selection_json ~requested_session_id ~requested_operation_id ~session ~opera
       ("available_session_count", `Int session_count);
     ]
 
-let room_json config =
+let namespace_json config =
   let state = Room.read_state config in
   `Assoc
     [
       ("project", `String state.project);
-      ("current_room", Json_util.string_opt_to_json (Room.read_current_room config));
+      ("namespace_id", `String "default");
+      ("namespace", `String "default");
+      ("namespace_mode", `String "flattened");
       ("paused", `Bool state.paused);
       ("message_seq", `Int state.message_seq);
     ]
+
+let room_json config = namespace_json config

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -33,6 +33,7 @@ let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
     ~name:"extend_turns"
     ~descriptor:{ kind = None;
                   shell = None; mutation_class = None;
+                  concurrency_class = None;
                   notes = []; examples = [] }
     ~description:"Request additional turns when you need more time. \
                    Guardrails check cost and idle before granting."

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -93,6 +93,11 @@ let oas_tool_of_masc ~name ~description ~input_schema
     to_oas_tool_result (success, msg)
   in
   let descriptor : Agent_sdk.Tool.descriptor =
-    { kind = None; shell = None; mutation_class = None; notes = []; examples = [] }
+    { kind = None;
+      shell = None;
+      mutation_class = None;
+      concurrency_class = None;
+      notes = [];
+      examples = [] }
   in
   Agent_sdk.Tool.create ~descriptor ~name ~description ~parameters oas_handler

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -249,6 +249,7 @@ let make_file_read ?workdir ?on_exec () =
     ~name:"file_read"
     ~descriptor:{ kind = None;
                   shell = None; mutation_class = None;
+                  concurrency_class = None;
                   notes = []; examples = [] }
     ~description:"Read file contents by absolute path. Returns file text. \
       Use shell_exec with 'ls' instead if you need directory listing. \
@@ -303,6 +304,7 @@ let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
     ~descriptor:{ kind = None; shell = None; mutation_class = None;
+                  concurrency_class = None;
                   notes = []; examples = [] }
     ~description:"Write content to a file by absolute path. Creates the file \
       if it doesn't exist, overwrites if it does. Creates parent directories. \
@@ -364,6 +366,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
     ~name:"shell_exec"
     ~descriptor:{ kind = None;
                   shell = None; mutation_class = None;
+                  concurrency_class = None;
                   notes = []; examples = [] }
     ~description
     ~parameters:[

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -114,6 +114,10 @@ let test_dashboard_execution_fixture () =
         check string "top queue handoff surface" "intervene"
           (execution_queue |> List.hd |> member "top_handoff" |> member "surface" |> to_string);
         check int "session briefs" 2 (List.length session_briefs);
+        check string "fixture session namespace" "default"
+          (session_briefs |> List.hd |> member "namespace" |> to_string);
+        check string "fixture session room alias kept" "default"
+          (session_briefs |> List.hd |> member "room" |> to_string);
         check int "fixture seen count" 3
           (session_briefs |> List.hd |> member "seen_count" |> to_int);
         check int "fixture planned count" 4

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -372,6 +372,12 @@ let test_dashboard_mission_projection () =
           (summary |> member "paused" = `Null);
         check bool "mission summary trims active_agents" true
           (summary |> member "active_agents" = `Null);
+        check string "mission summary namespace_id" "default"
+          (summary |> member "namespace_id" |> to_string);
+        check string "mission summary namespace" "default"
+          (summary |> member "namespace" |> to_string);
+        check string "mission summary namespace mode" "flattened"
+          (summary |> member "namespace_mode" |> to_string);
         check bool "full session cards omitted from mission payload" true
           (sessions = []);
         check bool "session brief keeps member previews" true
@@ -520,6 +526,10 @@ let test_dashboard_mission_http_default_bootstraps_first_success () =
         check bool "default mission leaves initializing placeholder" true
           (json |> member "summary" |> member "room_health" |> to_string
            <> "initializing");
+        check string "default mission exposes namespace id" "default"
+          (json |> member "summary" |> member "namespace_id" |> to_string);
+        check string "default mission exposes namespace" "default"
+          (json |> member "summary" |> member "namespace" |> to_string);
         check bool "default mission includes session briefs" true
           (json |> member "session_briefs" |> to_list
          |> List.exists (fun row -> row |> member "session_id" |> to_string = session_id));
@@ -557,6 +567,10 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
         check bool "default mission leaves initializing placeholder" true
           (json |> member "summary" |> member "room_health" |> to_string
            <> "initializing");
+        check string "default mission exposes namespace id" "default"
+          (json |> member "summary" |> member "namespace_id" |> to_string);
+        check string "default mission exposes namespace" "default"
+          (json |> member "summary" |> member "namespace" |> to_string);
         check bool "default mission includes session briefs" true
           (json |> member "session_briefs" |> to_list
          |> List.exists (fun row -> row |> member "session_id" |> to_string = session_id));

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -454,6 +454,27 @@ let test_build_briefing_sections_keeps_metadata_evidence_visible () =
       check bool "metadata evidence remains visible" true found
   | _ -> fail "expected communication evidence list"
 
+let test_build_briefing_sections_watch_evidence_uses_namespace_wording () =
+  let mission_summary_json =
+    `Assoc
+      [
+        ("room_health", `String "bad");
+        ("incident_count", `Int 0);
+        ("recommended_action_count", `Int 0);
+        ("top_attention_summary", `String "");
+      ]
+  in
+  let _watch_summary, sections =
+    Briefing.build_briefing_sections ~mission_summary_json ~sessions:[]
+      ~agents:[] ~recent_messages:[]
+      ~metadata_gaps:[]
+  in
+  let watch = find_section sections "watch" in
+  match get_field "evidence" watch with
+  | `List (`String evidence :: _) ->
+      check string "watch evidence wording" "Namespace health is bad" evidence
+  | _ -> fail "expected watch evidence list"
+
 let () =
   run "Dashboard Mission Briefing"
     [
@@ -487,5 +508,7 @@ let () =
             test_build_briefing_sections_demotes_metadata_only_communication;
           test_case "metadata evidence remains visible in communication" `Quick
             test_build_briefing_sections_keeps_metadata_evidence_visible;
+          test_case "watch evidence uses namespace wording" `Quick
+            test_build_briefing_sections_watch_evidence_uses_namespace_wording;
         ] );
     ]

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -324,6 +324,14 @@ let test_dashboard_proof_projection () =
         (json |> U.member "session_id" |> U.to_string);
       check string "selection mode" "latest_auto_selected"
         (json |> U.member "selection" |> U.member "mode" |> U.to_string);
+      check string "namespace id" "default"
+        (json |> U.member "namespace" |> U.member "namespace_id" |> U.to_string);
+      check string "namespace name" "default"
+        (json |> U.member "namespace" |> U.member "namespace" |> U.to_string);
+      check string "namespace mode" "flattened"
+        (json |> U.member "namespace" |> U.member "namespace_mode" |> U.to_string);
+      check string "legacy room alias keeps namespace id" "default"
+        (json |> U.member "room" |> U.member "namespace_id" |> U.to_string);
       check bool "timeline present" true
         ((json |> U.member "timeline" |> U.to_list) <> []);
       check bool "actor contributions present" true

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -332,6 +332,8 @@ let test_dashboard_proof_projection () =
         (json |> U.member "namespace" |> U.member "namespace_mode" |> U.to_string);
       check string "legacy room alias keeps namespace id" "default"
         (json |> U.member "room" |> U.member "namespace_id" |> U.to_string);
+      check string "legacy room alias keeps current_room" "default"
+        (json |> U.member "room" |> U.member "current_room" |> U.to_string);
       check bool "timeline present" true
         ((json |> U.member "timeline" |> U.to_list) <> []);
       check bool "actor contributions present" true

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -38,6 +38,22 @@ let test_readonly_tool_names () =
   let expected = ["file_read"; "shell_exec"] in
   Alcotest.(check (list string)) "readonly tool names match" expected names
 
+let test_tool_descriptors_validate_without_concurrency_class () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
+  let tool = find_tool "file_read" tools in
+  match Tool.descriptor tool with
+  | None -> Alcotest.fail "expected file_read descriptor"
+  | Some descriptor ->
+      (match Tool.validate_descriptor descriptor with
+      | Ok () -> ()
+      | Error msg -> Alcotest.failf "descriptor should validate: %s" msg);
+      Alcotest.(check bool) "concurrency class defaults to none" true
+        (Option.is_none descriptor.concurrency_class)
+
 (* --- file_read tests --- *)
 
 let test_file_read_existing () =
@@ -438,6 +454,8 @@ let () =
       Alcotest.test_case "tool count" `Quick test_tool_count;
       Alcotest.test_case "tool names" `Quick test_tool_names;
       Alcotest.test_case "readonly tool names" `Quick test_readonly_tool_names;
+      Alcotest.test_case "descriptors validate without concurrency class" `Quick
+        test_tool_descriptors_validate_without_concurrency_class;
     ];
     "file_read", [
       Alcotest.test_case "read existing file" `Quick test_file_read_existing;


### PR DESCRIPTION
## Summary
- rename remaining dashboard/briefing user-facing `room` wording to `namespace`
- add canonical `namespace` session brief fields while keeping `room` as a compatibility alias during rollout
- align local `Agent_sdk.Tool.descriptor` construction with the new `concurrency_class` field and add validation coverage
- extend transport-health and execution/dashboard tests to cover namespace rollout branches and alias migration behavior

## Product impact
- dashboard detail, transport, connector, and execution surfaces stay consistent with the flattened namespace model
- execution session brief consumers can read `namespace` immediately without dropping legacy `room` readers
- transport health namespace chip now has coverage for both default-cluster and prefixed-cluster formatting

## Evidence
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/components/transport-health.test.ts`
- `pnpm --dir dashboard exec vitest run src/store-normalizers.test.ts src/components/connector-status.test.ts`
- `dune build --root . _build/default/test/test_worker_dev_tools.exe _build/default/test/test_dashboard_execution.exe --display short`
- `./_build/default/test/test_worker_dev_tools.exe`
- `./_build/default/test/test_dashboard_execution.exe`

## Review evidence
- direct `sb glm-text` (`GLM-5.1`) rerun on the current branch diff: `No findings.`
- PR comments: `#issuecomment-4183769171`, `#issuecomment-4183880555`
- Copilot thread on `transport-health.test.ts` addressed with explicit non-default cluster coverage

## Linked issue
- Refs #4638
