### PR TITLE
fix(dashboard): make stagnation_score optional in meta-cognition parse

### DIFF
--- a/lib/meta_cognition_parse.ml
+++ b/lib/meta_cognition_parse.ml
@@ -136,9 +136,10 @@ let parse_optional_summary parse value =
 
 let parse_summary json =
   let open Yojson.Safe.Util in
-  match json_float_opt (member "stagnation_score" json) with
-  | None -> Error "summary.stagnation_score missing or invalid"
-  | Some stagnation_score -> (
+  let stagnation_score =
+    Option.value ~default:0.0 (json_float_opt (member "stagnation_score" json))
+  in
+  (
       match json_int_opt (member "belief_count" json),
             json_int_opt (member "contested_belief_count" json),
             parse_optional_summary parse_belief_summary (member "dominant_belief" json),

--- a/test/test_meta_cognition_feedback.ml
+++ b/test/test_meta_cognition_feedback.ml
@@ -213,6 +213,66 @@ let test_digest_body_keeps_secondary_signals () =
          && contains_substring post.body "comment:c-1")
   | [] -> Alcotest.fail "expected digest post to exist"
 
+module Meta_cognition = Masc_mcp.Meta_cognition
+
+(* --- parse_summary robustness tests --- *)
+
+let summary_json_without_stagnation_score =
+  `Assoc
+    [
+      ("belief_count", `Int 2);
+      ("contested_belief_count", `Int 1);
+      ( "dominant_belief",
+        `Assoc
+          [
+            ("id", `String "b1");
+            ("claim", `String "claim");
+            ("status", `String "active");
+            ("support_agent_count", `Int 1);
+            ("challenge_agent_count", `Int 0);
+            ("evidence_refs", `List []);
+            ("challenge_refs", `List []);
+          ] );
+      ( "top_tension",
+        `Assoc
+          [
+            ("id", `String "t1");
+            ("topic", `String "topic");
+            ("severity", `String "low");
+            ("needs_operator", `Bool false);
+            ("evidence_refs", `List []);
+          ] );
+      ( "top_desire",
+        `Assoc
+          [
+            ("id", `String "d1");
+            ("desired_state", `String "state");
+            ("actionability", `String "agent");
+            ("evidence_refs", `List []);
+          ] );
+    ]
+
+let test_parse_summary_without_stagnation_score () =
+  match Meta_cognition.parse_summary summary_json_without_stagnation_score with
+  | Error msg -> Alcotest.fail (Printf.sprintf "parse_summary should succeed without stagnation_score: %s" msg)
+  | Ok summary ->
+      Alcotest.(check (float 0.01)) "default stagnation_score is 0.0"
+        0.0 summary.stagnation_score
+
+let test_parse_summary_with_stagnation_score () =
+  let json =
+    `Assoc
+      (("stagnation_score", `Float 0.85)
+       :: (match summary_json_without_stagnation_score with
+           | `Assoc fields -> fields
+           | _ -> []))
+  in
+  match Meta_cognition.parse_summary json with
+  | Error msg -> Alcotest.fail (Printf.sprintf "parse_summary should succeed: %s" msg)
+  | Ok summary ->
+      Alcotest.(check (float 0.01)) "stagnation_score is parsed"
+        0.85 summary.stagnation_score
+
 let () =
   Alcotest.run "Meta_cognition_feedback"
     [
@@ -226,5 +286,12 @@ let () =
             test_exposes_latest_digest_reference;
           Alcotest.test_case "body keeps secondary signals" `Quick
             test_digest_body_keeps_secondary_signals;
+        ] );
+      ( "parse_summary",
+        [
+          Alcotest.test_case "succeeds without stagnation_score" `Quick
+            test_parse_summary_without_stagnation_score;
+          Alcotest.test_case "parses stagnation_score when present" `Quick
+            test_parse_summary_with_stagnation_score;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `stagnation_score` in meta-cognition summary is now optional with default `0.0` when missing from keeper output
- Eliminates 35 WARN logs per cycle (`summary.stagnation_score missing or invalid`)
- Added 2 tests: parse succeeds without the field, and parses correctly when present

Fixes #5056

## Test plan
- [x] `dune build` passes
- [x] `test_meta_cognition_feedback` -- all 6 tests pass (4 existing + 2 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)