### PR TITLE
fix(tool-surface): add keeper voice tools to internal SSOT

### DIFF
--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -46,6 +46,14 @@ let keeper_internal_tools =
     "keeper_shell_readonly";
     "keeper_bash";
     "keeper_github";
+    "keeper_voice_speak";
+    (* keeper_voice_listen is keeper-only; there is no public masc_voice_listen
+       counterpart on MCP surfaces. *)
+    "keeper_voice_listen";
+    "keeper_voice_agent";
+    "keeper_voice_sessions";
+    "keeper_voice_session_start";
+    "keeper_voice_session_end";
     (* keeper_deliberation_decision: Agent_sdk.Structured result schema, not
        a regular tool — does not need a keeper shard entry.
        keeper_unified: cascade name, not a tool. *)
@@ -64,6 +72,11 @@ let keeper_internal_replacement = function
   | "keeper_board_vote" -> Some "masc_board_vote"
   | "keeper_board_stats" -> Some "masc_board_stats"
   | "keeper_board_search" -> Some "masc_board_search"
+  | "keeper_voice_speak" -> Some "masc_voice_speak"
+  | "keeper_voice_agent" -> Some "masc_voice_agent"
+  | "keeper_voice_sessions" -> Some "masc_voice_sessions"
+  | "keeper_voice_session_start" -> Some "masc_voice_session_start"
+  | "keeper_voice_session_end" -> Some "masc_voice_session_end"
   | "keeper_tasks_list" -> Some "masc_tasks"
   | "keeper_broadcast" -> Some "masc_broadcast"
   | _ -> None

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -99,6 +99,32 @@ let test_keeper_internal_contains_known_tools () =
       Alcotest.(check bool) (name ^ " is internal") true (SS.mem name internal))
     [ "keeper_time_now"; "keeper_board_post"; "keeper_bash"; "keeper_memory_search" ]
 
+let test_keeper_voice_replacement_contract () =
+  Alcotest.(check (option string))
+    "voice speak maps to hidden public tool"
+    (Some "masc_voice_speak")
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_speak");
+  Alcotest.(check (option string))
+    "voice agent maps to hidden public tool"
+    (Some "masc_voice_agent")
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_agent");
+  Alcotest.(check (option string))
+    "voice sessions map to hidden public tool"
+    (Some "masc_voice_sessions")
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_sessions");
+  Alcotest.(check (option string))
+    "voice session start maps to hidden public tool"
+    (Some "masc_voice_session_start")
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_session_start");
+  Alcotest.(check (option string))
+    "voice session end maps to hidden public tool"
+    (Some "masc_voice_session_end")
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_session_end");
+  Alcotest.(check (option string))
+    "voice listen remains keeper-only"
+    None
+    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_listen")
+
 let test_is_on_surface_consistent () =
   List.iter (fun surface ->
     let tools = Tool_catalog.tools_for_surface surface in
@@ -296,6 +322,8 @@ let () =
             test_keeper_internal_disjoint_from_public_mcp;
           Alcotest.test_case "Keeper_internal contains known tools" `Quick
             test_keeper_internal_contains_known_tools;
+          Alcotest.test_case "Keeper voice replacement contract" `Quick
+            test_keeper_voice_replacement_contract;
           Alcotest.test_case "is_on_surface consistent" `Quick
             test_is_on_surface_consistent;
         ] );


### PR DESCRIPTION
## Summary
- add keeper voice tools to the Keeper_internal surface SSOT
- map keeper voice tools with hidden public twins where they exist
- lock the voice replacement contract in tool surface SSOT tests

## Product impact
- keeps keeper-internal surface metadata aligned with the actual voice tools exposed to keeper profiles
- does not reintroduce voice, portal, or a2a tools to public or spawned-agent surfaces

## Evidence
- current main already keeps public/spawned voice tools pruned in capability and spawn tests
- current main still exposes keeper voice tools through keeper registry/shards, so Keeper_internal SSOT was lagging behind runtime reality

## Review evidence
- pending

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-voice-surface-ssot _build/default/test/test_tool_surface_ssot.exe _build/default/test/test_capability_registry.exe _build/default/test/test_spawn.exe _build/default/test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_tool_surface_ssot.exe`
- `./_build/default/test/test_capability_registry.exe`
- `./_build/default/test/test_spawn.exe`
- `./_build/default/test/test_keeper_tool_exposure.exe`

Refs #5005