### PR TITLE
refactor: promote scheduled autonomous keeper naming

### DIFF
--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -11,7 +11,7 @@ const STAGES: { key: PipelineStage; label: string }[] = [
   { key: 'tool_use', label: 'tool' },
   { key: 'compacting', label: 'compact' },
   { key: 'handoff', label: 'handoff' },
-  { key: 'proactive', label: 'proactive' },
+  { key: 'scheduled_autonomous', label: 'auto' },
 ]
 
 const STAGE_ORDER: Record<string, number> = Object.fromEntries(

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -353,7 +353,7 @@ export type PipelineStage =
   | 'tool_use'
   | 'compacting'
   | 'handoff'
-  | 'proactive'
+  | 'scheduled_autonomous'
   | 'offline'
 
 // Aggregated metrics computed by the backend over a sliding window.

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -80,8 +80,10 @@ let compute_metrics_window
                 let channel = Safe_ops.json_string ~default:"turn" "channel" j in
                 let is_turn = channel = "turn" in
                 let is_heartbeat = channel = "heartbeat" in
-                let is_proactive = channel = "proactive" in
-                let is_interaction = is_turn || is_proactive in
+                let is_scheduled_autonomous =
+                  channel = "scheduled_autonomous" || channel = "proactive"
+                in
+                let is_interaction = is_turn || is_scheduled_autonomous in
                 let compacted = Safe_ops.json_bool ~default:false "compacted" j in
                 let gen = Safe_ops.json_int ~default:generation "generation" j in
                 let trace_id = Safe_ops.json_string ~default:"" "trace_id" j in
@@ -310,10 +312,10 @@ let compute_metrics_window
                 then
                   incr fallback_count;
                 if is_turn then incr turn_points;
-                if is_proactive then incr proactive_points;
-                if is_proactive && proactive_fallback_applied_now then
+                if is_scheduled_autonomous then incr proactive_points;
+                if is_scheduled_autonomous && proactive_fallback_applied_now then
                   incr proactive_fallback_count;
-                if is_proactive then
+                if is_scheduled_autonomous then
                   (match proactive_preview_now with
                    | Some preview ->
                        proactive_previews_rev := preview :: !proactive_previews_rev

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -218,7 +218,7 @@ let keeper_metrics_24h_json
           b.sample_points <- b.sample_points + 1;
           b.context_ratio_sum <- b.context_ratio_sum +. context_ratio;
           let channel = Safe_ops.json_string ~default:"turn" "channel" j in
-          if channel = "proactive" then begin
+          if channel = "scheduled_autonomous" || channel = "proactive" then begin
             incr proactive_points;
             b.proactive_points <- b.proactive_points + 1;
             let proactive_obj = Yojson.Safe.Util.member "proactive" j in
@@ -412,4 +412,3 @@ let top_count_name_and_count
 
 let get_agent_identity (name : string) =
   Dashboard_execution_helpers.get_agent_identity name
-

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -462,7 +462,7 @@ let keeper_diagnostic_json
 (** Derive pipeline stage from keeper_meta timestamps.
     Uses recency thresholds to infer what the keeper is doing.
     Stages: "idle" | "thinking" | "tool_use" | "compacting" | "handoff"
-            | "proactive" | "offline"
+            | "scheduled_autonomous" | "offline"
     The 30s recency window matches the typical keeper turn duration. *)
 let derive_pipeline_stage
     ~(meta : keeper_meta)
@@ -485,14 +485,15 @@ let derive_pipeline_stage
       if meta.runtime.last_handoff_ts <= 0.0 then Float.infinity
       else now_ts -. meta.runtime.last_handoff_ts
     in
-    let proactive_ago =
+    let scheduled_autonomous_ago =
       if meta.runtime.proactive_rt.last_ts <= 0.0 then Float.infinity
       else now_ts -. meta.runtime.proactive_rt.last_ts
     in
     (* Pick the most recent activity within the recency window.
-       Priority order when multiple are recent: handoff > compacting > proactive > thinking *)
+       Priority order when multiple are recent:
+       handoff > compacting > scheduled autonomous > thinking *)
     if handoff_ago < recency_threshold then "handoff"
     else if compaction_ago < recency_threshold then "compacting"
-    else if proactive_ago < recency_threshold then "proactive"
+    else if scheduled_autonomous_ago < recency_threshold then "scheduled_autonomous"
     else if turn_ago < recency_threshold then "thinking"
     else "idle"

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -95,6 +95,9 @@ let empty_tool_audit_snapshot =
     tool_audit_at = None;
   }
 
