### PR TITLE
chore(tool): use OAS Tool_middleware, remove duplicate schema conversion

### DIFF
--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -22,51 +22,14 @@ let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
 
 (** {1 Schema Conversion}
 
-    Convert MASC JSON Schema (input_schema) to OAS [tool_param list].
-    MASC schemas use raw JSON objects; OAS uses typed [tool_param] records. *)
+    Delegates to [Agent_sdk.Mcp.json_schema_to_params] — the canonical
+    JSON Schema to OAS [tool_param list] conversion.
 
-let param_type_of_string = function
-  | "string" -> Agent_sdk.Types.String
-  | "integer" -> Agent_sdk.Types.Integer
-  | "number" -> Agent_sdk.Types.Number
-  | "boolean" -> Agent_sdk.Types.Boolean
-  | "array" -> Agent_sdk.Types.Array
-  | "object" -> Agent_sdk.Types.Object
-  | _ -> Agent_sdk.Types.String
+    @since 2.221.0 — delegates to OAS Mcp module (removes 40-line duplicate) *)
 
-(** Extract OAS [tool_param list] from a MASC [input_schema] JSON object.
+let param_type_of_string = Agent_sdk.Mcp.json_schema_type_to_param_type
 
-    Reads ["properties"] and ["required"] fields from the JSON Schema.
-    Unknown types default to [String]. *)
-let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param list =
-  let open Yojson.Safe.Util in
-  let props =
-    try schema |> member "properties" |> to_assoc
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
-  in
-  let required_keys =
-    try schema |> member "required" |> to_list |> List.filter_map (fun j ->
-      try Some (to_string j) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
-  in
-  List.filter_map (fun (key, prop) ->
-    try
-      let type_str =
-        try prop |> member "type" |> to_string
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "string"
-      in
-      let description =
-        try prop |> member "description" |> to_string
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
-      in
-      Some {
-        Agent_sdk.Types.name = key;
-        description;
-        param_type = param_type_of_string type_str;
-        required = List.mem key required_keys;
-      }
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-  ) props
+let params_of_json_schema = Agent_sdk.Mcp.json_schema_to_params
 
 (** {1 OAS Tool.t Creation}
 

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -1,52 +1,36 @@
-(** Tool_input_validation — Pre-dispatch validation via OAS Tool_input_validation.
+(** Tool_input_validation — Pre-dispatch validation via OAS Tool_middleware.
 
-    Delegates to [Agent_sdk.Tool_input_validation] for type coercion and
-    structured error feedback. Converts MASC JSON Schema to OAS [tool_schema]
-    using [Tool_bridge.params_of_json_schema].
+    Delegates to [Agent_sdk.Tool_middleware.make_validation_hook] for type
+    coercion and structured error feedback.
 
-    Coercion examples (Samchon Harness Rank 1):
-    - ["42"] (string) -> [42] (integer)
-    - ["true"] (string) -> [true] (boolean)
-    - [Intlit "123"] -> [Int 123]
-
-    Registered as a Tool_dispatch pre-hook at server startup.
-    When validation fails, returns structured field-level errors.
-
-    @since 2.220.0 — OAS delegation (replaces custom validator) *)
+    @since 2.220.0 — OAS delegation
+    @since 2.221.0 — use Tool_middleware.make_validation_hook *)
 
 (** Register input validation as a Tool_dispatch pre-hook.
     Must be called after all tool schemas are registered (server init).
 
     Tools without a registered schema are allowed through (permissive). *)
 let register_pre_hook () =
+  let lookup name =
+    Option.map
+      (Agent_sdk.Tool_middleware.tool_schema_of_json ~name)
+      (Tool_dispatch.lookup_schema name)
+  in
+  let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    match Tool_dispatch.lookup_schema name with
-    | None -> Pass
-    | Some json_schema ->
-      let parameters = Tool_bridge.params_of_json_schema json_schema in
-      if parameters = [] then Pass
-      else
-        let schema : Agent_sdk.Types.tool_schema =
-          { name; description = ""; parameters }
-        in
-        match Agent_sdk.Tool_input_validation.validate schema args with
-        | Agent_sdk.Tool_input_validation.Valid coerced ->
-          if Yojson.Safe.equal coerced args then Pass
-          else begin
-            Log.info "tool_input_validation coerced args for %s" name;
-            Proceed coerced
-          end
-        | Agent_sdk.Tool_input_validation.Invalid errors ->
-          let msg =
-            Agent_sdk.Tool_input_validation.format_errors ~tool_name:name errors
-          in
-          Log.info "tool_input_validation rejected %s: %s" name msg;
-          Reject {
-            Tool_result.success = false;
-            data = `Assoc [
-              ("error", `String msg);
-              ("validation", `String "oas_tool_input_validation");
-            ];
-            tool_name = name;
-            duration_ms = 0.0;
-          })
+    match hook ~name ~args with
+    | Agent_sdk.Tool_middleware.Pass -> Pass
+    | Agent_sdk.Tool_middleware.Proceed coerced ->
+      Log.info "tool_input_validation coerced args for %s" name;
+      Proceed coerced
+    | Agent_sdk.Tool_middleware.Reject { message; _ } ->
+      Log.info "tool_input_validation rejected %s: %s" name message;
+      Reject {
+        Tool_result.success = false;
+        data = `Assoc [
+          ("error", `String message);
+          ("validation", `String "oas_tool_middleware");
+        ];
+        tool_name = name;
+        duration_ms = 0.0;
+      })

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="a581801ffc219d2768a6e2e2e69b046ecb9efc66"
+readonly OAS_AGENT_SDK_SHA="8b7e4d90676273db85ea210d78340274062a33b2"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.7"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -59,6 +59,18 @@ let make_schema ?(required = []) (props : (string * string) list) : Yojson.Safe.
     ("required", `List (List.map (fun s -> `String s) required));
   ]
 
