### PR TITLE
fix(test): raise tool matrix default timeout to 25s

### DIFF
--- a/test/test_mcp_tool_matrix.ml
+++ b/test/test_mcp_tool_matrix.ml
@@ -85,8 +85,8 @@ let tool_case_timeout_sec () =
   | Some raw -> (
       match int_of_string_opt (String.trim raw) with
       | Some value when value > 0 -> value
-      | _ -> 15)
-  | None -> 15
+      | _ -> 25)
+  | None -> 25
 
 let runner_path () =
   let candidate =


### PR DESCRIPTION
## Summary

- `test_mcp_tool_matrix` 기본 타임아웃을 15초에서 25초로 상향
- 호스트 부하 시 `masc_a2a_delegate` 등이 15초 내에 프로세스 스케줄링을 받지 못해 flake 발생
- `MCP_TOOL_MATRIX_CASE_TIMEOUT_SEC` 환경변수로 여전히 조절 가능

Closes #4861

🤖 Generated with [Claude Code](https://claude.com/claude-code)