### PR TITLE
refactor: SSOT batch 5 — remaining heuristic magic numbers

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -9,6 +9,14 @@
     - File_context: Recently modified files in working directory
 *)
 
+(** {1 Relevance scoring constants} *)
+
+let cache_default_relevance = 0.5
+let broadcast_relevance_cap = 0.8
+let file_base_relevance = 0.4
+let file_recency_weight = 0.3
+let file_name_match_bonus = 0.3
+
 (** {1 String Helpers} *)
 
 let string_contains = Dashboard_utils.string_contains
@@ -91,7 +99,7 @@ let fetch_from_cache (room_config : Room_utils.config) ~(config : recall_config)
     {
       source = Masc_cache;
       content = entry.value;
-      relevance = 0.5;  (* Default relevance, could be improved with query matching *)
+      relevance = cache_default_relevance;
       metadata = `Assoc [
         ("key", `String entry.key);
         ("tags", `List (List.map (fun t -> `String t) entry.tags));
@@ -112,7 +120,7 @@ let fetch_from_broadcasts (room_config : Room_utils.config) ~(config : recall_co
     {
       source = Recent_broadcasts;
       content = Printf.sprintf "[%s] %s" msg.from_agent msg.content;
-      relevance = relevance *. 0.8;  (* Cap at 0.8 for broadcasts *)
+      relevance = relevance *. broadcast_relevance_cap;
       metadata = `Assoc [
         ("seq", `Int msg.seq);
         ("from", `String msg.from_agent);
@@ -194,12 +202,12 @@ let fetch_from_file_context (room_config : Room_utils.config) ~config:(_config :
   let calc_relevance path content i =
     let name_lower = String.lowercase_ascii (Filename.basename path) in
     let content_lower = String.lowercase_ascii content in
-    let name_match = if query <> "" && String.length query > 2 && 
+    let name_match = if query <> "" && String.length query > 2 &&
                         (string_contains ~needle:query_lower name_lower ||
-                         string_contains ~needle:query_lower content_lower) 
-                     then 0.3 else 0.0 in
+                         string_contains ~needle:query_lower content_lower)
+                     then file_name_match_bonus else 0.0 in
     let recency = 1.0 -. (float_of_int i /. float_of_int (max 1 (List.length files))) in
-    min 1.0 (0.4 +. (recency *. 0.3) +. name_match)
+    min 1.0 (file_base_relevance +. (recency *. file_recency_weight) +. name_match)
   in
   
   List.filter_map (fun path ->

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -12,6 +12,10 @@
     Storage: .masc/cache/
 *)
 
+(** Eviction sample threshold: if >50% of sampled entries are expired,
+    run a full eviction pass. *)
+let eviction_sample_threshold = 0.5
+
 (** Cache entry *)
 type cache_entry = {
   key: string;
@@ -184,7 +188,7 @@ let maybe_evict_expired config =
               | _ -> acc
         ) 0 sample in
         let ratio = float_of_int expired_count /. float_of_int sample_size in
-        if ratio > 0.5 then
+        if ratio > eviction_sample_threshold then
           evict_expired config
         else
           0

--- a/lib/command_plane/cp_microarch_summary.ml
+++ b/lib/command_plane/cp_microarch_summary.ml
@@ -1,5 +1,12 @@
 module U = Yojson.Safe.Util
 
+(** Signal classification thresholds for microarch health tones. *)
+let rework_bad = 0.4
+let rework_warn = 0.2
+let scope_drift_bad = 0.5
+let scope_drift_warn = 0.25
+let spec_commit_warn = 0.5
+
 type search_row = {
   strategy : string;
   readiness : string;
@@ -253,19 +260,19 @@ let signals_json ~(pipeline : Yojson.Safe.t) ~(cache : Yojson.Safe.t)
       ("count", `Int verification_gate_failures);
     ]);
     ("rework_rate", `Assoc [
-      ("tone", `String (if rework_rate >= 0.4 then "bad" else if rework_rate >= 0.2 then "warn" else "ok"));
+      ("tone", `String (if rework_rate >= rework_bad then "bad" else if rework_rate >= rework_warn then "warn" else "ok"));
       ("value", `Float rework_rate);
     ]);
     ("artifact_scope_drift", `Assoc [
       ("tone", `String (if artifact_scope_active = 0 then "ok"  (* no tasks use artifact scopes = feature dormant *)
-                        else if artifact_scope_drift >= 0.5 then "bad"
-                        else if artifact_scope_drift >= 0.25 then "warn"
+                        else if artifact_scope_drift >= scope_drift_bad then "bad"
+                        else if artifact_scope_drift >= scope_drift_warn then "warn"
                         else "ok"));
       ("value", `Float artifact_scope_drift);
       ("active", `Int artifact_scope_active);
     ]);
     ("speculative_posture", `Assoc [
-      ("tone", `String (if spec_active > 0 && spec_commit_rate < 0.5 then "warn" else "ok"));
+      ("tone", `String (if spec_active > 0 && spec_commit_rate < spec_commit_warn then "warn" else "ok"));
       ("active_sessions", `Int spec_active);
       ("commit_rate", `Float spec_commit_rate);
       ("total_speculations", U.member "total_speculations" speculative);

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -11,6 +11,9 @@
 
     @since 2.73.0 *)
 
+(** Cost warning ratio (80%% of budget). Standard capacity planning threshold. *)
+let eval_cost_warn_ratio = 0.8
+
 (* ================================================================ *)
 (* Configuration                                                     *)
 (* ================================================================ *)
@@ -336,7 +339,7 @@ let post_eval
      alerts at 80%%). Gives ~20%% remaining budget for the agent to wrap up
      gracefully rather than hitting a hard wall mid-operation. *)
   let new_cost = accumulated_cost +. cost in
-  let cost_warn_ratio = 0.8 in
+  let cost_warn_ratio = eval_cost_warn_ratio in
   let approaching_limit = new_cost >= config.max_cost_usd *. cost_warn_ratio in
   let should_warn = approaching_limit in
   let warning =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -10,6 +10,10 @@
 
     @since Phase 5 — Keeper Agent.run encapsulation *)
 
+(** BM25 confidence threshold below which tool selection falls back to
+    the full policy-allowed preset. *)
+let bm25_confidence_threshold = 0.5
+
 (** Structured prompt result from [build_turn_prompt] callback.
     [system_prompt] contains hard constraints (identity, policy guards,
     tool guidance, direct-reply mode) that must stay in the system prompt.
@@ -550,7 +554,7 @@ let run_turn
         List.filteri (fun i _ -> i < max_fallback_tools) merged
       else merged
   in
-  let confidence_threshold = 0.5 in
+  let confidence_threshold = bm25_confidence_threshold in
   (* Runtime tool overlay: external callers (masc_tool_grant/revoke)
      push Tool_op.t values here. The hook applies them each turn.
      If caller provides one, use it; otherwise create a local one. *)

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -3,6 +3,11 @@ open Yojson.Safe.Util
 
 open Result_syntax
 
+(** Exponential moving average weights for latency smoothing.
+    ema_decay + ema_alpha = 1.0. Higher decay = more weight to history. *)
+let ema_decay = 0.8
+let ema_alpha = 0.2
+
 type runtime = {
   id : string;
   base_url : string;
@@ -560,7 +565,7 @@ let release (lease : lease) ~success ?error ?latency_ms () =
                 Some
                   (match runtime.latency_ema_ms with
                    | None -> latency
-                   | Some previous -> (previous *. 0.8) +. (latency *. 0.2))
+                   | Some previous -> (previous *. ema_decay) +. (latency *. ema_alpha))
             | None -> runtime.latency_ema_ms
           in
           let failure_streak, cooldown_until, last_error, total_success,

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -8,6 +8,9 @@
 
 open Printf
 
+(** Confidence threshold for routing documents to library vs candidates. *)
+let library_confidence_threshold = 0.5
+
 (* String helper - check if sub is contained in s *)
 let string_contains ~sub s =
   let sub_len = String.length sub in
@@ -179,7 +182,7 @@ let handle_add ctx args =
       (false, sprintf "Invalid source. Must be one of: %s" (String.concat ", " valid_sources))
     else begin
       (* Determine destination based on confidence *)
-      let dest_dir = if confidence < 0.5 then candidates_dir () else library_root () in
+      let dest_dir = if confidence < library_confidence_threshold then candidates_dir () else library_root () in
       let date = Time_compat.now () |> Unix.localtime in
       let date_str = sprintf "%04d%02d%02d" (date.tm_year + 1900) (date.tm_mon + 1) date.tm_mday in
       let topic_slug = String.lowercase_ascii title


### PR DESCRIPTION
## Summary

Final sweep. Extracts all remaining heuristic magic numbers into named constants across 7 files.

Refs #5067

## Product impact

None — default values unchanged. Named constants improve readability and enable future Runtime_params registration.

## Evidence

All 7 files had bare inline literals (0.5, 0.8, 0.4, 0.3, 0.2, 0.25) used in heuristic scoring/routing. Now each has a named module-level constant.

## Changes

| Module | Constants Extracted |
|--------|--------------------|
| `auto_recall` | cache_default_relevance, broadcast_relevance_cap, file_base/recency/match |
| `local_runtime_pool` | ema_decay, ema_alpha |
| `cp_microarch_summary` | rework_bad/warn, scope_drift_bad/warn, spec_commit_warn |
| `keeper_agent_run` | bm25_confidence_threshold |
| `eval_gate` | eval_cost_warn_ratio |
| `tool_library` | library_confidence_threshold |
| `cache_eio` | eviction_sample_threshold |

## Review evidence

- `dune build` passes

## Linked issue

Refs #5067

## Test plan

- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)