### PR TITLE
refactor(audit): persist system_internal tool call logs

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -331,6 +331,9 @@ let log_tool_call config ~agent_id ~tool_name ~success ~error_msg ?cost_estimate
   let outcome = if success then Success else Failure (Option.value error_msg ~default:"unknown") in
   log_action config ~agent_id ~action:(ToolCall tool_name) ?cost_estimate ?token_count ?trace_id ~outcome ()
 
+let remove_assoc_keys keys fields =
+  List.filter (fun (key, _) -> not (List.mem key keys)) fields
+
 let log_system_internal_tool_call config ~agent_id ~tool_name ~success ~error_msg
     ?(details : Yojson.Safe.t = `Null) ?cost_estimate ?token_count ?trace_id () =
   let outcome =
@@ -339,10 +342,11 @@ let log_system_internal_tool_call config ~agent_id ~tool_name ~success ~error_ms
   let details =
     match details with
     | `Assoc fields ->
+        let caller_fields = remove_assoc_keys [ "surface"; "tool_name" ] fields in
         `Assoc
           (("surface", `String "system_internal")
           :: ("tool_name", `String tool_name)
-          :: fields)
+          :: caller_fields)
     | other ->
         `Assoc
           [

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -331,6 +331,29 @@ let log_tool_call config ~agent_id ~tool_name ~success ~error_msg ?cost_estimate
   let outcome = if success then Success else Failure (Option.value error_msg ~default:"unknown") in
   log_action config ~agent_id ~action:(ToolCall tool_name) ?cost_estimate ?token_count ?trace_id ~outcome ()
 
+let log_system_internal_tool_call config ~agent_id ~tool_name ~success ~error_msg
+    ?(details : Yojson.Safe.t = `Null) ?cost_estimate ?token_count ?trace_id () =
+  let outcome =
+    if success then Success else Failure (Option.value error_msg ~default:"unknown")
+  in
+  let details =
+    match details with
+    | `Assoc fields ->
+        `Assoc
+          (("surface", `String "system_internal")
+          :: ("tool_name", `String tool_name)
+          :: fields)
+    | other ->
+        `Assoc
+          [
+            ("surface", `String "system_internal");
+            ("tool_name", `String tool_name);
+            ("context", other);
+          ]
+  in
+  log_action config ~agent_id ~action:(Custom "system_internal_tool_call")
+    ~details ?cost_estimate ?token_count ?trace_id ~outcome ()
+
 let log_client_tool_host_failure config ~agent_id ~client_name ~tool_name
     ~transport ~message ?phase ?request_id ?session_id ?trace_id ?timeout_ms () =
   let details =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -235,8 +235,44 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (match mcp_session_id with
    | Some sid -> Agent_registry_eio.set_resolved_name sid agent_name
    | None -> ());
+  let is_system_internal_tool =
+    Tool_catalog.is_on_surface Tool_catalog.System_internal name
+  in
+  let preview ?(max_len = 240) text =
+    if String.length text <= max_len then text
+    else String.sub text 0 max_len ^ "..."
+  in
+  let argument_keys_json =
+    match arguments with
+    | `Assoc fields ->
+        fields
+        |> List.map fst
+        |> List.sort_uniq String.compare
+        |> List.map (fun key -> `String key)
+    | _ -> []
+  in
+  let with_system_internal_audit ~agent_name ((success, message) as result) =
+    if is_system_internal_tool then (
+      let error_msg =
+        if success then None else Some (preview message)
+      in
+      let details =
+        `Assoc
+          [
+            ("source", `String "mcp_server_eio_execute");
+            ("visible_in_tools_list", `Bool (Tool_catalog.is_visible name));
+            ("allow_direct_call", `Bool (Tool_catalog.allow_direct_call name));
+            ("mcp_session_id_present", `Bool (Option.is_some mcp_session_id));
+            ("argument_keys", `List argument_keys_json);
+          ]
+      in
+      Audit_log.log_system_internal_tool_call config ~agent_id:agent_name
+        ~tool_name:name ~success ~error_msg ~details
+        ?trace_id:(Otel_spans.current_trace_id ()) ());
+    result
+  in
   match mode_gate_error with
-  | Some msg -> (false, msg)
+  | Some msg -> with_system_internal_audit ~agent_name (false, msg)
   | None ->
   (* Enforce tool authorization when enabled *)
   let auth_enabled = Auth.is_auth_enabled config.base_path in
@@ -250,7 +286,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   in
 
   match auth_result with
-  | Error err -> (false, Types.masc_error_to_string err)
+  | Error err ->
+      with_system_internal_audit ~agent_name
+        (false, Types.masc_error_to_string err)
   | Ok () ->
   let extract_nickname_from_join_result ~fallback result =
     try
@@ -306,7 +344,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   in
   match init_error with
   | Some msg ->
-      (false, Printf.sprintf "❌ %s" msg)
+      with_system_internal_audit ~agent_name
+        (false, Printf.sprintf "❌ %s" msg)
   | None ->
 
   let is_read_only = Tool_dispatch.is_read_only name in
@@ -410,13 +449,15 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     name agent_name join_required room_initialized is_joined;
 
   if join_required && not room_initialized then
-    (false, Printf.sprintf
-      "⚠️ MASC room not initialized.\n\n💡 Workflow: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
-      name agent_name room_initialized)
+    with_system_internal_audit ~agent_name
+      (false, Printf.sprintf
+         "⚠️ MASC room not initialized.\n\n💡 Workflow: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
+         name agent_name room_initialized)
   else if join_required && not is_joined then
