### PR TITLE
feat(task): extend task schema with goal decomposition metadata

### DIFF
--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -659,6 +659,11 @@ type task_status =
   | Completed of string   (* agent_id *)
   | Failed of string * string  (* agent_id, reason *)
 
+type complexity = {
+  estimated_turns: int;
+  reversibility: float;
+}
+
 type task = {
   id: string;
   description: string;
@@ -666,7 +671,21 @@ type task = {
   created_at: float;
   updated_at: float;
   priority: int;
+  parent_task_id: string option;
+  goal_id: string option;
+  complexity_estimate: complexity option;
 }
+
+let complexity_to_json c =
+  `Assoc [
+    ("estimated_turns", `Int c.estimated_turns);
+    ("reversibility", `Float c.reversibility);
+  ]
+
+let complexity_of_json json =
+  let open Yojson.Safe.Util in
+  { estimated_turns = json |> member "estimated_turns" |> to_int;
+    reversibility = json |> member "reversibility" |> to_number }
 
 let task_status_to_json = function
   | Pending -> `Assoc [("type", `String "pending")]
@@ -683,15 +702,26 @@ let task_status_of_json json =
   | "failed" -> Ok (Failed (json |> member "agent" |> to_string, json |> member "reason" |> to_string))
   | s -> Error ("Unknown task status: " ^ s)
 
+let json_string_opt_field name value =
+  match value with Some s -> [(name, `String s)] | None -> []
+
 let task_to_json task =
-  `Assoc [
+  let base = [
     ("id", `String task.id);
     ("description", `String task.description);
     ("status", task_status_to_json task.status);
     ("created_at", `Float task.created_at);
     ("updated_at", `Float task.updated_at);
     ("priority", `Int task.priority);
