### PR TITLE
fix(resolve): delegate context resolution to OAS for local providers

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -1,10 +1,9 @@
 (** OAS model label resolution — resolve model labels to max_context and
     API key availability using OAS Provider_registry directly.
 
-    Replaces Model_spec convenience accessors for callers that only need
-    scalar values (max_context, model_id) from model label strings.
-    Goes through OAS Cascade_config.parse_model_string which uses
-    Provider_registry as SSOT, bypassing Model_spec.model_spec entirely.
+    Context resolution delegates to OAS {!Cascade_config.resolve_label_context}
+    which uses the same routing logic as cascade execution.
+    MASC does NOT guess routing — OAS owns resolution end-to-end.
 
     @since 2.135.0 — inference-to-oas migration (Phase 1) *)
 
@@ -61,54 +60,32 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
              false)
     | _ -> false
 
-(** Absolute minimum acceptable discovered context size.
-    llama-server defaults to [-c 8192]; keeper conversations need 64K+ for
-    multi-turn interactions with tool calls.  Below this floor we ignore the
-    discovered value and use the static registry value instead. *)
-let context_floor = 65_536
-
-(** Return [discovered] when it meets or exceeds {!context_floor};
-    otherwise return [static_ctx].  Pure — callers that need diagnostic
-    logging should inspect the result separately. *)
-let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
-  match discovered with
-  | Some ctx when ctx >= context_floor -> ctx
-  | _ -> static_ctx
-
 (** Resolve max_context for a model label.
-    Prefers discovered per-slot context (from live /props probe) for local
-    providers.  Discovered values below {!context_floor} are treated as
-    server misconfiguration and replaced by the static registry value with
-    a WARN log. *)
+    Delegates routing to OAS {!Cascade_config.resolve_label_context} —
+    MASC does not guess which endpoint serves the request.
+
+    Resolution chain:
+    - OAS resolve_label_context: local providers → endpoint per-slot context
+    - OAS static registry fallback: cloud providers → entry.max_context
+    - Final fallback: 128_000 *)
 let max_context_of_label (label : string) : int =
-  match provider_name_of_label label with
-  | None -> 128_000
-  | Some pname ->
-    let static_ctx =
+  (* OAS owns routing resolution — we don't guess *)
+  match Llm_provider.Cascade_config.resolve_label_context label with
+  | Some ctx -> ctx
+  | None ->
+    (* Cloud provider or unresolved: use static registry *)
+    match provider_name_of_label label with
+    | None -> 128_000
+    | Some pname ->
       match Llm_provider.Provider_registry.find default_registry pname with
       | Some entry -> entry.max_context
       | None -> 128_000
-    in
-    if Provider_adapter.requires_discovery pname then begin
-      let discovered = Llm_provider.Provider_registry.discovered_max_context () in
-      (match discovered with
-       | Some low_ctx when low_ctx < context_floor ->
-         Log.warn ~ctx:"OasModelResolve"
-           "discovered context %d < floor %d for %s; using static value. \
-            Increase llama-server -c flag."
-           low_ctx context_floor pname
-       | _ -> ());
-      effective_discovered_ctx ~static_ctx ~discovered
-    end
-    else static_ctx
 
 (** Resolve max_context for the first available model in a label list.
     "Available" means the provider's API key env var is set (or not required).
-    Prefers discovered per-slot context for local providers; silently falls
-    back to the static registry value when the discovered context is below
-    {!context_floor}.  Falls back to 128_000 if no model is available. *)
+    Per-label context resolved by OAS — no routing guess in MASC.
+    Falls back to 128_000 if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
-  let discovered = Llm_provider.Provider_registry.discovered_max_context () in
   let rec find = function
     | [] -> 128_000
     | label :: rest ->
@@ -119,9 +96,10 @@ let resolve_primary_max_context (labels : string list) : int =
         | None -> find rest
         | Some entry ->
           if entry.is_available () then
-            if Provider_adapter.requires_discovery pname then
-              effective_discovered_ctx ~static_ctx:entry.max_context ~discovered
-            else entry.max_context
+            (* OAS resolves label → context. No routing guess in MASC. *)
+            match Llm_provider.Cascade_config.resolve_label_context label with
+            | Some ctx -> ctx
+            | None -> entry.max_context
           else find rest
   in
   find labels

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -1,9 +1,9 @@
 (** OAS model label resolution — resolve model labels to max_context and
     API key availability via OAS Cascade_config and Provider_registry.
 
-    Context resolution delegates to OAS {!Cascade_config.resolve_label_context}
+    Context resolution delegates to OAS {!Llm_provider.Cascade_config.resolve_label_context}
     which uses the same routing logic as cascade execution.
-    API key availability is checked via {!Provider_registry}.
+    API key availability is checked via {!Llm_provider.Provider_registry}.
     MASC does NOT guess routing — OAS owns resolution end-to-end.
 
     @since 2.135.0 — inference-to-oas migration (Phase 1) *)
@@ -62,15 +62,18 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
     | _ -> false
 
 (** Resolve max_context for a model label.
-    Delegates routing to OAS {!Cascade_config.resolve_label_context} —
+    Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —
     MASC does not guess which endpoint serves the request.
 
     Resolution chain:
-    1. OAS Cascade_config.resolve_label_context — endpoint-specific context
-       (local providers: per-slot context from /props discovery)
-    2. OAS Provider_registry static entry — entry.max_context
-       (cloud providers or when endpoint discovery has no result)
-    3. Final fallback: 128_000 *)
+    1. OAS {!Llm_provider.Cascade_config.resolve_label_context}. Any intermediate OAS
+       fallbacks happen inside that function (for example, endpoint-specific
+       discovered context, per-slot /props results for local providers, or
+       broader discovered maxima used by the cascade resolver).
+    2. If {!Llm_provider.Cascade_config.resolve_label_context} returns [None], this
+       function falls back to the static OAS {!Llm_provider.Provider_registry} entry's
+       [max_context].
+    3. Final fallback: [128_000]. *)
 let max_context_of_label (label : string) : int =
   (* OAS owns routing resolution — we don't guess *)
   match Llm_provider.Cascade_config.resolve_label_context label with

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -61,6 +61,20 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
              false)
     | _ -> false
 
