### PR TITLE
[codex] sanitize inherited base paths for local runtime

### DIFF
--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -15,9 +15,9 @@ let mcp_profile_by_session : (string, Server_mcp_transport_http_types.tool_profi
 let session_mutex = Eio.Mutex.create ()
 
 let default_base_path () =
-  match Env_config_core.me_root_opt () with
-  | Some path -> path
-  | None -> Sys.getcwd ()
+  (* Match the launcher guard: a direct binary launch from a checkout with its
+     own .masc must not silently inherit a stale parent MASC_BASE_PATH. *)
+  Room_utils_backend_setup.resolve_masc_base_path (Sys.getcwd ())
 
 let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -310,8 +310,13 @@ done
 # Did caller provide --base-path explicitly on CLI?
 BASE_PATH_EXPLICIT=0
 
-# Track whether MASC_BASE_PATH came from caller environment after shell/env-file restoration.
-MASC_BASE_PATH_WAS_SET="${__PRESERVE_MASC_BASE_PATH_SET:-0}"
+# Track whether MASC_BASE_PATH is set after shell/env-file restoration.
+# This must include ~/.zshenv and repo-local env files, not only caller-provided
+# exports, because both paths can accidentally inject a stale parent root.
+MASC_BASE_PATH_WAS_SET=0
+if [ -n "${MASC_BASE_PATH:-}" ]; then
+    MASC_BASE_PATH_WAS_SET=1
+fi
 
 raise_open_file_limit() {
     local desired="${MASC_NOFILE_TARGET:-4096}"
@@ -416,11 +421,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Guard against inherited MASC_BASE_PATH ambiguity. When the caller shell
-# exports a parent project root and both that root and this checkout have
-# their own .masc directories, the server can silently read/write the wrong
-# state tree. Explicit --base-path must still win; inherited env needs an
-# opt-in to survive this ambiguity.
+# Guard against inherited MASC_BASE_PATH ambiguity. When shell startup files
+# or env files inject a parent project root and both that root and this
+# checkout have their own .masc directories, the server can silently
+# read/write the wrong state tree. Explicit --base-path still wins; an
+# inherited/env-file root needs an opt-in to survive this ambiguity.
 if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
    [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && \
    [ -n "$BASE_PATH" ] && \

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -476,18 +476,17 @@ let test_keeper_msg_auto_team_session_bridge () =
      harness also exports
      CI_TEST_TIMEOUT_SEC, which is more reliable than ALCOTEST_QUICK_TESTS
      under dune test in CI. See: #1936 *)
-  let local_runtime_available =
-    Masc_mcp.Local_runtime_pool.healthy_runtime_count () > 0
-  in
   if Sys.getenv_opt "MASC_RUN_LIVE_KEEPER_TEAM_SESSION_TEST" <> Some "1"
      || Sys.getenv_opt "CI" = Some "true"
      || Sys.getenv_opt "ALCOTEST_QUICK_TESTS" = Some "1"
-     || Sys.getenv_opt "CI_TEST_TIMEOUT_SEC" <> None
-     || not local_runtime_available then
+     || Sys.getenv_opt "CI_TEST_TIMEOUT_SEC" <> None then
     Alcotest.skip ()
   else
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  if Masc_mcp.Local_runtime_pool.healthy_runtime_count () <= 0 then
+    Alcotest.skip ()
+  else
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -21,11 +21,30 @@ let rec rm_rf path =
     end else
       Sys.remove path
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
   Sys.remove dir;
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let with_cwd path f =
+  let saved = Sys.getcwd () in
+  Unix.chdir path;
+  Fun.protect ~finally:(fun () -> Unix.chdir saved) f
+
+let canonical_path path =
+  try Unix.realpath path with
+  | Unix.Unix_error _ -> path
 
 let test_detects_dual_masc_roots () =
   with_temp_dir "base-path-diag" @@ fun root ->
@@ -88,6 +107,36 @@ let test_to_yojson_exposes_effective_paths () =
   Alcotest.(check bool) "roots diverge field" true
     (json |> member "roots_diverge" |> to_bool)
 
+let test_default_base_path_sanitizes_inherited_dual_roots () =
+  with_temp_dir "base-path-default" @@ fun root ->
+  let me_root = Filename.concat root "me" in
+  let repo = Filename.concat me_root "workspace/yousleepwhen/masc-mcp" in
+  mkdir_p repo;
+  Unix.mkdir (Filename.concat me_root ".masc") 0o755;
+  Unix.mkdir (Filename.concat repo ".masc") 0o755;
+  with_cwd repo @@ fun () ->
+  with_env "ME_ROOT" (Some me_root) @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some me_root) @@ fun () ->
+  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
+  Alcotest.(check string) "default base path prefers checkout root"
+    (canonical_path repo)
+    (Server_mcp_transport_http.default_base_path () |> canonical_path)
+
+let test_default_base_path_respects_opt_in_for_inherited_root () =
+  with_temp_dir "base-path-default-optin" @@ fun root ->
+  let me_root = Filename.concat root "me" in
+  let repo = Filename.concat me_root "workspace/yousleepwhen/masc-mcp" in
+  mkdir_p repo;
+  Unix.mkdir (Filename.concat me_root ".masc") 0o755;
+  Unix.mkdir (Filename.concat repo ".masc") 0o755;
+  with_cwd repo @@ fun () ->
+  with_env "ME_ROOT" (Some me_root) @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some me_root) @@ fun () ->
+  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "1") @@ fun () ->
+  Alcotest.(check string) "opt-in keeps inherited root"
+    (canonical_path me_root)
+    (Server_mcp_transport_http.default_base_path () |> canonical_path)
+
 let () =
   Alcotest.run "Server_base_path_diagnostics"
     [
@@ -99,5 +148,9 @@ let () =
             test_strict_violation_respects_env;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
+          Alcotest.test_case "default base path sanitizes inherited dual roots"
+            `Quick test_default_base_path_sanitizes_inherited_dual_roots;
+          Alcotest.test_case "default base path honors inherited opt-in" `Quick
+            test_default_base_path_respects_opt_in_for_inherited_root;
         ] );
     ]

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -292,6 +292,38 @@ let test_parent_project_base_path_with_dual_masc_roots_is_sanitized () =
       check bool "parent root inheritance corrected to repo root" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ repo)))
 
