### PR TITLE
fix(test): align max_turns default assertion with #4818 change

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -670,7 +670,7 @@ let test_unified_turn_runtime_defaults () =
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
       (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 20
+    check int "unified max_turns default" 3
       (KC.keeper_unified_max_turns ()))))
 
 let test_meta_defaults_social_model () =


### PR DESCRIPTION
keeper_unified_max_turns default was lowered 20→3 in #4818 (memory fix) but test assertion was not updated. This is the last remaining CI blocker for multiple open PRs.