### PR TITLE
feat(dashboard): replace text loading states with lucide-preact Loader2 spinner

### DIFF
--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -25,9 +25,9 @@ interface LoadingStateProps {
 /** Loading indicator with spin animation */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
   return html`
-    <div class="loading-state flex-col py-8 text-[13px] ${cx ?? ''}">
+    <div class="loading-state flex flex-col items-center py-8 text-[13px] ${cx ?? ''}">
       <${Loader2} size=${24} class="animate-spin mb-3 opacity-60 text-accent" />
-      <span class="loading-pulse">${children ?? '불러오는 중...'}</span>
+      <span>${children ?? '불러오는 중...'}</span>
     </div>
   `
 }

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -25,9 +25,9 @@ interface LoadingStateProps {
 /** Loading indicator with spin animation */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
   return html`
-    <div class="flex flex-col items-center justify-center py-8 text-[13px] text-[var(--text-muted)] ${cx ?? ''}">
+    <div class="loading-state flex-col py-8 text-[13px] ${cx ?? ''}">
       <${Loader2} size=${24} class="animate-spin mb-3 opacity-60 text-accent" />
-      <span class="animate-pulse">${children ?? '불러오는 중...'}</span>
+      <span class="loading-pulse">${children ?? '불러오는 중...'}</span>
     </div>
   `
 }

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { Loader2 } from 'lucide-preact'
 
 interface EmptyStateProps {
   class?: string
@@ -21,11 +22,12 @@ interface LoadingStateProps {
   children?: ComponentChildren
 }
 
-/** Loading indicator with pulse animation */
+/** Loading indicator with spin animation */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
   return html`
-    <div class="text-center py-6 text-[13px] text-[var(--text-muted)] animate-pulse ${cx ?? ''}">
-      ${children ?? '불러오는 중...'}
+    <div class="flex flex-col items-center justify-center py-8 text-[13px] text-[var(--text-muted)] ${cx ?? ''}">
+      <${Loader2} size=${24} class="animate-spin mb-3 opacity-60 text-accent" />
+      <span class="animate-pulse">${children ?? '불러오는 중...'}</span>
     </div>
   `
 }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -17,6 +17,7 @@ import {
 } from '../config/navigation'
 import { RouteLink } from './common/route-link'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
+import { LoadingState } from './common/feedback-state'
 
 const buildIdentityOpen = signal(false)
 
@@ -26,8 +27,8 @@ const LazyOperations = lazy(async () => ({ default: (await import('./control')).
 const LazyLabSurface = lazy(async () => ({ default: (await import('./lab')).Lab }))
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
-function lazyTabFallback(label: string) {
-  return html`<div class="loading-state loading-pulse">${label} 불러오는 중...</div>`
+export function lazyTabFallback(label: string) {
+  return html`<${LoadingState}>${label} 불러오는 중...<//>`
 }
 
 function formatDisconnectDuration(): string {
@@ -313,7 +314,7 @@ function SurfaceLead() {
 
 export function DashboardMain() {
   if (dashboardLoading.value && !connected.value && !namespaceTruthInitializing.value) {
-    return html`<div class="loading-state loading-pulse">대시보드 불러오는 중...</div>`
+    return html`<${LoadingState}>대시보드 불러오는 중...<//>`
   }
 
   const routeLabel = [

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -27,7 +27,7 @@ const LazyOperations = lazy(async () => ({ default: (await import('./control')).
 const LazyLabSurface = lazy(async () => ({ default: (await import('./lab')).Lab }))
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
-export function lazyTabFallback(label: string) {
+function lazyTabFallback(label: string) {
   return html`<${LoadingState}>${label} 불러오는 중...<//>`
 }
 

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -5,6 +5,7 @@ import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
 import { EmptyState } from './common/empty-state'
+import { LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate } from '../router'
@@ -277,7 +278,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
       <div class="mt-4">
         <${Card} title="댓글">
           ${detailLoading.value
-            ? html`<div class="loading-state loading-pulse">댓글 불러오는 중...</div>`
+            ? html`<${LoadingState}>댓글 불러오는 중...<//>`
             : html`<${CommentThread} comments=${detailComments.value} postId=${post.id} />`}
           <${CommentForm} postId=${post.id} />
         <//>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -5,6 +5,7 @@ import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import { requestConfirm } from './common/confirm-dialog'
 import { EmptyState } from './common/empty-state'
+import { LoadingState } from './common/feedback-state'
 import { Markdown } from './common/markdown'
 import { TextInput, TextArea } from './common/input'
 import { stripStateBlocks } from '../keeper-message'
@@ -408,7 +409,7 @@ export function Memory() {
               onClick=${() => navigate('workspace', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
-              ? html`<div class="loading-state loading-pulse">글 불러오는 중...</div>`
+              ? html`<${LoadingState}>글 불러오는 중...<//>`
               : html`<${EmptyState} message="글을 찾지 못했습니다" compact />`}
           </div>
         `
@@ -427,7 +428,7 @@ export function Memory() {
         <${NewPostForm} />
       </div>
       ${boardLoading.value
-        ? html`<div class="loading-state loading-pulse">메모리 피드 불러오는 중...</div>`
+        ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
         : posts.length === 0
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`


### PR DESCRIPTION
## Overview
- Upgraded the `LoadingState` component and all inline `loading-pulse` divs to use a proper `Loader2` rotating SVG spinner from `lucide-preact`.
- This ensures users see a familiar, recognizable spinner when data is loading (memory posts, dashboard initialization, comments, etc.) rather than just blinking text, significantly improving the visual polish.