### PR TITLE
fix(dashboard): increase namespace-truth warm timeout 5s→8s

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -57,7 +57,7 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
           float_of_env_default_with_legacy
             ~canonical:"MASC_DASHBOARD_NAMESPACE_TRUTH_TIMEOUT_S"
             ~legacy:"MASC_DASHBOARD_ROOM_TRUTH_TIMEOUT_S"
-            ~default:5.0 ~min_v:2.0 ~max_v:25.0
+            ~default:8.0 ~min_v:2.0 ~max_v:25.0
         in
         let cold_timeout_s =
           float_of_env_default_with_legacy


### PR DESCRIPTION
## Summary
- namespace-truth warm timeout default 5s→8s (61x/day timeout 감소)
- 1 file, 1 line 변경

## Test plan
- [ ] `dune build` 확인
- [ ] 서버 운영 후 namespace-truth timeout 빈도 감소 확인

Refs #5090