### PR TITLE
refactor(room): remove scope field from config record

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -331,7 +331,7 @@ let resolve_execution_scope ~base_path ~(team_session_id : string option)
   | None -> (
       match team_session_id with
       | Some session_id -> (
-          match Team_session_store.load_session (Room.default_config base_path |> Room.config_with_resolved_scope) session_id with
+          match Team_session_store.load_session (Room.default_config base_path) session_id with
           | Some session -> session.execution_scope
           | None -> Team_session_types.Limited_code_change)
       | None -> Team_session_types.Limited_code_change)

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -472,7 +472,7 @@ type server_state = {
 let create_state ~base_path =
   let config =
     Room.default_config base_path
-    |> Room.config_with_resolved_scope
+   
   in
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)
@@ -520,7 +520,7 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
           Board_dispatch.init_jsonl ()
         end)
       base_path
-    |> Room.config_with_resolved_scope
+   
   in
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -6,25 +6,15 @@ type storage_backend =
   | FileSystem of Backend.FileSystem.t
   | PostgresNative of Backend.Postgres.t
 
-(** Room scope — determines which directory tree is active.
-    Resolved once at config creation time, never re-read from filesystem.
-    Since #4638 the Named variant has been removed; all state lives under
-    the root .masc/ directory directly. *)
-type scope =
-  | Default          (** Root .masc/ directory *)
-
-(** Room configuration *)
+(** Room configuration.
+    scope field removed — all state lives under root .masc/ directly. *)
 type config = {
   base_path: string;
   workspace_path: string;
   lock_expiry_minutes: int;
   backend_config: Backend_types.config;
   backend: storage_backend;
-  scope: scope;
 }
-
-(** Create a config targeting a different scope. Cheap record copy. *)
-let with_scope config scope = { config with scope }
 
 let _domain_local_pg_backend_created = Atomic.make 0
 let _domain_local_pg_backend_failed = Atomic.make 0
@@ -481,12 +471,11 @@ let default_config base_path =
                   Memory (Backend.Memory.get_or_create ~base_path:backend_config.cluster_name)))
   in
   {
-    base_path = resolved_path;  (* Use resolved path (git root for worktrees) *)
+    base_path = resolved_path;
     workspace_path = base_path;
     lock_expiry_minutes = 2;
     backend_config;
     backend;
-    scope = Default;
   }
 
 (** Create config with Eio context - required for PostgresNative backend.
@@ -534,7 +523,6 @@ let default_config_eio ~sw ~env ?(on_backend_ready = fun _backend -> ()) base_pa
     lock_expiry_minutes = 2;
     backend_config;
     backend;
-    scope = Default;
   }
 
 (* ============================================ *)

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -18,10 +18,6 @@ let room_dir_for config room_id =
 (** The operational namespace is always "default". *)
 let read_current_room _config = Some "default"
 
-(** Identity function retained for external callers during migration.
-    Will be removed in Phase 1b (scope field removal). *)
-let resolve_initial_scope _config = Default
-
 (** Directory resolution. Always resolves to the root .masc/ directory. *)
 let masc_dir config = masc_root_dir config
 
@@ -274,10 +270,6 @@ let is_initialized config =
       Sys.file_exists (masc_dir config) &&
       Sys.is_directory (masc_dir config) &&
       Sys.file_exists (state_path config)
-
-(** Identity: scope is always Default. Retained for 8 external callers.
-    Will be removed in Phase 1b (scope field removal). *)
-let config_with_resolved_scope config = config
 
 (* ============================================ *)
 (* Validation helpers                           *)

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -75,7 +75,7 @@ let load_findings ~base_path ~team_session_id : string list =
     with Sys_error _ -> []
 
 let build ~base_path ~team_session_id =
-  let room_config = Room.default_config base_path |> Room.config_with_resolved_scope in
+  let room_config = Room.default_config base_path in
   let session_opt =
     Team_session_store.load_session room_config team_session_id
   in

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -348,7 +348,7 @@ let handle_swarm_start (ctx : context) args =
                     | Some config -> config
                     | None ->
                         Room.default_config ctx.base_path
-                        |> Room.config_with_resolved_scope
+                       
                   in
                   let task_link_json =
                     match task_id with
@@ -417,7 +417,7 @@ let handle_stop (ctx : context) args =
     match Autoresearch.stop_loop ~base_path:ctx.base_path ~reason id with
     | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
     | Some state ->
