### PR TITLE
[codex] simplify project-scope language

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -340,7 +340,7 @@ export function fetchOperatorSnapshot(): Promise<OperatorSnapshot> {
 }
 
 export function fetchOperatorDigest(options: {
-  targetType?: 'room' | 'team_session'
+  targetType?: 'namespace' | 'room' | 'team_session'
   targetId?: string
   includeWorkers?: boolean
 } = {}): Promise<OperatorDigest> {

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -65,7 +65,7 @@ function kindLabel(kind: string): string {
     case 'operation': return '작전'
     case 'debate': return '토론'
     case 'post': return '게시글'
-    case 'room': return '네임스페이스'
+    case 'room': return '프로젝트'
     default: return kind
   }
 }

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -402,7 +402,7 @@ export function AgentProfile({ name }: { name: string }) {
           <${AgentLiveTimeline} name=${name} />
         <//>
 
-        <${Card} title="네임스페이스 활동" class="ff-card rounded-xl">
+        <${Card} title="프로젝트 활동" class="ff-card rounded-xl">
           ${lines.length === 0
             ? html`<${EmptyState} message="관련 활동 없음" compact />`
             : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -422,7 +422,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     </div>
                     <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-body)]">${fallbackStateMessage}</p>
                     <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
-                      <span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">namespace ${namespaceName}</span>
+                      <span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
                       ${namespaceBasePath ? html`<code class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px]">${namespaceBasePath}</code>` : null}
                     </div>
                   </div>

--- a/dashboard/src/components/collaboration-evidence.test.ts
+++ b/dashboard/src/components/collaboration-evidence.test.ts
@@ -10,7 +10,7 @@ function collaborationEvidenceFixture(): DashboardCollaborationEvidenceResponse 
     generated_at: '2026-03-27T00:00:00Z',
     evidence_status: 'partial',
     headline: '상호작용 흔적은 있지만 증거가 분산돼 있습니다.',
-    detail: '세션 이벤트나 namespace activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다.',
+    detail: '세션 이벤트나 project activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다.',
     session: null,
     room_id: 'default',
     counts: {
@@ -79,14 +79,14 @@ describe('collaborationEvidenceSupportRows', () => {
     fixture.counts.message_broadcast_count = 4
     fixture.linkage.selected_operation_id = 'op-1'
     fixture.linkage.unlinked_activity_count = 2
-    fixture.linkage.gaps = ['namespace activity exists without explicit session/operation linkage']
+    fixture.linkage.gaps = ['project activity exists without explicit session/operation linkage']
 
     expect(collaborationEvidenceSupportRows(fixture)).toEqual([
       'proof verdict · proven · available',
       'linked operation · op-1',
       'unlinked project activity · 2',
       'message broadcast count · 4',
-      'linkage gap · namespace activity exists without explicit session/operation linkage',
+      'linkage gap · project activity exists without explicit session/operation linkage',
     ])
   })
 })

