### PR TITLE
perf(dashboard): mock ToolExecutor to fix 100s+ vitest cold start

### DIFF
--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -47,6 +47,10 @@ vi.mock('./config-resolution-panel', () => ({
   ConfigResolutionPanel: () => html`<div>ConfigResolutionPanel</div>`,
 }))
 
+vi.mock('../tool-executor/tool-executor', () => ({
+  ToolExecutor: () => html`<div>ToolExecutor</div>`,
+}))
+
 import { Tools } from './tools-main'
 
 async function flush(): Promise<void> {


### PR DESCRIPTION
## Summary

- `tools-main.test.ts`가 cold start에서 100s+ 걸리던 문제 해결
- 원인: `ToolExecutor` 미mock으로 35개 transitive dependency(api barrel, MCP client 등)가 매번 transform됨
- `vi.mock('../tool-executor/tool-executor')` 추가 (테스트에서 해당 뷰를 활성화하지 않으므로 커버리지 영향 없음)

## Measured

| | Before | After |
|---|--------|-------|
| Total | 41s | 2.08s |
| Transform | 33s | 423ms |
| Import | 39s | 343ms |

## Test plan

- [x] `tools-main.test.ts` 3 tests pass
- [x] tools 디렉토리 전체 8 tests pass

Closes #4897

🤖 Generated with [Claude Code](https://claude.com/claude-code)