### PR TITLE
feat(dashboard): improve loading UX and fix pause status crash

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -18,7 +18,6 @@ import {
 } from '../config/navigation'
 import { RouteLink } from './common/route-link'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
-import { LoadingState } from './common/feedback-state'
 
 const buildIdentityOpen = signal(false)
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -9,6 +9,7 @@ import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { Overview } from './overview/overview'
 import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
+import { LoadingState } from './common/feedback-state'
 import {
   DASHBOARD_SURFACES,
   DASHBOARD_NAV_ITEMS,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -29,7 +29,7 @@ const LazyLabSurface = lazy(async () => ({ default: (await import('./lab')).Lab 
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
 function lazyTabFallback(label: string) {
-  return html`<${LoadingState} class="loading-state">${label} 불러오는 중...<//>`
+  return html`<${LoadingState}>${label} 불러오는 중...<//>`
 }
 
 function formatDisconnectDuration(): string {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -29,7 +29,7 @@ const LazyLabSurface = lazy(async () => ({ default: (await import('./lab')).Lab 
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
 function lazyTabFallback(label: string) {
-  return html`<${LoadingState}>${label} 불러오는 중...<//>`
+  return html`<${LoadingState} class="loading-state">${label} 불러오는 중...<//>`
 }
 
 function formatDisconnectDuration(): string {

--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -12,7 +12,7 @@ const fetchRoomStrategy = vi.fn().mockResolvedValue(undefined)
 const runGarbageCollection = vi.fn().mockResolvedValue(undefined)
 const cleanupZombies = vi.fn().mockResolvedValue(undefined)
 
-const flowState = { value: 'running' as 'running' | 'paused' | 'unknown' }
+const flowState = { value: 'running' as 'running' | 'paused' | 'initializing' | 'unknown' }
 const flowLoading = { value: false }
 const roomStrategy = { value: null as Record<string, unknown> | null }
 const roomStrategyLoading = { value: false }

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -15,8 +15,19 @@ import {
 const showInterruptConfirm = signal(false)
 const interruptReason = signal('')
 
-function stateLabel(s: string): string { return s === 'running' ? '실행 중' : s === 'paused' ? '일시정지' : '알 수 없음' }
-function stateTone(s: string): string { return s === 'running' ? 'ok' : s === 'paused' ? 'warn' : 'default' }
+function stateLabel(s: string): string {
+  return s === 'running'
+    ? '실행 중'
+    : s === 'paused'
+      ? '일시정지'
+      : s === 'initializing'
+        ? '초기화 중'
+        : '알 수 없음'
+}
+
+function stateTone(s: string): string {
+  return s === 'running' ? 'ok' : s === 'paused' ? 'warn' : 'default'
+}
 
 export function FlowControlPanel() {
   useEffect(() => { void fetchPauseStatus() }, [])
@@ -24,6 +35,7 @@ export function FlowControlPanel() {
   const state = flowState.value
   const isPaused = state === 'paused'
   const isRunning = state === 'running'
+  const isInitializing = state === 'initializing'
   return html`
     <${SurfaceCard} variant="compact" class="mb-4">
       <div class="flex items-center gap-3 mb-3">
@@ -31,9 +43,9 @@ export function FlowControlPanel() {
         <${CountBadge} tone=${stateTone(state)}>${stateLabel(state)}<//>
       </div>
       <div class="flex flex-wrap gap-2">
-        <${ActionButton} variant="ghost" size="md" disabled=${loading || isPaused} onClick=${() => void pauseRoom()}>
+        <${ActionButton} variant="ghost" size="md" disabled=${loading || isPaused || isInitializing} onClick=${() => void pauseRoom()}>
           ${loading && !isPaused ? '...' : '일시정지'}<//>
-        <${ActionButton} variant="primary" size="md" disabled=${loading || isRunning} onClick=${() => void resumeRoom()}>
+        <${ActionButton} variant="primary" size="md" disabled=${loading || isRunning || isInitializing} onClick=${() => void resumeRoom()}>
           ${loading && isPaused ? '...' : '재개'}<//>
         <${ActionButton} variant="danger" size="md" disabled=${loading}
           onClick=${() => { showInterruptConfirm.value = !showInterruptConfirm.value }}>인터럽트<//>

--- a/dashboard/src/components/flow-control/flow-control-state.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { callMcpTool } = vi.hoisted(() => ({
+  callMcpTool: vi.fn(),
+}))
+
+vi.mock('../../api/mcp', () => ({
+  callMcpTool,
+}))
+
+describe('flow-control-state', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    callMcpTool.mockReset()
+    const { flowState } = await import('./flow-control-state')
+    flowState.value = 'unknown'
+  })
+
+  afterEach(async () => {
+    const { flowState } = await import('./flow-control-state')
+    flowState.value = 'unknown'
+  })
+
+  it('keeps initializing rooms out of the running state', async () => {
+    callMcpTool.mockResolvedValueOnce(
+      JSON.stringify({ status: 'initializing', initializing: true, paused: null }),
+    )
+
+    const { fetchPauseStatus, flowState } = await import('./flow-control-state')
+    await fetchPauseStatus()
+
+    expect(flowState.value).toBe('initializing')
+  })
+
+  it('marks paused rooms as paused', async () => {
+    callMcpTool.mockResolvedValueOnce(
+      JSON.stringify({ status: 'paused', paused: true }),
+    )
+
+    const { fetchPauseStatus, flowState } = await import('./flow-control-state')
+    await fetchPauseStatus()
+
+    expect(flowState.value).toBe('paused')
+  })
+})

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -3,7 +3,7 @@ import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
 import { createAsyncResource, getData } from '../../lib/async-state'
 
-export type FlowState = 'unknown' | 'running' | 'paused'
+export type FlowState = 'unknown' | 'initializing' | 'running' | 'paused'
 export const flowState = signal<FlowState>('unknown')
 export const flowLoading = signal(false)
 
@@ -22,8 +22,16 @@ export const maintenanceLoading = signal(false)
 export async function fetchPauseStatus(): Promise<void> {
   try {
     const raw = await callMcpTool('masc_pause_status', {})
-    const parsed = JSON.parse(raw) as { paused?: boolean; status?: string }
-    flowState.value = parsed.paused === true || parsed.status === 'paused' ? 'paused' : 'running'
+    const parsed = JSON.parse(raw) as { paused?: boolean | null; status?: string; initializing?: boolean }
+    if (parsed.paused === true || parsed.status === 'paused') {
+      flowState.value = 'paused'
+      return
+    }
+    if (parsed.initializing === true || parsed.status === 'initializing') {
+      flowState.value = 'initializing'
+      return
+    }
+    flowState.value = 'running'
   } catch { flowState.value = 'unknown' }
 }
 

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -27,8 +27,12 @@ let handle_resume ctx _args =
 let handle_pause_status ctx args =
   let requested_namespace = get_string args "namespace_id" "" |> String.trim in
   let namespace_id = "default" in
+  let pause_info =
+    if Room.is_initialized ctx.config then Room.pause_info ctx.config
+    else None
+  in
   let payload =
-    match Room.pause_info ctx.config with
+    match pause_info with
     | Some (by, reason, at) ->
         `Assoc
           [

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -27,17 +27,25 @@ let handle_resume ctx _args =
 let handle_pause_status ctx args =
   let requested_namespace = get_string args "namespace_id" "" |> String.trim in
   let namespace_id = "default" in
-  let room_initialized = Room.is_initialized ctx.config in
-  let pause_info = if room_initialized then Room.pause_info ctx.config else None in
+  let pause_state =
+    if not (Room.is_initialized ctx.config) then `Initializing
+    else
+      let state = Room.read_state ctx.config in
+      if state.paused then
+        `Paused (state.paused_by, state.pause_reason, state.paused_at)
+      else
+        `Running
+  in
   let payload =
-    match pause_info with
-    | Some (by, reason, at) ->
+    match pause_state with
+    | `Paused (by, reason, at) ->
         `Assoc
           [
             ("ok", `Bool true);
             ("namespace_id", `String namespace_id);
             ("namespace", `String namespace_id);
             ("namespace_mode", `String "flattened");
+            ("initializing", `Bool false);
             ("status", `String "paused");
             ("paused", `Bool true);
             ("paused_by", Json_util.string_opt_to_json by);
@@ -49,24 +57,40 @@ let handle_pause_status ctx args =
               if requested_namespace = "" then `Null
               else `String requested_namespace );
           ]
-    | None ->
+    | `Running ->
         `Assoc
           [
             ("ok", `Bool true);
             ("namespace_id", `String namespace_id);
             ("namespace", `String namespace_id);
             ("namespace_mode", `String "flattened");
-            ("status", `String (if room_initialized then "running" else "initializing"));
+            ("initializing", `Bool false);
+            ("status", `String "running");
             ("paused", `Bool false);
+            ("paused_by", `Null);
+            ("pause_reason", `Null);
+            ("paused_at", `Null);
+            ("message", `String "Default project namespace is running (not paused)");
+            ( "requested_namespace_id",
+              if requested_namespace = "" then `Null
+              else `String requested_namespace );
+          ]
+    | `Initializing ->
+        `Assoc
+          [
+            ("ok", `Bool true);
+            ("namespace_id", `String namespace_id);
+            ("namespace", `String namespace_id);
+            ("namespace_mode", `String "flattened");
+            ("initializing", `Bool true);
+            ("status", `String "initializing");
+            ("paused", `Null);
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
             ( "message",
               `String
-                (if room_initialized then
-                   "Default project namespace is running (not paused)"
-                 else
-                   "Default project namespace is initializing; pause state is not available yet") );
+                "Default project namespace is initializing; pause state is not available yet" );
             ( "requested_namespace_id",
               if requested_namespace = "" then `Null
               else `String requested_namespace );

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -27,10 +27,8 @@ let handle_resume ctx _args =
 let handle_pause_status ctx args =
   let requested_namespace = get_string args "namespace_id" "" |> String.trim in
   let namespace_id = "default" in
-  let pause_info =
-    if Room.is_initialized ctx.config then Room.pause_info ctx.config
-    else None
-  in
+  let room_initialized = Room.is_initialized ctx.config in
+  let pause_info = if room_initialized then Room.pause_info ctx.config else None in
   let payload =
     match pause_info with
     | Some (by, reason, at) ->
@@ -58,12 +56,17 @@ let handle_pause_status ctx args =
             ("namespace_id", `String namespace_id);
             ("namespace", `String namespace_id);
             ("namespace_mode", `String "flattened");
-            ("status", `String "running");
+            ("status", `String (if room_initialized then "running" else "initializing"));
             ("paused", `Bool false);
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
-            ("message", `String "Default project namespace is running (not paused)");
+            ( "message",
+              `String
+                (if room_initialized then
+                   "Default project namespace is running (not paused)"
+                 else
+                   "Default project namespace is initializing; pause state is not available yet") );
             ( "requested_namespace_id",
               if requested_namespace = "" then `Null
               else `String requested_namespace );

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -20,7 +20,7 @@ let test name f =
 
 let test_counter = ref 0
 
-let with_ctx f =
+let with_ctx ?(initialize = true) f =
   Fun.protect
     ~finally:Fs_compat.clear_fs
     (fun () ->
@@ -35,7 +35,7 @@ let with_ctx f =
       in
       Unix.mkdir tmp 0o755;
       let config = Room.default_config tmp in
-      ignore (Room.init config ~agent_name:(Some "test-agent"));
+      if initialize then ignore (Room.init config ~agent_name:(Some "test-agent"));
       f { Tool_control.config; agent_name = "test-agent" })
 
 let () =
@@ -113,6 +113,21 @@ let () =
           assert
             (Yojson.Safe.Util.member "requested_namespace_id" json
              = `String "focus-room")
+      | None -> failwith "dispatch returned None")
+
+let () =
+  test "dispatch_pause_status_uninitialized_room_is_safe" (fun () ->
+      with_ctx ~initialize:false @@ fun ctx ->
+      match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
+      | Some (success, result) ->
+          assert success;
+          let json = parse_json result in
+          assert (Yojson.Safe.Util.member "status" json = `String "initializing");
+          assert (Yojson.Safe.Util.member "initializing" json = `Bool true);
+          assert (Yojson.Safe.Util.member "paused" json = `Null);
+          assert (Yojson.Safe.Util.member "namespace_id" json = `String "default");
+          assert (Yojson.Safe.Util.member "namespace" json = `String "default");
+          assert (Yojson.Safe.Util.member "namespace_mode" json = `String "flattened")
       | None -> failwith "dispatch returned None")
 
 let () =

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -257,13 +257,10 @@ let test_hook_skips_on_verify_error () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
-         tool_use_id = "test-id-1";
          tool_name = "keeper_bash";
          input = `Assoc [ ("cmd", `String "echo hi") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
-         schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -284,13 +281,10 @@ let test_hook_readonly_skips_verifier () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
-         tool_use_id = "test-id-2";
          tool_name = "read file";
          input = `Assoc [ ("path", `String "README.md") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
-         schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -257,10 +257,13 @@ let test_hook_skips_on_verify_error () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
+         tool_use_id = "test-id-1";
          tool_name = "keeper_bash";
          input = `Assoc [ ("cmd", `String "echo hi") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
+         schedule = { planned_index = 0; batch_index = 0;
+                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -281,10 +284,13 @@ let test_hook_readonly_skips_verifier () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
+         tool_use_id = "test-id-2";
          tool_name = "read file";
          input = `Assoc [ ("path", `String "README.md") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
+         schedule = { planned_index = 0; batch_index = 0;
+                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;


### PR DESCRIPTION
## Summary
- improve dashboard loading UX for lazy surfaces while keeping flow-control startup state explicit
- harden `masc_pause_status` so uninitialized rooms report `initializing` without a second room-state read
- add regression coverage for the uninitialized pause-status path in both OCaml and dashboard tests

## Product impact
- the dashboard flow-control badge now shows `초기화 중` during startup instead of misclassifying the room as `실행 중`
- pause/resume buttons stay disabled until the namespace has finished initializing
- `masc_pause_status` continues returning a stable JSON envelope before room bootstrap completes

## Evidence
- `opam exec -- dune build --root . test/test_tool_control_coverage.exe`
- `./_build/default/test/test_tool_control_coverage.exe`
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/flow-control/flow-control-state.test.ts src/components/flow-control/flow-control-panel.test.ts`

## Review evidence
- `2026-04-04 12:08:30 KST` direct `sb glm-text` review on `82232479105563676b0205a38a4d3d114fb5faef..1f52d69c01fbb978306a9a35fa05006c6b53a1db`: `No findings.`

## Linked issue
- context only: `#4803`, `#4777` (both already closed before this follow-up hardening pass)
