### PR TITLE
refactor(provider): remove provider_family type — MASC vendor-agnostic

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.100.3))
+  (agent_sdk (>= 0.100.4))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -7,13 +7,16 @@
     @since God file decomposition — extracted from oas_worker.ml *)
 
 (* ================================================================ *)
-(* Inference defaults — single definition point (ADR D2).            *)
-(* Callers override via optional params.                             *)
-(* Cascade config auto-resolution tracked in jeong-sik/me#915.      *)
+(* Inference defaults — delegated to OAS Constants.Inference_profile. *)
+(* SSOT: agent_sdk/lib/llm_provider/constants.ml                     *)
+(* See jeong-sik/oas#598, jeong-sik/me#915.                         *)
 (* ================================================================ *)
 
-let default_temperature = 0.7
-let default_max_tokens = 4096
+let default_temperature =
+  Llm_provider.Constants.Inference_profile.agent_default.temperature
+
+let default_max_tokens =
+  Llm_provider.Constants.Inference_profile.agent_default.max_tokens
 
 (* ================================================================ *)
 (* Cascade types                                                     *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -70,28 +70,37 @@ let string_of_voice_transport = function
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
 
+(* ── Canonical adapter names (single definition point) ──────── *)
+
+let cn_llama = "llama"
+let cn_claude = "claude-api"
+let cn_codex = "codex-api"
+let cn_gemini = "gemini-api"
+let cn_glm = "glm"
+let cn_openrouter = "openrouter"
+
 let direct_adapters =
   [
     {
-      canonical_name = "llama";
+      canonical_name = cn_llama;
       runtime_kind = Local;
       auth_mode = No_auth;
       aliases = [ "llama"; "llama.cpp"; "llamacpp" ];
     };
     {
-      canonical_name = "claude-api";
+      canonical_name = cn_claude;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ANTHROPIC_API_KEY";
       aliases = [ "claude-api"; "claude"; "anthropic" ];
     };
     {
-      canonical_name = "codex-api";
+      canonical_name = cn_codex;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENAI_API_KEY";
       aliases = [ "codex-api"; "openai" ];
     };
     {
-      canonical_name = "gemini-api";
+      canonical_name = cn_gemini;
       runtime_kind = Direct_api;
       auth_mode =
         Vertex_adc
@@ -102,13 +111,13 @@ let direct_adapters =
       aliases = [ "gemini-api"; "gemini"; "google" ];
     };
     {
-      canonical_name = "glm";
+      canonical_name = cn_glm;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ZAI_API_KEY";
       aliases = [ "glm"; "glm_cloud"; "zai" ];
     };
     {
-      canonical_name = "openrouter";
+      canonical_name = cn_openrouter;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENROUTER_API_KEY";
       aliases = [ "openrouter" ];
@@ -576,12 +585,12 @@ let provider_model_label provider model =
     MASC no longer knows vendor families — only canonical adapter names. *)
 let default_model_label_for_adapter (adapter : adapter) =
   match adapter.canonical_name with
-  | "claude-api" -> Ok "claude:auto"
-  | "gemini-api" -> Ok "gemini:auto"
-  | "codex-api" -> Ok "openai:auto"
-  | "glm" -> Ok "glm:auto"
-  | "llama" -> explicit_llama_model_label_result ()
-  | "openrouter" ->
+  | s when s = cn_claude -> Ok "claude:auto"
+  | s when s = cn_gemini -> Ok "gemini:auto"
+  | s when s = cn_codex -> Ok "openai:auto"
+  | s when s = cn_glm -> Ok "glm:auto"
+  | s when s = cn_llama -> explicit_llama_model_label_result ()
+  | s when s = cn_openrouter ->
       Error "OpenRouter requires explicit runtime_model"
   | name ->
       Error (Printf.sprintf "Provider '%s' requires explicit runtime_model" name)
@@ -608,7 +617,7 @@ let auto_detect_adapters =
   List.filter
     (fun (adapter : adapter) ->
       adapter.runtime_kind = Direct_api
-      && adapter.canonical_name <> "openrouter")
+      && adapter.canonical_name <> cn_openrouter)
     direct_adapters
 
 let preferred_execution_model_labels () =

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -2,15 +2,6 @@ type runtime_kind =
   | Local
   | Direct_api
 
-type provider_family =
-  | Claude_family
-  | OpenAI_family
-  | Gemini_family
-  | Glm_family
-  | Llama_family
-  | OpenRouter_family
-  | Custom_family of string
-
 type auth_mode =
   | No_auth
   | Api_key of string
@@ -27,7 +18,6 @@ type voice_transport =
 type adapter = {
   canonical_name : string;
   runtime_kind : runtime_kind;
-  provider_family : provider_family;
   auth_mode : auth_mode;
   aliases : string list;
 }
@@ -35,7 +25,6 @@ type adapter = {
 type voice_adapter = {
   canonical_name : string;
   transport : voice_transport;
-  provider_family : provider_family;
   auth_mode : auth_mode;
   aliases : string list;
 }
@@ -68,15 +57,6 @@ let string_of_runtime_kind = function
   | Local -> "local"
   | Direct_api -> "direct_api"
 
-let string_of_provider_family = function
-  | Claude_family -> "claude"
-  | OpenAI_family -> "openai"
-  | Gemini_family -> "gemini"
-  | Glm_family -> "glm"
-  | Llama_family -> "llama"
-  | OpenRouter_family -> "openrouter"
-  | Custom_family name -> "custom:" ^ name
-
 let string_of_auth_mode = function
   | No_auth -> "none"
   | Api_key env_name -> "api_key:" ^ env_name
@@ -95,28 +75,24 @@ let direct_adapters =
     {
       canonical_name = "llama";
       runtime_kind = Local;
-      provider_family = Llama_family;
       auth_mode = No_auth;
       aliases = [ "llama"; "llama.cpp"; "llamacpp" ];
     };
     {
       canonical_name = "claude-api";
       runtime_kind = Direct_api;
-      provider_family = Claude_family;
       auth_mode = Api_key "ANTHROPIC_API_KEY";
       aliases = [ "claude-api"; "claude"; "anthropic" ];
     };
     {
       canonical_name = "codex-api";
       runtime_kind = Direct_api;
-      provider_family = OpenAI_family;
       auth_mode = Api_key "OPENAI_API_KEY";
       aliases = [ "codex-api"; "openai" ];
     };
     {
       canonical_name = "gemini-api";
       runtime_kind = Direct_api;
-      provider_family = Gemini_family;
       auth_mode =
         Vertex_adc
           {
@@ -128,14 +104,12 @@ let direct_adapters =
     {
       canonical_name = "glm";
       runtime_kind = Direct_api;
-      provider_family = Glm_family;
       auth_mode = Api_key "ZAI_API_KEY";
       aliases = [ "glm"; "glm_cloud"; "zai" ];
     };
     {
       canonical_name = "openrouter";
       runtime_kind = Direct_api;
-      provider_family = OpenRouter_family;
       auth_mode = Api_key "OPENROUTER_API_KEY";
       aliases = [ "openrouter" ];
     };
@@ -145,7 +119,6 @@ let voice_openai_compat_adapter =
   {
     canonical_name = "voice-openai-compat";
     transport = Voice_openai_compat;
-    provider_family = OpenAI_family;
     auth_mode = No_auth;
     aliases =
       [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ];
@@ -155,7 +128,6 @@ let voice_elevenlabs_direct_adapter =
   {
     canonical_name = "elevenlabs-direct";
     transport = Voice_elevenlabs_direct;
-    provider_family = Custom_family "elevenlabs";
     auth_mode = Api_key "ELEVENLABS_API_KEY";
     aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ];
   }
@@ -164,7 +136,6 @@ let voice_mcp_adapter =
   {
     canonical_name = "voice-mcp";
     transport = Voice_mcp;
-    provider_family = Custom_family "voice_mcp";
     auth_mode = No_auth;
     aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ];
   }
@@ -600,18 +571,20 @@ let provider_model_label provider model =
   if model = "" then None
   else Some (Printf.sprintf "%s:%s" provider model)
 
-(** Family → model label. Uses "provider:auto" for cloud providers;
-    OAS cascade resolves the concrete model at runtime. *)
-let default_model_label_for_family = function
-  | Claude_family -> Ok "claude:auto"
-  | Gemini_family -> Ok "gemini:auto"
-  | OpenAI_family -> Ok "openai:auto"
-  | Glm_family -> Ok "glm:auto"
-  | Llama_family -> explicit_llama_model_label_result ()
-  | OpenRouter_family ->
+(** canonical_name → model label. Uses "provider:auto" for cloud providers;
+    OAS cascade resolves the concrete model at runtime.
+    MASC no longer knows vendor families — only canonical adapter names. *)
+let default_model_label_for_adapter (adapter : adapter) =
+  match adapter.canonical_name with
+  | "claude-api" -> Ok "claude:auto"
+  | "gemini-api" -> Ok "gemini:auto"
+  | "codex-api" -> Ok "openai:auto"
+  | "glm" -> Ok "glm:auto"
+  | "llama" -> explicit_llama_model_label_result ()
+  | "openrouter" ->
       Error "OpenRouter requires explicit runtime_model"
-  | Custom_family _ ->
-      Error "Custom provider requires explicit runtime_model"
+  | name ->
+      Error (Printf.sprintf "Provider '%s' requires explicit runtime_model" name)
 
 (** Build the "provider:auto" label for each adapter that has auth
     credentials present.  Used by preferred_*_model_labels to avoid
@@ -624,7 +597,7 @@ let auto_label_for_adapter (adapter : adapter) =
   in
   if not is_available then None
   else
-    match default_model_label_for_family adapter.provider_family with
+    match default_model_label_for_adapter adapter with
     | Ok label -> Some label
     | Error _ -> None
 
@@ -635,7 +608,7 @@ let auto_detect_adapters =
   List.filter
     (fun (adapter : adapter) ->
       adapter.runtime_kind = Direct_api
-      && adapter.provider_family <> OpenRouter_family)
+      && adapter.canonical_name <> "openrouter")
     direct_adapters
 
 let preferred_execution_model_labels () =

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.100.3"}
+  "agent_sdk" {>= "0.100.4"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.100.3"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.100.5"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="1b293e24a1e324b68cff2ae9d3c07d6d4d85de0b"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.100.3"
+readonly OAS_AGENT_SDK_SHA="ed330c26b15ddfd75cfe92e2128a17671ef9090f"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.100.4"

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -54,20 +54,6 @@ let test_adapter_well_formed () =
       true (List.length a.aliases > 0))
     Adapter.direct_adapters
 
-let test_provider_family_roundtrip () =
-  let cases =
-    [ (Adapter.Claude_family, "claude");
-      (Adapter.OpenAI_family, "openai");
-      (Adapter.Gemini_family, "gemini");
-      (Adapter.Glm_family, "glm");
-      (Adapter.Llama_family, "llama");
-      (Adapter.OpenRouter_family, "openrouter") ]
-  in
-  List.iter (fun (family, expected) ->
-    check string ("family -> string")
-      expected (Adapter.string_of_provider_family family))
-    cases
-
 let test_runtime_kind_strings () =
   check string "local" "local" (Adapter.string_of_runtime_kind Adapter.Local);
   check string "direct_api" "direct_api"
@@ -194,8 +180,6 @@ let () =
           test_case "whitespace trimmed" `Quick test_whitespace_trimmed;
           test_case "unknown returns none" `Quick test_unknown_returns_none;
           test_case "adapter well formed" `Quick test_adapter_well_formed;
-          test_case "provider family roundtrip" `Quick
-            test_provider_family_roundtrip;
           test_case "runtime kind strings" `Quick test_runtime_kind_strings;
         ] );
       ( "oas_model_resolve",

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -263,7 +263,7 @@ let test_hook_skips_on_verify_error () =
          accumulated_cost_usd = 0.0;
          turn = 1;
          schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
+                      batch_size = 1; batch_kind = "sequential"; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify called" true !verify_called;
@@ -290,7 +290,7 @@ let test_hook_readonly_skips_verifier () =
          accumulated_cost_usd = 0.0;
          turn = 1;
          schedule = { planned_index = 0; batch_index = 0;
-                      batch_size = 1; concurrency_class = "default" };
+                      batch_size = 1; batch_kind = "sequential"; concurrency_class = "default" };
        })
   in
   Alcotest.(check bool) "verify skipped" false !verify_called;


### PR DESCRIPTION
## Summary
**Phase 1+3 통합**: Inference SSOT + Vendor Isolation

### Vendor Isolation (Phase 3)
- `type provider_family` (7개 생성자) 완전 제거 — MASC가 벤더를 타입 시스템에서 더 이상 인코딩하지 않음
- `adapter`/`voice_adapter` record에서 `provider_family` 필드 제거
- `default_model_label_for_family` → `default_model_label_for_adapter` (canonical_name 기반)
- `cn_*` 상수로 매직 스트링 추출 (GLM 리뷰 반영)

### Inference SSOT (Phase 1, 흡수: #4941)
- `oas_worker_cascade.ml`: 로컬 magic numbers → OAS `Llm_provider.Constants.Inference_profile.agent_default` 참조

### OAS Pin Update
- `oas-agent-sdk-pin.sh`: v0.100.3 → v0.100.5 (Inference_profile + Response_harness 포함)

## Test plan
- [x] `dune build` 전체 성공
- [x] `provider_family` grep: 문자열 리터럴 1건만 잔존 (메타데이터 키)
- [x] GLM-5.1 교차 모델 리뷰 완료
- [ ] CI green
- [ ] Keeper cascade provider 선택 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)