### PR TITLE
fix(harness): resolve tool_matrix runner path from build context

### DIFF
--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -16,50 +16,6 @@ let requested_tool_names () =
       | [] -> None
       | names -> Some names
 
-let has_repo_root root =
-  Sys.file_exists (Filename.concat root "dune-project")
-  && Sys.file_exists (Filename.concat root "test/dune")
-
-let rec ascend_repo_root dir =
-  if has_repo_root dir then
-    Some dir
-  else
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then None else ascend_repo_root parent
-
-let executable_repo_root () =
-  ascend_repo_root (Filename.dirname Sys.executable_name)
-
-let source_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root when String.trim root <> "" && has_repo_root root -> root
-  | _ -> (
-      match
-        try Some (Sys.getcwd ()) with
-        | Sys_error _ -> None
-      with
-      | Some cwd -> (
-          match ascend_repo_root cwd with
-          | Some root -> root
-          | None -> (
-              match executable_repo_root () with
-              | Some root -> root
-              | None -> cwd))
-      | None -> (
-          match executable_repo_root () with
-          | Some root -> root
-          | None -> Filename.current_dir_name))
-
-let path_is_within ~parent ~child =
-  try
-    let parent = Unix.realpath parent in
-    let child = Unix.realpath child in
-    let prefix =
-      if String.ends_with ~suffix:"/" parent then parent else parent ^ "/"
-    in
-    String.starts_with ~prefix child
-  with _ -> false
-
 let quote = Filename.quote
 
 let read_file path =
@@ -82,17 +38,17 @@ let tool_case_timeout_sec () =
   | None -> 25
 
 let runner_path () =
+  let exe_dir = Filename.dirname Sys.executable_name in
   let candidate =
-    Filename.concat (Filename.dirname Sys.executable_name)
-      "keeper_tool_matrix_case_runner.exe"
+    Filename.concat exe_dir "keeper_tool_matrix_case_runner.exe"
   in
-  if Sys.file_exists candidate
-     && path_is_within ~parent:(source_root ()) ~child:candidate
-  then
+  if Sys.file_exists candidate then
     candidate
   else
-    Filename.concat (source_root ())
-      "_build/default/test/keeper_tool_matrix_case_runner.exe"
+    failwith
+      (Printf.sprintf
+         "keeper_tool_matrix_case_runner.exe not found next to test executable (%s)"
+         exe_dir)
 
 let find_result_line output =
   output

--- a/test/test_mcp_tool_matrix.ml
+++ b/test/test_mcp_tool_matrix.ml
@@ -22,51 +22,6 @@ let requested_tool_names () =
       | [] -> None
       | names -> Some names
 
-let has_repo_root root =
-  Sys.file_exists (Filename.concat root "dune-project")
-  && Sys.file_exists (Filename.concat root "test/dune")
-
-let rec ascend_repo_root dir =
-  if has_repo_root dir then
-    Some dir
-  else
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then None else ascend_repo_root parent
-
-let executable_repo_root () =
-  ascend_repo_root (Filename.dirname Sys.executable_name)
-
-let source_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root when String.trim root <> "" && has_repo_root root -> root
-  | _ -> (
-      match
-        try Some (Sys.getcwd ()) with
-        | Sys_error _ -> None
-      with
-      | Some cwd -> (
-          match ascend_repo_root cwd with
-          | Some root -> root
-          | None -> (
-              match executable_repo_root () with
-              | Some root -> root
-              | None -> cwd))
-      | None -> (
-          match executable_repo_root () with
-          | Some root -> root
-          | None -> Filename.current_dir_name))
-
-let path_is_within ~parent ~child =
-  try
-    let parent = Unix.realpath parent in
-    let child = Unix.realpath child in
-    let prefix =
-      if String.ends_with ~suffix:"/" parent then parent else parent ^ "/"
-    in
-    String.starts_with ~prefix child
-  with _ ->
-    false
-
 let quote = Filename.quote
 
 let read_file path =
@@ -89,15 +44,15 @@ let tool_case_timeout_sec () =
   | None -> 25
 
 let runner_path () =
-  let candidate =
-    Filename.concat (Filename.dirname Sys.executable_name) "tool_matrix_case_runner.exe"
-  in
-  if Sys.file_exists candidate
-     && path_is_within ~parent:(source_root ()) ~child:candidate
-  then
+  let exe_dir = Filename.dirname Sys.executable_name in
+  let candidate = Filename.concat exe_dir "tool_matrix_case_runner.exe" in
+  if Sys.file_exists candidate then
     candidate
   else
-    Filename.concat (source_root ()) "_build/default/test/tool_matrix_case_runner.exe"
+    failwith
+      (Printf.sprintf
+         "tool_matrix_case_runner.exe not found next to test executable (%s)"
+         exe_dir)
 
 let find_result_line output =
   output


### PR DESCRIPTION
## Summary
- Removes hardcoded `_build/default/test/` path from MCP and keeper tool matrix test runners.
- Derives runner executable path from `Sys.executable_name` (same directory as the test binary), which works under any dune build profile.
- Removes ~90 lines of dead code (`source_root`, `path_is_within`, `ascend_repo_root`, etc.) that only served the broken fallback.

Fixes #5047.

## Test plan
- [x] `dune build test/test_mcp_tool_matrix.exe test/test_keeper_tool_matrix.exe` compiles without warnings.
- [ ] CI green on standard `dune test` pipeline.

Generated with [Claude Code](https://claude.com/claude-code)