### PR TITLE
Fix remaining review follow-ups

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -103,15 +103,22 @@ let prioritized_disclosed_tool_names
   let fallback_tools =
     Keeper_exec_tools.dedupe_tool_names fallback_tools
   in
+  let seen = Hashtbl.create (max 16 max_tools) in
   let add_with_budget acc names =
     let remaining = max_tools - List.length acc in
     if remaining <= 0 then
       acc
     else
-      let unseen =
-        List.filter (fun name -> not (List.mem name acc)) names
-      in
-      acc @ take remaining unseen
+      let remaining = ref remaining in
+      let added_rev = ref [] in
+      List.iter (fun name ->
+        if !remaining > 0 && not (Hashtbl.mem seen name) then begin
+          Hashtbl.replace seen name ();
+          decr remaining;
+          added_rev := name :: !added_rev
+        end
+      ) names;
+      acc @ List.rev !added_rev
   in
   let acc = add_with_budget [] always_include_tools in
   let acc = add_with_budget acc retrieved_names in
@@ -673,11 +680,10 @@ let run_turn
           Log.Keeper.info
             "keeper:%s turn_budget turn=%d/%d last_turn=%b"
             meta.name turn max_turns is_last_turn;
-        (* Context overflow guard: cap tool count to prevent exceeding
-           small model context windows (e.g. 8K).  ~118 tokens/tool schema,
-           so 40 tools ≈ 4700 tokens — safe for 8K models.  Beyond 40,
-           truncate to always_include_tools + top BM25 results by score.
-           Configurable via MASC_KEEPER_MAX_TOOLS_PER_TURN. *)
+        (* Context overflow guard: tool disclosure is first budgeted via
+           prioritized_disclosed_tool_names, then overlays can still grow the
+           visible set. Cap the post-overlay set to stay inside small-model
+           context windows. Configurable via MASC_KEEPER_MAX_TOOLS_PER_TURN. *)
         let all_allowed =
           if List.length all_allowed > max_tools then begin
             Log.Keeper.info

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -328,7 +328,9 @@ let list_dir config path =
         Sys.readdir path |> Array.to_list
       else
         []
-  | Some _ when Sys.file_exists path && Sys.is_directory path ->
+  | Some _ when
+      (match config.backend with FileSystem _ -> true | Memory _ | PostgresNative _ -> false)
+      && Sys.file_exists path && Sys.is_directory path ->
       Sys.readdir path |> Array.to_list
   | Some key_prefix ->
       let prefix = key_prefix ^ ":" in

--- a/test/test_mcp_tool_matrix.ml
+++ b/test/test_mcp_tool_matrix.ml
@@ -56,6 +56,17 @@ let source_root () =
           | Some root -> root
           | None -> Filename.current_dir_name))
 
+let path_is_within ~parent ~child =
+  try
+    let parent = Unix.realpath parent in
+    let child = Unix.realpath child in
+    let prefix =
+      if String.ends_with ~suffix:"/" parent then parent else parent ^ "/"
+    in
+    String.starts_with ~prefix child
+  with _ ->
+    false
+
 let quote = Filename.quote
 
 let read_file path =
@@ -81,7 +92,9 @@ let runner_path () =
   let candidate =
     Filename.concat (Filename.dirname Sys.executable_name) "tool_matrix_case_runner.exe"
   in
-  if Sys.file_exists candidate then
+  if Sys.file_exists candidate
+     && path_is_within ~parent:(source_root ()) ~child:candidate
+  then
     candidate
   else
     Filename.concat (source_root ()) "_build/default/test/tool_matrix_case_runner.exe"

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,7 +300,6 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
-  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -997,10 +997,6 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
   Unix.putenv "SB_PG_URL" "";
   let base_path = temp_dir "mcp-tool-matrix-" in
   Unix.putenv "MASC_BASE_PATH" base_path;
-  let fixture =
-    make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path
-      (case_for_name schema.Types.name).init_mode
-  in
   let result =
     Fun.protect
       ~finally:(fun () ->
@@ -1014,9 +1010,13 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
         | Some home -> Unix.putenv "HOME" home
         | None -> Unix.putenv "HOME" "")
       (fun () ->
-        Unix.putenv "HOME" fixture.base_path;
+        Unix.putenv "HOME" base_path;
         try
           let case = case_for_name schema.Types.name in
+          let fixture =
+            make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path
+              case.init_mode
+          in
           case.prepare fixture;
           let arguments = case.arguments fixture schema in
           let response = call_tool_json fixture schema arguments in
@@ -1029,4 +1029,4 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
             (Printf.sprintf "%s raised during contract execution: %s"
                schema.Types.name (Printexc.to_string exn)))
   in
-  (fixture.base_path, result)
+  (base_path, result)

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,6 +300,7 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
+  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -624,6 +624,21 @@ let test_rooms_root_dir_with_cluster () =
   let result = Room_utils.rooms_root_dir cfg in
   check string "rooms with cluster" "/home/user/.masc/clusters/staging/rooms" result
 
