### PR TITLE
[codex] Stabilize keeper overflow retry and namespace wording

### DIFF
--- a/config/prompts/dashboard.operator_judge.md
+++ b/config/prompts/dashboard.operator_judge.md
@@ -4,11 +4,11 @@ category: dashboard
 template_variables: [facts_json]
 ---
 
-You are the operator judge for a MASC control room.
+You are the operator judge for the MASC namespace control surface.
 Read only the factual operator snapshot JSON below.
-Produce concise, operational judgments for the room and any team sessions that need attention.
+Produce concise, operational judgments for the namespace and any team sessions that need attention.
 Do not repeat raw facts. Do not invent evidence, ids, or actions. Omit entries when you are not confident.
-Allowed action_type values: broadcast, room_pause, room_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.
+Allowed action_type values: broadcast, namespace_pause, namespace_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.
 Output strict JSON only with this shape:
 {
   "room": {

--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -16,7 +16,7 @@ Detected triggers that require your attention:
 
 Available actions (pick exactly one):
 - noop: Do nothing. Use when triggers do not warrant action.
-- reply_in_room: Send a message to a specific room. Requires room_id and content.
+- reply_in_room: Compatibility action name for replying in the current namespace conversation. Requires room_id and content.
 - task_claim: Claim an unclaimed task. Requires task_id and reason.
 - broadcast: Send a broadcast message to all agents. Requires message.
 - board_post: Post to the community board. Requires content and optional hearth.
@@ -29,6 +29,6 @@ Respond with ONLY the tool input object for schema `keeper_deliberation_decision
 
 Examples:
 {"action":"noop","params":{"reason":"No urgent triggers"},"reasoning":"All triggers are low priority","confidence":0.9}
-{"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention needs response","confidence":0.8}
+{"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention in the namespace conversation needs a reply","confidence":0.8}
 {"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
 {"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs coordination update","confidence":0.6}{{multi_step_example}}

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -19,7 +19,7 @@ The next cycle will see your checkpoint and continue where you left off.
 Use extend_turns only when a single coherent action genuinely requires more steps (e.g., read-edit-build-verify). Do not use it to cram unrelated work into one cycle.
 
 ### Possible actions (pick one per cycle)
-- Reply to a pending mention (use room broadcast tools)
+- Reply to a pending mention in the current namespace conversation
 - Claim and work on one task (keeper_task_claim)
 - Post a finding or status update (keeper_board_post)
 - Respond to board activity (keeper_board_comment)

--- a/lib/dashboard/dashboard_collaboration_evidence.ml
+++ b/lib/dashboard/dashboard_collaboration_evidence.ml
@@ -77,6 +77,8 @@ let is_room_lifecycle_broadcast (event : Activity_graph.event) =
       || String.ends_with ~suffix:"joined the namespace" content
       || String.ends_with ~suffix:"left the room" content
       || String.ends_with ~suffix:"left the namespace" content
+      || String_util.contains_substring content " rejoined the namespace"
+      || String_util.contains_substring content " rejoined namespace "
   | None -> false
 
 let relevant_activity_event (event : Activity_graph.event) =

--- a/lib/dashboard/dashboard_collaboration_evidence.ml
+++ b/lib/dashboard/dashboard_collaboration_evidence.ml
@@ -74,7 +74,9 @@ let is_room_lifecycle_broadcast (event : Activity_graph.event) =
   match string_member_opt "content" event.payload with
   | Some content ->
       String.ends_with ~suffix:"joined the room" content
+      || String.ends_with ~suffix:"joined the namespace" content
       || String.ends_with ~suffix:"left the room" content
+      || String.ends_with ~suffix:"left the namespace" content
   | None -> false
 
 let relevant_activity_event (event : Activity_graph.event) =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -517,7 +517,11 @@ let run_turn
   let policy_allowed =
     Keeper_exec_tools.keeper_allowed_tool_names !meta_ref
   in
-  let max_fallback_tools = 30 in
+  let max_tools_per_turn =
+    if is_retry then Keeper_config.keeper_retry_max_tools_per_turn ()
+    else Keeper_config.keeper_max_tools_per_turn ()
+  in
+  let max_fallback_tools = min 30 max_tools_per_turn in
   let fallback_tools =
     let candidates =
       List.filter (fun name ->
@@ -597,10 +601,7 @@ let run_turn
           | [] -> 0.0
         in
         let use_fallback = top_score < confidence_threshold in
-        let max_tools =
-          Keeper_config.int_of_env_default
-            "MASC_KEEPER_MAX_TOOLS_PER_TURN" ~default:40 ~min_v:5 ~max_v:200
-        in
+        let max_tools = max_tools_per_turn in
         let portal_ctx : Tool_portal.context = {
           config;
           agent_name = meta.name;
@@ -651,6 +652,18 @@ let run_turn
                  what you accomplished and what the next generation should do. \
                  Do NOT start new tool work. If you need more turns, call extend_turns."
                 turn max_turns
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else if is_retry then
+            let warning =
+              Printf.sprintf
+                "[RETRY] The previous attempt overflowed the model context. \
+                 Stay concise, prefer already-loaded context, and only use the \
+                 smallest essential tool set if a tool call is strictly necessary. \
+                 Current tool budget: %d."
+                max_tools
             in
             (match ctx with
              | None -> Some warning

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -518,6 +518,16 @@ let keeper_tool_cost_max_usd () : float =
     ~min_v:0.01
     ~max_v:50.0
 
+let keeper_max_tools_per_turn () : int =
+  int_of_env_default
+    "MASC_KEEPER_MAX_TOOLS_PER_TURN"
+    ~default:40
+    ~min_v:5
+    ~max_v:200
+
+let keeper_retry_max_tools_per_turn () : int =
+  min 8 (keeper_max_tools_per_turn ())
+
 (* ================================================================ *)
 (* Rule engine thresholds                                           *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -52,6 +52,9 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
 let token_count (ctx : working_context) =
   count_tokens ctx.system_prompt ctx.messages
 
+let message_token_count (ctx : working_context) =
+  count_tokens "" ctx.messages
+
 let message_count (ctx : working_context) =
   List.length ctx.messages
 
@@ -929,10 +932,13 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
         compact_if_needed ~meta:retry_meta ~now_ts ctx
       in
       let strategy_after_tokens = token_count compacted_ctx in
+      let strategy_after_message_tokens =
+        message_token_count compacted_ctx
+      in
       let compacted_ctx =
         if
           primary_model_max_tokens > 0
-          && strategy_after_tokens > primary_model_max_tokens
+          && strategy_after_message_tokens > primary_model_max_tokens
         then
           hard_trim_context_to_budget compacted_ctx
             ~budget_tokens:primary_model_max_tokens
@@ -940,10 +946,11 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
           compacted_ctx
       in
       let after_tokens = token_count compacted_ctx in
+      let after_message_tokens = message_token_count compacted_ctx in
       let hard_trim_applied = after_tokens < strategy_after_tokens in
       let decision =
         if hard_trim_applied then
-          Printf.sprintf "%s+budget_trim(%d->%d<=%d)"
+          Printf.sprintf "%s+budget_trim(%d->%d,msg<=%d)"
             base_decision strategy_after_tokens after_tokens
             primary_model_max_tokens
         else
@@ -954,7 +961,8 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
       in
       let meaningful_reduction = after_tokens < before_tokens in
       let fits_budget =
-        primary_model_max_tokens <= 0 || after_tokens <= primary_model_max_tokens
+        primary_model_max_tokens <= 0
+        || after_message_tokens <= primary_model_max_tokens
       in
       if not (compaction_applied && meaningful_reduction && fits_budget) then None
       else

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -809,6 +809,18 @@ let clamp_context_max_tokens
   if clamped = ctx.max_tokens then ctx
   else sync_oas_context { ctx with max_tokens = clamped }
 
+let hard_trim_context_to_budget
+    (ctx : working_context)
+    ~(budget_tokens : int) : working_context =
+  if budget_tokens <= 0 then ctx
+  else
+    let reducer =
+      Agent_sdk.Context_reducer.from_context_config ~max_tokens:budget_tokens ()
+    in
+    let messages = Agent_sdk.Context_reducer.reduce reducer ctx.messages in
+    sync_oas_context
+      { ctx with messages; max_tokens = min ctx.max_tokens budget_tokens }
+
 let forced_overflow_retry_meta
     (meta : keeper_meta)
     ~(turn_generation : int)
@@ -913,15 +925,38 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
       let retry_meta =
         forced_overflow_retry_meta meta ~turn_generation ~now_ts
       in
-      let compacted_ctx, trigger, decision =
+      let compacted_ctx, trigger, base_decision =
         compact_if_needed ~meta:retry_meta ~now_ts ctx
       in
-      let compaction_applied =
-        String.starts_with ~prefix:"applied:" decision
+      let strategy_after_tokens = token_count compacted_ctx in
+      let compacted_ctx =
+        if
+          primary_model_max_tokens > 0
+          && strategy_after_tokens > primary_model_max_tokens
+        then
+          hard_trim_context_to_budget compacted_ctx
+            ~budget_tokens:primary_model_max_tokens
+        else
+          compacted_ctx
       in
       let after_tokens = token_count compacted_ctx in
+      let hard_trim_applied = after_tokens < strategy_after_tokens in
+      let decision =
+        if hard_trim_applied then
+          Printf.sprintf "%s+budget_trim(%d->%d<=%d)"
+            base_decision strategy_after_tokens after_tokens
+            primary_model_max_tokens
+        else
+          base_decision
+      in
+      let compaction_applied =
+        String.starts_with ~prefix:"applied:" base_decision || hard_trim_applied
+      in
       let meaningful_reduction = after_tokens < before_tokens in
-      if not (compaction_applied && meaningful_reduction) then None
+      let fits_budget =
+        primary_model_max_tokens <= 0 || after_tokens <= primary_model_max_tokens
+      in
+      if not (compaction_applied && meaningful_reduction && fits_budget) then None
       else
         let compaction =
           {

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -161,13 +161,13 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
          (List.length observation.active_goals));
     Buffer.add_string ubuf (format_goals observation.active_goals);
     Buffer.add_string ubuf "\n\n");
-  (* Room state *)
+  (* Namespace state *)
   if
     observation.unclaimed_task_count > 0
     || observation.failed_task_count > 0
     || observation.active_agent_count > 0
   then (
-    Buffer.add_string ubuf "### Room State\n";
+    Buffer.add_string ubuf "### Namespace State\n";
     if observation.unclaimed_task_count > 0 then
       Buffer.add_string ubuf
         (Printf.sprintf "- Unclaimed tasks: %d\n"
@@ -189,40 +189,40 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
   if meta.room_signal_prompt_enabled && has_room_signal_section observation then (
     match observation.room_signal_interpretation with
     | Some interpretation ->
-        Buffer.add_string ubuf "### Room Signal Interpretation\n";
+        Buffer.add_string ubuf "### Namespace Signal Interpretation\n";
         Buffer.add_string ubuf
-          (Printf.sprintf "- room_signal_primary: %s\n"
+          (Printf.sprintf "- namespace_signal_primary: %s\n"
              (format_room_signal_salience interpretation.primary_salience));
         (match interpretation.secondary_saliences with
          | [] -> ()
          | secondary ->
              Buffer.add_string ubuf
-               (Printf.sprintf "- room_signal_secondary: %s\n"
+               (Printf.sprintf "- namespace_signal_secondary: %s\n"
                   (secondary
                   |> List.map format_room_signal_salience
                   |> String.concat ", ")));
         Buffer.add_string ubuf
-          (Printf.sprintf "- room_signal_reason: %s\n" interpretation.reason);
+          (Printf.sprintf "- namespace_signal_reason: %s\n" interpretation.reason);
         (match interpretation.target_id with
          | Some target_id ->
              Buffer.add_string ubuf
-               (Printf.sprintf "- room_signal_target_id: %s\n" target_id)
+               (Printf.sprintf "- namespace_signal_target_id: %s\n" target_id)
          | None -> ());
         (match interpretation.evidence_refs with
          | [] -> ()
          | refs ->
              Buffer.add_string ubuf
-               (Printf.sprintf "- room_signal_evidence_refs: %s\n"
+               (Printf.sprintf "- namespace_signal_evidence_refs: %s\n"
                   (String.concat ", " refs)));
         (match observation.room_signal_digest_ref with
          | Some digest ->
              Buffer.add_string ubuf
-               (Printf.sprintf "- room_digest_post_id: %s\n" digest.post_id);
+               (Printf.sprintf "- namespace_digest_post_id: %s\n" digest.post_id);
              Buffer.add_string ubuf
-               (Printf.sprintf "- room_digest_title: %s\n" digest.title)
+               (Printf.sprintf "- namespace_digest_title: %s\n" digest.title)
          | None -> ());
         Buffer.add_string ubuf
-          "- room_signal_guard: do not call keeper_board_post or keeper_task_claim from this derived signal alone; read at least one raw board item from room_signal_evidence_refs or room_digest_post_id first.\n\n"
+          "- namespace_signal_guard: do not call keeper_board_post or keeper_task_claim from this derived signal alone; read at least one raw board item from namespace_signal_evidence_refs or namespace_digest_post_id first.\n\n"
     | None -> ());
   (* Context health *)
   Buffer.add_string ubuf

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -99,10 +99,27 @@ type overflow_retry_plan = {
   retry_generation : int;
 }
 
+let overflow_retry_history_budget
+    ~(available_context : int)
+    ~(system_prompt : string)
+    ~(user_message : string) : int =
+  let prompt_tokens =
+    Agent_sdk.Context_reducer.estimate_char_tokens system_prompt
+    + Agent_sdk.Context_reducer.estimate_char_tokens user_message
+  in
+  let prompt_reserve = max 1024 prompt_tokens in
+  let tool_reserve =
+    Keeper_config.keeper_retry_max_tools_per_turn () * 220
+  in
+  let safety_reserve = 512 in
+  max 256 (available_context - (prompt_reserve + tool_reserve + safety_reserve))
+
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
     ~(primary_max_context : int)
+    ~(system_prompt : string)
+    ~(user_message : string)
     ~(error : string) : overflow_retry_plan option =
   match context_overflow_limit error with
   | None -> None
@@ -111,18 +128,22 @@ let recover_context_overflow_retry
         if primary_max_context <= 0 then actual_limit
         else min primary_max_context actual_limit
       in
+      let retry_history_budget =
+        overflow_retry_history_budget ~available_context:retry_max_context
+          ~system_prompt ~user_message
+      in
       let model = Keeper_exec_context.checkpoint_model_of_meta meta in
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model
-          ~primary_model_max_tokens:retry_max_context
+          ~primary_model_max_tokens:retry_history_budget
       with
       | Some recovery ->
           Log.Keeper.warn
-            "%s: context overflow retry prepared with compacted checkpoint (%d->%d tokens, max_context=%d, generation=%d)"
+            "%s: context overflow retry prepared with compacted checkpoint (%d->%d tokens, max_context=%d, history_budget=%d, generation=%d)"
             meta.name recovery.compaction.before_tokens
             recovery.compaction.after_tokens
-            retry_max_context recovery.turn_generation;
+            retry_max_context retry_history_budget recovery.turn_generation;
           Some
             {
               retry_max_context;
@@ -729,7 +750,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                            && should_attempt_context_overflow_retry e -> (
                 match
                   recover_context_overflow_retry ~meta ~base_dir
-                    ~primary_max_context ~error:e
+                    ~primary_max_context ~system_prompt ~user_message ~error:e
                 with
                 | Some retry_plan ->
                     let retry_meta =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -75,6 +75,12 @@ val context_overflow_limit : string -> int option
 (** [true] when an error string should trigger overflow recovery handling. *)
 val should_attempt_context_overflow_retry : string -> bool
 
+val overflow_retry_history_budget :
+  available_context:int ->
+  system_prompt:string ->
+  user_message:string ->
+  int
+
 val run_unified_turn :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -49,7 +49,7 @@ let dedupe_tool_schemas_by_name (schemas : Types.tool_schema list) =
 
 let default_instructions =
   "MASC (Multi-Agent Streaming Coordination) enables AI agent collaboration. \
-ROOM: Agents sharing the same base path (.masc/ folder) or PostgreSQL cluster coordinate together. \
+NAMESPACE: Agents sharing the same base path (.masc/ folder) or PostgreSQL cluster coordinate together. \
 CLUSTER: Set MASC_CLUSTER_NAME for multi-machine coordination (defaults to basename of ME_ROOT). \
 READ: use resources/list + resources/read (status/tasks/agents/events/schema) for snapshots. \
 WRITE: prefer masc_transition (claim/start/done/cancel/release) with expected_version for CAS. \

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -88,7 +88,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
            { s with active_agents = agents }
          ) in
          let _ = broadcast config ~from_agent:nickname
-                   ~content:(Printf.sprintf "👋 %s rejoined the room" nickname) in
+                   ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname) in
          log_event config (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
            nickname agent_type new_session_id (now_iso ()));
@@ -104,7 +104,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
        end
      | Error e ->
          Log.Room.warn "agent rejoin: invalid agent JSON for %s: %s" nickname e);
-    Printf.sprintf "✅ %s already in room (last_seen updated)" nickname
+    Printf.sprintf "✅ %s already in the namespace (last_seen updated)" nickname
   end else begin
     (* Collect metadata *)
   let session_id = generate_session_id () in
@@ -140,7 +140,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   ) in
 
   (* Broadcast join *)
-  let _ = broadcast config ~from_agent:nickname ~content:(Printf.sprintf "👋 %s joined the room" nickname) in
+  let _ = broadcast config ~from_agent:nickname ~content:(Printf.sprintf "👋 %s joined the namespace" nickname) in
 
   (* Log event with metadata *)
   log_event config (Printf.sprintf
@@ -220,7 +220,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
         { s with active_agents = agents }
       ) in
       let _ = broadcast config ~from_agent:nickname
-                ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname legacy_room_id) in
+                ~content:(Printf.sprintf "👋 %s rejoined namespace %s" nickname legacy_room_id) in
       log_event config
         (Yojson.Safe.to_string
            (`Assoc
@@ -236,7 +236,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
         ~event_kind:"rejoin"
         ~details:(`Assoc [ ("rejoin", `Bool true) ]);
     end;
