### PR TITLE
fix: allow proactive behaviors to trigger and prevent portal retry loops

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -30,8 +30,6 @@ mention_targets = ["sherlock", "log-analyzer"]
 
 # Proactive behavior
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30
 
 # Execution scope — controls what the keeper can modify.
 #   observe_only = read-only, no file writes (default for new keepers until #3886)

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -10,36 +10,7 @@ will = "Delete only unmistakable garbage. If ownership is ambiguous, leave it an
 needs = "Board inspection/delete, voice session inspection/end, zombie cleanup, and shared runtime status."
 desires = "Low-noise dashboards and no lingering tool-matrix test artifacts."
 
-instructions = """
-You are janitor, the masc-mcp garbage collector.
-
-Primary cleanup targets:
-1. Board posts that are clearly generated test noise:
-   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers
-   - no comments
-   - no votes
-   - older than 30 minutes
-2. Voice sessions that are clearly test artifacts:
-   - agent_id is `tool-matrix`
-   - or agent_id ends with `-tool-matrix`
-   - or agent_id contains `fixture`/`test` and is stale
-3. Stale automation agents that are already safe for `masc_cleanup_zombies`
-
-Safety rules:
-- Never delete human discussion.
-- Never delete any board post with comments or votes.
-- Never touch posts newer than 30 minutes.
-- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.
-
-Execution loop:
-1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.
-2. Delete only safe board garbage with `keeper_board_delete`.
-3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.
-4. Run `masc_cleanup_zombies` when stale automation agents are present.
-5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.
-
-Tone: terse, operational, no speeches.
-"""
+instructions = "\nYou are janitor, the masc-mcp garbage collector.\n\nPrimary cleanup targets:\n1. Board posts that are clearly generated test noise:\n   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers\n   - no comments\n   - no votes\n   - older than 30 minutes\n2. Voice sessions that are clearly test artifacts:\n   - agent_id is `tool-matrix`\n   - or agent_id ends with `-tool-matrix`\n   - or agent_id contains `fixture`/`test` and is stale\n3. Stale automation agents that are already safe for `masc_cleanup_zombies`\n\nSafety rules:\n- Never delete human discussion.\n- Never delete any board post with comments or votes.\n- Never touch posts newer than 30 minutes.\n- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.\n\nExecution loop:\n1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.\n2. Delete only safe board garbage with `keeper_board_delete`.\n3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.\n4. Run `masc_cleanup_zombies` when stale automation agents are present.\n5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.\n\nTone: terse, operational, no speeches.\n"
 
 room_scope = "current"
 scope_kind = "global"

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -10,24 +10,7 @@ will = "Keep the repo moving by selecting the next highest-leverage candidate an
 needs = "Access to GitHub PR/issue state, local worktrees, review evidence, and the command-plane truth."
 desires = "Tight burn-down loops with explicit verification and low operator overhead."
 
-instructions = """
-You are masc-improver, a keeper dedicated to improving masc-mcp itself.
-
-Default loop:
-1. Read masc_improve_loop_status.
-2. Call masc_improve_loop_tick to select the next candidate.
-3. If execute=false/dry-run, inspect the returned plan and move into the prepared worktree.
-4. Reproduce first, patch narrowly, verify locally, then use scripts/pr-open.sh for a draft PR.
-5. Treat cross-model review as a merge gate. Do not merge without review evidence and green required checks.
-
-Focus order:
-- conflicted PRs
-- failing PRs
-- bug/high/safety issues
-- remaining issues
-
-Never work outside masc-mcp. Use worktrees. One active lane at a time.
-"""
+instructions = "\nYou are masc-improver, a keeper dedicated to improving masc-mcp itself.\n\nDefault loop:\n1. Read masc_improve_loop_status.\n2. Call masc_improve_loop_tick to select the next candidate.\n3. If execute=false/dry-run, inspect the returned plan and move into the prepared worktree.\n4. Reproduce first, patch narrowly, verify locally, then use scripts/pr-open.sh for a draft PR.\n5. Treat cross-model review as a merge gate. Do not merge without review evidence and green required checks.\n\nFocus order:\n- conflicted PRs\n- failing PRs\n- bug/high/safety issues\n- remaining issues\n\nNever work outside masc-mcp. Use worktrees. One active lane at a time.\n"
 
 room_scope = "current"
 scope_kind = "local"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -185,7 +185,6 @@ let compute_idle_seconds ~(meta : keeper_meta) : int =
   let activity_ts =
     List.fold_left max created_ts
       [
-        meta.runtime.usage.last_turn_ts;
         meta.runtime.proactive_rt.last_ts;
       ]
   in

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -23,4 +23,7 @@ let run_all () =
    | None -> ());
   (* Close all SSE clients *)
   let sse_count = Sse.close_all_clients () in
