### PR TITLE
fix(boundary): abstract hardcoded provider checks in oas_model_resolve

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -27,7 +27,7 @@ let max_context_of_label (label : string) : int =
   | None -> 128_000
   | Some pname ->
     (* For local providers, prefer discovered per-slot context *)
-    if pname = "llama" then
+    if Provider_adapter.requires_discovery pname then
       match Llm_provider.Provider_registry.discovered_max_context () with
       | Some ctx -> ctx
       | None ->
@@ -57,7 +57,7 @@ let resolve_primary_max_context (labels : string list) : int =
         | Some entry ->
           if entry.is_available () then
             (* For local providers, prefer discovered context *)
-            if pname = "llama" then
+            if Provider_adapter.requires_discovery pname then
               Option.value ~default:entry.max_context discovered
             else entry.max_context
           else find rest
@@ -140,8 +140,8 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
              Treat as available — the cascade resolves providers at runtime. *)
           true
       | Some pname ->
-        if pname = "custom" then
-          (* custom:model@url is self-hosted; always considered available *)
+        if Provider_adapter.is_local_provider pname then
+          (* Self-hosted / local runtime; always considered available *)
           true
         else
           match Llm_provider.Provider_registry.find default_registry pname with
@@ -154,7 +154,7 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
         match provider_name_of_label label with
         | None -> None
         | Some pname ->
-          if pname = "custom" then None  (* self-hosted, no API key needed *)
+          if Provider_adapter.is_local_provider pname then None
           else
             match Llm_provider.Provider_registry.find default_registry pname with
             | None -> Some (Printf.sprintf "%s (unknown provider)" pname)
@@ -182,7 +182,7 @@ let cascade_config_path () : string option =
 let models_of_cascade_name (cascade_name : string) : string list =
   let defaults =
     match Provider_adapter.preferred_execution_model_labels () with
-    | [] -> ["llama:auto"]
+    | [] -> [Provider_adapter.default_local_fallback_label ()]
     | labels -> labels
   in
   let config_path = cascade_config_path () in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -174,6 +174,44 @@ let voice_adapters =
     voice_mcp_adapter;
   ]
 
+(** The "custom" provider prefix represents user-provided self-hosted
+    endpoints (e.g. "custom:model@url").  It is not in [direct_adapters]
+    because it has no fixed config; it is always considered available and
+    requires no API key. *)
+let cn_custom = "custom"
+
+(** Returns true if the provider name represents a local runtime that
+    uses runtime discovery (e.g. the live /props probe for per-slot
+    context).  Any provider with [runtime_kind = Local] qualifies.
+    Adding a new local provider (ollama, vllm, ...) only requires
+    adding an entry with [runtime_kind = Local] in [direct_adapters]. *)
+let requires_discovery pname =
+  let normalized = normalize_label pname in
+  List.exists
+    (fun (adapter : adapter) ->
+      adapter.runtime_kind = Local
+      && List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+    direct_adapters
+
+(** Returns true if the provider is self-hosted and always considered
+    available (no API key validation needed).  Covers both
+    [runtime_kind = Local] adapters and the special "custom" prefix. *)
+let is_local_provider pname =
+  let normalized = normalize_label pname in
+  normalized = cn_custom || requires_discovery pname
+
+(** Default fallback label for local runtime when no other preferred
+    model labels are configured.  Uses "provider:auto" for the first
+    [Local] adapter found. *)
+let default_local_fallback_label () =
+  match
+    List.find_opt
+      (fun (adapter : adapter) -> adapter.runtime_kind = Local)
+      direct_adapters
+  with
+  | Some adapter -> adapter.canonical_name ^ ":auto"
+  | None -> "auto"
+
 let resolve_direct_adapter label =
   let normalized = normalize_label label in
   List.find_opt

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -139,6 +139,52 @@ let test_stt_request_openai_compat () =
            req.form_fields)
   | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
 
+let test_requires_discovery_llama () =
+  check bool "llama requires discovery" true
+    (Adapter.requires_discovery "llama");
+  check bool "llamacpp requires discovery" true
+    (Adapter.requires_discovery "llamacpp");
+  check bool "LLAMA case insensitive" true
+    (Adapter.requires_discovery "LLAMA")
+
+let test_requires_discovery_cloud () =
+  check bool "claude does not require discovery" false
+    (Adapter.requires_discovery "claude");
+  check bool "gemini does not require discovery" false
+    (Adapter.requires_discovery "gemini");
+  check bool "custom does not require discovery" false
+    (Adapter.requires_discovery "custom")
+
+let test_is_local_provider_llama () =
+  check bool "llama is local" true
+    (Adapter.is_local_provider "llama");
+  check bool "llamacpp is local" true
+    (Adapter.is_local_provider "llamacpp")
+
+let test_is_local_provider_custom () =
+  check bool "custom is local" true
+    (Adapter.is_local_provider "custom");
+  check bool "CUSTOM case insensitive" true
+    (Adapter.is_local_provider "CUSTOM")
+
+let test_is_local_provider_cloud () =
+  check bool "claude is not local" false
+    (Adapter.is_local_provider "claude");
+  check bool "gemini is not local" false
+    (Adapter.is_local_provider "gemini");
+  check bool "unknown is not local" false
+    (Adapter.is_local_provider "unknown-provider")
+
+let test_default_local_fallback_label () =
+  let label = Adapter.default_local_fallback_label () in
+  check bool "fallback label contains colon" true
+    (String.contains label ':');
+  check bool "fallback label ends with :auto" true
+    (let suffix = ":auto" in
+     let slen = String.length label in
+     let plen = String.length suffix in
+     slen >= plen && String.sub label (slen - plen) plen = suffix)
+
 let test_stt_request_mcp_rejected () =
   let endpoint : Masc_mcp.Voice_config.endpoint =
     { id = "test-mcp-stt"; kind = Voice_mcp;
@@ -171,6 +217,21 @@ let () =
           test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
           test_case "voice auth env resolution" `Quick
             test_voice_auth_env_resolution;
+        ] );
+      ( "local_provider",
+        [
+          test_case "requires_discovery llama" `Quick
+            test_requires_discovery_llama;
+          test_case "requires_discovery cloud" `Quick
+            test_requires_discovery_cloud;
+          test_case "is_local_provider llama" `Quick
+            test_is_local_provider_llama;
+          test_case "is_local_provider custom" `Quick
+            test_is_local_provider_custom;
+          test_case "is_local_provider cloud" `Quick
+            test_is_local_provider_cloud;
+          test_case "default_local_fallback_label" `Quick
+            test_default_local_fallback_label;
         ] );
       ( "stt",
         [


### PR DESCRIPTION
## Summary
- `oas_model_resolve.ml`의 하드코딩된 provider 이름 5건 제거
- `Provider_adapter`에 `requires_discovery`, `is_local_provider`, `default_local_fallback_label` 추가
- 새 local provider (ollama, vllm 등) 추가 시 `oas_model_resolve` 변경 불필요

## Changes
| Before | After |
|--------|-------|
| `if pname = "llama"` (2x) | `Provider_adapter.requires_discovery pname` |
| `if pname = "custom"` (2x) | `Provider_adapter.is_local_provider pname` |
| `["llama:auto"]` | `[Provider_adapter.default_local_fallback_label ()]` |

## Test plan
- [x] 20 tests pass (`test_provider_adapter.exe`)
- [x] `dune build` 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)