### PR TITLE
fix(catalog): resolve tool catalog SSOT drift

### DIFF
--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -514,14 +514,19 @@ let dispatch (ctx : context) ~name ~args : result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
+let _tool_spec_system_internal = [ "masc_autoresearch_status" ]
+
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
+      let is_system = List.mem s.name _tool_spec_system_internal in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
            ~description:s.description
            ~module_tag:Tool_dispatch.Mod_autoresearch
            ~input_schema:s.input_schema
+           ~visibility:(if is_system then Tool_catalog.Hidden else Tool_catalog.Default)
+           ~allow_direct_call_when_hidden:is_system
            ()))
     schemas

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -52,8 +52,9 @@ let keeper_internal_tools =
     "keeper_voice_sessions";
     "keeper_voice_session_start";
     "keeper_voice_session_end";
-    (* Phase 2: surface SSOT *)
-    "keeper_deliberation_decision"; "keeper_unified";
+    (* keeper_deliberation_decision: Agent_sdk.Structured result schema, not
+       a regular tool — does not need a keeper shard entry.
+       keeper_unified: cascade name, not a tool. *)
   ]
 
 let keeper_internal_set : (string, unit) Hashtbl.t =
@@ -133,6 +134,11 @@ let public_mcp_surface_tools =
     "masc_webrtc_offer"; "masc_webrtc_answer";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
+    (* Board extended *)
+    "masc_board_stats"; "masc_board_comment_vote";
+    "masc_board_profile"; "masc_board_hearths";
+    (* Agent discovery *)
+    "masc_agent_timeline";
     (* Phase 2: surface SSOT *)
     "masc_board_migrate"; "masc_board_reclassify"; "masc_bounded_run";
     "masc_episode_flush"; "masc_episode_list";
@@ -164,7 +170,9 @@ let spawned_agent_surface_tools =
     "masc_team_session_finalize"; "masc_team_session_stop";
     "masc_team_session_report"; "masc_team_session_list";
     "masc_a2a_delegate"; "masc_a2a_subscribe";
+    "masc_a2a_discover"; "masc_a2a_query_skill"; "masc_a2a_unsubscribe";
     "masc_poll_events"; "masc_spawn";
+    "masc_note_add";
     (* Phase 2: surface SSOT *)
     "masc_archive_view";
     "masc_code_delete"; "masc_code_edit"; "masc_code_git";
@@ -218,6 +226,7 @@ let admin_surface_tools =
     "masc_tool_admin_update"; "masc_tool_grant"; "masc_tool_revoke";
     "masc_operator_action"; "masc_operator_confirm"; "masc_operator_snapshot";
     "masc_team_session_finalize"; "masc_tool_admin_snapshot";
+    "masc_config";
     (* Phase 2: surface SSOT *)
     "masc_auth_disable"; "masc_auth_enable"; "masc_auth_list";
     "masc_auth_refresh"; "masc_auth_revoke"; "masc_auth_status";
@@ -280,7 +289,7 @@ let system_internal_surface_tools =
     (* Maintenance *)
     "masc_cleanup_zombies"; "masc_gc";
     (* Infrastructure control *)
-    "masc_cancellation"; "masc_subscription";
+    "masc_cancellation"; "masc_subscription"; "masc_progress";
     "masc_feature_flags"; "masc_compact_context";
     (* Internal monitoring *)
     "masc_autoresearch_status"; "masc_pause_status";

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -206,5 +206,7 @@ let () =
            ~description:s.description
            ~module_tag:Tool_dispatch.Mod_compact
            ~input_schema:s.input_schema
+           ~visibility:Tool_catalog.Hidden
+           ~allow_direct_call_when_hidden:true
            ()))
     schemas

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -207,10 +207,13 @@ Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead age
 (* ================================================================ *)
 
 let _tool_spec_requires_join = [ "masc_heartbeat" ]
+let _tool_spec_system_internal =
+  [ "masc_heartbeat_start"; "masc_heartbeat_stop"; "masc_heartbeat_list" ]
 
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
+      let is_system = List.mem s.name _tool_spec_system_internal in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -218,5 +221,7 @@ let () =
            ~module_tag:Tool_dispatch.Mod_heartbeat
            ~input_schema:s.input_schema
            ~requires_join:(List.mem s.name _tool_spec_requires_join)
+           ~visibility:(if is_system then Tool_catalog.Hidden else Tool_catalog.Default)
+           ~allow_direct_call_when_hidden:is_system
            ()))
     schemas

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -367,7 +367,7 @@ let _tool_spec_read_only = [ "masc_operator_snapshot"; "masc_operator_digest"; "
 let _tool_spec_requires_join = [ "masc_operator_action"; "masc_operator_confirm" ]
 
 (* Tools with explicit catalog metadata that must be preserved. *)
-let _tool_spec_hidden = [ "masc_operator_judgment_write" ]
+let _tool_spec_hidden = [ "masc_operator_judgment_write"; "masc_surface_audit" ]
 let _tool_spec_hidden_destructive = [ "masc_operator_action" ]
 
 let () =

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -595,10 +595,12 @@ let schemas = Tool_schemas_room.schemas
 (* ================================================================ *)
 
 let _tool_spec_read_only = [ "masc_status" ]
+let _tool_spec_system_internal = [ "masc_init"; "masc_reset" ]
 
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
+      let is_system = List.mem s.name _tool_spec_system_internal in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -607,5 +609,7 @@ let () =
            ~input_schema:s.input_schema
            ~is_read_only:(List.mem s.name _tool_spec_read_only)
            ~is_idempotent:(List.mem s.name _tool_spec_read_only)
+           ~visibility:(if is_system then Tool_catalog.Hidden else Tool_catalog.Default)
+           ~allow_direct_call_when_hidden:is_system
            ()))
     schemas

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -240,5 +240,7 @@ let () =
            ~module_tag:Tool_dispatch.Mod_suspend
            ~input_schema:s.input_schema
            ~requires_join:(List.mem s.name _tool_spec_requires_join)
+           ~visibility:Tool_catalog.Hidden
+           ~allow_direct_call_when_hidden:true
            ()))
     schemas


### PR DESCRIPTION
## Summary

- 11개 orphaned tool을 올바른 surface에 배치 (public_mcp, spawned_agent, admin, system_internal)
- 9개 System_internal tool에 Hidden visibility 설정
- keeper_internal_tools에서 tool이 아닌 2개 항목 제거 (keeper_deliberation_decision, keeper_unified)

## Test plan

- [x] `test_tool_surface_ssot.exe` 20개 테스트 전부 통과
- [x] 관련 테스트 (tool_spec, tool_dispatch, tool_registry 등) 회귀 없음
- [x] `dune build --root . lib/` 성공
- [x] GLM-5.1 교차 리뷰 LGTM

Closes #4870

🤖 Generated with [Claude Code](https://claude.com/claude-code)