### PR TITLE
fix(keeper): refresh local llama discovery before context sizing

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -173,6 +173,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          (false, "❌ " ^ e)
        | Ok () ->
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
+         ignore (Oas_model_resolve.refresh_local_discovery_if_possible effective_models);
          let primary_max_context =
            Oas_model_resolve.resolve_primary_max_context effective_models
          in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -180,6 +180,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ~fallback_token:env_token_gate
     in
     let cascade_models = Oas_model_resolve.models_of_cascade_name "keeper_unified" in
+    ignore (Oas_model_resolve.refresh_local_discovery_if_possible cascade_models);
     let primary_max_context = Oas_model_resolve.resolve_primary_max_context cascade_models in
     Progress.Tracker.step tracker ~message:"Initializing session directory" ();
     let trace_id = generate_trace_id () in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -750,6 +750,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
   | Ok () ->
+      ignore (Oas_model_resolve.refresh_local_discovery_if_possible model_labels);
       let primary_max_context =
         Oas_model_resolve.resolve_primary_max_context model_labels
       in

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -19,6 +19,48 @@ let provider_name_of_label (label : string) : string option =
     if idx = 0 then None
     else Some (String.sub label 0 idx |> String.trim |> String.lowercase_ascii)
 
+let labels_require_local_discovery (labels : string list) : bool =
+  List.exists
+    (fun label ->
+      match provider_name_of_label label with
+      | Some pname -> Provider_adapter.requires_discovery pname
+      | None -> false)
+    labels
+
+let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
+  if not (labels_require_local_discovery labels) then false
+  else
+    let sw =
+      match sw with Some value -> Some value | None -> Eio_context.get_switch_opt ()
+    in
+    let net =
+      match net with Some value -> Some value | None -> Eio_context.get_net_opt ()
+    in
+    match sw, net with
+    | Some sw, Some net ->
+        let before = Llm_provider.Provider_registry.discovered_max_context () in
+        (try
+           ignore
+             (Llm_provider.Provider_registry.refresh_llama_endpoints ~sw ~net ());
+           let after = Llm_provider.Provider_registry.discovered_max_context () in
+           (match before, after with
+            | Some prev, Some next when prev <> next ->
+                Log.info ~ctx:"OasModelResolve"
+                  "refreshed local runtime context: %d -> %d" prev next
+            | None, Some next ->
+                Log.info ~ctx:"OasModelResolve"
+                  "refreshed local runtime context: unset -> %d" next
+            | _ -> ());
+           true
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn ->
+             Log.warn ~ctx:"OasModelResolve"
+               "local runtime discovery refresh failed: %s"
+               (Printexc.to_string exn);
+             false)
+    | _ -> false
+
 (** Resolve max_context for a model label.
     Prefers discovered per-slot context (from live /props probe) for local
     providers, falls back to static Provider_registry value, then 128_000. *)

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -98,6 +98,17 @@ let test_max_context_of_label () =
       "nonexistent:model" in
   check int "fallback 128000" 128_000 fallback
 
+let test_labels_require_local_discovery () =
+  check bool "llama labels refresh local discovery" true
+    (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
+       [ "llama:auto"; "glm:auto" ]);
+  check bool "mixed non-local labels skip refresh" false
+    (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
+       [ "glm:auto"; "claude:auto" ]);
+  check bool "malformed labels skip refresh" false
+    (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
+       [ "default"; "glm:auto" ])
+
 (* ── Section 3: Dashboard schema contracts ── *)
 
 let test_heartbeat_snapshot_has_required_fields () =
@@ -190,6 +201,8 @@ let () =
             test_default_registry_populated;
           test_case "provider name of label" `Quick test_provider_name_of_label;
           test_case "max context of label" `Quick test_max_context_of_label;
+          test_case "local discovery label detection" `Quick
+            test_labels_require_local_discovery;
         ] );
       ( "dashboard_schema",
         [


### PR DESCRIPTION
## Summary
- refresh local llama discovery before keeper context sizing when a local provider is present in the cascade
- use the refreshed discovered max context in keeper create/turn/unified turn paths instead of stale cached sizing
- add a focused contract test for local discovery label detection

## Problem
Keepers with `llama:auto` first in the cascade were falling through to `glm:auto` because the runtime was still using a stale discovered context size of `8192`. That caused local runs to overflow before prompt execution even though the live llama runtime reported a much larger context window.

## Fix
- add `labels_require_local_discovery` and `refresh_local_discovery_if_possible` to `Oas_model_resolve`
- call the refresh helper immediately before `resolve_primary_max_context` in keeper bootstrap and turn paths
- log context refresh changes and tolerate refresh failures without breaking the request path

## Verification
- `./_build/default/test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_keeper_unified.exe`
