### PR TITLE
fix(keeper): Eio.Fiber.yield() at CPU-bound boundaries — HTTP starvation 방지

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -638,6 +638,10 @@ let run_turn
             all_allowed
         in
         let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
+        (* Yield after CPU-bound tool filtering to let HTTP handlers run.
+           Without this, N concurrent keeper fibers starve the Eio scheduler
+           during turn setup (tool list construction + prompt building). *)
+        Eio.Fiber.yield ();
         Agent_sdk.Hooks.AdjustParams
           { current_params with
             extra_system_context = ctx;

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -190,6 +190,10 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   let rec loop () =
     if Atomic.get stop then ()
     else (
+            (* Yield before each heartbeat cycle to prevent N keeper fibers
+               from monopolizing the Eio scheduler during CPU-bound phases
+               (tool filtering, snapshot construction, prompt building). *)
+            Eio.Fiber.yield ();
             (* Phase 0: timing markers *)
             let t_presence_start = Time_compat.now () in
             let meta_current =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -662,10 +662,14 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let primary_max_context =
         Oas_model_resolve.resolve_primary_max_context model_labels
       in
+      (* Yield before CPU-bound prompt construction so the Eio scheduler
+         can service HTTP handlers between keeper turn setups. *)
+      Eio.Fiber.yield ();
       (* 2. Build unified prompt *)
       let system_prompt, user_message =
         Keeper_unified_prompt.build_prompt ~meta ~observation
       in
+      Eio.Fiber.yield ();
       let base_dir = session_base_dir config in
       (* Ensure session dir tree for filesystem fallback (issue #3019) *)
       Keeper_types.mkdir_p (Filename.concat base_dir meta.runtime.trace_id);


### PR DESCRIPTION
## Summary

- Keeper fiber의 CPU-bound 구간에 `Eio.Fiber.yield()` 삽입
- 3곳: heartbeat cycle 시작, tool list truncation 후, prompt 구성 전후

## Problem

9 keeper가 동시에 돌 때 서버 /health가 응답 불가 → startup takeover가 SIGKILL → 반복 재시작.

원인: keeper fiber들이 tool filtering (162→40), prompt 구성 등 CPU-bound 작업을 yield 없이 실행. Eio single-domain scheduler에서 HTTP handler fiber가 schedule 되지 못함.

## Evidence

```
[Keeper] context overflow guard: 162 tools > max 40, truncating  (매 turn, yield 없음)
[Dashboard] [snapshot_json] sessions_json: 3142ms  (CPU-bound)
[WARN] PID 76282 alive but unresponsive on port 8935; sending SIGTERM
```

Keeper 코드 전체에 `Eio.Fiber.yield()` 가 1개뿐이었음 (keeper_unified_turn.ml:740, retry 경로).

## Test plan

- [x] `dune build` 성공
- [x] `test_keeper_unified.exe` 72 tests pass
- [ ] 실서버에서 keeper 3개 autoboot 후 /health 응답성 확인

Closes #4838

🤖 Generated with [Claude Code](https://claude.com/claude-code)