### PR TITLE
[codex] Fix remaining review follow-ups

### DIFF
--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,7 +300,6 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
-  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,6 +300,7 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
+  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -101,6 +101,8 @@ let test_wait_for_background_delegate_settle_ignores_other_worker_events () =
               ("success", `Bool true);
             ]);
       let target_worker_run_id = "target-run" in
+      let negative_path_attempts = 10 in
+      let negative_path_sleep_sec = 0.001 in
       Alcotest.match_raises
         "unrelated delegate event does not settle target"
         (function
@@ -108,7 +110,9 @@ let test_wait_for_background_delegate_settle_ignores_other_worker_events () =
               Room_utils.contains_substring (Printexc.to_string exn)
                 "background delegate did not settle before cleanup")
         (fun () ->
-          wait_for_background_delegate_settle ~attempts:10 ~sleep_sec:0.001
+          wait_for_background_delegate_settle
+            ~attempts:negative_path_attempts
+            ~sleep_sec:negative_path_sleep_sec
             ctx config session_id target_worker_run_id;
           ());
       Team_session_store.save_worker_run_meta_json config session_id target_worker_run_id


### PR DESCRIPTION
## What changed
- carries forward the review follow-ups from the stale `#4878` branch on a clean replacement branch
- shortens the negative-path background delegate settle test by making attempts/sleep test-tunable
- guarantees temp-dir cleanup with `Fun.protect` in the delegate-settle regression test
- extracts the local-dir backend predicate into a helper to keep `list_dir` readable

## Why
The original `#4878` PR stopped following the recreated head branch and kept reporting two empty commits in `PR Hygiene`. This replacement branch preserves the substantive fixes without those stale history artifacts.

## Validation
- `opam exec -- dune build -j 1 --root . /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/4820-tool-matrix-drift/lib/room/room_utils_paths_backend.ml`
- `sb glm-text` review on `62b98019d..964adf64f` -> `No findings.`

## Caveat
- `opam exec -- dune build -j 1 --root . test/test_tool_team_session.exe` and the narrower `test/test_tool_team_session_misc.ml` target hung locally in the original worktree without surfacing a compile error, so executable-level coverage still needs CI confirmation.
