### PR TITLE
fix: align keeper autonomous scheduling and tool selection

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -24,9 +24,9 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Post a finding or status update (keeper_board_post)
 - Respond to board activity (keeper_board_comment)
 - Search knowledge library (keeper_library_search/read)
-- Failed tasks are actionable operational signals. Audit them with `keeper_tasks_audit` before deciding there is nothing meaningful to do.
-- A live worktree delta is actionable context. Inspect listed files with `keeper_fs_read`, `keeper_shell_readonly`, or `masc_code_read` before deciding there is nothing meaningful to do.
-- `masc_heartbeat` is maintenance only. Do not use it as your only action when failed tasks, unclaimed tasks, pending mentions, board activity, or a live worktree delta are present.
+- Failed tasks are actionable operational signals. If `keeper_tasks_audit` is available under the current tool policy, audit them with it before deciding there is nothing meaningful to do.
+- A live worktree delta is actionable context. If `keeper_fs_read`, `keeper_shell_readonly`, or `masc_code_read` are available under the current tool policy, inspect listed files with the available tool before deciding there is nothing meaningful to do.
+- If `masc_heartbeat` is available under the current tool policy, treat it as maintenance only. Do not use it as your only action when failed tasks, unclaimed tasks, pending mentions, board activity, or a live worktree delta are present.
 - If blocked, set `SPEECH_ACT: request_help`
 - If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -24,6 +24,9 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Post a finding or status update (keeper_board_post)
 - Respond to board activity (keeper_board_comment)
 - Search knowledge library (keeper_library_search/read)
+- Failed tasks are actionable operational signals. Audit them with `keeper_tasks_audit` before deciding there is nothing meaningful to do.
+- A live worktree delta is actionable context. Inspect listed files with `keeper_fs_read`, `keeper_shell_readonly`, or `masc_code_read` before deciding there is nothing meaningful to do.
+- `masc_heartbeat` is maintenance only. Do not use it as your only action when failed tasks, unclaimed tasks, pending mentions, board activity, or a live worktree delta are present.
 - If blocked, set `SPEECH_ACT: request_help`
 - If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -93,6 +93,17 @@ let take n items =
     List.filteri (fun i _ -> i < n) items
 
 let tool_query_text_of_user_message (text : string) : string =
+  let allowed_sections =
+    [
+      "### Pending Mentions";
+      "### Scope Messages";
+      "### Active Goals";
+      "### Namespace State";
+      "### Board Activity";
+      "### Actionable Routes";
+      "### Live Worktree Delta";
+    ]
+  in
   let lines = String.split_on_char '\n' text in
   let rec loop current_section kept = function
     | [] ->
@@ -104,15 +115,17 @@ let tool_query_text_of_user_message (text : string) : string =
           if String.starts_with ~prefix:"### " trimmed then Some trimmed
           else current_section
         in
-        let skip_line =
+        let keep_line =
           match current_section with
-          | Some "### Continuity" -> true
-          | _ -> false
+          | None ->
+              String.starts_with ~prefix:"## Current World State" trimmed
+          | Some section ->
+              List.mem section allowed_sections
         in
-        if skip_line then
-          loop current_section kept rest
-        else
+        if keep_line then
           loop current_section (line :: kept) rest
+        else
+          loop current_section kept rest
   in
   loop None [] lines
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -104,6 +104,11 @@ let tool_query_text_of_user_message (text : string) : string =
       "### Live Worktree Delta";
     ]
   in
+  let is_allowed_section section =
+    List.exists
+      (fun allowed -> String.starts_with ~prefix:allowed section)
+      allowed_sections
+  in
   let lines = String.split_on_char '\n' text in
   let rec loop current_section kept = function
     | [] ->
@@ -120,7 +125,7 @@ let tool_query_text_of_user_message (text : string) : string =
           | None ->
               String.starts_with ~prefix:"## Current World State" trimmed
           | Some section ->
-              List.mem section allowed_sections
+              is_allowed_section section
         in
         if keep_line then
           loop current_section (line :: kept) rest

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -92,6 +92,30 @@ let take n items =
   else
     List.filteri (fun i _ -> i < n) items
 
+let tool_query_text_of_user_message (text : string) : string =
+  let lines = String.split_on_char '\n' text in
+  let rec loop current_section kept = function
+    | [] ->
+        let filtered = List.rev kept |> String.concat "\n" |> String.trim in
+        if filtered <> "" then filtered else String.trim text
+    | line :: rest ->
+        let trimmed = String.trim line in
+        let current_section =
+          if String.starts_with ~prefix:"### " trimmed then Some trimmed
+          else current_section
+        in
+        let skip_line =
+          match current_section with
+          | Some "### Continuity" -> true
+          | _ -> false
+        in
+        if skip_line then
+          loop current_section kept rest
+        else
+          loop current_section (line :: kept) rest
+  in
+  loop None [] lines
+
 let prioritized_disclosed_tool_names
     ~(max_tools : int)
     ~(always_include_tools : string list)
@@ -600,8 +624,9 @@ let run_turn
           ) "" messages
         in
         let query_text =