-        let config = Room.default_config ctx.base_path |> Room.config_with_resolved_scope in
+        let config = Room.default_config ctx.base_path in
         broadcast_loop_lifecycle "autoresearch_stopped" state;
         (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
         | Some link ->

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -589,7 +589,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                        Autoresearch.save_state ~base_path:ctx.base_path state;
                        let config =
                          Room.default_config ctx.base_path
-                         |> Room.config_with_resolved_scope
+                        
                        in
                        (match
                           Autoresearch.load_swarm_link_by_loop

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -47,7 +47,7 @@ let handle_start (ctx : context) : result option =
       if not (Sys.file_exists expanded && Sys.is_directory expanded) then
         Error (Printf.sprintf "Directory not found: %s" expanded)
       else begin
-        let cfg = Room.default_config expanded |> Room.config_with_resolved_scope in
+        let cfg = Room.default_config expanded in
         if Room.is_initialized cfg then begin
           state.Mcp_server.room_config <- cfg;
           Ok cfg
@@ -228,7 +228,7 @@ let handle_set_room (ctx : context) : result option =
     if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then
       Some (false, Printf.sprintf "No .masc/ directory found in: %s\nRun masc_init to initialize, or choose a MASC-enabled directory." resolved)
     else begin
-      state.Mcp_server.room_config <- Room.default_config expanded |> Room.config_with_resolved_scope;
+      state.Mcp_server.room_config <- Room.default_config expanded;
       let rc = state.Mcp_server.room_config in
       (* GC: reap zombie agents when entering a room (uses newly resolved config).
          Best-effort: GC failure must not block set_room. *)

--- a/test/test_handover_eio_coverage.ml
+++ b/test/test_handover_eio_coverage.ml
@@ -199,7 +199,6 @@ let make_test_config ~base_path : Room_utils.config =
     lock_expiry_minutes = 5;
     backend_config;
     backend = Room_utils.Memory memory_backend;
-    scope = Default;
   }
 
 let with_eio_env f =

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -356,7 +356,6 @@ let make_test_config base_path : Room_setup.config =
     lock_expiry_minutes = 2;
     backend_config;
     backend = Room_setup.Memory (Backend.Memory.create ());
-    scope = Room_setup.Default;
   }
 
 let test_resolve_config_scoped_hit () =

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -42,7 +42,7 @@ let with_config f =
 let select_room config room_id =
   Room.write_current_room config room_id;
   Room.ensure_room_bootstrap config room_id;
-  Room.config_with_resolved_scope config
+  config
 
 let test_current_room_defaults_to_default () =
   with_config (fun config ->

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -252,7 +252,6 @@ let with_memory_test_env f =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
-    scope = Default;
   } in
   let _ = Room.init config ~agent_name:(Some "claude") in
   try

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -547,7 +547,6 @@ let make_test_config ~base_path ~cluster_name : Room_utils.config =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
-    scope = Default;
   }
 
 let test_masc_root_dir_default_cluster () =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -182,7 +182,7 @@ let test_force_jsonl_fallback_env () =
 
 let test_constructor_is_pure () =
   with_temp_dir "startup-pure" (fun dir ->
-      let agents_dir = Room.agents_dir (Room.default_config dir |> Room.config_with_resolved_scope) in
+      let agents_dir = Room.agents_dir (Room.default_config dir) in
       Fs_compat.mkdir_p agents_dir;
       write_file (Filename.concat agents_dir "alice.json") "{}";
       let state = Mcp_server.create_state ~base_path:dir in
@@ -206,7 +206,7 @@ let test_restore_persisted_sessions_uses_flat_agents_dir () =
 let test_keeper_paths_use_cluster_root () =
   with_temp_dir "startup-cluster" (fun dir ->
       with_env "MASC_CLUSTER_NAME" (Some "cluster-alpha") (fun () ->
-          let config = Room.default_config dir |> Room.config_with_resolved_scope in
+          let config = Room.default_config dir in
           let keeper_dir = Keeper_types.keeper_dir config in
           let expected_root =
             Filename.concat
@@ -218,7 +218,7 @@ let test_keeper_paths_use_cluster_root () =
 
 let test_room_init_bootstraps_keeper_runtime_dirs () =
   with_temp_dir "startup-keeper-dirs" (fun dir ->
-      let config = Room.default_config dir |> Room.config_with_resolved_scope in
+      let config = Room.default_config dir in
       ignore (Room.init config ~agent_name:None);
       let root_dir = Room.masc_root_dir config in
       let keeper_dir = Filename.concat root_dir "keepers" in

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -229,7 +229,6 @@ let make_test_config ~base_path : Room_utils.config =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
-    scope = Default;
   }
 
 let test_tempo_file_basic () =

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -71,7 +71,7 @@ let () = test "dispatch_dashboard" (fun () ->
   ignore (Room.add_task ctx.config ~title:"default task" ~priority:2 ~description:"");
   Room.write_current_room ctx.config "second-room";
   Room.ensure_room_bootstrap ctx.config "second-room";
-  let second_room = Room.config_with_resolved_scope ctx.config in
+  let second_room = ctx.config in
   ignore (Room.add_task second_room ~title:"second task" ~priority:1 ~description:"");
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
@@ -103,7 +103,7 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   let ctx = make_test_ctx () in
   Room.write_current_room ctx.config "focus-room";
   Room.ensure_room_bootstrap ctx.config "focus-room";
-  let focused = Room.config_with_resolved_scope ctx.config in
+  let focused = ctx.config in
   ignore (Room.add_task focused ~title:"focus task" ~priority:2 ~description:"");
   let args = `Assoc [("scope", `String "current")] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with


### PR DESCRIPTION
## Summary

- Remove `scope` type (single variant `Default` since #4638) and field from `Room_utils_backend_setup.config`
- Delete `config_with_resolved_scope`, `resolve_initial_scope`, `with_scope`
- Remove `scope = Default` from 4 test record literals
- Remove `|> Room.config_with_resolved_scope` pipes from 15 call sites

This is a type API change -- all record literal constructors updated.

## Test plan

- [x] `dune build` passes
- [ ] `dune runtest` (CI)
- [ ] Cross-model review

Closes #5117

Generated with [Claude Code](https://claude.com/claude-code)
