### PR TITLE
refactor(verify): structured verdict via tool_use, fix permissive default (ADR D3)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -120,50 +120,104 @@ REJECT: <reason> - if the notes are vague, avoidant, or do not address the task|
     calibration_section
 
 (* ================================================================ *)
-(* Verdict parsing                                                  *)
+(* Structured Review Verdict: Tool Schema + JSON Parsing (ADR D3)   *)
 (* ================================================================ *)
 
-(** Parse LLM verdict text.
-    Returns [Some verdict] on successful parse, [None] on format mismatch.
-    Callers must decide how to handle [None] — the old behavior of silently
-    mapping format mismatch to [Approve] hides evaluator bias (RFC-0001 H1). *)
-let parse_verdict_opt (text : string) : verdict option =
+(** JSON schema for the report_review_verdict tool.
+    Forces the LLM to call a tool with typed parameters.
+    verdict is constrained to APPROVE/REJECT by enum. *)
+let report_review_verdict_schema : Types.tool_schema =
+  { name = "report_review_verdict";
+    description =
+      "Report your review verdict. You MUST call this tool with your assessment. \
+       verdict must be exactly APPROVE or REJECT.";
+    input_schema = `Assoc [
+      "type", `String "object";
+      "properties", `Assoc [
+        "verdict", `Assoc [
+          "type", `String "string";
+          "enum", `List [`String "APPROVE"; `String "REJECT"];
+          "description", `String "APPROVE if notes describe real work, REJECT if vague or avoidant";
+        ];
+        "reason", `Assoc [
+          "type", `String "string";
+          "description", `String "Brief explanation (required for REJECT)";
+        ];
+      ];
+      "required", `List [`String "verdict"];
+    ];
+  }
+
+(** Parse review verdict from tool call JSON arguments (deterministic). *)
+let parse_review_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let verdict_str =
+      args |> member "verdict" |> to_string |> String.uppercase_ascii
+    in
+    let reason =
+      try args |> member "reason" |> to_string
+      with Type_error _ -> ""
+    in
+    match verdict_str with
+    | "APPROVE" -> Ok Approve
+    | "REJECT" ->
+      let r = if reason = "" then "completion notes did not address the task" else reason in
+      Ok (Reject r)
+    | other ->
+      Error (sprintf "unexpected review verdict value: %s" other)
+  with
+  | Type_error (msg, _) ->
+    Error (sprintf "review verdict JSON type error: %s" msg)
+  | exn ->
+    Error (sprintf "review verdict JSON parse error: %s" (Printexc.to_string exn))
+
+(* ================================================================ *)
+(* Verdict parsing (text fallback — Samchon Rank 1: lenient)        *)
+(* ================================================================ *)
+
+(** Parse "APPROVE" or "REJECT: reason" from model text output.
+    Returns Result instead of bare verdict to avoid silent degradation.
+    ADR D3: unknown format returns Error, NOT a permissive default. *)
+let parse_verdict (text : string) : (verdict, string) result =
   let trimmed = String.trim text in
   let upper = String.uppercase_ascii trimmed in
-  if String.length upper >= 7 && String.sub upper 0 7 = "APPROVE" then
-    Some Approve
-  else if String.length upper >= 6 && String.sub upper 0 6 = "REJECT" then
+  let has_boundary prefix =
+    let plen = String.length prefix in
+    String.length upper = plen
+    || (String.length upper > plen
+        && let c = upper.[plen] in
+           c = ' ' || c = ':' || c = '-')
+  in
+  if String.length upper >= 7
+     && String.sub upper 0 7 = "APPROVE"
+     && has_boundary "APPROVE"
+  then
+    Ok Approve
+  else if String.length upper >= 6
+          && String.sub upper 0 6 = "REJECT"
+          && has_boundary "REJECT"
+  then
     let rest =
       if String.length trimmed > 6 then
         String.trim (String.sub trimmed 6 (String.length trimmed - 6))
       else ""
     in
