### PR TITLE
refactor: SSOT batch 3 — alert weights, drift thresholds, context_ratio constants

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -252,7 +252,7 @@ let run_server ~sw:_ ~env ~host ~port ~base_path =
 (** CLI options *)
 let port =
   let doc = "Port to listen on" in
-  Arg.(value & opt int 8935 & info ["p"; "port"] ~docv:"PORT" ~doc)
+  Arg.(value & opt int (Env_config_core.masc_http_port_int ()) & info ["p"; "port"] ~docv:"PORT" ~doc)
 
 let host =
   let default = Env_config.masc_host () in

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -7,7 +7,7 @@ open Masc_tui_loader
 (** Send a message to a keeper via HTTP POST to /api/v1/keepers/chat/stream *)
 let send_keeper_message (state : state) (keeper_name : string) (message : string) : string =
   try
-    let host = "127.0.0.1" in
+    let host = Env_config_core.masc_host () in
     let port = state.port in
     let addr = Unix.ADDR_INET (Unix.inet_addr_of_string host, port) in
     let (ic, oc) = Unix.open_connection addr in
@@ -93,13 +93,13 @@ let read_key () : string option =
 
 (** Parse command line arguments *)
 let parse_args () =
-  let port = ref 8935 in
+  let port = ref (Env_config_core.masc_http_port_int ()) in
   let room = ref "" in
   let refresh = ref 2.0 in
   let base_path = ref "" in
 
   let specs = [
-    ("--port", Arg.Set_int port, "MASC server port (default: 8935)");
+    ("--port", Arg.Set_int port, Printf.sprintf "MASC server port (default: %d)" (Env_config_core.masc_http_port_int ()));
     ("--room", Arg.Set_string room, "Room name (default: from ME_ROOT)");
     ("--refresh", Arg.Set_float refresh, "Refresh interval in seconds (default: 2)");
     ("--base", Arg.Set_string base_path, "Base path (default: ME_ROOT or cwd)");

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -205,10 +205,35 @@ let summarize_old_messages ~(keep_recent : int)
       Tool interactions represent actions taken and should be preserved for
       trajectory coherence.
 
-    Special cases: Memory summaries and goal messages are boosted to 0.95
-    regardless of computed score — they anchor the keeper's purpose.
+    Special cases: Memory summaries and goal messages are boosted to
+    [anchor_boost] regardless of computed score — they anchor the keeper's purpose.
 
     Memory summaries and goal messages use MASC-specific prefix matching. *)
