### PR TITLE
feat(boundary): RFC-0001 Gate A — det/nondet instrumentation

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -1,0 +1,124 @@
+(** Agent_stress -- RFC-0001 Phase 0.2 stress indicator recording.
+    See {!agent_stress.mli}. *)
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+type stress_kind =
+  | Failure_streak of int
+  | Fallback_approval
+  | Timeout
+  | Parse_degraded
+  | Task_released
+
+type event = {
+  agent_name : string;
+  room_id : string;
+  kind : stress_kind;
+  timestamp : float;
+}
+
+(* ================================================================ *)
+(* Serialization                                                    *)
+(* ================================================================ *)
+
+let stress_kind_to_json = function
+  | Failure_streak n ->
+    `Assoc [("type", `String "failure_streak"); ("count", `Int n)]
+  | Fallback_approval ->
+    `Assoc [("type", `String "fallback_approval")]
+  | Timeout ->
+    `Assoc [("type", `String "timeout")]
+  | Parse_degraded ->
+    `Assoc [("type", `String "parse_degraded")]
+  | Task_released ->
+    `Assoc [("type", `String "task_released")]
+
+let event_to_json (e : event) : Yojson.Safe.t =
+  `Assoc [
+    ("agent_name", `String e.agent_name);
+    ("room_id", `String e.room_id);
+    ("kind", stress_kind_to_json e.kind);
+    ("timestamp", `Float e.timestamp);
+  ]
+
+(* ================================================================ *)
+(* Storage (same pattern as Heuristic_metrics)                      *)
+(* ================================================================ *)
+
+let store_path_ref : string option ref = ref None
+let mu = Eio.Mutex.create ()
+let buffer : Yojson.Safe.t Queue.t = Queue.create ()
+let buffer_cap = 64
+
+let ensure_dir path =
+  let dir = Filename.dirname path in
+  if not (Sys.file_exists dir) then
+    (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+
+let do_flush () =
+  match !store_path_ref with
+  | None -> ()
+  | Some path ->
+    if Queue.is_empty buffer then ()
+    else begin
+      ensure_dir path;
+      let oc =
+        try open_out_gen [Open_append; Open_creat; Open_text] 0o644 path
+        with Sys_error msg ->
+          Log.warn ~ctx:"agent_stress" "cannot open %s: %s" path msg;
+          raise Exit
+      in
+      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+        Queue.iter (fun json ->
+          output_string oc (Yojson.Safe.to_string json);
+          output_char oc '\n'
+        ) buffer);
+      Queue.clear buffer
+    end
+
+let init ~base_path =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    match !store_path_ref with
+    | Some _ -> ()
+    | None ->
+      let masc_dir = Filename.concat base_path ".masc" in
+      let path = Filename.concat masc_dir "agent_stress.jsonl" in
+      store_path_ref := Some path)
+
+let record (e : event) =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    let json = event_to_json e in
+    Queue.add json buffer;
+    if Queue.length buffer >= buffer_cap then
+      (try do_flush () with Exit -> ()))
+
+let flush () =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    try do_flush () with Exit -> ())
+
+let recent n =
+  match !store_path_ref with
+  | None -> []
+  | Some path ->
+    if not (Sys.file_exists path) then []
+    else
+      match Safe_ops.read_file_safe path with
+      | Error _ -> []
+      | Ok content ->
+        let lines =
+          String.split_on_char '\n' content
+          |> List.filter (fun l -> String.length (String.trim l) > 0)
+        in
+        let total = List.length lines in
+        let to_skip = max 0 (total - n) in
+        let rec drop k = function
+          | [] -> []
+          | _ :: rest when k > 0 -> drop (k - 1) rest
+          | xs -> xs
+        in
+        drop to_skip lines
+        |> List.filter_map (fun line ->
+          try Some (Yojson.Safe.from_string line)
+          with Yojson.Json_error _ -> None)

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -1,0 +1,42 @@
+(** Agent_stress -- RFC-0001 Phase 0.2 stress indicator recording.
+
+    Tracks per-agent stress inputs: failure streaks, fallback approval ratios,
+    timeout frequency, and rehabilitation state.
+
+    Phase 0.2 records only.  No scheduling or keepalive integration (Gate D).
+
+    Thread-safe via {!Eio.Mutex}.
+
+    @since RFC-0001 Gate A *)
+
+(** Stress event kinds -- each maps to a measurable condition. *)
+type stress_kind =
+  | Failure_streak of int        (** consecutive failure count *)
+  | Fallback_approval            (** anti-rat or post-verifier fell back to approve *)
+  | Timeout                      (** OAS/LLM call timed out *)
+  | Parse_degraded               (** LLM response required fallback parsing *)
+  | Task_released                (** agent released a task (gave up) *)
+
+(** A single stress observation. *)
+type event = {
+  agent_name : string;
+  room_id : string;
+  kind : stress_kind;
+  timestamp : float;
+}
+
+val record : event -> unit
+(** Append a stress event.  Thread-safe.  No-op if not initialized. *)
+
+val init : base_path:string -> unit
+(** Initialize JSONL store under [base_path/.masc/agent_stress.jsonl].
+    Idempotent. *)
+
+val flush : unit -> unit
+(** Force flush pending writes. *)
+
+val recent : int -> Yojson.Safe.t list
+(** Read the N most recent events as JSON objects. *)
+
+val event_to_json : event -> Yojson.Safe.t
+(** Serialize an event for external consumption. *)

--- a/lib/dune
+++ b/lib/dune
@@ -386,6 +386,9 @@
    mention_inbox
    agent_reputation
    activity_feed
+   ;; RFC-0001 Gate A: Det/NonDet boundary instrumentation
+   heuristic_metrics
+   agent_stress
    transport
    transport_read_model
    transport_metrics

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -1,0 +1,134 @@
+(** Heuristic_metrics -- RFC-0001 Phase 0.1 instrumentation.
+    See {!heuristic_metrics.mli}. *)
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+type provenance =
+  | Post_verifier of string
+  | Thompson of string
+  | Drift_guard of string
+  | Anti_rationalization of string
+  | Agent_reputation of string
+
+type event = {
+  module_name : string;
+  site : string;
+  raw_value : float;
+  threshold : float;
+  triggered : bool;
+  provenance : provenance;
+  timestamp : float;
+}
+
+(* ================================================================ *)
+(* Serialization                                                    *)
+(* ================================================================ *)
+
+let provenance_to_json = function
+  | Post_verifier dim ->
+    `Assoc [("type", `String "post_verifier"); ("detail", `String dim)]
+  | Thompson kind ->
+    `Assoc [("type", `String "thompson"); ("detail", `String kind)]
+  | Drift_guard kind ->
+    `Assoc [("type", `String "drift_guard"); ("detail", `String kind)]
+  | Anti_rationalization gate ->
+    `Assoc [("type", `String "anti_rationalization"); ("detail", `String gate)]
+  | Agent_reputation metric ->
+    `Assoc [("type", `String "agent_reputation"); ("detail", `String metric)]
+
+let event_to_json (e : event) : Yojson.Safe.t =
+  `Assoc [
+    ("module", `String e.module_name);
+    ("site", `String e.site);
+    ("raw_value", `Float e.raw_value);
+    ("threshold", `Float e.threshold);
+    ("triggered", `Bool e.triggered);
+    ("provenance", provenance_to_json e.provenance);
+    ("timestamp", `Float e.timestamp);
+  ]
+
+(* ================================================================ *)
+(* Storage                                                          *)
+(* ================================================================ *)
+
+(** File path for the JSONL output. *)
+let store_path_ref : string option ref = ref None
+
+let mu = Eio.Mutex.create ()
+
+(** In-memory buffer to batch writes.  Flushed periodically or on [flush]. *)
+let buffer : Yojson.Safe.t Queue.t = Queue.create ()
+let buffer_cap = 64
+
+let ensure_dir path =
+  let dir = Filename.dirname path in
+  if not (Sys.file_exists dir) then
+    (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+
+let do_flush () =
+  match !store_path_ref with
+  | None -> ()
+  | Some path ->
+    if Queue.is_empty buffer then ()
+    else begin
+      ensure_dir path;
+      let oc =
+        try open_out_gen [Open_append; Open_creat; Open_text] 0o644 path
+        with Sys_error msg ->
+          Log.warn ~ctx:"heuristic_metrics" "cannot open %s: %s" path msg;
+          raise Exit
+      in
+      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+        Queue.iter (fun json ->
+          output_string oc (Yojson.Safe.to_string json);
+          output_char oc '\n'
+        ) buffer);
+      Queue.clear buffer
+    end
+
+let init ~base_path =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    match !store_path_ref with
+    | Some _ -> ()  (* idempotent *)
+    | None ->
+      let masc_dir = Filename.concat base_path ".masc" in
+      let path = Filename.concat masc_dir "heuristic_metrics.jsonl" in
+      store_path_ref := Some path)
+
+let record (e : event) =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    let json = event_to_json e in
+    Queue.add json buffer;
+    if Queue.length buffer >= buffer_cap then
+      (try do_flush () with Exit -> ()))
+
+let flush () =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    try do_flush () with Exit -> ())
+
+let recent n =
+  match !store_path_ref with
+  | None -> []
+  | Some path ->
+    if not (Sys.file_exists path) then []
+    else
+      match Safe_ops.read_file_safe path with
+      | Error _ -> []
+      | Ok content ->
+        let lines =
+          String.split_on_char '\n' content
+          |> List.filter (fun l -> String.length (String.trim l) > 0)
+        in
+        let total = List.length lines in
+        let to_skip = max 0 (total - n) in
+        let rec drop k = function
+          | [] -> []
+          | _ :: rest when k > 0 -> drop (k - 1) rest
+          | xs -> xs
+        in
+        drop to_skip lines
+        |> List.filter_map (fun line ->
+          try Some (Yojson.Safe.from_string line)
+          with Yojson.Json_error _ -> None)

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -1,0 +1,44 @@
+(** Heuristic_metrics -- RFC-0001 Phase 0.1 instrumentation.
+
+    Records raw values, thresholds, and trigger outcomes at every heuristic
+    decision site.  Pure observation -- no behavioral change.  Data accumulates
+    in [.masc/heuristic_metrics.jsonl] for later analysis (Gate B, Phase 1).
+
+    Thread-safe via {!Eio.Mutex}.
+
+    @since RFC-0001 Gate A *)
+
+(** Provenance tag describing which subsystem produced this metric. *)
+type provenance =
+  | Post_verifier of string   (** dimension name, e.g. "relevance" *)
+  | Thompson of string        (** signal kind, e.g. "quality_update" *)
+  | Drift_guard of string     (** drift type, e.g. "factual" *)
+  | Anti_rationalization of string  (** gate name, e.g. "length" / "excuse" / "llm" / "fallback" *)
+  | Agent_reputation of string      (** metric name, e.g. "overall_score" *)
+
+(** A single heuristic observation.  All fields are informational. *)
+type event = {
+  module_name : string;
+  site : string;
+  raw_value : float;
+  threshold : float;
+  triggered : bool;
+  provenance : provenance;
+  timestamp : float;
+}
+
+val record : event -> unit
+(** Append a metric event.  Thread-safe.  No-op if storage is not initialized. *)
+
+val init : base_path:string -> unit
+(** Initialize the JSONL store under [base_path/.masc/heuristic_metrics.jsonl].
+    Idempotent; second call is a no-op. *)
+
+val flush : unit -> unit
+(** Force flush pending writes (useful in tests). *)
+
+val recent : int -> Yojson.Safe.t list
+(** Read the N most recent events as JSON objects. *)
+
+val event_to_json : event -> Yojson.Safe.t
+(** Serialize an event for external consumption (dashboard, tests). *)


### PR DESCRIPTION
## Summary
- `heuristic_metrics.ml` + `.mli`: 휴리스틱 결정 사이트에서 raw value/threshold/triggered 기록
- `agent_stress.ml` + `.mli`: 에이전트별 스트레스 지표 (failure_streak, timeout, parse_degraded 등) 기록
- JSONL 저장, Eio.Mutex thread-safe, buffered writes (cap=64)
- 순수 관찰 — 동작 변경 없음. Gate B 분석을 위한 데이터 수집

## Motivation
Karpathy "March of Nines": 결정론적 단계를 LLM에서 분리하면 복합 실패율 감소.
Gate A는 현재 어떤 사이트가 det/nondet인지 측정하여, Gate B에서 typed boundary를 도입하는 근거를 마련.

## Test plan
- [x] `dune build` 통과
- [ ] 기존 테스트 regression 없음 (CI)
- [ ] 추후 test_heuristic_metrics.ml 추가 (별도 PR)

Closes #4825

🤖 Generated with [Claude Code](https://claude.com/claude-code)