+let test_list_dir_prefers_backend_for_memory_keys () =
+  let scratch = Filename.temp_dir "room-utils-list-dir-memory" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      let cfg = make_test_config ~base_path:scratch ~cluster_name:"default" in
+      let workers_dir = Filename.concat (Room_utils.masc_root_dir cfg) "workers" in
+      Room_utils.write_json cfg
+        (Filename.concat workers_dir "backend.json")
+        (`Assoc [ ("ok", `Bool true) ]);
+      write_file (Filename.concat workers_dir "rogue.json") "{}";
+      let listed = Room_utils.list_dir cfg workers_dir |> List.sort String.compare in
+      check (list string) "memory backend ignores local-only stale files"
+        [ "backend.json" ] listed)
+
 let test_read_current_room_warns_once_for_legacy_state () =
   let scratch = Filename.temp_dir "room-utils-legacy" "" in
   Fun.protect
@@ -793,6 +808,8 @@ let () =
       test_case "current_room_root_path" `Quick test_current_room_root_path;
       test_case "masc_root_dir nested with cluster" `Quick test_masc_root_dir_with_cluster_nested;
       test_case "rooms_root_dir with cluster" `Quick test_rooms_root_dir_with_cluster;
+      test_case "list_dir prefers backend for memory keys" `Quick
+        test_list_dir_prefers_backend_for_memory_keys;
       test_case "read_current_room warns once for legacy state" `Quick
         test_read_current_room_warns_once_for_legacy_state;
       test_case "read_current_room caches legacy rooms" `Quick

--- a/test/test_tool_portal_coverage.ml
+++ b/test/test_tool_portal_coverage.ml
@@ -22,7 +22,8 @@ let cleanup_dir dir =
       else
         Unix.unlink path
   in
-  try rm dir with _ -> ()
+  try rm dir with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 
 (* ============================================================
    Argument Helper Tests

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -103,6 +103,10 @@ let () =
             Test_tool_team_session_misc
               .test_delegate_ready_worker_accepts_background;
           Alcotest.test_case
+            "delegate-settle-ignores-other-worker-events" `Quick
+            Test_tool_team_session_misc
+              .test_wait_for_background_delegate_settle_ignores_other_worker_events;
+          Alcotest.test_case
             "delegate-rejects-corrupt-checkpoint-worker" `Quick
             Test_tool_team_session_misc
               .test_delegate_rejects_corrupt_checkpoint_worker;

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -63,7 +63,10 @@ let wait_for_background_delegate_settle
         Team_session_store.read_events config session_id
         |> List.filter (fun json ->
                Yojson.Safe.Util.member "event_type" json
-               = `String "team_step_delegate")
+               = `String "team_step_delegate"
+               && Yojson.Safe.Util.member "worker_run_id"
+                    (Yojson.Safe.Util.member "detail" json)
+                  = `String worker_run_id)
       in
       if delegate_events <> [] then ()
       else (
@@ -71,6 +74,41 @@ let wait_for_background_delegate_settle
         loop (attempts - 1))
   in
   loop 200
+
+let test_wait_for_background_delegate_settle_ignores_other_worker_events () =
+  with_eio @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None; net = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"delegate-settle-filter" |> get_session_id in
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_delegate"
+    ~detail:
+      (`Assoc
+        [
+          ("worker_run_id", `String "other-run");
+          ("target_agent", `String "worker-a");
+          ("success", `Bool true);
+        ]);
+  let target_worker_run_id = "target-run" in
+  Alcotest.match_raises
+    "unrelated delegate event does not settle target"
+    (function
+      | exn ->
+          Room_utils.contains_substring (Printexc.to_string exn)
+            "background delegate did not settle before cleanup")
+    (fun () ->
+      wait_for_background_delegate_settle ctx config session_id target_worker_run_id;
+      ());
+  Team_session_store.save_worker_run_meta_json config session_id target_worker_run_id
+    (`Assoc [ ("worker_run_id", `String target_worker_run_id) ]);
+  wait_for_background_delegate_settle ctx config session_id target_worker_run_id;
+  cleanup_dir base_dir
 
 let test_prove_strong_requires_additional_evidence () =
   with_eio @@ fun env ->


### PR DESCRIPTION
## Summary
- restrict `Room_utils.list_dir` local directory preference to filesystem backends only
- make `wait_for_background_delegate_settle` require matching `worker_run_id`
- keep MCP tool-matrix case runner cleanup and result reporting alive when fixture creation raises

## Product impact
- avoids stale local mirror entries masking memory/postgres-backed room data
- prevents background delegate cleanup from racing on unrelated prior delegate events
- preserves structured tool-matrix diagnostics on fixture/setup failures

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4820-tool-matrix-drift ./test/test_room_utils_coverage.exe ./test/test_tool_team_session.exe ./test/tool_matrix_case_runner.exe ./test/test_mcp_tool_matrix.exe`
- `./_build/default/test/test_room_utils_coverage.exe test path_helpers 8 --color=never`
- `./_build/default/test/test_tool_team_session.exe test team_session 43,44 --color=never`
- `env MCP_TOOL_MATRIX_ONLY=masc_status ./_build/default/test/test_mcp_tool_matrix.exe test matrix 0 --color=never`

## Review evidence
- direct `sb glm-text` attempted but did not return in a reasonable time during this session
- fallback `./scripts/review/local-review.sh --base HEAD^ --head HEAD --format text`
- fallback output had no actionable findings; reported concerns were based on misreading short-circuiting / intended base_path reporting behavior

## Linked issue
- Refs #4820

## Context
- follow-up for remaining merged-review comments after #4837
