### PR TITLE
feat(dashboard): goal tree visualization with convergence indicators

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -20,6 +20,7 @@ import type {
   DashboardMissionSessionDetailResponse,
   DashboardProofResponse,
   DashboardPlanningResponse,
+  DashboardGoalsTreeResponse,
   DashboardNamespaceTruthResponse,
   DashboardShellResponse,
   BoardSortMode,
@@ -486,6 +487,10 @@ export function fetchDashboardProof(
 
 export function fetchDashboardPlanning(): Promise<DashboardPlanningResponse> {
   return get('/api/v1/dashboard/planning')
+}
+
+export function fetchDashboardGoalsTree(): Promise<DashboardGoalsTreeResponse> {
+  return get('/api/v1/dashboard/goals')
 }
 
 // --- Tool metrics (P4 Phase 4.5) ---

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -1,0 +1,264 @@
+// Goal Tree — hierarchical goal decomposition with convergence indicators
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { fetchDashboardGoalsTree } from '../../api/dashboard'
+import { EmptyState } from '../common/empty-state'
+import { LoadingState } from '../common/feedback-state'
+import { ActionButton } from '../common/button'
+import { StatusBadge } from '../common/status-badge'
+import { TimeAgo } from '../common/time-ago'
+import type {
+  DashboardGoalsTreeResponse,
+  GoalTreeNode,
+  GoalTreeTask,
+  GoalTreeSummary,
+} from '../../types'
+import { horizonLabel, horizonColor, priorityStars } from './goal-helpers'
+
+// --- State ---
+
+const treeData = signal<DashboardGoalsTreeResponse | null>(null)
+const treeLoading = signal(false)
+const treeError = signal<string | null>(null)
+const expandedNodes = signal<Set<string>>(new Set())
+
+function toggleNode(id: string) {
+  const next = new Set(expandedNodes.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expandedNodes.value = next
+}
+
+function expandAll(nodes: GoalTreeNode[]) {
+  const ids = new Set(expandedNodes.value)
+  function walk(ns: GoalTreeNode[]) {
+    for (const n of ns) {
+      ids.add(n.id)
+      walk(n.children)
+    }
+  }
+  walk(nodes)
+  expandedNodes.value = ids
+}
+
+function collapseAll() {
+  expandedNodes.value = new Set()
+}
+
+async function refreshTree() {
+  treeLoading.value = true
+  treeError.value = null
+  try {
+    treeData.value = await fetchDashboardGoalsTree()
+  } catch (err) {
+    treeError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    treeLoading.value = false
+  }
+}
+
+// --- Convergence bar ---
+
+function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' }) {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const barColor =
+    clamped >= 80 ? '#4ade80'
+    : clamped >= 50 ? '#f59e0b'
+    : clamped >= 20 ? '#fb923c'
+    : '#ef4444'
+
+  const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
+  return html`
+    <div class="flex items-center gap-2">
+      <div class="flex-1 ${h} rounded-full bg-white/10 overflow-hidden">
+        <div class="${h} rounded-full transition-all duration-500" style="width:${clamped}%;background:${barColor}"></div>
+      </div>
+      <span class="text-[11px] font-semibold tabular-nums text-text-muted w-[36px] text-right">${clamped}%</span>
+    </div>
+  `
+}
+
+// --- Summary stats ---
+
+function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
+  return html`
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
+      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+        <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_goals}</div>
+        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">전체 목표</div>
+      </div>
+      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+        <div class="text-2xl font-bold text-ok tabular-nums">${summary.active_goals}</div>
+        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">진행 중</div>
+      </div>
+      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+        <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_tasks}</div>
+        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">연결 태스크</div>
+      </div>
+      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+        <div class="text-2xl font-bold text-ok tabular-nums">${summary.done_tasks}</div>
+        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
+      </div>
+      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3">
+        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
+        <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
+      </div>
+    </div>
+  `
+}
+
+// --- Task row inside a goal ---
+
+function TreeTask({ task }: { task: GoalTreeTask }) {
+  return html`
+    <div class="flex items-center gap-2 py-1.5 px-2 rounded-lg bg-white/3 text-[12px]">
+      <span class="size-2 rounded-full shrink-0" style="background:${task.status_color}"></span>
+      <span class="flex-1 min-w-0 truncate text-text-body">${task.title}</span>
+      ${task.assignee ? html`
+        <span class="shrink-0 rounded-md border border-accent/20 bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">${task.assignee}</span>
+      ` : null}
+      <${StatusBadge} status=${task.status} />
+    </div>
+  `
+}
+
+// --- Goal tree node (recursive) ---
+
+function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
+  const isExpanded = expandedNodes.value.has(node.id)
+  const hasContent = node.children.length > 0 || node.tasks.length > 0
+  const indent = depth * 20
+
+  return html`
+    <div class="flex flex-col" style="margin-left:${indent}px">
+      <div
+        class="group flex items-start gap-3 rounded-xl border border-card-border/60 bg-[rgba(8,13,22,0.86)] p-3 transition-colors hover:border-card-border/90 ${hasContent ? 'cursor-pointer' : ''}"
+        onClick=${hasContent ? () => toggleNode(node.id) : undefined}
+      >
+        ${hasContent ? html`
+          <span class="shrink-0 mt-0.5 text-[12px] text-text-dim transition-transform ${isExpanded ? 'rotate-90' : ''}">\u25B6</span>
+        ` : html`
+          <span class="shrink-0 mt-0.5 text-[12px] text-text-dim/30">\u25CB</span>
+        `}
+
+        <div class="flex-1 min-w-0">
+          <div class="flex flex-wrap items-center gap-2 mb-1">
+            <span class="shrink-0 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest" style="color:${horizonColor(node.horizon)}">
+              ${horizonLabel(node.horizon)}
+            </span>
+            <span class="text-[14px] font-semibold text-text-strong break-words line-clamp-2">${node.title}</span>
+            <span class="text-[11px] text-text-dim">${priorityStars(node.priority)}</span>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-3 text-[11px] text-text-muted">
+            ${node.metric ? html`
+              <span class="rounded-md border border-accent/20 bg-accent/10 px-2 py-0.5 text-accent">
+                ${node.metric}${node.target_value ? ` \u2192 ${node.target_value}` : ''}
+              </span>
+            ` : null}
+            ${node.due_date ? html`
+              <span class="rounded-md border border-bad/20 bg-bad/10 px-2 py-0.5 text-bad">
+                마감 <${TimeAgo} timestamp=${node.due_date} />
+              </span>
+            ` : null}
+            ${node.task_count > 0 ? html`
+              <span class="font-medium">${node.task_done_count}/${node.task_count} 태스크</span>
+            ` : null}
+            ${node.child_count > 0 ? html`
+              <span class="font-medium">${node.child_count} 하위 목표</span>
+            ` : null}
+          </div>
+
+          <div class="mt-2 max-w-[400px]">
+            <${ConvergenceBar} pct=${node.convergence_pct} size="sm" />
+          </div>
+        </div>
+
+        <div class="flex flex-col items-end gap-1 shrink-0">
+          <${StatusBadge} status=${node.status} />
+          <span class="text-[10px] text-text-dim">
+            <${TimeAgo} timestamp=${node.updated_at} />
+          </span>
+        </div>
+      </div>
+
+      ${isExpanded ? html`
+        <div class="mt-1.5 flex flex-col gap-1.5">
+          ${node.tasks.length > 0 ? html`
+            <div class="ml-6 flex flex-col gap-1 rounded-lg border border-card-border/40 bg-[rgba(5,9,16,0.6)] p-2">
+              <div class="text-[10px] font-semibold uppercase tracking-widest text-text-dim mb-1">연결된 태스크</div>
+              ${node.tasks.map(t => html`<${TreeTask} key=${t.id} task=${t} />`)}
+            </div>
+          ` : null}
+          ${node.children.map(child => html`
+            <${TreeNode} key=${child.id} node=${child} depth=${depth + 1} />
+          `)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+// --- Main GoalTree component ---
+
+export function GoalTree() {
+  useEffect(() => {
+    void refreshTree()
+  }, [])
+
+  const data = treeData.value
+  const loading = treeLoading.value
+  const error = treeError.value
+
+  return html`
+    <div class="flex flex-col gap-5">
+      <section class="rounded-2xl border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
+        <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
+          <div class="max-w-[760px]">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>
+            <h3 class="mt-1 text-[20px] font-semibold tracking-[-0.02em] text-text-strong">목표 계층 구조</h3>
+            <p class="mt-1.5 text-[13px] leading-relaxed text-text-muted">
+              목표의 부모-자식 관계와 연결된 태스크를 트리 형태로 보여줍니다. 수렴도는 하위 태스크 완료율 기반입니다.
+            </p>
+          </div>
+          <div class="flex items-center gap-2">
+            ${data && data.tree.length > 0 ? html`
+              <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
+                모두 펼치기
+              <//>
+              <${ActionButton} variant="ghost" size="sm" onClick=${collapseAll}>
+                모두 접기
+              <//>
+            ` : null}
+            <${ActionButton}
+              variant="ghost"
+              size="md"
+              disabled=${loading}
+              onClick=${() => { void refreshTree() }}
+            >
+              ${loading ? '새로고침 중...' : '새로고침'}
+            <//>
+          </div>
+        </div>
+
+        ${error ? html`
+          <div class="rounded-xl border border-bad/25 bg-bad/10 px-4 py-3 text-[13px] text-bad">${error}</div>
+        ` : null}
+
+        ${data ? html`<${TreeSummary} summary=${data.summary} />` : null}
+      </section>
+
+      ${loading && !data ? html`
+        <${LoadingState}>목표 트리 불러오는 중...<//>
+      ` : data && data.tree.length === 0 ? html`
+        <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert 도구로 목표를 등록하세요." />
+      ` : data ? html`
+        <section class="flex flex-col gap-2">
+          ${data.tree.map(node => html`<${TreeNode} key=${node.id} node=${node} depth=${0} />`)}
+        </section>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,18 +1,19 @@
 // MASC Dashboard — Work Tab
-// Absorbs: memory(board) + governance + proof + planning into pill-switched sections.
+// Absorbs: memory(board) + governance + proof + planning + goals into pill-switched sections.
 
 import { html } from 'htm/preact'
 import { route } from '../router'
 import { Memory } from './memory'
 import { Proof } from './proof'
 import { Planning } from './goals'
+import { GoalTree } from './goals/goal-tree'
 import { Worktrees } from './worktrees'
 import { ErrorBoundary } from './common/error-boundary'
 
-type WorkSection = 'board' | 'evidence' | 'planning' | 'worktrees'
+type WorkSection = 'board' | 'evidence' | 'planning' | 'goals' | 'worktrees'
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'evidence' || v === 'planning' || v === 'worktrees'
+  return v === 'board' || v === 'evidence' || v === 'planning' || v === 'goals' || v === 'worktrees'
 }
 
 export function Work() {
@@ -27,6 +28,7 @@ export function Work() {
           ${current === 'board' ? html`<${Memory} />`
             : current === 'evidence' ? html`<${Proof} />`
             : current === 'planning' ? html`<${Planning} />`
+            : current === 'goals' ? html`<${GoalTree} />`
             : html`<${Worktrees} />`
           }
         </>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -9,6 +9,7 @@ export type SurfaceSectionId =
   | 'governance'
   | 'evidence'
   | 'planning'
+  | 'goals'
   | 'worktrees'
   | 'intervene'
   | 'tools'
@@ -161,6 +162,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '계획 및 메트릭',
       description: 'backlog와 수동 등록형 goal 상태를 함께 보는 화면. goal은 자동 생성되지 않습니다.',
       params: { section: 'planning' },
+    },
+    {
+      id: 'goals',
+      label: '목표 트리',
+      description: '목표의 부모-자식 계층 구조와 수렴도. 태스크 연결, 에이전트 배정 상태 시각화.',
+      params: { section: 'goals' },
     },
     {
       id: 'worktrees',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -68,6 +68,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'planning') {
         return ['goals', 'execution']
       }
+      if (routeState.params.section === 'goals') {
+        return ['goals']
+      }
       if (routeState.params.section === 'board') {
         return ['board']
       }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -366,6 +366,56 @@ export interface DashboardPlanningResponse {
   }
 }
 
+// --- Goal Tree (hierarchical goal decomposition) ---
+
+export interface GoalTreeTask {
+  id: string
+  title: string
+  status: string
+  status_color: string
+  priority: number
+  assignee: string | null
+  is_terminal: boolean
+  created_at: string
+}
+
+export interface GoalTreeNode {
+  id: string
+  title: string
+  horizon: string
+  status: string
+  status_color: string
+  priority: number
+  metric: string | null
+  target_value: string | null
+  due_date: string | null
+  parent_goal_id: string | null
+  convergence: number
+  convergence_pct: number
+  tasks: GoalTreeTask[]
+  task_count: number
+  task_done_count: number
+  children: GoalTreeNode[]
+  child_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface GoalTreeSummary {
+  total_goals: number
+  active_goals: number
+  total_tasks: number
+  done_tasks: number
+  overall_convergence: number
+  overall_convergence_pct: number
+}
+
+export interface DashboardGoalsTreeResponse {
+  generated_at?: string
+  tree: GoalTreeNode[]
+  summary: GoalTreeSummary
+}
+
 
 export interface ServerStatus {
   namespace_id?: string

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -1,0 +1,205 @@
+(** Dashboard Goals — goal tree with task linkage and convergence indicators. *)
+
+(** A tree node represents a goal with its child goals and linked tasks. *)
+type tree_node = {
+  goal : Goal_store.goal;
+  children : tree_node list;
+  tasks : Types.task list;
+  convergence : float;  (** 0.0 .. 1.0 completion ratio *)
+}
+
+let task_is_linked_to_goal (task : Types.task) goal_id =
+  (* Tasks created by goal dispatch embed [goal:<id>] in the title. *)
+  let pattern = Printf.sprintf "[goal:%s]" goal_id in
+  try
+    let _ = Re.Str.search_forward (Re.Str.regexp_string pattern) task.title 0 in
+    true
+  with Not_found -> false
+
+let task_assignee (task : Types.task) : string option =
+  match task.task_status with
+  | Types.Claimed { assignee; _ } -> Some assignee
+  | Types.InProgress { assignee; _ } -> Some assignee
+  | Types.Done { assignee; _ } -> Some assignee
+  | Types.Todo | Types.Cancelled _ -> None
+
+let task_status_label (task : Types.task) : string =
+  match task.task_status with
+  | Types.Todo -> "pending"
+  | Types.Claimed _ -> "claimed"
+  | Types.InProgress _ -> "in_progress"
+  | Types.Done _ -> "completed"
+  | Types.Cancelled _ -> "cancelled"
+
+let task_is_terminal (task : Types.task) : bool =
+  match task.task_status with
+  | Types.Done _ | Types.Cancelled _ -> true
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> false
+
+let task_is_done (task : Types.task) : bool =
+  match task.task_status with
+  | Types.Done _ -> true
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ | Types.Cancelled _ -> false
+
+let compute_convergence (goal : Goal_store.goal) linked_tasks children =
+  (* Convergence = weighted average of own task completion + child convergence.
+     If there are no tasks or children, use the goal status as the signal. *)
+  let goal_done_weight =
+    match goal.status with
+    | Goal_store.Done -> 1.0
+    | Goal_store.Active | Goal_store.Paused -> 0.0
+    | Goal_store.Dropped -> 0.0
+  in
+  let task_count = List.length linked_tasks in
+  let done_count =
+    List.length (List.filter task_is_done linked_tasks)
+  in
+  let task_ratio =
+    if task_count = 0 then goal_done_weight
+    else float_of_int done_count /. float_of_int task_count
+  in
+  let child_ratios =
+    List.map (fun (c : tree_node) -> c.convergence) children
+  in
+  let child_avg =
+    match child_ratios with
+    | [] -> task_ratio
+    | rs ->
+        let sum = List.fold_left ( +. ) 0.0 rs in
+        sum /. float_of_int (List.length rs)
+  in
+  (* If we have both tasks and children, average them. *)
+  if task_count > 0 && children <> [] then
+    (task_ratio +. child_avg) /. 2.0
+  else if children <> [] then
+    child_avg
+  else
+    task_ratio
+
+let rec build_tree goals all_tasks goal =
+  let child_goals =
+    List.filter
+      (fun (g : Goal_store.goal) ->
+        g.parent_goal_id = Some goal.Goal_store.id)
+      goals
+  in
+  let linked_tasks =
+    List.filter (fun t -> task_is_linked_to_goal t goal.Goal_store.id) all_tasks
+  in
+  let children = List.map (build_tree goals all_tasks) child_goals in
+  let convergence = compute_convergence goal linked_tasks children in
+  { goal; children; tasks = linked_tasks; convergence }
+
+let build_forest ~goals ~tasks =
+  (* Root goals = goals without a parent, or whose parent is not in the set. *)
+  let goal_ids =
+    List.map (fun (g : Goal_store.goal) -> g.id) goals
+  in
+  let is_root (g : Goal_store.goal) =
+    match g.parent_goal_id with
+    | None -> true
+    | Some pid -> not (List.mem pid goal_ids)
+  in
+  let roots = List.filter is_root goals in
+  List.map (build_tree goals tasks) roots
+
+(* JSON serialization *)
+
+let goal_status_color = function
+  | Goal_store.Active -> "#4ade80"
+  | Goal_store.Paused -> "#f59e0b"
+  | Goal_store.Done -> "#60a5fa"
+  | Goal_store.Dropped -> "#6b7280"
+
+let task_status_color status_label =
+  match status_label with
+  | "pending" -> "#6b7280"
+  | "claimed" -> "#f59e0b"
+  | "in_progress" -> "#3b82f6"
+  | "completed" -> "#4ade80"
+  | "cancelled" -> "#ef4444"
+  | _ -> "#888888"
+
+let task_to_tree_json (task : Types.task) =
+  let status = task_status_label task in
+  `Assoc
+    [
+      ("id", `String task.id);
+      ("title", `String task.title);
+      ("status", `String status);
+      ("status_color", `String (task_status_color status));
+      ("priority", `Int task.priority);
+      ("assignee",
+       match task_assignee task with
+       | Some a -> `String a
+       | None -> `Null);
+      ("is_terminal", `Bool (task_is_terminal task));
+      ("created_at", `String task.created_at);
+    ]
+
+let rec tree_node_to_json node =
+  let g = node.goal in
+  `Assoc
+    [
+      ("id", `String g.id);
+      ("title", `String g.title);
+      ("horizon", Goal_store.horizon_to_yojson g.horizon);
+      ("status", Goal_store.goal_status_to_yojson g.status);
+      ("status_color", `String (goal_status_color g.status));
+      ("priority", `Int g.priority);
+      ("metric",
+       match g.metric with Some m -> `String m | None -> `Null);
+      ("target_value",
+       match g.target_value with Some v -> `String v | None -> `Null);
+      ("due_date",
+       match g.due_date with Some d -> `String d | None -> `Null);
+      ("parent_goal_id",
+       match g.parent_goal_id with Some pid -> `String pid | None -> `Null);
+      ("convergence", `Float node.convergence);
+      ("convergence_pct", `Int (int_of_float (node.convergence *. 100.0)));
+      ("tasks", `List (List.map task_to_tree_json node.tasks));
+      ("task_count", `Int (List.length node.tasks));
+      ("task_done_count",
+       `Int (List.length (List.filter task_is_done node.tasks)));
+      ("children", `List (List.map tree_node_to_json node.children));
+      ("child_count", `Int (List.length node.children));
+      ("created_at", `String g.created_at);
+      ("updated_at", `String g.updated_at);
+    ]
+
+let dashboard_goals_tree_json ~(config : Room.config) : Yojson.Safe.t =
+  let goals = Goal_store.list_goals config () in
+  let tasks = Room.get_tasks_raw_in_room config (Room.current_room_id config) in
+  let forest = build_forest ~goals ~tasks in
+  let total_goals = List.length goals in
+  let active_goals =
+    List.length (List.filter (fun (g : Goal_store.goal) -> g.status = Active) goals)
+  in
+  let total_tasks = List.length tasks in
+  let done_tasks =
+    List.length (List.filter task_is_done tasks)
+  in
+  let overall_convergence =
+    if total_goals = 0 then 0.0
+    else
+      let sum =
+        List.fold_left (fun acc n -> acc +. n.convergence) 0.0 forest
+      in
+      sum /. float_of_int (List.length forest)
+  in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ("tree", `List (List.map tree_node_to_json forest));
+      ("summary",
+       `Assoc
+         [
+           ("total_goals", `Int total_goals);
+           ("active_goals", `Int active_goals);
+           ("total_tasks", `Int total_tasks);
+           ("done_tasks", `Int done_tasks);
+           ("overall_convergence", `Float overall_convergence);
+           ("overall_convergence_pct",
+            `Int (int_of_float (overall_convergence *. 100.0)));
+         ]);
+    ]

