### PR TITLE
perf(command-plane): bound slot-samples fallback reads

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -82,6 +82,7 @@ masc_start(path="/your/project", task_title="My first task")
 
 ```text
 masc_start(path="/your/project")
+masc_join(agent_name="codex")
 masc_status()
 masc_add_task(title="My task")
 masc_claim_next()

--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -5,19 +5,20 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 let file_mtime path =
   try Some (Unix.stat path).st_mtime with Unix.Unix_error _ -> None
 
-let read_jsonl_local path =
-  match Safe_ops.read_file_safe path with
-  | Error _ -> []
-  | Ok content ->
-      content
-      |> String.split_on_char '\n'
-      |> List.filter_map (fun line ->
-             let trimmed = String.trim line in
-             if trimmed = "" then None
-             else
-               match Safe_ops.parse_json_safe ~context:path trimmed with
-               | Ok json -> Some json
-               | Error _ -> None)
+let swarm_slot_samples_tail_lines () =
+  Dashboard_http_helpers.int_of_env_default
+    "MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES"
+    ~default:2048 ~min_v:64 ~max_v:20000
+
+let read_jsonl_tail_json path ~max_lines =
+  read_jsonl_tail_lines path ~max_lines
+  |> List.filter_map (fun line ->
+         let trimmed = String.trim line in
+         if trimmed = "" then None
+         else
+           match Safe_ops.parse_json_safe ~context:path trimmed with
+           | Ok json -> Some json
+           | Error _ -> None)
 
 let swarm_live_dir config =
   Filename.concat (control_plane_dir config) "swarm-live"
@@ -94,7 +95,12 @@ let read_slot_metrics_from_json path =
         }
 
 let read_slot_metrics_from_samples path =
-  let rows = read_jsonl_local path in
+  let rows =
+    (* Fallback path only. Keep reads bounded so an oversized slot-samples
+       artifact cannot force command-plane summary refreshes to load the
+       entire file into memory. *)
+    read_jsonl_tail_json path ~max_lines:(swarm_slot_samples_tail_lines ())
+  in
   let peak_hot_slots =
     rows
     |> List.fold_left
@@ -108,6 +114,7 @@ let read_slot_metrics_from_samples path =
   in
   let ctx_per_slot =
     rows
+    |> List.rev
     |> List.find_map (fun row ->
            match U.member "ctx_per_slot" row with
            | `Int value -> Some value

--- a/test/dune
+++ b/test/dune
@@ -547,6 +547,7 @@
           test_command_plane_v2_support
           test_command_plane_v2_policy_inputs
           test_command_plane_v2_traces
+          test_command_plane_v2_summary
           test_command_plane_v2_scheduler_core_a
           test_command_plane_v2_scheduler_core_b
           test_command_plane_v2_scheduler_policy

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -82,6 +82,11 @@ let () =
             "trace filter keeps older matching operator events"
             `Quick
             Test_command_plane_v2_traces.test_trace_filter_reads_tail_bounded_operator_log;
+          Alcotest.test_case
+            "swarm proof fallback reads bounded slot-sample tail"
+            `Quick
+            Test_command_plane_v2_summary
+              .test_swarm_proof_fallback_reads_slot_samples_from_bounded_tail;
           Alcotest.test_case "dispatch assign requires operation_id" `Quick
             Test_command_plane_v2_policy_inputs.test_dispatch_assign_requires_operation_id;
           Alcotest.test_case "dispatch escalate requires operation_id"

--- a/test/test_command_plane_v2_summary.ml
+++ b/test/test_command_plane_v2_summary.ml
@@ -1,0 +1,67 @@
+open Masc_mcp
+open Test_command_plane_v2_support
+
+let swarm_live_dir config =
+  Filename.concat
+    (Filename.concat (Room.masc_dir config) "control-plane")
+    "swarm-live"
+
+let write_jsonl_rows path rows =
+  let body =
+    rows
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+  in
+  write_text_file path (body ^ "\n")
+
+let make_slot_sample ~timestamp ~active_slots ~ctx_per_slot =
+  `Assoc
+    [
+      ("timestamp", `String timestamp);
+      ("total_slots", `Int 12);
+      ("active_slots", `Int active_slots);
+      ("active_slot_ids", `List []);
+      ("ctx_per_slot", `Int ctx_per_slot);
+    ]
+
+let test_swarm_proof_fallback_reads_slot_samples_from_bounded_tail () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_eio_test base_dir @@ fun config ->
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let run_dir = Filename.concat (swarm_live_dir config) "run-001" in
+      let slot_samples_path = Filename.concat run_dir "slot-samples.jsonl" in
+      let noise_rows =
+        List.init 70 (fun idx ->
+            make_slot_sample
+              ~timestamp:(Printf.sprintf "2026-03-23T00:%02d:00Z" idx)
+              ~active_slots:1 ~ctx_per_slot:(2048 + idx))
+      in
+      let rows =
+        [ make_slot_sample ~timestamp:"2026-03-23T00:00:00Z" ~active_slots:99
+            ~ctx_per_slot:1024 ]
+        @ noise_rows
+        @ [
+            make_slot_sample ~timestamp:"2026-03-23T00:03:00Z" ~active_slots:7
+              ~ctx_per_slot:8192;
+            make_slot_sample ~timestamp:"2026-03-23T00:04:00Z" ~active_slots:8
+              ~ctx_per_slot:16384;
+            make_slot_sample ~timestamp:"2026-03-23T00:05:00Z" ~active_slots:9
+              ~ctx_per_slot:32768;
+          ]
+      in
+      write_jsonl_rows slot_samples_path rows;
+      with_env "MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES" "64" (fun () ->
+        let json = Command_plane_v2.summary_json config in
+        let swarm_proof = Yojson.Safe.Util.member "swarm_proof" json in
+        Alcotest.(check string) "fallback source" "slot_samples"
+          (swarm_proof |> Yojson.Safe.Util.member "source"
+         |> Yojson.Safe.Util.to_string);
+        Alcotest.(check int) "peak_hot_slots uses recent tail only" 9
+          (swarm_proof |> Yojson.Safe.Util.member "peak_hot_slots"
+         |> Yojson.Safe.Util.to_int);
+        Alcotest.(check int) "ctx_per_slot follows latest tail sample" 32768
+          (swarm_proof |> Yojson.Safe.Util.member "ctx_per_slot"
+         |> Yojson.Safe.Util.to_int)))


### PR DESCRIPTION
## Summary

- `cp_snapshot_summaries.ml`의 slot-samples fallback 읽기를 bounded tail로 제한 (기본 2048줄)
- 대형 slot-samples.jsonl이 command-plane summary refresh 시 전체 로드되던 메모리 스파이크 방지
- `MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES` 환경변수로 조절 가능

## Test plan

- [x] `dune build --root . lib/ bin/` 성공
- [x] 새 regression 테스트 `test_command_plane_v2_summary.ml` 포함
- [ ] CI green 확인

Supersedes #4864 (rebased, removed stale verifier changes)
Closes #4862

🤖 Generated with [Claude Code](https://claude.com/claude-code)