### PR TITLE
fix: align keeper runtime dashboard status

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -61,6 +61,7 @@ const mocks = vi.hoisted(() => ({
       paused: false,
       registered: true,
       keepalive_running: true,
+      registry_state: 'running',
       fiber_health: 'healthy',
       presence_keepalive: true,
       presence_keepalive_sec: 30,
@@ -137,6 +138,8 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('런타임 설정')
     expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')
     expect(container.textContent).toContain('활성 모델')
+    expect(container.textContent).toContain('레지스트리 상태')
+    expect(container.textContent).toContain('running')
 
     const editButton = Array.from(container.querySelectorAll('button')).find(button =>
       button.textContent?.includes('편집'),

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -670,6 +670,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
         <${BoolBadge} value=${c.runtime.keepalive_running} />
       </div>
+      <${ConfigRow} label="레지스트리 상태" value=${c.runtime.registry_state || '--'} />
       <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -609,6 +609,7 @@ export interface KeeperConfigRuntime {
   paused: boolean
   registered: boolean
   keepalive_running: boolean
+  registry_state?: string | null
   fiber_health: string
   presence_keepalive: boolean
   presence_keepalive_sec: number

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -466,6 +466,7 @@ let run_keepalive_unified_turn
       else meta_after_triage
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
+    | Keeper_registry.Keeper_heartbeat_failure _ as e -> raise e
     | exn ->
       Log.Keeper.error "unified turn exception: %s" (Printexc.to_string exn);
       meta_after_triage)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -308,17 +308,26 @@ let wakeup_all ?base_path () =
 let fiber_health_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with
   | None -> Fiber_unknown
-  | Some entry ->
-      if entry.state = Dead then Fiber_dead
-      else
-        match Eio.Promise.peek entry.done_p with
-        | None -> Fiber_alive
-        | Some `Stopped -> Fiber_unknown
-        | Some (`Crashed _) ->
-            let max_restarts = Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
-            if entry.restart_count >= max_restarts
-            then Fiber_dead
-            else Fiber_zombie
+  | Some entry -> (
+      match entry.state with
+      | Dead -> Fiber_dead
+      | Crashed ->
+          let max_restarts =
+            Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
+          in
+          if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie
+      | Stopped -> Fiber_unknown
+      | Running | Paused -> (
+          match Eio.Promise.peek entry.done_p with
+          | None -> Fiber_alive
+          | Some `Stopped -> Fiber_unknown
+          | Some (`Crashed _) ->
+              let max_restarts =
+                Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
+              in
+              if entry.restart_count >= max_restarts
+              then Fiber_dead
+              else Fiber_zombie))
 
 let crash_log_of ~base_path name =
   match get ~base_path name with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -860,17 +860,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           in
           if count >= threshold then begin
             Log.Keeper.error
-              "%s: %d consecutive turn failures (threshold=%d), marking crashed"
+              "%s: %d consecutive turn failures (threshold=%d), escalating to supervisor crash path"
               meta.name count threshold;
             let reason = Keeper_registry.Turn_consecutive_failures count in
-            Keeper_registry.set_failure_reason ~base_path meta.name (Some reason);
-            Keeper_registry.set_state ~base_path meta.name
-              Keeper_registry.Crashed;
-            Keeper_registry.record_crash ~base_path meta.name
-              (Time_compat.now ())
-              (Keeper_registry.failure_reason_to_string reason);
-            Keeper_registry.record_error ~base_path meta.name
-              (Printf.sprintf "turn_consecutive_failures(%d)" count)
+            raise
+              (Keeper_registry.Keeper_heartbeat_failure
+                 { reason; keeper_name = meta.name })
           end;
           Error e
       | Ok result ->

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -258,6 +258,14 @@ let test_fiber_health_crashed () =
   | Keeper_types.Fiber_zombie -> ()
   | _ -> fail "expected Fiber_zombie for crashed"
 
+let test_fiber_health_crashed_state_without_done_signal () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "fh3-state" (make_meta "fh3-state") in
+  R.set_state ~base_path:bp "fh3-state" R.Crashed;
+  match R.fiber_health_of ~base_path:bp "fh3-state" with
+  | Keeper_types.Fiber_zombie -> ()
+  | _ -> fail "expected Fiber_zombie for explicit crashed state"
+
 let test_fiber_health_dead_state () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fh4" (make_meta "fh4") in
@@ -453,6 +461,7 @@ let () =
           eio_test "fiber_health unknown" test_fiber_health_unknown;
           eio_test "fiber_health stopped" test_fiber_health_stopped;
           eio_test "fiber_health crashed" test_fiber_health_crashed;
+          eio_test "fiber_health explicit crashed state" test_fiber_health_crashed_state_without_done_signal;
           eio_test "fiber_health dead state" test_fiber_health_dead_state;
           eio_test "shared refs" test_shared_refs;
           eio_test "spawn slots" test_spawn_slots;


### PR DESCRIPTION
## Summary
Fix keeper runtime dashboard drift by aligning crash ownership with the supervisor and exposing registry state in the runtime panel.

## Product impact
- keeper runtime surfaces stop showing contradictory "crashed but alive" combinations for repeated turn-failure cases
- operators can distinguish runtime supervision state from agent presence because registry state is shown explicitly in the config runtime section
- repeated keeper turn failures now converge on the same supervisor-managed crash path instead of leaving the loop partially alive

## Changes
- escalate repeated keeper turn failures through the supervisor crash path instead of mutating registry state inline
- preserve structured crash propagation in keepalive so crashed loops stop pretending to be alive
- derive `fiber_health` from explicit registry `Crashed` state before promise inspection
- show `registry_state` in the keeper config runtime section
- add a registry test for explicit crashed-state health mapping
- rebase the branch onto current `origin/main` (`2.222.0`) so release-train and lint run against the current baseline

## Evidence
- Passed: `dashboard/node_modules/.bin/tsc --noEmit -p dashboard/tsconfig.json`
- Passed: `opam exec -- dune build --root . @install --force`
- Passed: `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD`
- GraphQL review-thread inspection: no unresolved review threads on PR #5019 at 2026-04-04 16:58 KST
- Runtime repro before fix showed contradictory states such as `keepalive_running=false`, `runtime.registry_state=crashed`, `runtime.fiber_health=alive`, `agent.status=active`

## Review evidence
- Cross-model review: direct `sb glm-text` (`GLM-5.1` path)
- Timestamp: 2026-04-04 16:53 KST
- Scope: correctness-only review of patch content
- Result: `No findings.`

## Linked issue
- Refs #2904

## Root Cause
The dashboard mixed agent presence, registry state, and fiber health from different sources. Repeated turn failures could set registry state to `crashed` while the keepalive loop kept running and `fiber_health_of` still reported `alive`, so the dashboard showed contradictory runtime data.
