### PR TITLE
fix(test): align dashboard and operator CI expectations

### DIFF
--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -187,10 +187,10 @@ let test_collaboration_evidence_tracks_unlinked_room_noise () =
       check string "linkage policy" "explicit_first"
         (linkage |> member "policy" |> to_string);
       check string "linkage gap wording"
-        "namespace activity exists without explicit session/operation linkage"
+        "project activity exists without explicit session/operation linkage"
         (linkage |> member "gaps" |> index 0 |> to_string);
       check string "strong detail wording"
-        "세션 이벤트나 explicit linked namespace activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다."
+        "세션 이벤트나 explicit linked project activity는 보이지만 proof 또는 관계 근거가 충분히 묶이지 않았습니다."
         (json |> member "detail" |> to_string);
       check bool "linkage gaps populated" true
         ((linkage |> member "gaps" |> to_list) <> []))

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -476,17 +476,19 @@ let test_keeper_msg_auto_team_session_bridge () =
      harness also exports
      CI_TEST_TIMEOUT_SEC, which is more reliable than ALCOTEST_QUICK_TESTS
      under dune test in CI. See: #1936 *)
-  let local_runtime_available =
-    Masc_mcp.Local_runtime_pool.healthy_runtime_count () > 0
-  in
   if Sys.getenv_opt "MASC_RUN_LIVE_KEEPER_TEAM_SESSION_TEST" <> Some "1"
      || Sys.getenv_opt "CI" = Some "true"
      || Sys.getenv_opt "ALCOTEST_QUICK_TESTS" = Some "1"
-     || Sys.getenv_opt "CI_TEST_TIMEOUT_SEC" <> None
-     || not local_runtime_available then
+     || Sys.getenv_opt "CI_TEST_TIMEOUT_SEC" <> None then
     Alcotest.skip ()
   else
   Eio_main.run @@ fun env ->
+  let local_runtime_available =
+    Masc_mcp.Local_runtime_pool.healthy_runtime_count () > 0
+  in
+  if not local_runtime_available then
+    Alcotest.skip ()
+  else
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -78,7 +78,7 @@ let () = test "dispatch_dashboard" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Scope: default (flattened)");
+      assert (str_contains result "Namespace: default (flattened)");
       assert (not (str_contains result "second-room"));
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
@@ -110,7 +110,7 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | Some (success, result) ->
       assert success;
       assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Scope: default (flattened)");
+      assert (str_contains result "Namespace: default (flattened)");
       assert (not (str_contains result "focus-room"))
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->


### PR DESCRIPTION
## Summary
- align `test_tool_misc_coverage` with the current dashboard Namespace wording
- align `test_dashboard_collaboration_evidence` with the shipped project wording
- skip the live keeper bridge test before probing runtime availability, and probe under Eio so CI/live gating stays safe

## Product impact
- unblocks unrelated PR CI runs that were failing on stale dashboard wording or the operator-control Eio crash
- keeps test expectations aligned with the already-shipped dashboard and collaboration wording changes

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-misc-dashboard-namespace`
- `CI=true dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-misc-dashboard-namespace ./test/test_operator_control.exe -- -q`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-misc-dashboard-namespace ./test/test_tool_misc_coverage.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-misc-dashboard-namespace ./test/test_dashboard_collaboration_evidence.exe`

## Review evidence
- GLM-5 direct `sb glm-text` review comment added on the PR (no findings)

## Linked issue
- Related: #4938