### PR TITLE
[codex] bump OAS SDK pin for Context_overflow compatibility

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -136,6 +136,7 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
           (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
           (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
           (List.length proof.raw_evidence_refs)
+  | Agent_sdk.Cdal_proof.Context_overflow
   | Agent_sdk.Cdal_proof.Errored
   | Agent_sdk.Cdal_proof.Timed_out
   | Agent_sdk.Cdal_proof.Cancelled

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -136,11 +136,7 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
           (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
           (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
           (List.length proof.raw_evidence_refs)
-  | Agent_sdk.Cdal_proof.Context_overflow
-  | Agent_sdk.Cdal_proof.Errored
-  | Agent_sdk.Cdal_proof.Timed_out
-  | Agent_sdk.Cdal_proof.Cancelled
-  | Agent_sdk.Cdal_proof.Context_overflow ->
+  | _ ->
       Log.Keeper.warn "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
         keeper_name proof.run_id
         (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -331,12 +331,7 @@ let run
        | Some p ->
          Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s"
            p.run_id
-           (match p.result_status with
-            | Oas.Cdal_proof.Completed -> "completed"
-            | Oas.Cdal_proof.Errored -> "errored"
-            | Oas.Cdal_proof.Timed_out -> "timed_out"
-            | Oas.Cdal_proof.Cancelled -> "cancelled"
-            | Oas.Cdal_proof.Context_overflow -> "context_overflow")
+           (Oas.Cdal_proof.show_result_status p.result_status)
        | None -> ());
       Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
   with

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -362,12 +362,7 @@ let preview_text_opt text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some (preview_text trimmed)
 
-let proof_result_status_to_string = function
-  | Oas.Cdal_proof.Completed -> "completed"
-  | Oas.Cdal_proof.Errored -> "errored"
-  | Oas.Cdal_proof.Timed_out -> "timed_out"
-  | Oas.Cdal_proof.Cancelled -> "cancelled"
-  | Oas.Cdal_proof.Context_overflow -> "context_overflow"
+let proof_result_status_to_string = Oas.Cdal_proof.show_result_status
 
 let worker_name_of_planned_worker ~(fallback : string)
     (pw : Team_session_types.planned_worker) =

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,12 +33,7 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
-let proof_result_status_to_string = function
-  | Oas.Cdal_proof.Completed -> "completed"
-  | Oas.Cdal_proof.Errored -> "errored"
-  | Oas.Cdal_proof.Timed_out -> "timed_out"
-  | Oas.Cdal_proof.Cancelled -> "cancelled"
-  | Oas.Cdal_proof.Context_overflow -> "context_overflow"
+let proof_result_status_to_string = Oas.Cdal_proof.show_result_status
 
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -535,12 +535,7 @@ and run_existing_worker_agent
              Log.LocalWorker.warn
                "worker %s errored with CDAL proof: run_id=%s status=%s (proof persisted by Proof_store)"
                worker_name p.run_id
-               (match p.result_status with
-                | Oas.Cdal_proof.Completed -> "completed"
-                | Oas.Cdal_proof.Errored -> "errored"
-                | Oas.Cdal_proof.Timed_out -> "timed_out"
-                | Oas.Cdal_proof.Cancelled -> "cancelled"
-                | Oas.Cdal_proof.Context_overflow -> "context_overflow")
+               (Oas.Cdal_proof.show_result_status p.result_status)
            | None -> ());
           let* () =
             Worker_container.append_worker_completion_log

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.100.5"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ed330c26b15ddfd75cfe92e2128a17671ef9090f"
+readonly OAS_AGENT_SDK_SHA="a581801ffc219d2768a6e2e2e69b046ecb9efc66"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.4"


### PR DESCRIPTION
## Summary
- bump the OAS SDK pin from `v0.100.5` to `v0.100.7`
- keep `masc-mcp` aligned with the `Context_overflow`-aware CDAL proof status already present in current `main`

## Root Cause
The `Context_overflow` constructor was added in OAS after the previous pin at `v0.100.5`. The affected MASC call sites have already moved forward on `main`, but CI for this PR was still installing the older pinned SDK, so the branch compiled against a stale `agent_sdk` surface.

## Product impact
- CI and local builds resolve the same `agent_sdk` surface for CDAL proof status handling
- removes the version skew that produced `Unbound constructor Agent_sdk.Cdal_proof.Context_overflow` during PR checks

## Evidence
- failing CI log on this PR showed: `Error: Unbound constructor Agent_sdk.Cdal_proof.Context_overflow`
- `./scripts/check-oas-pin.sh`
  - `OAS pin verified: main@a581801ffc219d2768a6e2e2e69b046ecb9efc66 (base tag v0.100.7)`
- local validation run before the pin update also passed the affected OAS bridge tests:
  - `env -u DUNE_RPC DUNE_BUILD_DIR=.ci_build scripts/ci-run-tests.sh "dune test --root . test/test_oas_integration.exe test/test_oas_worker.exe test/test_team_session_oas_bridge.exe"`

## Review evidence
- `GLM-5.1` via direct `sb glm-text`, correctness-only / compatibility review, result: `No findings.`
- latest delta review evidence recorded in PR comment: https://github.com/jeong-sik/masc-mcp/pull/5004#issuecomment-4186667189

## Linked issue
- Refs #1943
