### PR TITLE
fix: improve entropy detection logging with secret-safe args preview

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -180,8 +180,13 @@ let create_token config ~agent_name ~role : (string * agent_credential, masc_err
     created_at = now;
     expires_at;
   } in
-  save_credential config cred;
-  Ok (raw_token, cred)  (* Return raw token to user, store hash *)
+  (try
+     save_credential config cred;
+     Ok (raw_token, cred)  (* Return raw token to user, store hash *)
+   with exn ->
+     let msg = Printf.sprintf "Failed to save agent credential: %s" (Printexc.to_string exn) in
+     Log.Auth.error "%s" msg;
+     Error (IoError msg))
 
 (** Verify a token *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -238,13 +238,24 @@ let pre_check
             ~args_json acc tool_name in
           begin match entropy with
           | Some (_name, count) ->
-              let args_preview =
-                if String.length args_json > 120 then String.sub args_json 0 120 ^ "..."
-                else args_json
+              let args_preview_opt =
+                try
+                  let json = Yojson.Safe.from_string args_json in
+                  Observability_redact.redact_tool_input ~tool_name json
+                with Yojson.Json_error _ ->
+                  Some (Observability_redact.redact_preview args_json)
               in
-              Trajectory.Reject (Printf.sprintf
-                "entropy detected: '%s' called %d consecutive times with args=%s (threshold: %d)"
-                tool_name count args_preview config.entropy_threshold)
+              let reason = match args_preview_opt with
+                | None ->
+                    Printf.sprintf
+                      "entropy detected: '%s' called %d consecutive times (threshold: %d)"
+                      tool_name count config.entropy_threshold
+                | Some args_preview ->
+                    Printf.sprintf
+                      "entropy detected: '%s' called %d consecutive times with args=%s (threshold: %d)"
+                      tool_name count args_preview config.entropy_threshold
+              in
+              Trajectory.Reject reason
           | None ->
               (* 6. Destructive pattern check (bash tools only) *)
               if config.destructive_check_enabled

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -234,12 +234,17 @@ let pre_check
             calls_this_turn config.max_tool_calls_per_turn)
         else
           (* 5. Entropy detection *)
-          let entropy = Trajectory.detect_entropy ~threshold:config.entropy_threshold acc tool_name in
+          let entropy = Trajectory.detect_entropy ~threshold:config.entropy_threshold
+            ~args_json acc tool_name in
           begin match entropy with
           | Some (_name, count) ->
+              let args_preview =
+                if String.length args_json > 120 then String.sub args_json 0 120 ^ "..."
+                else args_json
+              in
               Trajectory.Reject (Printf.sprintf
-                "entropy detected: '%s' called %d consecutive times (threshold: %d)"
-                tool_name count config.entropy_threshold)
+                "entropy detected: '%s' called %d consecutive times with args=%s (threshold: %d)"
+                tool_name count args_preview config.entropy_threshold)
           | None ->
               (* 6. Destructive pattern check (bash tools only) *)
               if config.destructive_check_enabled

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -615,6 +615,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           Mcp_server_eio_execute.execute_tool_eio ~sw ~clock state
             ~name:tool_name ~arguments
         in
+        if not success then
+          Log.Server.error "gRPC tool call failed: %s — %s" tool_name result_str;
         if success then Ok result_str else Error result_str
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -616,7 +616,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             ~name:tool_name ~arguments
         in
         if not success then
-          Log.Server.error "gRPC tool call failed: %s — %s" tool_name result_str;
+          Log.Server.error "gRPC tool call failed: tool=%s error_bytes=%d"
+            tool_name (String.length result_str);
         if success then Ok result_str else Error result_str
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -78,6 +78,8 @@ let handle_auth_create_token ctx args =
       | Ok r -> r
       | Error _ -> Types.Worker
     in
+    Log.Auth.info "Creating token for agent '%s' with role '%s' (requested by '%s')"
+      target_agent (Types.agent_role_to_string role) ctx.agent_name;
     try
       match Auth.create_token ctx.config.base_path ~agent_name:target_agent ~role with
       | Ok (raw_token, cred) ->
@@ -86,6 +88,7 @@ let handle_auth_create_token ctx args =
             | Some exp -> exp
             | None -> "never"
           in