-    Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname legacy_room_id
+    Printf.sprintf "✅ %s already in namespace %s (last_seen updated)" nickname legacy_room_id
   end else begin
     let session_id = generate_session_id () in
     let meta : agent_meta = {
@@ -268,7 +268,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
     ) in
     let _ =
       broadcast config ~from_agent:nickname
-        ~content:(Printf.sprintf "👋 %s joined the room" nickname)
+        ~content:(Printf.sprintf "👋 %s joined the namespace" nickname)
     in
     log_event config
       (Yojson.Safe.to_string
@@ -294,7 +294,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
             ( "capabilities",
               `List (List.map (fun s -> `String s) capabilities) );
           ]);
-    Printf.sprintf "✅ %s joined room %s" nickname legacy_room_id
+    Printf.sprintf "✅ %s joined namespace %s" nickname legacy_room_id
   end
 
 (** Leave room *)
@@ -326,7 +326,7 @@ let leave config ~agent_name =
       { s with active_agents = List.filter ((<>) actual_name) s.active_agents }
     ) in
 
-    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "👋 %s left the room" actual_name) in
+    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "👋 %s left the namespace" actual_name) in
 
     (* Log event *)
     log_event config (Printf.sprintf
@@ -343,6 +343,6 @@ let leave config ~agent_name =
        Log.Room.error "relation-materializer leave hook error: %s"
          (Printexc.to_string exn));
 
