### PR TITLE
[codex] Reduce dashboard mission snapshot memory pressure

### DIFF
--- a/dashboard/src/components/mission-briefing-card.test.ts
+++ b/dashboard/src/components/mission-briefing-card.test.ts
@@ -168,7 +168,7 @@ describe('MissionBriefingCard', () => {
       source: 'judge_runtime',
       online: true,
     })
-  }, 20000)
+  }, 40000)
 
   it('falls back to available keepers and returns null when none are usable', async () => {
     const { resolveLiveJudgeTarget } = await loadMissionBriefingCard()
@@ -214,7 +214,7 @@ describe('MissionBriefingCard', () => {
     )
 
     expect(unavailableTarget).toBeNull()
-  }, 20000)
+  }, 40000)
 
   it('does not mark judge runtime online when runtime and keeper state are both unknown', async () => {
     const { resolveLiveJudgeTarget } = await loadMissionBriefingCard()
@@ -237,7 +237,7 @@ describe('MissionBriefingCard', () => {
       source: 'judge_runtime',
       online: false,
     })
-  }, 20000)
+  }, 40000)
 
   it('builds a safe situation report even when mission facts are sparse', async () => {
     const { buildLiveJudgeSituationReport } = await loadMissionBriefingCard()
@@ -317,5 +317,54 @@ describe('MissionBriefingCard', () => {
     expect(payload?.message).toContain('[상황 보고] live-judge · glm-5')
     expect(payload?.message).toContain('deterministic 요약')
     expect(payload?.message).toContain('답변 형식: 1) 지금 위험 1-3개 2) 바로 필요한 조치 3) 놓친 관측 공백')
+  }, 20000)
+
+  it('uses mission keeper briefs as a fallback without forcing operator snapshot state', async () => {
+    const navigateMock = vi.fn()
+    const {
+      MissionBriefingCard,
+      missionStore,
+      operatorStore,
+      sharedStore,
+      workflowContext,
+    } = await loadMissionBriefingCard(navigateMock)
+
+    missionStore.missionSnapshot.value = {
+      ...sampleMission(),
+      keeper_briefs: [
+        {
+          name: 'mission-judge',
+          status: 'running',
+        },
+      ],
+    } as unknown as DashboardMissionResponse
+    missionStore.missionBriefing.value = sampleBriefing()
+    missionStore.missionBriefingError.value = null
+    missionStore.missionBriefingLoading.value = false
+    operatorStore.operatorSnapshot.value = null
+    sharedStore.keepers.value = []
+
+    render(html`<${MissionBriefingCard} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('mission-judge')
+
+    const button = Array.from(container.querySelectorAll('button'))
+      .find(item => item.textContent?.includes('실제 판단 요청 열기'))
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      'command',
+      expect.objectContaining({
+        section: 'intervene',
+        action_type: 'keeper_message',
+        target_type: 'keeper',
+        target_id: 'mission-judge',
+      }),
+    )
+
+    const payload = workflowContext.dashboardWorkflowContext.value?.suggested_payload as Record<string, unknown> | null
+    expect(payload?.message).toContain('[상황 보고] mission-judge')
   }, 20000)
 })

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -14,7 +14,7 @@ import {
   refreshMissionBriefing,
 } from '../mission-store'
 import { keepers } from '../store'
-import { operatorSnapshot, refreshOperatorSnapshot } from '../operator-store'
+import { operatorSnapshot } from '../operator-store'
 import { navigate } from '../router'
 import {
   missionTargetTypeLabel,
@@ -31,6 +31,7 @@ import {
 import type { DashboardWorkflowContext } from '../workflow-context'
 import type {
   DashboardMissionBriefingResponse,
+  DashboardMissionKeeperBrief,
   DashboardMissionResponse,
   Keeper,
   OperatorSnapshot,
@@ -137,6 +138,15 @@ export function resolveLiveJudgeTarget(
   }
 }
 
+function fallbackKeepersFromMission(
+  mission: DashboardMissionResponse | null | undefined,
+): Keeper[] {
+  return (mission?.keeper_briefs ?? []).map((keeper: DashboardMissionKeeperBrief) => ({
+    name: keeper.name,
+    status: keeper.status ?? 'unknown',
+  }))
+}
+
 export function buildLiveJudgeSituationReport({
   mission,
   briefing,
@@ -206,7 +216,10 @@ function createLiveJudgeWorkflowContext(
 export function MissionBriefingCard() {
   const mission = missionSnapshot.value
   const briefing = missionBriefing.value
-  const liveJudge = resolveLiveJudgeTarget(operatorSnapshot.value, keepers.value)
+  const liveJudge = resolveLiveJudgeTarget(
+    operatorSnapshot.value,
+    keepers.value.length > 0 ? keepers.value : fallbackKeepersFromMission(mission),
+  )
   const liveJudgeTone = toneClass(liveJudge?.online ? 'ok' : 'warn')
   const liveJudgeReport =
     mission && liveJudge
@@ -223,12 +236,6 @@ export function MissionBriefingCard() {
       void refreshMissionBriefing()
     }
   }, [briefing, missionBriefingLoading.value, missionBriefingError.value])
-
-  useEffect(() => {
-    if (!operatorSnapshot.value) {
-      void refreshOperatorSnapshot({ force: true })
-    }
-  }, [])
 
   const openLiveJudgeIntervene = () => {
     if (!liveJudge) return

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -135,12 +135,12 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
     in
     let snapshot_json =
       (* Reuse the same lightweight summary shape as the operator/mission
-         dashboard surfaces. The briefing only needs session status/events and
-         keeper rows; pulling full command-plane and message payloads here
-         duplicates the heaviest snapshot path and can spike memory on rooms
-         with many keepers. *)
+         dashboard surfaces. The briefing only needs session status/events;
+         keeper metadata can come from mission_json. Pulling keepers,
+         command-plane, and message payloads here duplicates the heaviest
+         snapshot path and can spike memory on rooms with many keepers. *)
       Operator_control.snapshot_json ~actor:actor_name ~view:"summary"
-        ~include_messages:false ~include_sessions:true ~include_keepers:true
+        ~include_messages:false ~include_sessions:true ~include_keepers:false
         ~include_summary_fields:false ~include_command_plane:false
         ~lightweight_summary:true ctx
     in
@@ -168,7 +168,7 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
       Briefing_compactors.relevant_sessions_for_briefing ~current_namespace ~now_ts sessions
     in
     let keepers =
-      match snapshot_json |> member_assoc "keepers" |> member_assoc "items" with
+      match mission_json |> member_assoc "keeper_briefs" with
       | `List items -> items
       | _ -> []
     in

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -134,8 +134,15 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
       }
     in
     let snapshot_json =
+      (* Reuse the same lightweight summary shape as the operator/mission
+         dashboard surfaces. The briefing only needs session status/events and
+         keeper rows; pulling full command-plane and message payloads here
+         duplicates the heaviest snapshot path and can spike memory on rooms
+         with many keepers. *)
       Operator_control.snapshot_json ~actor:actor_name ~view:"summary"
-        ~include_messages:true ~include_sessions:true ~include_keepers:true ctx
+        ~include_messages:false ~include_sessions:true ~include_keepers:true
+        ~include_summary_fields:false ~include_command_plane:false
+        ~lightweight_summary:true ctx
     in
     let sessions =
       match snapshot_json |> member_assoc "sessions" |> member_assoc "items" with

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -325,6 +325,23 @@ let test_dashboard_component_split_contracts () =
     (file_contains_pattern "lib/room/room_utils_backend_setup.ml"
        "Transaction Pooler companion")
 
+let test_mission_briefing_memory_guard_contracts () =
+  check bool "mission briefing snapshot disables keeper payload" true
+    (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
+       "~include_keepers:false");
+  check bool "mission briefing snapshot stays off command plane" true
+    (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
+       "~include_command_plane:false");
+  check bool "mission briefing snapshot stays lightweight" true
+    (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
+       "~lightweight_summary:true");
+  check bool "mission briefing reuses mission keeper briefs" true
+    (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
+       {|mission_json |> member_assoc "keeper_briefs"|});
+  check bool "mission briefing card no longer forces eager operator snapshot" true
+    (file_not_contains_pattern "dashboard/src/components/mission-briefing-card.ts"
+       "refreshOperatorSnapshot({ force: true })")
+
 let test_activity_surface_contracts () =
   check bool "activity tab exposes activity graph label" true
     (file_contains_pattern "dashboard/src/components/activity.ts"
@@ -673,6 +690,8 @@ let () =
              test_room_current_validation_contracts;
            test_case "root redirect contracts" `Quick test_root_redirect_contracts;
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
+           test_case "mission briefing memory guard contracts" `Quick
+             test_mission_briefing_memory_guard_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;


### PR DESCRIPTION
## Summary
- make mission briefing reuse the lightweight operator summary snapshot path
- stop mission briefing from forcing an eager `/api/v1/operator` fetch on mission mount
- cover the fallback live-judge path in mission briefing card tests

## Verification
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard exec vitest run src/components/mission-briefing-card.test.ts --no-file-parallelism --maxWorkers=1`
- `opam exec -- dune build -j 1 --root . lib/dashboard/dashboard_mission_briefing.ml`

## Notes
- full `test/test_dashboard_mission_briefing.exe` target still hit the repo's intermittent dune/xcodebuild hang pattern in this worktree, so I validated the touched OCaml file target instead.