### PR TITLE
test(keeper): add keeper tool matrix smoke

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -15,6 +15,17 @@ let keeper_denied_set : (string, unit) Hashtbl.t =
     (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied);
   tbl
 
+let dedupe_tool_schemas (schemas : Types.tool_schema list) =
+  let seen = Hashtbl.create (max 16 (List.length schemas)) in
+  List.filter
+    (fun (schema : Types.tool_schema) ->
+      if Hashtbl.mem seen schema.name then
+        false
+      else (
+        Hashtbl.replace seen schema.name ();
+        true))
+    schemas
+
 let is_keeper_denied (name : string) : bool =
   Hashtbl.mem keeper_denied_set name
 
@@ -280,6 +291,7 @@ let keeper_preset_universe_model_tools (meta : keeper_meta) : Types.tool_schema 
   in
   all_schemas
   |> List.filter (fun tool -> List.mem tool.Types.name scoped)
+  |> dedupe_tool_schemas
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     Types.tool_schema list =
@@ -297,6 +309,7 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     let result =
       all_schemas
       |> List.filter (fun tool -> List.mem tool.Types.name allowed)
+      |> dedupe_tool_schemas
     in
     let count = List.length result in
     if count > 100 then
@@ -320,3 +333,4 @@ let keeper_universe_model_tools (meta : keeper_meta) : Types.tool_schema list =
   in
   all_schemas
   |> List.filter (fun tool -> List.mem tool.Types.name universe)
+  |> dedupe_tool_schemas

--- a/test/dune
+++ b/test/dune
@@ -607,6 +607,14 @@
  (deps tool_matrix_case_runner.exe)
  (libraries masc_test_deps))
 
+; Keeper Tool Matrix (3 modules + runner dep)
+(test
+ (name test_keeper_tool_matrix)
+ (modules test_keeper_tool_matrix test_keeper_tool_matrix_cases
+          test_mcp_tool_matrix_cases)
+ (deps keeper_tool_matrix_case_runner.exe)
+ (libraries masc_test_deps))
+
 ; ============================================================
 ; Special: Custom compiler flags
 ; ============================================================
@@ -794,4 +802,10 @@
 (executable
  (name tool_matrix_case_runner)
  (modules tool_matrix_case_runner test_mcp_tool_matrix_cases)
+ (libraries masc_test_deps))
+
+(executable
+ (name keeper_tool_matrix_case_runner)
+ (modules keeper_tool_matrix_case_runner test_keeper_tool_matrix_cases
+          test_mcp_tool_matrix_cases)
  (libraries masc_test_deps))

