### PR TITLE
[codex] fix keeper autoboot for declarative janitor cleanup

### DIFF
--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -1,0 +1,57 @@
+[keeper]
+goal = "Keep masc-mcp clean by removing tool-matrix and other obviously-generated garbage."
+short_goal = "Find stale tool-matrix artifacts and remove them conservatively."
+mid_goal = "Keep shared operator surfaces free of stale automation/test noise."
+long_goal = "Operate an always-on janitor loop that keeps masc-mcp usable without manual garbage collection."
+
+soul_profile = "delivery"
+
+will = "Delete only unmistakable garbage. If ownership is ambiguous, leave it and report."
+needs = "Board inspection/delete, voice session inspection/end, zombie cleanup, and shared runtime status."
+desires = "Low-noise dashboards and no lingering tool-matrix test artifacts."
+
+instructions = """
+You are janitor, the masc-mcp garbage collector.
+
+Primary cleanup targets:
+1. Board posts that are clearly generated test noise:
+   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers
+   - no comments
+   - no votes
+   - older than 30 minutes
+2. Voice sessions that are clearly test artifacts:
+   - agent_id is `tool-matrix`
+   - or agent_id ends with `-tool-matrix`
+   - or agent_id contains `fixture`/`test` and is stale
+3. Stale automation agents that are already safe for `masc_cleanup_zombies`
+
+Safety rules:
+- Never delete human discussion.
+- Never delete any board post with comments or votes.
+- Never touch posts newer than 30 minutes.
+- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.
+
+Execution loop:
+1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.
+2. Delete only safe board garbage with `keeper_board_delete`.
+3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.
+4. Run `masc_cleanup_zombies` when stale automation agents are present.
+5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.
+
+Tone: terse, operational, no speeches.
+"""
+
+room_scope = "all"
+scope_kind = "global"
+mention_targets = ["janitor", "garbage-keeper", "tool-matrix-janitor"]
+
+proactive_enabled = true
+execution_scope = "workspace"
+
+tool_preset = "research"
+tool_also_allow = [
+  "keeper_board_delete",
+  "masc_voice_sessions",
+  "masc_voice_session_end",
+  "masc_cleanup_zombies",
+]

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -3,6 +3,19 @@
 
 open Keeper_types
 
+type boot_meta_resolution = {
+  meta : keeper_meta;
+  materialized : bool;
+}
+
+let declarative_keeper_names () =
+  Config_dir_resolver.log_warnings ~context:"KeeperRuntime" ();
+  Keeper_types_profile.discover_keepers_toml (Config_dir_resolver.keepers_dir ())
+  |> List.map fst
+
+let bootable_keeper_names config =
+  dedupe_keep_order (keeper_names config @ declarative_keeper_names ())
+
 let ensure_keeper_meta config name =
   match read_meta config name with
   | Ok (Some meta) ->
@@ -46,6 +59,40 @@ let ensure_keeper_meta config name =
     Error (Printf.sprintf "no persistent meta for %s — run keeper_up to initialize" name)
   | Error msg -> Error msg
 
