### PR TITLE
fix(config): add multiline string support to TOML parser

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -29,8 +29,6 @@ mention_targets = ["sherlock", "log-analyzer"]
 
 # Proactive behavior
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30
 
 # Execution scope — controls what the keeper can modify.
 #   observe_only = read-only, no file writes (default for new keepers until #3886)

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -36,5 +36,3 @@ execution_scope = "workspace"
 allowed_paths = ["*"]
 
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -147,55 +147,124 @@ let parse_value (raw : string) : (toml_value, string) result =
       | None -> Error (Printf.sprintf "cannot parse value: %s" s)
   end
 
+let starts_with_triple_quote (s : string) : bool =
+  let t = String.trim s in
+  String.length t >= 3
+  && t.[0] = '"' && t.[1] = '"' && t.[2] = '"'
+
+let extract_after_triple_quote (s : string) : string =
+  let t = String.trim s in
+  String.sub t 3 (String.length t - 3)
+
 let parse_toml (content : string) : (toml_doc, string) result =
   let lines = String.split_on_char '\n' content in
   let current_table = ref "" in
   let acc = ref [] in
   let error = ref None in
   let line_num = ref 0 in
+  (* Multiline string accumulation state *)
+  let ml_key = ref "" in
+  let ml_buf = Buffer.create 256 in
+  let ml_active = ref false in
+  let emit_kv full_key v =
+    acc := (full_key, v) :: !acc
+  in
   List.iter (fun raw_line ->
     incr line_num;
     if Option.is_none !error then begin
-      let line = String.trim raw_line in
-      let line = strip_comment line in
-      if line = "" then ()
-      else if line.[0] = '[' then begin
-        (* Table header *)
-        let len = String.length line in
-        if line.[len - 1] <> ']' then
-          error := Some (Printf.sprintf "line %d: unterminated table header" !line_num)
-        else begin
-          let table_name =
-            String.sub line 1 (len - 2) |> String.trim
+      if !ml_active then begin
+        (* Inside a multiline basic string: accumulate until closing triple-quote *)
+        let trimmed = String.trim raw_line in
+        (* Check if this line contains the closing triple-quote *)
+        match String.index_opt trimmed '"' with
+        | Some _ when String.length trimmed >= 3 ->
+          (* Look for triple-quote anywhere in the line *)
+          let len = String.length raw_line in
+          let rec find_close i =
+            if i + 2 >= len then None
+            else if raw_line.[i] = '"' && raw_line.[i+1] = '"' && raw_line.[i+2] = '"' then
+              Some i
+            else find_close (i + 1)
           in
-          if table_name = "" then
-            error := Some (Printf.sprintf "line %d: empty table name" !line_num)
-          else
-            current_table := table_name
-        end
+          (match find_close 0 with
+           | Some pos ->
+             if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
+             Buffer.add_string ml_buf (String.sub raw_line 0 pos);
+             let value = Buffer.contents ml_buf in
+             emit_kv !ml_key (Toml_string value);
+             ml_active := false;
+             Buffer.clear ml_buf
+           | None ->
+             if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
+             Buffer.add_string ml_buf raw_line)
+        | _ ->
+          if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
+          Buffer.add_string ml_buf raw_line
       end
       else begin
-        (* key = value *)
-        match String.index_opt line '=' with
-        | None ->
-          error := Some (Printf.sprintf "line %d: expected key = value" !line_num)
-        | Some eq_pos ->
-          let key = String.sub line 0 eq_pos |> String.trim in
-          let value_raw = String.sub line (eq_pos + 1) (String.length line - eq_pos - 1) in
-          if key = "" then
-            error := Some (Printf.sprintf "line %d: empty key" !line_num)
-          else
-            let full_key =
-              if !current_table = "" then key
-              else !current_table ^ "." ^ key
+        let line = String.trim raw_line in
+        let line = strip_comment line in
+        if line = "" then ()
+        else if line.[0] = '[' then begin
+          (* Table header *)
+          let len = String.length line in
+          if line.[len - 1] <> ']' then
+            error := Some (Printf.sprintf "line %d: unterminated table header" !line_num)
+          else begin
+            let table_name =
+              String.sub line 1 (len - 2) |> String.trim
             in
-            match parse_value value_raw with
-            | Ok v -> acc := (full_key, v) :: !acc
-            | Error e ->
-              error := Some (Printf.sprintf "line %d: %s" !line_num e)
+            if table_name = "" then
+              error := Some (Printf.sprintf "line %d: empty table name" !line_num)
+            else
+              current_table := table_name
+          end
+        end
+        else begin
+          (* key = value *)
+          match String.index_opt line '=' with
+          | None ->
+            error := Some (Printf.sprintf "line %d: expected key = value" !line_num)
+          | Some eq_pos ->
+            let key = String.sub line 0 eq_pos |> String.trim in
+            let value_raw = String.sub line (eq_pos + 1) (String.length line - eq_pos - 1) in
+            if key = "" then
+              error := Some (Printf.sprintf "line %d: empty key" !line_num)
+            else
+              let full_key =
+                if !current_table = "" then key
+                else !current_table ^ "." ^ key
+              in
+              if starts_with_triple_quote value_raw then begin
+                (* Start multiline basic string *)
+                let after = extract_after_triple_quote value_raw in
+                (* Check if closing triple-quote is on the same line *)
+                let rec find_close_in s i =
+                  if i + 2 >= String.length s then None
+                  else if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"' then Some i
+                  else find_close_in s (i + 1)
+                in
+                match find_close_in after 0 with
+                | Some pos ->
+                  let value = String.sub after 0 pos in
+                  emit_kv full_key (Toml_string value)
+                | None ->
+                  ml_key := full_key;
+                  ml_active := true;
+                  Buffer.clear ml_buf;
+                  Buffer.add_string ml_buf after
+              end
+              else
+                match parse_value value_raw with
+                | Ok v -> emit_kv full_key v
+                | Error e ->
+                  error := Some (Printf.sprintf "line %d: %s" !line_num e)
+        end
       end
     end
   ) lines;
