### PR TITLE
fix(auth): add circuit breaker and exception trace for masc_auth_create_token

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -225,11 +225,13 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in
+       let trace = Printexc.get_backtrace () in
+       let err_detail = if String.length trace > 0 then err ^ "\n" ^ trace else err in
        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
          (false, Types.masc_error_to_string Types.NotInitialized)
        else
-         (Log.Mcp.error "tools/call crashed: %s" err;
-          false, Printf.sprintf "Internal error: %s" err)
+         (Log.Mcp.error "tools/call crashed: %s" err_detail;
+          false, Printf.sprintf "Internal error: %s" err_detail)
     in
     if !local_timeout_hit then timeout_hit := true;
     result

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -65,20 +65,28 @@ Bind Host: %s (%s)
   in
   (true, msg)
 
+let create_token_failures = Hashtbl.create 16
+
 let handle_auth_create_token ctx args =
   let target_agent = target_agent_name ctx args in
-  let role_str = get_string args "role" "worker" in
-  let role = match Types.agent_role_of_string role_str with
-    | Ok r -> r
-    | Error _ -> Types.Worker
-  in
-  match Auth.create_token ctx.config.base_path ~agent_name:target_agent ~role with
-  | Ok (raw_token, cred) ->
-      let expires = match cred.expires_at with
-        | Some exp -> exp
-        | None -> "never"
-      in
-      let msg = Printf.sprintf {|🔑 **Token Created for %s**
+  let failures = match Hashtbl.find_opt create_token_failures target_agent with Some f -> f | None -> 0 in
+  if failures >= 3 then
+    (false, Printf.sprintf "Circuit breaker open: masc_auth_create_token failed %d times for %s. Check auth directories permissions or secret key configuration." failures target_agent)
+  else
+    let role_str = get_string args "role" "worker" in
+    let role = match Types.agent_role_of_string role_str with
+      | Ok r -> r
+      | Error _ -> Types.Worker
+    in
+    try
+      match Auth.create_token ctx.config.base_path ~agent_name:target_agent ~role with
+      | Ok (raw_token, cred) ->
+          Hashtbl.replace create_token_failures target_agent 0;
+          let expires = match cred.expires_at with
+            | Some exp -> exp
+            | None -> "never"
+          in
+          let msg = Printf.sprintf {|🔑 **Token Created for %s**
 
 Token (SAVE THIS - shown only once):
 `%s`
@@ -88,9 +96,14 @@ Expires: %s
 
 Pass this token in requests to authenticate.
 |} target_agent raw_token (Types.agent_role_to_string role) expires in
-      (true, msg)
-  | Error e ->
-      (false, Types.masc_error_to_string e)
+          (true, msg)
+      | Error e ->
+          Hashtbl.replace create_token_failures target_agent (failures + 1);
+          (false, Printf.sprintf "Auth token creation failed: %s" (Types.masc_error_to_string e))
+    with exn ->
+      Hashtbl.replace create_token_failures target_agent (failures + 1);
+      let trace = Printexc.get_backtrace () in
+      (false, Printf.sprintf "Auth credential save crashed: %s\n%s" (Printexc.to_string exn) trace)
 
 let handle_auth_refresh ctx args =
   let target_agent = target_agent_name ctx args in


### PR DESCRIPTION
Fixes #5055

## Changes
- Include full backtrace in tool call failure details to aid debugging.
- Add a 3-strike circuit breaker to `masc_auth_create_token` to fail fast when repeatedly encountering systemic errors (e.g., permission issues on auth directories). This prevents infinite agent retry loops.
- Catch unexpected exceptions like `Sys_error` during credential saving.