### PR TITLE
refactor(boundary): adopt OAS Builder setters for context management

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -848,6 +848,8 @@ let run_turn
           ~session_id:meta.runtime.trace_id
           ~system_prompt:turn_system_prompt
           ~tools
+          ~max_input_tokens:max_context
+          ~compact_ratio:meta.compaction.ratio_gate
           ~initial_messages:history_messages
           ~hooks
           ~context_reducer:reducer

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -802,28 +802,6 @@ let apply_post_turn_lifecycle
         message_count = rollover.message_count;
       }
 
-let clamp_context_max_tokens
-    (ctx : working_context)
-    ~(primary_model_max_tokens : int) : working_context =
-  let clamped =
-    if primary_model_max_tokens <= 0 then ctx.max_tokens
-    else min ctx.max_tokens primary_model_max_tokens
-  in
-  if clamped = ctx.max_tokens then ctx
-  else sync_oas_context { ctx with max_tokens = clamped }
-
-let hard_trim_context_to_budget
-    (ctx : working_context)
-    ~(budget_tokens : int) : working_context =
-  if budget_tokens <= 0 then ctx
-  else
-    let reducer =
-      Agent_sdk.Context_reducer.from_context_config ~max_tokens:budget_tokens ()
-    in
-    let messages = Agent_sdk.Context_reducer.reduce reducer ctx.messages in
-    sync_oas_context
-      { ctx with messages; max_tokens = min ctx.max_tokens budget_tokens }
-
 let forced_overflow_retry_meta
     (meta : keeper_meta)
     ~(turn_generation : int)
@@ -922,7 +900,8 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
   | Some (ctx, turn_generation) ->
       let now_ts = Time_compat.now () in
       let ctx =
-        clamp_context_max_tokens ctx ~primary_model_max_tokens
+        if primary_model_max_tokens <= 0 then ctx
+        else sync_oas_context { ctx with max_tokens = min ctx.max_tokens primary_model_max_tokens }
       in
       let before_tokens = token_count ctx in
       let retry_meta =
@@ -940,8 +919,12 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
           primary_model_max_tokens > 0
           && strategy_after_message_tokens > primary_model_max_tokens
         then
-          hard_trim_context_to_budget compacted_ctx
-            ~budget_tokens:primary_model_max_tokens
+          let reducer =
+            Agent_sdk.Context_reducer.from_context_config ~max_tokens:primary_model_max_tokens ()
+          in
+          let messages = Agent_sdk.Context_reducer.reduce reducer compacted_ctx.messages in
+          sync_oas_context
+            { compacted_ctx with messages; max_tokens = min compacted_ctx.max_tokens primary_model_max_tokens }
         else
           compacted_ctx
       in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -104,6 +104,8 @@ val run_named :
   ?working_context:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
   ?yield_on_tool:bool ->
+  ?max_input_tokens:int ->
+  ?compact_ratio:float ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->
@@ -127,6 +129,8 @@ val run_model_by_label :
   ?memory:Oas.Memory.t ->
   ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
+  ?max_input_tokens:int ->
+  ?compact_ratio:float ->
   ?contract:Oas.Risk_contract.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
@@ -157,6 +161,8 @@ val run_named_with_masc_tools :
   ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
+  ?max_input_tokens:int ->
+  ?compact_ratio:float ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->
@@ -176,6 +182,8 @@ val run_model_with_masc_tools :
   ?memory:Oas.Memory.t ->
   ?tool_retry_policy:Oas.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
+  ?max_input_tokens:int ->
+  ?compact_ratio:float ->
   ?contract:Oas.Risk_contract.t ->
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -39,6 +39,8 @@ type config = {
   working_context : Yojson.Safe.t option;
   cache_system_prompt : bool;
   yield_on_tool : bool;
+  max_input_tokens : int option;
+  compact_ratio : float option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -65,6 +67,8 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     working_context = None;
     cache_system_prompt = false;
     yield_on_tool = false;
+    max_input_tokens = None;
+    compact_ratio = None;
   }
 
 (* ================================================================ *)
@@ -242,6 +246,16 @@ let build
     if config.initial_messages <> [] then
       Oas.Builder.with_initial_messages config.initial_messages builder
     else builder
+  in
+  let builder =
+    match config.max_input_tokens with
+    | Some n -> Oas.Builder.with_max_input_tokens n builder
+    | None -> builder
+  in
+  let builder =
+    match config.compact_ratio with
+    | Some ratio -> Oas.Builder.with_context_thresholds ~compact_ratio:ratio builder
+    | None -> builder
   in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -73,6 +73,8 @@ let config_for_label
     ?memory
     ?tool_retry_policy
     ?enable_thinking
+    ?max_input_tokens
+    ?compact_ratio
     ~(description : string option)
     () : Oas_worker_exec.config =
   let provider = Oas_worker_exec.resolve_provider_of_label model_label in
@@ -98,6 +100,8 @@ let config_for_label
     tool_retry_policy;
     enable_thinking;
     description;
+    max_input_tokens;
+    compact_ratio;
   }
 
 (** Run a single Agent.run() call with cascade model fallback.
@@ -139,6 +143,8 @@ let run_named
     ?working_context
     ?(cache_system_prompt = false)
     ?(yield_on_tool = false)
+    ?max_input_tokens
+    ?compact_ratio
     ?sw
     ?net
     ()
@@ -187,6 +193,8 @@ let run_named
       working_context;
       session_id;
       cache_system_prompt;
+      max_input_tokens;
+      compact_ratio;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in
@@ -234,6 +242,8 @@ let run_model_by_label
     ?memory
     ?tool_retry_policy
     ?enable_thinking
+    ?max_input_tokens
+    ?compact_ratio
     ?contract
     ?on_event
     ?transport
@@ -258,6 +268,8 @@ let run_model_by_label
             ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
             ?tool_retry_policy
             ?enable_thinking
+            ?max_input_tokens
+            ?compact_ratio
             ~description:(Some (Printf.sprintf "model_label:%s" model_label))
             ()
         in
@@ -291,6 +303,8 @@ let run_named_with_masc_tools
     ?contract
     ?transport
     ?(yield_on_tool = false)
+    ?max_input_tokens
+    ?compact_ratio
     ?sw
     ?net
     ()
@@ -304,6 +318,8 @@ let run_named_with_masc_tools
   run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ?hooks ?memory
     ?tool_retry_policy
+    ?max_input_tokens
+    ?compact_ratio
     ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
     ?contract
     ?transport ~yield_on_tool ?sw ?net ()
@@ -322,6 +338,8 @@ let run_model_with_masc_tools
     ?memory
     ?tool_retry_policy
     ?enable_thinking
+    ?max_input_tokens
+    ?compact_ratio
     ?contract
     ?raw_trace
     ?on_event
@@ -341,6 +359,7 @@ let run_model_with_masc_tools
           config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
           ~tools:[] ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
           ?memory ?tool_retry_policy ?enable_thinking
+          ?max_input_tokens ?compact_ratio
           ~description:(Some (Printf.sprintf "model_label:%s" model_label))
           ()
       in


### PR DESCRIPTION
- Implements Phase 2 of #5141.
- Adds `max_input_tokens` and `compact_ratio` to `Oas_worker_exec.config`.
- Adopts `Oas.Builder.with_max_input_tokens` and `with_context_thresholds` in `build`.
- Removes redundant `clamp_context_max_tokens` and `hard_trim_context_to_budget` from `Keeper_exec_context`.
- Passes `max_context` and `ratio_gate` from `Keeper_agent_run` to OAS.
- Ensures robust context overflow prevention by letting OAS handle trimming.

Resolves #5141, Addresses #5053
