### PR TITLE
refactor(keeper): split meta parsing and keepalive helpers

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -23,9 +23,11 @@ include Keeper_tool_policy
     [keeper_allowed_model_tools]. The set of recordable tool names
     is therefore bounded by the keeper's allowed tool list — not
     by arbitrary user input. *)
-let on_keeper_tool_call :
-  (tool_name:string -> success:bool -> duration_ms:int -> unit) ref =
+let on_keeper_tool_call
+  : (tool_name:string -> success:bool -> duration_ms:int -> unit) ref
+  =
   ref (fun ~tool_name:_ ~success:_ ~duration_ms:_ -> ())
+;;
 
 (** Tag-based dispatch callback for masc_* tools.
     Set at server initialization to Keeper_tag_dispatch.dispatch.
@@ -35,11 +37,17 @@ let on_keeper_tool_call :
 
     Default: returns None (falls through to "unregistered" error).
     See: mcp_server_eio.ml initialization, #4579. *)
-let tag_dispatch_fn :
-  (config:Room.config -> agent_name:string ->
-   tag:Tool_dispatch.module_tag -> name:string ->
-   args:Yojson.Safe.t -> (bool * string) option) ref =
+let tag_dispatch_fn
+  : (config:Room.config
+     -> agent_name:string
+     -> tag:Tool_dispatch.module_tag
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> (bool * string) option)
+      ref
+  =
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
+;;
 
 (** Estimate total token count for a working context (system prompt + messages).
     Mirrors [Keeper_exec_context.token_count] but avoids a dependency cycle. *)
@@ -47,52 +55,56 @@ let count_context_tokens (ctx : working_context) =
   Agent_sdk.Context_reducer.estimate_char_tokens ctx.system_prompt
   + List.fold_left
       (fun acc m -> acc + Agent_sdk.Context_reducer.estimate_message_tokens m)
-      0 ctx.messages
+      0
+      ctx.messages
+;;
 
 let ensure_keeper_board_post_args ~author ~source = function
   | `Assoc fields ->
-      let fields =
-        List.filter
-          (fun (k, _) -> k <> "author" && k <> "post_kind" && k <> "meta")
-          fields
-      in
-      let has_hearth =
-        List.exists
-          (fun (k, v) ->
-            k = "hearth"
-            && (match v with `String s -> String.trim s <> "" | _ -> false))
-          fields
-      in
-      let fields =
-        if has_hearth then fields
-        else
-          ("hearth", `String author)
-          :: List.filter (fun (k, _) -> k <> "hearth") fields
-      in
-      `Assoc
-        ([
-           ("author", `String author);
-           ("post_kind", `String "automation");
-           ("meta", `Assoc [ ("source", `String source) ]);
-         ]
-        @ fields)
+    let fields =
+      List.filter (fun (k, _) -> k <> "author" && k <> "post_kind" && k <> "meta") fields
+    in
+    let has_hearth =
+      List.exists
+        (fun (k, v) ->
+           k = "hearth"
+           &&
+           match v with
+           | `String s -> String.trim s <> ""
+           | _ -> false)
+        fields
+    in
+    let fields =
+      if has_hearth
+      then fields
+      else ("hearth", `String author) :: List.filter (fun (k, _) -> k <> "hearth") fields
+    in
+    `Assoc
+      ([ "author", `String author
+       ; "post_kind", `String "automation"
+       ; "meta", `Assoc [ "source", `String source ]
+       ]
+       @ fields)
   | other -> other
+;;
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in
   `Assoc
-    [
-      ("status", `String "text_fallback");
-      ("agent_id", `String agent_id);
-      ("voice", `String voice);
-      ("message_preview", `String (short_preview ~max_len:50 message));
+    [ "status", `String "text_fallback"
+    ; "agent_id", `String agent_id
+    ; "voice", `String voice
+    ; "message_preview", `String (short_preview ~max_len:50 message)
     ]
+;;
 
 let shell_readonly_limit args =
   max 1 (min 200 (Safe_ops.json_int ~default:40 "limit" args))
+;;
 
 let shell_readonly_cat_max_bytes args =
   max 256 (min 100000 (Safe_ops.json_int ~default:4000 "max_bytes" args))
+;;
 
 let lines_to_json ?(limit = max_int) (text : string) : Yojson.Safe.t =
   let lines =
@@ -101,786 +113,841 @@ let lines_to_json ?(limit = max_int) (text : string) : Yojson.Safe.t =
     |> fun rows -> if List.length rows > limit then take limit rows else rows
   in
   `List (List.map (fun line -> `String line) lines)
