### PR TITLE
test(ci): add TOML syntax validation and remove deprecated keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,11 @@ jobs:
           chmod +x scripts/check-feature-flag-consistency.sh
           scripts/check-feature-flag-consistency.sh
 
+      - name: Check TOML syntax
+        run: |
+          chmod +x scripts/check-toml-syntax.sh
+          scripts/check-toml-syntax.sh
+
       - name: Check MASC/OAS boundary ratchet
         run: |
           chmod +x scripts/check-boundary-guard.sh

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -36,5 +36,3 @@ execution_scope = "workspace"
 allowed_paths = ["*"]
 
 proactive_enabled = true
-presence_keepalive = true
-presence_keepalive_sec = 30

--- a/scripts/check-toml-syntax.sh
+++ b/scripts/check-toml-syntax.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "Checking TOML syntax..."
+python3 -c '
+import sys
+import glob
+
+# Try importing tomllib (Python 3.11+) or tomli (older versions)
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print("Error: Python 3.11+ (tomllib) or the tomli package is required for TOML validation.")
+        sys.exit(1)
+
+files = glob.glob("config/**/*.toml", recursive=True)
+has_error = False
+for f in files:
+    try:
+        with open(f, "rb") as file:
+            tomllib.load(file)
+    except Exception as e:
+        print(f"Syntax error in {f}: {e}")
+        has_error = True
+
+if has_error:
+    sys.exit(1)
+else:
+    print(f"All {len(files)} TOML files parsed successfully.")
+'


### PR DESCRIPTION
- Removes deprecated `presence_keepalive` keys from `masc-improver.toml`.
- Adds `scripts/check-toml-syntax.sh` to validate TOML syntax using Python.
- Integrates the syntax check into the CI lint workflow.

Resolves #5068
