### PR TITLE
fix(keeper): pass explicit priority through OAS named runner

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -252,7 +252,7 @@ let run_turn
     ?on_event
     ?(trajectory_acc : Trajectory.accumulator option)
     ?(tool_overlay : Agent_sdk.Tool_op.t ref option)
-    ?_priority
+    ?priority
     ?(is_retry = false)
     ()
   : (run_result, string) result =
@@ -784,10 +784,14 @@ let run_turn
   let on_resume = if yield_on_tool then Some (fun () ->
     Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" meta.name
   ) else None in
+  let priority =
+    Option.value priority ~default:Llm_provider.Request_priority.Proactive
+  in
   match
         Oas_worker.run_named
           ~cascade_name
           ~goal:user_message
+          ~priority
           ~session_id:meta.runtime.trace_id
           ~system_prompt:turn_system_prompt
           ~tools

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -77,6 +77,7 @@ val default_model_strings : cascade_name:string -> string list
 val run_named :
   cascade_name:string ->
   goal:string ->
+  ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->
   ?tools:Oas.Tool.t list ->
@@ -137,6 +138,7 @@ val run_model_by_label :
 val run_named_with_masc_tools :
   cascade_name:string ->
   goal:string ->
+  ?priority:Llm_provider.Request_priority.t ->
   ?system_prompt:string ->
   masc_tools:Types.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -14,6 +14,7 @@ type config = {
   name : string;
   provider : Oas.Provider.config;
   model_id : string;
+  priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Oas.Tool.t list;
   max_turns : int;
@@ -41,7 +42,7 @@ type config = {
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
-  { name; provider; model_id; system_prompt; tools;
+  { name; provider; model_id; priority = None; system_prompt; tools;
     max_turns = 20;
     max_idle_turns = 3;
     max_tokens = Oas_worker_cascade.default_max_tokens;
@@ -215,6 +216,11 @@ let build
   in
   let builder = match config.enable_thinking with
     | Some enabled -> Oas.Builder.with_enable_thinking enabled builder
+    | None -> builder
+  in
+  let builder =
+    match config.priority with
+    | Some priority -> Oas.Builder.with_priority priority builder
     | None -> builder
   in
   let builder =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -112,6 +112,7 @@ let config_for_label
 let run_named
     ~cascade_name
     ~goal
+    ?priority
     ?session_id
     ?(system_prompt = "")
     ?(tools = [])
@@ -177,6 +178,7 @@ let run_named
     { (Oas_worker_exec.default_config ~name ~provider ~model_id:primary_provider.model_id
       ~system_prompt ~tools)
     with
+      priority;
       max_turns; max_tokens; temperature; max_idle_turns;
       guardrails; hooks; context_reducer; memory; tool_retry_policy;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
@@ -270,6 +272,7 @@ let run_model_by_label
 let run_named_with_masc_tools
     ~cascade_name
     ~goal
+    ?priority
     ?(system_prompt = "")
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -298,7 +301,7 @@ let run_named_with_masc_tools
       ~input_schema:td.input_schema
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
-  run_named ~cascade_name ~goal ~system_prompt ~tools:oas_tools
+  run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
     ?tool_retry_policy
     ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -467,6 +467,48 @@ let test_oas_worker_exec_build_applies_retry_policy () =
       Oas.Agent.close agent
   | Error err -> Alcotest.fail err
 
+let test_oas_worker_exec_build_default_priority_unset () =
+  let provider = make_local_provider () in
+  let config =
+    Oas_worker_exec.default_config
+      ~name:"oas-worker-default-priority"
+      ~provider
+      ~model_id:"mock-model"
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  match Oas_worker_exec.build ~net:(require_test_net ()) ~config with
+  | Ok agent ->
+      let priority = (Oas.Agent.state agent).config.priority in
+      Alcotest.(check bool) "default priority remains unset" true
+        (Option.is_none priority);
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail err
+
+let test_oas_worker_exec_build_applies_priority () =
+  let provider = make_local_provider () in
+  let base_config =
+    Oas_worker_exec.default_config
+      ~name:"oas-worker-priority"
+      ~provider
+      ~model_id:"mock-model"
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  let config =
+    { base_config with
+      priority = Some Llm_provider.Request_priority.Proactive }
+  in
+  match Oas_worker_exec.build ~net:(require_test_net ()) ~config with
+  | Ok agent ->
+      let priority = (Oas.Agent.state agent).config.priority in
+      Alcotest.(check bool) "priority propagated to agent config" true
+        (match priority with
+         | Some Llm_provider.Request_priority.Proactive -> true
+         | _ -> false);
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail err
+
 let test_worker_build_agent_uses_default_internal_retry_policy () =
   with_raw_trace "worker_build_agent_retry" @@ fun raw_trace ->
   let meta = make_worker_meta () in
@@ -1316,6 +1358,10 @@ let () =
         test_oas_worker_exec_build_defaults_without_retry_policy;
       Alcotest.test_case "oas_worker opt-in applies retry policy" `Quick
         test_oas_worker_exec_build_applies_retry_policy;
+      Alcotest.test_case "oas_worker default priority remains unset" `Quick
+        test_oas_worker_exec_build_default_priority_unset;
+      Alcotest.test_case "oas_worker applies explicit priority" `Quick
+        test_oas_worker_exec_build_applies_priority;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## Summary
- thread explicit `Llm_provider.Request_priority.t` through `Oas_worker.run_named`
- default keeper turns to `Proactive` instead of falling through as unspecified
- add focused OAS worker coverage for explicit/default priority propagation

## Product impact
- keeper-originated named OAS calls now preserve explicit provider priority instead of silently dropping to the unspecified path
- proactive keeper turns keep the intended request class when they fan out through the named runner

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-5127 --build-dir /tmp/fix5127-build --cache=disabled lib/oas_worker_exec.ml lib/oas_worker_named.ml lib/keeper/keeper_agent_run.ml`

## Evidence
- focused isolated lib build passed on 2026-04-04

## Review evidence
- cross-model review via `sb glm-text` on 2026-04-04 reported `No findings.` and the evidence comment is attached on this PR

## Linked issue
- Refs #5127

## Notes
- test executable build was not completed in this environment; lib-only isolated build passed