+  if !ml_active && Option.is_none !error then
+    error := Some (Printf.sprintf "unterminated multiline string for key '%s'" !ml_key);
   match !error with
   | Some e -> Error e
   | None -> Ok (List.rev !acc)

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -218,7 +218,7 @@ let parse_toml (content : string) : (toml_doc, string) result =
              let value = Buffer.contents ml_buf in
              (* Validate no unexpected content after closing triple-quote *)
              let trailing = String.sub line_cr (pos + 3) (len - pos - 3) |> String.trim in
-             if trailing <> "" && (String.length trailing = 0 || trailing.[0] <> '#') then
+             if trailing <> "" && trailing.[0] <> '#' then
                error := Some (Printf.sprintf "line %d: unexpected characters after closing multiline delimiter" !line_num)
              else begin
                emit_kv !ml_key (Toml_string value);
@@ -280,7 +280,7 @@ let parse_toml (content : string) : (toml_doc, string) result =
                   let value = String.sub after 0 pos in
                   let trailing_start = pos + 3 in
                   let trailing = String.sub after trailing_start (String.length after - trailing_start) |> String.trim in
-                  if trailing <> "" && (String.length trailing = 0 || trailing.[0] <> '#') then
+                  if trailing <> "" && trailing.[0] <> '#' then
                     error := Some (Printf.sprintf "line %d: unexpected characters after closing multiline delimiter" !line_num)
                   else
                     emit_kv full_key (Toml_string value)

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -156,6 +156,10 @@ let extract_after_triple_quote (s : string) : string =
   let t = String.trim s in
   String.sub t 3 (String.length t - 3)
 
+let strip_trailing_cr (s : string) : string =
+  let len = String.length s in
+  if len > 0 && s.[len - 1] = '\r' then String.sub s 0 (len - 1) else s
+
 let parse_toml (content : string) : (toml_doc, string) result =
   let lines = String.split_on_char '\n' content in
   let current_table = ref "" in
@@ -166,6 +170,7 @@ let parse_toml (content : string) : (toml_doc, string) result =
   let ml_key = ref "" in
   let ml_buf = Buffer.create 256 in
   let ml_active = ref false in