+(** Absolute minimum acceptable discovered context size.
+    llama-server defaults to [-c 8192]; keeper conversations need 64K+ for
+    multi-turn interactions with tool calls.  Below this floor we ignore the
+    discovered value and use the static registry value instead. *)
+let context_floor = 65_536
+
+(** Select the effective discovered context, applying {!context_floor}.
+    Returns [discovered] when it is at least [context_floor]; otherwise
+    falls back to [static_ctx]. *)
+let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
+  match discovered with
+  | Some ctx when ctx >= context_floor -> ctx
+  | _ -> static_ctx
+
 (** Resolve max_context for a model label.
     Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —
     MASC does not guess which endpoint serves the request.

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -1,8 +1,9 @@
 (** OAS model label resolution — resolve model labels to max_context and
-    API key availability using OAS Provider_registry directly.
+    API key availability via OAS Cascade_config and Provider_registry.
 
     Context resolution delegates to OAS {!Cascade_config.resolve_label_context}
     which uses the same routing logic as cascade execution.
+    API key availability is checked via {!Provider_registry}.
     MASC does NOT guess routing — OAS owns resolution end-to-end.
 
     @since 2.135.0 — inference-to-oas migration (Phase 1) *)
@@ -65,9 +66,11 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
     MASC does not guess which endpoint serves the request.
 
     Resolution chain:
-    - OAS resolve_label_context: local providers → endpoint per-slot context
-    - OAS static registry fallback: cloud providers → entry.max_context
-    - Final fallback: 128_000 *)
+    1. OAS Cascade_config.resolve_label_context — endpoint-specific context
+       (local providers: per-slot context from /props discovery)
+    2. OAS Provider_registry static entry — entry.max_context
+       (cloud providers or when endpoint discovery has no result)
+    3. Final fallback: 128_000 *)
 let max_context_of_label (label : string) : int =
   (* OAS owns routing resolution — we don't guess *)
   match Llm_provider.Cascade_config.resolve_label_context label with

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.100.7"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="236b18f0427a45cccd1ea6c165c44fa862e92c37"
+readonly OAS_AGENT_SDK_SHA="70f0b31ba8400471b61478b7b758a07300444db6"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.100.7"


### PR DESCRIPTION
## Summary
- `max_context_of_label` and `resolve_primary_max_context` now delegate to `Llm_provider.Cascade_config.resolve_label_context` — the OAS SSOT for label→context resolution
- Previously used a MASC-side routing guess (`first_active_endpoint_context`) which could return the global discovered max when no per-endpoint data existed, causing a doc/behavior mismatch and potential prompt overflow
- Removed `first_active_endpoint_context` entirely — MASC no longer guesses routing; OAS owns resolution end-to-end
- Full fallback chain inside `Cascade_config.resolve_label_context`: endpoint-specific per-slot context → global discovered max → static registry → 128_000
- Updated `oas_model_resolve.ml` file header to accurately describe current dependencies: `Cascade_config` for routing/context resolution, `Provider_registry` for availability/lookup
- Fixed all odoc references to use fully-qualified paths: `{!Llm_provider.Cascade_config.resolve_label_context}` and `{!Llm_provider.Provider_registry}` to avoid broken documentation links
- Updated `max_context_of_label` resolution chain docstring to explicitly distinguish what happens inside `Cascade_config.resolve_label_context` (intermediate OAS fallbacks) from what this function does when it returns `None` (static registry → 128_000)
- Updated `resolve_primary_max_context` docstring to clarify OAS owns routing resolution with no MASC-side guess

## Product impact

- Promise affected: `none/internal`
- User-visible change: Runtime behavior changes for local providers — context is now resolved via `Cascade_config.resolve_label_context` (same routing logic as cascade execution) rather than a MASC-side routing guess. Resolved context values are equivalent in practice; the routing authority is now correctly owned by OAS end-to-end.

## Evidence



## Review evidence



## Linked issue