### PR TITLE
fix(keeper): allow read-only masc_pause_status in keeper dispatch

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -93,14 +93,14 @@ let dispatch
   | Mod_room ->
       Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args
   | Mod_control ->
-      (* Review #4579: Mod_control exposes room lifecycle tools.
-         Too risky for autonomous keeper dispatch. Return explicit error
-         (not None) so callers distinguish intentional blocking from
-         unknown-tool-for-tag. None is reserved for "tag has no handler
-         for this tool name". *)
-      Some (false,
-        Printf.sprintf
-          "tool '%s' is blocked in keeper context (Mod_control is operator-only)" name)
+      (* masc_pause_status is read-only — safe for keeper dispatch.
+         masc_pause/masc_resume modify room lifecycle — blocked. *)
+      if name = "masc_pause_status" then
+        Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args
+      else
+        Some (false,
+          Printf.sprintf
+            "tool '%s' is blocked in keeper context (Mod_control is operator-only)" name)
   | Mod_agent_timeline ->
       Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name }
         ~name ~args


### PR DESCRIPTION
## Summary

- `masc_pause_status`는 read-only 쿼리지만 `Mod_control` 전체 차단에 의해 keeper에서 호출 불가
- 일 13회 0ms 실패 발생 (keeper가 pause 상태를 확인하려 할 때)
- `masc_pause_status`만 허용, `masc_pause`/`masc_resume`은 차단 유지

Closes #4777

🤖 Generated with [Claude Code](https://claude.com/claude-code)