### PR TITLE
fix(test): align test wording with code — Scope→Namespace, namespace→project

### DIFF
--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -187,10 +187,10 @@ let test_collaboration_evidence_tracks_unlinked_room_noise () =
       check string "linkage policy" "explicit_first"
         (linkage |> member "policy" |> to_string);
       check string "linkage gap wording"
-        "namespace activity exists without explicit session/operation linkage"
+        "project activity exists without explicit session/operation linkage"
         (linkage |> member "gaps" |> index 0 |> to_string);
       check string "strong detail wording"
-        "세션 이벤트나 explicit linked namespace activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다."
+        "세션 이벤트나 explicit linked project activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다."
         (json |> member "detail" |> to_string);
       check bool "linkage gaps populated" true
         ((linkage |> member "gaps" |> to_list) <> []))

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -78,7 +78,7 @@ let () = test "dispatch_dashboard" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Scope: default (flattened)");
+      assert (str_contains result "Namespace: default (flattened)");
       assert (not (str_contains result "second-room"));
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
@@ -110,7 +110,7 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Scope: default (flattened)");
+      assert (str_contains result "Namespace: default (flattened)");
       assert (not (str_contains result "focus-room"))
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->


### PR DESCRIPTION
Summary
- Align stale test expectations with current wording in dashboard output and collaboration evidence.
- No runtime behavior changes; test-only wording sync.

Product impact
- Restores green CI for branches rebased onto current `main`.
- Prevents merge-queue failures caused by outdated assertions.

Evidence
- `gh pr checks 4969 --repo jeong-sik/masc-mcp`
- `opam exec -- dune build --root . test/test_dashboard_collaboration_evidence.exe test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_dashboard_collaboration_evidence.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`

Review evidence
- 2026-04-04 12:55:30 KST: direct `sb glm-text` correctness review on `origin/main...3eeae23f20bb21c7b50e837322e6a3b4dafc2534` -> `No findings.`
- Self-authored PR, so merge gate is satisfied with external non-self model review evidence instead of GitHub approval.

Linked issue
- Refs #4867