+;;
+
+let error_json ?(fields = []) (message : string) =
+  Yojson.Safe.to_string (`Assoc (("error", `String message) :: fields))
+;;
+
+let tool_result_or_error (ok, msg) = if ok then msg else error_json msg
+
+let assoc_override_string (key : string) (value : string) = function
+  | `Assoc fields ->
+    let kept_fields = List.filter (fun (k, _) -> k <> key) fields in
+    `Assoc ((key, `String value) :: kept_fields)
+  | other -> other
+;;
+
+let keeper_effective_allowed_paths ~(meta : keeper_meta) =
+  Keeper_alerting_path.effective_allowed_paths ~meta
+;;
+
+let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path : string)
+  =
+  resolve_keeper_target_path
+    ~config
+    ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+    ~raw_path
+;;
+
+let handle_keeper_board_tool
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  let dispatch tool_name tool_args =
+    tool_result_or_error (Tool_board.handle_tool tool_name tool_args)
+  in
+  match name with
+  | "keeper_board_post" ->
+    let author = meta.name in
+    Log.Keeper.info
+      "keeper_board_post called by %s, raw args: %s"
+      author
+      (Yojson.Safe.to_string args);
+    let board_args =
+      ensure_keeper_board_post_args
+        ~author
+        ~source:"keeper_board_post"
+        (assoc_override_string "author" author args)
+    in
+    Log.Keeper.info "board_args: %s" (Yojson.Safe.to_string board_args);
+    let result = Tool_board.handle_tool "masc_board_post" board_args in
+    let ok, msg = result in
+    Log.Keeper.info
+      "handle_tool result: ok=%b msg=%s"
+      ok
+      (if String.length msg > 200 then String.sub msg 0 200 ^ "..." else msg);
+    tool_result_or_error result
+  | "keeper_board_list" -> dispatch "masc_board_list" args
+  | "keeper_board_get" -> dispatch "masc_board_get" args
+  | "keeper_board_comment" ->
+    dispatch "masc_board_comment" (assoc_override_string "author" meta.name args)
+  | "keeper_board_vote" ->
+    dispatch "masc_board_vote" (assoc_override_string "voter" meta.name args)
+  | "keeper_board_stats" -> dispatch "masc_board_stats" args
+  | "keeper_board_search" -> dispatch "masc_board_search" args
+  | "keeper_board_delete" -> dispatch "masc_board_delete" args
+  | other -> error_json ~fields:[ "tool", `String other ] "unknown_board_tool"
+;;
+
+let handle_keeper_fs_read
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let path = Safe_ops.json_string ~default:"" "path" args in
+  let max_bytes =
+    Safe_ops.json_int ~default:20000 "max_bytes" args |> fun n -> max 512 (min 200000 n)
+  in
+  match resolve_keeper_path ~config ~meta ~raw_path:path with
+  | Error e -> error_json e
+  | Ok target ->
+    (match Safe_ops.read_file_safe target with
+     | Error e -> error_json ~fields:[ "path", `String target ] e
+     | Ok content ->
+       let total = String.length content in
+       let truncated = total > max_bytes in
+       let body = if truncated then String.sub content 0 max_bytes else content in
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool true
+             ; "path", `String target
+             ; "bytes", `Int total
+             ; "truncated", `Bool truncated
+             ; "content", `String body
+             ]))
+;;
+
+let handle_keeper_fs_edit
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let path = Safe_ops.json_string ~default:"" "path" args in
+  let content = Safe_ops.json_string ~default:"" "content" args in
+  let mode =
+    Safe_ops.json_string ~default:"overwrite" "mode" args |> String.lowercase_ascii
+  in
+  match resolve_keeper_path ~config ~meta ~raw_path:path with
+  | Error e -> error_json e
+  | Ok target ->
+    (try
+       let parent = Filename.dirname target in
+       Fs_compat.mkdir_p parent;
+       (match mode with
+        | "append" -> Fs_compat.append_file target content
+        | "overwrite" | "" -> Fs_compat.save_file target content
+        | other -> raise (Invalid_argument ("unsupported_mode:" ^ other)));
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool true
+             ; "path", `String target
+             ; "mode", `String (if mode = "" then "overwrite" else mode)
+             ; "bytes_written", `Int (String.length content)
+             ])
+     with
+     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
+     | Sys_error e -> error_json ~fields:[ "path", `String target ] e
+     | Unix.Unix_error (err, _, _) ->
+       error_json ~fields:[ "path", `String target ] (Unix.error_message err))
+;;
+
+let handle_keeper_bash
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
+  let timeout_sec =
+    Safe_ops.json_float ~default:30.0 "timeout_sec" args |> fun n -> max 1.0 (min 180.0 n)
+  in
+  if cmd = ""
+  then error_json "cmd_required"
+  else (
+    match Worker_dev_tools.validate_command cmd with
+    | Error reason ->
+      Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd;
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String "command_blocked"
+            ; "reason", `String reason
+            ])
+    | Ok () ->
+      if Worker_dev_tools.is_write_operation cmd
+      then (
+        Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s)" cmd meta.name;
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool false
+              ; "error", `String "write_operation_gated"
+              ; ( "reason"
+                , `String
+                    "This command modifies state (git push/commit, make deploy, etc.). \
+                     Use keeper_shell_readonly for read operations, or request \
+                     shell_mode=coding policy from the operator." )
+              ; "cmd", `String cmd
+              ]))
+      else (
+        let root = project_root_of_config config in
+        let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd in
+        let st, out =
+          Process_eio.run_argv_with_status ~timeout_sec [ "/bin/bash"; "-lc"; shell_cmd ]
+        in
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool (st = Unix.WEXITED 0)
+              ; "status", process_status_to_json st
+              ; "output", `String (truncate_tool_output out)
+              ])))
+;;
+
+let handle_keeper_shell_readonly
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let op =
+    Safe_ops.json_string ~default:"" "op" args |> String.trim |> String.lowercase_ascii
+  in
+  let root = project_root_of_config config in
+  let read_target () =
+    let raw_path = Safe_ops.json_string ~default:"." "path" args in
+    resolve_keeper_path ~config ~meta ~raw_path
+  in
+  let render_process_result ~cmd argv =
+    let st, out = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+    Yojson.Safe.to_string
+      (`Assoc
+          [ "ok", `Bool (st = Unix.WEXITED 0)
+          ; "op", `String op
+          ; "cmd", `String cmd
+          ; "status", process_status_to_json st
+          ; "output", `String (truncate_tool_output out)
+          ])
+  in
+  match op with
+  | "pwd" -> render_process_result ~cmd:"pwd" [ "/bin/pwd" ]
+  | "git_status" ->
+    render_process_result
+      ~cmd:"git -C <root> status --short --branch"
+      [ "git"; "-C"; root; "status"; "--short"; "--branch" ]
+  | "ls" ->
+    (match read_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok target ->
+       let st, out =
+         Process_eio.run_argv_with_status ~timeout_sec:15.0 [ "/bin/ls"; "-la"; target ]
+       in
+       let limit = shell_readonly_limit args in
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool (st = Unix.WEXITED 0)
+             ; "op", `String op
+             ; "path", `String target
+             ; "status", process_status_to_json st
+             ; "entries", lines_to_json ~limit out
+             ]))
+  | "cat" ->
+    (match read_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok target ->
+       let max_bytes = shell_readonly_cat_max_bytes args in
+       let st, out =
+         Process_eio.run_argv_with_status ~timeout_sec:15.0 [ "/bin/cat"; target ]
+       in
+       let body =
+         if String.length out > max_bytes then String.sub out 0 max_bytes else out
+       in
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool (st = Unix.WEXITED 0)
+             ; "op", `String op
+             ; "path", `String target
+             ; "status", process_status_to_json st
+             ; "truncated", `Bool (String.length out > max_bytes)
+             ; "content", `String body
+             ]))
+  | "rg" ->
+    let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
+    if pattern = ""
+    then error_json ~fields:[ "op", `String op ] "pattern_required"
+    else (
+      match read_target () with
+      | Error e -> error_json ~fields:[ "op", `String op ] e
+      | Ok target ->
+        let limit = shell_readonly_limit args in
+        let st, out =
+          Process_eio.run_argv_with_status
+            ~timeout_sec:15.0
+            [ "rg"; "-n"; "-m"; string_of_int limit; pattern; target ]
+        in
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool (st = Unix.WEXITED 0)
+              ; "op", `String op
+              ; "path", `String target
+              ; "pattern", `String pattern
+              ; "status", process_status_to_json st
+              ; "matches", lines_to_json ~limit out
+              ]))
+  | _ ->
+    Yojson.Safe.to_string
+      (`Assoc
+          [ "error", `String "unsupported_op"
+          ; "op", `String op
+          ; ( "supported_ops"
+            , `List
+                (List.map
+                   (fun name -> `String name)
+                   [ "pwd"; "ls"; "cat"; "rg"; "git_status" ]) )
+          ])
+;;
+
+let handle_keeper_github
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
+  let gh_args = Safe_ops.json_string_list "args" args in
+  let timeout_sec =
+    Safe_ops.json_float ~default:30.0 "timeout_sec" args |> fun n -> max 1.0 (min 180.0 n)
+  in
+  let gh_raw =
+    if cmd <> "" then cmd else if gh_args <> [] then String.concat " " gh_args else ""
+  in
+  if gh_raw = ""
+  then error_json "cmd_or_args_required"
+  else (
+    match Worker_dev_tools.validate_gh_command gh_raw with
+    | Error reason ->
+      Log.Keeper.warn "keeper_github blocked: %s (cmd=%s)" reason gh_raw;
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String "command_blocked"
+            ; "reason", `String reason
+            ])
+    | Ok () ->
+      if Worker_dev_tools.is_gh_destructive_operation gh_raw
+      then (
+        Log.Keeper.info "keeper_github destructive-gate: %s (keeper=%s)" gh_raw meta.name;
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool false
+              ; "error", `String "destructive_operation_gated"
+              ; ( "reason"
+                , `String
+                    "This gh command performs a destructive mutation \
+                     (merge/close/delete/archive). Use read-only commands \
+                     (view/list/diff/checks) or request operator approval." )
+              ; "cmd", `String ("gh " ^ gh_raw)
+              ]))
+      else (
+        let gh_cmd =
+          if cmd <> ""
+          then "gh " ^ cmd
+          else "gh " ^ String.concat " " (List.map Filename.quote gh_args)
+        in
+        let root = project_root_of_config config in
+        let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
+        let st, out =
+          Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
+        in
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool (st = Unix.WEXITED 0)
+              ; "status", process_status_to_json st
+              ; "output", `String (truncate_tool_output out)
+              ])))
+;;
+
+let keeper_agent_sender ~(meta : keeper_meta) = Printf.sprintf "keeper-%s" meta.name
+
+let keeper_tools_list_json ~(meta : keeper_meta) =
+  let names = keeper_allowed_tool_names meta in
+  let categorize n =
+    if String.starts_with ~prefix:"keeper_board" n
+    then "board"
+    else if String.starts_with ~prefix:"keeper_voice" n
+    then "voice"
+    else if String.starts_with ~prefix:"keeper_task" n
+    then "coordination"
+    else if
+      String.starts_with ~prefix:"keeper_shell" n
+      || n = "keeper_bash"
+      || n = "keeper_github"
+    then "shell"
+    else if
+      String.starts_with ~prefix:"keeper_fs" n
+      || String.starts_with ~prefix:"keeper_library" n
+    then "filesystem"
+    else if
+      String.starts_with ~prefix:"masc_code" n
+      || String.starts_with ~prefix:"masc_worktree" n
+    then "coding"
+    else if
+      String.starts_with ~prefix:"masc_governance" n
+      || String.starts_with ~prefix:"masc_petition" n
+      || String.starts_with ~prefix:"masc_case" n
+    then "governance"
+    else if String.starts_with ~prefix:"masc_autoresearch" n
+    then "autoresearch"
+    else if String.starts_with ~prefix:"masc_" n
+    then "masc_bridge"
+    else if String.starts_with ~prefix:"keeper_" n
+    then "base"
+    else "other"
+  in
+  let groups : (string, string list) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun n ->
+       let cat = categorize n in
+       let prev =
+         match Hashtbl.find_opt groups cat with
+         | Some l -> l
+         | None -> []
+       in
+       Hashtbl.replace groups cat (n :: prev))
+    names;
+  let entries =
+    Hashtbl.fold
+      (fun cat ns acc -> (cat, `List (List.rev_map (fun n -> `String n) ns)) :: acc)
+      groups
+      []
+  in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "total", `Int (List.length names)
+        ; ( "categories"
+          , `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries) )
+        ])
+;;
+
+let keeper_context_status_json ~(meta : keeper_meta) ~(ctx_work : working_context) =
+  let continuity = latest_state_snapshot_from_messages ctx_work.messages in
+  let continuity_summary =
+    match continuity with
+    | None ->
+      let trimmed = String.trim meta.continuity_summary in
+      if trimmed = "" then "No continuity snapshot available." else trimmed
+    | Some snapshot -> keeper_state_snapshot_to_summary_text snapshot
+  in
+  let ctx_tokens = count_context_tokens ctx_work in
+  let ctx_ratio =
+    if ctx_work.max_tokens = 0
+    then 0.0
+    else float_of_int ctx_tokens /. float_of_int ctx_work.max_tokens
+  in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "name", `String meta.name
+        ; "trace_id", `String meta.runtime.trace_id
+        ; "generation", `Int meta.runtime.generation
+        ; "context_ratio", `Float ctx_ratio
+        ; "context_tokens", `Int ctx_tokens
+        ; "context_max", `Int ctx_work.max_tokens
+        ; "message_count", `Int (List.length ctx_work.messages)
+        ; "last_model_used", `String meta.runtime.usage.last_model_used
+        ; ( "continuity_state"
+          , match continuity with
+            | None -> `Null
+            | Some snapshot -> keeper_state_snapshot_to_json snapshot )
+        ; "continuity_summary", `String continuity_summary
+        ])
+;;
+
+let keeper_memory_search_json ~(ctx_work : working_context) ~(args : Yojson.Safe.t) =
+  let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
+  let limit = max 1 (min 8 (Safe_ops.json_int ~default:5 "limit" args)) in
+  let user_msgs = extract_user_messages ctx_work in
+  let matches =
+    user_msgs
+    |> List.filter (fun msg -> query <> "" && contains_ci msg query)
+    |> List.rev
+    |> take limit
+    |> List.map (fun msg -> `String msg)
+  in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "query", `String query
+        ; "match_count", `Int (List.length matches)
+        ; "matches", `List matches
+        ])
+;;
+
+let handle_keeper_voice_tool
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  match name with
+  | "keeper_voice_speak" ->
+    let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
+    let provider =
+      Safe_ops.json_string_opt "provider" args
+      |> Option.map String.trim
+      |> function
+      | Some p when p <> "" -> Some p
+      | _ -> None
+    in
+    let priority = max 1 (Safe_ops.json_int ~default:1 "priority" args) in
+    if message = ""
+    then error_json "message_required"
+    else (
+      match
+        ( Eio_context.get_switch_opt ()
+        , Eio_context.get_clock_opt ()
+        , Eio_context.get_net_opt () )
+      with
+      | Some sw, Some clock, Some net ->
+        (match
+           Voice_bridge.agent_speak
+             ~sw
+             ~clock
+             ~net
+             ~agent_id:meta.name
+             ~message
+             ?provider
+             ~priority
+             ()
+         with
+         | Ok json -> Yojson.Safe.to_string json
+         | Error err ->
+           Yojson.Safe.to_string
+             (`Assoc
+                 [ "status", `String "error"
+                 ; "agent_id", `String meta.name
+                 ; "message", `String err
+                 ]))
+      | _ ->
+        Yojson.Safe.to_string (keeper_text_fallback_json ~agent_id:meta.name ~message))
+  | "keeper_voice_listen" ->
+    let timeout_sec = Safe_ops.json_float ~default:15.0 "timeout_seconds" args in
+    let language_code = Safe_ops.json_string_opt "language_code" args in
+    (match
+       Voice_bridge.record_and_transcribe
+         ~agent_id:meta.name
+         ~timeout_sec
+         ?language_code
+         ()
+     with
+     | Ok json -> Yojson.Safe.to_string json
+     | Error err ->
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "status", `String "error"
+             ; "error", `String err
+             ; "agent_id", `String meta.name
+             ]))
+  | "keeper_voice_agent" ->
+    (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
+     | Ok json -> Yojson.Safe.to_string json
+     | Error err ->
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "status", `String "error"
+             ; "agent_id", `String meta.name
+             ; "message", `String err
+             ]))
+  | "keeper_voice_sessions" ->
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let sessions = Voice_session_manager.list_sessions mgr in
+    Yojson.Safe.to_string
+      (`Assoc
+          [ "session_count", `Int (List.length sessions)
+          ; "sessions", `List (List.map Voice_session_manager.session_to_json sessions)
+          ])
+  | "keeper_voice_session_start" ->
+    let voice =
+      Safe_ops.json_string_opt "session_name" args
+      |> Option.map String.trim
+      |> function
+      | Some s when s <> "" -> Some s
+      | _ -> None
+    in
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let session = Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice () in
+    Yojson.Safe.to_string (Voice_session_manager.session_to_json session)
+  | "keeper_voice_session_end" ->
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
+    Yojson.Safe.to_string
+      (`Assoc
+          [ "status", `String (if ended then "ended" else "no_active_session")
+          ; "agent_id", `String meta.name
+          ])
+  | other -> error_json ~fields:[ "tool", `String other ] "unknown_voice_tool"
+;;
+
+let keeper_task_result_json = function
+  | Ok msg -> Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "result", `String msg ])
+  | Error e ->
+    Yojson.Safe.to_string
+      (`Assoc [ "ok", `Bool false; "error", `String (Types.masc_error_to_string e) ])
+;;
+
+let handle_keeper_task_tool
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  match name with
+  | "keeper_tasks_list" ->
+    let status_filter = Safe_ops.json_string_opt "status" args in
+    let include_done = Safe_ops.json_bool ~default:false "include_done" args in
+    Room.list_tasks ?status:status_filter ~include_done config
+  | "keeper_tasks_audit" ->
+    let orphans = Room.audit_orphan_tasks config in
+    let items =
+      List.map
+        (fun (task, assignee) ->
+           let task : Types.task = task in
+           `Assoc
+             [ "task_id", `String task.id
+             ; "title", `String task.title
+             ; "assignee", `String assignee
+             ; "status", `String (Types.string_of_task_status task.task_status)
+             ])
+        orphans
+    in
+    Yojson.Safe.to_string
+      (`Assoc [ "orphan_count", `Int (List.length orphans); "orphans", `List items ])
+  | "keeper_task_force_release" ->
+    let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
+    let reason = Safe_ops.json_string ~default:"" "reason" args in
+    if task_id = ""
+    then error_json "task_id required"
+    else (
+      let agent = keeper_agent_sender ~meta in
+      let _ =
+        Room.broadcast
+          config
+          ~from_agent:agent
+          ~content:
+            (Printf.sprintf
+               "Force-releasing task %s (reason: %s)"
+               task_id
+               (if reason = "" then "no reason given" else reason))
+      in
+      keeper_task_result_json
+        (Room.force_release_task_r config ~agent_name:agent ~task_id ()))
+  | "keeper_task_force_done" ->
+    let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
+    let notes = Safe_ops.json_string ~default:"" "notes" args in
+    if task_id = ""
+    then error_json "task_id required"
+    else
+      keeper_task_result_json
+        (Room.force_done_task_r
+           config
+           ~agent_name:(keeper_agent_sender ~meta)
+           ~task_id
+           ~notes
+           ())
+  | "keeper_broadcast" ->
+    let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
+    if message = ""
+    then error_json "message required"
+    else (
+      let _ =
+        Room.broadcast config ~from_agent:(keeper_agent_sender ~meta) ~content:message
+      in
+      Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "broadcast", `String message ]))
+  | "keeper_task_claim" ->
+    let result = Room.claim_next config ~agent_name:meta.agent_name in
+    Yojson.Safe.to_string (`Assoc [ "result", `String result ])
+  | "keeper_task_done" ->
+    let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
+    let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in
+    if task_id = ""
+    then error_json "task_id required"
+    else
+      keeper_task_result_json
+        (Room.force_done_task_r
+           config
+           ~agent_name:(keeper_agent_sender ~meta)
+           ~task_id
+           ~notes:(if result_text = "" then "" else result_text)
+           ())
+  | other -> error_json ~fields:[ "tool", `String other ] "unknown_task_tool"
+;;
+
+let handle_keeper_autoresearch_tool
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  let ctx : Tool_autoresearch.context =
+    { base_path = project_root_of_config config
+    ; agent_name = Some meta.name
+    ; start_operation = None
+    ; start_team_session = None
+    ; config = Some config
+    ; sw = None
+    ; clock = None
+    }
+  in
+  match Tool_autoresearch.dispatch ctx ~name ~args with
+  | Some (true, msg) -> msg
+  | Some (false, msg) -> error_json msg
+  | None -> error_json ~fields:[ "tool", `String name ] "unknown_autoresearch_tool"
+;;
+
+let keeper_masc_path_blocked
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let effective_paths = keeper_effective_allowed_paths ~meta in
+  if effective_paths = [] && meta.execution_scope <> "observe_only"
+  then None
+  else if meta.execution_scope = "observe_only" && effective_paths = []
+  then (
+    let has_path_arg =
+      List.exists
+        (fun key ->
+           match Yojson.Safe.Util.member key args with
+           | `String p when String.trim p <> "" -> true
+           | _ -> false)
+        [ "path"; "file_path"; "target_path" ]
+    in
+    if has_path_arg then Some "observe_only_scope: write paths blocked" else None)
+  else (
+    let candidates =
+      List.filter_map
+        (fun key ->
+           match Yojson.Safe.Util.member key args with
+           | `String p when String.trim p <> "" -> Some p
+           | _ -> None)
+        [ "path"; "file_path"; "target_path" ]
+    in
+    List.find_map
+      (fun raw ->
+         match
+           resolve_keeper_target_path ~config ~allowed_paths:effective_paths ~raw_path:raw
+         with
+         | Error e -> Some e
+         | Ok _ -> None)
+      candidates)
+;;
+
+let handle_keeper_masc_tool
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  match keeper_masc_path_blocked ~config ~meta ~args with
+  | Some err -> error_json err
+  | None ->
+    (match Tool_dispatch.mint_token ~name with
+     | Error reason ->
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "error", `String "unregistered_masc_tool"
+             ; "tool", `String name
+             ; "reason", `String reason
+             ])
+     | Ok token ->
+       (match Tool_dispatch.dispatch ~token ~args with
+        | Some (true, msg) -> msg
+        | Some (false, msg) -> error_json msg
+        | None ->
+          if Tool_dispatch.is_mcp_context_required name
+          then
+            error_json
+              (Printf.sprintf
+                 "tool '%s' requires MCP session (use keeper_* equivalent)"
+                 name)
+          else (
+            match Tool_dispatch.lookup_tag name with
+            | Some tag ->
+              let keeper_agent = keeper_agent_sender ~meta in
+              (match
+                 !tag_dispatch_fn ~config ~agent_name:keeper_agent ~tag ~name ~args
+               with
+               | Some (true, msg) -> msg
+               | Some (false, msg) -> error_json msg
+               | None ->
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "error", `String "tool_not_supported_in_keeper"
+                       ; "tool", `String name
+                       ; ( "hint"
+                         , `String
+                             "tag dispatch returned None; tool may be unsupported, \
+                              blocked, or misconfigured" )
+                       ]))
+            | None ->
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "error", `String "unregistered_masc_tool"; "tool", `String name ]))))
+;;
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)
 
 let execute_keeper_tool_call
-    ~(config : Room.config)
-    ~(meta : keeper_meta)
-    ~(ctx_work : working_context)
-    ~(name : string) ~(input : Yojson.Safe.t) : string =
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(ctx_work : working_context)
+      ~(name : string)
+      ~(input : Yojson.Safe.t)
+  : string
+  =
   let args = input in
   let now_ts = Time_compat.now () in
   let lookup = tool_access_lookup_of_meta meta in
-  if not (can_execute ~lookup name) then
+  if not (can_execute ~lookup name)
+  then
     Yojson.Safe.to_string
-      (`Assoc [ ("error", `String "tool_not_allowed");
-                ("tool", `String name) ])
-  else
-  match name with
-  | "keeper_tools_list" ->
-      let names = keeper_allowed_tool_names meta in
-      let categorize n =
-        if String.starts_with ~prefix:"keeper_board" n then "board"
-        else if String.starts_with ~prefix:"keeper_voice" n then "voice"
-        else if String.starts_with ~prefix:"keeper_task" n then "coordination"
-        else if String.starts_with ~prefix:"keeper_shell" n || n = "keeper_bash" || n = "keeper_github" then "shell"
-        else if String.starts_with ~prefix:"keeper_fs" n || String.starts_with ~prefix:"keeper_library" n then "filesystem"
-        else if String.starts_with ~prefix:"masc_code" n || String.starts_with ~prefix:"masc_worktree" n then "coding"
-        else if String.starts_with ~prefix:"masc_governance" n || String.starts_with ~prefix:"masc_petition" n || String.starts_with ~prefix:"masc_case" n then "governance"
-        else if String.starts_with ~prefix:"masc_autoresearch" n then "autoresearch"
-        else if String.starts_with ~prefix:"masc_" n then "masc_bridge"
-        else if String.starts_with ~prefix:"keeper_" n then "base"
-        else "other"
-      in
-      let groups : (string, string list) Hashtbl.t = Hashtbl.create 16 in
-      List.iter (fun n ->
-        let cat = categorize n in
-        let prev = match Hashtbl.find_opt groups cat with Some l -> l | None -> [] in
-        Hashtbl.replace groups cat (n :: prev)
-      ) names;
-      let entries =
-        Hashtbl.fold (fun cat ns acc ->
-          (cat, `List (List.rev_map (fun n -> `String n) ns)) :: acc
-        ) groups []
-      in
+      (`Assoc [ "error", `String "tool_not_allowed"; "tool", `String name ])
+  else (
+    match name with
+    | "keeper_tools_list" -> keeper_tools_list_json ~meta
+    | "keeper_time_now" ->
       Yojson.Safe.to_string
-        (`Assoc [
-          ("total", `Int (List.length names));
-          ("categories", `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries));
-        ])
-  | "keeper_time_now" ->
+        (`Assoc [ "now_iso", `String (now_iso ()); "now_unix", `Float now_ts ])
+    | "keeper_context_status" -> keeper_context_status_json ~meta ~ctx_work
+    | "keeper_memory_search" -> keeper_memory_search_json ~ctx_work ~args
+    | "keeper_library_search" ->
+      let ok, msg =
+        Tool_library.handle_search Tool_library.{ agent_name = meta.name } args
+      in
+      if ok then msg else Yojson.Safe.to_string (`Assoc [ "error", `String msg ])
+    | "keeper_library_read" ->
+      let ok, msg =
+        Tool_library.handle_read Tool_library.{ agent_name = meta.name } args
+      in
+      tool_result_or_error (ok, msg)
+    | "keeper_board_post"
+    | "keeper_board_list"
+    | "keeper_board_get"
+    | "keeper_board_comment"
+    | "keeper_board_vote"
+    | "keeper_board_stats"
+    | "keeper_board_search"
+    | "keeper_board_delete" -> handle_keeper_board_tool ~meta ~name ~args
+    | "keeper_fs_read" -> handle_keeper_fs_read ~config ~meta ~args
+    | "keeper_fs_edit" -> handle_keeper_fs_edit ~config ~meta ~args
+    | "keeper_bash" -> handle_keeper_bash ~config ~meta ~args
+    | "keeper_shell_readonly" -> handle_keeper_shell_readonly ~config ~meta ~args
+    | "keeper_voice_speak"
+    | "keeper_voice_listen"
+    | "keeper_voice_agent"
+    | "keeper_voice_sessions"
+    | "keeper_voice_session_start"
+    | "keeper_voice_session_end" -> handle_keeper_voice_tool ~meta ~name ~args
+    | "keeper_github" -> handle_keeper_github ~config ~meta ~args
+    | "keeper_tasks_list"
+    | "keeper_tasks_audit"
+    | "keeper_task_force_release"
+    | "keeper_task_force_done"
+    | "keeper_broadcast"
+    | "keeper_task_claim"
+    | "keeper_task_done" -> handle_keeper_task_tool ~config ~meta ~name ~args
+    | name when String.starts_with ~prefix:"masc_autoresearch_" name ->
+      handle_keeper_autoresearch_tool ~config ~meta ~name ~args
+    | name when String.starts_with ~prefix:"masc_" name ->
+      handle_keeper_masc_tool ~config ~meta ~name ~args
+    | other ->
       Yojson.Safe.to_string
-        (`Assoc
-          [ ("now_iso", `String (now_iso ())); ("now_unix", `Float now_ts) ])
-  | "keeper_context_status" ->
-      let continuity = latest_state_snapshot_from_messages ctx_work.messages in
-      let continuity_summary =
-        match continuity with
-        | None ->
-            let trimmed = String.trim meta.continuity_summary in
-            if trimmed = "" then "No continuity snapshot available." else trimmed
-        | Some snapshot -> keeper_state_snapshot_to_summary_text snapshot
-      in
-      let ctx_tokens = count_context_tokens ctx_work in
-      let ctx_ratio =
-        if ctx_work.max_tokens = 0 then 0.0
-        else float_of_int ctx_tokens /. float_of_int ctx_work.max_tokens
-      in
-      Yojson.Safe.to_string
-        (`Assoc
-          [
-            ("name", `String meta.name);
-            ("trace_id", `String meta.runtime.trace_id);
-            ("generation", `Int meta.runtime.generation);
-            ("context_ratio", `Float ctx_ratio);
-            ("context_tokens", `Int ctx_tokens);
-            ("context_max", `Int ctx_work.max_tokens);
-            ("message_count", `Int ((List.length ctx_work.messages)));
-            ("last_model_used", `String meta.runtime.usage.last_model_used);
-            ( "continuity_state",
-              match continuity with
-              | None -> `Null
-              | Some snapshot -> keeper_state_snapshot_to_json snapshot );
-            ("continuity_summary", `String continuity_summary);
-          ])
-  | "keeper_memory_search" ->
-      let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
-      let limit = max 1 (min 8 (Safe_ops.json_int ~default:5 "limit" args)) in
-      let user_msgs = extract_user_messages ctx_work in
-      let matches =
-        user_msgs
-        |> List.filter (fun msg -> query <> "" && contains_ci msg query)
-        |> List.rev
-        |> take limit
-        |> List.map (fun msg -> `String msg)
-      in
-      Yojson.Safe.to_string
-        (`Assoc
-          [
-            ("query", `String query);
-            ("match_count", `Int (List.length matches));
-            ("matches", `List matches);
-          ])
-  | "keeper_library_search" ->
-      let ok, msg = Tool_library.handle_search
-        Tool_library.{ agent_name = meta.name }
-        args
-      in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_library_read" ->
-      let ok, msg = Tool_library.handle_read
-        Tool_library.{ agent_name = meta.name }
-        args
-      in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_post" ->
-      let author = meta.name in
-      Log.Keeper.info "keeper_board_post called by %s, raw args: %s"
-        author (Yojson.Safe.to_string args);
-      let board_args =
-        match args with
-        | `Assoc fields ->
-            let fields' = List.filter (fun (k, _) -> k <> "author") fields in
-            `Assoc (("author", `String author) :: fields')
-        | other -> other
-      in
-      let board_args =
-        ensure_keeper_board_post_args
-          ~author ~source:"keeper_board_post" board_args
-      in
-      Log.Keeper.info "board_args: %s"
-        (Yojson.Safe.to_string board_args);
-      let ok, msg = Tool_board.handle_tool "masc_board_post" board_args in
-      Log.Keeper.info "handle_tool result: ok=%b msg=%s" ok
-        (if String.length msg > 200 then String.sub msg 0 200 ^ "..." else msg);
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_list" ->
-      let ok, msg = Tool_board.handle_tool "masc_board_list" args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_get" ->
-      let ok, msg = Tool_board.handle_tool "masc_board_get" args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_comment" ->
-      let author = meta.name in
-      let board_args =
-        match args with
-        | `Assoc fields ->
-            let fields' = List.filter (fun (k, _) -> k <> "author") fields in
-            `Assoc (("author", `String author) :: fields')
-        | other -> other
-      in
-      let ok, msg = Tool_board.handle_tool "masc_board_comment" board_args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_vote" ->
-      let voter = meta.name in
-      let board_args =
-        match args with
-        | `Assoc fields ->
-            let fields' = List.filter (fun (k, _) -> k <> "voter") fields in
-            `Assoc (("voter", `String voter) :: fields')
-        | other -> other
-      in
-      let ok, msg = Tool_board.handle_tool "masc_board_vote" board_args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_stats" ->
-      let ok, msg = Tool_board.handle_tool "masc_board_stats" args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_search" ->
-      let ok, msg = Tool_board.handle_tool "masc_board_search" args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_board_delete" ->
-      let ok, msg = Tool_board.handle_tool "masc_board_delete" args in
-      if ok then msg
-      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-  | "keeper_fs_read" ->
-      let path = Safe_ops.json_string ~default:"" "path" args in
-      let max_bytes =
-        Safe_ops.json_int ~default:20000 "max_bytes" args
-        |> fun n -> max 512 (min 200000 n)
-      in
-      (match resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path:path with
-      | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
-      | Ok target -> (
-          match Safe_ops.read_file_safe target with
-          | Error e ->
-              Yojson.Safe.to_string
-                (`Assoc [ ("error", `String e); ("path", `String target) ])
-          | Ok content ->
-              let total = String.length content in
-              let truncated = total > max_bytes in
-              let body =
-                if truncated then String.sub content 0 max_bytes else content
-              in
-              Yojson.Safe.to_string
-                (`Assoc
-                  [
-                    ("ok", `Bool true);
-                    ("path", `String target);
-                    ("bytes", `Int total);
-                    ("truncated", `Bool truncated);
-                    ("content", `String body);
-                  ])))
-  | "keeper_fs_edit" ->
-      let path = Safe_ops.json_string ~default:"" "path" args in
-      let content = Safe_ops.json_string ~default:"" "content" args in
-      let mode =
-        Safe_ops.json_string ~default:"overwrite" "mode" args
-        |> String.lowercase_ascii
-      in
-      (match resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path:path with
-      | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
-      | Ok target ->
-          (try
-             let parent = Filename.dirname target in
-             Fs_compat.mkdir_p parent;
-             (match mode with
-             | "append" ->
-                 Fs_compat.append_file target content
-             | "overwrite" | "" ->
-                 Fs_compat.save_file target content
-             | other -> raise (Invalid_argument ("unsupported_mode:" ^ other)));
-             Yojson.Safe.to_string
-               (`Assoc
-                 [
-                   ("ok", `Bool true);
-                   ("path", `String target);
-                   ("mode", `String (if mode = "" then "overwrite" else mode));
-                   ("bytes_written", `Int (String.length content));
-                 ])
-           with
-          | Invalid_argument e ->
-              Yojson.Safe.to_string
-                (`Assoc [ ("error", `String e); ("path", `String target) ])
-          | Sys_error e ->
-              Yojson.Safe.to_string
-                (`Assoc [ ("error", `String e); ("path", `String target) ])
-          | Unix.Unix_error (err, _, _) ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [
-                    ("error", `String (Unix.error_message err));
-                    ("path", `String target);
-                  ])))
-  | "keeper_bash" ->
-      let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
-      let timeout_sec =
-        Safe_ops.json_float ~default:30.0 "timeout_sec" args
-        |> fun n -> max 1.0 (min 180.0 n)
-      in
-      if cmd = "" then
-        Yojson.Safe.to_string (`Assoc [ ("error", `String "cmd_required") ])
-      else begin
-        match Worker_dev_tools.validate_command cmd with
-        | Error reason ->
-          Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd;
-          Yojson.Safe.to_string
-            (`Assoc [
-              ("ok", `Bool false);
-              ("error", `String "command_blocked");
-              ("reason", `String reason);
-            ])
-        | Ok () ->
-          if Worker_dev_tools.is_write_operation cmd then begin
-            Log.Keeper.info
-              "keeper_bash write-gate: %s (keeper=%s)"
-              cmd (meta.name);
-            Yojson.Safe.to_string
-              (`Assoc [
-                ("ok", `Bool false);
-                ("error", `String "write_operation_gated");
-                ("reason", `String
-                  "This command modifies state (git push/commit, make deploy, etc.). \
-                   Use keeper_shell_readonly for read operations, or request \
-                   shell_mode=coding policy from the operator.");
-                ("cmd", `String cmd);
-              ])
-          end else begin
-            let root = project_root_of_config config in
-            let shell_cmd =
-              Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd
-            in
-            let st, out =
-              Process_eio.run_argv_with_status ~timeout_sec
-                [ "/bin/bash"; "-lc"; shell_cmd ]
-            in
-            Yojson.Safe.to_string
-              (`Assoc
-                [
-                  ("ok", `Bool (st = Unix.WEXITED 0));
-                  ("status", process_status_to_json st);
-                  ("output", `String (truncate_tool_output out));
-                ])
-          end
-      end
-  | "keeper_shell_readonly" ->
-      let op =
-        Safe_ops.json_string ~default:"" "op" args
-        |> String.trim |> String.lowercase_ascii
-      in
-      let root = project_root_of_config config in
-      let read_target () =
-        let raw_path = Safe_ops.json_string ~default:"." "path" args in
-        resolve_keeper_target_path ~config ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta) ~raw_path
-      in
-      let render_process_result ~cmd argv =
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:15.0 argv
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-            [
-              ("ok", `Bool (st = Unix.WEXITED 0));
-              ("op", `String op);
-              ("cmd", `String cmd);
-              ("status", process_status_to_json st);
-              ("output", `String (truncate_tool_output out));
-            ])
-      in
-      (match op with
-      | "pwd" -> render_process_result ~cmd:"pwd" [ "/bin/pwd" ]
-      | "git_status" ->
-          render_process_result
-            ~cmd:"git -C <root> status --short --branch"
-            [ "git"; "-C"; root; "status"; "--short"; "--branch" ]
-      | "ls" -> (
-          match read_target () with
-          | Error e ->
-              Yojson.Safe.to_string
-                (`Assoc [ ("error", `String e); ("op", `String op) ])
-          | Ok target ->
-              let st, out =
-                Process_eio.run_argv_with_status ~timeout_sec:15.0
-                  [ "/bin/ls"; "-la"; target ]
-              in
-              let limit = shell_readonly_limit args in
-              Yojson.Safe.to_string
-                (`Assoc
-                  [
-                    ("ok", `Bool (st = Unix.WEXITED 0));
-                    ("op", `String op);
-                    ("path", `String target);
-                    ("status", process_status_to_json st);
-                    ("entries", lines_to_json ~limit out);
-                  ]))
-      | "cat" -> (
-          match read_target () with
-          | Error e ->
-              Yojson.Safe.to_string
-                (`Assoc [ ("error", `String e); ("op", `String op) ])
-          | Ok target ->
-              let max_bytes = shell_readonly_cat_max_bytes args in
-              let st, out =
-                Process_eio.run_argv_with_status ~timeout_sec:15.0
-                  [ "/bin/cat"; target ]
-              in
-              let body =
-                if String.length out > max_bytes then String.sub out 0 max_bytes
-                else out
-              in
-              Yojson.Safe.to_string
-                (`Assoc
-                  [
-                    ("ok", `Bool (st = Unix.WEXITED 0));
-                    ("op", `String op);
-                    ("path", `String target);
-                    ("status", process_status_to_json st);
-                    ("truncated", `Bool (String.length out > max_bytes));
-                    ("content", `String body);
-                  ]))
-      | "rg" -> (
-          let pattern =
-            Safe_ops.json_string ~default:"" "pattern" args |> String.trim
-          in
-          if pattern = "" then
-            Yojson.Safe.to_string
-              (`Assoc
-                [ ("error", `String "pattern_required"); ("op", `String op) ])
-          else
-            match read_target () with
-            | Error e ->
-                Yojson.Safe.to_string
-                  (`Assoc [ ("error", `String e); ("op", `String op) ])
-            | Ok target ->
-                let limit = shell_readonly_limit args in
-                let st, out =
-                  Process_eio.run_argv_with_status ~timeout_sec:15.0
-                    [ "rg"; "-n"; "-m"; string_of_int limit; pattern; target ]
-                in
-                Yojson.Safe.to_string
-                  (`Assoc
-                    [
-                      ("ok", `Bool (st = Unix.WEXITED 0));
-                      ("op", `String op);
-                      ("path", `String target);
-                      ("pattern", `String pattern);
-                      ("status", process_status_to_json st);
-                      ("matches", lines_to_json ~limit out);
-                    ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [
-                ("error", `String "unsupported_op");
-                ("op", `String op);
-                ( "supported_ops",
-                  `List
-                    (List.map
-                       (fun name -> `String name)
-                       [ "pwd"; "ls"; "cat"; "rg"; "git_status" ]) );
-              ]))
-  | "keeper_voice_speak" ->
-      let message =
-        Safe_ops.json_string ~default:"" "message" args |> String.trim
-      in
-      let provider =
-        Safe_ops.json_string_opt "provider" args
-        |> Option.map String.trim
-        |> function
-        | Some p when p <> "" -> Some p
-        | _ -> None
-      in
-      let priority = max 1 (Safe_ops.json_int ~default:1 "priority" args) in
-      if message = "" then
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String "message_required") ])
-      else
-        (match
-           ( Eio_context.get_switch_opt (),
-             Eio_context.get_clock_opt (),
-             Eio_context.get_net_opt () )
-         with
-        | Some sw, Some clock, Some net -> (
-            match
-              Voice_bridge.agent_speak ~sw ~clock ~net ~agent_id:meta.name
-                ~message ?provider ~priority ()
-            with
-            | Ok json -> Yojson.Safe.to_string json
-            | Error err ->
-                Yojson.Safe.to_string
-                  (`Assoc
-                    [
-                      ("status", `String "error");
-                      ("agent_id", `String meta.name);
-                      ("message", `String err);
-                    ]))
-        | _ ->
-            Yojson.Safe.to_string
-              (keeper_text_fallback_json ~agent_id:meta.name ~message))
-  | "keeper_voice_listen" ->
-      let timeout_sec =
-        Safe_ops.json_float ~default:15.0 "timeout_seconds" args
-      in
-      let language_code = Safe_ops.json_string_opt "language_code" args in
-      (match Voice_bridge.record_and_transcribe
-               ~agent_id:meta.name ~timeout_sec ?language_code () with
-      | Ok json ->
-          Yojson.Safe.to_string json
-      | Error err ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("error", `String err);
-                ("agent_id", `String meta.name) ]))
-  | "keeper_voice_agent" ->
-      (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
-      | Ok json -> Yojson.Safe.to_string json
-      | Error err ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("agent_id", `String meta.name);
-                ("message", `String err) ]))
-  | "keeper_voice_sessions" ->
-      let mgr = Keeper_voice_local.get_session_manager () in
-      let sessions = Voice_session_manager.list_sessions mgr in
-      Yojson.Safe.to_string
-        (`Assoc
-          [ ("session_count", `Int (List.length sessions));
-            ("sessions",
-              `List (List.map Voice_session_manager.session_to_json sessions)) ])
-  | "keeper_voice_session_start" ->
-      let voice =
-        Safe_ops.json_string_opt "session_name" args
-        |> Option.map String.trim
-        |> function Some s when s <> "" -> Some s | _ -> None
-      in
-      let mgr = Keeper_voice_local.get_session_manager () in
-      let session =
-        Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice ()
-      in
-      Yojson.Safe.to_string
-        (Voice_session_manager.session_to_json session)
-  | "keeper_voice_session_end" ->
-      let mgr = Keeper_voice_local.get_session_manager () in
-      let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
-      Yojson.Safe.to_string
-        (`Assoc
-          [ ("status", `String (if ended then "ended" else "no_active_session"));
-            ("agent_id", `String meta.name) ])
-  | "keeper_github" ->
-      let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
-      let gh_args = Safe_ops.json_string_list "args" args in
-      let timeout_sec =
-        Safe_ops.json_float ~default:30.0 "timeout_sec" args
-        |> fun n -> max 1.0 (min 180.0 n)
-      in
-      let gh_raw =
-        if cmd <> "" then cmd
-        else if gh_args <> [] then String.concat " " gh_args
-        else ""
-      in
-      if gh_raw = "" then
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String "cmd_or_args_required") ])
-      else begin
-        match Worker_dev_tools.validate_gh_command gh_raw with
-        | Error reason ->
-          Log.Keeper.warn "keeper_github blocked: %s (cmd=%s)" reason gh_raw;
-          Yojson.Safe.to_string
-            (`Assoc [
-              ("ok", `Bool false);
-              ("error", `String "command_blocked");
-              ("reason", `String reason);
-            ])
-        | Ok () ->
-          if Worker_dev_tools.is_gh_destructive_operation gh_raw then begin
-            Log.Keeper.info
-              "keeper_github destructive-gate: %s (keeper=%s)"
-              gh_raw (meta.name);
-            Yojson.Safe.to_string
-              (`Assoc [
-                ("ok", `Bool false);
-                ("error", `String "destructive_operation_gated");
-                ("reason", `String
-                  "This gh command performs a destructive mutation \
-                   (merge/close/delete/archive). Use read-only commands \
-                   (view/list/diff/checks) or request operator approval.");
-                ("cmd", `String ("gh " ^ gh_raw));
-              ])
-          end else begin
-            let gh_cmd =
-              if cmd <> "" then "gh " ^ cmd
-              else "gh " ^ String.concat " " (List.map Filename.quote gh_args)
-            in
-            let root = project_root_of_config config in
-            let shell_cmd =
-              Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd
-            in
-            let st, out =
-              Process_eio.run_argv_with_status ~timeout_sec
-                [ "/bin/zsh"; "-lc"; shell_cmd ]
-            in
-            Yojson.Safe.to_string
-              (`Assoc
-                [
-                  ("ok", `Bool (st = Unix.WEXITED 0));
-                  ("status", process_status_to_json st);
-                  ("output", `String (truncate_tool_output out));
-                ])
-          end
-      end
-  | "keeper_tasks_list" ->
-      let status_filter = Safe_ops.json_string_opt "status" args in
-      let include_done =
-        Safe_ops.json_bool ~default:false "include_done" args
-      in
-      Room.list_tasks ?status:status_filter ~include_done config
-  | "keeper_tasks_audit" ->
-      let orphans = Room.audit_orphan_tasks config in
-      let items =
-        List.map
-          (fun (task, assignee) ->
-            let task : Types.task = task in
-            `Assoc
-              [
-                ("task_id", `String task.id);
-                ("title", `String task.title);
-                ("assignee", `String assignee);
-                ("status", `String (Types.string_of_task_status task.task_status));
-              ])
-          orphans
-      in
-      Yojson.Safe.to_string
-        (`Assoc
-          [
-            ("orphan_count", `Int (List.length orphans));
-            ("orphans", `List items);
-          ])
-  | "keeper_task_force_release" ->
-      let task_id =
-        Safe_ops.json_string ~default:"" "task_id" args |> String.trim
-      in
-      let reason = Safe_ops.json_string ~default:"" "reason" args in
-      if task_id = "" then
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String "task_id required") ])
-      else
-        let agent = Printf.sprintf "keeper-%s" meta.name in
-        let _ =
-          Room.broadcast config ~from_agent:agent
-            ~content:
-              (Printf.sprintf "Force-releasing task %s (reason: %s)" task_id
-                 (if reason = "" then "no reason given" else reason))
-        in
-        (match Room.force_release_task_r config ~agent_name:agent ~task_id () with
-        | Ok msg ->
-            Yojson.Safe.to_string
-              (`Assoc [ ("ok", `Bool true); ("result", `String msg) ])
-        | Error e ->
-            Yojson.Safe.to_string
-              (`Assoc
-                [
-                  ("ok", `Bool false);
-                  ("error", `String (Types.masc_error_to_string e));
-                ]))
-  | "keeper_task_force_done" ->
-      let task_id =
-        Safe_ops.json_string ~default:"" "task_id" args |> String.trim
-      in
-      let notes = Safe_ops.json_string ~default:"" "notes" args in
-      if task_id = "" then
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String "task_id required") ])
-      else
-        let agent = Printf.sprintf "keeper-%s" meta.name in
-        (match
-           Room.force_done_task_r config ~agent_name:agent ~task_id ~notes ()
-         with
-        | Ok msg ->
-            Yojson.Safe.to_string
-              (`Assoc [ ("ok", `Bool true); ("result", `String msg) ])
-        | Error e ->
-            Yojson.Safe.to_string
-              (`Assoc
-                [
-                  ("ok", `Bool false);
-                  ("error", `String (Types.masc_error_to_string e));
-                ]))
-  | "keeper_broadcast" ->
-      let message =
-        Safe_ops.json_string ~default:"" "message" args |> String.trim
-      in
-      if message = "" then
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String "message required") ])
-      else
-        let agent = Printf.sprintf "keeper-%s" meta.name in
-        let _ = Room.broadcast config ~from_agent:agent ~content:message in
-        Yojson.Safe.to_string
-          (`Assoc [ ("ok", `Bool true); ("broadcast", `String message) ])
-  | "keeper_task_claim" ->
-      let result = Room.claim_next config ~agent_name:meta.agent_name in
-      Yojson.Safe.to_string (`Assoc [ ("result", `String result) ])
-  | "keeper_task_done" ->
-      let task_id =
-        Safe_ops.json_string ~default:"" "task_id" args |> String.trim
-      in
-      let result_text =
-        Safe_ops.json_string ~default:"" "result" args |> String.trim
-      in
-      if task_id = "" then
-        Yojson.Safe.to_string (`Assoc [ ("error", `String "task_id required") ])
-      else
-        let agent = Printf.sprintf "keeper-%s" meta.name in
-        let notes = if result_text = "" then "" else result_text in
-        (match
-           Room.force_done_task_r config ~agent_name:agent ~task_id ~notes ()
-         with
-         | Ok msg ->
-             Yojson.Safe.to_string
-               (`Assoc [ ("ok", `Bool true); ("result", `String msg) ])
-         | Error e ->
-             Yojson.Safe.to_string
-               (`Assoc [ ("ok", `Bool false);
-                          ("error", `String (Types.masc_error_to_string e)) ]))
-  | name when String.starts_with ~prefix:"masc_autoresearch_" name ->
-      let ctx : Tool_autoresearch.context = {
-        base_path = project_root_of_config config;
-        agent_name = Some meta.name;
-        start_operation = None;
-        start_team_session = None;
-        config = Some config;
-        sw = None;
-        clock = None;
-      } in
-      (match Tool_autoresearch.dispatch ctx ~name ~args with
-      | Some (true, msg) -> msg
-      | Some (false, msg) ->
-          Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-      | None ->
-          Yojson.Safe.to_string
-            (`Assoc [ ("error", `String "unknown_autoresearch_tool");
-                      ("tool", `String name) ]))
-  | name when String.starts_with ~prefix:"masc_" name ->
-      let effective_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
-      let path_blocked =
-        if effective_paths = [] && meta.execution_scope <> "observe_only" then None
-        else if meta.execution_scope = "observe_only" && effective_paths = [] then
-          let has_path_arg =
-            List.exists (fun key ->
-              match Yojson.Safe.Util.member key args with
-              | `String p when String.trim p <> "" -> true
-              | _ -> false) ["path"; "file_path"; "target_path"]
-          in
-          if has_path_arg then Some "observe_only_scope: write paths blocked"
-          else None
-        else
-          let candidates =
-            List.filter_map (fun key ->
-              match Yojson.Safe.Util.member key args with
-              | `String p when String.trim p <> "" -> Some p
-              | _ -> None)
-              ["path"; "file_path"; "target_path"]
-          in
-          List.find_map (fun raw ->
-            match resolve_keeper_target_path ~config
-                    ~allowed_paths:effective_paths ~raw_path:raw with
-            | Error e -> Some e
-            | Ok _ -> None) candidates
-      in
-      (match path_blocked with
-      | Some err ->
-          Yojson.Safe.to_string (`Assoc [ ("error", `String err) ])
-      | None ->
-      (* Phase 1: Try handler registry first.
-         Preserves masc_board_* which is registered in both tag_registry
-         (as Mod_inline) and handler_registry (via Tool_board.register).
-         Without this priority, Mod_inline would fail for keepers. *)
-      (match Tool_dispatch.mint_token ~name with
-       | Error reason ->
-           Yojson.Safe.to_string
-             (`Assoc [ ("error", `String "unregistered_masc_tool");
-                       ("tool", `String name);
-                       ("reason", `String reason) ])
-       | Ok token ->
-      (match Tool_dispatch.dispatch ~token ~args with
-        | Some (true, msg) -> msg
-        | Some (false, msg) ->
-            Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-        | None ->
-            (* Phase 2: Block MCP-session-only tools early — keepers lack
-               MCP session context so these always fail. #4775 *)
-            if Tool_dispatch.is_mcp_context_required name then
-              Yojson.Safe.to_string
-                (`Assoc [ ("error",
-                           `String (Printf.sprintf
-                              "tool '%s' requires MCP session (use keeper_* equivalent)" name)) ])
-            else
-            (* Phase 3: Handler returned None — try tag-based dispatch.
-               Most masc_* tools are only in tag_registry, not handler_registry.
-               tag_dispatch_fn is set to Keeper_tag_dispatch.dispatch at server
-               init (mcp_server_eio.ml) to break the dependency cycle. #4579 *)
-            (match Tool_dispatch.lookup_tag name with
-             | Some tag ->
-                 let keeper_agent = Printf.sprintf "keeper-%s" meta.name in
-                 (match !tag_dispatch_fn
-                          ~config ~agent_name:keeper_agent ~tag ~name ~args with
-                  | Some (true, msg) -> msg
-                  | Some (false, msg) ->
-                      Yojson.Safe.to_string
-                        (`Assoc [ ("error", `String msg) ])
-                  | None ->
-                      Yojson.Safe.to_string
-                        (`Assoc [ ("error", `String "tool_not_supported_in_keeper");
-                                  ("tool", `String name);
-                                  ("hint", `String "tag dispatch returned None; tool may be unsupported, blocked, or misconfigured") ]))
-             | None ->
-                 Yojson.Safe.to_string
-                   (`Assoc [ ("error", `String "unregistered_masc_tool");
-                             ("tool", `String name) ])))))
-  | other ->
-      Yojson.Safe.to_string
-        (`Assoc [ ("error", `String "unknown_tool"); ("tool", `String other) ])
+        (`Assoc [ "error", `String "unknown_tool"; "tool", `String other ]))
+;;
 
 (* keeper_tool_loop_system_prompt and keeper_tool_followup_prompt removed:
    Agent.run() handles tool dispatch and follow-up natively. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -11,6 +11,7 @@ open Keeper_execution
 
 let keepalive_interval_sec () =
   Runtime_params.get Governance_registry.keeper_keepalive_interval_sec
+;;
 
 (* ── Board-reactive policy constants ── *)
 
@@ -25,26 +26,32 @@ let get_bus () = !bus_ref
     [MASC_AGENT_TRANSPORT=grpc]. When set, heartbeat sends
     status pings over gRPC unary RPC. *)
 let grpc_client_ref : Masc_grpc_client.t option ref = ref None
+
 let grpc_env_ref : Eio_unix.Stdenv.base option ref = ref None
+
 let set_grpc_client ?(env : Eio_unix.Stdenv.base option) c =
   grpc_client_ref := Some c;
   grpc_env_ref := env
+;;
 
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~chunk_sec instead of waiting for the full interval. *)
 let interruptible_sleep ~clock ~stop ~wakeup duration =
   let chunk_sec = Env_config.KeeperKeepalive.sleep_chunk_sec in
   let rec wait remaining =
-    if Atomic.get stop then ()
-    else if Atomic.compare_and_set wakeup true false then ()
-    else if remaining <= 0.0 then ()
-    else begin
+    if Atomic.get stop
+    then ()
+    else if Atomic.compare_and_set wakeup true false
+    then ()
+    else if remaining <= 0.0
+    then ()
+    else (
       let chunk = Float.min chunk_sec remaining in
       Eio.Time.sleep clock chunk;
-      wait (remaining -. chunk)
-    end
+      wait (remaining -. chunk))
   in
   wait duration
+;;
 
 (** Wake up a specific keeper immediately, causing it to skip the rest of
     its sleep and run the next heartbeat cycle. Used by broadcast notification
@@ -52,573 +59,823 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
 let wakeup_keeper name =
   Keeper_registry.all ()
   |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
-         if String.equal entry.name name && entry.state = Keeper_registry.Running
-         then Keeper_registry.wakeup ~base_path:entry.base_path name)
+    if String.equal entry.name name && entry.state = Keeper_registry.Running
+    then Keeper_registry.wakeup ~base_path:entry.base_path name)
+;;
 
 (** Wake up all running keepers — used when a broadcast mentions @@all
     or when a system-wide event requires immediate attention. *)
-let wakeup_all_keepers () =
-  Keeper_registry.wakeup_all ()
+let wakeup_all_keepers () = Keeper_registry.wakeup_all ()
 
 let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
-  Keeper_registry.board_wakeup_allowed ~base_path keeper_name
-    ~post_id ~debounce_sec:board_reactive_debounce_sec
+  Keeper_registry.board_wakeup_allowed
+    ~base_path
+    keeper_name
+    ~post_id
+    ~debounce_sec:board_reactive_debounce_sec
+;;
 
 let wakeup_relevant_keeper_for_board_signal
-    ~(config : Room.config)
-    (signal : Board_dispatch.keeper_board_signal) =
+      ~(config : Room.config)
+      (signal : Board_dispatch.keeper_board_signal)
+  =
   let running_names =
     Keeper_registry.all ()
     |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-           if e.state = Keeper_registry.Running then Some e.name else None)
+      if e.state = Keeper_registry.Running then Some e.name else None)
   in
   let candidates =
     running_names
     |> List.filter_map (fun name ->
-           match read_meta config name with
-           | Ok (Some meta) ->
-               let matched =
-                 Keeper_world_observation.board_signal_match
-                   ~continuity_summary:meta.continuity_summary
-                   ~meta
-                   ~signal
-               in
-               Some (meta, matched)
-           | _ -> None)
+      match read_meta config name with
+      | Ok (Some meta) ->
+        let matched =
+          Keeper_world_observation.board_signal_match
+            ~continuity_summary:meta.continuity_summary
+            ~meta
+            ~signal
+        in
+        Some (meta, matched)
+      | _ -> None)
   in
   let explicit =
     candidates
-    |> List.filter (fun (_meta, (matched : Keeper_world_observation.board_signal_match)) ->
-           matched.explicit_mention)
+    |> List.filter
+         (fun (_meta, (matched : Keeper_world_observation.board_signal_match)) ->
+            matched.explicit_mention)
   in
   let wake_meta (meta : keeper_meta) reason =
-    if board_reactive_wakeup_allowed
-         ~base_path:config.base_path
-         ~keeper_name:meta.name
-         ~post_id:signal.post_id
+    if
+      board_reactive_wakeup_allowed
+        ~base_path:config.base_path
+        ~keeper_name:meta.name
+        ~post_id:signal.post_id
     then (
       wakeup_keeper meta.name;
-      Log.Keeper.info "board signal wakeup: keeper=%s reason=%s post=%s"
-        meta.name reason signal.post_id)
+      Log.Keeper.info
+        "board signal wakeup: keeper=%s reason=%s post=%s"
+        meta.name
+        reason
+        signal.post_id)
   in
   match explicit with
-  | (_ :: _) ->
-      explicit
-      |> List.iter (fun (meta, _matched) -> wake_meta meta "explicit_mention")
+  | _ :: _ ->
+    explicit |> List.iter (fun (meta, _matched) -> wake_meta meta "explicit_mention")
   | [] -> ()
+;;
 
 let max_consecutive_heartbeat_failures () =
   Runtime_params.get Governance_registry.keeper_max_hb_failures
+;;
 
 let max_consecutive_turn_failures () =
   Runtime_params.get Governance_registry.keeper_max_turn_failures
+;;
 
 (* Per-stage timing accumulator for Phase 0 profiling.
    In-memory ring of last 100 cycles. Flushed as aggregate at snapshot cadence.
    No additional file I/O — appended to existing snapshot JSON. *)
-type stage_timing = {
-  presence_ms : float;
-  snapshot_ms : float;
-  board_ms : float;
-  turn_ms : float;
-  recurring_ms : float;
-  improve_ms : float;
-}
+type stage_timing =
+  { presence_ms : float
+  ; snapshot_ms : float
+  ; board_ms : float
+  ; turn_ms : float
+  ; recurring_ms : float
+  ; improve_ms : float
+  }
 
 let stage_timing_ring_size () =
   Runtime_params.get Governance_registry.keeper_stage_timing_ring_size
+;;
 
 let percentile arr p =
   let n = Array.length arr in
-  if n = 0 then 0.0
-  else
+  if n = 0
+  then 0.0
+  else (
     let sorted = Array.copy arr in
     Array.sort Float.compare sorted;
     let idx = Float.to_int (Float.round (float_of_int (n - 1) *. p)) in
-    sorted.(min idx (n - 1))
+    sorted.(min idx (n - 1)))
+;;
 
 let stage_timing_to_json ~ring ~count =
   let n = min count (Array.length ring) in
-  if n = 0 then `Null
-  else
+  if n = 0
+  then `Null
+  else (
     let extract field =
       let arr = Array.init n (fun i -> field ring.(i)) in
-      `Assoc [
-        ("p50", `Float (percentile arr 0.5));
-        ("p95", `Float (percentile arr 0.95));
-        ("max", `Float (percentile arr 1.0));
-        ("samples", `Int n);
-      ]
+      `Assoc
+        [ "p50", `Float (percentile arr 0.5)
+        ; "p95", `Float (percentile arr 0.95)
+        ; "max", `Float (percentile arr 1.0)
+        ; "samples", `Int n
+        ]
     in
-    `Assoc [
-      ("presence", extract (fun t -> t.presence_ms));
-      ("snapshot", extract (fun t -> t.snapshot_ms));
-      ("board", extract (fun t -> t.board_ms));
-      ("turn", extract (fun t -> t.turn_ms));
-      ("recurring", extract (fun t -> t.recurring_ms));
-      ("improve", extract (fun t -> t.improve_ms));
-    ]
+    `Assoc
+      [ "presence", extract (fun t -> t.presence_ms)
+      ; "snapshot", extract (fun t -> t.snapshot_ms)
+      ; "board", extract (fun t -> t.board_ms)
+      ; "turn", extract (fun t -> t.turn_ms)
+      ; "recurring", extract (fun t -> t.recurring_ms)
+      ; "improve", extract (fun t -> t.improve_ms)
+      ])
+;;
 
-let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
-    (m : keeper_meta) (stop : bool Atomic.t) ~(wakeup : bool Atomic.t) : unit =
+let write_heartbeat_snapshot
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(now_ts : float)
+      ~(timing_ring : stage_timing array)
+      ~(timing_filled : int)
+  : unit
+  =
+  let metrics_store = keeper_metrics_store ctx.config meta_current.name in
+  let cascade_models =
+    Oas_model_resolve.models_of_cascade_name meta_current.cascade_name
+  in
+  let primary_max_context =
+    Oas_model_resolve.resolve_primary_max_context cascade_models
+  in
+  let base_dir = session_base_dir ctx.config in
+  ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));
+  let _session, ctx_opt =
+    load_context_from_checkpoint
+      ~trace_id:meta_current.runtime.trace_id
+      ~primary_model_max_tokens:primary_max_context
+      ~base_dir
+  in
+  match ctx_opt with
+  | None -> ()
+  | Some c ->
+    let latest_user_message =
+      latest_message_content_by_role ~role:Agent_sdk.Types.User c.messages
+    in
+    let latest_assistant_message =
+      latest_message_content_by_role ~role:Agent_sdk.Types.Assistant c.messages
+    in
+    let continuity_snapshot = latest_state_snapshot_from_messages c.messages in
+    let continuity_summary =
+      match continuity_snapshot with
+      | Some s -> keeper_state_snapshot_to_summary_text s
+      | None ->
+        let trimmed = String.trim meta_current.continuity_summary in
+        if trimmed = "" then "No continuity snapshot available." else trimmed
+    in
+    let repetition_risk =
+      repetition_risk_score ~messages:c.messages ~candidate_reply:None
+    in
+    let goal_alignment =
+      goal_alignment_score
+        ~meta:meta_current
+        ~user_message:latest_user_message
+        ~assistant_reply:latest_assistant_message
+    in
+    let response_alignment =
+      match latest_user_message, latest_assistant_message with
+      | Some user_message, Some assistant_message ->
+        jaccard_similarity user_message assistant_message
+      | _ -> 0.0
+    in
+    let auto_rules =
+      evaluate_keeper_auto_rules
+        ~meta:meta_current
+        ~context_ratio:(Keeper_exec_context.context_ratio c)
+        ~message_count:(Keeper_exec_context.message_count c)
+        ~token_count:(Keeper_exec_context.token_count c)
+        ~repetition_risk
+        ~goal_alignment
+        ~response_alignment
+        ()
+    in
+    let snapshot =
+      `Assoc
+        [ "ts", `String (now_iso ())
+        ; "ts_unix", `Float now_ts
+        ; "channel", `String "heartbeat"
+        ; "name", `String meta_current.name
+        ; "agent_name", `String meta_current.agent_name
+        ; "trace_id", `String meta_current.runtime.trace_id
+        ; "generation", `Int meta_current.runtime.generation
+        ; "model_used", `String meta_current.runtime.usage.last_model_used
+        ; ( "usage"
+          , `Assoc
+              [ "input_tokens", `Int 0; "output_tokens", `Int 0; "total_tokens", `Int 0 ]
+          )
+        ; "latency_ms", `Int 0
+        ; "cost_usd", `Float 0.0
+        ; "context_ratio", `Float (Keeper_exec_context.context_ratio c)
+        ; "context_tokens", `Int (Keeper_exec_context.token_count c)
+        ; "context_max", `Int c.max_tokens
+        ; "message_count", `Int (Keeper_exec_context.message_count c)
+        ; ( "continuity_state"
+          , match continuity_snapshot with
+            | None -> `Null
+            | Some s -> keeper_state_snapshot_to_json s )
+        ; "continuity_summary", `String continuity_summary
+        ; "compacted", `Bool false
+        ; "compaction_before_tokens", `Int (Keeper_exec_context.token_count c)
+        ; "compaction_after_tokens", `Int (Keeper_exec_context.token_count c)
+        ; "work_kind", `String "status_tick"
+        ; "tool_call_count", `Int 0
+        ; "tools_used", `List []
+        ; "snapshot_source", `String "keeper_context_status"
+        ; "memory_check", memory_check_default_json ()
+        ; "auto_rules", keeper_auto_rule_eval_to_json auto_rules
+        ; "reflection", keeper_reflection_payload_of_auto_rules auto_rules
+        ; "auto_reflect", `Bool auto_rules.reflect
+        ; "auto_plan", `Bool auto_rules.plan
+        ; "auto_compact", `Bool auto_rules.compact
+        ; "auto_handoff", `Bool auto_rules.handoff
+        ; "repetition_risk", `Float repetition_risk
+        ; "goal_alignment", `Float goal_alignment
+        ; "response_alignment", `Float response_alignment
+        ; "goal_drift", `Float auto_rules.goal_drift
+        ; "guardrail_stop", `Bool auto_rules.guardrail_stop
+        ; ( "guardrail_stop_reason"
+          , match auto_rules.guardrail_reason with
+            | Some reason -> `String reason
+            | None -> `Null )
+        ; "handoff", `Assoc [ "performed", `Bool false ]
+        ; "stage_timing", stage_timing_to_json ~ring:timing_ring ~count:timing_filled
+        ]
+    in
+    Dated_jsonl.append metrics_store snapshot;
+    (try
+       Sse.broadcast
+         (`Assoc
+             [ "type", `String "keeper_heartbeat"
+             ; "name", `String meta_current.name
+             ; "generation", `Int meta_current.runtime.generation
+             ; "context_ratio", `Float (Keeper_exec_context.context_ratio c)
+             ; "ts_unix", `Float now_ts
+             ])
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.error "heartbeat SSE broadcast failed: %s" (Printexc.to_string exn));
+    (match !bus_ref with
+     | Some bus ->
+       Oas_events.publish_keeper_snapshot
+         bus
+         ~keeper_name:meta_current.name
+         ~generation:meta_current.runtime.generation
+         ~context_ratio:(Keeper_exec_context.context_ratio c)
+         ~message_count:(List.length c.messages)
+     | None -> ());
+    (try
+       Keeper_registry.flush_tool_usage ~base_path:ctx.config.base_path meta_current.name
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> ())
+;;
+
+let keeper_agent_status (meta : keeper_meta) =
+  if meta.paused
+  then Types.Inactive
+  else (
+    match meta.current_task_id with
+    | Some _ -> Types.Busy
+    | None -> Types.Active)
+;;
+
+let sync_keeper_presence
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(t_presence_start : float)
+      ~(consecutive_failures : int ref)
+      ~(last_successful_heartbeat_ts : float ref)
+      ~(work_as_hb : unit -> bool)
+      ~(max_silence : unit -> float)
+  : keeper_meta
+  =
+  let presence_fresh =
+    work_as_hb () && t_presence_start -. !last_successful_heartbeat_ts < max_silence ()
+  in
+  if presence_fresh
+  then (
+    Log.Keeper.debug
+      "presence sync skipped: fresh heartbeat %.0fs ago"
+      (t_presence_start -. !last_successful_heartbeat_ts);
+    meta_current)
+  else (
+    try
+      let synced = ensure_keeper_room_presence ctx.config meta_current in
+      if synced.joined_room_ids = []
+      then (
+        incr consecutive_failures;
+        Log.Keeper.warn
+          "room presence returned empty rooms (%d/%d)"
+          !consecutive_failures
+          (max_consecutive_heartbeat_failures ()))
+      else (
+        consecutive_failures := 0;
+        last_successful_heartbeat_ts := Time_compat.now ());
+      match write_meta ctx.config synced with
+      | Ok () -> synced
+      | Error e ->
+        Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
+        synced
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      incr consecutive_failures;
+      Log.Keeper.error
+        "room heartbeat failed (%d/%d): %s"
+        !consecutive_failures
+        (max_consecutive_heartbeat_failures ())
+        (Printexc.to_string exn);
+      meta_current)
+;;
+
+let collect_keepalive_board_events
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(proactive_warmup_elapsed : bool)
+  =
+  if not proactive_warmup_elapsed
+  then [], meta_current
+  else (
+    let pending_board_events =
+      try
+        let events, _new_count, _mention_count =
+          Keeper_world_observation.collect_board_events
+            ~base_path:ctx.config.base_path
+            ~meta:meta_current
+            ~continuity_summary:meta_current.continuity_summary
+        in
+        events
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.warn "keepalive: board count query failed: %s" (Printexc.to_string exn);
+        []
+    in
+    pending_board_events, meta_current)
+;;
+
+let run_keepalive_unified_turn
+      ~(ctx : _ context)
+      ~(meta_after_triage : keeper_meta)
+      ~pending_board_events
+      ~(stop : bool Atomic.t)
+      ~(proactive_warmup_elapsed : bool)
+  : keeper_meta
+  =
+  if not proactive_warmup_elapsed
+  then meta_after_triage
+  else (
+    try
+      let obs =
+        Keeper_world_observation.observe
+          ~pending_board_events:(Some pending_board_events)
+          ~config:ctx.config
+          ~meta:meta_after_triage
+      in
+      if Atomic.get stop
+      then meta_after_triage
+      else if Keeper_world_observation.should_run_unified_turn ~meta:meta_after_triage obs
+      then (
+        match
+          Keeper_unified_turn.run_unified_turn
+            ~config:ctx.config
+            ~meta:meta_after_triage
+            ~observation:obs
+            ~generation:meta_after_triage.runtime.generation
+        with
+        | Error e ->
+          Log.Keeper.error "unified turn failed: %s" e;
+          (match read_meta ctx.config meta_after_triage.name with
+           | Ok (Some latest) -> latest
+           | _ -> meta_after_triage)
+        | Ok updated -> updated)
+      else meta_after_triage
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.error "unified turn exception: %s" (Printexc.to_string exn);
+      meta_after_triage)
+;;
+
+let refresh_work_as_heartbeat
+      ~(ctx : _ context)
+      ~(meta_after_proactive : keeper_meta)
+      ~(proactive_warmup_elapsed : bool)
+      ~(work_as_hb : unit -> bool)
+      ~(last_successful_heartbeat_ts : float ref)
+      ~(consecutive_failures : int ref)
+  : unit
+  =
+  if work_as_hb () && proactive_warmup_elapsed
+  then (
+    let hb_ok =
+      List.exists
+        (fun room_id ->
+           try
+             ignore
+               (Room.heartbeat_in_room
+                  ctx.config
+                  ~room_id
+                  ~agent_name:meta_after_proactive.agent_name);
+             true
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Keeper.debug
+               "heartbeat_in_room failed for %s: %s"
+               meta_after_proactive.name
+               (Printexc.to_string exn);
+             false)
+        meta_after_proactive.joined_room_ids
+    in
+    if hb_ok
+    then (
+      last_successful_heartbeat_ts := Time_compat.now ();
+      consecutive_failures := 0))
+;;
+
+let dispatch_recurring_keepalive
+      ~(ctx : _ context)
+      ~(meta_after_proactive : keeper_meta)
+      ~(now_ts : float)
+  : int
+  =
+  try
+    Keeper_recurring.dispatch_due
+      ~keeper_name:meta_after_proactive.name
+      ~now_ts
+      ~dispatch:(fun task action ->
+        match action with
+        | Keeper_recurring.Broadcast msg ->
+          (try
+             let _ =
+               Room.broadcast
+                 ctx.config
+                 ~from_agent:meta_after_proactive.agent_name
+                 ~content:(Printf.sprintf "[loop:%s] %s" task.label msg)
+             in
+             Log.Keeper.info "[recurring] %s dispatched: %s" task.id task.label;
+             Ok ()
+           with
+           | exn ->
+             Log.Keeper.warn "[recurring] %s failed: %s" task.id (Printexc.to_string exn);
+             Error (Printexc.to_string exn)))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn "[recurring] dispatch error: %s" (Printexc.to_string exn);
+    0
+;;
+
+let run_smart_heartbeat_gate
+      ~(clock : _ Eio.Time.clock)
+      ~(stop : bool Atomic.t)
+      ~(wakeup : bool Atomic.t)
+      ~(meta_current : keeper_meta)
+      ~(smart_hb_enabled : unit -> bool)
+      ~(smart_hb_config : Heartbeat_smart.config)
+      ~(last_successful_heartbeat_ts : float ref)
+      ~(last_heartbeat_cycle_ts : float ref)
+  : bool
+  =
+  let smart_hb_decision =
+    if smart_hb_enabled ()
+    then (
+      let agent_status = keeper_agent_status meta_current in
+      Heartbeat_smart.should_emit
+        ~config:smart_hb_config
+        ~agent_status
+        ~last_activity:!last_successful_heartbeat_ts
+        ~last_heartbeat:!last_heartbeat_cycle_ts)
+    else Heartbeat_smart.Emit
+  in
+  match smart_hb_decision with
+  | Heartbeat_smart.Skip_busy ->
+    Log.Keeper.debug
+      "smart heartbeat: skip (busy, task=%s)"
+      (Option.value ~default:"?" meta_current.current_task_id);
+    let base =
+      Heartbeat_smart.effective_interval
+        ~config:smart_hb_config
+        ~last_activity:!last_successful_heartbeat_ts
+    in
+    let jitter = base *. 0.2 *. Random.float 1.0 in
+    interruptible_sleep ~clock ~stop ~wakeup (base +. jitter);
+    false
+  | Heartbeat_smart.Skip_idle next_time ->
+    let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
+    Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
+    let jitter = wait *. 0.1 *. Random.float 1.0 in
+    interruptible_sleep ~clock ~stop ~wakeup (wait +. jitter);
+    false
+  | Heartbeat_smart.Emit ->
+    last_heartbeat_cycle_ts := Time_compat.now ();
+    true
+;;
+
+let maybe_write_heartbeat_snapshot
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(now_ts : float)
+      ~(last_snapshot_ts : float ref)
+      ~(snapshot_interval_sec : int)
+      ~(timing_ring : stage_timing array)
+      ~(timing_filled : int)
+  : unit
+  =
+  if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
+  then (
+    (try
+       write_heartbeat_snapshot ~ctx ~meta_current ~now_ts ~timing_ring ~timing_filled
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.error "heartbeat snapshot write failed: %s" (Printexc.to_string exn));
+    last_snapshot_ts := now_ts)
+;;
+
+let tick_keepalive_improve_loop ~(ctx : _ context) ~(meta_after_proactive : keeper_meta)
+  : unit
+  =
+  try
+    Tool_improve_loop.maybe_tick_from_keepalive
+      ~config:ctx.config
+      ~agent_name:meta_after_proactive.agent_name
+      ~keeper_name:meta_after_proactive.name
+      ~sw:ctx.sw
+      ~clock:ctx.clock
+      ~proc_mgr:ctx.proc_mgr
+      ~net:ctx.net
+      ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn "improve loop keepalive tick skipped: %s" (Printexc.to_string exn)
+;;
+
+let record_keepalive_stage_timing
+      ~(timing_ring : stage_timing array)
+      ~(timing_cursor : int ref)
+      ~(timing_filled : int ref)
+      ~(ring_sz : int)
+      ~(t_presence_start : float)
+      ~(t_presence_end : float)
+      ~(t_snapshot_start : float)
+      ~(t_snapshot_end : float)
+      ~(t_board_start : float)
+      ~(t_board_end : float)
+      ~(t_turn_start : float)
+      ~(t_turn_end : float)
+      ~(t_recurring_start : float)
+      ~(t_recurring_end : float)
+      ~(t_improve_start : float)
+      ~(t_improve_end : float)
+  : unit
+  =
+  let timing =
+    { presence_ms = (t_presence_end -. t_presence_start) *. 1000.0
+    ; snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0
+    ; board_ms = (t_board_end -. t_board_start) *. 1000.0
+    ; turn_ms = (t_turn_end -. t_turn_start) *. 1000.0
+    ; recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0
+    ; improve_ms = (t_improve_end -. t_improve_start) *. 1000.0
+    }
+  in
+  timing_ring.(!timing_cursor) <- timing;
+  timing_cursor := (!timing_cursor + 1) mod ring_sz;
+  if !timing_filled < ring_sz then incr timing_filled
+;;
+
+let run_heartbeat_loop
+      ~proactive_warmup_sec
+      (ctx : _ context)
+      (m : keeper_meta)
+      (stop : bool Atomic.t)
+      ~(wakeup : bool Atomic.t)
+  : unit
+  =
   let keepalive_started_ts = Time_compat.now () in
   let snapshot_interval_sec () =