+          Log.Auth.info "Token created successfully for agent '%s'" target_agent;
           let msg = Printf.sprintf {|🔑 **Token Created for %s**
 
 Token (SAVE THIS - shown only once):
@@ -99,10 +102,13 @@ Pass this token in requests to authenticate.
           (true, msg)
       | Error e ->
           Hashtbl.replace create_token_failures target_agent (failures + 1);
-          (false, Printf.sprintf "Auth token creation failed: %s" (Types.masc_error_to_string e))
+          let err_msg = Types.masc_error_to_string e in
+          Log.Auth.error "Token creation failed for agent '%s': %s" target_agent err_msg;
+          (false, Printf.sprintf "Auth token creation failed: %s" err_msg)
     with exn ->
       Hashtbl.replace create_token_failures target_agent (failures + 1);
       let trace = Printexc.get_backtrace () in
+      Log.Auth.error "Token creation crashed for agent '%s': %s" target_agent (Printexc.to_string exn);
       (false, Printf.sprintf "Auth credential save crashed: %s\n%s" (Printexc.to_string exn) trace)
 
 let handle_auth_refresh ctx args =

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -263,8 +263,13 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
 (* Entropy detection                                                *)
 (* ================================================================ *)
 
-(** Detect repeated tool calls: if the same tool is called N+ times
-    consecutively, return Some(tool_name, count). *)
+(** Detect whether the current candidate call would make a consecutive streak of
+    calls to [tool_name] reach or exceed [threshold]. The count includes the
+    candidate call being checked, so rejection can occur before executing the
+    threshold-th call.
+    If [args_json] is provided, only consecutive calls with the same tool name
+    and the same raw [args_json] string are counted; this is string equality,
+    not semantic JSON equality. *)
 let detect_entropy ?(threshold = 3) ?args_json (acc : accumulator) (tool_name : string) : (string * int) option =
   let recent =
     acc.entries

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -265,11 +265,15 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
 
 (** Detect repeated tool calls: if the same tool is called N+ times
     consecutively, return Some(tool_name, count). *)
-let detect_entropy ?(threshold = 3) (acc : accumulator) (tool_name : string) : (string * int) option =
+let detect_entropy ?(threshold = 3) ?args_json (acc : accumulator) (tool_name : string) : (string * int) option =
   let recent =
     acc.entries
     |> List.to_seq
-    |> Seq.take_while (fun e -> e.tool_name = tool_name)
+    |> Seq.take_while (fun e ->
+         e.tool_name = tool_name &&
+         match args_json with
+         | Some args -> e.args_json = args
+         | None -> true)
     |> List.of_seq
   in
   let count = List.length recent + 1 in  (* +1 for the upcoming call *)

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -104,7 +104,8 @@ val record_entry : accumulator -> tool_call_entry -> unit
 val finalize : accumulator -> trajectory_outcome -> trajectory
 
 val detect_entropy :
-  ?threshold:int -> accumulator -> string -> (string * int) option
-(** Detect if [tool_name] has been called [threshold]+ times consecutively. *)
+  ?threshold:int -> ?args_json:string -> accumulator -> string -> (string * int) option
+(** Detect if [tool_name] has been called [threshold]+ times consecutively.
+    If [args_json] is provided, only consecutive IDENTICAL calls (same tool and same args) are counted. *)
 
 val calls_in_current_turn : accumulator -> int

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -157,22 +157,23 @@ let test_pre_entropy () =
   with_tmpdir (fun dir ->
     let acc = make_acc dir in
     Trajectory.increment_turn acc;
-    let mk tool = { Trajectory.
+    let repeated_args = "{\"command\": \"echo hi\"}" in
+    let mk tool args = { Trajectory.
       ts = 1000.0; ts_iso = ""; turn = acc.Trajectory.turn; round = 0;
-      tool_name = tool; args_json = "{}";
+      tool_name = tool; args_json = args;
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
     } in
-    (* Add 3 consecutive same-tool calls *)
-    Trajectory.record_entry acc (mk "keeper_bash");
-    Trajectory.record_entry acc (mk "keeper_bash");
-    Trajectory.record_entry acc (mk "keeper_bash");
+    (* Add 3 consecutive same-tool calls with same args *)
+    Trajectory.record_entry acc (mk "keeper_bash" repeated_args);
+    Trajectory.record_entry acc (mk "keeper_bash" repeated_args);
+    Trajectory.record_entry acc (mk "keeper_bash" repeated_args);
     let decision = Eval_gate.pre_check
       ~config:default_config ~accumulated_cost:0.0
       ~trajectory_acc:(Some acc)
       ~tool_name:"keeper_bash"
-      ~args_json:"{\"command\": \"echo hi\"}" in
+      ~args_json:repeated_args in
     match decision with
     | Trajectory.Reject reason ->
         Alcotest.(check bool) "entropy reason" true
@@ -180,6 +181,34 @@ let test_pre_entropy () =
            try ignore (Str.search_forward (Str.regexp_string "entropy") r 0); true
            with Not_found -> false)
     | Trajectory.Pass -> Alcotest.fail "Should reject due to entropy")
+
+(* ================================================================ *)
+(* Test: pre_check — entropy does NOT trigger with different args    *)
+(* ================================================================ *)
+
+let test_pre_entropy_different_args () =
+  with_tmpdir (fun dir ->
+    let acc = make_acc dir in
+    Trajectory.increment_turn acc;
+    let mk tool args = { Trajectory.
+      ts = 1000.0; ts_iso = ""; turn = acc.Trajectory.turn; round = 0;
+      tool_name = tool; args_json = args;
+      gate_decision = Trajectory.Pass;
+      result = Some "ok"; duration_ms = 10;
+      error = None; cost_usd = 0.0001;
+    } in
+    (* Add 3 consecutive same-tool calls but with different args *)
+    Trajectory.record_entry acc (mk "keeper_bash" "{\"command\": \"echo a\"}");
+    Trajectory.record_entry acc (mk "keeper_bash" "{\"command\": \"echo b\"}");
+    Trajectory.record_entry acc (mk "keeper_bash" "{\"command\": \"echo c\"}");
+    let decision = Eval_gate.pre_check
+      ~config:default_config ~accumulated_cost:0.0
+      ~trajectory_acc:(Some acc)
+      ~tool_name:"keeper_bash"
+      ~args_json:"{\"command\": \"echo d\"}" in
+    match decision with
+    | Trajectory.Reject _ -> Alcotest.fail "Should NOT reject: different args do not form an entropy streak"
+    | Trajectory.Pass -> ())
 
 (* ================================================================ *)
 (* Test: pre_check — turn call limit                                 *)
@@ -358,6 +387,7 @@ let () =
       Alcotest.test_case "destructive bash" `Quick test_pre_destructive_bash;
       Alcotest.test_case "safe bash" `Quick test_pre_safe_bash;
       Alcotest.test_case "entropy" `Quick test_pre_entropy;
+      Alcotest.test_case "entropy different args" `Quick test_pre_entropy_different_args;
       Alcotest.test_case "turn limit" `Quick test_pre_turn_limit;
     ]);
     ("post_eval", [


### PR DESCRIPTION
## Summary

Extends the tool-call entropy gate to consider tool arguments when detecting repeated-call loops, and ensures rejection reasons and server logs never leak secrets.

- Added args-aware consecutive-call counting to `Trajectory.detect_entropy` via an optional `~args_json` parameter (raw string equality).
- Updated `detect_entropy` doc comment to accurately reflect that the count includes the pending call (so rejection can occur before executing the threshold-th call) and that `args_json` matching is raw string equality, not semantic JSON equality.
- Entropy rejection reason in `Eval_gate.pre_check` now generates the args preview via `Observability_redact.redact_tool_input ~tool_name` (parses JSON, redacts sensitive keys, strips long token patterns); falls back to `Observability_redact.redact_preview` for malformed JSON; omits args entirely for denied/sensitive tools (when redaction returns `None`), preventing secret leakage.
- Fixed gRPC tool call failure logging in `server_runtime_bootstrap.ml` to emit structured fields (`tool=%s error_bytes=%d`) instead of the full `result_str`, preventing sensitive error payloads from appearing in server logs.
- Fixed `test_pre_entropy` to use matching `args_json` across stored entries and the `pre_check` call.
- Added `test_pre_entropy_different_args` to verify that the same tool called with varying args does **not** trigger entropy rejection.

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Entropy rejection reasons in keeper logs now include a redacted args preview instead of raw JSON, preventing credential/token leakage while still surfacing the repeated-call pattern for diagnostics. gRPC tool call failure logs no longer expose sensitive result payloads.

## Evidence

- `test_pre_entropy` — identical tool+args streak triggers entropy rejection with "entropy" in the reason.
- `test_pre_entropy_different_args` — same tool with varying args passes without rejection.

## Review evidence

Reviewed by `copilot-pull-request-reviewer`. Security feedback on raw-args logging, gRPC error logging, doc comment accuracy, and test coverage all addressed.

## Linked issue