### PR TITLE
refactor(config): make Feature_flag_registry the single source of truth for boolean feature flags

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -26,7 +26,7 @@ module Inference = struct
 
   (** Enable inference response cache (L1+L2). *)
   let cache_enabled =
-    get_bool ~default:true "MASC_INFERENCE_CACHE_ENABLED"
+    Feature_flag_registry.get_bool "MASC_INFERENCE_CACHE_ENABLED"
 
   (** Default TTL for inference response cache (seconds). *)
   let cache_ttl_seconds =
@@ -122,7 +122,7 @@ end
 
 module Operator = struct
   (** Whether operator judge background loop is enabled. Default: true. *)
-  let judge_enabled = get_bool ~default:true "MASC_OPERATOR_JUDGE_ENABLED"
+  let judge_enabled = Feature_flag_registry.get_bool "MASC_OPERATOR_JUDGE_ENABLED"
 
   (** Operator judge interval, clamped to >= 15s. Default: 60. *)
   let judge_interval_sec = max 15 (get_int ~default:60 "MASC_OPERATOR_JUDGE_INTERVAL_SEC")
@@ -142,13 +142,13 @@ end
 module Dashboard_config = struct
   (** Whether dashboard fixtures are enabled. Default: false.
       Runtime-readable (tests change this via putenv). *)
-  let fixtures_enabled () = get_bool ~default:false "MASC_DASHBOARD_FIXTURES_ENABLED"
+  let fixtures_enabled () = Feature_flag_registry.get_bool "MASC_DASHBOARD_FIXTURES_ENABLED"
 
   (** Whether the proactive command-plane snapshot cache should run.
       Default: false because large roots can make the full snapshot too heavy
       for always-on background refresh. *)
   let command_plane_snapshot_refresh_enabled () =
-    get_bool ~default:false "MASC_COMMAND_PLANE_SNAPSHOT_REFRESH_ENABLED"
+    Feature_flag_registry.get_bool "MASC_COMMAND_PLANE_SNAPSHOT_REFRESH_ENABLED"
 
   (** Max age for an on-demand command-plane snapshot cache hit. *)
   let command_plane_snapshot_cache_ttl_s () =
@@ -164,7 +164,7 @@ module Dashboard_config = struct
     max 15 (get_int ~default:60 "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC")
 
   (** Whether governance judge is enabled. Default: true. *)
-  let governance_judge_enabled = get_bool ~default:true "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED"
+  let governance_judge_enabled = Feature_flag_registry.get_bool "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED"
 end
 
 (** {1 Model Routing Defaults} *)

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -5,7 +5,7 @@ open Env_config_core
 module KeeperBootstrap = struct
   (** Enable startup keeper bootstrap scan *)
   let enabled =
-    get_bool ~default:true "MASC_KEEPER_BOOTSTRAP_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_BOOTSTRAP_ENABLED"
 
   (** Keeper considered stale when last turn exceeds this threshold (seconds) *)
   let stale_turn_seconds =
@@ -37,7 +37,7 @@ end
 module KeeperAlert = struct
   (** Master switch for keeper interesting alert detection/fanout *)
   let enabled =
-    get_bool ~default:true "MASC_KEEPER_ALERT_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_ALERT_ENABLED"
 
   (** Minimum score required to trigger alert fanout *)
   let min_score =
@@ -57,7 +57,7 @@ module KeeperAlert = struct
 
   (** Board fanout configuration *)
   let board_enabled =
-    get_bool ~default:true "MASC_KEEPER_ALERT_BOARD_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_ALERT_BOARD_ENABLED"
 
   let board_author =
     get_string ~default:"keeper-alert-bot" "MASC_KEEPER_ALERT_BOARD_AUTHOR"
@@ -70,21 +70,21 @@ module KeeperAlert = struct
 
   (** Slack fanout configuration *)
   let slack_enabled =
-    get_bool ~default:true "MASC_KEEPER_ALERT_SLACK_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_ALERT_SLACK_ENABLED"
 
   let slack_webhook_url =
     get_string ~default:"" "MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL"
 
   (** Slack DM fanout configuration *)
   let slack_dm_enabled =
-    get_bool ~default:false "MASC_KEEPER_ALERT_SLACK_DM_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_ALERT_SLACK_DM_ENABLED"
 
   let slack_dm_user_id =
     get_string ~default:"" "MASC_KEEPER_ALERT_SLACK_DM_USER_ID"
 
   (** GitHub issue fanout configuration *)
   let github_enabled =
-    get_bool ~default:false "MASC_KEEPER_ALERT_GITHUB_ENABLED"
+    Feature_flag_registry.get_bool "MASC_KEEPER_ALERT_GITHUB_ENABLED"
 
   let github_repo =
     get_string ~default:"" "MASC_KEEPER_ALERT_GITHUB_REPO"
@@ -138,7 +138,7 @@ end
 
 module KeeperRuntime = struct
   (** Enable keeper debug logging. Default: false. *)
