### PR TITLE
feat: Expand structured data viewer to Traces, Goals, and Tool results

### DIFF
--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -1,6 +1,17 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
 
+export function parseJsonLikeData(data: unknown): unknown {
+  if (typeof data !== 'string') return data
+  const trimmed = data.trim()
+  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return data
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return data
+  }
+}
+
 export function JsonViewer({ data, label, initialCollapsed = false, level = 0, ancestors = [] }: { data: unknown; label?: string; initialCollapsed?: boolean; level?: number; ancestors?: object[] }) {
   const [collapsed, setCollapsed] = useState(initialCollapsed)
 
@@ -19,7 +30,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
   if (!isObject) {
     let valueNode
     if (typeof data === 'string') {
-      valueNode = html`<span class="text-[var(--ok)] break-all">"${data}"</span>`
+      valueNode = html`<span class="text-[var(--ok)] whitespace-pre-wrap break-words">"${data}"</span>`
     } else if (typeof data === 'number') {
       valueNode = html`<span class="text-[var(--warn)]">${data}</span>`
     } else if (typeof data === 'boolean') {

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -1,0 +1,92 @@
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+
+export function JsonViewer({ data, label, initialCollapsed = false, level = 0, ancestors = [] }: { data: unknown; label?: string; initialCollapsed?: boolean; level?: number; ancestors?: object[] }) {
+  const [collapsed, setCollapsed] = useState(initialCollapsed)
+
+  const isObject = data !== null && typeof data === 'object'
+  const isArray = Array.isArray(data)
+
+  if (isObject && ancestors.includes(data as object)) {
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--text-muted)] italic">[Circular]</span>
+      </div>
+    `
+  }
+
+  if (!isObject) {
+    let valueNode
+    if (typeof data === 'string') {
+      valueNode = html`<span class="text-[var(--ok)] break-all">"${data}"</span>`
+    } else if (typeof data === 'number') {
+      valueNode = html`<span class="text-[var(--warn)]">${data}</span>`
+    } else if (typeof data === 'boolean') {
+      valueNode = html`<span class="text-[#e27e8d]">${data ? 'true' : 'false'}</span>`
+    } else if (data === null) {
+      valueNode = html`<span class="text-[var(--text-muted)] italic">null</span>`
+    } else {
+      valueNode = html`<span class="text-[var(--text-muted)]">${String(data)}</span>`
+    }
+
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <div class="min-w-0 break-words">${valueNode}</div>
+      </div>
+    `
+  }
+
+  const entries = isArray ? (data as unknown[]) : Object.entries(data as Record<string, unknown>)
+  const isEmpty = isArray ? (data as unknown[]).length === 0 : entries.length === 0
+  const nextAncestors = isObject ? [...ancestors, data as object] : ancestors
+  const toggleLabel = label ?? (isArray ? 'JSON array' : 'JSON object')
+
+  if (isEmpty) {
+    return html`
+      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5">
+        ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
+        <span class="text-[var(--text-muted)]">${isArray ? '[]' : '{}'}</span>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="font-mono text-[13px] leading-relaxed flex flex-col py-0.5 w-full min-w-0">
+      <button
+        type="button"
+        class="flex items-center gap-1.5 cursor-pointer hover:bg-[var(--white-4)] rounded px-1 -mx-1 select-none w-max max-w-full text-left bg-transparent border-0"
+        onClick=${() => setCollapsed(!collapsed)}
+        aria-expanded=${!collapsed}
+        aria-label=${`${collapsed ? 'Expand' : 'Collapse'} ${toggleLabel}`}
+      >
+        <span aria-hidden="true" class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
+        ${label ? html`<span class="text-[var(--text-body)] font-medium truncate">${label}</span>` : null}
+        <span class="text-[var(--text-muted)] text-[11px] ml-1 shrink-0">
+          ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}
+        </span>
+      </button>
+
+      ${!collapsed && html`
+        <div class="pl-4 ml-1.5 border-l border-[var(--white-4)] mt-1 flex flex-col gap-0.5 w-full min-w-0">
+          ${isArray
+            ? (data as unknown[]).map((val, idx) => html`<${JsonViewer} key=${idx} data=${val} label=${String(idx)} level=${level + 1} initialCollapsed=${level >= 2} ancestors=${nextAncestors} />`)
+            : (entries as [string, unknown][]).map(([k, v]) => html`<${JsonViewer} key=${k} data=${v} label=${k} level=${level + 1} initialCollapsed=${level >= 2} ancestors=${nextAncestors} />`)
+          }
+        </div>
+      `}
+    </div>
+  `
+}
+
+export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
+  return html`
+    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded-xl overflow-hidden flex flex-col max-h-[400px]">
+      ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-[11px] uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
+      <div class="p-3 overflow-y-auto min-h-0 w-full">
+        <${JsonViewer} data=${data} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -5,10 +5,6 @@ import '@testing-library/jest-dom'
 import type { UnifiedTraceEvent } from '../session-trace/session-trace-state'
 import { activeFilter } from './task-detail-state'
 
-vi.mock('../common/markdown', () => ({
-  Markdown: ({ text }: { text: string }) => h('div', { 'data-testid': 'markdown' }, text),
-}))
-
 vi.mock('../common/time-ago', () => ({
   TimeAgo: ({ timestamp }: { timestamp: string }) => h('span', {}, timestamp),
 }))
@@ -40,7 +36,7 @@ describe('TaskActivityList', () => {
     vi.clearAllMocks()
   })
 
-  it('renders markdown lazily and preserves raw string payloads inside code fences', async () => {
+  it('renders string args lazily and preserves the raw payload text', async () => {
     const { container } = render(h(TaskActivityList, {
       events: [sampleToolCallEvent()],
       loading: false,
@@ -48,7 +44,8 @@ describe('TaskActivityList', () => {
       showToolCalls: true,
     }))
 
-    expect(screen.queryByTestId('markdown')).not.toBeInTheDocument()
+    expect(screen.queryByText('Args')).not.toBeInTheDocument()
+    expect(screen.queryByText('"*literal* `ticks`"')).not.toBeInTheDocument()
 
     const details = container.querySelector('details')
     expect(details).not.toBeNull()
@@ -58,20 +55,12 @@ describe('TaskActivityList', () => {
     fireEvent(details, new Event('toggle', { bubbles: true }))
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('markdown')).toHaveLength(1)
+      expect(screen.getByText('Args')).toBeInTheDocument()
     })
-    const blocks = screen.getAllByTestId('markdown')
-    expect(blocks).toHaveLength(1)
-    const firstBlock = blocks[0]
-    expect(firstBlock).toBeDefined()
-    if (!firstBlock) return
-    const text = firstBlock.textContent ?? ''
-    expect(text.startsWith('```')).toBe(true)
-    expect(text).toContain('*literal* `ticks`')
-    expect(text.endsWith('```')).toBe(true)
+    expect(screen.getByText('"*literal* `ticks`"')).toBeInTheDocument()
   })
 
