### PR TITLE
Fix local Discord gate fallback and persist bindings

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -304,6 +304,7 @@ let legacy_permission_for_tool = function
       Some CanCompleteTask
   | "masc_broadcast" | "masc_listen" | "masc_heartbeat"
   | "masc_webrtc_offer" | "masc_webrtc_answer"
+  | "channel_gate"
   | "masc_register_capabilities" | "masc_find_by_capability"
   | "masc_agent_update" | "masc_operator_action"
   | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_msg"

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -68,6 +68,7 @@ let worker_only_tools =
     (* CanBroadcast — transport *)
     "masc_webrtc_offer";
     "masc_webrtc_answer";
+    "channel_gate";
     (* CanBroadcast — capability registry *)
     "masc_register_capabilities";
     "masc_find_by_capability";

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -12,6 +12,13 @@ GATE_API_TOKEN=
 # Values: keeper names
 DISCORD_KEEPER_MAP={"1234567890": "luna"}
 
+# Durable store for runtime bind/unbind changes.
+# If this file exists, it becomes the effective binding SSOT on restart.
+DISCORD_BINDING_STORE_PATH=.masc/discord_keeper_bindings.json
+
+# Append-only operator audit trail for bind/unbind changes.
+DISCORD_BINDING_AUDIT_PATH=.masc/discord_keeper_binding_audit.jsonl
+
 # Discord role ID for admin commands (optional)
 DISCORD_ADMIN_ROLE_ID=
 

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -5,6 +5,8 @@ DISCORD_BOT_TOKEN=
 GATE_BASE_URL=http://localhost:8935
 
 # Channel Gate Bearer token for /api/v1/gate/* endpoints
+# Optional only when GATE_BASE_URL/MASC_MCP_URL is loopback and server auth
+# keeps require_token=false. Remote or strict-auth deployments should set it.
 GATE_API_TOKEN=
 
 # Channel-to-keeper mapping (JSON)

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -31,6 +31,10 @@ cp .env.example .env
 # BotConfig auto-loads .env from the current working directory
 ```
 
+`GATE_API_TOKEN` is recommended. For local loopback development only, the bot
+can omit it when the server keeps `require_token=false`; in that mode the
+connector falls back to same-origin auth headers against `127.0.0.1`/`localhost`.
+
 ### 3. Run
 
 ```bash

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -62,17 +62,28 @@ The `DISCORD_KEEPER_MAP` environment variable maps Discord channel IDs to keeper
 Messages in mapped channels are automatically forwarded to the corresponding keeper.
 Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 
+## Durable Runtime Bindings
+
+`/keeper-bind` and `/keeper-unbind` now persist the effective channel map to
+`DISCORD_BINDING_STORE_PATH` (default: `.masc/discord_keeper_bindings.json`).
+
+- If the store file does not exist, the bot starts from `DISCORD_KEEPER_MAP`
+- Once an operator persists a runtime bind/unbind, the store file becomes the
+  restart-time source of truth so admin changes survive process restarts
+- `/keeper-map` shows the active binding source and store path for operators
+- successful bind/unbind operations also append an audit record to
+  `DISCORD_BINDING_AUDIT_PATH` (default:
+  `.masc/discord_keeper_binding_audit.jsonl`)
+
 ## Operations Upgrades
 
 - `/keeper-status [keeper]`: connector health snapshot or single-keeper status
 - `/keeper-bind <keeper>`: runtime bind current channel to a keeper
 - `/keeper-unbind`: remove the current runtime binding
 - `/keeper-map`: inspect resolved binding + loaded runtime map
+- `/keeper-audit [limit]`: inspect recent bind/unbind audit entries
 - Keeper names support slash-command autocomplete via `/api/v1/gate/keepers`
 - The bot now forwards attachment-only messages by synthesizing a deterministic
   `Attachments:` block instead of dropping them as empty content
 - A lightweight transport circuit breaker prevents repeated timeouts / 5xx
   storms from hammering the gate while still serving cached status data
-
-Runtime binds are in-memory only. They override the initial `DISCORD_KEEPER_MAP`
-for the current process and reset on bot restart.