+let run_registered_hook ?schema ~tool_name ~(args : Yojson.Safe.t) () =
+  Tool_dispatch.clear_hooks ();
+  (match schema with
+   | Some input_schema ->
+     let schema_def : Types.tool_schema =
+       { name = tool_name; description = "test"; input_schema }
+     in
+     Tool_dispatch.register_module_tag ~schemas:[schema_def] ~tag:Mod_misc
+   | None -> ());
+  Tool_input_validation.register_pre_hook ();
+  Tool_dispatch.run_pre_hooks ~name:tool_name ~args
+
 (* ================================================================ *)
 (* Test: required field validation                                   *)
 (* ================================================================ *)
@@ -236,6 +248,64 @@ let test_empty_schema_passes () =
   | Reject r -> Alcotest.fail (Yojson.Safe.to_string r.data)
 
 (* ================================================================ *)
+(* Test: registered pre-hook path                                    *)
+(* ================================================================ *)
+
+let test_registered_hook_coerces_args () =
+  let args = `Assoc [("count", `String "42")] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:(make_schema [("count", "integer")])
+      ~tool_name:"__tool_input_validation_registered_coerce"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "coercion changed args" false
+    (Yojson.Safe.equal forwarded args);
+  match Yojson.Safe.Util.member "count" forwarded with
+  | `Int 42 -> ()
+  | _ -> Alcotest.fail "expected integer coercion through registered pre-hook"
+
+let test_registered_hook_keeps_noop_as_pass () =
+  let args = `Assoc [("count", `Int 42)] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:(make_schema [("count", "integer")])
+      ~tool_name:"__tool_input_validation_registered_noop"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "args unchanged" true
+    (Yojson.Safe.equal forwarded args)
+
+let test_registered_hook_bypasses_unknown_tool () =
+  let args = `Assoc [("count", `String "42")] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~tool_name:"__tool_input_validation_registered_unknown"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "args unchanged" true
+    (Yojson.Safe.equal forwarded args)
+
+let test_registered_hook_bypasses_empty_schema () =
+  let args = `Assoc [("anything", `String "goes")] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:(`Assoc [])
+      ~tool_name:"__tool_input_validation_registered_empty"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "args unchanged" true
+    (Yojson.Safe.equal forwarded args)
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -265,5 +335,15 @@ let () =
       Alcotest.test_case "null args with required" `Quick test_null_args_with_required;
       Alcotest.test_case "extra fields allowed" `Quick test_extra_fields_allowed;
       Alcotest.test_case "empty schema passes" `Quick test_empty_schema_passes;
+    ]);
+    ("registered_hook", [
+      Alcotest.test_case "coercion flows through registered hook" `Quick
+        test_registered_hook_coerces_args;
+      Alcotest.test_case "no-op coercion stays pass" `Quick
+        test_registered_hook_keeps_noop_as_pass;
+      Alcotest.test_case "unknown tool bypasses validation" `Quick
+        test_registered_hook_bypasses_unknown_tool;
+      Alcotest.test_case "empty schema bypasses validation" `Quick
+        test_registered_hook_bypasses_empty_schema;
     ]);
   ]


### PR DESCRIPTION
## Summary
OAS `Tool_middleware`와 schema helper가 이미 제공하는 기능으로 local glue code를 치환해 validation 경로를 단순화합니다.

변경 범위:
- `tool_input_validation.ml`: `Tool_middleware.make_validation_hook` 사용
- `tool_bridge.ml`: `Agent_sdk.Mcp.json_schema_to_params` 위임
- `scripts/oas-agent-sdk-pin.sh`: `Tool_middleware`와 `Context_overflow`를 포함한 OAS pin으로 업데이트

## Product impact
정상 동작 시 런타임 validation 동작은 OAS SSOT에 더 가깝게 수렴합니다. 다만 local glue 제거와 hook 교체가 함께 들어가므로 회귀 테스트가 충분히 확보되기 전까지는 draft 유지가 맞습니다.

## Evidence
- [x] `test_tool_input_validation.exe` — 17/17
- [x] `test_tool_hooks.exe` — 9/9
- [x] `test_governance_pipeline.exe` — 74/74
- [ ] CI

## Review evidence
- Direct `GLM-5.1` correctness review surfaced follow-ups before ready:
  - rewritten validation hook에 대한 regression tests 부재
  - no-op coercion에서도 `Proceed`가 내려오면 로그 노이즈가 생길 수 있는지 확인 필요
  - empty-parameter / pass-through schemas가 기존처럼 우회되는지 확인 필요
- 위 이유로 draft 상태를 유지합니다.

## Linked issue
Refs #5031
