### PR TITLE
fix(dashboard): return initializing envelope during server warm-up

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -430,6 +430,15 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
                      action = Types.show_permission permission;
                    }))
 
+let is_dashboard_bootstrap_path path =
+  String.starts_with ~prefix:"/api/v1/dashboard/" path
+
+let not_initialized_response path =
+  if is_dashboard_bootstrap_path path then
+    {|{"status":"initializing","message":"Server is warming up"}|}
+  else
+    {|{"error":"not initialized"}|}
+
 let rec with_public_read handler request reqd =
   let strict = http_auth_strict_enabled () in
   let path = Http_server_eio.Request.path request in
@@ -437,7 +446,7 @@ let rec with_public_read handler request reqd =
     with_read_auth handler request reqd
   else
     match !server_state with
-    | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
+    | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
     | Some state -> handler state request reqd
 
 and with_read_auth handler request reqd =


### PR DESCRIPTION
## Summary

- `with_public_read`가 서버 초기화 전 `{"error":"not initialized"}`를 반환하던 것을 dashboard bootstrap 경로(`/api/v1/dashboard/`)에 대해 `{"status":"initializing","message":"Server is warming up"}`으로 변경
- 프론트엔드의 warm-up retry 로직이 정상 동작하도록 함
- non-dashboard 경로는 기존 동작 유지

## Test plan

- [x] `dune build --root . lib/ bin/` 성공
- [ ] 수동 테스트: 서버 시작 직후 `/dashboard` 접속 시 warm-up 상태 표시

Closes #4803

🤖 Generated with [Claude Code](https://claude.com/claude-code)