### PR TITLE
[codex] fix keeper dashboard status truth

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -408,23 +408,22 @@ let keeper_surface_status
     |> Option.value ~default:"offline"
     |> String.lowercase_ascii
   in
-  if String.equal health_state "offline" then "offline"
-  else
-    match json_string_opt "status" agent_status with
-    | Some status -> (
-        match String.lowercase_ascii status with
-        | ("active" | "busy" | "listening" | "idle") as status -> status
-        | "offline" | "inactive" -> "offline"
-        | _ -> (
-            match health_state with
-            | "idle" -> "idle"
-            | "healthy" | "stale" | "degraded" -> "active"
-            | _ -> "offline"))
-    | None -> (
-        match health_state with
-        | "idle" -> "idle"
-        | "healthy" | "stale" | "degraded" -> "active"
-        | _ -> "offline")
+  let agent_runtime_status =
+    json_string_opt "status" agent_status |> Option.map String.lowercase_ascii
+  in
+  match health_state with
+  | "healthy" -> (
+      match agent_runtime_status with
+      | Some (("active" | "busy" | "listening" | "idle") as status) -> status
+      | Some ("offline" | "inactive") -> "offline"
+      | _ -> "active")
+  | "idle" -> "idle"
+  | "stale" | "degraded" | "zombie" | "dead" -> "inactive"
+  | "offline" -> "offline"
+  | _ -> (
+      match agent_runtime_status with
+      | Some ("offline" | "inactive") -> "offline"
+      | _ -> "inactive")
 
 let keeper_diagnostic_json
     ~(meta : keeper_meta)
@@ -470,7 +469,8 @@ let derive_pipeline_stage
     ~(surface_status : string)
     ~(now_ts : float)
   : string =
-  if String.equal surface_status "offline" then "offline"
+  if String.equal surface_status "offline" || String.equal surface_status "inactive"
+  then "offline"
   else
     let recency_threshold = 30.0 in
     let turn_ago =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -177,10 +177,12 @@ let proactive_outcome_of_result ~(has_text : bool) ~(has_tool_calls : bool) :
   | false, true -> Proactive_tool_use
   | true, true -> Proactive_mixed_response
 
+let has_substantive_tool_calls (tools_used : string list) : bool =
+  List.exists (fun tool_name -> tool_name <> "masc_heartbeat") tools_used
+
 let selected_mode_of_result (result : Keeper_agent_run.run_result) : string =
   let text = String.trim result.response_text in
-  if List.exists (fun tool_name -> tool_name <> "masc_heartbeat") result.tools_used
-  then "tool_use"
+  if has_substantive_tool_calls result.tools_used then "tool_use"
   else if text = "" then "noop"
   else if String.starts_with ~prefix:"SKIP:" text then "skip_text"
   else "text_response"
@@ -210,9 +212,6 @@ let observed_affordances_of_observation
   if observation.failed_task_count > 0 then add "task_audit";
   if Option.is_some observation.worktree_change_summary then add "inspect_worktree_delta";
   List.rev !affordances
-
-let has_substantive_tool_calls (tools_used : string list) : bool =
-  List.exists (fun tool_name -> tool_name <> "masc_heartbeat") tools_used
 
 let response_requests_confirmation (text : string) : bool =
   let trimmed = String.trim text in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -179,7 +179,8 @@ let proactive_outcome_of_result ~(has_text : bool) ~(has_tool_calls : bool) :
 
 let selected_mode_of_result (result : Keeper_agent_run.run_result) : string =
   let text = String.trim result.response_text in
-  if result.tools_used <> [] then "tool_use"
+  if List.exists (fun tool_name -> tool_name <> "masc_heartbeat") result.tools_used
+  then "tool_use"
   else if text = "" then "noop"
   else if String.starts_with ~prefix:"SKIP:" text then "skip_text"
   else "text_response"
@@ -403,7 +404,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       ~input_tokens:result.usage.input_tokens
       ~output_tokens:result.usage.output_tokens ()
   in
-  let has_tool_calls = result.tools_used <> [] in
+  let substantive_tool_call_count =
+    result.tools_used
+    |> List.filter (fun tool_name -> tool_name <> "masc_heartbeat")
+    |> List.length
+  in
   let has_substantive_tools = has_substantive_tool_calls result.tools_used in
   let has_text = String.trim result.response_text <> "" in
   let is_proactive_cycle = is_proactive_cycle_of_observation observation in
