### PR TITLE
fix(keeper): address review feedback on shutdown crash handling

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -116,8 +116,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
         if not !resolved then begin
           if Shutdown.is_shutting_down_global () then begin
             Log.Keeper.warn "%s: fiber unresolved during shutdown (not a crash)" meta.name;
-            Keeper_registry.set_state ~base_path meta.name
-              Keeper_registry.Dead;
+            Keeper_registry.mark_dead ~base_path meta.name
+              ~at:(Time_compat.now ());
             resolve_done (`Crashed "shutdown")
           end else begin
             let reason =

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -80,8 +80,12 @@ type hook = {
   action : unit -> unit;
 }
 
-(** Global shutdown flag — set to true when shutdown begins.
-    Readable from any module without passing [state]. *)
+(** Global shutdown-started flag.  Set to [true] on the first [initiate]
+    call.  This flag is sticky: it is never cleared, so it indicates that
+    shutdown has started at least once, not that shutdown is currently in
+    progress.  In production the process exits shortly after shutdown, so
+    the sticky semantics are safe.  In tests where [exit_fn] is a no-op,
+    callers must be aware that the flag stays [true]. *)
 let shutting_down_flag = Atomic.make false
 
 let is_shutting_down_global () = Atomic.get shutting_down_flag


### PR DESCRIPTION
## Summary
Follow-up to #5106 (merged). Addresses Copilot review comments:

- Use `mark_dead` instead of `set_state Dead` so `dead_since_ts` is set for TTL cleanup in `sweep_and_recover`
- Document that `shutting_down_flag` is sticky (never cleared) with implications for test environments

## Review evidence
Copilot review comments on #5106: IDs 3035483475, 3035483479

Closes #5077