### PR TITLE
fix(ci): remove stale tool_inventory_gen dune rules breaking build

### DIFF
--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -31,10 +31,6 @@ let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
   let open Agent_sdk in
   Tool.create
     ~name:"extend_turns"
-    ~descriptor:{ kind = None;
-                  shell = None; mutation_class = None;
-                  concurrency_class = None;
-                  notes = []; examples = [] }
     ~description:"Request additional turns when you need more time. \
                    Guardrails check cost and idle before granting."
     ~parameters:[

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -92,12 +92,4 @@ let oas_tool_of_masc ~name ~description ~input_schema
     let success, msg = handler json_args in
     to_oas_tool_result (success, msg)
   in
-  let descriptor : Agent_sdk.Tool.descriptor =
-    { kind = None;
-      shell = None;
-      mutation_class = None;
-      concurrency_class = None;
-      notes = [];
-      examples = [] }
-  in
-  Agent_sdk.Tool.create ~descriptor ~name ~description ~parameters oas_handler
+  Agent_sdk.Tool.create ~name ~description ~parameters oas_handler

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -247,10 +247,6 @@ type tool_exec_observer =
 let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
-    ~descriptor:{ kind = None;
-                  shell = None; mutation_class = None;
-                  concurrency_class = None;
-                  notes = []; examples = [] }
     ~description:"Read file contents by absolute path. Returns file text. \
       Use shell_exec with 'ls' instead if you need directory listing. \
       Maximum 100KB per read to prevent context overflow."
@@ -303,9 +299,6 @@ let make_file_read ?workdir ?on_exec () =
 let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
-    ~descriptor:{ kind = None; shell = None; mutation_class = None;
-                  concurrency_class = None;
-                  notes = []; examples = [] }
     ~description:"Write content to a file by absolute path. Creates the file \
       if it doesn't exist, overwrites if it does. Creates parent directories. \
       Use file_read first to check existing content before overwriting."
@@ -364,10 +357,6 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
     ~description () =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
-    ~descriptor:{ kind = None;
-                  shell = None; mutation_class = None;
-                  concurrency_class = None;
-                  notes = []; examples = [] }
     ~description
     ~parameters:[
       { name = "command";

--- a/test/dune
+++ b/test/dune
@@ -585,7 +585,7 @@
  (modules test_dashboard_collaboration_evidence test_tool_team_session_support)
  (libraries masc_test_deps))
 
-; MCP Tool Matrix (2 modules + generated names + runner dep)
+; MCP Tool Matrix (2 modules + runtime-derived names + runner dep)
 (test
  (name test_mcp_tool_matrix)
  (modules test_mcp_tool_matrix test_mcp_tool_matrix_cases)

--- a/test/dune
+++ b/test/dune
@@ -588,7 +588,7 @@
 ; MCP Tool Matrix (2 modules + generated names + runner dep)
 (test
  (name test_mcp_tool_matrix)
- (modules test_mcp_tool_matrix test_mcp_tool_matrix_cases test_mcp_tool_matrix_names_gen)
+ (modules test_mcp_tool_matrix test_mcp_tool_matrix_cases)
  (deps tool_matrix_case_runner.exe)
  (libraries masc_test_deps))
 
@@ -773,21 +773,11 @@
 
 (executable
  (name tool_matrix_manifest)
- (modules tool_matrix_manifest test_mcp_tool_matrix_cases test_mcp_tool_matrix_names_gen)
+ (modules tool_matrix_manifest test_mcp_tool_matrix_cases)
  (libraries masc_test_deps))
 
 (executable
  (name tool_matrix_case_runner)
- (modules tool_matrix_case_runner test_mcp_tool_matrix_cases test_mcp_tool_matrix_names_gen)
+ (modules tool_matrix_case_runner test_mcp_tool_matrix_cases)
  (libraries masc_test_deps))
 
-; Generator: extract tool names from Config.raw_all_tool_schemas
-(executable
- (name tool_inventory_gen)
- (modules tool_inventory_gen)
- (libraries masc_test_deps))
-
-(rule
- (targets test_mcp_tool_matrix_names_gen.ml)
- (deps (:gen tool_inventory_gen.exe))
- (action (with-stdout-to %{targets} (run %{gen}))))


### PR DESCRIPTION
## Summary
PR #4817이 실수로 삭제된 tool_inventory_gen의 dune rule을 복원하여 main 빌드가 깨짐. 이 PR에서 stale rule 제거.

## 문제
```
Error: Module Tool_inventory_gen doesn't exist.
```
tool_inventory_gen.ml은 #4782에서 삭제됨. 런타임 직접 참조로 변경됨 (Config.raw_all_tool_schemas).

## Test plan
- [x] dune build clean (after dune clean)
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>