### PR TITLE
refactor(keeper): remove dead reward/policy model and unused config (-356 lines)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -426,65 +426,12 @@ let normalize_proactive_cooldown_sec (v : int) : int =
   clamp_int v ~min_v:0 ~max_v:172800
 
 
-let keeper_proactive_similarity_threshold () : float =
-  float_of_env_default
-    "MASC_KEEPER_PROACTIVE_SIMILARITY"
-    ~default:0.72
-    ~min_v:0.0
-    ~max_v:1.0
-
-(* ================================================================ *)
-(* Keeper execution parameters (previously hardcoded)               *)
-(* ================================================================ *)
-
-let keeper_proactive_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_PROACTIVE_MAX_TOKENS"
-    ~default:1024
-    ~min_v:128
-    ~max_v:4096
-
-let keeper_deterministic_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_DETERMINISTIC_TEMP"
-    ~default:0.3
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_reflection_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_REFLECTION_TEMP"
-    ~default:0.6
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_planning_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_PLANNING_TEMP"
-    ~default:0.35
-    ~min_v:0.0
-    ~max_v:2.0
-
 let keeper_batch_limit () : int =
   int_of_env_default
     "MASC_KEEPER_BATCH_LIMIT"
     ~default:200
     ~min_v:10
     ~max_v:2000
-
-let keeper_msg_timeout_max_sec () : int =
-  int_of_env_default
-    "MASC_KEEPER_MSG_TIMEOUT_MAX_SEC"
-    ~default:300
-    ~min_v:5
-    ~max_v:3600
-
-let keeper_cost_gate_usd () : float =
-  float_of_env_default
-    "MASC_KEEPER_COST_GATE_USD"
-    ~default:0.10
-    ~min_v:0.01
-    ~max_v:10.0
 
 let keeper_tool_cost_max_usd () : float =
   float_of_env_default
@@ -559,61 +506,6 @@ let keeper_rule_guardrail_context_threshold () : float =
 (* ================================================================ *)
 (* Keeper execution — previously hardcoded magic numbers             *)
 (* ================================================================ *)
-
-(** Maximum tool loop rounds before forcing termination.
-    Used in proactive generation and social board event turns.
-    Env: [MASC_KEEPER_MAX_TOOL_ROUNDS]. Default: 3. *)
-let keeper_max_tool_rounds () : int =
-  int_of_env_default
-    "MASC_KEEPER_MAX_TOOL_ROUNDS"
-    ~default:3
-    ~min_v:1
-    ~max_v:20
-
-(** Max tokens for autonomous execution MODEL calls.
-    Env: [MASC_KEEPER_AUTONOMOUS_MAX_TOKENS]. Default: 4000. *)
-let keeper_autonomous_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_MAX_TOKENS"
-    ~default:4000
-    ~min_v:512
-    ~max_v:16000
-
-(** Max tokens for keeper deliberation calls.
-    Env: [MASC_KEEPER_DELIBERATION_MAX_TOKENS]. Default: 1024. *)
-let keeper_deliberation_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_DELIBERATION_MAX_TOKENS"
-    ~default:1024
-    ~min_v:256
-    ~max_v:8000
-
-(** Max tokens for explicit reply generation.
-    Env: [MASC_KEEPER_EXPLICIT_REPLY_MAX_TOKENS]. Default: 256. *)
-let keeper_explicit_reply_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_EXPLICIT_REPLY_MAX_TOKENS"
-    ~default:256
-    ~min_v:64
-    ~max_v:2048
-
-(** Max tokens for social board initial turn.
-    Env: [MASC_KEEPER_SOCIAL_INITIAL_MAX_TOKENS]. Default: 768. *)
-let keeper_social_initial_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_SOCIAL_INITIAL_MAX_TOKENS"
-    ~default:768
-    ~min_v:256
-    ~max_v:4096
-
-(** Max tokens for social board followup turns.
-    Env: [MASC_KEEPER_SOCIAL_FOLLOWUP_MAX_TOKENS]. Default: 512. *)
-let keeper_social_followup_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_SOCIAL_FOLLOWUP_MAX_TOKENS"
-    ~default:512
-    ~min_v:128
-    ~max_v:4096
 
 (* ================================================================ *)
 (* Unified Keeper Turn parameters                                   *)

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -3,17 +3,6 @@
 
 open Keeper_types
 
