### PR TITLE
fix(keeper): memory budget defaults + save truncation + OAS build fix

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -299,14 +299,17 @@ let keeper_compact_max_messages () : int =
 let keeper_compact_max_tokens () : int =
   int_of_env_default
     "MASC_KEEPER_COMPACT_MAX_TOKENS"
-    ~default:0
+    ~default:8000
     ~min_v:0
     ~max_v:5000000
 
+(** Cooldown between compaction attempts.  Previous default (90s) exceeded
+    the proactive heartbeat interval (30s), permanently blocking compaction
+    for proactive keepers.  15s allows compaction to fire every other cycle. *)
 let keeper_continuity_compaction_cooldown_sec () : int =
   int_of_env_default
     "MASC_KEEPER_CONTINUITY_COMPACTION_COOLDOWN_SEC"
-    ~default:90
+    ~default:15
     ~min_v:0
     ~max_v:172800
 
@@ -654,11 +657,12 @@ let keeper_unified_max_tokens () : int =
     A productive keeper workflow (read -> inspect -> edit -> build -> verify)
     can consume 8-12 turns once retries and board/reporting steps are included.
     Previous default (1000) caused 787s+ latency per turn.
-    At 10, multi-step workflows still truncate too often before [extend_turns]
-    is used. *)
+    20 caused 6.7GB RSS in 2 minutes with 3 concurrent keepers (each turn
+    serializes full message history as JSON for the LLM API call).
+    3 is sufficient for proactive "one observation, one action" cycles. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:20
+    ~default:3
     ~min_v:1
     ~max_v:50

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -13,6 +13,16 @@ open Keeper_alerting
 open Keeper_exec_status
 
 (* ================================================================ *)
+(* Constants                                                         *)
+(* ================================================================ *)
+
+(** Maximum messages to retain in checkpoints (load and save).
+    Caps both load-time deserialization and save-time persistence to prevent
+    unbounded memory growth.  The context_reducer (keep_last 30) trims
+    further during Agent.run, so 60 gives the reducer room to operate. *)
+let max_checkpoint_messages = 60
+
+(* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
 (* ================================================================ *)
 
@@ -245,13 +255,8 @@ let context_of_oas_checkpoint
   let max_tokens =
     checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
   in
-  (* Cap loaded messages to prevent unbounded memory growth.
-     Checkpoints accumulate full message history (200+ messages, 500KB+).
-     With 9 keepers loading simultaneously, this causes 14GB+ peak allocation.
-     The context_reducer (keep_last 30) trims during Agent.run anyway,
-     so loading more than ~60 messages from checkpoint is wasted work.
-     Keep last 60 to give the reducer room to operate. *)
-  let max_checkpoint_messages = 60 in
+  (* Cap loaded messages — see module-level max_checkpoint_messages. *)
+  let max_checkpoint_messages = max_checkpoint_messages in
   let messages =
     let n = List.length cp.messages in
     if n <= max_checkpoint_messages then cp.messages
@@ -290,6 +295,16 @@ let save_oas_checkpoint
   let checkpoint_context = Agent_sdk.Context.copy ctx.context in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
+  (* Truncate messages at save time to match the load-time cap.
+     Without this, checkpoints grow unbounded between compaction cycles,
+     causing multi-GB transient allocations when loaded by concurrent keepers. *)
+  let capped_messages =
+    let n = List.length ctx.messages in
+    if n <= max_checkpoint_messages then ctx.messages
+    else
+      let drop = n - max_checkpoint_messages in
+      List.filteri (fun i _ -> i >= drop) ctx.messages
+  in
   let state =
     {
       Agent_sdk.Types.config =
@@ -300,7 +315,7 @@ let save_oas_checkpoint
           system_prompt = Some ctx.system_prompt;
           max_total_tokens = Some ctx.max_tokens;
         };
-      messages = ctx.messages;
+      messages = capped_messages;
       turn_count = 0;
       usage = Agent_sdk.Types.empty_usage;
     }


### PR DESCRIPTION
## Summary

- Keeper 메모리 폭발(3개 동시 → 6.7GB/2분) 근본 수정
- max_turns 20→3, compaction cooldown 90→15s, token_gate 0→8000
- Checkpoint save-time message truncation (60 cap)
- OAS 0.100.3 build fix (Tool_retry_policy 제거, swarm dep 추가)

## Problem

3 keepers × `Agent.run(max_turns=20)` × 매 turn 전체 히스토리 JSON 직렬화 = 6.7GB RSS in 2분.
Compaction cooldown 90s > heartbeat interval 30s → compaction이 proactive keeper에서 영구 차단.

## Evidence

| 설정 | RSS | 안정성 |
|------|-----|--------|
| keeper 0 | 35MB | OK |
| keeper 1 | 138MB | OK |
| keeper 3, old defaults | 6.7GB (2분) | crash |
| **keeper 2, new defaults** | **155MB (10분+)** | **OK** |

## Changes

1. `keeper_config.ml`: max_turns=3, cooldown=15s, token_gate=8000
2. `keeper_exec_context.ml`: save-time truncation (60 msg cap), module-level constant
3. Build fix: Tool_retry_policy 참조 15곳 제거, agent_sdk.swarm dep 추가

## Test plan

- [x] `dune build bin/main_eio.exe` pass
- [x] Phase 0 env var 검증: keeper 2, 10분+, RSS 155MB 안정
- [ ] CI Build and Test
- [ ] Phase 1 검증: 코드 default로 keeper 3 안정성

Closes #4838

🤖 Generated with [Claude Code](https://claude.com/claude-code)