-    Printf.sprintf "✅ %s left the room" actual_name
+    Printf.sprintf "✅ %s left the namespace" actual_name
   end else
-    Printf.sprintf "⚠ %s was not in the room" actual_name
+    Printf.sprintf "⚠ %s was not in the namespace" actual_name

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -135,6 +135,7 @@ let collaboration_evidence_schema ~remote =
             schema_properties
               [
                 ("session_id", `Assoc [ ("type", `String "string") ]);
+                ("namespace_id", `Assoc [ ("type", `String "string") ]);
                 ("room_id", `Assoc [ ("type", `String "string") ]);
               ] );
         ];
@@ -324,7 +325,11 @@ let dispatch (ctx : 'a context) ~name ~args : result option =
       Some (true, Yojson.Safe.to_string (Dashboard_surface_readiness.json ?surface_id ()))
   | "masc_collaboration_evidence" ->
       let session_id = get_string_opt args "session_id" in
-      let room_id = get_string_opt args "room_id" in
+      let room_id =
+        match get_string_opt args "namespace_id" with
+        | Some value when String.trim value <> "" -> Some value
+        | _ -> get_string_opt args "room_id"
+      in
       Some
         ( true,
           Yojson.Safe.to_string

--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -238,6 +238,41 @@ let test_recent_unlinked_activity_preserves_chronological_order () =
           "unlinked-8" ]
         summaries)
 
