### PR TITLE
refactor(boundary): extract verifier_core from verifier_oas

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -497,6 +497,7 @@
    observability_redact
    oas_model_resolve
    context_compact_oas
+   verifier_core
    verifier_oas
    procedural_memory
    oas_events

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -1,0 +1,156 @@
+(** Verifier_core — Pure verification types, parsing, and read-only detection.
+
+    No Agent_sdk or OAS dependency. Extracted from verifier_oas.ml to enforce
+    the MASC-OAS boundary: core domain logic stays OAS-free.
+
+    @since 2.61.0 (verifier core)
+    @since 2.223.0 (structured verdict via report_verdict tool)
+    @since 2.233.0 (extracted from verifier_oas.ml) *)
+
+open Printf
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+type verification_request = {
+  action_description : string;
+  action_result : string;
+  goal : string;
+  context_summary : string;
+}
+
+type verdict =
+  | Pass
+  | Warn of string
+  | Fail of string
+
+(* ================================================================ *)
+(* Read-Only Detection                                              *)
+(* ================================================================ *)
+
+let read_only_patterns = [
+  "read"; "glob"; "grep";
+  "search"; "find"; "list"; "ls"; "cat"; "head"; "tail";
+  "git status"; "git log"; "git diff";
+  "status"; "view"; "get"; "fetch"; "query";
+]
+
+let is_word_char c =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+  | _ -> false
+
+let has_pattern_with_word_boundary ~text ~pat =
+  let tlen = String.length text in
+  let plen = String.length pat in
+  if plen = 0 || tlen < plen then false
+  else
+    let rec loop i =
+      if i > tlen - plen then false
+      else if String.sub text i plen = pat then
+        let before_ok = i = 0 || not (is_word_char text.[i - 1]) in
+        let after_idx = i + plen in
+        let after_ok = after_idx >= tlen || not (is_word_char text.[after_idx]) in
+        if before_ok && after_ok then true else loop (i + 1)
+      else
+        loop (i + 1)
+    in
+    loop 0
+
+let should_skip ~action_description =
+  let text = String.lowercase_ascii action_description in
+  List.exists (fun pat ->
+    has_pattern_with_word_boundary ~text ~pat
+  ) read_only_patterns
+
+(* ================================================================ *)
+(* Verdict Parsing                                                  *)
+(* ================================================================ *)
+
+let verdict_to_string = function
+  | Pass -> "PASS"
+  | Warn reason -> sprintf "WARN: %s" reason
+  | Fail reason -> sprintf "FAIL: %s" reason
+
+let has_keyword_boundary upper len =
+  let tlen = String.length upper in
+  len >= tlen || not (is_word_char upper.[len])
+
+let extract_reason trimmed keyword_len default_reason =
+  let reason =
+    if String.length trimmed > keyword_len + 1 then
+      String.trim (String.sub trimmed (keyword_len + 1) (String.length trimmed - keyword_len - 1))
+    else default_reason
+  in
+  if String.length reason > 0 && (reason.[0] = ':' || reason.[0] = '-') then
+    String.trim (String.sub reason 1 (String.length reason - 1))
+  else reason
+
+let parse_verdict (text : string) : (verdict, string) result =
+  let trimmed = String.trim text in
+  let upper = String.uppercase_ascii trimmed in
+  let len = String.length upper in
+  if len >= 4 && String.sub upper 0 4 = "PASS" && has_keyword_boundary upper 4 then
+    Ok Pass
+  else if len >= 4 && String.sub upper 0 4 = "WARN" && has_keyword_boundary upper 4 then
+    Ok (Warn (extract_reason trimmed 4 "unspecified concern"))
+  else if len >= 4 && String.sub upper 0 4 = "FAIL" && has_keyword_boundary upper 4 then
+    Ok (Fail (extract_reason trimmed 4 "action did not achieve goal"))
+  else if len = 0 then
+    Error "empty verifier output"
+  else
+    Error (sprintf "unrecognized verdict format: %s"
+      (if len > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
+
+(* ================================================================ *)
+(* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)
+(* ================================================================ *)
+
+let report_verdict_schema : Types.tool_schema =
+  { name = "report_verdict";
+    description =
+      "Report your verification verdict. You MUST call this tool \
+       with your assessment. verdict must be exactly PASS, WARN, or FAIL.";
+    input_schema = `Assoc [
+      "type", `String "object";
+      "properties", `Assoc [
+        "verdict", `Assoc [
+          "type", `String "string";
+          "enum", `List [`String "PASS"; `String "WARN"; `String "FAIL"];
+          "description", `String "PASS if correct, WARN if acceptable with concerns, FAIL if wrong or harmful";
+        ];
+        "reason", `Assoc [
+          "type", `String "string";
+          "description", `String "Brief explanation for the verdict (required for WARN and FAIL)";
+        ];
+      ];
+      "required", `List [`String "verdict"];
+    ];
+  }
+
+let parse_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let verdict_str =
+      args |> member "verdict" |> to_string |> String.uppercase_ascii
+    in
+    let reason =
+      try args |> member "reason" |> to_string
+      with Type_error _ -> ""
+    in
+    match verdict_str with
+    | "PASS" -> Ok Pass
+    | "WARN" ->
+      let r = if reason = "" then "unspecified concern" else reason in
+      Ok (Warn r)
+    | "FAIL" ->
+      let r = if reason = "" then "action did not achieve goal" else reason in
+      Ok (Fail r)
+    | other ->
+      Error (sprintf "unexpected verdict value: %s" other)
+  with
+  | Type_error (msg, _) ->
+    Error (sprintf "verdict JSON type error: %s" msg)
+  | exn ->
+    Error (sprintf "verdict JSON parse error: %s" (Printexc.to_string exn))

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -1,196 +1,32 @@
-(** Verifier_oas — Action verification engine with OAS Guardrails/Hooks bridge.
+(** Verifier_oas — OAS adapter for verification engine.
 
-    Cheap-model action verification for feedback loops.
-    Each action is sent to a cheap model with a [report_verdict] tool.
-    The model calls the tool with a typed verdict (PASS/WARN/FAIL + reason).
-    If the model responds with text instead of a tool call, a lenient
-    text parser serves as fallback (Samchon Rank 1: lenient parsing).
+    Bridges Verifier_core types to Agent_sdk Hooks/Guardrails.
+    Core verification types and parsing live in Verifier_core (no OAS dependency).
 
-    Budget: max 200 output tokens per verification (~0.01 cents).
-    Skip: read-only actions (file reads, glob, grep, searches).
-
-    OAS integration:
-    - [verdict_to_hook_decision]: Pass/Warn/Fail -> OAS Continue/Continue/Skip
-    - [make_pre_tool_hook]: wraps verify as an OAS PreToolUse hook
-    - [guardrails_with_read_only_tag]: wraps should_skip as OAS Custom filter
-
-    ADR D3: verdict extraction uses structured tool output (deterministic)
-    instead of regex/prefix matching on free text (nondeterministic).
-
-    @since 2.61.0 (verifier core)
     @since Phase 4 (OAS Guardrails adapter)
-    @since 2.223.0 (structured verdict via report_verdict tool) *)
+    @since 2.233.0 (core extracted to verifier_core.ml) *)
 
 open Printf
 
-(* ================================================================ *)
-(* Types                                                            *)
-(* ================================================================ *)
-
-type verification_request = {
+(* Re-export core types for backward compatibility *)
+type verification_request = Verifier_core.verification_request = {
   action_description : string;
   action_result : string;
   goal : string;
   context_summary : string;
 }
 
-type verdict =
+type verdict = Verifier_core.verdict =
   | Pass
   | Warn of string
   | Fail of string
 
-(* ================================================================ *)
-(* Read-Only Detection                                              *)
-(* ================================================================ *)
-
-(** Actions that are safe and need no verification. *)
-let read_only_patterns = [
-  "read"; "glob"; "grep";
-  "search"; "find"; "list"; "ls"; "cat"; "head"; "tail";
-  "git status"; "git log"; "git diff";
-  "status"; "view"; "get"; "fetch"; "query";
-]
-
-let is_word_char c =
-  match c with
-  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
-  | _ -> false
-
-let has_pattern_with_word_boundary ~text ~pat =
-  let tlen = String.length text in
-  let plen = String.length pat in
-  if plen = 0 || tlen < plen then false
-  else
-    let rec loop i =
-      if i > tlen - plen then false
-      else if String.sub text i plen = pat then
-        let before_ok = i = 0 || not (is_word_char text.[i - 1]) in
-        let after_idx = i + plen in
-        let after_ok = after_idx >= tlen || not (is_word_char text.[after_idx]) in
-        if before_ok && after_ok then true else loop (i + 1)
-      else
-        loop (i + 1)
-    in
-    loop 0
-
-let should_skip ~action_description =
-  let text = String.lowercase_ascii action_description in
-  List.exists (fun pat ->
-    has_pattern_with_word_boundary ~text ~pat
-  ) read_only_patterns
-
-(* ================================================================ *)
-(* Verdict Parsing                                                  *)
-(* ================================================================ *)
-
-let verdict_to_string = function
-  | Pass -> "PASS"
-  | Warn reason -> sprintf "WARN: %s" reason
-  | Fail reason -> sprintf "FAIL: %s" reason
-
-(** Check if keyword at position 0..len is followed by a word boundary.
-    A boundary is defined as end of string or a following non-word character.
-    Prevents "PASSING" matching as PASS while allowing "PASS." / "PASS\t...". *)
-let has_keyword_boundary upper len =
-  let tlen = String.length upper in
-  len >= tlen || not (is_word_char upper.[len])
-
-(** Extract reason text after keyword+separator, stripping leading colon/dash. *)
-let extract_reason trimmed keyword_len default_reason =
-  let reason =
-    if String.length trimmed > keyword_len + 1 then
-      String.trim (String.sub trimmed (keyword_len + 1) (String.length trimmed - keyword_len - 1))
-    else default_reason
-  in
-  if String.length reason > 0 && (reason.[0] = ':' || reason.[0] = '-') then
-    String.trim (String.sub reason 1 (String.length reason - 1))
-  else reason
-
-(** Parse "PASS", "WARN: reason", "FAIL: reason" from model output.
-    Returns Error on unrecognized format instead of silent degrade (ADR D3).
-    Requires word boundary after keyword to prevent "PASSING"/"WARNING" false matches. *)
-let parse_verdict (text : string) : (verdict, string) result =
-  let trimmed = String.trim text in
-  let upper = String.uppercase_ascii trimmed in
-  let len = String.length upper in
-  if len >= 4 && String.sub upper 0 4 = "PASS" && has_keyword_boundary upper 4 then
-    Ok Pass
-  else if len >= 4 && String.sub upper 0 4 = "WARN" && has_keyword_boundary upper 4 then
-    Ok (Warn (extract_reason trimmed 4 "unspecified concern"))
-  else if len >= 4 && String.sub upper 0 4 = "FAIL" && has_keyword_boundary upper 4 then
-    Ok (Fail (extract_reason trimmed 4 "action did not achieve goal"))
-  else if len = 0 then
-    Error "empty verifier output"
-  else
-    Error (sprintf "unrecognized verdict format: %s"
-      (if len > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
-
-(* ================================================================ *)
-(* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)
-(* ================================================================ *)
-
-(** JSON schema for the report_verdict tool.
-    Forces the LLM to call a tool with typed parameters instead of
-    producing free-text output.
-
-    Schema constrains verdict to exactly PASS/WARN/FAIL via enum,
-    making invalid values structurally impossible (Samchon: "constraint
-    through absence"). *)
-let report_verdict_schema : Types.tool_schema =
-  { name = "report_verdict";
-    description =
-      "Report your verification verdict. You MUST call this tool \
-       with your assessment. verdict must be exactly PASS, WARN, or FAIL.";
-    input_schema = `Assoc [
-      "type", `String "object";
-      "properties", `Assoc [
-        "verdict", `Assoc [
-          "type", `String "string";
-          "enum", `List [`String "PASS"; `String "WARN"; `String "FAIL"];
-          "description", `String "PASS if correct, WARN if acceptable with concerns, FAIL if wrong or harmful";
-        ];
-        "reason", `Assoc [
-          "type", `String "string";
-          "description", `String "Brief explanation for the verdict (required for WARN and FAIL)";
-        ];
-      ];
-      "required", `List [`String "verdict"];
-    ];
-  }
-
-(** Parse verdict from tool call JSON arguments (deterministic path).
-    The JSON is produced by the LLM calling report_verdict, so the
-    "verdict" field is constrained by the schema enum.
-
-    Handles Samchon absorption points:
-    - Type coercion: accepts both quoted and unquoted values
-    - Case insensitivity: "pass", "Pass", "PASS" all accepted
-    - Missing reason: defaults to descriptive string *)
-let parse_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) result =
-  let open Yojson.Safe.Util in
-  try
-    let verdict_str =
-      args |> member "verdict" |> to_string |> String.uppercase_ascii
-    in
-    let reason =
-      try args |> member "reason" |> to_string
-      with Type_error _ -> ""
-    in
-    match verdict_str with
-    | "PASS" -> Ok Pass
-    | "WARN" ->
-      let r = if reason = "" then "unspecified concern" else reason in
-      Ok (Warn r)
-    | "FAIL" ->
-      let r = if reason = "" then "action did not achieve goal" else reason in
-      Ok (Fail r)
-    | other ->
-      Error (sprintf "unexpected verdict value: %s" other)
-  with
-  | Type_error (msg, _) ->
-    Error (sprintf "verdict JSON type error: %s" msg)
-  | exn ->
-    Error (sprintf "verdict JSON parse error: %s" (Printexc.to_string exn))
+(* Re-export core functions *)
+let should_skip = Verifier_core.should_skip
+let verdict_to_string = Verifier_core.verdict_to_string
+let parse_verdict = Verifier_core.parse_verdict
+let report_verdict_schema = Verifier_core.report_verdict_schema
+let parse_verdict_from_json = Verifier_core.parse_verdict_from_json
 
 (* ================================================================ *)
 (* Verification Prompt                                              *)


### PR DESCRIPTION
## Summary

- Extract `verifier_core.ml` from `verifier_oas.ml` to enforce MASC-OAS boundary
- `verifier_core.ml`: Pure types, parsing, read-only detection, report_verdict schema (no Agent_sdk)
- `verifier_oas.ml`: OAS adapter (hooks, guardrails, verify). Re-exports core types for backward compat
- team_context OAS bridge split deferred to follow-up

## Test plan

- [x] `dune build` passes
- [ ] `dune runtest` (CI)
- [ ] Cross-model review

Toward #5118

Generated with [Claude Code](https://claude.com/claude-code)