--- a/sidecars/discord-bot/src/audit_store.py
+++ b/sidecars/discord-bot/src/audit_store.py
@@ -1,0 +1,75 @@
+"""Durable audit trail for Discord binding changes."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True, slots=True)
+class BindingAuditEvent:
+    """One binding mutation performed by an operator."""
+
+    timestamp: str
+    action: str
+    guild_id: str
+    channel_id: str
+    keeper_name: str
+    actor_id: str
+    actor_name: str
+    previous_keeper: str
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> BindingAuditEvent:
+        return BindingAuditEvent(
+            timestamp=str(data.get("timestamp", "")),
+            action=str(data.get("action", "")),
+            guild_id=str(data.get("guild_id", "")),
+            channel_id=str(data.get("channel_id", "")),
+            keeper_name=str(data.get("keeper_name", "")),
+            actor_id=str(data.get("actor_id", "")),
+            actor_name=str(data.get("actor_name", "")),
+            previous_keeper=str(data.get("previous_keeper", "")),
+        )
+
+
+class BindingAuditStore:
+    """Append-only JSONL audit store for operator binding changes."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def append(self, event: BindingAuditEvent) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(event), sort_keys=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def read_recent(self, *, limit: int) -> list[BindingAuditEvent]:
+        if limit <= 0 or not self.path.exists():
+            return []
+
+        events: list[BindingAuditEvent] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                raw: object = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(raw, dict):
+                continue
+            events.append(BindingAuditEvent.from_json(cast(dict[str, Any], raw)))
+        if len(events) <= limit:
+            return events
+        return events[-limit:]