+let load_or_materialize_boot_meta (ctx : _ context) name
+    : (boot_meta_resolution, string) result =
+  match ensure_keeper_meta ctx.config name with
+  | Ok meta -> Ok { meta; materialized = false }
+  | Error original_error -> (
+      match Config_dir_resolver.keeper_toml_path_opt name with
+      | None -> Error original_error
+      | Some toml_path ->
+          Log.Keeper.info
+            "bootstrapping declarative keeper %s from %s"
+            name toml_path;
+          let ok, body =
+            Keeper_turn.handle_keeper_up ctx
+              (`Assoc [ ("name", `String name) ])
+          in
+          if not ok then
+            Error
+              (Printf.sprintf
+                 "failed to materialize declarative keeper %s from %s: %s"
+                 name toml_path body)
+          else
+            match read_meta ctx.config name with
+            | Ok (Some meta) -> Ok { meta; materialized = true }
+            | Ok None ->
+                Error
+                  (Printf.sprintf
+                     "materialized declarative keeper %s from %s but no meta was written"
+                     name toml_path)
+            | Error msg ->
+                Error
+                  (Printf.sprintf
+                     "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                     name toml_path msg))
+
 type keeper_bootstrap_stats = {
   enabled: bool;
   scanned: int;
@@ -74,22 +121,20 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
          else
            max_int)
     in
-    let entries =
-      keeper_names ctx.config
-      |> take max_scan
-    in
+    let entries = bootable_keeper_names ctx.config |> take max_scan in
     let (enabled, scanned, started, stale, recovering) =
       List.fold_left
         (fun (enabled_acc, scanned_acc, started_acc, stale_acc, recovering_acc) name ->
-          match ensure_keeper_meta ctx.config name with
+          match load_or_materialize_boot_meta ctx name with
           | Error _ ->
               (enabled_acc, scanned_acc + 1, started_acc, stale_acc, recovering_acc)
-          | Ok m ->
+          | Ok { meta = m; materialized } ->
               if m.paused then
                 (enabled_acc, scanned_acc + 1, started_acc, stale_acc, recovering_acc)
               else
               let stale_now =
-                stale_turn_sec > 0.0
+                (not materialized)
+                && stale_turn_sec > 0.0
                 && (m.runtime.usage.last_turn_ts <= 0.0
                     || now_ts -. m.runtime.usage.last_turn_ts >= stale_turn_sec)
               in
@@ -97,7 +142,10 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 Keeper_registry.is_running ~base_path:ctx.config.base_path m.name
               in
               let started_here =
-                if already_running then false
+                if materialized then
+                  Keeper_registry.is_running
+                    ~base_path:ctx.config.base_path m.name
+                else if already_running then false
                 else if max_keepers > 0 && !remaining_slots <= 0 then false
                 else (
                   Keeper_supervisor.supervise_keepalive
@@ -194,7 +242,7 @@ let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
   Hashtbl.create 4
 
 let has_boot_entries config =
-  keepalive_keeper_names config <> []
+  bootable_keeper_names config <> []
 
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
   if stats.enabled

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -143,8 +143,13 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
               in
               let started_here =
                 if materialized then
-                  Keeper_registry.is_running
-                    ~base_path:ctx.config.base_path m.name
+                  let started_now =
+                    Keeper_registry.is_running
+                      ~base_path:ctx.config.base_path m.name
+                  in
+                  if started_now && max_keepers > 0 then
+                    remaining_slots := max 0 (!remaining_slots - 1);
+                  started_now
                 else if already_running then false
                 else if max_keepers > 0 && !remaining_slots <= 0 then false
                 else (

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -71,16 +71,25 @@ let select_existing_masc_tool_names names =
 
 (* ── Candidate aggregation ────────────────────────────────────── *)
 
-let keeper_all_candidate_tool_names () =
+let keeper_base_candidate_tool_names () =
   dedupe_tool_names
     ( keeper_internal_candidate_tool_names
-    @ keeper_optional_board_tool_names
     @ keeper_voice_tool_names
     @ keeper_governance_tool_names
     @ keeper_coding_shard_tool_names
     @ keeper_coding_tool_names
     @ keeper_autoresearch_tool_names
     @ injected_masc_tool_names () )
+
+let explicit_optional_candidate_tool_names (meta : keeper_meta) =
+  let requested =
+    match meta.tool_access with
+    | Preset { also_allow; _ } -> also_allow
+    | Custom allowlist -> allowlist
+  in
+  requested
+  |> List.filter (fun name -> List.mem name keeper_optional_board_tool_names)
+  |> dedupe_tool_names
 
 (* ── Presets ──────────────────────────────────────────────────── *)
 
@@ -119,7 +128,7 @@ let preset_allowlist = function
         @ keeper_governance_tool_names
         @ keeper_autoresearch_tool_names
         @ select_existing_masc_tool_names keeper_core_masc_tool_names )
-  | Full -> keeper_all_candidate_tool_names ()
+  | Full -> keeper_base_candidate_tool_names ()
 
 let tool_policy_of_meta (meta : keeper_meta) =
   let allow =
@@ -149,7 +158,10 @@ let tool_name_set names =
   tbl
 
 let tool_access_lookup_of_meta (meta : keeper_meta) =
-  let candidate_names = keeper_all_candidate_tool_names () in
+  let candidate_names =
+    dedupe_tool_names
+      (keeper_base_candidate_tool_names () @ explicit_optional_candidate_tool_names meta)
+  in
   let candidate_set = tool_name_set candidate_names in
   let allow_names =
     Tool_access_policy.resolve

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -74,6 +74,7 @@ let select_existing_masc_tool_names names =
 let keeper_all_candidate_tool_names () =
   dedupe_tool_names
     ( keeper_internal_candidate_tool_names
+    @ keeper_optional_board_tool_names
     @ keeper_voice_tool_names
     @ keeper_governance_tool_names
     @ keeper_coding_shard_tool_names

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -26,6 +26,12 @@ let keeper_board_tool_names =
     "keeper_board_search";
   ]
 
+let keeper_optional_board_tool_names =
+  [
+    (* Deliberately excluded from default presets. Explicit opt-in only. *)
+    "keeper_board_delete";
+  ]
+
 let keeper_voice_tool_names =
   [ "keeper_voice_speak"; "keeper_voice_listen"; "keeper_voice_agent";
     "keeper_voice_sessions";

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -242,27 +242,37 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           | Error e ->
             Log.Keeper.error "autoboot: failed to load meta for %s: %s" name e
           | Ok { meta = m; materialized } ->
-            if Keeper_registry.is_running ~base_path:config.base_path m.name then
+            let started_here =
+              if Keeper_registry.is_running ~base_path:config.base_path m.name then (
+                Log.Keeper.info
+                  "autoboot: %s already running%s"
+                  m.name
+                  (if materialized then " (materialized from TOML)" else "");
+                false
+              ) else begin
+                let warmup = base_warmup + (idx * stagger_step) in
+                Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
+                  name warmup;
+                let ctx : _ Keeper_types.context = {
+                  config;
+                  agent_name = m.agent_name;
+                  sw;
+                  clock;
+                  proc_mgr = Some proc_mgr;
+                  net = state.net;
+                } in
+                Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m;
+                Keeper_registry.is_running ~base_path:config.base_path m.name
+              end
+            in
+            if started_here then begin
+              incr booted;
+              Log.Keeper.info "autoboot: started keepalive for %s" m.name
+            end else
               Log.Keeper.info
-                "autoboot: %s already running%s"
+                "autoboot: keeper %s counted as already available%s"
                 m.name
-                (if materialized then " (materialized from TOML)" else "")
-            else begin
-              let warmup = base_warmup + (idx * stagger_step) in
-              Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
-                name warmup;
-              let ctx : _ Keeper_types.context = {
-                config;
-                agent_name = m.agent_name;
-                sw;
-                clock;
-                proc_mgr = Some proc_mgr;
-                net = state.net;
-              } in
-              Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m
-            end;
-            incr booted;
-            Log.Keeper.info "autoboot: started keepalive for %s" m.name
+                (if materialized then " after TOML materialization" else "")
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -219,7 +219,15 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Log.Keeper.info
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;
-      let names = Keeper_types.keepalive_keeper_names config in
+      let names = Keeper_runtime.bootable_keeper_names config in
+      let keeper_boot_ctx : _ Keeper_types.context = {
+        config;
+        agent_name = "keeper-autoboot";
+        sw;
+        clock;
+        proc_mgr = Some proc_mgr;
+        net = state.net;
+      } in
       Log.Keeper.info
         "autoboot: %d keeper(s) to boot; concurrent keeper turns throttled to %d via MASC_KEEPER_AUTOBOOT_MAX"
         (List.length names) Keeper_keepalive.keeper_turn_throttle_limit;
@@ -230,22 +238,29 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     List.iteri (fun idx name ->
         try
           Log.Keeper.info "autoboot: loading meta for %s" name;
-          match Keeper_runtime.ensure_keeper_meta config name with
+          match Keeper_runtime.load_or_materialize_boot_meta keeper_boot_ctx name with
           | Error e ->
             Log.Keeper.error "autoboot: failed to load meta for %s: %s" name e
-          | Ok m ->
-            let warmup = base_warmup + (idx * stagger_step) in
-            Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
-              name warmup;
-            let ctx : _ Keeper_types.context = {
-              config;
-              agent_name = m.agent_name;
-              sw;
-              clock;
-              proc_mgr = Some proc_mgr;
-              net = state.net;
-            } in
-            Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m;
+          | Ok { meta = m; materialized } ->
+            if Keeper_registry.is_running ~base_path:config.base_path m.name then
+              Log.Keeper.info
+                "autoboot: %s already running%s"
+                m.name
+                (if materialized then " (materialized from TOML)" else "")
+            else begin
+              let warmup = base_warmup + (idx * stagger_step) in
+              Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
+                name warmup;
+              let ctx : _ Keeper_types.context = {
+                config;
+                agent_name = m.agent_name;
+                sw;
+                clock;
+                proc_mgr = Some proc_mgr;
+                net = state.net;
+              } in
+              Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m
+            end;
             incr booted;
             Log.Keeper.info "autoboot: started keepalive for %s" m.name
         with

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -157,6 +157,18 @@ Use when looking for specific topics, past discussions, or related prior work.";
       ("required", `List [`String "query"]);
     ];
   };
+  {
+    name = "keeper_board_delete";
+    description = "Delete a board post that is clearly safe to remove. \
+Use only for generated garbage, expired automation, or other explicitly-approved cleanup cases.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to delete")]);
+      ]);
+      ("required", `List [`String "post_id"]);
+    ];
+  };
 ]
 
 let select_named_schemas (names : string list) (schemas : Types.tool_schema list) :

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -2209,6 +2209,7 @@ let test_keeper_board_delete_requires_explicit_opt_in () =
   Fun.protect
     ~finally:(fun () ->
       Masc_mcp.Keeper_keepalive.stop_keepalive "board-delete-demo";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "board-delete-full";
       Masc_mcp.Keeper_keepalive.stop_keepalive "board-delete-optin";
       rm_rf base_dir)
     (fun () ->
@@ -2233,6 +2234,17 @@ let test_keeper_board_delete_requires_explicit_opt_in () =
             ])
       in
       if not ok_default then fail ("default keeper_up failed: " ^ body_default);
