### PR TITLE
fix: address review followups from #4940 and #4942

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -201,15 +201,15 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
   return html`
     <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded-lg border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
       <table class="w-full text-xs">
-        <thead class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md shadow-[0_1px_2px_rgba(0,0,0,0.2)]">
+        <thead>
           <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
-            <th class="text-left py-2.5 px-3 font-medium">#</th>
-            <th class="text-left py-2.5 px-3 font-medium">가설</th>
-            <th class="text-right py-2.5 px-3 font-medium">이전</th>
-            <th class="text-right py-2.5 px-3 font-medium">이후</th>
-            <th class="text-right py-2.5 px-3 font-medium">변화</th>
-            <th class="text-center py-2.5 px-3 font-medium">판정</th>
-            <th class="text-right py-2.5 px-3 font-medium">시간</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">#</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">가설</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이전</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이후</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">변화</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-center py-2.5 px-3 font-medium">판정</th>
+            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
           </tr>
         </thead>
         <tbody>

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -87,11 +87,9 @@ let [@warning "-32"] cleanup_expired () =
     stale-while-revalidate can fork background fibers. *)
 let _bg_sw : Eio.Switch.t option ref = ref None
 
-type any_clock = Clock : _ Eio.Time.clock -> any_clock
-
-let clock_ref : any_clock option ref = ref None
-
-let set_clock clk = clock_ref := Some (Clock clk)
+(* clock_ref removed: Time_compat.sleep is the single sleep path
+   since the Fiber.yield spin-loop fix (#4948). *)
+let set_clock _clk = ()
 
 let set_sw sw = _bg_sw := Some sw
 
@@ -210,13 +208,8 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
     | `Hit v -> v
     | `Timed_out -> raise (Compute_timeout (key, true))
     | `Wait slot_cond ->
