### PR TITLE
fix(logging): include error detail in OAS worker CDAL proof logs

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -345,13 +345,16 @@ let run
           stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit };
         }
     | Error err ->
+      let detail = Oas.Error.to_string err in
       (match proof with
        | Some p ->
-         Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s"
+         Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s error=%s"
            p.run_id
            (proof_result_status_to_string p.result_status)
-       | None -> ());
-      Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
+           detail
+       | None ->
+         Log.Misc.warn "oas_worker: agent errored (no proof): %s" detail);
+      Error (Printf.sprintf "Agent run failed: %s" detail))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -552,10 +552,12 @@ and run_existing_worker_agent
           (match proof with
            | Some p ->
              Log.LocalWorker.warn
-               "worker %s errored with CDAL proof: run_id=%s status=%s (proof persisted by Proof_store)"
+               "worker %s errored with CDAL proof: run_id=%s status=%s error=%s"
                worker_name p.run_id
                (proof_result_status_to_string p.result_status)
-           | None -> ());
+               detail
+           | None ->
+             Log.LocalWorker.warn "worker %s errored (no proof): %s" worker_name detail);
           let* () =
             Worker_container.append_worker_completion_log
               ~base_path ~team_session_id ~worker_name ~prompt ~tool_names


### PR DESCRIPTION
## Summary
- `oas_worker_exec.ml`: CDAL proof 에러 시 `error=` 필드 추가, proof 없는 에러도 로깅
- `worker_oas.ml`: 동일 패턴 적용

이전에는 run_id와 status만 로깅되어 디버깅이 불가했음.

## Changes
- 2 files, +10/-5

## Test plan
- [ ] `dune build` 컴파일 확인
- [ ] OAS worker 에러 발생 시 로그에 상세 메시지 포함 확인

Refs #5069