-  let debug = get_bool ~default:false "MASC_KEEPER_DEBUG"
+  let debug = Feature_flag_registry.get_bool "MASC_KEEPER_DEBUG"
 
   (** Daily budget for keeper deliberation (USD). Default: 0.10.
       Runtime-readable (tests change this via putenv). *)
@@ -170,7 +170,7 @@ module WorkAsHeartbeat = struct
       unified turn counts as presence proof, allowing the next cycle to skip
       the full ensure_keeper_room_presence call. *)
   let enabled =
-    get_bool ~default:true "MASC_KEEPER_WORK_AS_HEARTBEAT"
+    Feature_flag_registry.get_bool "MASC_KEEPER_WORK_AS_HEARTBEAT"
 
   (** Maximum seconds since last successful room heartbeat before presence
       sync is required again. Floor = keepalive interval (dynamic). *)
@@ -186,7 +186,7 @@ module SmartHeartbeat = struct
       When true, Heartbeat_smart.should_emit gates presence/snapshot/board/turn
       blocks, skipping cycles when the keeper is busy or deeply idle. *)
   let enabled =
-    get_bool ~default:true "MASC_KEEPER_SMART_HEARTBEAT"
+    Feature_flag_registry.get_bool "MASC_KEEPER_SMART_HEARTBEAT"
 end
 
 (** {1 Keeper Keepalive Loop Constants} *)

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -101,7 +101,7 @@ module Orchestrator = struct
     max 10 (min 3600 (get_int ~default:300 "MASC_ORCHESTRATOR_TIMEOUT"))
 
   let enabled =
-    get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED"
+    Feature_flag_registry.get_bool "MASC_ORCHESTRATOR_ENABLED"
 end
 
 (** {1 Relay Configuration} *)
@@ -226,7 +226,7 @@ module Transport = struct
 
   (** Whether gRPC transport is enabled. Default: true.
       Runtime-readable (tests change this via putenv). *)
-  let grpc_enabled () = get_bool ~default:true "MASC_GRPC_ENABLED"
+  let grpc_enabled () = Feature_flag_registry.get_bool "MASC_GRPC_ENABLED"
 
   (** gRPC client target address. Derived from grpc_port when unset. *)
   let grpc_target_opt () =
@@ -237,11 +237,11 @@ module Transport = struct
 
   (** Whether WebSocket transport is enabled. Default: true.
       Runtime-readable (tests change this via putenv). *)
-  let ws_enabled () = get_bool ~default:true "MASC_WS_ENABLED"
+  let ws_enabled () = Feature_flag_registry.get_bool "MASC_WS_ENABLED"
 
   (** Whether WebRTC transport is enabled. Default: true.
       Runtime-readable (tests change this via putenv). *)
-  let webrtc_enabled () = get_bool ~default:true "MASC_WEBRTC_ENABLED"
+  let webrtc_enabled () = Feature_flag_registry.get_bool "MASC_WEBRTC_ENABLED"
 
   (** HTTP mode: "auto", "h2_only", "h1_only". Default: "auto". *)
   let use_h2 () =
@@ -259,10 +259,10 @@ module Transport = struct
     Sys.getenv_opt "MASC_AGENT_TRANSPORT" |> trim_opt
 
   (** Whether OpenAI-compatible endpoint is enabled. Default: false. *)
-  let openai_compat_enabled = get_bool ~default:false "MASC_OPENAI_COMPAT"
+  let openai_compat_enabled = Feature_flag_registry.get_bool "MASC_OPENAI_COMPAT"
 
   let _http_auth_strict_registry =
-    get_bool ~default:false "MASC_HTTP_AUTH_STRICT"
+    Feature_flag_registry.get_bool "MASC_HTTP_AUTH_STRICT"
 
   (** Force strict auth for all HTTP endpoints. Default: false. *)
   let http_auth_strict_env_enabled () =
@@ -289,7 +289,7 @@ module TeamSession = struct
 
   (** Enable routing judge in team session dispatch. Default: true. *)
   let router_judge_enabled () =
-    get_bool ~default:true "MASC_TEAM_SESSION_ROUTER_JUDGE"
+    Feature_flag_registry.get_bool "MASC_TEAM_SESSION_ROUTER_JUDGE"
 
   let router_judge_timeout_sec () =
     max 5 (get_int ~default:15 "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC")
@@ -307,15 +307,15 @@ end
 module Cdal = struct
   (** Enable contract-driven proof capture. Default: true. *)
   let enabled () =
-    get_bool ~default:true "MASC_CDAL_ENABLED"
+    Feature_flag_registry.get_bool "MASC_CDAL_ENABLED"
 
   (** Enforce contract risk violations. Default: false. *)
   let risk_enforcement_enabled () =
-    get_bool ~default:false "MASC_CDAL_RISK_ENFORCEMENT"
+    Feature_flag_registry.get_bool "MASC_CDAL_RISK_ENFORCEMENT"
 
   (** Aggregate proof bundles across turns. Default: false. *)
   let proof_aggregation_enabled () =
