### PR TITLE
[codex] improve dashboard contrast readability

### DIFF
--- a/dashboard/src/components/common/list-item.ts
+++ b/dashboard/src/components/common/list-item.ts
@@ -17,8 +17,8 @@ export function ListItem({ title, subtitle, detail, onClick, class: className }:
 
   const content = html`
     <strong class="text-[var(--text-strong)]">${title}</strong>
-    ${subtitle != null ? html`<span class="text-[rgba(255,255,255,0.72)] leading-snug">${subtitle}</span>` : null}
-    ${detail != null ? html`<small class="text-[rgba(255,255,255,0.72)] leading-snug">${detail}</small>` : null}
+    ${subtitle != null ? html`<span class="text-[var(--text-body)] leading-snug">${subtitle}</span>` : null}
+    ${detail != null ? html`<small class="text-[var(--text-muted)] leading-snug">${detail}</small>` : null}
   `
 
   if (onClick) {

--- a/dashboard/src/components/common/tag-badge.ts
+++ b/dashboard/src/components/common/tag-badge.ts
@@ -11,7 +11,7 @@ interface TagBadgeProps {
 }
 
 export function TagBadge({ children, onClick, class: className }: TagBadgeProps) {
-  const base = 'px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-xs leading-tight'
+  const base = 'px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-body)] text-xs leading-tight'
   if (onClick) {
     return html`<button type="button" class="${base} cursor-pointer ${className ?? ''}" onClick=${onClick}>${children}</button>`
   }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -178,7 +178,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+          class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
@@ -224,7 +224,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <//>
 
                 ${sections.length > 0 ? html`
-                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[rgba(255,255,255,0.05)] pl-3" role="list">
+                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[var(--border-subtle)] pl-3" role="list">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
@@ -306,7 +306,7 @@ function SurfaceLead() {
     <div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
       <h2 class="flex items-center gap-2 text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
         ${currentSection?.label ?? currentView?.label ?? '홈'}
-        ${description ? html`<span class="text-[13px] font-normal text-[rgba(255,255,255,0.44)] truncate min-w-0">${description}</span>` : null}
+        ${description ? html`<span class="text-[13px] font-normal text-[var(--text-dim)] truncate min-w-0">${description}</span>` : null}
       </h2>
     </div>
   `

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -19,7 +19,7 @@ export function PulseStrip() {
   if (pulses.length === 0) {
     return html`
       <div class="pulse-strip rounded-xl">
-        <span class="text-[rgba(255,255,255,0.3)] text-[13px]">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
+        <span class="text-[var(--text-dim)] text-[13px]">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
       </div>
     `
   }
@@ -34,7 +34,7 @@ export function PulseStrip() {
           title="${p.koreanName ? `${p.name} (${p.koreanName})` : p.name}${p.currentTask ? ` — ${p.currentTask}` : ''}"
         >
           <span class="text-[1.15rem] leading-none">${p.emoji || p.name.charAt(0).toUpperCase()}</span>
-          <span class="text-[0.65rem] text-[var(--white-55)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[64px]">${p.koreanName ?? p.name}</span>
+          <span class="text-[0.65rem] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[64px]">${p.koreanName ?? p.name}</span>
         </button>
       `)}
     </div>

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -179,7 +179,7 @@ export function InternalSignalCard({ item }: { item: DashboardMissionInternalSig
         <${StatusChip} label=${item.signal_type === 'action' && action ? workflowActionLabel(action.action_type) : attention?.kind ?? '내부 신호'} tone=${toneClass(item.severity)} />
         <span class="text-[var(--text-muted)] text-[13px]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
       </div>
-      <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${item.summary}</p>
+      <p class="m-0 text-[var(--text-body)] leading-normal">${item.summary}</p>
       ${action ? html`<div class="py-3 px-4 rounded-xl bg-[var(--white-5)] border border-[var(--white-8)] text-[var(--text-strong)] leading-snug">${action.reason}</div>` : null}
       <${ActionBar}>
         ${action

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -333,7 +333,7 @@ export function MissionBriefingCard() {
                       ${section.evidence_quality ? html`<${StatusChip} label=${section.evidence_quality} />` : null}
                     </div>
                   </div>
-                  <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${section.summary}</p>
+                  <p class="m-0 text-[var(--text-body)] leading-normal">${section.summary}</p>
                   ${section.evidence.length > 0
                     ? html`
                         <details class="pt-2 border-t border-[var(--white-6)] mt-3">
@@ -367,7 +367,7 @@ export function MissionBriefingCard() {
                       <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
                       <${StatusChip} label=${statusLabel(item.severity)} tone=${item.severity === 'watch' ? 'warn' : ''} />
                     </div>
-                    <p class="m-0 text-[rgba(255,255,255,0.78)] leading-snug">${item.summary}</p>
+                    <p class="m-0 text-[var(--text-body)] leading-snug">${item.summary}</p>
                   </article>
                 `)}
               </div>

--- a/dashboard/src/styles/command-plane.css
+++ b/dashboard/src/styles/command-plane.css
@@ -9,7 +9,7 @@
     box-shadow: 0 0 0 1px var(--cyan-16);
   }
   & span {
-    color: var(--white-60);
+    color: var(--text-muted);
     font-size: var(--fs-sm);
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -18,7 +18,7 @@
     line-height: 1.3;
   }
   & strong { font-size: 28px; line-height: 1; }
-  & small { color: var(--white-50); font-size: var(--fs-sm); }
+  & small { color: var(--text-dim); font-size: var(--fs-sm); }
 }
 
 @utility cmd-focus-banner {
@@ -32,7 +32,7 @@
     line-height: 1.2;
     word-break: break-word;
   }
-  & p { margin: 0; color: var(--frost-72); line-height: 1.5; }
+  & p { margin: 0; color: var(--text-body); line-height: 1.5; }
 }
 
 @utility cmd-hero {
@@ -65,7 +65,7 @@
   & p {
     margin: 0;
     max-width: 60ch;
-    color: rgba(226, 232, 240, 0.76);
+    color: var(--text-body);
     line-height: 1.6;
   }
 }
@@ -80,11 +80,11 @@
   &.bad {
     border-color: rgba(248,113,113,0.24);
   }
-  & p { margin: 10px 0 0; color: var(--white-82); line-height: 1.5; }
+  & p { margin: 10px 0 0; color: var(--text-body); line-height: 1.5; }
 }
 
 @utility cmd-readiness-row {
-  & p { margin: 8px 0 0; color: var(--white-82); line-height: 1.5; }
+  & p { margin: 8px 0 0; color: var(--text-body); line-height: 1.5; }
 }
 
 @utility cmd-surface-tab {
@@ -106,7 +106,7 @@
 @utility cmd-alert {
   & p {
     margin: 10px 0 0;
-    color: var(--white-78);
+    color: var(--text-body);
     line-height: 1.5;
     overflow-wrap: anywhere;
     word-break: break-word;
@@ -134,14 +134,14 @@
   letter-spacing: 0.03em;
   border-radius: 9999px;
   background: var(--white-8);
-  color: rgba(255,255,255,0.86);
+  color: var(--text-body);
   white-space: nowrap;
   line-height: 1.3;
   border: 1px solid transparent;
   &.ok { background: rgba(74,222,128,0.14); color: var(--ok); border-color: rgba(74,222,128,0.25); }
   &.warn { background: rgba(251,191,36,0.14); color: var(--warn); border-color: rgba(251,191,36,0.25); }
   &.bad { background: rgba(248,113,113,0.14); color: var(--bad-light); border-color: rgba(248,113,113,0.25); }
-  &.muted { background: var(--white-6); color: var(--white-35); border-color: var(--white-8); }
+  &.muted { background: var(--white-6); color: var(--text-dim); border-color: var(--white-8); }
 }
 
 @utility cmd-tag {
@@ -154,12 +154,12 @@
   text-transform: uppercase;
   border-radius: 6px;
   background: var(--white-8);
-  color: rgba(255,255,255,0.86);
+  color: var(--text-body);
   white-space: nowrap;
   &.ok { background: rgba(74,222,128,0.12); color: var(--ok); }
   &.warn { background: rgba(251,191,36,0.12); color: var(--warn); }
   &.bad { background: rgba(248,113,113,0.12); color: var(--bad-light); }
-  &.muted { background: var(--white-6); color: var(--white-35); }
+  &.muted { background: var(--white-6); color: var(--text-dim); }
 }
 
 @utility cmd-tag-row {
@@ -167,7 +167,7 @@
   gap: 8px;
   flex-wrap: wrap;
   margin-top: 8px;
-  color: var(--white-56);
+  color: var(--text-muted);
   font-size: var(--fs-sm);
 }
 
@@ -192,15 +192,15 @@
 }
 
 @utility cmd-gauge-copy {
-  & span { color: rgba(191, 219, 254, 0.92); font-size: var(--fs-sm); letter-spacing: 0.08em; text-transform: uppercase; }
-  & small { color: rgba(226, 232, 240, 0.7); line-height: 1.5; }
+  & span { color: var(--text-muted); font-size: var(--fs-sm); letter-spacing: 0.08em; text-transform: uppercase; }
+  & small { color: var(--text-body); line-height: 1.5; }
 }
 
 @utility cmd-signal-rail {
   &.ok { border-color: var(--ok-18); }
   &.warn { border-color: var(--warn-20); }
   &.bad { border-color: rgba(248,113,113,0.22); }
-  & small { color: rgba(226, 232, 240, 0.66); line-height: 1.5; }
+  & small { color: var(--text-body); line-height: 1.5; }
 }
 
 @utility cmd-signal-copy {
@@ -210,7 +210,7 @@
     line-height: 1.1;
   }
   & span {
-    color: rgba(148, 163, 184, 0.9);
+    color: var(--text-muted);
     font-size: var(--fs-sm);
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -238,4 +238,3 @@
 @utility tone-bg-ok { background: var(--ok-soft); color: var(--ok); }
 @utility tone-bg-warn { background: rgba(251,191,36,0.16); color: var(--warn); }
 @utility tone-bg-bad { background: rgba(248,113,113,0.16); color: var(--bad-light); }
-

--- a/dashboard/src/styles/live-monitor.css
+++ b/dashboard/src/styles/live-monitor.css
@@ -20,11 +20,11 @@
 
 @utility activity-filter-btn {
   transition: background 0.15s, color 0.15s, border-color 0.15s;
-  &.active { color: rgba(255,255,255,0.85); border-color: var(--white-20); background: var(--white-6); }
+  &.active { color: var(--text-strong); border-color: var(--white-20); background: var(--white-6); }
   &.live-event-broadcast.active { border-color: rgba(96,165,250,0.4); color: var(--accent); }
   &.live-event-task.active { border-color: var(--ok-40); color: var(--ok); }
   &.live-event-keeper.active { border-color: rgba(168,85,247,0.4); color: #a855f7; }
-  &.live-event-system.active { border-color: var(--white-20); color: var(--white-70); }
+  &.live-event-system.active { border-color: var(--white-20); color: var(--text-muted); }
 }
 
 @utility activity-item {
@@ -44,7 +44,7 @@
   &.live-event-broadcast { background: var(--blue-400-15); color: var(--accent); }
   &.live-event-task { background: var(--ok-soft); color: var(--ok); }
   &.live-event-keeper { background: rgba(168,85,247,0.15); color: #a855f7; }
-  &.live-event-system { background: var(--white-6); color: var(--white-50); }
+  &.live-event-system { background: var(--white-6); color: var(--text-muted); }
 }
 
 @utility focus-agent-card {

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -1,6 +1,9 @@
 /* MASC Dashboard — CSS Custom Properties (Semantic Theme System) */
 
 :root {
+  /* The dashboard shell is still authored against dark surfaces.
+     Keep the browser chrome and semantic tokens aligned until
+     a full light-theme token migration lands. */
   color-scheme: dark;
 
   /* Base & Backgrounds */

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -1,6 +1,8 @@
 /* MASC Dashboard — CSS Custom Properties (Semantic Theme System) */
 
 :root {
+  color-scheme: dark;
+
   /* Base & Backgrounds */
   --bg-root: #0b1220;
   --bg-panel: rgba(16, 24, 42, 0.92);
@@ -154,30 +156,4 @@
   --z-layout: 1;
   --z-tab-sticky: 30;
   --z-header: 40;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg-root: #f8fafc;
-    --bg-panel: rgba(255, 255, 255, 0.95);
-    --bg-panel-hover: rgba(241, 245, 249, 0.95);
-    --bg-1: var(--bg-panel-hover);
-    
-    --text-strong: #0f172a;
-    --text-body: #334155;
-    --text-muted: #64748b;
-    --text-dim: #94a3b8;
-    
-    --border-subtle: rgba(15, 23, 42, 0.08);
-    --border-base: rgba(15, 23, 42, 0.15);
-    --border-strong: rgba(15, 23, 42, 0.25);
-
-    /* Overlays */
-    --white-3: rgba(0, 0, 0, 0.03);
-    --white-5: rgba(0, 0, 0, 0.05);
-    --white-10: rgba(0, 0, 0, 0.10);
-    --white-20: rgba(0, 0, 0, 0.20);
-    --white-50: rgba(0, 0, 0, 0.50);
-    --white-80: rgba(0, 0, 0, 0.80);
-  }
 }


### PR DESCRIPTION
## What changed
- pinned the dashboard theme to the intended dark color scheme instead of flipping palettes on system light mode
- replaced several hardcoded semi-transparent white text treatments with semantic text tokens in shared shell, mission briefing, pulse strip, and command/live monitor surfaces
- tightened a few shared badges/list rows so metadata and helper copy stay readable against panel backgrounds

## Why
The dashboard was mixing a light-mode token override with components that still assumed a dark surface and used white-on-white style overlays. That produced low-contrast text in some environments and made secondary copy hard to read.

## Impact
- navigation and section descriptions stay readable
- overview/mission briefing cards have stronger body copy contrast
- command/live monitor chips and helper text are easier to scan
- the dashboard keeps a consistent dark presentation across system color-scheme changes

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- local preview snapshot checked at `/dashboard/` for shell and overview readability

## Root cause
A `prefers-color-scheme: light` override changed the semantic palette to light surfaces while many components still hardcoded translucent white text and overlays. The palette and component assumptions diverged.