### PR TITLE
feat(dashboard): integrate ninja-keys command palette for power user keyboard navigation

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,6 +25,7 @@
     "lucide-preact": "^1.7.0",
     "marked": "^17.0.5",
     "mermaid": "^11.12.0",
+    "ninja-keys": "^1.2.2",
     "preact": "^10.25.4",
     "shiki": "^4.0.2",
     "vis-data": "^8.0.3",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       mermaid:
         specifier: ^11.12.0
         version: 11.12.3
+      ninja-keys:
+        specifier: ^1.2.2
+        version: 1.2.2
       preact:
         specifier: ^10.25.4
         version: 10.28.3
@@ -386,6 +389,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/reactive-element@1.6.3':
+    resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
+
+  '@material/mwc-icon@0.25.3':
+    resolution: {integrity: sha512-36076AWZIRSr8qYOLjuDDkxej/HA0XAosrj7TS1ZeLlUBnLUtbDtvc1S7KSa0hqez7ouzOqGaWK24yoNnTa2OA==}
+    deprecated: MWC beta is longer supported. Please upgrade to @material/web
 
   '@mermaid-js/parser@1.0.0':
     resolution: {integrity: sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==}
@@ -1383,6 +1396,9 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  hotkeys-js@3.8.7:
+    resolution: {integrity: sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==}
+
   htm@3.1.1:
     resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
@@ -1585,6 +1601,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lit-element@3.3.3:
+    resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
+
+  lit-html@2.8.0:
+    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
+
+  lit@2.2.6:
+    resolution: {integrity: sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==}
+
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -1659,6 +1684,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  ninja-keys@1.2.2:
+    resolution: {integrity: sha512-ylo8jzKowi3XBHkgHRjBJaKQkl32WRLr7kRiA0ajiku11vHRDJ2xANtTScR5C7XlDwKEOYvUPesCKacUeeLAYw==}
 
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
@@ -2405,6 +2433,17 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/reactive-element@1.6.3':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+
+  '@material/mwc-icon@0.25.3':
+    dependencies:
+      lit: 2.2.6
+      tslib: 2.8.1
+
   '@mermaid-js/parser@1.0.0':
     dependencies:
       langium: 4.2.1
@@ -2820,8 +2859,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -3446,6 +3484,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  hotkeys-js@3.8.7: {}
+
   htm@3.1.1: {}
 
   html-void-elements@3.0.0: {}
@@ -3612,6 +3652,22 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lit-element@3.3.3:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 1.6.3
+      lit-html: 2.8.0
+
+  lit-html@2.8.0:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@2.2.6:
+    dependencies:
+      '@lit/reactive-element': 1.6.3
+      lit-element: 3.3.3
+      lit-html: 2.8.0
+
   lodash-es@4.17.23: {}
 
   loose-envify@1.4.0:
@@ -3704,6 +3760,12 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  ninja-keys@1.2.2:
+    dependencies:
+      '@material/mwc-icon': 0.25.3
+      hotkeys-js: 3.8.7
+      lit: 2.2.6
 
   node-html-parser@6.1.13:
     dependencies:

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -22,6 +22,7 @@ import { AgentDetailOverlay } from './components/agent-detail'
 import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
