### PR TITLE
[codex] Adopt internal-only tool retry policy

### DIFF
--- a/docs/design/tool-calling-quality-and-self-healing-rfc.md
+++ b/docs/design/tool-calling-quality-and-self-healing-rfc.md
@@ -1,6 +1,6 @@
 # Tool Calling Quality and Self-Healing RFC
 
-**Status**: Design-complete for benchmark and internal-runtime scope; implementation not started
+**Status**: Internal-runtime scope implemented in local worktrees; benchmark/program work remains partially unimplemented
 **Date**: 2026-04-03
 **Scope**: `masc-mcp` + `oas` + local benchmark harness
 **One sentence**: tool calling 품질을 `first-pass selection`에서 `bounded convergence under validation pressure`로 재정의하고, public MCP와 internal OAS 자율 경로의 경계를 유지한 채 self-healing helper와 공통 benchmark contract를 도입한다.
@@ -21,6 +21,19 @@
   - `/Users/dancer/me/.worktrees/exp-gemma4-tool-bench/docs/gemma4-tool-benchmark-20260403.md`
   - `/Users/dancer/me/.worktrees/exp-gemma4-tool-bench/docs/strict-v2-quality-summary-20260403.md`
   - `/Users/dancer/me/.worktrees/exp-gemma4-tool-bench/docs/samchon-runtime-audit-20260403.md`
+
+## Implementation Update (2026-04-04)
+
+Runtime scope has moved since the original draft.
+
+- `oas` now has a generic internal helper `Tool_retry_policy` and uses it in both the generic agent tool loop and `Structured.extract_with_retry`.
+- `masc-mcp` now opts in to that helper only on internal OAS-backed autonomous paths:
+  - keeper turn path
+  - proactive keeper generation path
+  - OAS worker builder path
+  - local worker resume path
+- `masc-mcp` public MCP path remains one-shot and deterministic. No model-facing retry loop was added there.
+- Benchmark runner abstraction, MLX harness lane, and the broader program phases below are still proposal-level unless explicitly marked otherwise.
 
 ## 1. Problem Statement
 
@@ -73,21 +86,22 @@
 
 ### 3.2 Runtime truth
 
-`samchon` parity는 현재 surface별로 다르다.
+`samchon` parity는 여전히 surface별로 다르지만, internal runtime scope에서는 helper boundary가 이제 명시적이다.
 
 - `masc-mcp` public MCP path:
   - deterministic validation 있음
   - model-facing retry loop 없음
 - `masc-mcp` internal keeper/OAS path:
   - validation 있음
-  - same-run correction 가능
+  - bounded same-run correction 가능
+  - OAS `Tool_retry_policy.default_internal`로 opt-in
 - `oas` generic tool loop:
-  - invalid input을 structured error `ToolResult`로 되돌림
-  - same-run next turn correction 가능
+  - invalid input / recoverable tool error를 typed retry decision으로 평가
+  - policy-enabled agent에서 same-run next turn correction 가능
 - `oas` structured path:
-  - `Structured.extract_with_retry`가 explicit bounded retry를 제공
+  - `Structured.extract_with_retry`가 같은 helper core를 사용해 explicit bounded retry를 제공
 
-이 상태는 useful하지만 uneven하다. reusable helper와 adoption boundary가 필요하다.
+이 상태는 여전히 uneven하지만, reusable helper와 adoption boundary 자체는 이제 코드로 존재한다.
 
 ### 3.3 Backend truth
 
@@ -237,6 +251,13 @@ control-only retained model:
 
 OAS에 generic internal helper `tool_retry_policy`를 추가한다.
 
+Implementation status:
+
+- done in local worktrees
+- core module exists
+- generic pipeline adoption exists
+- structured-path adoption exists
+
 typed fields:
 
 - `max_retries : int`
@@ -255,6 +276,11 @@ adoption target:
 
 - internal OAS-backed autonomous path: retry policy 사용 가능
 - public MCP path: retry policy 금지, current deterministic validation 유지
+
+Implementation status:
+
+- internal keeper / worker OAS-backed paths: adopted
+- public MCP path: unchanged
 
 이 boundary는 red line이다.
 
@@ -392,26 +418,36 @@ Phase 0:
 - RFC + execution program doc
 - model catalog draft
 
+Status: pending
+
 Phase 1:
 
 - runner abstraction
 - `benchmark_result_v2`
 - MLX local runner
 
+Status: pending
+
 Phase 2:
 
 - `pressure_behavior_v1`
 - updated summaries and tables
+
+Status: pending
 
 Phase 3:
 
 - OAS `tool_retry_policy`
 - internal-path-only integration in `masc-mcp`
 
+Status: completed in local worktrees on 2026-04-04
+
 Phase 4:
 
 - compare `first-pass` vs `final convergence`
 - decide default serving profile for local model path
+
+Status: pending
 
 ## 13. Risks
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -707,6 +707,7 @@ let run_turn
           ~hooks
           ~context_reducer:reducer
           ~memory
+          ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
           ~max_turns
           ~max_idle_turns:5
           ~temperature

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -1112,6 +1112,7 @@ let run_proactive_generation
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
             ~tools ~initial_messages:ctx_work.messages
+            ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
             ~max_turns:(Keeper_config.keeper_unified_max_turns ())
             ~temperature ~max_tokens
             ()) in

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -508,6 +508,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       provider = Some provider;
       hooks;
       guardrails = effective_guardrails;
+      tool_retry_policy = Some Oas.Tool_retry_policy.default_internal;
       raw_trace = Some raw_trace;
       periodic_callbacks;
     }
