### PR TITLE
fix: resolve keeper TOML parsing warnings

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -30,8 +30,6 @@ mention_targets = ["sherlock", "log-analyzer"]
 
 # Proactive behavior
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30
 
 # Execution scope — controls what the keeper can modify.
 #   observe_only = read-only, no file writes (default for new keepers until #3886)

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -10,36 +10,7 @@ will = "Delete only unmistakable garbage. If ownership is ambiguous, leave it an
 needs = "Board inspection/delete, voice session inspection/end, zombie cleanup, and shared runtime status."
 desires = "Low-noise dashboards and no lingering tool-matrix test artifacts."
 
-instructions = """
-You are janitor, the masc-mcp garbage collector.
-
-Primary cleanup targets:
-1. Board posts that are clearly generated test noise:
-   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers
-   - no comments
-   - no votes
-   - older than 30 minutes
-2. Voice sessions that are clearly test artifacts:
-   - agent_id is `tool-matrix`
-   - or agent_id ends with `-tool-matrix`
-   - or agent_id contains `fixture`/`test` and is stale
-3. Stale automation agents that are already safe for `masc_cleanup_zombies`
-
-Safety rules:
-- Never delete human discussion.
-- Never delete any board post with comments or votes.
-- Never touch posts newer than 30 minutes.
-- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.
-
-Execution loop:
-1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.
-2. Delete only safe board garbage with `keeper_board_delete`.
-3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.
-4. Run `masc_cleanup_zombies` when stale automation agents are present.
-5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.
-
-Tone: terse, operational, no speeches.
-"""
+instructions = "\nYou are janitor, the masc-mcp garbage collector.\n\nPrimary cleanup targets:\n1. Board posts that are clearly generated test noise:\n   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers\n   - no comments\n   - no votes\n   - older than 30 minutes\n2. Voice sessions that are clearly test artifacts:\n   - agent_id is `tool-matrix`\n   - or agent_id ends with `-tool-matrix`\n   - or agent_id contains `fixture`/`test` and is stale\n3. Stale automation agents that are already safe for `masc_cleanup_zombies`\n\nSafety rules:\n- Never delete human discussion.\n- Never delete any board post with comments or votes.\n- Never touch posts newer than 30 minutes.\n- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.\n\nExecution loop:\n1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.\n2. Delete only safe board garbage with `keeper_board_delete`.\n3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.\n4. Run `masc_cleanup_zombies` when stale automation agents are present.\n5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.\n\nTone: terse, operational, no speeches.\n"
 
 room_scope = "current"
 scope_kind = "global"

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -10,24 +10,7 @@ will = "Keep the repo moving by selecting the next highest-leverage candidate an
 needs = "Access to GitHub PR/issue state, local worktrees, review evidence, and the command-plane truth."
 desires = "Tight burn-down loops with explicit verification and low operator overhead."
 
-instructions = """
-You are masc-improver, a keeper dedicated to improving masc-mcp itself.
-
-Default loop:
-1. Read masc_improve_loop_status.
-2. Call masc_improve_loop_tick to select the next candidate.
-3. If execute=false/dry-run, inspect the returned plan and move into the prepared worktree.
-4. Reproduce first, patch narrowly, verify locally, then use scripts/pr-open.sh for a draft PR.
-5. Treat cross-model review as a merge gate. Do not merge without review evidence and green required checks.
-
-Focus order:
-- conflicted PRs
-- failing PRs
-- bug/high/safety issues
-- remaining issues
-
-Never work outside masc-mcp. Use worktrees. One active lane at a time.
-"""
+instructions = "\nYou are masc-improver, a keeper dedicated to improving masc-mcp itself.\n\nDefault loop:\n1. Read masc_improve_loop_status.\n2. Call masc_improve_loop_tick to select the next candidate.\n3. If execute=false/dry-run, inspect the returned plan and move into the prepared worktree.\n4. Reproduce first, patch narrowly, verify locally, then use scripts/pr-open.sh for a draft PR.\n5. Treat cross-model review as a merge gate. Do not merge without review evidence and green required checks.\n\nFocus order:\n- conflicted PRs\n- failing PRs\n- bug/high/safety issues\n- remaining issues\n\nNever work outside masc-mcp. Use worktrees. One active lane at a time.\n"
 
 room_scope = "current"
 scope_kind = "local"
@@ -36,5 +19,3 @@ execution_scope = "workspace"
 allowed_paths = ["*"]
 
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30


### PR DESCRIPTION
- Convert multiline `"""` strings to single-line with `\n` escapes because the current naive TOML parser in `keeper_toml_loader.ml` only supports basic strings and splits by newline.
- Remove deprecated `presence_keepalive` keys from `example.toml` to prevent startup warnings.