### PR TITLE
[codex] fix dashboard keeper lifecycle routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The dashboard is a read / operate UI. Canonical write and control paths remain M
   `PORT="$(scripts/run-local.sh --print-port --target-dir "$PWD")"`
   `cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run dev`
 - For manual rebuilds, run `cd dashboard && pnpm run build`.
+- For local admin bearer bootstrap and dashboard keeper lifecycle control, see [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md).
 
 ## Verification
 
@@ -209,6 +210,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - [docs/BENCHMARK-RUNBOOK.md](docs/BENCHMARK-RUNBOOK.md) — single-agent vs swarm comparison
 - [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) — supervised team-session / operator workflow
 - [docs/REMOTE-MCP-OPERATOR.md](docs/REMOTE-MCP-OPERATOR.md) — remote-safe operator endpoint and confirm flow
+- [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) — local admin bearer bootstrap, base-path checks, and dashboard keeper lifecycle control
 - [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) — keeper lifecycle and troubleshooting
 - [docs/spec/SPEC-INDEX.md](docs/spec/SPEC-INDEX.md) — spec suite front door
 - `llms.txt` / `llms-full.txt` — compressed front door for language models

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -1,0 +1,213 @@
+# Local Dashboard Auth Runbook
+
+This runbook is the local operator path for dashboard-side keeper lifecycle actions such as:
+
+- `POST /api/v1/keepers/:name/boot`
+- `POST /api/v1/keepers/:name/shutdown`
+- `PATCH /api/v1/keepers/:name/config`
+
+Those routes are stricter than normal local `/mcp` calls:
+
+- they require room auth enabled
+- they require `require_token=true`
+- they require an admin bearer token
+
+If the dashboard can read state but keeper boot/config/shutdown fails, use this runbook.
+
+## 1. Confirm the Real Base Path
+
+Always check which `.masc` root the server is actually using before editing auth state.
+
+```bash
+curl -sS http://127.0.0.1:8935/health | jq '.paths'
+```
+
+Truth fields:
+
+- `effective_base_path`
+- `effective_masc_root`
+- `cwd_masc_root`
+- `roots_diverge`
+
+If `effective_base_path` is not the repo you expected, fix that first. In shared `~/me` setups, the live auth store may be `~/me/.masc/auth` even when the server process is running from a sub-repo worktree.
+
+## 2. Understand the Gate
+
+Quick read:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell | jq '.auth'
+```
+
+Important fields:
+
+- `enabled`
+- `require_token`
+- `effective_role`
+- `can_keeper_msg`
+- `keeper_msg_error`
+
+For dashboard-side keeper lifecycle control, the target shape is:
+
+```json
+{
+  "enabled": true,
+  "require_token": true,
+  "effective_role": "admin"
+}
+```
+
+## 3. Supported Local Start
+
+When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
+
+```bash
+MASC_BASE_PATH="$HOME/me" \
+MASC_ALLOW_INHERITED_BASE_PATH=1 \
+./_build/default/bin/main_eio.exe \
+  --host 127.0.0.1 \
+  --port 8935 \
+  --base-path "$HOME/me"
+```
+
+Then re-check `/health` and confirm `effective_base_path` is the same path you intended.
+
+## 4. Bootstrap an Admin Bearer
+
+If you already have an admin bearer, skip to step 5.
+
+If you do not, the reliable local fallback is to seed the auth store directly.
+
+1. Back up the auth config:
+
+```bash
+cp "$HOME/me/.masc/auth/config.json" "$HOME/me/.masc/auth/config.json.bak"
+```
+
+2. Generate a token and its SHA256 hash:
+
+```bash
+TOKEN="$(openssl rand -hex 32)"
+HASH="$(printf '%s' "$TOKEN" | shasum -a 256 | awk '{print $1}')"
+CREATED="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+EXPIRES="$(date -u -v+72H +"%Y-%m-%dT%H:%M:%SZ")"
+printf 'token=%s\nhash=%s\n' "$TOKEN" "$HASH"
+```
+
+3. Write an admin credential file under the live auth root:
+
+```json
+{
+  "agent_name": "codex-tool-matrix",
+  "token": "<sha256 hash>",
+  "role": "admin",
+  "created_at": "<created_at>",
+  "expires_at": "<expires_at>"
+}
+```
+
+Path:
+
+```text
+<effective_base_path>/.masc/auth/agents/codex-tool-matrix.json
+```
+
+4. Set `require_token=true` in the live auth config:
+
+```json
+{
+  "enabled": true,
+  "require_token": true,
+  "default_role": "worker"
+}
+```
+
+Path:
+
+```text
+<effective_base_path>/.masc/auth/config.json
+```
+
+Notes:
+
+- the server stores only the SHA256 hash, not the raw bearer
+- keep the raw bearer outside the repo
+- this is for trusted local operator use, not a remote/public bootstrap path
+
+## 5. Open the Dashboard as Admin
+
+Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
+
+```text
+http://127.0.0.1:8935/dashboard?agent=codex-tool-matrix&token=<raw-token>
+```
+
+You can verify the session with:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-tool-matrix" \
+  | jq '.auth'
+```
+
+Expected:
+
+- `token_present=true`
+- `effective_agent="codex-tool-matrix"`
+- `effective_role="admin"`
+
+## 6. Verify Keeper Lifecycle Routes
+
+Use a low-risk keeper first.
+
+Boot:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/boot \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-tool-matrix"
+```
+
+Shutdown:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/shutdown \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-tool-matrix"
+```
+
+Then inspect the execution snapshot:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-tool-matrix" \
+  | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
+```
+
+## 7. Rollback
+
+If you need to go back to anonymous loopback behavior:
+
+1. restore the config backup
+2. remove the seeded credential file
+3. restart the server
+
+Example:
+
+```bash
+mv "$HOME/me/.masc/auth/config.json.bak" "$HOME/me/.masc/auth/config.json"
+rm -f "$HOME/me/.masc/auth/agents/codex-tool-matrix.json"
+```
+
+## 8. Known Failure Modes
+
+- `effective_base_path` points somewhere else:
+  you edited the wrong `.masc/auth` tree
+- `require_token=false`:
+  dashboard keeper boot/config/shutdown remains blocked even with auth enabled
+- `effective_role=worker`:
+  your bearer is valid but not admin
+- `{"error":"not found"}` on keeper boot/shutdown:
+  you may still be running an older server build without the fixed route classifier

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -153,6 +153,172 @@ let handle_keeper_tools_post state req reqd =
              Http.Response.json ~status:`Bad_request
                (Printf.sprintf {|{"error":"invalid json: %s"}|} (String.escaped e)) reqd))
 
