### PR TITLE
fix(dashboard): improve text contrast on dark backgrounds

### DIFF
--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -77,26 +77,16 @@ function syncTimelineSelection(
   })
 }
 
-function spanColor(kind: string): string {
-  switch (kind) {
-    case 'task': return '#fbbf24'
-    case 'operation': return '#4ade80'
-    case 'autonomy': return '#22d3ee'
-    case 'presence': return 'rgba(148, 163, 184, 0.25)'
-    default: return '#94a3b8'
-  }
+const SPAN_STYLES: Record<string, { bg: string; text: string }> = {
+  task:      { bg: '#fbbf24', text: '#0f172a' },
+  operation: { bg: '#4ade80', text: '#0f172a' },
+  autonomy:  { bg: '#22d3ee', text: '#0f172a' },
+  presence:  { bg: 'rgba(148, 163, 184, 0.25)', text: '#e2e8f0' },
 }
+const SPAN_DEFAULT = { bg: '#94a3b8', text: '#e2e8f0' } as const
 
-/** Dark text on bright backgrounds, light text on dark/transparent backgrounds */
-function spanTextColor(kind: string): string {
-  switch (kind) {
-    case 'task':
-    case 'operation':
-    case 'autonomy':
-      return '#0f172a'
-    default:
-      return '#e2e8f0'
-  }
+function spanStyle(kind: string) {
+  return SPAN_STYLES[kind] ?? SPAN_DEFAULT
 }
 
 function loadSwimlane(since?: string) {
@@ -133,8 +123,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
     const itemIdsByAgent = new Map<string, TimelineItemId[]>()
     let idCounter = 1
     const items = new DataSet(data.spans.map(span => {
-      const color = spanColor(span.kind)
-      const textColor = spanTextColor(span.kind)
+      const { bg: color, text: textColor } = spanStyle(span.kind)
       const duration = formatDurationMs(span.end_ms - span.start_ms)
       const itemId = idCounter++
       const title = tooltipHtml([span.label || span.kind, `종류: ${span.kind}`, `지속: ${duration}`])

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -87,6 +87,18 @@ function spanColor(kind: string): string {
   }
 }
 
+/** Dark text on bright backgrounds, light text on dark/transparent backgrounds */
+function spanTextColor(kind: string): string {
+  switch (kind) {
+    case 'task':
+    case 'operation':
+    case 'autonomy':
+      return '#0f172a'
+    default:
+      return '#e2e8f0'
+  }
+}
+
 function loadSwimlane(since?: string) {
   return swimlaneResource.load(() => fetchSwimlane(since))
 }
@@ -122,6 +134,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
     let idCounter = 1
     const items = new DataSet(data.spans.map(span => {
       const color = spanColor(span.kind)
+      const textColor = spanTextColor(span.kind)
       const duration = formatDurationMs(span.end_ms - span.start_ms)
       const itemId = idCounter++
       const title = tooltipHtml([span.label || span.kind, `종류: ${span.kind}`, `지속: ${duration}`])
@@ -142,7 +155,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
         className: span.kind === 'presence'
           ? 'activity-swimlane-item activity-swimlane-item--presence'
           : 'activity-swimlane-item',
-        style: `background-color: ${color}; border-color: ${color}; color: #0f172a; font-size: 10px; border-radius: 3px; font-family: system-ui, sans-serif; overflow: hidden;`
+        style: `background-color: ${color}; border-color: ${color}; color: ${textColor}; font-size: 10px; border-radius: 3px; font-family: system-ui, sans-serif; overflow: hidden;`
       }
     }))
 

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -83,7 +83,7 @@ const SPAN_STYLES: Record<string, { bg: string; text: string }> = {
   autonomy:  { bg: '#22d3ee', text: '#0f172a' },
   presence:  { bg: 'rgba(148, 163, 184, 0.25)', text: '#e2e8f0' },
 }
-const SPAN_DEFAULT = { bg: '#94a3b8', text: '#e2e8f0' } as const
+const SPAN_DEFAULT = { bg: '#94a3b8', text: '#0f172a' } as const
 
 function spanStyle(kind: string) {
   return SPAN_STYLES[kind] ?? SPAN_DEFAULT

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -479,7 +479,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         >취소</button>
       ` : html`
         <button type="button"
-          class="${btnBase} bg-[var(--purple)] text-[#000]"
+          class="${btnBase} bg-[var(--purple)] text-[#1e1b4b]"
           onClick=${enterEditMode}
         >편집</button>
       `}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -324,7 +324,7 @@
 
 .swimlane-vis-container .vis-item.activity-swimlane-item {
   border-color: transparent;
-  color: #0f172a;
+  color: var(--text-body);
 }
 
 .swimlane-vis-container .vis-item.activity-swimlane-item--presence {


### PR DESCRIPTION
## Summary
- Swimlane timeline 아이템의 텍스트 색상을 배경 밝기에 따라 분기 (밝은 배경=어두운 텍스트, 어두운/투명 배경=밝은 텍스트)
- CSS 기본값을 하드코딩 `#0f172a` 대신 `var(--text-body)`로 변경
- Keeper 편집 버튼 텍스트를 `#000` → `#1e1b4b`(어두운 인디고)로 개선

## 변경 파일
- `dashboard/src/components/activity-swimlane.ts` — `SPAN_STYLES`/`spanStyle()`로 swimlane 아이템 인라인 스타일을 배경 대비 기준으로 정리
- `dashboard/src/styles/dashboard.css` — `.activity-swimlane-item` color를 CSS 변수로 전환
- `dashboard/src/components/keeper-config-panel.ts` — 보라색 버튼 텍스트 색상 조정

## Test plan
- [ ] 대시보드 Activity Swimlane에서 task/operation/autonomy 아이템 텍스트 가독성 확인
- [ ] presence 아이템(투명 배경)에서 텍스트가 보이는지 확인
- [ ] Keeper 설정 패널의 편집 버튼 가독성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