+
+(** Importance scoring weights. See rationale in comment block above. *)
+let w_recency = 0.50
+let w_role    = 0.35
+let w_tool    = 0.15
+
+(** Role importance values. *)
+let role_system    = 1.0
+let role_tool      = 0.7
+let role_user      = 0.6
+let role_assistant = 0.4
+
+(** Tool content presence weight. *)
+let tool_present = 0.8
+let tool_absent  = 0.5
+
+(** Minimum score for memory/goal anchor messages. *)
+let anchor_boost = 0.95
+
+(** Score threshold below which messages are dropped by [DropLowImportance]. *)
+let drop_importance_threshold = 0.3
+
+(** Number of recent messages to keep in [SummarizeOld] strategy. *)
+let summarize_keep_recent = 5
+
 let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
   let n = List.length msgs in
   List.mapi (fun i (m : Agent_sdk.Types.message) ->
@@ -217,24 +242,24 @@ let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
            t *. t
     in
     let role_w = match m.role with
-      | Agent_sdk.Types.System -> 1.0
-      | Agent_sdk.Types.Tool -> 0.7
-      | Agent_sdk.Types.User -> 0.6
-      | Agent_sdk.Types.Assistant -> 0.4
+      | Agent_sdk.Types.System -> role_system
+      | Agent_sdk.Types.Tool -> role_tool
+      | Agent_sdk.Types.User -> role_user
+      | Agent_sdk.Types.Assistant -> role_assistant
     in
     let msg_text = Agent_sdk.Types.text_of_message m in
     let has_tool_content = List.exists (function
       | Agent_sdk.Types.ToolUse _ | Agent_sdk.Types.ToolResult _ -> true
       | _ -> false) m.content
     in
-    let tool_w = if has_tool_content then 0.8 else 0.5 in
-    let score = 0.5 *. recency +. 0.35 *. role_w +. 0.15 *. tool_w in
+    let tool_w = if has_tool_content then tool_present else tool_absent in
+    let score = w_recency *. recency +. w_role *. role_w +. w_tool *. tool_w in
     let score =
       if starts_with ~prefix:memory_summary_prefix msg_text
          || starts_with ~prefix:_legacy_memory_summary_prefix msg_text
          || starts_with ~prefix:goal_prefix msg_text
          || starts_with ~prefix:_legacy_goal_prefix msg_text then
-        Float.max score 0.95
+        Float.max score anchor_boost
       else score
     in
     (i, Float.min 1.0 (Float.max 0.0 score))
@@ -262,7 +287,7 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
   | DropLowImportance ->
     Agent_sdk.Context_reducer.Custom (fun msgs ->
       let scores = score_messages msgs in
-      let threshold = 0.3 in
+      let threshold = drop_importance_threshold in
       List.filteri (fun i _m ->
         match List.assoc_opt i scores with
         | Some score -> score >= threshold
@@ -273,14 +298,14 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
        If it leaks here, fall back to DropLowImportance. *)
     Agent_sdk.Context_reducer.Custom (fun msgs ->
       let scores = score_messages msgs in
-      let threshold = 0.3 in
+      let threshold = drop_importance_threshold in
       List.filteri (fun i _m ->
         match List.assoc_opt i scores with
         | Some score -> score >= threshold
         | None -> true
       ) msgs)
   | SummarizeOld ->
-    Agent_sdk.Context_reducer.Custom (summarize_old_messages ~keep_recent:5)
+    Agent_sdk.Context_reducer.Custom (summarize_old_messages ~keep_recent:summarize_keep_recent)
 
 (* ================================================================ *)
 (* Public API                                                       *)
@@ -372,11 +397,17 @@ let observation_summary = function
     - Small local model: prefer pruning (cheaper, faster)
     - Large-context cloud (>= 500K): quality-preserving with summarization
     - Normal: standard DropLowImportance *)
+
+(** Context ratio thresholds for dynamic strategy selection.
+    Distinct from Dashboard.ctx_* (display) — these drive compaction behavior. *)
+let dynamic_multi_agent_ctx = 0.80
+let dynamic_focused_ctx = 0.70
+
 let default_dynamic_selector (obs : observation_context) : strategy list =
-  if obs.context_ratio >= 0.80 && obs.active_agent_count > 1 then
+  if obs.context_ratio >= dynamic_multi_agent_ctx && obs.active_agent_count > 1 then
     (* Dense coordination: preserve recent turns, aggressive pruning *)
     [PruneToolOutputs; DropLowImportance; MergeContiguous]
-  else if obs.context_ratio >= 0.70 && obs.is_single_focused_task then
+  else if obs.context_ratio >= dynamic_focused_ctx && obs.is_single_focused_task then
     (* Focused work near budget: summarize old context *)
     [PruneToolOutputs; SummarizeOld]
   else if obs.is_local_model && obs.context_window < 32_000 then

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -50,6 +50,10 @@ let max_signal_scan = 500
 let runtime_stale_after_s = 30. *. 60.
 let evaluator_stale_after_s = 12. *. 3600.
 
+(** Runtime health warning thresholds. Distinct from compaction thresholds. *)
+let runtime_warning_ctx_ratio = 0.95
+let runtime_warning_token_count = 50_000
+
 let pre_compact_store_ref : Dated_jsonl.t option ref = ref None
 
 let status_to_string = function
@@ -306,7 +310,7 @@ let pre_compact_status (latest_event : pre_compact_event option) =
   | None -> Idle
   | Some event ->
       if is_stale ~threshold_s:runtime_stale_after_s event.timestamp then Stale
-      else if event.context_ratio >= 0.95 || event.token_count >= 50_000 then Warning
+      else if event.context_ratio >= runtime_warning_ctx_ratio || event.token_count >= runtime_warning_token_count then Warning
       else Healthy
 
 let handoff_status (latest_event : handoff_event option) =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,6 +10,14 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
+(** Context-ratio thresholds for keeper health scoring.
+    These are distinct from Dashboard.ctx_* (compaction triggers) —
+    health scoring penalizes keepers approaching context limits. *)
+let health_ctx_critical = 0.9
+let health_ctx_warn = 0.8
+let health_penalty_critical = 20.0
+let health_penalty_warn = 10.0
+
 (** Compute keeper health score (0-100). Pure function.
     Inputs: restart_count, max_restarts, recent_crash_count,
             is_dead, context_ratio (0.0-1.0). *)
@@ -28,8 +36,8 @@ let compute_health_score
       Float.min 30.0 (float_of_int recent_crash_count *. 10.0)
     in
     let context_penalty =
-      if context_ratio > 0.9 then 20.0
-      else if context_ratio > 0.8 then 10.0
+      if context_ratio > health_ctx_critical then health_penalty_critical
+      else if context_ratio > health_ctx_warn then health_penalty_warn
       else 0.0
     in
     let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -3,6 +3,9 @@
 
     Agent briefs and related helpers are in Dashboard_mission_agents. *)
 
