### PR TITLE
perf(dashboard): enable Executor_pool offloading for FileSystem backend

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -277,36 +277,48 @@ module FileSystem = struct
     | _ -> acc
 
   let ensure_key_index t =
-    if ki_length t > 0 then ()
-    else
-      match t.key_index_promise with
-      | Some p ->
-        (* Another fiber is populating — wait for it rather than
-           proceeding with an empty index or starting a duplicate. *)
-        (match Eio.Promise.await p with
-         | Ok () -> ()
-         | Error _ -> ())
-      | None ->
-        let p, r = Eio.Promise.create () in
-        t.key_index_promise <- Some p;
-        (try
-           let keys =
-             collect_keys_under ~requested_prefix:"" ~logical_prefix:"" t.fs []
-           in
-           ki_replace_bulk t (List.map (fun k -> (k, ())) keys);
-           let len = ki_length t in
-           if len > 0 then
-             Log.legacy_traceln ~level:Log.Info ~module_name:"Backend"
-               (Printf.sprintf "key_index populated: %d keys" len);
-           Eio.Promise.resolve_ok r ()
-         with exn ->
-           t.key_index_promise <- None;
-           Eio.Promise.resolve_error r exn;
-           match exn with
-           | Eio.Cancel.Cancelled _ -> raise exn
-           | _ ->
-             Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-               (Printf.sprintf "key_index population failed: %s" (Printexc.to_string exn)))
+    (* Domain-safe check-and-populate.  Stdlib.Mutex serializes the
+       check of key_index length + key_index_promise so that two
+       Executor_pool domains cannot both start a population traverse.
+       The mutex is released BEFORE Eio.Promise.await (which needs Eio
+       fiber context and would deadlock under a held Stdlib.Mutex). *)
+    let action =
+      Mutex.lock t.key_index_mu;
+      Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+        if Hashtbl.length t.key_index > 0 then `Done
+        else match t.key_index_promise with
+          | Some p -> `Wait p
+          | None ->
+            let p, r = Eio.Promise.create () in
+            t.key_index_promise <- Some p;
+            `Populate r)
+    in
+    match action with
+    | `Done -> ()
+    | `Wait p ->
+      (match Eio.Promise.await p with Ok () -> () | Error _ -> ())
+    | `Populate r ->
+      (try
+         let keys =
+           collect_keys_under ~requested_prefix:"" ~logical_prefix:"" t.fs []
+         in
+         ki_replace_bulk t (List.map (fun k -> (k, ())) keys);
+         let len = ki_length t in
+         if len > 0 then
+           Log.legacy_traceln ~level:Log.Info ~module_name:"Backend"
+             (Printf.sprintf "key_index populated: %d keys" len);
+         Eio.Promise.resolve_ok r ()
+       with exn ->
+         Mutex.lock t.key_index_mu;
+         Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+           t.key_index_promise <- None);
+         Eio.Promise.resolve_error r exn;
+         match exn with
+         | Eio.Cancel.Cancelled _ -> raise exn
+         | _ ->
+           Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+             (Printf.sprintf "key_index population failed: %s"
+                (Printexc.to_string exn)))
 
   (** Check if key exists (in-memory index first, filesystem fallback) *)
   let exists t key =

--- a/lib/server/server_dashboard_http_runtime_support.ml
+++ b/lib/server/server_dashboard_http_runtime_support.ml
@@ -132,11 +132,14 @@ let run_dashboard_compute state ?(mode = Offloaded_readonly) ?runtime ~sw ~clock
   match mode with
   | Inline_shared -> fallback ()
   | Offloaded_readonly ->
-      (* Non-PG backends (FileSystem, Memory) run inline: filesystem ops are
-         lightweight and Keeper_registry uses no mutex (non-yielding ops in
-         single-domain Eio are inherently atomic).  The executor pool exists
-         for PG connection isolation only. *)
-      if is_pg then offloaded () else fallback ()
+      (* All backends offload to executor pool when available.
+         FileSystem: key_index protected by Stdlib.Mutex (domain-safe),
+         file I/O by Eio.Mutex (domain-safe via Stdlib.Mutex internally).
+         Memory: Eio_guard.with_mutex delegates to Eio.Mutex (domain-safe).
+         PG: creates domain-local connection pool (already supported).
+         Offloading isolates dashboard compute from keeper turns on the
+         main domain, eliminating contention-induced latency spikes. *)
+      offloaded ()
 
 let dashboard_active_or_recent_sessions_cached state ~clock
     ~refresh_interval_s config load_sessions =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -100,9 +100,10 @@ let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
     (result_domain = caller_domain)
 
 let test_run_dashboard_compute_with_pool_uses_executor_domain () =
-  (* Non-PG backends (FileSystem, Memory) run inline even when a pool is
-     available, to avoid cross-domain Eio.Mutex deadlock.  Only PG backends
-     offload to the executor pool.  This test verifies the inline path. *)
+  (* All backends offload to the executor pool when available.
+     FileSystem key_index is domain-safe via Stdlib.Mutex; Eio.Mutex
+     is domain-safe via Stdlib.Mutex internally.  Offloading isolates
+     dashboard compute from keeper turns on the main domain. *)
   with_test_env @@ fun ~env ~sw ~config ->
   let exec_pool =
     Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
@@ -116,8 +117,8 @@ let test_run_dashboard_compute_with_pool_uses_executor_domain () =
       ~config
       (fun ~config:_ ~sw:_ -> Domain.self ())
   in
-  check bool "non-PG backend stays on caller domain (inline)" true
-    (result_domain = caller_domain)
+  check bool "non-PG backend offloads to executor pool domain" true
+    (result_domain <> caller_domain)
 
 let test_run_dashboard_compute_without_pool_uses_isolated_pg_backend () =
   with_pg_test_env @@ fun ~env ~sw ~config ->


### PR DESCRIPTION
## Summary
- `ensure_key_index` TOCTOU race를 Stdlib.Mutex로 수정하여 cross-domain 안전성 확보
- `run_dashboard_compute`에서 `is_pg` 가드 제거 → FileSystem/Memory 모두 Executor_pool offload
- Dashboard snapshot이 별도 domain에서 실행되어 keeper turn과의 contention 제거

## Product impact
Keeper 활성 시 dashboard snapshot latency: avg 3061ms → ~600-800ms (추정, 도메인 분리 효과)

## Evidence
```
# Before: keeper 활성 시 same-domain contention
sessions_json: min=600ms avg=2094ms max=6348ms (20 sessions)

# After: separate domain, no contention
Expected: ~600ms consistently (idle baseline과 동일)
```

## Review evidence
교차 모델 리뷰 예정 (GLM-5.1)

Closes #4894

## Test plan
- [ ] 테스트 assertion 변경: non-PG backend가 executor pool domain으로 offload되는지 확인
- [ ] 서버 재빌드 후 keeper 활성 상태에서 snapshot_json total 측정
- [ ] key_index populated 로그가 1회만 출현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)