### PR TITLE
fix(ci): remove direct Context_overflow matches

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -128,19 +128,28 @@ let prioritized_disclosed_tool_names
     acc
 
 let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
+  let status_string =
+    Agent_sdk.Cdal_proof.show_result_status proof.result_status
+    |> fun raw ->
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+        String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw
+    |> String.lowercase_ascii
+  in
   match proof.result_status with
   | Agent_sdk.Cdal_proof.Completed ->
       if Keeper_types_profile.keeper_debug then
         Log.Keeper.debug "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
           keeper_name proof.run_id
           (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
-          (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
+          status_string
           (List.length proof.raw_evidence_refs)
   | _ ->
       Log.Keeper.warn "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
         keeper_name proof.run_id
         (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
-        (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
+        status_string
         (List.length proof.raw_evidence_refs)
 
 let log_keeper_contract_verdict

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -136,10 +136,7 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
           (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
           (Agent_sdk.Cdal_proof.show_result_status proof.result_status)
           (List.length proof.raw_evidence_refs)
-  | Agent_sdk.Cdal_proof.Errored
-  | Agent_sdk.Cdal_proof.Timed_out
-  | Agent_sdk.Cdal_proof.Cancelled
-  | Agent_sdk.Cdal_proof.Context_overflow ->
+  | _ ->
       Log.Keeper.warn "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
         keeper_name proof.run_id
         (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -83,6 +83,9 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+let proof_result_status_to_string status =
+  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+
 (* ================================================================ *)
 (* Internal: resolve provider                                        *)
 (* ================================================================ *)
@@ -331,12 +334,7 @@ let run
        | Some p ->
          Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s"
            p.run_id
-           (match p.result_status with
-            | Oas.Cdal_proof.Completed -> "completed"
-            | Oas.Cdal_proof.Errored -> "errored"
-            | Oas.Cdal_proof.Timed_out -> "timed_out"
-            | Oas.Cdal_proof.Cancelled -> "cancelled"
-            | Oas.Cdal_proof.Context_overflow -> "context_overflow")
+           (proof_result_status_to_string p.result_status)
        | None -> ());
       Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
   with

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -83,8 +83,17 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+let lowercase_enum_case_name raw =
+  let raw =
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+        String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw
+  in
+  String.lowercase_ascii raw
+
 let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
 
 (* ================================================================ *)
 (* Internal: resolve provider                                        *)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -362,8 +362,17 @@ let preview_text_opt text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some (preview_text trimmed)
 
+let lowercase_enum_case_name raw =
+  let raw =
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+        String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw
+  in
+  String.lowercase_ascii raw
+
 let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
 
 let worker_name_of_planned_worker ~(fallback : string)
     (pw : Team_session_types.planned_worker) =

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -362,12 +362,8 @@ let preview_text_opt text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some (preview_text trimmed)
 
-let proof_result_status_to_string = function
-  | Oas.Cdal_proof.Completed -> "completed"
-  | Oas.Cdal_proof.Errored -> "errored"
-  | Oas.Cdal_proof.Timed_out -> "timed_out"
-  | Oas.Cdal_proof.Cancelled -> "cancelled"
-  | Oas.Cdal_proof.Context_overflow -> "context_overflow"
+let proof_result_status_to_string status =
+  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
 
 let worker_name_of_planned_worker ~(fallback : string)
     (pw : Team_session_types.planned_worker) =

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,8 +33,17 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
+let lowercase_enum_case_name raw =
+  let raw =
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+        String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw
+  in
+  String.lowercase_ascii raw
+
 let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
 
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,12 +33,8 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
-let proof_result_status_to_string = function
-  | Oas.Cdal_proof.Completed -> "completed"
-  | Oas.Cdal_proof.Errored -> "errored"
-  | Oas.Cdal_proof.Timed_out -> "timed_out"
-  | Oas.Cdal_proof.Cancelled -> "cancelled"
-  | Oas.Cdal_proof.Context_overflow -> "context_overflow"
+let proof_result_status_to_string status =
+  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
 
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -38,8 +38,17 @@ let max_turns_cap_of_scope (scope : Team_session_types.execution_scope) : int =
   | Limited_code_change -> 20
   | Autonomous -> 30
 
+let lowercase_enum_case_name raw =
+  let raw =
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+        String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw
+  in
+  String.lowercase_ascii raw
+
 let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
 
 (** Derive max_turns from worker meta, applying the scope cap.
     When max_turns_override is set, it is clamped to [1, cap].

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -38,6 +38,9 @@ let max_turns_cap_of_scope (scope : Team_session_types.execution_scope) : int =
   | Limited_code_change -> 20
   | Autonomous -> 30
 
+let proof_result_status_to_string status =
+  Oas.Cdal_proof.show_result_status status |> String.lowercase_ascii
+
 (** Derive max_turns from worker meta, applying the scope cap.
     When max_turns_override is set, it is clamped to [1, cap].
     When absent, timeout_seconds / 20 is used as a heuristic. *)
@@ -535,12 +538,7 @@ and run_existing_worker_agent
              Log.LocalWorker.warn
                "worker %s errored with CDAL proof: run_id=%s status=%s (proof persisted by Proof_store)"
                worker_name p.run_id
-               (match p.result_status with
-                | Oas.Cdal_proof.Completed -> "completed"
-                | Oas.Cdal_proof.Errored -> "errored"
-                | Oas.Cdal_proof.Timed_out -> "timed_out"
-                | Oas.Cdal_proof.Cancelled -> "cancelled"
-                | Oas.Cdal_proof.Context_overflow -> "context_overflow")
+               (proof_result_status_to_string p.result_status)
            | None -> ());
           let* () =
             Worker_container.append_worker_completion_log


### PR DESCRIPTION
## Summary
- remove direct `Context_overflow` constructor matches from CDAL proof logging paths
- switch OAS proof-status stringification to `show_result_status`-based rendering
- treat non-`Completed` keeper proof statuses via `_` so future variants do not break compilation

## Product impact
This restores build compatibility for PR merge refs on current `main`, where `Lint`, `Build and Test`, `Health`, and `Contract Harness` all fail before tests run.

## Evidence
- failing run: `23974205787`
- failing jobs:
  - `69928617065` (`Lint`)
  - `69928624525` (`Build and Test`)
  - `69928624505` (`Health`)
  - `69928624504` (`Contract Harness`)
- representative errors:
  - `Error: Unbound constructor Oas.Cdal_proof.Context_overflow`
  - `Error: Unbound constructor Agent_sdk.Cdal_proof.Context_overflow`

## Linked issue
Refs #5023

## Review evidence
- Local analysis: all four failed jobs stop on the same constructor-compatibility error before reaching their downstream steps.

## Verification
- Confirmed the failing CI logs all stop on the same five call sites
- Removed all direct `Context_overflow` references from `lib/`
- Attempted local `dune build` verification, but the full repo build in this environment is too heavy to complete interactively within the session budget; CI is the authoritative verifier for this fix
