### PR TITLE
refactor(gate): decouple Channel Gate from Agent_identity and Tool_keeper

### DIFF
--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -1,10 +1,14 @@
 (** Channel_gate -- deterministic router for external chat platforms.
-    See [channel_gate.mli] for the full contract. *)
+    See [channel_gate.mli] for the full contract.
 
-(* ── Types ──────────────────────────────────────────────────── *)
+    This module owns dedup state and metrics recording.
+    Types come from {!Gate_protocol}.
+    Keeper dispatch is injected via [dispatch_fn]. *)
 
-type inbound_message = {
-  channel : Agent_identity.channel;
+(* ── Re-exported types from Gate_protocol ────────────────────── *)
+
+type inbound_message = Gate_protocol.inbound_message = {
+  channel : string;
   channel_user_id : string;
   channel_user_name : string;
   channel_room_id : string;
@@ -14,25 +18,38 @@ type inbound_message = {
   metadata : (string * string) list;
 }
 
-type turn_stats = {
+type turn_stats = Gate_protocol.turn_stats = {
   model_used : string;
   duration_ms : int;
   tokens_used : int;
 }
 
-type outbound_message = {
+type outbound_message = Gate_protocol.outbound_message = {
   keeper_name : string;
   content : string;
   turn_stats : turn_stats option;
 }
 
-type validation_error =
+type validation_error = Gate_protocol.validation_error =
   | Empty_content
   | Content_too_long of int
   | Empty_keeper_name
   | Empty_channel_user_id
   | Empty_idempotency_key
   | Duplicate_message of string
+
+type gate_error = Gate_protocol.gate_error =
+  | Validation of validation_error
+  | Keeper_error of string
+  | Dispatch_unavailable
+  | Internal of string
+
+type dispatch_fn =
+  channel:string ->
+  channel_user_id:string ->
+  keeper_name:string ->
+  content:string ->
+  Gate_keeper_backend.dispatch_result
 
 (* ── Configuration ──────────────────────────────────────────── *)
 
@@ -48,12 +65,10 @@ let dedup_ttl_sec () =
 
 (* ── Deduplication (TTL hashtable, Eio-guarded mutex) ───────── *)
 
-(** Seen idempotency keys with their insertion timestamp. *)
 let dedup_table : (string, float) Hashtbl.t = Hashtbl.create 256
 
 let dedup_mutex = Eio.Mutex.create ()
 
-(** Max dedup entries to prevent unbounded memory growth. *)
 let dedup_max_entries = 10_000
 
 let with_dedup_lock f = Eio_guard.with_mutex dedup_mutex f
@@ -70,7 +85,6 @@ let dedup_check key =
       | None -> false
     in
     if not result then begin
-      (* Evict oldest if at capacity *)
       if Hashtbl.length dedup_table >= dedup_max_entries then begin
         let oldest_key = ref "" in
         let oldest_ts = ref Float.max_float in
@@ -99,83 +113,26 @@ let dedup_table_size () =
 (* Register dedup_table_size callback to break cycle *)
 let () = Channel_gate_metrics.register_dedup_size_fn dedup_table_size
 
-let normalize_channel_label channel =
-  Agent_identity.string_of_channel channel
+(* ── Delegated helpers ───────────────────────────────────────── *)
 
-(* ── Validation (pure) ──────────────────────────────────────── *)
+let validation_error_to_string = Gate_protocol.validation_error_to_string
+let gate_error_to_string = Gate_protocol.gate_error_to_string
+let inbound_of_json = Gate_protocol.inbound_of_json
+let outbound_to_json = Gate_protocol.outbound_to_json
+let error_json = Gate_protocol.error_json
 
-let validation_error_to_string = function
-  | Empty_content -> "content is required"
-  | Content_too_long len ->
-      Printf.sprintf "content too long: %d chars (max %d)" len (max_content_length ())
-  | Empty_keeper_name -> "keeper_name is required"
-  | Empty_channel_user_id -> "channel_user_id is required"
-  | Empty_idempotency_key -> "idempotency_key is required"
-  | Duplicate_message key ->
-      Printf.sprintf "duplicate message (idempotency_key=%s)" key
-
-type gate_error =
-  | Validation of validation_error
-  | Keeper_error of string
-  | Dispatch_unavailable
-  | Internal of string
-
-let gate_error_to_string = function
-  | Validation e -> validation_error_to_string e
-  | Keeper_error msg -> Printf.sprintf "keeper error: %s" msg
-  | Dispatch_unavailable -> "keeper dispatch unavailable"
-  | Internal _ -> "internal error"
+(* ── Validation (uses local dedup) ───────────────────────────── *)
 
 let validate (msg : inbound_message) =
-  let content = String.trim msg.content in
-  let name = String.trim msg.keeper_name in
-  if name = "" then Error Empty_keeper_name
-  else if String.trim msg.channel_user_id = "" then Error Empty_channel_user_id
-  else if String.trim msg.idempotency_key = "" then Error Empty_idempotency_key
-  else if content = "" then Error Empty_content
-  else
-    let len = String.length content in
-    if len > max_content_length () then Error (Content_too_long len)
-    else if dedup_check msg.idempotency_key then
-      Error (Duplicate_message msg.idempotency_key)
-    else Ok ()
+  Gate_protocol.validate
+    ~max_content_length:(max_content_length ())
+    ~dedup_check
+    msg
 
-(* ── Dispatch ───────────────────────────────────────────────── *)
+(* ── Dispatch ────────────────────────────────────────────────── *)
 
-let extract_turn_stats (body : string) : turn_stats option =
-  try
-    let json = Yojson.Safe.from_string body in
-    let open Yojson.Safe.Util in
-    let model =
-      json |> member "model_used" |> to_string_option
-      |> Option.value
-           ~default:
-             (json |> member "model" |> to_string_option
-              |> Option.value ~default:"")
-    in
-    let dur = json |> member "duration_ms" |> to_int_option
-              |> Option.value ~default:0 in
-    let tok = json |> member "total_tokens" |> to_int_option
-              |> Option.value ~default:0 in
-    if model = "" && dur = 0 && tok = 0 then None
-    else Some { model_used = model; duration_ms = dur; tokens_used = tok }
-  with _ -> None
-
-let extract_reply_text (body : string) : string =
-  try
-    let json = Yojson.Safe.from_string body in
-    let open Yojson.Safe.Util in
-    (* keeper_msg returns {reply, ...} or plain text *)
-    match json |> member "reply" |> to_string_option with
-    | Some r -> r
-    | None ->
-        (match json |> member "text" |> to_string_option with
-         | Some t -> t
-         | None -> body)
-  with _ -> body
-
-let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
-  let channel = normalize_channel_label msg.channel in
+let handle_inbound ~dispatch (msg : inbound_message) =
+  let channel = msg.channel in
   match validate msg with
   | Error e ->
       Channel_gate_metrics.record_attempt
@@ -190,106 +147,40 @@ let handle_inbound ~sw ~clock ~proc_mgr ~net ~config (msg : inbound_message) =
                (validation_error_to_string e));
       Error (Validation e)
   | Ok () ->
-      let args =
-        `Assoc [
-          ("name", `String (String.trim msg.keeper_name));
-          ("message", `String (String.trim msg.content));
-        ]
+      let keeper = String.trim msg.keeper_name in
+      let result =
+        dispatch
+          ~channel
+          ~channel_user_id:msg.channel_user_id
+          ~keeper_name:keeper
+          ~content:(String.trim msg.content)
       in
-      let keeper_ctx : _ Tool_keeper.context = {
-        config;
-        agent_name =
-          Printf.sprintf "gate:%s:%s" channel msg.channel_user_id;
-        sw;
-        clock;
-        proc_mgr;
-        net;
-      } in
-      let start_time = Unix.gettimeofday () in
-      match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
-      | Some (true, body) ->
-          let duration_ms =
-            int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
-          in
-          let keeper = String.trim msg.keeper_name in
-          Channel_gate_metrics.record_attempt
-            ~channel
-            ~room_id:msg.channel_room_id
-            ~keeper
-            ~duration_ms
-            Channel_gate_metrics.Success;
-          let reply = extract_reply_text body in
-          let stats = match extract_turn_stats body with
-            | Some s -> Some { s with duration_ms }
-            | None -> Some { model_used = ""; duration_ms; tokens_used = 0 }
-          in
-          Ok { keeper_name = keeper; content = reply; turn_stats = stats }
-      | Some (false, err) ->
-          let duration_ms =
-            int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
-          in
-          Channel_gate_metrics.record_attempt
-            ~channel
-            ~room_id:msg.channel_room_id
-            ~keeper:(String.trim msg.keeper_name)
-            ~duration_ms
-            (Channel_gate_metrics.Keeper_error err);
-          Error (Keeper_error err)
-      | None ->
-          Channel_gate_metrics.record_attempt
-            ~channel
-            ~room_id:msg.channel_room_id
-            ~keeper:(String.trim msg.keeper_name)
-            ~duration_ms:0
-            Channel_gate_metrics.Dispatch_unavailable;
-          Error Dispatch_unavailable
-
-(* ── JSON helpers ───────────────────────────────────────────── *)
-
-let error_json msg =
-  `Assoc [ ("ok", `Bool false); ("error", `String msg) ]
-
-let outbound_to_json out =
-  let stats_json = match out.turn_stats with
-    | None -> `Null
-    | Some s ->
-        `Assoc [
-          ("model_used", `String s.model_used);
-          ("duration_ms", `Int s.duration_ms);
-          ("tokens_used", `Int s.tokens_used);
-        ]
-  in
-  `Assoc [
-    ("ok", `Bool true);
-    ("keeper_name", `String out.keeper_name);
-    ("reply", `String out.content);
-    ("turn_stats", stats_json);
-  ]
-
-let inbound_of_json json =
-  let open Yojson.Safe.Util in
-  try
-    let str key = json |> member key |> to_string_option
-                  |> Option.value ~default:"" in
-    let channel = str "channel" |> Agent_identity.channel_of_string in
-    let metadata =
-      match json |> member "metadata" with
-      | `Assoc pairs ->
-          List.filter_map (fun (k, v) ->
-            match v with `String s -> Some (k, s) | _ -> None
-          ) pairs
-      | _ -> []
-    in
-    Ok {
-      channel;
-      channel_user_id = str "channel_user_id";
-      channel_user_name = str "channel_user_name";
-      channel_room_id = str "channel_room_id";
-      keeper_name = str "keeper_name";
-      content = str "content";
-      idempotency_key = str "idempotency_key";
-      metadata;
-    }
-  with
-  | Yojson.Json_error e -> Error ("invalid json: " ^ e)
-  | exn -> Error ("parse error: " ^ Printexc.to_string exn)
+      (match result with
+       | Gate_keeper_backend.Reply { content = reply; stats } ->
+           let duration_ms = match stats with
+             | Some s -> s.duration_ms
+             | None -> 0
+           in
+           Channel_gate_metrics.record_attempt
+             ~channel
+             ~room_id:msg.channel_room_id
+             ~keeper
+             ~duration_ms
+             Channel_gate_metrics.Success;
+           Ok { keeper_name = keeper; content = reply; turn_stats = stats }
+       | Gate_keeper_backend.Keeper_error err ->
+           Channel_gate_metrics.record_attempt
+             ~channel
+             ~room_id:msg.channel_room_id
+             ~keeper
+             ~duration_ms:0
+             (Channel_gate_metrics.Keeper_error err);
+           Error (Keeper_error err)
+       | Gate_keeper_backend.Unavailable ->
+           Channel_gate_metrics.record_attempt
+             ~channel
+             ~room_id:msg.channel_room_id
+             ~keeper
+             ~duration_ms:0
+             Channel_gate_metrics.Dispatch_unavailable;
+           Error Dispatch_unavailable)

--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -49,7 +49,7 @@ type dispatch_fn =
   channel_user_id:string ->
   keeper_name:string ->
   content:string ->
-  Gate_keeper_backend.dispatch_result
+  Gate_protocol.dispatch_result
 
 (* ── Configuration ──────────────────────────────────────────── *)
 
@@ -156,7 +156,7 @@ let handle_inbound ~dispatch (msg : inbound_message) =
           ~content:(String.trim msg.content)
       in
       (match result with
-       | Gate_keeper_backend.Reply { content = reply; stats } ->
+       | Gate_protocol.Reply { content = reply; stats } ->
            let duration_ms = match stats with
              | Some s -> s.duration_ms
              | None -> 0
@@ -168,7 +168,7 @@ let handle_inbound ~dispatch (msg : inbound_message) =
              ~duration_ms
              Channel_gate_metrics.Success;
            Ok { keeper_name = keeper; content = reply; turn_stats = stats }
-       | Gate_keeper_backend.Keeper_error err ->
+       | Gate_protocol.Keeper_error_result err ->
            Channel_gate_metrics.record_attempt
              ~channel
              ~room_id:msg.channel_room_id
@@ -176,7 +176,7 @@ let handle_inbound ~dispatch (msg : inbound_message) =
              ~duration_ms:0
              (Channel_gate_metrics.Keeper_error err);
            Error (Keeper_error err)
-       | Gate_keeper_backend.Unavailable ->
+       | Gate_protocol.Unavailable_result ->
            Channel_gate_metrics.record_attempt
              ~channel
              ~room_id:msg.channel_room_id

--- a/lib/channel_gate.mli
+++ b/lib/channel_gate.mli
@@ -85,7 +85,7 @@ type dispatch_fn =
   channel_user_id:string ->
   keeper_name:string ->
   content:string ->
-  Gate_keeper_backend.dispatch_result
+  Gate_protocol.dispatch_result
 
 val handle_inbound :
   dispatch:dispatch_fn ->

--- a/lib/channel_gate.mli
+++ b/lib/channel_gate.mli
@@ -6,15 +6,19 @@
     No LLM calls, no heuristics, no fuzzy matching.
 
     Consumers talk to the gate via HTTP ([/api/v1/gate/*]).
-    The gate talks to keepers via [Tool_keeper.dispatch].
+    The gate dispatches to keepers through an injected [dispatch]
+    function, keeping it decoupled from [Tool_keeper] internals.
 
-    @since 2.217.0 *)
+    Wire types live in {!Gate_protocol}.
+    Keeper dispatch adapter lives in {!Gate_keeper_backend}.
 
-(** {1 Inbound / Outbound Types} *)
+    @since 2.217.0
+    @modified 2.222.0 Decoupled from Agent_identity and Tool_keeper *)
 
-(** Message arriving from an external channel consumer. *)
-type inbound_message = {
-  channel : Agent_identity.channel;
+(** {1 Re-exported Wire Types} *)
+
+type inbound_message = Gate_protocol.inbound_message = {
+  channel : string;
   channel_user_id : string;
   channel_user_name : string;
   channel_room_id : string;
@@ -24,22 +28,21 @@ type inbound_message = {
   metadata : (string * string) list;
 }
 
-(** Successful response to send back to the consumer. *)
-type outbound_message = {
-  keeper_name : string;
-  content : string;
-  turn_stats : turn_stats option;
-}
-
-and turn_stats = {
+type turn_stats = Gate_protocol.turn_stats = {
   model_used : string;
   duration_ms : int;
   tokens_used : int;
 }
 
+type outbound_message = Gate_protocol.outbound_message = {
+  keeper_name : string;
+  content : string;
+  turn_stats : turn_stats option;
+}
+
 (** {1 Validation} *)
 
-type validation_error =
+type validation_error = Gate_protocol.validation_error =
   | Empty_content
   | Content_too_long of int
   | Empty_keeper_name
@@ -67,9 +70,7 @@ val dedup_table_size : unit -> int
 
 (** {1 Dispatch} *)
 
-(** {1 Dispatch errors (typed, not string)} *)
-
-type gate_error =
+type gate_error = Gate_protocol.gate_error =
   | Validation of validation_error
   | Keeper_error of string
   | Dispatch_unavailable
@@ -77,17 +78,22 @@ type gate_error =
 
 val gate_error_to_string : gate_error -> string
 
+(** Dispatch function signature.  Provided by the wiring layer
+    (typically a partial application of {!Gate_keeper_backend.dispatch}). *)
+type dispatch_fn =
+  channel:string ->
+  channel_user_id:string ->
+  keeper_name:string ->
+  content:string ->
+  Gate_keeper_backend.dispatch_result
+
 val handle_inbound :
-  sw:Eio.Switch.t ->
-  clock:_ Eio.Time.clock ->
-  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
-  config:Room.config ->
+  dispatch:dispatch_fn ->
   inbound_message ->
   (outbound_message, gate_error) result
 (** Validate, dedup, dispatch to keeper, return response.
     The only non-deterministic step is the keeper turn itself
-    (which is on the other side of the boundary). *)
+    (which is on the other side of the [dispatch] boundary). *)
 
 (** {1 JSON helpers} *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -34,6 +34,8 @@
    cancellation
    channel_gate
    channel_gate_metrics
+   gate_protocol
+   gate_keeper_backend
    command_plane_v2
    command_plane_orchestra
    cp_orchestra_helpers

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -1,0 +1,76 @@
+(** Gate_keeper_backend -- adapter between the Channel Gate and the keeper subsystem.
+    See [gate_keeper_backend.mli] for the full contract. *)
+
+type dispatch_result =
+  | Reply of { content : string; stats : Gate_protocol.turn_stats option }
+  | Keeper_error of string
+  | Unavailable
+
+(* ── Keeper response parsing ─────────────────────────────────── *)
+
+let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
+  try
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    let model =
+      json |> member "model_used" |> to_string_option
+      |> Option.value
+           ~default:
+             (json |> member "model" |> to_string_option
+              |> Option.value ~default:"")
+    in
+    let dur = json |> member "duration_ms" |> to_int_option
+              |> Option.value ~default:0 in
+    let tok = json |> member "total_tokens" |> to_int_option
+              |> Option.value ~default:0 in
+    if model = "" && dur = 0 && tok = 0 then None
+    else Some { Gate_protocol.model_used = model; duration_ms = dur; tokens_used = tok }
+  with _ -> None
+
+let extract_reply_text (body : string) : string =
+  try
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    match json |> member "reply" |> to_string_option with
+    | Some r -> r
+    | None ->
+        (match json |> member "text" |> to_string_option with
+         | Some t -> t
+         | None -> body)
+  with _ -> body
+
+(* ── Dispatch ────────────────────────────────────────────────── *)
+
+let dispatch ~sw ~clock ~proc_mgr ~net ~config
+    ~channel ~channel_user_id ~keeper_name ~content =
+  let agent_name = Printf.sprintf "gate:%s:%s" channel channel_user_id in
+  let args =
+    `Assoc [
+      ("name", `String (String.trim keeper_name));
+      ("message", `String (String.trim content));
+    ]
+  in
+  let keeper_ctx : _ Tool_keeper.context = {
+    config;
+    agent_name;
+    sw;
+    clock;
+    proc_mgr;
+    net;
+  } in
+  let start_time = Unix.gettimeofday () in
+  match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
+  | Some (true, body) ->
+      let duration_ms =
+        int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
+      in
+      let reply = extract_reply_text body in
+      let stats = match extract_turn_stats body with
+        | Some s -> Some { s with duration_ms }
+        | None -> Some { Gate_protocol.model_used = ""; duration_ms; tokens_used = 0 }
+      in
+      Reply { content = reply; stats }
+  | Some (false, err) ->
+      Keeper_error err
+  | None ->
+      Unavailable

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -1,11 +1,6 @@
 (** Gate_keeper_backend -- adapter between the Channel Gate and the keeper subsystem.
     See [gate_keeper_backend.mli] for the full contract. *)
 
-type dispatch_result =
-  | Reply of { content : string; stats : Gate_protocol.turn_stats option }
-  | Keeper_error of string
-  | Unavailable
-
 (* ── Keeper response parsing ─────────────────────────────────── *)
 
 let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
@@ -69,8 +64,8 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
         | Some s -> Some { s with duration_ms }
         | None -> Some { Gate_protocol.model_used = ""; duration_ms; tokens_used = 0 }
       in
-      Reply { content = reply; stats }
+      Gate_protocol.Reply { content = reply; stats }
   | Some (false, err) ->
-      Keeper_error err
+      Gate_protocol.Keeper_error_result err
   | None ->
-      Unavailable
+      Gate_protocol.Unavailable_result

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -4,13 +4,11 @@
     and [Room].  The gate orchestrator ([Channel_gate]) calls
     {!dispatch} without knowing how keeper dispatch works internally.
 
-    @since 2.222.0 *)
+    The return type {!Gate_protocol.dispatch_result} lives in
+    [Gate_protocol] so that [Channel_gate] does not need to depend
+    on this module for type definitions.
 
-(** Result of dispatching a message to a keeper. *)
-type dispatch_result =
-  | Reply of { content : string; stats : Gate_protocol.turn_stats option }
-  | Keeper_error of string
-  | Unavailable
+    @since 2.222.0 *)
 
 val dispatch :
   sw:Eio.Switch.t ->
@@ -22,7 +20,7 @@ val dispatch :
   channel_user_id:string ->
   keeper_name:string ->
   content:string ->
-  dispatch_result
+  Gate_protocol.dispatch_result
 (** Build a keeper context, call [Tool_keeper.dispatch], and parse
     the response.  The [channel] and [channel_user_id] are used to
     construct the agent name ([gate:<channel>:<user_id>]). *)

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -1,0 +1,28 @@
+(** Gate_keeper_backend -- adapter between the Channel Gate and the keeper subsystem.
+
+    This module owns the coupling to [Tool_keeper], [Agent_identity],
+    and [Room].  The gate orchestrator ([Channel_gate]) calls
+    {!dispatch} without knowing how keeper dispatch works internally.
+
+    @since 2.222.0 *)
+
+(** Result of dispatching a message to a keeper. *)
+type dispatch_result =
+  | Reply of { content : string; stats : Gate_protocol.turn_stats option }
+  | Keeper_error of string
+  | Unavailable
+
+val dispatch :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  config:Room.config ->
+  channel:string ->
+  channel_user_id:string ->
+  keeper_name:string ->
+  content:string ->
+  dispatch_result
+(** Build a keeper context, call [Tool_keeper.dispatch], and parse
+    the response.  The [channel] and [channel_user_id] are used to
+    construct the agent name ([gate:<channel>:<user_id>]). *)

--- a/lib/gate_protocol.ml
+++ b/lib/gate_protocol.ml
@@ -1,0 +1,131 @@
+(** Gate_protocol -- wire-level types for the Channel Gate HTTP API.
+    See [gate_protocol.mli] for the full contract. *)
+
+(* ── Wire Types ──────────────────────────────────────────────── *)
+
+type inbound_message = {
+  channel : string;
+  channel_user_id : string;
+  channel_user_name : string;
+  channel_room_id : string;
+  keeper_name : string;
+  content : string;
+  idempotency_key : string;
+  metadata : (string * string) list;
+}
+
+type turn_stats = {
+  model_used : string;
+  duration_ms : int;
+  tokens_used : int;
+}
+
+type outbound_message = {
+  keeper_name : string;
+  content : string;
+  turn_stats : turn_stats option;
+}
+
+(* ── Validation ──────────────────────────────────────────────── *)
+
+type validation_error =
+  | Empty_content
+  | Content_too_long of int
+  | Empty_keeper_name
+  | Empty_channel_user_id
+  | Empty_idempotency_key
+  | Duplicate_message of string
+
+let validation_error_to_string = function
+  | Empty_content -> "content is required"
+  | Content_too_long len ->
+      Printf.sprintf "content too long: %d chars" len
+  | Empty_keeper_name -> "keeper_name is required"
+  | Empty_channel_user_id -> "channel_user_id is required"
+  | Empty_idempotency_key -> "idempotency_key is required"
+  | Duplicate_message key ->
+      Printf.sprintf "duplicate message (idempotency_key=%s)" key
+
+let validate ~max_content_length ~dedup_check (msg : inbound_message) =
+  let name = String.trim msg.keeper_name in
+  if name = "" then Error Empty_keeper_name
+  else if String.trim msg.channel_user_id = "" then Error Empty_channel_user_id
+  else if String.trim msg.idempotency_key = "" then Error Empty_idempotency_key
+  else
+    let content = String.trim msg.content in
+    if content = "" then Error Empty_content
+    else
+      let len = String.length content in
+      if len > max_content_length then Error (Content_too_long len)
+      else if dedup_check msg.idempotency_key then
+        Error (Duplicate_message msg.idempotency_key)
+      else Ok ()
+
+(* ── Errors ──────────────────────────────────────────────────── *)
+
+type gate_error =
+  | Validation of validation_error
+  | Keeper_error of string
+  | Dispatch_unavailable
+  | Internal of string
+
+let gate_error_to_string = function
+  | Validation e -> validation_error_to_string e
+  | Keeper_error msg -> Printf.sprintf "keeper error: %s" msg
+  | Dispatch_unavailable -> "keeper dispatch unavailable"
+  | Internal _ -> "internal error"
+
+(* ── JSON Codecs ─────────────────────────────────────────────── *)
+
+let inbound_of_json json =
+  let open Yojson.Safe.Util in
+  try
+    let str key =
+      json |> member key |> to_string_option
+      |> Option.value ~default:""
+    in
+    let channel =
+      let raw = str "channel" in
+      String.lowercase_ascii (String.trim raw)
+    in
+    let metadata =
+      match json |> member "metadata" with
+      | `Assoc pairs ->
+          List.filter_map (fun (k, v) ->
+            match v with `String s -> Some (k, s) | _ -> None
+          ) pairs
+      | _ -> []
+    in
+    Ok {
+      channel;
+      channel_user_id = str "channel_user_id";
+      channel_user_name = str "channel_user_name";
+      channel_room_id = str "channel_room_id";
+      keeper_name = str "keeper_name";
+      content = str "content";
+      idempotency_key = str "idempotency_key";
+      metadata;
+    }
+  with
+  | Yojson.Json_error e -> Error ("invalid json: " ^ e)
+  | exn -> Error ("parse error: " ^ Printexc.to_string exn)
+
+let outbound_to_json out =
+  let stats_json = match out.turn_stats with
+    | None -> `Null
+    | Some s ->
+        `Assoc [
+          ("model_used", `String s.model_used);
+          ("duration_ms", `Int s.duration_ms);
+          ("tokens_used", `Int s.tokens_used);
+        ]
+  in
+  `Assoc [
+    ("ok", `Bool true);
+    ("keeper_name", `String out.keeper_name);
+    ("reply", `String out.content);
+    ("turn_stats", stats_json);
+  ]
+
+let error_json msg =
+  `Assoc [ ("ok", `Bool false); ("error", `String msg) ]

--- a/lib/gate_protocol.ml
+++ b/lib/gate_protocol.ml
@@ -75,6 +75,13 @@ let gate_error_to_string = function
   | Dispatch_unavailable -> "keeper dispatch unavailable"
   | Internal _ -> "internal error"
 
+(* ── Dispatch Result ─────────────────────────────────────────── *)
+
+type dispatch_result =
+  | Reply of { content : string; stats : turn_stats option }
+  | Keeper_error_result of string
+  | Unavailable_result
+
 (* ── JSON Codecs ─────────────────────────────────────────────── *)
 
 let inbound_of_json json =

--- a/lib/gate_protocol.mli
+++ b/lib/gate_protocol.mli
@@ -71,6 +71,16 @@ type gate_error =
 
 val gate_error_to_string : gate_error -> string
 
+(** {1 Dispatch Result}
+
+    Returned by the injected dispatch function.
+    Lives here so that [Channel_gate] does not depend on [Gate_keeper_backend]. *)
+
+type dispatch_result =
+  | Reply of { content : string; stats : turn_stats option }
+  | Keeper_error_result of string
+  | Unavailable_result
+
 (** {1 JSON Codecs} *)
 
 val inbound_of_json : Yojson.Safe.t -> (inbound_message, string) result

--- a/lib/gate_protocol.mli
+++ b/lib/gate_protocol.mli
@@ -1,0 +1,84 @@
+(** Gate_protocol -- wire-level types for the Channel Gate HTTP API.
+
+    Pure module: no Eio, no Agent_identity, no Tool_keeper, no Room.
+    Only depends on Yojson for JSON serialization.
+
+    Connectors (Discord, Telegram, etc.) and the gate orchestrator
+    both speak this protocol.  Neither side knows about the other's
+    internals.
+
+    @since 2.222.0 *)
+
+(** {1 Wire Types} *)
+
+(** Message arriving from an external channel consumer. *)
+type inbound_message = {
+  channel : string;
+      (** Opaque channel label ("discord", "telegram", …).
+          The gate never interprets this beyond passing it to metrics. *)
+  channel_user_id : string;
+  channel_user_name : string;
+  channel_room_id : string;
+  keeper_name : string;
+  content : string;
+  idempotency_key : string;
+  metadata : (string * string) list;
+}
+
+(** Turn-level statistics from the keeper. *)
+type turn_stats = {
+  model_used : string;
+  duration_ms : int;
+  tokens_used : int;
+}
+
+(** Successful response to send back to the consumer. *)
+type outbound_message = {
+  keeper_name : string;
+  content : string;
+  turn_stats : turn_stats option;
+}
+
+(** {1 Validation} *)
+
+type validation_error =
+  | Empty_content
+  | Content_too_long of int
+  | Empty_keeper_name
+  | Empty_channel_user_id
+  | Empty_idempotency_key
+  | Duplicate_message of string
+
+val validation_error_to_string : validation_error -> string
+
+val validate :
+  max_content_length:int ->
+  dedup_check:(string -> bool) ->
+  inbound_message ->
+  (unit, validation_error) result
+(** Pure validation with injected dedup check.
+    Returns [Ok ()] when the message can proceed.
+    The [dedup_check] function is provided by the caller
+    so this module stays free of mutable state. *)
+
+(** {1 Errors} *)
+
+type gate_error =
+  | Validation of validation_error
+  | Keeper_error of string
+  | Dispatch_unavailable
+  | Internal of string
+
+val gate_error_to_string : gate_error -> string
+
+(** {1 JSON Codecs} *)
+
+val inbound_of_json : Yojson.Safe.t -> (inbound_message, string) result
+(** Parse an inbound message from the HTTP request body.
+    The [channel] field is kept as a raw string -- no variant conversion. *)
+
+val outbound_to_json : outbound_message -> Yojson.Safe.t
+(** Serialize an outbound message to JSON for the HTTP response. *)
+
+val error_json : string -> Yojson.Safe.t
+(** [{ok: false, error: "<msg>"}] *)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -63,10 +63,7 @@ let metric_context_of_json json =
   let channel =
     match field "channel" with
     | "" -> "unknown"
-    | value ->
-        value
-        |> Agent_identity.channel_of_string
-        |> Agent_identity.string_of_channel
+    | value -> String.lowercase_ascii (String.trim value)
   in
   (channel, field "channel_room_id", field "keeper_name")
 
@@ -104,7 +101,7 @@ let record_internal_error_metric ~duration_ms body_str exn =
     match Channel_gate.inbound_of_json json with
     | Ok msg ->
         Channel_gate_metrics.record_internal_error_exn
-          ~channel:(Agent_identity.string_of_channel msg.channel)
+          ~channel:msg.channel
           ~room_id:msg.channel_room_id
           ~keeper:msg.keeper_name
           ~duration_ms exn
@@ -115,6 +112,13 @@ let record_internal_error_metric ~duration_ms body_str exn =
 let handle_gate_message ~sw ~clock state request reqd =
   Http.Request.read_body_async reqd (fun body_str ->
     let request_started = Unix.gettimeofday () in
+    let dispatch =
+      Gate_keeper_backend.dispatch
+        ~sw ~clock
+        ~proc_mgr:state.Mcp_server.proc_mgr
+        ~net:state.Mcp_server.net
+        ~config:state.Mcp_server.room_config
+    in
     let result =
       try
         let json = Yojson.Safe.from_string body_str in
@@ -126,13 +130,7 @@ let handle_gate_message ~sw ~clock state request reqd =
             record_validation_error_metric ~duration_ms body_str e;
             Error (Channel_gate.Validation Channel_gate.Empty_content, e)
         | Ok msg ->
-            (match Channel_gate.handle_inbound
-              ~sw ~clock
-              ~proc_mgr:(state.Mcp_server.proc_mgr)
-              ~net:(state.Mcp_server.net)
-              ~config:state.Mcp_server.room_config
-              msg
-            with
+            (match Channel_gate.handle_inbound ~dispatch msg with
             | Ok out -> Ok out
             | Error gate_err ->
                 Error (gate_err, Channel_gate.gate_error_to_string gate_err))

--- a/test/dune
+++ b/test/dune
@@ -698,6 +698,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_gate_protocol)
+ (modules test_gate_protocol)
+ (libraries masc_test_deps))
+
+(test
  (name test_local_review_script)
  (modules test_local_review_script)
  (libraries alcotest unix yojson))

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -4,7 +4,7 @@ open Masc_mcp
 let make_message ?(content = "hello") ?(keeper_name = "luna")
     ?(channel_user_id = "user-1") ?(idempotency_key = "key-1") () =
   {
-    Channel_gate.channel = Agent_identity.channel_of_string "discord";
+    Channel_gate.channel = "discord";
     channel_user_id;
     channel_user_name = "user";
     channel_room_id = "room-1";
@@ -135,9 +135,59 @@ let test_inbound_of_json_normalizes_channel_label () =
   in
   match Channel_gate.inbound_of_json json with
   | Ok msg ->
-      check string "channel normalized" "discord"
-        (Agent_identity.string_of_channel msg.channel)
+      check string "channel normalized" "discord" msg.channel
   | Error err -> fail ("expected inbound json to parse: " ^ err)
+
+(* ── Mock dispatch for handle_inbound tests ──────────────────── *)
+
+let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+  Gate_keeper_backend.Reply {
+    content = "mock reply";
+    stats = Some { Gate_protocol.model_used = "test-model"; duration_ms = 42; tokens_used = 10 };
+  }
+
+let mock_dispatch_error ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+  Gate_keeper_backend.Keeper_error "mock keeper error"
+
+let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+  Gate_keeper_backend.Unavailable
+
+let test_handle_inbound_success () =
+  reset_dedup ();
+  let msg = make_message ~idempotency_key:(unique_key "dispatch-ok") () in
+  match Channel_gate.handle_inbound ~dispatch:mock_dispatch_ok msg with
+  | Ok out ->
+      check string "reply content" "mock reply" out.content;
+      check string "keeper name" "luna" out.keeper_name;
+      (match out.turn_stats with
+       | Some s -> check string "model" "test-model" s.model_used
+       | None -> fail "expected turn_stats")
+  | Error e -> fail (Channel_gate.gate_error_to_string e)
+
+let test_handle_inbound_keeper_error () =
+  reset_dedup ();
+  let msg = make_message ~idempotency_key:(unique_key "dispatch-err") () in
+  match Channel_gate.handle_inbound ~dispatch:mock_dispatch_error msg with
+  | Error (Channel_gate.Keeper_error err) ->
+      check string "error message" "mock keeper error" err
+  | Error _ -> fail "expected Keeper_error"
+  | Ok _ -> fail "expected error"
+
+let test_handle_inbound_unavailable () =
+  reset_dedup ();
+  let msg = make_message ~idempotency_key:(unique_key "dispatch-unavail") () in
+  match Channel_gate.handle_inbound ~dispatch:mock_dispatch_unavailable msg with
+  | Error Channel_gate.Dispatch_unavailable -> ()
+  | Error _ -> fail "expected Dispatch_unavailable"
+  | Ok _ -> fail "expected error"
+
+let test_handle_inbound_validation_blocks_dispatch () =
+  reset_dedup ();
+  let msg = make_message ~content:"   " ~idempotency_key:(unique_key "val-block") () in
+  match Channel_gate.handle_inbound ~dispatch:mock_dispatch_ok msg with
+  | Error (Channel_gate.Validation Channel_gate.Empty_content) -> ()
+  | Error _ -> fail "expected Validation(Empty_content)"
+  | Ok _ -> fail "expected validation to block dispatch"
 
 let () =
   Alcotest.run "Channel_gate"
@@ -162,5 +212,16 @@ let () =
             test_validation_error_to_string;
           test_case "normalizes inbound channel labels" `Quick
             test_inbound_of_json_normalizes_channel_label;
+        ] );
+      ( "handle_inbound",
+        [
+          test_case "dispatches and returns reply" `Quick
+            test_handle_inbound_success;
+          test_case "returns keeper error" `Quick
+            test_handle_inbound_keeper_error;
+          test_case "returns unavailable" `Quick
+            test_handle_inbound_unavailable;
+          test_case "validation blocks dispatch" `Quick
+            test_handle_inbound_validation_blocks_dispatch;
         ] );
     ]

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -141,16 +141,16 @@ let test_inbound_of_json_normalizes_channel_label () =
 (* ── Mock dispatch for handle_inbound tests ──────────────────── *)
 
 let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
-  Gate_keeper_backend.Reply {
+  Gate_protocol.Reply {
     content = "mock reply";
     stats = Some { Gate_protocol.model_used = "test-model"; duration_ms = 42; tokens_used = 10 };
   }
 
 let mock_dispatch_error ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
-  Gate_keeper_backend.Keeper_error "mock keeper error"
+  Gate_protocol.Keeper_error_result "mock keeper error"
 
 let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
-  Gate_keeper_backend.Unavailable
+  Gate_protocol.Unavailable_result
 
 let test_handle_inbound_success () =
   reset_dedup ();

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -1,0 +1,190 @@
+open Alcotest
+open Masc_mcp
+
+let make_msg ?(channel = "discord") ?(content = "hello") ?(keeper_name = "luna")
+    ?(channel_user_id = "user-1") ?(idempotency_key = "key-1") () : Gate_protocol.inbound_message =
+  {
+    channel;
+    channel_user_id;
+    channel_user_name = "user";
+    channel_room_id = "room-1";
+    keeper_name;
+    content;
+    idempotency_key;
+    metadata = [];
+  }
+
+let no_dedup _ = false
+let always_dedup _ = true
+
+(* ── Validation tests (pure, no Eio) ────────────────────────── *)
+
+let test_validate_ok () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup (make_msg ()) with
+  | Ok () -> ()
+  | Error _ -> fail "expected valid message"
+
+let test_validate_empty_content () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup (make_msg ~content:"  " ()) with
+  | Error Gate_protocol.Empty_content -> ()
+  | _ -> fail "expected Empty_content"
+
+let test_validate_content_too_long () =
+  let long = String.make 101 'x' in
+  match Gate_protocol.validate ~max_content_length:100 ~dedup_check:no_dedup (make_msg ~content:long ()) with
+  | Error (Gate_protocol.Content_too_long 101) -> ()
+  | _ -> fail "expected Content_too_long"
+
+let test_validate_empty_keeper_name () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup (make_msg ~keeper_name:"" ()) with
+  | Error Gate_protocol.Empty_keeper_name -> ()
+  | _ -> fail "expected Empty_keeper_name"
+
+let test_validate_empty_user_id () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup (make_msg ~channel_user_id:"" ()) with
+  | Error Gate_protocol.Empty_channel_user_id -> ()
+  | _ -> fail "expected Empty_channel_user_id"
+
+let test_validate_empty_idempotency_key () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup (make_msg ~idempotency_key:"" ()) with
+  | Error Gate_protocol.Empty_idempotency_key -> ()
+  | _ -> fail "expected Empty_idempotency_key"
+
+let test_validate_duplicate () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:always_dedup (make_msg ()) with
+  | Error (Gate_protocol.Duplicate_message "key-1") -> ()
+  | _ -> fail "expected Duplicate_message"
+
+let test_validate_keeper_name_checked_before_content () =
+  match Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup
+    (make_msg ~keeper_name:"" ~content:"  " ()) with
+  | Error Gate_protocol.Empty_keeper_name -> ()
+  | _ -> fail "keeper_name should be checked before content"
+
+(* ── JSON round-trip tests ───────────────────────────────────── *)
+
+let test_inbound_of_json_basic () =
+  let json =
+    `Assoc [
+      ("channel", `String "telegram");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "alice");
+      ("channel_room_id", `String "r1");
+      ("keeper_name", `String "luna");
+      ("content", `String "hi");
+      ("idempotency_key", `String "k1");
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg ->
+      check string "channel" "telegram" msg.channel;
+      check string "content" "hi" msg.content
+  | Error e -> fail e
+
+let test_inbound_of_json_normalizes_case () =
+  let json =
+    `Assoc [
+      ("channel", `String "  DisCord  ");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "bob");
+      ("channel_room_id", `String "r1");
+      ("keeper_name", `String "luna");
+      ("content", `String "hello");
+      ("idempotency_key", `String "k2");
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg -> check string "channel lowercased and trimmed" "discord" msg.channel
+  | Error e -> fail e
+
+let test_inbound_of_json_with_metadata () =
+  let json =
+    `Assoc [
+      ("channel", `String "slack");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "carol");
+      ("channel_room_id", `String "r1");
+      ("keeper_name", `String "luna");
+      ("content", `String "hey");
+      ("idempotency_key", `String "k3");
+      ("metadata", `Assoc [("x-channel-guild-id", `String "g1"); ("num", `Int 42)]);
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg ->
+      check int "metadata has 1 string entry" 1 (List.length msg.metadata);
+      check string "guild id" "g1" (List.assoc "x-channel-guild-id" msg.metadata)
+  | Error e -> fail e
+
+let test_inbound_of_json_invalid () =
+  match Gate_protocol.inbound_of_json (`String "not an object") with
+  | Error _ -> ()
+  | Ok _ -> fail "expected parse error"
+
+let test_outbound_to_json_roundtrip () =
+  let out : Gate_protocol.outbound_message = {
+    keeper_name = "luna";
+    content = "reply text";
+    turn_stats = Some { model_used = "m1"; duration_ms = 100; tokens_used = 50 };
+  } in
+  let json = Gate_protocol.outbound_to_json out in
+  let open Yojson.Safe.Util in
+  check bool "ok" true (json |> member "ok" |> to_bool);
+  check string "reply" "reply text" (json |> member "reply" |> to_string);
+  check string "keeper" "luna" (json |> member "keeper_name" |> to_string);
+  let stats = json |> member "turn_stats" in
+  check int "duration" 100 (stats |> member "duration_ms" |> to_int)
+
+let test_error_json () =
+  let json = Gate_protocol.error_json "something broke" in
+  let open Yojson.Safe.Util in
+  check bool "ok is false" false (json |> member "ok" |> to_bool);
+  check string "error" "something broke" (json |> member "error" |> to_string)
+
+(* ── String conversion tests ─────────────────────────────────── *)
+
+let test_validation_error_strings () =
+  check string "empty content" "content is required"
+    (Gate_protocol.validation_error_to_string Gate_protocol.Empty_content);
+  check string "empty keeper" "keeper_name is required"
+    (Gate_protocol.validation_error_to_string Gate_protocol.Empty_keeper_name);
+  check string "duplicate" "duplicate message (idempotency_key=k)"
+    (Gate_protocol.validation_error_to_string (Gate_protocol.Duplicate_message "k"))
+
+let test_gate_error_strings () =
+  check string "keeper error" "keeper error: boom"
+    (Gate_protocol.gate_error_to_string (Gate_protocol.Keeper_error "boom"));
+  check string "unavailable" "keeper dispatch unavailable"
+    (Gate_protocol.gate_error_to_string Gate_protocol.Dispatch_unavailable);
+  check string "internal" "internal error"
+    (Gate_protocol.gate_error_to_string (Gate_protocol.Internal "details"))
+
+let () =
+  Alcotest.run "Gate_protocol"
+    [
+      ( "validate",
+        [
+          test_case "accepts valid" `Quick test_validate_ok;
+          test_case "rejects empty content" `Quick test_validate_empty_content;
+          test_case "rejects too-long content" `Quick test_validate_content_too_long;
+          test_case "rejects empty keeper" `Quick test_validate_empty_keeper_name;
+          test_case "rejects empty user_id" `Quick test_validate_empty_user_id;
+          test_case "rejects empty idempotency_key" `Quick test_validate_empty_idempotency_key;
+          test_case "rejects duplicate" `Quick test_validate_duplicate;
+          test_case "keeper checked before content" `Quick test_validate_keeper_name_checked_before_content;
+        ] );
+      ( "json",
+        [
+          test_case "inbound basic" `Quick test_inbound_of_json_basic;
+          test_case "inbound normalizes case" `Quick test_inbound_of_json_normalizes_case;
+          test_case "inbound with metadata" `Quick test_inbound_of_json_with_metadata;
+          test_case "inbound invalid" `Quick test_inbound_of_json_invalid;
+          test_case "outbound roundtrip" `Quick test_outbound_to_json_roundtrip;
+          test_case "error_json" `Quick test_error_json;
+        ] );
+      ( "strings",
+        [
+          test_case "validation error strings" `Quick test_validation_error_strings;
+          test_case "gate error strings" `Quick test_gate_error_strings;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- extract `gate_protocol.ml` as the pure wire/validation/JSON layer with zero MASC runtime deps
- extract `gate_keeper_backend.ml` as the only adapter that still touches `Tool_keeper`, `Room`, and `Agent_identity`
- refactor `channel_gate.ml` so dispatch is injected and the module no longer imports `Agent_identity`, `Tool_keeper`, `Room`, or `Gate_keeper_backend`
- remove the unnecessary `Agent_identity.channel_of_string |> string_of_channel` round-trip from the HTTP route wiring

### Dependency Isolation (verified)
```text
channel_gate.ml:      Agent_identity=0, Tool_keeper=0, Room=0, Gate_keeper_backend=0
gate_protocol.ml:     MASC runtime deps=0 (Yojson only)
gate_keeper_backend:  Tool_keeper/Room/Agent_identity remain isolated here by design
```

## Product impact
- the Channel Gate boundary is now easier to reason about because wire validation and backend dispatch are separated cleanly
- future Channel Gate changes can evolve protocol validation without pulling keeper/runtime dependencies into the hot gate path
- HTTP/API behavior stays compatible because the route contract and channel normalization behavior are preserved

## Evidence
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature/gate-connector-decoupling --build-dir _build_5027 ./bin/main_eio.exe ./test/test_gate_protocol.exe ./test/test_channel_gate.exe ./test/test_oas_worker.exe`
- `./_build_5027/default/test/test_gate_protocol.exe`
- `./_build_5027/default/test/test_channel_gate.exe`
- `./_build_5027/default/test/test_oas_worker.exe`
- result: all targeted builds/tests passed after rebasing onto latest `main`

## Review evidence
- prior direct `GLM-5.1` review on the branch surfaced the `dispatch_result` boundary issue; that fix is already in branch head
- incremental direct `sb glm-text` review on the latest `main` sync diff at `2026-04-04 17:40 KST`
- scope: correctness/regressions only for the rebase/sync update
- result: `No findings.`

## Linked issue
Refs #4381
