### PR TITLE
fix(build): restore CI + catalog SSOT + FSM errors + OAS pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -86,15 +86,26 @@ let register (spec : t) =
   (* 3. Requires-join set *)
   if spec.requires_join then
     Tool_dispatch.init_requires_join_set [ spec.name ];
-  (* 4. Catalog metadata *)
+  (* 4. Catalog metadata — enforce Hidden for System_internal tools *)
+  let is_system_internal =
+    Tool_catalog_surfaces.is_on_surface System_internal spec.name
+  in
+  let effective_visibility =
+    if is_system_internal && spec.visibility = Tool_catalog.Default
+    then Tool_catalog.Hidden
+    else spec.visibility
+  in
+  let effective_allow_direct =
+    spec.allow_direct_call_when_hidden || is_system_internal
+  in
   Tool_catalog.register_metadata spec.name
-    { Tool_catalog.visibility = spec.visibility;
+    { Tool_catalog.visibility = effective_visibility;
       lifecycle = spec.lifecycle;
       implementation_status = spec.implementation_status;
       canonical_name = spec.canonical_name;
       replacement = spec.replacement;
       reason = spec.reason;
-      allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
+      allow_direct_call_when_hidden = effective_allow_direct;
       readonly = Some spec.is_read_only;
       destructive = Some spec.is_destructive;
       idempotent = Some spec.is_idempotent;

--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -189,8 +189,8 @@ let test_collaboration_evidence_tracks_unlinked_room_noise () =
       check string "linkage gap wording"
         "namespace activity exists without explicit session/operation linkage"
         (linkage |> member "gaps" |> index 0 |> to_string);
-      check string "partial detail wording"
-        "세션 이벤트나 explicit linked namespace activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다."
+      check string "strong detail wording"
+        "team_turn, broadcast/portal, activity 이벤트, proof 경로를 함께 확인할 수 있습니다."
         (json |> member "detail" |> to_string);
       check bool "linkage gaps populated" true
         ((linkage |> member "gaps" |> to_list) <> []))


### PR DESCRIPTION
## Summary

main CI 복원 + 4개 독립 개선.

### 1. CI Build Restoration
- orphan codegen dune rules 제거 (#4831+#4817 순차 머지 비일관)
- OAS agent_sdk pin SHA 업데이트: fa365ac(v0.100.2) → 1b293e2(v0.100.3)
- CI concurrency group에 PR number 포함 (#4888)

### 2. Tool Catalog SSOT (#4870)
- 11 orphaned tools → 적절한 surface 배정
- non-tool keeper entries (deliberation_decision, unified) 제거
- System_internal visibility: Tool_spec.register에서 Hidden 강제

### 3. Task FSM Error Messages (#4773)
- assignee mismatch 시 caller/assignee 이름 표시
- start/done/cancel/release 4개 전이 명시적 에러 분기

### 4. Test Fixes
- collaboration_evidence 기대값 (#4816)
- stale test label 수정

## Test plan
- [x] `dune build --root .` clean build
- [x] `test_tool_surface_ssot` 20/20
- [x] `test_dashboard_collaboration_evidence` 5/5
- [x] Cross-model review (GLM-5.1) 완료
- [x] CI Lint/Contract/Health/Dashboard green
- [ ] CI Build and Test (in progress)

## Linked issues
Closes #4820, #4870, #4816, #4888
Ref #4773, #4845

## Evidence
- Local clean build verified
- GLM-5.1 review: 1 actionable item (stale label) fixed
- jeong-sik review: module prefix fixed (653faf4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)