### PR TITLE
[codex] fix governance retired dashboard surface

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -273,6 +273,9 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
       : []
     return {
       generated_at: asNullableIsoTimestamp(raw.generated_at) ?? undefined,
+      case_tracking_available:
+        typeof raw.case_tracking_available === 'boolean' ? raw.case_tracking_available : undefined,
+      note: typeof raw.note === 'string' && raw.note.trim() !== '' ? raw.note.trim() : undefined,
       summary: isRecord(raw.summary)
         ? {
             cases_open: asInt(raw.summary.cases_open) ?? undefined,

--- a/dashboard/src/components/common/stat-row.ts
+++ b/dashboard/src/components/common/stat-row.ts
@@ -24,7 +24,7 @@ export function StatRow({ label, class: cx, children }: StatRowProps) {
 // ── KPI card (vertical: label on top, big number, optional hint) ──
 interface KpiCardProps {
   label: string
-  value: ComponentChildren
+  value: string | number | ComponentChildren
   hint?: string
   tone?: string
   class?: string

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -135,7 +135,7 @@ describe('Governance surface', () => {
     expect(fetchGovernanceCaseStatus.mock.calls.filter(([caseId]) => caseId === 'gov-case-1').length)
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
-  }, 60000)
+  }, 45000)
 
   it('shows keeper guidance when governance feed is empty', async () => {
     const emptyResponse: DashboardGovernanceResponse = {

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -135,7 +135,7 @@ describe('Governance surface', () => {
     expect(fetchGovernanceCaseStatus.mock.calls.filter(([caseId]) => caseId === 'gov-case-1').length)
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
-  }, 45000)
+  }, 20000)
 
   it('shows keeper guidance when governance feed is empty', async () => {
     const emptyResponse: DashboardGovernanceResponse = {

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -1,10 +1,9 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Vitest from 'vitest'
 import type { DashboardGovernanceResponse, GovernanceCaseBundle } from '../types'
 
-void vi
-
+const { afterEach, beforeEach, describe, expect, it } = Vitest
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()
@@ -76,10 +75,10 @@ async function loadComponentWithApi(api: {
   submitGovernanceCaseBrief: () => Promise<GovernanceCaseBundle>
   submitGovernancePetition: () => Promise<{ case: { id: string } }>
 }) {
-  vi.resetModules()
-  vi.doMock('../api', () => api)
-  vi.doMock('../sse-store', () => ({
-    registerGovernanceRefresh: vi.fn(),
+  Vitest.vi.resetModules()
+  Vitest.vi.doMock('../api', () => api)
+  Vitest.vi.doMock('../sse-store', () => ({
+    registerGovernanceRefresh: Vitest.vi.fn(),
   }))
   return import('./governance')
 }
@@ -95,25 +94,25 @@ describe('Governance surface', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
-    vi.resetModules()
-    vi.clearAllMocks()
-    vi.doUnmock('../api')
-    vi.doUnmock('../sse-store')
+    Vitest.vi.resetModules()
+    Vitest.vi.clearAllMocks()
+    Vitest.vi.doUnmock('../api')
+    Vitest.vi.doUnmock('../sse-store')
   })
 
   it('renders and refreshes without corrupting the DOM tree', async () => {
-    const fetchDashboardGovernance = vi.fn<() => Promise<DashboardGovernanceResponse>>()
+    const fetchDashboardGovernance = Vitest.vi.fn<() => Promise<DashboardGovernanceResponse>>()
       .mockResolvedValue(governanceResponse())
-    const fetchGovernanceCaseStatus = vi.fn<(caseId: string) => Promise<GovernanceCaseBundle>>()
+    const fetchGovernanceCaseStatus = Vitest.vi.fn<(caseId: string) => Promise<GovernanceCaseBundle>>()
       .mockResolvedValue(governanceBundle())
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance,
       fetchGovernanceCaseStatus,
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     expect(() => {
@@ -136,7 +135,7 @@ describe('Governance surface', () => {
     expect(fetchGovernanceCaseStatus.mock.calls.filter(([caseId]) => caseId === 'gov-case-1').length)
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
-  }, 30000)
+  }, 60000)
 
   it('shows keeper guidance when governance feed is empty', async () => {
     const emptyResponse: DashboardGovernanceResponse = {
@@ -154,12 +153,12 @@ describe('Governance surface', () => {
     }
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: vi.fn().mockResolvedValue(emptyResponse),
-      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(emptyResponse),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     render(html`<${Governance} />`, container)
@@ -184,12 +183,12 @@ describe('Governance surface', () => {
     }
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: vi.fn().mockResolvedValue(retiredResponse),
-      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(retiredResponse),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     render(html`<${Governance} />`, container)
@@ -223,12 +222,12 @@ describe('Governance surface', () => {
     }
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: vi.fn().mockResolvedValue(withJudgments),
-      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(withJudgments),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     render(html`<${Governance} />`, container)
@@ -261,12 +260,12 @@ describe('Governance surface', () => {
     }
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: vi.fn().mockResolvedValue(offlineJudge),
-      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(offlineJudge),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     render(html`<${Governance} />`, container)
@@ -295,12 +294,12 @@ describe('Governance surface', () => {
     }
 
     const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: vi.fn().mockResolvedValue(emptyWithAge),
-      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(emptyWithAge),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
     })
 
     render(html`<${Governance} />`, container)

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -136,7 +136,7 @@ describe('Governance surface', () => {
     expect(fetchGovernanceCaseStatus.mock.calls.filter(([caseId]) => caseId === 'gov-case-1').length)
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
-  }, 20000)
+  }, 30000)
 
   it('shows keeper guidance when governance feed is empty', async () => {
     const emptyResponse: DashboardGovernanceResponse = {
@@ -169,10 +169,11 @@ describe('Governance surface', () => {
   }, 20000)
 
   it('shows retired guidance when case tracking is disabled', async () => {
+    const serverNote = 'Server says governance case tracking is retired; only live judge signals remain.'
     const retiredResponse: DashboardGovernanceResponse = {
       generated_at: '2026-03-26T00:00:00Z',
       case_tracking_available: false,
-      note: 'Governance case tracking is retired; dashboard surfaces only live judge status and recent judgments.',
+      note: serverNote,
       summary: {
         judge_online: false,
       },
@@ -194,7 +195,7 @@ describe('Governance surface', () => {
     render(html`<${Governance} />`, container)
     await flushUi()
 
-    expect(container.textContent).toContain('거버넌스 케이스 추적은 중단되었고')
+    expect(container.textContent).toContain(serverNote)
     expect(container.textContent).toContain('judge-only / 최근 판단 0건')
     expect(container.textContent).not.toContain('keeper가 활동 중일 때 자동 생성됩니다')
   }, 20000)

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -168,6 +168,37 @@ describe('Governance surface', () => {
     expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
   }, 20000)
 
+  it('shows retired guidance when case tracking is disabled', async () => {
+    const retiredResponse: DashboardGovernanceResponse = {
+      generated_at: '2026-03-26T00:00:00Z',
+      case_tracking_available: false,
+      note: 'Governance case tracking is retired; dashboard surfaces only live judge status and recent judgments.',
+      summary: {
+        judge_online: false,
+      },
+      items: [],
+      activity: [],
+      judgments: [],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(retiredResponse),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('거버넌스 케이스 추적은 중단되었고')
+    expect(container.textContent).toContain('judge-only / 최근 판단 0건')
+    expect(container.textContent).not.toContain('keeper가 활동 중일 때 자동 생성됩니다')
+  }, 20000)
+
   it('renders judgments section with recommended action', async () => {
     const withJudgments: DashboardGovernanceResponse = {
       generated_at: '2026-03-30T00:00:00Z',

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -44,6 +44,8 @@ function governanceCaseTrackingRetired(): boolean {
 }
 
 function governanceRetiredMessage(): string {
+  const note = governanceData.value?.note?.trim()
+  if (note) return note
   return '거버넌스 케이스 추적은 중단되었고, 이 화면은 live judge 상태와 최근 판단만 표시합니다.'
 }
 

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -54,7 +54,7 @@ function GovernanceSummaryStrip() {
   const summary = data?.summary
   const oldestAge = summary?.oldest_open_case_age_s
   const lastActivityAge = summary?.last_activity_age_s
-  const caseTrackingRetired = data?.case_tracking_available === false
+  const caseTrackingRetired = governanceCaseTrackingRetired()
   const isStale = (oldestAge != null && oldestAge > 86400) || (lastActivityAge != null && lastActivityAge > 86400)
   const itemCount = data?.items?.length ?? 0
   const activityCount = data?.activity?.length ?? 0

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -65,13 +65,13 @@ function GovernanceSummaryStrip() {
   return html`
     ${caseTrackingRetired ? html`
       <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-accent/25 bg-accent/10 p-3.5 text-[13px] font-medium text-text-strong shadow-sm" data-testid="governance-retired-banner">
-        <div class="shrink-0"><${AlertTriangle} size=${18} /></div>
+        <div class="shrink-0"><${AlertTriangle} size=${18} aria-hidden="true" /></div>
         <div>${governanceRetiredMessage()}</div>
       </div>
     ` : null}
     ${isStale ? html`
       <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
-        <div class="shrink-0"><${AlertTriangle} size=${18} /></div>
+        <div class="shrink-0"><${AlertTriangle} size=${18} aria-hidden="true" /></div>
         <div>
           모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
           ${lastActivityAge != null ? html` 마지막 활동: ${formatAgeSummary(lastActivityAge)} 전.` : null}

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -39,16 +39,34 @@ import {
 // Re-export for consumers that import from './governance'
 export { refreshGovernance, loadRuntimeParams, loadParamAudit } from './governance-store'
 
+function governanceCaseTrackingRetired(): boolean {
+  return governanceData.value?.case_tracking_available === false
+}
+
+function governanceRetiredMessage(): string {
+  return '거버넌스 케이스 추적은 중단되었고, 이 화면은 live judge 상태와 최근 판단만 표시합니다.'
+}
+
 function GovernanceSummaryStrip() {
   const data = governanceData.value
   const summary = data?.summary
   const oldestAge = summary?.oldest_open_case_age_s
   const lastActivityAge = summary?.last_activity_age_s
+  const caseTrackingRetired = data?.case_tracking_available === false
   const isStale = (oldestAge != null && oldestAge > 86400) || (lastActivityAge != null && lastActivityAge > 86400)
   const itemCount = data?.items?.length ?? 0
   const activityCount = data?.activity?.length ?? 0
+  const judgmentCount = data?.judgments?.length ?? 0
+  const retiredValue = '-'
+  const retiredHint = 'retired'
 
   return html`
+    ${caseTrackingRetired ? html`
+      <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-accent/25 bg-accent/10 p-3.5 text-[13px] font-medium text-text-strong shadow-sm" data-testid="governance-retired-banner">
+        <div class="shrink-0"><${AlertTriangle} size=${18} /></div>
+        <div>${governanceRetiredMessage()}</div>
+      </div>
+    ` : null}
     ${isStale ? html`
       <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
         <div class="shrink-0"><${AlertTriangle} size=${18} /></div>
@@ -62,16 +80,18 @@ function GovernanceSummaryStrip() {
     <div class="mb-2.5 flex items-center justify-between px-0.5">
       <div class="flex items-center gap-3">
         <h2 class="text-lg font-bold text-text-strong tracking-wide">거버넌스</h2>
-        <span class="rounded-md border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-muted">진행 중 ${itemCount}건 / 활동 ${activityCount}건</span>
+        <span class="rounded-md border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-muted">
+          ${caseTrackingRetired ? `judge-only / 최근 판단 ${judgmentCount}건` : `진행 중 ${itemCount}건 / 활동 ${activityCount}건`}
+        </span>
       </div>
       ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}
     </div>
     <div class="mb-5 grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
-      <${KpiCard} label="열린 케이스" value=${summary?.cases_open ?? itemCount} />
-      <${KpiCard} label="판정 대기" value=${summary?.pending_ruling ?? 0} />
-      <${KpiCard} label="자동집행 준비" value=${summary?.ready_auto_execute ?? 0} />
-      <${KpiCard} label="관리자 승인 대기" value=${summary?.needs_human_gate ?? 0} />
-      <${KpiCard} label="집행 완료" value=${summary?.executed ?? 0} />
+      <${KpiCard} label="열린 케이스" value=${caseTrackingRetired ? retiredValue : (summary?.cases_open ?? itemCount)} hint=${caseTrackingRetired ? retiredHint : undefined} />
+      <${KpiCard} label="판정 대기" value=${caseTrackingRetired ? retiredValue : (summary?.pending_ruling ?? 0)} hint=${caseTrackingRetired ? retiredHint : undefined} />
+      <${KpiCard} label="자동집행 준비" value=${caseTrackingRetired ? retiredValue : (summary?.ready_auto_execute ?? 0)} hint=${caseTrackingRetired ? retiredHint : undefined} />
+      <${KpiCard} label="관리자 승인 대기" value=${caseTrackingRetired ? retiredValue : (summary?.needs_human_gate ?? 0)} hint=${caseTrackingRetired ? retiredHint : undefined} />
+      <${KpiCard} label="집행 완료" value=${caseTrackingRetired ? retiredValue : (summary?.executed ?? 0)} hint=${caseTrackingRetired ? retiredHint : undefined} />
     </div>
     <${JudgeStatusBar} />
   `
@@ -172,6 +192,13 @@ function governanceEmptyMessage(): string {
   const judgments = data?.judgments ?? []
   const lastActivityAge = data?.summary?.last_activity_age_s
 
+  if (data?.case_tracking_available === false) {
+    if (judgments.length > 0) {
+      return '거버넌스 케이스 추적은 중단되었고, 아래 AI Judge 판단만 유지됩니다.'
+    }
+    return governanceRetiredMessage()
+  }
+
   // All items and judgments empty — show guidance
   if (allItems.length === 0 && judgments.length === 0) {
     const ageText = formatAgeSummary(lastActivityAge)
@@ -187,8 +214,9 @@ function governanceEmptyMessage(): string {
 
 function DecisionInbox() {
   const items = filteredItemsByFilter(governanceFilter.value, governanceData.value?.items ?? [])
+  const caseTrackingRetired = governanceCaseTrackingRetired()
   return html`
-    <${Card} title="사건 수신함" class="section mb-5" variant="compact">
+    <${Card} title=${caseTrackingRetired ? '사건 수신함 (retired)' : '사건 수신함'} class="section mb-5" variant="compact">
       <div class="flex flex-col gap-3 governance-inbox">
         ${items.length === 0
           ? html`<${EmptyState} message=${governanceEmptyMessage()} />`
@@ -242,7 +270,7 @@ function JudgmentsSection() {
   const judgments = governanceData.value?.judgments ?? []
   if (judgments.length === 0) return null
   return html`
-    <${Card} title="AI Judge 판단" class="section mb-5" variant="compact">
+    <${Card} title=${governanceCaseTrackingRetired() ? 'AI Judge 판단 (live)' : 'AI Judge 판단'} class="section mb-5" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
           <div class="rounded-lg border border-card-border bg-card/34 p-3.5 text-[13px]" data-testid="judgment-item">

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -194,7 +194,7 @@ function governanceEmptyMessage(): string {
   const judgments = data?.judgments ?? []
   const lastActivityAge = data?.summary?.last_activity_age_s
 
-  if (data?.case_tracking_available === false) {
+  if (governanceCaseTrackingRetired()) {
     if (judgments.length > 0) {
       return '거버넌스 케이스 추적은 중단되었고, 아래 AI Judge 판단만 유지됩니다.'
     }

--- a/dashboard/src/ninja-keys.d.ts
+++ b/dashboard/src/ninja-keys.d.ts
@@ -1,0 +1,1 @@
+declare module 'ninja-keys'

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -331,6 +331,8 @@ export interface DashboardMemoryResponse {
 
 export interface DashboardGovernanceResponse {
   generated_at?: string
+  case_tracking_available?: boolean
+  note?: string
   summary?: {
     cases_open?: number
     pending_ruling?: number

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -167,6 +167,7 @@ export interface BoardMonitoring {
 
 export interface GovernanceMonitoring {
   alert_level?: 'ok' | 'warn' | 'bad' | string
+  case_tracking_available?: boolean
   cases_open?: number
   pending_ruling?: number
   ready_auto_execute?: number

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -168,6 +168,7 @@ export interface BoardMonitoring {
 export interface GovernanceMonitoring {
   alert_level?: 'ok' | 'warn' | 'bad' | string
   case_tracking_available?: boolean
+  note?: string
   cases_open?: number
   pending_ruling?: number
   ready_auto_execute?: number

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -159,8 +159,8 @@ export MASC_PERSONAS_DIR=/srv/masc/personas
 
 상세: `docs/KEEPER-USER-MANUAL.md`
 
-Compatibility note:
-- explicit join flow is still supported when you want to attach an agent without the full bootstrap shortcut: `masc_join(agent_name="codex")`
+호환성 참고:
+- 전체 부트스트랩 단축 경로 없이 에이전트만 연결하려는 경우에도 명시적 join 흐름을 계속 지원한다: `masc_join(agent_name="codex")`
 
 ## References
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -159,6 +159,9 @@ export MASC_PERSONAS_DIR=/srv/masc/personas
 
 상세: `docs/KEEPER-USER-MANUAL.md`
 
+Compatibility note:
+- explicit join flow is still supported when you want to attach an agent without the full bootstrap shortcut: `masc_join(agent_name="codex")`
+
 ## References
 
 - `docs/COMMAND-PLANE-RUNBOOK.md` — CPv2 benchmark/swarm path

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -15,13 +15,19 @@ let retired_case_tracking_fields =
 
 let string_option_json = option_to_yojson (fun value -> `String value)
 
+let timestamp_option_json value unix_value =
+  match value, unix_value with
+  | Some iso, _ -> `String iso
+  | None, Some ts -> `String (Types.iso8601_of_unix_seconds ts)
+  | None, None -> `Null
+
 let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot) =
   `Assoc
     [
       ("judge_online", `Bool runtime.judge_online);
       ("refreshing", `Bool runtime.refreshing);
-      ("generated_at", string_option_json runtime.generated_at);
-      ("expires_at", string_option_json runtime.expires_at);
+      ("generated_at", timestamp_option_json runtime.generated_at runtime.generated_at_unix);
+      ("expires_at", timestamp_option_json runtime.expires_at runtime.expires_at_unix);
       ("model_used", string_option_json runtime.model_used);
       ("keeper_name", `String runtime.keeper_name);
       ("last_error", string_option_json runtime.last_error);
@@ -40,7 +46,7 @@ let summary_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapsh
       ("oldest_open_case_age_s", `Null);
       ("last_activity_age_s", `Null);
       ("judge_online", `Bool runtime.judge_online);
-      ("judge_last_seen_at", string_option_json runtime.generated_at);
+      ("judge_last_seen_at", timestamp_option_json runtime.generated_at runtime.generated_at_unix);
     ]
 
 let factual_snapshot_json ~base_path:_ =

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -69,7 +69,6 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
     @ retired_case_tracking_fields)
 
 let cases_json ~base_path:_ ~limit ~offset ~status_filter:_ ~include_test:_ =
-  ignore (limit, offset);
   `Assoc
     ([
        ("cases", `List []);

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -1,64 +1,89 @@
-(** Dashboard Governance — compatibility stubs only. *)
+(** Dashboard Governance — retired case tracking with live judge status. *)
 
 type detail_status = [ `OK | `Not_found ]
 
-let _option_to_yojson = Json_util.option_to_yojson
-let _iso_of_unix = Dashboard_utils.iso_of_unix
+let option_to_yojson = Json_util.option_to_yojson
+
+let case_tracking_note =
+  "Governance case tracking is retired; dashboard surfaces only live judge status and recent judgments."
+
+let retired_case_tracking_fields =
+  [
+    ("case_tracking_available", `Bool false);
+    ("note", `String case_tracking_note);
+  ]
+
+let string_option_json = option_to_yojson (fun value -> `String value)
+
+let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot) =
+  `Assoc
+    [
+      ("judge_online", `Bool runtime.judge_online);
+      ("refreshing", `Bool runtime.refreshing);
+      ("generated_at", string_option_json runtime.generated_at);
+      ("expires_at", string_option_json runtime.expires_at);
+      ("model_used", string_option_json runtime.model_used);
+      ("keeper_name", `String runtime.keeper_name);
+      ("last_error", string_option_json runtime.last_error);
+    ]
+
+let summary_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot) =
+  `Assoc
+    [
+      ("cases_open", `Int 0);
+      ("pending_ruling", `Int 0);
+      ("ready_auto_execute", `Int 0);
+      ("needs_human_gate", `Int 0);
+      ("executed", `Int 0);
+      ("blocked", `Int 0);
+      ("ready_to_execute", `Int 0);
+      ("oldest_open_case_age_s", `Null);
+      ("last_activity_age_s", `Null);
+      ("judge_online", `Bool runtime.judge_online);
+      ("judge_last_seen_at", string_option_json runtime.generated_at);
+    ]
 
 let factual_snapshot_json ~base_path:_ =
   `Assoc
-    [
-      ("generated_at", `String (Types.now_iso ()));
-      ("items", `List []);
-      ("activity", `List []);
-      ("note", `String "Governance case tracking is no longer available.");
-    ]
+    ([
+       ("generated_at", `String (Types.now_iso ()));
+       ("items", `List []);
+       ("activity", `List []);
+     ]
+    @ retired_case_tracking_fields)
 
-let dashboard_json ~base_path:_ ~limit:_ ~offset:_ ~status_filter:_ =
+let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
+  let runtime = Dashboard_governance_judge.runtime_status base_path in
+  let judgments = Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit in
   `Assoc
-    [
-      ("generated_at", `String (Types.now_iso ()));
-      ("summary",
-        `Assoc
-          [
-            ("cases_open", `Int 0);
-            ("pending_ruling", `Int 0);
-            ("ready_auto_execute", `Int 0);
-            ("needs_human_gate", `Int 0);
-            ("executed", `Int 0);
-            ("blocked", `Int 0);
-            ("ready_to_execute", `Int 0);
-            ("oldest_open_case_age_s", `Null);
-            ("last_activity_age_s", `Null);
-            ("judge_online", `Bool false);
-            ("judge_last_seen_at", `Null);
-          ]);
-      ("items", `List []);
-      ("activity", `List []);
-      ("judge", `Assoc [
-        ("judge_online", `Bool false);
-        ("refreshing", `Bool false);
-        ("generated_at", `Null);
-        ("expires_at", `Null);
-        ("model_used", `Null);
-        ("keeper_name", `String Dashboard_governance_judge.keeper_name);
-        ("last_error", `Null);
-      ]);
-      ("judgments", `List []);
-      ("pending_actions", `List []);
-      ("cases", `List []);
-    ]
+    ([
+       ("generated_at", `String (Types.now_iso ()));
+       ("summary", summary_json_of_runtime runtime);
+       ("items", `List []);
+       ("activity", `List []);
+       ("judge", judge_json_of_runtime runtime);
+       ("judgments", `List judgments);
+       ("pending_actions", `List []);
+       ("cases", `List []);
+     ]
+    @ retired_case_tracking_fields)
 
 let cases_json ~base_path:_ ~limit ~offset ~status_filter:_ ~include_test:_ =
   ignore (limit, offset);
   `Assoc
-    [
-      ("cases", `List []);
-      ("count", `Int 0);
-      ("limit", `Int limit);
-      ("offset", `Int offset);
-    ]
+    ([
+       ("cases", `List []);
+       ("count", `Int 0);
+       ("limit", `Int limit);
+       ("offset", `Int offset);
+     ]
+    @ retired_case_tracking_fields)
 
 let case_detail_json ~base_path:_ ~case_id =
   ignore case_id;
-  (`Not_found, `Assoc [ ("error", `String "Governance case tracking unavailable") ])
+  ( `Not_found,
+    `Assoc
+      ([
+         ("error", `String "Governance case tracking unavailable");
+       ]
+      @ retired_case_tracking_fields) )

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -4,7 +4,9 @@ type runtime_snapshot = {
   judge_online : bool;
   refreshing : bool;
   generated_at : string option;
+  generated_at_unix : float option;
   expires_at : string option;
+  expires_at_unix : float option;
   model_used : string option;
   keeper_name : string;
   last_error : string option;
@@ -178,7 +180,9 @@ let runtime_status_at ~now_ts base_path =
           | None -> false);
         refreshing = st.refreshing;
         generated_at = st.generated_at;
+        generated_at_unix = st.generated_at_unix;
         expires_at = st.expires_at;
+        expires_at_unix = st.expires_at_unix;
         model_used = st.model_used;
         keeper_name;
         last_error = st.last_error;

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -166,7 +166,7 @@ let fresh_judgments_json ~base_path ~limit =
     Float.compare (judgment_generated_at b) (judgment_generated_at a))
   |> List.filteri (fun i _ -> i < limit)
 
-let runtime_status base_path =
+let runtime_status_at ~now_ts base_path =
   let st = get_state base_path in
   with_lock st (fun () ->
       {
@@ -174,7 +174,7 @@ let runtime_status base_path =
           st.judge_online
           &&
           (match st.expires_at_unix with
-          | Some expires_at -> Unix.gettimeofday () < expires_at
+          | Some expires_at -> now_ts < expires_at
           | None -> false);
         refreshing = st.refreshing;
         generated_at = st.generated_at;
@@ -183,6 +183,9 @@ let runtime_status base_path =
         keeper_name;
         last_error = st.last_error;
       })
+
+let runtime_status base_path =
+  runtime_status_at ~now_ts:(Unix.gettimeofday ()) base_path
 
 let parse_string_list json key =
   match json |> member key with

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -112,8 +112,7 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
 
 let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
   : Yojson.Safe.t * bool =
-  ignore now_ts;
-  let runtime = Dashboard_governance_judge.runtime_status base_path in
+  let runtime = Dashboard_governance_judge.runtime_status_at ~now_ts base_path in
   (* Governance case tracking is retired, but judge runtime status is still live. *)
   (`Assoc [
     ("alert_level", `String "ok");

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -112,8 +112,9 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
 
 let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
   : Yojson.Safe.t * bool =
-  ignore (now_ts, base_path);
-  (* Governance case tracking is retired — return empty governance status *)
+  ignore now_ts;
+  let runtime = Dashboard_governance_judge.runtime_status base_path in
+  (* Governance case tracking is retired, but judge runtime status is still live. *)
   (`Assoc [
     ("alert_level", `String "ok");
     ("cases_open", `Int 0);
@@ -126,7 +127,8 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
     ("last_activity_age_s", `Null);
     ("slo_target_case_age_s", `Int 0);
     ("slo_breached", `Bool false);
-    ("judge_online", `Bool false);
+    ("judge_online", `Bool runtime.judge_online);
+    ("case_tracking_available", `Bool false);
   ], true)
 
 let slot_monitoring_json () : Yojson.Safe.t =

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -113,9 +113,10 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
 let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
   : Yojson.Safe.t * bool =
   let runtime = Dashboard_governance_judge.runtime_status_at ~now_ts base_path in
+  let alert_level = if runtime.judge_online then "ok" else "warn" in
   (* Governance case tracking is retired, but judge runtime status is still live. *)
   (`Assoc [
-    ("alert_level", `String "ok");
+    ("alert_level", `String alert_level);
     ("cases_open", `Int 0);
     ("pending_ruling", `Int 0);
     ("ready_auto_execute", `Int 0);

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -128,6 +128,7 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
     ("slo_breached", `Bool false);
     ("judge_online", `Bool runtime.judge_online);
     ("case_tracking_available", `Bool false);
+    ("note", `String Dashboard_governance.case_tracking_note);
   ], true)
 
 let slot_monitoring_json () : Yojson.Safe.t =

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -21,6 +21,20 @@ let cleanup_dir dir =
   in
   rm dir
 
+let ensure_dir path =
+  if not (Sys.file_exists path) then Unix.mkdir path 0o755
+
+let write_legacy_judgment ~base_path json =
+  let masc = Filename.concat base_path ".masc" in
+  let governance = Filename.concat masc "governance" in
+  ensure_dir masc;
+  ensure_dir governance;
+  let path = Filename.concat governance "judgments.jsonl" in
+  let oc = open_out path in
+  output_string oc (Yojson.Safe.to_string json);
+  output_char oc '\n';
+  close_out oc
+
 let test_empty_governance_structure () =
   let dir = test_dir () in
   Fun.protect
@@ -36,6 +50,10 @@ let test_empty_governance_structure () =
       in
       let open Yojson.Safe.Util in
       let _gen = json |> member "generated_at" |> to_string in
+      check bool "case tracking retired" false
+        (json |> member "case_tracking_available" |> to_bool);
+      check bool "retirement note present" true
+        (json |> member "note" |> to_string |> String.length > 0);
       let summary = json |> member "summary" in
       check int "cases_open is 0" 0 (summary |> member "cases_open" |> to_int);
       check int "pending_ruling is 0" 0 (summary |> member "pending_ruling" |> to_int);
@@ -66,6 +84,75 @@ let test_empty_governance_structure () =
       check int "judgments empty" 0 (List.length judgments);
       let pending = json |> member "pending_actions" |> to_list in
       check int "pending_actions empty" 0 (List.length pending))
+
+let test_runtime_status_and_judgments_are_live () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let now = Unix.gettimeofday () in
+      let generated_at = "2026-04-04T12:00:00Z" in
+      let expires_at = Dashboard_utils.iso_of_unix (now +. 3600.0) in
+      let legacy_judgment =
+        `Assoc
+          [
+            ("target_kind", `String "agent_health");
+            ("target_id", `String "dreamer");
+            ("status", `String "active");
+            ("summary", `String "dreamer has been stalled for 30 minutes");
+            ("confidence", `Float 0.85);
+            ("generated_at", `String generated_at);
+            ("expires_at", `String expires_at);
+            ("model_used", `String "llama:qwen3.5");
+            ("keeper_name", `String Lib.Dashboard_governance_judge.keeper_name);
+            ( "recommended_action",
+              `Assoc
+                [
+                  ("action_kind", `String "recover");
+                  ("resolved_tool", `String "masc_operator_confirm");
+                  ("target_type", `String "agent");
+                  ("target_id", `String "dreamer");
+                  ("reason", `String "zombie agent detected");
+                ] );
+            ( "guardrail_state",
+              `Assoc
+                [
+                  ("requires_human_gate", `Bool true);
+                  ("ready_to_execute", `Bool false);
+                ] );
+          ]
+      in
+      write_legacy_judgment ~base_path:dir legacy_judgment;
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      st.judge_online <- true;
+      st.generated_at <- Some generated_at;
+      st.generated_at_unix <- Some now;
+      st.expires_at <- Some expires_at;
+      st.expires_at_unix <- Some (now +. 3600.0);
+      st.model_used <- Some "llama:qwen3.5";
+      st.last_error <- None;
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let summary = json |> member "summary" in
+      check bool "summary judge_online is live" true
+        (summary |> member "judge_online" |> to_bool);
+      check string "summary judge_last_seen_at uses runtime" generated_at
+        (summary |> member "judge_last_seen_at" |> to_string);
+      let judge = json |> member "judge" in
+      check bool "judge section online" true
+        (judge |> member "judge_online" |> to_bool);
+      check string "judge model uses runtime" "llama:qwen3.5"
+        (judge |> member "model_used" |> to_string);
+      let judgments = json |> member "judgments" |> to_list in
+      check int "legacy judgment surfaced" 1 (List.length judgments);
+      let first = List.hd judgments in
+      check string "judgment target id" "dreamer"
+        (first |> member "target_id" |> to_string);
+      check string "judgment tool" "masc_operator_confirm"
+        (first |> member "recommended_action" |> member "resolved_tool" |> to_string))
 
 let test_governance_dir_created_before_read () =
   let dir = test_dir () in
@@ -104,6 +191,8 @@ let () =
         [
           test_case "empty governance structure" `Quick
             test_empty_governance_structure;
+          test_case "runtime status and judgments are live" `Quick
+            test_runtime_status_and_judgments_are_live;
         ] );
       ( "init",
         [

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -91,12 +91,16 @@ let test_empty_governance_structure () =
       check int "pending_actions empty" 0 (List.length pending))
 
 let test_factual_snapshot_marks_surface_retired () =
-  let json = Lib.Dashboard_governance.factual_snapshot_json ~base_path:"/tmp/unused" in
-  let open Yojson.Safe.Util in
-  check bool "factual snapshot marks case tracking retired" false
-    (json |> member "case_tracking_available" |> to_bool);
-  check bool "factual snapshot includes note" true
-    (json |> member "note" |> to_string |> String.length > 0)
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let json = Lib.Dashboard_governance.factual_snapshot_json ~base_path:dir in
+      let open Yojson.Safe.Util in
+      check bool "factual snapshot marks case tracking retired" false
+        (json |> member "case_tracking_available" |> to_bool);
+      check bool "factual snapshot includes note" true
+        (json |> member "note" |> to_string |> String.length > 0))
 
 let test_runtime_status_and_judgments_are_live () =
   let dir = test_dir () in

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -22,10 +22,7 @@ let cleanup_dir dir =
   rm dir
 
 let iso8601_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+  Types.iso8601_of_unix_seconds ts
 
 let write_legacy_judgment ~base_path json =
   let masc = Filename.concat base_path ".masc" in

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -21,6 +21,12 @@ let cleanup_dir dir =
   in
   rm dir
 
+let iso8601_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
 let write_legacy_judgment ~base_path json =
   let masc = Filename.concat base_path ".masc" in
   let governance = Filename.concat masc "governance" in
@@ -100,8 +106,9 @@ let test_runtime_status_and_judgments_are_live () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let now = Unix.gettimeofday () in
-      let generated_at = "2026-04-04T12:00:00Z" in
-      let expires_at = "2099-01-01T00:00:00Z" in
+      let generated_at = iso8601_of_unix now in
+      let expires_at_unix = now +. 3600.0 in
+      let expires_at = iso8601_of_unix expires_at_unix in
       let legacy_judgment =
         `Assoc
           [
@@ -138,7 +145,7 @@ let test_runtime_status_and_judgments_are_live () =
         st.generated_at <- Some generated_at;
         st.generated_at_unix <- Some now;
         st.expires_at <- Some expires_at;
-        st.expires_at_unix <- Some (now +. 3600.0);
+        st.expires_at_unix <- Some expires_at_unix;
         st.model_used <- Some "llama:qwen3.5";
         st.last_error <- None);
       let json =
@@ -185,6 +192,9 @@ let test_governance_monitoring_uses_live_runtime () =
       check bool "monitoring call succeeds" true ok;
       check bool "monitoring marks case tracking retired" false
         (json |> member "case_tracking_available" |> to_bool);
+      check string "monitoring includes retirement note"
+        Lib.Dashboard_governance.case_tracking_note
+        (json |> member "note" |> to_string);
       check bool "monitoring exposes live judge_online" true
         (json |> member "judge_online" |> to_bool))
 

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -28,9 +28,11 @@ let write_legacy_judgment ~base_path json =
   Fs_compat.mkdir_p governance;
   let path = Filename.concat governance "judgments.jsonl" in
   let oc = open_out path in
-  output_string oc (Yojson.Safe.to_string json);
-  output_char oc '\n';
-  close_out oc
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (Yojson.Safe.to_string json);
+      output_char oc '\n')
 
 let test_empty_governance_structure () =
   let dir = test_dir () in
@@ -131,13 +133,14 @@ let test_runtime_status_and_judgments_are_live () =
       in
       write_legacy_judgment ~base_path:dir legacy_judgment;
       let st = Lib.Dashboard_governance_judge.get_state dir in
-      st.judge_online <- true;
-      st.generated_at <- Some generated_at;
-      st.generated_at_unix <- Some now;
-      st.expires_at <- Some expires_at;
-      st.expires_at_unix <- Some (now +. 3600.0);
-      st.model_used <- Some "llama:qwen3.5";
-      st.last_error <- None;
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.judge_online <- true;
+        st.generated_at <- Some generated_at;
+        st.generated_at_unix <- Some now;
+        st.expires_at <- Some expires_at;
+        st.expires_at_unix <- Some (now +. 3600.0);
+        st.model_used <- Some "llama:qwen3.5";
+        st.last_error <- None);
       let json =
         Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
           ~status_filter:None
@@ -170,9 +173,10 @@ let test_governance_monitoring_uses_live_runtime () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let st = Lib.Dashboard_governance_judge.get_state dir in
       let now = Unix.gettimeofday () in
-      st.judge_online <- true;
-      st.generated_at_unix <- Some now;
-      st.expires_at_unix <- Some (now +. 300.0);
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.judge_online <- true;
+        st.generated_at_unix <- Some now;
+        st.expires_at_unix <- Some (now +. 300.0));
       let (json, ok) =
         Lib.Dashboard_http_monitoring.governance_monitoring_json ~now_ts:now
           ~base_path:dir

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -85,6 +85,14 @@ let test_empty_governance_structure () =
       let pending = json |> member "pending_actions" |> to_list in
       check int "pending_actions empty" 0 (List.length pending))
 
+let test_factual_snapshot_marks_surface_retired () =
+  let json = Lib.Dashboard_governance.factual_snapshot_json ~base_path:"/tmp/unused" in
+  let open Yojson.Safe.Util in
+  check bool "factual snapshot marks case tracking retired" false
+    (json |> member "case_tracking_available" |> to_bool);
+  check bool "factual snapshot includes note" true
+    (json |> member "note" |> to_string |> String.length > 0)
+
 let test_runtime_status_and_judgments_are_live () =
   let dir = test_dir () in
   Fun.protect
@@ -154,6 +162,27 @@ let test_runtime_status_and_judgments_are_live () =
       check string "judgment tool" "masc_operator_confirm"
         (first |> member "recommended_action" |> member "resolved_tool" |> to_string))
 
+let test_governance_monitoring_uses_live_runtime () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      st.judge_online <- true;
+      st.generated_at_unix <- Some now;
+      st.expires_at_unix <- Some (now +. 300.0);
+      let (json, ok) =
+        Lib.Dashboard_http_monitoring.governance_monitoring_json ~now_ts:now
+          ~base_path:dir
+      in
+      let open Yojson.Safe.Util in
+      check bool "monitoring call succeeds" true ok;
+      check bool "monitoring marks case tracking retired" false
+        (json |> member "case_tracking_available" |> to_bool);
+      check bool "monitoring exposes live judge_online" true
+        (json |> member "judge_online" |> to_bool))
+
 let test_governance_dir_created_before_read () =
   let dir = test_dir () in
   Fun.protect
@@ -191,8 +220,12 @@ let () =
         [
           test_case "empty governance structure" `Quick
             test_empty_governance_structure;
+          test_case "factual snapshot marks retired surface" `Quick
+            test_factual_snapshot_marks_surface_retired;
           test_case "runtime status and judgments are live" `Quick
             test_runtime_status_and_judgments_are_live;
+          test_case "monitoring uses live runtime" `Quick
+            test_governance_monitoring_uses_live_runtime;
         ] );
       ( "init",
         [

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -21,14 +21,11 @@ let cleanup_dir dir =
   in
   rm dir
 
-let ensure_dir path =
-  if not (Sys.file_exists path) then Unix.mkdir path 0o755
-
 let write_legacy_judgment ~base_path json =
   let masc = Filename.concat base_path ".masc" in
   let governance = Filename.concat masc "governance" in
-  ensure_dir masc;
-  ensure_dir governance;
+  Fs_compat.mkdir_p masc;
+  Fs_compat.mkdir_p governance;
   let path = Filename.concat governance "judgments.jsonl" in
   let oc = open_out path in
   output_string oc (Yojson.Safe.to_string json);
@@ -98,9 +95,11 @@ let test_runtime_status_and_judgments_are_live () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
       let now = Unix.gettimeofday () in
       let generated_at = "2026-04-04T12:00:00Z" in
-      let expires_at = Dashboard_utils.iso_of_unix (now +. 3600.0) in
+      let expires_at = "2099-01-01T00:00:00Z" in
       let legacy_judgment =
         `Assoc
           [
@@ -167,6 +166,8 @@ let test_governance_monitoring_uses_live_runtime () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
       let st = Lib.Dashboard_governance_judge.get_state dir in
       let now = Unix.gettimeofday () in
       st.judge_online <- true;

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -40,13 +40,24 @@ let write_legacy_judgment ~base_path json =
       output_string oc (Yojson.Safe.to_string json);
       output_char oc '\n')
 
+let with_test_fs env f =
+  let previous_fs = Fs_compat.get_fs_opt () in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous_fs with
+      | Some fs -> Fs_compat.set_fs fs
+      | None -> Fs_compat.clear_fs ())
+    (fun () ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      f ())
+
 let test_empty_governance_structure () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_fs env @@ fun () ->
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json =
@@ -108,7 +119,7 @@ let test_runtime_status_and_judgments_are_live () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_fs env @@ fun () ->
       let now = Unix.gettimeofday () in
       let generated_at = iso8601_of_unix now in
       let expires_at_unix = now +. 3600.0 in
@@ -175,13 +186,47 @@ let test_runtime_status_and_judgments_are_live () =
       check string "judgment tool" "masc_operator_confirm"
         (first |> member "recommended_action" |> member "resolved_tool" |> to_string))
 
+let test_runtime_timestamps_fallback_to_unix_values () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      let expires_at_unix = now +. 600.0 in
+      let generated_at = iso8601_of_unix now in
+      let expires_at = iso8601_of_unix expires_at_unix in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.judge_online <- true;
+        st.generated_at <- None;
+        st.generated_at_unix <- Some now;
+        st.expires_at <- None;
+        st.expires_at_unix <- Some expires_at_unix;
+        st.model_used <- Some "llama:qwen3.5";
+        st.last_error <- None);
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let summary = json |> member "summary" in
+      check string "summary falls back to generated_at_unix" generated_at
+        (summary |> member "judge_last_seen_at" |> to_string);
+      let judge = json |> member "judge" in
+      check string "judge generated_at falls back to unix" generated_at
+        (judge |> member "generated_at" |> to_string);
+      check string "judge expires_at falls back to unix" expires_at
+        (judge |> member "expires_at" |> to_string))
+
 let test_governance_monitoring_uses_live_runtime () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_fs env @@ fun () ->
       let st = Lib.Dashboard_governance_judge.get_state dir in
       let now = Unix.gettimeofday () in
       Lib.Dashboard_governance_judge.with_lock st (fun () ->
@@ -221,7 +266,7 @@ let test_governance_dir_created_before_read () =
         (Sys.file_exists judgments && Sys.is_directory judgments);
       (* read_recent on empty dir returns [] — dashboard_json should still work *)
       Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_fs env @@ fun () ->
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json =
@@ -243,6 +288,8 @@ let () =
             test_factual_snapshot_marks_surface_retired;
           test_case "runtime status and judgments are live" `Quick
             test_runtime_status_and_judgments_are_live;
+          test_case "runtime timestamps fallback to unix values" `Quick
+            test_runtime_timestamps_fallback_to_unix_values;
           test_case "monitoring uses live runtime" `Quick
             test_governance_monitoring_uses_live_runtime;
         ] );


### PR DESCRIPTION
## Summary
- replaced the governance dashboard compatibility stub with a retired-surface contract that explicitly reports `case_tracking_available=false`
- wired dashboard and monitoring responses to live `Dashboard_governance_judge` runtime state and recent judgments instead of hardcoded `judge_online=false` / empty judgments
- rebased the branch onto current `main`, resolved outdated review threads, and added the missing frontend type declarations needed for the current dashboard dependency set

## Product impact
- operators now see that governance case tracking is retired instead of a misleading healthy zero-state
- live judge status and recent judgments remain visible on the dashboard and monitoring surfaces
- the governance dashboard no longer implies keeper-generated cases will appear later when that path is retired

## Evidence
- `bash scripts/check-oas-pin.sh`
- `bash scripts/check-doc-truth.sh`
- `dune build --root . test/test_dashboard_governance.exe`
- `./_build/default/test/test_dashboard_governance.exe`
- `dashboard ./node_modules/.bin/tsc --noEmit --pretty false`
- `dashboard ./node_modules/.bin/vitest run src/components/governance.test.ts`

## Review evidence
- Cross-model review: direct ZAI GLM via `sb glm-text` at 2026-04-04 00:40:37 KST, 6 findings, no high/critical issues
- Copilot review threads addressed and resolved on the latest head

## Linked issue
- Refs #4360
