### PR TITLE
fix(ci): bump OAS SDK pin to v0.100.7 for Context_overflow support

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.100.4))
+  (agent_sdk (>= 0.100.6))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.100.4"}
+  "agent_sdk" {>= "0.100.6"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="a581801bff7e4e8edc104c8e47e1ef964f2a2a0d"
+readonly OAS_AGENT_SDK_SHA="8b7e4d90676273db85ea210d78340274062a33b2"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.6"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.100.5"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ed330c26b15ddfd75cfe92e2128a17671ef9090f"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.100.4"
+readonly OAS_AGENT_SDK_SHA="a581801bff7e4e8edc104c8e47e1ef964f2a2a0d"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.100.6"


### PR DESCRIPTION
## Summary

- OAS SDK pin을 `ed330c26` (v0.100.5) → `a581801b` (v0.100.7)로 업데이트
- `Cdal_proof.Context_overflow` 생성자가 OAS #607 (v0.100.6)에서 추가되었으나 pin이 뒤처져 CI 빌드 실패

## Product impact

CI 빌드 복구. 런타임 변경 없음 (이미 로컬에서 해당 SDK 버전 사용 중).

## Evidence

- CI 로그: `Unbound constructor Oas.Cdal_proof.Context_overflow` (5개 파일)
- OAS git log: `16a0d2b feat(cdal): add Context_overflow result status` (ed330c26 이후)

## Review evidence

Pin bump만으로 코드 변경 없음.

## Linked issue

Fixes CI build failure on main.

## Test plan

- [ ] CI Build and Test pass
- [ ] CI Lint pass (warnings as errors)
- [ ] CI Contract Harness pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)