### PR TITLE
fix: handle self-claiming gracefully and reduce backend log spam

### DIFF
--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -457,6 +457,8 @@ let broadcast ?trace_context config ~from_agent ~content =
   (match backend_publish config ~channel:(broadcast_channel config)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
    | Ok _ -> ()
+   | Error (Backend_types.BackendNotSupported msg) when String.starts_with ~prefix:"FileSystem backend" msg ->
+       Log.Misc.debug "broadcast publish skipped for %s: %s" room_id msg
    | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id (Backend_types.show_error e));
   emit_message_activity config ~from_agent:safe_agent ~content:safe_content
     ~mention ();

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -415,6 +415,8 @@ let claim_task_r config ~agent_name ~task_id
                   | Todo ->
                       let t' = { t with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } } in
                       (`Claimed_ok, t' :: acc)
+                  | Claimed { assignee; _ } | InProgress { assignee; _ } when assignee = agent_name ->
+                      (`Already_mine, t :: acc)
                   | Claimed { assignee; _ } | InProgress { assignee; _ }
                   | Done { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
                       (`Claimed_by assignee, t :: acc)
@@ -426,6 +428,7 @@ let claim_task_r config ~agent_name ~task_id
             match claim_state with
             | `Not_found -> Error (Types.TaskNotFound task_id)
             | `Claimed_by other -> Error (Types.TaskAlreadyClaimed { task_id; by = other })
+            | `Already_mine -> Ok (Printf.sprintf "Task %s is already claimed by you" task_id)
             | `Claimed_ok ->
                   let new_backlog = {
                     tasks = new_tasks;


### PR DESCRIPTION
- Return `Ok` with a message when an agent tries to claim a task it already claimed or is currently working on. This prevents a retry loop where the agent gets an error for trying to claim its own task.
- Downgrade the `BackendNotSupported` publish error for the FileSystem backend to a debug log to prevent log spam during broadcasts.