### PR TITLE
[codex] fix keeper allowed path normalization

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -787,6 +787,11 @@ let run_turn
   let priority =
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
+  let oas_allowed_paths =
+    Keeper_alerting_path.absolute_allowed_paths
+      ~config
+      ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+  in
   match
         Oas_worker.run_named
           ~cascade_name
@@ -810,7 +815,7 @@ let run_turn
           ?on_resume
           ~agent_ref
           ?contract
-          ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+          ~allowed_paths:oas_allowed_paths
           ~cache_system_prompt:true
           ~yield_on_tool
           ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -787,12 +787,17 @@ let run_turn
   let priority =
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
-  let oas_allowed_paths =
-    Keeper_alerting_path.absolute_allowed_paths
-      ~config
-      ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+  let effective_allowed_paths =
+    Keeper_alerting_path.effective_allowed_paths ~meta
   in
   match
+        Keeper_alerting_path.absolute_allowed_paths_result
+          ~config
+          ~allowed_paths:effective_allowed_paths
+      with
+      | Error e -> Error e
+      | Ok oas_allowed_paths ->
+        (match
         Oas_worker.run_named
           ~cascade_name
           ~goal:user_message
@@ -940,4 +945,4 @@ let run_turn
            checkpoint = result.checkpoint;
            proof = result.proof;
            stop_reason = result.stop_reason;
-         })
+         }))

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -27,7 +27,8 @@ let normalize_allowed_path_for_check ~(root : string) (path : string) : string o
     let candidate =
       if Filename.is_relative raw then Filename.concat root raw else raw
     in
-    Some (normalize_path_for_check candidate |> strip_trailing_slashes)
+    let normalized = normalize_path_for_check candidate |> strip_trailing_slashes in
+    if normalized = "" then None else Some normalized
 
 let absolute_allowed_paths ~(config : Room.config) ~(allowed_paths : string list)
     : string list =
@@ -57,22 +58,23 @@ let resolve_keeper_target_path ~(config : Room.config)
     else if allowed_paths = [] then
       Ok candidate
     else
+      let allowed_norms =
+        allowed_paths
+        |> List.filter_map (normalize_allowed_path_for_check ~root:root_norm)
+      in
       let matches_any =
         List.exists
-          (fun allowed_path ->
-             match normalize_allowed_path_for_check ~root:root_norm allowed_path with
-             | None -> false
-             | Some allowed_norm ->
-               target_norm = allowed_norm
-               || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
-          allowed_paths
+          (fun allowed_norm ->
+             target_norm = allowed_norm
+             || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
+          allowed_norms
       in
       if matches_any then Ok candidate
       else
         Error
           (Printf.sprintf
              "path_not_in_allowed_paths: %s (allowed: [%s])"
-             raw (String.concat ", " allowed_paths))
+             raw (String.concat ", " allowed_norms))
 
 (** Compute effective allowed_paths from keeper meta, applying scope-based
     defaults when the operator has not set an explicit list.

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -20,6 +20,20 @@ let normalize_path_for_check (path : string) : string =
     in
     Filename.concat parent_norm (Filename.basename path)
 
+let normalize_allowed_path_for_check ~(root : string) (path : string) : string option =
+  let raw = String.trim path in
+  if raw = "" then None
+  else
+    let candidate =
+      if Filename.is_relative raw then Filename.concat root raw else raw
+    in
+    Some (normalize_path_for_check candidate |> strip_trailing_slashes)
+
+let absolute_allowed_paths ~(config : Room.config) ~(allowed_paths : string list)
+    : string list =
+  let root = project_root_of_config config in
+  allowed_paths |> List.filter_map (normalize_allowed_path_for_check ~root)
+
 let resolve_keeper_target_path ~(config : Room.config)
     ~(allowed_paths : string list) ~(raw_path : string)
     : (string, string) result =
@@ -43,18 +57,15 @@ let resolve_keeper_target_path ~(config : Room.config)
     else if allowed_paths = [] then
       Ok candidate
     else
-      let rel =
-        let prefix = root_norm ^ "/" in
-        if starts_with ~prefix target_norm then
-          String.sub target_norm (String.length prefix)
-            (String.length target_norm - String.length prefix)
-        else ""
-      in
       let matches_any =
-        List.exists (fun ap ->
-          let ap' = strip_trailing_slashes ap in
-          rel = ap' || starts_with ~prefix:(ap' ^ "/") rel
-        ) allowed_paths
+        List.exists
+          (fun allowed_path ->
+             match normalize_allowed_path_for_check ~root:root_norm allowed_path with
+             | None -> false
+             | Some allowed_norm ->
+               target_norm = allowed_norm
+               || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
+          allowed_paths
       in
       if matches_any then Ok candidate
       else

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -35,6 +35,17 @@ let absolute_allowed_paths ~(config : Room.config) ~(allowed_paths : string list
   let root = project_root_of_config config in
   allowed_paths |> List.filter_map (normalize_allowed_path_for_check ~root)
 
+let absolute_allowed_paths_result ~(config : Room.config)
+    ~(allowed_paths : string list) : (string list, string) result =
+  let normalized = absolute_allowed_paths ~config ~allowed_paths in
+  if allowed_paths <> [] && normalized = [] then
+    Error
+      (Printf.sprintf
+         "allowed_paths_normalized_empty: [%s]"
+         (String.concat ", " allowed_paths))
+  else
+    Ok normalized
+
 let resolve_keeper_target_path ~(config : Room.config)
     ~(allowed_paths : string list) ~(raw_path : string)
     : (string, string) result =

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -427,6 +427,20 @@ let test_absolute_allowed_paths_slashes_only_rejected () =
     check bool "slashes-only allow path does not allow all" true
       (Result.is_error result))
 
+let test_absolute_allowed_paths_result_rejects_invalid_explicit_allowlist () =
+  let dir = make_path_test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let result =
+      Keeper_alerting_path.absolute_allowed_paths_result
+        ~config
+        ~allowed_paths:["////"]
+    in
+    check bool "explicit invalid allowlist is rejected" true
+      (Result.is_error result))
+
 let test_path_allowed_paths_single_trailing_slash () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
@@ -550,6 +564,8 @@ let () =
         test_absolute_allowed_paths_normalization;
       test_case "slashes-only allowed_paths rejected" `Quick
         test_absolute_allowed_paths_slashes_only_rejected;
+      test_case "invalid explicit allowlist result rejected" `Quick
+        test_absolute_allowed_paths_result_rejects_invalid_explicit_allowlist;
       test_case "allowed_paths single trailing slash" `Quick
         test_path_allowed_paths_single_trailing_slash;
       test_case "empty path rejected" `Quick test_path_empty_rejected;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -373,6 +373,43 @@ let test_path_allowed_paths_filter_strips_all_trailing_slashes () =
     check bool "lib path allowed with repeated trailing slash" true
       (Result.is_ok ok_result))
 
