### PR TITLE
refactor(boundary): extract hardcoded GLM URL to SSOT

### DIFF
--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -150,7 +150,7 @@ let endpoint_url_for_provider provider =
   | "llama" -> Some Env_config_runtime.Llama.server_url
   | "claude-api" -> Some "https://api.anthropic.com"
   | "codex-api" -> Some "https://api.openai.com"
-  | "glm" -> Some "https://api.z.ai"
+  | "glm" -> Some Oas_worker_cascade.glm_base_url_root
   | "gemini-api" -> (
       match Provider_adapter.resolve_gemini_direct_auth () with
       | Provider_adapter.Gemini_vertex_adc { project; location } ->

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -415,7 +415,7 @@ let oas_provider_of_label (label : string) : Oas.Provider.config =
       (Llm_provider.Provider_config.make
          ~kind:Llm_provider.Provider_config.Glm
          ~model_id:label
-         ~base_url:"https://api.z.ai/api/coding/paas/v4"
+         ~base_url:Oas_worker_cascade.glm_base_url
          ~request_path:"/chat/completions" ())
 
 (** Resolve provider from a model label string.

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -25,6 +25,10 @@ let worker_top_k = 20
 let worker_min_p = 0.0
 let worker_max_tool_calls_per_turn = 12
 
+(** GLM provider base URL — SSOT for fallback provider construction. *)
+let glm_base_url = "https://api.z.ai/api/coding/paas/v4"
+let glm_base_url_root = "https://api.z.ai"
+
 (* ================================================================ *)
 (* Cascade types                                                     *)
 (* ================================================================ *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -163,7 +163,7 @@ let run_named
       Llm_provider.Provider_config.make
         ~kind:Llm_provider.Provider_config.Glm
         ~model_id:"auto"
-        ~base_url:"https://api.z.ai/api/coding/paas/v4"
+        ~base_url:Oas_worker_cascade.glm_base_url
         ~request_path:"/chat/completions"
         ()
   in


### PR DESCRIPTION
## Summary
- GLM base URL 3곳 하드코딩 → `Oas_worker_cascade.glm_base_url` / `glm_base_url_root`
- 4 files, +7/-3

## Test plan
- [x] `dune build` 확인

Closes #5184. Refs #5141.