### PR TITLE
fix(oas): restore capacity-aware local backoff

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -108,7 +108,11 @@ let has_background_capacity () =
         not
           (capacity.all_discovered && capacity.endpoints_found > 0
            && capacity.process_available <= 0)
-      with _ -> true)
+      with
+      | Eio.Cancel.Cancelled _ as ex -> raise ex
+      | ex ->
+        Eio.traceln "[autoresearch] capacity check failed: %s" (Printexc.to_string ex);
+        true)
   | _ -> true
 
 (** Generate code change via Cascade "autoresearch" profile.

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -97,9 +97,19 @@ let parse_model_code_response response =
     | Ok _ ->
       Result.error "MODEL response must be a JSON object"
 
-(* local_capacity_for_selections removed from OAS SDK.
-   TODO(#4326): reimplement via Discovery.discover when needed. *)
-let has_background_capacity () = true
+let has_background_capacity () =
+  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+  | Some sw, Some net -> (
+      try
+        let capacity =
+          Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+            [ "autoresearch" ]
+        in
+        not
+          (capacity.all_discovered && capacity.endpoints_found > 0
+           && capacity.process_available <= 0)
+      with _ -> true)
+  | _ -> true
 
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -343,10 +343,14 @@ let append_judgments base_path judgments =
   let store = get_judgments_store base_path in
   List.iter (fun json -> Dated_jsonl.append store json) judgments
 
-let should_backoff ~sw:_ ~net:_ =
+let should_backoff ~sw ~net =
   try
-    (* local_capacity_for_selections removed from OAS SDK. TODO(#4326) *)
-    false
+    let capacity =
+      Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+        [ "governance_judge" ]
+    in
+    capacity.all_discovered && capacity.endpoints_found > 0
+    && capacity.process_available <= 0
   with exn ->
     Eio.traceln
       "[governance] capacity check failed in should_backoff: %s"

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -254,10 +254,14 @@ let compute_judgments
       | exn ->
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 
-let should_backoff ~sw:_ ~net:_ =
+let should_backoff ~sw ~net =
   try
-    (* local_capacity_for_selections removed from OAS SDK. TODO(#4326) *)
-    false
+    let capacity =
+      Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+        [ "operator_judge" ]
+    in
+    capacity.all_discovered && capacity.endpoints_found > 0
+    && capacity.process_available <= 0
   with exn ->
     Eio.traceln
       "[operator] capacity check failed in should_backoff: %s"

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -759,14 +759,21 @@ let session_to_swarm_config
       match all_selections with
       | [] -> entry_count
       | _ ->
-          let capacity =
-            Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
-              all_selections
-          in
-          slot_aware_concurrency_cap ~entry_count
-            ~selection_count:(List.length all_selections)
-            ~all_discovered:capacity.all_discovered
-            ~endpoints_found:capacity.endpoints_found ~total:capacity.total
+          (try
+            let capacity =
+              Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+                all_selections
+            in
+            slot_aware_concurrency_cap ~entry_count
+              ~selection_count:(List.length all_selections)
+              ~all_discovered:capacity.all_discovered
+              ~endpoints_found:capacity.endpoints_found ~total:capacity.total
+          with
+          | Eio.Cancel.Cancelled _ as ex -> raise ex
+          | ex ->
+            Eio.traceln "[swarm] capacity probe failed, using entry_count: %s"
+              (Printexc.to_string ex);
+            entry_count)
   in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -714,7 +714,8 @@ let planned_worker_to_entry
 (* ── session -> swarm_config ───────────────────────────────────── *)
 
 let session_to_swarm_config
-    ~sw:_ ~net:(_net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : Room.config)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -758,8 +759,14 @@ let session_to_swarm_config
       match all_selections with
       | [] -> entry_count
       | _ ->
-          (* local_capacity_for_selections removed from OAS SDK. TODO(#4326) *)
-          entry_count
+          let capacity =
+            Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+              all_selections
+          in
+          slot_aware_concurrency_cap ~entry_count
+            ~selection_count:(List.length all_selections)
+            ~all_discovered:capacity.all_discovered
+            ~endpoints_found:capacity.endpoints_found ~total:capacity.total
   in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -547,6 +547,32 @@ let test_oas_worker_capability_threading_contracts () =
     (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
        "?raw_trace ~proof_ref ?contract ~sw")
 
+let test_oas_capacity_restore_contracts () =
+  check bool "operator judge backoff uses OAS local capacity" true
+    (file_contains_pattern "lib/dashboard/dashboard_operator_judge.ml"
+       "local_capacity_for_selections ~sw ~net");
+  check bool "operator judge selection is explicit" true
+    (file_contains_pattern "lib/dashboard/dashboard_operator_judge.ml"
+       {|[ "operator_judge" ]|});
+  check bool "governance judge backoff uses OAS local capacity" true
+    (file_contains_pattern "lib/dashboard/dashboard_governance_judge.ml"
+       "local_capacity_for_selections ~sw ~net");
+  check bool "governance judge selection is explicit" true
+    (file_contains_pattern "lib/dashboard/dashboard_governance_judge.ml"
+       {|[ "governance_judge" ]|});
+  check bool "team session swarm config restores slot-aware OAS capacity query" true
+    (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
+       "local_capacity_for_selections ~sw ~net");
+  check bool "team session swarm config reuses slot-aware cap helper" true
+    (file_contains_pattern "lib/team_session/team_session_oas_bridge.ml"
+       "slot_aware_concurrency_cap ~entry_count");
+  check bool "autoresearch background gating restores OAS capacity query" true
+    (file_contains_pattern "lib/autoresearch_codegen.ml"
+       "local_capacity_for_selections ~sw ~net");
+  check bool "autoresearch uses Eio context fallback for capacity probing" true
+    (file_contains_pattern "lib/autoresearch_codegen.ml"
+       "Eio_context.get_switch_opt (), Eio_context.get_net_opt ()")
+
 let test_team_session_spawn_tool_contracts () =
   check bool "team session spawn preflights via Worker_runtime" true
     (file_contains_pattern "lib/tool_team_session_step_spawn.ml"
@@ -705,6 +731,8 @@ let () =
              test_worktree_list_contracts;
            test_case "oas worker capability threading contracts" `Quick
              test_oas_worker_capability_threading_contracts;
+           test_case "oas capacity restore contracts" `Quick
+             test_oas_capacity_restore_contracts;
            test_case "team session spawn tool contracts" `Quick
              test_team_session_spawn_tool_contracts;
            test_case "dashboard timeout guard contracts" `Quick


### PR DESCRIPTION
## Summary
- restore OAS-backed local capacity checks in operator/governance judge backoff paths
- restore slot-aware `max_concurrent_agents` calculation in `team_session_oas_bridge`
- restore autoresearch background-capacity gating via global Eio context when available
- add source-contract coverage so these OAS capacity calls do not get stubbed out again

## Product impact
- operator and governance judges stop scheduling local work when discovered local slots are saturated
- team sessions recover slot-aware swarm concurrency instead of always running at raw worker count
- autoresearch no longer ignores local saturation whenever Eio context is available

## Evidence
- `opam exec -- dune build --root .`
- `opam exec -- dune exec test/test_team_session_oas_bridge.exe --root .`
- `opam exec -- dune exec test/test_ci_hardening_source.exe --root .`
- `opam exec -- dune exec test/test_dashboard_governance.exe --root .`
- `opam exec -- dune exec test/test_dashboard_autoresearch.exe --root .`
- `opam exec -- dune exec test/test_autoresearch_codegen.exe --root .`

## Review evidence
- direct `sb glm-text` review attempt stalled twice with no response on 2026-04-04 KST
- `scripts/review/local-review.sh --base origin/main --head HEAD --format text` failed because local reviewer endpoint `127.0.0.1:8085` was unavailable (`curl: (7) Failed to connect`)
- draft PR left open until cross-model review path is available again

## Linked issue
- Refs #4326