-type keeper_reward_candidate = {
-  bias: float;
-  weights: (string * float) list;
-}
-
-type keeper_reward_model = {
-  version: string;
-  path: string;
-  candidates: (string * keeper_reward_candidate) list;
-}
-
 type keeper_policy_observation = {
   source_kind: string;
   room_id: string option;
@@ -28,137 +17,6 @@ type keeper_policy_observation = {
   room_scope: Keeper_contract.room_scope;
   last_turn_ago_s: float;
 }
-
-type keeper_policy_candidate_score = {
-  action: string;
-  bias: float;
-  feature_scores: (string * float) list;
-  score: float;
-  allowed: bool;
-}
-
-let empty_keeper_reward_candidate = { bias = 0.0; weights = [] }
-
-let policy_action_order action =
-  match action with
-  | "noop" -> 0
-  | "reply_in_room" -> 1
-  | "board_post" -> 2
-  | _ -> 9
-
-let keeper_policy_feature_vector (obs : keeper_policy_observation) : (string * float) list =
-  let clamp01 value = max 0.0 (min 1.0 value) in
-  [
-    ("direct_mention", if obs.direct_mention then 1.0 else 0.0);
-    ("question_mark", if obs.has_question then 1.0 else 0.0);
-    ("message_chars", clamp01 (float_of_int obs.message_chars /. 400.0));
-    ("active_goal_count", clamp01 (float_of_int obs.active_goal_count /. 5.0));
-    ("joined_room_count", clamp01 (float_of_int obs.joined_room_count /. 5.0));
-    ( "room_scope_all",
-      if Keeper_contract.room_scope_to_string obs.room_scope = "all" then 1.0 else 0.0 );
-    ("idle_seconds", clamp01 (obs.last_turn_ago_s /. 3600.0));
-  ]
-
-let float_assoc_to_json (items : (string * float) list) : Yojson.Safe.t =
-  `Assoc (List.map (fun (key, value) -> (key, `Float value)) items)
-
-let keeper_policy_observation_to_json (obs : keeper_policy_observation) : Yojson.Safe.t =
-  `Assoc
-    [
-      ("source_kind", `String obs.source_kind);
-      ("room_id", Json_util.string_opt_to_json obs.room_id);
-      ("from_agent", `String obs.from_agent);
-      ("message", `String obs.message);
-      ("direct_mention", `Bool obs.direct_mention);
-      ("has_question", `Bool obs.has_question);
-      ("message_chars", `Int obs.message_chars);
-      ("total_turns", `Int obs.total_turns);
-      ("active_goal_count", `Int obs.active_goal_count);
-      ("joined_room_count", `Int obs.joined_room_count);
-      ("room_scope", `String (Keeper_contract.room_scope_to_string obs.room_scope));
-      ("last_turn_ago_s", `Float obs.last_turn_ago_s);
-    ]
-
-let keeper_policy_candidate_score_to_json
-    (candidate : keeper_policy_candidate_score) : Yojson.Safe.t =
-  `Assoc
-    [
-      ("action", `String candidate.action);
-      ("bias", `Float candidate.bias);
-      ("feature_scores", float_assoc_to_json candidate.feature_scores);
-      ("score", `Float candidate.score);
-      ("allowed", `Bool candidate.allowed);
-    ]
-
-let reward_candidate_of_json (json : Yojson.Safe.t) : keeper_reward_candidate =
-  let bias = Safe_ops.json_float ~default:0.0 "bias" json in
-  let weights =
-    match Yojson.Safe.Util.member "weights" json with
-    | `Assoc fields ->
-        fields
-        |> List.filter_map (fun (feature, value) ->
-               match value with
-               | `Float weight -> Some (feature, weight)
-               | `Int n -> Some (feature, float_of_int n)
-               | `Intlit raw ->
-                   Some (feature, Safe_ops.float_of_string_with_default ~default:0.0 raw)
-               | _ -> None)
-    | _ -> []
-  in
-  { bias; weights }
-
-let load_keeper_reward_model (path : string) : (keeper_reward_model, string) result =
-  let path = String.trim path in
-  if path = "" then
-    Error "reward_model_path is required for learned_offline_v1"
-  else
-    match Safe_ops.read_json_file_safe path with
-    | Error e -> Error e
-    | Ok json ->
-        let version = Safe_ops.json_string ~default:"reward-model-v1" "version" json in
-        let candidates =
-          match Yojson.Safe.Util.member "candidates" json with
-          | `Assoc fields ->
-              fields |> List.map (fun (name, value) -> (name, reward_candidate_of_json value))
-          | _ -> []
-        in
-        if candidates = [] then
-          Error "reward model must define candidates"
-        else
-          Ok { version; path; candidates }
-
-let score_keeper_policy_candidate
-    ~(model : keeper_reward_model)
-    ~(features : (string * float) list)
-    ~(action : string)
-    ~(allowed : bool) : keeper_policy_candidate_score =
-  let candidate_model =
-    model.candidates
-    |> List.find_map (fun (candidate_action, candidate_model) ->
-           if candidate_action = action then Some candidate_model else None)
-    |> Option.value ~default:empty_keeper_reward_candidate
-  in
-  let feature_scores =
-    candidate_model.weights
-    |> List.map (fun (feature_name, weight) ->
-           let feature_value =
-             features
-             |> List.find_map (fun (name, value) ->
-                    if name = feature_name then Some value else None)
-             |> Option.value ~default:0.0
-           in
-           (feature_name, weight *. feature_value))
-  in
-  let score =
-    List.fold_left (fun acc (_, value) -> acc +. value) candidate_model.bias feature_scores
-  in
-  {
-    action;
-    bias = candidate_model.bias;
-    feature_scores;
-    score;
-    allowed;
-  }
 
 let observation_has_question (message : string) =
   String.contains message '?'
@@ -188,30 +46,6 @@ let keeper_policy_observation_of_room_message
     room_scope = Keeper_contract.room_scope_of_string meta.room_scope;
     last_turn_ago_s;
   }
-
-let deterministic_policy_baseline_action_typed
-    (obs : keeper_policy_observation) : Keeper_deliberation.deliberation_action =
-  if obs.direct_mention then
-    Keeper_deliberation.ReplyInRoom { room_id = ""; content = "" }
-  else
-    Keeper_deliberation.Noop "no_trigger"
-
-(** Backward-compatible string interface for existing callers. *)
-let deterministic_policy_baseline_action (obs : keeper_policy_observation) : string =
-  deterministic_policy_baseline_action_typed obs
-  |> Keeper_deliberation.deliberation_action_to_policy_label
-
-let choose_policy_action (candidates : keeper_policy_candidate_score list) :
-    keeper_policy_candidate_score option =
-  candidates
-  |> List.filter (fun candidate -> candidate.allowed)
-  |> List.sort (fun a b ->
-         let score_cmp = Float.compare b.score a.score in
-         if score_cmp <> 0 then score_cmp
-         else compare (policy_action_order a.action) (policy_action_order b.action))
-  |> function
-  | candidate :: _ -> Some candidate
-  | [] -> None
 
 type alert_channel_result = {
   channel: string;
@@ -257,23 +91,6 @@ let alert_channel_result_to_json (r : alert_channel_result) : Yojson.Safe.t =
       match r.detail with
       | Some d when String.trim d <> "" -> `String d
       | _ -> `Null);
-  ]
-
-let interesting_alert_result_to_json (r : interesting_alert_result) : Yojson.Safe.t =
-  `Assoc [
-    ("enabled", `Bool r.enabled);
-    ("triggered", `Bool r.triggered);
-    ("score", `Float r.score);
-    ("threshold", `Float r.threshold);
-    ("reasons", `List (List.map (fun s -> `String s) r.reasons));
-    ("keywords", `List (List.map (fun s -> `String s) r.keywords));
-    ("alert_id",
-      match r.alert_id with
-      | Some id when String.trim id <> "" -> `String id
-      | _ -> `Null);
-    ("channels", `List (List.map alert_channel_result_to_json r.channels));
-    ("retry_queued", `Bool r.retry_queued);
-    ("deadlettered", `Bool r.deadlettered);
   ]
 
 type keeper_state_snapshot = {
@@ -513,26 +330,6 @@ let latest_state_snapshot_from_messages (messages : Agent_sdk.Types.message list
       | Some snapshot -> Some snapshot
   in
   loop (List.rev messages)
-
-let append_continuity_context_prompt
-    ~(base_prompt : string)
-    (snapshot : keeper_state_snapshot option)
-    ~(continuity_summary : string) : string =
-  let fallback_summary =
-    let trimmed = String.trim continuity_summary in
-    if trimmed = "" then "No continuity snapshot available." else trimmed
-  in
-  let summary =
-    match snapshot with
-    | None -> fallback_summary
-    | Some s -> keeper_state_snapshot_to_summary_text s
-  in
-  if summary = "No continuity snapshot available." then base_prompt
-  else
-    Printf.sprintf
-      "%s\n\nRecent continuity snapshot:\n%s"
-      base_prompt
-      summary
 
 let priority_for_kind ~soul_profile ~(kind : string) : int =
   match soul_profile, kind with

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -273,10 +273,3 @@ let skill_route_context_text
     soul_profile
     fallback_route.primary_skill
 
-let skill_route_system_prompt_agent
-    ~(base_system_prompt : string)
-    ~(fallback_route : keeper_skill_route)
-    ~(soul_profile : string) : string =
-  Printf.sprintf "%s\n\n%s"
-    base_system_prompt
-    (skill_route_context_text ~fallback_route ~soul_profile)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -97,24 +97,6 @@ let soul_profile_policy profile =
       "SOUL profile: balanced.\n\
        Preserve in this order: safety/trust continuity, goal progress & decisions, unresolved risks, tool outcomes, style preferences."
 
-let proactive_seed_for_soul_profile (profile : string) : string =
-  match canonical_soul_profile profile |> Option.value ~default:default_soul_profile with
-  | "safety" ->
-      "Safety hint: prioritize current risk signals and mitigations."
-  | "delivery" ->
-      "Delivery hint: prioritize concrete next actions and execution momentum."
-  | "research" ->
-      "Research hint: you have access to masc_autoresearch_* tools. \
-       Use masc_autoresearch_start to begin an autonomous experiment loop. \
-       Check masc_autoresearch_status for progress and masc_autoresearch_search_findings for results. \
-       Prioritize hypotheses, evidence, and validation steps."
-  | "relationship" ->
-      "Relationship hint: prioritize user intent alignment and collaboration continuity."
-  | "minimal" ->
-      "Minimal hint: keep only high-signal continuity and next move."
-  | _ ->
-      "Balanced hint: keep a practical mix of risk, progress, and next step."
-
 let take n xs =
   let rec go i acc = function
     | [] -> List.rev acc

--- a/test/test_keeper_turn_prompt.ml
+++ b/test/test_keeper_turn_prompt.ml
@@ -55,24 +55,7 @@ let test_skill_route_context_text_standalone () =
     (let re = Str.regexp_string "delivery" in
      try ignore (Str.search_forward re text 0); true with Not_found -> false)
 
-let test_skill_route_system_prompt_uses_context_text () =
-  let route : KSR.keeper_skill_route =
-    { primary_skill = "code_review"; secondary_skills = []; reason = "" }
-  in
-  let base = "Base prompt here." in
-  let combined = KSR.skill_route_system_prompt_agent
-    ~base_system_prompt:base
-    ~fallback_route:route
-    ~soul_profile:"research" in
-  let standalone = KSR.skill_route_context_text
-    ~fallback_route:route
-    ~soul_profile:"research" in
-  (* Combined should be base + separator + standalone *)
-  let expected = Printf.sprintf "%s\n\n%s" base standalone in
-  check string "system_prompt_agent = base + context_text"
-    expected combined
-
-(* ── hard constraint: direct_reply_mode ─────────────────── *)
+(* ── hard constraint: direct_reply_mode ──────────────��──── *)
 
 let test_direct_reply_stays_in_system () =
   let base = "Identity prompt." in
@@ -146,8 +129,6 @@ let () =
       ( "skill_route_context_text",
         [
           test_case "standalone text" `Quick test_skill_route_context_text_standalone;
-          test_case "system_prompt_agent = base + context_text" `Quick
-            test_skill_route_system_prompt_uses_context_text;
         ] );
       ( "hard_constraints",
         [


### PR DESCRIPTION
## Summary

- Old 3-path dispatcher의 reward/policy model 시스템 전체 제거 (keeper_memory_policy.ml)
- 11개 미사용 env var reader 제거 (keeper_config.ml)
- proactive_seed_for_soul_profile, skill_route_system_prompt_agent 제거
- 5 files, -356 lines

## Product impact

Dead code 제거. 런타임 동작 변경 없음.

## Evidence

16개 함수 각각 `grep -rn` 검증 → 외부 호출자 0개. 내부 사용자도 dead 함수뿐.

## Test plan

- [x] `dune build` — 에러 0개
- [x] dead 함수 테스트 제거 (test_keeper_turn_prompt.ml)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)