@@ -467,7 +472,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
            else rt.proactive_rt.last_visible_ts);
         last_outcome =
           (if update_proactive_rt && is_proactive_cycle then
-             proactive_outcome_of_result ~has_text ~has_tool_calls
+             proactive_outcome_of_result ~has_text
+               ~has_tool_calls:has_substantive_tools
            else rt.proactive_rt.last_outcome);
         last_reason =
           (if not update_proactive_rt || not is_proactive_cycle then rt.proactive_rt.last_reason
@@ -488,24 +494,24 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       (* Autonomous action tracking from tool calls *)
       autonomous_action_count =
         rt.autonomous_action_count
-        + (if is_autonomous_turn then List.length result.tools_used else 0);
+        + (if is_autonomous_turn then substantive_tool_call_count else 0);
       autonomous_turn_count =
         rt.autonomous_turn_count + (if is_autonomous_turn then 1 else 0);
       autonomous_text_turn_count =
         rt.autonomous_text_turn_count
-        + (if is_autonomous_turn && has_text && not has_tool_calls then 1 else 0);
+        + (if is_autonomous_turn && has_text && not has_substantive_tools then 1 else 0);
       autonomous_tool_turn_count =
         rt.autonomous_tool_turn_count
-        + (if is_autonomous_turn && has_tool_calls then 1 else 0);
+        + (if is_autonomous_turn && has_substantive_tools then 1 else 0);
       board_reactive_turn_count =
         rt.board_reactive_turn_count + (if is_board_reactive then 1 else 0);
       mention_reactive_turn_count =
         rt.mention_reactive_turn_count + (if is_mention_reactive then 1 else 0);
       noop_turn_count =
         rt.noop_turn_count
-        + (if is_autonomous_turn && not has_text && not has_tool_calls then 1 else 0);
+        + (if is_autonomous_turn && not has_text && not has_substantive_tools then 1 else 0);
       last_autonomous_action_at =
-        (if is_autonomous_turn && has_tool_calls then now_iso ()
+        (if is_autonomous_turn && has_substantive_tools then now_iso ()
          else rt.last_autonomous_action_at);
       last_speech_act = Social.speech_act_to_string social_state.speech_act;
       last_blocker = Option.value ~default:"" social_state.blocker;
@@ -530,7 +536,7 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let work_kind =
-    if result.tools_used <> [] then "tool_use"
+    if has_substantive_tool_calls result.tools_used then "tool_use"
     else if String.trim result.response_text <> "" then "text_turn"
     else "noop"
   in
@@ -539,7 +545,7 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
       Some
         (proactive_outcome_of_result
            ~has_text:(String.trim result.response_text <> "")
-           ~has_tool_calls:(result.tools_used <> []))
+           ~has_tool_calls:(has_substantive_tool_calls result.tools_used))
     else None
   in
   let metrics_store = keeper_metrics_store config meta.name in

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,7 @@
         test_post_verifier
         test_swarm_checkpoint test_swarm_goal_loop
         test_keeper_memory
+        test_keeper_exec_status
         test_keeper_lifecycle
         test_keeper_deliberation
         test_keeper_registry
@@ -104,6 +105,7 @@
           test_post_verifier
           test_swarm_checkpoint test_swarm_goal_loop
           test_keeper_memory
+          test_keeper_exec_status
           test_keeper_lifecycle
           test_keeper_deliberation
           test_keeper_registry

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -49,6 +49,26 @@ let test_keeper_surface_status_maps_degraded_to_inactive () =
   in
   check string "degraded keeper is not surfaced as listening" "inactive" status
 
+let test_keeper_surface_status_maps_zombie_to_inactive () =
+  let status =
+    ES.keeper_surface_status
+      ~agent_status:
+        (`Assoc
+          [ ("exists", `Bool true); ("status", `String "active") ])
+      ~diagnostic:(`Assoc [ ("health_state", `String "zombie") ])
+  in
+  check string "zombie keeper is not surfaced as active" "inactive" status
+
+let test_keeper_surface_status_maps_dead_to_inactive () =
+  let status =
+    ES.keeper_surface_status
+      ~agent_status:
+        (`Assoc
+          [ ("exists", `Bool true); ("status", `String "busy") ])
+      ~diagnostic:(`Assoc [ ("health_state", `String "dead") ])
+  in
+  check string "dead keeper is not surfaced as busy" "inactive" status
+
 let test_derive_pipeline_stage_treats_inactive_as_offline () =
   let meta =
     let base = make_meta () in
@@ -79,6 +99,10 @@ let () =
             test_keeper_surface_status_maps_stale_to_inactive;
           test_case "maps degraded to inactive" `Quick
             test_keeper_surface_status_maps_degraded_to_inactive;
+          test_case "maps zombie to inactive" `Quick
+            test_keeper_surface_status_maps_zombie_to_inactive;
+          test_case "maps dead to inactive" `Quick
+            test_keeper_surface_status_maps_dead_to_inactive;
           test_case "inactive pipeline stage becomes offline" `Quick
             test_derive_pipeline_stage_treats_inactive_as_offline;
         ] );

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -1,0 +1,85 @@
+open Alcotest
+
+module ES = Masc_mcp.Keeper_exec_status
+module KT = Masc_mcp.Keeper_types
+
+let make_meta ?(name = "keeper-exec-status-test")
+    ?(trace_id = "trace-keeper-exec-status") () =
+  match
+    KT.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String name);
+          ("trace_id", `String trace_id);
+          ("cascade_name", `String "keeper_unified");
+          ("last_model_used", `String "llama:auto");
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let test_keeper_surface_status_preserves_live_agent_states () =
+  let status =
+    ES.keeper_surface_status
+      ~agent_status:
+        (`Assoc
+          [ ("exists", `Bool true); ("status", `String "busy") ])
+      ~diagnostic:(`Assoc [ ("health_state", `String "healthy") ])
+  in
+  check string "healthy busy keeper stays busy" "busy" status
+
+let test_keeper_surface_status_maps_stale_to_inactive () =
+  let status =
+    ES.keeper_surface_status
+      ~agent_status:
+        (`Assoc
+          [ ("exists", `Bool true); ("status", `String "active") ])
+      ~diagnostic:(`Assoc [ ("health_state", `String "stale") ])
+  in
+  check string "stale keeper is not surfaced as active" "inactive" status
+
+let test_keeper_surface_status_maps_degraded_to_inactive () =
+  let status =
+    ES.keeper_surface_status
+      ~agent_status:
+        (`Assoc
+          [ ("exists", `Bool true); ("status", `String "listening") ])
+      ~diagnostic:(`Assoc [ ("health_state", `String "degraded") ])
+  in
+  check string "degraded keeper is not surfaced as listening" "inactive" status
+
+let test_derive_pipeline_stage_treats_inactive_as_offline () =
+  let meta =
+    let base = make_meta () in
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          usage = { base.runtime.usage with last_turn_ts = Time_compat.now () };
+        };
+    }
+  in
+  let stage =
+    ES.derive_pipeline_stage ~meta ~surface_status:"inactive"
+      ~now_ts:(Time_compat.now ())
+  in
+  check string "inactive keeper does not advertise a live pipeline stage"
+    "offline" stage
+
+let () =
+  run "keeper_exec_status"
+    [
+      ( "surface_status",
+        [
+          test_case "preserves live agent states" `Quick
+            test_keeper_surface_status_preserves_live_agent_states;
+          test_case "maps stale to inactive" `Quick
+            test_keeper_surface_status_maps_stale_to_inactive;
+          test_case "maps degraded to inactive" `Quick
+            test_keeper_surface_status_maps_degraded_to_inactive;
+          test_case "inactive pipeline stage becomes offline" `Quick
+            test_derive_pipeline_stage_treats_inactive_as_offline;
+        ] );
+    ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -765,6 +765,34 @@ let test_metrics_noop_response () =
     updated.runtime.autonomous_action_count;
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
 
+let test_metrics_heartbeat_only_tool_response_is_maintenance_only () =
+  let result =
+    make_run_result ~text:"" ~tools:["masc_heartbeat"]
+      ~model:"test-model" ~input_tok:40 ~output_tok:0
+  in
+  let updated =
+    UT.update_metrics_from_result minimal_meta ~latency_ms:80
+      ~observation:base_observation result
+  in
+  check int "proactive_count +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
+    updated.runtime.proactive_rt.count_total;
+  check int "proactive visible_count unchanged"
+    minimal_meta.runtime.proactive_rt.visible_count_total
+    updated.runtime.proactive_rt.visible_count_total;
+  check bool "heartbeat-only outcome stays silent" true
+    (updated.runtime.proactive_rt.last_outcome
+     = Masc_mcp.Keeper_types.Proactive_silent);
+  check int "autonomous action unchanged"
+    minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check int "autonomous tool turn unchanged"
+    minimal_meta.runtime.autonomous_tool_turn_count
+    updated.runtime.autonomous_tool_turn_count;
+  check int "noop turn increments"
+    (minimal_meta.runtime.noop_turn_count + 1)
+    updated.runtime.noop_turn_count
+
 let test_metrics_reactive_turn_does_not_mutate_proactive_runtime () =
   let reactive_observation =
     { base_observation with
@@ -1601,6 +1629,8 @@ let () =
           test_case "text response" `Quick test_metrics_text_response;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
+          test_case "heartbeat-only tool response is maintenance only" `Quick
+            test_metrics_heartbeat_only_tool_response_is_maintenance_only;
           test_case "reactive turn leaves proactive runtime untouched" `Quick
             test_metrics_reactive_turn_does_not_mutate_proactive_runtime;
           test_case "silent proactive cycle advances cooldown anchor" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -371,7 +371,9 @@ let test_snapshot_keeper_tool_audit_fallback () =
               (Yojson.Safe.to_string snapshot)
       in
       let keeper = load_keeper_snapshot 10 in
-      Alcotest.(check string) "durable keeper is idle after keeper_up" "idle"
+      (* keeper_up creates a healthy durable keeper; before any turn runs it should
+         surface as idle rather than active. *)
+      Alcotest.(check string) "durable keeper is idle before first turn after keeper_up" "idle"
         (keeper |> member "status" |> to_string);
       Alcotest.(check bool) "allowed tool fallback present" true
         ((keeper |> member "allowed_tool_names" |> to_list) <> []);

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -371,7 +371,7 @@ let test_snapshot_keeper_tool_audit_fallback () =
               (Yojson.Safe.to_string snapshot)
       in
       let keeper = load_keeper_snapshot 10 in
-      Alcotest.(check string) "durable keeper is active after keeper_up" "active"
+      Alcotest.(check string) "durable keeper is idle after keeper_up" "idle"
         (keeper |> member "status" |> to_string);
       Alcotest.(check bool) "allowed tool fallback present" true
         ((keeper |> member "allowed_tool_names" |> to_list) <> []);


### PR DESCRIPTION
## Summary
- fix keeper surface status so stale/degraded/zombie/dead runtime states no longer surface as `active`
- treat heartbeat-only proactive cycles as maintenance/noop instead of substantive tool work
- add regression coverage for both state mapping and heartbeat-only metrics behavior

## Product impact
- stale keepers stop showing up as active in dashboard keeper surfaces and downstream active-agent summaries
- operator-facing status now matches actual runtime health more closely
- heartbeat-only maintenance cycles no longer inflate autonomous action/tool-use metrics

## Evidence
- local: `./_build/default/test/test_keeper_exec_status.exe`
- local: `./_build/default/test/test_keeper_unified.exe -q`
- root cause reproduced from `.masc` state: `health_state=stale` while linked agent status remained `active`

## Review evidence
- `GLM-5.1` via direct `sb glm-text` at `2026-04-04T13:36Z`
- result: `No findings.`

## Linked issue
- Fixes #5137

## What changed
- fixed keeper surface status mapping so `stale`, `degraded`, `zombie`, and `dead` runtime states no longer surface as `active`
- treated heartbeat-only proactive cycles as maintenance/noop instead of substantive tool work
- added regression tests for keeper status truth and heartbeat-only metrics behavior

## Why this changed
The dashboard was showing keepers as active even when their runtime was stale. The backend correctly derived `health_state = stale`, but `keeper_surface_status` still preferred the persisted agent status (`active`) and leaked that into dashboard summaries.

## Commit
- `2fd5b0272` `fix keeper status truth`
