### PR TITLE
refactor(keeper): replace regex split and O(n^2) jaccard with stdlib

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -45,24 +45,25 @@ let normalize_similarity_text (s : string) : string =
 let similarity_tokens (s : string) : string list =
   s
   |> normalize_similarity_text
-  |> Re.split (Re.Pcre.re "[ \t\r\n]+" |> Re.compile)
+  |> String.split_on_char ' '
   |> List.filter (fun t -> String.length t >= 2)
 
 let jaccard_similarity (a : string list) (b : string list) : float =
-  let to_set xs =
-    List.fold_left
-      (fun acc x -> if List.mem x acc then acc else x :: acc)
-      []
-      xs
+  let set_of_list xs =
+    let tbl = Hashtbl.create (List.length xs) in
+    List.iter (fun x -> Hashtbl.replace tbl x ()) xs;
+    tbl
   in
-  let sa = to_set a in
-  let sb = to_set b in
-  if sa = [] && sb = [] then 1.0
+  let sa = set_of_list a in
+  let sb = set_of_list b in
+  let sa_len = Hashtbl.length sa in
+  let sb_len = Hashtbl.length sb in
+  if sa_len = 0 && sb_len = 0 then 1.0
   else
     let inter =
-      List.fold_left (fun n x -> if List.mem x sb then n + 1 else n) 0 sa
+      Hashtbl.fold (fun k () n -> if Hashtbl.mem sb k then n + 1 else n) sa 0
     in
-    let union = List.length sa + List.length sb - inter in
+    let union = sa_len + sb_len - inter in
     if union <= 0 then 0.0 else float_of_int inter /. float_of_int union
 
 let proactive_similarity_score ~(candidate : string) ~(previous : string) : float =


### PR DESCRIPTION
## Summary

- `similarity_tokens`: `Re.Pcre.re + Re.compile` → `String.split_on_char ' '` (regex 불필요 — 선행 normalize가 이미 공백만 남김)
- `jaccard_similarity`: `List.mem` O(n^2) → `Hashtbl` O(n)

## Product impact

proactive similarity check 성능 개선. 동작 변경 없음.

## Evidence

`normalize_similarity_text`가 `[^a-z0-9 ]`을 모두 `' '`로 변환하므로 split 대상에 `\t\r\n`이 존재하지 않음 → regex 불필요.

## Test plan

- [x] `dune build` — 에러 0개
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)