### PR TITLE
refactor(room): add Room-free module aliases for gradual migration

### DIFF
--- a/lib/room/agent_lifecycle.ml
+++ b/lib/room/agent_lifecycle.ml
@@ -1,0 +1,4 @@
+(** Agent_lifecycle — New name for Room_lifecycle.
+    Provides agent join/leave/rejoin operations.
+    Room_lifecycle remains for backward compatibility. *)
+include Room_lifecycle

--- a/lib/room/agent_status.ml
+++ b/lib/room/agent_status.ml
@@ -1,0 +1,4 @@
+(** Agent_status — New name for Room_agent.
+    Agent status, capability registration, discovery.
+    Room_agent remains for backward compatibility. *)
+include Room_agent

--- a/lib/room/coord_hooks.ml
+++ b/lib/room/coord_hooks.ml
@@ -1,0 +1,4 @@
+(** Coord_hooks — New name for Room_hooks.
+    Callback refs for cross-module wiring.
+    Room_hooks remains for backward compatibility. *)
+include Room_hooks

--- a/lib/room/coord_init.ml
+++ b/lib/room/coord_init.ml
@@ -1,0 +1,4 @@
+(** Coord_init — New name for Room_init.
+    Initialization, reset, pause, resume.
+    Room_init remains for backward compatibility. *)
+include Room_init

--- a/lib/room/coord_query.ml
+++ b/lib/room/coord_query.ml
@@ -1,0 +1,4 @@
+(** Coord_query — New name for Room_query.
+    Task/agent/message query and listing.
+    Room_query remains for backward compatibility. *)
+include Room_query

--- a/lib/room/coord_state.ml
+++ b/lib/room/coord_state.ml
@@ -1,0 +1,4 @@
+(** Coord_state — New name for Room_state.
+    Coordination state: read/write/update, sequence numbers, pause control.
+    Room_state remains for backward compatibility. *)
+include Room_state

--- a/lib/room/coord_status.ml
+++ b/lib/room/coord_status.ml
@@ -1,0 +1,4 @@
+(** Coord_status — New name for Room_status.
+    Status display rendering.
+    Room_status remains for backward compatibility. *)
+include Room_status

--- a/lib/room/dune
+++ b/lib/room/dune
@@ -4,6 +4,7 @@
  (public_name masc_mcp.masc_room)
  (wrapped false)
  (modules
+  ;; Original modules (backward compat)
   room_hooks
   room_utils_backend_setup
   room_utils
@@ -28,8 +29,20 @@
   mention
   resilience
   heartbeat
- heartbeat_smart
- nickname)
+  heartbeat_smart
+  nickname
+  ;; New aliases (Room-free names for gradual migration)
+  agent_lifecycle
+  agent_status
+  coord_state
+  coord_init
+  coord_query
+  coord_status
+  coord_hooks
+  task_engine
+  task_schedule
+  gc_engine
+  worktree_ops)
  (libraries
   masc_types
   masc_core

--- a/lib/room/gc_engine.ml
+++ b/lib/room/gc_engine.ml
@@ -1,0 +1,4 @@
+(** Gc_engine — New name for Room_gc.
+    Heartbeat, zombie cleanup, garbage collection.
+    Room_gc remains for backward compatibility. *)
+include Room_gc

--- a/lib/room/task_engine.ml
+++ b/lib/room/task_engine.ml
@@ -1,0 +1,4 @@
+(** Task_engine — New name for Room_task.
+    Task add/claim/transition/complete/cancel.
+    Room_task remains for backward compatibility. *)
+include Room_task

--- a/lib/room/task_schedule.ml
+++ b/lib/room/task_schedule.ml
@@ -1,0 +1,4 @@
+(** Task_schedule — New name for Room_task_schedule.
+    Task scheduling: claim_next, release_stale_claims.
+    Room_task_schedule remains for backward compatibility. *)
+include Room_task_schedule

--- a/lib/room/worktree_ops.ml
+++ b/lib/room/worktree_ops.ml
@@ -1,0 +1,4 @@
+(** Worktree_ops — New name for Room_worktree.
+    Git worktree integration.
+    Room_worktree remains for backward compatibility. *)
+include Room_worktree


### PR DESCRIPTION
## Summary

Add 11 Room-free module aliases for gradual migration away from the Room namespace. Original modules remain — zero breakage. New code can use direct names.

| New Name | Original |
|---|---|
| `Agent_lifecycle` | `Room_lifecycle` |
| `Agent_status` | `Room_agent` |
| `Coord_state` | `Room_state` |
| `Coord_init` | `Room_init` |
| `Coord_query` | `Room_query` |
| `Coord_status` | `Room_status` |
| `Coord_hooks` | `Room_hooks` |
| `Task_engine` | `Room_task` |
| `Task_schedule` | `Room_task_schedule` |
| `Gc_engine` | `Room_gc` |
| `Worktree_ops` | `Room_worktree` |

Portal, Vote, Tempo, Mention, Nickname, Heartbeat already have Room-free names.

## Test plan

- [x] `dune build` passes (additive change, no callers modified)
- [ ] `dune runtest` (CI)

Closes #5119

Generated with [Claude Code](https://claude.com/claude-code)
