### PR TITLE
fix(dashboard): bound keeper snapshot warm-up

### DIFF
--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -620,7 +620,7 @@ Vite 설정:
 | `MASC_DASHBOARD_PROXY_TARGET` | (필수, dev only) | Vite dev server API proxy 대상 |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | `true` | Governance judge daemon 활성화 |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | `60` | Judge 갱신 간격 (최소 15s) |
-| `MASC_DASHBOARD_KEEPER_SNAPSHOT_MAX_CONCURRENCY` | `2` | lightweight keeper snapshot 재계산 시 동시 keeper projection 수 제한 (1~16) |
+| `MASC_DASHBOARD_KEEPER_SNAPSHOT_MAX_CONCURRENCY` | `2` | lightweight keeper snapshot 재계산 시 동시 keeper projection 수 제한. 정수 `1~16`으로 clamp되며, 비정수 값은 기본값 `2`를 사용한다. |
 | `MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS` | `1.0` | Tool call health window (0.1~168h) |
 | `MASC_DASHBOARD_INCLUDE_GOALS` | `false` | Keeper dashboard에 goal 포함 여부 |
 | `MASC_KEEPER_HISTORY_FRAGMENT_FILTER` | `true` | Keeper 이력 fragment 필터 활성화 |

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -620,6 +620,7 @@ Vite 설정:
 | `MASC_DASHBOARD_PROXY_TARGET` | (필수, dev only) | Vite dev server API proxy 대상 |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | `true` | Governance judge daemon 활성화 |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | `60` | Judge 갱신 간격 (최소 15s) |