+      let ok_full, body_full =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "board-delete-full");
+              ("goal", `String "Check full board delete policy");
+              ("proactive_enabled", `Bool false);
+              ("tool_preset", `String "full");
+            ])
+      in
+      if not ok_full then fail ("full keeper_up failed: " ^ body_full);
       let ok_optin, body_optin =
         dispatch "masc_keeper_up"
           (`Assoc
@@ -2257,8 +2269,16 @@ let test_keeper_board_delete_requires_explicit_opt_in () =
         | Ok None -> fail "missing board-delete-optin meta"
         | Error e -> fail e
       in
+      let full_meta =
+        match Masc_mcp.Keeper_types.read_meta config "board-delete-full" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing board-delete-full meta"
+        | Error e -> fail e
+      in
       check_keeper_exec_tool_presence "default research preset board delete"
         default_meta ~tool_name:"keeper_board_delete" ~expect_allowed:false;
+      check_keeper_exec_tool_presence "default full preset board delete"
+        full_meta ~tool_name:"keeper_board_delete" ~expect_allowed:false;
       check_keeper_exec_tool_presence "explicit board delete opt-in"
         optin_meta ~tool_name:"keeper_board_delete" ~expect_allowed:true)
 

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -2148,6 +2148,120 @@ let test_keeper_bootstrap_marks_stale_explicit_keeper () =
       check bool "diagnostic removed from status" true
         Yojson.Safe.Util.(status_json |> member "diagnostic" = `Null))
 
+let janitor_toml_contents = {|
+[keeper]
+goal = "Keep the runtime clean."
+short_goal = "Materialize from TOML."
+mid_goal = "Stay bootable from declarative config."
+long_goal = "Remain durable."
+soul_profile = "delivery"
+instructions = "Bootstrap from TOML only."
+room_scope = "all"
+scope_kind = "global"
+mention_targets = ["janitor"]
+proactive_enabled = false
+tool_preset = "research"
+tool_also_allow = ["keeper_board_delete"]
+|}
+
+let test_keeper_bootstrap_materializes_toml_only_keeper () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Masc_mcp.Keeper_registry.clear ();
+  let base_dir = temp_dir () in
+  let config_root = Filename.concat (Filename.concat base_dir ".masc") "config" in
+  let keepers_root = Filename.concat config_root "keepers" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Config_dir_resolver.reset ();
+      Masc_mcp.Keeper_keepalive.stop_keepalive "janitor";
+      Masc_mcp.Keeper_registry.clear ();
+      rm_rf base_dir)
+    (fun () ->
+      write_file (Filename.concat keepers_root "janitor.toml") janitor_toml_contents;
+      with_env "MASC_CONFIG_DIR" config_root (fun () ->
+        Masc_mcp.Config_dir_resolver.reset ();
+        let config = Masc_mcp.Room.default_config base_dir in
+        ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+        let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+          { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+        in
+        check bool "bootable keeper names include declarative janitor" true
+          (List.mem "janitor" (Masc_mcp.Keeper_runtime.bootable_keeper_names config));
+        let stats = Masc_mcp.Keeper_runtime.bootstrap_existing_keepers keeper_ctx in
+        check bool "bootstrap enabled" true stats.enabled;
+        check int "declarative keeper started" 1 stats.started;
+        check int "declarative keeper not stale on first materialization" 0 stats.stale;
+        let meta =
+          match Masc_mcp.Keeper_types.read_meta config "janitor" with
+          | Ok (Some meta) -> meta
+          | Ok None -> fail "missing janitor meta"
+          | Error e -> fail e
+        in
+        check string "goal came from TOML" "Keep the runtime clean." meta.goal;
+        check bool "janitor keepalive running" true
+          (Masc_mcp.Keeper_registry.is_running ~base_path:config.base_path "janitor")))
+
+let test_keeper_board_delete_requires_explicit_opt_in () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "board-delete-demo";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "board-delete-optin";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok_default, body_default =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "board-delete-demo");
+              ("goal", `String "Check default board delete policy");
+              ("proactive_enabled", `Bool false);
+              ("tool_preset", `String "research");
+            ])
+      in
+      if not ok_default then fail ("default keeper_up failed: " ^ body_default);
+      let ok_optin, body_optin =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "board-delete-optin");
+              ("goal", `String "Check explicit board delete policy");
+              ("proactive_enabled", `Bool false);
+              ("tool_preset", `String "research");
+              ("tool_also_allow", `List [ `String "keeper_board_delete" ]);
+            ])
+      in
+      if not ok_optin then fail ("opt-in keeper_up failed: " ^ body_optin);
+      let default_meta =
+        match Masc_mcp.Keeper_types.read_meta config "board-delete-demo" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing board-delete-demo meta"
+        | Error e -> fail e
+      in
+      let optin_meta =
+        match Masc_mcp.Keeper_types.read_meta config "board-delete-optin" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing board-delete-optin meta"
+        | Error e -> fail e
+      in
+      check_keeper_exec_tool_presence "default research preset board delete"
+        default_meta ~tool_name:"keeper_board_delete" ~expect_allowed:false;
+      check_keeper_exec_tool_presence "explicit board delete opt-in"
+        optin_meta ~tool_name:"keeper_board_delete" ~expect_allowed:true)
+
 let test_keeper_supervisor_recovers_missing_desired_keeper () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -2693,6 +2807,10 @@ let () =
            test_parse_agent_status_reads_compressed_filesystem_backend;
          test_case "keeper bootstrap marks stale explicit keeper" `Quick
            test_keeper_bootstrap_marks_stale_explicit_keeper;
+         test_case "keeper bootstrap materializes TOML-only keeper" `Quick
+           test_keeper_bootstrap_materializes_toml_only_keeper;
+         test_case "keeper board delete requires explicit opt-in" `Quick
+           test_keeper_board_delete_requires_explicit_opt_in;
          test_case "keeper supervisor recovers missing desired keeper" `Quick
            test_keeper_supervisor_recovers_missing_desired_keeper;
          test_case "legacy presence_keepalive false migrates to paused" `Quick


### PR DESCRIPTION
## Summary
- add a declarative `janitor` keeper for tool-matrix and other obvious garbage cleanup
- materialize TOML-only keepers into durable JSON meta during bootstrap/autoboot
- keep `keeper_board_delete` behind explicit opt-in, including full-preset keepers
- account for materialized keepers in bootstrap slot bookkeeping

## Why
The repo already had janitor cleanup intent, but server autoboot only read `.masc/keepers/*.json`. A keeper declared only in `config/keepers/*.toml` never got materialized or started on first boot, so no garbage janitor lane existed in practice.

## Impact
- `config/keepers/janitor.toml` now boots automatically on server startup
- declarative keepers no longer require a manual first `masc_keeper_up` just to become durable
- destructive board cleanup remains opt-in instead of becoming part of the default keeper surface

## Product impact
- shared masc-mcp runtimes get a real janitor lane for stale `tool-matrix` garbage
- operators can rely on declarative keeper config without a manual warm-up step
- cleanup capability stays conservative by default

## Evidence
- local runtime change verified with targeted bootstrap and delete-gating tests
- PR includes a durable janitor declaration under `config/keepers/`
- slot accounting updated so materialized keepers consume bootstrap capacity correctly

## Review evidence
- GLM-5 cross-model review evidence is attached in PR comments
- Copilot review comment about `booted` accounting was addressed in follow-up commit `5743fcd37`

## Linked issue
- Refs #4820

## Validation
- `dune build --root .`
- `./_build/default/test/test_tool_keeper.exe`
- `./_build/default/test/test_tool_keeper.exe test 'read_file_tail_lines' 45-47`