### PR TITLE
refactor(keeper): deduplicate contains_ci via String_util

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -12,6 +12,7 @@ let contains_substring haystack needle =
     loop 0
 
 let contains_substring_ci haystack needle =
+  needle <> "" &&
   contains_substring
     (String.lowercase_ascii haystack)
     (String.lowercase_ascii needle)

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -10,3 +10,8 @@ let contains_substring haystack needle =
       else loop (idx + 1)
     in
     loop 0
+
+let contains_substring_ci haystack needle =
+  contains_substring
+    (String.lowercase_ascii haystack)
+    (String.lowercase_ascii needle)

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -6,4 +6,6 @@ val contains_substring : string -> string -> bool
     is empty. *)
 
 val contains_substring_ci : string -> string -> bool
-(** Case-insensitive version of [contains_substring]. *)
+(** Case-insensitive version of [contains_substring].
+    Returns [false] when [needle] is empty, matching the behavior
+    of the original per-module [contains_ci] helpers. *)

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -4,3 +4,6 @@ val contains_substring : string -> string -> bool
 (** [contains_substring haystack needle] returns [true] if [needle]
     appears anywhere inside [haystack].  Returns [true] when [needle]
     is empty. *)
+
+val contains_substring_ci : string -> string -> bool
+(** Case-insensitive version of [contains_substring]. *)

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -21,11 +21,7 @@ let merge_usage
        | Some x, None | None, Some x -> Some x
        | None, None -> None) }
 
-let contains_ci (haystack : string) (needle : string) : bool =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  if n = "" then false
-  else Re.execp (Re.str n |> Re.compile) h
+let contains_ci = String_util.contains_substring_ci
 
 let alert_retryable_error (msg : string) : bool =
   let text = String.lowercase_ascii (String.trim msg) in

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -4,13 +4,7 @@
 
 open Keeper_types
 
-(** Case-insensitive substring check. Local copy to break
-    Keeper_prompt -> Keeper_alerting -> Keeper_prompt cycle. *)
-let contains_ci (haystack : string) (needle : string) : bool =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  if n = "" then false
-  else Re.execp (Re.str n |> Re.compile) h
+let contains_ci = String_util.contains_substring_ci
 
 let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -24,11 +24,7 @@ type keeper_skill_route_resolution = {
   provenance: string;
 }
 
-let contains_ci (haystack : string) (needle : string) : bool =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  if n = "" then false
-  else Re.execp (Re.str n |> Re.compile) h
+let contains_ci = String_util.contains_substring_ci
 
 let keeper_skill_selection_mode () : keeper_skill_selection_mode =
   SkillSelectAgent


### PR DESCRIPTION
## Summary

- `String_util.contains_substring_ci` 추가 (case-insensitive substring 검색)
- keeper 3개 파일의 동일 로컬 `contains_ci` 구현 제거 → 공유 함수로 교체
- 매 호출마다 `Re.str needle |> Re.compile` → regex 없는 순수 문자열 검색

## Product impact

성능 개선 + 코드 중복 제거. 동작 변경 없음.

## Evidence

변경 전: `contains_ci` 3곳 복사, 각각 `Re.compile` 매 호출
변경 후: `String_util.contains_substring_ci` 1곳, regex 없음

## Test plan

- [ ] CI green (로컬 SDK 버전 불일치로 로컬 빌드 불가, CI에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)