### PR TITLE
test(room): align join_in_room namespace wording

### DIFF
--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -115,8 +115,8 @@ let test_join_in_room_sanitizes_invalid_room_id () =
             Room.join_in_room config ~room_id:"bad\"\nroom" ~agent_name:"claude"
               ~capabilities:[ "debug" ] ()
           in
-          check bool "result uses sanitized room label" true
-            (str_contains result "room default");
+          check bool "result uses sanitized namespace label" true
+            (str_contains result "namespace default");
           check (option string) "hook sees sanitized room label" (Some "default")
             !captured_room_id;
           let event_log =


### PR DESCRIPTION
## Summary
- align `test_multi_room` with the current `Room.join_in_room` return wording
- keep the sanitize assertions on hook/event payloads unchanged
- remove the stale `room default` expectation that now mismatches flattened namespace wording

## Product impact
This removes the visible `current_room` test failure caused by stale wording drift, so CI can proceed to the next real failures instead of stopping on an already-correct sanitize path.

## Evidence
- Local repro from existing build artifact: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/test/test_multi_room.exe`
- Observed failure: `current_room 3 join_in_room sanitizes invalid room...`
- Current implementation returns `"joined namespace %s"` in `lib/room/room_lifecycle.ml`
- The hook and event assertions in `test/test_multi_room.ml` still expect sanitized `default` and were left intact

## Linked issue
Part of #5005

## Verification
- Reproduced the stale assertion failure locally via the existing built test executable
- Static check: updated assertion now matches the current `Room.join_in_room` result string
- Full `dune build` re-run in this workspace is currently blocked by unrelated local warning-as-error failures around `Context_overflow` exhaustiveness on current `main`
