### PR TITLE
fix(task): provide specific errors for assignee mismatch

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -421,10 +421,15 @@ let transition_task_r config ~agent_name ~task_id ~action
                        | Types.Release, Types.Claimed { assignee; _ }
                        | Types.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
                            Ok (Types.Todo, None)
+                       | Types.Start, Types.Claimed { assignee; _ } ->
+                           Error (Types.TaskInvalidState
+                             (Printf.sprintf
+                               "Cannot start %s: claimed by '%s', caller is '%s'"
+                               task_id assignee agent_name))
                        | _ ->
                            Error (Types.TaskInvalidState
-                             (Printf.sprintf "Invalid transition: %s -> %s (%s)"
-                               (task_status_to_string task.task_status) action_s task_id))
+                             (Printf.sprintf "Invalid transition: %s -> %s (%s, agent=%s)"
+                               (task_status_to_string task.task_status) action_s task_id agent_name))
                      in
                      (match transition with
                       | Error e -> Error e


### PR DESCRIPTION
Resolves #4773

### Description
When an agent attempts to start, complete, cancel, or release a task that is already claimed by someone else, the transition previously failed with a generic 'Invalid transition' error. This PR intercepts these specific transitions and returns an explicit error message ('Cannot [action]: Task X is claimed by Y, but you are Z.') so the agent can clearly understand the failure reason.