+let test_rejoined_namespace_broadcast_is_excluded_from_unlinked_activity () =
+  with_eio @@ fun _env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      let started_at = Time_compat.now () -. 60.0 in
+      let planned_end_at = started_at +. 600.0 in
+      let session =
+        make_manual_session config ~goal:"namespace lifecycle filtering"
+          ~created_by:"tester" ~agent_names:[ "alice"; "bob" ] ~min_agents:1
+          ~checkpoint_interval_sec:30 ~started_at ~planned_end_at
+          ~fallback_policy:Team_session_types.Fallback_cascade_then_task
+          ~model_cascade:[ "glm:auto" ]
+      in
+      ignore
+        (Activity_graph.emit config ~room_id:session.room_id
+           ~kind:"message.broadcast"
+           ~actor:(Activity_graph.entity ~kind:"agent" "system")
+           ~payload:
+             (`Assoc
+               [
+                 ("content", `String "👋 alice rejoined namespace default");
+               ])
+           ~tags:[ "message"; "broadcast" ] ());
+      let json =
+        Dashboard_collaboration_evidence.json ~session_id:session.session_id
+          ~config ()
+      in
+      let counts = json |> U.member "counts" in
+      check int "rejoin lifecycle excluded from unlinked activity" 0
+        (counts |> U.member "unlinked_activity_count" |> U.to_int))
+
 let test_emit_message_activity_normalizes_evidence_refs () =
   with_eio @@ fun _env ->
   let base_dir = temp_dir () in
