### PR TITLE
[codex] collapse keeper allowlist previews

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
 
 import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
-import { resolveKeeperCurrentTaskLabel } from './keeper-detail-runtime'
+import {
+  AllowlistPreview,
+  resolveAllowlistPreview,
+  resolveKeeperCurrentTaskLabel,
+} from './keeper-detail-runtime'
 import {
   resolveKeeperObservedToolAudit,
   resolveKeeperToolPolicy,
 } from './keeper-detail-source'
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('resolveKeeperToolPolicy', () => {
   it('uses keeper config as the authoritative policy source', () => {
@@ -218,5 +229,36 @@ describe('resolveKeeperCurrentTaskLabel', () => {
     }
 
     expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('not_collected')
+  })
+})
+
+describe('resolveAllowlistPreview', () => {
+  it('keeps only the requested prefix and reports the remainder', () => {
+    expect(resolveAllowlistPreview(['a', 'b', 'c', 'd'], 2)).toEqual({
+      visibleTools: ['a', 'b'],
+      hiddenCount: 2,
+    })
+  })
+})
+
+describe('AllowlistPreview', () => {
+  it('collapses long allowlists until explicitly expanded', () => {
+    const tools = Array.from({ length: 15 }, (_, index) => `tool-${index + 1}`)
+    render(h(AllowlistPreview, {
+      tools,
+      emptyLabel: 'none',
+      previewLimit: 12,
+    }))
+
+    expect(screen.getByText('tool-1')).toBeInTheDocument()
+    expect(screen.getByText('tool-12')).toBeInTheDocument()
+    expect(screen.queryByText('tool-13')).not.toBeInTheDocument()
+    expect(screen.getByText('나머지 3개 보기')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('나머지 3개 보기'))
+
+    expect(screen.getByText('tool-13')).toBeInTheDocument()
+    expect(screen.getByText('tool-15')).toBeInTheDocument()
+    expect(screen.getByText('접기')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -239,9 +239,43 @@ describe('resolveAllowlistPreview', () => {
       hiddenCount: 2,
     })
   })
+
+  it('clamps zero and negative limits to an empty preview', () => {
+    expect(resolveAllowlistPreview(['a', 'b'], 0)).toEqual({
+      visibleTools: [],
+      hiddenCount: 2,
+    })
+    expect(resolveAllowlistPreview(['a', 'b'], -3)).toEqual({
+      visibleTools: [],
+      hiddenCount: 2,
+    })
+  })
 })
 
 describe('AllowlistPreview', () => {
+  it('renders the empty fallback when there are no tools', () => {
+    render(h(AllowlistPreview, {
+      tools: [],
+      emptyLabel: 'none',
+      previewLimit: 12,
+    }))
+
+    expect(screen.getByText('none')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('does not show a toggle when the tool count is exactly at the preview limit', () => {
+    const tools = Array.from({ length: 12 }, (_, index) => `tool-${index + 1}`)
+    render(h(AllowlistPreview, {
+      tools,
+      emptyLabel: 'none',
+      previewLimit: 12,
+    }))
+
+    expect(screen.getByText('tool-12')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /허용된 도구/ })).not.toBeInTheDocument()
+  })
+
   it('collapses long allowlists until explicitly expanded', () => {
     const tools = Array.from({ length: 15 }, (_, index) => `tool-${index + 1}`)
     render(h(AllowlistPreview, {

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -253,12 +253,15 @@ describe('AllowlistPreview', () => {
     expect(screen.getByText('tool-1')).toBeInTheDocument()
     expect(screen.getByText('tool-12')).toBeInTheDocument()
     expect(screen.queryByText('tool-13')).not.toBeInTheDocument()
+    const toggle = screen.getByRole('button', { name: '허용된 도구 나머지 3개 보기' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(screen.getByText('나머지 3개 보기')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('나머지 3개 보기'))
+    fireEvent.click(toggle)
 
     expect(screen.getByText('tool-13')).toBeInTheDocument()
     expect(screen.getByText('tool-15')).toBeInTheDocument()
     expect(screen.getByText('접기')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '허용된 도구 접기' })).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -4,7 +4,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { serverStatus } from '../store'
@@ -32,6 +32,7 @@ import {
 } from './keeper-config-panel'
 
 const showAllowlistEditor = signal(false)
+const DEFAULT_ALLOWLIST_PREVIEW_LIMIT = 12
 
 // ── Utility functions ────────────────────────────────────
 
@@ -104,6 +105,68 @@ function ToolChip({ name }: { name: string }) {
       title="클릭하여 도구 상세 보기"
       onClick=${() => openToolsInventory(name)}
     >${name}</button>
+  `
+}
+
+export function resolveAllowlistPreview(
+  tools: string[],
+  previewLimit = DEFAULT_ALLOWLIST_PREVIEW_LIMIT,
+): { visibleTools: string[]; hiddenCount: number } {
+  const normalizedLimit = Math.max(0, previewLimit)
+  const visibleTools = tools.slice(0, normalizedLimit)
+  return {
+    visibleTools,
+    hiddenCount: Math.max(0, tools.length - visibleTools.length),
+  }
+}
+
+export function AllowlistPreview({
+  tools,
+  emptyLabel,
+  previewLimit = DEFAULT_ALLOWLIST_PREVIEW_LIMIT,
+}: {
+  tools: string[]
+  emptyLabel: string
+  previewLimit?: number
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const toolsKey = tools.join('\u0000')
+
+  useEffect(() => {
+    setExpanded(false)
+  }, [toolsKey, previewLimit])
+
+  if (tools.length === 0) {
+    return html`<span class="text-[11px] text-[var(--text-muted)] italic">${emptyLabel}</span>`
+  }
+
+  const { visibleTools, hiddenCount } = expanded
+    ? { visibleTools: tools, hiddenCount: 0 }
+    : resolveAllowlistPreview(tools, previewLimit)
+
+  return html`
+    <div class="flex flex-col gap-2">
+      <div class="flex flex-wrap gap-1.5">
+        ${visibleTools.map(tool => html`<${ToolChip} name=${tool} />`)}
+        ${!expanded && hiddenCount > 0
+          ? html`
+              <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+                +${hiddenCount}
+              </span>
+            `
+          : null}
+      </div>
+      ${tools.length > previewLimit
+        ? html`
+            <button type="button"
+              class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              onClick=${() => setExpanded(value => !value)}
+            >
+              ${expanded ? '접기' : `나머지 ${hiddenCount}개 보기`}
+            </button>
+          `
+        : null}
+    </div>
   `
 }
 
@@ -372,11 +435,10 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
                   ? '정적 도구 정책 로드에 실패했습니다.'
                   : '정적 도구 정책을 아직 확인할 수 없습니다.'}
           </span>
-          <div class="flex flex-wrap gap-1.5">
-            ${allowedTools.length > 0
-              ? allowedTools.map((tool: string) => html`<${ToolChip} name=${tool} />`)
-              : html`<span class="text-[11px] text-[var(--text-muted)] italic">${policyLoading ? 'loading' : policyEditable ? allowlistFallback : unavailablePolicyLabel}</span>`}
-          </div>
+          <${AllowlistPreview}
+            tools=${allowedTools}
+            emptyLabel=${policyLoading ? 'loading' : policyEditable ? allowlistFallback : unavailablePolicyLabel}
+          />
         `}
 
       <${ToolSection}

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -130,11 +130,12 @@ export function AllowlistPreview({
   previewLimit?: number
 }) {
   const [expanded, setExpanded] = useState(false)
-  const toolsKey = tools.join('\u0000')
+  const firstTool = tools[0] ?? null
+  const lastTool = tools.length > 0 ? tools[tools.length - 1] : null
 
   useEffect(() => {
     setExpanded(false)
-  }, [toolsKey, previewLimit])
+  }, [tools.length, firstTool, lastTool, previewLimit])
 
   if (tools.length === 0) {
     return html`<span class="text-[11px] text-[var(--text-muted)] italic">${emptyLabel}</span>`
@@ -160,6 +161,8 @@ export function AllowlistPreview({
         ? html`
             <button type="button"
               class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              aria-expanded=${expanded}
+              aria-label=${expanded ? '허용된 도구 접기' : `허용된 도구 나머지 ${hiddenCount}개 보기`}
               onClick=${() => setExpanded(value => !value)}
             >
               ${expanded ? '접기' : `나머지 ${hiddenCount}개 보기`}

--- a/dashboard/src/components/tools/tool-allowlist-editor.test.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.test.ts
@@ -1,0 +1,89 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
+
+import {
+  buildResolvedAllowlistGroups,
+  ResolvedPreview,
+} from './tool-allowlist-editor'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('buildResolvedAllowlistGroups', () => {
+  it('groups tools by category and sorts larger groups first', () => {
+    const groups = buildResolvedAllowlistGroups(
+      ['board-a', 'misc-a', 'board-b'],
+      new Map([
+        ['board-a', 'board'],
+        ['board-b', 'board'],
+        ['misc-a', 'misc'],
+      ]),
+    )
+
+    expect(groups).toEqual([
+      { category: 'board', names: ['board-a', 'board-b'] },
+      { category: 'misc', names: ['misc-a'] },
+    ])
+  })
+})
+
+describe('ResolvedPreview', () => {
+  it('shows only a collapsed subset until expanded', () => {
+    const tools = [
+      'board-1',
+      'board-2',
+      'board-3',
+      'board-4',
+      'board-5',
+      'board-6',
+      'board-7',
+      'shell-1',
+      'shell-2',
+      'shell-3',
+      'shell-4',
+      'shell-5',
+      'shell-6',
+      'shell-7',
+      'memory-1',
+      'memory-2',
+      'memory-3',
+      'memory-4',
+      'memory-5',
+      'memory-6',
+      'memory-7',
+      'graph-1',
+      'graph-2',
+      'graph-3',
+      'graph-4',
+      'graph-5',
+      'graph-6',
+      'graph-7',
+      'extra-1',
+    ]
+    const catMap = new Map<string, string>()
+    for (const name of tools) {
+      if (name.startsWith('board')) catMap.set(name, 'board')
+      else if (name.startsWith('shell')) catMap.set(name, 'shell')
+      else if (name.startsWith('memory')) catMap.set(name, 'memory')
+      else if (name.startsWith('graph')) catMap.set(name, 'graph')
+      else catMap.set(name, 'extra')
+    }
+
+    render(h(ResolvedPreview, { tools, catMap }))
+
+    expect(screen.getByText('board-1')).toBeInTheDocument()
+    expect(screen.getByText('board-6')).toBeInTheDocument()
+    expect(screen.queryByText('board-7')).not.toBeInTheDocument()
+    expect(screen.queryByText('extra (1)')).not.toBeInTheDocument()
+    expect(screen.getByText(`전체 ${tools.length}개 보기`)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText(`전체 ${tools.length}개 보기`))
+
+    expect(screen.getByText('board-7')).toBeInTheDocument()
+    expect(screen.getByText('extra (1)')).toBeInTheDocument()
+    expect(screen.getByText('접기')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/tools/tool-allowlist-editor.test.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.test.ts
@@ -78,12 +78,15 @@ describe('ResolvedPreview', () => {
     expect(screen.getByText('board-6')).toBeInTheDocument()
     expect(screen.queryByText('board-7')).not.toBeInTheDocument()
     expect(screen.queryByText('extra (1)')).not.toBeInTheDocument()
+    const toggle = screen.getByRole('button', { name: `resolved allowlist 전체 ${tools.length}개 보기` })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(screen.getByText(`전체 ${tools.length}개 보기`)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText(`전체 ${tools.length}개 보기`))
+    fireEvent.click(toggle)
 
     expect(screen.getByText('board-7')).toBeInTheDocument()
     expect(screen.getByText('extra (1)')).toBeInTheDocument()
     expect(screen.getByText('접기')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'resolved allowlist 접기' })).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -151,11 +151,12 @@ export function buildResolvedAllowlistGroups(
 
 export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Map<string, string> }) {
   const [expanded, setExpanded] = useState(false)
-  const toolsKey = tools.join('\u0000')
+  const firstTool = tools[0] ?? null
+  const lastTool = tools.length > 0 ? tools[tools.length - 1] : null
 
   useEffect(() => {
     setExpanded(false)
-  }, [toolsKey])
+  }, [tools.length, firstTool, lastTool])
 
   if (tools.length === 0) {
     return html`
@@ -201,6 +202,8 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
         ? html`
             <button type="button"
               class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              aria-expanded=${expanded}
+              aria-label=${expanded ? 'resolved allowlist 접기' : `resolved allowlist 전체 ${tools.length}개 보기`}
               onClick=${() => setExpanded(value => !value)}
             >
               ${expanded ? '접기' : `전체 ${tools.length}개 보기`}

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -58,6 +58,9 @@ const usageCountMap = computed<Map<string, number>>(() => {
   return m
 })
 
+const RESOLVED_CATEGORY_PREVIEW_LIMIT = 4
+const RESOLVED_TOOLS_PER_CATEGORY_LIMIT = 6
+
 // ── Helpers ──────────────────────────────────
 
 function parseToolList(raw: string): string[] {
@@ -121,7 +124,39 @@ function ReadOnlyChip({ name }: { name: string }) {
 }
 
 /** Resolved allowlist grouped by category. */
-function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Map<string, string> }) {
+export interface ResolvedAllowlistGroup {
+  category: string
+  names: string[]
+}
+
+export function buildResolvedAllowlistGroups(
+  tools: string[],
+  catMap: Map<string, string>,
+): ResolvedAllowlistGroup[] {
+  const groups = new Map<string, string[]>()
+  for (const name of tools) {
+    const cat = catMap.get(name) ?? 'other'
+    const list = groups.get(cat)
+    if (list) list.push(name)
+    else groups.set(cat, [name])
+  }
+
+  return Array.from(groups.entries())
+    .map(([category, names]) => ({
+      category,
+      names,
+    }))
+    .sort((left, right) => right.names.length - left.names.length || left.category.localeCompare(right.category))
+}
+
+export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Map<string, string> }) {
+  const [expanded, setExpanded] = useState(false)
+  const toolsKey = tools.join('\u0000')
+
+  useEffect(() => {
+    setExpanded(false)
+  }, [toolsKey])
+
   if (tools.length === 0) {
     return html`
       <div class="flex flex-col gap-1">
@@ -131,29 +166,47 @@ function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Map<strin
     `
   }
 
-  const groups = new Map<string, string[]>()
-  for (const name of tools) {
-    const cat = catMap.get(name) ?? 'other'
-    const list = groups.get(cat)
-    if (list) list.push(name)
-    else groups.set(cat, [name])
-  }
+  const groups = buildResolvedAllowlistGroups(tools, catMap)
+  const visibleGroups = expanded ? groups : groups.slice(0, RESOLVED_CATEGORY_PREVIEW_LIMIT)
+  const hasHiddenContent = groups.length > RESOLVED_CATEGORY_PREVIEW_LIMIT
+    || groups.some(group => group.names.length > RESOLVED_TOOLS_PER_CATEGORY_LIMIT)
 
   return html`
     <div class="flex flex-col gap-1">
       <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-        resolved allowlist (${tools.length}개, ${groups.size} 카테고리)
+        resolved allowlist (${tools.length}개, ${groups.length} 카테고리)
       </span>
-      <div class="flex flex-col gap-2 max-h-[160px] overflow-y-auto">
-        ${Array.from(groups.entries()).map(([cat, names]) => html`
+      <div class="flex flex-col gap-2">
+        ${visibleGroups.map(group => {
+          const visibleNames = expanded ? group.names : group.names.slice(0, RESOLVED_TOOLS_PER_CATEGORY_LIMIT)
+          const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
+          return html`
           <div class="flex flex-col gap-1">
-            <span class="text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${cat} (${names.length})</span>
+            <span class="text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
             <div class="flex flex-wrap gap-1">
-              ${names.map(name => html`<${ReadOnlyChip} name=${name} />`)}
+              ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
+              ${!expanded && hiddenToolCount > 0
+                ? html`
+                    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+                      +${hiddenToolCount}
+                    </span>
+                  `
+                : null}
             </div>
           </div>
-        `)}
+        `
+        })}
       </div>
+      ${hasHiddenContent
+        ? html`
+            <button type="button"
+              class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              onClick=${() => setExpanded(value => !value)}
+            >
+              ${expanded ? '접기' : `전체 ${tools.length}개 보기`}
+            </button>
+          `
+        : null}
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- collapse the keeper detail allowlist section so large resolved tool policies do not dump hundreds of chips by default
- collapse the allowlist editor's resolved preview by category and per-category chip count, with explicit expand/collapse controls
- add dashboard tests that cover collapsed and expanded behavior, plus allowlist preview edge cases

## Why
Large preset-derived allowlists were technically correct but the UI rendered the entire resolved set at once, which made keeper detail noisy and hard to scan.

## Product impact
- keeper detail stays readable even when a resolved allowlist contains hundreds of tools
- the allowlist editor still exposes the full resolved set, but only after an explicit expand action
- expand/collapse controls now expose toggle state to assistive tech

## Evidence
- `npx tsc --noEmit --pretty false`
- `npm test -- src/components/keeper-detail-runtime.test.ts src/components/tools/tool-allowlist-editor.test.ts`
- targeted review fixes addressed: toggle accessibility metadata and cheaper allowlist change keys

## Review evidence
- `sb glm-text` cross-model review on `c184512224b511dcfc497d7bdc305268cd82ee90` against `main`
- `2026-04-04 23:21:45 KST`
- Result: `No findings.`

## Linked issue
- Closes #5160

## Validation
- `npx tsc --noEmit --pretty false`
- `npm test -- src/components/keeper-detail-runtime.test.ts src/components/tools/tool-allowlist-editor.test.ts`
