### PR TITLE
feat(observability): add durable call logs for System_internal tools

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -369,6 +369,7 @@
    tool_prefilter
    tool_metrics
    tool_metrics_persist
+   tool_usage_log
    tool_inline_dispatch_types
    tool_inline_dispatch_room
    tool_inline_dispatch_comm

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -303,6 +303,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     result);
   Tool_metrics_persist.start_flush_fiber ~sw ~clock
     ~base_path:state.room_config.base_path;
+  (* System_internal tool usage log: durable JSONL for pruning evidence (#5120) *)
+  Tool_usage_log.init ~base_path:state.room_config.base_path;
+  Tool_usage_log.install ();
   Otel_dispatch_hook.install ();
   Otel_spans.setup_exporter ~sw env;
   Shutdown.register ~name:"otel_exporter" ~priority:20 Otel_spans.shutdown;

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -25,8 +25,11 @@ let store_ref : Dated_jsonl.t option ref = ref None
 
 let init ~base_path =
   let dir = Filename.concat base_path ".masc/tool_usage" in
-  let store = Dated_jsonl.create ~base_dir:dir () in
-  store_ref := Some store
+  (try
+     let store = Dated_jsonl.create ~base_dir:dir () in
+     store_ref := Some store
+   with exn ->
+     Log.Misc.warn "tool_usage_log: init failed: %s" (Printexc.to_string exn))
 
 (* -- Record format -- *)
 

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -1,0 +1,101 @@
+(** Tool_usage_log -- Durable call logging for System_internal surface tools.
+
+    Persists tool invocations to [.masc/tool_usage/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}. Only tools on the {!Tool_catalog_surfaces.System_internal}
+    surface are logged, providing evidence for safe pruning decisions.
+
+    Writes are immediate (no buffering) since System_internal call volume
+    is low. All I/O failures are caught and logged (best-effort).
+
+    @since 2.190.0 -- Issue #5120 *)
+
+(* -- System_internal membership set (O(1) lookup) -- *)
+
+let system_internal_set : (string, unit) Hashtbl.t =
+  let tools = Tool_catalog_surfaces.system_internal_surface_tools in
+  let tbl = Hashtbl.create (List.length tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) tools;
+  tbl
+
+let is_system_internal name = Hashtbl.mem system_internal_set name
+
+(* -- Store management -- *)
+
+let store_ref : Dated_jsonl.t option ref = ref None
+
+let init ~base_path =
+  let dir = Filename.concat base_path ".masc/tool_usage" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  store_ref := Some store
+
+(* -- Record format -- *)
+
+let record_to_json ~tool_name ~success ~caller =
+  let fields =
+    [ ("tool_name", `String tool_name)
+    ; ("ts", `Float (Time_compat.now ()))
+    ; ("success", `Bool success)
+    ]
+  in
+  let fields = match caller with
+    | Some c when c <> "" && c <> "unknown" ->
+        fields @ [("caller", `String c)]
+    | _ -> fields
+  in
+  `Assoc fields
+
+(* -- Write -- *)
+
+let log_call ~tool_name ~success ~caller =
+  match !store_ref with
+  | None ->
+      Log.Misc.debug "tool_usage_log: store not initialized, skipping %s" tool_name
+  | Some store ->
+      let json = record_to_json ~tool_name ~success ~caller in
+      (try Dated_jsonl.append store json
+       with exn ->
+         Log.Misc.warn "tool_usage_log: append failed for %s: %s"
+           tool_name (Printexc.to_string exn))
+
+(* -- Post-hook installation -- *)
+
+(** Caller extraction from tool result data.
+    The caller (agent_name) is not in Tool_result.t directly, so we
+    extract it from the structured data if present, or default to None. *)
+let extract_caller (result : Tool_result.t) : string option =
+  match result.data with
+  | `Assoc fields ->
+      (match List.assoc_opt "agent_name" fields with
+       | Some (`String s) -> Some s
+       | _ -> None)
+  | _ -> None
+
+let install () =
+  Tool_dispatch.register_post_hook (fun (result : Tool_result.t) ->
+    if is_system_internal result.tool_name then
+      log_call
+        ~tool_name:result.tool_name
+        ~success:result.success
+        ~caller:(extract_caller result);
+    result)
+
+(* -- Read utilities (for analysis) -- *)
+
+let read_recent ?(n = 10_000) () : Yojson.Safe.t list =
+  match !store_ref with
+  | None -> []
+  | Some store -> Dated_jsonl.read_recent store n
+
+let summary () : (string * int) list =
+  let entries = read_recent ~n:100_000 () in
+  let counts : (string, int) Hashtbl.t = Hashtbl.create 64 in
+  List.iter (fun json ->
+    match Safe_ops.json_string_opt "tool_name" json with
+    | Some name ->
+        let c = match Hashtbl.find_opt counts name with
+          | Some n -> n | None -> 0 in
+        Hashtbl.replace counts name (c + 1)
+    | None -> ()
+  ) entries;
+  let pairs = Hashtbl.fold (fun k v acc -> (k, v) :: acc) counts [] in
+  List.sort (fun (_, a) (_, b) -> Int.compare b a) pairs

--- a/lib/tool_usage_log.mli
+++ b/lib/tool_usage_log.mli
@@ -1,0 +1,32 @@
+(** Tool_usage_log -- Durable call logging for System_internal surface tools.
+
+    Persists tool invocations to [.masc/tool_usage/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}. Only tools on the {!Tool_catalog_surfaces.System_internal}
+    surface are logged, providing evidence for safe pruning decisions.
+
+    @since 2.190.0 -- Issue #5120 *)
+
+val init : base_path:string -> unit
+(** [init ~base_path] creates the Dated_jsonl store under
+    [base_path/.masc/tool_usage/]. Must be called before [install]. *)
+
+val install : unit -> unit
+(** [install ()] registers a {!Tool_dispatch} post-hook that logs
+    System_internal tool calls to the JSONL store. Calls to non-System_internal
+    tools are ignored. *)
+
+val log_call : tool_name:string -> success:bool -> caller:string option -> unit
+(** [log_call ~tool_name ~success ~caller] appends a single entry to the
+    JSONL store. Primarily used by the post-hook; exposed for testing. *)
+
+val is_system_internal : string -> bool
+(** [is_system_internal name] returns true if [name] is on the
+    System_internal surface. O(1) hashtable lookup. *)
+
+val read_recent : ?n:int -> unit -> Yojson.Safe.t list
+(** [read_recent ~n ()] reads the most recent [n] entries (default 10000)
+    from the JSONL store. Returns [] if store is not initialized. *)
+
+val summary : unit -> (string * int) list
+(** [summary ()] returns [(tool_name, call_count)] pairs sorted by count
+    descending. Reads up to 100k entries from the store. *)


### PR DESCRIPTION
## Summary

- Add `tool_usage_log.ml` — persisted JSONL logging for System_internal tool calls
- Post-hook pattern via `Tool_dispatch.register_post_hook` (O(1) Hashtbl filter)
- Storage: `.masc/tool_usage/YYYY-MM/DD.jsonl` via `Dated_jsonl`
- Wired in `server_bootstrap_loops.ml` after `Tool_metrics_persist`
- Analysis: `read_recent` and `summary` for pruning evidence queries
- Tool_metrics unchanged (in-memory, separate concern)

This provides durable cross-restart evidence needed before safely pruning System_internal tools.

## Test plan

- [x] `dune build` passes
- [ ] `dune runtest` (CI)
- [ ] Cross-model review

Closes #5120

Generated with [Claude Code](https://claude.com/claude-code)