@@ -278,6 +313,8 @@ let () =
             test_collaboration_evidence_tracks_unlinked_room_noise;
           test_case "recent unlinked activity preserves order" `Quick
             test_recent_unlinked_activity_preserves_chronological_order;
+          test_case "rejoined namespace broadcast is excluded" `Quick
+            test_rejoined_namespace_broadcast_is_excluded_from_unlinked_activity;
           test_case "emit message activity normalizes evidence refs" `Quick
             test_emit_message_activity_normalizes_evidence_refs;
         ] );

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -65,6 +65,12 @@ let build_dense_context ~turns ~max_tokens ~state_reply =
   KEC.append ctx (Agent_sdk.Types.assistant_msg state_reply)
   |> KEC.sync_oas_context
 
+let message_token_count (ctx : KT.working_context) =
+  List.fold_left
+    (fun acc (msg : Agent_sdk.Types.message) ->
+      acc + Agent_sdk.Context_reducer.estimate_message_tokens msg)
+    0 ctx.messages
+
 let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
   let session =
     KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
@@ -315,6 +321,49 @@ let test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint () 
           | None -> fail "expected compacted checkpoint after legacy recovery")
       | None -> fail "expected overflow retry recovery from legacy checkpoint")
 
+let test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_prompt_in_history_budget () =
+  let base_dir = temp_dir "keeper_lifecycle_overflow_retry_system_prompt" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let meta = make_keeper_meta ~trace_id:"trace-overflow-retry-system-prompt" () in
+      let long_system_prompt = String.make 4000 's' in
+      let original_ctx =
+        let rec loop idx ctx =
+          if idx > 20 then ctx else loop (idx + 1) (append_turn ctx idx)
+        in
+        let ctx =
+          loop 1
+            (KEC.create ~system_prompt:long_system_prompt ~max_tokens:4096)
+        in
+        KEC.append ctx
+          (Agent_sdk.Types.assistant_msg
+             "done\n\n[STATE]\nGoal: retry despite large system prompt\nProgress: ready\n[/STATE]")
+        |> KEC.sync_oas_context
+      in
+      ignore (save_checkpoint ~base_dir ~meta ~ctx:original_ctx);
+      match
+        KEC.recover_latest_checkpoint_for_overflow_retry ~base_dir ~meta
+          ~model:"llama:auto" ~primary_model_max_tokens:512
+      with
+      | Some _ ->
+          (match
+             load_context ~base_dir ~trace_id:meta.runtime.trace_id
+               ~max_tokens:512
+           with
+          | Some loaded ->
+              check bool "history messages fit budget" true
+                (message_token_count loaded <= 512);
+              check bool "stored context may exceed history budget once system prompt is counted"
+                true (KEC.token_count loaded > 512)
+          | None -> fail "expected overflow retry checkpoint to be saved")
+      | None ->
+          fail
+            "expected overflow retry recovery to keep message history within budget even with a large checkpoint system prompt")
+
 let () =
   run "keeper_lifecycle"
     [
@@ -330,5 +379,9 @@ let () =
             test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint;
           test_case "overflow retry falls back to legacy checkpoint" `Quick
             test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint;