-      (* Sleep briefly outside the mutex. Prefer the cache-local Eio clock when
-         tests or embedders registered one via [set_clock], and fall back to
-         Time_compat so server paths without an explicit local clock still
-         avoid the pre-fix Fiber.yield spin loop. *)
-      (match !clock_ref with
-       | Some (Clock clk) -> Eio.Time.sleep clk wait_poll_interval_sec
-       | None -> Time_compat.sleep wait_poll_interval_sec);
+      (* Sleep briefly outside the mutex — cooperative suspension point. *)
+      Time_compat.sleep wait_poll_interval_sec;
       try_get ~waited:(waited +. wait_poll_interval_sec)
         ~watching_cond:(Some slot_cond)
     | `Stale (stale_value, cond) ->

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -10,8 +10,8 @@
     This prevents slow endpoints from blocking HTTP responses. *)
 
 val set_clock : _ Eio.Time.clock -> unit
-(** Register the Eio clock for bounded-wait poll loops.
-    Call once inside [Eio_main.run] after {!Eio_guard.enable}. *)
+(** No-op since #4948 (Time_compat.sleep is the sole sleep path).
+    Retained for backward compatibility with existing callers. *)
 
 val set_sw : Eio.Switch.t -> unit
 (** Register the server switch for background revalidation fibers.

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -542,12 +542,12 @@ let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
    tree which can be several MB.  Unbounded growth caused OOM when the
    dashboard was connected for extended periods (#4795). *)
 let _snapshot_max_entries =
-  match Sys.getenv_opt "MASC_DASHBOARD_SNAPSHOT_CACHE_MAX_ENTRIES" with
-  | Some s -> (try max 4 (min 64 (int_of_string (String.trim s))) with Failure _ -> 16)
-  | None -> 16
+  Dashboard_http_helpers.int_of_env_default
+    "MASC_DASHBOARD_SNAPSHOT_CACHE_MAX_ENTRIES" ~default:16 ~min_v:4 ~max_v:64
 
-(* Evict one expired or oldest entry when table exceeds _snapshot_max_entries.
-   Must be called inside _snapshot_mu. *)
+(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
+   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
+   single-threaded so no lock is needed. *)
 let _maybe_evict_snapshot () =
   if Hashtbl.length _snapshot_table >= _snapshot_max_entries then begin
     let now_ts = Time_compat.now () in
@@ -563,19 +563,25 @@ let _maybe_evict_snapshot () =
      | Some key -> Hashtbl.remove _snapshot_table key
      | None ->
        (* All fresh or computing — evict the entry closest to expiry *)
-       let oldest = ref None in
+       let oldest_cached = ref None in
+       let any_key = ref None in
        Hashtbl.iter (fun key slot ->
          match slot with
          | Cached { expires_at; _ } ->
-           (match !oldest with
-            | None -> oldest := Some (key, expires_at)
-            | Some (_, e) when expires_at < e -> oldest := Some (key, expires_at)
+           (match !oldest_cached with
+            | None -> oldest_cached := Some (key, expires_at)
+            | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
             | _ -> ())
-         | _ -> ()
+         | Computing _ ->
+           if !any_key = None then any_key := Some key
        ) _snapshot_table;
-       (match !oldest with
+       (match !oldest_cached with
         | Some (key, _) -> Hashtbl.remove _snapshot_table key
-        | None -> ()))
+        | None ->
+          (* Last resort: evict a Computing slot to enforce the cap *)
+          (match !any_key with
+           | Some key -> Hashtbl.remove _snapshot_table key
+           | None -> ())))
   end
 
 let invalidate_snapshot_cache () =

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -85,19 +85,19 @@ let direct_adapters =
       canonical_name = cn_llama;
       runtime_kind = Local;
       auth_mode = No_auth;
-      aliases = [ "llama"; "llama.cpp"; "llamacpp" ];
+      aliases = [ cn_llama; "llama.cpp"; "llamacpp" ];
     };
     {
       canonical_name = cn_claude;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ANTHROPIC_API_KEY";
-      aliases = [ "claude-api"; "claude"; "anthropic" ];
+      aliases = [ cn_claude; "claude"; "anthropic" ];
     };
     {
       canonical_name = cn_codex;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENAI_API_KEY";
-      aliases = [ "codex-api"; "openai" ];
+      aliases = [ cn_codex; "openai" ];
     };
     {
       canonical_name = cn_gemini;
@@ -108,19 +108,19 @@ let direct_adapters =
             project_env = google_cloud_project_env;
             location_env = google_cloud_location_env;
           };
-      aliases = [ "gemini-api"; "gemini"; "google" ];
+      aliases = [ cn_gemini; "gemini"; "google" ];
     };
     {
       canonical_name = cn_glm;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ZAI_API_KEY";
-      aliases = [ "glm"; "glm_cloud"; "zai" ];
+      aliases = [ cn_glm; "glm_cloud"; "zai" ];
     };
     {
       canonical_name = cn_openrouter;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENROUTER_API_KEY";
-      aliases = [ "openrouter" ];
+      aliases = [ cn_openrouter ];
     };
   ]
 
@@ -501,9 +501,10 @@ let auth_env_var_of_adapter (adapter : adapter) =
 let provider_auth_available label =
   match resolve_direct_adapter label with
   | Some adapter ->
-      (match auth_env_var_of_adapter adapter with
-       | Some env_name -> env_present env_name
-       | None -> true)
+      (match adapter.auth_mode with
+       | No_auth -> true
+       | Api_key env_name -> env_present env_name
+       | Vertex_adc { project_env; _ } -> env_present project_env)
   | None -> false
 
 (** Derive the auth_kind string for a provider by looking up its
@@ -600,9 +601,10 @@ let default_model_label_for_adapter (adapter : adapter) =
     hardcoding vendor env var names. *)
 let auto_label_for_adapter (adapter : adapter) =
   let is_available =
-    match auth_env_var_of_adapter adapter with
-    | Some env_name -> env_present env_name
-    | None -> true  (* No_auth providers always available *)
+    match adapter.auth_mode with
+    | No_auth -> true
+    | Api_key env_name -> env_present env_name
+    | Vertex_adc { project_env; _ } -> env_present project_env
   in
   if not is_available then None
   else


### PR DESCRIPTION
## Summary
Batch follow-up for review comments from recently merged PRs.

### From #4942 (provider_adapter)
- Fix Gemini Vertex_adc auto-detection: was always-available, now checks GOOGLE_CLOUD_PROJECT
- Use cn_* constants in aliases arrays (single definition point)

### From #4940 (operator_control_snapshot)
- Replace manual env parsing with Dashboard_http_helpers.int_of_env_default
- Add Computing slot fallback eviction so snapshot cache cap enforced
- Fix mutex comment to match pre-Eio calling convention

### From #4935 (autoresearch table)
- Move sticky from thead to th for Safari compatibility
- Add scope="col" for accessibility

### From #4948 (dashboard_cache dead code)
- Remove clock_ref/any_clock — dead state after Time_compat.sleep switch
- Simplify to single Time_compat.sleep call; set_clock retained as no-op

### Resolved by upstream merges (dropped during rebase)
- #4932 html escaping — resolved by #4951 (JsonViewerCard replaced Markdown blocks)
- #4951/#4959 --bg-1 — resolved by #4951 theme system upgrade (--bg-1: var(--bg-panel-hover))

Refs #4940, #4942, #4935, #4948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)