### PR TITLE
fix(dashboard): namespace-truth shell fiber timeout graceful degradation

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -8,13 +8,22 @@ open Server_dashboard_http_core
     Used for adaptive timeout in namespace-truth: cold path gets more time. *)
 let _shell_warmed = ref false
 
+(** Last-known-good shell result for graceful degradation on timeout.
+    When the shell fiber times out (I/O contention), returning the stale
+    shell JSON is strictly better than returning empty [`Assoc []] which
+    zeros out namespace counts and focus data. Updated on every successful
+    shell fetch. *)
+let _last_good_shell : Yojson.Safe.t ref = ref (`Assoc [])
+
 let warm_shell_cache (state : Mcp_server.server_state) =
   let t0 = Time_compat.now () in
   (try
-     ignore
-       (dashboard_shell_http_json ?clock:state.Mcp_server.clock
-          state.Mcp_server.room_config);
+     let result =
+       dashboard_shell_http_json ?clock:state.Mcp_server.clock
+         state.Mcp_server.room_config
+     in
      _shell_warmed := true;
+     _last_good_shell := result;
      Log.Dashboard.info "shell cache pre-warmed (%.1fms)"
        ((Time_compat.now () -. t0) *. 1000.0)
    with

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -84,20 +84,35 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
                 (Printexc.to_string exn);
               fallback
         in
-        let shell_timeout_s =
-          if !(Execution_surfaces._shell_warmed) then base_timeout_s
-          else cold_timeout_s
+        (* Shell fiber timeout: must exceed inner cache timeout
+           (dashboard_shell_timeout_s, default 8s) to avoid the double-timeout
+           race where the inner cache returns timeout-error JSON while the outer
+           fiber also fires, discarding even stale data.  Fixes #5090. *)
+        let shell_fiber_timeout_s =
+          float_of_env_default "MASC_DASHBOARD_SHELL_FIBER_TIMEOUT_S"
+            ~default:12.0 ~min_v:5.0 ~max_v:30.0
         in
+        let shell_timeout_s =
+          if !(Execution_surfaces._shell_warmed) then shell_fiber_timeout_s
+          else Float.max cold_timeout_s (shell_fiber_timeout_s +. 4.0)
+        in
+        (* Graceful degradation: on timeout fall back to the last successful
+           shell result rather than empty JSON, which would zero out namespace
+           counts and focus data (61x/day under I/O contention). *)
+        let shell_fallback = !(Execution_surfaces._last_good_shell) in
         (* Sequential fetch to avoid PG connection concurrent usage (#3305). *)
         shell_ref :=
           fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
             (fun () -> dashboard_shell_http_json ~clock config)
-            (`Assoc []);
+            shell_fallback;
         execution_ref := cached_surface_json Execution_surfaces._execution_cache;
         (* command_plane_summary_http_json reads from a proactive cache ref. *)
         command_ref :=
           Server_command_plane_http.command_plane_summary_http_json ~state;
         let shell_json = !shell_ref in
+        (* Update last-known-good shell on success. *)
+        if shell_json <> `Assoc [] && shell_json <> shell_fallback then
+          Execution_surfaces._last_good_shell := shell_json;
         if (not !(Execution_surfaces._shell_warmed)) && shell_json <> `Assoc [] then
           Execution_surfaces._shell_warmed := true;
         let execution_json = !execution_ref in
@@ -136,9 +151,13 @@ let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
     let config = state.Mcp_server.room_config in
     let shell_json =
       if !(Execution_surfaces._shell_warmed) then
-        try dashboard_shell_http_json ?clock:state.Mcp_server.clock config
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> `Assoc []
-      else `Assoc []
+        (try
+           let result = dashboard_shell_http_json ?clock:state.Mcp_server.clock config in
+           Execution_surfaces._last_good_shell := result;
+           result
+         with Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> !(Execution_surfaces._last_good_shell))
+      else !(Execution_surfaces._last_good_shell)
     in
     let execution_json = cached_surface_json Execution_surfaces._execution_cache in
     let command_summary_json =

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -502,6 +502,44 @@ let test_dashboard_namespace_truth_cold_cache_falls_back_to_partial_truth () =
           (json |> member "projection_diagnostics" |> member "execution_cache_state" |> to_string);
       ))
 
+let test_last_good_shell_fallback_preserves_counts () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      warm_execution_cache ();
+      (* Warm the shell cache so _last_good_shell gets populated. *)
+      Lib.Server_dashboard_http.warm_shell_cache state;
+      let last_good = !(Lib.Server_dashboard_http._last_good_shell) in
+      check bool "last good shell is non-empty after warm"
+        true
+        (last_good <> `Assoc []);
+      (* Now verify that _last_good_shell has namespace counts. *)
+      let open Yojson.Safe.Util in
+      let counts = last_good |> member "counts" in
+      check bool "last good shell contains counts block"
+        true
+        (counts <> `Null);
+      (* Verify namespace-truth snapshot_from_caches uses the stale shell data
+         even when the warmed flag is false (cold path, simulating timeout). *)
+      Lib.Server_dashboard_http._shell_warmed := false;
+      let snapshot =
+        match Lib.Server_dashboard_http.namespace_truth_snapshot_from_caches state with
+        | Some json -> json
+        | None -> fail "expected cached namespace-truth snapshot"
+      in
+      let ns_counts = snapshot |> member "namespace" |> member "counts" in
+      (* Shell was warmed once then reset; snapshot_from_caches should still
+         produce a valid namespace block via the _last_good_shell fallback. *)
+      check bool "namespace counts block present in fallback snapshot"
+        true
+        (ns_counts <> `Null);
+      (* Restore warmed state for subsequent tests. *)
+      Lib.Server_dashboard_http._shell_warmed := true)
+
 let () =
   Alcotest.run "Dashboard Namespace Truth"
     [
@@ -523,5 +561,7 @@ let () =
             test_namespace_truth_cached_snapshot_matches_http_projection_blocks;
           test_case "expired execution warmup falls back to partial truth" `Quick
             test_dashboard_namespace_truth_cold_cache_falls_back_to_partial_truth;
+          test_case "last-good shell fallback preserves namespace counts" `Quick
+            test_last_good_shell_fallback_preserves_counts;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Add `_last_good_shell` stale-but-valid fallback for the namespace-truth shell fiber, eliminating empty-JSON responses that zeroed namespace counts and focus data (61x/day under I/O contention).
- Introduce dedicated `MASC_DASHBOARD_SHELL_FIBER_TIMEOUT_S` (default 12s) to decouple the outer fiber timeout from the inner cache timeout (8s), resolving the double-timeout race.
- Cold path now uses `max(cold_timeout, shell_fiber_timeout + 4s)` for adequate headroom.

Fixes #5090

## Test plan
- [x] All 11 namespace-truth tests pass (including new `last-good shell fallback preserves namespace counts` regression test)
- [ ] Monitor `namespace-truth fiber shell timed out` log frequency in production (expect significant reduction from 61x/day baseline)
- [ ] Verify dashboard namespace counts remain populated during I/O contention periods

## Files changed
- `lib/server/server_dashboard_http_execution_surfaces.ml` — add `_last_good_shell` ref, update `warm_shell_cache` to populate it
- `lib/server/server_dashboard_http_namespace_truth.ml` — use `_last_good_shell` as fallback, add dedicated shell fiber timeout
- `test/test_dashboard_namespace_truth.ml` — regression test for fallback mechanism