### PR TITLE
refactor: SSOT batch 2 — configurable thresholds and named constants

### DIFF
--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -150,7 +150,7 @@ let set_resolved_name sid name =
 (** {1 Statistics} *)
 
 (** Get count of active agents *)
-let active_count ?(within_seconds = 300.0) () =
+let active_count ?(within_seconds = Env_config.Zombie.threshold_seconds) () =
   match get_registry () with
   | Ok reg -> List.length (Agent_identity.Registry.list_active reg ~within_seconds)
   | Error e ->
@@ -166,7 +166,7 @@ let total_count () =
       0
 
 (** List all active identities *)
-let list_active ?(within_seconds = 300.0) () =
+let list_active ?(within_seconds = Env_config.Zombie.threshold_seconds) () =
   match get_registry () with
   | Ok reg -> Agent_identity.Registry.list_active reg ~within_seconds
   | Error e ->

--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -141,17 +141,29 @@ let count_mention_activity (config : Room.config) ~(agent_name : string)
 
 (** {1 Overall Score Computation} *)
 
-(** Compute weighted overall score.
-    - 0.4 * completion_rate
-    - 0.3 * response_rate
-    - 0.3 * board_activity_normalized (capped at 20 actions) *)
+(** {1 Reputation Score Weights}
+
+    Weighted linear combination for overall reputation.
+    Rationale: task completion is the primary signal (0.4) because
+    it directly measures value delivered. Response rate (0.3) and
+    board activity (0.3) are secondary engagement signals.
+
+    Board activity is capped at [board_activity_cap] to prevent
+    high-volume low-quality posting from inflating scores.
+
+    TODO(RFC-0001 Phase 3): Register in Runtime_params for tuning. *)
+let weight_completion = 0.4
+let weight_response   = 0.3
+let weight_board      = 0.3
+let board_activity_cap = 20.0
+
 let compute_overall_score ~completion_rate ~response_rate
     ~board_posts ~board_comments : float =
   let board_total = float_of_int (board_posts + board_comments) in
-  let board_norm = Float.min 1.0 (board_total /. 20.0) in
-  (0.4 *. completion_rate)
-  +. (0.3 *. response_rate)
-  +. (0.3 *. board_norm)
+  let board_norm = Float.min 1.0 (board_total /. board_activity_cap) in
+  (weight_completion *. completion_rate)
+  +. (weight_response *. response_rate)
+  +. (weight_board *. board_norm)
 
 (** {1 Main Computation} *)
 

--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -69,7 +69,10 @@ let dedup_table : (string, float) Hashtbl.t = Hashtbl.create 256
 
 let dedup_mutex = Eio.Mutex.create ()
 
-let dedup_max_entries = 10_000
+let dedup_max_entries =
+  match Sys.getenv_opt "MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES" with
+  | Some s -> (try max 100 (min 100_000 (int_of_string s)) with _ -> 10_000)
+  | None -> 10_000
 
 let with_dedup_lock f = Eio_guard.with_mutex dedup_mutex f
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -16,8 +16,16 @@ type lock_entry = {
   mutable last_used : float;
 }
 
-let max_lock_entries = 512
-let stale_lock_seconds = 600.0
+(** Self-contained config. [masc_process] is below [masc_config] in the
+    dependency graph, so env var reading is local. *)
+let max_lock_entries =
+  (match Sys.getenv_opt "MASC_FILE_LOCK_MAX_ENTRIES" with
+   | Some s -> (try max 64 (min 4096 (int_of_string s)) with _ -> 512)
+   | None -> 512)
+let stale_lock_seconds =
+  (match Sys.getenv_opt "MASC_FILE_LOCK_STALE_SEC" with
+   | Some s -> (try Float.max 60.0 (Float.min 7200.0 (float_of_string s)) with _ -> 600.0)
+   | None -> 600.0)
 
 let table : (string, lock_entry) Hashtbl.t = Hashtbl.create 64
 let table_mu = Eio.Mutex.create ()


### PR DESCRIPTION
## Summary

Follow-up to #5038. Continues SSOT consolidation across 4 additional modules.

- `agent_registry_eio`: Active agent threshold → `Env_config.Zombie` SSOT
- `channel_gate`: Dedup capacity limit now configurable via `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` (RFC-0001 H5)
- `file_lock_eio`: Lock table capacity and stale timeout configurable via env vars (self-contained, respects dependency direction)
- `agent_reputation`: Scoring weights 0.4/0.3/0.3 extracted to named constants with rationale

## New Environment Variables

| Variable | Default | Range | Module |
|----------|---------|-------|--------|
| `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` | 10000 | [100, 100000] | channel_gate |
| `MASC_FILE_LOCK_MAX_ENTRIES` | 512 | [64, 4096] | file_lock_eio |
| `MASC_FILE_LOCK_STALE_SEC` | 600.0 | [60, 7200] | file_lock_eio |

## Test plan

- [x] `dune build` passes
- [ ] CI green
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)