### PR TITLE
refactor(keeper): precompile regex patterns in keeper_text_processing

### DIFF
--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -6,16 +6,26 @@
 
 open Keeper_memory_policy
 
+(* Pre-compiled regex patterns — compiled once at module init. *)
+let re_state_start = Re.str "[STATE]" |> Re.compile
+let re_state_end = Re.str "[/STATE]" |> Re.compile
+let re_whitespace = Re.Pcre.re "[ \t\r\n]+" |> Re.compile
+let re_terminal_punct = Re.Pcre.re "[.!?。！？]$" |> Re.compile
+let re_korean_ending =
+  Re.Pcre.re "(다|요|니다|습니다|중입니다|함)$" |> Re.compile
+let re_unclosed_bracket = Re.Pcre.re {|["'(\[{]$|} |> Re.compile
+let re_trailing_punct = Re.Pcre.re "[:;,\\-]$" |> Re.compile
+let re_trailing_connector =
+  Re.Pcre.re "(and|or|with|to|for|그리고|또는|및)$" |> Re.compile
+
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
   let end_marker = "[/STATE]" in
-  let start_re = Re.str start_marker |> Re.compile in
-  let end_re = Re.str end_marker |> Re.compile in
   let len = String.length s in
   let rec loop from (buf : Buffer.t) =
     if from >= len then ()
     else
-      match Re.exec_opt ~pos:from start_re s with
+      match Re.exec_opt ~pos:from re_state_start s with
       | None ->
         Buffer.add_substring buf s from (len - from)
       | Some g ->
@@ -23,7 +33,7 @@ let strip_state_blocks_text (s : string) : string =
         if i > from then Buffer.add_substring buf s from (i - from);
         let block_start = i + String.length start_marker in
         let next_from =
-          match Re.exec_opt ~pos:block_start end_re s with
+          match Re.exec_opt ~pos:block_start re_state_end s with
           | None -> len
           | Some g2 ->
             Re.Group.start g2 0 + String.length end_marker
@@ -65,7 +75,7 @@ let user_visible_reply_text ?fallback (raw : string) : string =
 let normalize_proactive_text (raw : string) : string =
   raw
   |> strip_internal_reply_markup
-  |> Re.replace_string (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) ~by:" "
+  |> Re.replace_string re_whitespace ~by:" "
   |> String.trim
 
 let extract_checkin_text (raw : string) : string option =
@@ -94,14 +104,11 @@ let extract_checkin_text (raw : string) : string option =
 
 let proactive_has_terminal_punct (s : string) : bool =
   let t = String.trim s in
-  t <> "" && Re.execp (Re.Pcre.re "[.!?。！？]$" |> Re.compile) t
+  t <> "" && Re.execp re_terminal_punct t
 
 let proactive_has_terminal_korean_ending (s : string) : bool =
   let t = String.trim s in
-  t <> ""
-  && Re.execp
-       (Re.Pcre.re "(다|요|니다|습니다|중입니다|함)$" |> Re.compile)
-       t
+  t <> "" && Re.execp re_korean_ending t
 
 let proactive_has_terminal_ending (s : string) : bool =
   proactive_has_terminal_punct s || proactive_has_terminal_korean_ending s
@@ -109,8 +116,8 @@ let proactive_has_terminal_ending (s : string) : bool =
 let proactive_looks_fragmentary (s : string) : bool =
   let t = String.trim s in
   t = ""
-  || Re.execp (Re.Pcre.re {|["'(\[{]$|} |> Re.compile) t
-  || Re.execp (Re.Pcre.re "[:;,\\-]$" |> Re.compile) t
+  || Re.execp re_unclosed_bracket t
+  || Re.execp re_trailing_punct t
 
 let looks_fragmentary_history_text (raw : string) : bool =
   let t = normalize_proactive_text raw in
@@ -118,19 +125,12 @@ let looks_fragmentary_history_text (raw : string) : bool =
   else
     let hard_fragment = proactive_looks_fragmentary t in
     let has_terminal = proactive_has_terminal_ending t in
-    let ends_korean_sentence =
-      Re.execp
-        (Re.Pcre.re "(다|요|니다|습니다|중입니다|함)$" |> Re.compile)
-        t
-    in
+    let ends_korean_sentence = Re.execp re_korean_ending t in
     let short_unterminated =
       (not has_terminal) && (not ends_korean_sentence) && String.length t <= 24
     in
     let trailing_connector =
       (not has_terminal)
-      && Re.execp
-           (Re.Pcre.re
-              "(and|or|with|to|for|그리고|또는|및)$" |> Re.compile)
-           (String.lowercase_ascii t)
+      && Re.execp re_trailing_connector (String.lowercase_ascii t)
     in
     hard_fragment || short_unterminated || trailing_connector


### PR DESCRIPTION
## Summary

- `keeper_text_processing.ml`의 인라인 `Re.Pcre.re ... |> Re.compile` 호출 10곳을 모듈 top-level `let` 바인딩으로 이동
- 상수 패턴이 매 함수 호출마다 재컴파일되던 것을 모듈 초기화 시 1회로 변경

## Product impact

성능 개선 (dashboard 요청, heartbeat마다 regex 컴파일 비용 제거). 동작 변경 없음.

## Evidence

변경 전: 함수 호출당 `Re.Pcre.re + Re.compile` 10회
변경 후: 모듈 로드 시 1회, 이후 참조만

## Test plan

- [x] `dune build` — 에러 0개
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)