### PR TITLE
perf: bypass full filesystem scan in session listing

### DIFF
--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -644,7 +644,11 @@ let list_sessions ?(since_unix = 0.0) ?(limit = 0) config : Team_session_types.s
           (if pg_recent_attempted then "pg_recent_failed"
            else "pg_recent_unavailable")
           err;
-        match backend_get_all config ~prefix:query_prefix with
+        match
+          (match config.backend with
+           | FileSystem _ -> Error (Backend_types.BackendNotSupported "force optimized filesystem scan")
+           | _ -> backend_get_all config ~prefix:query_prefix)
+        with
         | Ok rows -> Ok ("backend_get_all", rows)
         | Error err ->
             set_fallback "backend_get_all_failed" err;


### PR DESCRIPTION
- For the FileSystem backend, `backend_get_all` would scan all historical team sessions and parse JSON for each one, causing the dashboard session list to frequently time out after 5 seconds.
- Returning an explicit `BackendNotSupported` error bypasses `backend_get_all` and forces execution of the `filesystem_scan` fallback block which contains an optimized check filtering by `mtime` and partial buffer reads, ensuring queries remain fast.