+let test_path_absolute_allowed_paths_filter () =
+  let dir = make_path_test_dir () in
+  let lib_dir = Filename.concat dir "lib" in
+  (try Unix.mkdir lib_dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let ok_result = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:[lib_dir] ~raw_path:"lib/foo.ml" in
+    check bool "absolute lib path allowed" true (Result.is_ok ok_result);
+    let err_result = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:[lib_dir] ~raw_path:"src/bar.ml" in
+    check bool "absolute lib still rejects src" true (Result.is_error err_result))
+
+let test_absolute_allowed_paths_normalization () =
+  let dir = make_path_test_dir () in
+  let lib_dir = Filename.concat dir "lib" in
+  let docs_dir = Filename.concat dir "docs" in
+  (try Unix.mkdir lib_dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  (try Unix.mkdir docs_dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let normalized =
+      Keeper_alerting_path.absolute_allowed_paths
+        ~config
+        ~allowed_paths:["lib/"; docs_dir ^ "//"]
+    in
+    check (list string) "normalized absolute allowed paths"
+      [Unix.realpath lib_dir; Unix.realpath docs_dir]
+      normalized)
+
 let test_path_allowed_paths_single_trailing_slash () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
@@ -490,6 +527,10 @@ let () =
       test_case "allowed_paths filter" `Quick test_path_allowed_paths_filter;
       test_case "allowed_paths strip all trailing slashes" `Quick
         test_path_allowed_paths_filter_strips_all_trailing_slashes;
+      test_case "absolute allowed_paths filter" `Quick
+        test_path_absolute_allowed_paths_filter;
+      test_case "absolute allowed_paths normalization" `Quick
+        test_absolute_allowed_paths_normalization;
       test_case "allowed_paths single trailing slash" `Quick
         test_path_allowed_paths_single_trailing_slash;
       test_case "empty path rejected" `Quick test_path_empty_rejected;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -410,6 +410,23 @@ let test_absolute_allowed_paths_normalization () =
       [Unix.realpath lib_dir; Unix.realpath docs_dir]
       normalized)
 
+let test_absolute_allowed_paths_slashes_only_rejected () =
+  let dir = make_path_test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let normalized =
+      Keeper_alerting_path.absolute_allowed_paths
+        ~config
+        ~allowed_paths:["////"]
+    in
+    check (list string) "slashes-only allow path ignored" [] normalized;
+    let result = Keeper_alerting_path.resolve_keeper_target_path
+      ~config ~allowed_paths:["////"] ~raw_path:"lib/foo.ml" in
+    check bool "slashes-only allow path does not allow all" true
+      (Result.is_error result))
+
 let test_path_allowed_paths_single_trailing_slash () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
@@ -531,6 +548,8 @@ let () =
         test_path_absolute_allowed_paths_filter;
       test_case "absolute allowed_paths normalization" `Quick
         test_absolute_allowed_paths_normalization;
+      test_case "slashes-only allowed_paths rejected" `Quick
+        test_absolute_allowed_paths_slashes_only_rejected;
       test_case "allowed_paths single trailing slash" `Quick
         test_path_allowed_paths_single_trailing_slash;
       test_case "empty path rejected" `Quick test_path_empty_rejected;


### PR DESCRIPTION
## Summary
- normalize keeper allowed_paths entries against the project root before matching so relative and absolute paths compare on the same basis
- pass normalized absolute allowlists into keeper OAS runs so runtime validation matches keeper policy
- add regression coverage for absolute allowlists, normalization, and slash-only misconfiguration handling

## Root Cause
keeper path checks and downstream runtime validation were comparing the same locations through different path representations. Relative keeper allowlists and absolute runtime paths could refer to the same location but still fail comparison, blocking keeper-facing masc tools.

## Product impact
- restores keeper access to board and task surfaces when allowlists cross relative and absolute path boundaries
- prevents slash-only allowlist misconfiguration from degrading into an accidental allow-all within the project root

## Evidence
- dune build --root . --build-dir _build test/test_keeper_tool_exposure.exe --display short
- _build/default/test/test_keeper_tool_exposure.exe

## Review evidence
- GitHub Copilot PR reviewer commented on 2026-04-04; both actionable findings were patched in commit 5465e60c6 and the related threads are being resolved
- direct ZAI GLM, masc fallback chain, and local llama fallback were unavailable during this turn; failure evidence is logged in the PR discussion

## Linked issue
Fixes #5158
