### PR TITLE
perf(dashboard): move command_plane_json into parallel fiber block

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -717,18 +717,6 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
       ]
     else [])
   in
-  let command_plane_json = timed "command_plane_json" (fun () ->
-    if initialized && include_command_plane then
-      Command_plane_v2.snapshot_json ~sessions:tracked_sessions config
-    else
-      `Null)
-  in
-  let swarm_status_json =
-    if initialized && include_command_plane then
-      Swarm_status.build_json_from_snapshot config command_plane_json
-    else
-      `Null
-  in
   let keeper_names =
     if initialized && include_keepers then
       Keeper_types.keeper_names config
@@ -746,13 +734,17 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
          ("namespace", room_json config);
        ]
       @ (
-         (* Parallelize independent I/O: sessions, keepers, persistent_agents.
-            Eio.Fiber.all runs all thunks as fibers within the current switch,
-            completing when all finish. On failure, remaining fibers are cancelled. *)
+         (* Parallelize independent I/O: sessions, keepers, persistent_agents,
+            and command_plane + swarm_status.  command_plane_json was previously
+            computed sequentially before the fiber block, blocking the entire
+            snapshot when CP took 13s+.  Now it runs as a 4th fiber, overlapping
+            with sessions/keepers I/O. *)
          let empty_section = `Assoc [ ("count", `Int 0); ("items", `List []) ] in
          let sessions_ref = ref empty_section in
          let keepers_ref = ref empty_section in
          let persistent_ref = ref empty_section in
+         let command_plane_ref = ref `Null in
+         let swarm_status_ref = ref `Null in
          Eio.Fiber.all [
            (fun () ->
              sessions_ref :=
@@ -760,8 +752,6 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
                  if initialized && include_sessions then
                    let capped =
                      if lightweight_summary then
-                       (* Lightweight: only active/paused + last 5 recent.
-                          Full session_status_json is heavy (reads events per session). *)
                        let active, rest =
                          List.partition (fun (s : Team_session_types.session) ->
                            s.status = Running || s.status = Paused) tracked_sessions
@@ -789,16 +779,27 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
                  if initialized && include_keepers then
                    persistent_agents_json ~keeper_names config
                  else empty_section));
+           (fun () ->
+             let cp = timed "command_plane_json" (fun () ->
+               if initialized && include_command_plane then
+                 Command_plane_v2.snapshot_json ~sessions:tracked_sessions config
+               else `Null)
+             in
+             command_plane_ref := cp;
+             swarm_status_ref :=
+               if initialized && include_command_plane then
+                 Swarm_status.build_json_from_snapshot config cp
+               else `Null);
          ];
          [
            ("sessions", !sessions_ref);
            ("keepers", !keepers_ref);
            ("persistent_agents", !persistent_ref);
-           ("command_plane", command_plane_json);
+           ("command_plane", !command_plane_ref);
          ]
       )
       @ [
-         ("swarm_status", swarm_status_json);
+         ("swarm_status", !swarm_status_ref);
        ]
       @ (let (role_census, runtime_pools, lane_census, controller_census,
               control_domains, task_profiles, escalation_count) =

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -796,11 +796,9 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
            ("keepers", !keepers_ref);
            ("persistent_agents", !persistent_ref);
            ("command_plane", !command_plane_ref);
+           ("swarm_status", !swarm_status_ref);
          ]
       )
-      @ [
-         ("swarm_status", !swarm_status_ref);
-       ]
       @ (let (role_census, runtime_pools, lane_census, controller_census,
               control_domains, task_profiles, escalation_count) =
            timed "aggregates" (fun () -> aggregate_all_worker_metrics tracked_sessions)


### PR DESCRIPTION
## Summary
- `command_plane_json` + `swarm_status_json`이 Eio.Fiber.all 바깥에서 순차 실행되던 것을 4번째 fiber로 이동
- CP snapshot이 13초+ 걸릴 때 sessions/keepers를 블로킹하던 문제 해결

## Product impact
snapshot total = command_plane + max(sessions, keepers) → max(command_plane, sessions, keepers)

## Evidence
```
# Before: CP가 13s일 때
total = 13s(cp) + 1s(max(sessions,keepers)) = 14s

# After: 병렬
total = max(13s, 1s) = 13s (CP 자체 최적화는 별도 이슈)

# CP가 1s일 때
Before: total = 1s(cp) + 1s = 2s
After:  total = max(1s, 1s) = 1s
```

## Review evidence
교차 모델 리뷰 예정

## Test plan
- [ ] snapshot_json total 로그에서 command_plane_json이 sessions/keepers와 병렬 실행 확인
- [ ] command_plane/swarm_status 결과 무결성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)