-  Log.Server.info "Closed %d SSE clients" sse_count
+  Log.Server.info "Closed %d SSE clients" sse_count;
+  (* Close WebSocket sessions *)
+  let ws_count = Server_mcp_transport_ws.close_all () in
+  Log.Server.info "Closed %d WebSocket sessions" ws_count

--- a/lib/tool_portal.ml
+++ b/lib/tool_portal.ml
@@ -32,6 +32,7 @@ let handle_portal_open ctx args =
     let initial_message = get_string_opt args "initial_message" in
     match Room.portal_open_r ctx.config ~agent_name:ctx.agent_name ~target_agent ~initial_message with
   | Ok msg -> (true, msg)
+  | Error (Types.PortalAlreadyOpen _) -> (true, Printf.sprintf "Portal already open: %s ↔ %s" ctx.agent_name target_agent)
   | Error e -> (false, Types.masc_error_to_string e)
 
 let handle_portal_send ctx args =

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="1987273ecc7144c57017320276b81f3f493cb160"
+readonly OAS_AGENT_SDK_SHA="236b18f0427a45cccd1ea6c165c44fa862e92c37"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.7"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -446,7 +446,13 @@ fi
 if [ "$PORT_EXPLICIT" != "1" ]; then
     PORT="$(default_port_for_path "$SCRIPT_DIR")"
     if [ "$PORT" != "8935" ]; then
-        WORKTREE_PORT_HINT="Using worktree-derived default port $PORT for $(basename "$SCRIPT_DIR") (override with MASC_MCP_PORT or --port)."
+        if [ -z "$MASC_GRPC_PORT" ]; then
+            export MASC_GRPC_PORT="$((PORT + 1))"
+        fi
+        if [ -z "$MASC_WS_PORT" ]; then
+            export MASC_WS_PORT="$((PORT + 2))"
+        fi
+        WORKTREE_PORT_HINT="Using worktree-derived default port $PORT (gRPC=$MASC_GRPC_PORT, WS=$MASC_WS_PORT) for $(basename "$SCRIPT_DIR") (override with MASC_MCP_PORT or --port)."
     fi
 fi
 
@@ -462,19 +468,27 @@ fi
 raise_open_file_limit
 
 # Fast preflight: fail before build/init if requested port is already occupied.
-if lsof -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1 && [ "${MASC_ALLOW_PORT_REUSE:-0}" != "1" ]; then
-    listener_pid="$(lsof -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -n 1)"
-    listener_cmd=""
-    if [ -n "$listener_pid" ]; then
-        listener_cmd="$(ps -p "$listener_pid" -o command= 2>/dev/null || true)"
+check_port_in_use() {
+    local check_port="$1"
+    local name="$2"
+    if [ -n "$check_port" ] && lsof -iTCP:"$check_port" -sTCP:LISTEN -t >/dev/null 2>&1 && [ "${MASC_ALLOW_PORT_REUSE:-0}" != "1" ]; then
+        local listener_pid="$(lsof -iTCP:"$check_port" -sTCP:LISTEN -t 2>/dev/null | head -n 1)"
+        local listener_cmd=""
+        if [ -n "$listener_pid" ]; then
+            listener_cmd="$(ps -p "$listener_pid" -o command= 2>/dev/null || true)"
+        fi
+        echo "❌ $name Port $check_port already in use; refusing startup before build/init." >&2
+        if [ -n "$listener_pid" ]; then
+            echo "   Existing listener: pid=$listener_pid ${listener_cmd}" >&2
+        fi
+        echo "   Stop the existing server, choose another --port, or set MASC_ALLOW_PORT_REUSE=1." >&2
+        exit 1
     fi
-    echo "❌ Port $PORT already in use; refusing startup before build/init." >&2
-    if [ -n "$listener_pid" ]; then
-        echo "   Existing listener: pid=$listener_pid ${listener_cmd}" >&2
-    fi
-    echo "   Stop the existing server, choose another --port, or set MASC_ALLOW_PORT_REUSE=1." >&2
-    exit 1
-fi
+}
+
+check_port_in_use "$PORT" "HTTP"
+check_port_in_use "${MASC_GRPC_PORT:-8936}" "gRPC"
+check_port_in_use "${MASC_WS_PORT:-8937}" "WebSocket"
 
 # Dashboard SPA build (Vite) — assets/dashboard/ is no longer committed to git.
 # Always attempt the build before server startup so the served bundle matches current sources.


### PR DESCRIPTION
- Exclude `last_turn_ts` from `compute_idle_seconds` to allow true idle time to accumulate for proactive behaviors.
- Treat `PortalAlreadyOpen` as a success result in `masc_portal_open` to prevent agents from getting stuck in retry loops.