### PR TITLE
feat(keeper): throttle concurrent keepalive turns (#4826)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -22,6 +22,34 @@ let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
 let set_bus bus = bus_ref := Some bus
 let get_bus () = !bus_ref
 
+let keeper_turn_throttle_limit () =
+  Keeper_config.int_of_env_default
+    "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
+;;
+
+let turn_semaphore_ref : Eio.Semaphore.t option ref = ref None
+let turn_semaphore_limit_ref : int option ref = ref None
+
+let keeper_turn_semaphore () =
+  let limit = keeper_turn_throttle_limit () in
+  match !turn_semaphore_ref, !turn_semaphore_limit_ref with
+  | Some sem, Some current when current = limit -> sem
+  | _ ->
+    let sem = Eio.Semaphore.make limit in
+    turn_semaphore_ref := Some sem;
+    turn_semaphore_limit_ref := Some limit;
+    Log.Keeper.info
+      "keeper turn throttle semaphore created (limit=%d, env=MASC_KEEPER_AUTOBOOT_MAX)"
+      limit;
+    sem
+;;
+
+let with_keeper_turn_slot f =
+  let sem = keeper_turn_semaphore () in
+  Eio.Semaphore.acquire sem;
+  Fun.protect ~finally:(fun () -> Eio.Semaphore.release sem) f
+;;
+
 (** Optional gRPC client + env — set at server bootstrap when
     [MASC_AGENT_TRANSPORT=grpc]. When set, heartbeat sends
     status pings over gRPC unary RPC. *)
@@ -437,19 +465,20 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if Keeper_world_observation.should_run_unified_turn ~meta:meta_after_triage obs
       then (
-        match
-          Keeper_unified_turn.run_unified_turn
-            ~config:ctx.config
-            ~meta:meta_after_triage
-            ~observation:obs
-            ~generation:meta_after_triage.runtime.generation
-        with
-        | Error e ->
-          Log.Keeper.error "unified turn failed: %s" e;
-          (match read_meta ctx.config meta_after_triage.name with
-           | Ok (Some latest) -> latest
-           | _ -> meta_after_triage)
-        | Ok updated -> updated)
+        with_keeper_turn_slot (fun () ->
+          match
+            Keeper_unified_turn.run_unified_turn
+              ~config:ctx.config
+              ~meta:meta_after_triage
+              ~observation:obs
+              ~generation:meta_after_triage.runtime.generation
+          with
+          | Error e ->
+            Log.Keeper.error "unified turn failed: %s" e;
+            (match read_meta ctx.config meta_after_triage.name with
+             | Ok (Some latest) -> latest
+             | _ -> meta_after_triage)
+          | Ok updated -> updated))
       else meta_after_triage
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -22,30 +22,16 @@ let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
 let set_bus bus = bus_ref := Some bus
 let get_bus () = !bus_ref
 
-let keeper_turn_throttle_limit () =
+let keeper_turn_throttle_limit =
   Keeper_config.int_of_env_default
     "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
 ;;
 
-let turn_semaphore_ref : Eio.Semaphore.t option ref = ref None
-
-let keeper_turn_semaphore () =
-  match !turn_semaphore_ref with
-  | Some sem -> sem
-  | _ ->
-    let limit = keeper_turn_throttle_limit () in
-    let sem = Eio.Semaphore.make limit in
-    turn_semaphore_ref := Some sem;
-    Log.Keeper.info
-      "keeper turn throttle semaphore created (limit=%d, env=MASC_KEEPER_AUTOBOOT_MAX)"
-      limit;
-    sem
-;;
+let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
 
 let with_keeper_turn_slot f =
-  let sem = keeper_turn_semaphore () in
-  Eio.Semaphore.acquire sem;
-  Fun.protect ~finally:(fun () -> Eio.Semaphore.release sem) f
+  Eio.Semaphore.acquire turn_semaphore;
+  Fun.protect ~finally:(fun () -> Eio.Semaphore.release turn_semaphore) f
 ;;
 
 (** Optional gRPC client + env — set at server bootstrap when

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -28,16 +28,14 @@ let keeper_turn_throttle_limit () =
 ;;
 
 let turn_semaphore_ref : Eio.Semaphore.t option ref = ref None
-let turn_semaphore_limit_ref : int option ref = ref None
 
 let keeper_turn_semaphore () =
-  let limit = keeper_turn_throttle_limit () in
-  match !turn_semaphore_ref, !turn_semaphore_limit_ref with
-  | Some sem, Some current when current = limit -> sem
+  match !turn_semaphore_ref with
+  | Some sem -> sem
   | _ ->
+    let limit = keeper_turn_throttle_limit () in
     let sem = Eio.Semaphore.make limit in
     turn_semaphore_ref := Some sem;
-    turn_semaphore_limit_ref := Some limit;
     Log.Keeper.info
       "keeper turn throttle semaphore created (limit=%d, env=MASC_KEEPER_AUTOBOOT_MAX)"
       limit;

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -24,6 +24,10 @@ val wakeup_keeper : string -> unit
     or system-wide events. *)
 val wakeup_all_keepers : unit -> unit
 
