### PR TITLE
fix(build): remove unmerged Oas.Tool_retry_policy references

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -768,7 +768,6 @@ let run_turn
           ~hooks
           ~context_reducer:reducer
           ~memory
-          ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
           ~max_turns
           ~max_idle_turns:5
           ~temperature

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -1112,7 +1112,6 @@ let run_proactive_generation
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
             ~tools ~initial_messages:ctx_work.messages
-            ~tool_retry_policy:Agent_sdk.Tool_retry_policy.default_internal
             ~max_turns:(Keeper_config.keeper_unified_max_turns ())
             ~temperature ~max_tokens
             ()) in

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -508,7 +508,6 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       provider = Some provider;
       hooks;
       guardrails = effective_guardrails;
-      tool_retry_policy = Some Oas.Tool_retry_policy.default_internal;
       raw_trace = Some raw_trace;
       periodic_callbacks;
     }

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -92,7 +92,7 @@ val run_named :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -126,7 +126,7 @@ val run_model_by_label :
   ?hooks:Oas.Hooks.hooks ->
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
@@ -148,7 +148,7 @@ val run_named_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -174,7 +174,7 @@ val run_model_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
-  ?tool_retry_policy:Oas.Tool_retry_policy.t ->
+
   ?enable_thinking:bool ->
   ?contract:Oas.Risk_contract.t ->
   ?raw_trace:Oas.Raw_trace.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -30,7 +30,6 @@ type config = {
   session_id : string option;
   description : string option;
   memory : Oas.Memory.t option;
-  tool_retry_policy : Oas.Tool_retry_policy.t option;
   named_cascade : Oas.Api.named_cascade option;
   initial_messages : Oas.Types.message list;
   raw_trace : Oas.Raw_trace.t option;
@@ -56,7 +55,6 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     session_id = None;
     description = None;
     memory = None;
-    tool_retry_policy = None;
     named_cascade = None;
     initial_messages = [];
     raw_trace = None;
@@ -189,10 +187,6 @@ let build
   in
   let builder = match config.memory with
     | Some m -> Oas.Builder.with_memory m builder
-    | None -> builder
-  in
-  let builder = match config.tool_retry_policy with
-    | Some policy -> Oas.Builder.with_tool_retry_policy policy builder
     | None -> builder
   in
   let builder = match config.raw_trace with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -71,7 +71,6 @@ let config_for_label
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ~(description : string option)
     () : Oas_worker_exec.config =
@@ -95,7 +94,6 @@ let config_for_label
     hooks;
     context_reducer;
     memory;
-    tool_retry_policy;
     enable_thinking;
     description;
   }
@@ -125,7 +123,6 @@ let run_named
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -178,7 +175,7 @@ let run_named
          ~system_prompt ~tools)
       with
       max_turns; max_tokens; temperature; max_idle_turns;
-      guardrails; hooks; context_reducer; memory; tool_retry_policy;
+      guardrails; hooks; context_reducer; memory;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
       transport = transport_resolved;
       allowed_paths;
@@ -230,7 +227,6 @@ let run_model_by_label
     ?hooks
     ?context_reducer
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?on_event
@@ -254,7 +250,7 @@ let run_model_by_label
           config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
             ~tools ~max_turns ~max_tokens ~temperature
             ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
-            ?tool_retry_policy ?enable_thinking
+            ?enable_thinking
             ~description:(Some (Printf.sprintf "model_label:%s" model_label))
             ()
         in
@@ -278,7 +274,6 @@ let run_named_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -299,7 +294,7 @@ let run_named_with_masc_tools
   ) masc_tools in
   run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
-    ?tool_retry_policy ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
+    ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
     ?contract
     ?transport ~yield_on_tool ?sw ?net ()
 
@@ -315,7 +310,6 @@ let run_model_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
-    ?tool_retry_policy
     ?enable_thinking
     ?contract
     ?raw_trace
@@ -335,7 +329,7 @@ let run_model_with_masc_tools
       let config =
         config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
           ~tools:[] ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
-          ?memory ?tool_retry_policy ?enable_thinking
+          ?memory ?enable_thinking
           ~description:(Some (Printf.sprintf "model_label:%s" model_label))
           ()
       in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -260,7 +260,6 @@ let build_agent
     |> Oas.Builder.with_tools tools
     |> Oas.Builder.with_hooks hooks
     |> Oas.Builder.with_guardrails guardrails
-    |> Oas.Builder.with_tool_retry_policy Oas.Tool_retry_policy.default_internal
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)


### PR DESCRIPTION
## Summary

- `Oas.Tool_retry_policy`는 OAS `feat/internal-tool-self-heal` 브랜치에만 존재하며 main에 머지되지 않음
- 이전 로컬 opam pin이 해당 브랜치를 가리키고 있어서 빌드됐지만, CI pin(`fa365ac`)에는 해당 모듈 없음
- 7개 파일에서 16개 참조 제거

## Test plan

- [x] `dune build --root . lib/ bin/` 성공 (에러 0)

Closes #4893

🤖 Generated with [Claude Code](https://claude.com/claude-code)