+type keeper_post_route_kind =
+  | Keeper_post_tools
+  | Keeper_post_config
+  | Keeper_post_boot
+  | Keeper_post_shutdown
+  | Keeper_post_unknown
+
+let classify_keeper_post_route req_path =
+  let prefix = "/api/v1/keepers/" in
+  let plen = String.length prefix in
+  let tlen = String.length req_path in
+  let ends_with suffix =
+    let slen = String.length suffix in
+    tlen > plen + slen
+    && String.sub req_path 0 plen = prefix
+    && String.sub req_path (tlen - slen) slen = suffix
+  in
+  if ends_with "/tools" then Keeper_post_tools
+  else if ends_with "/config" then Keeper_post_config
+  else if ends_with "/boot" then Keeper_post_boot
+  else if ends_with "/shutdown" then Keeper_post_shutdown
+  else Keeper_post_unknown
+
+let extract_keeper_name_for_post req_path suffix =
+  let prefix = "/api/v1/keepers/" in
+  let plen = String.length prefix in
+  let slen = String.length suffix in
+  String.trim
+    (String.sub req_path plen (String.length req_path - plen - slen))
+
+let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_post req_path "/config" in
+  if String.length name = 0 then
+    Http.Response.json ~status:`Bad_request
+      {|{"error":"keeper name is required"}|} reqd
+  else
+    let config = state.Mcp_server.room_config in
+    match Keeper_types.read_meta config name with
+    | Error msg ->
+        Http.Response.json ~status:`Not_found
+          (Printf.sprintf {|{"error":"%s"}|}
+             (String.escaped msg))
+          reqd
+    | Ok None ->
+        Http.Response.json ~status:`Not_found
+          (Printf.sprintf {|{"error":"keeper %S not found"}|} name)
+          reqd
+    | Ok (Some meta0) ->
+        (try
+           let args = Yojson.Safe.from_string body_str in
+           let fields_opt =
+             match args with
+             | `Assoc fields -> Some fields
+             | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _
+             | `String _ | `List _ ->
+                 None
+           in
+           match fields_opt with
+           | Some fields ->
+               let body_name =
+                 match List.assoc_opt "name" fields with
+                 | Some (`String value) ->
+                     let trimmed = String.trim value in
+                     if trimmed = "" then None else Some trimmed
+                 | _ -> None
+               in
+               if Option.is_some body_name
+                  && body_name <> Some name
+               then
+                 Http.Response.json ~status:`Bad_request
+                   (Printf.sprintf
+                      {|{"error":"keeper name mismatch: route=%S body=%S"}|}
+                      name (Option.value ~default:"" body_name))
+                   reqd
+               else
+                 let args_with_name =
+                   `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
+                 in
+                 let keeper_ctx : _ Tool_keeper.context =
+                   {
+                     config;
+                     agent_name;
+                     sw;
+                     clock;
+                     proc_mgr = state.Mcp_server.proc_mgr;
+                     net = state.Mcp_server.net;
+                   }
+                 in
+                 (match Keeper_turn_up_args.parse keeper_ctx args_with_name with
+                 | Error (_ok, msg) ->
+                     Http.Response.json ~status:`Bad_request
+                       (Printf.sprintf {|{"error":"%s"}|}
+                          (String.escaped msg))
+                       reqd
+                 | Ok parsed ->
+                     let ok, msg =
+                       Keeper_turn_up_update.update_keeper keeper_ctx parsed meta0
+                     in
+                     if not ok then
+                       Http.Response.json ~status:`Bad_request
+                         (Printf.sprintf {|{"error":"%s"}|}
+                            (String.escaped msg))
+                         reqd
+                     else
+                       let (_st, json) =
+                         Dashboard_http_keeper.keeper_config_json config name
+                       in
+                       Http.Response.json ~compress:true ~request:req
+                         (Yojson.Safe.to_string json) reqd)
+           | None ->
+               Http.Response.json ~status:`Bad_request
+                 {|{"error":"request body must be a JSON object"}|}
+                 reqd
+         with Yojson.Json_error e ->
+           Http.Response.json ~status:`Bad_request
+             (Printf.sprintf {|{"error":"invalid json: %s"}|}
+                (String.escaped e))
+             reqd)
+
+let handle_keeper_lifecycle_post ~sw ~clock ~tool_name ~action state agent_name req reqd =
+  let req_path = Http.Request.path req in
+  let suffix =
+    match action with
+    | "boot" -> "/boot"
+    | "shutdown" -> "/shutdown"
+    | _ -> ""
+  in
+  let name = extract_keeper_name_for_post req_path suffix in
+  if String.length name = 0 then
+    Http.Response.json ~status:`Bad_request
+      {|{"error":"keeper name is required"}|} reqd
+  else
+    let config = state.Mcp_server.room_config in
+    let keeper_ctx : _ Tool_keeper.context =
+      {
+        config;
+        agent_name;
+        sw;
+        clock;
+        proc_mgr = state.Mcp_server.proc_mgr;
+        net = state.Mcp_server.net;
+      }
+    in
+    let args = `Assoc [("name", `String name)] in
+    match Tool_keeper.dispatch keeper_ctx ~name:tool_name ~args with
+    | Some (true, body) when String.equal action "boot" ->
+        Http.Response.json ~compress:true ~request:req
+          (Printf.sprintf {|{"ok":true,"action":"boot","name":"%s","detail":%s}|}
+             (String.escaped name) body)
+          reqd
+    | Some (true, _body) ->
+        Http.Response.json ~compress:true ~request:req
+          (Printf.sprintf {|{"ok":true,"action":"shutdown","name":"%s"}|}
+             (String.escaped name))
+          reqd
+    | Some (false, body) ->
+        Http.Response.json ~status:`Bad_request ~request:req
+          (Yojson.Safe.to_string
+             (`Assoc [("ok", `Bool false); ("error", `String body)]))
+          reqd
+    | None ->
+        Http.Response.json ~status:`Internal_server_error ~request:req
+          {|{"ok":false,"error":"dispatch returned None"}|}
+          reqd
+
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -565,242 +731,34 @@ let rec add_routes ~sw ~clock router =
      /tools gets with_tool_auth (localhost-friendly) while /config keeps
      with_token_permission_auth (admin token required). *)
   |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       let _p = Http.Request.path request in
-       let _pfx_len = 16 in (* String.length "/api/v1/keepers/" *)
-       let _tl = "/tools" in let _tll = String.length _tl in let _pl = String.length _p in
-       if _pl > _pfx_len + _tll && String.sub _p (_pl - _tll) _tll = _tl then begin
-         with_tool_auth ~tool_name:"masc_keeper_up"
-           (fun state req reqd ->
-             handle_keeper_tools_post state req reqd
-           ) request reqd
-       end else begin
-       with_token_permission_auth ~permission:Types.CanAdmin
-         (fun state agent_name req reqd ->
-         Http.Request.read_body_async reqd (fun body_str ->
-           let req_path = Http.Request.path req in
-           let prefix = "/api/v1/keepers/" in
-           let suffix = "/config" in
-           let plen = String.length prefix in
-           let slen = String.length suffix in
-           let tlen = String.length req_path in
-           if tlen > plen + slen
-              && String.sub req_path 0 plen = prefix
-              && String.sub req_path (tlen - slen) slen = suffix
-           then
-             let name =
-               String.trim
-                 (String.sub req_path plen (tlen - plen - slen))
-             in
-             if String.length name = 0 then
-               Http.Response.json ~status:`Bad_request
-                 {|{"error":"keeper name is required"}|} reqd
-             else
-               let config = state.Mcp_server.room_config in
-               match Keeper_types.read_meta config name with
-               | Error msg ->
-                   Http.Response.json ~status:`Not_found
-                     (Printf.sprintf {|{"error":"%s"}|}
-                        (String.escaped msg))
-                     reqd
-               | Ok None ->
-                   Http.Response.json ~status:`Not_found
-                     (Printf.sprintf {|{"error":"keeper %S not found"}|} name)
-                     reqd
-               | Ok (Some meta0) ->
-                   (try
-                      let args = Yojson.Safe.from_string body_str in
-                      let fields_opt =
-                        match args with
-                        | `Assoc fields -> Some fields
-                        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _
-                        | `String _ | `List _ ->
-                            None
-                      in
-                      match fields_opt with
-                      | Some fields ->
-                          let body_name =
-                            match List.assoc_opt "name" fields with
-                            | Some (`String value) ->
-                                let trimmed = String.trim value in
-                                if trimmed = "" then None else Some trimmed
-                            | _ -> None
-                          in
-                          if Option.is_some body_name
-                             && body_name <> Some name
-                          then
-                            Http.Response.json ~status:`Bad_request
-                              (Printf.sprintf
-                                 {|{"error":"keeper name mismatch: route=%S body=%S"}|}
-                                 name (Option.value ~default:"" body_name))
-                              reqd
-                          else
-                            let args_with_name =
-                              `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
-                            in
-                            let keeper_ctx : _ Tool_keeper.context =
-                              {
-                                config;
-                                agent_name;
-                                sw;
-                                clock;
-                                proc_mgr = state.Mcp_server.proc_mgr;
-                                net = state.Mcp_server.net;
-                              }
-                            in
-                            (match Keeper_turn_up_args.parse keeper_ctx args_with_name with
-                            | Error (_ok, msg) ->
-                                Http.Response.json ~status:`Bad_request
-                                  (Printf.sprintf {|{"error":"%s"}|}
-                                     (String.escaped msg))
-                                  reqd
-                            | Ok parsed ->
-                                let ok, msg =
-                                  Keeper_turn_up_update.update_keeper keeper_ctx parsed meta0
-                                in
-                                if not ok then
-                                  Http.Response.json ~status:`Bad_request
-                                    (Printf.sprintf {|{"error":"%s"}|}
-                                       (String.escaped msg))
-                                    reqd
-                                else
-                                  let (_st, json) =
-                                    Dashboard_http_keeper.keeper_config_json config name
-                                  in
-                                  Http.Response.json ~compress:true ~request:req
-                                    (Yojson.Safe.to_string json) reqd)
-                      | None ->
-                          Http.Response.json ~status:`Bad_request
-                            {|{"error":"request body must be a JSON object"}|}
-                            reqd
-                    with Yojson.Json_error e ->
-                      Http.Response.json ~status:`Bad_request
-                        (Printf.sprintf {|{"error":"invalid json: %s"}|}
-                           (String.escaped e))
-                        reqd)
-           else
-             Http.Response.json ~status:`Not_found
-               {|{"error":"not found"}|} reqd
-         )
-       ) request reqd
-       end)
-
-  (* Keeper boot — POST /api/v1/keepers/:name/boot *)
-  |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       with_token_permission_auth ~permission:Types.CanAdmin
-         (fun state agent_name req reqd ->
-           let req_path = Http.Request.path req in
-           let prefix = "/api/v1/keepers/" in
-           let suffix = "/boot" in
-           let plen = String.length prefix in
-           let slen = String.length suffix in
-           let tlen = String.length req_path in
-           if tlen > plen + slen
-              && String.sub req_path 0 plen = prefix
-              && String.sub req_path (tlen - slen) slen = suffix
-           then
-             let name =
-               String.trim
-                 (String.sub req_path plen (tlen - plen - slen))
-             in
-             if String.length name = 0 then
-               Http.Response.json ~status:`Bad_request
-                 {|{"error":"keeper name is required"}|} reqd
-             else
-               let config = state.Mcp_server.room_config in
-               let keeper_ctx : _ Tool_keeper.context =
-                 {
-                   config;
-                   agent_name;
-                   sw;
-                   clock;
-                   proc_mgr = state.Mcp_server.proc_mgr;
-                   net = state.Mcp_server.net;
-                 }
-               in
-               let args = `Assoc [("name", `String name)] in
-               (match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up" ~args with
-               | Some (true, body) ->
-                   Http.Response.json ~compress:true ~request:req
-                     (Printf.sprintf {|{"ok":true,"action":"boot","name":"%s","detail":%s}|}
-                        (String.escaped name) body)
-                     reqd
-               | Some (false, body) ->
-                   Http.Response.json ~status:`Bad_request ~request:req
-                     (Yojson.Safe.to_string
-                        (`Assoc [("ok", `Bool false); ("error", `String body)]))
-                     reqd
-               | None ->
-                   Http.Response.json ~status:`Internal_server_error ~request:req
-                     {|{"ok":false,"error":"dispatch returned None"}|}
-                     reqd)
-           else
-             Http.Response.json ~status:`Not_found
-               {|{"error":"not found"}|} reqd
-         ) request reqd)
-
-  (* Keeper shutdown — POST /api/v1/keepers/:name/shutdown *)
-  |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       let _p = Http.Request.path request in
-       let _pfx_len = 16 in (* String.length "/api/v1/keepers/" *)
-       let _tl = "/tools" in let _tll = String.length _tl in let _pl = String.length _p in
-       if _pl > _pfx_len + _tll && String.sub _p (_pl - _tll) _tll = _tl then begin
-         with_tool_auth ~tool_name:"masc_keeper_up"
-           (fun state req reqd ->
-             handle_keeper_tools_post state req reqd
-           ) request reqd
-       end else begin
-       with_token_permission_auth ~permission:Types.CanAdmin
-         (fun state agent_name req reqd ->
-           let req_path = Http.Request.path req in
-           let prefix = "/api/v1/keepers/" in
-           let suffix = "/shutdown" in
-           let plen = String.length prefix in
-           let slen = String.length suffix in
-           let tlen = String.length req_path in
-           if tlen > plen + slen
-              && String.sub req_path 0 plen = prefix
-              && String.sub req_path (tlen - slen) slen = suffix
-           then
-             let name =
-               String.trim
-                 (String.sub req_path plen (tlen - plen - slen))
-             in
-             if String.length name = 0 then
-               Http.Response.json ~status:`Bad_request
-                 {|{"error":"keeper name is required"}|} reqd
-             else
-               let config = state.Mcp_server.room_config in
-               let keeper_ctx : _ Tool_keeper.context =
-                 {
-                   config;
-                   agent_name;
-                   sw;
-                   clock;
-                   proc_mgr = state.Mcp_server.proc_mgr;
-                   net = state.Mcp_server.net;
-                 }
-               in
-               let args = `Assoc [("name", `String name)] in
-               (match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_down" ~args with
-               | Some (true, _body) ->
-                   Http.Response.json ~compress:true ~request:req
-                     (Printf.sprintf {|{"ok":true,"action":"shutdown","name":"%s"}|}
-                        (String.escaped name))
-                     reqd
-               | Some (false, body) ->
-                   Http.Response.json ~status:`Bad_request ~request:req
-                     (Yojson.Safe.to_string
-                        (`Assoc [("ok", `Bool false); ("error", `String body)]))
-                     reqd
-               | None ->
-                   Http.Response.json ~status:`Internal_server_error ~request:req
-                     {|{"ok":false,"error":"dispatch returned None"}|}
-                     reqd)
-           else
-             Http.Response.json ~status:`Not_found
-               {|{"error":"not found"}|} reqd
-         ) request reqd
-       end)
+       match classify_keeper_post_route (Http.Request.path request) with
+       | Keeper_post_tools ->
+           with_tool_auth ~tool_name:"masc_keeper_up"
+             (fun state req reqd ->
+               handle_keeper_tools_post state req reqd
+             ) request reqd
+       | Keeper_post_config ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str
+               )
+             ) request reqd
+       | Keeper_post_boot ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               handle_keeper_lifecycle_post ~sw ~clock ~tool_name:"masc_keeper_up"
+                 ~action:"boot" state agent_name req reqd
+             ) request reqd
+       | Keeper_post_shutdown ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               handle_keeper_lifecycle_post ~sw ~clock ~tool_name:"masc_keeper_down"
+                 ~action:"shutdown" state agent_name req reqd
+             ) request reqd
+       | Keeper_post_unknown ->
+           Http.Response.json ~status:`Not_found
+             {|{"error":"not found"}|} reqd)
 
   |> add_agent_api_routes
   |> add_autoresearch_routes

--- a/test/dune
+++ b/test/dune
@@ -41,7 +41,6 @@
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
-        test_dashboard_keeper_routes
         test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
@@ -100,7 +99,6 @@
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events
-          test_dashboard_keeper_routes
           test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
@@ -660,6 +658,12 @@
  (libraries masc_test_deps)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+
+(test
+ (name test_dashboard_keeper_routes)
+ (modules test_dashboard_keeper_routes)
+ (libraries masc_test_deps)
+ (deps ../bin/main_eio.exe))
 
 (test
  (name test_compression_boundary)

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,7 @@
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
+        test_dashboard_keeper_routes
         test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
@@ -99,6 +100,7 @@
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events
+          test_dashboard_keeper_routes
           test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -333,6 +333,8 @@ let with_seeded_server f =
       [ "MASC_AUTONOMY_ENABLED", "0"
       ; "GRAPHQL_API_KEY", ""
       ; "GRAPHQL_URL", "http://127.0.0.1:9/graphql"
+      ; "MASC_BASE_PATH", base_path
+      ; "MASC_ALLOW_INHERITED_BASE_PATH", "1"
       ; "MASC_POSTGRES_URL", ""
       ; "DATABASE_URL", ""
       ; "SUPABASE_DB_URL", ""

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1,0 +1,464 @@
+open Alcotest
+module Routes = Masc_mcp.Server_routes_http_routes_dashboard
+
+type http_result =
+  { status : int option
+  ; body : string
+  ; curl_exit : int
+  ; stderr : string
+  }
+
+let read_all ic =
+  let buf = Buffer.create 1024 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 4096
+     done
+   with
+   | End_of_file -> ());
+  Buffer.contents buf
+;;
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len)
+;;
+
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let trim_cr s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
+;;
+
+let parse_status header_raw =
+  let lines = String.split_on_char '\n' header_raw |> List.map trim_cr in
+  let rec find_http = function
+    | [] -> None
+    | line :: rest ->
+      if String.length line >= 5 && String.sub line 0 5 = "HTTP/"
+      then (
+        match String.split_on_char ' ' line with
+        | _proto :: code :: _ ->
+          (try Some (int_of_string code) with
+           | _ -> None)
+        | _ -> None)
+      else find_http rest
+  in
+  find_http lines
+;;
+
+let contains_substr needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    if i + n > h
+    then false
+    else if String.sub haystack i n = needle
+    then true
+    else loop (i + 1)
+  in
+  n = 0 || loop 0
+;;
+
+let find_main_eio_exe () =
+  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
+  let candidates =
+    match env_override with
+    | Some p -> [ p ]
+    | None ->
+      let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
+      let build_candidates =
+        List.map
+          (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
+          build_roots
+      in
+      [ "./bin/main_eio.exe"
+      ; "../bin/main_eio.exe"
+      ; "../../bin/main_eio.exe"
+      ; "../../../bin/main_eio.exe"
+      ; "../../../../bin/main_eio.exe"
+      ]
+      @ build_candidates
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+    fail
+      "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build \
+       bin/main_eio.exe`."
+;;
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close socket)
+    (fun () ->
+       Unix.setsockopt socket Unix.SO_REUSEADDR true;
+       match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
+       | () ->
+         (match Unix.getsockname socket with
+          | Unix.ADDR_INET (_, port) -> Some port
+          | _ -> fail "unexpected socket address")
+       | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) -> None)
+;;
+
+let wait_for_health ~port ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if Unix.gettimeofday () > deadline
+    then false
+    else (
+      let res =
+        let header_file = Filename.temp_file "dashboard-keeper-health-" ".hdr" in
+        let body_file = Filename.temp_file "dashboard-keeper-health-" ".body" in
+        let url = Printf.sprintf "http://127.0.0.1:%d/health" port in
+        let args =
+          [| "curl"
+           ; "-sS"
+           ; "--http1.1"
+           ; "--max-time"
+           ; "1"
+           ; "-X"
+           ; "GET"
+           ; "-o"
+           ; body_file
+           ; "-D"
+           ; header_file
+           ; url
+          |]
+        in
+        let ic, oc, ec = Unix.open_process_args_full "curl" args (Unix.environment ()) in
+        close_out_noerr oc;
+        let _stdout = read_all ic in
+        let stderr = read_all ec in
+        let curl_exit =
+          match Unix.close_process_full (ic, oc, ec) with
+          | Unix.WEXITED code -> code
+          | Unix.WSIGNALED code -> 128 + code
+          | Unix.WSTOPPED code -> 256 + code
+        in
+        let status = parse_status (read_file header_file) in
+        let body = read_file body_file in
+        (try Sys.remove header_file with
+         | _ -> ());
+        (try Sys.remove body_file with
+         | _ -> ());
+        { status; body; curl_exit; stderr }
+      in
+      match res.status with
+      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
+      | _ ->
+        Unix.sleepf 0.1;
+        loop ())
+  in
+  loop ()
+;;
+
+let wait_pid_exit ~pid ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    match Unix.waitpid [ Unix.WNOHANG ] pid with
+    | 0, _ ->
+      if Unix.gettimeofday () > deadline
+      then false
+      else (
+        Unix.sleepf 0.05;
+        loop ())
+    | _pid, _status -> true
+    | exception Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  in
+  loop ()
+;;
+
+let merge_env_overrides overrides =
+  let override_keys = List.map fst overrides in
+  let is_override_key entry =
+    match String.index_opt entry '=' with
+    | None -> false
+    | Some idx ->
+      let key = String.sub entry 0 idx in
+      List.mem key override_keys
+  in
+  let base =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun entry -> not (is_override_key entry))
+  in
+  let injected = List.map (fun (k, v) -> k ^ "=" ^ v) overrides in
+  Array.of_list (base @ injected)
+;;
+
+let run_curl_post ?body ?token ~port ~path () =
+  let header_file = Filename.temp_file "dashboard-keeper-post-" ".hdr" in
+  let body_file = Filename.temp_file "dashboard-keeper-post-" ".body" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let base_args =
+    [ "curl"
+    ; "-sS"
+    ; "--http1.1"
+    ; "--max-time"
+    ; "3"
+    ; "-X"
+    ; "POST"
+    ; "-o"
+    ; body_file
+    ; "-D"
+    ; header_file
+    ]
+  in
+  let data_file =
+    match body with
+    | None -> None
+    | Some payload ->
+      let path = Filename.temp_file "dashboard-keeper-post-" ".json" in
+      write_file path payload;
+      Some path
+  in
+  let args =
+    let args =
+      match data_file with
+      | Some payload_path ->
+        base_args
+        @ [ "-H"; "Content-Type: application/json"; "--data-binary"; "@" ^ payload_path ]
+      | None -> base_args
+    in
+    let args =
+      match token with
+      | Some raw_token ->
+        args @ [ "-H"; Printf.sprintf "Authorization: Bearer %s" raw_token ]
+      | None -> args
+    in
+    Array.of_list (args @ [ url ])
+  in
+  let ic, oc, ec = Unix.open_process_args_full "curl" args (Unix.environment ()) in
+  close_out_noerr oc;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let status = parse_status (read_file header_file) in
+  let body = read_file body_file in
+  (try Sys.remove header_file with
+   | _ -> ());
+  (try Sys.remove body_file with
+   | _ -> ());
+  Option.iter
+    (fun path ->
+       try Sys.remove path with
+       | _ -> ())
+    data_file;
+  { status; body; curl_exit; stderr }
+;;
+
+let make_keeper_meta_json ?(name = "route-shadow-demo") () =
+  match
+    Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+          ; "trace_id", `String ("trace-" ^ name ^ "-seed")
+          ; "goal", `String "Route shadow regression fixture"
+          ; "cascade_name", `String "keeper_unified"
+          ; "updated_at", `String "2026-04-04T00:00:00Z"
+          ; "paused", `Bool true
+          ])
+  with
+  | Ok meta -> Masc_mcp.Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
+  | Error err -> fail ("keeper meta fixture parse failed: " ^ err)
+;;
+
+let seed_auth_and_keeper ~base_path ~keeper_name =
+  let config = Masc_mcp.Room.default_config base_path in
+  ignore (Masc_mcp.Room.init config ~agent_name:(Some "bootstrap-admin"));
+  Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+  write_file
+    (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+    (make_keeper_meta_json ~name:keeper_name ());
+  ignore
+    (Masc_mcp.Auth.enable_auth
+       base_path
+       ~require_token:true
+       ~agent_name:"bootstrap-admin");
+  let admin_token =
+    match
+      Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin
+    with
+    | Ok (token, _cred) -> token
+    | Error err -> fail (Types.masc_error_to_string err)
+  in
+  config, admin_token
+;;
+
+let with_seeded_server f =
+  let exe = find_main_eio_exe () in
+  let port =
+    match find_free_port () with
+    | Some p -> p
+    | None -> Alcotest.skip ()
+  in
+  let log_file = Filename.temp_file "dashboard-keeper-routes-" ".log" in
+  let base_path = Filename.temp_file "dashboard-keeper-base-" "" in
+  let keeper_name = "route-shadow-demo" in
+  (try Sys.remove base_path with
+   | _ -> ());
+  Unix.mkdir base_path 0o755;
+  let config, admin_token = seed_auth_and_keeper ~base_path ~keeper_name in
+  let log_fd =
+    Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+  in
+  let env =
+    merge_env_overrides
+      [ "MASC_AUTONOMY_ENABLED", "0"
+      ; "GRAPHQL_API_KEY", ""
+      ; "GRAPHQL_URL", "http://127.0.0.1:9/graphql"
+      ; "MASC_POSTGRES_URL", ""
+      ; "DATABASE_URL", ""
+      ; "SUPABASE_DB_URL", ""
+      ; "SB_PG_URL", ""
+      ; "MASC_BOARD_BACKEND", "jsonl"
+      ]
+  in
+  let argv =
+    [| exe
+     ; "--host"
+     ; "127.0.0.1"
+     ; "--port"
+     ; string_of_int port
+     ; "--base-path"
+     ; base_path
+    |]
+  in
+  let pid = Unix.create_process_env exe argv env Unix.stdin log_fd log_fd in
+  Unix.close log_fd;
+  let cleanup () =
+    (try Unix.kill pid Sys.sigterm with
+     | _ -> ());
+    if not (wait_pid_exit ~pid ~timeout_s:2.0)
+    then (
+      try Unix.kill pid Sys.sigkill with
+      | _ -> ());
+    ignore (wait_pid_exit ~pid ~timeout_s:1.0);
+    rm_rf log_file;
+    rm_rf base_path
+  in
+  if not (wait_for_health ~port ~timeout_s:20.0)
+  then (
+    let logs = read_file log_file in
+    cleanup ();
+    fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs));
+  Fun.protect ~finally:cleanup (fun () -> f ~port ~config ~admin_token ~keeper_name)
+;;
+
+let check_route path expected =
+  let actual = Routes.classify_keeper_post_route path in
+  if actual <> expected
+  then
+    failf
+      "expected %s for %s"
+      (match expected with
+       | Routes.Keeper_post_tools -> "tools"
+       | Routes.Keeper_post_config -> "config"
+       | Routes.Keeper_post_boot -> "boot"
+       | Routes.Keeper_post_shutdown -> "shutdown"
+       | Routes.Keeper_post_unknown -> "unknown")
+      path
+;;
+
+let test_keeper_post_route_classification () =
+  check_route "/api/v1/keepers/sangsu/tools" Routes.Keeper_post_tools;
+  check_route "/api/v1/keepers/sangsu/config" Routes.Keeper_post_config;
+  check_route "/api/v1/keepers/sangsu/boot" Routes.Keeper_post_boot;
+  check_route "/api/v1/keepers/sangsu/shutdown" Routes.Keeper_post_shutdown;
+  check_route "/api/v1/keepers/sangsu" Routes.Keeper_post_unknown;
+  check_route "/api/v1/keepers//boot" Routes.Keeper_post_unknown
+;;
+
+let require_status label expected result =
+  match result.status with
+  | Some code -> check int label expected code
+  | None ->
+    fail
+      (Printf.sprintf
+         "%s missing HTTP status (curl_exit=%d stderr=%s body=%s)"
+         label
+         result.curl_exit
+         result.stderr
+         result.body)
+;;
+
+let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
+  let shutdown_path = Printf.sprintf "/api/v1/keepers/%s/shutdown" keeper_name in
+  let boot_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
+  in
+  require_status "boot route returns 200" 200 boot_result;
+  check
+    bool
+    "boot route is not generic 404"
+    false
+    (contains_substr {|{"error":"not found"}|} boot_result.body);
+  check
+    bool
+    "boot route reaches lifecycle handler"
+    true
+    (contains_substr {|"action":"boot"|} boot_result.body);
+  let shutdown_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:shutdown_path ()
+  in
+  require_status "shutdown route returns 200" 200 shutdown_result;
+  check
+    bool
+    "shutdown route is not generic 404"
+    false
+    (contains_substr {|{"error":"not found"}|} shutdown_result.body);
+  check
+    bool
+    "shutdown route reaches lifecycle handler"
+    true
+    (contains_substr {|"action":"shutdown"|} shutdown_result.body);
+  match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  | Ok (Some meta) -> check bool "shutdown persists paused keeper meta" true meta.paused
+  | Ok None -> fail "keeper meta missing after shutdown route"
+  | Error err -> fail ("failed to read keeper meta after shutdown: " ^ err)
+;;
+
+let () =
+  run
+    "dashboard_keeper_routes"
+    [ ( "dashboard_keeper_routes"
+      , [ test_case
+            "classify keeper POST routes"
+            `Quick
+            test_keeper_post_route_classification
+        ; test_case
+            "lifecycle POST routes do not fall through to generic 404"
+            `Slow
+            test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- fix dashboard `POST /api/v1/keepers/:name/boot` and `.../shutdown` routing so keeper lifecycle actions no longer fall through a generic `/api/v1/keepers/*` handler and return `{"error":"not found"}`
- add a local dashboard auth runbook for bootstrapping an admin bearer and using keeper lifecycle controls from the built-in dashboard
- add an HTTP-level regression test for the keeper lifecycle routes and stabilize the test by forcing the child server to use its temp base path

## Product impact
- local dashboard keeper boot/shutdown now works when bearer auth is configured correctly
- operators have a documented local auth/bootstrap path for dashboard control
- the regression is covered by a real HTTP test instead of only route-classifier unit coverage

## Evidence
- local repro confirmed `boot/shutdown -> 404` before the route fix
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp ./test/test_dashboard_keeper_routes.exe`
- the regression test now exercises real HTTP `POST /api/v1/keepers/:name/boot` and `.../shutdown` against a spawned server

## Review evidence
- external review completed with `GLM-5` via `sb glm-text`
- reviewer findings were triaged as non-blocking and recorded in PR comments
- no unresolved review threads are present on the PR at the time of update

## Linked issue
- Relates #4991