+  let ml_start_line = ref 0 in
   let emit_kv full_key v =
     acc := (full_key, v) :: !acc
   in
@@ -174,32 +179,39 @@ let parse_toml (content : string) : (toml_doc, string) result =
     if Option.is_none !error then begin
       if !ml_active then begin
         (* Inside a multiline basic string: accumulate until closing triple-quote *)
-        let trimmed = String.trim raw_line in
+        let line_cr = strip_trailing_cr raw_line in
+        let trimmed = String.trim line_cr in
         (* Check if this line contains the closing triple-quote *)
         match String.index_opt trimmed '"' with
         | Some _ when String.length trimmed >= 3 ->
           (* Look for triple-quote anywhere in the line *)
-          let len = String.length raw_line in
+          let len = String.length line_cr in
           let rec find_close i =
             if i + 2 >= len then None
-            else if raw_line.[i] = '"' && raw_line.[i+1] = '"' && raw_line.[i+2] = '"' then
+            else if line_cr.[i] = '"' && line_cr.[i+1] = '"' && line_cr.[i+2] = '"' then
               Some i
             else find_close (i + 1)
           in
           (match find_close 0 with
            | Some pos ->
              if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
-             Buffer.add_string ml_buf (String.sub raw_line 0 pos);
+             Buffer.add_string ml_buf (String.sub line_cr 0 pos);
              let value = Buffer.contents ml_buf in
-             emit_kv !ml_key (Toml_string value);
-             ml_active := false;
-             Buffer.clear ml_buf
+             (* Validate no unexpected content after closing triple-quote *)
+             let trailing = String.sub line_cr (pos + 3) (len - pos - 3) |> String.trim in
+             if trailing <> "" && (String.length trailing = 0 || trailing.[0] <> '#') then
+               error := Some (Printf.sprintf "line %d: unexpected characters after closing multiline delimiter" !line_num)
+             else begin
+               emit_kv !ml_key (Toml_string value);
+               ml_active := false;
+               Buffer.clear ml_buf
+             end
            | None ->
              if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
-             Buffer.add_string ml_buf raw_line)
+             Buffer.add_string ml_buf line_cr)
         | _ ->
           if Buffer.length ml_buf > 0 then Buffer.add_char ml_buf '\n';
-          Buffer.add_string ml_buf raw_line
+          Buffer.add_string ml_buf line_cr
       end
       else begin
         let line = String.trim raw_line in
@@ -247,10 +259,16 @@ let parse_toml (content : string) : (toml_doc, string) result =
                 match find_close_in after 0 with
                 | Some pos ->
                   let value = String.sub after 0 pos in
-                  emit_kv full_key (Toml_string value)
+                  let trailing_start = pos + 3 in
+                  let trailing = String.sub after trailing_start (String.length after - trailing_start) |> String.trim in
+                  if trailing <> "" && (String.length trailing = 0 || trailing.[0] <> '#') then
+                    error := Some (Printf.sprintf "line %d: unexpected characters after closing multiline delimiter" !line_num)
+                  else
+                    emit_kv full_key (Toml_string value)
                 | None ->
                   ml_key := full_key;
                   ml_active := true;
+                  ml_start_line := !line_num;
                   Buffer.clear ml_buf;
                   Buffer.add_string ml_buf after
               end
@@ -264,7 +282,7 @@ let parse_toml (content : string) : (toml_doc, string) result =
     end
   ) lines;
   if !ml_active && Option.is_none !error then
-    error := Some (Printf.sprintf "unterminated multiline string for key '%s'" !ml_key);
+    error := Some (Printf.sprintf "line %d: unterminated multiline string for key '%s'" !ml_start_line !ml_key);
   match !error with
   | Some e -> Error e
   | None -> Ok (List.rev !acc)

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -147,14 +147,31 @@ let parse_value (raw : string) : (toml_value, string) result =
       | None -> Error (Printf.sprintf "cannot parse value: %s" s)
   end
 
+let skip_leading_ws (s : string) : int =
+  let len = String.length s in
+  let rec aux i = if i < len && is_ws s.[i] then aux (i + 1) else i in
+  aux 0
+
 let starts_with_triple_quote (s : string) : bool =