+let is_scheduled_autonomous_channel (channel : string) : bool =
+  channel = "scheduled_autonomous" || channel = "proactive"
+
 let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
   let interaction_points = s.turn_points + s.proactive_points in
   let intervention_share =
@@ -232,8 +235,10 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
         let is_turn = channel = "turn" in
         let is_heartbeat = channel = "heartbeat" in
-        let is_proactive = channel = "proactive" in
-        let is_interaction = is_turn || is_proactive in
+        let is_scheduled_autonomous =
+          is_scheduled_autonomous_channel channel
+        in
+        let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in
         let before_tokens =
           Safe_ops.json_int ~default:0 "compaction_before_tokens" j
@@ -357,7 +362,8 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
           sample_points = acc.sample_points + 1;
           turn_points = acc.turn_points + (if is_turn then 1 else 0);
           heartbeat_points = acc.heartbeat_points + (if is_heartbeat then 1 else 0);
-          proactive_points = acc.proactive_points + (if is_proactive then 1 else 0);
+          proactive_points =
+            acc.proactive_points + (if is_scheduled_autonomous then 1 else 0);
           auto_reflect_count =
             acc.auto_reflect_count + (if is_interaction && auto_reflect_now then 1 else 0);
           auto_plan_count =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -21,6 +21,8 @@ type proactive_policy =
   ; cooldown_sec : int
   }
 
+type scheduled_autonomous_policy = proactive_policy
+
 type proactive_cycle_outcome =
   | Proactive_never_started
   | Proactive_unknown
@@ -29,6 +31,8 @@ type proactive_cycle_outcome =
   | Proactive_tool_use
   | Proactive_mixed_response
   | Proactive_error
+
+type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 type tool_preset =
   | Minimal
@@ -64,6 +68,8 @@ type proactive_runtime =
   ; last_reason : string
   ; last_preview : string
   }
