### PR TITLE
feat(dashboard): use shiki-powered Markdown for structured JSON telemetry visualization

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
+import { Markdown } from '../common/markdown'
 import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
 export type ChatTranscriptVariant = 'default' | 'messenger'
@@ -288,7 +289,7 @@ export function ChatMessageBubble({
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
                       </button>
                       ${rawExpanded
-                        ? html`<pre class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[rgba(2,10,24,0.84)] px-3 py-3">${JSON.stringify(entry.details.rawPayload, null, 2)}</pre>`
+                        ? html`<div class="mt-2"><${Markdown} text=${`\`\`\`json\n${JSON.stringify(entry.details.rawPayload, null, 2)}\n\`\`\``} /></div>`
                         : null}
                     </div>
                   `

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it} from 'vitest'
 import { Markdown } from './markdown'
 
 describe('Markdown', () => {

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Markdown } from './markdown'
 
 describe('Markdown', () => {

--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -62,7 +62,10 @@ describe('TaskActivityList', () => {
     })
     const blocks = screen.getAllByTestId('markdown')
     expect(blocks).toHaveLength(1)
-    const text = blocks[0].textContent ?? ''
+    const firstBlock = blocks[0]
+    expect(firstBlock).toBeDefined()
+    if (!firstBlock) return
+    const text = firstBlock.textContent ?? ''
     expect(text.startsWith('```')).toBe(true)
     expect(text).toContain('*literal* `ticks`')
     expect(text.endsWith('```')).toBe(true)

--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -1,0 +1,108 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import type { UnifiedTraceEvent } from '../session-trace/session-trace-state'
+import { activeFilter } from './task-detail-state'
+
+vi.mock('../common/markdown', () => ({
+  Markdown: ({ text }: { text: string }) => h('div', { 'data-testid': 'markdown' }, text),
+}))
+
+vi.mock('../common/time-ago', () => ({
+  TimeAgo: ({ timestamp }: { timestamp: string }) => h('span', {}, timestamp),
+}))
+
+import { TaskActivityList } from './task-activity-list'
+
+function sampleToolCallEvent(overrides: Partial<UnifiedTraceEvent> = {}): UnifiedTraceEvent {
+  return {
+    id: 'evt-1',
+    ts: 1,
+    ts_iso: '2026-04-03T00:00:00Z',
+    kind: 'tool_call',
+    summary: 'tool summary',
+    detail: {},
+    toolArgs: '*literal* `ticks`',
+    toolResult: null,
+    ...overrides,
+  }
+}
+
+describe('TaskActivityList', () => {
+  beforeEach(() => {
+    activeFilter.value = 'all'
+  })
+
+  afterEach(() => {
+    cleanup()
+    activeFilter.value = 'all'
+    vi.clearAllMocks()
+  })
+
+  it('renders markdown lazily and preserves raw string payloads inside code fences', async () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent()],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    expect(screen.queryByTestId('markdown')).not.toBeInTheDocument()
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    if (!details) return
+
+    details.open = true
+    fireEvent(details, new Event('toggle', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('markdown')).toHaveLength(1)
+    })
+    const blocks = screen.getAllByTestId('markdown')
+    expect(blocks).toHaveLength(1)
+    const text = blocks[0].textContent ?? ''
+    expect(text.startsWith('```')).toBe(true)
+    expect(text).toContain('*literal* `ticks`')
+    expect(text.endsWith('```')).toBe(true)
+  })
+
+  it('formats object args as fenced json when expanded', async () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent({ toolArgs: { ok: true } })],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    if (!details) return
+
+    details.open = true
+    fireEvent(details, new Event('toggle', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('markdown')).toBeInTheDocument()
+    })
+    const text = screen.getByTestId('markdown').textContent ?? ''
+    expect(text.startsWith('```json')).toBe(true)
+    expect(text).toContain('"ok": true')
+    expect(text.endsWith('```')).toBe(true)
+  })
+
+  it('marks decorative icons as hidden from assistive tech', () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent({ toolArgs: undefined, toolResult: null })],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    const icon = container.querySelector('[data-icon="Settings"]')
+    expect(icon).not.toBeNull()
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
+    expect(icon).toHaveAttribute('focusable', 'false')
+  })
+})

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -2,6 +2,7 @@
 // Independent from global traceSlots (avoids keeper-detail overlay collision).
 
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
@@ -12,12 +13,12 @@ import { activeFilter, type ActivityFilter } from './task-detail-state'
 
 function kindIcon(kind: TraceEventKind) {
   switch (kind) {
-    case 'tool_call': return html`<${Settings} size=${14} />`
-    case 'broadcast': return html`<${MessageSquare} size=${14} />`
-    case 'task': return html`<${CheckSquare} size=${14} />`
-    case 'heartbeat': return html`<${Heart} size=${14} />`
-    case 'lifecycle': return html`<${RefreshCcw} size=${14} />`
-    default: return html`<${Dot} size=${14} />`
+    case 'tool_call': return html`<${Settings} size=${14} aria-hidden="true" focusable="false" />`
+    case 'broadcast': return html`<${MessageSquare} size=${14} aria-hidden="true" focusable="false" />`
+    case 'task': return html`<${CheckSquare} size=${14} aria-hidden="true" focusable="false" />`
+    case 'heartbeat': return html`<${Heart} size=${14} aria-hidden="true" focusable="false" />`
+    case 'lifecycle': return html`<${RefreshCcw} size=${14} aria-hidden="true" focusable="false" />`
+    default: return html`<${Dot} size=${14} aria-hidden="true" focusable="false" />`
   }
 }
 
