### PR TITLE
feat: Improve telemetry and structured data visibility with JsonViewerCard

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -80,7 +80,7 @@ export function App() {
           <div class="min-w-0">
             <div class="flex items-center gap-4">
               <button type="button"
-                class="hidden max-[768px]:flex size-10 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+                class="hidden max-[768px]:flex size-10 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 aria-controls="dashboard-side-rail"
@@ -88,7 +88,7 @@ export function App() {
               >
                 ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
-              <div class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[15px] font-bold text-[#bfe7ff]">
+              <div class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[15px] font-bold text-[var(--text-strong)]">
                 ${currentView?.icon ?? 'M'}
               </div>
               <div class="min-w-0 flex flex-col justify-center">
@@ -98,7 +98,7 @@ export function App() {
                 <h1 class="text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none flex items-center gap-1.5">
                   ${currentView?.label ?? 'Multi-Agent Namespace Console'}
                   ${currentSection && currentSection.label !== currentView?.label
-                    ? html`<span class="text-[13px] font-medium text-[rgba(154,217,255,0.5)]">/</span><span class="text-[15px] font-medium text-[rgba(154,217,255,0.8)]">${currentSection.label}</span>`
+                    ? html`<span class="text-[13px] font-medium text-[var(--text-muted)]">/</span><span class="text-[15px] font-medium text-[rgba(154,217,255,0.8)]">${currentSection.label}</span>`
                     : null}
                 </h1>
               </div>

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -38,10 +38,10 @@ export function AgentTimelineSection() {
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
-          ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">메시지 ${summary.messages_sent}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+          ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">메시지 ${summary.messages_sent}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
         </div>
       ` : null}
       ${events.length === 0

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -40,7 +40,7 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
           <div class="flex items-baseline gap-2 text-[13px]">
             <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${worker.signal_truth}</span>` : null}
+            ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">${worker.signal_truth}</span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -229,12 +229,12 @@ function CharacterPlate({ name }: { name: string }) {
             ${displayName}
           </h2>
           ${koreanName ? html`<span class="text-base text-[var(--text-muted)]">(${koreanName})</span>` : ''}
-          ${generation != null ? html`<span class="text-sm font-bold text-[var(--accent)] bg-[var(--accent-10)] border border-[rgba(71,184,255,0.25)] px-1.5 py-px tabular-nums rounded" title="세대 번호 — 핸드오프마다 증가 (레벨/등급 아님)">Gen.${generation}</span>` : null}
+          ${generation != null ? html`<span class="text-sm font-bold text-[var(--accent)] bg-[var(--accent-10)] border border-[var(--accent-30)] px-1.5 py-px tabular-nums rounded" title="세대 번호 — 핸드오프마다 증가 (레벨/등급 아님)">Gen.${generation}</span>` : null}
         </div>
 
         <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
-          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-[11px] text-[var(--text-muted)] bg-[var(--accent-8)] border border-[rgba(71,184,255,0.15)] px-[5px] py-px rounded">${model}</span>` : null}
+          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-[11px] text-[var(--text-muted)] bg-[var(--accent-8)] border border-[var(--accent-10)] px-[5px] py-px rounded">${model}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
@@ -324,7 +324,7 @@ export function AgentProfile({ name }: { name: string }) {
       </div>
 
       ${ps.status === 'error'
-        ? html`<div class="rounded-lg border border-[rgba(239,68,68,0.35)] bg-[rgba(239,68,68,0.08)] px-3 py-2">${ps.message}</div>`
+        ? html`<div class="rounded-lg border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-2">${ps.message}</div>`
         : null}
 
       <${CharacterPlate} name=${name} />
@@ -338,7 +338,7 @@ export function AgentProfile({ name }: { name: string }) {
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
                 <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg" key=${t.id}>
-                  <span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${t.id}</span>
+                  <span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">${t.id}</span>
                   <span class="flex-1 text-[#d7e7ff]">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
@@ -413,7 +413,7 @@ export function AgentProfile({ name }: { name: string }) {
           <${Card} title="태스크 이력" class="ff-card rounded-xl col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
-                <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${row.taskId}</span></div>
+                <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">${row.taskId}</span></div>
                 <pre class="m-0 whitespace-pre-wrap text-[13px] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -414,7 +414,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           ${showExecutionFallbackState
             ? html`
-                <div class="rounded-2xl border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[rgba(251,191,36,0.08)]' : 'border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
+                <div class="rounded-2xl border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[var(--warn-10)]' : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
                   <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap items-center gap-2">
                       <strong class="text-[12px] font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>
@@ -479,7 +479,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼 런타임' : '일반 에이전트'}</span>
                     ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
                     ${keeper?.model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${keeper.model}</span>` : null}
-                    ${keeper?.generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[rgba(71,184,255,0.15)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${keeper.generation}</span>` : null}
+                    ${keeper?.generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[var(--accent-10)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${keeper.generation}</span>` : null}
                   </div>
                 </div>
               </div>

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -67,7 +67,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
         <div class="flex flex-col gap-2">
           <div class="text-[11px] text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>
           <button type="button"
-            class="w-full py-1.5 px-3 rounded-md text-[11px] border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded-md text-[11px] border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] cursor-pointer transition-colors"
             onClick=${handleClearToken}
           >토큰 제거</button>
         </div>
@@ -83,7 +83,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
             onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') handleSetToken() }}
           />
           <button type="button"
-            class="w-full py-1.5 px-3 rounded-md text-[11px] border border-[rgba(71,184,255,0.3)] bg-[rgba(71,184,255,0.08)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded-md text-[11px] border border-[rgba(71,184,255,0.3)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
             onClick=${handleSetToken}
           >토큰 설정</button>
         </div>
@@ -96,11 +96,11 @@ export function RemoteWarningBanner() {
   if (bannerDismissed.value || !isRemoteAccess() || getStoredToken()) return null
 
   return html`
-    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[rgba(251,191,36,0.08)] border-b border-[rgba(251,191,36,0.2)] text-[12px] text-[#fbbf24]">
+    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[rgba(251,191,36,0.2)] text-[12px] text-[#fbbf24]">
       <span>원격 접속이 감지되었습니다. Mutation 작업을 위해 Bearer token을 설정하세요.</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"
-          class="px-2 py-0.5 rounded text-[11px] border border-[rgba(71,184,255,0.3)] bg-[rgba(71,184,255,0.08)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
+          class="px-2 py-0.5 rounded text-[11px] border border-[rgba(71,184,255,0.3)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
           onClick=${() => { popoverOpen.value = true }}
         >토큰 입력</button>
         <button type="button"

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
+import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
-import { Markdown } from '../common/markdown'
 import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
 export type ChatTranscriptVariant = 'default' | 'messenger'
@@ -205,7 +205,7 @@ export function ChatMessageBubble({
           ? html`
               <button
                 type="button"
-                class=${`border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)] ${
+                class=${`border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
                   isMessenger ? 'rounded-xl px-2.5 py-1' : 'rounded-full px-3 py-1'
                 }`}
                 onClick=${() => { setExpanded(!expanded) }}
@@ -219,7 +219,7 @@ export function ChatMessageBubble({
       ${showMetadata && detailItems.length > 0
         ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
-              <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.16)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[10px] font-medium text-[#bfe8ff]">
+              <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.16)] bg-[var(--accent-10)] px-2.5 py-1 text-[10px] font-medium text-[#bfe8ff]">
                 ${item}
               </span>
             `)}
@@ -244,7 +244,7 @@ export function ChatMessageBubble({
                 ? html`
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
-                        <div class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-3 py-2.5">
+                        <div class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-3 py-2.5">
                           <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
                           <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
@@ -269,8 +269,8 @@ export function ChatMessageBubble({
                       <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
-                          <div class="rounded-2xl border border-[rgba(71,184,255,0.14)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
-                            <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#9ad9ff]">${item.label}</div>
+                          <div class="rounded-2xl border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
+                            <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--accent)]">${item.label}</div>
                             <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-body)]">${item.value}</div>
                           </div>
                         `)}
@@ -283,13 +283,13 @@ export function ChatMessageBubble({
                     <div class="flex flex-col gap-2">
                       <button
                         type="button"
-                        class="self-start rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)]"
+                        class="self-start rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
                         onClick=${() => { setRawExpanded(!rawExpanded) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
                       </button>
                       ${rawExpanded
-                        ? html`<div class="mt-2"><${Markdown} text=${`\`\`\`json\n${JSON.stringify(entry.details.rawPayload, null, 2)}\n\`\`\``} /></div>`
+                        ? html`<div class="mt-2"><${JsonViewerCard} data=${entry.details.rawPayload} /></div>`
                         : null}
                     </div>
                   `
@@ -333,7 +333,7 @@ export function ChatTranscript({
     >
       ${entries.length === 0
         ? html`
-            <div class="flex min-h-[220px] flex-col items-center justify-center rounded-[18px] border border-dashed border-[rgba(148,163,184,0.18)] bg-[rgba(255,255,255,0.03)] px-6 text-center">
+            <div class="flex min-h-[220px] flex-col items-center justify-center rounded-[18px] border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
               <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
               <div class="mt-3 max-w-[34rem] text-[13px] leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
             </div>

--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -18,7 +18,7 @@ import { prettyJson, displayStatus } from '../../lib/status-label'
 export { relativeTime, formatElapsed, toneClass, toneBorder, toneBg, chainStatusTone, sessionStatusTone, expiryTone, prettyJson, displayStatus }
 
 export function alertBorderTone(tone: string): string {
-  if (tone === 'warn') return 'border-[rgba(251,191,36,0.26)]'
+  if (tone === 'warn') return 'border-[var(--warn-30)]'
   if (tone === 'bad') return 'border-[rgba(248,113,113,0.3)]'
   return ''
 }

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -88,7 +88,7 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
           : null}
       </div>
       ${lane.blockers.length > 0
-        ? html`<div class="bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.25)] py-1.5 px-2.5 text-[0.78rem] text-[var(--bad)] mt-1 rounded-md">막힘: ${lane.blockers.join(' · ')}</div>`
+        ? html`<div class="bg-[var(--bad-10)] border border-[rgba(239,68,68,0.25)] py-1.5 px-2.5 text-[0.78rem] text-[var(--bad)] mt-1 rounded-md">막힘: ${lane.blockers.join(' · ')}</div>`
         : null}
       ${lane.hard_flags.length > 0
         ? html`

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { Markdown } from "../common/markdown"
+import { JsonViewerCard } from '../common/json-viewer'
 import { StatusChip } from '../common/status-chip'
 import type { CommandPlaneTraceEvent } from '../../types'
 import { relativeTime } from './helpers'
@@ -19,7 +19,7 @@ export function TraceRow({ event }: { event: CommandPlaneTraceEvent }) {
           ${event.actor ? ` · ${event.actor}` : ''}
         </div>
       </div>
-      <div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(event.detail, null, 2) + '\n```'} /></div>
+      <${JsonViewerCard} data=${event.detail} title="Event Detail" />
     </article>
   `
 }

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -109,11 +109,11 @@ export function CommandPalette() {
     // Add Agents dynamically
     const agents = missionAgentBriefs.value || []
     const agentActions: CommandPaletteAction[] = agents.map(agent => ({
-      id: `nav-agent-${agent.name}`,
-      title: `에이전트 상세: ${agent.name}`,
+      id: `nav-agent-${agent.agent_name}`,
+      title: `에이전트 상세: ${agent.display_name || agent.agent_name}`,
       section: 'Agents',
-      keywords: `worker detail status ${agent.state || ''}`,
-      handler: () => navigate('overview', { section: 'worker', operation_id: agent.name })
+      keywords: `worker detail status ${agent.status || ''}`,
+      handler: () => navigate('overview', { section: 'worker', operation_id: agent.agent_name })
     }))
 
     // Add Keepers dynamically
@@ -122,18 +122,18 @@ export function CommandPalette() {
       id: `nav-keeper-${keeper.name}`,
       title: `키퍼 상세: ${keeper.name}`,
       section: 'Keepers',
-      keywords: `bot detail status ${keeper.state || ''}`,
+      keywords: `bot detail status ${keeper.status || ''}`,
       handler: () => navigate('overview', { section: 'keeper', operation_id: keeper.name })
     }))
 
     // Add Sessions dynamically
     const sessions = missionSnapshot.value?.sessions || missionSnapshot.value?.session_briefs || []
     const sessionActions: CommandPaletteAction[] = sessions.map(s => ({
-      id: `nav-session-${s.id}`,
-      title: `세션 확인: ${s.title || s.id}`,
+      id: `nav-session-${s.session_id}`,
+      title: `세션 확인: ${s.goal || s.session_id}`,
       section: 'Sessions',
       keywords: `task run ${s.status || ''}`,
-      handler: () => navigate('workspace', { section: 'session', session_id: s.id })
+      handler: () => navigate('workspace', { section: 'session', session_id: s.session_id })
     }))
 
     ref.current.data = [...baseActions, ...agentActions, ...keeperActions, ...sessionActions]
@@ -162,4 +162,3 @@ export function CommandPalette() {
     ></ninja-keys>
   `
 }
-

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -3,11 +3,14 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { navigate } from '../../router'
 import { requestConfirm } from './confirm-dialog'
 import { runGarbageCollection, cleanupZombies } from '../flow-control/flow-control-state'
+import { missionSnapshot, missionAgentBriefs, missionKeeperBriefs } from '../../mission-signals'
 
 interface CommandPaletteAction {
   id: string
   title: string
   handler: () => void | Promise<void>
+  section?: string
+  keywords?: string
 }
 
 interface NinjaKeysElement extends HTMLElement {
@@ -34,44 +37,58 @@ export function CommandPalette() {
     }
   }, [])
 
+  // Sync data whenever the mission snapshot changes
   useEffect(() => {
     if (!ready || !ref.current) return
-    const frameId = window.requestAnimationFrame(() => {
-      if (!ref.current) return
-      ref.current.data = [
+
+    const baseActions: CommandPaletteAction[] = [
       {
         id: 'nav-overview',
         title: '상황판으로 이동 (Overview)',
+        section: 'Navigation',
+        keywords: 'home main board',
         handler: () => navigate('overview')
       },
       {
         id: 'nav-monitoring',
         title: '모니터링으로 이동 (Monitoring)',
+        section: 'Navigation',
+        keywords: 'status health metrics',
         handler: () => navigate('monitoring')
       },
       {
         id: 'nav-workspace',
         title: '작업 화면으로 이동 (Workspace)',
+        section: 'Navigation',
+        keywords: 'tasks work',
         handler: () => navigate('workspace')
       },
       {
         id: 'nav-command',
         title: '운영 개입으로 이동 (Command Plane)',
+        section: 'Navigation',
+        keywords: 'control admin ops',
         handler: () => navigate('command')
       },
       {
         id: 'nav-lab',
         title: '실험실로 이동 (Lab)',
+        section: 'Navigation',
+        keywords: 'experiment test',
         handler: () => navigate('lab')
       },
       {
         id: 'nav-logs',
         title: '로그 뷰어로 이동 (Logs)',
+        section: 'Navigation',
+        keywords: 'debug output system',
         handler: () => navigate('logs')
       },
       {
         id: 'action-gc',
         title: '유지보수: GC (Garbage Collection) 실행',
+        section: 'System Ops',
+        keywords: 'clear clean memory',
         handler: async () => {
           const confirmed = await requestConfirm({ title: '유지보수', message: 'GC를 실행합니까?' })
           if (confirmed) void runGarbageCollection()
@@ -80,38 +97,69 @@ export function CommandPalette() {
       {
         id: 'action-zombie',
         title: '유지보수: 좀비 에이전트 정리',
+        section: 'System Ops',
+        keywords: 'kill process clear',
         handler: async () => {
           const confirmed = await requestConfirm({ title: '유지보수', message: '좀비 에이전트를 정리합니까?', tone: 'danger' })
           if (confirmed) void cleanupZombies()
         }
       }
-      ]
-    })
+    ]
 
-    return () => {
-      window.cancelAnimationFrame(frameId)
-    }
-  }, [ready])
+    // Add Agents dynamically
+    const agents = missionAgentBriefs.value || []
+    const agentActions: CommandPaletteAction[] = agents.map(agent => ({
+      id: `nav-agent-${agent.name}`,
+      title: `에이전트 상세: ${agent.name}`,
+      section: 'Agents',
+      keywords: `worker detail status ${agent.state || ''}`,
+      handler: () => navigate('overview', { section: 'worker', operation_id: agent.name })
+    }))
+
+    // Add Keepers dynamically
+    const keepers = missionKeeperBriefs.value || []
+    const keeperActions: CommandPaletteAction[] = keepers.map(keeper => ({
+      id: `nav-keeper-${keeper.name}`,
+      title: `키퍼 상세: ${keeper.name}`,
+      section: 'Keepers',
+      keywords: `bot detail status ${keeper.state || ''}`,
+      handler: () => navigate('overview', { section: 'keeper', operation_id: keeper.name })
+    }))
+
+    // Add Sessions dynamically
+    const sessions = missionSnapshot.value?.sessions || missionSnapshot.value?.session_briefs || []
+    const sessionActions: CommandPaletteAction[] = sessions.map(s => ({
+      id: `nav-session-${s.id}`,
+      title: `세션 확인: ${s.title || s.id}`,
+      section: 'Sessions',
+      keywords: `task run ${s.status || ''}`,
+      handler: () => navigate('workspace', { section: 'session', session_id: s.id })
+    }))
+
+    ref.current.data = [...baseActions, ...agentActions, ...keeperActions, ...sessionActions]
+
+  }, [ready, missionSnapshot.value, missionAgentBriefs.value, missionKeeperBriefs.value])
 
   if (!ready) return null
 
   return html`
     <ninja-keys
       ref=${ref}
-      placeholder="명령어를 검색하세요... (⌘/Ctrl+K)"
+      placeholder="명령어 또는 에이전트/세션 검색... (⌘/Ctrl+K)"
       hideBreadcrumbs
       style="
-        --ninja-modal-background: rgba(13, 21, 38, 0.98);
+        --ninja-modal-background: var(--bg-panel);
         --ninja-modal-shadow: 0 24px 64px rgba(0,0,0,0.6);
         --ninja-text-color: var(--text-body);
-        --ninja-secondary-background-color: var(--white-4);
+        --ninja-secondary-background-color: var(--white-5);
         --ninja-secondary-text-color: var(--text-muted);
         --ninja-selected-background: var(--white-10);
         --ninja-icon-color: var(--text-muted);
-        --ninja-key-background: var(--white-5);
+        --ninja-key-background: var(--white-10);
         --ninja-key-text-color: var(--text-strong);
-        --ninja-border-bottom: 1px solid var(--card-border);
+        --ninja-border-bottom: 1px solid var(--border-base);
       "
     ></ninja-keys>
   `
 }
+

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -1,11 +1,20 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
 
-export function JsonViewer({ data, label, initialCollapsed = false, level = 0 }: { data: unknown; label?: string; initialCollapsed?: boolean; level?: number }) {
+export function JsonViewer({ data, label, initialCollapsed = false, level = 0, ancestors = [] }: { data: unknown; label?: string; initialCollapsed?: boolean; level?: number; ancestors?: object[] }) {
   const [collapsed, setCollapsed] = useState(initialCollapsed)
 
   const isObject = data !== null && typeof data === 'object'
   const isArray = Array.isArray(data)
+
+  if (isObject && ancestors.includes(data as object)) {
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--text-muted)] italic">[Circular]</span>
+      </div>
+    `
+  }
 
   if (!isObject) {
     let valueNode
@@ -31,6 +40,8 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0 }:
 
   const entries = isArray ? (data as unknown[]) : Object.entries(data as Record<string, unknown>)
   const isEmpty = isArray ? (data as unknown[]).length === 0 : entries.length === 0
+  const nextAncestors = isObject ? [...ancestors, data as object] : ancestors
+  const toggleLabel = label ?? (isArray ? 'JSON array' : 'JSON object')
 
   if (isEmpty) {
     return html`
@@ -43,19 +54,25 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0 }:
 
   return html`
     <div class="font-mono text-[13px] leading-relaxed flex flex-col py-0.5 w-full min-w-0">
-      <div class="flex items-center gap-1.5 cursor-pointer hover:bg-[var(--white-4)] rounded px-1 -mx-1 select-none w-max max-w-full" onClick=${() => setCollapsed(!collapsed)}>
-        <span class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
+      <button
+        type="button"
+        class="flex items-center gap-1.5 cursor-pointer hover:bg-[var(--white-4)] rounded px-1 -mx-1 select-none w-max max-w-full text-left bg-transparent border-0"
+        onClick=${() => setCollapsed(!collapsed)}
+        aria-expanded=${!collapsed}
+        aria-label=${`${collapsed ? 'Expand' : 'Collapse'} ${toggleLabel}`}
+      >
+        <span aria-hidden="true" class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
         ${label ? html`<span class="text-[var(--text-body)] font-medium truncate">${label}</span>` : null}
         <span class="text-[var(--text-muted)] text-[11px] ml-1 shrink-0">
           ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}
         </span>
-      </div>
+      </button>
       
       ${!collapsed && html`
         <div class="pl-4 ml-1.5 border-l border-[var(--white-4)] mt-1 flex flex-col gap-0.5 w-full min-w-0">
           ${isArray
-            ? (data as unknown[]).map((val, idx) => html`<${JsonViewer} key=${idx} data=${val} label=${String(idx)} level=${level + 1} initialCollapsed=${level >= 2} />`)
-            : (entries as [string, unknown][]).map(([k, v]) => html`<${JsonViewer} key=${k} data=${v} label=${k} level=${level + 1} initialCollapsed=${level >= 2} />`)
+            ? (data as unknown[]).map((val, idx) => html`<${JsonViewer} key=${idx} data=${val} label=${String(idx)} level=${level + 1} initialCollapsed=${level >= 2} ancestors=${nextAncestors} />`)
+            : (entries as [string, unknown][]).map(([k, v]) => html`<${JsonViewer} key=${k} data=${v} label=${k} level=${level + 1} initialCollapsed=${level >= 2} ancestors=${nextAncestors} />`)
           }
         </div>
       `}

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -1,0 +1,75 @@
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+
+export function JsonViewer({ data, label, initialCollapsed = false, level = 0 }: { data: unknown; label?: string; initialCollapsed?: boolean; level?: number }) {
+  const [collapsed, setCollapsed] = useState(initialCollapsed)
+
+  const isObject = data !== null && typeof data === 'object'
+  const isArray = Array.isArray(data)
+
+  if (!isObject) {
+    let valueNode
+    if (typeof data === 'string') {
+      valueNode = html`<span class="text-[var(--ok)] break-all">"${data}"</span>`
+    } else if (typeof data === 'number') {
+      valueNode = html`<span class="text-[var(--warn)]">${data}</span>`
+    } else if (typeof data === 'boolean') {
+      valueNode = html`<span class="text-[#e27e8d]">${data ? 'true' : 'false'}</span>`
+    } else if (data === null) {
+      valueNode = html`<span class="text-[var(--text-muted)] italic">null</span>`
+    } else {
+      valueNode = html`<span class="text-[var(--text-muted)]">${String(data)}</span>`
+    }
+
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <div class="min-w-0 break-words">${valueNode}</div>
+      </div>
+    `
+  }
+
+  const entries = isArray ? (data as unknown[]) : Object.entries(data as Record<string, unknown>)
+  const isEmpty = isArray ? (data as unknown[]).length === 0 : entries.length === 0
+
+  if (isEmpty) {
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--text-muted)]">${isArray ? '[]' : '{}'}</span>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="font-mono text-[13px] leading-relaxed flex flex-col py-0.5 w-full min-w-0">
+      <div class="flex items-center gap-1.5 cursor-pointer hover:bg-[var(--white-4)] rounded px-1 -mx-1 select-none w-max max-w-full" onClick=${() => setCollapsed(!collapsed)}>
+        <span class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
+        ${label ? html`<span class="text-[var(--text-body)] font-medium truncate">${label}</span>` : null}
+        <span class="text-[var(--text-muted)] text-[11px] ml-1 shrink-0">
+          ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}
+        </span>
+      </div>
+      
+      ${!collapsed && html`
+        <div class="pl-4 ml-1.5 border-l border-[var(--white-4)] mt-1 flex flex-col gap-0.5 w-full min-w-0">
+          ${isArray
+            ? (data as unknown[]).map((val, idx) => html`<${JsonViewer} key=${idx} data=${val} label=${String(idx)} level=${level + 1} initialCollapsed=${level >= 2} />`)
+            : (entries as [string, unknown][]).map(([k, v]) => html`<${JsonViewer} key=${k} data=${v} label=${k} level=${level + 1} initialCollapsed=${level >= 2} />`)
+          }
+        </div>
+      `}
+    </div>
+  `
+}
+
+export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
+  return html`
+    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded-xl overflow-hidden flex flex-col max-h-[400px]">
+      ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-[11px] uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
+      <div class="p-3 overflow-y-auto min-h-0 w-full">
+        <${JsonViewer} data=${data} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -82,7 +82,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="text-[11px] py-[6px] px-[11px] rounded-md border border-solid border-[rgba(71,184,255,0.28)] bg-[rgba(71,184,255,0.12)] text-[#bfe7ff] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[rgba(71,184,255,0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="text-[11px] py-[6px] px-[11px] rounded-md border border-solid border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--text-strong)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         onClick=${() => {
           buildIdentityOpen.value = !buildIdentityOpen.value
@@ -92,7 +92,7 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+8px)] right-0 min-w-[280px] rounded-lg border border-solid border-[var(--card-border)] bg-[rgba(6,14,28,0.96)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
+            <div class="absolute top-[calc(100%+8px)] right-0 min-w-[280px] rounded-lg border border-solid border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
                 <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
@@ -173,12 +173,12 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
-            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">내비게이션</div>
+            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">내비게이션</div>
             <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[rgba(255,255,255,0.08)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+          class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
@@ -198,7 +198,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center justify-center w-full rounded-xl border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.16)] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.18)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)]'}"
+                  class="flex items-center justify-center w-full rounded-xl border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
                   title=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
@@ -212,14 +212,14 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center gap-2 w-full rounded-lg border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.18)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)]'}"
+                  class="flex items-center gap-2 w-full rounded-lg border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[var(--white-5)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.03)] text-[14px]">
+                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-3)] text-[14px]">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
+                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--accent)]' : ''}">${surface.label}</div>
                   </div>
                 <//>
 