-  let t = String.trim s in
-  String.length t >= 3
-  && t.[0] = '"' && t.[1] = '"' && t.[2] = '"'
+  let i = skip_leading_ws s in
+  let len = String.length s in
+  len >= i + 3 && s.[i] = '"' && s.[i + 1] = '"' && s.[i + 2] = '"'
 
 let extract_after_triple_quote (s : string) : string =
-  let t = String.trim s in
-  String.sub t 3 (String.length t - 3)
+  (* Skip whitespace before the opening triple-quote, then return everything
+     after the delimiter WITHOUT trimming -- preserves significant whitespace.
+     Known limitations:
+     - Escaped triple-quotes inside multiline strings are not supported;
+       they will be treated as the closing delimiter.
+     - strip_comment runs on the key=value line before triple-quote
+       detection, so a hash in the value portion of a same-line triple-quoted
+       string may be misinterpreted as a comment.  Multi-line form is
+       unaffected since the opening line typically has no content after
+       the delimiter. *)
+  let i = skip_leading_ws s in
+  let len = String.length s in
+  if i + 3 <= len then String.sub s (i + 3) (len - i - 3)
+  else ""
 
 let strip_trailing_cr (s : string) : string =
   let len = String.length s in
@@ -178,13 +195,15 @@ let parse_toml (content : string) : (toml_doc, string) result =
     incr line_num;
     if Option.is_none !error then begin
       if !ml_active then begin
-        (* Inside a multiline basic string: accumulate until closing triple-quote *)
+        (* Inside a multiline basic string: accumulate until closing
+           triple-quote delimiter.  find_close scans the untrimmed line_cr
+           so content whitespace is preserved.  trimmed is only used as a
+           fast-path skip when the line has no quote character at all. *)
         let line_cr = strip_trailing_cr raw_line in
         let trimmed = String.trim line_cr in
-        (* Check if this line contains the closing triple-quote *)
         match String.index_opt trimmed '"' with
         | Some _ when String.length trimmed >= 3 ->
-          (* Look for triple-quote anywhere in the line *)
+          (* Look for triple-quote anywhere in the untrimmed line *)
           let len = String.length line_cr in
           let rec find_close i =
             if i + 2 >= len then None

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -172,6 +172,38 @@ let test_parse_multiline_string_unterminated () =
     check bool "mentions unterminated" true (contains e "unterminated");
     check bool "includes line number" true (contains e "line")
 
+let test_parse_multiline_preserves_leading_whitespace () =
+  (* Content lines with leading whitespace must be preserved exactly *)
+  let input = "key = \"\"\"\n  indented line\n    double indented\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "preserves leading ws" "  indented line\n    double indented\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
+let test_parse_multiline_consecutive_empty_lines () =
+  let input = "key = \"\"\"\nfirst\n\n\nlast\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "consecutive empty lines" "first\n\n\nlast\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
+let test_parse_multiline_content_on_opening_line () =
+  (* Content starting on the same line as the opening delimiter *)
+  let input = "key = \"\"\"content starts here\nand continues\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "content on opening line" "content starts here\nand continues\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
 let test_parse_multiline_with_other_keys () =
   let input = "[sec]\na = \"before\"\nb = \"\"\"\nmulti\nline\n\"\"\"\nc = \"after\"" in
   match TL.parse_toml input with
