### PR TITLE
fix(ci): update OAS pin SHA to v0.100.3 (1b293e2)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.3"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="fa365ac60309631ea3b5b46c9ca33b7cf9c4a379"
+readonly OAS_AGENT_SDK_SHA="1b293e24a1e324b68cff2ae9d3c07d6d4d85de0b"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.3"


### PR DESCRIPTION
## Summary
- Update `OAS_AGENT_SDK_SHA` from `fa365ac` (v0.100.2) to `1b293e2` (v0.100.3)
- Fixes CI failure: `agent_sdk >= 0.100.3 no matching version`
- Root cause: #4895 bumped MIN_VERSION to 0.100.3 but left SHA at the v0.100.2 commit

## Test plan
- [x] CI should resolve agent_sdk dependency and proceed to build