-    (* Strip leading colon/dash *)
     let reason =
       if String.length rest > 0 && (rest.[0] = ':' || rest.[0] = '-') then
         String.trim (String.sub rest 1 (String.length rest - 1))
       else rest
     in
-    if reason = "" then Some (Reject "completion notes did not address the task")
-    else Some (Reject reason)
+    if reason = "" then Ok (Reject "completion notes did not address the task")
+    else Ok (Reject reason)
+  else if String.length trimmed = 0 then
+    Error "empty review output"
   else
-    None
-
-(** Backward-compatible wrapper. Logs a warning on format mismatch and
-    falls back to [Approve] for liveness. Prefer [parse_verdict_opt] in
-    new code to make the fallback explicit. *)
-let parse_verdict (text : string) : verdict =
-  match parse_verdict_opt text with
-  | Some v -> v
-  | None ->
-    let preview =
-      let t = String.trim text in
-      if String.length t > 80 then String.sub t 0 80 ^ "..." else t
-    in
-    Log.Task.warn
-      "[anti-rationalization] format mismatch in LLM verdict (falling back to Approve): %S"
-      preview;
-    Approve
+    (* ADR D3: unknown format is NOT silently approved.
+       Previous behavior defaulted to Approve here — this was a
+       D3 + Unknown→Permissive double violation. *)
+    Error (sprintf "unrecognized review format: %s"
+      (if String.length trimmed > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
 
 (* ================================================================ *)
 (* Cross-model cascade selection (#3067)                             *)
@@ -262,17 +316,29 @@ let review
     emit { verdict = Reject reason;
       evaluator_cascade; generator_cascade; gate = "contract"; fallback_reason = None }
   | None ->
-    (* Gate 3: LLM review via evaluator cascade *)
+    (* Gate 3: LLM review via evaluator cascade (structured tool output, ADR D3) *)
     let prompt = build_prompt ~few_shot_block req in
     (match generator_cascade with
      | Some gc when gc = evaluator_cascade ->
        Log.Task.warn "[anti-rationalization] same cascade for generator (%s) and evaluator (%s) — cross-model separation not active"
          gc evaluator_cascade
      | _ -> ());
+    let verdict_ref = ref None in
+    let dispatch ~name:_ ~args =
+      match parse_review_verdict_from_json args with
+      | Ok v ->
+        verdict_ref := Some v;
+        (false, match v with Approve -> "Approved" | Reject r -> "Rejected: " ^ r)
+      | Error msg ->
+        Log.Task.warn "[anti-rationalization] structured verdict parse failed: %s" msg;
+        (false, sprintf "Invalid verdict format: %s" msg)
+    in
     (match
-       Oas_worker.run_named
+       Oas_worker.run_named_with_masc_tools
          ~cascade_name:evaluator_cascade
          ~goal:prompt
+         ~masc_tools:[report_review_verdict_schema]
+         ~dispatch
          ~max_turns:1
          ~temperature:0.0
          ~max_tokens:200
@@ -280,22 +346,32 @@ let review
          ()
      with
      | Ok result ->
-       let text = Oas_response.text_of_response result.response in
-       let (v, gate) = match parse_verdict_opt text with
-         | Some verdict -> (verdict, "llm")
-         | None -> (Approve, "format_fallback")
+       let (v, gate, fallback_reason) = match !verdict_ref with
+         | Some v ->
+           Log.Task.info "[anti-rationalization] verdict via structured tool call";
+           (v, "structured_tool", None)
+         | None ->
+           (* LLM responded with text — lenient fallback *)
+           let text = Oas_response.text_of_response result.response in
+           Log.Task.info "[anti-rationalization] verdict via text fallback";
+           (match parse_verdict text with
+            | Ok v -> (v, "llm_text_fallback", None)
+            | Error parse_err ->
+              (* ADR D3: parse failure is NOT silently approved.
+                 Use Reject instead of Approve for unknown format. *)
+              Log.Task.warn "[anti-rationalization] verdict parse failed: %s (rejecting)" parse_err;
+              ( Reject (sprintf "review format unrecognized: %s" parse_err),
+                "format_reject",
+                Some parse_err ))
        in
        (match v with
         | Reject reason ->
           Log.Task.info "[anti-rationalization] LLM rejected: agent=%s task=%s cascade=%s reason=%s"
             req.agent_name req.task_title evaluator_cascade reason
-        | Approve when gate = "format_fallback" ->
-          Log.Task.warn "[anti-rationalization] LLM format mismatch → Approve fallback: agent=%s task=%s cascade=%s"
-            req.agent_name req.task_title evaluator_cascade
         | Approve ->
           Log.Task.info "[anti-rationalization] LLM approved: agent=%s task=%s cascade=%s"
             req.agent_name req.task_title evaluator_cascade);
-       emit { verdict = v; evaluator_cascade; generator_cascade; gate; fallback_reason = None }
+       emit { verdict = v; evaluator_cascade; generator_cascade; gate; fallback_reason }
      | Error msg ->
        (* Liveness > correctness: if LLM is unavailable, approve *)
        Log.Task.warn "[anti-rationalization] LLM unavailable: %s (approving by default)" msg;

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -75,8 +75,14 @@ val review_result_to_json : review_result -> Yojson.Safe.t
     Exposed for testing. *)
 val find_excuse_pattern : string -> (string * string) option
 
-(** Parse LLM output into a verdict.
-    "APPROVE" -> [Approve], "REJECT: reason" -> [Reject reason].
-    Unrecognized format defaults to [Approve] (liveness).
-    Exposed for testing. *)
-val parse_verdict : string -> verdict
+(** Parse LLM text output into a verdict (lenient fallback path).
+    "APPROVE" -> [Ok Approve], "REJECT: reason" -> [Ok (Reject reason)].
+    Unrecognized format returns [Error] instead of silently approving (ADR D3).
+    Exposed for testing.
+    @since 2.223.0 changed return type from [verdict] to [(verdict, string) result] *)
+val parse_verdict : string -> (verdict, string) result
+
+(** Parse verdict from structured tool call JSON arguments (primary path).
+    Deterministic extraction from report_review_verdict tool output.
+    @since 2.223.0 *)
+val parse_review_verdict_from_json : Yojson.Safe.t -> (verdict, string) result

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -1,9 +1,10 @@
 (** Verifier_oas — Action verification engine with OAS Guardrails/Hooks bridge.
 
     Cheap-model action verification for feedback loops.
-    Each action is sent to a cheap model with a structured prompt:
-    "Given goal X, action Y produced result Z. Is this correct?"
-    The model responds PASS/WARN/FAIL with a brief reason.
+    Each action is sent to a cheap model with a [report_verdict] tool.
+    The model calls the tool with a typed verdict (PASS/WARN/FAIL + reason).
+    If the model responds with text instead of a tool call, a lenient
+    text parser serves as fallback (Samchon Rank 1: lenient parsing).
 
     Budget: max 200 output tokens per verification (~0.01 cents).
     Skip: read-only actions (file reads, glob, grep, searches).
@@ -13,8 +14,12 @@
     - [make_pre_tool_hook]: wraps verify as an OAS PreToolUse hook
     - [guardrails_with_read_only_tag]: wraps should_skip as OAS Custom filter
 
+    ADR D3: verdict extraction uses structured tool output (deterministic)
+    instead of regex/prefix matching on free text (nondeterministic).
+
     @since 2.61.0 (verifier core)
-    @since Phase 4 (OAS Guardrails adapter) *)
+    @since Phase 4 (OAS Guardrails adapter)
+    @since 2.223.0 (structured verdict via report_verdict tool) *)
 
 open Printf
 
@@ -121,6 +126,73 @@ let parse_verdict (text : string) : (verdict, string) result =
       (if len > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
 
 (* ================================================================ *)
+(* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)
+(* ================================================================ *)
+
+(** JSON schema for the report_verdict tool.
+    Forces the LLM to call a tool with typed parameters instead of
+    producing free-text output.
+
+    Schema constrains verdict to exactly PASS/WARN/FAIL via enum,
+    making invalid values structurally impossible (Samchon: "constraint
+    through absence"). *)
+let report_verdict_schema : Types.tool_schema =
+  { name = "report_verdict";
+    description =
+      "Report your verification verdict. You MUST call this tool \
+       with your assessment. verdict must be exactly PASS, WARN, or FAIL.";
+    input_schema = `Assoc [
+      "type", `String "object";
+      "properties", `Assoc [
+        "verdict", `Assoc [
+          "type", `String "string";
+          "enum", `List [`String "PASS"; `String "WARN"; `String "FAIL"];
+          "description", `String "PASS if correct, WARN if acceptable with concerns, FAIL if wrong or harmful";
+        ];
+        "reason", `Assoc [
+          "type", `String "string";
+          "description", `String "Brief explanation for the verdict (required for WARN and FAIL)";
+        ];
+      ];
+      "required", `List [`String "verdict"];
+    ];
+  }
+
+(** Parse verdict from tool call JSON arguments (deterministic path).
+    The JSON is produced by the LLM calling report_verdict, so the
+    "verdict" field is constrained by the schema enum.
+
+    Handles Samchon absorption points:
+    - Type coercion: accepts both quoted and unquoted values
+    - Case insensitivity: "pass", "Pass", "PASS" all accepted
+    - Missing reason: defaults to descriptive string *)
+let parse_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let verdict_str =
+      args |> member "verdict" |> to_string |> String.uppercase_ascii
+    in
+    let reason =
+      try args |> member "reason" |> to_string
+      with Type_error _ -> ""
+    in
+    match verdict_str with
+    | "PASS" -> Ok Pass
+    | "WARN" ->
+      let r = if reason = "" then "unspecified concern" else reason in
+      Ok (Warn r)
+    | "FAIL" ->
+      let r = if reason = "" then "action did not achieve goal" else reason in
+      Ok (Fail r)
+    | other ->
+      Error (sprintf "unexpected verdict value: %s" other)
+  with
+  | Type_error (msg, _) ->
+    Error (sprintf "verdict JSON type error: %s" msg)
+  | exn ->
+    Error (sprintf "verdict JSON parse error: %s" (Printexc.to_string exn))
+
+(* ================================================================ *)
 (* Verification Prompt                                              *)
 (* ================================================================ *)
 
@@ -155,28 +227,56 @@ One line only.|}
 (* Core: verify                                                     *)
 (* ================================================================ *)
 
+(** Verify an action using structured tool output (ADR D3 compliant).
+
+    Primary path: LLM calls [report_verdict] tool with typed verdict.
+    Fallback path: if LLM responds with text, [parse_verdict] extracts
+    the verdict from free text (Samchon Rank 1: lenient fallback).
+
+    The structured path is deterministic (JSON schema constrains output).
+    The fallback path is nondeterministic but returns Error on failure
+    instead of silently degrading. *)
 let verify (req : verification_request) : (verdict, string) result =
   if should_skip ~action_description:req.action_description then
     Ok Pass
   else
     let prompt = build_prompt req in
+    let verdict_ref = ref None in
+    let dispatch ~name:_ ~args =
+      match parse_verdict_from_json args with
+      | Ok v ->
+        verdict_ref := Some v;
+        (false, sprintf "Verdict recorded: %s" (verdict_to_string v))
+      | Error msg ->
+        Log.Verifier.warn "Structured verdict parse failed: %s" msg;
+        (false, sprintf "Invalid verdict format: %s" msg)
+    in
     match
-      Oas_worker.run_named
+      Oas_worker_named.run_named_with_masc_tools
         ~cascade_name:"verifier"
         ~goal:prompt
+        ~masc_tools:[report_verdict_schema]
+        ~dispatch
         ~max_turns:1
         ~temperature:0.0
         ~max_tokens:200
         ()
     with
     | Ok result ->
-      let text = Oas_response.text_of_response result.response in
-      (match parse_verdict text with
-       | Ok verdict -> Ok verdict
-       | Error parse_err ->
-         Log.Verifier.warn "Verdict parse failed (%s); raw=%s"
-           parse_err (String.sub text 0 (min 80 (String.length text)));
-         Error (sprintf "verdict parse: %s" parse_err))
+      (match !verdict_ref with
+       | Some v ->
+         Log.Verifier.debug "verdict via structured tool call";
+         Ok v
+       | None ->
+         (* LLM responded with text instead of tool call — lenient fallback *)
+         let text = Oas_response.text_of_response result.response in
+         Log.Verifier.info "verdict via text fallback (model did not call report_verdict)";
+         (match parse_verdict text with
+          | Ok verdict -> Ok verdict
+          | Error parse_err ->
+            Log.Verifier.warn "Verdict parse failed (%s); raw=%s"
+              parse_err (String.sub text 0 (min 80 (String.length text)));
+            Error (sprintf "verdict parse: %s" parse_err)))
     | Error message ->
       Error message
 

--- a/test/test_anti_rationalization_coverage.ml
+++ b/test/test_anti_rationalization_coverage.ml
@@ -221,40 +221,46 @@ let () = test "check_contract_direct" (fun () ->
 
 let () = test "parse_verdict_approve" (fun () ->
   match Anti_rationalization.parse_verdict "APPROVE" with
-  | Anti_rationalization.Approve -> ()
-  | _ -> failwith "expected Approve")
+  | Ok Anti_rationalization.Approve -> ()
+  | Ok _ -> failwith "expected Approve"
+  | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
 let () = test "parse_verdict_approve_with_trailing" (fun () ->
   match Anti_rationalization.parse_verdict "APPROVE - looks good" with
-  | Anti_rationalization.Approve -> ()
-  | _ -> failwith "expected Approve")
+  | Ok Anti_rationalization.Approve -> ()
+  | Ok _ -> failwith "expected Approve"
+  | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
 let () = test "parse_verdict_reject_with_reason" (fun () ->
   match Anti_rationalization.parse_verdict "REJECT: vague notes" with
-  | Anti_rationalization.Reject reason ->
+  | Ok (Anti_rationalization.Reject reason) ->
     assert (String.lowercase_ascii reason |> fun s ->
       let len = String.length s in len >= 5 && String.sub s 0 5 = "vague")
-  | _ -> failwith "expected Reject")
+  | Ok _ -> failwith "expected Reject"
+  | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
 let () = test "parse_verdict_reject_bare" (fun () ->
   match Anti_rationalization.parse_verdict "REJECT" with
-  | Anti_rationalization.Reject _ -> ()
-  | _ -> failwith "expected Reject")
+  | Ok (Anti_rationalization.Reject _) -> ()
+  | Ok _ -> failwith "expected Reject"
+  | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
 let () = test "parse_verdict_reject_colon_only" (fun () ->
   match Anti_rationalization.parse_verdict "REJECT:" with
-  | Anti_rationalization.Reject _ -> ()
-  | _ -> failwith "expected Reject")
+  | Ok (Anti_rationalization.Reject _) -> ()
+  | Ok _ -> failwith "expected Reject"
+  | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
-let () = test "parse_verdict_unrecognized_defaults_approve" (fun () ->
+(* ADR D3: unrecognized format now returns Error, NOT Approve *)
+let () = test "parse_verdict_unrecognized_returns_error" (fun () ->
   match Anti_rationalization.parse_verdict "I think it looks good" with
-  | Anti_rationalization.Approve -> ()
-  | _ -> failwith "expected Approve")
+  | Error _ -> ()
+  | Ok _ -> failwith "expected Error for unrecognized format (ADR D3)")
 
-let () = test "parse_verdict_empty_defaults_approve" (fun () ->
+let () = test "parse_verdict_empty_returns_error" (fun () ->
   match Anti_rationalization.parse_verdict "" with
-  | Anti_rationalization.Approve -> ()
-  | _ -> failwith "expected Approve")
+  | Error _ -> ()
+  | Ok _ -> failwith "expected Error for empty input (ADR D3)")
 
 (* ================================================================ *)
 (* find_excuse_pattern                                               *)

--- a/test/test_anti_rationalization_coverage.ml
+++ b/test/test_anti_rationalization_coverage.ml
@@ -234,8 +234,7 @@ let () = test "parse_verdict_approve_with_trailing" (fun () ->
 let () = test "parse_verdict_reject_with_reason" (fun () ->
   match Anti_rationalization.parse_verdict "REJECT: vague notes" with
   | Ok (Anti_rationalization.Reject reason) ->
-    assert (String.lowercase_ascii reason |> fun s ->
-      let len = String.length s in len >= 5 && String.sub s 0 5 = "vague")
+    assert (String.equal (String.lowercase_ascii reason) "vague notes")
   | Ok _ -> failwith "expected Reject"
   | Error e -> failwith (Printf.sprintf "unexpected error: %s" e))
 
@@ -256,6 +255,16 @@ let () = test "parse_verdict_unrecognized_returns_error" (fun () ->
   match Anti_rationalization.parse_verdict "I think it looks good" with
   | Error _ -> ()
   | Ok _ -> failwith "expected Error for unrecognized format (ADR D3)")
+
+let () = test "parse_verdict_approved_word_returns_error" (fun () ->
+  match Anti_rationalization.parse_verdict "APPROVED" with
+  | Error _ -> ()
+  | Ok _ -> failwith "expected Error for APPROVED without boundary")
+
+let () = test "parse_verdict_rejected_word_returns_error" (fun () ->
+  match Anti_rationalization.parse_verdict "REJECTED" with
+  | Error _ -> ()
+  | Ok _ -> failwith "expected Error for REJECTED without boundary")
 
 let () = test "parse_verdict_empty_returns_error" (fun () ->
   match Anti_rationalization.parse_verdict "" with


### PR DESCRIPTION
## Summary
- `verifier_oas`: free-text verdict parsing을 `report_verdict` tool call 기반 structured extraction으로 올림
- `anti_rationalization`: unknown text format의 permissive `Approve` default를 제거하고 `Error`로 승격
- `parse_verdict`: `verdict` → `(verdict, string) result`
- follow-up: `APPROVED` / `REJECTED` 같은 접두사 오인식을 막도록 token boundary를 추가하고, coverage assertions를 exact match로 강화

## Product impact
- verifier / review gates가 free-text prefix accident에 덜 흔들리고, tool-call path를 우선하는 deterministic boundary를 갖게 됨
- `APPROVED` / `REJECTED` 같은 비정규 응답이 더 이상 `APPROVE` / `REJECT`로 오인식되지 않음
- ADR D3 의도대로 unknown format은 silent success가 아니라 explicit error/reject로 남음

## Evidence
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/structured-verdict --build-dir _build_5051e lib/verifier_oas.ml lib/anti_rationalization.ml`
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/structured-verdict --build-dir _build_5051d ./test/test_anti_rationalization_coverage.exe`
- `./_build_5051d/default/test/test_anti_rationalization_coverage.exe`
- result: rebase 후 coverage suite passed

## Review evidence
- prior cross-model review on the earlier head surfaced two medium findings: missing verdict boundary checks and weak prefix-based assertions
- direct `sb glm-text` follow-up review on rebased head `de74a17a8` at `2026-04-04 18:27 KST`
- parser-boundary fix itself did not surface a new material correctness bug; remaining comments were design-level concerns already intended by ADR D3 or about the synchronous `verdict_ref` capture pattern

## Linked issue
Refs #5040
Refs RFC-0001

## Motivation
ADR D3: LLM text → regex → system action is prohibited.
- verifier_oas controlled tool gating via text prefix matching
- anti_rationalization silently approved unknown formats (D3 + Unknown→Permissive double violation)

## Design
**Primary path (structured):** LLM calls `report_verdict` / `report_review_verdict` tool with typed enum parameters (`PASS|WARN|FAIL` / `APPROVE|REJECT`). Dispatch extracts verdict from JSON deterministically.

**Fallback path (text):** If the LLM responds with text instead of a tool call, `parse_verdict` handles only the bounded canonical tokens and returns `Error` for unknown formats.
