### PR TITLE
fix(operator): harden cp summary and autoresearch startup

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -121,6 +121,7 @@ let prepare_managed_worktree = Autoresearch_git.prepare_managed_worktree
 (* ================================================================ *)
 
 let has_path_traversal = Autoresearch_file.has_path_traversal
+let resolve_target_file_path = Autoresearch_file.resolve_target_file_path
 let validate_target_file = Autoresearch_file.validate_target_file
 let read_file = Autoresearch_file.read_file
 let apply_code_change = Autoresearch_file.apply_code_change

--- a/lib/autoresearch/autoresearch_file.ml
+++ b/lib/autoresearch/autoresearch_file.ml
@@ -30,6 +30,14 @@ let rec nearest_existing_path path =
     else
       nearest_existing_path parent
 
+let safe_realpath path =
+  try Result.ok (Unix.realpath path)
+  with
+  | Unix.Unix_error (code, _, _) ->
+      Result.error
+        (Printf.sprintf "realpath failed for %s: %s" path
+           (Unix.error_message code))
+
 (** Resolve [target_file] to an absolute path within [workdir] without
     requiring the file to already exist. Existing parent directories are
     resolved via [realpath] so symlink escapes are rejected before callers
@@ -43,18 +51,17 @@ let resolve_target_file_path ~workdir target_file =
     Result.error (Printf.sprintf "target_file contains '..': %s" target_file)
   else
     let abs = Filename.concat workdir target_file in
-    let real_workdir = Unix.realpath workdir in
     let parent = Filename.dirname abs in
-    let real_parent =
-      nearest_existing_path parent
-      |> Unix.realpath
-    in
-    if is_safe_subpath ~parent:real_workdir ~child:real_parent then
-      Result.ok abs
-    else
-      Result.error
-        (Printf.sprintf
-           "target_file escapes workdir via symlink: %s" target_file)
+    match safe_realpath workdir, safe_realpath (nearest_existing_path parent) with
+    | Error message, _ -> Result.error message
+    | _, Error message -> Result.error message
+    | Ok real_workdir, Ok real_parent ->
+        if is_safe_subpath ~parent:real_workdir ~child:real_parent then
+          Result.ok abs
+        else
+          Result.error
+            (Printf.sprintf
+               "target_file escapes workdir via symlink: %s" target_file)
 
 (** Validate target_file: must be relative, no path traversal, must exist,
     must not escape workdir via symlink.
@@ -68,13 +75,15 @@ let validate_target_file ~workdir target_file =
     else if Sys.is_directory abs then
       Result.error (Printf.sprintf "target_file is a directory: %s" target_file)
     else
-      let real_path = Unix.realpath abs in
-      let real_workdir = Unix.realpath workdir in
-      if is_safe_subpath ~parent:real_workdir ~child:real_path then
-        Result.ok real_path
-      else
-        Result.error (Printf.sprintf
-          "target_file escapes workdir via symlink: %s" target_file)
+      match safe_realpath abs, safe_realpath workdir with
+      | Error message, _ -> Result.error message
+      | _, Error message -> Result.error message
+      | Ok real_path, Ok real_workdir ->
+          if is_safe_subpath ~parent:real_workdir ~child:real_path then
+            Result.ok real_path
+          else
+            Result.error (Printf.sprintf
+              "target_file escapes workdir via symlink: %s" target_file)
 
 (** Read entire file contents. *)
 let read_file path =

--- a/lib/autoresearch/autoresearch_file.ml
+++ b/lib/autoresearch/autoresearch_file.ml
@@ -12,10 +12,29 @@ let has_path_traversal path =
   || (let len = String.length path in
       len >= 3 && String.sub path (len - 3) 3 = "/..")
 
-(** Validate target_file: must be relative, no path traversal, must exist,
-    must not escape workdir via symlink.
-    Returns Ok absolute_path or Error reason. *)
-let validate_target_file ~workdir target_file =
+let is_safe_subpath ~parent ~child =
+  if child = parent then
+    true
+  else
+    let prefix = parent ^ "/" in
+    String.length child >= String.length prefix
+    && String.sub child 0 (String.length prefix) = prefix
+
+let rec nearest_existing_path path =
+  if Sys.file_exists path then
+    path
+  else
+    let parent = Filename.dirname path in
+    if parent = path then
+      path
+    else
+      nearest_existing_path parent
+
+(** Resolve [target_file] to an absolute path within [workdir] without
+    requiring the file to already exist. Existing parent directories are
+    resolved via [realpath] so symlink escapes are rejected before callers
+    create or seed files. *)
+let resolve_target_file_path ~workdir target_file =
   if String.length target_file = 0 then
     Result.error "target_file is empty"
   else if String.get target_file 0 = '/' then
@@ -24,6 +43,26 @@ let validate_target_file ~workdir target_file =
     Result.error (Printf.sprintf "target_file contains '..': %s" target_file)
   else
     let abs = Filename.concat workdir target_file in
+    let real_workdir = Unix.realpath workdir in
+    let parent = Filename.dirname abs in
+    let real_parent =
+      nearest_existing_path parent
+      |> Unix.realpath
+    in
+    if is_safe_subpath ~parent:real_workdir ~child:real_parent then
+      Result.ok abs
+    else
+      Result.error
+        (Printf.sprintf
+           "target_file escapes workdir via symlink: %s" target_file)
+
+(** Validate target_file: must be relative, no path traversal, must exist,
+    must not escape workdir via symlink.
+    Returns Ok absolute_path or Error reason. *)
+let validate_target_file ~workdir target_file =
+  match resolve_target_file_path ~workdir target_file with
+  | Error _ as error -> error
+  | Ok abs ->
     if not (Sys.file_exists abs) then
       Result.error (Printf.sprintf "target_file not found: %s" abs)
     else if Sys.is_directory abs then
@@ -31,10 +70,7 @@ let validate_target_file ~workdir target_file =
     else
       let real_path = Unix.realpath abs in
       let real_workdir = Unix.realpath workdir in
-      let prefix = real_workdir ^ "/" in
-      if real_path = real_workdir
-         || (String.length real_path >= String.length prefix
-             && String.sub real_path 0 (String.length prefix) = prefix) then
+      if is_safe_subpath ~parent:real_workdir ~child:real_path then
         Result.ok real_path
       else
         Result.error (Printf.sprintf

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -63,6 +63,26 @@ let _cp_summary_refresh_interval_s =
     "MASC_CP_SUMMARY_REFRESH_INTERVAL_S"
     ~default:120.0 ~min_v:30.0 ~max_v:600.0
 
+type cp_snapshot_cache = {
+  snapshot : Yojson.Safe.t;
+  cached_at : float;
+}
+
+let _cp_snapshot_cache : cp_snapshot_cache ref =
+  ref
+    {
+      snapshot =
+        `Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")];
+      cached_at = 0.0;
+    }
+
+let cached_cp_snapshot_opt () =
+  let cache = !_cp_snapshot_cache in
+  if cache.cached_at > 0.0 then
+    Some cache.snapshot
+  else
+    None
+
 let compute_cp_summary ~state =
   let config = state.Mcp_server.room_config in
   let t0 = Time_compat.now () in
@@ -115,19 +135,6 @@ let command_plane_summary_http_json ~state:_ =
    legitimately take much longer than the dashboard-friendly summary surfaces.
    Use a slower cadence and larger timeout to avoid constant timeout/backoff
    churn while still keeping a warm cached snapshot available. *)
-
-type cp_snapshot_cache = {
-  snapshot : Yojson.Safe.t;
-  cached_at : float;
-}
-
-let _cp_snapshot_cache : cp_snapshot_cache ref =
-  ref
-    {
-      snapshot =
-        `Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")];
-      cached_at = 0.0;
-    }
 
 let _cp_snapshot_compute_mu = Eio.Mutex.create ()
 let _cp_snapshot_refresh_interval_s =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -120,6 +120,32 @@ let register_loop (ctx : context) state =
     latest_loop_id := Some state.loop_id);
   state
 
+let prepare_managed_target_file ~source_workdir ~managed_workdir target_file =
+  match Autoresearch.validate_target_file ~workdir:managed_workdir target_file with
+  | Ok _ -> Ok []
+  | Error managed_error ->
+      match Autoresearch.validate_target_file ~workdir:source_workdir target_file with
+      | Error _ ->
+          Error (Printf.sprintf "Invalid target_file: %s" managed_error)
+      | Ok source_abs ->
+          (match
+             Autoresearch.resolve_target_file_path ~workdir:managed_workdir
+               target_file
+           with
+          | Error path_error ->
+              Error (Printf.sprintf "Invalid target_file: %s" path_error)
+          | Ok managed_abs ->
+              try
+                Fs_compat.mkdir_p (Filename.dirname managed_abs);
+                Fs_compat.save_file managed_abs
+                  (Autoresearch.read_file source_abs);
+                Ok [ "target_file_seeded_from_source" ]
+              with exn ->
+                Error
+                  (Printf.sprintf
+                     "Failed to seed target_file into managed worktree: %s"
+                     (Printexc.to_string exn)))
+
 let setup_running_loop (ctx : context) (params : start_params) =
   let state =
     Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
@@ -134,12 +160,15 @@ let setup_running_loop (ctx : context) (params : start_params) =
   with
   | Error message -> Error message
   | Ok (managed_workdir, source_workdir, warnings) -> (
-      let state = { state with workdir = managed_workdir; warnings } in
-      let baseline_result =
-        match Autoresearch.validate_target_file ~workdir:managed_workdir params.target_file with
-        | Error e ->
-            Error (Printf.sprintf "Invalid target_file: %s" e)
-        | Ok _ -> (
+      match
+        prepare_managed_target_file ~source_workdir ~managed_workdir
+          params.target_file
+      with
+      | Error message -> Error message
+      | Ok target_file_warnings ->
+          let warnings = warnings @ target_file_warnings in
+          let state = { state with workdir = managed_workdir; warnings } in
+          let baseline_result =
             match params.baseline_override with
             | Some baseline -> Ok baseline
             | None -> (
@@ -150,14 +179,14 @@ let setup_running_loop (ctx : context) (params : start_params) =
                 | Ok (baseline, _ms) -> Ok baseline
                 | Error e ->
                     Error
-                      (Printf.sprintf "Failed to measure baseline: %s" e)))
-      in
-      match baseline_result with
-      | Error message -> Error message
-      | Ok baseline ->
-          let state = { state with
-            baseline; best_score = baseline; source_workdir } in
-          Ok (register_loop ctx state))
+                      (Printf.sprintf "Failed to measure baseline: %s" e))
+          in
+          match baseline_result with
+          | Error message -> Error message
+          | Ok baseline ->
+              let state = { state with
+                baseline; best_score = baseline; source_workdir } in
+              Ok (register_loop ctx state))
 
 let status_json (ctx : context) ~loop_id json_fields =
   let strip_keys keys fields =

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -404,7 +404,9 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                         | Agent_sdk.Autonomy_diff_guard.Empty_patch -> true
                         | _ -> false)
                       report.issues
