### PR TITLE
refactor(inference): delegate defaults to OAS Inference_profile SSOT

### DIFF
--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -7,13 +7,16 @@
     @since God file decomposition — extracted from oas_worker.ml *)
 
 (* ================================================================ *)
-(* Inference defaults — single definition point (ADR D2).            *)
-(* Callers override via optional params.                             *)
-(* Cascade config auto-resolution tracked in jeong-sik/me#915.      *)
+(* Inference defaults — delegated to OAS Constants.Inference_profile. *)
+(* SSOT: agent_sdk/lib/llm_provider/constants.ml                     *)
+(* See jeong-sik/oas#598, jeong-sik/me#915.                         *)
 (* ================================================================ *)
 
-let default_temperature = 0.7
-let default_max_tokens = 4096
+let default_temperature =
+  Llm_provider.Constants.Inference_profile.agent_default.temperature
+
+let default_max_tokens =
+  Llm_provider.Constants.Inference_profile.agent_default.max_tokens
 
 (* ================================================================ *)
 (* Cascade types                                                     *)

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -263,7 +263,8 @@ let test_hook_skips_on_verify_error () =
          accumulated_cost_usd = 0.0;
          turn = 1;
          schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
+                      batch_size = 1; batch_kind = "sequential";
+                      concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -290,7 +291,8 @@ let test_hook_readonly_skips_verifier () =
          accumulated_cost_usd = 0.0;
          turn = 1;
          schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
+                      batch_size = 1; batch_kind = "sequential";
+                      concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;


### PR DESCRIPTION
## Summary
- `oas_worker_cascade.ml`: 로컬 `default_temperature=0.7 / default_max_tokens=4096`을 OAS `Llm_provider.Constants.Inference_profile.agent_default`로 교체
- `test_verifier_oas_bridge.ml`: OAS 0.100.4의 `batch_kind` 필드 호환성 수정

## Context
Det/NonDet 경계 재정립 Phase 1 MASC 측. MASC가 자체 추론 기본값을 유지하는 대신 OAS SSOT를 참조하도록 변경.

**Depends on**: jeong-sik/oas#598 (merged)

## Test plan
- [x] `dune build` 전체 성공 (lib/ + test/)
- [ ] `dune runtest` 전체 통과
- [ ] Keeper 기동 후 cascade 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)