### PR TITLE
feat(dashboard): polish form inputs with modern hover, focus rings, and transitions

### DIFF
--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] accent-[var(--accent)]'
+const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
 
 interface CheckboxProps {
   checked?: boolean

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]'
+const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface TextInputProps {
   value?: string

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]'
+const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface NumberInputProps {
   value?: number | string

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const SELECT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)] appearance-none cursor-pointer'
+const SELECT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
 
 interface SelectOption { value: string; label: string }
 

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -92,14 +92,10 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
   return html`
     <div class="mt-2 space-y-1.5">
       ${event.toolArgs ? html`
-        <div class="text-[11px] font-mono text-[var(--text-muted)] bg-[var(--white-3)] px-3 py-2 rounded-lg overflow-x-auto whitespace-pre-wrap break-all">
-          ${typeof event.toolArgs === 'string' ? event.toolArgs : JSON.stringify(event.toolArgs, null, 2)}
-        </div>
+        <div class="max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]"><${Markdown} text=${typeof event.toolArgs === 'string' ? event.toolArgs : '```json\n' + JSON.stringify(event.toolArgs, null, 2) + '\n```'} /></div>
       ` : null}
       ${event.toolResult || event.error ? html`
-        <div class="text-[11px] font-mono ${event.error ? 'text-[var(--bad)]' : 'text-[var(--text-dim)]'} bg-[var(--white-3)] px-3 py-2 rounded-lg overflow-x-auto whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
-          ${event.error ?? event.toolResult}
-        </div>
+        <div class="max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]"><${Markdown} text=${typeof (event.error ?? event.toolResult) === 'string' && String(event.error ?? event.toolResult).includes('```') ? String(event.error ?? event.toolResult) : '```json\n' + JSON.stringify((event.error ?? event.toolResult), null, 2) + '\n```'} /></div>
       ` : null}
       ${gateRejected ? html`
         <div class="text-[10px] px-2 py-1 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444] inline-block">

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { Markdown } from "../common/markdown"
 import { useSignal } from '@preact/signals'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
@@ -36,8 +37,9 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
         </div>
         ${expanded.value ? html`
-          <pre class="px-3 py-2 text-[12px] font-mono overflow-x-auto max-h-[400px] overflow-y-auto
-            ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${formatted}</pre>
+          <div class="max-h-[400px] overflow-auto bg-[var(--bg-0)]">
+            <${Markdown} text=${'```json\n' + formatted + '\n```'} />
+          </div>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -2,6 +2,7 @@
 
 :root {
   --bg-0: #0b1220;
+  --bg-1: rgba(30, 41, 59, 0.95);
   --card: rgba(16, 24, 42, 0.92);
   --card-border: rgba(138, 163, 211, 0.2);
   --text-strong: #eaf1ff;


### PR DESCRIPTION
## Summary
- Polish dashboard native form controls (`TextInput`, `TextArea`, `NumberInput`, `Select`, `Checkbox`) with stronger hover/focus treatment.
- Upgrade remaining raw JSON-style dumps to Shiki Markdown blocks for more consistent structured output rendering.
- Sync the branch onto current `main` so stale merge-ref test expectations no longer fail unrelated CI.

## Product impact
- Improves dashboard form affordance and keyboard-focus clarity without changing interaction semantics.
- Keeps structured dashboard output visually consistent with the newer markdown/code presentation.

## Evidence
- `opam exec -- dune build --root .`
- `pnpm -C dashboard build`
- `./_build/default/test/test_dashboard_collaboration_evidence.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- GitHub Actions reran on current head `04172643bfcbe4b026d6044d7b45fec910272065`

## Review evidence
- Existing cross-model review on feature head `7d321af5f40e3010e3149128944ff718385092b5` at 2026-04-04 12:43:55 KST: GLM-5 via `sb glm-text` -> `NO_HIGH_CRITICAL_FINDINGS`.
- Sync follow-up on `04172643bfcbe4b026d6044d7b45fec910272065` only merges current `main`; dashboard feature diff itself is unchanged and was revalidated locally with the evidence above.

## Linked issue
- Refs #4969

## Overview
- Upgraded the CSS utility classes for all native form elements (`TextInput`, `TextArea`, `NumberInput`, `Select`, `Checkbox`) to align with the recently enhanced Card and Button aesthetics.
- **Hover States**: Inputs now slightly brighten (`bg-[var(--white-6)]`) when hovered, signaling interactivity.
- **Focus Rings**: When focused, inputs drop their background to near-transparent (`bg-[var(--bg-0)]`) while displaying a crisp, offset brand-colored focus ring (`ring-2 ring-[rgba(71,184,255,0.45)] ring-offset-2`). This matches standard modern UI practices (like Tailwind UI or Radix) and dramatically improves keyboard navigation accessibility.