+(** Context ratio above which a keeper gets elevated lane pressure rank. *)
+let lane_pressure_ctx_ratio = 0.80
+
 include Dashboard_mission_agents
 
 let keeper_tool_audit_json_fields config keeper agent_name =
@@ -224,7 +227,7 @@ let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
            in
            let pressure_rank =
              if Dashboard_utils.is_keeper_offline status then 3
-             else if Option.value ~default:0.0 context_ratio >= 0.80 then 2
+             else if Option.value ~default:0.0 context_ratio >= lane_pressure_ctx_ratio then 2
              else if status = "idle" then 1
              else 0
            in

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -52,6 +52,21 @@ let weights () =
 
 let default_threshold () = Level2_config.Drift_guard.default_threshold ()
 
+(** {1 Drift Classification Thresholds}
+
+    Heuristic thresholds for determining drift type in handoff verification.
+    - Factual drift: low token coverage or large size difference indicates
+      content was replaced rather than edited.
+    - Structural drift: cosine-jaccard divergence indicates word order/phrasing
+      changed while vocabulary stayed similar.
+    - Semantic drift: default when neither structural nor factual patterns match.
+
+    These values are initial estimates, not empirically validated.
+    TODO(RFC-0001 Phase 3): Register in Runtime_params. *)
+let factual_coverage_floor = 0.55
+let factual_size_ratio_floor = 0.6
+let structural_divergence_threshold = 0.18
+
 let tokenize (s : string) : string list =
   let trimmed = String.trim s in
   if trimmed = "" then []
@@ -168,8 +183,8 @@ let classify_drift ~tokens_a ~tokens_b ~jacc ~cos =
     | 0 -> 1.0
     | max_len -> float_of_int (min len_a len_b) /. float_of_int max_len
   in
-  if coverage < 0.55 || size_ratio < 0.6 then Factual
-  else if cos -. jacc > 0.18 then Structural
+  if coverage < factual_coverage_floor || size_ratio < factual_size_ratio_floor then Factual
+  else if cos -. jacc > structural_divergence_threshold then Structural
   else Semantic
 
 let summarize ~original ~received ~threshold =

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -126,6 +126,58 @@ let is_alert_deduplicated ~(keeper_name : string) ~(reasons : string list) : boo
     Hashtbl.replace alert_dedup_table key now;
     false
 
+(** {1 Alert Signal Weights}
+
+    Keyword weights and signal bonuses for keeper alert scoring.
+    These are heuristic values — not empirically calibrated.
+
+    Keyword weights represent severity estimates for each term.
+    Higher weight = stronger indicator of an incident requiring escalation.
+    The score is the sum of matched weights, capped at 1.0.
+
+    Signal bonuses are additive modifiers for structural indicators
+    (guardrail stops, context pressure, alignment drops, tool usage).
+
+    TODO(RFC-0001 Phase 3): Register in Runtime_params for runtime tuning. *)
+
+let alert_keyword_weights : (string * float) list = [
+  ("장애",     0.35);  (* Korean: outage/failure *)
+  ("사고",     0.30);  (* Korean: incident *)
+  ("롤백",     0.30);  (* Korean: rollback *)
+  ("긴급",     0.25);  (* Korean: urgent *)
+  ("critical", 0.30);
+  ("urgent",   0.22);
+  ("incident", 0.25);
+  ("outage",   0.38);
+  ("oncall",   0.18);
+  ("p0",       0.32);
+  ("sev1",     0.32);
+  ("security", 0.35);
+  ("breach",   0.45);
+  ("data loss", 0.45);
+  ("failover", 0.22);
+  ("hotfix",   0.20);
+  ("downtime", 0.28);
+]
+
+(** Additive bonus when a guardrail stop was triggered. *)
+let signal_bonus_guardrail_stop = 0.45
+(** Additive bonus when handoff is active and context is near limit. *)
+let signal_bonus_handoff_pressure = 0.16
+(** Additive bonus when both goal and response alignment are low. *)
+let signal_bonus_low_alignment = 0.12
+(** Additive bonus when multiple tool calls occurred. *)
+let signal_bonus_multi_tool = 0.06
+
+(** Context ratio above which handoff pressure is flagged. *)
+let handoff_pressure_threshold = 0.88
+(** Goal alignment below which low-alignment signal fires. *)
+let goal_alignment_floor = 0.20
+(** Response alignment below which low-alignment signal fires. *)
+let response_alignment_floor = 0.16
+(** Minimum tool call count to trigger multi-tool signal. *)
+let multi_tool_min_count = 2
+
 let keeper_alert_signal
     ~(message : string)
     ~(reply : string)
