### PR TITLE
feat(tools): structured field-path validation feedback

### DIFF
--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -126,3 +126,129 @@ let get_int_required args key =
 (** Monadic bind for [(ok, string) result] → [(bool * string)].
     Chains required field extractions with early error return. *)
 let ( let*! ) r f = match r with Ok v -> f v | Error e -> (false, e)
+
+(** {1 Structured Field Validation}
+
+    Machine-readable field-path error feedback for keeper tool argument
+    validation.  Callers receive which field failed, what was expected,
+    and what was received, enabling deterministic self-correction.
+
+    @since 2.170.0
+    @see <https://github.com/jeong-sik/masc-mcp/issues/4963> *)
+
+(** Validation constraint that a field must satisfy. *)
+type field_constraint =
+  | Required          (** field must be present *)
+  | Non_empty         (** string field must not be empty after trimming *)
+  | Type_string       (** value must be a JSON string *)
+  | Type_int          (** value must be a JSON integer *)
+  | Type_float        (** value must be a JSON number *)
+  | Type_bool         (** value must be a JSON boolean *)
+  | Min_int of int    (** integer must be >= min *)
+  | Max_int of int    (** integer must be <= max *)
+  | One_of of string list  (** string must be one of the listed values *)
+
+let field_constraint_to_string = function
+  | Required -> "required"
+  | Non_empty -> "non_empty"
+  | Type_string -> "type_string"
+  | Type_int -> "type_int"
+  | Type_float -> "type_float"
+  | Type_bool -> "type_bool"
+  | Min_int v -> Printf.sprintf "min_int(%d)" v
+  | Max_int v -> Printf.sprintf "max_int(%d)" v
+  | One_of vs -> Printf.sprintf "one_of(%s)" (String.concat "," vs)
+
+(** A single field-level validation error. *)
+type field_error = {
+  field : string;
+  constraint_violated : field_constraint;
+  message : string;
+  expected : string option;
+  received : string option;
+}
+
+let field_error_to_yojson (e : field_error) : Yojson.Safe.t =
+  `Assoc (
+    [ ("field", `String e.field);
+      ("constraint", `String (field_constraint_to_string e.constraint_violated));
+      ("message", `String e.message) ]
+    @ (match e.expected with Some v -> [("expected", `String v)] | None -> [])
+    @ (match e.received with Some v -> [("received", `String v)] | None -> [])
+  )
+
+(** Build a structured validation error response with per-field errors.
+    Produces: [\{"status":"error","error_code":"validation_error",
+    "field_errors":[...],"message":"N field error(s)"\}] *)
+let validation_error_response (errors : field_error list) : string =
+  let field_errors = List.map field_error_to_yojson errors in
+  Yojson.Safe.to_string
+    (`Assoc [
+      ("status", `String "error");
+      ("error_code", `String "validation_error");
+      ("field_errors", `List field_errors);
+      ("message", `String (Printf.sprintf "%d field error(s)" (List.length errors)));
+    ])
+
+(** Convenience: [(false, validation_error_response errors)] *)
+let validation_error_result errors = (false, validation_error_response errors)
+
+(** {2 Field Validators}
+
+    Each validator returns [Ok value] or [Error field_error].
+    Use [validate_all] to collect multiple errors before returning. *)
+
+(** Validate that a string field is present and non-empty. *)
+let validate_string_required args field : (string, field_error) result =
+  match Safe_ops.json_string_opt field args with
+  | Some s when String.trim s <> "" -> Ok (String.trim s)
+  | Some s ->
+    Error { field; constraint_violated = Non_empty;
+            message = Printf.sprintf "%s must not be empty" field;
+            expected = Some "non-empty string";
+            received = Some (Printf.sprintf "%S" s) }
+  | None ->
+    Error { field; constraint_violated = Required;
+            message = Printf.sprintf "%s is required" field;
+            expected = Some "string"; received = None }
+
+(** Validate that an integer field is present. *)
+let validate_int_required args field : (int, field_error) result =
+  match Safe_ops.json_int_opt field args with
+  | Some i -> Ok i
+  | None ->
+    Error { field; constraint_violated = Required;
+            message = Printf.sprintf "%s is required" field;
+            expected = Some "integer"; received = None }
+
+(** Validate that an integer field (if present) is within [min, max]. *)
+let validate_int_range args field ~min_v ~max_v ~default : (int, field_error) result =
+  let v = get_int args field default in
+  if v < min_v then
+    Error { field; constraint_violated = Min_int min_v;
+            message = Printf.sprintf "%s must be >= %d" field min_v;
+            expected = Some (Printf.sprintf ">= %d" min_v);
+            received = Some (string_of_int v) }
+  else if v > max_v then
+    Error { field; constraint_violated = Max_int max_v;
+            message = Printf.sprintf "%s must be <= %d" field max_v;
+            expected = Some (Printf.sprintf "<= %d" max_v);
+            received = Some (string_of_int v) }
+  else Ok v
+
+(** Validate that a string field (if present) is one of allowed values. *)
+let validate_one_of args field ~allowed ~default : (string, field_error) result =
+  let v = get_string args field default in
+  if List.mem v allowed then Ok v
+  else
+    Error { field; constraint_violated = One_of allowed;
+            message = Printf.sprintf "%s must be one of: %s" field (String.concat ", " allowed);
+            expected = Some (String.concat "|" allowed);
+            received = Some v }
+
+(** Collect all field errors from a list of validation results.
+    Returns [Ok values] if all pass, [Error field_errors] otherwise. *)
+let validate_all (results : (unit, field_error) result list) : (unit, field_error list) result =
+  let errors = List.filter_map (function Error e -> Some e | Ok () -> None) results in
+  if errors = [] then Ok ()
+  else Error errors

--- a/test/dune
+++ b/test/dune
@@ -502,7 +502,7 @@
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage)
+        test_anti_rationalization_coverage test_field_validation)
  (modules test_backend_coverage test_tools_coverage test_types_utils_coverage
         test_agent_card_coverage test_misc_coverage test_relay_coverage
         test_tempo_coverage test_transport_coverage test_validation_coverage
@@ -535,7 +535,7 @@
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage)
+        test_anti_rationalization_coverage test_field_validation)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_field_validation.ml
+++ b/test/test_field_validation.ml
@@ -1,0 +1,178 @@
+(** Field-level validation feedback tests.
+    Verifies Tool_args structured field_error responses. *)
+
+open Alcotest
+open Masc_mcp
+
+let check_field_error msg (e : Tool_args.field_error) ~field ~constraint_s =
+  check string (msg ^ " field") field e.field;
+  check string (msg ^ " constraint")
+    constraint_s
+    (Tool_args.field_constraint_to_string e.constraint_violated)
+
+(* -- validate_string_required ------------------------------------------- *)
+
+let test_string_required_ok () =
+  let args = `Assoc [("name", `String "alice")] in
+  match Tool_args.validate_string_required args "name" with
+  | Ok v -> check string "trimmed value" "alice" v
+  | Error _ -> fail "expected Ok"
+
+let test_string_required_trims () =
+  let args = `Assoc [("name", `String "  bob  ")] in
+  match Tool_args.validate_string_required args "name" with
+  | Ok v -> check string "trimmed" "bob" v
+  | Error _ -> fail "expected Ok"
+
+let test_string_required_missing () =
+  let args = `Assoc [] in
+  match Tool_args.validate_string_required args "name" with
+  | Ok _ -> fail "expected Error"
+  | Error e -> check_field_error "missing" e ~field:"name" ~constraint_s:"required"
+
+let test_string_required_empty () =
+  let args = `Assoc [("name", `String "")] in
+  match Tool_args.validate_string_required args "name" with
+  | Ok _ -> fail "expected Error"
+  | Error e -> check_field_error "empty" e ~field:"name" ~constraint_s:"non_empty"
+
+let test_string_required_whitespace_only () =
+  let args = `Assoc [("name", `String "   ")] in
+  match Tool_args.validate_string_required args "name" with
+  | Ok _ -> fail "expected Error"
+  | Error e -> check_field_error "whitespace" e ~field:"name" ~constraint_s:"non_empty"
+
+(* -- validate_int_required ---------------------------------------------- *)
+
+let test_int_required_ok () =
+  let args = `Assoc [("count", `Int 42)] in
+  match Tool_args.validate_int_required args "count" with
+  | Ok v -> check int "value" 42 v
+  | Error _ -> fail "expected Ok"
+
+let test_int_required_missing () =
+  let args = `Assoc [] in
+  match Tool_args.validate_int_required args "count" with
+  | Ok _ -> fail "expected Error"
+  | Error e -> check_field_error "missing" e ~field:"count" ~constraint_s:"required"
+
+(* -- validate_int_range ------------------------------------------------- *)
+
+let test_int_range_ok () =
+  let args = `Assoc [("priority", `Int 3)] in
+  match Tool_args.validate_int_range args "priority" ~min_v:1 ~max_v:5 ~default:2 with
+  | Ok v -> check int "in range" 3 v
+  | Error _ -> fail "expected Ok"
+
+let test_int_range_below_min () =
+  let args = `Assoc [("priority", `Int 0)] in
+  match Tool_args.validate_int_range args "priority" ~min_v:1 ~max_v:5 ~default:2 with
+  | Ok _ -> fail "expected Error"
+  | Error e ->
+    check_field_error "below" e ~field:"priority" ~constraint_s:"min_int(1)";
+    check (option string) "received" (Some "0") e.received
+
+let test_int_range_above_max () =
+  let args = `Assoc [("priority", `Int 10)] in
+  match Tool_args.validate_int_range args "priority" ~min_v:1 ~max_v:5 ~default:2 with
+  | Ok _ -> fail "expected Error"
+  | Error e ->
+    check_field_error "above" e ~field:"priority" ~constraint_s:"max_int(5)"
+
+(* -- validate_one_of ---------------------------------------------------- *)
+
+let test_one_of_ok () =
+  let args = `Assoc [("mode", `String "strict")] in
+  match Tool_args.validate_one_of args "mode" ~allowed:["strict"; "lenient"] ~default:"strict" with
+  | Ok v -> check string "value" "strict" v
+  | Error _ -> fail "expected Ok"
+
+let test_one_of_rejected () =
+  let args = `Assoc [("mode", `String "yolo")] in
+  match Tool_args.validate_one_of args "mode" ~allowed:["strict"; "lenient"] ~default:"strict" with
+  | Ok _ -> fail "expected Error"
+  | Error e ->
+    check_field_error "rejected" e ~field:"mode" ~constraint_s:"one_of(strict,lenient)";
+    check (option string) "received" (Some "yolo") e.received
+
+(* -- validate_all ------------------------------------------------------- *)
+
+let test_validate_all_pass () =
+  let results = [ Ok (); Ok (); Ok () ] in
+  match Tool_args.validate_all results with
+  | Ok () -> ()
+  | Error _ -> fail "expected Ok"
+
+let test_validate_all_collects_errors () =
+  let err1 : Tool_args.field_error =
+    { field = "a"; constraint_violated = Required;
+      message = "a required"; expected = None; received = None } in
+  let err2 : Tool_args.field_error =
+    { field = "b"; constraint_violated = Non_empty;
+      message = "b empty"; expected = None; received = None } in
+  let results = [ Error err1; Ok (); Error err2 ] in
+  match Tool_args.validate_all results with
+  | Ok () -> fail "expected Error"
+  | Error errs ->
+    check int "error count" 2 (List.length errs);
+    check string "first field" "a" (List.hd errs).field;
+    check string "second field" "b" (List.nth errs 1).field
+
+(* -- validation_error_response ------------------------------------------ *)
+
+let test_response_json_shape () =
+  let err : Tool_args.field_error =
+    { field = "agent_id"; constraint_violated = Required;
+      message = "agent_id is required";
+      expected = Some "string"; received = None } in
+  let json_str = Tool_args.validation_error_response [err] in
+  let json = Yojson.Safe.from_string json_str in
+  let open Yojson.Safe.Util in
+  check string "status" "error" (json |> member "status" |> to_string);
+  check string "error_code" "validation_error" (json |> member "error_code" |> to_string);
+  let field_errors = json |> member "field_errors" |> to_list in
+  check int "field_errors length" 1 (List.length field_errors);
+  let fe = List.hd field_errors in
+  check string "fe.field" "agent_id" (fe |> member "field" |> to_string);
+  check string "fe.constraint" "required" (fe |> member "constraint" |> to_string);
+  check string "fe.expected" "string" (fe |> member "expected" |> to_string)
+
+(* -- Runner ------------------------------------------------------------- *)
+
+let () =
+  run ~and_exit:false "Field_validation"
+    [
+      ( "string_required",
+        [
+          test_case "ok" `Quick test_string_required_ok;
+          test_case "trims whitespace" `Quick test_string_required_trims;
+          test_case "missing" `Quick test_string_required_missing;
+          test_case "empty" `Quick test_string_required_empty;
+          test_case "whitespace only" `Quick test_string_required_whitespace_only;
+        ] );
+      ( "int_required",
+        [
+          test_case "ok" `Quick test_int_required_ok;
+          test_case "missing" `Quick test_int_required_missing;
+        ] );
+      ( "int_range",
+        [
+          test_case "in range" `Quick test_int_range_ok;
+          test_case "below min" `Quick test_int_range_below_min;
+          test_case "above max" `Quick test_int_range_above_max;
+        ] );
+      ( "one_of",
+        [
+          test_case "accepted" `Quick test_one_of_ok;
+          test_case "rejected" `Quick test_one_of_rejected;
+        ] );
+      ( "validate_all",
+        [
+          test_case "all pass" `Quick test_validate_all_pass;
+          test_case "collects errors" `Quick test_validate_all_collects_errors;
+        ] );
+      ( "response_shape",
+        [
+          test_case "json structure" `Quick test_response_json_shape;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
Add structured field-level validation feedback to tool_args.ml so keeper tool argument errors include which field failed, what constraint was violated, and what was expected vs received.

## Changes
- `field_constraint` type: Required, Non_empty, Type_*, Min_int, Max_int, One_of
- `field_error` record: field, constraint_violated, message, expected, received
- `validation_error_response`: JSON with `field_errors` array
- Validators: `validate_string_required`, `validate_int_required`, `validate_int_range`, `validate_one_of`
- `validate_all`: collects all field errors before returning (batch mode)
- 15 Alcotest cases covering all validators and JSON shape

## Design
- Additive: existing `get_*` / `get_*_required` API untouched
- New validators return `(value, field_error) result` instead of `(value, string) result`
- Tools can opt in by switching to `validate_*` functions

## Test plan
- [x] `dune exec test/test_field_validation.exe` — 15/15 pass
- [ ] CI Build and Test

Closes #4963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)