### PR TITLE
feat(boundary): Gate A instrumentation wiring — 4 heuristic decision sites

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -48,7 +48,8 @@ let event_to_json (e : event) : Yojson.Safe.t =
 (* ================================================================ *)
 
 let store_path_ref : string option ref = ref None
-let mu = Eio.Mutex.create ()
+(* Stdlib.Mutex: record is non-yielding, callers may run outside Eio context *)
+let mu = Stdlib.Mutex.create ()
 let buffer : Yojson.Safe.t Queue.t = Queue.create ()
 let buffer_cap = 64
 
@@ -79,7 +80,7 @@ let do_flush () =
     end
 
 let init ~base_path =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     match !store_path_ref with
     | Some _ -> ()
     | None ->
@@ -88,14 +89,14 @@ let init ~base_path =
       store_path_ref := Some path)
 
 let record (e : event) =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     let json = event_to_json e in
     Queue.add json buffer;
     if Queue.length buffer >= buffer_cap then
       (try do_flush () with Exit -> ()))
 
 let flush () =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     try do_flush () with Exit -> ())
 
 let recent n =

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -206,6 +206,14 @@ let text_similarity original received =
 let verify_handoff ~original ~received ?threshold () =
   let threshold = Option.value threshold ~default:(default_threshold ()) in
   let summary, tokens_a, tokens_b = summarize ~original ~received ~threshold in
+  (* RFC-0001 Gate A: record drift guard observation *)
+  Heuristic_metrics.record {
+    module_name = "drift_guard"; site = "verify_handoff";
+    raw_value = summary.similarity; threshold;
+    triggered = summary.similarity < threshold;
+    provenance = Drift_guard "handoff";
+    timestamp = Unix.gettimeofday ();
+  };
   if summary.similarity >= threshold then Verified summary
   else
     let drift_type =

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -56,7 +56,9 @@ let event_to_json (e : event) : Yojson.Safe.t =
 (** File path for the JSONL output. *)
 let store_path_ref : string option ref = ref None
 
-let mu = Eio.Mutex.create ()
+(* Stdlib.Mutex: record is non-yielding (Queue.add + file I/O),
+   and callers may run outside Eio context (e.g., tests). *)
+let mu = Stdlib.Mutex.create ()
 
 (** In-memory buffer to batch writes.  Flushed periodically or on [flush]. *)
 let buffer : Yojson.Safe.t Queue.t = Queue.create ()
@@ -89,7 +91,7 @@ let do_flush () =
     end
 
 let init ~base_path =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     match !store_path_ref with
     | Some _ -> ()  (* idempotent *)
     | None ->
@@ -98,14 +100,14 @@ let init ~base_path =
       store_path_ref := Some path)
 
 let record (e : event) =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     let json = event_to_json e in
     Queue.add json buffer;
     if Queue.length buffer >= buffer_cap then
       (try do_flush () with Exit -> ()))
 
 let flush () =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  Stdlib.Mutex.protect mu (fun () ->
     try do_flush () with Exit -> ())
 
 let recent n =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -386,6 +386,13 @@ let sync_keeper_presence
       if synced.joined_room_ids = []
       then (
         incr consecutive_failures;
+        (* RFC-0001 Gate A: record failure streak *)
+        Agent_stress.record {
+          agent_name = meta_current.name;
+          room_id = (match meta_current.joined_room_ids with r :: _ -> r | [] -> "");
+          kind = Failure_streak !consecutive_failures;
+          timestamp = Unix.gettimeofday ();
+        };
         Log.Keeper.warn
           "room presence returned empty rooms (%d/%d)"
           !consecutive_failures

--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -209,7 +209,18 @@ let verify ~content =
     | (_, _, Warn r) -> Warn (Printf.sprintf "safety: %s" r)
     | (Pass, Pass, Pass) -> Pass
   in
-  { relevance; quality; safety; overall }
+  let result = { relevance; quality; safety; overall } in
+  (* RFC-0001 Gate A: record per-dimension heuristic observations *)
+  let verdict_score = function Pass -> 1.0 | Warn _ -> 0.5 | Fail _ -> 0.0 in
+  List.iter (fun (dim, v) ->
+    Heuristic_metrics.record {
+      module_name = "post_verifier"; site = "verify";
+      raw_value = verdict_score v; threshold = 0.5;
+      triggered = (match v with Fail _ -> true | _ -> false);
+      provenance = Post_verifier (match dim with Relevance -> "relevance" | Quality -> "quality" | Safety -> "safety");
+      timestamp = Unix.gettimeofday ();
+    }) [(Relevance, relevance); (Quality, quality); (Safety, safety)];
+  result
 
 (** Check if content passes verification (Pass or Warn). *)
 let is_acceptable result =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -63,6 +63,9 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     end
   in
   Unix.putenv "MASC_BASE_PATH" base_path;
+  (* RFC-0001 Gate A: initialize instrumentation stores *)
+  Heuristic_metrics.init ~base_path;
+  Agent_stress.init ~base_path;
   let state =
     Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock
       ~mono_clock ~net

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -406,6 +406,14 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
         let s = get_stats name in
         let ticks = ticks_since_selection ~stats:s ~tick_interval_s in
         let signal = starvation_bonus ~ticks in
+        (* RFC-0001 Gate A: record thompson selection observation *)
+        Heuristic_metrics.record {
+          module_name = "thompson_sampling"; site = "priority_trigger";
+          raw_value = signal; threshold = 0.0;
+          triggered = true;
+          provenance = Thompson "starvation_bonus";
+          timestamp = Unix.gettimeofday ();
+        };
         add_selected {
           agent_name = name;
           trigger;


### PR DESCRIPTION
## Summary
RFC-0001 Gate A 모듈(#5110)을 실제 결정 사이트에 연결.

### Heuristic_metrics 배선 (3 sites)
- `post_verifier.verify`: relevance/quality/safety 각 dimension verdict 기록
- `thompson_sampling`: starvation_bonus 계산 시 signal 값 기록
- `drift_guard.verify_handoff`: similarity vs threshold 비교 기록

### Agent_stress 배선 (1 site)
- `keeper_keepalive`: heartbeat failure streak 기록

### 초기화
- `server_runtime_bootstrap`: 서버 시작 시 JSONL store init

### Skipped (follow-up)
- `room_task_schedule`: 별도 `masc_room` 라이브러리 — 순환 의존 방지를 위해 callback 패턴 필요

## Test plan
- [x] `dune build` 통과
- [ ] CI green
- [ ] keeper 시작 후 `.masc/heuristic_metrics.jsonl` 생성 확인

Part of RFC-0001 Gate A (#4825)

🤖 Generated with [Claude Code](https://claude.com/claude-code)