### PR TITLE
refactor(boundary): deduplicate sampling params, proof_status, estimate_tokens

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -77,9 +77,7 @@ let make_config
 
 (** {1 Token Estimation} *)
 
-(** CJK-aware token estimate delegated to OAS Context_reducer. *)
-let estimate_tokens (s : string) : int =
-  if s = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens s
+let estimate_tokens = Inference_utils.estimate_tokens
 
 (** {1 Source Fetchers} *)
 

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -27,6 +27,10 @@ let int_of_env_default name ~default ~min_v ~max_v =
 (** Compute total tokens from OAS api_usage. *)
 let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens
 
+(** CJK-aware token estimate delegated to OAS Context_reducer. *)
+let estimate_tokens (s : string) : int =
+  if s = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens s
+
 (** Zero usage marker — delegates to OAS Types.zero_api_usage.
     @since 2.123.0 — delegated to OAS *)
 let zero_usage : Agent_sdk.Types.api_usage =

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -11,6 +11,9 @@ val int_of_env_default : string -> default:int -> min_v:int -> max_v:int -> int
 (** Compute total tokens from OAS api_usage. *)
 val total_tokens : Agent_sdk.Types.api_usage -> int
 
+(** CJK-aware token estimate delegated to OAS Context_reducer. *)
+val estimate_tokens : string -> int
+
 (** Zero usage marker. *)
 val zero_usage : Agent_sdk.Types.api_usage
 

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -487,10 +487,10 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       system_prompt = Some system_prompt;
       max_tokens = local_worker_max_tokens ();
       max_turns;
-      temperature = Some 0.2;
-      top_p = Some 0.95;
-      top_k = Some 20;
-      min_p = Some 0.0;
+      temperature = Some Oas_worker_cascade.worker_temperature;
+      top_p = Some Oas_worker_cascade.worker_top_p;
+      top_k = Some Oas_worker_cascade.worker_top_k;
+      min_p = Some Oas_worker_cascade.worker_min_p;
       enable_thinking = Some thinking_enabled;
       tool_choice = Some Oas.Types.Auto;
     }
@@ -501,7 +501,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     | None ->
         { Oas.Guardrails.tool_filter =
             Oas.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some 12;
+          max_tool_calls_per_turn = Some Oas_worker_cascade.worker_max_tool_calls_per_turn;
         }
   in
   let options =

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -18,6 +18,13 @@ let default_temperature =
 let default_max_tokens =
   Llm_provider.Constants.Inference_profile.agent_default.max_tokens
 
+(** Worker defaults — SSOT for worker_oas.ml + worker_container.ml. *)
+let worker_temperature = 0.2
+let worker_top_p = 0.95
+let worker_top_k = 20
+let worker_min_p = 0.0
+let worker_max_tool_calls_per_turn = 12
+
 (* ================================================================ *)
 (* Cascade types                                                     *)
 (* ================================================================ *)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -362,17 +362,8 @@ let preview_text_opt text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some (preview_text trimmed)
 
-let lowercase_enum_case_name raw =
-  let raw =
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-        String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw
-  in
-  String.lowercase_ascii raw
-
-let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+let proof_result_status_to_string =
+  Oas_worker_exec.proof_result_status_to_string
 
 let worker_name_of_planned_worker ~(fallback : string)
     (pw : Team_session_types.planned_worker) =

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,17 +33,8 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
-let lowercase_enum_case_name raw =
-  let raw =
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-        String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw
-  in
-  String.lowercase_ascii raw
-
-let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+let proof_result_status_to_string =
+  Oas_worker_exec.proof_result_status_to_string
 
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -38,17 +38,8 @@ let max_turns_cap_of_scope (scope : Team_session_types.execution_scope) : int =
   | Limited_code_change -> 20
   | Autonomous -> 30
 
-let lowercase_enum_case_name raw =
-  let raw =
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-        String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw
-  in
-  String.lowercase_ascii raw
-
-let proof_result_status_to_string status =
-  Oas.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+let proof_result_status_to_string =
+  Oas_worker_exec.proof_result_status_to_string
 
 (** Derive max_turns from worker meta, applying the scope cap.
     When max_turns_override is set, it is clamped to [1, cap].
@@ -78,10 +69,10 @@ let agent_config_of_worker_meta
     system_prompt = Some system_prompt;
     max_tokens;
     max_turns = effective_max_turns meta;
-    temperature = Some 0.2;
-    top_p = Some 0.95;
-    top_k = Some 20;
-    min_p = Some 0.0;
+    temperature = Some Oas_worker_cascade.worker_temperature;
+    top_p = Some Oas_worker_cascade.worker_top_p;
+    top_k = Some Oas_worker_cascade.worker_top_k;
+    min_p = Some Oas_worker_cascade.worker_min_p;
     enable_thinking = Some (Option.value ~default:false meta.thinking_enabled);
     tool_choice = Some Oas.Types.Auto;
   }
@@ -255,7 +246,7 @@ let build_agent
     | None ->
         {
           Oas.Guardrails.tool_filter = AllowList tool_names;
-          max_tool_calls_per_turn = Some 12;
+          max_tool_calls_per_turn = Some Oas_worker_cascade.worker_max_tool_calls_per_turn;
         }
   in
   let builder =
@@ -264,10 +255,10 @@ let build_agent
     |> Oas.Builder.with_system_prompt system_prompt
     |> Oas.Builder.with_max_tokens config.max_tokens
     |> Oas.Builder.with_max_turns config.max_turns
-    |> Oas.Builder.with_temperature 0.2
-    |> Oas.Builder.with_top_p 0.95
-    |> Oas.Builder.with_top_k 20
-    |> Oas.Builder.with_min_p 0.0
+    |> Oas.Builder.with_temperature Oas_worker_cascade.worker_temperature
+    |> Oas.Builder.with_top_p Oas_worker_cascade.worker_top_p
+    |> Oas.Builder.with_top_k Oas_worker_cascade.worker_top_k
+    |> Oas.Builder.with_min_p Oas_worker_cascade.worker_min_p
     |> Oas.Builder.with_enable_thinking
          (Option.value ~default:false meta.thinking_enabled)
     |> Oas.Builder.with_tool_choice Oas.Types.Auto


### PR DESCRIPTION
## Summary
Phase 2 of #5141 (OAS boundary cleanup):

1. **Sampling params SSOT**: temperature/top_p/top_k/min_p 3곳 하드코딩 → `Oas_worker_cascade.worker_*`
2. **max_tool_calls_per_turn**: 2곳 `12` → SSOT 상수
3. **proof_result_status_to_string**: 4파일 10줄씩 복붙 → `Oas_worker_exec` 참조
4. **estimate_tokens**: `auto_recall.ml` 중복 → `Inference_utils` 참조

## Changes
8 files, +35/-50 (net -15 lines). No behavioral change.

## Test plan
- [x] `dune build` 확인
- [ ] 기존 테스트 통과

Refs #5141