### PR TITLE
feat(dashboard): smooth animations for kanban tasks and tab transitions

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@formkit/auto-animate": "^0.9.0",
     "@preact/signals": "^2.0.2",
     "dompurify": "^3.3.3",
     "downshift": "^9.3.2",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@formkit/auto-animate':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@preact/signals':
         specifier: ^2.0.2
         version: 2.8.1(preact@10.28.3)
@@ -355,6 +358,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@formkit/auto-animate@0.9.0':
+    resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -2222,6 +2228,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@formkit/auto-animate@0.9.0': {}
 
   '@iconify/types@2.0.0': {}
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -331,7 +331,9 @@ export function DashboardMain() {
     ` : null}
     <${SurfaceLead} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
-      <${TabContent} />
+      <div class="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-both">
+        <${TabContent} />
+      </div>
     <//>
   `
 }

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -2,7 +2,9 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { useRef, useEffect } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
+import autoAnimate from '@formkit/auto-animate'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
@@ -159,6 +161,14 @@ function TaskColumn({
   badgeClass: string
   children: ComponentChildren
 }) {
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (listRef.current) {
+      autoAnimate(listRef.current, { duration: 250, easing: 'ease-out' })
+    }
+  }, [listRef])
+
   return html`
     <section class="flex min-h-[240px] flex-col gap-4 rounded-2xl border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
       <div class="flex items-start justify-between gap-3 border-b border-card-border/50 pb-3">
@@ -168,7 +178,7 @@ function TaskColumn({
         </div>
         <span class="rounded-lg px-2.5 py-1 text-[12px] font-semibold ${badgeClass}">${count}</span>
       </div>
-      <div class="flex max-h-[680px] flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
+      <div ref=${listRef} class="flex max-h-[680px] flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
         ${children}
       </div>
     </section>


### PR DESCRIPTION
## Overview
- Integrated `@formkit/auto-animate` into the Kanban columns (`TaskColumn`). Now, when tasks are claimed, moved to in-progress/done, or deleted, they smoothly animate to their new positions instead of instantly jumping.
- Added a `fade-in slide-in-from-bottom-2` animation to the main `TabContent` wrapper in the dashboard shell. This gives a much softer and more polished transition feeling when navigating between different sections (Overview, Monitoring, Workspace, etc.).