-  it('formats object args as fenced json when expanded', async () => {
+  it('renders object args in the JsonViewer when expanded', async () => {
     const { container } = render(h(TaskActivityList, {
       events: [sampleToolCallEvent({ toolArgs: { ok: true } })],
       loading: false,
@@ -87,12 +76,11 @@ describe('TaskActivityList', () => {
     fireEvent(details, new Event('toggle', { bubbles: true }))
 
     await waitFor(() => {
-      expect(screen.getByTestId('markdown')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Collapse JSON object' })).toBeInTheDocument()
     })
-    const text = screen.getByTestId('markdown').textContent ?? ''
-    expect(text.startsWith('```json')).toBe(true)
-    expect(text).toContain('"ok": true')
-    expect(text.endsWith('```')).toBe(true)
+    expect(screen.getByText('Args')).toBeInTheDocument()
+    expect(screen.getByText('ok:')).toBeInTheDocument()
+    expect(screen.getByText('true')).toBeInTheDocument()
   })
 
   it('marks decorative icons as hidden from assistive tech', () => {

--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -5,10 +5,14 @@ import '@testing-library/jest-dom'
 import type { UnifiedTraceEvent } from '../session-trace/session-trace-state'
 import { activeFilter } from './task-detail-state'
 
-vi.mock('../common/json-viewer', () => ({
-  JsonViewerCard: ({ data, title }: { data: unknown; title?: string }) =>
-    h('div', { 'data-testid': 'json-viewer-card', 'data-title': title ?? '' }, typeof data === 'string' ? data : JSON.stringify(data)),
-}))
+vi.mock('../common/json-viewer', async importOriginal => {
+  const actual = await importOriginal<typeof import('../common/json-viewer')>()
+  return {
+    ...actual,
+    JsonViewerCard: ({ data, title }: { data: unknown; title?: string }) =>
+      h('div', { 'data-testid': 'json-viewer-card', 'data-title': title ?? '' }, typeof data === 'string' ? data : JSON.stringify(data)),
+  }
+})
 vi.mock('../common/time-ago', () => ({
   TimeAgo: ({ timestamp }: { timestamp: string }) => h('span', {}, timestamp),
 }))
@@ -88,6 +92,29 @@ describe('TaskActivityList', () => {
     await waitFor(() => {
       expect(screen.getByTestId('json-viewer-card')).toBeInTheDocument()
     })
+    const text = screen.getByTestId('json-viewer-card').textContent ?? ''
+    expect(text).toContain('"ok":true')
+  })
+
+  it('parses JSON string payloads before passing them to the structured viewer', async () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent({ toolArgs: undefined, toolResult: '{"ok":true}' })],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    if (!details) return
+
+    details.open = true
+    fireEvent(details, new Event('toggle', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('json-viewer-card')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('json-viewer-card')).toHaveAttribute('data-title', 'Result')
     const text = screen.getByTestId('json-viewer-card').textContent ?? ''
     expect(text).toContain('"ok":true')
   })

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -6,7 +6,7 @@ import { useState } from 'preact/hooks'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
-import { JsonViewerCard } from '../common/json-viewer'
+import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { Settings, MessageSquare, CheckSquare, Heart, RefreshCcw, Dot, ChevronRight } from 'lucide-preact'
 import type { UnifiedTraceEvent, TraceEventKind } from '../session-trace/session-trace-state'
 import { activeFilter, type ActivityFilter } from './task-detail-state'
@@ -74,12 +74,12 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <div class="px-3 pb-2 pt-1 ml-7">
           ${event.toolArgs != null ? html`
             <div class="mb-1">
-              <${JsonViewerCard} data=${event.toolArgs} title="Args" />
+              <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} title="Args" />
             </div>
           ` : null}
           ${event.toolResult != null ? html`
             <div class="mb-1">
-              <${JsonViewerCard} data=${event.toolResult} title="Result" />
+              <${JsonViewerCard} data=${parseJsonLikeData(event.toolResult)} title="Result" />
             </div>
           ` : null}
           ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -6,7 +6,7 @@ import { useState } from 'preact/hooks'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
-import { Markdown } from '../common/markdown'
+import { JsonViewerCard } from '../common/json-viewer'
 import { Settings, MessageSquare, CheckSquare, Heart, RefreshCcw, Dot, ChevronRight } from 'lucide-preact'
 import type { UnifiedTraceEvent, TraceEventKind } from '../session-trace/session-trace-state'
 import { activeFilter, type ActivityFilter } from './task-detail-state'
@@ -40,17 +40,6 @@ function durationColor(ms: number | undefined): string {
   return 'text-bad'
 }
 
-function wrapAsCodeBlock(text: string, language = ''): string {
-  const matches = text.match(/`+/g)
-  const longestFence = matches ? Math.max(...matches.map(match => match.length)) : 0
-  const fence = '`'.repeat(Math.max(3, longestFence + 1))
-  return `${fence}${language}\n${text}\n${fence}`
-}
-
-function formatPayload(value: unknown): string {
-  if (typeof value === 'string') return wrapAsCodeBlock(value)
-  return wrapAsCodeBlock(JSON.stringify(value ?? null, null, 2), 'json')
-}
 
 function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
   const hasDetail = event.toolArgs != null || event.toolResult != null || (event.detail && Object.keys(event.detail).length > 0)
@@ -85,18 +74,12 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <div class="px-3 pb-2 pt-1 ml-7">
           ${event.toolArgs != null ? html`
             <div class="mb-1">
-              <div class="text-[10px] text-text-dim mb-0.5">args</div>
-              <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
-                <${Markdown} text=${formatPayload(event.toolArgs)} />
-              </div>
+              <${JsonViewerCard} data=${event.toolArgs} title="Args" />
             </div>
           ` : null}
           ${event.toolResult != null ? html`
-            <div>
-              <div class="text-[10px] text-text-dim mb-0.5">result</div>
-              <div class="max-h-[300px] overflow-y-auto custom-scrollbar">
-                <${Markdown} text=${formatPayload(event.toolResult)} />
-              </div>
+            <div class="mb-1">
+              <${JsonViewerCard} data=${event.toolResult} title="Result" />
             </div>
           ` : null}
           ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -2,6 +2,7 @@
 // Reuses tool category patterns from keeper-trajectory-timeline.ts.
 
 import { html } from 'htm/preact'
+import { JsonViewerCard } from '../common/json-viewer'
 import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { truncate } from '../../lib/truncate'
@@ -92,8 +93,8 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
   return html`
     <div class="mt-2 space-y-1.5">
       ${event.toolArgs ? html`
-        <div class="text-[11px] font-mono text-[var(--text-muted)] bg-[var(--white-3)] px-3 py-2 rounded-lg overflow-x-auto whitespace-pre-wrap break-all">
-          ${typeof event.toolArgs === 'string' ? event.toolArgs : JSON.stringify(event.toolArgs, null, 2)}
+        <div class="mt-1">
+          <${JsonViewerCard} data=${event.toolArgs} title="Args" />
         </div>
       ` : null}
       ${event.toolResult || event.error ? html`

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -2,7 +2,7 @@
 // Reuses tool category patterns from keeper-trajectory-timeline.ts.
 
 import { html } from 'htm/preact'
-import { JsonViewerCard } from '../common/json-viewer'
+import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { truncate } from '../../lib/truncate'
@@ -94,7 +94,7 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
     <div class="mt-2 space-y-1.5">
       ${event.toolArgs ? html`
         <div class="mt-1">
-          <${JsonViewerCard} data=${event.toolArgs} title="Args" />
+          <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} title="Args" />
         </div>
       ` : null}
       ${event.toolResult || event.error ? html`

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
+import { JsonViewer } from '../common/json-viewer'
 
 interface ToolResultProps {
   success: boolean
@@ -10,14 +11,19 @@ interface ToolResultProps {
   timestamp: number
 }
 
-function tryFormatJson(text: string): { isJson: boolean; formatted: string } {
-  try { const parsed = JSON.parse(text); return { isJson: true, formatted: JSON.stringify(parsed, null, 2) } }
-  catch { return { isJson: false, formatted: text } }
+function tryParseJson(text: string): { isJson: boolean; parsed: unknown; formatted: string } {
+  try { 
+    const parsed = JSON.parse(text); 
+    return { isJson: true, parsed, formatted: JSON.stringify(parsed, null, 2) } 
+  }
+  catch { 
+    return { isJson: false, parsed: null, formatted: text } 
+  }
 }
 
 export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolResultProps) {
   const expanded = useSignal(true)
-  const { formatted } = tryFormatJson(text)
+  const { isJson, parsed, formatted } = tryParseJson(text)
   const timeStr = new Date(timestamp).toLocaleTimeString('ko-KR')
   const lines = formatted.split('\n').length
   return html`
@@ -36,8 +42,12 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
         </div>
         ${expanded.value ? html`
-          <pre class="px-3 py-2 text-[12px] font-mono overflow-x-auto max-h-[400px] overflow-y-auto
-            ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${formatted}</pre>
+          <div class="px-3 py-2 overflow-x-auto max-h-[400px] overflow-y-auto">
+            ${isJson 
+              ? html`<${JsonViewer} data=${parsed} />`
+              : html`<pre class="text-[12px] font-mono ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${formatted}</pre>`
+            }
+          </div>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -11,21 +11,19 @@ interface ToolResultProps {
   timestamp: number
 }
 
-function tryParseJson(text: string): { isJson: boolean; parsed: unknown; formatted: string } {
-  try { 
-    const parsed = JSON.parse(text); 
-    return { isJson: true, parsed, formatted: JSON.stringify(parsed, null, 2) } 
-  }
-  catch { 
-    return { isJson: false, parsed: null, formatted: text } 
+function tryParseJson(text: string): { isJson: boolean; parsed: unknown } {
+  try {
+    return { isJson: true, parsed: JSON.parse(text) }
+  } catch {
+    return { isJson: false, parsed: null }
   }
 }
 
 export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolResultProps) {
   const expanded = useSignal(true)
-  const { isJson, parsed, formatted } = tryParseJson(text)
+  const { isJson, parsed } = tryParseJson(text)
   const timeStr = new Date(timestamp).toLocaleTimeString('ko-KR')
-  const lines = formatted.split('\n').length
+  const lines = text.split('\n').length
   return html`
     <div class="flex flex-col gap-2 mt-3">
       <div class="flex items-center gap-2">
@@ -45,7 +43,7 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <div class="px-3 py-2 overflow-x-auto max-h-[400px] overflow-y-auto">
             ${isJson
               ? html`<${JsonViewer} data=${parsed} />`
-              : html`<pre class="text-[12px] font-mono ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${formatted}</pre>`
+              : html`<pre class="text-[12px] font-mono ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${text}</pre>`
             }
           </div>
         ` : null}


### PR DESCRIPTION
## Summary
- Expand the structured data viewer across Session Trace, Goals activity items, and manual tool execution results.
- Add the shared `dashboard/src/components/common/json-viewer.ts` module and follow-up review fixes so JSON-like strings render as expandable objects/arrays when possible.
- Preserve multiline string formatting in the viewer and remove unnecessary JSON pretty-print work from `ToolResultDisplay`.

## Product impact
- Deep tool args/results are easier to inspect across the dashboard.
- Payloads delivered as JSON strings now render as structured trees instead of quoted scalars.
- Large tool outputs avoid extra stringify overhead on the structured JSON path.

## Evidence
- `opam exec -- dune build --root .`
- `./_build/default/test/test_dashboard_collaboration_evidence.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- `pnpm -C dashboard build`
- `pnpm -C dashboard test`

## Review evidence
- `2026-04-04 12:43:55 KST` direct `sb glm-text` on feature head `3e7185e76354300fdb006148ff41b395660af435`: `NO_HIGH_CRITICAL_FINDINGS`
- `2026-04-04 13:24:29 KST` direct `sb glm-text` on test follow-up head `3f62f34b26b1d9d41630a56632e12be38c4912d5`: `NO_HIGH_CRITICAL_FINDINGS`
- `2026-04-04 13:38:48 KST` direct `sb glm-text` on the current review-follow-up diff into head `f3293b8b615ad4c1e9f61bf624c62ccf48a792a2`: `No findings.`

## Linked issue
- Refs #4959
