### PR TITLE
fix(task): add refresh hint to TaskNotFound error message

### DIFF
--- a/lib/types/error.ml
+++ b/lib/types/error.ml
@@ -90,7 +90,7 @@ let to_string = function
       | RoomFull max -> Printf.sprintf "Room full (max %d agents)" max)
   | Task e -> (
       match e with
-      | TaskNotFound id -> Printf.sprintf "Task not found: %s" id
+      | TaskNotFound id -> Printf.sprintf "Task not found: %s. Call masc_status to refresh your task list." id
       | TaskAlreadyClaimed owner -> Printf.sprintf "Task already claimed by: %s" owner
       | TaskInvalidState (current, expected) ->
           Printf.sprintf "Invalid task state: %s (expected %s)" current expected

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -140,7 +140,7 @@ let rec masc_error_to_string = function
   | AgentNotFound name -> Printf.sprintf "❌ Agent not found: %s" name
   | AgentNotJoined name -> Printf.sprintf "❌ Agent not joined: %s. Use masc_join first." name
   | AgentAlreadyJoined name -> Printf.sprintf "⚠ %s is already in the room" name
-  | TaskNotFound id -> Printf.sprintf "❌ Task not found: %s" id
+  | TaskNotFound id -> Printf.sprintf "❌ Task not found: %s. Call masc_status to refresh your task list." id
   | TaskAlreadyClaimed { task_id; by } ->
       Printf.sprintf
         "❌ Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."


### PR DESCRIPTION
## Summary
- When an agent tries to transition a stale/deleted task, the error message now includes guidance to refresh via `masc_status`
- Observed in production logs (2026-04-04): gemini agent attempted `masc_transition` on task-291 and task-300, both already removed

## Changes
- `lib/types/error.ml`: TaskNotFound message -> append ". Call masc_status to refresh your task list."
- `lib/types/types_auth.ml`: Same change for the auth-layer variant

## Product impact
- Improves agent self-recovery on stale task IDs by pointing callers to the authoritative refresh path.
- Reduces repeated retries against deleted backlog entries after task list drift.

## Evidence
- `opam exec -- dune build --root .`
- `./_build/default/test/test_dashboard_collaboration_evidence.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_types_coverage.exe`
- `./_build/default/test/test_error_coverage.exe`
- GitHub Actions reran on current head `be866cfd47c20a57e124ded31b7537d3845fef99`

## Review evidence
- 2026-04-04 13:01:49 KST: direct `sb glm-text` correctness review on `origin/main...be866cfd47c20a57e124ded31b7537d3845fef99` -> `No findings.`
- Local validation was run on a tree identical to the current remote head (`git diff --stat HEAD origin/fix/task-not-found-hint` -> no diff).

## Linked issue
- Closes #4968

## Test plan
- [x] Build passes
- [x] No existing tests assert on exact TaskNotFound wording
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