-          if String.trim last_user_text <> "" then last_user_text
-          else user_message
+          (if String.trim last_user_text <> "" then last_user_text
+           else user_message)
+          |> tool_query_text_of_user_message
         in
         (* Confidence-gated union: always retrieve, but union fallback
            when BM25 confidence is low (e.g. Korean query vs English docs).

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -345,7 +345,7 @@ let keeper_proactive_task_min_cooldown_sec () : int =
   int_of_env_default
     "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC"
     ~default:60
-    ~min_v:0
+    ~min_v:1
     ~max_v:1800
 
 let keeper_compaction_policy_from_env () : (float * int * int) =

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -334,6 +334,20 @@ let keeper_proactive_min_cooldown_sec () : int =
     ~min_v:60
     ~max_v:1800
 
+let keeper_proactive_task_cooldown_divisor () : int =
+  int_of_env_default
+    "MASC_KEEPER_PROACTIVE_TASK_COOLDOWN_DIVISOR"
+    ~default:3
+    ~min_v:1
+    ~max_v:12
+
+let keeper_proactive_task_min_cooldown_sec () : int =
+  int_of_env_default
+    "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC"
+    ~default:60
+    ~min_v:0
+    ~max_v:1800
+
 let keeper_compaction_policy_from_env () : (float * int * int) =
   ( keeper_compact_ratio (),
     keeper_compact_max_messages (),

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -458,17 +458,28 @@ let run_keepalive_unified_turn
       let has_message_signal =
         obs.pending_mentions <> [] || obs.pending_scope_messages <> []
       in
+      let turn_decision =
+        Keeper_world_observation.unified_turn_decision
+          ~meta:meta_after_triage
+          obs
+      in
       let should_run_turn =
         (not (Atomic.get stop))
-        && Keeper_world_observation.should_run_unified_turn
-             ~meta:meta_after_triage
-             obs
+        && turn_decision.should_run
       in
       let meta_after_observe =
         Keeper_world_observation.apply_message_cursor_updates
           meta_after_triage
           obs.message_cursor_updates
       in
+      if should_run_turn then
+        Log.Keeper.info
+          "keepalive turn scheduled for %s: channel=%s reasons=%s"
+          meta_after_triage.name
+          (match turn_decision.channel with
+           | Keeper_world_observation.Reactive -> "reactive"
+           | Keeper_world_observation.Scheduled_autonomous -> "scheduled_autonomous")
+          (String.concat "," turn_decision.reasons);
       if (not should_run_turn)
          && (not has_message_signal)
          && obs.message_cursor_updates <> []

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -13,7 +13,13 @@ let dedupe_tool_names names =
 (* ── Static tool name lists ────────────────────────────────────── *)
 
 let keeper_coordination_tool_names =
-  [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_task_done"; "keeper_broadcast" ]
+  [
+    "keeper_tasks_list";
+    "keeper_tasks_audit";
+    "keeper_task_claim";
+    "keeper_task_done";
+    "keeper_broadcast";
+  ]
 
 let keeper_board_tool_names =
   [

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -73,6 +73,68 @@ let line_block label value =
 let format_room_signal_salience salience =
   Meta_cognition.salience_to_string salience
 
+let actionable_routes
+    (observation : Keeper_world_observation.world_observation) : string list =
+  let routes = ref [] in
+  let add route = routes := route :: !routes in
+  if observation.pending_mentions <> [] then
+    add
+      "- Pending mentions: reply in-room before going silent.";
+  if observation.pending_board_events <> [] then
+    add
+      "- Board activity: use keeper_board_comment or keeper_board_post if a visible response is warranted.";
+  if observation.unclaimed_task_count > 0 then
+    add
+      "- Unclaimed tasks: use keeper_task_claim before treating the room as idle.";
+  if observation.failed_task_count > 0 then
+    add
+      "- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.";
+  if Option.is_some observation.worktree_change_summary then
+    add
+      "- Live worktree delta: inspect changed files with keeper_fs_read, keeper_shell_readonly, or masc_code_read if you need to understand whether action is required.";
+  List.rev !routes
+
+let autonomous_trigger_lines
+    ~(decision : Keeper_world_observation.unified_turn_decision)
+    ~(observation : Keeper_world_observation.world_observation) : string list =
+  match decision.channel, decision.should_run with
+  | Keeper_world_observation.Scheduled_autonomous, true ->
+      let lines =
+        [
+          Some "- Scheduler: scheduled autonomous keepalive turn.";
+          (match decision.reasons with
+           | [] -> None
+           | reasons ->
+               Some
+                 (Printf.sprintf "- Reasons: %s"
+                    (String.concat ", " reasons)));
+          (match decision.idle_gate_sec with
+           | Some idle_gate ->
+               Some
+                 (Printf.sprintf "- Idle gate: %ds (current idle: %ds)"
+                    idle_gate observation.idle_seconds)
+           | None -> None);
+          (match decision.since_last_proactive, decision.effective_cooldown with
+           | Some since_last, Some cooldown ->
+               Some
+                 (Printf.sprintf
+                    "- Since last autonomous turn: %ds, effective cooldown: %ds"
+                    since_last cooldown)
+           | _ -> None);
+          (match decision.task_reactive_cooldown with
+           | Some cooldown
+             when observation.unclaimed_task_count > 0
+                  || observation.failed_task_count > 0 ->
+               Some
+                 (Printf.sprintf
+                    "- Backlog acceleration cooldown: %ds for unclaimed/failed tasks"
+                    cooldown)
+           | _ -> None);
+        ]
+      in
+      List.filter_map Fun.id lines
+  | _ -> []
+
 let has_room_signal_section
     (observation : Keeper_world_observation.world_observation) =
   match observation.room_signal_interpretation with
@@ -258,8 +320,23 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
    | Frugal ->
        Buffer.add_string ubuf "- Economy: Frugal (reduce token usage)\n"
    | Hustle ->
-       Buffer.add_string ubuf
-         "- Economy: Hustle (minimize actions, conserve budget)\n");
+        Buffer.add_string ubuf
+          "- Economy: Hustle (minimize actions, conserve budget)\n");
+  let turn_decision =
+    Keeper_world_observation.unified_turn_decision ~meta observation
+  in
+  let autonomous_trigger =
+    autonomous_trigger_lines ~decision:turn_decision ~observation
+  in
+  if autonomous_trigger <> [] then (
+    Buffer.add_string ubuf "\n### Autonomous Trigger\n";
+    Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
+    Buffer.add_string ubuf "\n");
+  let routes = actionable_routes observation in
+  if routes <> [] then (
+    Buffer.add_string ubuf "\n### Actionable Routes\n";
+    Buffer.add_string ubuf (String.concat "\n" routes);
+    Buffer.add_string ubuf "\n");
   (* Continuity *)
   if
     observation.continuity_summary <> ""

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -73,25 +73,52 @@ let line_block label value =
 let format_room_signal_salience salience =
   Meta_cognition.salience_to_string salience
 
-let actionable_routes
+let actionable_routes ~(meta : Keeper_types.keeper_meta)
     (observation : Keeper_world_observation.world_observation) : string list =
+  let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
+  let can tool_name = List.mem tool_name allowed_tools in
+  let available tool_names =
+    List.filter (fun tool_name -> can tool_name) tool_names
+  in
   let routes = ref [] in
   let add route = routes := route :: !routes in
   if observation.pending_mentions <> [] then
     add
       "- Pending mentions: reply in-room before going silent.";
   if observation.pending_board_events <> [] then
-    add
-      "- Board activity: use keeper_board_comment or keeper_board_post if a visible response is warranted.";
+    (match available [ "keeper_board_comment"; "keeper_board_post" ] with
+     | [] ->
+         add
+           "- Board activity is actionable, but board reply tools are unavailable under the current tool policy."
+     | tools ->
+         add
+           (Printf.sprintf
+              "- Board activity: use %s if a visible response is warranted."
+              (String.concat " or " tools)));
   if observation.unclaimed_task_count > 0 then
-    add
-      "- Unclaimed tasks: use keeper_task_claim before treating the room as idle.";
+    if can "keeper_task_claim" then
+      add
+        "- Unclaimed tasks: use keeper_task_claim before treating the room as idle."
+    else
+      add
+        "- Unclaimed tasks are present, but task-claim tooling is unavailable under the current tool policy.";
   if observation.failed_task_count > 0 then
-    add
-      "- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.";
+    if can "keeper_tasks_audit" then
+      add
+        "- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do."
+    else
+      add
+        "- Failed tasks are actionable, but task-audit tooling is unavailable under the current tool policy.";
   if Option.is_some observation.worktree_change_summary then
-    add
-      "- Live worktree delta: inspect changed files with keeper_fs_read, keeper_shell_readonly, or masc_code_read if you need to understand whether action is required.";
+    (match available [ "keeper_fs_read"; "keeper_shell_readonly"; "masc_code_read" ] with
+     | [] ->
+         add
+           "- Live worktree delta is actionable, but file-inspection tools are unavailable under the current tool policy."
+     | tools ->
+         add
+           (Printf.sprintf
+              "- Live worktree delta: inspect changed files with %s if you need to understand whether action is required."
+              (String.concat ", " tools)));
   List.rev !routes
 
 let autonomous_trigger_lines
@@ -332,7 +359,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  let routes = actionable_routes observation in
+  let routes = actionable_routes ~meta observation in
   if routes <> [] then (
     Buffer.add_string ubuf "\n### Actionable Routes\n";
     Buffer.add_string ubuf (String.concat "\n" routes);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -44,6 +44,20 @@ type world_observation = {
   last_turn_budget : (int * int) option;
 }
 
+type unified_turn_channel =
+  | Reactive
+  | Scheduled_autonomous
+
+type unified_turn_decision = {
+  should_run : bool;
+  channel : unified_turn_channel;
+  reasons : string list;
+  since_last_proactive : int option;
+  effective_cooldown : int option;
+  task_reactive_cooldown : int option;
+  idle_gate_sec : int option;
+}
+
 type board_signal_match = {
   explicit_mention : bool;
   matched_targets : string list;
@@ -592,33 +606,90 @@ let effective_proactive_cooldown ~(base_cooldown : int) ~(since_last : int) : in
     let factor = 1.0 /. (Float.pow 2.0 (float_of_int capped_periods)) in
     max floor (int_of_float (float_of_int base_cooldown *. factor))
 
-let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observation) =
-  let has_external_event =
-    observation.pending_mentions <> []
-    || observation.pending_board_events <> []
-    || observation.pending_scope_messages <> []
+let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation) =
+  let reactive_reasons =
+    [
+      (if observation.pending_mentions <> [] then Some "pending_mentions" else None);
+      (if observation.pending_board_events <> [] then Some "pending_board_events" else None);
+      (if observation.pending_scope_messages <> [] then Some "pending_scope_messages" else None);
+    ]
+    |> List.filter_map Fun.id
   in
-  if has_external_event then
-    true
-  else
-    let since_last_proactive =
-      if meta.runtime.proactive_rt.last_ts <= 0.0 then max_int
-      else int_of_float (max 0.0 (Time_compat.now () -. meta.runtime.proactive_rt.last_ts))
-    in
-    if not meta.proactive.enabled then false
-    else
-      let effective_cooldown =
-        effective_proactive_cooldown
-          ~base_cooldown:meta.proactive.cooldown_sec
-          ~since_last:since_last_proactive
+  match reactive_reasons with
+  | _ :: _ ->
+      {
+        should_run = true;
+        channel = Reactive;
+        reasons = reactive_reasons;
+        since_last_proactive = None;
+        effective_cooldown = None;
+        task_reactive_cooldown = None;
+        idle_gate_sec = None;
+      }
+  | [] ->
+      let since_last_proactive =
+        if meta.runtime.proactive_rt.last_ts <= 0.0 then max_int
+        else
+          int_of_float (max 0.0 (Time_compat.now () -. meta.runtime.proactive_rt.last_ts))
       in
-      let cooldown_elapsed = since_last_proactive >= effective_cooldown in
-      let has_actionable_tasks =
-        observation.unclaimed_task_count > 0 || observation.failed_task_count > 0
-      in
-      (* When actionable tasks sit in the backlog, use a shorter cooldown
-         (1/3 of normal, floor 60s) so the keeper reacts faster to work.
-         Regular proactive turns still fire on the effective cooldown. *)
-      let task_reactive_cooldown = max 60 (effective_cooldown / 3) in
-      cooldown_elapsed
-      || (has_actionable_tasks && since_last_proactive >= task_reactive_cooldown)
+      let idle_gate_sec = meta.proactive.idle_sec in
+      if not meta.proactive.enabled then
+        {
+          should_run = false;
+          channel = Scheduled_autonomous;
+          reasons = [ "proactive_disabled" ];
+          since_last_proactive = Some since_last_proactive;
+          effective_cooldown = None;
+          task_reactive_cooldown = None;
+          idle_gate_sec = Some idle_gate_sec;
+        }
+      else
+        let effective_cooldown =
+          effective_proactive_cooldown
+            ~base_cooldown:meta.proactive.cooldown_sec
+            ~since_last:since_last_proactive
+        in
+        let task_cooldown_divisor =
+          Keeper_config.keeper_proactive_task_cooldown_divisor ()
+        in
+        let task_cooldown_floor =
+          Keeper_config.keeper_proactive_task_min_cooldown_sec ()
+        in
+        let task_reactive_cooldown =
+          max task_cooldown_floor
+            (effective_cooldown / max 1 task_cooldown_divisor)
+        in
+        let has_actionable_tasks =
+          observation.unclaimed_task_count > 0 || observation.failed_task_count > 0
+        in
+        let idle_gate_elapsed = observation.idle_seconds >= idle_gate_sec in
+        let cooldown_elapsed = since_last_proactive >= effective_cooldown in
+        let backlog_elapsed =
+          has_actionable_tasks
+          && since_last_proactive >= task_reactive_cooldown
+        in
+        let reasons =
+          [
+            Some "scheduled_autonomous_turn";
+            (if since_last_proactive = max_int then Some "never_started" else None);
+            (if idle_gate_elapsed then Some "idle_gate_elapsed" else Some "idle_gate_wait");
+            (if cooldown_elapsed then Some "cooldown_elapsed" else None);
+            (if has_actionable_tasks then Some "actionable_backlog" else None);
+            (if observation.unclaimed_task_count > 0 then Some "unclaimed_tasks" else None);
+            (if observation.failed_task_count > 0 then Some "failed_tasks" else None);
+            (if backlog_elapsed then Some "task_reactive_cooldown_elapsed" else None);
+          ]
+          |> List.filter_map Fun.id
+        in
+        {
+          should_run = idle_gate_elapsed && (cooldown_elapsed || backlog_elapsed);
+          channel = Scheduled_autonomous;
+          reasons;
+          since_last_proactive = Some since_last_proactive;
+          effective_cooldown = Some effective_cooldown;
+          task_reactive_cooldown = Some task_reactive_cooldown;
+          idle_gate_sec = Some idle_gate_sec;
+        }
+
+let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observation) =
+  (unified_turn_decision ~meta observation).should_run

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -82,6 +82,20 @@ type world_observation = {
   (** Previous generation's turn usage as [(used, total)], if available. *)
 }
 
+type unified_turn_channel =
+  | Reactive
+  | Scheduled_autonomous
+
+type unified_turn_decision = {
+  should_run : bool;
+  channel : unified_turn_channel;
+  reasons : string list;
+  since_last_proactive : int option;
+  effective_cooldown : int option;
+  task_reactive_cooldown : int option;
+  idle_gate_sec : int option;
+}
+
 type board_signal_match = {
   explicit_mention : bool;
   matched_targets : string list;
@@ -130,6 +144,9 @@ val apply_message_cursor_updates :
     additional period, down to a configurable floor. *)
 val effective_proactive_cooldown :
   base_cooldown:int -> since_last:int -> int
+
+val unified_turn_decision :
+  meta:Keeper_types.keeper_meta -> world_observation -> unified_turn_decision
 
 val should_run_unified_turn :
   meta:Keeper_types.keeper_meta -> world_observation -> bool

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -480,6 +480,38 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
   check bool "marks backlog cooldown elapsed" true
     (List.mem "task_reactive_cooldown_elapsed" decision.reasons)
 
+let test_task_reactive_cooldown_floor_never_hits_zero () =
+  with_env "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC" "0" (fun () ->
+    let meta =
+      {
+        minimal_meta with
+        proactive =
+          { minimal_meta.proactive with
+            enabled = true;
+            idle_sec = 60;
+            cooldown_sec = 900;
+          };
+        runtime =
+          {
+            minimal_meta.runtime with
+            proactive_rt =
+              { minimal_meta.runtime.proactive_rt with
+                last_ts = Time_compat.now () -. 320.0;
+              };
+          };
+      }
+    in
+    let obs =
+      {
+        base_observation with
+        idle_seconds = 120;
+        failed_task_count = 1;
+      }
+    in
+    let decision = WO.unified_turn_decision ~meta obs in
+    check (option int) "task reactive cooldown clamps to positive floor" (Some 300)
+      decision.task_reactive_cooldown)
+
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
   check bool "contains name" true (String.length sys > 0);
@@ -552,6 +584,18 @@ let test_prompt_includes_autonomous_trigger_section () =
     (contains_substring user "scheduled autonomous keepalive turn");
   check bool "includes cooldown detail" true
     (contains_substring user "effective cooldown")
+
+let test_prompt_omits_autonomous_trigger_for_reactive_turn () =
+  let obs =
+    {
+      base_observation with
+      pending_mentions = [ ("alice", "please check this") ];
+      idle_seconds = 999;
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  check bool "reactive turn omits autonomous trigger section" false
+    (contains_substring user "Autonomous Trigger")
 
 let test_prompt_omits_empty_sections () =
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
@@ -1484,13 +1528,15 @@ let test_prioritized_disclosed_tool_names_skips_fallback_when_disabled () =
 
 let test_tool_query_text_of_user_message_strips_continuity_noise () =
   let user_message =
-    "## Current World State\n\n### Room State\n- Failed tasks: 5\n\n### Actionable Routes\n- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.\n\n### Continuity\nDONE: 하트비트 갱신\nNEXT: 대기 유지\n\n### Live Worktree Delta\n<git_status_change>\n?? lib/example.ml\n</git_status_change>\n"
+    "## Current World State\n\n### Namespace State\n- Failed tasks: 5\n\n### Actionable Routes\n- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.\n\n### Autonomous Trigger\n- Scheduler: scheduled autonomous keepalive turn.\n\n### Continuity\nDONE: 하트비트 갱신\nNEXT: 대기 유지\n\n### Live Worktree Delta\n<git_status_change>\n?? lib/example.ml\n</git_status_change>\n"
   in
   let query = KAR.tool_query_text_of_user_message user_message in
   check bool "continuity heading stripped" false
     (contains_substring query "### Continuity");
   check bool "heartbeat residue stripped" false
     (contains_substring query "하트비트 갱신");
+  check bool "autonomous trigger stripped" false
+    (contains_substring query "Autonomous Trigger");
   check bool "actionable routes preserved" true
     (contains_substring query "keeper_tasks_audit");
   check bool "worktree section preserved" true
@@ -1693,6 +1739,8 @@ let () =
             test_idle_decay_triggers_turn;
           test_case "scheduled decision uses backlog acceleration" `Quick
             test_scheduled_turn_decision_uses_backlog_acceleration;
+          test_case "task reactive cooldown floor never hits zero" `Quick
+            test_task_reactive_cooldown_floor_never_hits_zero;
           test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );
@@ -1706,6 +1754,8 @@ let () =
             test_prompt_includes_operational_tool_guidance;
           test_case "includes autonomous trigger section" `Quick
             test_prompt_includes_autonomous_trigger_section;
+          test_case "omits autonomous trigger for reactive turn" `Quick
+            test_prompt_omits_autonomous_trigger_for_reactive_turn;
           test_case "omits empty sections" `Quick test_prompt_omits_empty_sections;
           test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
           test_case "includes board activity" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -69,6 +69,15 @@ let contains_disallowed_control_char s =
   in
   loop 0
 
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect ~finally:(fun () ->
+    match old with
+    | Some v -> Unix.putenv name v
+    | None -> (try Unix.putenv name "" with _ -> ()))
+    f
+
 (* ---------- World Observation type tests ---------- *)
 
 let base_observation : WO.world_observation =
@@ -153,6 +162,13 @@ let minimal_meta : Masc_mcp.Keeper_types.keeper_meta =
   match Masc_mcp.Keeper_types.meta_of_json json with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
+
+let minimal_policy_meta =
+  {
+    minimal_meta with
+    tool_access =
+      Preset { preset = Minimal; also_allow = [] };
+  }
 
 let room_signal_meta =
   { minimal_meta with room_signal_prompt_enabled = true }
@@ -327,11 +343,7 @@ let test_scheduled_turn_uses_cooldown_only () =
   let meta =
     { minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 0;
-          cooldown_sec = 60;
-        };
+        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
       runtime =
         { minimal_meta.runtime with
           proactive_rt =
@@ -349,11 +361,7 @@ let test_scheduled_turn_respects_cooldown () =
   let meta =
     { minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 0;
-          cooldown_sec = 300;
-        };
+        { enabled = true; idle_sec = 0; cooldown_sec = 300 };
       runtime =
         { minimal_meta.runtime with
           proactive_rt =
@@ -371,11 +379,7 @@ let test_scheduled_turn_requires_idle_gate () =
     {
       minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 300;
-          cooldown_sec = 60;
-        };
+        { enabled = true; idle_sec = 300; cooldown_sec = 60 };
       runtime =
         {
           minimal_meta.runtime with
@@ -429,11 +433,7 @@ let test_idle_decay_triggers_turn () =
   let meta =
     { minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 0;
-          cooldown_sec = 1800;
-        };
+        { enabled = true; idle_sec = 0; cooldown_sec = 1800 };
       runtime =
         { minimal_meta.runtime with
           proactive_rt =
@@ -451,11 +451,7 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
     {
       minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 60;
-          cooldown_sec = 900;
-        };
+        { enabled = true; idle_sec = 60; cooldown_sec = 900 };
       runtime =
         {
           minimal_meta.runtime with
@@ -486,11 +482,7 @@ let test_task_reactive_cooldown_floor_never_hits_zero () =
       {
         minimal_meta with
         proactive =
-          { minimal_meta.proactive with
-            enabled = true;
-            idle_sec = 60;
-            cooldown_sec = 900;
-          };
+          { enabled = true; idle_sec = 60; cooldown_sec = 900 };
         runtime =
           {
             minimal_meta.runtime with
@@ -552,6 +544,8 @@ let test_prompt_includes_operational_tool_guidance () =
   let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
   check bool "mentions task audit guidance" true
     (contains_substring sys "keeper_tasks_audit");
+  check bool "mentions policy-aware availability" true
+    (contains_substring sys "current tool policy");
   check bool "mentions worktree inspection guidance" true
     (contains_substring sys "masc_code_read");
   check bool "mentions heartbeat maintenance guidance" true
@@ -562,11 +556,7 @@ let test_prompt_includes_autonomous_trigger_section () =
     {
       minimal_meta with
       proactive =
-        { minimal_meta.proactive with
-          enabled = true;
-          idle_sec = 0;
-          cooldown_sec = 60;
-        };
+        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
       runtime =
         {
           minimal_meta.runtime with
@@ -741,9 +731,31 @@ let test_prompt_includes_actionable_routes_for_operational_signals () =
   check bool "includes task audit route" true
     (contains_substring user "keeper_tasks_audit");
   check bool "includes worktree inspection route" true
-    (contains_substring user "masc_code_read");
+    (contains_substring user "inspect changed files with");
   check bool "includes fs inspection route" true
     (contains_substring user "keeper_fs_read")
+
+let test_prompt_actionable_routes_respect_tool_policy () =
+  let obs =
+    {
+      base_observation with
+      failed_task_count = 2;
+      worktree_change_summary =
+        Some
+          "<git_status_change>\nWorking tree changed since last keeper turn (1 files):\n?? lib/example.ml\n</git_status_change>";
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_policy_meta ~observation:obs in
+  check bool "keeps actionable routes section" true
+    (contains_substring user "Actionable Routes");
+  check bool "does not recommend unavailable task audit tool" false
+    (contains_substring user "keeper_tasks_audit");
+  check bool "does not recommend unavailable file inspection tool" false
+    (contains_substring user "keeper_fs_read");
+  check bool "explains task audit unavailable" true
+    (contains_substring user "task-audit tooling is unavailable");
+  check bool "explains file inspection unavailable" true
+    (contains_substring user "file-inspection tools are unavailable")
 
 let test_prompt_omits_room_signal_when_flag_disabled () =
   let interpretation : Masc_mcp.Meta_cognition.interpretation =
@@ -822,15 +834,6 @@ let test_prompt_includes_room_signal_when_flag_enabled () =
     (contains_substring user "namespace_digest_post_id: post-digest-1")
 
 (* ---------- Config tests ---------- *)
-
-let with_env name value f =
-  let old = Sys.getenv_opt name in
-  Unix.putenv name value;
-  Fun.protect ~finally:(fun () ->
-    match old with
-    | Some v -> Unix.putenv name v
-    | None -> (try Unix.putenv name "" with _ -> ()))
-    f
 
 let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_TEMP" "" (fun () ->
@@ -1769,6 +1772,8 @@ let () =
           test_case "room state section" `Quick test_prompt_room_state_section;
           test_case "includes actionable routes for operational signals" `Quick
             test_prompt_includes_actionable_routes_for_operational_signals;
+          test_case "actionable routes respect tool policy" `Quick
+            test_prompt_actionable_routes_respect_tool_policy;
           test_case "omits room signal when disabled" `Quick
             test_prompt_omits_room_signal_when_flag_disabled;
           test_case "includes room signal when enabled" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1545,6 +1545,30 @@ let test_tool_query_text_of_user_message_strips_continuity_noise () =
   check bool "worktree section preserved" true
     (contains_substring query "Live Worktree Delta")
 
+let test_tool_query_text_of_user_message_keeps_counted_headers () =
+  let obs =
+    {
+      base_observation with
+      pending_mentions = [ ("alice", "please inspect the failures") ];
+      pending_scope_messages = [ ("bob", "recent room update") ];
+      active_goals = [ "goal-1" ];
+      pending_board_events = [ sample_board_event ];
+      failed_task_count = 2;
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  let query = KAR.tool_query_text_of_user_message user in
+  check bool "keeps counted pending mentions header" true
+    (contains_substring query "### Pending Mentions (1)");
+  check bool "keeps mention content" true
+    (contains_substring query "@alice: please inspect the failures");
+  check bool "keeps counted scope messages header" true
+    (contains_substring query "### Scope Messages (1 recent)");
+  check bool "keeps counted active goals header" true
+    (contains_substring query "### Active Goals (1)");
+  check bool "keeps counted board activity header" true
+    (contains_substring query "### Board Activity (1 new)")
+
 let test_social_model_silences_skip_only_turn () =
   let result =
     make_run_result
@@ -1835,6 +1859,8 @@ let () =
             test_prioritized_disclosed_tool_names_skips_fallback_when_disabled;
           test_case "tool query strips continuity noise" `Quick
             test_tool_query_text_of_user_message_strips_continuity_noise;
+          test_case "tool query keeps counted headers" `Quick
+            test_tool_query_text_of_user_message_keeps_counted_headers;
           test_case "social model silences skip-only turn" `Quick
             test_social_model_silences_skip_only_turn;
           test_case "social model requires explicit headers" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -329,6 +329,7 @@ let test_scheduled_turn_uses_cooldown_only () =
       proactive =
         { minimal_meta.proactive with
           enabled = true;
+          idle_sec = 0;
           cooldown_sec = 60;
         };
       runtime =
@@ -350,6 +351,7 @@ let test_scheduled_turn_respects_cooldown () =
       proactive =
         { minimal_meta.proactive with
           enabled = true;
+          idle_sec = 0;
           cooldown_sec = 300;
         };
       runtime =
@@ -363,6 +365,33 @@ let test_scheduled_turn_respects_cooldown () =
   in
   check bool "cooldown blocks scheduled turn" false
     (WO.should_run_unified_turn ~meta base_observation)
+
+let test_scheduled_turn_requires_idle_gate () =
+  let meta =
+    {
+      minimal_meta with
+      proactive =
+        { minimal_meta.proactive with
+          enabled = true;
+          idle_sec = 300;
+          cooldown_sec = 60;
+        };
+      runtime =
+        {
+          minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 600.0;
+            };
+        };
+    }
+  in
+  let obs = { base_observation with idle_seconds = 120 } in
+  check bool "idle gate blocks scheduled turn" false
+    (WO.should_run_unified_turn ~meta obs);
+  let decision = WO.unified_turn_decision ~meta obs in
+  check bool "decision records idle wait reason" true
+    (List.mem "idle_gate_wait" decision.reasons)
 
 let test_effective_cooldown_no_decay_within_base () =
   (* Within the base cooldown period, no decay should apply. *)
@@ -402,6 +431,7 @@ let test_idle_decay_triggers_turn () =
       proactive =
         { minimal_meta.proactive with
           enabled = true;
+          idle_sec = 0;
           cooldown_sec = 1800;
         };
       runtime =
@@ -415,6 +445,40 @@ let test_idle_decay_triggers_turn () =
   in
   check bool "idle decay triggers turn before base cooldown" true
     (WO.should_run_unified_turn ~meta base_observation)
+
+let test_scheduled_turn_decision_uses_backlog_acceleration () =
+  let meta =
+    {
+      minimal_meta with
+      proactive =
+        { minimal_meta.proactive with
+          enabled = true;
+          idle_sec = 60;
+          cooldown_sec = 900;
+        };
+      runtime =
+        {
+          minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 320.0;
+            };
+        };
+    }
+  in
+  let obs =
+    {
+      base_observation with
+      idle_seconds = 120;
+      failed_task_count = 2;
+    }
+  in
+  let decision = WO.unified_turn_decision ~meta obs in
+  check bool "backlog acceleration opens scheduled turn" true decision.should_run;
+  check bool "marks actionable backlog" true
+    (List.mem "actionable_backlog" decision.reasons);
+  check bool "marks backlog cooldown elapsed" true
+    (List.mem "task_reactive_cooldown_elapsed" decision.reasons)
 
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
@@ -451,6 +515,43 @@ let test_prompt_mentions_extend_turns_guidance () =
          true
        with Not_found -> false
      in found)