--- a/dashboard/src/components/collaboration-evidence.test.ts
+++ b/dashboard/src/components/collaboration-evidence.test.ts
@@ -84,7 +84,7 @@ describe('collaborationEvidenceSupportRows', () => {
     expect(collaborationEvidenceSupportRows(fixture)).toEqual([
       'proof verdict · proven · available',
       'linked operation · op-1',
-      'unlinked namespace activity · 2',
+      'unlinked project activity · 2',
       'message broadcast count · 4',
       'linkage gap · namespace activity exists without explicit session/operation linkage',
     ])

--- a/dashboard/src/components/collaboration-evidence.ts
+++ b/dashboard/src/components/collaboration-evidence.ts
@@ -74,10 +74,10 @@ export function collaborationEvidenceSupportRows(
     rows.push(`linked operation · ${data.linkage.selected_operation_id}`)
   }
   if (data.linkage.explicit_linked_activity_count > 0) {
-    rows.push(`linked namespace activity · ${data.linkage.explicit_linked_activity_count}`)
+    rows.push(`linked project activity · ${data.linkage.explicit_linked_activity_count}`)
   }
   if (data.linkage.unlinked_activity_count > 0) {
-    rows.push(`unlinked namespace activity · ${data.linkage.unlinked_activity_count}`)
+    rows.push(`unlinked project activity · ${data.linkage.unlinked_activity_count}`)
   }
   if (data.counts.message_broadcast_count > 0) {
     rows.push(`message broadcast count · ${data.counts.message_broadcast_count}`)
@@ -135,7 +135,7 @@ export function CollaborationEvidencePanel({
   if (data && data.recent_unlinked_activity.length > 0) {
     evidencePanels.push({
       key: 'recent-unlinked',
-      title: '최근 미연결 네임스페이스 활동',
+      title: '최근 미연결 프로젝트 활동',
       rows: data.recent_unlinked_activity.map(item => ({
         key: `${item.ts_iso ?? 'na'}:${item.kind}:${item.actor ?? 'na'}`,
         content: html`
@@ -157,7 +157,7 @@ export function CollaborationEvidencePanel({
               ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] uppercase tracking-[0.06em] ${evidenceTone(data.evidence_status)}">${data.evidence_status}</span>`
               : null}
           </div>
-          <span class="text-[12px] text-[var(--text-body)]">${data?.headline ?? '세션/네임스페이스 상호작용 근거를 읽는 중입니다.'}</span>
+          <span class="text-[12px] text-[var(--text-body)]">${data?.headline ?? '세션/프로젝트 상호작용 근거를 읽는 중입니다.'}</span>
           <span class="text-[12px] text-[var(--text-muted)]">${data?.detail ?? ''}</span>
         </div>
         <div class="text-[11px] text-[var(--text-muted)] font-mono">

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -36,7 +36,7 @@ function truncateText(value: string | null | undefined, maxLength: number): stri
 export function orchestraNodeKindLabel(kind?: string | null): string {
   switch ((kind ?? '').trim().toLowerCase()) {
     case 'namespace':
-      return '네임스페이스'
+      return '프로젝트'
     case 'session':
       return '세션'
     case 'operation':

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -336,7 +336,7 @@ export function OrchestraSurface() {
         <div class="card rounded-xl-title">오케스트라 맵</div>
       </div>
       <p class="cmd-card rounded-xl-sub">
-        네임스페이스 전체를 한 장의 작전판으로 읽는 시각화입니다. 확대/이동으로 밀집 구간을 읽고, 노드를 눌러 상세 신호와 연결 대상을 확인합니다.
+        프로젝트 전체를 한 장의 작전판으로 읽는 시각화입니다. 확대/이동으로 밀집 구간을 읽고, 노드를 눌러 상세 신호와 연결 대상을 확인합니다.
       </p>
 
       <div class="orchestra-toolbar">

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -59,7 +59,7 @@ export function SwarmLivePanels() {
                     이 화면은 swarm-live의 사회 truth 자체가 아니라, 실험적 오케스트레이션을 읽기 위한 파생 관찰면입니다.
                   </div>
                   <div class="command-summary-grid">
-                    <${CmdStatCard} label="실행 런" value=${swarm.run_id ?? runId ?? 'swarm-live'} detail=${swarm.room_id ?? 'namespace 정보 없음'} />
+                    <${CmdStatCard} label="실행 런" value=${swarm.run_id ?? runId ?? 'swarm-live'} detail=${swarm.room_id ?? 'scope 정보 없음'} />
                     <${CmdStatCard} label="워커" value=${`${swarm.summary?.joined_workers ?? 0}/${swarm.summary?.expected_workers ?? 0}`} detail=${`${swarm.summary?.live_workers ?? 0}개 가동 · ${swarm.summary?.completed_workers ?? 0}개 완료`} />
                     <${CmdStatCard} label="런타임" value=${runtimeState} detail=${`slots ${actualSlots}/${expectedSlots} · ctx ${actualCtx}/${expectedCtx}`} />
                     <${CmdStatCard} label="고동시성" value=${swarm.summary?.pass_hot_concurrency ? '통과' : '확인 필요'} detail=${swarm.provider?.slot_url ?? 'slot 정보 없음'} />

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -29,14 +29,14 @@ export async function fetchPauseStatus(): Promise<void> {
 
 export async function pauseRoom(): Promise<void> {
   flowLoading.value = true
-  try { await callMcpTool('masc_pause', {}); flowState.value = 'paused'; showToast('네임스페이스 일시정지', 'success') }
+  try { await callMcpTool('masc_pause', {}); flowState.value = 'paused'; showToast('프로젝트 일시정지', 'success') }
   catch (err) { showToast(`일시정지 실패: ${err instanceof Error ? err.message : String(err)}`, 'error') }
   finally { flowLoading.value = false }
 }
 
 export async function resumeRoom(): Promise<void> {
   flowLoading.value = true
-  try { await callMcpTool('masc_resume', {}); flowState.value = 'running'; showToast('네임스페이스 재개', 'success') }
+  try { await callMcpTool('masc_resume', {}); flowState.value = 'running'; showToast('프로젝트 재개', 'success') }
   catch (err) { showToast(`재개 실패: ${err instanceof Error ? err.message : String(err)}`, 'error') }
   finally { flowLoading.value = false }
 }
@@ -47,7 +47,7 @@ export async function interruptRoom(reason?: string): Promise<void> {
     const args: Record<string, unknown> = {}
     if (reason) args.reason = reason
     await callMcpTool('masc_interrupt', args)
-    showToast('네임스페이스 인터럽트 전송', 'success')
+    showToast('프로젝트 인터럽트 전송', 'success')
     await fetchPauseStatus()
   } catch (err) {
     showToast(`인터럽트 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
@@ -61,7 +61,7 @@ export async function fetchRoomStrategy(): Promise<void> {
     const raw = await callMcpTool('masc_room_strategy_get', {})
     return JSON.parse(raw) as Record<string, unknown>
   }).catch(() => {
-    showToast('네임스페이스 전략 조회 실패', 'error')
+    showToast('프로젝트 전략 조회 실패', 'error')
   })
 }
 
@@ -69,10 +69,10 @@ export async function setRoomStrategy(updates: Record<string, unknown>): Promise
   roomStrategyMutating.value = true
   try {
     await callMcpTool('masc_room_strategy_set', updates)
-    showToast('네임스페이스 전략 업데이트 완료', 'success')
+    showToast('프로젝트 전략 업데이트 완료', 'success')
     await fetchRoomStrategy()
   } catch (err) {
-    showToast(`네임스페이스 전략 저장 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    showToast(`프로젝트 전략 저장 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
   } finally {
     roomStrategyMutating.value = false
   }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -678,14 +678,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
 
       <${SectionHeader} title="조율" />
-      <${ConfigRow} label="네임스페이스 범위" value=${c.coordination.room_scope || '--'} />
+      <${ConfigRow} label="프로젝트 범위" value=${c.coordination.room_scope || '--'} />
       <${ConfigRow} label="범위 유형" value=${c.coordination.scope_kind || '--'} />
       <div class="mt-1.5">
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 네임스페이스</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 범위</div>
         <${ModelList} models=${c.coordination.joined_room_ids} />
       </div>
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -315,7 +315,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-col gap-1.5">
-      <${SignalRow} label="네임스페이스" value=${namespaceName} />
+      <${SignalRow} label="프로젝트 범위" value=${namespaceName} />
       <${SignalRow} label="프로젝트" value=${project} />
       ${clusterVisible ? html`<${SignalRow} label="클러스터" value=${clusterRaw} />` : null}
       <${SignalRow} label="현재 태스크" value=${currentTaskLabel} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -68,7 +68,7 @@ async function runSocialSweep(): Promise<void> {
     await runOperatorAction({
       actor: currentDashboardActor(),
       action_type: 'social_sweep',
-      target_type: 'room',
+      target_type: 'namespace',
       payload: {},
     })
     invalidateDashboardCache()

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
@@ -94,10 +94,10 @@ describe('spawnKeeperFromPersona', () => {
     expect(spawnResult.value).toEqual({
       success: false,
       message:
-        'agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.',
+        'agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 프로젝트의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 프로젝트 기본 권한을 올린 뒤 다시 시도하세요.',
     })
     expect(showToast).toHaveBeenCalledWith(
-      '키퍼 생성 실패: agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.',
+      '키퍼 생성 실패: agent-3a9df104 세션은 현재 키퍼 생성 권한이 없습니다. 이 프로젝트의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 프로젝트 기본 권한을 올린 뒤 다시 시도하세요.',
       'error',
     )
   })

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -60,7 +60,7 @@ function formatKeeperSpawnError(message: string): string {
   if (!forbiddenMatch) return message
 
   const actor = forbiddenMatch[1]
-  return `${actor} 세션은 현재 키퍼 생성 권한이 없습니다. 이 방의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 방 기본 권한을 올린 뒤 다시 시도하세요.`
+  return `${actor} 세션은 현재 키퍼 생성 권한이 없습니다. 이 프로젝트의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 프로젝트 기본 권한을 올린 뒤 다시 시도하세요.`
 }
 
 export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRun?: boolean; roomScope?: string }): Promise<void> {

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -31,7 +31,7 @@ import {
 
 export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
   const info = extractAgentInfo(row.brief.agent_name)
-  const who = row.withWhom.length > 0 ? row.withWhom.slice(0, 3).join(', ') : '단독 또는 방 단위'
+  const who = row.withWhom.length > 0 ? row.withWhom.slice(0, 3).join(', ') : '단독 또는 프로젝트 범위'
   const recentToolsLabel =
     row.recentTools.length > 0
       ? row.recentTools.join(', ')

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -197,7 +197,7 @@ function createLiveJudgeWorkflowContext(
     focus_kind: 'live_judgment',
     operation_id: null,
     summary: `${target.name}에게 상황판 요약을 보내 live 판단을 받습니다.`,
-    payload_preview: `namespace ${mission?.summary.namespace ?? mission?.summary.namespace_id ?? 'default'} · attention ${mission?.attention_queue.length ?? 0} · gaps ${metadataGapCount}`,
+    payload_preview: `scope ${mission?.summary.namespace ?? mission?.summary.namespace_id ?? 'default'} · attention ${mission?.attention_queue.length ?? 0} · gaps ${metadataGapCount}`,
     suggested_payload: { message },
     preview: {
       keeper_name: target.name,

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -25,7 +25,7 @@ export function MissionContextBar({
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
       <${StatCell} label="프로젝트" value=${project ?? '확인 없음'} />
-      <${StatCell} label="네임스페이스" value=${namespace ?? 'default'} />
+      <${StatCell} label="프로젝트 범위" value=${namespace ?? 'default'} />
       <${StatCell} label="갱신 시각" value=${generatedAt ? relativeTime(generatedAt) : '기록 없음'} />
       ${cluster && cluster !== 'unknown'
         ? html`<${StatCell} label="배포 메타" value=${cluster} />`

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -59,9 +59,9 @@ export const selectedSessionId = signal<string | null>(null)
 export function missionTargetTypeLabel(value?: string | null): string {
   switch ((value ?? '').trim().toLowerCase()) {
     case 'namespace':
-      return '네임스페이스'
+      return '프로젝트'
     case 'room':
-      return '네임스페이스'
+      return '프로젝트'
     case 'team_session':
     case 'session':
       return '세션'

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -252,10 +252,10 @@ export function actionTypeLabel(value?: string | null): string {
       return '전체 공지'
     case 'namespace_pause':
     case 'room_pause':
-      return '네임스페이스 일시정지'
+      return '프로젝트 일시정지'
     case 'namespace_resume':
     case 'room_resume':
-      return '네임스페이스 재개'
+      return '프로젝트 재개'
     case 'team_turn':
       return '세션 업데이트'
     case 'team_note':
@@ -288,9 +288,9 @@ export function actionTypeLabel(value?: string | null): string {
 export function targetTypeLabel(value?: string | null): string {
   switch (value) {
     case 'namespace':
-      return '네임스페이스'
+      return '프로젝트 범위'
     case 'room':
-      return '네임스페이스'
+      return '프로젝트 범위'
     case 'team_session':
       return '세션'
     case 'keeper':
@@ -574,7 +574,7 @@ export async function submitBroadcast() {
   if (!message) return
   const result = await executeAction({
     action_type: 'broadcast',
-    target_type: 'room',
+    target_type: 'namespace',
     payload: { message },
     successMessage: '전체 공지를 보냈습니다',
   })
@@ -583,19 +583,19 @@ export async function submitBroadcast() {
 
 export async function submitPause() {
   await executeAction({
-    action_type: 'room_pause',
-    target_type: 'room',
+    action_type: 'namespace_pause',
+    target_type: 'namespace',
     payload: { reason: pauseReason.value.trim() || '운영 점검' },
-    successMessage: '네임스페이스 일시정지를 요청했습니다',
+    successMessage: '프로젝트 일시정지를 요청했습니다',
   })
 }
 
 export async function submitResume() {
   await executeAction({
-    action_type: 'room_resume',
-    target_type: 'room',
+    action_type: 'namespace_resume',
+    target_type: 'namespace',
     payload: {},
-    successMessage: '네임스페이스 재개를 요청했습니다',
+    successMessage: '프로젝트 재개를 요청했습니다',
   })
 }
 
@@ -604,7 +604,7 @@ export async function submitTaskInject() {
   if (!title) return
   const result = await executeAction({
     action_type: 'task_inject',
-    target_type: 'room',
+    target_type: 'namespace',
     payload: {
       title,
       description: taskDescription.value.trim() || '개입 화면에서 주입',

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -147,7 +147,7 @@ describe('Ops intervene surface', () => {
     expect(container.textContent).toContain('즉시 검토 0')
     expect(container.textContent).toContain('보류 1')
     expect(container.textContent).toContain('최근 처리 2')
-    expect(container.textContent).toContain('네임스페이스 진행 중')
+    expect(container.textContent).toContain('프로젝트 진행 중')
     expect(container.textContent).not.toContain('Active Queue')
     expect(container.textContent).not.toContain('Healthy Console')
 
@@ -234,7 +234,7 @@ describe('Ops intervene surface', () => {
     await flushUi()
 
     expect(container.textContent).toContain('즉시 검토 1')
-    expect(container.textContent).toContain('네임스페이스 일시정지')
+    expect(container.textContent).toContain('프로젝트 일시정지')
     expect(container.textContent).toContain('실행 작업대')
     expect(container.textContent).toContain('현재 상태')
     expect(container.textContent).toContain('마찰 요인')

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -190,8 +190,8 @@ function renderSummaryBadges(activeCount: number, deferredCount: number, recentC
   const roomPaused = operatorSnapshot.value?.namespace?.paused
   const roomLabel =
     typeof roomPaused === 'boolean'
-      ? roomPaused ? '네임스페이스 일시정지' : '네임스페이스 진행 중'
-      : '네임스페이스 확인 필요'
+      ? roomPaused ? '프로젝트 일시정지' : '프로젝트 진행 중'
+      : '프로젝트 상태 확인 필요'
   const roomTone: ActivityTone =
     typeof roomPaused !== 'boolean'
       ? 'default'
@@ -250,7 +250,7 @@ function renderTruth(item: OperatorReviewItem | null) {
     return html`
       <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Namespace</div>
+          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Project</div>
           <strong>${room.namespace ?? room.namespace_id ?? 'default'}</strong>
           <div class="text-[12px] text-[var(--text-muted)]">${room.project ?? 'project'} · ${room.cluster ?? 'cluster'}</div>
         </div>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -1,4 +1,4 @@
-// Ops — Namespace column: broadcast, pause/resume, task inject, recommended actions, pending confirmations, namespace feed
+// Ops — Project-scope column: broadcast, pause/resume, task inject, recommended actions, pending confirmations, shared feed
 
 import { html } from 'htm/preact'
 import { Markdown } from "../common/markdown"
@@ -113,7 +113,7 @@ export function OpsRoomColumn() {
         ` : activeRecommendedActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${activeRecommendedActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'room'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
+              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'namespace'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
@@ -219,13 +219,13 @@ export function OpsRoomColumn() {
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel">
         <div class="pb-2 border-b border-[var(--card-border)] mb-1">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Namespace 상태</h3>
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">프로젝트 상태</h3>
         </div>
-        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. namespace 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. 프로젝트 전체에 손댈 때만 아래 고급 제어를 여세요.</p>
 
         <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
-            <span>네임스페이스</span>
+            <span>기본 범위</span>
             <strong>${room.namespace ?? room.namespace_id ?? 'default'}</strong>
           </div>
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
@@ -252,9 +252,9 @@ export function OpsRoomColumn() {
           open=${room.paused ? true : undefined}
         >
           <summary class="ops-control-summary list-none cursor-pointer grid gap-1 p-3 px-3.5">
-            <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 namespace 제어</span>
-            <strong>${room.paused ? '지금은 namespace가 멈춰 있어 재개 동선이 열려 있습니다.' : '전체 공지, 일시정지, 작업 주입'}</strong>
-            <span>${room.paused ? '운영 점검 후 재개하거나 공지를 보내세요.' : '기본 화면은 읽기 중심이고, 실제 namespace 변경은 이 안에서만 합니다.'}</span>
+            <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 프로젝트 제어</span>
+            <strong>${room.paused ? '지금은 프로젝트 범위가 멈춰 있어 재개 동선이 열려 있습니다.' : '전체 공지, 일시정지, 작업 주입'}</strong>
+            <span>${room.paused ? '운영 점검 후 재개하거나 공지를 보내세요.' : '기본 화면은 읽기 중심이고, 실제 전체 변경은 이 안에서만 합니다.'}</span>
           </summary>
 
           <div class="grid gap-3 px-3.5 pb-3.5 border-t border-[var(--white-8)]">
@@ -264,7 +264,7 @@ export function OpsRoomColumn() {
                 id="ops-broadcast"
                 class="control-input"
                 type="text"
-                placeholder="@agent 또는 namespace 전체 공지"
+                placeholder="@agent 또는 전체 공지"
                 value=${broadcastMessage.value}
                 onInput=${(event: Event) => { broadcastMessage.value = (event.target as HTMLInputElement).value }}
                 onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') void submitBroadcast() }}
@@ -333,9 +333,9 @@ export function OpsRoomColumn() {
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0">
         <div class="pb-2 border-b border-[var(--card-border)] mb-1">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">최근 Namespace 메시지</h3>
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">최근 전체 메시지</h3>
         </div>
-        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">namespace 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">전체 메시지는 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
         ${roomFeed.length > 0 ? html`
           <div class="flex flex-col gap-3 max-h-[400px] overflow-y-auto min-w-0 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${roomFeed.map(message => html`
@@ -348,7 +348,7 @@ export function OpsRoomColumn() {
               </article>
             `)}
           </div>
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">최근 namespace 메시지가 없습니다.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">최근 전체 메시지가 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -36,8 +36,8 @@ export const keeperMessage = signal('')
 export const hydratedWorkflowId = signal<string | null>(null)
 
 // QuickIntervene: unified message target
-// 'room' = broadcast, 'session:{id}' = team_note, 'keeper:{name}' = keeper_message
-export const quickTarget = signal('room')
+// 'namespace' = broadcast, 'session:{id}' = team_note, 'keeper:{name}' = keeper_message
+export const quickTarget = signal('namespace')
 export const quickMessage = signal('')
 
 export function persistActorName(value: string): void {

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -59,9 +59,9 @@ describe('QuickIntervene', () => {
     actorName.value = 'dashboard-eager-manta'
     operatorActionBusy.value = false
     quickMessage.value = ''
-    quickTarget.value = 'room'
+    quickTarget.value = 'namespace'
     operatorSnapshot.value = {
-      room: { paused: false },
+      namespace: { paused: false, namespace: 'default' },
       sessions: [{ session_id: 'session-a', status: 'active' }],
       keepers: [{ name: 'keeper-a', status: 'online' }],
       recent_messages: [],
@@ -73,6 +73,7 @@ describe('QuickIntervene', () => {
     await flushUi()
 
     expect(container.textContent).toContain('빠른 개입')
+    expect((container.querySelector('select[aria-label="개입 대상"]') as HTMLSelectElement | null)?.value).toBe('namespace')
     expect(container.querySelector('input[name="quick_intervene_actor"]')).toBeNull()
 
     const toggle = Array.from(container.querySelectorAll('button'))

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -1,6 +1,6 @@
 // QuickIntervene — unified message input. Pick a target, type, send.
 // Target selection determines action_type automatically:
-//   'room' → broadcast, 'session:{id}' → team_note, 'keeper:{name}' → keeper_message
+//   'namespace' → broadcast, 'session:{id}' → team_note, 'keeper:{name}' → keeper_message
 
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
@@ -16,7 +16,7 @@ import { executeAction, normalizeStatus } from './helpers'
 
 function parseTarget(value: string): {
   action_type: 'broadcast' | 'team_note' | 'keeper_message'
-  target_type: 'room' | 'team_session' | 'keeper'
+  target_type: 'namespace' | 'team_session' | 'keeper'
   target_id?: string
   label: string
 } {
@@ -28,7 +28,7 @@ function parseTarget(value: string): {
     const name = value.slice('keeper:'.length)
     return { action_type: 'keeper_message', target_type: 'keeper', target_id: name, label: name }
   }
-  return { action_type: 'broadcast', target_type: 'room', label: '전체' }
+  return { action_type: 'broadcast', target_type: 'namespace', label: '전체' }
 }
 
 async function submitQuickMessage() {
@@ -80,7 +80,7 @@ export function QuickIntervene() {
           onChange=${(e: Event) => { quickTarget.value = (e.target as HTMLSelectElement).value }}
           disabled=${busy}
         >
-          <option value="room">전체</option>
+          <option value="namespace">전체</option>
           ${runningSessions.map(s => html`
             <option key=${s.session_id} value=${`session:${s.session_id}`}>
               세션 ${s.session_id.slice(0, 8)}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -71,7 +71,7 @@ function OverviewFreshnessStrip() {
               : html` <strong class="text-[var(--text-strong)]">아직 불러오지 않음</strong>`}
           </div>
           <div class="mt-1 text-[11px] text-[var(--text-muted)]">
-            기준: namespace truth와 mission snapshot 중 더 오래된 시각
+            기준: project truth와 mission snapshot 중 더 오래된 시각
           </div>
         </div>
         <${ActionButton}
@@ -217,7 +217,7 @@ function desireActionabilityLabel(actionability?: string | null): string {
     case 'operator_or_scheduler':
       return '운영자/스케줄러 액션'
     case 'room_or_operator':
-      return '네임스페이스/운영자 액션'
+      return '프로젝트/운영자 액션'
     default:
       return '추가 판독 필요'
   }

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -22,7 +22,7 @@ export function TaskCreateForm() {
     return html`
       <div class="flex flex-col gap-3">
         <div class="text-[12px] leading-relaxed text-text-muted">
-          이 방의 백로그에 바로 추가됩니다. 우선순위는 <code class="rounded bg-white/5 px-1 py-0.5 text-[11px] text-text-strong">P1</code>이 가장 높습니다.
+          이 프로젝트의 백로그에 바로 추가됩니다. 우선순위는 <code class="rounded bg-white/5 px-1 py-0.5 text-[11px] text-text-strong">P1</code>이 가장 높습니다.
         </div>
         <${ActionButton}
           variant="primary"

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -165,7 +165,7 @@ describe('TransportHealthPanel', () => {
     expect(container.textContent).toContain('shared_http')
     expect(container.innerHTML).toContain('signaling down')
     expect(container.innerHTML).not.toContain('2 ICE')
-    expect(container.textContent).toContain('namespace default')
+    expect(container.textContent).toContain('scope default')
   })
 
   it('renders namespace chip with cluster prefix for non-default clusters', async () => {
@@ -194,6 +194,6 @@ describe('TransportHealthPanel', () => {
     await flushUi()
 
     expect(get).toHaveBeenCalledWith('/api/v1/dashboard/transport-health')
-    expect(container.textContent).toContain('prod / namespace default')
+    expect(container.textContent).toContain('prod / scope default')
   })
 })

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -414,8 +414,8 @@ export function TransportHealthPanel() {
     : `topology ${data.cluster.topology_source}`
   const namespaceChip =
     data.cluster.cluster && data.cluster.cluster !== 'unknown' && data.cluster.cluster !== 'default'
-      ? `${data.cluster.cluster} / namespace ${data.cluster.room_id}`
-      : `namespace ${data.cluster.room_id}`
+      ? `${data.cluster.cluster} / scope ${data.cluster.room_id}`
+      : `scope ${data.cluster.room_id}`
 
   return html`
     <div class="space-y-4">

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -58,7 +58,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: '모니터링',
     icon: '📡',
-    description: '세션, 네임스페이스 및 에이전트/키퍼 현황 관찰',
+    description: '세션, 프로젝트 범위, 에이전트/키퍼 현황 관찰',
     defaultTab: 'monitoring',
     defaultParams: { section: 'sessions' },
     tabs: ['monitoring'],
@@ -112,8 +112,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   monitoring: [
     {
       id: 'sessions',
-      label: '세션 & 네임스페이스',
-      description: '세션 = SSE로 연결된 실시간 작업 단위. 네임스페이스 = 같은 .masc/ 폴더를 공유하는 에이전트 조정 공간.',
+      label: '세션 & 프로젝트 범위',
+      description: '세션 = SSE로 연결된 실시간 작업 단위. 프로젝트 범위 = 같은 .masc/ 폴더를 공유하는 에이전트 조정 공간.',
       params: { section: 'sessions' },
     },
     {
@@ -133,7 +133,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'intervene',
       label: '실시간 개입',
-      description: '네임스페이스 일시정지, 세션 중단, 키퍼 재시작 등 운영 개입.',
+      description: '프로젝트 일시정지, 세션 중단, 키퍼 재시작 등 운영 개입.',
       params: { section: 'intervene' },
     },
     {

--- a/dashboard/src/lib/keeper-chat-access.test.ts
+++ b/dashboard/src/lib/keeper-chat-access.test.ts
@@ -44,7 +44,7 @@ describe('keeperDirectChatAccess', () => {
     expect(result.blocked).toBe(true)
     expect(result.message).toContain('@alice는 masc_keeper_msg 권한이 없습니다.')
     expect(result.message).toContain('현재 역할은 worker입니다.')
-    expect(result.message).toContain('namespace 기본 권한을 올린 뒤 다시 시도하세요.')
+    expect(result.message).toContain('프로젝트 기본 권한을 올린 뒤 다시 시도하세요.')
     expect(result.message).not.toContain('Bearer token이 없어')
     expect(result.message).not.toContain('public read fallback')
   })

--- a/dashboard/src/lib/keeper-chat-access.ts
+++ b/dashboard/src/lib/keeper-chat-access.ts
@@ -36,7 +36,7 @@ export function keeperDirectChatAccess(
   return {
     blocked: true,
     message: compactWhitespace(
-      `직접 통신 비활성화: ${reason}.${roleHint}${tokenHint} worker/admin 권한 토큰을 사용하거나 namespace 기본 권한을 올린 뒤 다시 시도하세요.`,
+      `직접 통신 비활성화: ${reason}.${roleHint}${tokenHint} worker/admin 권한 토큰을 사용하거나 프로젝트 기본 권한을 올린 뒤 다시 시도하세요.`,
     ),
   }
 }

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -43,7 +43,7 @@ async function doFetchNamespaceTruth(): Promise<void> {
       normalized.namespace.status ?? null,
     )
   } catch (err) {
-    const detail = err instanceof Error ? err.message : 'Failed to load namespace truth'
+    const detail = err instanceof Error ? err.message : 'Failed to load project truth'
     console.warn('[namespace-truth] fetch failed:', detail)
     namespaceTruthError.value = detail
   } finally {

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -99,7 +99,7 @@ export async function refreshOperatorRoomDigest(opts?: RefreshOptions): Promise<
   operatorDigestError.value = null
   roomDigestRefreshInflight = (async () => {
     try {
-      const raw = await fetchOperatorDigest({ targetType: 'room' })
+      const raw = await fetchOperatorDigest({ targetType: 'namespace' })
       operatorRoomDigest.value = normalizeOperatorDigest(raw)
       lastRoomDigestRefreshAt = Date.now()
     } catch (err) {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -308,7 +308,7 @@ export function normalizeOperatorDigest(raw: unknown): OperatorDigest {
   const root = isRecord(raw) ? raw : {}
   return {
     trace_id: asString(root.trace_id),
-    target_type: asString(root.target_type) ?? 'room',
+    target_type: asString(root.target_type) ?? 'namespace',
     target_id: asString(root.target_id) ?? null,
     health: asString(root.health),
     judgment_owner: asString(root.judgment_owner) ?? null,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -240,12 +240,12 @@ function handleEvent(event: SSEEvent): void {
   switch (type) {
     case 'agent_joined':
       addTypedJournalEntry(agent, 'Joined', 'system', 'agent_joined', {
-        narrativeText: `${actorLabel(agent)}가 room에 참여했습니다.`,
+        narrativeText: `${actorLabel(agent)}가 프로젝트에 참여했습니다.`,
       })
       break
     case 'agent_left':
       addTypedJournalEntry(agent, 'Left', 'system', 'agent_left', {
-        narrativeText: `${actorLabel(agent)}가 room에서 나갔습니다.`,
+        narrativeText: `${actorLabel(agent)}가 프로젝트에서 나갔습니다.`,
       })
       break
     case 'broadcast':

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -165,7 +165,7 @@ function workflowContextId(
     sourceLabel,
     actionType ?? 'action',
     targetType ?? 'target',
-    targetId ?? 'room',
+    targetId ?? 'namespace',
     focusKind ?? 'focus',
     operationId ?? 'operation',
     createdAt,
@@ -307,21 +307,25 @@ export function missionInterveneParams(context: DashboardWorkflowContext): Recor
 
 export function workflowTargetLabel(context?: DashboardWorkflowContext | null): string {
   if (!context?.target_type) return '대상 정보 없음'
-  return context.target_id ? `${context.target_type} · ${context.target_id}` : context.target_type
+  const targetType =
+    context.target_type === 'room' || context.target_type === 'namespace'
+      ? '프로젝트'
+      : context.target_type
+  return context.target_id ? `${targetType} · ${context.target_id}` : targetType
 }
 
 export function workflowActionLabel(actionType?: string | null): string {
   switch (actionType) {
     case 'broadcast':
-      return 'namespace 방송'
+      return '전체 공지'
     case 'namespace_pause':
     case 'room_pause':
-      return 'namespace 일시정지'
+      return '프로젝트 일시정지'
     case 'namespace_resume':
     case 'room_resume':
-      return 'namespace 재개'
+      return '프로젝트 재개'
     case 'task_inject':
-      return 'namespace 작업 주입'
+      return '프로젝트 작업 주입'
     case 'team_turn':
       return 'session 업데이트'
     case 'team_note':

--- a/lib/dashboard/dashboard_collaboration_evidence.ml
+++ b/lib/dashboard/dashboard_collaboration_evidence.ml
@@ -301,7 +301,7 @@ let json ?session_id ?room_id ~(config : Room.config) () =
   let linkage_gaps =
     Team_session_types.dedup_strings
       ((if unlinked_activity_count > 0 then
-          [ "namespace activity exists without explicit session/operation linkage" ]
+          [ "project activity exists without explicit session/operation linkage" ]
         else
           [])
       @
@@ -332,11 +332,11 @@ let json ?session_id ?room_id ~(config : Room.config) () =
     else if interaction_event_count > 0 || explicit_linked_activity_count > 0 then
       ( "partial",
         "상호작용 흔적은 있지만 증거가 분산돼 있습니다.",
-        "세션 이벤트나 explicit linked namespace activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다." )
+        "세션 이벤트나 explicit linked project activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다." )
     else if unlinked_activity_count > 0 then
       ( "partial",
-        "네임스페이스 활동은 보이지만 세션 연결이 비어 있습니다.",
-        "namespace activity는 있으나 session_id 또는 operation_id linkage가 없어 협업 근거로 승격되지 않았습니다." )
+        "프로젝트 활동은 보이지만 세션 연결이 비어 있습니다.",
+        "project activity는 있으나 session_id 또는 operation_id linkage가 없어 협업 근거로 승격되지 않았습니다." )
     else
       ( "missing",
         "기록된 협업 근거가 아직 약합니다.",

--- a/lib/operator/operator_digest_review_types.ml
+++ b/lib/operator/operator_digest_review_types.ml
@@ -72,10 +72,10 @@ let stale_sec_of_iso ~now iso =
 
 let review_action_copy = function
   | "broadcast" -> "전체 공지"
-  | "namespace_pause" -> "네임스페이스 일시정지"
-  | "room_pause" -> "방 일시정지"
-  | "namespace_resume" -> "네임스페이스 재개"
-  | "room_resume" -> "방 재개"
+  | "namespace_pause" -> "프로젝트 일시정지"
+  | "room_pause" -> "프로젝트 일시정지"
+  | "namespace_resume" -> "프로젝트 재개"
+  | "room_resume" -> "프로젝트 재개"
   | "team_note" -> "세션 메모"
   | "team_broadcast" -> "세션 공지"
   | "team_task_inject" -> "세션 작업 주입"

--- a/lib/server/server_command_plane_http_help.ml
+++ b/lib/server/server_command_plane_http_help.ml
@@ -115,9 +115,9 @@ let command_plane_help_http_json () =
       ( "concepts",
         `List
           [
-            concept ~id:"namespace" ~title:"Namespace"
+            concept ~id:"namespace" ~title:"Project Scope"
               ~summary:
-                "Project coordination namespace. Use masc_start as the primary onboarding entrypoint. Historical room naming remains only as a compatibility alias, and masc_set_room now selects only the project coordination root while runtime state still lives in the flattened default namespace under .masc/.";
+                "Shared project coordination scope. Use masc_start as the primary onboarding entrypoint. Historical room naming remains only as a compatibility alias, and masc_set_room now selects only the project coordination root while runtime state still lives in the flattened default scope under .masc/.";
             concept ~id:"task" ~title:"Task"
               ~summary:
                 "Backlog work item. Claim semantics differ by tool: masc_transition(action=claim) leaves planning current_task unset, while masc_claim_next auto-binds it in current builds.";
@@ -137,26 +137,26 @@ let command_plane_help_http_json () =
       ( "golden_paths",
         `List
           [
-            path ~id:"namespace_task_hygiene" ~title:"Namespace / Task Hygiene"
+            path ~id:"namespace_task_hygiene" ~title:"Project Scope / Task Hygiene"
               ~summary:
-                "Minimal MCP sequence before doing any real work in the project namespace."
+                "Minimal MCP sequence before doing any real work in the shared project scope."
               ~when_to_use:
                 "Use this before benchmark runs, CPv2 experiments, or ordinary implementation work."
               ~steps:
                 [
-                  step ~id:"start" ~title:"Start namespace onboarding" ~tool:"masc_start"
+                  step ~id:"start" ~title:"Start project onboarding" ~tool:"masc_start"
                     ~summary:
-                      "Preferred front door. Sets the project coordination root, joins the default namespace, and can optionally create+claim a task in one call."
+                      "Preferred front door. Sets the project coordination root, joins the default shared scope, and can optionally create+claim a task in one call."
                     ~success_signals:
                       [ "coordination root resolves to the project root"; "agent can appear in masc_status immediately after onboarding" ]
                     ~pitfalls:
                       [ "calling masc_set_room only changes project scope; it does not complete the full onboarding flow";
                         "omitting task_title means you still need a later claim/create step" ];
-                  step ~id:"status" ~title:"Verify namespace state" ~tool:"masc_status"
+                  step ~id:"status" ~title:"Verify project state" ~tool:"masc_status"
                     ~summary:
-                      "Confirm the namespace is healthy, your agent is visible, and the backlog is in the expected state."
+                      "Confirm the shared project scope is healthy, your agent is visible, and the backlog is in the expected state."
                     ~success_signals:
-                      [ "agent visible in masc_status"; "namespace agent roster includes your agent" ]
+                      [ "agent visible in masc_status"; "project agent roster includes your agent" ]
                     ~pitfalls:
                       [ "if you only called masc_set_room, or masc_start did not complete successfully, your agent may not be joined and will not appear for scheduling" ];
                   step ~id:"claim" ~title:"Claim or create work" ~tool:"masc_transition"

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -456,7 +456,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
             }
           in
           match
-            Operator_control.digest_json ~actor:"dashboard" ~target_type:"room"
+            Operator_control.digest_json ~actor:"dashboard" ~target_type:"namespace"
               ~sessions ?command_plane_summary ?swarm_status ctx
           with
           | Ok json ->
@@ -577,21 +577,24 @@ let operator_digest_http_json ~state ~sw ~clock request =
     | Some ("1" | "true" | "yes") -> Some true
     | _ -> None
   in
-  let default_room_request =
+  let namespace_target_type value =
+    match Option.map (fun raw -> String.lowercase_ascii (String.trim raw)) value with
+    | None -> true
+    | Some "namespace" | Some "room" -> true
+    | Some _ -> false
+  in
+  let default_namespace_request =
     actor = None
     && target_id = None
     && include_workers = None
-    &&
-    match target_type with
-    | None -> true
-    | Some raw -> String.equal (String.lowercase_ascii (String.trim raw)) "room"
+    && namespace_target_type target_type
   in
-  if default_room_request then
+  if default_namespace_request then
     Ok (cached_surface_json _operator_digest_cache)
   else
     let started_at = Unix.gettimeofday () in
     let effective_target_type =
-      Option.value ~default:"room" target_type
+      Option.value ~default:"namespace" target_type
     in
     match Eio.Time.with_timeout clock _dashboard_request_timeout_s (fun () ->
       Ok
@@ -611,13 +614,13 @@ let operator_digest_http_json ~state ~sw ~clock request =
                }
              in
              let command_plane_summary, swarm_status =
-               if String.equal effective_target_type "room" then
+               if namespace_target_type (Some effective_target_type) then
                  command_plane_summary_cache_parts ~allow_initializing:false ~state
                else
                  (None, None)
              in
              let sessions =
-               if String.equal effective_target_type "room"
+               if namespace_target_type (Some effective_target_type)
                   && Room.is_initialized config
                then
                  Some (dashboard_active_or_recent_sessions ~clock config)

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -22,7 +22,7 @@ let handle_pause ctx args =
 let handle_resume ctx _args =
   match Room.resume ctx.config ~by:ctx.agent_name with
   | `Resumed -> (true, Printf.sprintf "Resumed by %s" ctx.agent_name)
-  | `Already_running -> (true, "Default project namespace is not paused")
+  | `Already_running -> (true, "Default project scope is not paused")
 
 let handle_pause_status ctx args =
   let requested_namespace = get_string args "namespace_id" "" |> String.trim in
@@ -42,7 +42,7 @@ let handle_pause_status ctx args =
             ( "pause_reason",
               Json_util.string_opt_to_json reason );
             ("paused_at", Json_util.string_opt_to_json at);
-            ("message", `String "Default project namespace is paused");
+            ("message", `String "Default project scope is paused");
             ( "requested_namespace_id",
               if requested_namespace = "" then `Null
               else `String requested_namespace );
@@ -59,7 +59,7 @@ let handle_pause_status ctx args =
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
-            ("message", `String "Default project namespace is running (not paused)");
+            ("message", `String "Default project scope is running (not paused)");
             ( "requested_namespace_id",
               if requested_namespace = "" then `Null
               else `String requested_namespace );

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -239,11 +239,11 @@ let handle_set_room (ctx : context) : result option =
       let root_note =
         if rc.workspace_path <> rc.base_path then
           Printf.sprintf
-            "MASC project scope set.\n   coordination root: %s\n   workspace: %s\n   namespace: default (flattened)\n   .masc/ status: %s"
+            "MASC project scope set.\n   coordination root: %s\n   workspace: %s\n   shared scope: default (flattened)\n   .masc/ status: %s"
             rc.base_path rc.workspace_path status
         else
           Printf.sprintf
-            "MASC project scope set to: %s\n   namespace: default (flattened)\n   .masc/ status: %s"
+            "MASC project scope set to: %s\n   shared scope: default (flattened)\n   .masc/ status: %s"
             rc.base_path status
       in
       Some (true, root_note)

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -299,7 +299,7 @@ let status_summary_string (ctx : context) =
   if cluster_name <> state.project then
     Buffer.add_string buf (Printf.sprintf "📦 Project: %s\n" state.project);
   Buffer.add_string buf
-    (Printf.sprintf "📍 Namespace: %s (flattened)\n" current_room);
+    (Printf.sprintf "📍 Scope: %s (flattened)\n" current_room);
   Buffer.add_string buf (Printf.sprintf "📁 Path: %s\n" ctx.config.base_path);
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
   Buffer.add_string buf

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -71,6 +71,9 @@ let () =
           Alcotest.test_case "task inject immediate flow" `Quick
             Test_operator_control_actions
             .test_task_inject_executes_immediately;
+          Alcotest.test_case "digest defaults to namespace target" `Quick
+            Test_operator_control_actions
+            .test_digest_defaults_to_namespace_target;
           Alcotest.test_case "team turn fallback actor" `Quick
             Test_operator_control_actions.test_team_turn_falls_back_to_session_actor;
           Alcotest.test_case "team note logs action" `Quick

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -48,6 +48,25 @@ let test_task_inject_executes_immediately () =
       let tasks = Room.get_tasks_raw config in
       Alcotest.(check int) "task injected" 1 (List.length tasks))
 
+let test_digest_defaults_to_namespace_target () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let ctx = operator_ctx env sw config "operator" in
+      let digest_json =
+        match Operator_control.digest_json ctx with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "default target_type" "namespace"
+        Yojson.Safe.Util.(digest_json |> member "target_type" |> to_string))
+
 let test_team_turn_falls_back_to_session_actor () =
   Eio_main.run @@ fun env ->
   ensure_fs env;

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -78,7 +78,7 @@ let () = test "dispatch_dashboard" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Namespace: default (flattened)");
+      assert (str_contains result "Scope: default (flattened)");
       assert (not (str_contains result "second-room"));
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
@@ -110,7 +110,7 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Namespace: default (flattened)");
+      assert (str_contains result "Scope: default (flattened)");
       assert (not (str_contains result "focus-room"))
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->


### PR DESCRIPTION
## Summary
- reduce user-facing `room` and `namespace` language across dashboard, CLI, and help surfaces
- keep `namespace` as the internal canonical/protocol field while presenting project-scope wording to operators
- keep legacy `room` as an inbound compatibility alias only

## Why
The runtime is already flattened to the default shared scope, so exposing both `room` and `namespace` as first-class user concepts adds unnecessary cognitive load. This change narrows the public mental model without changing the underlying compatibility contract.

## What Changed
- switched operator/dashboard defaults and outgoing actions to namespace-first canonical targets
- replaced user-facing copy like `namespace`, `Namespace`, and `네임스페이스` with `프로젝트`, `프로젝트 범위`, `전체`, or `scope` depending on the surface
- updated CLI/help strings to describe a shared project scope instead of a user-managed namespace concept
- added regression coverage for the default operator digest target and updated text assertions for the new wording

## Product impact
- operators and dashboard users no longer need to reason about both `room` and `namespace` as separate first-class concepts
- user-facing surfaces now describe the shared flattened coordination area as project scope / project-wide control instead of exposing internal protocol naming
- inbound compatibility for legacy `room` payloads and actions remains intact, so existing integrations do not lose compatibility

## Evidence
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec vitest run src/components/ops/index.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec vitest run src/components/ops/quick-intervene.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec vitest run src/components/keeper-spawn/keeper-spawn-state.test.ts --no-file-parallelism --maxWorkers=1`
- `opam exec -- dune build --root . --build-dir /tmp/masc-project-scope-build test/test_operator_control.exe test/test_dashboard_execution.exe test/test_misc_coverage.exe`
- `opam exec -- dune exec --root . --build-dir /tmp/masc-project-scope-build ./test/test_operator_control.exe`
- `opam exec -- dune exec --root . --build-dir /tmp/masc-project-scope-build ./test/test_dashboard_execution.exe`
- `opam exec -- dune exec --root . --build-dir /tmp/masc-project-scope-build ./test/test_misc_coverage.exe`
- note: local `vitest` runs are stable per file; bundling the three files under one single-worker invocation can hit the repo's existing 15s per-test timeout

## Review evidence
- `GLM-5` via direct `sb glm-text` reviewer path
- commit reviewed: `0c3b6dd14`
- result: `No material findings.`
- timeline comment: https://github.com/jeong-sik/masc-mcp/pull/4936#issuecomment-4185955428

## Linked issue
- Refs #4938
