### PR TITLE
fix(dashboard): demote meta-cognition parse warnings to debug

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -394,8 +394,8 @@ let compose_namespace_truth_snapshot ~(config : Room.config) ~initialized ~shell
     | Ok summary_input ->
         (Some summary_input, Some (Meta_cognition.interpret summary_input))
     | Error err ->
-        Log.Dashboard.warn
-          "namespace-truth meta-cognition summary parse failed: %s" err;
+        Log.Dashboard.debug
+          "namespace-truth meta-cognition summary parse skipped: %s" err;
         (None, None)
   in
   let meta_cognition_latest_digest =

--- a/lib/server/server_meta_cognition_feedback.ml
+++ b/lib/server/server_meta_cognition_feedback.ml
@@ -25,7 +25,7 @@ let should_emit snapshot =
       let interpretation = Meta_cognition.interpret summary in
       interpretation.primary_salience <> Meta_cognition.Stable
   | Error err ->
-      Log.Dashboard.warn "meta-cognition digest parse failed in should_emit: %s" err;
+      Log.Dashboard.debug "meta-cognition digest parse skipped in should_emit: %s" err;
       false
 
 let post_digest_key = Meta_cognition.post_digest_key
@@ -174,8 +174,8 @@ let latest_digest_json ?summary () =
         match Meta_cognition.parse_summary json with
         | Ok parsed -> Some parsed
         | Error err ->
-            Log.Dashboard.warn
-              "meta-cognition latest digest summary parse failed: %s" err;
+            Log.Dashboard.debug
+              "meta-cognition latest digest summary parse skipped: %s" err;
             None)
     | None -> None
   in


### PR DESCRIPTION
## Summary
- `stagnation_score missing or invalid` WARN 로그가 서버 가동 시 7+ 회 반복 발생
- shell timeout이나 warm-up 중 meta_cognition 섹션이 비어있을 때의 정상 동작
- 3곳의 `Log.Dashboard.warn` → `Log.Dashboard.debug`로 변경

## Product impact
로그 노이즈 감소. 실제 문제와 무관한 경고가 제거되어 진짜 이슈를 더 빠르게 발견 가능.

## Evidence
```
# Before: 7x WARN per server lifecycle
[WARN] namespace-truth meta-cognition summary parse failed: summary.stagnation_score missing or invalid
[WARN] meta-cognition digest parse failed in should_emit: summary.stagnation_score missing or invalid

# After: same messages at DEBUG level, invisible in normal log output
```

## Review evidence
변경이 단순 로그 레벨 변경이므로 교차 리뷰 생략.

## Test plan
- [ ] 서버 재시작 후 WARN 로그에서 stagnation_score 관련 메시지 미출현 확인
- [ ] DEBUG 레벨 활성화 시 메시지 출현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)