+val keeper_turn_throttle_limit : int
+(** Runtime keeper turn concurrency limit derived from
+    [MASC_KEEPER_AUTOBOOT_MAX]. *)
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Room.config -> Board_dispatch.keeper_board_signal -> unit
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -220,13 +220,9 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;
       let names = Keeper_types.keepalive_keeper_names config in
-      let turn_limit =
-        Keeper_config.int_of_env_default
-          "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
-      in
       Log.Keeper.info
         "autoboot: %d keeper(s) to boot; concurrent keeper turns throttled to %d via MASC_KEEPER_AUTOBOOT_MAX"
-        (List.length names) turn_limit;
+        (List.length names) Keeper_keepalive.keeper_turn_throttle_limit;
       Log.Keeper.info "autoboot: keeper set [%s]" (String.concat ", " names);
       let booted = ref 0 in
       let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -219,29 +219,18 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Log.Keeper.info
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;
-      let all_names = Keeper_types.keepalive_keeper_names config in
-      let all_count_names = List.length all_names in
-    (* Cap concurrent keepers to prevent Eio event loop starvation.
-       Each keeper heartbeat cycle does CPU-bound snapshot construction +
-       LLM API calls.  With 9+ concurrent keepers, the single-domain Eio
-       scheduler cannot service HTTP handlers between keeper fibers.
-       Configurable via MASC_KEEPER_AUTOBOOT_MAX (default 3). *)
-    let max_boot =
-      Keeper_config.int_of_env_default
-        "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
-    in
-    let names =
-      if all_count_names > max_boot then begin
-        Log.Keeper.warn "autoboot: capping %d keepers to max %d (MASC_KEEPER_AUTOBOOT_MAX)"
-          all_count_names max_boot;
-        List.filteri (fun i _ -> i < max_boot) all_names
-      end else all_names
-    in
-    Log.Keeper.info "autoboot: %d keeper(s) to boot: [%s]"
-      (List.length names) (String.concat ", " names);
-    let booted = ref 0 in
-    let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
-    let stagger_step = Keeper_config.keeper_bootstrap_stagger_step_sec () in
+      let names = Keeper_types.keepalive_keeper_names config in
+      let turn_limit =
+        Keeper_config.int_of_env_default
+          "MASC_KEEPER_AUTOBOOT_MAX" ~default:3 ~min_v:1 ~max_v:20
+      in
+      Log.Keeper.info
+        "autoboot: %d keeper(s) to boot; concurrent keeper turns throttled to %d via MASC_KEEPER_AUTOBOOT_MAX"
+        (List.length names) turn_limit;
+      Log.Keeper.info "autoboot: keeper set [%s]" (String.concat ", " names);
+      let booted = ref 0 in
+      let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
+      let stagger_step = Keeper_config.keeper_bootstrap_stagger_step_sec () in
     List.iteri (fun idx name ->
         try
           Log.Keeper.info "autoboot: loading meta for %s" name;


### PR DESCRIPTION
## Summary
- stop truncating the keeper autoboot list at startup based on `MASC_KEEPER_AUTOBOOT_MAX`
- reinterpret `MASC_KEEPER_AUTOBOOT_MAX` as the concurrent keepalive turn throttle and enforce it with a shared `Eio.Semaphore`
- keep all keeper keepalive loops booted while limiting simultaneous `Keeper_unified_turn.run_unified_turn` executions

## Product impact
- previously offline keepers are no longer silently skipped just because the autoboot list exceeded the old startup cap
- runtime-added keepers now share the same turn concurrency guard as bootstrapped keepers
- HTTP/event-loop starvation risk is reduced by throttling the expensive turn boundary instead of dropping keepers entirely

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-4826-keeper-turn-throttle`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-4826-keeper-turn-throttle ./test/test_keeper_registry.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-4826-keeper-turn-throttle ./test/test_start_masc_mcp_script.exe` was started but did not complete in a reasonable local window, so it is not counted as passing evidence

## Review evidence
- pending cross-model review comment via `sb glm-text`

## Linked issue
- Closes #4826