-  ]
+  ] in
+  let opt_fields =
+    json_string_opt_field "parent_task_id" task.parent_task_id
+    @ json_string_opt_field "goal_id" task.goal_id
+    @ (match task.complexity_estimate with
+       | Some c -> [("complexity_estimate", complexity_to_json c)]
+       | None -> [])
+  in
+  `Assoc (base @ opt_fields)
 
 let task_of_json json =
   let open Yojson.Safe.Util in
@@ -699,6 +729,13 @@ let task_of_json json =
     match task_status_of_json (json |> member "status") with
     | Error e -> Error e
     | Ok status ->
+        let str_opt key = match json |> member key with
+          | `String s -> Some s | _ -> None
+        in
+        let complexity_opt = match json |> member "complexity_estimate" with
+          | `Assoc _ as j -> Some (complexity_of_json j)
+          | _ -> None
+        in
         Ok {
           id = json |> member "id" |> to_string;
           description = json |> member "description" |> to_string;
@@ -706,13 +743,16 @@ let task_of_json json =
           created_at = json |> member "created_at" |> to_float;
           updated_at = json |> member "updated_at" |> to_float;
           priority = json |> member "priority" |> to_int;
+          parent_task_id = str_opt "parent_task_id";
+          goal_id = str_opt "goal_id";
+          complexity_estimate = complexity_opt;
         }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
 (** Create a new task *)
-let create_task config ~description ?(priority=1) () =
+let create_task config ~description ?(priority=1) ?parent_task_id ?goal_id ?complexity_estimate () =
   let id = Printf.sprintf "task_%d_%04x" (int_of_float (Time_compat.now () *. 1000.)) (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFF) in
   let now = Time_compat.now () in
   let task = {
@@ -722,6 +762,9 @@ let create_task config ~description ?(priority=1) () =
     created_at = now;
     updated_at = now;
     priority;
+    parent_task_id;
+    goal_id;
+    complexity_estimate;
   } in
   let json_str = Yojson.Safe.to_string (task_to_json task) in
   match Backend.FileSystem.set config.backend (task_key id) json_str with

--- a/lib/room/room_eio.mli
+++ b/lib/room/room_eio.mli
@@ -82,7 +82,15 @@ type task_status =
   | Completed of string   (** agent_id *)
   | Failed of string * string  (** agent_id, reason *)
 
-(** A coordination task. *)
+(** Task complexity estimate for goal decomposition.
+    @since 2.223.0 *)
+type complexity = {
+  estimated_turns: int;
+  reversibility: float;
+}
+
+(** A coordination task with optional goal decomposition metadata.
+    New fields default to None for backward-compatible JSON deserialization. *)
 type task = {
   id: string;
   description: string;
@@ -90,6 +98,9 @@ type task = {
   created_at: float;
   updated_at: float;
   priority: int;
+  parent_task_id: string option;
+  goal_id: string option;
+  complexity_estimate: complexity option;
 }
 
 (** {1 Helpers} *)
@@ -243,7 +254,9 @@ val task_of_json : Yojson.Safe.t -> (task, string) result
 
 (** Create a new task with the given description and optional priority. *)
 val create_task :
-  config -> description:string -> ?priority:int -> unit ->
+  config -> description:string -> ?priority:int ->
+  ?parent_task_id:string -> ?goal_id:string ->
+  ?complexity_estimate:complexity -> unit ->
   (task, string) result
 
 (** Claim a pending task for [agent].  Fails if already claimed. *)

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -13,6 +13,8 @@ type task = {
   status : string;
   priority : int;
   claimed_by : string option;
+  parent_task_id : string option;
+  goal_id : string option;
 }
 
 type keeper = {
@@ -151,6 +153,8 @@ let decode_task json =
   let* status = require_string_field json "status" in
   let* priority = optional_int json "priority" in
   let* claimed_by = optional_string json "claimed_by" in
+  let* parent_task_id = optional_string json "parent_task_id" in
+  let* goal_id = optional_string json "goal_id" in
   Ok
     {
       id;
@@ -158,6 +162,8 @@ let decode_task json =
       status;
       priority = Option.value priority ~default:3;
       claimed_by;
+      parent_task_id;
+      goal_id;
     }
 
 let decode_keeper ~filename json =

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -11,6 +11,8 @@ type task = {
   status : string;
   priority : int;
   claimed_by : string option;
+  parent_task_id : string option;
+  goal_id : string option;
 }
 
 type keeper = {

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -888,10 +888,54 @@ let test_room_eio_task_roundtrip () =
     created_at = 1704067200.0;
     updated_at = 1704070800.0;
     priority = 2;
+    parent_task_id = None;
+    goal_id = None;
+    complexity_estimate = None;
   } in
   let json = Room_eio.task_to_json task in
   let result = Room_eio.task_of_json json in
   check bool "roundtrip ok" true (is_ok result)
+
+let test_room_eio_task_with_goal_metadata () =
+  let task = Room_eio.{
+    id = "task-456";
+    description = "Sub-task: implement login";
+    status = Pending;
+    created_at = 1704067200.0;
+    updated_at = 1704067200.0;
+    priority = 1;
+    parent_task_id = Some "task-123";
+    goal_id = Some "goal-auth";
+    complexity_estimate = Some { estimated_turns = 5; reversibility = 0.8 };
+  } in
+  let json = Room_eio.task_to_json task in
+  let result = Room_eio.task_of_json json in
+  match result with
+  | Ok t ->
+    check bool "parent preserved" true (t.parent_task_id = Some "task-123");
+    check bool "goal preserved" true (t.goal_id = Some "goal-auth");
+    check bool "complexity preserved" true
+      (match t.complexity_estimate with
+       | Some c -> c.estimated_turns = 5 && c.reversibility = 0.8
+       | None -> false)
+  | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
+
+let test_room_eio_task_backward_compat () =
+  (* Old JSON without new fields should still parse *)
+  let old_json = `Assoc [
+    ("id", `String "task-old");
+    ("description", `String "legacy task");
+    ("status", `Assoc [("type", `String "pending")]);
+    ("created_at", `Float 1704067200.0);
+    ("updated_at", `Float 1704067200.0);
+    ("priority", `Int 1);
+  ] in
+  match Room_eio.task_of_json old_json with
+  | Ok t ->
+    check bool "parent is none" true (t.parent_task_id = None);
+    check bool "goal is none" true (t.goal_id = None);
+    check bool "complexity is none" true (t.complexity_estimate = None)
+  | Error e -> fail (Printf.sprintf "backward compat failed: %s" e)
 
 (* ============================================================ *)
 (* Test Suite                                                    *)
@@ -1079,6 +1123,8 @@ let room_eio_task_status_tests = [
 
 let room_eio_task_tests = [
   "task roundtrip", `Quick, test_room_eio_task_roundtrip;
+  "task with goal metadata", `Quick, test_room_eio_task_with_goal_metadata;
+  "task backward compat", `Quick, test_room_eio_task_backward_compat;
 ]
 
 let () =


### PR DESCRIPTION
## Summary
- Add `parent_task_id`, `goal_id`, `complexity_estimate` to task type
- `complexity` type: `estimated_turns` + Karpathy `reversibility` metric
- All fields optional (None default) — backward compatible JSON

## Motivation
Phase 3 foundation: hierarchical goal → sub-goal → task decomposition.
Without parent_task_id, tasks are flat. Without complexity_estimate,
automatic task splitting is impossible.

## Sync Points (all updated)
1. `room_eio.ml` — type + task_to_json + task_of_json + create_task
2. `room_eio.mli` — interface
3. `tui_decode.ml` + `.mli` — TUI rendering
4. `test_types_utils_coverage.ml` — roundtrip + goal metadata + backward compat

## Test plan
- [x] `dune build` passes
- [x] test_room_eio_task_roundtrip (existing, updated)
- [x] test_room_eio_task_with_goal_metadata (new)
- [x] test_room_eio_task_backward_compat (new — old JSON without new fields)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)