+
+type scheduled_autonomous_runtime = proactive_runtime
 
 type usage_metrics =
   { total_turns : int
@@ -224,6 +230,14 @@ let proactive_cycle_outcome_of_string raw =
   | "mixed_response" -> Proactive_mixed_response
   | "error" -> Proactive_error
   | _ -> Proactive_unknown
+;;
+
+let scheduled_autonomous_cycle_outcome_to_string =
+  proactive_cycle_outcome_to_string
+;;
+
+let scheduled_autonomous_cycle_outcome_of_string =
+  proactive_cycle_outcome_of_string
 ;;
 
 let normalize_tool_access = function
@@ -403,6 +417,10 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
   : keeper_meta
   =
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
+;;
+
+let map_scheduled_autonomous_rt =
+  map_proactive_rt
 ;;
 
 let now_iso () = Types.now_iso ()

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -23,6 +23,8 @@ type proactive_policy = {
   cooldown_sec: int;
 }
 
+type scheduled_autonomous_policy = proactive_policy
+
 type proactive_cycle_outcome =
   | Proactive_never_started
   | Proactive_unknown
@@ -31,6 +33,8 @@ type proactive_cycle_outcome =
   | Proactive_tool_use
   | Proactive_mixed_response
   | Proactive_error
+
+type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 type tool_preset =
   | Minimal
@@ -66,6 +70,8 @@ type proactive_runtime = {
   last_reason: string;
   last_preview: string;
 }
+
+type scheduled_autonomous_runtime = proactive_runtime
 
 type usage_metrics = {
   total_turns: int;
@@ -161,6 +167,10 @@ val tool_preset_to_string : tool_preset -> string
 val tool_preset_of_string : string -> tool_preset option
 val proactive_cycle_outcome_to_string : proactive_cycle_outcome -> string
 val proactive_cycle_outcome_of_string : string -> proactive_cycle_outcome
+val scheduled_autonomous_cycle_outcome_to_string :
+  scheduled_autonomous_cycle_outcome -> string
+val scheduled_autonomous_cycle_outcome_of_string :
+  string -> scheduled_autonomous_cycle_outcome
 val tool_access_preset : tool_access -> tool_preset option
 val tool_access_custom_allowlist : tool_access -> string list option
 val tool_access_also_allowlist : tool_access -> string list
@@ -173,6 +183,9 @@ val map_runtime : (agent_runtime_state -> agent_runtime_state) -> keeper_meta ->
 val map_usage : (usage_metrics -> usage_metrics) -> keeper_meta -> keeper_meta
 val map_compaction_rt : (compaction_runtime -> compaction_runtime) -> keeper_meta -> keeper_meta
 val map_proactive_rt : (proactive_runtime -> proactive_runtime) -> keeper_meta -> keeper_meta
+val map_scheduled_autonomous_rt :
+  (scheduled_autonomous_runtime -> scheduled_autonomous_runtime) ->
+  keeper_meta -> keeper_meta
 
 (** {1 Legacy model arg rejection} *)
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -141,7 +141,7 @@ let autonomous_trigger_lines
                  (Printf.sprintf "- Idle gate: %ds (current idle: %ds)"
                     idle_gate observation.idle_seconds)
            | None -> None);
-          (match decision.since_last_proactive, decision.effective_cooldown with
+          (match decision.since_last_scheduled_autonomous, decision.effective_cooldown with
            | Some since_last, Some cooldown ->
                Some
                  (Printf.sprintf

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -163,14 +163,21 @@ let decision_channel_of_observation
   then
     "turn"
   else
-    "proactive"
+    "scheduled_autonomous"
 
-let is_proactive_cycle_of_observation
+let is_scheduled_autonomous_channel (channel : string) : bool =
+  String.equal channel "scheduled_autonomous"
+  || String.equal channel "proactive"
+
+let is_scheduled_autonomous_cycle_of_observation
     (observation : Keeper_world_observation.world_observation) : bool =
-  String.equal (decision_channel_of_observation observation) "proactive"
+  String.equal
+    (decision_channel_of_observation observation)
+    "scheduled_autonomous"
 
-let proactive_outcome_of_result ~(has_text : bool) ~(has_tool_calls : bool) :
-    proactive_cycle_outcome =
+let scheduled_autonomous_outcome_of_result
+    ~(has_text : bool) ~(has_tool_calls : bool) :
+    scheduled_autonomous_cycle_outcome =
   match has_text, has_tool_calls with
   | false, false -> Proactive_silent
   | true, false -> Proactive_text_response
@@ -410,7 +417,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   in
   let has_substantive_tools = has_substantive_tool_calls result.tools_used in
   let has_text = String.trim result.response_text <> "" in
-  let is_proactive_cycle = is_proactive_cycle_of_observation observation in
+  let is_scheduled_autonomous_cycle =
+    is_scheduled_autonomous_cycle_of_observation observation
+  in
   let is_board_reactive = observation.pending_board_events <> [] in
   let is_mention_reactive = observation.pending_mentions <> [] in
   let rt = meta.runtime in
@@ -447,44 +456,47 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
         last_total_tokens = Keeper_exec_context.total_tokens result.usage;
         last_latency_ms = latency_ms;
       };
-      (* Deterministic proactive cycle accounting is separated from
+      (* Deterministic scheduled autonomous cycle accounting is separated from
          nondeterministic model output visibility. *)
       proactive_rt = {
         count_total =
           rt.proactive_rt.count_total
-          + (if update_proactive_rt && is_proactive_cycle then 1 else 0);
+          + (if update_proactive_rt && is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          (if update_proactive_rt && is_proactive_cycle then now_ts
+          (if update_proactive_rt && is_scheduled_autonomous_cycle then now_ts
            else rt.proactive_rt.last_ts);
         visible_count_total =
           rt.proactive_rt.visible_count_total
           + (if update_proactive_rt
-               && is_proactive_cycle
+               && is_scheduled_autonomous_cycle
                && (has_text || has_substantive_tools)
              then 1
              else 0);
         last_visible_ts =
           (if update_proactive_rt
-              && is_proactive_cycle
+              && is_scheduled_autonomous_cycle
               && (has_text || has_substantive_tools)
            then now_ts
            else rt.proactive_rt.last_visible_ts);
         last_outcome =
-          (if update_proactive_rt && is_proactive_cycle then
-             proactive_outcome_of_result ~has_text
+          (if update_proactive_rt && is_scheduled_autonomous_cycle then
+             scheduled_autonomous_outcome_of_result ~has_text
                ~has_tool_calls:has_substantive_tools
            else rt.proactive_rt.last_outcome);
         last_reason =
-          (if not update_proactive_rt || not is_proactive_cycle then rt.proactive_rt.last_reason
+          (if not update_proactive_rt || not is_scheduled_autonomous_cycle
+           then rt.proactive_rt.last_reason
            else if has_substantive_tools then
              Printf.sprintf "unified:tools=[%s]"
                (String.concat "," result.tools_used)
            else if not has_text then
-             "unified:" ^ proactive_cycle_outcome_to_string Proactive_silent
+             "unified:"
+             ^ scheduled_autonomous_cycle_outcome_to_string Proactive_silent
             else if has_text then "unified:text_response"
             else rt.proactive_rt.last_reason);
         last_preview =
-          (if not update_proactive_rt || not is_proactive_cycle then rt.proactive_rt.last_preview
+          (if not update_proactive_rt || not is_scheduled_autonomous_cycle
+           then rt.proactive_rt.last_preview
            else if has_text then short_preview result.response_text
            else if has_substantive_tools then
              Printf.sprintf "(tools: %s)" (String.concat ", " result.tools_used)
@@ -539,10 +551,10 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
     else if String.trim result.response_text <> "" then "text_turn"
     else "noop"
   in
-  let proactive_outcome =
-    if String.equal channel "proactive" then
+  let scheduled_autonomous_outcome =
+    if is_scheduled_autonomous_channel channel then
       Some
-        (proactive_outcome_of_result
+        (scheduled_autonomous_outcome_of_result
            ~has_text:(String.trim result.response_text <> "")
            ~has_tool_calls:(has_substantive_tool_calls result.tools_used))
     else None
@@ -584,9 +596,15 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
           | Some reason -> `String reason
           | None -> `Null);
         ("work_kind", `String work_kind);
+        ( "scheduled_autonomous_outcome",
+          match scheduled_autonomous_outcome with
+          | Some outcome ->
+              `String (scheduled_autonomous_cycle_outcome_to_string outcome)
+          | None -> `Null );
         ( "proactive_outcome",
-          match proactive_outcome with
-          | Some outcome -> `String (proactive_cycle_outcome_to_string outcome)
+          match scheduled_autonomous_outcome with
+          | Some outcome ->
+              `String (scheduled_autonomous_cycle_outcome_to_string outcome)
           | None -> `Null );
         ("tool_call_count", `Int result.tool_calls_made);
         ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
@@ -697,7 +715,9 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
     ~(reason : string) ?social_state () : keeper_meta =
   let now_ts = Time_compat.now () in
-  let is_proactive_cycle = is_proactive_cycle_of_observation observation in
+  let is_scheduled_autonomous_cycle =
+    is_scheduled_autonomous_cycle_of_observation observation
+  in
   let preview =
     let trimmed = String.trim reason in
     if trimmed = "" then "unified turn failed"
@@ -715,18 +735,18 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
       proactive_rt = { meta.runtime.proactive_rt with
         count_total =
           meta.runtime.proactive_rt.count_total
-          + (if is_proactive_cycle then 1 else 0);
+          + (if is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          if is_proactive_cycle then now_ts
+          if is_scheduled_autonomous_cycle then now_ts
           else meta.runtime.proactive_rt.last_ts;
         last_outcome =
-          if is_proactive_cycle then Proactive_error
+          if is_scheduled_autonomous_cycle then Proactive_error
           else meta.runtime.proactive_rt.last_outcome;
         last_reason =
-          if is_proactive_cycle then "unified:error:" ^ String.trim reason
+          if is_scheduled_autonomous_cycle then "unified:error:" ^ String.trim reason
           else meta.runtime.proactive_rt.last_reason;
         last_preview =
-          if is_proactive_cycle then preview
+          if is_scheduled_autonomous_cycle then preview
           else meta.runtime.proactive_rt.last_preview;
       };
       last_speech_act =
@@ -951,7 +971,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                then
                  "turn"
                else
-                 "proactive"
+                 "scheduled_autonomous"
              in
              append_metrics_snapshot ~config ~meta:updated_meta ~observation
                ~result ~latency_ms ~turn_cost

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -1,6 +1,6 @@
 (** Keeper_unified_turn — Single entry point for keeper turns via OAS Agent.run().
 
-    Replaces the 3-path dispatcher (social/proactive/autonomy) with a unified
+    Replaces the 3-path dispatcher (social/scheduled-autonomous/autonomy) with a unified
     observe -> prompt -> Agent.run(tools, guardrails, hooks) loop.
     The model decides what to do; code only enforces safety and observes results.
 
@@ -26,6 +26,9 @@ val update_metrics_from_result :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   ?is_autonomous_turn:bool ->
+  (** Compatibility label: still named [update_proactive_rt] because serialized
+      runtime fields remain [proactive_*] for now, but it controls scheduled
+      autonomous runtime accounting in the unified loop. *)
   ?update_proactive_rt:bool ->
   ?social_state:Keeper_social_model.social_state ->
   Keeper_agent_run.run_result ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -52,7 +52,7 @@ type unified_turn_decision = {
   should_run : bool;
   channel : unified_turn_channel;
   reasons : string list;
-  since_last_proactive : int option;
+  since_last_scheduled_autonomous : int option;
   effective_cooldown : int option;
   task_reactive_cooldown : int option;
   idle_gate_sec : int option;
@@ -589,11 +589,12 @@ let observe ~(pending_board_events : pending_board_event list option)
     last_turn_budget = None;
   }
 
-(** Compute effective proactive cooldown with idle decay.
+(** Compute effective scheduled autonomous cooldown with idle decay.
     After extended idle (> base cooldown), halve the cooldown each
     additional period, down to a configurable floor.  This prevents
     permanent silence when no external events arrive. *)
-let effective_proactive_cooldown ~(base_cooldown : int) ~(since_last : int) : int =
+let effective_scheduled_autonomous_cooldown
+    ~(base_cooldown : int) ~(since_last : int) : int =
   let min_cooldown = Keeper_config.keeper_proactive_min_cooldown_sec () in
   (* Floor must not exceed the base cooldown — otherwise decay would
      paradoxically increase a short cooldown. *)
@@ -604,6 +605,9 @@ let effective_proactive_cooldown ~(base_cooldown : int) ~(since_last : int) : in
     let capped_periods = min decay_periods 4 in
     let factor = 1.0 /. (Float.pow 2.0 (float_of_int capped_periods)) in
     max floor (int_of_float (float_of_int base_cooldown *. factor))
+
+let effective_proactive_cooldown =
+  effective_scheduled_autonomous_cooldown
 
 let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation) =
   let reactive_reasons =
@@ -620,13 +624,13 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
         should_run = true;
         channel = Reactive;
         reasons = reactive_reasons;
-        since_last_proactive = None;
+        since_last_scheduled_autonomous = None;
         effective_cooldown = None;
         task_reactive_cooldown = None;
         idle_gate_sec = None;
       }
   | [] ->
-      let since_last_proactive =
+      let since_last_scheduled_autonomous =
         if meta.runtime.proactive_rt.last_ts <= 0.0 then max_int
         else
           int_of_float (max 0.0 (Time_compat.now () -. meta.runtime.proactive_rt.last_ts))
@@ -636,17 +640,17 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
         {
           should_run = false;
           channel = Scheduled_autonomous;
-          reasons = [ "proactive_disabled" ];
-          since_last_proactive = Some since_last_proactive;
+          reasons = [ "scheduled_autonomous_disabled" ];
+          since_last_scheduled_autonomous = Some since_last_scheduled_autonomous;
           effective_cooldown = None;
           task_reactive_cooldown = None;
           idle_gate_sec = Some idle_gate_sec;
         }
       else
         let effective_cooldown =
-          effective_proactive_cooldown
+          effective_scheduled_autonomous_cooldown
             ~base_cooldown:meta.proactive.cooldown_sec
-            ~since_last:since_last_proactive
+            ~since_last:since_last_scheduled_autonomous
         in
         let task_cooldown_divisor =
           Keeper_config.keeper_proactive_task_cooldown_divisor ()
@@ -662,15 +666,18 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
           observation.unclaimed_task_count > 0 || observation.failed_task_count > 0
         in
         let idle_gate_elapsed = observation.idle_seconds >= idle_gate_sec in
-        let cooldown_elapsed = since_last_proactive >= effective_cooldown in
+        let cooldown_elapsed =
+          since_last_scheduled_autonomous >= effective_cooldown
+        in
         let backlog_elapsed =
           has_actionable_tasks
-          && since_last_proactive >= task_reactive_cooldown
+          && since_last_scheduled_autonomous >= task_reactive_cooldown
         in
         let reasons =
           [
             Some "scheduled_autonomous_turn";
-            (if since_last_proactive = max_int then Some "never_started" else None);
+            (if since_last_scheduled_autonomous = max_int then Some "never_started"
+             else None);
             (if idle_gate_elapsed then Some "idle_gate_elapsed" else Some "idle_gate_wait");
             (if cooldown_elapsed then Some "cooldown_elapsed" else None);
             (if has_actionable_tasks then Some "actionable_backlog" else None);
@@ -684,7 +691,7 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
           should_run = idle_gate_elapsed && (cooldown_elapsed || backlog_elapsed);
           channel = Scheduled_autonomous;
           reasons;
-          since_last_proactive = Some since_last_proactive;
+          since_last_scheduled_autonomous = Some since_last_scheduled_autonomous;
           effective_cooldown = Some effective_cooldown;
           task_reactive_cooldown = Some task_reactive_cooldown;
           idle_gate_sec = Some idle_gate_sec;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -46,7 +46,7 @@ type world_observation = {
       reprocessing the same broadcast stream. *)
 
   idle_seconds : int;
-  (** Seconds since last keeper activity (turn or proactive). *)
+  (** Seconds since last keeper activity (turn or scheduled autonomous cycle). *)
 
   active_goals : string list;
   (** Goal IDs currently assigned to this keeper. *)
@@ -90,7 +90,7 @@ type unified_turn_decision = {
   should_run : bool;
   channel : unified_turn_channel;
   reasons : string list;
-  since_last_proactive : int option;
+  since_last_scheduled_autonomous : int option;
   effective_cooldown : int option;
   task_reactive_cooldown : int option;
   idle_gate_sec : int option;
@@ -139,9 +139,13 @@ val apply_message_cursor_updates :
   (string * int) list ->
   Keeper_types.keeper_meta
 
-(** Compute effective proactive cooldown with idle decay.
+(** Compute effective scheduled autonomous cooldown with idle decay.
     After extended idle (> base cooldown), halve the cooldown each
     additional period, down to a configurable floor. *)
+val effective_scheduled_autonomous_cooldown :
+  base_cooldown:int -> since_last:int -> int
+
+(** Backward-compatible alias for the pre-rename helper name. *)
 val effective_proactive_cooldown :
   base_cooldown:int -> since_last:int -> int
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -88,6 +88,28 @@ let test_derive_pipeline_stage_treats_inactive_as_offline () =
   check string "inactive keeper does not advertise a live pipeline stage"
     "offline" stage
 
+let test_derive_pipeline_stage_prefers_scheduled_autonomous () =
+  let meta =
+    let base = make_meta () in
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          usage =
+            { base.runtime.usage with last_turn_ts = Time_compat.now () -. 120.0 };
+          proactive_rt =
+            { base.runtime.proactive_rt with last_ts = Time_compat.now () };
+        };
+    }
+  in
+  let stage =
+    ES.derive_pipeline_stage ~meta ~surface_status:"active"
+      ~now_ts:(Time_compat.now ())
+  in
+  check string "recent scheduled autonomous cycle wins pipeline stage"
+    "scheduled_autonomous" stage
+
 let () =
   run "keeper_exec_status"
     [
@@ -105,5 +127,7 @@ let () =
             test_keeper_surface_status_maps_dead_to_inactive;
           test_case "inactive pipeline stage becomes offline" `Quick
             test_derive_pipeline_stage_treats_inactive_as_offline;
+          test_case "scheduled autonomous pipeline stage" `Quick
+            test_derive_pipeline_stage_prefers_scheduled_autonomous;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -399,32 +399,50 @@ let test_scheduled_turn_requires_idle_gate () =
 
 let test_effective_cooldown_no_decay_within_base () =
   (* Within the base cooldown period, no decay should apply. *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:900 in
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:900
+  in
   check int "no decay within base" 1800 result
 
 let test_effective_cooldown_at_boundary () =
   (* Exactly at the base cooldown, no decay yet. *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:1800 in
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:1800
+  in
   check int "no decay at boundary" 1800 result
 
 let test_effective_cooldown_first_decay () =
   (* One full extra period: cooldown halved. *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:3600 in
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:3600
+  in
   check int "first decay halves cooldown" 900 result
 
 let test_effective_cooldown_second_decay () =
   (* Two extra periods: cooldown quartered. *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:5400 in
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:5400
+  in
   check int "second decay quarters cooldown" 450 result
 
 let test_effective_cooldown_floor () =
   (* Four+ extra periods: cooldown at floor (300s default). *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:10800 in
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:10800
+  in
   check int "decay floors at min_cooldown" 300 result
 
 let test_effective_cooldown_max_int () =
-  (* max_int (first proactive ever): should hit floor immediately. *)
-  let result = WO.effective_proactive_cooldown ~base_cooldown:1800 ~since_last:max_int in
+  (* max_int (first scheduled autonomous cycle ever): should hit floor immediately. *)
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:max_int
+  in
   check int "max_int hits floor" 300 result
 
 let test_idle_decay_triggers_turn () =

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1004,7 +1004,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
           {|{"channel":"turn","generation":0,"trace_id":"trace-1","context_ratio":0.41,"context_tokens":120,"context_max":1024,"message_count":4,"memory_check":{"performed":true,"passed":true,"final_score":0.9},"skill_primary":"masc-heartbeat","skill_secondary":["masc-keeper-autonomy"],"skill_reason":"stateful routing","skill_selection_mode":"agent","skill_provenance":"judgment","action_source":"structured_model"}|}
       in
       let compaction_json = Yojson.Safe.from_string
-          {|{"channel":"proactive","generation":0,"trace_id":"trace-1","compacted":true,"compaction_before_tokens":180,"compaction_after_tokens":120,"memory_compaction_performed":true,"memory_compaction_before_notes":4,"memory_compaction_after_notes":2,"memory_compaction_dropped_notes":2,"memory_compaction_invalid_dropped":1,"memory_compaction_reason":"dedupe"}|}
+          {|{"channel":"scheduled_autonomous","generation":0,"trace_id":"trace-1","compacted":true,"compaction_before_tokens":180,"compaction_after_tokens":120,"memory_compaction_performed":true,"memory_compaction_before_notes":4,"memory_compaction_after_notes":2,"memory_compaction_dropped_notes":2,"memory_compaction_invalid_dropped":1,"memory_compaction_reason":"dedupe"}|}
       in
       Dated_jsonl.append metrics_store turn_json;
       Dated_jsonl.append metrics_store compaction_json;


### PR DESCRIPTION
## Summary
- promote keeper unified-loop internals from `proactive` terminology to `scheduled_autonomous` where the concept is specifically the scheduler-driven autonomous turn path
- emit `scheduled_autonomous` as the new metrics channel and pipeline stage while keeping backward compatibility for historical `proactive` records
- add type aliases and regression coverage so internal rename does not break existing serialized runtime fields or dashboard aggregation

## Product impact
- keeper telemetry now uses a clearer scheduler-specific name for autonomous keepalive turns
- dashboard pipeline stage and metrics consumers understand both old and new channel labels, so older JSONL history remains readable
- the rename reduces conceptual drift between the explicit `Scheduled_autonomous` turn decision and downstream metrics/status views

## Evidence
- `dune exec --root . test/test_keeper_exec_status.exe` (7 tests, pass)
- `dune exec --root . test/test_keeper_unified.exe` (93 tests, pass)
- `dune exec --root . test/test_tool_keeper.exe` (58 tests, pass)
- `npx tsc --noEmit --pretty` could not run in this environment because the dashboard worktree does not have a local `typescript` compiler installed

## Review evidence
- `GLM-5` via `sb glm-text`: `No findings.`

## Linked issue
- Refs #5162

## Notes
- serialized/runtime field names such as `proactive_*` are intentionally left intact in this PR for compatibility; this change promotes scheduled-autonomous nomenclature in core scheduling, channels, and type aliases first
- ready for review; waiting on CI