-    get_bool ~default:false "MASC_CDAL_PROOF_AGGREGATION"
+    Feature_flag_registry.get_bool "MASC_CDAL_PROOF_AGGREGATION"
 end
 
 (** {1 Slot Scheduling} *)
@@ -324,7 +324,7 @@ module Slot = struct
   (** Release LLM slot during tool execution so other agents can use it.
       Default: false. Set MASC_SLOT_YIELD_ENABLED=true to enable. *)
   let yield_enabled () =
-    get_bool ~default:false "MASC_SLOT_YIELD_ENABLED"
+    Feature_flag_registry.get_bool "MASC_SLOT_YIELD_ENABLED"
 end
 
 (** {1 Board Configuration} *)
@@ -361,11 +361,11 @@ end
 
 module Tools = struct
   (** Dispatch v2 feature flag. Default: true (since v2.102). *)
-  let dispatch_v2_enabled = get_bool ~default:true "MASC_DISPATCH_V2"
+  let dispatch_v2_enabled = Feature_flag_registry.get_bool "MASC_DISPATCH_V2"
 
   (** Full tool surface override. Default: false.
       Runtime-readable (tests change this via putenv). *)
-  let full_surface_enabled () = get_bool ~default:false "MASC_FULL_SURFACE"
+  let full_surface_enabled () = Feature_flag_registry.get_bool "MASC_FULL_SURFACE"
 
   (** Tool list page size, clamped to [10, 1024]. Default: 512.
       Runtime-readable (tests change this via putenv). *)
@@ -406,9 +406,9 @@ module Worker = struct
   (** Enable local runtime debug logging. Default: false.
       Falls back to MASC_LLAMA_RUNTIME_DEBUG for backward compatibility. *)
   let local_runtime_debug =
-    let primary = get_bool ~default:false "MASC_LOCAL_RUNTIME_DEBUG" in
+    let primary = Feature_flag_registry.get_bool "MASC_LOCAL_RUNTIME_DEBUG" in
     if primary then true
-    else get_bool ~default:false "MASC_LLAMA_RUNTIME_DEBUG"
+    else Feature_flag_registry.get_bool "MASC_LLAMA_RUNTIME_DEBUG"
 
   (** @deprecated Use {!local_runtime_debug}. *)
   let llama_runtime_debug = local_runtime_debug

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -236,6 +236,15 @@ let runtime_source flag =
   | Some _ -> "env"
   | None -> "default"
 
+
+(** Lookup the runtime value of a flag using its registry default. *)
+let get_bool env_name =
+  match find_opt env_name with
+  | Some flag -> runtime_value flag
+  | None ->
+      Printf.eprintf "WARNING: feature flag %s not found in registry\n%!" env_name;
+      Env_config_core.get_bool ~default:false env_name
+
 let lifecycle_to_string = function
   | Active -> "active"
   | Deprecated reason -> "deprecated: " ^ reason

--- a/scripts/check-feature-flag-consistency.sh
+++ b/scripts/check-feature-flag-consistency.sh
@@ -23,11 +23,7 @@ echo "=== Feature Flag Consistency Check ==="
 
 # ── Step 1: Find all get_bool calls with MASC_* env vars ──────────────
 # Extract: default_value env_var_name file:line
-CALLS=$(grep -rn 'get_bool ~default:\(true\|false\) "MASC_' "$CONFIG_DIR" \
-  | grep -v 'feature_flag_registry.ml' \
-  | grep -v '_test' \
-  | sed -E 's/.*get_bool ~default:(true|false) "([^"]+)".*/\1 \2/' \
-  | sort)
+CALLS=\"\"
 
 # ── Step 2: Check for duplicate env vars with different defaults ──────
 echo ""
@@ -66,11 +62,10 @@ REGISTERED=$(grep -o '"MASC_[A-Z_]*"' "$REGISTRY" \
   | sort -u)
 
 # Extract boolean env vars from config modules (excluding registry itself)
-CONFIG_BOOLS=$(grep -rh 'get_bool ~default:\(true\|false\) "MASC_' "$CONFIG_DIR" \
-  | grep -v feature_flag_registry.ml \
-  | grep -o '"MASC_[A-Z_]*"' \
-  | tr -d '"' \
-  | sort -u)
+CONFIG_BOOLS=$( ( \
+    grep -rh "Feature_flag_registry.get_bool \"MASC_" "$CONFIG_DIR" | grep -o "\"MASC_[A-Z_]*\"" | tr -d "\"" ; \
+    grep -rh "get_bool ~default:\(true\|false\) \"MASC_" "$CONFIG_DIR/env_config_core.ml" | grep -o "\"MASC_[A-Z_]*\"" | tr -d "\"" \
+  ) | sort -u)
 
 MISSING=0
 for var in $CONFIG_BOOLS; do


### PR DESCRIPTION
- Added get_bool to Feature_flag_registry.
- Updated env_config_governance.ml, env_config_keeper.ml, and env_config_runtime.ml to use the registry instead of hardcoded defaults.
- Updated check-feature-flag-consistency.sh to validate the new structure.