-    Runtime_params.get Governance_registry.keeper_snapshot_sec in
+    Runtime_params.get Governance_registry.keeper_snapshot_sec
+  in
   let last_snapshot_ts = ref 0.0 in
   let consecutive_failures = ref 0 in
   (* Phase 0: per-stage timing ring buffer.
      ring_size is read once at fiber start — mid-flight resize requires
      ring buffer reallocation, so new values apply on next fiber restart. *)
   let ring_sz = stage_timing_ring_size () in
-  let timing_ring = Array.make ring_sz
-    { presence_ms = 0.0; snapshot_ms = 0.0; board_ms = 0.0;
-      turn_ms = 0.0; recurring_ms = 0.0; improve_ms = 0.0 } in
+  let timing_ring =
+    Array.make
+      ring_sz
+      { presence_ms = 0.0
+      ; snapshot_ms = 0.0
+      ; board_ms = 0.0
+      ; turn_ms = 0.0
+      ; recurring_ms = 0.0
+      ; improve_ms = 0.0
+      }
+  in
   let timing_cursor = ref 0 in
   let timing_filled = ref 0 in
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Room.heartbeat_in_room success after turn. *)
   let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
-  let work_as_hb () =
-    Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
+  let work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
   let max_silence () =
-    Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec in
+    Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec
+  in
   (* Phase 2: smart heartbeat — adaptive scheduling via Heartbeat_smart *)
   let smart_hb_enabled () =
