### PR TITLE
fix(ci): restore main merge-ref blockers

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -81,7 +81,7 @@ masc_start(path="/your/project", task_title="My first task")
 수동 제어가 필요하면:
 
 ```text
-masc_start(path="/your/project")
+masc_set_room(path="/your/project")
 masc_join(agent_name="codex")
 masc_status()
 masc_add_task(title="My task")
@@ -90,7 +90,7 @@ masc_claim_next()
 # masc_plan_set_task(task_id="task-001")  # only if current_task is still missing
 ```
 
-`masc_join(agent_name="codex")` 는 이미 열린 default namespace에 agent identity를 명시적으로 묶고 싶을 때 쓰는 가장 짧은 수동 join 예시다.
+수동 경로에서는 먼저 project scope만 고르고(`masc_set_room`), 그 다음 `masc_join(agent_name="codex")` 로 agent identity를 명시적으로 붙인다. `masc_start(path=...)` 는 이미 default namespace join까지 처리하므로, 같은 흐름에서 `masc_join(...)` 를 바로 이어 호출하지 않는다.
 
 `masc_set_room(path=...)` 는 여전히 호출 가능하지만 compatibility alias 이고, project scope 만 고른다. 기본 온보딩은 `masc_start(...)` 를 쓴다.
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -90,6 +90,8 @@ masc_claim_next()
 # masc_plan_set_task(task_id="task-001")  # only if current_task is still missing
 ```
 
+`masc_join(agent_name="codex")` 는 이미 열린 default namespace에 agent identity를 명시적으로 묶고 싶을 때 쓰는 가장 짧은 수동 join 예시다.
+
 `masc_set_room(path=...)` 는 여전히 호출 가능하지만 compatibility alias 이고, project scope 만 고른다. 기본 온보딩은 `masc_start(...)` 를 쓴다.
 
 ## 5. Tool Surface

--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.100.0))
+  (agent_sdk (>= 0.100.3))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.100.0"}
+  "agent_sdk" {>= "0.100.3"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.3"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="5cc2735d5f6dc677ff380e45c29282cb46da6a67"
+readonly OAS_AGENT_SDK_SHA="fa365ac60309631ea3b5b46c9ca33b7cf9c4a379"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.100.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.100.3"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="fa365ac60309631ea3b5b46c9ca33b7cf9c4a379"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.100.0"
+readonly OAS_AGENT_SDK_SHA="5cc2735d5f6dc677ff380e45c29282cb46da6a67"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.100.3"


### PR DESCRIPTION
## Summary
- restore the explicit `masc_join(agent_name="codex")` manual onboarding example in `docs/QUICK-START.md` so front-door doc truth passes on merge refs
- ratchet the OAS/`agent_sdk` pin to upstream `main` (`5cc2735`, `0.100.3`)
- raise the repo `agent_sdk` floor in `dune-project` and `masc_mcp.opam` to match the APIs the current code already uses

## Product impact
- unblocks Health CI failures caused by `docs/QUICK-START.md` drift
- unblocks Build CI failures caused by the stale `agent_sdk 0.100.0` pin diverging from current repo code
- no runtime behavior changes in masc-mcp itself

## Evidence
- `bash scripts/check-doc-truth.sh`
- `bash scripts/check-version-truth.sh`
- `bash scripts/check-oas-pin.sh`

## Review evidence
- GLM-5 direct `sb glm-text` review: No findings

## Linked issue
- none (merge blocker hotfix)