@@ -585,6 +617,9 @@ let () =
           test_case "multiline string same line" `Quick test_parse_multiline_string_same_line;
           test_case "multiline string unterminated" `Quick test_parse_multiline_string_unterminated;
           test_case "multiline with other keys" `Quick test_parse_multiline_with_other_keys;
+          test_case "multiline preserves leading whitespace" `Quick test_parse_multiline_preserves_leading_whitespace;
+          test_case "multiline consecutive empty lines" `Quick test_parse_multiline_consecutive_empty_lines;
+          test_case "multiline content on opening line" `Quick test_parse_multiline_content_on_opening_line;
         ] );
       ( "profile_defaults",
         [

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -140,6 +140,48 @@ let test_parse_error_no_equals () =
   | Ok _ -> fail "expected parse error"
   | Error _ -> ()
 
+let test_parse_multiline_string () =
+  let input = "[keeper]\ngoal = \"test\"\ninstructions = \"\"\"\nYou are a helper.\n\nDo things.\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "keeper.instructions" doc with
+     | Some (TL.Toml_string s) ->
+       check string "multiline content" "You are a helper.\n\nDo things.\n" s
+     | _ -> fail "expected Toml_string for multiline")
+  | Error e -> fail e
+
+let test_parse_multiline_string_same_line () =
+  let input = {|key = """inline"""  |} in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) -> check string "inline multiline" "inline" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
+let test_parse_multiline_string_unterminated () =
+  let input = "key = \"\"\"\nunterminated content" in
+  match TL.parse_toml input with
+  | Ok _ -> fail "expected error for unterminated multiline"
+  | Error e ->
+    check bool "mentions unterminated" true
+      (String.length e > 0)
+
+let test_parse_multiline_with_other_keys () =
+  let input = "[sec]\na = \"before\"\nb = \"\"\"\nmulti\nline\n\"\"\"\nc = \"after\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "sec.a" doc with
+     | Some (TL.Toml_string s) -> check string "before" "before" s
+     | _ -> fail "expected sec.a");
+    (match List.assoc_opt "sec.b" doc with
+     | Some (TL.Toml_string s) -> check string "multiline" "multi\nline\n" s
+     | _ -> fail "expected sec.b");
+    (match List.assoc_opt "sec.c" doc with
+     | Some (TL.Toml_string s) -> check string "after" "after" s
+     | _ -> fail "expected sec.c")
+  | Error e -> fail e
+
 (* ================================================================ *)
 (* Profile defaults conversion tests                                 *)
 (* ================================================================ *)
@@ -534,6 +576,10 @@ let () =
           test_case "inline comment" `Quick test_parse_inline_comment;
           test_case "error: unterminated table" `Quick test_parse_error_unterminated_table;
           test_case "error: no equals" `Quick test_parse_error_no_equals;
+          test_case "multiline string" `Quick test_parse_multiline_string;
+          test_case "multiline string same line" `Quick test_parse_multiline_string_same_line;
+          test_case "multiline string unterminated" `Quick test_parse_multiline_string_unterminated;
+          test_case "multiline with other keys" `Quick test_parse_multiline_with_other_keys;
         ] );
       ( "profile_defaults",
         [

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -164,8 +164,13 @@ let test_parse_multiline_string_unterminated () =
   match TL.parse_toml input with
   | Ok _ -> fail "expected error for unterminated multiline"
   | Error e ->
-    check bool "mentions unterminated" true
-      (String.length e > 0)
+    let contains s sub =
+      try
+        let _ = Re.exec (Re.compile (Re.str sub)) s in true
+      with Not_found -> false
+    in
+    check bool "mentions unterminated" true (contains e "unterminated");
+    check bool "includes line number" true (contains e "line")
 
 let test_parse_multiline_with_other_keys () =
   let input = "[sec]\na = \"before\"\nb = \"\"\"\nmulti\nline\n\"\"\"\nc = \"after\"" in


### PR DESCRIPTION
## Summary

- TOML 파서에 triple-quote multiline string 지원 추가
- `janitor.toml`, `masc-improver.toml`의 `instructions` 필드가 매 keeper cycle마다 파싱 실패하던 문제 해결
- `example.toml`, `masc-improver.toml`에서 제거된 키(`presence_keepalive`, `presence_keepalive_sec`) 삭제
- TOML 파서 테스트 4개 추가 (multiline, same-line, unterminated, mixed keys)

## Root Cause

`parse_toml`은 줄 단위 파서로, triple-quote 시작을 빈 문자열로 파싱한 후 다음 줄을 `key = value`로 기대하여 에러 발생. 주석에는 "multiline" 지원이라고 명시되어 있었으나 실제 구현이 누락.

## Test Plan

- [x] `dune exec test/test_keeper_toml.exe` — 35 tests all passing
- [ ] CI green
- [ ] 서버 재시작 후 `toml_loader: skipping` WARN 소멸 확인

Closes #5068