-                 then
+                 then (
+                   restore_original_content
+                     ~workdir ~target_file ~original_content ~sync_index:false;
                    let (state, record) =
                      forced_discard_record state
                        ~hypothesis ~score_before ~elapsed_ms:0
@@ -412,8 +414,8 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                        ()
                    in
                    persist_discard_record ctx state
-                     ~loop_id:id ~hypothesis ~reason:"no diff produced" record
-                 else if not report.accepted then
+                     ~loop_id:id ~hypothesis ~reason:"no diff produced" record)
+                 else if not report.accepted then (
                    let summary = diff_guard_summary report in
                    restore_original_content
                      ~workdir ~target_file ~original_content ~sync_index:false;
@@ -434,7 +436,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                    persist_discard_record ctx state
                      ~loop_id:id ~hypothesis
                      ~reason:("diff guard rejected patch: " ^ summary)
-                     record
+                     record)
                  else
                    let commit_result =
                      Autoresearch.git_commit_cycle
@@ -462,6 +464,8 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                          ("cycle", `Int state.current_cycle);
                        ]
                    | Ok None ->
+                     restore_original_content
+                       ~workdir ~target_file ~original_content ~sync_index:false;
                      let (state, record) =
                        forced_discard_record state
                          ~hypothesis ~score_before ~elapsed_ms:0

--- a/lib/tool_autoresearch_repo_synthesis.ml
+++ b/lib/tool_autoresearch_repo_synthesis.ml
@@ -139,7 +139,7 @@ let ensure_repo_synthesis_units config ~actor ~active_roster =
     ]
   in
   let rec loop = function
-    | [] -> Ok platoon_id
+    | [] -> Ok company_id
     | json :: rest -> (
         match ensure_unit json with
         | Ok () -> loop rest

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -296,6 +296,105 @@ let test_build_verify_downgrade_rewrites_history () =
     "discard"
     (Lib.Autoresearch.decision_to_string next_history_head.decision)
 
+let test_start_seeds_source_only_target_file_into_managed_worktree () =
+  with_temp_dir "masc_autoresearch_seed" @@ fun root ->
+  with_me_root root @@ fun () ->
+  with_eio @@ fun ~sw ~clock ->
+  with_clean_state @@ fun () ->
+  let repo = Filename.concat root "repo" in
+  Unix.mkdir repo 0o755;
+  init_git_repo repo;
+  let target_file = ".masc/keepers/admin-keeper/test_ar.py" in
+  let source_path = Filename.concat repo target_file in
+  write_file source_path "print('seeded')\n";
+  let ctx : Lib.Tool_autoresearch.context =
+    {
+      base_path = root;
+      agent_name = Some "test";
+      start_operation = None;
+      start_team_session = None;
+      config = None;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  match
+    Lib.Tool_autoresearch.dispatch ctx ~name:"masc_autoresearch_start"
+      ~args:
+        (`Assoc
+          [
+            ("goal", `String "Improve keeper helper");
+            ("metric_fn", `String "/usr/bin/printf 1.0");
+            ("target_file", `String target_file);
+            ("workdir", `String repo);
+            ("max_cycles", `Int 1);
+          ])
+  with
+  | None -> fail "dispatch returned None"
+  | Some (false, msg) -> fail msg
+  | Some (true, payload) ->
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string payload in
+      let managed_workdir = json |> member "workdir" |> to_string in
+      check bool "seed warning present" true
+        (json |> member "warnings" |> to_list
+         |> List.exists (fun value -> to_string value = "target_file_seeded_from_source"));
+      check string "seeded content preserved" "print('seeded')\n"
+        (Fs_compat.load_file (Filename.concat managed_workdir target_file))
+
+let test_cycle_restores_ignored_target_after_empty_diff () =
+  with_temp_dir "masc_autoresearch_restore" @@ fun root ->
+  with_me_root root @@ fun () ->
+  with_eio @@ fun ~sw ~clock ->
+  with_clean_state @@ fun () ->
+  let repo = Filename.concat root "repo" in
+  Unix.mkdir repo 0o755;
+  init_git_repo repo;
+  run_in_dir repo "git checkout -q -b ignored-target-loop";
+  write_file (Filename.concat repo ".gitignore") ".ignored/\n";
+  run_in_dir repo "git add .gitignore";
+  run_in_dir repo "git commit -q -m ignore";
+  let target_file = ".ignored/target.txt" in
+  let target_path = Filename.concat repo target_file in
+  write_file target_path "original\n";
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"Try ignored file"
+      ~metric_fn:"/usr/bin/printf 1.0"
+      ~model_model:"glm:test"
+      ~target_file
+      ~cycle_timeout_s:5.0
+      ~max_cycles:3
+      ~workdir:repo
+      ()
+  in
+  Lib.Autoresearch.with_loops_rw (fun () ->
+      Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state;
+      Lib.Autoresearch.latest_loop_id := Some state.loop_id);
+  let ctx : Lib.Tool_autoresearch_repo_synthesis.context =
+    {
+      base_path = root;
+      agent_name = Some "test";
+      start_operation = None;
+      start_team_session = None;
+      config = None;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  Lib.Tool_autoresearch_registry.set_generator state.loop_id
+    (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
+       Ok ("ignored file edit", "changed\n"));
+  let result =
+    Lib.Tool_autoresearch_cycle.handle_cycle ctx
+      (`Assoc [ ("loop_id", `String state.loop_id) ])
+  in
+  let open Yojson.Safe.Util in
+  check string "ignored file discarded" "discard"
+    (result |> member "decision" |> to_string);
+  check string "ignored file restored" "original\n"
+    (Fs_compat.load_file target_path)
+
 let () =
   run "autoresearch_oas_primitives"
     [
@@ -312,5 +411,9 @@ let () =
             test_cycle_reinjects_diff_guard_lesson;
           test_case "build verify downgrade rewrites history" `Quick
             test_build_verify_downgrade_rewrites_history;
+          test_case "start seeds source-only target file" `Quick
+            test_start_seeds_source_only_target_file_into_managed_worktree;
+          test_case "cycle restores ignored target after empty diff" `Quick
+            test_cycle_restores_ignored_target_after_empty_diff;
         ] );
     ]

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -342,6 +342,20 @@ let test_start_seeds_source_only_target_file_into_managed_worktree () =
       check string "seeded content preserved" "print('seeded')\n"
         (Fs_compat.load_file (Filename.concat managed_workdir target_file))
 
+let test_resolve_target_file_path_reports_realpath_errors () =
+  let missing_root =
+    Filename.concat (temp_dir "masc_autoresearch_missing_root") "missing"
+  in
+  match
+    Lib.Autoresearch.resolve_target_file_path ~workdir:missing_root
+      ".masc/keepers/admin-keeper/test_ar.py"
+  with
+  | Ok path ->
+      failf "expected missing workdir to error, got %s" path
+  | Error message ->
+      check bool "realpath failure surfaced" true
+        (contains message "realpath failed")
+
 let test_cycle_restores_ignored_target_after_empty_diff () =
   with_temp_dir "masc_autoresearch_restore" @@ fun root ->
   with_me_root root @@ fun () ->
@@ -413,6 +427,8 @@ let () =
             test_build_verify_downgrade_rewrites_history;
           test_case "start seeds source-only target file" `Quick
             test_start_seeds_source_only_target_file_into_managed_worktree;
+          test_case "resolve target file reports realpath errors" `Quick
+            test_resolve_target_file_path_reports_realpath_errors;
           test_case "cycle restores ignored target after empty diff" `Quick
             test_cycle_restores_ignored_target_after_empty_diff;
         ] );

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -669,6 +669,12 @@ let test_command_plane_snapshot_review_contracts () =
   check bool "on-demand snapshot uses timeout guard" true
     (file_contains_pattern "lib/server/server_command_plane_http_support.ml"
        "Eio.Time.with_timeout_exn (cp_snapshot_runtime_clock state)");
+  check bool "cp summary derives swarm status from cached snapshot" true
+    (file_contains_pattern "lib/server/server_command_plane_http_support.ml"
+       "Swarm_status.build_json_from_snapshot ~timeline_limit_override:6");
+  check bool "cp summary no longer performs live swarm scan" true
+    (file_not_contains_pattern "lib/server/server_command_plane_http_support.ml"
+       "Swarm_status.build_json ~timeline_limit_override:6 config");
   check bool "on-demand snapshot uses single-flight mutex" true
     (file_contains_pattern "lib/server/server_command_plane_http_support.ml"
        "Eio.Mutex.use_rw ~protect:true _cp_snapshot_compute_mu");

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -25,6 +25,30 @@ let with_temp_base f =
   let dir = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () -> f dir)
 
+let saturate_repo_synthesis_platoon config ~actor =
+  match
+    Lib.Tool_autoresearch_repo_synthesis.ensure_repo_synthesis_units config
+      ~actor ~active_roster:[ actor ]
+  with
+  | Error message -> fail message
+  | Ok _ ->
+      for idx = 1 to 8 do
+        match
+          Lib.Command_plane_v2.start_operation config ~actor
+            (`Assoc
+              [
+                ("assigned_unit_id", `String "platoon-repo-synthesis");
+                ("objective", `String (Printf.sprintf "Warm repo synthesis slot %d" idx));
+                ("policy_class", `String "guarded");
+                ("budget_class", `String "standard");
+                ("workload_profile", `String "coding_task");
+                ("stage", `String "inspect");
+              ])
+        with
+        | Ok _ -> ()
+        | Error message -> fail message
+      done
+
 let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -112,6 +136,77 @@ let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
           session_json |> member "session" |> member "planned_workers" |> to_list
           |> List.length)
 
