### PR TITLE
fix(keeper): use discovered per-slot context for context_reducer

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -114,13 +114,22 @@ let handle_keeper_status ctx args : tool_result =
            | None -> None
            | Some cfg ->
              let pricing = Llm_provider.Pricing.pricing_for_model cfg.model_id in
-             let provider_name = Llm_provider.Provider_config.(match cfg.kind with
-               | Anthropic -> "claude" | OpenAI_compat -> "openai"
-               | Gemini -> "gemini" | Glm -> "glm" | Claude_code -> "claude_code") in
+             (* Extract provider name from label directly to avoid
+                OpenAI_compat conflating llama/openrouter *)
+             let provider_name =
+               match String.index_opt label ':' with
+               | Some idx when idx > 0 ->
+                 String.sub label 0 idx |> String.trim |> String.lowercase_ascii
+               | _ ->
+                 Llm_provider.Provider_config.(match cfg.kind with
+                   | Anthropic -> "claude" | OpenAI_compat -> "openai"
+                   | Gemini -> "gemini" | Glm -> "glm" | Claude_code -> "claude_code")
+             in
              Some (`Assoc [
                ("provider", `String provider_name);
                ("model_id", `String cfg.model_id);
-               ("max_context", `Int cfg.max_tokens);
+               ("max_context", `Int (Oas_model_resolve.max_context_of_label label));
+               ("max_output_tokens", `Int cfg.max_tokens);
                ("api_key_env", if cfg.api_key <> "" then `String "(set)" else `Null);
                ("cost_per_million_input", `Float pricing.input_per_million);
                ("cost_per_million_output", `Float pricing.output_per_million);

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -19,20 +19,33 @@ let provider_name_of_label (label : string) : string option =
     if idx = 0 then None
     else Some (String.sub label 0 idx |> String.trim |> String.lowercase_ascii)
 
-(** Resolve max_context for a model label by looking up the OAS Provider_registry.
-    Falls back to 128_000 if the provider is unknown. *)
+(** Resolve max_context for a model label.
+    Prefers discovered per-slot context (from live /props probe) for local
+    providers, falls back to static Provider_registry value, then 128_000. *)
 let max_context_of_label (label : string) : int =
   match provider_name_of_label label with
   | None -> 128_000
   | Some pname ->
-    match Llm_provider.Provider_registry.find default_registry pname with
-    | Some entry -> entry.max_context
-    | None -> 128_000
+    (* For local providers, prefer discovered per-slot context *)
+    if pname = "llama" then
+      match Llm_provider.Provider_registry.discovered_max_context () with
+      | Some ctx -> ctx
+      | None ->
+        (match Llm_provider.Provider_registry.find default_registry pname with
+         | Some entry -> entry.max_context
+         | None -> 128_000)
+    else
+      match Llm_provider.Provider_registry.find default_registry pname with
+      | Some entry -> entry.max_context
+      | None -> 128_000
 
 (** Resolve max_context for the first available model in a label list.
     "Available" means the provider's API key env var is set (or not required).
+    Prefers discovered per-slot context for local providers.
     Falls back to 128_000 if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
+  (* Check discovered context first — applies to any local provider *)
+  let discovered = Llm_provider.Provider_registry.discovered_max_context () in
   let rec find = function
     | [] -> 128_000
     | label :: rest ->
@@ -42,7 +55,11 @@ let resolve_primary_max_context (labels : string list) : int =
         match Llm_provider.Provider_registry.find default_registry pname with
         | None -> find rest
         | Some entry ->
-          if entry.is_available () then entry.max_context
+          if entry.is_available () then
+            (* For local providers, prefer discovered context *)
+            if pname = "llama" then
+              Option.value ~default:entry.max_context discovered
+            else entry.max_context
           else find rest
   in
   find labels

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="8b7e4d90676273db85ea210d78340274062a33b2"
+readonly OAS_AGENT_SDK_SHA="1987273ecc7144c57017320276b81f3f493cb160"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.7"


### PR DESCRIPTION
## Summary

- `oas_model_resolve.resolve_primary_max_context`: llama:* provider일 때 `discovered_max_context()`를 우선 사용. Discovery가 /props에서 읽은 per-slot context (ctx_size/total_slots)를 반영.
- `keeper_status_detail`: `max_context` 필드가 실제 context window 표시 (기존: output limit 500 표시). provider 이름도 label에서 직접 추출 (기존: OpenAI_compat→"openai" 뭉개짐 수정).
- OAS pin bump: `discovered_max_context` API 포함 커밋.

### 근본 원인
OAS Discovery가 /props에서 ctx_size를 읽지만 context_reducer까지 값이 도달하지 않아서, 128K로 가정하고 실제 8K/32K 서버에 과대 요청 → keeper overflow stuck.

### 의존
- OAS PR: jeong-sik/oas#613 (머지 필요)

## Test plan
- [x] test_channel_gate: 13/13
- [x] test_gate_protocol: 16/16
- [x] `dune build --root .` 로컬 성공 (OAS pin 로컬)
- [ ] OAS #613 머지 후 CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)