### PR TITLE
fix(keeper): warn when discovered LLM context is below 16K

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -85,6 +85,12 @@ let max_context_of_label (label : string) : int =
     "Available" means the provider's API key env var is set (or not required).
     Prefers discovered per-slot context for local providers.
     Falls back to 128_000 if no model is available. *)
+(** Minimum context below which a warning is emitted.
+    8K is the llama-server default, but most keeper conversations
+    need 32K+. If discovered < this, the operator should increase
+    the llama-server -c flag. *)
+let context_warning_threshold = 16_000
+
 let resolve_primary_max_context (labels : string list) : int =
   (* Check discovered context first — applies to any local provider *)
   let discovered = Llm_provider.Provider_registry.discovered_max_context () in
@@ -98,9 +104,14 @@ let resolve_primary_max_context (labels : string list) : int =
         | None -> find rest
         | Some entry ->
           if entry.is_available () then
-            (* For local providers, prefer discovered context *)
             if Provider_adapter.requires_discovery pname then
-              Option.value ~default:entry.max_context discovered
+              let ctx = Option.value ~default:entry.max_context discovered in
+              (if ctx < context_warning_threshold then
+                 Log.warn ~ctx:"OasModelResolve"
+                   "discovered context %d < %d for %s — keeper turns will likely overflow. \
+                    Increase llama-server -c flag (model supports up to %d)."
+                   ctx context_warning_threshold pname entry.max_context);
+              ctx
             else entry.max_context
           else find rest
   in


### PR DESCRIPTION
## Summary

Partial fix for #5053.

- `resolve_primary_max_context`에서 discovered context가 16K 미만일 때 WARN 로그 추가
- llama-server의 기본 `-c 8192`로 인한 keeper context overflow를 사전 진단
- 모델의 실제 지원 context 크기를 함께 출력하여 운영자가 설정 수정 가능

## Root Cause

llama-server는 기본 `-c 8192`로 시작되지만, Qwen3.5-35B-A3B는 131K 지원. MASC가 llama-server에서 context 크기를 발견하면 8192를 그대로 사용 → keeper 대화가 8K를 초과하면 반복 실패 (80+ ERROR/세션).

## This PR

경고 로깅만 추가 (동작 변경 없음). 전체 해결은 llama-server `-c` 설정 증가 + compaction 로직 조사가 추가로 필요.

## Test plan

- [x] 빌드 성공
- [ ] CI Build and Test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)