+
+let test_prompt_includes_operational_tool_guidance () =
+  let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
+  check bool "mentions task audit guidance" true
+    (contains_substring sys "keeper_tasks_audit");
+  check bool "mentions worktree inspection guidance" true
+    (contains_substring sys "masc_code_read");
+  check bool "mentions heartbeat maintenance guidance" true
+    (contains_substring sys "masc_heartbeat")
+
+let test_prompt_includes_autonomous_trigger_section () =
+  let meta =
+    {
+      minimal_meta with
+      proactive =
+        { minimal_meta.proactive with
+          enabled = true;
+          idle_sec = 0;
+          cooldown_sec = 60;
+        };
+      runtime =
+        {
+          minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 300.0;
+            };
+        };
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta ~observation:base_observation in
+  check bool "has autonomous trigger section" true
+    (contains_substring user "Autonomous Trigger");
+  check bool "includes scheduled reason" true
+    (contains_substring user "scheduled autonomous keepalive turn");
+  check bool "includes cooldown detail" true
+    (contains_substring user "effective cooldown")
 
 let test_prompt_omits_empty_sections () =
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
@@ -579,6 +680,26 @@ let test_prompt_room_state_section () =
          true
        with Not_found -> false
      in found)
+
+let test_prompt_includes_actionable_routes_for_operational_signals () =
+  let obs =
+    {
+      base_observation with
+      failed_task_count = 2;
+      worktree_change_summary =
+        Some
+          "<git_status_change>\nWorking tree changed since last keeper turn (1 files):\n?? lib/example.ml\n</git_status_change>";
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  check bool "has actionable routes section" true
+    (contains_substring user "Actionable Routes");
+  check bool "includes task audit route" true
+    (contains_substring user "keeper_tasks_audit");
+  check bool "includes worktree inspection route" true
+    (contains_substring user "masc_code_read");
+  check bool "includes fs inspection route" true
+    (contains_substring user "keeper_fs_read")
 
 let test_prompt_omits_room_signal_when_flag_disabled () =
   let interpretation : Masc_mcp.Meta_cognition.interpretation =
@@ -1361,6 +1482,20 @@ let test_prioritized_disclosed_tool_names_skips_fallback_when_disabled () =
     [ "always-1"; "always-2"; "retrieved-1"; "retrieved-2" ]
     selected
 
+let test_tool_query_text_of_user_message_strips_continuity_noise () =
+  let user_message =
+    "## Current World State\n\n### Room State\n- Failed tasks: 5\n\n### Actionable Routes\n- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.\n\n### Continuity\nDONE: 하트비트 갱신\nNEXT: 대기 유지\n\n### Live Worktree Delta\n<git_status_change>\n?? lib/example.ml\n</git_status_change>\n"
+  in
+  let query = KAR.tool_query_text_of_user_message user_message in
+  check bool "continuity heading stripped" false
+    (contains_substring query "### Continuity");
+  check bool "heartbeat residue stripped" false
+    (contains_substring query "하트비트 갱신");
+  check bool "actionable routes preserved" true
+    (contains_substring query "keeper_tasks_audit");
+  check bool "worktree section preserved" true
+    (contains_substring query "Live Worktree Delta")
+
 let test_social_model_silences_skip_only_turn () =
   let result =
     make_run_result
@@ -1540,6 +1675,8 @@ let () =
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn respects cooldown" `Quick
             test_scheduled_turn_respects_cooldown;
+          test_case "scheduled turn requires idle gate" `Quick
+            test_scheduled_turn_requires_idle_gate;
           test_case "idle decay: no decay within base" `Quick
             test_effective_cooldown_no_decay_within_base;
           test_case "idle decay: at boundary" `Quick
@@ -1554,6 +1691,8 @@ let () =
             test_effective_cooldown_max_int;
           test_case "idle decay: triggers turn" `Quick
             test_idle_decay_triggers_turn;
+          test_case "scheduled decision uses backlog acceleration" `Quick
+            test_scheduled_turn_decision_uses_backlog_acceleration;
           test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );
@@ -1563,6 +1702,10 @@ let () =
           test_case "contains goal" `Quick test_prompt_contains_goal;
           test_case "mentions extend_turns guidance" `Quick
             test_prompt_mentions_extend_turns_guidance;
+          test_case "includes operational tool guidance" `Quick
+            test_prompt_includes_operational_tool_guidance;
+          test_case "includes autonomous trigger section" `Quick
+            test_prompt_includes_autonomous_trigger_section;
           test_case "omits empty sections" `Quick test_prompt_omits_empty_sections;
           test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
           test_case "includes board activity" `Quick
@@ -1574,6 +1717,8 @@ let () =
           test_case "hustle economy" `Quick test_prompt_hustle_economy;
           test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
           test_case "room state section" `Quick test_prompt_room_state_section;
+          test_case "includes actionable routes for operational signals" `Quick
+            test_prompt_includes_actionable_routes_for_operational_signals;
           test_case "omits room signal when disabled" `Quick
             test_prompt_omits_room_signal_when_flag_disabled;
           test_case "includes room signal when enabled" `Quick
@@ -1633,6 +1778,8 @@ let () =
             test_prioritized_disclosed_tool_names_uses_fallback_remaining_budget;
           test_case "tool disclosure skips fallback when disabled" `Quick
             test_prioritized_disclosed_tool_names_skips_fallback_when_disabled;
+          test_case "tool query strips continuity noise" `Quick
+            test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "social model silences skip-only turn" `Quick
             test_social_model_silences_skip_only_turn;
           test_case "social model requires explicit headers" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -344,17 +344,23 @@ let test_keeper_msg_rejects_removed_runtime_args () =
 let make_keeper_exec_meta
     ?(name = "sangsu")
     ?(allowed_paths = [])
+    ?tool_access
     () =
-  let json =
-    `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String name);
-        ("trace_id", `String ("trace-" ^ name));
-        ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
-      ]
+  let fields =
+    [
+      ("name", `String name);
+      ("agent_name", `String name);
+      ("trace_id", `String ("trace-" ^ name));
+      ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
+    ]
   in