@@ -39,8 +40,21 @@ function durationColor(ms: number | undefined): string {
   return 'text-bad'
 }
 
+function wrapAsCodeBlock(text: string, language = ''): string {
+  const matches = text.match(/`+/g)
+  const longestFence = matches ? Math.max(...matches.map(match => match.length)) : 0
+  const fence = '`'.repeat(Math.max(3, longestFence + 1))
+  return `${fence}${language}\n${text}\n${fence}`
+}
+
+function formatPayload(value: unknown): string {
+  if (typeof value === 'string') return wrapAsCodeBlock(value)
+  return wrapAsCodeBlock(JSON.stringify(value ?? null, null, 2), 'json')
+}
+
 function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
   const hasDetail = event.toolArgs != null || event.toolResult != null || (event.detail && Object.keys(event.detail).length > 0)
+  const [isOpen, setIsOpen] = useState(false)
 
   if (!hasDetail) {
     return html`
@@ -53,37 +67,42 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
     `
   }
 
-  const formatArgs = (val: any) => typeof val === 'string' ? val : `\`\`\`json\n${JSON.stringify(val, null, 2)}\n\`\`\``
-
   return html`
-    <details class="rounded-lg hover:bg-[var(--white-3)] transition-colors">
+    <details
+      class="rounded-lg hover:bg-[var(--white-3)] transition-colors"
+      onToggle=${(evt: Event) => {
+        setIsOpen((evt.currentTarget as HTMLDetailsElement).open)
+      }}
+    >
       <summary class="flex items-center gap-3 py-1.5 px-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
         <span class="text-[13px] ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
         <span class="flex-1 text-[12px] text-text-body truncate">${event.summary}</span>
         ${event.duration_ms != null ? html`<span class="text-[10px] tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
         ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-text-dim shrink-0" />` : null}
-        <span class="text-[10px] text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} /></span>
+        <span class="text-[10px] text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} aria-hidden="true" focusable="false" /></span>
       </summary>
-      <div class="px-3 pb-2 pt-1 ml-7">
-        ${event.toolArgs != null ? html`
-          <div class="mb-1">
-            <div class="text-[10px] text-text-dim mb-0.5">args</div>
-            <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
-              <${Markdown} text=${formatArgs(event.toolArgs)} />
+      ${isOpen ? html`
+        <div class="px-3 pb-2 pt-1 ml-7">
+          ${event.toolArgs != null ? html`
+            <div class="mb-1">
+              <div class="text-[10px] text-text-dim mb-0.5">args</div>
+              <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
+                <${Markdown} text=${formatPayload(event.toolArgs)} />
+              </div>
             </div>
-          </div>
-        ` : null}
-        ${event.toolResult != null ? html`
-          <div>
-            <div class="text-[10px] text-text-dim mb-0.5">result</div>
-            <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
-              <${Markdown} text=${formatArgs(event.toolResult)} />
+          ` : null}
+          ${event.toolResult != null ? html`
+            <div>
+              <div class="text-[10px] text-text-dim mb-0.5">result</div>
+              <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
+                <${Markdown} text=${formatPayload(event.toolResult)} />
+              </div>
             </div>
-          </div>
-        ` : null}
-        ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}
-        ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
-      </div>
+          ` : null}
+          ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}
+          ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
+        </div>
+      ` : null}
     </details>
   `
 }

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -5,17 +5,19 @@ import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
+import { Markdown } from '../common/markdown'
+import { Settings, MessageSquare, CheckSquare, Heart, RefreshCcw, Dot, ChevronRight } from 'lucide-preact'
 import type { UnifiedTraceEvent, TraceEventKind } from '../session-trace/session-trace-state'
 import { activeFilter, type ActivityFilter } from './task-detail-state'
 
-function kindIcon(kind: TraceEventKind): string {
+function kindIcon(kind: TraceEventKind) {
   switch (kind) {
-    case 'tool_call': return '\u2699'
-    case 'broadcast': return '\u25B6'
-    case 'task': return '\u2611'
-    case 'heartbeat': return '\u2764'
-    case 'lifecycle': return '\u21C4'
-    default: return '\u00B7'
+    case 'tool_call': return html`<${Settings} size=${14} />`
+    case 'broadcast': return html`<${MessageSquare} size=${14} />`
+    case 'task': return html`<${CheckSquare} size=${14} />`
+    case 'heartbeat': return html`<${Heart} size=${14} />`
+    case 'lifecycle': return html`<${RefreshCcw} size=${14} />`
+    default: return html`<${Dot} size=${14} />`
   }
 }
 
@@ -51,6 +53,8 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
     `
   }
 