+let test_zshenv_inherited_base_path_with_dual_roots_is_sanitized () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let parent = Filename.concat dir "parent-root" in
+      let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
+      let home_dir = Filename.concat dir "home" in
+      mkdir_p repo;
+      mkdir_p home_dir;
+      mkdir_p (Filename.concat parent ".masc");
+      mkdir_p (Filename.concat repo ".masc");
+      write_file (Filename.concat home_dir ".zshenv")
+        (Printf.sprintf "export MASC_BASE_PATH=%s\n" parent);
+      let script = Filename.concat repo "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe repo;
+      let capture = Filename.concat dir "captured-zshenv-sanitized.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
+              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
+            ]
+          (Printf.sprintf "%s --http --port 9965" (quote script))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "zshenv inherited base path corrected to repo root" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ repo)))
+
 let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
@@ -424,6 +456,8 @@ let () =
             test_inherited_base_path_with_dual_masc_roots_is_sanitized;
           test_case "parent project inherited base path is sanitized" `Quick
             test_parent_project_base_path_with_dual_masc_roots_is_sanitized;
+          test_case "zshenv inherited base path is sanitized" `Quick
+            test_zshenv_inherited_base_path_with_dual_roots_is_sanitized;
           test_case "dual roots opt-in preserves inherited base path" `Quick
             test_dual_masc_roots_opt_in_preserves_inherited_base_path;
           test_case "worktree prefers local build over workspace build" `Quick


### PR DESCRIPTION
## Summary
- sanitize direct binary base-path resolution with the same dual-root guard used by the launcher
- sanitize inherited `MASC_BASE_PATH` values loaded from `~/.zshenv` or env files in `start-masc-mcp.sh`
- add regression tests for dual-root resolution and zshenv-injected base paths
- gate the live keeper runtime probe in `test_operator_control_keeper.ml` behind the intended opt-in/Eio path so quick-suite skips cleanly in CI

## Root Cause
- direct `main_eio.exe` launches defaulted to `ME_ROOT` even when the checkout had its own `.masc` root
- `start-masc-mcp.sh` only treated caller-exported `MASC_BASE_PATH` as inherited, so shell startup files could still pin the runtime to `~/me/.masc`
- after refreshing the PR merge base, CI exposed an unrelated quick-suite bug where `test_keeper_msg_auto_team_session_bridge` evaluated `Local_runtime_pool.healthy_runtime_count()` before the CI/quick-suite skip gates and outside Eio context

## Product impact
- local `masc-mcp` launches now stay on the repo-local/worktree-local `.masc` root instead of silently writing to `~/me/.masc`
- direct binary launches and `./start-masc-mcp.sh` now agree on inherited base-path sanitization behavior
- CI quick-suite no longer fails on the non-opt-in live keeper runtime probe path

## Validation
- `dune exec --root . ./test/test_operator_control.exe`
- `dune exec --root . ./test/test_server_base_path_diagnostics.exe`
- `dune exec --root . ./test/test_start_masc_mcp_script.exe`
- `dune exec --root . ./test/test_dashboard_collaboration_evidence.exe`
- GitHub Actions CI run `23971464248`

## Evidence
- repo-local runtime verification showed `/health.effective_base_path=/Users/dancer/me/workspace/yousleepwhen/masc-mcp` and `roots_diverge=false`
- CI run `23971464248` completed green after the quick-suite skip fix for `test_operator_control_keeper.ml`
- follow-up review finding about raw-string path comparison in the launcher ambiguity guard was recorded as `Refs #4979`

## Review evidence
- GLM cross-model review comment: https://github.com/jeong-sik/masc-mcp/pull/4966#issuecomment-4186210321
- merge-base refresh + GLM re-review: https://github.com/jeong-sik/masc-mcp/pull/4966#issuecomment-4186285941
- quick-suite follow-up + GLM re-review: https://github.com/jeong-sik/masc-mcp/pull/4966#issuecomment-4186333455

## Linked issue
- Refs #4979