+let test_repo_synthesis_swarm_start_avoids_saturated_platoon_cap () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  with_temp_base @@ fun base_path ->
+  let config = Lib.Room.default_config base_path in
+  ignore (Lib.Room.init config ~agent_name:(Some "owner"));
+  ignore (Lib.Room.join config ~agent_name:"owner" ~capabilities:[ "ocaml"; "docs" ] ());
+  saturate_repo_synthesis_platoon config ~actor:"owner";
+  let start_team_session ~goal ~operation_id ~loop_id:_ ~target_file:_ ~program_note:_ =
+    Lib.Team_session_engine_eio.start_session
+      ~sw
+      ~env
+      ~config
+      ~created_by:"owner"
+      ~goal
+      ~duration_seconds:300
+      ~execution_scope:Team_session_types.Limited_code_change
+      ~checkpoint_interval_sec:30
+      ~min_agents:1
+      ~scale_profile:Team_session_types.Scale_standard
+      ~control_profile:Team_session_types.Control_hierarchical_quality_v1
+      ~orchestration_mode:Team_session_types.Assist
+      ~communication_mode:Team_session_types.Comm_broadcast
+      ~model_cascade:[]
+      ~fallback_policy:Team_session_types.Fallback_cascade_then_task
+      ~instruction_profile:Team_session_types.Profile_strict
+      ~alert_channel:Team_session_types.Alert_broadcast
+      ~auto_resume:true
+      ~report_formats:[ Team_session_types.Markdown; Team_session_types.Json ]
+      ~agent_names:[]
+      ~operation_id
+  in
+  let ctx : Lib.Tool_autoresearch.context =
+    {
+      base_path;
+      agent_name = Some "owner";
+      start_operation = None;
+      start_team_session = Some start_team_session;
+      config = Some config;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("goal", `String "Avoid platoon cap");
+        ("question", `String "How is repo synthesis routed?");
+        ("repo_root", `String base_path);
+      ]
+  in
+  match
+    Lib.Tool_autoresearch.dispatch ctx ~name:"masc_repo_synthesis_swarm_start"
+      ~args
+  with
+  | None -> fail "dispatch returned None"
+  | Some (false, msg) -> fail msg
+  | Some (true, payload) ->
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string payload in
+      let operation_id = json |> member "operation_id" |> to_string in
+      let operations =
+        Lib.Command_plane_v2.operation_status_json config ~operation_id ()
+      in
+      check string "repo synthesis assigns company unit"
+        "company-repo-synthesis"
+        (operations |> member "operations" |> index 0 |> member "operation"
+         |> member "assigned_unit_id" |> to_string)
+
 let () =
   run "tool_repo_synthesis"
     [
@@ -119,5 +214,7 @@ let () =
        [
          test_case "swarm_start creates operation session and run" `Quick
            test_repo_synthesis_swarm_start_creates_operation_session_and_run;
+         test_case "swarm_start avoids saturated platoon cap" `Quick
+           test_repo_synthesis_swarm_start_avoids_saturated_platoon_cap;
        ]);
     ]


### PR DESCRIPTION
## Summary
- make command-plane summary derive `swarm_status` from the cached snapshot path instead of a live swarm scan so cp-summary refresh stops timing out on heavy filesystem reads
- allow `masc_autoresearch_start` to seed source-only target files into the managed worktree and restore ignored targets on empty-diff/no-commit discard paths
- route repo synthesis swarm startup through the repo-synthesis company unit so a saturated platoon cap does not block new startup operations

## Product impact
- Promise: `ops visibility`
- Promise: `delivery swarm`

## Evidence
- `git diff --check`
- `ocamlc -stop-after parsing lib/autoresearch.ml lib/autoresearch/autoresearch_file.ml lib/server/server_command_plane_http_support.ml lib/tool_autoresearch.ml lib/tool_autoresearch_cycle.ml lib/tool_autoresearch_repo_synthesis.ml test/test_autoresearch_oas_primitives.ml test/test_ci_hardening_source.ml test/test_tool_repo_synthesis.ml`
- `DUNE_BUILD_DIR=_build_codex_fix dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-operator-timeouts-autoresearch-cap ./test/test_ci_hardening_source.exe`
- `DUNE_BUILD_DIR=_build_codex_fix dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-operator-timeouts-autoresearch-cap ./test/test_autoresearch_oas_primitives.exe`
- `DUNE_BUILD_DIR=_build_codex_fix dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-operator-timeouts-autoresearch-cap ./test/test_tool_repo_synthesis.exe`

## Review evidence
- Cross-model review posted as a PR comment using direct `sb glm-text`
- Result: no high/critical findings

## Linked issue
- none