@@ -559,4 +560,3 @@ let materialize_direct_evidence ~base_path ~worker_name
           Log.LocalWorker.error
             "direct evidence persist failed for %s/%s: %s"
             worker_name session_id (Oas.Error.to_string err)
-

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -498,6 +498,7 @@ type config = {
   session_id : string option;
   description : string option;
   memory : Oas.Memory.t option;
+  tool_retry_policy : Oas.Tool_retry_policy.t option;
   named_cascade : Oas.Api.named_cascade option;
   initial_messages : Oas.Types.message list;
   raw_trace : Oas.Raw_trace.t option;
@@ -523,6 +524,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     session_id = None;
     description = None;
     memory = None;
+    tool_retry_policy = None;
     named_cascade = None;
     initial_messages = [];
     raw_trace = None;
@@ -662,6 +664,10 @@ let build
   in
   let builder = match config.memory with
     | Some m -> Oas.Builder.with_memory m builder
+    | None -> builder
+  in
+  let builder = match config.tool_retry_policy with
+    | Some policy -> Oas.Builder.with_tool_retry_policy policy builder
     | None -> builder
   in
   let builder = match config.raw_trace with
@@ -922,6 +928,7 @@ let config_for_label
     ?hooks
     ?context_reducer
     ?memory
+    ?tool_retry_policy
     ?enable_thinking
     ~(description : string option)
     () : config =
@@ -946,6 +953,7 @@ let config_for_label
     hooks;
     context_reducer;
     memory;
+    tool_retry_policy;
     enable_thinking;
     description;
   }
@@ -978,6 +986,7 @@ let run_named
     ?hooks
     ?context_reducer
     ?memory
+    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -1033,7 +1042,7 @@ let run_named
          ~system_prompt ~tools)
       with
       max_turns; max_tokens; temperature; max_idle_turns;
-      guardrails; hooks; context_reducer; memory;
+      guardrails; hooks; context_reducer; memory; tool_retry_policy;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
       transport = transport_resolved;
       allowed_paths;
@@ -1085,6 +1094,7 @@ let run_model_by_label
     ?hooks
     ?context_reducer
     ?memory
+    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?on_event
@@ -1107,8 +1117,9 @@ let run_model_by_label
         in
         let config =
           config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
-            ~tools ~max_turns ~max_tokens ~temperature ~max_idle_turns ?guardrails ?hooks
-            ?context_reducer ?memory ?enable_thinking
+            ~tools ~max_turns ~max_tokens ~temperature
+            ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
+            ?tool_retry_policy ?enable_thinking
             ~description:(Some (Printf.sprintf "model_label:%s" model_label))
             ()
         in
@@ -1132,6 +1143,7 @@ let run_named_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
+    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -1154,7 +1166,8 @@ let run_named_with_masc_tools
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
-    ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref ?contract
+    ?tool_retry_policy ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
+    ?contract
     ?transport ~yield_on_tool ?sw ?net ()
 
 let run_model_with_masc_tools
@@ -1169,6 +1182,7 @@ let run_model_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
+    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?raw_trace
@@ -1188,7 +1202,7 @@ let run_model_with_masc_tools
       let config =
         config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
           ~tools:[] ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
-          ?memory ?enable_thinking
+          ?memory ?tool_retry_policy ?enable_thinking
           ~description:(Some (Printf.sprintf "model_label:%s" model_label))
           ()
       in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -92,6 +92,7 @@ val run_named :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -125,6 +126,7 @@ val run_model_by_label :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
@@ -146,6 +148,7 @@ val run_named_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -171,6 +174,7 @@ val run_model_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
+  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?raw_trace:Oas.Raw_trace.t ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -260,6 +260,7 @@ let build_agent
     |> Oas.Builder.with_tools tools
     |> Oas.Builder.with_hooks hooks
     |> Oas.Builder.with_guardrails guardrails
+    |> Oas.Builder.with_tool_retry_policy Oas.Tool_retry_policy.default_internal
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)


### PR DESCRIPTION
## What changed

This adopts the new OAS internal tool retry policy on autonomous OAS-backed MASC paths only.

- passes `Tool_retry_policy.default_internal` into keeper turn and proactive keeper generation paths
- threads optional retry policy through `Oas_worker`
- enables the policy on worker OAS builder and local worker resume flows
- updates the RFC to reflect the implemented runtime boundary
- fixes descriptor records to include the newer concurrency metadata field

## Why

The internal keeper and worker paths already relied on OAS for model execution, but they did not have a single explicit self-healing policy.
This change adopts the shared OAS helper while keeping public MCP semantics unchanged.

## Impact

- internal autonomous OAS paths get bounded same-run retry for validation and recoverable tool failures
- public MCP remains one-shot and deterministic
- the runtime boundary is now documented as code and in the RFC

## Root cause

The retry behavior lived mostly in OAS and was only partially reachable from MASC internal paths.
There was no explicit adoption path or boundary marker for internal-only use.

## Dependency

- depends on OAS PR: https://github.com/jeong-sik/oas/pull/573
- local verification used a pinned local `agent_sdk` built from the matching OAS worktree

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/internal-tool-self-heal bin/main_eio.exe`
- `ocamlfind ocamlc -package agent_sdk -c /tmp/agent_sdk_smoke.ml`

## Notes

- full `@default` is still blocked by the pre-existing generated test-module issue around `Test_mcp_tool_matrix_names_gen`
- this PR intentionally does not add any model-facing retry loop to the public MCP surface