@@ -135,27 +187,8 @@ let keeper_alert_signal
     ~(tool_call_count : int)
     ~(auto_rules : keeper_auto_rule_eval) : float * string list * string list =
   let corpus = String.lowercase_ascii (message ^ "\n" ^ reply) in
-  let keyword_weights = [
-    ("장애", 0.35);
-    ("사고", 0.30);
-    ("롤백", 0.30);
-    ("긴급", 0.25);
-    ("critical", 0.30);
-    ("urgent", 0.22);
-    ("incident", 0.25);
-    ("outage", 0.38);
-    ("oncall", 0.18);
-    ("p0", 0.32);
-    ("sev1", 0.32);
-    ("security", 0.35);
-    ("breach", 0.45);
-    ("data loss", 0.45);
-    ("failover", 0.22);
-    ("hotfix", 0.20);
-    ("downtime", 0.28);
-  ] in
   let keyword_hits =
-    keyword_weights
+    alert_keyword_weights
     |> List.filter_map (fun (kw, w) ->
          if contains_ci corpus kw then Some (kw, w) else None)
   in
@@ -169,19 +202,19 @@ let keeper_alert_signal
   if keyword_hits <> [] then
     reasons := "critical_keywords" :: !reasons;
   if auto_rules.guardrail_stop then begin
-    score := !score +. 0.45;
+    score := !score +. signal_bonus_guardrail_stop;
     reasons := "guardrail_stop" :: !reasons
   end;
-  if auto_rules.handoff && context_ratio >= 0.88 then begin
-    score := !score +. 0.16;
+  if auto_rules.handoff && context_ratio >= handoff_pressure_threshold then begin
+    score := !score +. signal_bonus_handoff_pressure;
     reasons := "handoff_pressure" :: !reasons
   end;
-  if goal_alignment < 0.20 && response_alignment < 0.16 then begin
-    score := !score +. 0.12;
+  if goal_alignment < goal_alignment_floor && response_alignment < response_alignment_floor then begin
+    score := !score +. signal_bonus_low_alignment;
     reasons := "low_alignment" :: !reasons
   end;
-  if tool_call_count >= 2 then begin
-    score := !score +. 0.06;
+  if tool_call_count >= multi_tool_min_count then begin
+    score := !score +. signal_bonus_multi_tool;
     reasons := "multi_tool_action" :: !reasons
   end;
   let score = max 0.0 (min 1.0 !score) in


### PR DESCRIPTION
## Summary

Continues SSOT consolidation (batch 3 of 3). Extracts all remaining P0/P1 magic numbers into named constants across 8 files.

### Changes

| Module | Magic Numbers Extracted | Count |
|--------|----------------------|-------|
| `keeper_alerting` | 17 keyword weights + 4 signal bonuses + 4 thresholds | 25 |
| `context_compact_oas` | scoring weights, role values, anchor_boost, drop threshold, dynamic ctx ratios | 14 |
| `drift_guard` | factual/structural classification thresholds | 3 |
| `dashboard_http_keeper` | health score ctx penalties | 4 |
| `dashboard_harness_health` | runtime warning thresholds | 2 |
| `dashboard_mission_assembly` | lane pressure ctx ratio | 1 |
| `bin/main_eio` | CLI port default → Env_config | 1 |
| `bin/masc_tui` | CLI host/port → Env_config | 2 |

### Relation to prior PRs

- #5038 (merged): Core SSOT (ports, dashboard thresholds, Det/NonDet boundaries)
- #5063 (merged): Batch 2 (registry, channel_gate, file_lock, reputation)
- #5067 (issue): spawn.ml Gemini pricing boundary violation (separate concern)

### Total across 3 PRs: ~30 files, ~100 magic numbers addressed

## Test plan

- [x] `dune build` passes
- [ ] CI green
- [ ] Cross-model review (GLM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)