### PR TITLE
feat(keeper): add turn result logging for observability

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -835,8 +835,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                            && attempt <= max_transient_retries ->
                 let delay = transient_backoff_sec attempt in
                 Log.Keeper.warn
-                  "%s: transient network error (retry %d/%d), backoff %.0fs: %s"
-                  meta.name attempt max_transient_retries delay
+                  "%s: transient network error cascade=%s max_context=%d retry=%d/%d backoff=%.0fs: %s"
+                  meta.name meta.cascade_name max_context
+                  attempt max_transient_retries delay
                   (short_preview e);
                 Eio.Time.sleep (Eio_context.get_clock ()) delay;
                 retry_loop ~run_meta ~max_context ~run_generation
@@ -872,6 +873,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       in
       match run_result with
       | Error e ->
+          Log.Keeper.error
+            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms error=%s"
+            meta.name meta.cascade_name primary_max_context latency_ms
+            (short_preview e);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e
           in
@@ -1000,6 +1005,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             ~selected_mode:(selected_mode_of_result result)
             ~social_state
             ~result:(Some result) ();
+          Log.Keeper.info
+            "%s: unified turn OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
+            updated_meta.name result.model_used
+            (result.usage.input_tokens + result.usage.output_tokens)
+            latency_ms
+            (selected_mode_of_result result)
+            (match result.stop_reason with
+             | Oas_worker.Completed -> "completed"
+             | Oas_worker.TurnBudgetExhausted { turns_used; limit; _ } ->
+                 Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit);
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with
            | Ok () -> ()


### PR DESCRIPTION
## Summary
- Add `Log.Keeper.error` when keeper turn fails (cascade name, max_context, latency, error message)
- Add `Log.Keeper.info` when keeper turn succeeds (model, tokens, latency, mode, stop reason)
- Improve transient retry warning with cascade name and max_context

## Motivation
이전 세션에서 3개 llama 서버(8085/8086/8087)로 인한 discovery min context(8192) 문제가
발생했을 때, stderr 로그에 키퍼 턴 실패 상세가 노출되지 않아 원인 파악이 어려웠다.
이 변경으로 키퍼 턴의 성공/실패가 서버 stderr에 실시간으로 출력된다.

### Before
```
(only JSONL decision record written to file, nothing in stderr)
```

### After
```
[ERROR] minhee: unified turn FAILED cascade=keeper_unified max_context=8192 latency=5000ms error=request (11447 tokens) exceeds...
[INFO] minhee: unified turn OK model=qwen3.5-9b-local tokens=8333 latency=2300ms mode=proactive stop=completed
[WARN] minhee: transient network error cascade=keeper_unified max_context=262144 retry=1/2 backoff=1s: Connection refused
```

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes (running)
- [ ] 서버 재시작 후 키퍼 로그에서 에러/성공 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)