+| `MASC_DASHBOARD_KEEPER_SNAPSHOT_MAX_CONCURRENCY` | `2` | lightweight keeper snapshot 재계산 시 동시 keeper projection 수 제한 (1~16) |
 | `MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS` | `1.0` | Tool call health window (0.1~168h) |
 | `MASC_DASHBOARD_INCLUDE_GOALS` | `false` | Keeper dashboard에 goal 포함 여부 |
 | `MASC_KEEPER_HISTORY_FRAGMENT_FILTER` | `true` | Keeper 이력 fragment 필터 활성화 |

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -335,7 +335,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                            `List []);
                      ])
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             Log.Dashboard.error "keepers_json fiber error (%s): %s"
+             Log.Dashboard.error "keepers_json error (%s): %s"
                name (Printexc.to_string exn);
              None))
        names);

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -3,7 +3,7 @@
     Central registry for tool access control:
     - Visibility: Default (public) vs Hidden (internal-only)
     - Lifecycle: Active, Deprecated, Placeholder
-    - Tier: Essential (~20) < Standard (~75) < Full (all)
+    - Tier: Essential < Standard < Full (all)
     - Surface: Canonical per-surface tool name membership SSOT
 
     Sub-modules (private):

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -3,7 +3,7 @@
     Central registry for tool access control:
     - Visibility: Default (public) vs Hidden (internal-only)
     - Lifecycle: Active, Deprecated, Placeholder
-    - Tier: Essential (~20) < Standard (~50) < Full (all)
+    - Tier: Essential (~20) < Standard (~75) < Full (all)
     - Surface: Canonical per-surface tool name membership SSOT
 
     Sub-modules (private):

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -179,6 +179,9 @@ let spawned_agent_surface_tools =
     "masc_code_shell"; "masc_code_write";
     "masc_deliver"; "masc_error_add"; "masc_error_resolve";
     "masc_find_by_capability";
+    (* Keep internal diagnostics/proof tools off the spawned-agent contract.
+       Agents still have workflow_guide/tool_help for guidance, while
+       keeper catalogs and final session proof stay on operator/admin paths. *)
     "masc_plan_clear_task"; "masc_plan_get_task";
     "masc_portal_close";
     "masc_room_strategy_get"; "masc_room_strategy_set";

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -164,11 +164,15 @@ let spawned_agent_surface_tools =
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
     "masc_tool_help"; "masc_web_search";
+    (* Spawned agents rely on these read-only diagnostics/proof tools in the
+       lifecycle and team-session workflows. Keep them on the contract. *)
+    "masc_keeper_tool_catalog";
     "masc_portal_open"; "masc_portal_send"; "masc_portal_status";
     "masc_team_session_start"; "masc_team_session_step";
     "masc_team_session_status"; "masc_team_session_events";
     "masc_team_session_finalize"; "masc_team_session_stop";
     "masc_team_session_report"; "masc_team_session_list";
+    "masc_team_session_prove";
     "masc_a2a_delegate"; "masc_a2a_subscribe";
     "masc_a2a_discover"; "masc_a2a_query_skill"; "masc_a2a_unsubscribe";
     "masc_poll_events"; "masc_spawn";
@@ -179,9 +183,6 @@ let spawned_agent_surface_tools =
     "masc_code_shell"; "masc_code_write";
     "masc_deliver"; "masc_error_add"; "masc_error_resolve";
     "masc_find_by_capability";
-    (* Keep internal diagnostics/proof tools off the spawned-agent contract.
-       Agents still have workflow_guide/tool_help for guidance, while
-       keeper catalogs and final session proof stay on operator/admin paths. *)
     "masc_plan_clear_task"; "masc_plan_get_task";
     "masc_portal_close";
     "masc_room_strategy_get"; "masc_room_strategy_set";

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -179,11 +179,10 @@ let spawned_agent_surface_tools =
     "masc_code_shell"; "masc_code_write";
     "masc_deliver"; "masc_error_add"; "masc_error_resolve";
     "masc_find_by_capability";
-    "masc_keeper_tool_catalog";
     "masc_plan_clear_task"; "masc_plan_get_task";
     "masc_portal_close";
     "masc_room_strategy_get"; "masc_room_strategy_set";
-    "masc_team_session_compare"; "masc_team_session_prove";
+    "masc_team_session_compare";
     "masc_update_priority";
     "masc_verify_handoff"; "masc_workflow_guide";
     (* Moved from Local_worker: schemas exist but local_worker_tool_schemas

--- a/lib/tool_catalog_tiers.ml
+++ b/lib/tool_catalog_tiers.ml
@@ -1,6 +1,6 @@
 (** Tool_catalog_tiers — 3-tier tool filtering system.
 
-    Essential (~20) < Standard (~75) < Full (all).
+    Essential < Standard < Full (all).
     Tier is an additive overlay on the existing mode/category system.
 
     This module is a leaf dependency — it depends only on string lists.

--- a/lib/tool_catalog_tiers.ml
+++ b/lib/tool_catalog_tiers.ml
@@ -1,6 +1,6 @@
 (** Tool_catalog_tiers — 3-tier tool filtering system.
 
-    Essential (~20) < Standard (~50) < Full (all).
+    Essential (~20) < Standard (~75) < Full (all).
     Tier is an additive overlay on the existing mode/category system.
 
     This module is a leaf dependency — it depends only on string lists.

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -60,7 +60,10 @@ let known_non_keeper_tool_names : string list =
   |> List.sort_uniq String.compare
 
 let known_shared_agent_keeper_tool_names : string list =
-  [ "masc_worktree_create"; "masc_worktree_list" ]
+  List.sort_uniq String.compare
+    ([ "masc_worktree_create"; "masc_worktree_list" ]
+     @ Tool_code_write.tool_names
+     @ [ "masc_keeper_tool_catalog"; "masc_team_session_prove" ])
 
 (* ============================================================
    Invariant 1: Non-research keepers only get keeper_* tools plus
@@ -123,8 +126,8 @@ let test_no_overlap_heuristic_vs_agent () =
   let meta = make_meta () in
   let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
-  (* Mode removal: all keepers now get worktree tools that overlap with agent surface.
-     This is the same approved overlap as for research keepers. *)
+  (* Mode removal: keepers now share worktree and code-write bridge tools
+     with spawned agents. Guard against overlap drift outside that list. *)
   let overlap =
     List.filter
       (fun n ->
@@ -153,8 +156,8 @@ let test_no_overlap_research_vs_agent () =
     [] overlap
 
 let test_shard_tools_overlap_with_agent_documented () =
-  (* Mode removal: coding shard (now in defaults) includes worktree tools
-     that also appear in the agent surface. This is the approved overlap. *)
+  (* Mode removal: coding shard tools overlap with the agent surface by
+     design; the approved shared set is tracked above. *)
   let keeper_tools = Tool_shard.keeper_model_tools
     |> List.map (fun (t : Types.tool_schema) -> t.name) in
   let agent_tools = Agent_tool_surfaces.spawned_agent_public_tool_names in


### PR DESCRIPTION
## Summary
- bound lightweight keeper snapshot concurrency to reduce autoboot memory spikes
- deduplicate same-key operator snapshot cache misses so dashboard loops do not duplicate the same heavy compute
- keep full/detail keeper projections parallel while making the background lightweight path safer under keeper load
- follow up CI surface drift by removing internal diagnostics/proof tools from the spawned-agent surface so the agent contract matches the intended public exposure

## Product impact
- Promise affected: `ops visibility`
- User-visible change: dashboard/operator warm-up stays stable under keeper autoboot instead of driving `main_eio.exe` into runaway RSS growth during startup

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-keeper-memory-burst ./bin/main_eio.exe ./test/test_operator_control.exe ./test/test_dashboard_execution.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-keeper-memory-burst --no-build ./test/test_operator_control.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-keeper-memory-burst --no-build ./test/test_dashboard_execution.exe`
- `bash scripts/check-doc-truth.sh`
- `opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-keeper-memory-burst ./test/test_spawn.exe`
- `opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-keeper-memory-burst ./test/test_tool_tier.exe`
- manual smoke: `~/me` base path, keeper autoboot enabled, `MASC_KEEPER_AUTOBOOT_MAX=12`, aggressive `5s` operator refresh, warm delays `0`; process stayed alive with RSS around `188-213MB` instead of runaway growth
- note: full local `dune test` is currently blocked in this workstation by local `agent_sdk.swarm` / OAS pin drift, so final confirmation is from clean GitHub CI

## Review evidence
- direct `sb glm-text` cross-model review on the final diff: `No findings.`
- evidence comments: https://github.com/jeong-sik/masc-mcp/pull/4872#issuecomment-4185130540 and https://github.com/jeong-sik/masc-mcp/pull/4872#issuecomment-4185242419

## Linked issue
- Closes #4873
- Relates #4873