### PR TITLE
fix(config): add multiline string support to TOML parser

### DIFF
--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -52,6 +52,18 @@ let multiline_suffix_is_valid suffix =
   let i = skip_ws 0 in
   i >= len || suffix.[i] = '#'
 
+(* TOML allows up to two `"` chars immediately after the closing `"""` to be
+   part of the string content.  Extract those and return (trailing, rest). *)
+let extract_trailing_quotes suffix =
+  let n = String.length suffix in
+  let count =
+    if n > 0 && suffix.[0] = '"' then
+      if n > 1 && suffix.[1] = '"' then 2
+      else 1
+    else 0
+  in
+  (String.make count '"', String.sub suffix count (n - count))
+
 let strip_comment (line : string) : string =
   (* Find # that is not inside a quoted string. *)
   let len = String.length line in
@@ -84,6 +96,16 @@ let parse_basic_string (s : string) : (string, string) result =
         | 'r' -> Buffer.add_char buf '\r'; loop (i + 2)
         | '\\' -> Buffer.add_char buf '\\'; loop (i + 2)
         | '"' -> Buffer.add_char buf '"'; loop (i + 2)
+        | '\n' | '\r' ->
+          (* TOML multiline line-ending backslash: trim the backslash, the
+             newline, and any subsequent whitespace/newlines. *)
+          let rec skip_ws j =
+            if j >= len then j
+            else if s.[j] = ' ' || s.[j] = '\t' || s.[j] = '\n' || s.[j] = '\r'
+            then skip_ws (j + 1)
+            else j
+          in
+          loop (skip_ws (i + 2))
         | c -> Error (Printf.sprintf "unknown escape \\%c" c)
     end
     else begin
@@ -184,23 +206,22 @@ let starts_with_triple_quote s =
   let len = String.length s in
   len >= 3 && s.[0] = '"' && s.[1] = '"' && s.[2] = '"'
 
-let is_escaped_quote s idx =
-  let rec count_backslashes i count =
-    if i < 0 then count
-    else if s.[i] = '\\' then count_backslashes (i - 1) (count + 1)
-    else count
-  in
-  (count_backslashes (idx - 1) 0) mod 2 = 1
-
 let find_closing_triple_quote s start =
   let len = String.length s in
-  let rec scan i =
+  (* Scan forward, tracking the number of consecutive backslashes immediately
+     preceding the current index (parity determines whether a quote is escaped).
+     This keeps the overall search O(n) rather than O(n^2). *)
+  let rec scan i backslashes =
     if i + 2 >= len then None
-    else if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"'
-            && not (is_escaped_quote s i) then Some i
-    else scan (i + 1)
+    else
+      let escaped = (backslashes mod 2) = 1 in
+      if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"' && not escaped then
+        Some i
+      else
+        let next_backslashes = if s.[i] = '\\' then backslashes + 1 else 0 in
+        scan (i + 1) next_backslashes
   in
-  scan start
+  scan start 0
 
 let parse_toml (content : string) : (toml_doc, string) result =
   let lines = String.split_on_char '\n' content in
@@ -226,13 +247,15 @@ let parse_toml (content : string) : (toml_doc, string) result =
             String.sub raw_line (close_pos + 3)
               (String.length raw_line - close_pos - 3)
           in
-          if not (multiline_suffix_is_valid suffix) then
+          let trailing_quotes, suffix_remainder = extract_trailing_quotes suffix in
+          if not (multiline_suffix_is_valid suffix_remainder) then
             error := Some
               (Printf.sprintf "line %d: unexpected content after closing multiline string"
                  !line_num)
           else begin
             if Buffer.length !ml_buf > 0 then Buffer.add_char !ml_buf '\n';
             Buffer.add_string !ml_buf prefix;
+            Buffer.add_string !ml_buf trailing_quotes;
             let raw_str = Buffer.contents !ml_buf in
             (match parse_basic_string raw_str with
              | Ok v -> acc := (!ml_key, Toml_string v) :: !acc
@@ -291,12 +314,13 @@ let parse_toml (content : string) : (toml_doc, string) result =
                     String.sub after_open (close_pos + 3)
                       (String.length after_open - close_pos - 3)
                   in
-                  if not (multiline_suffix_is_valid suffix) then
+                  let trailing_quotes, suffix_remainder = extract_trailing_quotes suffix in
+                  if not (multiline_suffix_is_valid suffix_remainder) then
                     error := Some
                       (Printf.sprintf "line %d: unexpected content after closing multiline string"
                          !line_num)
                   else
-                    (match parse_basic_string inner with
+                    (match parse_basic_string (inner ^ trailing_quotes) with
                      | Ok v -> acc := (full_key, Toml_string v) :: !acc
                      | Error e ->
                        error := Some (Printf.sprintf "line %d: %s" !line_num e))

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -19,6 +19,39 @@ type toml_doc = (string * toml_value) list
 
 let is_ws c = c = ' ' || c = '\t'
 
+let strip_trailing_cr s =
+  let len = String.length s in
+  if len > 0 && s.[len - 1] = '\r' then String.sub s 0 (len - 1) else s
+
+let trim_leading_ws s =
+  let len = String.length s in
+  let rec scan i =
+    if i >= len then len
+    else if is_ws s.[i] then scan (i + 1)
+    else i
+  in
+  let start = scan 0 in
+  String.sub s start (len - start)
+
+let trim_initial_multiline_newline s =
+  let len = String.length s in
+  if len >= 2 && s.[0] = '\r' && s.[1] = '\n' then
+    String.sub s 2 (len - 2)
+  else if len >= 1 && s.[0] = '\n' then
+    String.sub s 1 (len - 1)
+  else
+    s
+
+let multiline_suffix_is_valid suffix =
+  let len = String.length suffix in
+  let rec skip_ws i =
+    if i >= len then len
+    else if is_ws suffix.[i] then skip_ws (i + 1)
+    else i
+  in
+  let i = skip_ws 0 in
+  i >= len || suffix.[i] = '#'
+
 let strip_comment (line : string) : string =
   (* Find # that is not inside a quoted string. *)
   let len = String.length line in
@@ -151,11 +184,20 @@ let starts_with_triple_quote s =
   let len = String.length s in
   len >= 3 && s.[0] = '"' && s.[1] = '"' && s.[2] = '"'
 
+let is_escaped_quote s idx =
+  let rec count_backslashes i count =
+    if i < 0 then count
+    else if s.[i] = '\\' then count_backslashes (i - 1) (count + 1)
+    else count
+  in
+  (count_backslashes (idx - 1) 0) mod 2 = 1
+
 let find_closing_triple_quote s start =
   let len = String.length s in
   let rec scan i =
     if i + 2 >= len then None
-    else if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"' then Some i
+    else if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"'
+            && not (is_escaped_quote s i) then Some i
     else scan (i + 1)
   in
   scan start
@@ -173,38 +215,48 @@ let parse_toml (content : string) : (toml_doc, string) result =
   let ml_start_line = ref 0 in
   List.iter (fun raw_line ->
     incr line_num;
+    let raw_line = strip_trailing_cr raw_line in
     if Option.is_none !error then begin
       if !ml_active then begin
         (* Inside a multiline string -- look for closing triple-quote *)
         match find_closing_triple_quote raw_line 0 with
         | Some close_pos ->
           let prefix = String.sub raw_line 0 close_pos in
-          if prefix <> "" then begin
+          let suffix =
+            String.sub raw_line (close_pos + 3)
+              (String.length raw_line - close_pos - 3)
+          in
+          if not (multiline_suffix_is_valid suffix) then
+            error := Some
+              (Printf.sprintf "line %d: unexpected content after closing multiline string"
+                 !line_num)
+          else begin
             if Buffer.length !ml_buf > 0 then Buffer.add_char !ml_buf '\n';
-            Buffer.add_string !ml_buf prefix
-          end;
-          let raw_str = Buffer.contents !ml_buf in
-          (match parse_basic_string raw_str with
-           | Ok v -> acc := (!ml_key, Toml_string v) :: !acc
-           | Error e ->
-             error := Some (Printf.sprintf "line %d: multiline string: %s" !ml_start_line e));
-          ml_active := false
+            Buffer.add_string !ml_buf prefix;
+            let raw_str = Buffer.contents !ml_buf in
+            (match parse_basic_string raw_str with
+             | Ok v -> acc := (!ml_key, Toml_string v) :: !acc
+             | Error e ->
+               error := Some
+                 (Printf.sprintf "line %d: multiline string: %s" !ml_start_line e));
+            ml_active := false
+          end
         | None ->
           if Buffer.length !ml_buf > 0 then Buffer.add_char !ml_buf '\n';
           Buffer.add_string !ml_buf raw_line
       end
       else begin
-        let line = String.trim raw_line in
-        let line = strip_comment line in
-        if line = "" then ()
-        else if line.[0] = '[' then begin
+        let line = strip_comment raw_line in
+        let trimmed_line = String.trim line in
+        if trimmed_line = "" then ()
+        else if trimmed_line.[0] = '[' then begin
           (* Table header *)
-          let len = String.length line in
-          if line.[len - 1] <> ']' then
+          let len = String.length trimmed_line in
+          if trimmed_line.[len - 1] <> ']' then
             error := Some (Printf.sprintf "line %d: unterminated table header" !line_num)
           else begin
             let table_name =
-              String.sub line 1 (len - 2) |> String.trim
+              String.sub trimmed_line 1 (len - 2) |> String.trim
             in
             if table_name = "" then
               error := Some (Printf.sprintf "line %d: empty table name" !line_num)
@@ -227,7 +279,7 @@ let parse_toml (content : string) : (toml_doc, string) result =
                 if !current_table = "" then key
                 else !current_table ^ "." ^ key
               in
-              let trimmed = String.trim value_raw in
+              let trimmed = trim_leading_ws value_raw in
               if starts_with_triple_quote trimmed then begin
                 (* Start of multiline basic string *)
                 let after_open = String.sub trimmed 3 (String.length trimmed - 3) in
@@ -235,17 +287,26 @@ let parse_toml (content : string) : (toml_doc, string) result =
                 | Some close_pos ->
                   (* Single-line: triple-quoted on one line *)
                   let inner = String.sub after_open 0 close_pos in
-                  (match parse_basic_string inner with
-                   | Ok v -> acc := (full_key, Toml_string v) :: !acc
-                   | Error e ->
-                     error := Some (Printf.sprintf "line %d: %s" !line_num e))
+                  let suffix =
+                    String.sub after_open (close_pos + 3)
+                      (String.length after_open - close_pos - 3)
+                  in
+                  if not (multiline_suffix_is_valid suffix) then
+                    error := Some
+                      (Printf.sprintf "line %d: unexpected content after closing multiline string"
+                         !line_num)
+                  else
+                    (match parse_basic_string inner with
+                     | Ok v -> acc := (full_key, Toml_string v) :: !acc
+                     | Error e ->
+                       error := Some (Printf.sprintf "line %d: %s" !line_num e))
                 | None ->
                   (* Multiline continues on next lines.
                      TOML spec: newline after opening delimiter is trimmed,
                      so we start with empty buffer. *)
                   ml_key := full_key;
                   ml_buf := Buffer.create 256;
-                  let stripped = String.trim after_open in
+                  let stripped = trim_initial_multiline_newline after_open in
                   if stripped <> "" then
                     Buffer.add_string !ml_buf stripped;
                   ml_active := true;

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -147,55 +147,121 @@ let parse_value (raw : string) : (toml_value, string) result =
       | None -> Error (Printf.sprintf "cannot parse value: %s" s)
   end
 
+let starts_with_triple_quote s =
+  let len = String.length s in
+  len >= 3 && s.[0] = '"' && s.[1] = '"' && s.[2] = '"'
+
+let find_closing_triple_quote s start =
+  let len = String.length s in
+  let rec scan i =
+    if i + 2 >= len then None
+    else if s.[i] = '"' && s.[i+1] = '"' && s.[i+2] = '"' then Some i
+    else scan (i + 1)
+  in
+  scan start
+
 let parse_toml (content : string) : (toml_doc, string) result =
   let lines = String.split_on_char '\n' content in
   let current_table = ref "" in
   let acc = ref [] in
   let error = ref None in
   let line_num = ref 0 in
+  (* Multiline string accumulation state *)
+  let ml_key = ref "" in
+  let ml_buf = ref (Buffer.create 0) in
+  let ml_active = ref false in
+  let ml_start_line = ref 0 in
   List.iter (fun raw_line ->
     incr line_num;
     if Option.is_none !error then begin
-      let line = String.trim raw_line in
-      let line = strip_comment line in
-      if line = "" then ()
-      else if line.[0] = '[' then begin
-        (* Table header *)
-        let len = String.length line in
-        if line.[len - 1] <> ']' then
-          error := Some (Printf.sprintf "line %d: unterminated table header" !line_num)
-        else begin
-          let table_name =
-            String.sub line 1 (len - 2) |> String.trim
-          in
-          if table_name = "" then
-            error := Some (Printf.sprintf "line %d: empty table name" !line_num)
-          else
-            current_table := table_name
-        end
+      if !ml_active then begin
+        (* Inside a multiline string -- look for closing triple-quote *)
+        match find_closing_triple_quote raw_line 0 with
+        | Some close_pos ->
+          let prefix = String.sub raw_line 0 close_pos in
+          if prefix <> "" then begin
+            if Buffer.length !ml_buf > 0 then Buffer.add_char !ml_buf '\n';
+            Buffer.add_string !ml_buf prefix
+          end;
+          let raw_str = Buffer.contents !ml_buf in
+          (match parse_basic_string raw_str with
+           | Ok v -> acc := (!ml_key, Toml_string v) :: !acc
+           | Error e ->
+             error := Some (Printf.sprintf "line %d: multiline string: %s" !ml_start_line e));
+          ml_active := false
+        | None ->
+          if Buffer.length !ml_buf > 0 then Buffer.add_char !ml_buf '\n';
+          Buffer.add_string !ml_buf raw_line
       end
       else begin
-        (* key = value *)
-        match String.index_opt line '=' with
-        | None ->
-          error := Some (Printf.sprintf "line %d: expected key = value" !line_num)
-        | Some eq_pos ->
-          let key = String.sub line 0 eq_pos |> String.trim in
-          let value_raw = String.sub line (eq_pos + 1) (String.length line - eq_pos - 1) in
-          if key = "" then
-            error := Some (Printf.sprintf "line %d: empty key" !line_num)
-          else
-            let full_key =
-              if !current_table = "" then key
-              else !current_table ^ "." ^ key
+        let line = String.trim raw_line in
+        let line = strip_comment line in
+        if line = "" then ()
+        else if line.[0] = '[' then begin
+          (* Table header *)
+          let len = String.length line in
+          if line.[len - 1] <> ']' then
+            error := Some (Printf.sprintf "line %d: unterminated table header" !line_num)
+          else begin
+            let table_name =
+              String.sub line 1 (len - 2) |> String.trim
             in
-            match parse_value value_raw with
-            | Ok v -> acc := (full_key, v) :: !acc
-            | Error e ->
-              error := Some (Printf.sprintf "line %d: %s" !line_num e)
+            if table_name = "" then
+              error := Some (Printf.sprintf "line %d: empty table name" !line_num)
+            else
+              current_table := table_name
+          end
+        end
+        else begin
+          (* key = value *)
+          match String.index_opt line '=' with
+          | None ->
+            error := Some (Printf.sprintf "line %d: expected key = value" !line_num)
+          | Some eq_pos ->
+            let key = String.sub line 0 eq_pos |> String.trim in
+            let value_raw = String.sub line (eq_pos + 1) (String.length line - eq_pos - 1) in
+            if key = "" then
+              error := Some (Printf.sprintf "line %d: empty key" !line_num)
+            else
+              let full_key =
+                if !current_table = "" then key
+                else !current_table ^ "." ^ key
+              in
+              let trimmed = String.trim value_raw in
+              if starts_with_triple_quote trimmed then begin
+                (* Start of multiline basic string *)
+                let after_open = String.sub trimmed 3 (String.length trimmed - 3) in
+                match find_closing_triple_quote after_open 0 with
+                | Some close_pos ->
+                  (* Single-line: triple-quoted on one line *)
+                  let inner = String.sub after_open 0 close_pos in
+                  (match parse_basic_string inner with
+                   | Ok v -> acc := (full_key, Toml_string v) :: !acc
+                   | Error e ->
+                     error := Some (Printf.sprintf "line %d: %s" !line_num e))
+                | None ->
+                  (* Multiline continues on next lines.
+                     TOML spec: newline after opening delimiter is trimmed,
+                     so we start with empty buffer. *)
+                  ml_key := full_key;
+                  ml_buf := Buffer.create 256;
+                  let stripped = String.trim after_open in
+                  if stripped <> "" then
+                    Buffer.add_string !ml_buf stripped;
+                  ml_active := true;
+                  ml_start_line := !line_num
+              end
+              else
+                match parse_value value_raw with
+                | Ok v -> acc := (full_key, v) :: !acc
+                | Error e ->
+                  error := Some (Printf.sprintf "line %d: %s" !line_num e)
+        end
       end
     end
   ) lines;
+  if !ml_active && Option.is_none !error then
+    error := Some (Printf.sprintf "line %d: unterminated multiline string" !ml_start_line);
   match !error with
   | Some e -> Error e
   | None -> Ok (List.rev !acc)

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -232,6 +232,52 @@ let test_parse_multiline_normalizes_crlf () =
      | _ -> fail "expected Toml_string")
   | Error e -> fail ("multiline CRLF failed: " ^ e)
 
+(* TOML spec: up to two `"` immediately after closing `"""` are content. *)
+let test_parse_multiline_single_trailing_quote_inline () =
+  (* key = """"one quote"""" → content is `"one quote"` *)
+  let input = {|key = """"one quote""""|} in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "single trailing quote inline" "\"one quote\"" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("single trailing quote inline failed: " ^ e)
+
+let test_parse_multiline_double_trailing_quote_inline () =
+  (* key = """""two quotes""""" → content is `""two quotes""` *)
+  let input = {|key = """""two quotes"""""|} in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "double trailing quote inline" "\"\"two quotes\"\"" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("double trailing quote inline failed: " ^ e)
+
+let test_parse_multiline_trailing_quote_on_close_line () =
+  (* Multiline with one extra `"` on the closing line *)
+  let input = "key = \"\"\"\nsome content\n\"\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "trailing quote multiline" "some content\n\"" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("trailing quote multiline failed: " ^ e)
+
+let test_parse_multiline_line_ending_backslash () =
+  (* TOML line-ending backslash: `\` at end of line trims newline and following
+     indentation, joining with the next non-whitespace content. *)
+  let input = "key = \"\"\"\nfirst \\\n    second\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "line ending backslash" "first second\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("line ending backslash failed: " ^ e)
+
 let test_parse_error_unterminated_table () =
   let input = "[missing_bracket" in
   match TL.parse_toml input with
@@ -651,6 +697,14 @@ let () =
             test_parse_multiline_rejects_trailing_garbage;
           test_case "multiline normalizes CRLF" `Quick
             test_parse_multiline_normalizes_crlf;
+          test_case "multiline single trailing quote inline" `Quick
+            test_parse_multiline_single_trailing_quote_inline;
+          test_case "multiline double trailing quote inline" `Quick
+            test_parse_multiline_double_trailing_quote_inline;
+          test_case "multiline trailing quote on close line" `Quick
+            test_parse_multiline_trailing_quote_on_close_line;
+          test_case "multiline line-ending backslash" `Quick
+            test_parse_multiline_line_ending_backslash;
           test_case "error: unterminated table" `Quick test_parse_error_unterminated_table;
           test_case "error: no equals" `Quick test_parse_error_no_equals;
         ] );

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -234,7 +234,7 @@ let test_parse_multiline_normalizes_crlf () =
 
 (* TOML spec: up to two `"` immediately after closing `"""` are content. *)
 let test_parse_multiline_single_trailing_quote_inline () =
-  (* key = """"one quote"""" → content is `"one quote"` *)
+  (* Inline multiline string with one trailing quote kept as content. *)
   let input = {|key = """"one quote""""|} in
   match TL.parse_toml input with
   | Ok doc ->
@@ -245,7 +245,7 @@ let test_parse_multiline_single_trailing_quote_inline () =
   | Error e -> fail ("single trailing quote inline failed: " ^ e)
 
 let test_parse_multiline_double_trailing_quote_inline () =
-  (* key = """""two quotes""""" → content is `""two quotes""` *)
+  (* Inline multiline string with two trailing quotes kept as content. *)
   let input = {|key = """""two quotes"""""|} in
   match TL.parse_toml input with
   | Ok doc ->
@@ -256,7 +256,7 @@ let test_parse_multiline_double_trailing_quote_inline () =
   | Error e -> fail ("double trailing quote inline failed: " ^ e)
 
 let test_parse_multiline_trailing_quote_on_close_line () =
-  (* Multiline with one extra `"` on the closing line *)
+  (* Multiline string with one trailing quote on the closing line. *)
   let input = "key = \"\"\"\nsome content\n\"\"\"\"" in
   match TL.parse_toml input with
   | Ok doc ->
@@ -267,8 +267,7 @@ let test_parse_multiline_trailing_quote_on_close_line () =
   | Error e -> fail ("trailing quote multiline failed: " ^ e)
 
 let test_parse_multiline_line_ending_backslash () =
-  (* TOML line-ending backslash: `\` at end of line trims newline and following
-     indentation, joining with the next non-whitespace content. *)
+  (* Line-ending backslash joins the next non-whitespace content. *)
   let input = "key = \"\"\"\nfirst \\\n    second\n\"\"\"" in
   match TL.parse_toml input with
   | Ok doc ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -128,6 +128,66 @@ let test_parse_inline_comment () =
      | _ -> fail "expected Toml_string")
   | Error e -> fail e
 
+let test_parse_multiline_basic_string () =
+  let input = "[keeper]\ninstructions = \"\"\"\nline one\nline two\nline three\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "keeper.instructions" doc with
+     | Some (TL.Toml_string s) ->
+       check string "multiline content" "line one\nline two\nline three" s
+     | _ -> fail "expected Toml_string for multiline")
+  | Error e -> fail ("multiline parse failed: " ^ e)
+
+let test_parse_multiline_single_line () =
+  let input = {|key = """inline multiline"""|} in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "inline multiline" "inline multiline" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("inline multiline failed: " ^ e)
+
+let test_parse_multiline_empty () =
+  let input = "key = \"\"\"\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "empty multiline" "" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("empty multiline failed: " ^ e)
+
+let test_parse_multiline_unterminated () =
+  let input = "key = \"\"\"\nunterminated content" in
+  match TL.parse_toml input with
+  | Ok _ -> fail "expected parse error for unterminated multiline"
+  | Error _ -> ()
+
+let test_parse_multiline_with_escapes () =
+  let input = "key = \"\"\"\nfirst\\nsecond\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "multiline with escape" "first\nsecond" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("multiline escape failed: " ^ e)
+
+let test_parse_multiline_with_values_after () =
+  let input = "[keeper]\ninstructions = \"\"\"\nsome text\n\"\"\"\ngoal = \"test\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "keeper.instructions" doc with
+     | Some (TL.Toml_string s) ->
+       check string "multiline" "some text" s
+     | _ -> fail "expected instructions");
+    (match List.assoc_opt "keeper.goal" doc with
+     | Some (TL.Toml_string s) ->
+       check string "goal after multiline" "test" s
+     | _ -> fail "expected goal after multiline")
+  | Error e -> fail ("multiline with values after failed: " ^ e)
+
 let test_parse_error_unterminated_table () =
   let input = "[missing_bracket" in
   match TL.parse_toml input with
@@ -533,6 +593,12 @@ let () =
           test_case "empty array" `Quick test_parse_empty_array;
           test_case "table" `Quick test_parse_table;
           test_case "inline comment" `Quick test_parse_inline_comment;
+          test_case "multiline basic string" `Quick test_parse_multiline_basic_string;
+          test_case "multiline single line" `Quick test_parse_multiline_single_line;
+          test_case "multiline empty" `Quick test_parse_multiline_empty;
+          test_case "multiline unterminated" `Quick test_parse_multiline_unterminated;
+          test_case "multiline with escapes" `Quick test_parse_multiline_with_escapes;
+          test_case "multiline with values after" `Quick test_parse_multiline_with_values_after;
           test_case "error: unterminated table" `Quick test_parse_error_unterminated_table;
           test_case "error: no equals" `Quick test_parse_error_no_equals;
         ] );

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -134,7 +134,7 @@ let test_parse_multiline_basic_string () =
   | Ok doc ->
     (match List.assoc_opt "keeper.instructions" doc with
      | Some (TL.Toml_string s) ->
-       check string "multiline content" "line one\nline two\nline three" s
+       check string "multiline content" "line one\nline two\nline three\n" s
      | _ -> fail "expected Toml_string for multiline")
   | Error e -> fail ("multiline parse failed: " ^ e)
 
@@ -170,7 +170,7 @@ let test_parse_multiline_with_escapes () =
   | Ok doc ->
     (match List.assoc_opt "key" doc with
      | Some (TL.Toml_string s) ->
-       check string "multiline with escape" "first\nsecond" s
+       check string "multiline with escape" "first\nsecond\n" s
      | _ -> fail "expected Toml_string")
   | Error e -> fail ("multiline escape failed: " ^ e)
 
@@ -180,13 +180,57 @@ let test_parse_multiline_with_values_after () =
   | Ok doc ->
     (match List.assoc_opt "keeper.instructions" doc with
      | Some (TL.Toml_string s) ->
-       check string "multiline" "some text" s
+       check string "multiline" "some text\n" s
      | _ -> fail "expected instructions");
     (match List.assoc_opt "keeper.goal" doc with
      | Some (TL.Toml_string s) ->
        check string "goal after multiline" "test" s
      | _ -> fail "expected goal after multiline")
   | Error e -> fail ("multiline with values after failed: " ^ e)
+
+let test_parse_multiline_preserves_leading_spaces () =
+  let input = "key = \"\"\"  keep-leading-space\nnext line\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "multiline preserves spaces" "  keep-leading-space\nnext line\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("multiline whitespace preservation failed: " ^ e)
+
+let test_parse_multiline_allows_escaped_triple_quotes () =
+  let input = "key = \"\"\"\ncontains \\\"\\\"\\\" quotes\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "escaped triple quotes" "contains \"\"\" quotes\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("escaped triple quotes failed: " ^ e)
+
+let test_parse_multiline_rejects_trailing_garbage () =
+  let inputs =
+    [
+      "key = \"\"\"inline\"\"\" garbage";
+      "key = \"\"\"\nline\n\"\"\" garbage";
+    ]
+  in
+  List.iter
+    (fun input ->
+      match TL.parse_toml input with
+      | Ok _ -> fail "expected parse error for trailing garbage after multiline close"
+      | Error _ -> ())
+    inputs
+
+let test_parse_multiline_normalizes_crlf () =
+  let input = "key = \"\"\"\r\nfirst\r\nsecond\r\n\"\"\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) ->
+       check string "crlf normalized" "first\nsecond\n" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail ("multiline CRLF failed: " ^ e)
 
 let test_parse_error_unterminated_table () =
   let input = "[missing_bracket" in
@@ -599,6 +643,14 @@ let () =
           test_case "multiline unterminated" `Quick test_parse_multiline_unterminated;
           test_case "multiline with escapes" `Quick test_parse_multiline_with_escapes;
           test_case "multiline with values after" `Quick test_parse_multiline_with_values_after;
+          test_case "multiline preserves leading spaces" `Quick
+            test_parse_multiline_preserves_leading_spaces;
+          test_case "multiline allows escaped triple quotes" `Quick
+            test_parse_multiline_allows_escaped_triple_quotes;
+          test_case "multiline rejects trailing garbage" `Quick
+            test_parse_multiline_rejects_trailing_garbage;
+          test_case "multiline normalizes CRLF" `Quick
+            test_parse_multiline_normalizes_crlf;
           test_case "error: unterminated table" `Quick test_parse_error_unterminated_table;
           test_case "error: no equals" `Quick test_parse_error_no_equals;
         ] );


### PR DESCRIPTION
## Summary
- add robust multiline basic string parsing for keeper TOML loader
- preserve TOML multiline string semantics around opening-newline trimming and trailing newlines
- reject invalid trailing garbage after a closing `"""` delimiter and cover multiline edge cases with regression tests
- replace O(n²) escape-aware closing-delimiter scan with an O(n) forward scan tracking backslash parity
- consume up to two `"` chars immediately after `"""` as string content per TOML spec (`""""value""""` → `"value"`)
- support TOML line-ending backslash continuation (`\` + newline trims the backslash, newline, and subsequent indentation)

## Product impact

- Promise affected: `none/internal`
- User-visible change: keeper TOML files with multiline instructions stop failing on parser edge cases during reload cycles; multiline content is now parsed to full TOML spec compliance including trailing-quote content, line-ending backslash continuation, escaped triple quotes, and CRLF inputs; invalid multiline TOML fails fast instead of being silently accepted with truncated content

## Evidence

- `test_keeper_toml.exe` (45 tests, pass) — 4 new regression tests cover single/double trailing quote inline, trailing quote on multiline close line, and line-ending backslash continuation

## Review evidence

- reviewer: direct `sb glm-text` (`GLM-5` path)
- scope: incremental diff in `cdca78793` and `b94dc6d`
- result: `No findings.`

## Linked issue