### PR TITLE
refactor: SSOT batch 4 — internal timers and TTLs centralized

### DIFF
--- a/lib/cancellation.ml
+++ b/lib/cancellation.ml
@@ -24,7 +24,7 @@ module TokenStore = struct
   let tokens : (string, token) Hashtbl.t = Hashtbl.create 64
   let lock : Eio.Mutex.t option ref = ref None
   let last_cleanup : float ref = ref 0.0
-  let cleanup_interval = 300.0  (* 5 minutes *)
+  let cleanup_interval = Env_config.InternalTimers.cancellation_cleanup_sec
 
   (** Initialize the token store with Eio mutex. Call once at server startup. *)
   let init () : unit =

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -497,4 +497,47 @@ module Dashboard = struct
     get_float ~default:0.50 "MASC_DASHBOARD_CTX_COMPACTING"
 end
 
+(** {1 Internal Timers and TTLs}
+
+    Internal cache/GC/flush intervals. Low operational impact but
+    centralized here to eliminate scattered magic 300.0/3600.0 literals. *)
+
+module InternalTimers = struct
+  (** Tool metrics flush interval (seconds). Default: 300 (5 min). *)
+  let metrics_flush_sec =
+    get_float ~default:300.0 "MASC_METRICS_FLUSH_SEC"
+
+  (** Team session live turn window (seconds). Default: 300 (5 min). *)
+  let session_live_turn_window_sec =
+    get_float ~default:300.0 "MASC_SESSION_LIVE_TURN_WINDOW_SEC"
+
+  (** Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). *)
+  let label_quiet_threshold_sec =
+    get_float ~default:300.0 "MASC_LABEL_QUIET_THRESHOLD_SEC"
+
+  (** Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). *)
+  let briefing_cache_ttl_sec =
+    get_float ~default:300.0 "MASC_BRIEFING_CACHE_TTL_SEC"
+
+  (** Keeper world observation bootstrap window (seconds). Default: 300 (5 min). *)
+  let bootstrap_window_sec =
+    get_float ~default:300.0 "MASC_KEEPER_BOOTSTRAP_WINDOW_SEC"
+
+  (** SSE buffer TTL (seconds). Default: 300 (5 min). *)
+  let sse_buffer_ttl_sec =
+    get_float ~default:300.0 "MASC_SSE_BUFFER_TTL_SEC"
+
+  (** Cancellation token cleanup interval (seconds). Default: 300 (5 min). *)
+  let cancellation_cleanup_sec =
+    get_float ~default:300.0 "MASC_CANCELLATION_CLEANUP_SEC"
+
+  (** Provider run finished TTL (seconds). Default: 3600 (1 hour). *)
+  let provider_run_ttl_sec =
+    get_float ~default:3600.0 "MASC_PROVIDER_RUN_TTL_SEC"
+
+  (** Operator digest stalled session threshold (seconds). Default: 300 (5 min). *)
+  let stalled_session_threshold_sec =
+    get_float ~default:300.0 "MASC_STALLED_SESSION_THRESHOLD_SEC"
+end
+
 (** {1 Internal Safety Configuration} *)

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -62,7 +62,7 @@ let format_elapsed now timestamp fallback =
 let stuck_threshold_sec = 900.0 (* 15 minutes *)
 
 (** Threshold in seconds for "quiet" warning *)
-let quiet_threshold_sec = 300.0 (* 5 minutes *)
+let quiet_threshold_sec = Env_config.InternalTimers.label_quiet_threshold_sec
 
 (** Translate agent status + elapsed time into operator-readable description. *)
 let translate_agent_status ~(now : float) (status : Types.agent_status)

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -7,7 +7,7 @@
 
 open Briefing_json_helpers
 
