### PR TITLE
fix: tolerate headerless tool-only keeper turns

### DIFF
--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -170,6 +170,39 @@ let protocol_violation_state ~(meta : keeper_meta)
     delivery_surface = Silent;
   }
 
+let inferred_tool_surface tools =
+  if List.mem "keeper_board_comment" tools then
+    Some (Comment_board, Board_comment)
+  else if List.mem "keeper_board_post" tools then
+    Some (Post_board, Board_post)
+  else if List.mem "keeper_broadcast" tools then
+    Some (Broadcast, Broadcast_surface)
+  else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
+    Some (Claim_task, Task_claim_surface)
+  else
+    None
+
+let tool_only_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(result : Keeper_agent_run.run_result) =
+  let speech_act, delivery_surface =
+    match inferred_tool_surface result.tools_used with
+    | Some routed -> routed
+    | None ->
+        if String.trim result.response_text <> "" then (Inform, Visible_reply)
+        else (Defer, Silent)
+  in
+  {
+    social_model = meta.social_model;
+    belief_summary = belief_summary_of_observation observation;
+    active_desire = None;
+    current_intention = None;
+    blocker = None;
+    need = None;
+    speech_act;
+    delivery_surface;
+  }
+
 let social_state_of_headers ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation) headers =
   match nonempty_header_opt headers "SPEECH_ACT", header_assoc_opt headers "DELIVERY_SURFACE" with
@@ -271,7 +304,13 @@ let apply_to_result ~(meta : keeper_meta)
     (result : Keeper_agent_run.run_result) =
   let headers, response_body = parse_header_block result.response_text in
   let state =
-    social_state_of_headers ~meta ~observation headers
+    if headers <> [] then
+      social_state_of_headers ~meta ~observation headers
+    else if result.tools_used <> [] then
+      tool_only_state ~meta ~observation ~result
+    else
+      protocol_violation_state ~meta ~observation
+        ~reason:"missing social headers"
   in
   match state.speech_act, state.delivery_surface with
   | Request_help, Board_post when result.tools_used = [] ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1450,6 +1450,41 @@ let test_social_model_routes_blocker_to_board_post () =
             (contains_substring post.body "blocked")
       | _ -> fail "expected one request-help board post")
 
+let test_social_model_tool_only_turn_skips_protocol_violation () =
+  let result =
+    make_run_result ~text:"" ~tools:["masc_heartbeat"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation result
+  in
+  check string "speech act" "defer"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "silent"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check (option string) "no protocol violation blocker" None state.blocker;
+  check string "visible response suppressed" "" routed.response_text;
+  check (list string) "tool list preserved" ["masc_heartbeat"] routed.tools_used
+
+let test_social_model_infers_board_comment_from_tool_use () =
+  let result =
+    make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_heartbeat"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation result
+  in
+  check string "speech act" "comment_board"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "board_comment"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check (option string) "no protocol violation blocker" None state.blocker;
+  check string "visible response empty" "" routed.response_text;
+  check (list string) "tool list preserved"
+    ["keeper_board_comment"; "masc_heartbeat"] routed.tools_used
+
 (* ---------- render_inline_skip_reason tests ---------- *)
 
 let str_contains s sub =
@@ -1639,6 +1674,10 @@ let () =
             test_social_model_requires_explicit_headers;
           test_case "social model routes blocker to board post" `Quick
             test_social_model_routes_blocker_to_board_post;
+          test_case "social model tool-only turn skips protocol violation" `Quick
+            test_social_model_tool_only_turn_skips_protocol_violation;
+          test_case "social model infers board comment from tool use" `Quick
+            test_social_model_infers_board_comment_from_tool_use;
           test_case "render_inline deny" `Quick
             test_render_inline_skip_reason_deny;
           test_case "render_inline cost" `Quick


### PR DESCRIPTION
## Summary
- treat headerless tool-only unified keeper turns as valid tool-first outcomes instead of protocol violations
- infer social surface from tool usage for board comments, board posts, broadcasts, and task claims
- add regression tests covering headerless tool-only turns and inferred board-comment routing

## Verification
- `dune build --root . test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe`
- Result: 82 tests passed

## Cross-model review
- `sb glm-text` (`GLM-5.1`) reviewed commit `18e74d11042908291b32813524eb33f1659a2ce7`
- Result: `No findings.`