### PR TITLE
refactor(registry): consolidate 3 agent maps into Provider_adapter SSOT

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -20,6 +20,8 @@ type adapter = {
   runtime_kind : runtime_kind;
   auth_mode : auth_mode;
   aliases : string list;
+  spawn_key : string option;       (** Key into Spawn.default_configs. None = not spawnable via CLI. *)
+  default_voice : string option;   (** Default TTS voice name. None = no voice assignment. *)
 }
 
 type voice_adapter = {
@@ -79,6 +81,10 @@ let cn_gemini = "gemini-api"
 let cn_glm = "glm"
 let cn_openrouter = "openrouter"
 
+(** Single source of truth for all agent adapters.
+    spawn_key maps to Spawn.default_configs keys.
+    default_voice maps to TTS voice names.
+    Adding a new agent = adding one entry here. *)
 let direct_adapters =
   [
     {
@@ -86,18 +92,24 @@ let direct_adapters =
       runtime_kind = Local;
       auth_mode = No_auth;
       aliases = [ cn_llama; "llama.cpp"; "llamacpp" ];
+      spawn_key = Some "llama";
+      default_voice = Some "Laura";
     };
     {
       canonical_name = cn_claude;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ANTHROPIC_API_KEY";
-      aliases = [ cn_claude; "claude"; "anthropic" ];
+      aliases = [ cn_claude; "claude"; "anthropic"; "claude-code"; "claude-api" ];
+      spawn_key = Some "claude";
+      default_voice = Some "Sarah";
     };
     {
       canonical_name = cn_codex;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENAI_API_KEY";
-      aliases = [ cn_codex; "openai" ];
+      aliases = [ cn_codex; "openai"; "codex-cli"; "codex-api" ];
+      spawn_key = Some "codex";
+      default_voice = Some "George";
     };
     {
       canonical_name = cn_gemini;
@@ -108,19 +120,25 @@ let direct_adapters =
             project_env = google_cloud_project_env;
             location_env = google_cloud_location_env;
           };
-      aliases = [ cn_gemini; "gemini"; "google" ];
+      aliases = [ cn_gemini; "gemini"; "google"; "gemini-cli"; "gemini-api" ];
+      spawn_key = Some "gemini";
+      default_voice = Some "Roger";
     };
     {
       canonical_name = cn_glm;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ZAI_API_KEY";
       aliases = [ cn_glm; "glm_cloud"; "zai" ];
+      spawn_key = None;
+      default_voice = None;
     };
     {
       canonical_name = cn_openrouter;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENROUTER_API_KEY";
       aliases = [ cn_openrouter ];
+      spawn_key = None;
+      default_voice = None;
     };
   ]
 
@@ -165,6 +183,33 @@ let resolve_direct_adapter label =
 
 let resolve_direct_canonical_name label =
   Option.map (fun (adapter : adapter) -> adapter.canonical_name) (resolve_direct_adapter label)
+
+(** Resolve spawn_key for an agent label.
+    Returns the key to look up in Spawn.default_configs. *)
+let resolve_spawn_key label =
+  match resolve_direct_adapter label with
+  | Some adapter -> adapter.spawn_key
+  | None -> None
+
+(** Resolve default TTS voice for an agent label. *)
+let resolve_default_voice label =
+  match resolve_direct_adapter label with
+  | Some adapter -> adapter.default_voice
+  | None -> None
+
+(** All agents that are spawnable via CLI. *)
+let spawnable_canonical_names () =
+  direct_adapters
+  |> List.filter_map (fun a -> if a.spawn_key <> None then Some a.canonical_name else None)
+
+(** All agent voices as (canonical_name, voice_name) pairs.
+    For backward compatibility with voice_bridge_core. *)
+let all_agent_voices () =
+  direct_adapters
+  |> List.filter_map (fun a ->
+    match a.default_voice with
+    | Some v -> Some (a.canonical_name, v)
+    | None -> None)
 
 let resolve_voice_adapter label =
   let normalized = normalize_label label in

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -196,30 +196,15 @@ let default_configs = [
   });
 ]
 
-(** Map CLI tool names and provider aliases to default_configs keys. *)
-let spawn_alias_map = [
-  ("claude-code", "claude");
-  ("claude-api", "claude");
-  ("anthropic", "claude");
-  ("gemini-cli", "gemini");
-  ("gemini-api", "gemini");
-  ("google", "gemini");
-  ("codex-cli", "codex");
-  ("codex-api", "codex");
-  ("openai", "codex");
-  ("llama.cpp", "llama");
-  ("llamacpp", "llama");
-]
-
 (** Get spawn config for agent.
-    Resolves CLI tool names (e.g. "claude-code") and provider canonical names
-    (e.g. "claude-api") to the short keys used in default_configs. *)
+    Resolves all aliases via Provider_adapter registry (SSOT).
+    spawn_alias_map removed — aliases are now in Provider_adapter.direct_adapters. *)
 let get_config agent_name =
   let normalized = String.lowercase_ascii (String.trim agent_name) in
   match List.assoc_opt normalized default_configs with
   | Some _ as result -> result
   | None ->
-    match List.assoc_opt normalized spawn_alias_map with
+    match Provider_adapter.resolve_spawn_key normalized with
     | Some key -> List.assoc_opt key default_configs
     | None -> None
 

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -27,13 +27,9 @@ let default_max_retries = 3
 let default_initial_backoff_seconds = 1.0
 let default_backoff_multiplier = 2.0
 
-let default_agent_voices =
-  [
-    ("claude", "Sarah");
-    ("gemini", "Roger");
-    ("codex", "George");
-    ("llama", "Laura");
-  ]
+(** Default agent voices from Provider_adapter registry (SSOT).
+    Hardcoded list removed — voices defined in Provider_adapter.direct_adapters. *)
+let default_agent_voices () = Provider_adapter.all_agent_voices ()
 
 let load_voice_config () = Voice_config.load ()
 
@@ -45,7 +41,7 @@ let backoff_multiplier () = default_backoff_multiplier
 let agent_voices () =
   match load_voice_config () with
   | Ok config -> config.tts.agent_voices
-  | Error _ -> default_agent_voices
+  | Error _ -> default_agent_voices ()
 
 let tuning_for_agent agent_id =
   match load_voice_config () with


### PR DESCRIPTION
## Summary
- Extend `Provider_adapter.adapter` with `spawn_key` and `default_voice` fields
- Remove `spawn_alias_map` from spawn.ml (12-entry duplicate)
- Remove `default_agent_voices` from voice_bridge_core.ml (4-entry duplicate)
- Adding a new agent now requires one entry in `direct_adapters`, zero changes elsewhere

## Motivation
4 separate agent lists (provider_adapter, spawn, voice_bridge, mention) that drift independently. ADR D4: Adapter Registry Pattern — single registration point for new agents.

## Changes
| File | Before | After |
|------|--------|-------|
| `provider_adapter.ml` | `adapter` has 4 fields | + `spawn_key`, `default_voice` |
| `spawn.ml` | `spawn_alias_map` (12 aliases) | `Provider_adapter.resolve_spawn_key` |
| `voice_bridge_core.ml` | hardcoded 4-voice list | `Provider_adapter.all_agent_voices()` |

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes (running)
- [ ] CI checks pass
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)