### PR TITLE
fix(ci): align tool surface tests with post-prune state

### DIFF
--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -16,17 +16,18 @@ let test_public_visible_surface_hides_deprecated_aliases () =
   check bool "public contains masc_transition" true
     (List.mem "masc_transition" names)
 
-let test_public_visible_surface_includes_voice_tools () =
+let test_public_visible_surface_excludes_voice_tools () =
+  (* Voice tools moved to System_internal surface; hidden from public. *)
   let names =
     Lib.Capability_registry.visible_public_tool_schemas_from
       Lib.Config.raw_all_tool_schemas
     |> List.map (fun (schema : Types.tool_schema) -> schema.name)
   in
-  check bool "public contains masc_voice_agent" true
+  check bool "public hides masc_voice_agent" false
     (List.mem "masc_voice_agent" names);
-  check bool "public contains masc_voice_speak" true
+  check bool "public hides masc_voice_speak" false
     (List.mem "masc_voice_speak" names);
-  check bool "public contains masc_voice_ping_pong" true
+  check bool "public hides masc_voice_ping_pong" false
     (List.mem "masc_voice_ping_pong" names)
 
 let test_board_post_capability_merges_public_and_keeper_projections () =
@@ -106,8 +107,8 @@ let () =
         [
           test_case "public surface hides deprecated aliases" `Quick
             test_public_visible_surface_hides_deprecated_aliases;
-          test_case "public surface includes voice tools" `Quick
-            test_public_visible_surface_includes_voice_tools;
+          test_case "public surface excludes voice tools" `Quick
+            test_public_visible_surface_excludes_voice_tools;
           test_case "board capability merges public and keeper projections"
             `Quick
             test_board_post_capability_merges_public_and_keeper_projections;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -562,17 +562,18 @@ let test_handle_request_tools_list () =
     "contains masc_board_post (public surface)"
     true
     (List.mem "masc_board_post" names);
+  (* Voice tools moved to System_internal surface; hidden from public tools/list. *)
   Alcotest.(check bool)
-    "contains masc_voice_agent (public surface)"
-    true
+    "hides masc_voice_agent (system_internal)"
+    false
     (List.mem "masc_voice_agent" names);
   Alcotest.(check bool)
-    "contains masc_voice_speak (public surface)"
-    true
+    "hides masc_voice_speak (system_internal)"
+    false
     (List.mem "masc_voice_speak" names);
   Alcotest.(check bool)
-    "contains masc_voice_ping_pong (public surface)"
-    true
+    "hides masc_voice_ping_pong (system_internal)"
+    false
     (List.mem "masc_voice_ping_pong" names);
   Alcotest.(check bool)
     "board_search hidden from public surface"
@@ -812,11 +813,12 @@ let test_handle_request_tools_list_managed_profile () =
                    (List.mem "masc_status" names);
                  Alcotest.(check bool) "omits raw masc_transition" false
                    (List.mem "masc_transition" names);
-                 Alcotest.(check bool) "includes managed voice agent" true
+                 (* Voice tools moved to System_internal surface; hidden from managed profile. *)
+                 Alcotest.(check bool) "hides managed voice agent" false
                    (List.mem "masc_voice_agent" names);
-                 Alcotest.(check bool) "includes managed voice speak" true
+                 Alcotest.(check bool) "hides managed voice speak" false
                    (List.mem "masc_voice_speak" names);
-                 Alcotest.(check bool) "includes managed voice ping pong" true
+                 Alcotest.(check bool) "hides managed voice ping pong" false
                    (List.mem "masc_voice_ping_pong" names)
              | _ -> Alcotest.fail "tools not a list")
         | _ -> Alcotest.fail "result not an object")

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -127,11 +127,13 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits tool_admin_snapshot" false
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "includes keeper_tool_catalog" true
+  (* keeper_tool_catalog removed from spawned-agent surface in #5011 *)
+  Alcotest.(check bool) "omits keeper_tool_catalog (pruned)" false
     (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits operator_snapshot" false
     (List.mem "mcp__masc__masc_operator_snapshot" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "includes team_session_prove" true
+  (* team_session_prove removed from spawned-agent surface in #5011 *)
+  Alcotest.(check bool) "omits team_session_prove (pruned)" false
     (List.mem "mcp__masc__masc_team_session_prove" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits tool_list (no schema)" false
     (List.mem "mcp__masc__masc_tool_list" Spawn.masc_mcp_tools);

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -143,7 +143,8 @@ let test_masc_mcp_tools_has_handover () =
   check bool "has handover" true (List.mem "mcp__masc__masc_handover_create" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_relay_status () =
-  check bool "has relay_status" true
+  (* relay_status removed from spawned-agent surface in #5011 *)
+  check bool "omits relay_status (pruned)" false
     (List.mem "mcp__masc__masc_relay_status" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_team_session_step () =
@@ -155,7 +156,8 @@ let test_masc_mcp_tools_has_team_session_finalize () =
     (List.mem "mcp__masc__masc_team_session_finalize" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_a2a_delegate () =
-  check bool "has a2a_delegate" true
+  (* a2a_delegate removed from spawned-agent surface in #4999 *)
+  check bool "omits a2a_delegate (pruned)" false
     (List.mem "mcp__masc__masc_a2a_delegate" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_run_deliverable () =
@@ -175,7 +177,8 @@ let test_masc_mcp_tools_has_tool_admin_snapshot () =
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_keeper_tool_catalog () =
-  check bool "includes keeper_tool_catalog" true
+  (* keeper_tool_catalog removed from spawned-agent surface in #5011 *)
+  check bool "omits keeper_tool_catalog (pruned)" false
     (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_tool_list () =


### PR DESCRIPTION
## Summary
- Align test expectations in 4 test files with tool surface state after pruning PRs #4999 and #5011
- `keeper_tool_catalog`, `team_session_prove`, `relay_status`, `a2a_delegate` removed from spawned_agent surface: tests now assert omission
- Voice tools (`masc_voice_agent`, `masc_voice_speak`, `masc_voice_ping_pong`) are on System_internal surface, not public: tests now assert exclusion from public/managed profile surfaces
- All 164 tests across 4 files pass

## Test plan
- [x] `test_spawn.exe`: 8 tests pass
- [x] `test_capability_registry.exe`: 7 tests pass
- [x] `test_spawn_coverage.exe`: 87 tests pass
- [x] `test_mcp_server_eio.exe`: 62 tests pass
- [ ] CI green on push

Fixes #5005

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>