### PR TITLE
fix(ci): stabilize quick-suite follow-ups

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -284,9 +284,9 @@ let personas_dirs_with inputs resolution =
     if resolution.personas.exists then [ resolution.personas.path ] else []
   in
   let explicit_personas_dir_override = trim_opt inputs.env_personas_dir in
-  (* inputs.env_personas_dir is populated only from MASC_PERSONAS_DIR.
-     A generic config-root env override should still include HOME/base
-     personas dirs. *)
+  (* inputs.env_personas_dir is populated only from MASC_PERSONAS_DIR, so
+     only that explicit override becomes sole-source. A generic config-root
+     env override still leaves HOME/base personas discovery enabled. *)
   match explicit_personas_dir_override with
   | Some _ -> dedupe_paths primary
   | _ ->

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -283,12 +283,11 @@ let personas_dirs_with inputs resolution =
   let primary =
     if resolution.personas.exists then [ resolution.personas.path ] else []
   in
-  (* When MASC_PERSONAS_DIR is explicitly set, it acts as the sole
-     override — do not append $HOME or $MASC_BASE_PATH dirs.
-     Check the input env var directly rather than the resolved source,
-     because child_item inherits the config_root source (which may be
-     Env from MASC_CONFIG_DIR) even when MASC_PERSONAS_DIR is unset. *)
-  match trim_opt inputs.env_personas_dir with
+  let explicit_personas_dir_override = trim_opt inputs.env_personas_dir in
+  (* inputs.env_personas_dir is populated only from MASC_PERSONAS_DIR.
+     A generic config-root env override should still include HOME/base
+     personas dirs. *)
+  match explicit_personas_dir_override with
   | Some _ -> dedupe_paths primary
   | _ ->
     let extra_candidates =

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -60,8 +60,23 @@ let known_non_keeper_tool_names : string list =
   |> List.sort_uniq String.compare
 
 let known_shared_agent_keeper_tool_names : string list =
-  [ "masc_worktree_create"; "masc_worktree_list";
-    "masc_code_write"; "masc_code_edit"; "masc_code_shell"; "masc_code_git" ]
+  [
+    "masc_worktree_create";
+    "masc_worktree_list";
+    "masc_code_write";
+    "masc_code_edit";
+    "masc_code_shell";
+    "masc_code_git";
+  ]
+
+let test_known_shared_tools_exist_on_agent_surface () =
+  let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (name ^ " is exposed on spawned agent surface")
+        true (List.mem name agent_names))
+    known_shared_agent_keeper_tool_names
 
 (* ============================================================
    Invariant 1: Non-research keepers only get keeper_* tools plus
@@ -234,6 +249,8 @@ let () =
       Alcotest.test_case "spawned agent surface" `Quick test_agent_surface_no_keeper_tools;
     ]);
     ("disjoint_namespaces", [
+      Alcotest.test_case "shared tool whitelist stays real" `Quick
+        test_known_shared_tools_exist_on_agent_surface;
       Alcotest.test_case "heuristic vs agent" `Quick test_no_overlap_heuristic_vs_agent;
       Alcotest.test_case "research vs agent" `Quick test_no_overlap_research_vs_agent;
       Alcotest.test_case "shard vs agent" `Quick test_shard_tools_overlap_with_agent_documented;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,7 +300,6 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
-  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -300,6 +300,7 @@ let ensure_joined fixture =
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in
+  Unix.putenv "MASC_BASE_PATH" base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;


### PR DESCRIPTION
## Summary
- keep `personas_dirs_with` sole-source behavior tied only to explicit `MASC_PERSONAS_DIR`, so generic config-root overrides still retain HOME/base personas discovery
- align dashboard collaboration-evidence quick-suite expectations with the current partial-linkage branch
- document the shared keeper-agent tool overlap and assert the whitelist still points at the spawned-agent public surface

## Product impact
- restores the quick-suite cases that failed in `Build and Test` after the earlier CI follow-up branch
- keeps the follow-up PR scoped to the three files that still differ from `main`

## Evidence
- clean checkout targeted tests passed:
  - `test_config_dir_resolver.exe -- test personas_dirs 1`
  - `test_keeper_agent_isolation.exe -- test disjoint_namespaces`
  - `test_dashboard_collaboration_evidence.exe -- test collaboration_evidence`
  - `test_ci_hardening_source.exe -- test source_guard 20`

## Review evidence
- direct `sb glm-text` review produced context-limited notes only; manual follow-up confirmed the referenced production string and agent-surface symbol already exist on current `main`
- fallback `./scripts/review/local-review.sh --base origin/main --head HEAD --format text` produced the same context-limited notes

## Linked issue
- Refs #4820
- Refs #4888
