### PR TITLE
chore: address review follow-ups from #4818 and #4835

### DIFF
--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -77,6 +77,9 @@ let friction_of_outcome = function
 (* JSONL persistence                                                *)
 (* ================================================================ *)
 
+(* Evaluated at module init time (eager). MASC_DATA_DIR / ME_ROOT must
+   be set before this module is loaded. Safe in practice because the
+   server sets all env vars at process startup. *)
 let default_base_path =
   let root = try Sys.getenv "MASC_DATA_DIR"
     with Not_found ->

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -172,6 +172,9 @@ let host_port_of_request request =
           host_header (Printexc.to_string exn);
         None)
 
+(* Evaluated at module init time (eager). MASC_ALLOW_ANONYMOUS_MUTATIONS
+   must be set before the module is loaded. This is safe because the
+   server process sets all env vars at startup before any module init. *)
 let allow_anonymous_mutations =
   match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
   | Some ("1" | "true") -> true

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -220,6 +220,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;
       let all_names = Keeper_types.keepalive_keeper_names config in
+      let all_count_names = List.length all_names in
     (* Cap concurrent keepers to prevent Eio event loop starvation.
        Each keeper heartbeat cycle does CPU-bound snapshot construction +
        LLM API calls.  With 9+ concurrent keepers, the single-domain Eio
@@ -230,9 +231,9 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
     in
     let names =
-      if List.length all_names > max_boot then begin
+      if all_count_names > max_boot then begin
         Log.Keeper.warn "autoboot: capping %d keepers to max %d (MASC_KEEPER_AUTOBOOT_MAX)"
-          (List.length all_names) max_boot;
+          all_count_names max_boot;
         List.filteri (fun i _ -> i < max_boot) all_names
       end else all_names
     in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -29,9 +29,9 @@ let () =
     let open Gc in
     let ctrl = get () in
     set { ctrl with
-      minor_heap_size = 2 * 1024 * 1024;  (* 16MB; reduces minor->major promotion rate *)
+      minor_heap_size = 2 * 1024 * 1024;  (* 2M words = 16MB on 64-bit; reduces minor->major promotion rate *)
       space_overhead = 200;               (* default 120; less frequent major GC slices *)
-      max_overhead = 500;                 (* default 500; keep compaction enabled *)
+      max_overhead = 500;                 (* compaction triggers when free memory exceeds 500% of live data *)
     }
   end
 


### PR DESCRIPTION
## Summary

- GC `max_overhead` / `minor_heap_size` 코멘트 수정 (값 모순 해소, word 단위 명시)
- `List.length all_names` 중복 계산 → `let all_count_names` 추출
- eager eval 동작 변경(`allow_anonymous_mutations`, `default_base_path`)에 module-init 제약 코멘트 추가

## Dismissed items (by design)

- Hidden + allow_direct_call_when_hidden: system tool 의도적 설계
- List.mem O(n*m): 리스트 <20개, bottleneck 아님
- Eio.Fiber.yield 도메인 설명: 정확하나 버그 아님

Closes #4883

🤖 Generated with [Claude Code](https://claude.com/claude-code)