### PR TITLE
feat(goal): keeper convergence detection + CreateTask/CreateIssue actions

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -255,6 +255,7 @@
    goal_guard
    goal_orchestrator
    goal_scheduler
+   convergence
    swarm
    swarm_goal_loop
    worker_run_evidence_summary

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -1,0 +1,76 @@
+(** Convergence detection for goal-driven task execution.
+
+    Pure deterministic logic — no Eio, no LLM calls.
+    Evaluates whether a goal's associated tasks have reached
+    a terminal state or progress has stalled. *)
+
+type convergence_signal =
+  | MetricMet of { metric : string; value : float; threshold : float }
+  | AllSubTasksDone of { completed : int; total : int }
+  | StagnationDetected of { iterations_without_progress : int }
+
+let convergence_signal_to_yojson = function
+  | MetricMet { metric; value; threshold } ->
+      `Assoc
+        [
+          ("type", `String "metric_met");
+          ("metric", `String metric);
+          ("value", `Float value);
+          ("threshold", `Float threshold);
+        ]
+  | AllSubTasksDone { completed; total } ->
+      `Assoc
+        [
+          ("type", `String "all_sub_tasks_done");
+          ("completed", `Int completed);
+          ("total", `Int total);
+        ]
+  | StagnationDetected { iterations_without_progress } ->
+      `Assoc
+        [
+          ("type", `String "stagnation_detected");
+          ("iterations_without_progress", `Int iterations_without_progress);
+        ]
+
+(** A task belongs to a goal when its title contains the goal tag [goal:<id>]. *)
+let task_matches_goal ~goal_id (task : Types.task) =
+  let tag = Printf.sprintf "[goal:%s]" goal_id in
+  let title_lower = String.lowercase_ascii task.title in
+  let tag_lower = String.lowercase_ascii tag in
+  (* Simple substring search *)
+  let tag_len = String.length tag_lower in
+  let title_len = String.length title_lower in
+  if tag_len > title_len then false
+  else
+    let found = ref false in
+    for i = 0 to title_len - tag_len do
+      if not !found then
+        if String.sub title_lower i tag_len = tag_lower then found := true
+    done;
+    !found
+
+(** A task is in a terminal state (completed or cancelled). *)
+let is_terminal (task : Types.task) =
+  match task.task_status with
+  | Types.Done _ | Types.Cancelled _ -> true
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> false
+
+(** A task counts as completed (not merely cancelled). *)
+let is_completed (task : Types.task) =
+  match task.task_status with
+  | Types.Done _ -> true
+  | _ -> false
+
+let check_convergence ~goal_id ~tasks ?(stagnation_threshold = 5)
+    ~iterations_without_progress () =
+  let goal_tasks = List.filter (task_matches_goal ~goal_id) tasks in
+  let total = List.length goal_tasks in
+  if total = 0 then None
+  else
+    let completed = List.length (List.filter is_completed goal_tasks) in
+    let all_terminal = List.for_all is_terminal goal_tasks in
+    if all_terminal && completed = total then
+      Some (AllSubTasksDone { completed; total })
+    else if iterations_without_progress >= stagnation_threshold then
+      Some (StagnationDetected { iterations_without_progress })
+    else None

--- a/lib/goal/convergence.mli
+++ b/lib/goal/convergence.mli
@@ -1,0 +1,33 @@
+(** Convergence detection for goal-driven task execution.
+
+    Pure deterministic logic with no Eio dependency. Evaluates whether
+    a goal's associated tasks have reached a terminal state. *)
+
+(** Signal emitted when convergence is detected or progress has stalled. *)
+type convergence_signal =
+  | MetricMet of { metric : string; value : float; threshold : float }
+  | AllSubTasksDone of { completed : int; total : int }
+  | StagnationDetected of { iterations_without_progress : int }
+
+(** Serialize a convergence signal to JSON. *)
+val convergence_signal_to_yojson : convergence_signal -> Yojson.Safe.t
+
+(** Check whether a goal's tasks have converged.
+
+    Returns [Some signal] when convergence or stagnation is detected,
+    [None] when work is still in progress.
+
+    @param goal_id  The goal whose tasks to evaluate.
+    @param tasks    All tasks in the room (filtered internally by goal_id prefix in title).
+    @param stagnation_threshold  Number of iterations without progress before
+                                 emitting [StagnationDetected]. Defaults to [5].
+    @param iterations_without_progress  Current count of iterations with no task
+                                        completions. Caller is responsible for
+                                        tracking this across invocations. *)
+val check_convergence :
+  goal_id:string ->
+  tasks:Types.task list ->
+  ?stagnation_threshold:int ->
+  iterations_without_progress:int ->
+  unit ->
+  convergence_signal option

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -48,6 +48,8 @@ type deliberation_action =
   | ProposeSpawn of { topic: string; reason: string }
   | StartDiscussion of { topic: string; context: string }
   | ShareFinding of { finding: string; source: string }
+  | CreateTask of { title: string; description: string; priority: int }
+  | CreateIssue of { title: string; body: string; labels: string list }
   | MultiStep of deliberation_action list
 
 let rec deliberation_action_to_string = function
@@ -61,6 +63,8 @@ let rec deliberation_action_to_string = function
   | ProposeSpawn _ -> "propose_spawn"
   | StartDiscussion { topic; _ } -> "start_discussion:" ^ topic
   | ShareFinding { finding; _ } -> "share_finding:" ^ finding
+  | CreateTask { title; _ } -> "create_task:" ^ title
+  | CreateIssue { title; _ } -> "create_issue:" ^ title
   | MultiStep actions ->
       "multi_step:["
       ^ String.concat "," (List.map deliberation_action_to_string actions)
@@ -78,6 +82,8 @@ let deliberation_action_to_policy_label = function
   | ProposeSpawn _ -> "propose_spawn"
   | StartDiscussion _ -> "start_discussion"
   | ShareFinding _ -> "share_finding"
+  | CreateTask _ -> "create_task"
+  | CreateIssue _ -> "create_issue"
   | MultiStep _ -> "multi_step"
 
 let rec deliberation_action_to_json = function
@@ -143,6 +149,22 @@ let rec deliberation_action_to_json = function
           ("type", `String "share_finding");
           ("finding", `String finding);
           ("source", `String source);
+        ]
+  | CreateTask { title; description; priority } ->
+      `Assoc
+        [
+          ("type", `String "create_task");
+          ("title", `String title);
+          ("description", `String description);
+          ("priority", `Int priority);
+        ]
+  | CreateIssue { title; body; labels } ->
+      `Assoc
+        [
+          ("type", `String "create_issue");
+          ("title", `String title);
+          ("body", `String body);
+          ("labels", `List (List.map (fun l -> `String l) labels));
         ]
   | MultiStep actions ->
       `Assoc
@@ -459,6 +481,14 @@ let rec legality_error (obs : world_observation) = function
   | ShareFinding _ ->
       if has_board_signal obs || obs.active_goal_count > 0 then None
       else Some "share_finding requires board activity or active goals"
+  | CreateTask _ ->
+      if obs.active_goal_count > 0 || obs.failed_task_count > 0
+         || has_operational_signal obs then None
+      else Some "create_task requires active goals, failed tasks, or an operational signal"
+  | CreateIssue _ ->
+      if obs.active_goal_count > 0 || obs.failed_task_count > 0
+         || has_operational_signal obs then None
+      else Some "create_issue requires active goals, failed tasks, or an operational signal"
   | MultiStep actions -> (
       match actions with
       | [] -> Some "multi_step requires non-empty steps"
@@ -612,6 +642,18 @@ let rec parse_action_from_json (json : Yojson.Safe.t)
       let reason = Safe_ops.json_string ~default:"" "reason" params in
       if topic = "" then Error "propose_spawn requires non-empty topic"
       else Ok (ProposeSpawn { topic; reason })
+  | "create_task" ->
+      let title = Safe_ops.json_string ~default:"" "title" params in
+      let description = Safe_ops.json_string ~default:"" "description" params in
+      let priority = Safe_ops.json_int ~default:3 "priority" params in
+      if title = "" then Error "create_task requires non-empty title"
+      else Ok (CreateTask { title; description; priority })
+  | "create_issue" ->
+      let title = Safe_ops.json_string ~default:"" "title" params in
+      let body = Safe_ops.json_string ~default:"" "body" params in
+      let labels = Safe_ops.json_string_list "labels" params in
+      if title = "" then Error "create_issue requires non-empty title"
+      else Ok (CreateIssue { title; body; labels })
   | "multi_step" -> (
       let steps_json =
         match params with
@@ -690,7 +732,7 @@ let structured_result_schema : structured_result Agent_sdk.Structured.schema =
       [
         {
           Agent_sdk.Types.name = "action";
-          description = "One of: noop, reply_in_room, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
+          description = "One of: noop, reply_in_room, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, create_task, create_issue, multi_step.";
           param_type = Agent_sdk.Types.String;
           required = true;
         };

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -32,6 +32,8 @@ type deliberation_action =
   | ProposeSpawn of { topic: string; reason: string }
   | StartDiscussion of { topic: string; context: string }
   | ShareFinding of { finding: string; source: string }
+  | CreateTask of { title: string; description: string; priority: int }
+  | CreateIssue of { title: string; body: string; labels: string list }
   | MultiStep of deliberation_action list
 
 val deliberation_action_to_string : deliberation_action -> string


### PR DESCRIPTION
## Summary
- Add `lib/goal/convergence.ml` + `.mli`: deterministic convergence detection for goal-driven task execution (AllSubTasksDone, StagnationDetected, MetricMet signals)
- Extend `keeper_deliberation.ml` with `CreateTask` and `CreateIssue` action types (variant, JSON serialization, parsing, legality, schema)
- Register `convergence` module in `lib/dune`

## Details

### Convergence module
Pure logic, no Eio dependency. Matches tasks to goals via `[goal:<id>]` title tag prefix (same convention as `goal_orchestrator.ml`). Three signal types:
- `AllSubTasksDone` — all goal-tagged tasks reached Done status
- `StagnationDetected` — caller-tracked iteration count exceeds threshold (default 5)
- `MetricMet` — placeholder for external metric integration

### Keeper deliberation extension
- `CreateTask { title; description; priority }` — create a new MASC task
- `CreateIssue { title; body; labels }` — create a GitHub issue for research needs
- Both actions require active goals, failed tasks, or operational signals (legality check)
- JSON parsing validates required fields (empty title rejected)

## Test plan
- [ ] `dune build --root .` passes (verified locally)
- [ ] `dune build @check --root .` passes (verified locally)
- [ ] Unit tests for convergence signal detection
- [ ] Unit tests for CreateTask/CreateIssue JSON round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)