+          test_case
+            "overflow retry history budget ignores checkpoint system prompt"
+            `Quick
+            test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_prompt_in_history_budget;
         ] );
     ]

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -269,9 +269,11 @@ let test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint ()
           (match
              load_context ~base_dir ~trace_id:meta.runtime.trace_id
                ~max_tokens:256
-           with
+          with
           | Some loaded ->
               check int "checkpoint max tokens clamped" 256 loaded.max_tokens;
+              check bool "recovered context fits budget" true
+                (KEC.token_count loaded <= 256);
               check bool "message count reduced" true
                 (List.length loaded.messages < original_message_count)
           | None -> fail "expected compacted OAS checkpoint")
@@ -307,7 +309,9 @@ let test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint () 
                ~max_tokens:192
            with
           | Some loaded ->
-              check int "legacy retry max tokens clamped" 192 loaded.max_tokens
+              check int "legacy retry max tokens clamped" 192 loaded.max_tokens;
+              check bool "legacy recovered context fits budget" true
+                (KEC.token_count loaded <= 192)
           | None -> fail "expected compacted checkpoint after legacy recovery")
       | None -> fail "expected overflow retry recovery from legacy checkpoint")
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -569,9 +569,12 @@ let test_prompt_room_state_section () =
     }
   in
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
-  check bool "has room state" true
+  check bool "has namespace state" true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Room State") user 0); true
+       try
+         ignore
+           (Str.search_forward (Str.regexp_string "Namespace State") user 0);
+         true
        with Not_found -> false
      in found)
 
@@ -603,8 +606,8 @@ let test_prompt_omits_room_signal_when_flag_disabled () =
     }
   in
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
-  check bool "room signal section omitted" true
-    (not (contains_substring user "Room Signal Interpretation"))
+  check bool "namespace signal section omitted" true
+    (not (contains_substring user "Namespace Signal Interpretation"))
 
 let test_prompt_includes_room_signal_when_flag_enabled () =
   let interpretation : Masc_mcp.Meta_cognition.interpretation =
@@ -638,18 +641,18 @@ let test_prompt_includes_room_signal_when_flag_enabled () =
     }
   in
   let _sys, user = UP.build_prompt ~meta:room_signal_meta ~observation:obs in
-  check bool "room signal section included" true
-    (contains_substring user "Room Signal Interpretation");
-  check bool "room signal primary included" true
-    (contains_substring user "room_signal_primary: contested_belief");
-  check bool "room signal secondary included" true
-    (contains_substring user "room_signal_secondary: operator_tension, stagnant_room");
-  check bool "room signal evidence refs included" true
-    (contains_substring user "room_signal_evidence_refs: post:p-root, comment:c-1");
-  check bool "room signal guard included" true
-    (contains_substring user "room_signal_guard:");
-  check bool "room digest ref included" true
-    (contains_substring user "room_digest_post_id: post-digest-1")
+  check bool "namespace signal section included" true
+    (contains_substring user "Namespace Signal Interpretation");
+  check bool "namespace signal primary included" true
+    (contains_substring user "namespace_signal_primary: contested_belief");
+  check bool "namespace signal secondary included" true
+    (contains_substring user "namespace_signal_secondary: operator_tension, stagnant_room");
+  check bool "namespace signal evidence refs included" true
+    (contains_substring user "namespace_signal_evidence_refs: post:p-root, comment:c-1");
+  check bool "namespace signal guard included" true
+    (contains_substring user "namespace_signal_guard:");
+  check bool "namespace digest ref included" true
+    (contains_substring user "namespace_digest_post_id: post-digest-1")
 
 (* ---------- Config tests ---------- *)
 
@@ -1066,6 +1069,16 @@ let test_overflow_detection_and_limit_parsing () =
     (UT.context_overflow_limit "Network error: connection reset");
   check bool "unrelated error not overflow" false
     (UT.should_attempt_context_overflow_retry "Network error: timeout")
+
+let test_overflow_retry_history_budget_reserves_headroom () =
+  let system_prompt = String.make 2400 's' in
+  let user_message = String.make 1800 'u' in
+  let budget =
+    UT.overflow_retry_history_budget ~available_context:8192
+      ~system_prompt ~user_message
+  in
+  check bool "budget is reduced below raw context" true (budget < 8192);
+  check bool "budget leaves meaningful history room" true (budget >= 256)
 
 let test_metrics_mixed_response () =
   let result =
@@ -1552,5 +1565,7 @@ let () =
             test_context_overflow_limit_parses_common_oas_errors;
           test_case "overflow retry gate only opens for overflow errors" `Quick
             test_should_attempt_context_overflow_retry_only_for_overflow_errors;
