### PR TITLE
refactor(room): remove config scope field and identity resolver

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -470,10 +470,7 @@ type server_state = {
 }
 
 let create_state ~base_path =
-  let config =
-    Room.default_config base_path
-   
-  in
+  let config = Room.default_config base_path in
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
@@ -520,7 +517,6 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
           Board_dispatch.init_jsonl ()
         end)
       base_path
-   
   in
   let registry = Session.create () in
   (* Wire notification harness: subscription events → session queues *)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -6,8 +6,7 @@ type storage_backend =
   | FileSystem of Backend.FileSystem.t
   | PostgresNative of Backend.Postgres.t
 
-(** Room configuration.
-    scope field removed — all state lives under root .masc/ directly. *)
+(** Room configuration *)
 type config = {
   base_path: string;
   workspace_path: string;
@@ -471,7 +470,7 @@ let default_config base_path =
                   Memory (Backend.Memory.get_or_create ~base_path:backend_config.cluster_name)))
   in
   {
-    base_path = resolved_path;
+    base_path = resolved_path;  (* Use resolved path (git root for worktrees) *)
     workspace_path = base_path;
     lock_expiry_minutes = 2;
     backend_config;

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -346,9 +346,7 @@ let handle_swarm_start (ctx : context) args =
                   let room_config =
                     match ctx.config with
                     | Some config -> config
-                    | None ->
-                        Room.default_config ctx.base_path
-                       
+                    | None -> Room.default_config ctx.base_path
                   in
                   let task_link_json =
                     match task_id with

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -587,10 +587,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                        Autoresearch.with_loops_rw (fun () ->
                          Hashtbl.replace Autoresearch.active_loops id state);
                        Autoresearch.save_state ~base_path:ctx.base_path state;
-                       let config =
-                         Room.default_config ctx.base_path
-                        
-                       in
+                       let config = Room.default_config ctx.base_path in
                        (match
                           Autoresearch.load_swarm_link_by_loop
                             ~base_path:ctx.base_path id


### PR DESCRIPTION
## Summary
- remove `Room.config.scope` and the dead `config_with_resolved_scope` identity path
- update remaining room/config callers to use flattened default config directly
- update affected tests and record literals

## Product impact
- room configuration no longer carries an unused `scope` field that suggested behavior which no longer exists
- remaining call sites now read the flattened room config shape directly, reducing stale compatibility paths

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-5117 --build-dir /tmp/refactor5117-build --cache=disabled lib/room/room_utils_backend_setup.ml lib/room/room_utils_paths_backend.ml lib/team_context.ml lib/mcp_server.ml lib/tool_inline_dispatch_room.ml lib/tool_autoresearch.ml lib/tool_autoresearch_cycle.ml lib/local/worker_container.ml`

## Evidence
- focused isolated lib build passed on 2026-04-04

## Review evidence
- cross-model review via `sb glm-text` on 2026-04-04 reported `No findings.` and the evidence comment is attached on this PR

## Linked issue
- Refs #5117