@@ -232,7 +232,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           role="listitem"
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded-lg border px-2 py-1 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.14)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border-[rgba(71,184,255,0.14)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded-lg border px-2 py-1 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)] hover:text-[var(--text-body)]'}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>
@@ -247,7 +247,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </div>
       </div>
 
-      <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] px-2 py-2">
+      <div class="shrink-0 border-t border-[var(--white-10)] px-2 py-2">
         <${HealthIndicator} collapsed=${collapsed} />
       </div>
     </nav>

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -100,7 +100,7 @@ export function KanbanCard({ task }: { task: Task }) {
         </div>
         <button
           type="button"
-          class="rounded-lg border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] px-2 py-1 text-[10px] font-semibold text-[#f87171] transition-colors hover:bg-[rgba(239,68,68,0.16)] disabled:opacity-50 disabled:cursor-not-allowed"
+          class="rounded-lg border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[10px] font-semibold text-[#f87171] transition-colors hover:bg-[rgba(239,68,68,0.16)] disabled:opacity-50 disabled:cursor-not-allowed"
           onClick=${handleDelete}
           disabled=${isDeleting}
         >

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -143,7 +143,7 @@ export function TaskActivityList({
             type="button"
             class="px-2 py-1 rounded-md text-[11px] font-medium border cursor-pointer transition-colors ${
               filter === chip.key
-                ? 'border-accent/40 bg-accent/12 text-[#9ad9ff]'
+                ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
                 : 'border-[var(--white-10)] bg-[var(--white-4)] text-text-muted hover:bg-[var(--white-8)]'
             }"
             onClick=${() => { activeFilter.value = chip.key }}

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -148,7 +148,7 @@ export function TaskDetailOverlay() {
               type="button"
               class="px-3 py-1.5 rounded-lg text-[12px] font-medium border cursor-pointer transition-colors ${
                 activeTab.value === tab
-                  ? 'border-accent/40 bg-accent/12 text-[#9ad9ff]'
+                  ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
                   : 'border-transparent text-text-muted hover:bg-[var(--white-8)]'
               }"
               onClick=${() => tab === 'activity' ? switchToActivityTab(task) : (activeTab.value = 'overview')}

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -181,7 +181,7 @@ function GovernanceToolbar() {
           active=${governanceFilter}
           onChange=${() => { void refreshGovernance() }}
         />
-        ${governanceError.value ? html`<div class="mt-2 rounded-lg border border-[rgba(239,68,68,0.35)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
+        ${governanceError.value ? html`<div class="mt-2 rounded-lg border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
       </div>
       <//>
     </div>

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -188,7 +188,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
           </div>
         </div>
         <div class="flex items-center gap-2">
-          <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[11px] font-medium text-[#bfe8ff]">
+          <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[var(--accent-10)] px-2.5 py-1 text-[11px] font-medium text-[#bfe8ff]">
             ${entries.length}개 메시지
           </span>
         </div>
@@ -209,7 +209,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
         ? html`<div class="mx-4 mb-4 rounded-[18px] border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#ffb4b4]">${chatError.value}</div>`
         : null}
 
-      <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
+      <div class="border-t border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-4 py-4">
         <${ChatComposer}
           draft=${chatInput.value}
           placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : '메시지 입력...'}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -137,7 +137,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
               const pct = Math.round((count / totalCalls) * 100)
               return html`
                 <div class="flex items-center gap-2 text-xs">
-                  <span class="shrink-0 w-[140px] truncate font-mono text-[11px] text-[#9ad9ff]" title=${model}>${model}</span>
+                  <span class="shrink-0 w-[140px] truncate font-mono text-[11px] text-[var(--accent)]" title=${model}>${model}</span>
                   <div class="flex-1 h-1.5 bg-[var(--white-6)] rounded-full overflow-hidden">
                     <div class="h-full rounded-full bg-[var(--accent)]" style="width:${pct}%"></div>
                   </div>
@@ -307,7 +307,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
-          <span class="text-xs font-mono tabular-nums text-[#9ad9ff]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+          <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
           ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="#9ad9ff" stroke-width="1.5"/>` : null}
@@ -446,7 +446,7 @@ export function RelationshipList({ rels }: { rels: Record<string, string> }) {
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
         <div class="flex items-center gap-2 py-2 px-3 bg-[var(--white-3)] rounded-lg">
-          <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${name}</span>
+          <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${name}</span>
           <span class="text-[11px] text-[var(--text-muted)] font-mono">${relation}</span>
         </div>
       `)}
@@ -461,7 +461,7 @@ export function TraitsList({ traits, label }: { traits: string[]; label: string 
     <div class="mb-3">
       <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
       <div class="flex flex-wrap gap-1.5">
-        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${t}</span>`)}
+        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${t}</span>`)}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -100,7 +100,7 @@ function SignalRow({ label, value }: { label: string; value: string | number }) 
 function ToolChip({ name }: { name: string }) {
   return html`
     <button type="button"
-      class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)] hover:bg-[rgba(71,184,255,0.18)] cursor-pointer transition-colors"
+      class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
       title="클릭하여 도구 상세 보기"
       onClick=${() => openToolsInventory(name)}
     >${name}</button>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -338,7 +338,7 @@ export function KeeperDetailOverlay() {
                   const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
                   const display = lastUsed || keeper.active_model || keeper.model
                   return display ? html`
-                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.2)]"
+                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.2)]"
                       title=${lastUsed && keeper.model ? `마지막 호출: ${lastUsed}\n설정: ${keeper.model}` : ''}
                     >${display}</span>
                   ` : null
@@ -372,7 +372,7 @@ export function KeeperDetailOverlay() {
                 >기동</button>`
               if (isRunning) return html`
                 <button type="button"
-                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
                   onClick=${() => {
                     void (async () => {
                       const confirmed = await requestConfirm({

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -140,7 +140,7 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
     return 'border-[rgba(76,181,137,0.26)] bg-[rgba(76,181,137,0.12)] text-[#b9f1d1]'
   }
   if (hydrating) {
-    return 'border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.12)] text-[#bfe8ff]'
+    return 'border-[rgba(71,184,255,0.26)] bg-[var(--accent-10)] text-[#bfe8ff]'
   }
   return 'border-[rgba(148,163,184,0.18)] bg-[rgba(148,163,184,0.08)] text-[var(--text-body)]'
 }
@@ -155,7 +155,7 @@ function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnosti
 
 function DiagChip({ label }: { label: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${label}</span>
+    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${label}</span>
   `
 }
 
@@ -366,7 +366,7 @@ export function KeeperConversationPanel({
             `
           : null}
 
-        <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
+        <div class="border-t border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-4 py-4">
           <${ChatComposer}
             draft=${draft}
             placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : placeholder}
@@ -449,11 +449,11 @@ export function KeeperRuntimeActions({
 
   const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-medium cursor-pointer transition-colors border'
   const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`
-  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.2)]`
-  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)] text-[#fbbf24] hover:bg-[rgba(251,191,36,0.15)]`
+  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.2)]`
+  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[#fbbf24] hover:bg-[rgba(251,191,36,0.15)]`
   const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[rgba(251,191,36,0.15)] text-[#fbbf24] hover:bg-[rgba(251,191,36,0.2)]`
   const bootBtn = `${btnBase} border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[#4ade80] hover:bg-[rgba(34,197,94,0.15)]`
-  const shutdownBtn = `${btnBase} border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)]`
+  const shutdownBtn = `${btnBase} border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)]`
 
   return html`
     <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -64,7 +64,7 @@ const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; colo
   { match: n => n.includes('bash'),                         icon: '>', color: 'text-[#4ade80]' },
   { match: n => n.includes('edit') || n.includes('fs'),     icon: 'E', color: 'text-[#fbbf24]' },
   { match: n => n.includes('board') || n.includes('social'),icon: 'B', color: 'text-[#a78bfa]' },
-  { match: n => n.includes('github'),                       icon: 'G', color: 'text-[#9ad9ff]' },
+  { match: n => n.includes('github'),                       icon: 'G', color: 'text-[var(--accent)]' },
   { match: n => n.includes('search') || n.includes('read'), icon: 'R', color: 'text-[#60a5fa]' },
 ]
 const DEFAULT_TOOL_STYLE = { icon: 'T', color: 'text-[#94a3b8]' }
@@ -119,10 +119,10 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
           <span class="text-xs font-mono font-medium ${cat.color}">${entry.tool_name}</span>
           <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}R${entry.round}</span>
           ${gateRejected
-            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">거부: ${entry.gate.reason ?? ''}</span>`
+            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[#ef4444]">거부: ${entry.gate.reason ?? ''}</span>`
             : null}
           ${entry.error
-            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">오류</span>`
+            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[#ef4444]">오류</span>`
             : null}
         </div>
 

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -7,7 +7,7 @@ import { openAgentDetail, selectedAgentName } from '../agent-detail'
 function pulseStateClass(state: PulseState): string {
   switch (state) {
     case 'working': return 'pulse-working'
-    case 'stale': return 'border-[rgba(239,68,68,0.3)] opacity-60'
+    case 'stale': return 'border-[var(--bad-30)] opacity-60'
     default: return 'border-[var(--white-10)]'
   }
 }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -140,13 +140,13 @@ export function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
 function sourceTone(source: string): string {
   switch (source) {
     case 'client_tool_host':
-      return 'text-[#dff3ff] bg-[rgba(71,184,255,0.12)] border-[rgba(71,184,255,0.22)]'
+      return 'text-[#dff3ff] bg-[var(--accent-10)] border-[rgba(71,184,255,0.22)]'
     case 'legacy_stderr':
       return 'text-[#ffb4b4] bg-[rgba(224,80,80,0.12)] border-[rgba(224,80,80,0.18)]'
     case 'legacy_traceln':
       return 'text-[#ffd88a] bg-[rgba(230,167,0,0.12)] border-[rgba(230,167,0,0.18)]'
     default:
-      return 'text-[var(--text-muted)] bg-[rgba(255,255,255,0.04)] border-[rgba(255,255,255,0.08)]'
+      return 'text-[var(--text-muted)] bg-[rgba(255,255,255,0.04)] border-[var(--white-10)]'
   }
 }
 
@@ -227,34 +227,34 @@ function renderLogRow(entry: LogEntry) {
           ${sourceLabel(source)}
         </span>
         ${entry.legacy_classified
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">classified</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">classified</span>`
           : null}
         ${rawLevelChanged
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
           : null}
         ${clientName
           ? html`<span class="rounded-full border border-[rgba(71,184,255,0.16)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${toolName}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${toolName}</span>`
           : null}
         ${phase
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`
           : null}
         ${requestId
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">req ${requestId}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">req ${requestId}</span>`
           : null}
         ${sessionId
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">session ${sessionId}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">session ${sessionId}</span>`
           : null}
         ${failure
           ? html`<span class="rounded-full border border-[rgba(224,80,80,0.24)] bg-[rgba(224,80,80,0.12)] px-2 py-0.5 text-[10px] text-[#ffb4b4]">${failure.cause_code}</span>`
           : null}
         ${failure
-          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${failure.recoverability}</span>`
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${failure.recoverability}</span>`
           : null}
         ${failure?.operator_action
-          ? html`<span class="rounded-full border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)] px-2 py-0.5 text-[10px] text-[#dff3ff]">next ${failure.operator_action}</span>`
+          ? html`<span class="rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-[10px] text-[#dff3ff]">next ${failure.operator_action}</span>`
           : null}
       </div>
       <div
@@ -297,7 +297,7 @@ export function LogViewer() {
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <select
-              class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded-md border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${levelFilter.value}
               onChange=${(e: Event) => {
                 levelFilter.value = (e.target as HTMLSelectElement).value
@@ -336,7 +336,7 @@ export function LogViewer() {
             />
 
             <select
-              class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded-md border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${String(logLimit.value)}
               onChange=${(e: Event) => {
                 logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -354,7 +354,7 @@ export function LogViewer() {
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
-            <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
+            <span class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
                 type="checkbox"
@@ -365,7 +365,7 @@ export function LogViewer() {
             </label>
             <button
               type="button"
-              class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]"
+              class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[var(--accent-10)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]"
               onClick=${() => {
                 latestSeq.value = null
                 logResource.reset()

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -202,7 +202,7 @@ function SortBar() {
         <div class="ml-auto flex items-center gap-2">
           ${selectedPostIds.value.size > 0 ? html`
             <button type="button"
-              class="px-3 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-[rgba(239,68,68,0.1)] text-[#f87171] border-[rgba(239,68,68,0.3)] hover:bg-[rgba(239,68,68,0.2)] disabled:opacity-50 disabled:cursor-not-allowed"
+              class="px-3 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[#f87171] border-[var(--bad-30)] hover:bg-[rgba(239,68,68,0.2)] disabled:opacity-50 disabled:cursor-not-allowed"
               onClick=${bulkDeleteSelected}
               disabled=${bulkDeleting.value}
             >
@@ -368,7 +368,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
           <!-- Delete button -->
           <button type="button"
-            class="ml-auto px-2 py-0.5 rounded text-[10px] font-semibold border border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.1)] text-[#f87171] hover:bg-[rgba(239,68,68,0.2)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="ml-auto px-2 py-0.5 rounded text-[10px] font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#f87171] hover:bg-[rgba(239,68,68,0.2)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${handleDelete}
             disabled=${isDeleting}
           >

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -760,10 +760,10 @@ export function formatMessageContent(content: string): string {
 /** Map log entry severity/outcome to Tailwind border class */
 export function logEntryBorderClass(severity?: string | null): string {
   switch (severity) {
-    case 'preview': return 'border-[rgba(251,191,36,0.26)]'
+    case 'preview': return 'border-[var(--warn-30)]'
     case 'confirmed':
-    case 'executed': return 'border-[rgba(74,222,128,0.26)]'
-    case 'error': return 'border-[rgba(239,68,68,0.26)]'
+    case 'executed': return 'border-[var(--ok-30)]'
+    case 'error': return 'border-[var(--bad-30)]'
     default: return ''
   }
 }

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { Markdown } from "../common/markdown"
+import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect } from 'preact/hooks'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
@@ -51,9 +51,9 @@ import { FlowControlPanel } from '../flow-control/flow-control-panel'
 function severityClass(value?: string | null): string {
   switch ((value ?? '').trim().toLowerCase()) {
     case 'bad':
-      return 'border-[rgba(239,68,68,0.26)] bg-[rgba(239,68,68,0.08)]'
+      return 'border-[var(--bad-30)] bg-[var(--bad-10)]'
     case 'warn':
-      return 'border-[rgba(251,191,36,0.26)] bg-[rgba(251,191,36,0.08)]'
+      return 'border-[var(--warn-30)] bg-[var(--warn-10)]'
     default:
       return 'border-[var(--card-border)] bg-[var(--white-3)]'
   }
@@ -359,7 +359,7 @@ function renderFriction(item: OperatorReviewItem | null) {
       ` : null}
       <details class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
         <summary class="cursor-pointer text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Raw Friction</summary>
-        <div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(item.friction, null, 2) + '\n```'} /></div>
+        <${JsonViewerCard} data=${item.friction} />
       </details>
     </div>
   `
@@ -597,7 +597,7 @@ export function Ops() {
 
                   ${confirmToken
                     ? html`
-                        <article class="p-3 rounded-xl border border-[rgba(251,191,36,0.26)] bg-[rgba(251,191,36,0.08)] grid gap-2">
+                        <article class="p-3 rounded-xl border border-[var(--warn-30)] bg-[var(--warn-10)] grid gap-2">
                           <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">승인 대기</div>
                           <div class="text-[13px] text-[var(--text-body)]">${confirmToken}</div>
                           <div class="flex gap-2 flex-wrap">

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -88,7 +88,7 @@ export function OpsKeeperColumn() {
                     ${displayStatus(keeper.status)}
                   </span>
                   <button type="button"
-                    class="text-[11px] py-0.5 px-2 rounded-md border border-[rgba(71,184,255,0.25)] bg-[rgba(71,184,255,0.08)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.18)] cursor-pointer transition-colors"
+                    class="text-[11px] py-0.5 px-2 rounded-md border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
                     onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
                   >상세 보기</button>
                 </div>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -1,7 +1,7 @@
 // Ops — Project-scope column: broadcast, pause/resume, task inject, recommended actions, pending confirmations, shared feed
 
 import { html } from 'htm/preact'
-import { Markdown } from "../common/markdown"
+import { JsonViewerCard } from '../common/json-viewer'
 import { signal } from '@preact/signals'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
@@ -192,7 +192,7 @@ export function OpsRoomColumn() {
                   <span>${item.delegated_tool ?? '위임 도구 확인 필요'}</span>
                   <span>owner ${item.actor ?? 'unknown'}</span>
                 </div>
-                ${item.preview ? html`<div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(item.preview, null, 2) + '\n```'} /></div>` : null}
+                ${item.preview ? html`<${JsonViewerCard} data=${item.preview} title="Preview" />` : null}
                 <div class="mt-2 text-[12px] leading-[1.45] text-[var(--text-muted)]">
                   ${canManage ? '' : '읽기 전용'}
                 </div>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -1,8 +1,8 @@
 // Ops — Session column: session list, selected session digest, session actions
 
 import { signal } from '@preact/signals'
-import { Markdown } from "../common/markdown"
 import { html } from 'htm/preact'
+import { JsonViewerCard } from '../common/json-viewer'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import {
@@ -294,7 +294,7 @@ export function OpsSessionColumn() {
                 : null}
             ` : null}
             ${selectedSession.recent_events && selectedSession.recent_events.length > 0 ? html`
-              <div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(selectedSession.recent_events.slice(-3), null, 2) + '\n```'} /></div>
+              <${JsonViewerCard} data=${selectedSession.recent_events.slice(-3)} title="Recent Events" />
             ` : null}
           </div>
         ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 세션을 하나 고르세요.</div>`}

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -163,7 +163,7 @@ function toneBorderClass(tone: SituationTone): string {
 
 function toneBgClass(tone: SituationTone): string {
   if (tone === 'bad') return 'bg-[rgba(239,68,68,0.06)]'
-  if (tone === 'warn') return 'bg-[rgba(251,191,36,0.05)]'
+  if (tone === 'warn') return 'bg-[var(--warn-10)]'
   return 'bg-[var(--white-3)]'
 }
 

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { Markdown } from "./common/markdown"
+import { JsonViewerCard } from './common/json-viewer'
 import { useEffect } from 'preact/hooks'
 import { Card, CARD_STANDARD } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -214,7 +214,7 @@ export function Proof() {
           <${KeyValueGrid} rows=${goalBindingRows} />
           <details class="pt-1 border-t border-[var(--white-6)] mt-2">
             <summary class="cursor-pointer text-[12px] text-[var(--text-muted)] py-1.5 hover:text-[var(--text-body)] transition-colors">원본 목표 연결 JSON</summary>
-            <div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(snapshot?.goal_binding ?? {}, null, 2) + '\n```'} /></div>
+            <${JsonViewerCard} data=${snapshot?.goal_binding ?? {}} title="Goal Binding" />
           </details>
         <//>
       </div>
@@ -280,7 +280,7 @@ export function Proof() {
           <${KeyValueGrid} rows=${backingSummaryRows} />
           <details class="pt-1 border-t border-[var(--white-6)] mt-2">
             <summary class="cursor-pointer text-[12px] text-[var(--text-muted)] py-1.5 hover:text-[var(--text-body)] transition-colors">원본 CPv2 backing JSON</summary>
-            <div class=\"max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]\"><${Markdown} text=${'```json\n' + JSON.stringify(cpEvidence ?? {}, null, 2) + '\n```'} /></div>
+            <${JsonViewerCard} data=${cpEvidence ?? {}} title="Evidence" />
           </details>
         <//>
       </div>

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -35,7 +35,7 @@ const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; colo
   { match: n => n.includes('bash'),                          icon: '>', color: 'text-[#4ade80]' },
   { match: n => n.includes('edit') || n.includes('fs'),      icon: 'E', color: 'text-[#fbbf24]' },
   { match: n => n.includes('board') || n.includes('social'), icon: 'B', color: 'text-[#a78bfa]' },
-  { match: n => n.includes('github'),                        icon: 'G', color: 'text-[#9ad9ff]' },
+  { match: n => n.includes('github'),                        icon: 'G', color: 'text-[var(--accent)]' },
   { match: n => n.includes('search') || n.includes('read'),  icon: 'R', color: 'text-[#60a5fa]' },
 ]
 
@@ -102,7 +102,7 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
         </div>
       ` : null}
       ${gateRejected ? html`
-        <div class="text-[10px] px-2 py-1 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444] inline-block">
+        <div class="text-[10px] px-2 py-1 rounded bg-[var(--bad-10)] text-[#ef4444] inline-block">
           거부: ${event.gate?.reason ?? ''}
         </div>
       ` : null}
@@ -175,8 +175,8 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
               ${taskIcon(String(event.detail.type))}
             </span>
           ` : null}
-          ${event.error ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">오류</span>` : null}
-          ${gateRejected ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444]">거부</span>` : null}
+          ${event.error ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[#ef4444]">오류</span>` : null}
+          ${gateRejected ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[#ef4444]">거부</span>` : null}
         </div>
         <div class="mt-0.5 text-[11px] text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
           ${summaryText}

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -131,7 +131,7 @@ export function PromptRegistryPanel() {
               <button
                 type="button"
                 class="rounded-lg border px-3 py-2 text-left transition-colors ${selectedPrompt?.key === prompt.key
-                  ? 'border-[rgba(71,184,255,0.35)] bg-[rgba(71,184,255,0.12)]'
+                  ? 'border-[var(--accent-30)] bg-[var(--accent-10)]'
                   : 'border-[var(--card-border)] bg-[var(--white-2)] hover:bg-[var(--white-4)]'}"
                 onClick=${() => {
                   setSelectedKey(prompt.key)

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -101,10 +101,10 @@ function removeFromList(listSig: typeof alsoAllowItems, name: string) {
 
 function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void }) {
   return html`
-    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">
+    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
       ${name}
       <button type="button"
-        class="text-[#9ad9ff]/50 hover:text-[#ff6b6b] cursor-pointer text-[11px] leading-none transition-colors"
+        class="text-[var(--accent)]/50 hover:text-[#ff6b6b] cursor-pointer text-[11px] leading-none transition-colors"
         onClick=${onRemove}
         title="제거"
       >\u00d7</button>
@@ -114,7 +114,7 @@ function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void 
 
 function ReadOnlyChip({ name }: { name: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">
+    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
       ${name}
     </span>
   `
@@ -267,8 +267,8 @@ function ToolSearchPicker({
                     ...${getItemProps({ item: name, index: idx })}
                     class=${`w-full flex items-start gap-2 text-left px-3 py-1.5 cursor-pointer transition-colors ${
                       highlightedIndex === idx
-                        ? 'bg-[rgba(71,184,255,0.16)] text-[#9ad9ff]'
-                        : 'hover:bg-[rgba(71,184,255,0.08)]'
+                        ? 'bg-[var(--accent-soft)] text-[var(--accent)]'
+                        : 'hover:bg-[var(--accent-10)]'
                     }`}
                   >
                     <span class="text-[11px] text-[var(--text-body)] font-medium shrink-0">${name}</span>
@@ -443,7 +443,7 @@ export function ToolAllowlistEditor({
           <button type="button"
             class=${`py-1 px-3 rounded-lg text-[10px] font-medium border transition-colors cursor-pointer ${
               policyMode.value === mode
-                ? 'border-[rgba(71,184,255,0.35)] bg-[rgba(71,184,255,0.16)] text-[#9ad9ff]'
+                ? 'border-[var(--accent-30)] bg-[var(--accent-soft)] text-[var(--accent)]'
                 : 'border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)]'
             }`}
             onClick=${() => { policyMode.value = mode; textInputSection.value = null }}
@@ -494,7 +494,7 @@ export function ToolAllowlistEditor({
 
             ${isCustomEmpty
               ? html`
-                <div class="flex flex-col gap-2 px-3 py-2 rounded-lg bg-[rgba(239,68,68,0.12)] border border-[rgba(239,68,68,0.3)]">
+                <div class="flex flex-col gap-2 px-3 py-2 rounded-lg bg-[rgba(239,68,68,0.12)] border border-[var(--bad-30)]">
                   <div class="flex items-start gap-2">
                     <span class="text-red-400 text-[13px] shrink-0 font-bold">0</span>
                     <span class="text-[11px] text-red-300 leading-snug">
@@ -504,7 +504,7 @@ export function ToolAllowlistEditor({
                   ${resolvedAllowlist.length > 0
                     ? html`
                       <button type="button"
-                        class="self-start py-1 px-3 rounded-lg text-[10px] font-medium border border-[rgba(71,184,255,0.35)] bg-[rgba(71,184,255,0.12)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.22)] cursor-pointer transition-colors"
+                        class="self-start py-1 px-3 rounded-lg text-[10px] font-medium border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.22)] cursor-pointer transition-colors"
                         onClick=${() => { customAllowItems.value = [...resolvedAllowlist] }}
                       >현재 resolved list에서 복사 (${resolvedAllowlist.length}개)</button>
                     `

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -1,134 +1,118 @@
-/* MASC Dashboard — CSS Custom Properties (legacy compat) */
+/* MASC Dashboard — CSS Custom Properties (Semantic Theme System) */
 
 :root {
-  --bg-0: #0b1220;
-  --card: rgba(16, 24, 42, 0.92);
-  --card-border: rgba(138, 163, 211, 0.2);
+  /* Base & Backgrounds */
+  --bg-root: #0b1220;
+  --bg-panel: rgba(16, 24, 42, 0.92);
+  --bg-panel-hover: rgba(30, 41, 59, 0.95);
+  
+  /* Text & Typography */
   --text-strong: #eaf1ff;
   --text-body: #c0d2f2;
   --text-muted: #a8bfdf;
+  --text-dim: #a0a8b4;
+  
+  /* Borders */
+  --border-subtle: rgba(138, 163, 211, 0.12);
+  --border-base: rgba(138, 163, 211, 0.2);
+  --border-strong: rgba(138, 163, 211, 0.35);
+
+  /* Semantic Colors (Core) */
   --accent: #47b8ff;
-  --accent-soft: rgba(71, 184, 255, 0.16);
   --ok: #4ade80;
   --warn: #fbbf24;
   --bad: #ef4444;
-  --radius-lg: 12px;
-  --radius-md: 8px;
-  --radius-sm: 6px;
-  --header-h: 94px;
 
-  /* Agent status (soft tones) */
-  --agent-working: #7ae09a;
-  --agent-busy: #f0c060;
+  /* Semantic - Accent (Blue) */
+  --accent-soft: rgba(71, 184, 255, 0.16);
+  --accent-10: rgba(71, 184, 255, 0.10);
+  --accent-20: rgba(71, 184, 255, 0.20);
+  --accent-30: rgba(71, 184, 255, 0.30);
 
-  /* Tone variants */
-  --bad-light: #f87171;
+  /* Semantic - Success (Green) */
+  --ok-soft: rgba(74, 222, 128, 0.15);
+  --ok-10: rgba(74, 222, 128, 0.10);
+  --ok-20: rgba(74, 222, 128, 0.20);
+
+  /* Semantic - Warning (Yellow) */
   --warn-bright: #f97316;
+  --warn-soft: rgba(251, 191, 36, 0.15);
+  --warn-10: rgba(251, 191, 36, 0.10);
+  --warn-20: rgba(251, 191, 36, 0.20);
 
-  /* White overlay (glass morphism tints) */
-  --white-2: rgba(255, 255, 255, 0.02);
+  /* Semantic - Critical (Red) */
+  --bad-light: #f87171;
+  --bad-soft: rgba(239, 68, 68, 0.15);
+  --bad-10: rgba(239, 68, 68, 0.10);
+  --bad-20: rgba(239, 68, 68, 0.20);
+
+  /* Overlays (White Alpha) */
   --white-3: rgba(255, 255, 255, 0.03);
-  --white-3h: rgba(255, 255, 255, 0.035);
-  --white-4: rgba(255, 255, 255, 0.04);
   --white-5: rgba(255, 255, 255, 0.05);
-  --white-6: rgba(255, 255, 255, 0.06);
-  --white-8: rgba(255, 255, 255, 0.08);
   --white-10: rgba(255, 255, 255, 0.10);
-  --white-12: rgba(255, 255, 255, 0.12);
   --white-20: rgba(255, 255, 255, 0.20);
-  --white-25: rgba(255, 255, 255, 0.25);
+  --white-50: rgba(255, 255, 255, 0.50);
+  --white-80: rgba(255, 255, 255, 0.80);
+
+  /* Legacy Compatibility Variables */
+  --bg-0: var(--bg-root);
+  --card: var(--bg-panel);
+  --card-border: var(--border-base);
+  --accent-8: var(--accent-10);
+  --accent-12: var(--accent-10);
+  --accent-14: var(--accent-10);
+  --accent-18: var(--accent-20);
+  --ok-8: var(--ok-10);
+  --ok-12: var(--ok-10);
+  --ok-18: var(--ok-20);
+  --ok-22: var(--ok-20);
+  --ok-24: var(--ok-20);
+  --ok-25: var(--ok-20);
+  --ok-30: rgba(74, 222, 128, 0.30);
+  --ok-35: rgba(74, 222, 128, 0.30);
+  --ok-40: rgba(74, 222, 128, 0.40);
+  --ok-48: rgba(74, 222, 128, 0.50);
+  --bad-8: var(--bad-10);
+  --bad-12: var(--bad-10);
+  --bad-15: var(--bad-10);
+  --bad-30: rgba(248, 113, 113, 0.3);
+  --warn-12: var(--warn-10);
+  --warn-15: var(--warn-10);
+  --warn-28: var(--warn-30);
+  --warn-30: rgba(251, 191, 36, 0.3);
+  --white-2: var(--white-3);
+  --white-3h: var(--white-3);
+  --white-4: var(--white-5);
+  --white-6: var(--white-5);
+  --white-8: var(--white-10);
+  --white-12: var(--white-10);
+  --white-25: var(--white-20);
   --white-30: rgba(255, 255, 255, 0.30);
   --white-35: rgba(255, 255, 255, 0.35);
   --white-40: rgba(255, 255, 255, 0.40);
   --white-45: rgba(255, 255, 255, 0.45);
-  --white-50: rgba(255, 255, 255, 0.50);
-  --white-55: rgba(255, 255, 255, 0.55);
-  --white-56: rgba(255, 255, 255, 0.56);
+  --white-55: var(--white-50);
+  --white-56: var(--white-50);
   --white-60: rgba(255, 255, 255, 0.60);
-  --white-68: rgba(255, 255, 255, 0.68);
+  --white-68: rgba(255, 255, 255, 0.70);
   --white-70: rgba(255, 255, 255, 0.70);
-  --white-72: rgba(255, 255, 255, 0.72);
-  --white-78: rgba(255, 255, 255, 0.78);
-  --white-82: rgba(255, 255, 255, 0.82);
+  --white-72: rgba(255, 255, 255, 0.70);
+  --white-78: var(--white-80);
+  --white-82: var(--white-80);
   --white-90: rgba(255, 255, 255, 0.9);
+  --border-slate-8: var(--border-subtle);
+  --border-slate-12: var(--border-subtle);
+  --border-slate-16: var(--border-base);
+  --border-slate-18: var(--border-base);
+  --border-slate-22: var(--border-base);
+  --border-slate-30: var(--border-strong);
+  --border-slate-35: var(--border-strong);
 
-  /* Border slate (138, 163, 211) */
-  --border-slate-8: rgba(138, 163, 211, 0.08);
-  --border-slate-12: rgba(138, 163, 211, 0.12);
-  --border-slate-16: rgba(138, 163, 211, 0.16);
-  --border-slate-18: rgba(138, 163, 211, 0.18);
-  --border-slate-22: rgba(138, 163, 211, 0.22);
-  --border-slate-30: rgba(138, 163, 211, 0.3);
-  --border-slate-35: rgba(138, 163, 211, 0.35);
-
-  /* OK / green (74, 222, 128) */
-  --ok-8: rgba(74, 222, 128, 0.08);
-  --ok-10: rgba(74, 222, 128, 0.10);
-  --ok-12: rgba(74, 222, 128, 0.12);
-  --ok-soft: rgba(74, 222, 128, 0.15);
-  --ok-18: rgba(74, 222, 128, 0.18);
-  --ok-20: rgba(74, 222, 128, 0.2);
-  --ok-22: rgba(74, 222, 128, 0.22);
-  --ok-24: rgba(74, 222, 128, 0.24);
-  --ok-25: rgba(74, 222, 128, 0.25);
-  --ok-30: rgba(74, 222, 128, 0.30);
-  --ok-35: rgba(74, 222, 128, 0.35);
-  --ok-40: rgba(74, 222, 128, 0.40);
-  --ok-48: rgba(74, 222, 128, 0.48);
-
-  /* Bad / red (239, 68, 68 and 248, 113, 113) */
-  --bad-soft: rgba(239, 68, 68, 0.15);
-  --bad-12: rgba(239, 68, 68, 0.12);
-  --bad-8: rgba(248, 113, 113, 0.08);
-  --bad-15: rgba(248, 113, 113, 0.15);
-  --bad-30: rgba(248, 113, 113, 0.3);
-
-  /* Warn / yellow (251, 191, 36) */
-  --warn-soft: rgba(251, 191, 36, 0.15);
-  --warn-12: rgba(251, 191, 36, 0.12);
-  --warn-15: rgba(251, 191, 36, 0.15);
-  --warn-20: rgba(251, 191, 36, 0.2);
-  --warn-28: rgba(251, 191, 36, 0.28);
-  --warn-30: rgba(251, 191, 36, 0.3);
-
-  /* Accent / blue (71, 184, 255) */
-  --accent-8: rgba(71, 184, 255, 0.08);
-  --accent-10: rgba(71, 184, 255, 0.10);
-  --accent-12: rgba(71, 184, 255, 0.12);
-  --accent-14: rgba(71, 184, 255, 0.14);
-  --accent-18: rgba(71, 184, 255, 0.18);
-  --accent-20: rgba(71, 184, 255, 0.20);
-
-  /* Cyan (34, 211, 238) */
-  --cyan-12: rgba(34, 211, 238, 0.12);
-  --cyan-16: rgba(34, 211, 238, 0.16);
-
-  /* FF gold (200, 168, 78) */
-  --ff-gold-8: rgba(200, 168, 78, 0.08);
-  --ff-gold-10: rgba(200, 168, 78, 0.1);
-  --ff-gold-15: rgba(200, 168, 78, 0.15);
-  --ff-gold-20: rgba(200, 168, 78, 0.2);
-
-  /* Slate gray (148, 163, 184) */
-  --slate-gray-8: rgba(148, 163, 184, 0.08);
-  --slate-gray-10: rgba(148, 163, 184, 0.1);
-  --slate-gray-12: rgba(148, 163, 184, 0.12);
-  --slate-gray-15: rgba(148, 163, 184, 0.15);
-  --slate-gray-20: rgba(148, 163, 184, 0.2);
-
-  /* FF navy (10, 22, 40) */
-  --ff-navy-44: rgba(10, 22, 40, 0.44);
-  --ff-navy-60: rgba(10, 22, 40, 0.6);
-
-  /* Blue-400 (96, 165, 250) */
-  --blue-400-8: rgba(96, 165, 250, 0.08);
-  --blue-400-15: rgba(96, 165, 250, 0.15);
-
-  /* Frost (226, 232, 240) */
-  --frost-72: rgba(226, 232, 240, 0.72);
-
-  /* Dark panels (15, 23, 42) */
-  --panel-dark-60: rgba(15, 23, 42, 0.6);
+  /* Layout & Sizing */
+  --radius-lg: 12px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
+  --header-h: 94px;
 
   /* Font-size scale */
   --fs-2xs: 11px;
@@ -138,19 +122,61 @@
   --fs-md: 15px;
   --fs-lg: 16px;
 
-  /* Extended text scale */
-  --text-dim: #a0a8b4;
-  --text-slate: #b0bfd4;
-  --text-slate-light: #cbd5e1;
-
   /* Extended palette */
   --cyan: #22d3ee;
+  --cyan-12: rgba(34, 211, 238, 0.12);
+  --cyan-16: rgba(34, 211, 238, 0.16);
   --purple: #a78bfa;
+  --text-slate: #b0bfd4;
+  --text-slate-light: #cbd5e1;
   --text-near-white: #f8fafc;
+  
+  --ff-gold-8: rgba(200, 168, 78, 0.08);
+  --ff-gold-10: rgba(200, 168, 78, 0.1);
+  --ff-gold-15: rgba(200, 168, 78, 0.15);
+  --ff-gold-20: rgba(200, 168, 78, 0.2);
+  --slate-gray-8: rgba(148, 163, 184, 0.08);
+  --slate-gray-10: rgba(148, 163, 184, 0.1);
+  --slate-gray-12: rgba(148, 163, 184, 0.12);
+  --slate-gray-15: rgba(148, 163, 184, 0.15);
+  --slate-gray-20: rgba(148, 163, 184, 0.2);
+  --ff-navy-44: rgba(10, 22, 40, 0.44);
+  --ff-navy-60: rgba(10, 22, 40, 0.6);
+  --blue-400-8: rgba(96, 165, 250, 0.08);
+  --blue-400-15: rgba(96, 165, 250, 0.15);
+  --frost-72: rgba(226, 232, 240, 0.72);
+  --panel-dark-60: rgba(15, 23, 42, 0.6);
+  --agent-working: #7ae09a;
+  --agent-busy: #f0c060;
 
-  /* Stacking layers (low -> high) */
+  /* Stacking layers */
   --z-layout: 1;
   --z-tab-sticky: 30;
   --z-header: 40;
-  /* Overlay z-index: fallback values in each component (keeper:3020 agent:3030 trpg:3040 toast:3070 tooltip:3080) */
 }
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-root: #f8fafc;
+    --bg-panel: rgba(255, 255, 255, 0.95);
+    --bg-panel-hover: rgba(241, 245, 249, 0.95);
+    
+    --text-strong: #0f172a;
+    --text-body: #334155;
+    --text-muted: #64748b;
+    --text-dim: #94a3b8;
+    
+    --border-subtle: rgba(15, 23, 42, 0.08);
+    --border-base: rgba(15, 23, 42, 0.15);
+    --border-strong: rgba(15, 23, 42, 0.25);
+
+    /* Overlays */
+    --white-3: rgba(0, 0, 0, 0.03);
+    --white-5: rgba(0, 0, 0, 0.05);
+    --white-10: rgba(0, 0, 0, 0.10);
+    --white-20: rgba(0, 0, 0, 0.20);
+    --white-50: rgba(0, 0, 0, 0.50);
+    --white-80: rgba(0, 0, 0, 0.80);
+  }
+}
+

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -56,6 +56,7 @@
 
   /* Legacy Compatibility Variables */
   --bg-0: var(--bg-root);
+  --bg-1: var(--bg-panel-hover);
   --card: var(--bg-panel);
   --card-border: var(--border-base);
   --accent-8: var(--accent-10);
@@ -160,6 +161,7 @@
     --bg-root: #f8fafc;
     --bg-panel: rgba(255, 255, 255, 0.95);
     --bg-panel-hover: rgba(241, 245, 249, 0.95);
+    --bg-1: var(--bg-panel-hover);
     
     --text-strong: #0f172a;
     --text-body: #334155;
@@ -179,4 +181,3 @@
     --white-80: rgba(0, 0, 0, 0.80);
   }
 }
-


### PR DESCRIPTION
## Summary
- Introduce `JsonViewer` / `JsonViewerCard` so deeply nested structured data can be inspected as a collapsible tree instead of stringified markdown blocks.
- Improve command palette entity mappings and accessibility follow-ups around the JSON viewer.
- Sync the branch onto current `main` so stale merge-ref test expectations no longer fail unrelated CI.

## Product impact
- Makes raw telemetry, proof data, traces, and bindings much easier to inspect in the dashboard.
- Improves command palette navigation quality and basic accessibility semantics for viewer toggles.

## Evidence
- `opam exec -- dune build --root .`
- `pnpm -C dashboard build`
- `./_build/default/test/test_dashboard_collaboration_evidence.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- GitHub Actions reran on current head `815c284cf29d242d78da662900518b983f089ac4`

## Review evidence
- Existing cross-model review on feature head `d3aab57ec886d9ca430fbae709933962a74575b8` at 2026-04-04 12:43:55 KST: GLM-5 via `sb glm-text` -> `NO_HIGH_CRITICAL_FINDINGS`.
- Sync follow-up on `815c284cf29d242d78da662900518b983f089ac4` only merges current `main`; the dashboard feature diff itself is unchanged and was revalidated locally with the evidence above.

## Linked issue
- Refs #4969

Introduced a collapsible JSON tree viewer for deep nested arrays and objects replacing simple stringified markdown blocks. Improves readability of raw friction, traces, goal bindings, and proof data.