--- a/test/keeper_tool_matrix_case_runner.ml
+++ b/test/keeper_tool_matrix_case_runner.ml
@@ -1,0 +1,65 @@
+module Cases = Test_keeper_tool_matrix_cases
+
+let result_prefix = "__KEEPER_TOOL_MATRIX_RESULT__"
+
+let emit_result ~base_path name = function
+  | Ok () ->
+      Printf.printf "%s%s\n" result_prefix
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("name", `String name);
+               ("ok", `Bool true);
+               ("base_path", `String base_path);
+             ]))
+  | Error message ->
+      Printf.printf "%s%s\n" result_prefix
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("name", `String name);
+               ("ok", `Bool false);
+               ("base_path", `String base_path);
+               ("message", `String message);
+             ]))
+
+let find_schema name =
+  Cases.all_keeper_tool_schemas ()
+  |> List.find_opt (fun (schema : Types.tool_schema) ->
+         String.equal schema.name name)
+
+let () =
+  Printexc.record_backtrace true;
+  if Array.length Sys.argv <> 2 then begin
+    prerr_endline "usage: keeper_tool_matrix_case_runner.exe <tool-name>";
+    flush stderr;
+    Unix._exit 2
+  end;
+  let tool_name = Sys.argv.(1) in
+  match find_schema tool_name with
+  | None ->
+      emit_result ~base_path:"" tool_name
+        (Error ("unknown keeper tool: " ^ tool_name));
+      flush stdout;
+      Unix._exit 2
+  | Some schema ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Masc_mcp.Mcp_server_eio.set_net (Eio.Stdenv.net env);
+      Masc_mcp.Mcp_server_eio.set_clock (Eio.Stdenv.clock env);
+      let clock = Eio.Stdenv.clock env in
+      let proc_mgr = Eio.Stdenv.process_mgr env in
+      let fs = Eio.Stdenv.fs env in
+      let net = Eio.Stdenv.net env in
+      let mono_clock = Eio.Stdenv.mono_clock env in
+      let base_path, result =
+        Eio.Switch.run @@ fun sw ->
+        Cases.run_case sw ~proc_mgr ~fs ~net ~mono_clock clock schema
+      in
+      emit_result ~base_path tool_name result;
+      flush stdout;
+      flush stderr;
+      Unix._exit
+        (match result with
+        | Ok () -> 0
+        | Error _ -> 1)

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -162,51 +162,86 @@ let parse_case_result ~tool_name output =
           })
 
 let run_tool_case_process tool_name =
+  let tmp_root = Filename.temp_file "keeper-tool-matrix-base" "" in
+  Sys.remove tmp_root;
+  Unix.mkdir tmp_root 0o700;
   let out_file = Filename.temp_file "keeper-tool-matrix-out" ".txt" in
   let err_file = Filename.temp_file "keeper-tool-matrix-err" ".txt" in
+  let cleanup_file path =
+    if Sys.file_exists path then Sys.remove path
+  in
+  let cleanup_dir path =
+    if Sys.file_exists path then Cases.cleanup_dir path
+  in
   let timeout_prefix =
     match timeout_command () with
     | Some bin ->
         Printf.sprintf "%s -k 1s %ds " bin (tool_case_timeout_sec ())
     | None -> ""
   in
+  let env_prefix =
+    Printf.sprintf "TMPDIR=%s TEMP=%s TMP=%s " (quote tmp_root)
+      (quote tmp_root) (quote tmp_root)
+  in
   let cmd =
-    Printf.sprintf "%s%s %s" timeout_prefix (quote (runner_path ()))
-      (quote tool_name)
+    Printf.sprintf "%s%s%s %s" env_prefix timeout_prefix
+      (quote (runner_path ())) (quote tool_name)
   in
   let wrapped =
     Printf.sprintf "%s > %s 2> %s" cmd (quote out_file) (quote err_file)
   in
-  let status = Sys.command wrapped in
-  let output =
-    String.concat "\n" [ read_file out_file; read_file err_file ]
-  in
-  Sys.remove out_file;
-  Sys.remove err_file;
-  let parsed = parse_case_result ~tool_name output in
-  (match parsed.base_path with
-  | Some path -> Cases.cleanup_dir path
-  | None -> ());
-  match status with
-  | 0 -> parsed.outcome
-  | 124 ->
-      Error
-        (Printf.sprintf "%s timed out after %ds\n%s" tool_name
-           (tool_case_timeout_sec ()) output)
-  | _ -> (
-      match parsed.outcome with
-      | Ok () ->
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_file out_file;
+      cleanup_file err_file;
+      cleanup_dir tmp_root)
+    (fun () ->
+      let status = Sys.command wrapped in
+      let output =
+        String.concat "\n" [ read_file out_file; read_file err_file ]
+      in
+      let parsed = parse_case_result ~tool_name output in
+      (match parsed.base_path with
+      | Some path when path <> tmp_root -> cleanup_dir path
+      | Some _ | None -> ());
+      match status with
+      | 0 -> parsed.outcome
+      | 124 ->
           Error
-            (Printf.sprintf
-               "%s exited nonzero without failure payload\n%s"
-               tool_name output)
-      | Error message -> Error message)
+            (Printf.sprintf "%s timed out after %ds\n%s" tool_name
+               (tool_case_timeout_sec ()) output)
+      | _ -> (
+          match parsed.outcome with
+          | Ok () ->
+              Error
+                (Printf.sprintf
+                   "%s exited nonzero without failure payload\n%s"
+                   tool_name output)
+          | Error message -> Error message))
 
 let test_keeper_inventory_is_unique () =
   let names = Cases.all_keeper_tool_names in
-  let unique = List.sort_uniq String.compare names in
-  check int "keeper inventory unique count" (List.length unique)
-    (List.length names)
+  let counts = Hashtbl.create (max 16 (List.length names)) in
+  List.iter
+    (fun name ->
+      let count =
+        match Hashtbl.find_opt counts name with
+        | Some n -> n
+        | None -> 0
+      in
+      Hashtbl.replace counts name (count + 1))
+    names;
+  let duplicates =
+    Hashtbl.fold
+      (fun name count acc -> if count > 1 then (name, count) :: acc else acc)
+      counts []
+    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  in
+  if duplicates <> [] then
+    failf "keeper inventory contains duplicate tool names:\n%s"
+      (duplicates
+      |> List.map (fun (name, count) -> Printf.sprintf "  - %s (%d)" name count)
+      |> String.concat "\n")
 
 let test_keeper_inventory_has_cases () =
   let names = Cases.all_keeper_tool_names in

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -1,0 +1,264 @@
+open Alcotest
+
+module Cases = Test_keeper_tool_matrix_cases
+
+let result_prefix = "__KEEPER_TOOL_MATRIX_RESULT__"
+
+let requested_tool_names () =
+  match Sys.getenv_opt "KEEPER_TOOL_MATRIX_ONLY" with
+  | None -> None
+  | Some raw ->
+      raw
+      |> String.split_on_char ','
+      |> List.map String.trim
+      |> List.filter (fun value -> value <> "")
+      |> function
+      | [] -> None
+      | names -> Some names
+
+let has_repo_root root =
+  Sys.file_exists (Filename.concat root "dune-project")
+  && Sys.file_exists (Filename.concat root "test/dune")
+
+let rec ascend_repo_root dir =
+  if has_repo_root dir then
+    Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else ascend_repo_root parent
+
+let executable_repo_root () =
+  ascend_repo_root (Filename.dirname Sys.executable_name)
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when String.trim root <> "" && has_repo_root root -> root
+  | _ -> (
+      match
+        try Some (Sys.getcwd ()) with
+        | Sys_error _ -> None
+      with
+      | Some cwd -> (
+          match ascend_repo_root cwd with
+          | Some root -> root
+          | None -> (
+              match executable_repo_root () with
+              | Some root -> root
+              | None -> cwd))
+      | None -> (
+          match executable_repo_root () with
+          | Some root -> root
+          | None -> Filename.current_dir_name))
+
+let path_is_within ~parent ~child =
+  try
+    let parent = Unix.realpath parent in
+    let child = Unix.realpath child in
+    let prefix =
+      if String.ends_with ~suffix:"/" parent then parent else parent ^ "/"
+    in
+    String.starts_with ~prefix child
+  with _ -> false
+
+let quote = Filename.quote
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let timeout_command () =
+  if Sys.command "command -v timeout >/dev/null 2>&1" = 0 then
+    Some "timeout"
+  else if Sys.command "command -v gtimeout >/dev/null 2>&1" = 0 then
+    Some "gtimeout"
+  else
+    None
+
+let tool_case_timeout_sec () =
+  match Sys.getenv_opt "KEEPER_TOOL_MATRIX_CASE_TIMEOUT_SEC" with
+  | Some raw -> (
+      match int_of_string_opt (String.trim raw) with
+      | Some value when value > 0 -> value
+      | _ -> 25)
+  | None -> 25
+
+let runner_path () =
+  let candidate =
+    Filename.concat (Filename.dirname Sys.executable_name)
+      "keeper_tool_matrix_case_runner.exe"
+  in
+  if Sys.file_exists candidate
+     && path_is_within ~parent:(source_root ()) ~child:candidate
+  then
+    candidate
+  else
+    Filename.concat (source_root ())
+      "_build/default/test/keeper_tool_matrix_case_runner.exe"
+
+let find_result_line output =
+  output
+  |> String.split_on_char '\n'
+  |> List.find_map (fun line ->
+         if String.starts_with ~prefix:result_prefix line then
+           Some
+             (String.sub line (String.length result_prefix)
+                (String.length line - String.length result_prefix))
+         else
+           None)
+
+type case_process_result = {
+  base_path : string option;
+  outcome : (unit, string) result;
+}
+
+let parse_case_result ~tool_name output =
+  match find_result_line output with
+  | None ->
+      {
+        base_path = None;
+        outcome =
+          Error
+            (Printf.sprintf "%s missing runner result marker\n%s" tool_name
+               output);
+      }
+  | Some raw -> (
+      match Yojson.Safe.from_string raw with
+      | `Assoc fields -> (
+          let base_path =
+            match List.assoc_opt "base_path" fields with
+            | Some (`String value) when value <> "" -> Some value
+            | _ -> None
+          in
+          match List.assoc_opt "ok" fields with
+          | Some (`Bool true) -> { base_path; outcome = Ok () }
+          | Some (`Bool false) -> (
+              match List.assoc_opt "message" fields with
+              | Some (`String message) ->
+                  { base_path; outcome = Error message }
+              | _ ->
+                  {
+                    base_path;
+                    outcome =
+                      Error
+                        (Printf.sprintf
+                           "%s returned malformed failure payload: %s"
+                           tool_name raw);
+                  })
+          | _ ->
+              {
+                base_path;
+                outcome =
+                  Error
+                    (Printf.sprintf "%s returned malformed runner payload: %s"
+                       tool_name raw);
+              })
+      | _ ->
+          {
+            base_path = None;
+            outcome =
+              Error
+                (Printf.sprintf
+                   "%s returned non-object runner payload: %s"
+                   tool_name raw);
+          })
+
+let run_tool_case_process tool_name =
+  let out_file = Filename.temp_file "keeper-tool-matrix-out" ".txt" in
+  let err_file = Filename.temp_file "keeper-tool-matrix-err" ".txt" in
+  let timeout_prefix =
+    match timeout_command () with
+    | Some bin ->
+        Printf.sprintf "%s -k 1s %ds " bin (tool_case_timeout_sec ())
+    | None -> ""
+  in
+  let cmd =
+    Printf.sprintf "%s%s %s" timeout_prefix (quote (runner_path ()))
+      (quote tool_name)
+  in
+  let wrapped =
+    Printf.sprintf "%s > %s 2> %s" cmd (quote out_file) (quote err_file)
+  in
+  let status = Sys.command wrapped in
+  let output =
+    String.concat "\n" [ read_file out_file; read_file err_file ]
+  in
+  Sys.remove out_file;
+  Sys.remove err_file;
+  let parsed = parse_case_result ~tool_name output in
+  (match parsed.base_path with
+  | Some path -> Cases.cleanup_dir path
+  | None -> ());
+  match status with
+  | 0 -> parsed.outcome
+  | 124 ->
+      Error
+        (Printf.sprintf "%s timed out after %ds\n%s" tool_name
+           (tool_case_timeout_sec ()) output)
+  | _ -> (
+      match parsed.outcome with
+      | Ok () ->
+          Error
+            (Printf.sprintf
+               "%s exited nonzero without failure payload\n%s"
+               tool_name output)
+      | Error message -> Error message)
+
+let test_keeper_inventory_is_unique () =
+  let names = Cases.all_keeper_tool_names in
+  let unique = List.sort_uniq String.compare names in
+  check int "keeper inventory unique count" (List.length unique)
+    (List.length names)
+
+let test_keeper_inventory_has_cases () =
+  let names = Cases.all_keeper_tool_names in
+  let missing =
+    List.filter
+      (fun name ->
+        try
+          ignore (Cases.case_for_name name);
+          false
+        with Failure _ -> true)
+      names
+  in
+  if missing <> [] then
+    failf "keeper matrix missing contracts:\n%s"
+      (missing |> List.map (fun name -> "  - " ^ name) |> String.concat "\n")
+
+let test_full_keeper_tools_call_matrix () =
+  let requested = requested_tool_names () in
+  let failures = ref [] in
+  let schemas =
+    match requested with
+    | None -> Cases.all_keeper_tool_schemas ()
+    | Some requested ->
+        Cases.all_keeper_tool_schemas ()
+        |> List.filter (fun (schema : Types.tool_schema) ->
+               List.mem schema.name requested)
+  in
+  List.iter
+    (fun (schema : Types.tool_schema) ->
+      match run_tool_case_process schema.name with
+      | Ok () -> ()
+      | Error message -> failures := ("- " ^ message) :: !failures)
+    schemas;
+  match List.rev !failures with
+  | [] -> ()
+  | failures ->
+      failf "keeper tool matrix failures (%d)\n%s" (List.length failures)
+        (String.concat "\n" failures)
+
+let () =
+  run "keeper_tool_matrix"
+    [
+      ( "inventory",
+        [
+          test_case "keeper inventory is unique" `Quick
+            test_keeper_inventory_is_unique;
+          test_case "keeper inventory has case contracts" `Quick
+            test_keeper_inventory_has_cases;
+        ] );
+      ( "matrix",
+        [
+          test_case "full keeper tool matrix" `Slow
+            test_full_keeper_tools_call_matrix;
+        ] );
+    ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -99,15 +99,18 @@ let make_meta ?(name = "keeper-tool-matrix") () =
   | Ok meta -> meta
   | Error err -> failwith ("make_meta failed: " ^ err)
 
-let all_keeper_tool_schemas () =
+let all_keeper_tool_schemas_raw () =
   init_keeper_bridge ();
   KET.keeper_allowed_model_tools (make_meta ())
-  |> dedupe_tool_schemas
   |> List.sort (fun (left : Types.tool_schema) right ->
          String.compare left.name right.name)
 
+let all_keeper_tool_schemas () =
+  all_keeper_tool_schemas_raw ()
+  |> dedupe_tool_schemas
+
 let all_keeper_tool_names =
-  all_keeper_tool_schemas ()
+  all_keeper_tool_schemas_raw ()
   |> List.map (fun (schema : Types.tool_schema) -> schema.name)
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -1,0 +1,442 @@
+module Generic = Test_mcp_tool_matrix_cases
+module KET = Masc_mcp.Keeper_exec_tools
+module KTO = Masc_mcp.Keeper_tools_oas
+module Tool = Agent_sdk.Tool
+
+type init_mode = Generic.init_mode =
+  | Fresh
+  | Init_only
+  | Init_joined
+
+type expectation = Generic.expectation =
+  | Expect_success
+  | Expect_success_or_guard of string list
+  | Expect_guard of string list
+
+type keeper_case = {
+  init_mode : init_mode;
+  prepare : fixture -> unit;
+  arguments : fixture -> Types.tool_schema -> Yojson.Safe.t;
+  expectation : expectation;
+}
+
+and fixture = {
+  generic : Generic.fixture;
+  config : Masc_mcp.Room.config;
+  meta : Masc_mcp.Keeper_types.keeper_meta;
+  ctx_ref : Masc_mcp.Keeper_types.working_context ref;
+  tools : Agent_sdk.Tool.t list;
+}
+
+let string_starts_with = Generic.string_starts_with
+let contains_any = Generic.contains_any
+let cleanup_dir = Generic.cleanup_dir
+
+let keeper_matrix_guard_fragments =
+  [
+    "tool_not_allowed";
+    "tool_not_supported_in_keeper";
+    "unknown_tool";
+    "unregistered_masc_tool";
+  ]
+
+let dedupe_tool_schemas (schemas : Types.tool_schema list) =
+  let seen = Hashtbl.create (max 16 (List.length schemas)) in
+  List.filter
+    (fun (schema : Types.tool_schema) ->
+      if Hashtbl.mem seen schema.name then
+        false
+      else (
+        Hashtbl.replace seen schema.name ();
+        true))
+    schemas
+
+let github_guard_fragments =
+  Generic.git_guard_fragments
+  @ Generic.provider_guard_fragments
+  @
+  [
+    "not logged into any github hosts";
+    "authentication failed";
+    "gh auth login";
+    "gh_token";
+    "gh: command not found";
+    "could not resolve host";
+  ]
+
+let voice_guard_fragments =
+  Generic.provider_guard_fragments
+  @
+  [
+    "rec process failed";
+    "no active audio session";
+    "transcription";
+    "microphone";
+    "audio";
+  ]
+
+let init_keeper_bridge () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
+  KET.tag_dispatch_fn := Masc_mcp.Keeper_tag_dispatch.dispatch;
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
+
+let make_meta ?(name = "keeper-tool-matrix") () =
+  match
+    Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String name);
+          ("trace_id", `String "keeper-tool-matrix-trace");
+          ("allowed_paths", `List [ `String "*" ]);
+          ( "tool_access",
+            Masc_mcp.Keeper_types.tool_access_to_json
+              (Masc_mcp.Keeper_types.Preset
+                 { preset = Masc_mcp.Keeper_types.Full; also_allow = [] } ) );
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> failwith ("make_meta failed: " ^ err)
+
+let all_keeper_tool_schemas () =
+  init_keeper_bridge ();
+  KET.keeper_allowed_model_tools (make_meta ())
+  |> dedupe_tool_schemas
+  |> List.sort (fun (left : Types.tool_schema) right ->
+         String.compare left.name right.name)
+
+let all_keeper_tool_names =
+  all_keeper_tool_schemas ()
+  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+
+let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
+  init_keeper_bridge ();
+  let generic =
+    Generic.make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode
+  in
+  let config = Masc_mcp.Room.default_config base_path in
+  let ctx =
+    Masc_mcp.Keeper_exec_context.create ~system_prompt:"keeper tool matrix"
+      ~max_tokens:4000
+    |> fun ctx ->
+    Masc_mcp.Keeper_exec_context.append ctx
+      (Agent_sdk.Types.user_msg "tool matrix memory needle")
+  in
+  let ctx_ref = ref ctx in
+  let meta = make_meta () in
+  let tools = KTO.make_tools ~config ~meta ~ctx_ref () in
+  (match init_mode with
+   | Init_joined ->
+       ignore
+         (Masc_mcp.Room.join config ~agent_name:("keeper-" ^ meta.name)
+            ~capabilities:[] ())
+   | Fresh | Init_only -> ());
+  { generic; config; meta; ctx_ref; tools }
+
+let keeper_agent_name fixture = "keeper-" ^ fixture.meta.name
+
+let find_tool fixture name =
+  List.find_opt
+    (fun (tool : Agent_sdk.Tool.t) -> String.equal tool.schema.name name)
+    fixture.tools
+
+let ensure_sample_file fixture =
+  let relative = "keeper-tool-matrix.txt" in
+  let absolute = Filename.concat fixture.generic.base_path relative in
+  Generic.write_text_file absolute "needle\nsecond line\n";
+  relative
+
+let ensure_keeper_claim fixture =
+  ignore (Generic.ensure_task fixture.generic);
+  ignore
+    (Masc_mcp.Room.claim_next fixture.config
+       ~agent_name:(keeper_agent_name fixture))
+
+let ensure_voice_session fixture =
+  let mgr = Masc_mcp.Keeper_voice_local.get_session_manager () in
+  ignore
+    (Masc_mcp.Voice_session_manager.start_session mgr ~agent_id:fixture.meta.name
+       ~voice:"tool-matrix" ())
+
+let prepare_keeper_name fixture name =
+  if
+    List.mem name
+      [ "keeper_board_get"; "keeper_board_comment"; "keeper_board_vote";
+        "keeper_board_search" ]
+  then
+    ignore (Generic.ensure_board_post fixture.generic);
+  if
+    List.mem name
+      [ "keeper_library_search"; "keeper_library_read" ]
+  then
+    ignore (Generic.ensure_library_topic fixture.generic);
+  if
+    List.mem name
+      [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_tasks_audit";
+        "keeper_task_force_release"; "keeper_task_force_done";
+        "keeper_task_done" ]
+  then
+    ignore (Generic.ensure_task fixture.generic);
+  if
+    List.mem name
+      [ "keeper_task_force_release"; "keeper_task_force_done";
+        "keeper_task_done" ]
+  then
+    ensure_keeper_claim fixture;
+  if name = "keeper_voice_session_end" then ensure_voice_session fixture;
+  if name = "keeper_memory_search" then
+    fixture.ctx_ref :=
+      Masc_mcp.Keeper_exec_context.append !(fixture.ctx_ref)
+        (Agent_sdk.Types.user_msg "keeper tool matrix memory needle")
+
+let keeper_arguments fixture (schema : Types.tool_schema) =
+  let name = schema.name in
+  match name with
+  | "keeper_time_now"
+  | "keeper_context_status"
+  | "keeper_tools_list"
+  | "keeper_tasks_audit"
+  | "keeper_task_claim"
+  | "keeper_voice_agent"
+  | "keeper_voice_sessions"
+  | "keeper_voice_session_end" ->
+      `Assoc []
+  | "keeper_memory_search" ->
+      `Assoc [ ("query", `String "memory needle"); ("limit", `Int 2) ]
+  | "keeper_board_post" ->
+      `Assoc
+        [
+          ("title", `String "Keeper Tool Matrix");
+          ("content", `String "tool-matrix-post");
+          ("visibility", `String "internal");
+        ]
+  | "keeper_board_get" ->
+      `Assoc [ ("post_id", `String (Generic.ensure_board_post fixture.generic)) ]
+  | "keeper_board_list" -> `Assoc [ ("limit", `Int 5) ]
+  | "keeper_board_comment" ->
+      `Assoc
+        [
+          ("post_id", `String (Generic.ensure_board_post fixture.generic));
+          ("content", `String "tool-matrix-comment");
+        ]
+  | "keeper_board_vote" ->
+      `Assoc
+        [
+          ("post_id", `String (Generic.ensure_board_post fixture.generic));
+          ("direction", `String "up");
+        ]
+  | "keeper_board_stats" -> `Assoc []
+  | "keeper_board_search" ->
+      `Assoc [ ("query", `String "tool-matrix"); ("limit", `Int 5) ]
+  | "keeper_fs_read" ->
+      `Assoc [ ("path", `String (ensure_sample_file fixture)) ]
+  | "keeper_fs_edit" ->
+      `Assoc
+        [
+          ("path", `String "keeper-matrix-write.txt");
+          ("content", `String "matrix write\n");
+          ("mode", `String "overwrite");
+        ]
+  | "keeper_shell_readonly" -> `Assoc [ ("op", `String "git_status") ]
+  | "keeper_bash" ->
+      `Assoc [ ("cmd", `String "pwd"); ("timeout_sec", `Float 5.0) ]
+  | "keeper_github" ->
+      `Assoc [ ("cmd", `String "status"); ("timeout_sec", `Float 5.0) ]
+  | "keeper_voice_speak" ->
+      `Assoc [ ("message", `String "tool matrix hello") ]
+  | "keeper_voice_listen" ->
+      `Assoc [ ("timeout_seconds", `Float 1.0) ]
+  | "keeper_voice_session_start" ->
+      `Assoc [ ("session_name", `String "tool-matrix") ]
+  | "keeper_library_search" ->
+      `Assoc [ ("query", `String "tool matrix") ]
+  | "keeper_library_read" ->
+      `Assoc [ ("topic", `String (Generic.ensure_library_topic fixture.generic)) ]
+  | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
+  | "keeper_task_force_release" ->
+      `Assoc
+        [
+          ("task_id", `String (Generic.ensure_task fixture.generic));
+          ("reason", `String "tool matrix release");
+        ]
+  | "keeper_task_force_done" ->
+      `Assoc
+        [
+          ("task_id", `String (Generic.ensure_task fixture.generic));
+          ("notes", `String "tool matrix done");
+        ]
+  | "keeper_broadcast" ->
+      `Assoc [ ("message", `String "tool matrix broadcast") ]
+  | "keeper_task_done" ->
+      `Assoc
+        [
+          ("task_id", `String (Generic.ensure_task fixture.generic));
+          ("result", `String "tool matrix result");
+        ]
+  | other -> failwith ("missing keeper arguments contract for " ^ other)
+
+let keeper_expectation_for_name name =
+  match name with
+  | "keeper_github" -> Expect_success_or_guard github_guard_fragments
+  | "keeper_voice_listen"
+  | "keeper_voice_agent" ->
+      Expect_success_or_guard voice_guard_fragments
+  | _ -> Expect_success
+
+let extra_guard_fragments_for_name = function
+  | "masc_auth_refresh" ->
+      [ "agent_name must match the authenticated agent";
+        "no credential found" ]
+  | "masc_auth_revoke" -> [ "no credential found" ]
+  | "masc_autoresearch_cycle"
+  | "masc_autoresearch_inject"
+  | "masc_autoresearch_status"
+  | "masc_autoresearch_stop" ->
+      [ "no autoresearch loop running" ]
+  | "masc_autoresearch_swarm_start" ->
+      [ "requires local team-session runtime context" ]
+  | "masc_board_migrate" -> [ "requires postgresql backend" ]
+  | "masc_get_metrics" -> [ "no metrics found" ]
+  | "masc_library_promote" -> [ "no candidate matching" ]
+  | "masc_portal_send" -> [ "no portal open" ]
+  | "masc_repo_synthesis_swarm_start" ->
+      [ "requires team-session launch support" ]
+  | "masc_voice_conference_start"
+  | "masc_voice_conference_end" ->
+      [ "agent_ids must include at least one agent";
+        "no active voice sessions";
+        "no active session" ]
+  | "masc_worktree_remove" -> [ "worktree not found" ]
+  | _ -> []
+
+let merge_expectation base extras =
+  match base with
+  | Expect_success when extras <> [] -> Expect_success_or_guard extras
+  | Expect_success -> Expect_success
+  | Expect_guard fragments -> Expect_guard (fragments @ extras)
+  | Expect_success_or_guard fragments ->
+      Expect_success_or_guard (fragments @ extras)
+
+let case_for_name name =
+  if string_starts_with ~prefix:"masc_" name then
+    let generic_case = Generic.case_for_name name in
+    {
+      init_mode = generic_case.init_mode;
+      prepare = (fun fixture -> Generic.prepare_for_name fixture.generic name);
+      arguments =
+        (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
+      expectation =
+        merge_expectation generic_case.expectation
+          (extra_guard_fragments_for_name name);
+    }
+  else if string_starts_with ~prefix:"keeper_" name then
+    {
+      init_mode = Init_joined;
+      prepare = (fun fixture -> prepare_keeper_name fixture name);
+      arguments = keeper_arguments;
+      expectation = keeper_expectation_for_name name;
+    }
+  else
+    failwith ("missing keeper tool contract for " ^ name)
+
+let fatal_fragments =
+  Generic.fatal_fragments @ keeper_matrix_guard_fragments
+
+let evaluate_expectation ~name expectation = function
+  | Ok _ ->
+      (match expectation with
+       | Expect_success -> Ok ()
+       | Expect_success_or_guard _ -> Ok ()
+       | Expect_guard fragments ->
+           Error
+             (Printf.sprintf "%s expected guard %s but succeeded" name
+                (String.concat ", " fragments)))
+  | Error { Agent_sdk.Types.message; _ } ->
+      if contains_any message fatal_fragments then
+        Error
+          (Printf.sprintf "%s hit fatal keeper-tool failure: %s" name message)
+      else
+        match expectation with
+        | Expect_success ->
+            Error
+              (Printf.sprintf "%s expected success but got error: %s" name
+                 message)
+        | Expect_guard fragments ->
+            if contains_any message fragments then
+              Ok ()
+            else
+              Error
+                (Printf.sprintf "%s expected guard %s but got: %s" name
+                   (String.concat ", " fragments) message)
+        | Expect_success_or_guard fragments ->
+            if contains_any message fragments then
+              Ok ()
+            else
+              Error
+                (Printf.sprintf
+                   "%s expected success or guard %s but got: %s"
+                   name
+                   (String.concat ", " fragments)
+                   message)
+
+let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
+    (schema : Types.tool_schema) =
+  let saved_home = Sys.getenv_opt "HOME" in
+  let saved_env =
+    [
+      ("MASC_BASE_PATH", Sys.getenv_opt "MASC_BASE_PATH");
+      ("MASC_STORAGE_TYPE", Sys.getenv_opt "MASC_STORAGE_TYPE");
+      ("MASC_POSTGRES_URL", Sys.getenv_opt "MASC_POSTGRES_URL");
+      ("DATABASE_URL", Sys.getenv_opt "DATABASE_URL");
+      ("SUPABASE_DB_URL", Sys.getenv_opt "SUPABASE_DB_URL");
+      ("SB_PG_URL", Sys.getenv_opt "SB_PG_URL");
+    ]
+  in
+  Unix.putenv "MASC_STORAGE_TYPE" "filesystem";
+  Unix.putenv "MASC_POSTGRES_URL" "";
+  Unix.putenv "DATABASE_URL" "";
+  Unix.putenv "SUPABASE_DB_URL" "";
+  Unix.putenv "SB_PG_URL" "";
+  let base_path = Generic.temp_dir "keeper-tool-matrix-" in
+  Unix.putenv "MASC_BASE_PATH" base_path;
+  let result =
+    Fun.protect
+      ~finally:(fun () ->
+        List.iter
+          (fun (name, value) ->
+            match value with
+            | Some raw -> Unix.putenv name raw
+            | None -> Unix.putenv name "")
+          saved_env;
+        match saved_home with
+        | Some home -> Unix.putenv "HOME" home
+        | None -> Unix.putenv "HOME" "")
+      (fun () ->
+        Unix.putenv "HOME" base_path;
+        try
+          let case = case_for_name schema.Types.name in
+          let fixture =
+            make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path
+              case.init_mode
+          in
+          case.prepare fixture;
+          let args = case.arguments fixture schema in
+          match find_tool fixture schema.Types.name with
+          | None ->
+              Error
+                (Printf.sprintf "missing keeper Tool.t for %s" schema.Types.name)
+          | Some tool ->
+              let outcome = Tool.execute tool args in
+              if String.equal schema.Types.name "masc_heartbeat_start" then
+                Heartbeat.list ()
+                |> List.iter (fun (hb : Heartbeat.t) ->
+                       ignore (Heartbeat.stop hb.id));
+              evaluate_expectation ~name:schema.Types.name case.expectation
+                outcome
+        with exn ->
+          Error
+            (Printf.sprintf "%s raised during keeper case: %s"
+               schema.Types.name (Printexc.to_string exn)))
+  in
+  (base_path, result)


### PR DESCRIPTION
## Summary

- add a keeper-specific tool matrix that executes every keeper-exposed `Tool.t`
- reuse the existing MCP tool matrix fixture/contract generation for `masc_*` bridge coverage
- dedupe keeper model schemas by tool name so full-preset inventory is stable and non-duplicated

## Why

Keepers had many focused tests, but no single guard that proved the full keeper tool surface was still callable end-to-end. New keeper tools could be added without a matrix-style smoke pass, and duplicated schema entries were inflating the disclosed tool inventory.

## Product impact

- tighter regression coverage for the keeper tool surface
- stable full-preset keeper inventory with duplicate schemas removed before disclosure/execution wrapping

## Evidence

- full keeper tool matrix passed locally over 214 unique keeper-visible tool schemas
- focused smoke pass also succeeded for `keeper_bash`, `keeper_github`, `keeper_shell_readonly`, `keeper_fs_read`, `keeper_fs_edit`, `keeper_tasks_list`, `masc_status`, `masc_tasks`, and `masc_worktree_list`

## Verification

- `dune build --root . _build/default/test/test_keeper_tool_matrix.exe _build/default/test/keeper_tool_matrix_case_runner.exe`
- `KEEPER_TOOL_MATRIX_ONLY='keeper_bash,keeper_github,keeper_shell_readonly,keeper_fs_read,keeper_fs_edit,keeper_tasks_list,masc_status,masc_tasks,masc_worktree_list' dune exec --root . ./test/test_keeper_tool_matrix.exe`
- `dune exec --root . ./test/test_keeper_tool_matrix.exe`
- `dune exec --root . ./test/test_keeper_tools_oas.exe`

## Review evidence

- GLM-5.1 via `sb glm-text`: `No findings`
- evidence comment: https://github.com/jeong-sik/masc-mcp/pull/4984#issuecomment-4186436543

## Linked issue

- Refs #4985

## Notes

- `test_keeper_masc_bridge.exe` and `test_tool_keeper.exe` were probed after the change but were left out of the verification set because they sat idle for an extended period during ad-hoc runs.