-    Runtime_params.get Governance_registry.keeper_smart_hb_enabled in
+    Runtime_params.get Governance_registry.keeper_smart_hb_enabled
+  in
   let smart_hb_config = Heartbeat_smart.default_config in
   let last_heartbeat_cycle_ts = ref 0.0 in
   let rec loop () =
-    if Atomic.get stop then ()
+    if Atomic.get stop
+    then ()
     else (
-            (* Yield before each heartbeat cycle to prevent N keeper fibers
+      (* Yield before each heartbeat cycle to prevent N keeper fibers
                from monopolizing the Eio scheduler during CPU-bound phases
                (tool filtering, snapshot construction, prompt building). *)
-            Eio.Fiber.yield ();
-            (* Phase 0: timing markers *)
-            let t_presence_start = Time_compat.now () in
-            let meta_current =
-              match read_meta ctx.config m.name with
-              | Ok (Some latest) -> latest
-              | _ -> m
-            in
-            (* Phase 2: smart heartbeat — skip cycle when busy or deeply idle *)
-            let smart_hb_decision =
-              if smart_hb_enabled () then
-                let agent_status =
-                  if meta_current.paused then Types.Inactive
-                  else match meta_current.current_task_id with
-                    | Some _ -> Types.Busy
-                    | None -> Types.Active
-                in
-                Heartbeat_smart.should_emit
-                  ~config:smart_hb_config
-                  ~agent_status
-                  ~last_activity:!last_successful_heartbeat_ts
-                  ~last_heartbeat:!last_heartbeat_cycle_ts
-              else
-                Heartbeat_smart.Emit
-            in
-            (match smart_hb_decision with
-             | Heartbeat_smart.Skip_busy ->
-               Log.Keeper.debug "smart heartbeat: skip (busy, task=%s)"
-                 (Option.value ~default:"?" meta_current.current_task_id);
-               let base = Heartbeat_smart.effective_interval
-                 ~config:smart_hb_config
-                 ~last_activity:!last_successful_heartbeat_ts in
-               let jitter = base *. 0.2 *. Random.float 1.0 in
-               interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
-               if Atomic.get stop then () else loop ()
-             | Heartbeat_smart.Skip_idle next_time ->
-               let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
-               Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
-               let jitter = wait *. 0.1 *. Random.float 1.0 in
-               interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (wait +. jitter);
-               if Atomic.get stop then () else loop ()
-             | Heartbeat_smart.Emit ->
-               last_heartbeat_cycle_ts := Time_compat.now ());
-            (* Phase 1: skip presence sync when recent room heartbeat proves freshness *)
-            let presence_fresh =
-              work_as_hb ()
-              && t_presence_start -. !last_successful_heartbeat_ts < max_silence ()
-            in
-            let meta_current =
-              if presence_fresh then (
-                Log.Keeper.debug "presence sync skipped: fresh heartbeat %.0fs ago"
-                  (t_presence_start -. !last_successful_heartbeat_ts);
-                meta_current)
-              else
-                try
-                  let synced = ensure_keeper_room_presence ctx.config meta_current in
-                  if synced.joined_room_ids = [] then (
-                    incr consecutive_failures;
-                    Log.Keeper.warn "room presence returned empty rooms (%d/%d)"
-                      !consecutive_failures (max_consecutive_heartbeat_failures ()))
-                  else (
-                    consecutive_failures := 0;
-                    last_successful_heartbeat_ts := Time_compat.now ());
-                  (match write_meta ctx.config synced with
-                   | Ok () -> synced
-                   | Error e ->
-                     Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
-                     synced)
-                with
-                | Eio.Cancel.Cancelled _ as e -> raise e
-                | exn ->
-                  incr consecutive_failures;
-                  Log.Keeper.error "room heartbeat failed (%d/%d): %s"
-                    !consecutive_failures (max_consecutive_heartbeat_failures ())
-                    (Printexc.to_string exn);
-                  meta_current
-            in
-            (* Phase 2: structured exception instead of silent stop *)
-            if !consecutive_failures >= max_consecutive_heartbeat_failures () then
-              raise (Keeper_registry.Keeper_heartbeat_failure {
-                reason = Keeper_registry.Heartbeat_consecutive_failures !consecutive_failures;
-                keeper_name = m.name;
-              });
-            let t_presence_end = Time_compat.now () in
-            let now_ts = t_presence_end in
-            let t_snapshot_start = now_ts in
-            if now_ts -. !last_snapshot_ts >= float_of_int (snapshot_interval_sec ())
-            then (
-              (try
-                 let metrics_store =
-                   keeper_metrics_store ctx.config meta_current.name
-                 in
-                 let cascade_models = Oas_model_resolve.models_of_cascade_name meta_current.cascade_name in
-                 let primary_max_context =
-                   Oas_model_resolve.resolve_primary_max_context cascade_models
-                 in
-                 let base_dir = session_base_dir ctx.config in
-                 (* Ensure session directory tree for filesystem fallback (issue #3019) *)
-                 ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));
-                 let _session, ctx_opt =
-                   load_context_from_checkpoint
-                     ~trace_id:meta_current.runtime.trace_id
-                     ~primary_model_max_tokens:primary_max_context
-                     ~base_dir
-                 in
-                 (match ctx_opt with
-                 | None -> ()
-                 | Some c ->
-                     let latest_user_message =
-                       latest_message_content_by_role ~role:Agent_sdk.Types.User
-                         c.messages
-                     in
-                     let latest_assistant_message =
-                       latest_message_content_by_role
-                         ~role:Agent_sdk.Types.Assistant c.messages
-                     in
-                     let continuity_snapshot =
-                       latest_state_snapshot_from_messages c.messages
-                     in
-                     let continuity_summary =
-                       match continuity_snapshot with
-                       | Some s -> keeper_state_snapshot_to_summary_text s
-                       | None ->
-                           let trimmed =
-                             String.trim meta_current.continuity_summary
-                           in
-                           if trimmed = "" then
-                             "No continuity snapshot available."
-                           else trimmed
-                     in
-                     let repetition_risk =
-                       repetition_risk_score ~messages:c.messages
-                         ~candidate_reply:None
-                     in
-                     let goal_alignment =
-                       goal_alignment_score ~meta:meta_current
-                         ~user_message:latest_user_message
-                         ~assistant_reply:latest_assistant_message
-                     in
-                     let response_alignment =
-                       match latest_user_message, latest_assistant_message with
-                       | Some user_message, Some assistant_message ->
-                           jaccard_similarity user_message assistant_message
-                       | _ -> 0.0
-                     in
-                     let auto_rules =
-                       evaluate_keeper_auto_rules ~meta:meta_current
-                         ~context_ratio:(Keeper_exec_context.context_ratio c)
-                         ~message_count:(Keeper_exec_context.message_count c)
-                         ~token_count:(Keeper_exec_context.token_count c)
-                         ~repetition_risk
-                         ~goal_alignment ~response_alignment
-                         ()
-                     in
-                     let snapshot =
-                       `Assoc
-                         [
-                           ("ts", `String (now_iso ()));
-                           ("ts_unix", `Float now_ts);
-                           ("channel", `String "heartbeat");
-                           ("name", `String meta_current.name);
-                           ("agent_name", `String meta_current.agent_name);
-                           ("trace_id", `String meta_current.runtime.trace_id);
-                           ("generation", `Int meta_current.runtime.generation);
-                           ("model_used", `String meta_current.runtime.usage.last_model_used);
-                           ( "usage",
-                             `Assoc
-                               [
-                                 ("input_tokens", `Int 0);
-                                 ("output_tokens", `Int 0);
-                                 ("total_tokens", `Int 0);
-                               ] );
-                           ("latency_ms", `Int 0);
-                           ("cost_usd", `Float 0.0);
-                           ( "context_ratio",
-                             `Float (Keeper_exec_context.context_ratio c) );
-                           ("context_tokens", `Int (Keeper_exec_context.token_count c));
-                           ("context_max", `Int c.max_tokens);
-                           ("message_count", `Int (Keeper_exec_context.message_count c));
-                           ( "continuity_state",
-                             match continuity_snapshot with
-                             | None -> `Null
-                             | Some s -> keeper_state_snapshot_to_json s );
-                           ("continuity_summary", `String continuity_summary);
-                           ("compacted", `Bool false);
-                           ("compaction_before_tokens", `Int (Keeper_exec_context.token_count c));
-                           ("compaction_after_tokens", `Int (Keeper_exec_context.token_count c));
-                           ("work_kind", `String "status_tick");
-                           ("tool_call_count", `Int 0);
-                           ("tools_used", `List []);
-                           ("snapshot_source", `String "keeper_context_status");
-                           ("memory_check", memory_check_default_json ());
-                           ( "auto_rules",
-                             keeper_auto_rule_eval_to_json auto_rules );
-                           ( "reflection",
-                             keeper_reflection_payload_of_auto_rules auto_rules
-                           );
-                           ("auto_reflect", `Bool auto_rules.reflect);
-                           ("auto_plan", `Bool auto_rules.plan);
-                           ("auto_compact", `Bool auto_rules.compact);
-                           ("auto_handoff", `Bool auto_rules.handoff);
-                           ("repetition_risk", `Float repetition_risk);
-                           ("goal_alignment", `Float goal_alignment);
-                           ("response_alignment", `Float response_alignment);
-                           ("goal_drift", `Float auto_rules.goal_drift);
-                           ("guardrail_stop", `Bool auto_rules.guardrail_stop);
-                           ( "guardrail_stop_reason",
-                             match auto_rules.guardrail_reason with
-                             | Some reason -> `String reason
-                             | None -> `Null );
-                           ("handoff", `Assoc [ ("performed", `Bool false) ]);
-                           ("stage_timing",
-                             stage_timing_to_json ~ring:timing_ring ~count:!timing_filled);
-                         ]
-                     in
-                     Dated_jsonl.append metrics_store snapshot;
-                     (try
-                        Sse.broadcast
-                          (`Assoc
-                            [
-                              ("type", `String "keeper_heartbeat");
-                              ("name", `String meta_current.name);
-                              ("generation", `Int meta_current.runtime.generation);
-                              ( "context_ratio",
-                                `Float (Keeper_exec_context.context_ratio c) );
-                              ("ts_unix", `Float now_ts);
-                            ])
-                      with
-                      | Eio.Cancel.Cancelled _ as e -> raise e
-                      | exn ->
-                        Log.Keeper.error "heartbeat SSE broadcast failed: %s"
-                          (Printexc.to_string exn));
-                     (* OAS: publish keeper snapshot event *)
-                     (match !bus_ref with
-                      | Some bus ->
-                          Oas_events.publish_keeper_snapshot bus
-                            ~keeper_name:meta_current.name
-                            ~generation:meta_current.runtime.generation
-                            ~context_ratio:(Keeper_exec_context.context_ratio c)
-                            ~message_count:(List.length c.messages)
-                      | None -> ());
-                     (* Flush tool usage stats to disk for persistence *)
-                     (try
-                        Keeper_registry.flush_tool_usage
-                          ~base_path:ctx.config.base_path
-                          meta_current.name
-                      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()))
-               with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn ->
-                 Log.Keeper.error "heartbeat snapshot write failed: %s"
-                   (Printexc.to_string exn));
-              last_snapshot_ts := now_ts);
-            let t_snapshot_end = Time_compat.now () in
-            let t_board_start = t_snapshot_end in
-            (* Compute warmup state BEFORE board collection so cursor
-               is not advanced while keeper cannot act on events. *)
-            let proactive_warmup_elapsed =
-              proactive_warmup_sec <= 0
-              || now_ts -. keepalive_started_ts
-                 >= float_of_int proactive_warmup_sec
-            in
-            let pending_board_events, meta_after_triage =
-              if not proactive_warmup_elapsed then
-                (* During warmup: skip board collection to preserve cursor.
-                   First post-warmup cycle will pick up the full bootstrap
-                   window (300s) of board events. *)
-                ([], meta_current)
-              else
-                let pending_board_events =
-                  (try
-                     let events, _new_count, _mention_count =
-                       Keeper_world_observation.collect_board_events
-                         ~base_path:ctx.config.base_path
-                         ~meta:meta_current
-                         ~continuity_summary:meta_current.continuity_summary
-                     in
-                     events
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | exn ->
-                       Log.Keeper.warn "keepalive: board count query failed: %s"
-                         (Printexc.to_string exn);
-                       [])
-                in
-                (pending_board_events, meta_current)
-            in
-            let t_board_end = Time_compat.now () in
-            let t_turn_start = t_board_end in
-            let meta_after_proactive =
-              if proactive_warmup_elapsed then
-                (try
-                   let obs =
-                     Keeper_world_observation.observe
-                       ~pending_board_events:(Some pending_board_events)
-                       ~config:ctx.config ~meta:meta_after_triage
-                    in
-                   if Atomic.get stop then
-                     meta_after_triage
-                   else if
-                     Keeper_world_observation.should_run_unified_turn
-                       ~meta:meta_after_triage
-                       obs
-                   then
-                     match
-                       Keeper_unified_turn.run_unified_turn
-                         ~config:ctx.config ~meta:meta_after_triage
-                         ~observation:obs
-                         ~generation:meta_after_triage.runtime.generation
-                     with
-                     | Error e ->
-                         Log.Keeper.error "unified turn failed: %s" e;
-                         (match read_meta ctx.config meta_after_triage.name with
-                          | Ok (Some latest) -> latest
-                          | _ -> meta_after_triage)
-                     | Ok updated -> updated
-                   else
-                     meta_after_triage
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                   Log.Keeper.error "unified turn exception: %s"
-                     (Printexc.to_string exn);
-                   meta_after_triage)
-              else meta_after_triage
-            in
-            (* Turn failure threshold: registry tracks count (via unified_turn),
-               keepalive raises to terminate the fiber for supervisor restart. *)
-            let turn_fail_count =
-              Keeper_registry.get_turn_failures
-                ~base_path:ctx.config.base_path m.name in
-            if turn_fail_count >= max_consecutive_turn_failures () then
-              raise (Keeper_registry.Keeper_heartbeat_failure {
-                reason = Keeper_registry.Turn_consecutive_failures turn_fail_count;
-                keeper_name = m.name;
-              });
-            (* Phase 1: work-as-heartbeat — renew point (b).
-               After turn, call Room.heartbeat_in_room to prove room I/O health.
-               On success: refresh freshness lease + reset consecutive_failures.
-               On failure: leave timestamp unchanged → presence sync resumes next cycle. *)
-            (if work_as_hb () && proactive_warmup_elapsed then
-               let hb_ok = List.exists (fun room_id ->
-                 try
-                   ignore
-                     (Room.heartbeat_in_room ctx.config ~room_id
-                        ~agent_name:meta_after_proactive.agent_name);
-                   true
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                     Log.Keeper.debug "heartbeat_in_room failed for %s: %s"
-                       meta_after_proactive.name (Printexc.to_string exn);
-                     false
-               ) meta_after_proactive.joined_room_ids in
-               if hb_ok then (
-                 last_successful_heartbeat_ts := Time_compat.now ();
-                 consecutive_failures := 0));
-            let t_turn_end = Time_compat.now () in
-            let t_recurring_start = t_turn_end in
-            (* Recurring task dispatch (#3190) *)
-            let _recurring_dispatched =
-              try
-                Keeper_recurring.dispatch_due
-                  ~keeper_name:meta_after_proactive.name
-                  ~now_ts
-                  ~dispatch:(fun task action ->
-                    match action with
-                    | Keeper_recurring.Broadcast msg ->
-                      (try
-                         let _ = Room.broadcast ctx.config
-                           ~from_agent:meta_after_proactive.agent_name
-                           ~content:(Printf.sprintf "[loop:%s] %s" task.label msg) in
-                         Log.Keeper.info "[recurring] %s dispatched: %s"
-                           task.id task.label;
-                         Ok ()
-                       with exn ->
-                         Log.Keeper.warn "[recurring] %s failed: %s"
-                           task.id (Printexc.to_string exn);
-                         Error (Printexc.to_string exn)))
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                Log.Keeper.warn "[recurring] dispatch error: %s"
-                  (Printexc.to_string exn);
-                0
-            in
-            let t_recurring_end = Time_compat.now () in
-            let t_improve_start = t_recurring_end in
-            let base =
-              if smart_hb_enabled () then
-                Heartbeat_smart.effective_interval
-                  ~config:smart_hb_config
-                  ~last_activity:!last_successful_heartbeat_ts
-              else
-                float_of_int (keepalive_interval_sec ())
-            in
-            (try
-               Tool_improve_loop.maybe_tick_from_keepalive ~config:ctx.config
-                 ~agent_name:meta_after_proactive.agent_name
-                 ~keeper_name:meta_after_proactive.name
-                 ~sw:ctx.sw ~clock:ctx.clock ~proc_mgr:ctx.proc_mgr
-                 ~net:ctx.net ()
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               Log.Keeper.warn "improve loop keepalive tick skipped: %s"
-                 (Printexc.to_string exn));
-            let t_improve_end = Time_compat.now () in
-            (* Phase 0: push stage timing to ring buffer *)
-            let timing = {
-              presence_ms = (t_presence_end -. t_presence_start) *. 1000.0;
-              snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0;
-              board_ms = (t_board_end -. t_board_start) *. 1000.0;
-              turn_ms = (t_turn_end -. t_turn_start) *. 1000.0;
-              recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0;
-              improve_ms = (t_improve_end -. t_improve_start) *. 1000.0;
-            } in
-            timing_ring.(!timing_cursor) <- timing;
-            timing_cursor := (!timing_cursor + 1) mod ring_sz;
-            if !timing_filled < ring_sz then incr timing_filled;
-            let jitter = base *. Env_config.KeeperKeepalive.jitter_factor *. Random.float 1.0 in
-            interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
-            if Atomic.get stop then ()
-            else loop ())
+      Eio.Fiber.yield ();
+      (* Phase 0: timing markers *)
+      let t_presence_start = Time_compat.now () in
+      let meta_current =
+        match read_meta ctx.config m.name with
+        | Ok (Some latest) -> latest
+        | _ -> m
+      in
+      if
+        run_smart_heartbeat_gate
+          ~clock:ctx.clock
+          ~stop
+          ~wakeup
+          ~meta_current
+          ~smart_hb_enabled
+          ~smart_hb_config
+          ~last_successful_heartbeat_ts
+          ~last_heartbeat_cycle_ts
+      then (
+        (* Phase 1: skip presence sync when recent room heartbeat proves freshness *)
+        let meta_current =
+          sync_keeper_presence
+            ~ctx
+            ~meta_current
+            ~t_presence_start
+            ~consecutive_failures
+            ~last_successful_heartbeat_ts
+            ~work_as_hb
+            ~max_silence
+        in
+        (* Phase 2: structured exception instead of silent stop *)
+        if !consecutive_failures >= max_consecutive_heartbeat_failures ()
+        then
+          raise
+            (Keeper_registry.Keeper_heartbeat_failure
+               { reason =
+                   Keeper_registry.Heartbeat_consecutive_failures !consecutive_failures
+               ; keeper_name = m.name
+               });
+        let t_presence_end = Time_compat.now () in
+        let now_ts = t_presence_end in
+        let t_snapshot_start = now_ts in
+        maybe_write_heartbeat_snapshot
+          ~ctx
+          ~meta_current
+          ~now_ts
+          ~last_snapshot_ts
+          ~snapshot_interval_sec:(snapshot_interval_sec ())
+          ~timing_ring
+          ~timing_filled:!timing_filled;
+        let t_snapshot_end = Time_compat.now () in
+        let t_board_start = t_snapshot_end in
+        (* Compute warmup state BEFORE board collection so cursor
+                 is not advanced while keeper cannot act on events. *)
+        let proactive_warmup_elapsed =
+          proactive_warmup_sec <= 0
+          || now_ts -. keepalive_started_ts >= float_of_int proactive_warmup_sec
+        in
+        let pending_board_events, meta_after_triage =
+          collect_keepalive_board_events ~ctx ~meta_current ~proactive_warmup_elapsed
+        in
+        let t_board_end = Time_compat.now () in
+        let t_turn_start = t_board_end in
+        let meta_after_proactive =
+          run_keepalive_unified_turn
+            ~ctx
+            ~meta_after_triage
+            ~pending_board_events
+            ~stop
+            ~proactive_warmup_elapsed
+        in
+        (* Turn failure threshold: registry tracks count (via unified_turn),
+                 keepalive raises to terminate the fiber for supervisor restart. *)
+        let turn_fail_count =
+          Keeper_registry.get_turn_failures ~base_path:ctx.config.base_path m.name
+        in
+        if turn_fail_count >= max_consecutive_turn_failures ()
+        then
+          raise
+            (Keeper_registry.Keeper_heartbeat_failure
+               { reason = Keeper_registry.Turn_consecutive_failures turn_fail_count
+               ; keeper_name = m.name
+               });
+        (* Phase 1: work-as-heartbeat — renew point (b).
+                 After turn, call Room.heartbeat_in_room to prove room I/O health.
+                 On success: refresh freshness lease + reset consecutive_failures.
+                 On failure: leave timestamp unchanged → presence sync resumes next cycle. *)
+        refresh_work_as_heartbeat
+          ~ctx
+          ~meta_after_proactive
+          ~proactive_warmup_elapsed
+          ~work_as_hb
+          ~last_successful_heartbeat_ts
+          ~consecutive_failures;
+        let t_turn_end = Time_compat.now () in
+        let t_recurring_start = t_turn_end in
+        (* Recurring task dispatch (#3190) *)
+        let _recurring_dispatched =
+          dispatch_recurring_keepalive ~ctx ~meta_after_proactive ~now_ts
+        in
+        let t_recurring_end = Time_compat.now () in
+        let t_improve_start = t_recurring_end in
+        let base =
+          if smart_hb_enabled ()
+          then
+            Heartbeat_smart.effective_interval
+              ~config:smart_hb_config
+              ~last_activity:!last_successful_heartbeat_ts
+          else float_of_int (keepalive_interval_sec ())
+        in
+        tick_keepalive_improve_loop ~ctx ~meta_after_proactive;
+        let t_improve_end = Time_compat.now () in
+        (* Phase 0: push stage timing to ring buffer *)
+        record_keepalive_stage_timing
+          ~timing_ring
+          ~timing_cursor
+          ~timing_filled
+          ~ring_sz
+          ~t_presence_start
+          ~t_presence_end
+          ~t_snapshot_start
+          ~t_snapshot_end
+          ~t_board_start
+          ~t_board_end
+          ~t_turn_start
+          ~t_turn_end
+          ~t_recurring_start
+          ~t_recurring_end
+          ~t_improve_start
+          ~t_improve_end;
+        let jitter =
+          base *. Env_config.KeeperKeepalive.jitter_factor *. Random.float 1.0
+        in
+        interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter));
+      if Atomic.get stop then () else loop ())
   in
   loop ()
+;;
+
+let with_keeper_entry_by_agent_name ~agent_name ~on_missing f =
+  match Keeper_registry.find_by_agent_name agent_name with
+  | Some entry -> f entry
+  | None -> on_missing ()
+;;
+
+let set_keeper_paused_state ~agent_name paused =
+  with_keeper_entry_by_agent_name
+    ~agent_name
+    ~on_missing:(fun () ->
+      let action = if paused then "pause" else "resume" in
+      Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
+    (fun entry ->
+       Keeper_registry.update_meta
+         ~base_path:entry.base_path
+         entry.name
+         { entry.meta with paused })
+;;
+
+let wakeup_keeper_by_agent_name ~agent_name =
+  with_keeper_entry_by_agent_name
+    ~agent_name
+    ~on_missing:(fun () ->
+      Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
+    (fun entry -> wakeup_keeper entry.name)
+;;
+
+let assign_keeper_task_from_directive ~agent_name ~task_id =
+  with_keeper_entry_by_agent_name
+    ~agent_name
+    ~on_missing:(fun () ->
+      Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
+    (fun entry ->
+       Keeper_registry.update_meta
+         ~base_path:entry.base_path
+         entry.name
+         { entry.meta with current_task_id = Some task_id };
+       wakeup_keeper entry.name)
+;;
 
 (** Process a single directive received from a gRPC HeartbeatAck.
     Directives are string commands: "pause", "resume", "wakeup",
@@ -627,38 +884,92 @@ let process_directive ~agent_name directive =
   match directive with
   | "pause" ->
     Log.Keeper.info "directive: pausing keeper %s" agent_name;
-    (match Keeper_registry.find_by_agent_name agent_name with
-     | Some entry ->
-       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
-         { entry.meta with paused = true }
-     | None ->
-       Log.Keeper.warn "directive pause: agent %s not in registry" agent_name)
+    set_keeper_paused_state ~agent_name true
   | "resume" ->
     Log.Keeper.info "directive: resuming keeper %s" agent_name;
-    (match Keeper_registry.find_by_agent_name agent_name with
-     | Some entry ->
-       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
-         { entry.meta with paused = false }
-     | None ->
-       Log.Keeper.warn "directive resume: agent %s not in registry" agent_name)
+    set_keeper_paused_state ~agent_name false
   | "wakeup" ->
     Log.Keeper.debug "directive: waking up %s" agent_name;
-    (match Keeper_registry.find_by_agent_name agent_name with
-     | Some entry -> wakeup_keeper entry.name
-     | None ->
-       Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
+    wakeup_keeper_by_agent_name ~agent_name
   | s when String.length s > 6 && String.sub s 0 6 = "claim:" ->
     let task_id = String.sub s 6 (String.length s - 6) in
     Log.Keeper.info "directive: server assigned task %s to %s" task_id agent_name;
-    (match Keeper_registry.find_by_agent_name agent_name with
-     | Some entry ->
-       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
-         { entry.meta with current_task_id = Some task_id };
-       wakeup_keeper entry.name
-     | None ->
-       Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
-  | unknown ->
-    Log.Keeper.warn "unknown gRPC directive for %s: %s" agent_name unknown
+    assign_keeper_task_from_directive ~agent_name ~task_id
+  | unknown -> Log.Keeper.warn "unknown gRPC directive for %s: %s" agent_name unknown
+;;
+
+let current_task_id_for_agent agent_name =
+  match Keeper_registry.find_by_agent_name agent_name with
+  | Some e -> Option.value ~default:"" e.meta.current_task_id
+  | None -> ""
+;;
+
+let make_grpc_heartbeat_ping ~agent_name ~session_id =
+  Masc_grpc_types.HeartbeatPing.
+    { agent_name
+    ; session_id
+    ; timestamp_ms = Int64.of_float (Time_compat.now () *. 1000.0)
+    ; current_task_id = current_task_id_for_agent agent_name
+    }
+;;
+
+let handle_grpc_heartbeat_ack ~agent_name (ack : Masc_grpc_types.HeartbeatAck.t) =
+  Log.Keeper.debug
+    "gRPC bidi heartbeat: agent=%s agents=%d tasks=%d directives=%d"
+    agent_name
+    ack.active_agent_count
+    ack.pending_task_count
+    (List.length ack.directives);
+  List.iter (process_directive ~agent_name) ack.directives
+;;
+
+let run_grpc_heartbeat_stream
+      ~stop
+      ~close_ref
+      ~clock
+      ~interval_sec
+      ~agent_name
+      ~session_id
+      send
+      recv
+  =
+  let rec tick () =
+    if Atomic.get stop || !close_ref
+    then ()
+    else (
+      (try
+         send (make_grpc_heartbeat_ping ~agent_name ~session_id);
+         match recv () with
+         | Ok ack -> handle_grpc_heartbeat_ack ~agent_name ack
+         | Error err -> Log.Keeper.warn "gRPC heartbeat recv: %s" err
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | End_of_file -> raise End_of_file
+       | exn -> Log.Keeper.error "gRPC heartbeat tick error: %s" (Printexc.to_string exn));
+      if not (Atomic.get stop || !close_ref)
+      then (
+        let no_wakeup = Atomic.make false in
+        interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
+        tick ()))
+  in
+  tick ()
+;;
+
+let log_grpc_heartbeat_stream_failure ~agent_name ~attempts = function
+  | `Closed ->
+    Log.Keeper.warn
+      "gRPC heartbeat stream closed for %s (attempt %d/%d)"
+      agent_name
+      (attempts + 1)
+      Env_config.KeeperGrpc.max_reconnect_attempts
+  | `Error exn ->
+    Log.Keeper.warn
+      "gRPC heartbeat stream error for %s: %s (attempt %d/%d)"
+      agent_name
+      (Printexc.to_string exn)
+      (attempts + 1)
+      Env_config.KeeperGrpc.max_reconnect_attempts
+;;
 
 (** Run a gRPC heartbeat sender in a background fiber.
     Opens a bidirectional [Heartbeat] stream and sends [HeartbeatPing]
@@ -669,99 +980,133 @@ let process_directive ~agent_name directive =
     Requires [grpc_client_ref] to be set (via [set_grpc_client])
     and Eio switch/env to be available in [Eio_context]. *)
 let max_reconnect_attempts = Env_config.KeeperGrpc.max_reconnect_attempts
+
 let reconnect_backoff_sec = Env_config.KeeperGrpc.reconnect_backoff_sec
 
-let run_grpc_heartbeat_fiber ~sw ~stop
-    ~(grpc_client : Masc_grpc_client.t)
-    ~(agent_name : string) ~(session_id : string)
-    ~(interval_sec : float) ~(clock : _ Eio.Time.clock) =
+let run_grpc_heartbeat_fiber
+      ~sw
+      ~stop
+      ~(grpc_client : Masc_grpc_client.t)
+      ~(agent_name : string)
+      ~(session_id : string)
+      ~(interval_sec : float)
+      ~(clock : _ Eio.Time.clock)
+  =
   match Eio_context.get_switch_opt (), !grpc_env_ref with
   | None, _ | _, None ->
     Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
     None
   | Some grpc_sw, Some env ->
-  let close_ref = ref false in
-  Eio.Fiber.fork ~sw (fun () ->
-    let make_ping () =
-      let current_task_id =
-        match Keeper_registry.find_by_agent_name agent_name with
-        | Some e -> Option.value ~default:"" e.meta.current_task_id
-        | None -> ""
-      in
-      Masc_grpc_types.HeartbeatPing.{
-        agent_name;
-        session_id;
-        timestamp_ms = Int64.of_float (Time_compat.now () *. 1000.0);
-        current_task_id;
-      }
-    in
-    (* Inner loop: send ping → recv ack → sleep → repeat on one stream *)
-    let run_stream send recv =
-      let rec tick () =
-        if Atomic.get stop || !close_ref then ()
+    let close_ref = ref false in
+    Eio.Fiber.fork ~sw (fun () ->
+      (* Outer loop: reconnect on stream failure *)
+      let rec connect_loop attempts =
+        if Atomic.get stop || !close_ref
+        then ()
+        else if attempts >= max_reconnect_attempts
+        then
+          Log.Keeper.error
+            "gRPC heartbeat: exceeded %d reconnect attempts for %s, stopping"
+            max_reconnect_attempts
+            agent_name
         else (
+          let send, recv, close_stream =
+            Masc_grpc_client.heartbeat_stream grpc_client ~sw:grpc_sw ~env
+          in
           (try
-            send (make_ping ());
-            (match recv () with
-             | Ok (ack : Masc_grpc_types.HeartbeatAck.t) ->
-               Log.Keeper.debug
-                 "gRPC bidi heartbeat: agent=%s agents=%d tasks=%d directives=%d"
-                 agent_name ack.active_agent_count ack.pending_task_count
-                 (List.length ack.directives);
-               List.iter (process_directive ~agent_name) ack.directives
-             | Error err ->
-               Log.Keeper.warn "gRPC heartbeat recv: %s" err)
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | End_of_file -> raise End_of_file
-          | exn ->
-            Log.Keeper.error "gRPC heartbeat tick error: %s"
-              (Printexc.to_string exn));
-          if not (Atomic.get stop || !close_ref) then (
-            let no_wakeup = Atomic.make false in
-            interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
-            tick ()))
+             run_grpc_heartbeat_stream
+               ~stop
+               ~close_ref
+               ~clock
+               ~interval_sec
+               ~agent_name
+               ~session_id
+               send
+               recv
+           with
+           | Eio.Cancel.Cancelled _ as e ->
+             close_stream ();
+             raise e
+           | End_of_file ->
+             log_grpc_heartbeat_stream_failure ~agent_name ~attempts `Closed;
+             close_stream ()
+           | exn ->
+             log_grpc_heartbeat_stream_failure ~agent_name ~attempts (`Error exn);
+             close_stream ());
+          if not (Atomic.get stop || !close_ref)
+          then (
+            Eio.Time.sleep clock reconnect_backoff_sec;
+            connect_loop (attempts + 1)))
       in
-      tick ()
-    in
-    (* Outer loop: reconnect on stream failure *)
-    let rec connect_loop attempts =
-      if Atomic.get stop || !close_ref then ()
-      else if attempts >= max_reconnect_attempts then
-        Log.Keeper.error
-          "gRPC heartbeat: exceeded %d reconnect attempts for %s, stopping"
-          max_reconnect_attempts agent_name
-      else (
-        let send, recv, close_stream =
-          Masc_grpc_client.heartbeat_stream grpc_client ~sw:grpc_sw ~env
-        in
-        (try run_stream send recv
-         with
-         | Eio.Cancel.Cancelled _ as e -> close_stream (); raise e
-         | End_of_file ->
-           Log.Keeper.warn
-             "gRPC heartbeat stream closed for %s (attempt %d/%d)"
-             agent_name (attempts + 1) max_reconnect_attempts;
-           close_stream ()
-         | exn ->
-           Log.Keeper.warn
-             "gRPC heartbeat stream error for %s: %s (attempt %d/%d)"
-             agent_name (Printexc.to_string exn)
-             (attempts + 1) max_reconnect_attempts;
-           close_stream ());
-        if not (Atomic.get stop || !close_ref) then (
-          Eio.Time.sleep clock reconnect_backoff_sec;
-          connect_loop (attempts + 1)))
-    in
-    connect_loop 0);
-  Some (fun () -> close_ref := true)
+      connect_loop 0);
+    Some (fun () -> close_ref := true)
+;;
 
-let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
-    (m : keeper_meta) : unit =
-  if Keeper_registry.is_running ~base_path:ctx.config.base_path m.name then
-    Log.Keeper.info "start_keepalive: skipped %s (already running)" m.name
-  else if not (Keeper_registry.spawn_slots_available ()) then
-    Log.Keeper.info "start_keepalive: skipped %s (no spawn slots)" m.name
+let start_keeper_grpc_heartbeat
+      ~(ctx : _ context)
+      ~(m : keeper_meta)
+      ~(stop : bool Atomic.t)
+  : (unit -> unit) option
+  =
+  match Masc_grpc_transport.from_env (), !grpc_client_ref with
+  | Masc_grpc_transport.Grpc, Some client ->
+    Log.Keeper.info "keeper %s: starting gRPC heartbeat fiber" m.name;
+    let interval = float_of_int (keepalive_interval_sec ()) in
+    let session_id =
+      Printf.sprintf
+        "keeper-%s-%Ld"
+        m.name
+        (Int64.of_float (Time_compat.now () *. 1000.0))
+    in
+    run_grpc_heartbeat_fiber
+      ~sw:ctx.sw
+      ~stop
+      ~grpc_client:client
+      ~agent_name:m.agent_name
+      ~session_id
+      ~interval_sec:interval
+      ~clock:ctx.clock
+  | Masc_grpc_transport.Grpc, None ->
+    Log.Keeper.warn "keeper %s: gRPC transport requested but no client configured" m.name;
+    None
+  | _ -> None
+;;
+
+let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_meta =
+  try
+    if not (Room_utils.is_initialized ctx.config)
+    then (
+      let (_init_msg : string) = Room.init ctx.config ~agent_name:None in
+      ());
+    let synced = ensure_keeper_room_presence ctx.config m in
+    (match write_meta ctx.config synced with
+     | Ok () -> ()
+     | Error e -> Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
+    synced
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.error "room presence bootstrap failed: %s" (Printexc.to_string exn);
+    m
+;;
+
+let publish_keeper_started ~(live_meta : keeper_meta) : unit =
+  match get_bus () with
+  | Some bus ->
+    Oas_events.publish_keeper_lifecycle
+      bus
+      ~event:"started"
+      ~keeper_name:live_meta.name
+      ~detail:"keepalive"
+  | None -> ()
+;;
+
+let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_meta) : unit
+  =
+  if Keeper_registry.is_running ~base_path:ctx.config.base_path m.name
+  then Log.Keeper.info "start_keepalive: skipped %s (already running)" m.name
+  else if not (Keeper_registry.spawn_slots_available ())
+  then Log.Keeper.info "start_keepalive: skipped %s (no spawn slots)" m.name
   else (
     (* Register in Keeper_registry first — single source of truth. *)
     let reg = Keeper_registry.register ~base_path:ctx.config.base_path m.name m in
@@ -770,77 +1115,47 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     let stop = reg.fiber_stop in
     let wakeup = reg.fiber_wakeup in
     (* Start optional gRPC heartbeat fiber *)
-    let grpc_close =
-      match Masc_grpc_transport.from_env (), !grpc_client_ref with
-      | Masc_grpc_transport.Grpc, Some client ->
-        Log.Keeper.info "keeper %s: starting gRPC heartbeat fiber" m.name;
-        let interval = float_of_int (keepalive_interval_sec ()) in
-        let session_id =
-          Printf.sprintf "keeper-%s-%Ld" m.name
-            (Int64.of_float (Time_compat.now () *. 1000.0))
-        in
-        run_grpc_heartbeat_fiber ~sw:ctx.sw ~stop ~grpc_client:client
-          ~agent_name:m.agent_name ~session_id
-          ~interval_sec:interval ~clock:ctx.clock
-      | Masc_grpc_transport.Grpc, None ->
-        Log.Keeper.warn "keeper %s: gRPC transport requested but no client configured" m.name;
-        None
-      | _ -> None
-    in
+    let grpc_close = start_keeper_grpc_heartbeat ~ctx ~m ~stop in
     (match grpc_close with
      | Some _ ->
-         Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name
-           grpc_close
+       Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name grpc_close
      | None -> ());
-    let live_meta =
-      try
-        (if not (Room_utils.is_initialized ctx.config) then
-           let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ());
-        let synced = ensure_keeper_room_presence ctx.config m in
-        (match write_meta ctx.config synced with
-         | Ok () -> ()
-         | Error e -> Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
-        synced
-      with
+    let live_meta = bootstrap_live_keeper_meta ~ctx m in
+    Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
+    publish_keeper_started ~live_meta;
+    Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+      try run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Log.Keeper.error "room presence bootstrap failed: %s"
-          (Printexc.to_string exn);
-        m
-    in
-    Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
-    (match get_bus () with
-     | Some bus ->
-         Oas_events.publish_keeper_lifecycle bus ~event:"started"
-           ~keeper_name:live_meta.name ~detail:"keepalive"
-     | None -> ());
-    Eio.Fiber.fork ~sw:ctx.sw (fun () ->
-        try run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Keeper.error "heartbeat loop for %s crashed: %s"
-            live_meta.name (Printexc.to_string exn)))
+        Log.Keeper.error
+          "heartbeat loop for %s crashed: %s"
+          live_meta.name
+          (Printexc.to_string exn)))
+;;
 
 let stop_keepalive name =
   let entries =
     Keeper_registry.all ()
-    |> List.filter (fun (e : Keeper_registry.registry_entry) ->
-           String.equal e.name name)
+    |> List.filter (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name)
   in
-  List.iter (fun (entry : Keeper_registry.registry_entry) ->
-      Atomic.set entry.fiber_stop true;
-      (match Atomic.get entry.grpc_close with
-       | Some close_fn ->
-         (try close_fn ()
-          with Eio.Cancel.Cancelled _ as e -> raise e | _exn -> ())
-       | None -> ());
-      Keeper_registry.set_state ~base_path:entry.base_path name
-        Keeper_registry.Stopped;
-      Keeper_registry.cleanup_tracking ~base_path:entry.base_path name;
-      (match get_bus () with
+  List.iter
+    (fun (entry : Keeper_registry.registry_entry) ->
+       Atomic.set entry.fiber_stop true;
+       (match Atomic.get entry.grpc_close with
+        | Some close_fn ->
+          (try close_fn () with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | _exn -> ())
+        | None -> ());
+       Keeper_registry.set_state ~base_path:entry.base_path name Keeper_registry.Stopped;
+       Keeper_registry.cleanup_tracking ~base_path:entry.base_path name;
+       match get_bus () with
        | Some bus ->
-           Oas_events.publish_keeper_lifecycle bus ~event:"stopped"
-             ~keeper_name:name ~detail:"manual stop"
+         Oas_events.publish_keeper_lifecycle
+           bus
+           ~event:"stopped"
+           ~keeper_name:name
+           ~detail:"manual stop"
        | None -> ())
-  ) entries
+    entries
+;;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -5,22 +5,21 @@
    extracted to Keeper_types_profile *)
 include Keeper_types_profile
 
-
 (* -- Policy types (remain in keeper_meta top-level) -- *)
 
-type compaction_policy = {
-  profile: string;
-  ratio_gate: float;
-  message_gate: int;
-  token_gate: int;
-  cooldown_sec: int;
-}
+type compaction_policy =
+  { profile : string
+  ; ratio_gate : float
+  ; message_gate : int
+  ; token_gate : int
+  ; cooldown_sec : int
+  }
 
-type proactive_policy = {
-  enabled: bool;
-  idle_sec: int;
-  cooldown_sec: int;
-}
+type proactive_policy =
+  { enabled : bool
+  ; idle_sec : int
+  ; cooldown_sec : int
+  }
 
 type tool_preset =
   | Minimal
@@ -30,119 +29,119 @@ type tool_preset =
   | Full
 
 type tool_access =
-  | Preset of {
-      preset : tool_preset;
-      also_allow : string list;
-    }
+  | Preset of
+      { preset : tool_preset
+      ; also_allow : string list
+      }
   | Custom of string list
 
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
-type compaction_runtime = {
-  count: int;
-  last_ts: float;
-  last_before_tokens: int;
-  last_after_tokens: int;
-  last_check_ts: float;
-  last_decision: string;
-}
+type compaction_runtime =
+  { count : int
+  ; last_ts : float
+  ; last_before_tokens : int
+  ; last_after_tokens : int
+  ; last_check_ts : float
+  ; last_decision : string
+  }
 
-type proactive_runtime = {
-  count_total: int;
-  last_ts: float;
-  last_reason: string;
-  last_preview: string;
-}
+type proactive_runtime =
+  { count_total : int
+  ; last_ts : float
+  ; last_reason : string
+  ; last_preview : string
+  }
 
-type usage_metrics = {
-  total_turns: int;
-  total_input_tokens: int;
-  total_output_tokens: int;
-  total_tokens: int;
-  total_cost_usd: float;
-  last_turn_ts: float;
-  last_model_used: string;
-  last_input_tokens: int;
-  last_output_tokens: int;
-  last_total_tokens: int;
-  last_latency_ms: int;
-}
+type usage_metrics =
+  { total_turns : int
+  ; total_input_tokens : int
+  ; total_output_tokens : int
+  ; total_tokens : int
+  ; total_cost_usd : float
+  ; last_turn_ts : float
+  ; last_model_used : string
+  ; last_input_tokens : int
+  ; last_output_tokens : int
+  ; last_total_tokens : int
+  ; last_latency_ms : int
+  }
 
-type agent_runtime_state = {
-  usage: usage_metrics;
-  compaction_rt: compaction_runtime;
-  proactive_rt: proactive_runtime;
-  generation: int;
-  trace_id: string;
-  trace_history: string list;
-  last_handoff_ts: float;
-  last_continuity_update_ts: float;
-  last_autonomous_action_at: string;
-  autonomous_action_count: int;
-  autonomous_turn_count: int;
-  autonomous_text_turn_count: int;
-  autonomous_tool_turn_count: int;
-  board_reactive_turn_count: int;
-  mention_reactive_turn_count: int;
-  noop_turn_count: int;
-  last_speech_act: string;
-  last_blocker: string;
-  last_need: string;
-}
+type agent_runtime_state =
+  { usage : usage_metrics
+  ; compaction_rt : compaction_runtime
+  ; proactive_rt : proactive_runtime
+  ; generation : int
+  ; trace_id : string
+  ; trace_history : string list
+  ; last_handoff_ts : float
+  ; last_continuity_update_ts : float
+  ; last_autonomous_action_at : string
+  ; autonomous_action_count : int
+  ; autonomous_turn_count : int
+  ; autonomous_text_turn_count : int
+  ; autonomous_tool_turn_count : int
+  ; board_reactive_turn_count : int
+  ; mention_reactive_turn_count : int
+  ; noop_turn_count : int
+  ; last_speech_act : string
+  ; last_blocker : string
+  ; last_need : string
+  }
 
-type keeper_meta = {
-  (* -- Identity & profile -- *)
-  name: string;
-  agent_name: string;
-  goal: string;
-  short_goal: string;
-  mid_goal: string;
-  long_goal: string;
-  soul_profile: string;
-  social_model: string;
-  cascade_name: string;
-  will: string;
-  needs: string;
-  desires: string;
-  instructions: string;
-  (* -- Policy -- *)
-  policy_voice_enabled: bool;
-  execution_scope: string;
-  allowed_paths: string list;
-  scope_kind: string;
-  tool_access: tool_access;
-  tool_denylist: string list;
-  room_scope: string;
-  mention_targets: string list;
-  room_signal_prompt_enabled: bool;
-  joined_room_ids: string list;
-  last_seen_seq_by_room: (string * int) list;
-  proactive: proactive_policy;
-  compaction: compaction_policy;
-  auto_handoff: bool;
-  handoff_threshold: float;
-  handoff_cooldown_sec: int;
-  (* -- Voice -- *)
-  voice_enabled: bool;
-  voice_channel: string;
-  voice_agent_id: string;
-  (* -- Lifecycle -- *)
-  created_at: string;
-  updated_at: string;
-  (* -- Operational control (top-level, not runtime) -- *)
-  continuity_summary: string;
-  active_goal_ids: string list;
-  active_team_session_id: string option;
-  last_team_session_started_at: string;
-  team_session_start_count_total: int;
-  paused: bool;
-  current_task_id: string option;
-  (** Currently claimed task ID for cost attribution.
+type keeper_meta =
+  { (* -- Identity & profile -- *)
+    name : string
+  ; agent_name : string
+  ; goal : string
+  ; short_goal : string
+  ; mid_goal : string
+  ; long_goal : string
+  ; soul_profile : string
+  ; social_model : string
+  ; cascade_name : string
+  ; will : string
+  ; needs : string
+  ; desires : string
+  ; instructions : string
+  ; (* -- Policy -- *)
+    policy_voice_enabled : bool
+  ; execution_scope : string
+  ; allowed_paths : string list
+  ; scope_kind : string
+  ; tool_access : tool_access
+  ; tool_denylist : string list
+  ; room_scope : string
+  ; mention_targets : string list
+  ; room_signal_prompt_enabled : bool
+  ; joined_room_ids : string list
+  ; last_seen_seq_by_room : (string * int) list
+  ; proactive : proactive_policy
+  ; compaction : compaction_policy
+  ; auto_handoff : bool
+  ; handoff_threshold : float
+  ; handoff_cooldown_sec : int
+  ; (* -- Voice -- *)
+    voice_enabled : bool
+  ; voice_channel : string
+  ; voice_agent_id : string
+  ; (* -- Lifecycle -- *)
+    created_at : string
+  ; updated_at : string
+  ; (* -- Operational control (top-level, not runtime) -- *)
+    continuity_summary : string
+  ; active_goal_ids : string list
+  ; active_team_session_id : string option
+  ; last_team_session_started_at : string
+  ; team_session_start_count_total : int
+  ; paused : bool
+  ; current_task_id : string option
+    (** Currently claimed task ID for cost attribution.
       Set when keeper claims a task; cleared on masc_done.
       Propagated to trajectory accumulator for per-task cost tracking. *)
-  (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
-  runtime: agent_runtime_state;
-}
+  ; (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
+    runtime : agent_runtime_state
+  }
 
 let default_social_model = "bdi_speech_v1"
 
@@ -151,14 +150,17 @@ let normalize_tool_names names =
   |> List.map String.trim
   |> List.filter (fun name -> name <> "")
   |> dedupe_keep_order
+;;
 
 let legacy_keeper_internal_tool_names =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+;;
 
 let legacy_standard_tool_names = Tool_catalog.standard_tools
 
 let migrate_legacy_restricted_tools names =
   Custom (normalize_tool_names (legacy_keeper_internal_tool_names @ names))
+;;
 
 let tool_preset_to_string = function
   | Minimal -> "minimal"
@@ -166,6 +168,7 @@ let tool_preset_to_string = function
   | Coding -> "coding"
   | Research -> "research"
   | Full -> "full"
+;;
 
 let tool_preset_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
@@ -175,817 +178,952 @@ let tool_preset_of_string raw =
   | "research" -> Some Research
   | "full" -> Some Full
   | _ -> None
+;;
 
 let normalize_tool_access = function
   | Preset { preset; also_allow } ->
-      Preset { preset; also_allow = normalize_tool_names also_allow }
+    Preset { preset; also_allow = normalize_tool_names also_allow }
   | Custom names -> Custom (normalize_tool_names names)
+;;
 
 let tool_access_preset = function
   | Preset { preset; _ } -> Some preset
   | Custom _ -> None
+;;
 
 let tool_access_custom_allowlist = function
   | Preset _ -> None
   | Custom names -> Some names
+;;
 
 let tool_access_also_allowlist = function
   | Preset { also_allow; _ } -> also_allow
   | Custom _ -> []
+;;
 
 let tool_access_to_json access =
   match normalize_tool_access access with
   | Preset { preset; also_allow } ->
-      `Assoc
-        [
-          ("kind", `String "preset");
-          ("preset", `String (tool_preset_to_string preset));
-          ("also_allow", `List (List.map (fun s -> `String s) also_allow));
-        ]
+    `Assoc
+      [ "kind", `String "preset"
+      ; "preset", `String (tool_preset_to_string preset)
+      ; "also_allow", `List (List.map (fun s -> `String s) also_allow)
+      ]
   | Custom names ->
-      `Assoc
-        [
-          ("kind", `String "custom");
-          ("tools", `List (List.map (fun s -> `String s) names));
-        ]
+    `Assoc
+      [ "kind", `String "custom"; "tools", `List (List.map (fun s -> `String s) names) ]
+;;
 
 let json_member_present key (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields -> List.mem_assoc key fields
   | _ -> false
+;;
 
 let json_object_member_present key (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member key json with
   | `Assoc _ -> true
   | _ -> false
+;;
 
 let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
   let label = Option.value ~default:field_name label in
   match Yojson.Safe.Util.member field_name json with
   | `List items ->
-      let rec collect acc index = function
-        | [] -> Ok (List.rev acc)
-        | `String value :: rest -> collect (value :: acc) (index + 1) rest
-        | _ :: _ ->
-            Error
-              (Printf.sprintf
-                 "keeper %s[%d] must be a string"
-                 label index)
-      in
-      collect [] 0 items
-  | `Null ->
-      Error (Printf.sprintf "keeper %s must be an array of strings" label)
-  | _ ->
-      Error (Printf.sprintf "keeper %s must be an array of strings" label)
+    let rec collect acc index = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> collect (value :: acc) (index + 1) rest
+      | _ :: _ -> Error (Printf.sprintf "keeper %s[%d] must be a string" label index)
+    in
+    collect [] 0 items
+  | `Null -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
+  | _ -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
+;;
 
 let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member field_name json with
   | `Null -> Ok []
   | _ -> string_list_field_result ?label ~field_name json
+;;
 
 let parse_tool_preset_projection (json : Yojson.Safe.t) =
   let preset_member = Yojson.Safe.Util.member "tool_preset" json in
   match preset_member with
-  | `String raw -> (
-      match tool_preset_of_string raw with
-      | Some preset -> Ok preset
-      | None ->
-          Error
-            (Printf.sprintf "invalid keeper tool_preset: %s" raw))
+  | `String raw ->
+    (match tool_preset_of_string raw with
+     | Some preset -> Ok preset
+     | None -> Error (Printf.sprintf "invalid keeper tool_preset: %s" raw))
   | `Null -> Error "keeper tool_preset required"
   | _ -> Error "keeper tool_preset must be a string"
+;;
 
 let tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
   let custom_present = json_member_present "tool_custom_allowlist" json in
   let preset_present = json_member_present "tool_preset" json in
   let also_allow_present = json_member_present "tool_also_allow" json in
   let legacy_allowlist_present = json_member_present "tool_allowlist" json in
-  if custom_present then
+  if custom_present
+  then (
     match string_list_field_result ~field_name:"tool_custom_allowlist" json with
     | Ok tools -> Ok (normalize_tool_access (Custom tools))
-    | Error msg -> Error msg
-  else if preset_present || also_allow_present then
+    | Error msg -> Error msg)
+  else if preset_present || also_allow_present
+  then (
     match parse_tool_preset_projection json with
     | Error msg -> Error msg
-    | Ok preset -> (
-        match string_list_field_opt_result ~field_name:"tool_also_allow" json with
-        | Ok also_allow ->
-            Ok (normalize_tool_access (Preset { preset; also_allow }))
-        | Error msg -> Error msg)
-  else if legacy_allowlist_present then
+    | Ok preset ->
+      (match string_list_field_opt_result ~field_name:"tool_also_allow" json with
+       | Ok also_allow -> Ok (normalize_tool_access (Preset { preset; also_allow }))
+       | Error msg -> Error msg))
+  else if legacy_allowlist_present
+  then (
     match string_list_field_result ~field_name:"tool_allowlist" json with
     | Ok names -> Ok (migrate_legacy_restricted_tools names)
-    | Error msg -> Error msg
-  else
-    Ok (migrate_legacy_restricted_tools legacy_standard_tool_names)
+    | Error msg -> Error msg)
+  else Ok (migrate_legacy_restricted_tools legacy_standard_tool_names)
+;;
 
 let tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member "tool_access" json with
-  | `Null ->
-      tool_access_projection_of_meta_json json
-  | `Assoc _ as access_json -> (
-      let kind =
-        Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
-      in
-      match kind with
-      | Some "unrestricted" ->
-          Ok (Preset { preset = Full; also_allow = [] } |> normalize_tool_access)
-      | Some "restricted" -> (
-          match string_list_field_opt_result
-                  ~field_name:"tools" ~label:"tool_access.tools" access_json
-          with
-          | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
-          | Error msg -> Error msg)
-      | Some "preset" -> (
-          let preset_raw =
-            Yojson.Safe.Util.member "preset" access_json
-            |> Yojson.Safe.Util.to_string_option
-          in
-          match preset_raw with
-          | None -> Error "keeper tool_access.preset required"
-          | Some raw -> (
-              match tool_preset_of_string raw with
-              | None ->
-                  Error
-                    (Printf.sprintf
-                       "invalid keeper tool_access.preset: %s"
-                       raw)
-              | Some preset -> (
-                  match string_list_field_opt_result
-                          ~field_name:"also_allow" ~label:"tool_access.also_allow" access_json
-                  with
-                  | Ok also_allow ->
-                      Ok
-                        (normalize_tool_access
-                           (Preset { preset; also_allow }))
-                  | Error msg -> Error msg)))
-      | Some "custom" -> (
-          match string_list_field_result
-                  ~field_name:"tools" ~label:"tool_access.tools" access_json
-          with
-          | Ok tools -> Ok (normalize_tool_access (Custom tools))
-          | Error msg -> Error msg)
-      | Some other ->
-          Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
-      | None -> Error "keeper tool_access.kind required")
+  | `Null -> tool_access_projection_of_meta_json json
+  | `Assoc _ as access_json ->
+    let kind =
+      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+    in
+    (match kind with
+     | Some "unrestricted" ->
+       Ok (Preset { preset = Full; also_allow = [] } |> normalize_tool_access)
+     | Some "restricted" ->
+       (match
+          string_list_field_opt_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
+        | Error msg -> Error msg)
+     | Some "preset" ->
+       let preset_raw =
+         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
+       in
+       (match preset_raw with
+        | None -> Error "keeper tool_access.preset required"
+        | Some raw ->
+          (match tool_preset_of_string raw with
+           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
+           | Some preset ->
+             (match
+                string_list_field_opt_result
+                  ~field_name:"also_allow"
+                  ~label:"tool_access.also_allow"
+                  access_json
+              with
+              | Ok also_allow ->
+                Ok (normalize_tool_access (Preset { preset; also_allow }))
+              | Error msg -> Error msg)))
+     | Some "custom" ->
+       (match
+          string_list_field_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (normalize_tool_access (Custom tools))
+        | Error msg -> Error msg)
+     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+     | None -> Error "keeper tool_access.kind required")
   | _ -> Error "keeper tool_access must be an object"
+;;
 
 (* -- Updater helpers for nested record updates -- *)
 
-let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta) : keeper_meta =
+let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta)
+  : keeper_meta
+  =
   { m with runtime = f m.runtime }
+;;
 
 let map_usage (f : usage_metrics -> usage_metrics) (m : keeper_meta) : keeper_meta =
   { m with runtime = { m.runtime with usage = f m.runtime.usage } }
+;;
 
-let map_compaction_rt (f : compaction_runtime -> compaction_runtime) (m : keeper_meta) : keeper_meta =
+let map_compaction_rt (f : compaction_runtime -> compaction_runtime) (m : keeper_meta)
+  : keeper_meta
+  =
   { m with runtime = { m.runtime with compaction_rt = f m.runtime.compaction_rt } }
+;;
 
-let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_meta) : keeper_meta =
+let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_meta)
+  : keeper_meta
+  =
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
+;;
 
 let now_iso () = Types.now_iso ()
-
 let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
 
 let runtime_meta_write_sync_hook : (Room.config -> keeper_meta -> unit) ref =
   ref (fun _ _ -> ())
+;;
 
-let register_runtime_meta_write_sync f =
-  runtime_meta_write_sync_hook := f
+let register_runtime_meta_write_sync f = runtime_meta_write_sync_hook := f
 
 let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
   let present =
     keeper_legacy_model_arg_names
     |> List.filter (fun key ->
-           match Yojson.Safe.Util.member key args with
-           | `Null -> false
-           | _ -> true)
+      match Yojson.Safe.Util.member key args with
+      | `Null -> false
+      | _ -> true)
   in
   match present with
   | [] -> Ok ()
   | fields ->
-      Error
-        (Printf.sprintf
-           "legacy keeper model args removed for %s: %s. Keepers now use cascade_name and last_model_used only."
-           tool_name (String.concat ", " fields))
+    Error
+      (Printf.sprintf
+         "legacy keeper model args removed for %s: %s. Keepers now use cascade_name and \
+          last_model_used only."
+         tool_name
+         (String.concat ", " fields))
+;;
 
 let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t =
   match json with
-  | `Assoc fields ->
-      `Assoc
-        (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
+  | `Assoc fields -> `Assoc (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
   | _ -> json
+;;
 
 let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
   let present = present_json_keys removed_keeper_meta_key_names json in
   match present with
   | [] -> Ok ()
   | fields ->
-      Error
-        (Printf.sprintf
-           "removed keeper meta fields: %s"
-           (String.concat ", " fields))
+    Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
+;;
 
-let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) :
-    Yojson.Safe.t * bool =
+let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
   match json with
   | `Assoc fields ->
-      let present =
-        fields
-        |> List.filter_map (fun (key, _) ->
-               if List.mem key removed_keeper_meta_key_names then Some key else None)
+    let present =
+      fields
+      |> List.filter_map (fun (key, _) ->
+        if List.mem key removed_keeper_meta_key_names then Some key else None)
+    in
+    if present = []
+    then json, false
+    else (
+      let migrate_legacy_disabled_keepalive =
+        (match List.assoc_opt "presence_keepalive" fields with
+         | Some (`Bool false) -> true
+         | _ -> false)
+        && not (List.mem_assoc "paused" fields)
       in
-      if present = [] then (json, false)
-      else
-        let migrate_legacy_disabled_keepalive =
-          (match List.assoc_opt "presence_keepalive" fields with
-          | Some (`Bool false) -> true
-          | _ -> false)
-          && not (List.mem_assoc "paused" fields)
-        in
-        let scrubbed =
-          let base = drop_assoc_keys removed_keeper_meta_key_names json in
-          match base with
-          | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
-              `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
-          | _ -> base
-        in
-        let content = Yojson.Safe.pretty_to_string scrubbed in
-        (try
-           Fs_compat.save_file path content;
-           Log.Keeper.info
-             "scrubbed removed keeper meta fields for %s: %s%s"
-             path
-             (String.concat ", " present)
-             (if migrate_legacy_disabled_keepalive then
-                " (migrated presence_keepalive=false to paused=true)"
-              else
-                "")
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-             Log.Keeper.warn
-               "failed to scrub removed keeper meta fields for %s: %s"
-               path
-               (Printexc.to_string exn));
-        (scrubbed, true)
-  | _ -> (json, false)
+      let scrubbed =
+        let base = drop_assoc_keys removed_keeper_meta_key_names json in
+        match base with
+        | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
+          `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
+        | _ -> base
+      in
+      let content = Yojson.Safe.pretty_to_string scrubbed in
+      (try
+         Fs_compat.save_file path content;
+         Log.Keeper.info
+           "scrubbed removed keeper meta fields for %s: %s%s"
+           path
+           (String.concat ", " present)
+           (if migrate_legacy_disabled_keepalive
+            then " (migrated presence_keepalive=false to paused=true)"
+            else "")
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Keeper.warn
+           "failed to scrub removed keeper meta fields for %s: %s"
+           path
+           (Printexc.to_string exn));
+      scrubbed, true)
+  | _ -> json, false
+;;
 
 let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
   let rt = m.runtime in
   `Assoc
-    [
-      ("name", `String m.name);
-      ("agent_name", `String m.agent_name);
-      ("trace_id", `String rt.trace_id);
-      ("trace_history", `List (List.map (fun s -> `String s) rt.trace_history));
-      ("goal", `String m.goal);
-      ("short_goal", `String m.short_goal);
-      ("mid_goal", `String m.mid_goal);
-      ("long_goal", `String m.long_goal);
-      ("soul_profile", `String m.soul_profile);
-      ("social_model", `String m.social_model);
-      ("cascade_name", `String m.cascade_name);
-      ("will", `String m.will);
-      ("needs", `String m.needs);
-      ("desires", `String m.desires);
-      ("instructions", `String m.instructions);
-      ("policy_voice_enabled", `Bool m.policy_voice_enabled);
-      ("execution_scope", `String m.execution_scope);
-      ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
-      ("scope_kind", `String m.scope_kind);
-      ("tool_access", tool_access_to_json m.tool_access);
-      ("tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist));
-      ("room_scope", `String m.room_scope);
-      ("mention_targets", `List (List.map (fun s -> `String s) m.mention_targets));
-      ("room_signal_prompt_enabled", `Bool m.room_signal_prompt_enabled);
-      ("joined_room_ids", `List (List.map (fun s -> `String s) m.joined_room_ids));
-      ("last_seen_seq_by_room", room_seq_map_to_json m.last_seen_seq_by_room);
-      ("generation", `Int rt.generation);
-      ("proactive_enabled", `Bool m.proactive.enabled);
-      ("proactive_idle_sec", `Int m.proactive.idle_sec);
-      ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
-      ("compaction_profile", `String m.compaction.profile);
-      ("compaction_ratio_gate", `Float m.compaction.ratio_gate);
-      ("compaction_message_gate", `Int m.compaction.message_gate);
-      ("compaction_token_gate", `Int m.compaction.token_gate);
-      ("continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec);
-      ("auto_handoff", `Bool m.auto_handoff);
-      ("handoff_threshold", `Float m.handoff_threshold);
-      ("handoff_cooldown_sec", `Int m.handoff_cooldown_sec);
-      ("voice_enabled", `Bool m.voice_enabled);
-      ("voice_channel", `String m.voice_channel);
-      ("voice_agent_id", `String m.voice_agent_id);
-      ("last_handoff_ts", `Float rt.last_handoff_ts);
-      ("created_at", `String m.created_at);
-      ("updated_at", `String m.updated_at);
-      ("total_turns", `Int rt.usage.total_turns);
-      ("total_input_tokens", `Int rt.usage.total_input_tokens);
-      ("total_output_tokens", `Int rt.usage.total_output_tokens);
-      ("total_tokens", `Int rt.usage.total_tokens);
-      ("total_cost_usd", `Float rt.usage.total_cost_usd);
-      ("last_turn_ts", `Float rt.usage.last_turn_ts);
-      ("last_model_used", `String rt.usage.last_model_used);
-      ("last_input_tokens", `Int rt.usage.last_input_tokens);
-      ("last_output_tokens", `Int rt.usage.last_output_tokens);
-      ("last_total_tokens", `Int rt.usage.last_total_tokens);
-      ("last_latency_ms", `Int rt.usage.last_latency_ms);
-      ("compaction_count", `Int rt.compaction_rt.count);
-      ("last_compaction_ts", `Float rt.compaction_rt.last_ts);
-      ("last_compaction_before_tokens", `Int rt.compaction_rt.last_before_tokens);
-      ("last_compaction_after_tokens", `Int rt.compaction_rt.last_after_tokens);
-      ("proactive_count_total", `Int rt.proactive_rt.count_total);
-      ("last_proactive_ts", `Float rt.proactive_rt.last_ts);
-      ("last_proactive_reason", `String rt.proactive_rt.last_reason);
-      ("last_proactive_preview", `String rt.proactive_rt.last_preview);
-      ("last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts);
-      ("last_compaction_decision", `String rt.compaction_rt.last_decision);
-      ("last_continuity_update_ts", `Float rt.last_continuity_update_ts);
-      ("continuity_summary", `String m.continuity_summary);
-      ("active_goal_ids", `List (List.map (fun s -> `String s) m.active_goal_ids));
-      ( "active_team_session_id",
-        match m.active_team_session_id with
+    [ "name", `String m.name
+    ; "agent_name", `String m.agent_name
+    ; "trace_id", `String rt.trace_id
+    ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
+    ; "goal", `String m.goal
+    ; "short_goal", `String m.short_goal
+    ; "mid_goal", `String m.mid_goal
+    ; "long_goal", `String m.long_goal
+    ; "soul_profile", `String m.soul_profile
+    ; "social_model", `String m.social_model
+    ; "cascade_name", `String m.cascade_name
+    ; "will", `String m.will
+    ; "needs", `String m.needs
+    ; "desires", `String m.desires
+    ; "instructions", `String m.instructions
+    ; "policy_voice_enabled", `Bool m.policy_voice_enabled
+    ; "execution_scope", `String m.execution_scope
+    ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)
+    ; "scope_kind", `String m.scope_kind
+    ; "tool_access", tool_access_to_json m.tool_access
+    ; "tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist)
+    ; "room_scope", `String m.room_scope
+    ; "mention_targets", `List (List.map (fun s -> `String s) m.mention_targets)
+    ; "room_signal_prompt_enabled", `Bool m.room_signal_prompt_enabled
+    ; "joined_room_ids", `List (List.map (fun s -> `String s) m.joined_room_ids)
+    ; "last_seen_seq_by_room", room_seq_map_to_json m.last_seen_seq_by_room
+    ; "generation", `Int rt.generation
+    ; "proactive_enabled", `Bool m.proactive.enabled
+    ; "proactive_idle_sec", `Int m.proactive.idle_sec
+    ; "proactive_cooldown_sec", `Int m.proactive.cooldown_sec
+    ; "compaction_profile", `String m.compaction.profile
+    ; "compaction_ratio_gate", `Float m.compaction.ratio_gate
+    ; "compaction_message_gate", `Int m.compaction.message_gate
+    ; "compaction_token_gate", `Int m.compaction.token_gate
+    ; "continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec
+    ; "auto_handoff", `Bool m.auto_handoff
+    ; "handoff_threshold", `Float m.handoff_threshold
+    ; "handoff_cooldown_sec", `Int m.handoff_cooldown_sec
+    ; "voice_enabled", `Bool m.voice_enabled
+    ; "voice_channel", `String m.voice_channel
+    ; "voice_agent_id", `String m.voice_agent_id
+    ; "last_handoff_ts", `Float rt.last_handoff_ts
+    ; "created_at", `String m.created_at
+    ; "updated_at", `String m.updated_at
+    ; "total_turns", `Int rt.usage.total_turns
+    ; "total_input_tokens", `Int rt.usage.total_input_tokens
+    ; "total_output_tokens", `Int rt.usage.total_output_tokens
+    ; "total_tokens", `Int rt.usage.total_tokens
+    ; "total_cost_usd", `Float rt.usage.total_cost_usd
+    ; "last_turn_ts", `Float rt.usage.last_turn_ts
+    ; "last_model_used", `String rt.usage.last_model_used
+    ; "last_input_tokens", `Int rt.usage.last_input_tokens
+    ; "last_output_tokens", `Int rt.usage.last_output_tokens
+    ; "last_total_tokens", `Int rt.usage.last_total_tokens
+    ; "last_latency_ms", `Int rt.usage.last_latency_ms
+    ; "compaction_count", `Int rt.compaction_rt.count
+    ; "last_compaction_ts", `Float rt.compaction_rt.last_ts
+    ; "last_compaction_before_tokens", `Int rt.compaction_rt.last_before_tokens
+    ; "last_compaction_after_tokens", `Int rt.compaction_rt.last_after_tokens
+    ; "proactive_count_total", `Int rt.proactive_rt.count_total
+    ; "last_proactive_ts", `Float rt.proactive_rt.last_ts
+    ; "last_proactive_reason", `String rt.proactive_rt.last_reason
+    ; "last_proactive_preview", `String rt.proactive_rt.last_preview
+    ; "last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts
+    ; "last_compaction_decision", `String rt.compaction_rt.last_decision
+    ; "last_continuity_update_ts", `Float rt.last_continuity_update_ts
+    ; "continuity_summary", `String m.continuity_summary
+    ; "active_goal_ids", `List (List.map (fun s -> `String s) m.active_goal_ids)
+    ; ( "active_team_session_id"
+      , match m.active_team_session_id with
         | Some value -> `String value
-        | None -> `Null );
-      ("last_team_session_started_at", `String m.last_team_session_started_at);
-      ("team_session_start_count_total", `Int m.team_session_start_count_total);
-      ("last_autonomous_action_at", `String rt.last_autonomous_action_at);
-      ("autonomous_action_count", `Int rt.autonomous_action_count);
-      ("autonomous_turn_count", `Int rt.autonomous_turn_count);
-      ("autonomous_text_turn_count", `Int rt.autonomous_text_turn_count);
-      ("autonomous_tool_turn_count", `Int rt.autonomous_tool_turn_count);
-      ("board_reactive_turn_count", `Int rt.board_reactive_turn_count);
-      ("mention_reactive_turn_count", `Int rt.mention_reactive_turn_count);
-      ("noop_turn_count", `Int rt.noop_turn_count);
-      ("last_speech_act", `String rt.last_speech_act);
-      ("last_blocker", `String rt.last_blocker);
-      ("last_need", `String rt.last_need);
-      ("paused", `Bool m.paused);
-      ("current_task_id", Json_util.string_opt_to_json m.current_task_id);
+        | None -> `Null )
+    ; "last_team_session_started_at", `String m.last_team_session_started_at
+    ; "team_session_start_count_total", `Int m.team_session_start_count_total
+    ; "last_autonomous_action_at", `String rt.last_autonomous_action_at
+    ; "autonomous_action_count", `Int rt.autonomous_action_count
+    ; "autonomous_turn_count", `Int rt.autonomous_turn_count
+    ; "autonomous_text_turn_count", `Int rt.autonomous_text_turn_count
+    ; "autonomous_tool_turn_count", `Int rt.autonomous_tool_turn_count
+    ; "board_reactive_turn_count", `Int rt.board_reactive_turn_count
+    ; "mention_reactive_turn_count", `Int rt.mention_reactive_turn_count
+    ; "noop_turn_count", `Int rt.noop_turn_count
+    ; "last_speech_act", `String rt.last_speech_act
+    ; "last_blocker", `String rt.last_blocker
+    ; "last_need", `String rt.last_need
+    ; "paused", `Bool m.paused
+    ; "current_task_id", Json_util.string_opt_to_json m.current_task_id
     ]
+;;
+
+type parsed_keeper_identity =
+  { pk_name : string
+  ; pk_agent_name : string
+  ; pk_trace_id : string
+  ; pk_trace_history : string list
+  ; pk_goal : string
+  ; pk_short_goal : string
+  ; pk_mid_goal : string
+  ; pk_long_goal : string
+  ; pk_soul_profile : string
+  ; pk_social_model : string
+  ; pk_cascade_name : string
+  ; pk_will : string
+  ; pk_needs : string
+  ; pk_desires : string
+  ; pk_instructions : string
+  }
+
+type parsed_keeper_policy =
+  { pp_policy_voice_enabled : bool
+  ; pp_execution_scope : string
+  ; pp_allowed_paths : string list
+  ; pp_scope_kind : string
+  ; pp_tool_access : tool_access
+  ; pp_tool_denylist : string list
+  ; pp_room_scope : string
+  ; pp_mention_targets : string list
+  ; pp_room_signal_prompt_enabled : bool
+  ; pp_joined_room_ids : string list
+  ; pp_last_seen_seq_by_room : (string * int) list
+  ; pp_proactive : proactive_policy
+  ; pp_compaction : compaction_policy
+  ; pp_auto_handoff : bool
+  ; pp_handoff_threshold : float
+  ; pp_handoff_cooldown_sec : int
+  ; pp_voice_enabled : bool
+  ; pp_voice_channel : string
+  ; pp_voice_agent_id : string
+  }
+
+type parsed_keeper_state =
+  { ps_created_at_raw : string
+  ; ps_updated_at_raw : string
+  ; ps_continuity_summary : string
+  ; ps_active_goal_ids : string list
+  ; ps_active_team_session_id : string option
+  ; ps_last_team_session_started_at : string
+  ; ps_team_session_start_count_total : int
+  ; ps_paused : bool
+  ; ps_current_task_id : string option
+  ; ps_runtime : agent_runtime_state
+  }
+
+let parse_keeper_identity (json : Yojson.Safe.t) : parsed_keeper_identity =
+  let pk_name = Safe_ops.json_string ~default:"" "name" json in
+  let pk_agent_name = Safe_ops.json_string ~default:"" "agent_name" json in
+  let pk_trace_id = Safe_ops.json_string ~default:"" "trace_id" json in
+  let pk_trace_history =
+    Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
+  in
+  let pk_goal =
+    Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_horizon_text
+  in
+  let pk_short_goal, pk_mid_goal, pk_long_goal =
+    resolve_goal_horizons
+      ~goal:pk_goal
+      ~short_goal_opt:
+        (normalize_goal_horizon_opt (Safe_ops.json_string_opt "short_goal" json))
+      ~mid_goal_opt:
+        (normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" json))
+      ~long_goal_opt:
+        (normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" json))
+  in
+  let pk_soul_profile =
+    Safe_ops.json_string ~default:default_soul_profile "soul_profile" json
+    |> canonical_soul_profile
+    |> Option.value ~default:default_soul_profile
+  in
+  let pk_social_model =
+    Safe_ops.json_string ~default:default_social_model "social_model" json
+  in
+  let pk_will =
+    Safe_ops.json_string ~default:default_keeper_will "will" json
+    |> normalize_self_model_text
+  in
+  let pk_needs =
+    Safe_ops.json_string ~default:default_keeper_needs "needs" json
+    |> normalize_self_model_text
+  in
+  let pk_desires =
+    Safe_ops.json_string ~default:default_keeper_desires "desires" json
+    |> normalize_self_model_text
+  in
+  let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
+  let pk_cascade_name =
+    Safe_ops.json_string ~default:"keeper_unified" "cascade_name" json
+  in
+  { pk_name
+  ; pk_agent_name
+  ; pk_trace_id
+  ; pk_trace_history
+  ; pk_goal
+  ; pk_short_goal
+  ; pk_mid_goal
+  ; pk_long_goal
+  ; pk_soul_profile
+  ; pk_social_model
+  ; pk_cascade_name
+  ; pk_will
+  ; pk_needs
+  ; pk_desires
+  ; pk_instructions
+  }
+;;
+
+let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
+  : (parsed_keeper_policy, string) result
+  =
+  let voice_enabled_default = default_voice_enabled_for keeper_name in
+  match tool_access_of_meta_json json with
+  | Error msg -> Error ("meta parse error: " ^ msg)
+  | Ok pp_tool_access ->
+    let pp_policy_voice_enabled =
+      Safe_ops.json_bool ~default:voice_enabled_default "policy_voice_enabled" json
+    in
+    let pp_execution_scope =
+      Safe_ops.json_string ~default:default_execution_scope "execution_scope" json
+    in
+    let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
+    let pp_scope_kind =
+      Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
+    in
+    let pp_tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
+    let pp_room_scope =
+      Safe_ops.json_string ~default:"current" "room_scope" json |> canonical_room_scope
+    in
+    let pp_mention_targets =
+      Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
+    in
+    let pp_room_signal_prompt_enabled =
+      Safe_ops.json_bool
+        ~default:default_room_signal_prompt_enabled
+        "room_signal_prompt_enabled"
+        json
+    in
+    let pp_joined_room_ids =
+      Safe_ops.json_string_list "joined_room_ids" json
+      |> List.filter validate_name
+      |> dedupe_keep_order
+    in
+    let pp_last_seen_seq_by_room =
+      Yojson.Safe.Util.member "last_seen_seq_by_room" json |> room_seq_map_of_json
+    in
+    let proactive_enabled =
+      Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
+    in
+    let proactive_idle_sec =
+      Safe_ops.json_int ~default:default_proactive_idle_sec "proactive_idle_sec" json
+      |> normalize_proactive_idle_sec
+    in
+    let proactive_cooldown_sec =
+      Safe_ops.json_int
+        ~default:default_proactive_cooldown_sec
+        "proactive_cooldown_sec"
+        json
+      |> normalize_proactive_cooldown_sec
+    in
+    let env_ratio_gate, env_message_gate, env_token_gate =
+      keeper_compaction_policy_from_env ()
+    in
+    let compaction_profile =
+      Safe_ops.json_string ~default:default_compaction_profile "compaction_profile" json
+      |> canonical_compaction_profile
+      |> Option.value ~default:default_compaction_profile
+    in
+    let compaction_ratio_gate =
+      Safe_ops.json_float ~default:env_ratio_gate "compaction_ratio_gate" json
+      |> normalize_compaction_ratio_gate
+    in
+    let compaction_message_gate =
+      Safe_ops.json_int ~default:env_message_gate "compaction_message_gate" json
+      |> normalize_compaction_message_gate
+    in
+    let compaction_token_gate =
+      Safe_ops.json_int ~default:env_token_gate "compaction_token_gate" json
+      |> normalize_compaction_token_gate
+    in
+    let continuity_compaction_cooldown_sec =
+      Safe_ops.json_int
+        ~default:(keeper_continuity_compaction_cooldown_sec ())
+        "continuity_compaction_cooldown_sec"
+        json
+      |> normalize_continuity_compaction_cooldown_sec
+    in
+    let pp_auto_handoff = Safe_ops.json_bool ~default:true "auto_handoff" json in
+    let pp_handoff_threshold =
+      Safe_ops.json_float ~default:0.85 "handoff_threshold" json
+    in
+    let pp_handoff_cooldown_sec =
+      Safe_ops.json_int ~default:300 "handoff_cooldown_sec" json
+    in
+    let pp_voice_enabled =
+      Safe_ops.json_bool ~default:voice_enabled_default "voice_enabled" json
+    in
+    let pp_voice_channel =
+      Safe_ops.json_string
+        ~default:(default_voice_channel_for keeper_name)
+        "voice_channel"
+        json
+      |> canonical_voice_channel
+    in
+    let pp_voice_agent_id =
+      Safe_ops.json_string
+        ~default:(default_voice_agent_id_for keeper_name)
+        "voice_agent_id"
+        json
+    in
+    Ok
+      { pp_policy_voice_enabled
+      ; pp_execution_scope
+      ; pp_allowed_paths
+      ; pp_scope_kind
+      ; pp_tool_access
+      ; pp_tool_denylist
+      ; pp_room_scope
+      ; pp_mention_targets
+      ; pp_room_signal_prompt_enabled
+      ; pp_joined_room_ids
+      ; pp_last_seen_seq_by_room
+      ; pp_proactive =
+          { enabled = proactive_enabled
+          ; idle_sec = proactive_idle_sec
+          ; cooldown_sec = proactive_cooldown_sec
+          }
+      ; pp_compaction =
+          { profile = compaction_profile
+          ; ratio_gate = compaction_ratio_gate
+          ; message_gate = compaction_message_gate
+          ; token_gate = compaction_token_gate
+          ; cooldown_sec = continuity_compaction_cooldown_sec
+          }
+      ; pp_auto_handoff
+      ; pp_handoff_threshold
+      ; pp_handoff_cooldown_sec
+      ; pp_voice_enabled
+      ; pp_voice_channel
+      ; pp_voice_agent_id
+      }
+;;
+
+let parse_usage_metrics (json : Yojson.Safe.t) : usage_metrics =
+  { total_turns = Safe_ops.json_int ~default:0 "total_turns" json
+  ; total_input_tokens = Safe_ops.json_int ~default:0 "total_input_tokens" json
+  ; total_output_tokens = Safe_ops.json_int ~default:0 "total_output_tokens" json
+  ; total_tokens = Safe_ops.json_int ~default:0 "total_tokens" json
+  ; total_cost_usd = Safe_ops.json_float ~default:0.0 "total_cost_usd" json
+  ; last_turn_ts = Safe_ops.json_float ~default:0.0 "last_turn_ts" json
+  ; last_model_used = Safe_ops.json_string ~default:"" "last_model_used" json
+  ; last_input_tokens = Safe_ops.json_int ~default:0 "last_input_tokens" json
+  ; last_output_tokens = Safe_ops.json_int ~default:0 "last_output_tokens" json
+  ; last_total_tokens = Safe_ops.json_int ~default:0 "last_total_tokens" json
+  ; last_latency_ms = Safe_ops.json_int ~default:0 "last_latency_ms" json
+  }
+;;
+
+let parse_compaction_runtime (json : Yojson.Safe.t) : compaction_runtime =
+  { count = Safe_ops.json_int ~default:0 "compaction_count" json
+  ; last_ts = Safe_ops.json_float ~default:0.0 "last_compaction_ts" json
+  ; last_before_tokens = Safe_ops.json_int ~default:0 "last_compaction_before_tokens" json
+  ; last_after_tokens = Safe_ops.json_int ~default:0 "last_compaction_after_tokens" json
+  ; last_check_ts = Safe_ops.json_float ~default:0.0 "last_compaction_check_ts" json
+  ; last_decision =
+      Safe_ops.json_string ~default:"uninitialized" "last_compaction_decision" json
+  }
+;;
+
+let parse_proactive_runtime (json : Yojson.Safe.t) : proactive_runtime =
+  { count_total = Safe_ops.json_int ~default:0 "proactive_count_total" json
+  ; last_ts = Safe_ops.json_float ~default:0.0 "last_proactive_ts" json
+  ; last_reason = Safe_ops.json_string ~default:"" "last_proactive_reason" json
+  ; last_preview = Safe_ops.json_string ~default:"" "last_proactive_preview" json
+  }
+;;
+
+let parse_last_continuity_update_ts ~(continuity_summary : string) (json : Yojson.Safe.t) =
+  let parsed_ts = Safe_ops.json_float ~default:0.0 "last_continuity_update_ts" json in
+  if parsed_ts <= 0.0 && String.trim continuity_summary <> ""
+  then Time_compat.now ()
+  else parsed_ts
+;;
+
+let parse_keeper_state
+      (json : Yojson.Safe.t)
+      ~(trace_id : string)
+      ~(trace_history : string list)
+  : parsed_keeper_state
+  =
+  let generation = Safe_ops.json_int ~default:0 "generation" json in
+  let last_handoff_ts = Safe_ops.json_float ~default:0.0 "last_handoff_ts" json in
+  let ps_created_at_raw = Safe_ops.json_string ~default:"" "created_at" json in
+  let ps_updated_at_raw = Safe_ops.json_string ~default:"" "updated_at" json in
+  let ps_continuity_summary =
+    Safe_ops.json_string ~default:"" "continuity_summary" json
+  in
+  let last_continuity_update_ts =
+    parse_last_continuity_update_ts ~continuity_summary:ps_continuity_summary json
+  in
+  let ps_active_goal_ids = Safe_ops.json_string_list "active_goal_ids" json in
+  let ps_active_team_session_id =
+    Safe_ops.json_string_opt "active_team_session_id" json
+  in
+  let ps_last_team_session_started_at =
+    Safe_ops.json_string ~default:"" "last_team_session_started_at" json
+  in
+  let ps_team_session_start_count_total =
+    Safe_ops.json_int ~default:0 "team_session_start_count_total" json
+  in
+  let last_autonomous_action_at =
+    Safe_ops.json_string ~default:"" "last_autonomous_action_at" json
+  in
+  let autonomous_action_count =
+    Safe_ops.json_int ~default:0 "autonomous_action_count" json
+  in
+  let autonomous_turn_count = Safe_ops.json_int ~default:0 "autonomous_turn_count" json in
+  let autonomous_text_turn_count =
+    Safe_ops.json_int ~default:0 "autonomous_text_turn_count" json
+  in
+  let autonomous_tool_turn_count =
+    Safe_ops.json_int ~default:0 "autonomous_tool_turn_count" json
+  in
+  let board_reactive_turn_count =
+    Safe_ops.json_int ~default:0 "board_reactive_turn_count" json
+  in
+  let mention_reactive_turn_count =
+    Safe_ops.json_int ~default:0 "mention_reactive_turn_count" json
+  in
+  let noop_turn_count = Safe_ops.json_int ~default:0 "noop_turn_count" json in
+  let last_speech_act = Safe_ops.json_string ~default:"" "last_speech_act" json in
+  let last_blocker = Safe_ops.json_string ~default:"" "last_blocker" json in
+  let last_need = Safe_ops.json_string ~default:"" "last_need" json in
+  let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
+  let ps_current_task_id = Safe_ops.json_string_opt "current_task_id" json in
+  { ps_created_at_raw
+  ; ps_updated_at_raw
+  ; ps_continuity_summary
+  ; ps_active_goal_ids
+  ; ps_active_team_session_id
+  ; ps_last_team_session_started_at
+  ; ps_team_session_start_count_total
+  ; ps_paused
+  ; ps_current_task_id
+  ; ps_runtime =
+      { usage = parse_usage_metrics json
+      ; compaction_rt = parse_compaction_runtime json
+      ; proactive_rt = parse_proactive_runtime json
+      ; generation
+      ; trace_id
+      ; trace_history
+      ; last_handoff_ts
+      ; last_continuity_update_ts
+      ; last_autonomous_action_at
+      ; autonomous_action_count
+      ; autonomous_turn_count
+      ; autonomous_text_turn_count
+      ; autonomous_tool_turn_count
+      ; board_reactive_turn_count
+      ; mention_reactive_turn_count
+      ; noop_turn_count
+      ; last_speech_act
+      ; last_blocker
+      ; last_need
+      }
+  }
+;;
 
 let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
   try
     match reject_removed_keeper_meta_fields json with
     | Error e -> Error e
     | Ok () ->
-    let name = Safe_ops.json_string ~default:"" "name" json in
-    let agent_name = Safe_ops.json_string ~default:"" "agent_name" json in
-    let trace_id = Safe_ops.json_string ~default:"" "trace_id" json in
-    let trace_history =
-      Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
-    in
-    let goal =
-      Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_horizon_text
-    in
-    let (short_goal, mid_goal, long_goal) =
-      resolve_goal_horizons
-        ~goal
-        ~short_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "short_goal" json))
-        ~mid_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" json))
-        ~long_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" json))
-    in
-    let soul_profile =
-      Safe_ops.json_string ~default:default_soul_profile "soul_profile" json
-      |> canonical_soul_profile
-      |> Option.value ~default:default_soul_profile
-    in
-    let social_model =
-      Safe_ops.json_string ~default:default_social_model "social_model" json
-    in
-    let will =
-      Safe_ops.json_string ~default:default_keeper_will "will" json
-      |> normalize_self_model_text
-    in
-    let needs =
-      Safe_ops.json_string ~default:default_keeper_needs "needs" json
-      |> normalize_self_model_text
-    in
-    let desires =
-      Safe_ops.json_string ~default:default_keeper_desires "desires" json
-      |> normalize_self_model_text
-    in
-    let instructions = Safe_ops.json_string ~default:"" "instructions" json in
-    let cascade_name =
-      Safe_ops.json_string ~default:"keeper_unified" "cascade_name" json
-    in
-    let policy_voice_enabled =
-      Safe_ops.json_bool ~default:(default_voice_enabled_for name) "policy_voice_enabled" json
-    in
-    let execution_scope =
-      Safe_ops.json_string ~default:default_execution_scope "execution_scope" json
-    in
-    let allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
-    let voice_enabled =
-      Safe_ops.json_bool ~default:(default_voice_enabled_for name) "voice_enabled" json
-    in
-    let voice_channel =
-      Safe_ops.json_string ~default:(default_voice_channel_for name) "voice_channel" json
-      |> canonical_voice_channel
-    in
-    let voice_agent_id =
-      Safe_ops.json_string ~default:(default_voice_agent_id_for name) "voice_agent_id" json
-    in
-    let scope_kind =
-      Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
-    in
-    match tool_access_of_meta_json json with
-    | Error msg -> Error ("meta parse error: " ^ msg)
-    | Ok tool_access ->
-        let tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
-        let room_scope =
-          Safe_ops.json_string ~default:"current" "room_scope" json |> canonical_room_scope
-        in
-        let mention_targets =
-          Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
-        in
-        let room_signal_prompt_enabled =
-          Safe_ops.json_bool
-            ~default:default_room_signal_prompt_enabled
-            "room_signal_prompt_enabled" json
-        in
-        let joined_room_ids =
-          Safe_ops.json_string_list "joined_room_ids" json
-          |> List.filter validate_name
-          |> dedupe_keep_order
-        in
-        let last_seen_seq_by_room =
-          Yojson.Safe.Util.member "last_seen_seq_by_room" json |> room_seq_map_of_json
-        in
-        let generation = Safe_ops.json_int ~default:0 "generation" json in
-        let proactive_enabled =
-          Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
-        in
-        let proactive_idle_sec =
-          Safe_ops.json_int ~default:default_proactive_idle_sec "proactive_idle_sec" json
-          |> normalize_proactive_idle_sec
-        in
-        let proactive_cooldown_sec =
-          Safe_ops.json_int ~default:default_proactive_cooldown_sec "proactive_cooldown_sec" json
-          |> normalize_proactive_cooldown_sec
-        in
-        let (env_ratio_gate, env_message_gate, env_token_gate) =
-          keeper_compaction_policy_from_env ()
-        in
-        let compaction_profile =
-          Safe_ops.json_string ~default:default_compaction_profile "compaction_profile" json
-          |> canonical_compaction_profile
-          |> Option.value ~default:default_compaction_profile
-        in
-        let compaction_ratio_gate =
-          Safe_ops.json_float ~default:env_ratio_gate "compaction_ratio_gate" json
-          |> normalize_compaction_ratio_gate
-        in
-        let compaction_message_gate =
-          Safe_ops.json_int ~default:env_message_gate "compaction_message_gate" json
-          |> normalize_compaction_message_gate
-        in
-        let compaction_token_gate =
-          Safe_ops.json_int ~default:env_token_gate "compaction_token_gate" json
-          |> normalize_compaction_token_gate
-        in
-        let continuity_compaction_cooldown_sec =
-          Safe_ops.json_int
-            ~default:(keeper_continuity_compaction_cooldown_sec ())
-            "continuity_compaction_cooldown_sec"
-            json
-          |> normalize_continuity_compaction_cooldown_sec
-        in
-        let auto_handoff = Safe_ops.json_bool ~default:true "auto_handoff" json in
-        let handoff_threshold = Safe_ops.json_float ~default:0.85 "handoff_threshold" json in
-        let handoff_cooldown_sec =
-          Safe_ops.json_int ~default:300 "handoff_cooldown_sec" json
-        in
-        let last_handoff_ts = Safe_ops.json_float ~default:0.0 "last_handoff_ts" json in
-        let created_at = Safe_ops.json_string ~default:"" "created_at" json in
-        let updated_at = Safe_ops.json_string ~default:"" "updated_at" json in
-        let total_turns = Safe_ops.json_int ~default:0 "total_turns" json in
-        let total_input_tokens = Safe_ops.json_int ~default:0 "total_input_tokens" json in
-        let total_output_tokens = Safe_ops.json_int ~default:0 "total_output_tokens" json in
-        let total_tokens = Safe_ops.json_int ~default:0 "total_tokens" json in
-        let total_cost_usd = Safe_ops.json_float ~default:0.0 "total_cost_usd" json in
-        let last_turn_ts = Safe_ops.json_float ~default:0.0 "last_turn_ts" json in
-        let last_model_used = Safe_ops.json_string ~default:"" "last_model_used" json in
-        let last_input_tokens = Safe_ops.json_int ~default:0 "last_input_tokens" json in
-        let last_output_tokens = Safe_ops.json_int ~default:0 "last_output_tokens" json in
-        let last_total_tokens = Safe_ops.json_int ~default:0 "last_total_tokens" json in
-        let last_latency_ms = Safe_ops.json_int ~default:0 "last_latency_ms" json in
-        let compaction_count = Safe_ops.json_int ~default:0 "compaction_count" json in
-        let last_compaction_ts = Safe_ops.json_float ~default:0.0 "last_compaction_ts" json in
-        let last_compaction_before_tokens =
-          Safe_ops.json_int ~default:0 "last_compaction_before_tokens" json
-        in
-        let last_compaction_after_tokens =
-          Safe_ops.json_int ~default:0 "last_compaction_after_tokens" json
-        in
-        let proactive_count_total =
-          Safe_ops.json_int ~default:0 "proactive_count_total" json
-        in
-        let last_proactive_ts = Safe_ops.json_float ~default:0.0 "last_proactive_ts" json in
-        let last_proactive_reason =
-          Safe_ops.json_string ~default:"" "last_proactive_reason" json
-        in
-        let last_proactive_preview =
-          Safe_ops.json_string ~default:"" "last_proactive_preview" json
-        in
-        let last_compaction_check_ts =
-          Safe_ops.json_float ~default:0.0 "last_compaction_check_ts" json
-        in
-        let last_compaction_decision =
-          Safe_ops.json_string ~default:"uninitialized" "last_compaction_decision" json
-        in
-        let continuity_summary = Safe_ops.json_string ~default:"" "continuity_summary" json in
-        let last_continuity_update_ts =
-          let parsed_ts = Safe_ops.json_float ~default:0.0 "last_continuity_update_ts" json in
-          if parsed_ts <= 0.0 && String.trim continuity_summary <> "" then
-            Time_compat.now ()
-          else
-            parsed_ts
-        in
-        let active_goal_ids = Safe_ops.json_string_list "active_goal_ids" json in
-        let active_team_session_id =
-          Safe_ops.json_string_opt "active_team_session_id" json
-        in
-        let last_team_session_started_at =
-          Safe_ops.json_string ~default:"" "last_team_session_started_at" json
-        in
-        let team_session_start_count_total =
-          Safe_ops.json_int ~default:0 "team_session_start_count_total" json
-        in
-        let last_autonomous_action_at =
-          Safe_ops.json_string ~default:"" "last_autonomous_action_at" json
-        in
-        let autonomous_action_count =
-          Safe_ops.json_int ~default:0 "autonomous_action_count" json
-        in
-        let autonomous_turn_count =
-          Safe_ops.json_int ~default:0 "autonomous_turn_count" json
-        in
-        let autonomous_text_turn_count =
-          Safe_ops.json_int ~default:0 "autonomous_text_turn_count" json
-        in
-        let autonomous_tool_turn_count =
-          Safe_ops.json_int ~default:0 "autonomous_tool_turn_count" json
-        in
-        let board_reactive_turn_count =
-          Safe_ops.json_int ~default:0 "board_reactive_turn_count" json
-        in
-        let mention_reactive_turn_count =
-          Safe_ops.json_int ~default:0 "mention_reactive_turn_count" json
-        in
-        let noop_turn_count =
-          Safe_ops.json_int ~default:0 "noop_turn_count" json
-        in
-        let last_speech_act =
-          Safe_ops.json_string ~default:"" "last_speech_act" json
-        in
-        let last_blocker =
-          Safe_ops.json_string ~default:"" "last_blocker" json
-        in
-        let last_need =
-          Safe_ops.json_string ~default:"" "last_need" json
-        in
-        let paused =
-          Safe_ops.json_bool ~default:false "paused" json
-        in
-        let current_task_id = Safe_ops.json_string_opt "current_task_id" json in
-        if not (validate_name name) then
-          Error "invalid keeper meta (bad name)"
-        else if not (validate_name trace_id) then
-          Error "invalid keeper meta (bad trace_id)"
-        else
-          Ok
-            {
-          name;
-          agent_name = if agent_name = "" then keeper_agent_name name else agent_name;
-          goal;
-          short_goal;
-          mid_goal;
-          long_goal;
-          soul_profile;
-          social_model;
-          cascade_name;
-          will;
-          needs;
-          desires;
-          instructions;
-          policy_voice_enabled;
-          execution_scope;
-          allowed_paths;
-          scope_kind;
-          tool_access;
-          tool_denylist;
-          room_scope;
-          mention_targets;
-          room_signal_prompt_enabled;
-          joined_room_ids;
-          last_seen_seq_by_room;
-          proactive = {
-            enabled = proactive_enabled;
-            idle_sec = proactive_idle_sec;
-            cooldown_sec = proactive_cooldown_sec;
-          };
-          compaction = {
-            profile = compaction_profile;
-            ratio_gate = compaction_ratio_gate;
-            message_gate = compaction_message_gate;
-            token_gate = compaction_token_gate;
-            cooldown_sec = continuity_compaction_cooldown_sec;
-          };
-          auto_handoff;
-          handoff_threshold;
-          handoff_cooldown_sec;
-          voice_enabled;
-          voice_channel;
-          voice_agent_id;
-          created_at = if created_at = "" then now_iso () else created_at;
-          updated_at = if updated_at = "" then now_iso () else updated_at;
-          continuity_summary;
-          active_goal_ids;
-          active_team_session_id;
-          last_team_session_started_at;
-          team_session_start_count_total;
-          paused;
-          current_task_id;
-          runtime = {
-            usage = {
-              total_turns;
-              total_input_tokens;
-              total_output_tokens;
-              total_tokens;
-              total_cost_usd;
-              last_turn_ts;
-              last_model_used;
-              last_input_tokens;
-              last_output_tokens;
-              last_total_tokens;
-              last_latency_ms;
-            };
-            compaction_rt = {
-              count = compaction_count;
-              last_ts = last_compaction_ts;
-              last_before_tokens = last_compaction_before_tokens;
-              last_after_tokens = last_compaction_after_tokens;
-              last_check_ts = last_compaction_check_ts;
-              last_decision = last_compaction_decision;
-            };
-            proactive_rt = {
-              count_total = proactive_count_total;
-              last_ts = last_proactive_ts;
-              last_reason = last_proactive_reason;
-              last_preview = last_proactive_preview;
-            };
-            generation;
-            trace_id;
-            trace_history;
-            last_handoff_ts;
-            last_continuity_update_ts;
-            last_autonomous_action_at;
-            autonomous_action_count;
-            autonomous_turn_count;
-            autonomous_text_turn_count;
-            autonomous_tool_turn_count;
-            board_reactive_turn_count;
-            mention_reactive_turn_count;
-            noop_turn_count;
-            last_speech_act;
-            last_blocker;
-            last_need;
-          };
-        }
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
+      let identity = parse_keeper_identity json in
+      (match parse_keeper_policy json ~keeper_name:identity.pk_name with
+       | Error _ as e -> e
+       | Ok policy ->
+         let state =
+           parse_keeper_state
+             json
+             ~trace_id:identity.pk_trace_id
+             ~trace_history:identity.pk_trace_history
+         in
+         if not (validate_name identity.pk_name)
+         then Error "invalid keeper meta (bad name)"
+         else if not (validate_name identity.pk_trace_id)
+         then Error "invalid keeper meta (bad trace_id)"
+         else
+           Ok
+             { name = identity.pk_name
+             ; agent_name =
+                 (if identity.pk_agent_name = ""
+                  then keeper_agent_name identity.pk_name
+                  else identity.pk_agent_name)
+             ; goal = identity.pk_goal
+             ; short_goal = identity.pk_short_goal
+             ; mid_goal = identity.pk_mid_goal
+             ; long_goal = identity.pk_long_goal
+             ; soul_profile = identity.pk_soul_profile
+             ; social_model = identity.pk_social_model
+             ; cascade_name = identity.pk_cascade_name
+             ; will = identity.pk_will
+             ; needs = identity.pk_needs
+             ; desires = identity.pk_desires
+             ; instructions = identity.pk_instructions
+             ; policy_voice_enabled = policy.pp_policy_voice_enabled
+             ; execution_scope = policy.pp_execution_scope
+             ; allowed_paths = policy.pp_allowed_paths
+             ; scope_kind = policy.pp_scope_kind
+             ; tool_access = policy.pp_tool_access
+             ; tool_denylist = policy.pp_tool_denylist
+             ; room_scope = policy.pp_room_scope
+             ; mention_targets = policy.pp_mention_targets
+             ; room_signal_prompt_enabled = policy.pp_room_signal_prompt_enabled
+             ; joined_room_ids = policy.pp_joined_room_ids
+             ; last_seen_seq_by_room = policy.pp_last_seen_seq_by_room
+             ; proactive = policy.pp_proactive
+             ; compaction = policy.pp_compaction
+             ; auto_handoff = policy.pp_auto_handoff
+             ; handoff_threshold = policy.pp_handoff_threshold
+             ; handoff_cooldown_sec = policy.pp_handoff_cooldown_sec
+             ; voice_enabled = policy.pp_voice_enabled
+             ; voice_channel = policy.pp_voice_channel
+             ; voice_agent_id = policy.pp_voice_agent_id
+             ; created_at =
+                 (if state.ps_created_at_raw = ""
+                  then now_iso ()
+                  else state.ps_created_at_raw)
+             ; updated_at =
+                 (if state.ps_updated_at_raw = ""
+                  then now_iso ()
+                  else state.ps_updated_at_raw)
+             ; continuity_summary = state.ps_continuity_summary
+             ; active_goal_ids = state.ps_active_goal_ids
+             ; active_team_session_id = state.ps_active_team_session_id
+             ; last_team_session_started_at = state.ps_last_team_session_started_at
+             ; team_session_start_count_total = state.ps_team_session_start_count_total
+             ; paused = state.ps_paused
+             ; current_task_id = state.ps_current_task_id
+             ; runtime = state.ps_runtime
+             })
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
+;;
 
 let fallback_canonical_keeper_meta_key_names =
-  [
-    "name";
-    "agent_name";
-    "trace_id";
-    "trace_history";
-    "goal";
-    "short_goal";
-    "mid_goal";
-    "long_goal";
-    "soul_profile";
-    "social_model";
-    "cascade_name";
-    "will";
-    "needs";
-    "desires";
-    "instructions";
-    "policy_voice_enabled";
-    "execution_scope";
-    "allowed_paths";
-    "scope_kind";
-    "tool_access";
-    "tool_denylist";
-    "room_scope";
-    "mention_targets";
-    "room_signal_prompt_enabled";
-    "joined_room_ids";
-    "last_seen_seq_by_room";
-    "generation";
-    "proactive_enabled";
-    "proactive_idle_sec";
-    "proactive_cooldown_sec";
-    "compaction_profile";
-    "compaction_ratio_gate";
-    "compaction_message_gate";
-    "compaction_token_gate";
-    "continuity_compaction_cooldown_sec";
-    "auto_handoff";
-    "handoff_threshold";
-    "handoff_cooldown_sec";
-    "voice_enabled";
-    "voice_channel";
-    "voice_agent_id";
-    "last_handoff_ts";
-    "created_at";
-    "updated_at";
-    "total_turns";
-    "total_input_tokens";
-    "total_output_tokens";
-    "total_tokens";
-    "total_cost_usd";
-    "last_turn_ts";
-    "last_model_used";
-    "last_input_tokens";
-    "last_output_tokens";
-    "last_total_tokens";
-    "last_latency_ms";
-    "compaction_count";
-    "last_compaction_ts";
-    "last_compaction_before_tokens";
-    "last_compaction_after_tokens";
-    "proactive_count_total";
-    "last_proactive_ts";
-    "last_proactive_reason";
-    "last_proactive_preview";
-    "last_compaction_check_ts";
-    "last_compaction_decision";
-    "last_continuity_update_ts";
-    "continuity_summary";
-    "active_goal_ids";
-    "active_team_session_id";
-    "last_team_session_started_at";
-    "team_session_start_count_total";
-    "last_autonomous_action_at";
-    "autonomous_action_count";
-    "autonomous_turn_count";
-    "autonomous_text_turn_count";
-    "autonomous_tool_turn_count";
-    "board_reactive_turn_count";
-    "mention_reactive_turn_count";
-    "noop_turn_count";
-    "last_speech_act";
-    "last_blocker";
-    "last_need";
-    "paused";
-    "current_task_id";
+  [ "name"
+  ; "agent_name"
+  ; "trace_id"
+  ; "trace_history"
+  ; "goal"
+  ; "short_goal"
+  ; "mid_goal"
+  ; "long_goal"
+  ; "soul_profile"
+  ; "social_model"
+  ; "cascade_name"
+  ; "will"
+  ; "needs"
+  ; "desires"
+  ; "instructions"
+  ; "policy_voice_enabled"
+  ; "execution_scope"
+  ; "allowed_paths"
+  ; "scope_kind"
+  ; "tool_access"
+  ; "tool_denylist"
+  ; "room_scope"
+  ; "mention_targets"
+  ; "room_signal_prompt_enabled"
+  ; "joined_room_ids"
+  ; "last_seen_seq_by_room"
+  ; "generation"
+  ; "proactive_enabled"
+  ; "proactive_idle_sec"
+  ; "proactive_cooldown_sec"
+  ; "compaction_profile"
+  ; "compaction_ratio_gate"
+  ; "compaction_message_gate"
+  ; "compaction_token_gate"
+  ; "continuity_compaction_cooldown_sec"
+  ; "auto_handoff"
+  ; "handoff_threshold"
+  ; "handoff_cooldown_sec"
+  ; "voice_enabled"
+  ; "voice_channel"
+  ; "voice_agent_id"
+  ; "last_handoff_ts"
+  ; "created_at"
+  ; "updated_at"
+  ; "total_turns"
+  ; "total_input_tokens"
+  ; "total_output_tokens"
+  ; "total_tokens"
+  ; "total_cost_usd"
+  ; "last_turn_ts"
+  ; "last_model_used"
+  ; "last_input_tokens"
+  ; "last_output_tokens"
+  ; "last_total_tokens"
+  ; "last_latency_ms"
+  ; "compaction_count"
+  ; "last_compaction_ts"
+  ; "last_compaction_before_tokens"
+  ; "last_compaction_after_tokens"
+  ; "proactive_count_total"
+  ; "last_proactive_ts"
+  ; "last_proactive_reason"
+  ; "last_proactive_preview"
+  ; "last_compaction_check_ts"
+  ; "last_compaction_decision"
+  ; "last_continuity_update_ts"
+  ; "continuity_summary"
+  ; "active_goal_ids"
+  ; "active_team_session_id"
+  ; "last_team_session_started_at"
+  ; "team_session_start_count_total"
+  ; "last_autonomous_action_at"
+  ; "autonomous_action_count"
+  ; "autonomous_turn_count"
+  ; "autonomous_text_turn_count"
+  ; "autonomous_tool_turn_count"
+  ; "board_reactive_turn_count"
+  ; "mention_reactive_turn_count"
+  ; "noop_turn_count"
+  ; "last_speech_act"
+  ; "last_blocker"
+  ; "last_need"
+  ; "paused"
+  ; "current_task_id"
   ]
+;;
 
 let canonical_keeper_meta_key_names =
   let seed_json =
     `Assoc
-      [
-        ("name", `String "__keeper-meta-key-seed__");
-        ("agent_name", `String "__keeper-meta-key-seed__");
-        ("trace_id", `String "__keeper-meta-key-seed__");
+      [ "name", `String "__keeper-meta-key-seed__"
+      ; "agent_name", `String "__keeper-meta-key-seed__"
+      ; "trace_id", `String "__keeper-meta-key-seed__"
       ]
   in
   match meta_of_json seed_json with
-  | Ok meta -> (
-      match meta_to_json meta with
-      | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
-      | _ -> fallback_canonical_keeper_meta_key_names)
+  | Ok meta ->
+    (match meta_to_json meta with
+     | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
+     | _ -> fallback_canonical_keeper_meta_key_names)
   | Error msg ->
-      Log.Keeper.warn
-        "canonical_keeper_meta_key_names seed failed: %s; falling back to static keys"
-        msg;
-      fallback_canonical_keeper_meta_key_names
+    Log.Keeper.warn
+      "canonical_keeper_meta_key_names seed failed: %s; falling back to static keys"
+      msg;
+    fallback_canonical_keeper_meta_key_names
+;;
 
 let compatibility_keeper_meta_key_names =
   [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+;;
 
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
-      let known_keeper_meta_key_names =
-        canonical_keeper_meta_key_names
-        @ compatibility_keeper_meta_key_names
-      in
-      let unknown =
-        fields
-        |> List.filter_map (fun (key, _) ->
-               if List.mem key known_keeper_meta_key_names then None else Some key)
-        |> dedupe_keep_order
-      in
-      if unknown <> [] then
-        Log.Keeper.warn
-          "keeper meta %s has unknown keys: %s"
-          path (String.concat ", " unknown)
+    let known_keeper_meta_key_names =
+      canonical_keeper_meta_key_names @ compatibility_keeper_meta_key_names
+    in
+    let unknown =
+      fields
+      |> List.filter_map (fun (key, _) ->
+        if List.mem key known_keeper_meta_key_names then None else Some key)
+      |> dedupe_keep_order
+    in
+    if unknown <> []
+    then
+      Log.Keeper.warn
+        "keeper meta %s has unknown keys: %s"
+        path
+        (String.concat ", " unknown)
   | _ -> ()
+;;
 
 let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
   let compat_present =
@@ -995,66 +1133,70 @@ let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
   match compat_present with
   | [] -> ()
   | fields ->
-      if json_object_member_present "tool_access" json then
-        Log.Keeper.warn
-          "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
-          path (String.concat ", " fields)
-      else
-        Log.Keeper.warn
-          "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
-          path (String.concat ", " fields)
+    if json_object_member_present "tool_access" json
+    then
+      Log.Keeper.warn
+        "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
+        path
+        (String.concat ", " fields)
+    else
+      Log.Keeper.warn
+        "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
+        path
+        (String.concat ", " fields)
+;;
 
 let read_meta_file_path path : (keeper_meta option, string) result =
-  if not (Sys.file_exists path) then Ok None
-  else
+  if not (Sys.file_exists path)
+  then Ok None
+  else (
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
-        let json, _scrubbed =
-          scrub_persisted_keeper_meta_json ~path json
-        in
-        warn_unknown_keeper_meta_keys ~path json;
-        warn_tool_access_compat_keys ~path json;
-        (match meta_of_json json with
-         | Ok meta -> Ok (Some meta)
-         | Error e ->
-             Log.Keeper.warn "keeper meta parse failed for %s: %s" path e;
-             Error e)
+      let json, _scrubbed = scrub_persisted_keeper_meta_json ~path json in
+      warn_unknown_keeper_meta_keys ~path json;
+      warn_tool_access_compat_keys ~path json;
+      (match meta_of_json json with
+       | Ok meta -> Ok (Some meta)
+       | Error e ->
+         Log.Keeper.warn "keeper meta parse failed for %s: %s" path e;
+         Error e))
+;;
 
 let keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with
   | Error _ -> []
   | Ok files ->
-      files
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.map Filename.remove_extension
-      |> List.filter validate_name
-      |> List.sort String.compare
+    files
+    |> List.filter (fun f -> Filename.check_suffix f ".json")
+    |> List.map Filename.remove_extension
+    |> List.filter validate_name
+    |> List.sort String.compare
+;;
 
 let keepalive_keeper_names config =
   keeper_names config
   |> List.filter_map (fun name ->
-         match read_meta_file_path (keeper_meta_path config name) with
-         | Ok (Some meta) when not meta.paused -> Some meta.name
-         | _ -> None)
+    match read_meta_file_path (keeper_meta_path config name) with
+    | Ok (Some meta) when not meta.paused -> Some meta.name
+    | _ -> None)
+;;
 
-let persistent_agent_names _config =
-  []
+let persistent_agent_names _config = []
 
 let fresher_meta config (meta : keeper_meta) : keeper_meta =
   match read_meta_file_path (keeper_meta_path config meta.name) with
   | Ok (Some existing) ->
-      let existing_ts =
-        Resilience.Time.parse_iso8601_opt existing.updated_at
-        |> Option.value ~default:0.0
-      in
-      let incoming_ts =
-        Resilience.Time.parse_iso8601_opt meta.updated_at
-        |> Option.value ~default:0.0
-      in
-      if existing_ts > incoming_ts then existing else meta
+    let existing_ts =
+      Resilience.Time.parse_iso8601_opt existing.updated_at |> Option.value ~default:0.0
+    in
+    let incoming_ts =
+      Resilience.Time.parse_iso8601_opt meta.updated_at |> Option.value ~default:0.0
+    in
+    if existing_ts > incoming_ts then existing else meta
   | Ok None | Error _ -> meta
+;;
 
 let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result =
   let persisted = if force then m else fresher_meta config m in
@@ -1062,17 +1204,25 @@ let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result
   let json = meta_to_json persisted in
   try
     Keeper_fs.save_json_atomic path json;
-    (!runtime_meta_write_sync_hook) config persisted;
+    !runtime_meta_write_sync_hook config persisted;
     Ok ()
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
+;;
 
 let read_meta config name : (keeper_meta option, string) result =
   let path = keeper_meta_path config name in
-  if keeper_debug then
-    Log.Keeper.debug "read_meta name=%s path=%s exists=%b"
-      name path (Sys.file_exists path);
+  if keeper_debug
+  then
+    Log.Keeper.debug
+      "read_meta name=%s path=%s exists=%b"
+      name
+      path
+      (Sys.file_exists path);
   read_meta_file_path path
+;;
 
 (* Model selection, path utilities, and JSONL helpers
    extracted to Keeper_types_support *)
@@ -1082,43 +1232,43 @@ include Keeper_types_support
     Defined here (not in Keeper_supervisor) to avoid circular
     dependencies between keeper_exec_status and the keeper supervisor. *)
 type fiber_health =
-  | Fiber_alive    (** Fiber running, promise unresolved *)
-  | Fiber_zombie   (** Registry entry exists but fiber terminated *)
-  | Fiber_dead     (** Restart budget exhausted, manual recovery needed *)
-  | Fiber_unknown  (** Not in supervised registry *)
+  | Fiber_alive (** Fiber running, promise unresolved *)
+  | Fiber_zombie (** Registry entry exists but fiber terminated *)
+  | Fiber_dead (** Restart budget exhausted, manual recovery needed *)
+  | Fiber_unknown (** Not in supervised registry *)
 
 (** Per-tool usage entry for keeper tool tracking.
     Defined here so Keeper_registry can embed it without depending
     on Keeper_tools_oas (avoids module init order issues). *)
-type tool_call_entry = {
-  mutable count : int;
-  mutable successes : int;
-  mutable failures : int;
-  mutable last_used_at : float;
-}
+type tool_call_entry =
+  { mutable count : int
+  ; mutable successes : int
+  ; mutable failures : int
+  ; mutable last_used_at : float
+  }
 
 (* ================================================================ *)
 (* Working Context Types (moved from Keeper_working_context)         *)
 (* ================================================================ *)
 
-type working_context = {
-  system_prompt : string;
-  messages : Agent_sdk.Types.message list;
-  max_tokens : int;
-  context : Agent_sdk.Context.t;
-}
+type working_context =
+  { system_prompt : string
+  ; messages : Agent_sdk.Types.message list
+  ; max_tokens : int
+  ; context : Agent_sdk.Context.t
+  }
 
-type checkpoint = {
-  checkpoint_id : string;
-  timestamp : float;
-  generation : int;
-  message_count : int;
-  token_count : int;
-  serialized : string;
-}
+type checkpoint =
+  { checkpoint_id : string
+  ; timestamp : float
+  ; generation : int
+  ; message_count : int
+  ; token_count : int
+  ; serialized : string
+  }
 
-type session_context = {
-  session_id : string;
-  session_dir : string;
-  mutable checkpoints : checkpoint list;
-}
+type session_context =
+  { session_id : string
+  ; session_dir : string
+  ; mutable checkpoints : checkpoint list
+  }


### PR DESCRIPTION
## Summary
- split `keeper_types.meta_of_json` into focused parsing helpers
- split keeper tool dispatch into board/fs/shell/voice/task/masc helpers
- split keepalive loop, directive handling, gRPC heartbeat, and startup bootstrap into smaller helpers

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor/keeper-meta-parse-split ./_build/default/test/test_keeper_registry.exe ./_build/default/test/test_smart_heartbeat_keepalive.exe ./_build/default/test/test_heartbeat_integration.exe ./_build/default/test/test_tool_keeper.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe`
- `./_build/default/test/test_heartbeat_integration.exe`
- `./_build/default/test/test_tool_keeper.exe`

## Cross-Model Review Evidence
- direct `sb glm-text` review on keeper refactor excerpts: no findings
- local `llama-server` review via `scripts/review/local-review.sh`: no findings (2026-04-04T02:39:25Z)

## Issue
- ref #4436
