### PR TITLE
fix(test): restore PreToolUse fields reverted by #4864

### DIFF
--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -257,10 +257,13 @@ let test_hook_skips_on_verify_error () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
+         tool_use_id = "test-id-1";
          tool_name = "keeper_bash";
          input = `Assoc [ ("cmd", `String "echo hi") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
+         schedule = { planned_index = 0; batch_index = 0;
+                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -281,10 +284,13 @@ let test_hook_readonly_skips_verifier () =
   let decision =
     hook
       (Oas.Hooks.PreToolUse {
+         tool_use_id = "test-id-2";
          tool_name = "read file";
          input = `Assoc [ ("path", `String "README.md") ];
          accumulated_cost_usd = 0.0;
          turn = 1;
+         schedule = { planned_index = 0; batch_index = 0;
+                      batch_size = 1; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;


### PR DESCRIPTION
## Summary

- #4864 머지 시 #4839에서 추가한 `tool_use_id`/`schedule` 필드가 제거됨
- OAS v0.100.2 호환을 위해 해당 필드 복원

## Test plan

- [x] `dune build --root . lib/ bin/` 성공

Closes regression from #4864

🤖 Generated with [Claude Code](https://claude.com/claude-code)