### PR TITLE
fix(keeper): sort overflow guard truncation by BM25 score

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -617,7 +617,7 @@ let run_turn
         (* Context overflow guard: cap tool count to prevent exceeding
            small model context windows (e.g. 8K).  ~118 tokens/tool schema,
            so 40 tools ≈ 4700 tokens — safe for 8K models.  Beyond 40,
-           truncate to always_include_tools + top BM25 results.
+           truncate to always_include_tools + top BM25 results by score.
            Configurable via MASC_KEEPER_MAX_TOOLS_PER_TURN. *)
         let max_tools =
           Keeper_config.int_of_env_default
@@ -633,7 +633,18 @@ let run_turn
             let non_essential = List.filter
               (fun name -> not (List.mem name always_include_tools)) all_allowed in
             let budget = max_tools - List.length essential in
-            essential @ (List.filteri (fun i _ -> i < budget) non_essential)
+            (* Sort non-essential by BM25 score descending so the most
+               relevant tools survive truncation.  Tools not in the
+               retrieved set (e.g. fallback) get score 0.0. *)
+            let score_of name =
+              match List.assoc_opt name retrieved with
+              | Some s -> s
+              | None -> 0.0
+            in
+            let sorted = List.sort
+              (fun a b -> compare (score_of b) (score_of a))
+              non_essential in
+            essential @ (List.filteri (fun i _ -> i < budget) sorted)
           end else
             all_allowed
         in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -641,7 +641,7 @@ let run_turn
               | Some s -> s
               | None -> 0.0
             in
-            let sorted = List.sort
+            let sorted = List.stable_sort
               (fun a b -> compare (score_of b) (score_of a))
               non_essential in
             essential @ (List.filteri (fun i _ -> i < budget) sorted)


### PR DESCRIPTION
## Summary
- Context overflow guard가 non-essential tools를 단순 index 순서로 truncation하던 버그 수정
- BM25 score 기반 내림차순 정렬 후 truncation → 쿼리 관련성 높은 도구가 생존
- fallback tools (score 0.0)이 먼저 제거됨

## Product impact
Keeper가 151-175개 도구 중 40개를 선택할 때, BM25 검색으로 관련성을 매겨놓고도 무시하던 문제 해결.

## Evidence
```
# Before: index 순서로 truncation (BM25 score 무시)
context overflow guard: 151 tools > max 40, truncating
→ essential(~15) + non_essential[:25] (index 순서)

# After: BM25 score 기반 정렬 후 truncation
→ essential(~15) + top-25 non_essential by BM25 score
```

## Review evidence
교차 모델 리뷰 예정

Refs #4709

## Test plan
- [ ] Keeper turn 시 overflow guard 로그 확인
- [ ] BM25 고점수 tool이 truncation 후에도 유지되는지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)