-let cache_ttl_sec = 300.0
+let cache_ttl_sec = Env_config.InternalTimers.briefing_cache_ttl_sec
 
 let mission_briefing_surface_contract_json =
   `Assoc

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -36,7 +36,7 @@ type run_record = {
 
 let provider_runs : (string, run_record) Hashtbl.t = Hashtbl.create 32
 let provider_runs_mutex = Eio.Mutex.create ()
-let finished_run_ttl_seconds = 3600.0
+let finished_run_ttl_seconds = Env_config.InternalTimers.provider_run_ttl_sec
 let max_finished_runs = 128
 
 let trim_nonempty value =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -296,7 +296,7 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
       if trimmed = "" then "No continuity snapshot available." else trimmed
 
 (** Board event cursor bootstrap window (seconds). *)
-let bootstrap_window_sec = 300.0
+let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
 
 let is_self_author ~self_tokens (author : string) : bool =
   List.mem (String.lowercase_ascii (String.trim author)) self_tokens

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -76,7 +76,7 @@ type session_digest = {
   risk_digest : Yojson.Safe.t;
 }
 
-let stalled_session_threshold_sec = 300.0
+let stalled_session_threshold_sec = Env_config.InternalTimers.stalled_session_threshold_sec
 let planned_worker_turn_grace_sec = 180.0
 let room_digest_session_limit = 10
 

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -172,7 +172,7 @@ let event_counter = Atomic.make 0
 
 (** Event buffer for resumability - stores (event_id, event_string, timestamp) *)
 let max_buffer_size = 100
-let buffer_ttl_seconds = 300.0
+let buffer_ttl_seconds = Env_config.InternalTimers.sse_buffer_ttl_sec
 let event_buffer : (int * string * float) Queue.t = Queue.create ()
 
 (** Add event to buffer, maintaining max size *)

--- a/lib/swarm_status/swarm_status_types.ml
+++ b/lib/swarm_status/swarm_status_types.ml
@@ -124,8 +124,12 @@ type session_info = {
     300s (5 min): A typical tool-call round trip (LLM inference 10-20s + tool
     execution 5-30s + network latency) completes within 1-2 minutes. 5 minutes
     accommodates 2-3 consecutive round trips without false "stalled" signals.
-    If no event occurs within this window, the lane transitions to "waiting". *)
-let moving_window_sec = 300.0
+    If no event occurs within this window, the lane transitions to "waiting".
+    Self-contained config (masc_swarm_status is below masc_config). *)
+let moving_window_sec =
+  match Sys.getenv_opt "MASC_SWARM_MOVING_WINDOW_SEC" with
+  | Some s -> (try Float.max 30.0 (float_of_string s) with _ -> 300.0)
+  | None -> 300.0
 
 (** Time window for "stalled" (no activity, likely stuck) status.
     900s (15 min) = 3x moving_window. The 1:3 ratio mirrors common

--- a/lib/team_session/team_session_engine_helpers.ml
+++ b/lib/team_session/team_session_engine_helpers.ml
@@ -49,7 +49,7 @@ let room_active_agent_names (config : Room.config) =
   |> Team_session_types.dedup_strings
   |> List.sort String.compare
 
-let session_live_turn_window_sec = 300.0
+let session_live_turn_window_sec = Env_config.InternalTimers.session_live_turn_window_sec
 
 let event_type_of_json json =
   match Yojson.Safe.Util.member "event_type" json with

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -11,7 +11,7 @@
 
     @since 2.108.0 — Issue #3280 *)
 
-let flush_interval_s = 300.0 (* 5 minutes *)
+let flush_interval_s = Env_config.InternalTimers.metrics_flush_sec
 
 (* ── JSONL record format ────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

Final SSOT batch. Centralizes all remaining hardcoded 300.0/3600.0 internal timer constants into `Env_config.InternalTimers` module (9 new env vars) + 1 self-contained in swarm_status.

Refs #5067

## Product impact

None — default values unchanged. Only adds env var override capability for operational tuning.

## Evidence

`rg "let .* = 300\.0\|let .* = 3600\.0" lib/ --type ocaml | grep -v env_config` returns 0 matches after this PR.

## Files (11)

| Module | Old Value | New SSOT |
|--------|-----------|----------|
| `tool_metrics_persist` | 300.0 | `MASC_METRICS_FLUSH_SEC` |
| `team_session_engine_helpers` | 300.0 | `MASC_SESSION_LIVE_TURN_WINDOW_SEC` |
| `dashboard_labels` | 300.0 | `MASC_LABEL_QUIET_THRESHOLD_SEC` |
| `dashboard_mission_briefing` | 300.0 | `MASC_BRIEFING_CACHE_TTL_SEC` |
| `keeper_world_observation` | 300.0 | `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` |
| `sse` | 300.0 | `MASC_SSE_BUFFER_TTL_SEC` |
| `cancellation` | 300.0 | `MASC_CANCELLATION_CLEANUP_SEC` |
| `dashboard_provider_runs` | 3600.0 | `MASC_PROVIDER_RUN_TTL_SEC` |
| `operator_digest_types` | 300.0 | `MASC_STALLED_SESSION_THRESHOLD_SEC` |
| `swarm_status_types` | 300.0 | `MASC_SWARM_MOVING_WINDOW_SEC` (self-contained) |

## Review evidence

- `dune build` passes (type safety verified)
- No behavioral change (all defaults match original literals)

## Linked issue

Refs #5067 (spawn.ml Gemini pricing boundary violation — separate concern)

## Test plan

- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)