### PR TITLE
fix(server): replace Stdlib.Lazy with eager eval to prevent CamlinternalLazy.Undefined

### DIFF
--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -77,16 +77,15 @@ let friction_of_outcome = function
 (* JSONL persistence                                                *)
 (* ================================================================ *)
 
-let default_base_path = lazy (
+let default_base_path =
   let root = try Sys.getenv "MASC_DATA_DIR"
     with Not_found ->
       try Filename.concat (Sys.getenv "ME_ROOT") "data"
       with Not_found -> "data"
   in
   Filename.concat root "cdal_verdicts"
-)
 
-let persist ?(base_dir = Lazy.force default_base_path)
+let persist ?(base_dir = default_base_path)
     (verdict : Cdal_types.contract_verdict) : unit =
   let store = Dated_jsonl.create ~base_dir () in
   Dated_jsonl.append store (Cdal_types.contract_verdict_to_json verdict)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -946,25 +946,24 @@ let fallback_canonical_keeper_meta_key_names =
   ]
 
 let canonical_keeper_meta_key_names =
-  lazy
-    (let seed_json =
-       `Assoc
-         [
-           ("name", `String "__keeper-meta-key-seed__");
-           ("agent_name", `String "__keeper-meta-key-seed__");
-           ("trace_id", `String "__keeper-meta-key-seed__");
-         ]
-     in
-     match meta_of_json seed_json with
-     | Ok meta -> (
-         match meta_to_json meta with
-         | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
-         | _ -> fallback_canonical_keeper_meta_key_names)
-     | Error msg ->
-         Log.Keeper.warn
-           "canonical_keeper_meta_key_names seed failed: %s; falling back to static keys"
-           msg;
-         fallback_canonical_keeper_meta_key_names)
+  let seed_json =
+    `Assoc
+      [
+        ("name", `String "__keeper-meta-key-seed__");
+        ("agent_name", `String "__keeper-meta-key-seed__");
+        ("trace_id", `String "__keeper-meta-key-seed__");
+      ]
+  in
+  match meta_of_json seed_json with
+  | Ok meta -> (
+      match meta_to_json meta with
+      | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
+      | _ -> fallback_canonical_keeper_meta_key_names)
+  | Error msg ->
+      Log.Keeper.warn
+        "canonical_keeper_meta_key_names seed failed: %s; falling back to static keys"
+        msg;
+      fallback_canonical_keeper_meta_key_names
 
 let compatibility_keeper_meta_key_names =
   [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
@@ -973,7 +972,7 @@ let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
       let known_keeper_meta_key_names =
-        Lazy.force canonical_keeper_meta_key_names
+        canonical_keeper_meta_key_names
         @ compatibility_keeper_meta_key_names
       in
       let unknown =

--- a/lib/prompt_registry/prompt_registry_store.ml
+++ b/lib/prompt_registry/prompt_registry_store.ml
@@ -21,9 +21,9 @@ let create () =
     mutex = Eio.Mutex.create ();
   }
 
-let default_state : t Lazy.t = lazy (create ())
+let default_state : t = create ()
 
-let default () = Lazy.force default_state
+let default () = default_state
 
 let with_lock state f =
   Eio_guard.with_mutex state.mutex f

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -173,15 +173,15 @@ let host_port_of_request request =
         None)
 
 let allow_anonymous_mutations =
-  lazy (match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
-    | Some ("1" | "true") -> true
-    | _ -> false)
+  match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
+  | Some ("1" | "true") -> true
+  | _ -> false
 
 let ensure_same_origin_browser_request request :
     (unit, Types.masc_error) result =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
   | None ->
-    if Lazy.force allow_anonymous_mutations then Ok ()
+    if allow_anonymous_mutations then Ok ()
     else
       Error (Types.Unauthorized
         "Authentication required: provide a bearer token or Origin header. \

--- a/lib/server/server_dashboard_http_runtime_support.ml
+++ b/lib/server/server_dashboard_http_runtime_support.ml
@@ -24,9 +24,9 @@ let create () =
     shared_sessions_at = 0.0;
   }
 
-let default_state : t Lazy.t = lazy (create ())
+let default_state : t = create ()
 
-let default () = Lazy.force default_state
+let default () = default_state
 
 let set_executor_pool pool = Executor_pool_ref.set pool
 


### PR DESCRIPTION
## Summary
- `CamlinternalLazy.Undefined` 크래시로 keeper autoboot 및 dashboard warm cache 실패
- 5개 파일의 `Stdlib.Lazy` 사용을 즉시 평가로 전환 (모두 순수 계산)

## Root Cause
`Stdlib.Lazy`는 Eio fiber에서 concurrent force 시 `CamlinternalLazy.Undefined` 발생.

## Test plan
- [x] worktree에서 빌드 성공
- [x] 서버 기동 시 에러 없음
- [x] keeper autoboot 9개 정상 완료
- [x] MCP tool call (keeper_up) 정상 동작

Closes #4819

🤖 Generated with [Claude Code](https://claude.com/claude-code)