+import { CommandPalette } from './components/common/command-palette'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
@@ -133,6 +134,7 @@ export function App() {
       <${TaskDetailOverlay} />
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
+      <${CommandPalette} />
     </div>
   `
 }

--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -1,0 +1,89 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+const requestConfirm = vi.fn()
+const runGarbageCollection = vi.fn().mockResolvedValue(undefined)
+const cleanupZombies = vi.fn().mockResolvedValue(undefined)
+
+async function loadPalette() {
+  vi.resetModules()
+  vi.doMock('../../router', () => ({ navigate }))
+  vi.doMock('./confirm-dialog', () => ({ requestConfirm }))
+  vi.doMock('../flow-control/flow-control-state', () => ({
+    cleanupZombies,
+    runGarbageCollection,
+  }))
+  return import('./command-palette')
+}
+
+describe('CommandPalette', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../../router')
+    vi.doUnmock('./confirm-dialog')
+    vi.doUnmock('../flow-control/flow-control-state')
+  })
+
+  it('loads the web component lazily and wires navigation commands without reserved hotkeys', async () => {
+    const { CommandPalette } = await loadPalette()
+
+    render(html`<${CommandPalette} />`, container)
+    await waitFor(() => {
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string; handler: () => void; hotkey?: string }>
+      }) | null
+      expect(palette).not.toBeNull()
+      expect(palette?.data?.length).toBeGreaterThan(0)
+    })
+
+    const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+      data?: Array<{ id: string; handler: () => void; hotkey?: string }>
+    }) | null
+
+    expect(palette).not.toBeNull()
+    expect(palette?.getAttribute('placeholder')).toContain('⌘/Ctrl+K')
+    expect(palette?.data?.every((item) => item.hotkey == null)).toBe(true)
+
+    const overview = palette?.data?.find((item) => item.id === 'nav-overview')
+    overview?.handler()
+
+    expect(navigate).toHaveBeenCalledWith('overview')
+  })
+
+  it('runs maintenance actions only after confirmation', async () => {
+    const { CommandPalette } = await loadPalette()
+
+    render(html`<${CommandPalette} />`, container)
+    await waitFor(() => {
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string; handler: () => Promise<void> | void }>
+      }) | null
+      expect(palette?.data?.length).toBeGreaterThan(0)
+    })
+
+    const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+      data?: Array<{ id: string; handler: () => Promise<void> | void }>
+    }) | null
+
+    requestConfirm.mockResolvedValueOnce(true)
+    await palette?.data?.find((item) => item.id === 'action-gc')?.handler()
+    expect(runGarbageCollection).toHaveBeenCalledTimes(1)
+
+    requestConfirm.mockResolvedValueOnce(false)
+    await palette?.data?.find((item) => item.id === 'action-zombie')?.handler()
+    expect(cleanupZombies).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -25,7 +25,9 @@ export function CommandPalette() {
       .then(() => {
         if (!cancelled) setReady(true)
       })
-      .catch(() => {})
+      .catch((error) => {
+        console.error('Failed to load ninja-keys', error)
+      })
 
     return () => {
       cancelled = true
@@ -34,7 +36,9 @@ export function CommandPalette() {
 
   useEffect(() => {
     if (!ready || !ref.current) return
-    ref.current.data = [
+    const frameId = window.requestAnimationFrame(() => {
+      if (!ref.current) return
+      ref.current.data = [
       {
         id: 'nav-overview',
         title: '상황판으로 이동 (Overview)',
@@ -81,7 +85,12 @@ export function CommandPalette() {
           if (confirmed) void cleanupZombies()
         }
       }
-    ]
+      ]
+    })
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+    }
   }, [ready])
 
   if (!ready) return null

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -1,50 +1,68 @@
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
-import 'ninja-keys'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { navigate } from '../../router'
 import { requestConfirm } from './confirm-dialog'
 import { runGarbageCollection, cleanupZombies } from '../flow-control/flow-control-state'
 
+interface CommandPaletteAction {
+  id: string
+  title: string
+  handler: () => void | Promise<void>
+}
+
+interface NinjaKeysElement extends HTMLElement {
+  data: CommandPaletteAction[]
+}
+
 export function CommandPalette() {
-  const ref = useRef<any>(null)
+  const ref = useRef<NinjaKeysElement | null>(null)
+  const [ready, setReady] = useState(false)
 
   useEffect(() => {
-    if (!ref.current) return
+    let cancelled = false
+
+    void import('ninja-keys')
+      .then(() => {
+        if (!cancelled) setReady(true)
+      })
+      .catch(() => {})
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ready || !ref.current) return
     ref.current.data = [
       {
         id: 'nav-overview',
         title: '상황판으로 이동 (Overview)',
-        hotkey: 'ctrl+1',
         handler: () => navigate('overview')
       },
       {
         id: 'nav-monitoring',
         title: '모니터링으로 이동 (Monitoring)',
-        hotkey: 'ctrl+2',
         handler: () => navigate('monitoring')
       },
       {
         id: 'nav-workspace',
         title: '작업 화면으로 이동 (Workspace)',
-        hotkey: 'ctrl+3',
         handler: () => navigate('workspace')
       },
       {
         id: 'nav-command',
         title: '운영 개입으로 이동 (Command Plane)',
-        hotkey: 'ctrl+4',
         handler: () => navigate('command')
       },
       {
         id: 'nav-lab',
         title: '실험실로 이동 (Lab)',
-        hotkey: 'ctrl+5',
         handler: () => navigate('lab')
       },
       {
         id: 'nav-logs',
         title: '로그 뷰어로 이동 (Logs)',
-        hotkey: 'ctrl+6',
         handler: () => navigate('logs')
       },
       {
@@ -64,12 +82,14 @@ export function CommandPalette() {
         }
       }
     ]
-  }, [])
+  }, [ready])
+
+  if (!ready) return null
 
   return html`
     <ninja-keys
       ref=${ref}
-      placeholder="명령어를 검색하세요... (Cmd+K)"
+      placeholder="명령어를 검색하세요... (⌘/Ctrl+K)"
       hideBreadcrumbs
       style="
         --ninja-modal-background: rgba(13, 21, 38, 0.98);

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -1,0 +1,88 @@
+import { html } from 'htm/preact'
+import { useEffect, useRef } from 'preact/hooks'
+import 'ninja-keys'
+import { navigate } from '../../router'
+import { requestConfirm } from './confirm-dialog'
+import { runGarbageCollection, cleanupZombies } from '../flow-control/flow-control-state'
+
+export function CommandPalette() {
+  const ref = useRef<any>(null)
+
+  useEffect(() => {
+    if (!ref.current) return
+    ref.current.data = [
+      {
+        id: 'nav-overview',
+        title: '상황판으로 이동 (Overview)',
+        hotkey: 'ctrl+1',
+        handler: () => navigate('overview')
+      },
+      {
+        id: 'nav-monitoring',
+        title: '모니터링으로 이동 (Monitoring)',
+        hotkey: 'ctrl+2',
+        handler: () => navigate('monitoring')
+      },
+      {
+        id: 'nav-workspace',
+        title: '작업 화면으로 이동 (Workspace)',
+        hotkey: 'ctrl+3',
+        handler: () => navigate('workspace')
+      },
+      {
+        id: 'nav-command',
+        title: '운영 개입으로 이동 (Command Plane)',
+        hotkey: 'ctrl+4',
+        handler: () => navigate('command')
+      },
+      {
+        id: 'nav-lab',
+        title: '실험실로 이동 (Lab)',
+        hotkey: 'ctrl+5',
+        handler: () => navigate('lab')
+      },
+      {
+        id: 'nav-logs',
+        title: '로그 뷰어로 이동 (Logs)',
+        hotkey: 'ctrl+6',
+        handler: () => navigate('logs')
+      },
+      {
+        id: 'action-gc',
+        title: '유지보수: GC (Garbage Collection) 실행',
+        handler: async () => {
+          const confirmed = await requestConfirm({ title: '유지보수', message: 'GC를 실행합니까?' })
+          if (confirmed) void runGarbageCollection()
+        }
+      },
+      {
+        id: 'action-zombie',
+        title: '유지보수: 좀비 에이전트 정리',
+        handler: async () => {
+          const confirmed = await requestConfirm({ title: '유지보수', message: '좀비 에이전트를 정리합니까?', tone: 'danger' })
+          if (confirmed) void cleanupZombies()
+        }
+      }
+    ]
+  }, [])
+
+  return html`
+    <ninja-keys
+      ref=${ref}
+      placeholder="명령어를 검색하세요... (Cmd+K)"
+      hideBreadcrumbs
+      style="
+        --ninja-modal-background: rgba(13, 21, 38, 0.98);
+        --ninja-modal-shadow: 0 24px 64px rgba(0,0,0,0.6);
+        --ninja-text-color: var(--text-body);
+        --ninja-secondary-background-color: var(--white-4);
+        --ninja-secondary-text-color: var(--text-muted);
+        --ninja-selected-background: var(--white-10);
+        --ninja-icon-color: var(--text-muted);
+        --ninja-key-background: var(--white-5);
+        --ninja-key-text-color: var(--text-strong);
+        --ninja-border-bottom: 1px solid var(--card-border);
+      "
+    ></ninja-keys>
+  `
+}

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -44,3 +44,8 @@ vi.mock('shiki', () => {
     })
   }
 })
+
+// Mock ninja-keys Web Component to avoid Happy DOM parsing errors
+vi.mock('ninja-keys', () => {
+  return {}
+})

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -47,5 +47,13 @@ vi.mock('shiki', () => {
 
 // Mock ninja-keys Web Component to avoid Happy DOM parsing errors
 vi.mock('ninja-keys', () => {
+  if (!customElements.get('ninja-keys')) {
+    class NinjaKeysStub extends HTMLElement {
+      data: unknown[] = []
+    }
+
+    customElements.define('ninja-keys', NinjaKeysStub)
+  }
+
   return {}
 })


### PR DESCRIPTION
## Overview
- Added the `ninja-keys` Web Component to provide a sleek, fast Command Palette.
- Users can now press `Cmd + K` (or `Ctrl + K`) anywhere in the dashboard to instantly jump between sections (Overview, Monitoring, Workspace, Command Plane, etc.).
- Critical maintenance actions (Garbage Collection, Zombie Cleanup) have been mapped as searchable commands directly within the palette for blazing fast operator access.
- Fully styled to match the dark MASC Dashboard theme utilizing native CSS variables.
- Mocked out correctly in `vitest-setup.ts` to maintain testing stability without happy-dom overhead.