### PR TITLE
fix(boundary): remove vendor/model hardcoding from MASC layer (7 HIGH)

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -325,7 +325,7 @@ let default_keeper_model_label (meta : keeper_meta) =
   | "" -> (
       match Oas_model_resolve.models_of_cascade_name meta.cascade_name with
       | first :: _ when String.trim first <> "" -> first
-      | _ -> "llama:qwen3.5-9b-local")
+      | _ -> Env_config.Local_runtime.default_model)
   | model -> model
 
 let annotate_keeper_repair_json ~(keeper_name : string) body =

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -11,10 +11,10 @@ type context = {
 
 type result = bool * string
 
-let handle_relay_status _ctx args =
+let handle_relay_status ctx args =
   let*! messages = get_int_required args "messages" in
   let*! tool_calls = get_int_required args "tool_calls" in
-  let model = get_string args "model" "claude" in
+  let model = get_string args "model" ctx.agent_name in
   let metrics = Relay.estimate_context ~messages ~tool_calls ~model in
   let actual_tokens_opt = match Yojson.Safe.Util.member "actual_tokens" args with
     | `Int n -> Some n
@@ -36,7 +36,7 @@ let handle_relay_status _ctx args =
   ] in
   (true, Yojson.Safe.pretty_to_string json)
 
-let handle_relay_checkpoint _ctx args =
+let handle_relay_checkpoint ctx args =
   let*! summary = get_string_required args "summary" in
   let*! messages = get_int_required args "messages" in
   let*! tool_calls = get_int_required args "tool_calls" in
@@ -51,7 +51,7 @@ let handle_relay_checkpoint _ctx args =
    if goal_ids <> [] then
      Log.Misc.info "[RELAY] active_goal_ids provided but not persisted (goal store not integrated): %s"
        (String.concat "," goal_ids));
-  let metrics = Relay.estimate_context ~messages ~tool_calls ~model:"claude" in
+  let metrics = Relay.estimate_context ~messages ~tool_calls ~model:ctx.agent_name in
   let _cp = Relay.save_checkpoint ~summary ~task:current_task ~todos ~pdca:pdca_state ~files:relevant_files ~metrics in
   let json = `Assoc [
     ("status", `String "checkpoint_saved");
@@ -64,7 +64,7 @@ let handle_relay_checkpoint _ctx args =
 let handle_relay_now ctx args =
   let summary = get_string args "summary" "" in
   let current_task = get_string_opt args "current_task" in
-  let target_agent = get_string args "target_agent" "claude" in
+  let target_agent = get_string args "target_agent" ctx.agent_name in
   let generation = get_int args "generation" 0 in
   let active_goal_ids = get_string_list args "active_goal_ids" in
   let goal_blockers = get_string_list args "goal_blockers" in
@@ -113,7 +113,7 @@ let handle_relay_now ctx args =
   ] in
   (true, Yojson.Safe.pretty_to_string json)
 
-let handle_relay_smart_check _ctx args =
+let handle_relay_smart_check ctx args =
   let messages = get_int args "messages" 0 in
   let tool_calls = get_int args "tool_calls" 0 in
   let hint_str = get_string args "task_hint" "simple" in
@@ -126,7 +126,8 @@ let handle_relay_smart_check _ctx args =
     | "exploration" -> Relay.Exploration_task
     | _ -> Relay.Simple_task
   in
-  let metrics = Relay.estimate_context ~messages ~tool_calls ~model:"claude" in
+  let model = get_string args "model" ctx.agent_name in
+  let metrics = Relay.estimate_context ~messages ~tool_calls ~model in
   let decision = Relay.should_relay_smart ~config:Relay.default_config ~metrics ~task_hint in
   let decision_str = match decision with
     | `Proactive -> "proactive"
@@ -158,8 +159,7 @@ let schemas : Types.tool_schema list = [
         ]);
         ("model", `Assoc [
           ("type", `String "string");
-          ("description", `String "Model name (claude, gemini, codex) for max context lookup");
-          ("default", `String "claude");
+          ("description", `String "Model name for max context lookup. Defaults to the calling agent's own name.");
         ]);
       ]);
       ("required", `List [`String "messages"; `String "tool_calls"]);

--- a/lib/tool_repair_loop_types.ml
+++ b/lib/tool_repair_loop_types.ml
@@ -282,7 +282,7 @@ let state_of_json (json : Yojson.Safe.t) : state =
     validator_profile =
       Option.value ~default:"snippet_ocamlc" (json_string_opt "validator_profile" json);
     model_label =
-      Option.value ~default:"llama:qwen3.5-9b-local" (json_string_opt "model_label" json);
+      Option.value ~default:Env_config.Local_runtime.default_model (json_string_opt "model_label" json);
     max_attempts = Option.value ~default:2 (json_int_opt "max_attempts" json);
     attempt_count = Option.value ~default:0 (json_int_opt "attempt_count" json);
     artifact_session_id =


### PR DESCRIPTION
## Summary
- Remove 5 hardcoded "claude" defaults from tool_relay.ml → use `ctx.agent_name`
- Remove 2 hardcoded "llama:qwen3.5-9b-local" from tool_keeper.ml and tool_repair_loop_types.ml → use `Env_config.Local_runtime.default_model`

## Motivation
MASC must not know vendor names or specific model IDs (ADR boundary).
Audit found 7 HIGH violations where MASC code contained hardcoded vendor/model references.

## Changes
| File | Before | After |
|------|--------|-------|
| `tool_relay.ml` | `"claude"` x5 | `ctx.agent_name` (dynamic) |
| `tool_keeper.ml` | `"llama:qwen3.5-9b-local"` | `Env_config.Local_runtime.default_model` |
| `tool_repair_loop_types.ml` | `"llama:qwen3.5-9b-local"` | `Env_config.Local_runtime.default_model` |

## Test plan
- [x] `dune build` passes
- [ ] CI checks pass
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)