--- a/lib/dune
+++ b/lib/dune
@@ -99,6 +99,7 @@
    dashboard_http_keeper
    dashboard_http_autoresearch
    dashboard_harness_health
+   dashboard_goals
    dashboard_feature_health
    dashboard_http_repo_synthesis
    dashboard_provider_runs
@@ -553,6 +554,7 @@
  dashboard_http_keeper
  dashboard_http_autoresearch
  dashboard_harness_health
+ dashboard_goals
  server_routes_http_common
  server_routes_http_pages
  server_routes_http_runtime

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -107,6 +107,9 @@ let dashboard_planning_http_json ~(config : Room.config) : Yojson.Safe.t =
           ] );
     ]
 
+let dashboard_goals_tree_http_json ~(config : Room.config) : Yojson.Safe.t =
+  Dashboard_goals.dashboard_goals_tree_json ~config
+
 let operator_action_http_json ~state ~sw ~clock request ~args =
   let ctx : _ Operator_control.context =
     {

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -534,6 +534,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/goals" ->
+          let state = get_server_state () in
+          let json =
+            dashboard_goals_tree_http_json
+              ~config:state.Mcp_server.room_config
+          in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/dashboard/mission" ->
           let state = get_server_state () in
           let json = dashboard_mission_http_json ~state ~sw ~clock httpun_request in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -495,6 +495,11 @@ let rec add_routes ~sw ~clock router =
          let json = dashboard_planning_http_json ~config:state.Mcp_server.room_config in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/goals" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/mission" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_mission_http_json ~state ~sw ~clock req in


### PR DESCRIPTION
## Summary
- Add hierarchical goal tree view at `/dashboard/goals` (workspace > "목표 트리" section)
- Backend `dashboard_goals.ml` builds a forest from `parent_goal_id` linkage and computes per-node convergence from linked task completion ratios
- Frontend `GoalTree` component renders expandable tree nodes with convergence progress bars, task lists, and agent assignment badges
- API endpoint: `GET /api/v1/dashboard/goals` (both HTTP/1.1 and H2 gateways)

## Files changed (11 files, ~557 lines added)

**Backend (OCaml)**
- `lib/dashboard/dashboard_goals.ml` — new module: goal forest builder + convergence computation + JSON serialization
- `lib/dune` — register `dashboard_goals` module
- `lib/server/server_dashboard_http.ml` — expose `dashboard_goals_tree_http_json` facade
- `lib/server/server_routes_http_routes_dashboard.ml` — HTTP/1.1 route
- `lib/server/server_h2_gateway.ml` — H2 route

**Frontend (TypeScript)**
- `dashboard/src/components/goals/goal-tree.ts` — new GoalTree component
- `dashboard/src/types/dashboard-execution.ts` — GoalTreeNode, GoalTreeTask, GoalTreeSummary types
- `dashboard/src/api/dashboard.ts` — `fetchDashboardGoalsTree()` API function
- `dashboard/src/config/navigation.ts` — "goals" section in workspace surface
- `dashboard/src/components/work.ts` — wire GoalTree into Work tab routing
- `dashboard/src/tab-refresh.ts` — trigger goals refresh on section visit

## Test plan
- [ ] `dune build --root .` passes (verified locally)
- [ ] TypeScript `tsc --noEmit` passes (verified locally)
- [ ] Navigate to dashboard > 작업 > 목표 트리 — tree renders with goals
- [ ] Expand/collapse nodes; verify convergence bars reflect task completion
- [ ] Empty state shown when no goals registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)