### PR TITLE
fix(boundary): remove hardcoded Gemini pricing from spawn parser

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -139,18 +139,7 @@ let parse_gemini_output raw =
     let cached_tokens =
       match from_usage "cachedContentTokenCount" with
       | Some _ as v -> v | None -> from_stats_first ["cached"] in
-    let cost_usd =
-      match input_tokens, output_tokens, cached_tokens with
-      | Some inp, Some out, Some cached ->
-          let uncached = inp - cached in
-          Some (float_of_int uncached *. 0.00015 /. 1000.0
-                +. float_of_int cached *. 0.000015 /. 1000.0
-                +. float_of_int out *. 0.0006 /. 1000.0)
-      | Some inp, Some out, None ->
-          Some (float_of_int inp *. 0.00015 /. 1000.0
-                +. float_of_int out *. 0.0006 /. 1000.0)
-      | _ -> None
-    in
+    let cost_usd = Safe_ops.json_float_opt "total_cost_usd" json in
     { text = response_text; input_tokens; output_tokens;
       cache_creation_tokens = None; cache_read_tokens = cached_tokens; cost_usd }
   with Yojson.Json_error _ ->

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -447,7 +447,8 @@ let test_parse_gemini_output_with_cache () =
   check (option int) "input" (Some 100) p.input_tokens;
   check (option int) "output" (Some 50) p.output_tokens;
   check (option int) "cached" (Some 80) p.cache_read_tokens;
-  check bool "has cost" true (Option.is_some p.cost_usd)
+  (* cost_usd now requires explicit total_cost_usd in JSON; no hardcoded pricing *)
+  check bool "no cost without total_cost_usd" true (p.cost_usd = None)
 
 let test_parse_gemini_output_cli_json () =
   let json = {|
@@ -465,7 +466,8 @@ let test_parse_gemini_output_cli_json () =
   check (option int) "input" (Some 15769) p.input_tokens;
   check (option int) "output" (Some 85) p.output_tokens;
   check (option int) "cached" None p.cache_read_tokens;
-  check bool "has cost" true (Option.is_some p.cost_usd)
+  (* cost_usd now requires explicit total_cost_usd in JSON; no hardcoded pricing *)
+  check bool "no cost without total_cost_usd" true (p.cost_usd = None)
 
 let test_parse_gemini_output_invalid () =
   let p = Spawn.parse_gemini_output "invalid" in


### PR DESCRIPTION
## Summary
- `parse_gemini_output`에서 하드코딩된 Gemini 토큰 가격(input/cached/output) 제거
- provider 응답의 `total_cost_usd` 필드를 직접 사용, 없으면 `None`
- MASC model-agnostic 원칙 준수 — cascade가 provider를 추상화

## Changes
- `lib/spawn.ml`: -12 lines (하드코딩 가격 계산), +1 line (`Safe_ops.json_float_opt`)

## Test plan
- [ ] `dune build` 컴파일 확인
- [ ] 기존 spawn 테스트 통과
- [ ] Gemini spawn 시 `cost_usd` 가 `None` 또는 provider 리턴값인지 확인

Closes #5067