### PR TITLE
chore: address review comments from #4911 and #4912

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -83,9 +83,17 @@ module FileSystem = struct
       (fun () -> Hashtbl.length t.key_index)
 
   let ki_iter t f =
+    let entries =
+      Mutex.lock t.key_index_mu;
+      Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+        Hashtbl.fold (fun k v acc -> (k, v) :: acc) t.key_index [])
+    in
+    List.iter (fun (k, v) -> f k v) entries
+
+  let ki_replace_bulk t entries =
     Mutex.lock t.key_index_mu;
-    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu)
-      (fun () -> Hashtbl.iter f t.key_index)
+    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+      List.iter (fun (k, v) -> Hashtbl.replace t.key_index k v) entries)
 
   (** {2 Key Validation} *)
 
@@ -285,7 +293,7 @@ module FileSystem = struct
            let keys =
              collect_keys_under ~requested_prefix:"" ~logical_prefix:"" t.fs []
            in
-           List.iter (fun k -> ki_replace t k ()) keys;
+           ki_replace_bulk t (List.map (fun k -> (k, ())) keys);
            let len = ki_length t in
            if len > 0 then
              Log.legacy_traceln ~level:Log.Info ~module_name:"Backend"

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -100,7 +100,7 @@ let dispatch
       else
         Some (false,
           Printf.sprintf
-            "tool '%s' is blocked in keeper context (Mod_control is operator-only)" name)
+            "tool '%s' is blocked in keeper context (lifecycle-mutating Mod_control tools are operator-only)" name)
   | Mod_agent_timeline ->
       Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name }
         ~name ~args

--- a/test/dune
+++ b/test/dune
@@ -249,6 +249,7 @@
         test_keeper_tool_exposure
         test_keeper_voice_loop
         test_keeper_task_dispatch
+        test_keeper_tag_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio
         test_mcp_server_eio_call_tool
@@ -389,6 +390,7 @@
         test_keeper_tool_exposure
         test_keeper_voice_loop
         test_keeper_task_dispatch
+        test_keeper_tag_dispatch
         test_autoresearch_knowledge
         test_mcp_server_eio
         test_mcp_server_eio_call_tool

--- a/test/test_keeper_tag_dispatch.ml
+++ b/test/test_keeper_tag_dispatch.ml
@@ -1,0 +1,90 @@
+(** Regression tests for Keeper_tag_dispatch — Mod_control gate.
+
+    Verifies that masc_pause_status (read-only) is allowed while
+    lifecycle-mutating tools (masc_pause, masc_resume) are blocked. *)
+
+open Alcotest
+open Masc_mcp
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+(* Temp directory setup matching test_keeper_task_dispatch.ml pattern. *)
+let with_room f =
+  Eio_main.run @@ fun _env ->
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tag_dispatch_%d" (Random.int 1_000_000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try
+        let rec rm path =
+          if Sys.is_directory path then begin
+            Sys.readdir path |> Array.iter (fun f ->
+              rm (Filename.concat path f));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+        in
+        rm dir
+      with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let _msg = Room.init config ~agent_name:(Some "test-keeper") in
+      f config)
+
+let dispatch config name =
+  Keeper_tag_dispatch.dispatch
+    ~config ~agent_name:"test-keeper"
+    ~tag:Tool_dispatch.Mod_control
+    ~name ~args:(`Assoc [])
+
+(* masc_pause_status is read-only — should be allowed. *)
+let test_pause_status_allowed () =
+  with_room (fun config ->
+    match dispatch config "masc_pause_status" with
+    | Some (true, _msg) -> ()
+    | Some (false, msg) ->
+        fail (Printf.sprintf "masc_pause_status should succeed, got error: %s" msg)
+    | None ->
+        fail "masc_pause_status returned None (tool not recognized)")
+
+(* masc_pause mutates lifecycle — should be blocked. *)
+let test_pause_blocked () =
+  with_room (fun config ->
+    match dispatch config "masc_pause" with
+    | Some (false, msg) ->
+        check bool "error mentions blocked" true
+          (contains_substring msg "blocked")
+    | Some (true, _) ->
+        fail "masc_pause should be blocked in keeper context"
+    | None ->
+        fail "masc_pause returned None")
+
+(* masc_resume mutates lifecycle — should be blocked. *)
+let test_resume_blocked () =
+  with_room (fun config ->
+    match dispatch config "masc_resume" with
+    | Some (false, msg) ->
+        check bool "error mentions blocked" true
+          (contains_substring msg "blocked")
+    | Some (true, _) ->
+        fail "masc_resume should be blocked in keeper context"
+    | None ->
+        fail "masc_resume returned None")
+
+let () =
+  Alcotest.run "Keeper_tag_dispatch" [
+    "Mod_control gate", [
+      test_case "masc_pause_status allowed" `Quick test_pause_status_allowed;
+      test_case "masc_pause blocked" `Quick test_pause_blocked;
+      test_case "masc_resume blocked" `Quick test_resume_blocked;
+    ];
+  ]


### PR DESCRIPTION
## Summary

머지된 PR의 Copilot 리뷰 코멘트 일괄 대응:

### #4912 (keeper dispatch)
- 에러 메시지를 "lifecycle-mutating Mod_control tools are operator-only"로 수정
- keeper tag dispatch 회귀 테스트 3개 추가 (pause_status 허용, pause/resume 차단)

### #4911 (domain-safe key_index)
- `ki_iter` snapshot-then-iterate 패턴으로 변경 (콜백 중 교착 방지)
- `ki_replace_bulk` 추가 — 초기 population 시 lock 1회로 축소

## Test plan

- [x] `dune build --root . lib/ bin/ test/` 성공
- [x] keeper_tag_dispatch 테스트 3개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)