### PR TITLE
fix(keeper): distinguish shutdown fiber cleanup from real crashes

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -114,6 +114,12 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
       ~finally:(fun () ->
         Keeper_registry.cleanup_tracking ~base_path meta.name;
         if not !resolved then begin
+          if Shutdown.is_shutting_down_global () then begin
+            Log.Keeper.warn "%s: fiber unresolved during shutdown (not a crash)" meta.name;
+            Keeper_registry.set_state ~base_path meta.name
+              Keeper_registry.Dead;
+            resolve_done (`Crashed "shutdown")
+          end else begin
             let reason =
               Keeper_registry.failure_reason_to_string
                 Keeper_registry.Fiber_unresolved in
@@ -131,6 +137,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               Keeper_registry.Crashed;
             resolve_done (`Crashed reason);
             publish_lifecycle "crashed" meta.name reason
+          end
         end))
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -80,6 +80,12 @@ type hook = {
   action : unit -> unit;
 }
 
+(** Global shutdown flag — set to true when shutdown begins.
+    Readable from any module without passing [state]. *)
+let shutting_down_flag = Atomic.make false
+
+let is_shutting_down_global () = Atomic.get shutting_down_flag
+
 let hooks : hook list ref = ref []
 
 let register ~name ?(priority = 50) action =
@@ -153,6 +159,7 @@ let initiate state ~clock ~reason ~notify_fn ~drain_check ~exit_fn =
     Log.Server.warn "[Shutdown] already in progress (phase=%s), ignoring"
       (phase_to_string state.phase);
   end else begin
+    Atomic.set shutting_down_flag true;
     state.started_at <- Eio.Time.now clock;
     state.reason <- reason;
     Log.Server.info "[Shutdown] initiated: %s" reason;


### PR DESCRIPTION
## Summary
- Shutdown 시 keeper fiber cancel → `Fiber_unresolved` crash 기록 방지
- `Shutdown.is_shutting_down_global()` flag로 shutdown context 구분
- Shutdown 중: WARN 로그 + Dead 상태 (crash 기록/persistence 없음)
- Runtime crash: 기존 동작 유지 (ERROR + Crashed + persistence)

## Changes
- `lib/shutdown.ml`: `shutting_down_flag` atomic + `is_shutting_down_global()` 추가
- `lib/keeper/keeper_supervisor.ml`: `~finally` 블록에서 shutdown 체크

## Impact
매 서버 재시작마다 14 ERROR 로그 (7 keepers x crash+error) → 0으로 감소

## Test plan
- [ ] `dune build` 컴파일 확인
- [ ] 서버 재시작 후 keeper crash 로그 없음 확인
- [ ] runtime keeper crash 시 기존대로 ERROR 기록 확인

Closes #5077