### PR TITLE
feat(dashboard): convert more raw JSON/text pre blocks to rich Markdown UI components

### DIFF
--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] accent-[var(--accent)]'
+const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
 
 interface CheckboxProps {
   checked?: boolean

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]'
+const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface TextInputProps {
   value?: string

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]'
+const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface NumberInputProps {
   value?: number | string

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-const SELECT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)] appearance-none cursor-pointer'
+const SELECT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
 
 interface SelectOption { value: string; label: string }
 

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { Markdown } from "./common/markdown"
 import { AlertTriangle } from 'lucide-preact'
 import { ActionButton } from './common/button'
 import { TextArea } from './common/input'
@@ -148,7 +149,7 @@ export function ActionRequestCard({ order }: { order: GovernanceExecutionOrder |
       </div>
       ${request.target_type ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">대상 ${request.target_type}${request.target_id ? `:${request.target_id}` : ''}</div>` : null}
       ${request.reason ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">${request.reason}</div>` : null}
-      ${request.payload_preview ? html`<pre class="mt-0 max-h-[180px] overflow-auto whitespace-pre-wrap rounded-[9px] border border-[var(--card-border)] bg-[rgba(0,0,0,0.26)] p-2.5 text-[11px] leading-[1.5] text-[#d3e3ff] font-mono">${serializePreview(request.payload_preview)}</pre>` : null}
+      ${request.payload_preview ? html`<div class="mt-0 max-h-[180px] overflow-auto rounded-[9px] border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```json\n' + serializePreview(request.payload_preview) + '\n```'} /></div>` : null}
       ${order.execution_ref ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">결과 참조 ${order.execution_ref}</div>` : null}
       ${order.result_summary ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">${order.result_summary}</div>` : null}
     </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
 import { requestConfirm } from './common/confirm-dialog'
 import { isOfflineStatus } from '../lib/status-utils'
@@ -226,7 +227,7 @@ export function KeeperDiagnosticSummary({
         ? html`<div class="text-xs text-[#ffb4b4] leading-relaxed mt-1">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<pre class="mt-3 py-3 px-4 rounded-lg border border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[11px] leading-relaxed whitespace-pre-wrap break-words font-mono max-h-[240px] overflow-auto">${detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.'}</pre>`
+        ? html`<div class="mt-3 max-h-[240px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`
         : null}
     </div>
   `

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -92,14 +92,10 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
   return html`
     <div class="mt-2 space-y-1.5">
       ${event.toolArgs ? html`
-        <div class="text-[11px] font-mono text-[var(--text-muted)] bg-[var(--white-3)] px-3 py-2 rounded-lg overflow-x-auto whitespace-pre-wrap break-all">
-          ${typeof event.toolArgs === 'string' ? event.toolArgs : JSON.stringify(event.toolArgs, null, 2)}
-        </div>
+        <div class="max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]"><${Markdown} text=${typeof event.toolArgs === 'string' ? event.toolArgs : '```json\n' + JSON.stringify(event.toolArgs, null, 2) + '\n```'} /></div>
       ` : null}
       ${event.toolResult || event.error ? html`
-        <div class="text-[11px] font-mono ${event.error ? 'text-[var(--bad)]' : 'text-[var(--text-dim)]'} bg-[var(--white-3)] px-3 py-2 rounded-lg overflow-x-auto whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
-          ${event.error ?? event.toolResult}
-        </div>
+        <div class="max-h-[300px] overflow-auto rounded-xl border border-[var(--white-6)] bg-[var(--bg-0)]"><${Markdown} text=${typeof (event.error ?? event.toolResult) === 'string' && String(event.error ?? event.toolResult).includes('```') ? String(event.error ?? event.toolResult) : '```json\n' + JSON.stringify((event.error ?? event.toolResult), null, 2) + '\n```'} /></div>
       ` : null}
       ${gateRejected ? html`
         <div class="text-[10px] px-2 py-1 rounded bg-[rgba(239,68,68,0.1)] text-[#ef4444] inline-block">

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { Markdown } from "../common/markdown"
 import { useSignal } from '@preact/signals'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
@@ -36,8 +37,9 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
         </div>
         ${expanded.value ? html`
-          <pre class="px-3 py-2 text-[12px] font-mono overflow-x-auto max-h-[400px] overflow-y-auto
-            ${success ? 'text-[var(--text-body)]' : 'text-[#fda4af]'}">${formatted}</pre>
+          <div class="max-h-[400px] overflow-auto bg-[var(--bg-0)]">
+            <${Markdown} text=${'```json\n' + formatted + '\n```'} />
+          </div>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { Markdown } from "../common/markdown"
 import { useEffect, useState } from 'preact/hooks'
 import {
   clearPromptOverride,
@@ -184,7 +185,7 @@ export function PromptRegistryPanel() {
 
             <div class="mb-4">
               <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
-              <pre class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[rgba(6,12,24,0.72)] px-3 py-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-[var(--text-body)]">${selectedPrompt.file_value ?? '없음'}</pre>
+              <div class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">


### PR DESCRIPTION
## Overview
- Identified several remaining components (e.g., `SessionTraceEntry`, `ToolResultDisplay`, `GovernancePanels`, `KeeperShared`, `PromptRegistryPanel`) that were still using raw `<pre>` tags to display JSON data, payloads, or raw text.
- Upgraded all these instances to use the `Markdown` component with Shiki syntax highlighting. 
- This ensures that structured data, JSON payloads, and detailed telemetry are now rendered with beautiful syntax highlighting, wrapped in the new custom scrollbar containers, dramatically improving readability and the overall 'premium' feel of the dashboard's detailed views.