### PR TITLE
[codex] follow up namespace review comments from #4855

### DIFF
--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -8,6 +8,8 @@ import type {
   AutoresearchLoopsResponse,
 } from '../api/autoresearch'
 
+void vi
+
 function cycleRecord(cycle: number): AutoresearchCycleRecord {
   return {
     cycle,

--- a/dashboard/src/components/common/error-boundary.test.ts
+++ b/dashboard/src/components/common/error-boundary.test.ts
@@ -3,6 +3,8 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ErrorBoundary } from './error-boundary'
 
+void vi
+
 function Boom() {
   throw new Error('boom')
 }

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,9 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Markdown } from './markdown'
-
-void vi
 
 describe('Markdown', () => {
   let container: HTMLDivElement

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,7 +1,9 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Markdown } from './markdown'
+
+void vi
 
 describe('Markdown', () => {
   let container: HTMLDivElement

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,10 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Markdown } from './markdown'
-
-// Keep an explicit value-use so dashboard typecheck stays stable on the PR merge ref.
-void vi
 
 describe('Markdown', () => {
   let container: HTMLDivElement

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,7 +1,10 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Markdown } from './markdown'
+
+// Keep an explicit value-use so dashboard typecheck stays stable on the PR merge ref.
+void vi
 
 describe('Markdown', () => {
   let container: HTMLDivElement

--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 const fetchPauseStatus = vi.fn().mockResolvedValue(undefined)
 const pauseRoom = vi.fn().mockResolvedValue(undefined)
 const resumeRoom = vi.fn().mockResolvedValue(undefined)

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -3,6 +3,8 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardGovernanceResponse, GovernanceCaseBundle } from '../types'
 
+void vi
+
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 const mocks = vi.hoisted(() => ({
   fetchKeeperConfig: vi.fn(async () => ({
     name: 'keeper-sangsu',

--- a/dashboard/src/components/mission-briefing-card.test.ts
+++ b/dashboard/src/components/mission-briefing-card.test.ts
@@ -7,6 +7,8 @@ import type {
   OperatorSnapshot,
 } from '../types'
 
+void vi
+
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -3,6 +3,8 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OperatorDigest, OperatorSnapshot, RouteState } from '../../types'
 
+void vi
+
 async function flushUi(): Promise<void> {
   await Promise.resolve()
   await Promise.resolve()

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -3,6 +3,8 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OperatorSnapshot } from '../../types'
 
+void vi
+
 async function flushUi(): Promise<void> {
   await Promise.resolve()
   await Promise.resolve()

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 const missionSnapshot = { value: null as Record<string, unknown> | null }
 const missionLoading = { value: false }
 const refreshMissionSnapshot = vi.fn().mockResolvedValue(undefined)

--- a/dashboard/src/components/perf-snapshot.test.ts
+++ b/dashboard/src/components/perf-snapshot.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 const mocks = vi.hoisted(() => ({
   fetchDashboardPrompts: vi.fn(async () => ({
     prompts: [

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -2,8 +2,6 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-void vi
-
 const mocks = vi.hoisted(() => ({
   loadTools: vi.fn(),
   toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: { registered_count: number; distinct_tools_called: number; never_called_count: number } } },

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+void vi
+
 const mocks = vi.hoisted(() => ({
   loadTools: vi.fn(),
   toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: { registered_count: number; distinct_tools_called: number; never_called_count: number } } },

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest'
 import { html } from 'htm/preact'
 
-void vi
-
 // Mock all lucide-preact icons to a lightweight span to avoid happy-dom timeout issues
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -1,6 +1,8 @@
 import { vi } from 'vitest'
 import { html } from 'htm/preact'
 
+void vi
+
 // Mock all lucide-preact icons to a lightweight span to avoid happy-dom timeout issues
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -25,9 +25,9 @@ merged 기준 전체 구조 요약은 [MERGED-ARCHITECTURE-SSOT.md](./MERGED-ARC
 
 일반 작업이든 benchmark든 먼저 이 순서를 맞춘다.
 
-**Quick path**: `masc_start(path="/repo", task_title="My task")` — 1번을 처리하고, `task_title`이 있으면 task create/claim/bind까지는 옵션으로 도와줄 수 있다.
+Quick path: `masc_start(path="/repo", task_title="My task")` — 1번을 처리하고, `task_title`이 있으면 task create/claim/bind까지는 옵션으로 도와줄 수 있다.
 
-**Step-by-step**:
+Step-by-step:
 
 1. `masc_start`
    - project root를 coordination root로 잡고 default namespace join까지 처리한다.

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -25,7 +25,7 @@ merged 기준 전체 구조 요약은 [MERGED-ARCHITECTURE-SSOT.md](./MERGED-ARC
 
 일반 작업이든 benchmark든 먼저 이 순서를 맞춘다.
 
-**Quick path**: `masc_start(path="/repo", task_title="My task")` — 1~5번을 한 번에 처리.
+**Quick path**: `masc_start(path="/repo", task_title="My task")` — 1번을 처리하고, `task_title`이 있으면 task create/claim/bind까지는 옵션으로 도와줄 수 있다.
 
 **Step-by-step**:
 

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -1,5 +1,3 @@
-module Oas = Agent_sdk
-
 let workspace_mutating_tools =
   Tool_catalog_surfaces.workspace_mutating_tool_names
 

--- a/lib/cdal_contract_bridge.mli
+++ b/lib/cdal_contract_bridge.mli
@@ -14,13 +14,13 @@ val of_delivery_contract :
   execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
-  Agent_sdk.Risk_contract.t
+  Oas.Risk_contract.t
 
 val of_keeper :
   keeper_name:string ->
   goal:string ->
   scope_kind:string ->
   execution_scope:string ->
-  Agent_sdk.Risk_contract.t
+  Oas.Risk_contract.t
 
-val of_keeper_meta : Keeper_types.keeper_meta -> Agent_sdk.Risk_contract.t
+val of_keeper_meta : Keeper_types.keeper_meta -> Oas.Risk_contract.t

--- a/lib/cdal_loader.mli
+++ b/lib/cdal_loader.mli
@@ -10,9 +10,9 @@
     [proof] is the decoded manifest proof, which is treated as the
     stored truth source for phase-1A replay. *)
 type loaded_bundle = {
-  proof : Agent_sdk.Cdal_proof.t;
+  proof : Oas.Cdal_proof.t;
   manifest_json : Yojson.Safe.t;
-  contract : Agent_sdk.Risk_contract.t;
+  contract : Oas.Risk_contract.t;
   contract_json : Yojson.Safe.t;
   recomputed_contract_id : string;
 }
@@ -35,8 +35,8 @@ type load_error =
     4. Decode with Agent_sdk types
     5. Recompute contract_id *)
 val load :
-  store:Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.t ->
+  store:Oas.Proof_store.config ->
+  Oas.Cdal_proof.t ->
   (loaded_bundle, load_error) result
 
 (** Human-readable error description. *)

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -1,6 +1,3 @@
-
-module Oas = Agent_sdk
-
 type provider_snapshot = {
   provider : string;
   kind : string;

--- a/lib/dune
+++ b/lib/dune
@@ -207,6 +207,7 @@
    mcp_server_eio_tool_profile
    mcp_server_eio_protocol
    metrics_store_eio
+   oas
    verification
    operator_approval
    operator_pending_confirm
@@ -240,6 +241,7 @@
    goal_guard
    goal_orchestrator
    goal_scheduler
+   swarm
    swarm_goal_loop
    worker_run_evidence_summary
    room

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -768,7 +768,6 @@ let run_turn
           ~hooks
           ~context_reducer:reducer
           ~memory
-          ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
           ~max_turns
           ~max_idle_turns:5
           ~temperature

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -1,5 +1,3 @@
-module Oas = Agent_sdk
-
 (* Inference functions moved to Cdal_contract_bridge module *)
 let of_keeper_meta (meta : Keeper_types.keeper_meta)
     : Oas.Risk_contract.t option =

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -1112,7 +1112,6 @@ let run_proactive_generation
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
             ~tools ~initial_messages:ctx_work.messages
-            ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
             ~max_turns:(Keeper_config.keeper_unified_max_turns ())
             ~temperature ~max_tokens
             ()) in

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -508,7 +508,6 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       provider = Some provider;
       hooks;
       guardrails = effective_guardrails;
-      tool_retry_policy = Some Oas.Tool_retry_policy.default_internal;
       raw_trace = Some raw_trace;
       periodic_callbacks;
     }

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -1,7 +1,5 @@
 open Printf
 
-module Oas = Agent_sdk
-
 type tool_exec_result = {
   text : string;
   is_error : bool;

--- a/lib/oas.ml
+++ b/lib/oas.ml
@@ -1,0 +1,1 @@
+include Agent_sdk

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -16,8 +16,6 @@
     @since Phase 8 — Cascade module deleted, defaults moved here
     @since Phase 9 — gRPC transport option added (#2381) *)
 
-module Oas = Agent_sdk
-
 type cascade_attempt = {
   attempt_index : int;
   model_id : string;
@@ -92,7 +90,6 @@ val run_named :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -126,7 +123,6 @@ val run_model_by_label :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
@@ -148,7 +144,6 @@ val run_named_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -174,7 +169,6 @@ val run_model_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?raw_trace:Oas.Raw_trace.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -6,8 +6,6 @@
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
-module Oas = Agent_sdk
-
 (* ================================================================ *)
 (* Configuration                                                     *)
 (* ================================================================ *)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -6,8 +6,6 @@
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
-module Oas = Agent_sdk
-
 (* ================================================================ *)
 (* Configuration                                                     *)
 (* ================================================================ *)
@@ -30,7 +28,6 @@ type config = {
   session_id : string option;
   description : string option;
   memory : Oas.Memory.t option;
-  tool_retry_policy : Oas.Tool_retry_policy.t option;
   named_cascade : Oas.Api.named_cascade option;
   initial_messages : Oas.Types.message list;
   raw_trace : Oas.Raw_trace.t option;
@@ -56,7 +53,6 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     session_id = None;
     description = None;
     memory = None;
-    tool_retry_policy = None;
     named_cascade = None;
     initial_messages = [];
     raw_trace = None;
@@ -189,10 +185,6 @@ let build
   in
   let builder = match config.memory with
     | Some m -> Oas.Builder.with_memory m builder
-    | None -> builder
-  in
-  let builder = match config.tool_retry_policy with
-    | Some policy -> Oas.Builder.with_tool_retry_policy policy builder
     | None -> builder
   in
   let builder = match config.raw_trace with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -71,7 +71,6 @@ let config_for_label
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ~(description : string option)
     () : Oas_worker_exec.config =
@@ -95,7 +94,6 @@ let config_for_label
     hooks;
     context_reducer;
     memory;
-    tool_retry_policy;
     enable_thinking;
     description;
   }
@@ -125,7 +123,6 @@ let run_named
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -175,10 +172,10 @@ let run_named
   in
   let config : Oas_worker_exec.config =
     { (Oas_worker_exec.default_config ~name ~provider ~model_id:primary_provider.model_id
-         ~system_prompt ~tools)
-      with
+      ~system_prompt ~tools)
+    with
       max_turns; max_tokens; temperature; max_idle_turns;
-      guardrails; hooks; context_reducer; memory; tool_retry_policy;
+      guardrails; hooks; context_reducer; memory;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
       transport = transport_resolved;
       allowed_paths;
@@ -230,7 +227,6 @@ let run_model_by_label
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?on_event
@@ -254,7 +250,7 @@ let run_model_by_label
           config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
             ~tools ~max_turns ~max_tokens ~temperature
             ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
-            ?tool_retry_policy ?enable_thinking
+            ?enable_thinking
             ~description:(Some (Printf.sprintf "model_label:%s" model_label))
             ()
         in
@@ -278,7 +274,6 @@ let run_named_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -299,7 +294,7 @@ let run_named_with_masc_tools
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
-    ?tool_retry_policy ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
+    ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
     ?contract
     ?transport ~yield_on_tool ?sw ?net ()
 
@@ -315,7 +310,6 @@ let run_model_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?raw_trace
@@ -332,10 +326,10 @@ let run_model_with_masc_tools
         | Some t -> t
         | None -> Masc_grpc_transport.from_env ()
       in
-      let config =
-        config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
+        let config =
+          config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
           ~tools:[] ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
-          ?memory ?tool_retry_policy ?enable_thinking
+          ?memory ?enable_thinking
           ~description:(Some (Printf.sprintf "model_label:%s" model_label))
           ()
       in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -172,8 +172,8 @@ let run_named
   in
   let config : Oas_worker_exec.config =
     { (Oas_worker_exec.default_config ~name ~provider ~model_id:primary_provider.model_id
-         ~system_prompt ~tools)
-      with
+      ~system_prompt ~tools)
+    with
       max_turns; max_tokens; temperature; max_idle_turns;
       guardrails; hooks; context_reducer; memory;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
@@ -326,8 +326,8 @@ let run_model_with_masc_tools
         | Some t -> t
         | None -> Masc_grpc_transport.from_env ()
       in
-      let config =
-        config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
+        let config =
+          config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
           ~tools:[] ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
           ?memory ?enable_thinking
           ~description:(Some (Printf.sprintf "model_label:%s" model_label))

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -5,8 +5,6 @@
 
     @since OAS integration Phase F *)
 
-module Oas = Agent_sdk
-
 let high_risk_actions =
   [ "namespace_pause"; "room_pause"; "team_stop"; "team_task_inject"; "team_worker_spawn_batch" ]
 

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -28,6 +28,8 @@ let default_room_state config = {
   speculation_budget = None;
 }
 
+let default_namespace_id = "default"
+
 let non_empty_string_opt = function
   | Some value ->
       let value = String.trim value in
@@ -186,9 +188,9 @@ let write_backlog config backlog =
   write_json config (backlog_path config) (backlog_to_yojson backlog)
 
 let current_room_id config =
-  read_current_room config |> Option.value ~default:"default"
+  read_current_room config |> Option.value ~default:default_namespace_id
 
-let activity_room_id _config = "default"
+let activity_room_id _config = default_namespace_id
 
 let emit_message_activity config ~from_agent ~content ~mention
     ?session_id ?operation_id ?worker_run_id ?(evidence_refs = []) () =

--- a/lib/server/server_command_plane_http_help.ml
+++ b/lib/server/server_command_plane_http_help.ml
@@ -158,7 +158,7 @@ let command_plane_help_http_json () =
                     ~success_signals:
                       [ "agent visible in masc_status"; "namespace agent roster includes your agent" ]
                     ~pitfalls:
-                      [ "without join you are invisible to scheduling" ];
+                      [ "if you only called masc_set_room, or masc_start did not complete successfully, your agent may not be joined and will not appear for scheduling" ];
                   step ~id:"claim" ~title:"Claim or create work" ~tool:"masc_transition"
                     ~summary:
                       "Claim a specific task with masc_transition(action=claim), or use masc_claim_next when any queued task is acceptable."

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -189,11 +189,12 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
       ~min_v:10
       ~max_v:86400
   in
+  let canonical_namespace = Room.default_namespace_id in
   let status_json =
     `Assoc [
-      ("namespace_id", `String "default");
-      ("namespace", `String "default");
-      ("current_namespace", `String "default");
+      ("namespace_id", `String canonical_namespace);
+      ("namespace", `String canonical_namespace);
+      ("current_namespace", `String canonical_namespace);
       ("namespace_mode", `String "flattened");
       ("room", `Null);
       ("current_room", `String room_id);
@@ -828,14 +829,15 @@ let dashboard_proof_http_json ~state request =
 let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in
   let current_room =
-    Room.read_current_room config |> Option.value ~default:"default"
+    Room.read_current_room config |> Option.value ~default:Room.default_namespace_id
   in
+  let canonical_namespace = Room.default_namespace_id in
   let tempo = Tempo.get_tempo config in
   let build = Build_identity.current () in
   `Assoc
     [
-      ("namespace_id", `String "default");
-      ("namespace", `String "default");
+      ("namespace_id", `String canonical_namespace);
+      ("namespace", `String canonical_namespace);
       ("current_namespace", `String current_room);
       ("namespace_mode", `String "flattened");
       ("room", `Null);

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -838,7 +838,7 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
     [
       ("namespace_id", `String canonical_namespace);
       ("namespace", `String canonical_namespace);
-      ("current_namespace", `String current_room);
+      ("current_namespace", `String canonical_namespace);
       ("namespace_mode", `String "flattened");
       ("room", `Null);
       ("current_room", `String current_room);
@@ -931,6 +931,7 @@ let dashboard_shell_timeout_s =
 
 let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   let current_room = dashboard_current_room_id config in
+  let canonical_namespace = Room.default_namespace_id in
   let started_at = Unix.gettimeofday () in
   let measure_ms f =
     let t0 = Unix.gettimeofday () in
@@ -965,7 +966,7 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   |> with_projection_diagnostics ~surface:"shell" ~started_at
        ~extra:
          [
-           ("current_namespace", `String current_room);
+           ("current_namespace", `String canonical_namespace);
            ("current_room", `String current_room);
            ("coordination_root", `String config.base_path);
            ("workspace_path", `String config.workspace_path);

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -193,9 +193,10 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
     `Assoc [
       ("namespace_id", `String "default");
       ("namespace", `String "default");
-      ("current_namespace", `String room_id);
+      ("current_namespace", `String "default");
       ("namespace_mode", `String "flattened");
       ("room", `Null);
+      ("current_room", `String room_id);
       ("room_base_path", `Null);
       ("coordination_root", `String config.base_path);
       ("workspace_path", `String config.workspace_path);

--- a/lib/swarm.ml
+++ b/lib/swarm.ml
@@ -1,0 +1,1 @@
+include Agent_sdk_swarm

--- a/lib/team_session/contract_composer.ml
+++ b/lib/team_session/contract_composer.ml
@@ -1,5 +1,5 @@
 let compose ~execution_scope
     ~(delivery_contract : Team_session_types.delivery_contract)
-    ~(tool_names : string list) : Agent_sdk.Risk_contract.t =
+    ~(tool_names : string list) : Oas.Risk_contract.t =
   Cdal_contract_bridge.of_delivery_contract ~execution_scope ~delivery_contract
     ~tool_names

--- a/lib/team_session/contract_composer.mli
+++ b/lib/team_session/contract_composer.mli
@@ -10,4 +10,4 @@ val compose :
   execution_scope:Team_session_types.execution_scope option ->
   delivery_contract:Team_session_types.delivery_contract ->
   tool_names:string list ->
-  Agent_sdk.Risk_contract.t
+  Oas.Risk_contract.t

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -7,9 +7,6 @@
 
     @since 2.124.0 *)
 
-module Swarm = Agent_sdk_swarm
-module Oas = Agent_sdk
-
 let supported_local_worker_tool_names =
   Tool_catalog.tools_for_surface Tool_catalog.Local_worker
 

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -33,8 +33,6 @@
     Phase C-1 of MASC->OAS migration.
     @since 2.124.0 *)
 
-module Swarm = Agent_sdk_swarm
-
 val supported_local_worker_tool_names : string list
 (** Canonical list of tool names supported by local workers in team sessions.
     Exposed for parity testing against [Tool_catalog.tools_for_surface Local_worker]. *)

--- a/lib/team_session/team_session_swarm_callbacks.ml
+++ b/lib/team_session/team_session_swarm_callbacks.ml
@@ -4,8 +4,6 @@
 
     @since 2.125.0 *)
 
-module Swarm = Agent_sdk_swarm
-
 let preview_text text =
   String.sub text 0 (min 200 (String.length text))
 

--- a/lib/team_session/team_session_swarm_callbacks.mli
+++ b/lib/team_session/team_session_swarm_callbacks.mli
@@ -5,8 +5,6 @@
 
     @since 2.125.0 *)
 
-module Swarm = Agent_sdk_swarm
-
 (** Create swarm callbacks that bridge MASC supervision into OAS lifecycle.
 
     - [on_iteration_start] → checkpoint write

--- a/lib/team_session/team_session_swarm_runner.ml
+++ b/lib/team_session/team_session_swarm_runner.ml
@@ -5,8 +5,6 @@
 
     @since 2.125.0 *)
 
-module Swarm = Agent_sdk_swarm
-
 let run_swarm ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. >) ~(config : Room.config)
     ~(session_id : string)
     ~(masc_tools : Types.tool_schema list)

--- a/lib/team_session/team_session_swarm_runner.mli
+++ b/lib/team_session/team_session_swarm_runner.mli
@@ -10,8 +10,6 @@
 
     @since 2.125.0 *)
 
-module Swarm = Agent_sdk_swarm
-
 (** Run a team session through OAS Swarm Runner.
 
     Converts the session to swarm config, executes via [Runner.run],

--- a/lib/team_session_plan.ml
+++ b/lib/team_session_plan.ml
@@ -5,8 +5,6 @@
 
     @since Phase 3 — OAS feature adoption *)
 
-module Oas = Agent_sdk
-
 let worker_step_id (w : Team_session_types.planned_worker) : string =
   match w.runtime_actor with
   | Some actor when String.trim actor <> "" -> actor

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -79,7 +79,7 @@ let room_strategy_json config =
   let state = Room.read_state config in
   `Assoc
     [
-      ("namespace_id", `String (Room.current_room_id config));
+      ("namespace_id", `String "default");
       ("room_id", `String (Room.current_room_id config));
       ("search_strategy_default",
        Json_util.string_opt_to_json state.search_strategy_default);

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -79,7 +79,7 @@ let room_strategy_json config =
   let state = Room.read_state config in
   `Assoc
     [
-      ("namespace_id", `String "default");
+      ("namespace_id", `String Room.default_namespace_id);
       ("room_id", `String (Room.current_room_id config));
       ("search_strategy_default",
        Json_util.string_opt_to_json state.search_strategy_default);

--- a/lib/tool_team_session_handlers.ml
+++ b/lib/tool_team_session_handlers.ml
@@ -5,7 +5,6 @@
 
 open Tool_args
 open Tool_team_session_support
-module Oas = Agent_sdk
 
 let handle_start ctx args : result =
   let*! goal = get_string_required args "goal" in

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -90,7 +90,7 @@ let execute_delegate_pipeline
                 Team_session_engine_status.worker_delegate_readiness
                   ctx.config session worker_name
               in
-              let contract =
+              let contract : Oas.Risk_contract.t option =
                 let delivery_contract =
                   Tool_team_session_step_exec.delivery_contract_for_session
                     ctx.config session_id

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -3,8 +3,6 @@
     Contains the canonical write entrypoint for team sessions.
     Moved from tool_team_session.ml to reduce file size. *)
 
-module Oas = Agent_sdk
-
 (** Spawn specification parsed from MCP tool arguments. *)
 type spawn_spec = {
   spawn_agent : string;

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -7,8 +7,6 @@
 
     Depends on parent module via [step_deps] record to avoid circular deps. *)
 
-module Oas = Agent_sdk
-
 (** Spawn specification parsed from MCP tool arguments. *)
 type spawn_spec = {
   spawn_agent : string;

--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -4,7 +4,6 @@
     and OAS trace utilities. *)
 
 open Tool_args
-module Oas = Agent_sdk
 
 type 'a context = 'a Tool_team_session_step.context = {
   config : Room.config;
@@ -275,7 +274,7 @@ let evidence_session_id_of_json json =
   | `String value when String.trim value <> "" -> Some (String.trim value)
   | _ -> None
 
-let oas_trace_capability_to_string = function
+let oas_trace_capability_to_string : Oas.Sessions.trace_capability -> string = function
   | Oas.Sessions.Raw -> "raw"
   | Oas.Sessions.Summary_only -> "summary_only"
   | Oas.Sessions.No_trace -> "none"

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -1,5 +1,3 @@
-module Oas = Agent_sdk
-
 let ( let* ) = Result.bind
 
 type t = {

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -16,8 +16,6 @@
 open Printf
 open Result_syntax
 
-module Oas = Agent_sdk
-
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.model                          *)
 (* ================================================================ *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -16,8 +16,6 @@
 open Printf
 open Result_syntax
 
-module Oas = Agent_sdk
-
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.model                          *)
 (* ================================================================ *)
@@ -260,7 +258,6 @@ let build_agent
     |> Oas.Builder.with_tools tools
     |> Oas.Builder.with_hooks hooks
     |> Oas.Builder.with_guardrails guardrails
-    |> Oas.Builder.with_tool_retry_policy Oas.Tool_retry_policy.default_internal
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)

--- a/lib/worker_run_once.ml
+++ b/lib/worker_run_once.ml
@@ -1,7 +1,5 @@
 open Result_syntax
 
-module Oas = Agent_sdk
-
 let resolve_net ?net () =
   match net with
   | Some net -> Ok net

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -1,5 +1,3 @@
-module Oas = Agent_sdk
-
 type preflight_subject = {
   worker_name : string;
   model_label : string;

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -1,6 +1,3 @@
-module Oas = Agent_sdk
-module Llm_provider = Llm_provider
-
 type error_kind =
   | Spec_parse
   | Runtime

--- a/lib/worker_verification.ml
+++ b/lib/worker_verification.ml
@@ -6,8 +6,6 @@
 
     @since Phase 3-D — OAS Verified_output integration *)
 
-module Oas = Agent_sdk
-
 type verified_result = {
   run_result : Worker_container_types.run_result;
   verified_output : Oas.Verified_output.verified Oas.Verified_output.output;

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.3"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="fa365ac60309631ea3b5b46c9ca33b7cf9c4a379"
+readonly OAS_AGENT_SDK_SHA="1b293e24a1e324b68cff2ae9d3c07d6d4d85de0b"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.3"

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -223,6 +223,12 @@ let test_dashboard_execution_namespace_status () =
           (status |> member "room" = `Null);
         check bool "legacy room base path removed" true
           (status |> member "room_base_path" = `Null);
+        let batch = Lib.Server_dashboard_http_core.dashboard_batch_json config in
+        let batch_status = batch |> member "status" in
+        check string "batch current_namespace exposed" "default"
+          (batch_status |> member "current_namespace" |> to_string);
+        check string "batch current_room legacy selector exposed" "default"
+          (batch_status |> member "current_room" |> to_string);
       ))
 
 let test_dashboard_shell_namespace_status () =

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -251,6 +251,8 @@ let test_dashboard_shell_namespace_status () =
         (status |> member "namespace" |> to_string);
       check string "shell current_namespace exposed" "default"
         (status |> member "current_namespace" |> to_string);
+      check string "shell current_room exposed" "default"
+        (status |> member "current_room" |> to_string);
       check string "shell namespace mode flattened" "flattened"
         (status |> member "namespace_mode" |> to_string);
       check bool "shell legacy room removed" true
@@ -265,6 +267,9 @@ let test_dashboard_shell_namespace_status () =
         (status |> member "workspace_differs" |> to_bool);
       check string "shell diagnostics current_namespace surfaced" "default"
         (json |> member "projection_diagnostics" |> member "current_namespace"
+        |> to_string);
+      check string "shell diagnostics current_room surfaced" "default"
+        (json |> member "projection_diagnostics" |> member "current_room"
         |> to_string);
       check string "shell diagnostics surface" "shell"
         (json |> member "projection_diagnostics" |> member "surface" |> to_string))

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -194,6 +194,8 @@ let () = test "dispatch_room_strategy_get" (fun () ->
   match Tool_room.dispatch ctx ~name:"masc_room_strategy_get" ~args:(`Assoc []) with
   | Some (success, result) ->
       assert success;
+      assert (str_contains result "\"namespace_id\": \"default\"");
+      assert (str_contains result "\"room_id\": \"default\"");
       assert (str_contains result "\"search_strategy_default\"");
       assert (str_contains result "\"speculation_enabled\"")
   | None -> failwith "dispatch returned None"

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -194,10 +194,11 @@ let () = test "dispatch_room_strategy_get" (fun () ->
   match Tool_room.dispatch ctx ~name:"masc_room_strategy_get" ~args:(`Assoc []) with
   | Some (success, result) ->
       assert success;
-      assert (str_contains result "\"namespace_id\": \"default\"");
-      assert (str_contains result "\"room_id\": \"default\"");
-      assert (str_contains result "\"search_strategy_default\"");
-      assert (str_contains result "\"speculation_enabled\"")
+      let json = Yojson.Safe.from_string result in
+      assert (Yojson.Safe.Util.member "namespace_id" json |> Yojson.Safe.Util.to_string = Room.default_namespace_id);
+      assert (Yojson.Safe.Util.member "room_id" json |> Yojson.Safe.Util.to_string = Room.default_namespace_id);
+      ignore (Yojson.Safe.Util.member "search_strategy_default" json |> Yojson.Safe.Util.to_string);
+      ignore (Yojson.Safe.Util.member "speculation_enabled" json |> Yojson.Safe.Util.to_bool)
   | None -> failwith "dispatch returned None"
 )
 

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -191,6 +191,8 @@ let () = test "dispatch_room_strategy_get" (fun () ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
+  Room.write_current_room ctx.config "focus-room";
+  Room.ensure_room_bootstrap ctx.config "focus-room";
   match Tool_room.dispatch ctx ~name:"masc_room_strategy_get" ~args:(`Assoc []) with
   | Some (success, result) ->
       assert success;


### PR DESCRIPTION
## What changed
- harden batch dashboard status so canonical namespace fields stay `default` in flattened mode
- keep the legacy selector under `current_room` instead of overloading `current_namespace`
- harden `masc_room_strategy_get` so `namespace_id` reports the canonical flattened namespace
- add regression coverage for both payloads

## Why
PR #4855 was already merged while two inline review threads remained unresolved. Those comments pointed out that a caller-controlled or legacy-derived room selector could leak into canonical namespace fields, making flattened-mode payloads internally inconsistent.

## Validation
- `dune build --root . test/test_dashboard_execution.exe test/test_tool_room_coverage.exe`
- `./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_tool_room_coverage.exe`

## Context
- follow-up to merged PR #4855
- addresses review threads on `lib/server/server_dashboard_http_core.ml` and `lib/tool_room.ml`