+  const formatArgs = (val: any) => typeof val === 'string' ? val : `\`\`\`json\n${JSON.stringify(val, null, 2)}\n\`\`\``
+
   return html`
     <details class="rounded-lg hover:bg-[var(--white-3)] transition-colors">
       <summary class="flex items-center gap-3 py-1.5 px-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
@@ -58,19 +62,23 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <span class="flex-1 text-[12px] text-text-body truncate">${event.summary}</span>
         ${event.duration_ms != null ? html`<span class="text-[10px] tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
         ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-text-dim shrink-0" />` : null}
-        <span class="text-[10px] text-text-dim">\u25B8</span>
+        <span class="text-[10px] text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} /></span>
       </summary>
       <div class="px-3 pb-2 pt-1 ml-7">
         ${event.toolArgs != null ? html`
           <div class="mb-1">
             <div class="text-[10px] text-text-dim mb-0.5">args</div>
-            <pre class="text-[11px] text-text-body whitespace-pre-wrap break-all bg-[var(--white-3)] rounded p-2 max-h-[200px] overflow-y-auto">${typeof event.toolArgs === 'string' ? event.toolArgs : JSON.stringify(event.toolArgs, null, 2)}</pre>
+            <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
+              <${Markdown} text=${formatArgs(event.toolArgs)} />
+            </div>
           </div>
         ` : null}
         ${event.toolResult != null ? html`
           <div>
             <div class="text-[10px] text-text-dim mb-0.5">result</div>
-            <pre class="text-[11px] text-text-body whitespace-pre-wrap break-all bg-[var(--white-3)] rounded p-2 max-h-[200px] overflow-y-auto">${typeof event.toolResult === 'string' ? event.toolResult : JSON.stringify(event.toolResult, null, 2)}</pre>
+            <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
+              <${Markdown} text=${formatArgs(event.toolResult)} />
+            </div>
           </div>
         ` : null}
         ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -258,11 +258,9 @@ let test_hook_skips_on_verify_error () =
     hook
       (Oas.Hooks.PreToolUse {
          tool_name = "keeper_bash";
-         tool_use_id = "tu-test-001";
          input = `Assoc [ ("cmd", `String "echo hi") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
-         schedule = { planned_index = 0; batch_index = 0; batch_size = 1; concurrency_class = "" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -284,11 +282,9 @@ let test_hook_readonly_skips_verifier () =
     hook
       (Oas.Hooks.PreToolUse {
          tool_name = "read file";
-         tool_use_id = "tu-test-002";
          input = `Assoc [ ("path", `String "README.md") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
-         schedule = { planned_index = 0; batch_index = 0; batch_size = 1; concurrency_class = "" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;


### PR DESCRIPTION
## Overview
- Leveraged the newly integrated `shiki` Markdown component to replace raw `<pre>` tags for telemetry data.
- Now, structured JSON data like `toolArgs`, `toolResult`, and `rawPayload` in Task Activity Lists and Chat Diagnostics are rendered with full syntax highlighting.
- This massively improves the readability of deep JSON telemetry objects for operators debugging agent sessions.