-    (false, Printf.sprintf
-      "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
-      name name agent_name is_joined)
+    with_system_internal_audit ~agent_name
+      (false, Printf.sprintf
+         "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
+         name name agent_name is_joined)
   else
 
   (* === Fix 1: Tag-based lazy context dispatch ===
@@ -581,7 +622,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
      Validate). If mint fails, the tool is truly unknown. *)
   match Tool_dispatch.mint_token ~name with
   | Error reason ->
-      (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
+      with_system_internal_audit ~agent_name
+        (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
   | Ok _token ->
       (* Token proves the name is registered in at least one registry.
          lookup_tag None after mint is a registry inconsistency (tool in
@@ -592,7 +634,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         | None -> None
       in
       (match tag_result with
-       | Some result -> result
+       | Some result -> with_system_internal_audit ~agent_name result
        | None ->
            Log.Mcp.warn "registry inconsistency: %s minted but no tag" name;
-           (false, Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))
+           with_system_internal_audit ~agent_name
+             (false,
+              Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))

--- a/test/dune
+++ b/test/dune
@@ -33,7 +33,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_room test_room_state_recovery test_types test_auth test_http_negotiation
+ (names test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -90,7 +90,7 @@
         test_worker_oas_scope_gate
         test_run_local_script
         test_tool_prefilter)
- (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
+ (modules test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -1,0 +1,67 @@
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_audit_log_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let assoc_key_count key = function
+  | `Assoc fields ->
+      List.length (List.filter (fun (field, _) -> String.equal field key) fields)
+  | _ -> 0
+
+let test_system_internal_details_deduplicate_canonical_keys () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      Audit_log.log_system_internal_tool_call config ~agent_id:"codex"
+        ~tool_name:"masc_status" ~success:true ~error_msg:None
+        ~details:
+          (`Assoc
+             [
+               ("surface", `String "overridden");
+               ("tool_name", `String "wrong_name");
+               ("source", `String "unit_test");
+             ])
+        ();
+      let entry =
+        match Audit_log.read_entries ~n:10 config with
+        | [ entry ] -> entry
+        | _ -> fail "expected one audit entry"
+      in
+      check string "canonical surface wins" "system_internal"
+        Yojson.Safe.Util.(entry.details |> member "surface" |> to_string);
+      check string "canonical tool name wins" "masc_status"
+        Yojson.Safe.Util.(entry.details |> member "tool_name" |> to_string);
+      check int "surface appears once" 1 (assoc_key_count "surface" entry.details);
+      check int "tool_name appears once" 1
+        (assoc_key_count "tool_name" entry.details);
+      check string "keeps non-canonical fields" "unit_test"
+        Yojson.Safe.Util.(entry.details |> member "source" |> to_string))
+
+let () =
+  run "Audit_log"
+    [
+      ( "audit_log",
+        [
+          test_case "system_internal details deduplicate canonical keys" `Quick
+            test_system_internal_details_deduplicate_canonical_keys;
+        ] );
+    ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1088,6 +1088,31 @@ let test_handle_request_tools_call_system_internal_transport_status () =
     Yojson.Safe.Util.(structured |> member "http" <> `Null);
   Alcotest.(check bool) "transport status includes websocket block" true
     Yojson.Safe.Util.(structured |> member "websocket" <> `Null);
+  let audit_entries = Masc_mcp.Audit_log.read_entries ~n:100 state.room_config in
+  let system_internal_entry =
+    List.find_opt
+      (fun (entry : Masc_mcp.Audit_log.audit_entry) ->
+        match entry.action with
+        | Masc_mcp.Audit_log.Custom "system_internal_tool_call" ->
+            Yojson.Safe.Util.(
+              entry.details |> member "tool_name" |> to_string_option
+              = Some "masc_transport_status")
+        | _ -> false)
+      audit_entries
+  in
+  let entry =
+    match system_internal_entry with
+    | Some entry -> entry
+    | None ->
+        Alcotest.fail
+          "missing durable audit entry for system_internal tool call"
+  in
+  Alcotest.(check string) "audit surface" "system_internal"
+    Yojson.Safe.Util.(entry.details |> member "surface" |> to_string);
+  Alcotest.(check bool) "audit visibility hidden" false
+    Yojson.Safe.Util.(entry.details |> member "visible_in_tools_list" |> to_bool);
+  Alcotest.(check bool) "audit callable when hidden" true
+    Yojson.Safe.Util.(entry.details |> member "allow_direct_call" |> to_bool);
   cleanup_dir base_path
 
 let test_handle_request_tools_list_rejects_nonstandard_names_filter () =


### PR DESCRIPTION
## Summary
- add durable audit entries for `System_internal` tool calls
- capture surface/callability/visibility metadata at `mcp_server_eio_execute`
- add targeted audit coverage asserting canonical system-internal metadata is persisted once

## Product impact
- hidden-but-callable `System_internal` tools now leave a durable audit record with stable canonical metadata
- downstream JSON consumers no longer see duplicate `surface` or `tool_name` keys when caller details already contain those fields

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor/review-5150 --build-dir /tmp/review5150-build --cache=disabled lib/audit_log.ml lib/mcp_server_eio_execute.ml test/test_audit_log.exe`
- `/tmp/review5150-build/default/test/test_audit_log.exe`

## Evidence
- focused isolated build passed on 2026-04-04
- targeted audit regression test passed on 2026-04-04

## Review evidence
- cross-model review via `sb glm-text` on 2026-04-04 reported `No findings.` and the evidence comment is attached on this PR
- Copilot review feedback about duplicate canonical JSON keys was patched in `67341d7ed`

## Linked issue
- Refs #5120
