### PR TITLE
fix(test): align tool surface assertions with #4999 pruning

### DIFF
--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -79,12 +79,9 @@ let test_spawned_agent_surface_stays_curated () =
     (List.mem "mcp__masc__masc_status" names);
   check bool "contains team_session_step" true
     (List.mem "mcp__masc__masc_team_session_step" names);
-  check bool "contains voice agent" true
-    (List.mem "mcp__masc__masc_voice_agent" names);
-  check bool "contains voice speak" true
-    (List.mem "mcp__masc__masc_voice_speak" names);
-  check bool "contains voice ping pong" true
-    (List.mem "mcp__masc__masc_voice_ping_pong" names)
+  (* voice tools were pruned from spawned_agent surface in #4999 *)
+  check bool "no voice agent in spawned surface" false
+    (List.mem "mcp__masc__masc_voice_agent" names)
 
 let test_privileged_keeper_surface_is_split () =
   check bool "keeper_bash privileged" true

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -562,18 +562,11 @@ let test_handle_request_tools_list () =
     "contains masc_board_post (public surface)"
     true
     (List.mem "masc_board_post" names);
+  (* voice tools pruned from public surface in #4999 *)
   Alcotest.(check bool)
-    "contains masc_voice_agent (public surface)"
-    true
+    "no masc_voice_agent in public surface"
+    false
     (List.mem "masc_voice_agent" names);
-  Alcotest.(check bool)
-    "contains masc_voice_speak (public surface)"
-    true
-    (List.mem "masc_voice_speak" names);
-  Alcotest.(check bool)
-    "contains masc_voice_ping_pong (public surface)"
-    true
-    (List.mem "masc_voice_ping_pong" names);
   Alcotest.(check bool)
     "board_search hidden from public surface"
     false
@@ -812,12 +805,9 @@ let test_handle_request_tools_list_managed_profile () =
                    (List.mem "masc_status" names);
                  Alcotest.(check bool) "omits raw masc_transition" false
                    (List.mem "masc_transition" names);
-                 Alcotest.(check bool) "includes managed voice agent" true
-                   (List.mem "masc_voice_agent" names);
-                 Alcotest.(check bool) "includes managed voice speak" true
-                   (List.mem "masc_voice_speak" names);
-                 Alcotest.(check bool) "includes managed voice ping pong" true
-                   (List.mem "masc_voice_ping_pong" names)
+                 (* voice tools pruned from managed surface in #4999 *)
+                 Alcotest.(check bool) "no managed voice agent" false
+                   (List.mem "masc_voice_agent" names)
              | _ -> Alcotest.fail "tools not a list")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -112,9 +112,10 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_team_session_step" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains team_session_finalize" true
     (List.mem "mcp__masc__masc_team_session_finalize" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains portal_send" true
+  (* portal_send and a2a_delegate pruned from spawned surface in #4999 *)
+  Alcotest.(check bool) "no portal_send in spawned" false
     (List.mem "mcp__masc__masc_portal_send" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains a2a_delegate" true
+  Alcotest.(check bool) "no a2a_delegate in spawned" false
     (List.mem "mcp__masc__masc_a2a_delegate" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits run_deliverable" false
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);


### PR DESCRIPTION
## Summary
#4999에서 pruned된 tool surface에 맞춰 stale test assertion을 정리합니다.

수정 범위:
- `test_capability_registry.ml`: pruned voice tools 부재 확인
- `test_spawn.ml`: spawned surface에서 pruned portal/a2a 부재 확인
- `test_mcp_server_eio.ml`: public/managed surface에서 pruned voice tools 부재 확인

## Product impact
런타임 동작 변경은 없습니다. 현재 surface SSOT에 맞춰 테스트 기대값만 정렬해 CI 신호를 복구하는 패치입니다.

## Evidence
- [x] `test_capability_registry.exe` 기존 범위 로컬 확인
- [x] `test_spawn.exe` 기존 범위 로컬 확인
- [x] `test_mcp_server_eio.exe` 기존 범위 로컬 확인
- [ ] CI

## Review evidence
- Direct `GLM-5.1` review highlighted one follow-up: `voice_agent`만이 아니라 `voice_speak`와 `voice_ping_pong`의 부재도 capability/mcp surface tests에서 함께 확인해야 함.
- 해당 follow-up은 branch 후속 수정으로 반영 중입니다.

## Linked issue
Closes #5005
