### PR TITLE
feat(dashboard): polish custom-scrollbar aesthetics for dark mode

### DIFF
--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -392,3 +392,29 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(71, 184, 255, 0.08);
   border-color: rgba(71, 184, 255, 0.25);
 }
+
+/* ── Custom Webkit Scrollbar ── */
+@layer utilities {
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--white-10) transparent;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: var(--white-10);
+    border-radius: 10px;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: var(--white-20);
+  }
+}


### PR DESCRIPTION
## Overview
- Fixed the missing `.custom-scrollbar` CSS definition that caused the dashboard to fallback to native, chunky OS scrollbars in several places (e.g., Autoresearch table, Kanban columns, etc.).
- The new custom scrollbars are thin, sleek, and perfectly match the dark, translucent aesthetic of the MASC dashboard (with an elegant `var(--white-10)` semi-transparent thumb that brightens on hover).