### PR TITLE
fix(keeper): use meta.agent_name instead of ad-hoc keeper- prefix

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -351,7 +351,7 @@ let run_turn
     Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
   (* 7. Set up agent *)
   let ctx_ref = ref ctx_work in
-  let agent_name = Printf.sprintf "keeper-%s" meta.name in
+  let agent_name = meta.agent_name in
   let meta_ref = ref meta in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in
   let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in


### PR DESCRIPTION
## Summary
- `keeper_agent_run.ml:354`: `"keeper-%s" meta.name` → `meta.agent_name`
- `meta.agent_name`은 `keeper_agent_name()`로 생성된 `"keeper-%s-agent"` 형식
- 이전 ad-hoc prefix는 `-agent` suffix가 빠져 auth identity mismatch 발생

## Root Cause
keeper registry는 `"keeper-admin-keeper-agent"`로 등록하고, OAS agent run은 `"keeper-admin-keeper"`로 요청 → `agent_name must match the authenticated agent` 에러.

## Impact
- #5103 (auth refresh 3x fail → blocked) 해결
- #5104 (portal duplicate open) 해결 (같은 이름 불일치 root cause)
- #5055 (auth token failures) 관련 가능성

## Changes
- 1 file, 1 line

## Test plan
- [x] `dune build` 확인
- [ ] keeper auth refresh 성공 확인
- [ ] portal duplicate 에러 소멸 확인

Closes #5103
Refs #5104