+          test_case "overflow retry history budget reserves headroom" `Quick
+            test_overflow_retry_history_budget_reserves_headroom;
         ] );
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -673,7 +673,7 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
-          ~primary_model_max_tokens:256
+          ~primary_model_max_tokens:512
       with
       | None ->
           Alcotest.fail
@@ -681,7 +681,7 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
       | Some recovery ->
           let recovered_ctx =
             Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
-              ~primary_model_max_tokens:256
+              ~primary_model_max_tokens:512
           in
           Alcotest.(check int) "fallback uses OAS generation" 11
             recovery.turn_generation;
@@ -780,17 +780,19 @@ let test_overflow_retry_saves_compacted_checkpoint () =
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
-          ~primary_model_max_tokens:256
+          ~primary_model_max_tokens:512
       with
       | None -> Alcotest.fail "expected overflow retry recovery to compact"
       | Some recovery ->
           let recovered_ctx =
             Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
-              ~primary_model_max_tokens:256
+              ~primary_model_max_tokens:512
           in
           Alcotest.(check bool) "token count reduced" true
             (Keeper_exec_context.token_count recovered_ctx < before_tokens);
-          Alcotest.(check int) "max tokens clamped" 256 recovered_ctx.max_tokens)
+          Alcotest.(check bool) "token count fits retry budget" true
+            (Keeper_exec_context.token_count recovered_ctx <= 512);
+          Alcotest.(check int) "max tokens clamped" 512 recovered_ctx.max_tokens)
 
 (* ================================================================ *)
 (* Same-trace checkpoint continuity regression (OAS #467)            *)


### PR DESCRIPTION
## Summary

- stabilize keeper overflow retry for small-context models by budgeting history against the full retry payload instead of checkpoint history alone
- cap retry-time tool exposure more aggressively to reduce schema token pressure
- continue the room-to-namespace wording migration on active keeper/operator surfaces while keeping compatibility aliases in place

## Product impact

- reduces repeated keeper overflow failures on 8K-class models
- makes retry behavior more deterministic after checkpoint compaction
- keeps collaboration evidence and lifecycle messaging aligned during the namespace wording migration

## Root cause

- overflow retry previously treated compacted checkpoint size as the success condition even though the retried request still had to carry the current system prompt, user message, and tool schemas
- the namespace migration updated visible wording on some surfaces but missed compatibility filters for lifecycle broadcasts

## Evidence

- `dune build --root ... --build-dir _build_fast --display short test/test_keeper_unified.exe`
- `dune exec --root ... --build-dir _build_fast ./test/test_keeper_unified.exe`
- `dune exec --root ... --build-dir _build_fast ./test/test_keeper_lifecycle.exe`
- `dune exec --root ... --build-dir _build_fast ./test/test_dashboard_collaboration_evidence.exe`
- `dune exec --root ... --build-dir _build_fast ./test/test_oas_worker.exe`

## Review evidence

- GLM-5 via direct `sb glm-text` on the PR diff: No findings. Commented on the PR at 2026-04-04 15:14:36 KST.
- Copilot actionable review threads addressed in `c7394c179` and resolved.

## Linked issue

- Refs #4993