--- a/sidecars/discord-bot/src/binding_store.py
+++ b/sidecars/discord-bot/src/binding_store.py
@@ -1,0 +1,71 @@
+"""Persistent Discord channel binding store.
+
+Stores the effective channel -> keeper map on local disk so operator changes
+survive bot restarts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import cast
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_bindings(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        raise ValueError("binding store must be a JSON object")
+
+    typed_raw = cast(dict[object, object], raw)
+    bindings: dict[str, str] = {}
+    for raw_channel_id, raw_keeper in typed_raw.items():
+        channel_id = str(raw_channel_id).strip()
+        keeper_name = str(raw_keeper).strip()
+        if not channel_id or not keeper_name:
+            continue
+        bindings[channel_id] = keeper_name
+    return bindings
+
+
+class BindingStore:
+    """Load and save the durable Discord binding map."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load(self) -> dict[str, str] | None:
+        """Return persisted bindings, or None when no valid store exists."""
+        if not self.path.exists():
+            return None
+
+        try:
+            raw: object = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to read binding store %s: %s", self.path, exc)
+            return None
+
+        try:
+            return _normalize_bindings(raw)
+        except ValueError as exc:
+            logger.warning("Invalid binding store %s: %s", self.path, exc)
+            return None
+
+    def save(self, bindings: dict[str, str]) -> None:
+        """Persist bindings atomically using replace-on-write."""
+        normalized = _normalize_bindings(bindings)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        payload = json.dumps(normalized, indent=2, sort_keys=True)
+
+        try:
+            tmp_path.write_text(f"{payload}\n", encoding="utf-8")
+            os.replace(tmp_path, self.path)
+        except OSError:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -403,6 +403,12 @@ async def keeper_ask(
             embed = format_keeper_embed(response)
             await interaction.followup.send(embed=embed)
     else:
+        if response.error == "duplicate message":
+            await interaction.followup.send(
+                "이미 접수된 요청입니다. 잠시 기다린 뒤 새 요청으로 다시 시도해 주세요.",
+                ephemeral=True,
+            )
+            return
         embed = format_error_embed(response.error)
         await interaction.followup.send(embed=embed, ephemeral=True)
 

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -17,6 +17,8 @@ from typing import Any, cast
 import discord
 from discord import app_commands
 
+from .audit_store import BindingAuditEvent, BindingAuditStore, utc_now_iso
+from .binding_store import BindingStore
 from .config import get_config
 from .formatters import (
     chunk_text,
@@ -71,7 +73,15 @@ class GateBot(discord.Client):
         self.tree = app_commands.CommandTree(self)
         self.gate = GateClient()
         self.cfg = get_config()
-        self.keeper_bindings = self.cfg.keeper_map()
+        self.binding_store = BindingStore(self.cfg.binding_store_path())
+        self.audit_store = BindingAuditStore(self.cfg.binding_audit_path())
+        persisted_bindings = self.binding_store.load()
+        if persisted_bindings is None:
+            self.keeper_bindings = self.cfg.keeper_map()
+            self.binding_source = "env-seed"
+        else:
+            self.keeper_bindings = persisted_bindings
+            self.binding_source = "persisted"
 
     async def setup_hook(self) -> None:
         """Register slash commands on startup."""
@@ -80,6 +90,7 @@ class GateBot(discord.Client):
         self.tree.add_command(keeper_bind)  # pyright: ignore[reportUnknownArgumentType]
         self.tree.add_command(keeper_unbind)  # pyright: ignore[reportUnknownArgumentType]
         self.tree.add_command(keeper_map)  # pyright: ignore[reportUnknownArgumentType]
+        self.tree.add_command(keeper_audit)  # pyright: ignore[reportUnknownArgumentType]
         await self.tree.sync()
         logger.info("Slash commands synced")
 
@@ -91,7 +102,13 @@ class GateBot(discord.Client):
     async def on_ready(self) -> None:
         assert self.user is not None
         logger.info("Bot ready: %s (id=%s)", self.user.name, self.user.id)
-        logger.info("Keeper map: %s", self.keeper_bindings)
+        logger.info(
+            "Keeper map (%s @ %s, audit %s): %s",
+            self.binding_source,
+            self.binding_store.path,
+            self.audit_store.path,
+            self.keeper_bindings,
+        )
 
         healthy = await self.gate.health_check()
         if healthy:
@@ -119,11 +136,39 @@ class GateBot(discord.Client):
                 return inherited, "thread-parent"
         return None, "unmapped"
 
-    def set_channel_binding(self, channel_id: str, keeper_name: str) -> None:
+    def set_channel_binding(self, channel_id: str, keeper_name: str) -> str | None:
+        previous = self.keeper_bindings.get(channel_id)
         self.keeper_bindings[channel_id] = keeper_name
+        return previous
 
     def remove_channel_binding(self, channel_id: str) -> str | None:
         return self.keeper_bindings.pop(channel_id, None)
+
+    def persist_bindings(self) -> None:
+        self.binding_store.save(self.keeper_bindings)
+        self.binding_source = "persisted"
+
+    def append_binding_audit(
+        self,
+        *,
+        action: str,
+        interaction: discord.Interaction,
+        channel_id: str,
+        keeper_name: str,
+        previous_keeper: str | None,
+    ) -> None:
+        self.audit_store.append(
+            BindingAuditEvent(
+                timestamp=utc_now_iso(),
+                action=action,
+                guild_id=str(interaction.guild_id or ""),
+                channel_id=channel_id,
+                keeper_name=keeper_name,
+                actor_id=str(interaction.user.id),
+                actor_name=str(interaction.user),
+                previous_keeper=previous_keeper or "",
+            )
+        )
 
     def _compose_gate_content(self, message: discord.Message) -> str:
         return compose_gate_content(message.content, attachment_lines(message))
@@ -294,6 +339,20 @@ def connector_status_embed(
     return embed
 
 
+def format_audit_event_line(event: BindingAuditEvent) -> str:
+    action = event.action or "unknown"
+    target = event.keeper_name or "-"
+    previous = f" (prev {event.previous_keeper})" if event.previous_keeper else ""
+    actor = event.actor_name or event.actor_id or "unknown"
+    channel = event.channel_id or "-"
+    guild = event.guild_id or "-"
+    timestamp = event.timestamp or "-"
+    return (
+        f"{timestamp} · {action} · channel {channel} · guild {guild} · "
+        f"keeper {target}{previous} · by {actor}"
+    )
+
+
 async def keeper_name_autocomplete(
     interaction: discord.Interaction,
     current: str,
@@ -441,9 +500,33 @@ async def keeper_bind(
             return
 
     channel_id = str(interaction.channel.id)
-    bot.set_channel_binding(channel_id, keeper_name)
+    previous = bot.set_channel_binding(channel_id, keeper_name)
+    try:
+        bot.persist_bindings()
+        bot.append_binding_audit(
+            action="bind",
+            interaction=interaction,
+            channel_id=channel_id,
+            keeper_name=keeper_name,
+            previous_keeper=previous,
+        )
+    except OSError as exc:
+        if previous is None:
+            bot.remove_channel_binding(channel_id)
+        else:
+            bot.set_channel_binding(channel_id, previous)
+        try:
+            bot.persist_bindings()
+        except OSError as rollback_exc:
+            logger.error("Binding rollback failed for %s: %s", channel_id, rollback_exc)
+        embed = format_error_embed(f"failed to persist binding store: {exc}")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+        return
+
     await interaction.followup.send(
-        f"Bound channel `{channel_id}` to keeper `{keeper_name}`.",
+        f"Bound channel `{channel_id}` to keeper `{keeper_name}`.\n"
+        f"Store: `{bot.binding_store.path}`\n"
+        f"Audit: `{bot.audit_store.path}`",
         ephemeral=True,
     )
 
@@ -485,8 +568,29 @@ async def keeper_unbind(interaction: discord.Interaction) -> None:
         )
         return
 
+    try:
+        bot.persist_bindings()
+        bot.append_binding_audit(
+            action="unbind",
+            interaction=interaction,
+            channel_id=channel_id,
+            keeper_name=removed,
+            previous_keeper=removed,
+        )
+    except OSError as exc:
+        bot.set_channel_binding(channel_id, removed)
+        try:
+            bot.persist_bindings()
+        except OSError as rollback_exc:
+            logger.error("Binding rollback failed for %s: %s", channel_id, rollback_exc)
+        embed = format_error_embed(f"failed to persist binding store: {exc}")
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        return
+
     await interaction.response.send_message(
-        f"Removed binding `{channel_id}` -> `{removed}`.",
+        f"Removed binding `{channel_id}` -> `{removed}`.\n"
+        f"Store: `{bot.binding_store.path}`\n"
+        f"Audit: `{bot.audit_store.path}`",
         ephemeral=True,
     )
 
@@ -508,11 +612,52 @@ async def keeper_map(interaction: discord.Interaction) -> None:
     lines = [
         f"current channel: {interaction.channel_id or 'n/a'}",
         f"resolved keeper: {binding[0] or 'unmapped'} ({binding[1]})",
+        f"binding source: {bot.binding_source}",
+        f"binding store: {bot.binding_store.path}",
+        f"audit log: {bot.audit_store.path}",
         f"runtime bindings: {len(bot.keeper_bindings)}",
     ]
 
     for channel_id, keeper_name in sorted(bot.keeper_bindings.items())[:10]:
         lines.append(f"- {channel_id} -> {keeper_name}")
+
+    await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+@app_commands.command(
+    name="keeper-audit",
+    description="Show recent Discord binding changes",
+)
+@app_commands.describe(limit="Number of recent audit events to show")
+async def keeper_audit(
+    interaction: discord.Interaction,
+    limit: app_commands.Range[int, 1, 20] = 10,
+) -> None:
+    """Show recent bind/unbind audit entries."""
+    bot = interaction.client
+    assert isinstance(bot, GateBot)
+
+    if not bot.is_admin(interaction):
+        await interaction.response.send_message(
+            "Admin role or Manage Server permission required.",
+            ephemeral=True,
+        )
+        return
+
+    events = bot.audit_store.read_recent(limit=limit)
+    if not events:
+        await interaction.response.send_message(
+            f"No audit entries found in `{bot.audit_store.path}`.",
+            ephemeral=True,
+        )
+        return
+
+    lines = [
+        f"audit log: {bot.audit_store.path}",
+        f"showing last {len(events)} event(s)",
+    ]
+    for event in reversed(events):
+        lines.append(f"- {format_audit_event_line(event)}")
 
     await interaction.response.send_message("\n".join(lines), ephemeral=True)
 

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -7,6 +7,7 @@ Fails fast at startup if any required config is missing.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Final, cast
 
 from pydantic import AliasChoices, Field, field_validator
@@ -44,6 +45,20 @@ class BotConfig(BaseSettings):
     discord_keeper_map: str = Field(
         default="{}",
         validation_alias=AliasChoices("DISCORD_KEEPER_MAP", "discord_keeper_map"),
+    )
+    discord_binding_store_path: str = Field(
+        default=".masc/discord_keeper_bindings.json",
+        validation_alias=AliasChoices(
+            "DISCORD_BINDING_STORE_PATH",
+            "discord_binding_store_path",
+        ),
+    )
+    discord_binding_audit_path: str = Field(
+        default=".masc/discord_keeper_binding_audit.jsonl",
+        validation_alias=AliasChoices(
+            "DISCORD_BINDING_AUDIT_PATH",
+            "discord_binding_audit_path",
+        ),
     )
 
     # Optional
@@ -117,6 +132,13 @@ class BotConfig(BaseSettings):
             raise ValueError(f"DISCORD_KEEPER_MAP is not valid JSON: {e}") from e
         return v
 
+    @field_validator("discord_binding_store_path", "discord_binding_audit_path")
+    @classmethod
+    def validate_non_empty_path(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("binding persistence paths must not be empty")
+        return v.strip()
+
     @field_validator("gate_timeout_sec")
     @classmethod
     def validate_positive_timeout(cls, v: int) -> int:
@@ -148,6 +170,23 @@ class BotConfig(BaseSettings):
             return {}
         typed_raw = cast(dict[object, object], raw)
         return {str(key): str(value) for key, value in typed_raw.items()}
+
+    def binding_store_path(self) -> Path:
+        """Return the durable binding store path.
+
+        Relative paths are resolved from the current working directory so the
+        bot can be started from the sidecar directory without extra flags.
+        """
+        path = Path(self.discord_binding_store_path).expanduser()
+        if path.is_absolute():
+            return path
+        return Path.cwd() / path
+
+    def binding_audit_path(self) -> Path:
+        path = Path(self.discord_binding_audit_path).expanduser()
+        if path.is_absolute():
+            return path
+        return Path.cwd() / path
 
     def gate_message_url(self) -> str:
         base = self.masc_mcp_url.rstrip("/")

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -6,12 +6,26 @@ Fails fast at startup if any required config is missing.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from pathlib import Path
 from typing import Final, cast
+from urllib.parse import urlparse
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+
+def _is_loopback_host(raw_host: str | None) -> bool:
+    if raw_host is None:
+        return False
+    host = raw_host.strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 class BotConfig(BaseSettings):
@@ -33,6 +47,7 @@ class BotConfig(BaseSettings):
         ),
     )
     masc_api_token: str = Field(
+        default="",
         validation_alias=AliasChoices(
             "MASC_API_TOKEN",
             "masc_api_token",
@@ -109,12 +124,16 @@ class BotConfig(BaseSettings):
 
     @field_validator("masc_api_token")
     @classmethod
-    def api_token_not_empty(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError(
-                "MASC_API_TOKEN is required (GATE_API_TOKEN is also accepted as a legacy alias)"
-            )
+    def normalize_api_token(cls, v: str) -> str:
         return v.strip()
+
+    @model_validator(mode="after")
+    def validate_gate_auth_mode(self) -> BotConfig:
+        if self.masc_api_token or self.gate_base_url_is_loopback():
+            return self
+        raise ValueError(
+            "MASC_API_TOKEN is required unless GATE_BASE_URL/MASC_MCP_URL points at a loopback host"
+        )
 
     @field_validator("discord_keeper_map")
     @classmethod
@@ -203,6 +222,16 @@ class BotConfig(BaseSettings):
     @property
     def gate_api_token(self) -> str:
         return self.masc_api_token
+
+    def gate_base_url_is_loopback(self) -> bool:
+        parsed = urlparse(self.gate_base_url)
+        return _is_loopback_host(parsed.hostname)
+
+    def gate_origin(self) -> str:
+        parsed = urlparse(self.gate_base_url)
+        if parsed.scheme and parsed.netloc:
+            return f"{parsed.scheme}://{parsed.netloc}"
+        return self.gate_base_url.rstrip("/")
 
 
 # Lazy singleton - instantiated on first get_config() call.

--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -6,7 +6,6 @@ The gate is the only interface; no direct keeper access.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -256,47 +255,38 @@ class GateClient:
         }
 
         client = self._get_client()
-        max_attempts = self._max_attempts()
-        for attempt in range(1, max_attempts + 1):
-            try:
-                resp = await client.post(self._url, json=payload)
-                if resp.status_code == 409:
-                    self._note_success()
-                    logger.info("Duplicate message (idempotency): %s", message_id)
-                    return GateResponse.from_error("duplicate message")
-
-                if resp.status_code >= 500:
-                    if attempt < max_attempts:
-                        await asyncio.sleep(min(0.25 * attempt, 1.0))
-                        continue
-                    self._note_transport_failure(f"gate returned {resp.status_code}")
-                    return GateResponse.from_error(f"gate returned {resp.status_code}")
-
-                raw_data = resp.json()
-                if not isinstance(raw_data, dict):
-                    self._note_success()
-                    return GateResponse.from_error("gate returned invalid json")
-                data = cast(dict[str, Any], raw_data)
-
+        try:
+            # POST /gate/message is currently not replay-safe across 5xx/timeouts.
+            # Retrying with the same idempotency key only converts the first
+            # transport error into a noisy duplicate response for slash commands.
+            resp = await client.post(self._url, json=payload)
+            if resp.status_code == 409:
                 self._note_success()
-                return GateResponse.from_json(data)
+                logger.info("Duplicate message (idempotency): %s", message_id)
+                return GateResponse.from_error("duplicate message")
 
-            except httpx.TimeoutException:
-                if attempt < max_attempts:
-                    await asyncio.sleep(min(0.25 * attempt, 1.0))
-                    continue
-                self._note_transport_failure(f"gate timeout after {self._timeout}s")
-                return GateResponse.from_error(f"gate timeout after {self._timeout}s")
-            except httpx.HTTPError as e:
-                self._note_transport_failure(f"gate http error: {e}")
-                return GateResponse.from_error(f"gate http error: {e}")
-            except Exception as e:  # pragma: no cover - defensive logging
-                self._note_transport_failure(f"gate error: {e}")
-                return GateResponse.from_error(f"gate error: {e}")
+            if resp.status_code >= 500:
+                self._note_transport_failure(f"gate returned {resp.status_code}")
+                return GateResponse.from_error(f"gate returned {resp.status_code}")
 
-        return GateResponse.from_error(
-            f"gate retries exhausted after {max_attempts} attempts"
-        )
+            raw_data = resp.json()
+            if not isinstance(raw_data, dict):
+                self._note_success()
+                return GateResponse.from_error("gate returned invalid json")
+            data = cast(dict[str, Any], raw_data)
+
+            self._note_success()
+            return GateResponse.from_json(data)
+
+        except httpx.TimeoutException:
+            self._note_transport_failure(f"gate timeout after {self._timeout}s")
+            return GateResponse.from_error(f"gate timeout after {self._timeout}s")
+        except httpx.HTTPError as e:
+            self._note_transport_failure(f"gate http error: {e}")
+            return GateResponse.from_error(f"gate http error: {e}")
+        except Exception as e:  # pragma: no cover - defensive logging
+            self._note_transport_failure(f"gate error: {e}")
+            return GateResponse.from_error(f"gate error: {e}")
 
     async def health_check(self) -> bool:
         """Check if the gate is reachable."""

--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -18,6 +18,8 @@ from .config import get_config
 
 logger = logging.getLogger(__name__)
 
+CONNECTOR_AGENT_NAME = "discord-gate-bot"
+
 
 @dataclass(frozen=True, slots=True)
 class GateResponse:
@@ -89,10 +91,7 @@ class GateClient:
         self._keeper_cache_ttl = cfg.keeper_cache_ttl_sec
         self._breaker_failure_threshold = cfg.gate_breaker_failure_threshold
         self._breaker_reset_sec = cfg.gate_breaker_reset_sec
-        self._headers = {
-            "Authorization": f"Bearer {cfg.gate_api_token}",
-            "Content-Type": "application/json",
-        }
+        self._headers = self._build_headers(cfg)
         self._client: httpx.AsyncClient | None = None
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
@@ -100,6 +99,17 @@ class GateClient:
         self._status_cache: tuple[float, dict[str, Any]] | None = None
         self._keeper_names_cache: tuple[float, list[str]] | None = None
         self._keeper_status_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+    def _build_headers(self, cfg: Any) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "X-MASC-Agent": CONNECTOR_AGENT_NAME,
+        }
+        if cfg.gate_api_token:
+            headers["Authorization"] = f"Bearer {cfg.gate_api_token}"
+        else:
+            headers["Origin"] = cfg.gate_origin()
+        return headers
 
     def _now(self) -> float:
         return time.monotonic()

--- a/sidecars/discord-bot/tests/test_audit_store.py
+++ b/sidecars/discord-bot/tests/test_audit_store.py
@@ -1,0 +1,98 @@
+"""Tests for durable binding audit logging."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.audit_store import BindingAuditEvent, BindingAuditStore
+
+
+def test_audit_store_appends_jsonl_events(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    store = BindingAuditStore(path)
+
+    store.append(
+        BindingAuditEvent(
+            timestamp="2026-04-04T12:00:00Z",
+            action="bind",
+            guild_id="g1",
+            channel_id="c1",
+            keeper_name="luna",
+            actor_id="u1",
+            actor_name="alice",
+            previous_keeper="",
+        )
+    )
+    store.append(
+        BindingAuditEvent(
+            timestamp="2026-04-04T12:01:00Z",
+            action="unbind",
+            guild_id="g1",
+            channel_id="c1",
+            keeper_name="luna",
+            actor_id="u2",
+            actor_name="bob",
+            previous_keeper="luna",
+        )
+    )
+
+    rows = [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert rows == [
+        {
+            "action": "bind",
+            "actor_id": "u1",
+            "actor_name": "alice",
+            "channel_id": "c1",
+            "guild_id": "g1",
+            "keeper_name": "luna",
+            "previous_keeper": "",
+            "timestamp": "2026-04-04T12:00:00Z",
+        },
+        {
+            "action": "unbind",
+            "actor_id": "u2",
+            "actor_name": "bob",
+            "channel_id": "c1",
+            "guild_id": "g1",
+            "keeper_name": "luna",
+            "previous_keeper": "luna",
+            "timestamp": "2026-04-04T12:01:00Z",
+        },
+    ]
+
+
+def test_audit_store_reads_recent_tail(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    store = BindingAuditStore(path)
+
+    for idx in range(5):
+        store.append(
+            BindingAuditEvent(
+                timestamp=f"2026-04-04T12:0{idx}:00Z",
+                action="bind",
+                guild_id="g1",
+                channel_id=f"c{idx}",
+                keeper_name="luna",
+                actor_id=f"u{idx}",
+                actor_name=f"user{idx}",
+                previous_keeper="",
+            )
+        )
+
+    recent = store.read_recent(limit=2)
+    assert [event.channel_id for event in recent] == ["c3", "c4"]
+
+
+def test_audit_store_skips_invalid_lines(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    path.write_text('{"timestamp":"2026-04-04T12:00:00Z","action":"bind"}\nnot-json\n', encoding="utf-8")
+    store = BindingAuditStore(path)
+
+    recent = store.read_recent(limit=5)
+    assert len(recent) == 1
+    assert recent[0].action == "bind"

--- a/sidecars/discord-bot/tests/test_binding_store.py
+++ b/sidecars/discord-bot/tests/test_binding_store.py
@@ -1,0 +1,53 @@
+"""Tests for durable Discord binding persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from src.binding_store import BindingStore
+from src.config import BotConfig
+
+
+def test_binding_store_load_returns_none_when_missing(tmp_path: Path) -> None:
+    store = BindingStore(tmp_path / "bindings.json")
+    assert store.load() is None
+
+
+def test_binding_store_round_trips_saved_bindings(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "bindings.json"
+    store = BindingStore(path)
+
+    store.save({"123": "luna", "456": "sangsu"})
+
+    assert store.load() == {"123": "luna", "456": "sangsu"}
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "123": "luna",
+        "456": "sangsu",
+    }
+
+
+def test_binding_store_ignores_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bindings.json"
+    path.write_text("{invalid", encoding="utf-8")
+    store = BindingStore(path)
+
+    assert store.load() is None
+
+
+def test_config_resolves_relative_binding_store_path(tmp_path: Path) -> None:
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        masc_api_token="test-api-token",
+        discord_binding_store_path="state/discord.json",
+        discord_binding_audit_path="audit/discord.jsonl",
+    )
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        assert cfg.binding_store_path() == tmp_path / "state" / "discord.json"
+        assert cfg.binding_audit_path() == tmp_path / "audit" / "discord.jsonl"
+    finally:
+        os.chdir(original_cwd)

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -123,6 +123,71 @@ async def test_send_message_uses_retry_count_after_first_attempt() -> None:
     await client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_loopback_client_uses_origin_fallback_when_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_headers: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.update({key.lower(): value for key, value in request.headers.items()})
+        return httpx.Response(
+            200,
+            json={"ok": True, "keeper_name": "luna", "reply": "pong"},
+        )
+
+    monkeypatch.setenv("GATE_API_TOKEN", "")
+    monkeypatch.setenv("GATE_BASE_URL", "http://127.0.0.1:8935")
+    config_module.reset_config_cache()
+    client = make_client(httpx.MockTransport(handler))
+
+    response = await client.send_message(
+        keeper_name="luna",
+        content="hello",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="origin-fallback",
+    )
+
+    assert response.ok is True
+    assert "authorization" not in seen_headers
+    assert seen_headers["origin"] == "http://127.0.0.1:8935"
+    assert seen_headers["x-masc-agent"] == "discord-gate-bot"
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_client_uses_bearer_auth_when_token_configured() -> None:
+    seen_headers: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.update({key.lower(): value for key, value in request.headers.items()})
+        return httpx.Response(
+            200,
+            json={"ok": True, "keeper_name": "luna", "reply": "pong"},
+        )
+
+    client = make_client(httpx.MockTransport(handler))
+
+    response = await client.send_message(
+        keeper_name="luna",
+        content="hello",
+        channel_user_id="u1",
+        channel_user_name="user",
+        channel_room_id="room",
+        message_id="bearer-auth",
+    )
+
+    assert response.ok is True
+    assert seen_headers["authorization"] == "Bearer test-api-token"
+    assert seen_headers["x-masc-agent"] == "discord-gate-bot"
+    assert "origin" not in seen_headers
+
+    await client.aclose()
+
+
 def test_config_allows_zero_disable_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GATE_MAX_RETRIES", raising=False)
     monkeypatch.delenv("STATUS_CACHE_TTL_SEC", raising=False)
@@ -145,6 +210,27 @@ def test_config_allows_zero_disable_values(monkeypatch: pytest.MonkeyPatch) -> N
     assert cfg.keeper_cache_ttl_sec == 0
     assert cfg.gate_breaker_failure_threshold == 0
     assert cfg.gate_breaker_reset_sec == 0
+
+
+def test_config_allows_blank_token_for_loopback_url() -> None:
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        masc_api_token="",
+        masc_mcp_url="http://127.0.0.1:8935",
+    )
+
+    assert cfg.gate_api_token == ""
+    assert cfg.gate_base_url_is_loopback() is True
+    assert cfg.gate_origin() == "http://127.0.0.1:8935"
+
+
+def test_config_rejects_blank_token_for_non_loopback_url() -> None:
+    with pytest.raises(ValueError, match="MASC_API_TOKEN is required"):
+        BotConfig(
+            discord_bot_token="test-token",
+            masc_api_token="",
+            masc_mcp_url="https://masc.example.com",
+        )
 
 
 def test_legacy_env_aliases_still_work(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -96,7 +96,7 @@ async def test_list_keepers_uses_cached_names_when_breaker_is_open() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_message_uses_retry_count_after_first_attempt() -> None:
+async def test_send_message_does_not_retry_non_replay_safe_post() -> None:
     attempts = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -105,8 +105,6 @@ async def test_send_message_uses_retry_count_after_first_attempt() -> None:
         return httpx.Response(503, json={"ok": False, "error": "down"})
 
     client = make_client(httpx.MockTransport(handler))
-    client._max_retries = 2  # pyright: ignore[reportPrivateUsage]
-
     response = await client.send_message(
         keeper_name="luna",
         content="hello",
@@ -118,7 +116,7 @@ async def test_send_message_uses_retry_count_after_first_attempt() -> None:
 
     assert response.ok is False
     assert response.error == "gate returned 503"
-    assert attempts == 3
+    assert attempts == 1
 
     await client.aclose()
 

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -132,7 +132,7 @@ def test_config_allows_zero_disable_values(monkeypatch: pytest.MonkeyPatch) -> N
 
     cfg = BotConfig(
         discord_bot_token="test-token",
-        gate_api_token="test-api-token",
+        masc_api_token="test-api-token",
         gate_max_retries=0,
         status_cache_ttl_sec=0,
         keeper_cache_ttl_sec=0,

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -246,6 +246,11 @@ let test_permission_for_tool_webrtc_answer () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_channel_gate () =
+  match Auth.permission_for_tool "channel_gate" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
 let test_permission_for_tool_board_list () =
   match Auth.permission_for_tool "masc_board_list" with
   | Some Types.CanReadState -> ()
@@ -732,6 +737,7 @@ let () =
       test_case "broadcast" `Quick test_permission_for_tool_broadcast;
       test_case "webrtc_offer" `Quick test_permission_for_tool_webrtc_offer;
       test_case "webrtc_answer" `Quick test_permission_for_tool_webrtc_answer;
+      test_case "channel_gate" `Quick test_permission_for_tool_channel_gate;
       test_case "board_list" `Quick test_permission_for_tool_board_list;
       test_case "board_post" `Quick test_permission_for_tool_board_post;
       test_case "board_reclassify" `Quick test_permission_for_tool_board_reclassify;

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -155,6 +155,14 @@ let test_worker_allows_worker_only_tools () =
       (Tool_access_policy.allows_name worker_policy tool_name)
   ) Tool_access_role.worker_only_tools
 
+let test_channel_gate_requires_worker () =
+  let reader_policy = Tool_access_role.policy_for_role Reader in
+  let worker_policy = Tool_access_role.policy_for_role Worker in
+  check bool "Reader denies channel_gate" false
+    (Tool_access_policy.allows_name reader_policy "channel_gate");
+  check bool "Worker allows channel_gate" true
+    (Tool_access_policy.allows_name worker_policy "channel_gate")
+
 (* ================================================================ *)
 (* Unregistered tool behavior                                        *)
 (* ================================================================ *)
@@ -229,6 +237,8 @@ let () =
             test_reader_denies_worker_only_tools;
           test_case "Worker allows worker_only" `Quick
             test_worker_allows_worker_only_tools;
+          test_case "channel_gate requires worker" `Quick
+            test_channel_gate_requires_worker;
         ] );
       ( "unregistered",
         [


### PR DESCRIPTION
## Summary
- persist Discord runtime bindings and audit trail in the sidecar
- register `channel_gate` as a worker-level tool so local same-origin gate routes are not blocked by auth policy
- allow the Discord sidecar to omit `GATE_API_TOKEN` on loopback when server auth keeps `require_token=false`, using `Origin` + `X-MASC-Agent` fallback

## Verification
- `.venv/bin/pytest tests`
- `.venv/bin/pyright --pythonpath .venv/bin/python src tests`
- `.venv/bin/ruff check src tests`
- `_build_codex_discord/default/test/test_auth_coverage.exe`
- `_build_codex_discord/default/test/test_tool_access_role.exe`
- `_build_codex_discord/default/test/test_channel_gate.exe`
- `_build_codex_discord/default/test/test_channel_gate_metrics.exe`
- `_build_codex_discord/default/test/test_gate_protocol.exe`
- live smoke on patched `main_eio.exe` at `127.0.0.1:8945`:
  - `GET /api/v1/gate/keepers` -> 200
  - `GET /api/v1/gate/keeper-status?name=sangsu` -> 200
  - `POST /api/v1/gate/message` -> 200 with keeper reply

## Notes
- actual Discord login was not completed because no `DISCORD_BOT_TOKEN` source was present in the current workspace/env
- handoff note: `memory/handoff-2026-04-04-discord-gate-live-smoke.md`