-  match Masc_mcp.Keeper_types.meta_of_json json with
+  let fields =
+    match tool_access with
+    | Some access ->
+        ("tool_access", Masc_mcp.Keeper_types.tool_access_to_json access) :: fields
+    | None -> fields
+  in
+  match Masc_mcp.Keeper_types.meta_of_json (`Assoc fields) with
   | Ok meta -> meta
   | Error e -> failwith ("make_keeper_exec_meta failed: " ^ e)
 
@@ -476,6 +482,18 @@ let test_keeper_fs_read_policy_gates () =
   let unified = make_keeper_exec_meta () in
   check_keeper_exec_tool_presence "unified fs_read" unified
     ~tool_name:"keeper_fs_read" ~expect_allowed:true
+
+let test_research_preset_includes_task_audit () =
+  let research =
+    make_keeper_exec_meta
+      ~name:"research-keeper"
+      ~tool_access:
+        (Masc_mcp.Keeper_types.Preset
+           { preset = Masc_mcp.Keeper_types.Research; also_allow = [] })
+      ()
+  in
+  check_keeper_exec_tool_presence "research preset task audit" research
+    ~tool_name:"keeper_tasks_audit" ~expect_allowed:true
 
 let test_keeper_fs_read_enforces_allowed_paths_and_truncation () =
   Eio_main.run @@ fun env ->
@@ -2781,6 +2799,8 @@ let () =
            test_keeper_shell_readonly_enforces_allowed_paths;
          test_case "fs_read policy gates" `Quick
            test_keeper_fs_read_policy_gates;
+         test_case "research preset includes task audit" `Quick
+           test_research_preset_includes_task_audit;
          test_case "fs_read enforces allowed paths and truncation" `Quick
            test_keeper_fs_read_enforces_allowed_paths_and_truncation;
          test_case "keeper bash requires cmd and runs" `Quick


### PR DESCRIPTION
## Summary
- align keeper autonomous turn scheduling with explicit scheduler decisions instead of hidden proactive heuristics
- keep failed-task and worktree guidance aligned with the current tool policy so restricted keepers are not steered toward blocked tools
- preserve counted world-state sections in tool-disclosure queries so retrieval keeps actionable prompt context

## Product impact
- keeper behavior is easier to debug because scheduled autonomous turns expose reasons, cooldowns, and idle gates
- restricted keepers now see only executable actionable routes, or an explicit unavailable note, instead of impossible tool recommendations
- counted headers such as Pending Mentions and Board Activity now survive query extraction, improving retrieval signal for tool selection

## Evidence
- `DUNE_BUILD_DIR=_build_codex_fix_unified dune exec --root . test/test_keeper_unified.exe` (90 tests, pass)
- `./_build_codex_fix_toolkeeper/default/test/test_tool_keeper.exe` (58 tests, pass earlier in this branch)

## Review evidence
- `GLM-5` via `sb glm-text` on the final diffs: `No findings.`
- responded to actionable Copilot review comments with follow-up commits `f8d96bd95` and `c08a31a4a`

## Linked issue
- Refs #5162

## Notes
- keeps compatibility with existing `proactive_*` fields while shifting runtime semantics toward scheduled autonomous turns
- ready for human review; GitHub checks are not visible yet on the latest head
