### PR TITLE
fix(observability): improve shutdown and idle loop logging

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -348,9 +348,12 @@ let run_cmd host port base_path =
             in
             Sse.broadcast (Yojson.Safe.from_string shutdown_data);
             Log.Server.info
-              "[Shutdown] Phase 1/4 NOTIFY: sent to %d SSE clients (%.2fs)"
+              "[Shutdown] Phase 1/4 NOTIFY: sent to %d SSE clients (%.2fs) [active conn: %d, ws: %d]"
               (Sse.client_count ())
-              (Unix.gettimeofday () -. t_phase);
+              (Unix.gettimeofday () -. t_phase)
+              (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
+              (Masc_mcp.Server_mcp_transport_ws.session_count ());
+
             Eio.Time.sleep clock shutdown_cfg.notify_delay_s;
             (* Phase 2: Run shutdown hooks with cleanup timeout *)
             let t_phase = Unix.gettimeofday () in
@@ -372,9 +375,11 @@ let run_cmd host port base_path =
                   (Unix.gettimeofday () -. t_phase)
                   (Printexc.to_string exn));
             let now = Unix.gettimeofday () in
-            Log.Server.info "[Shutdown] Phase 2/4 HOOKS: done (%.2fs, total=%.1fs)"
+            Log.Server.info "[Shutdown] Phase 2/4 HOOKS: done (%.2fs, total=%.1fs) [active conn: %d, ws: %d]"
               (now -. t_phase)
-              (now -. t_shutdown_start);
+              (now -. t_shutdown_start)
+              (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
+              (Masc_mcp.Server_mcp_transport_ws.session_count ());
             (* Phase 3: Board flush with 2s timeout *)
             let t_phase = Unix.gettimeofday () in
             Log.Server.info "[Shutdown] Phase 3/4 BOARD: flush starting (timeout=2.0s)";
@@ -393,25 +398,33 @@ let run_cmd host port base_path =
                   (Unix.gettimeofday () -. t_phase)
                   (Printexc.to_string exn));
             let now = Unix.gettimeofday () in
-            Log.Server.info "[Shutdown] Phase 3/4 BOARD: done (%.2fs, total=%.1fs)"
+            Log.Server.info "[Shutdown] Phase 3/4 BOARD: done (%.2fs, total=%.1fs) [active conn: %d, ws: %d]"
               (now -. t_phase)
-              (now -. t_shutdown_start);
+              (now -. t_shutdown_start)
+              (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
+              (Masc_mcp.Server_mcp_transport_ws.session_count ());
+
             (* Phase 4: Return normally — Eio.Fiber.first will cancel
                run_server cleanly via Eio.Cancel.Cancelled. *)
             Log.Server.info
-              "[Shutdown] Phase 4/4 CANCEL: server cancel (total=%.1fs)"
-              (Unix.gettimeofday () -. t_shutdown_start);
+              "[Shutdown] Phase 4/4 CANCEL: server cancel (total=%.1fs) [active conn: %d, ws: %d]"
+              (Unix.gettimeofday () -. t_shutdown_start)
+              (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
+              (Masc_mcp.Server_mcp_transport_ws.session_count ());
             ()
-      in
-      Eio.Fiber.first
-        (fun () -> run_server ~sw ~env ~host ~port ~base_path)
-        await_shutdown_signal;
-      (* Server stopped; close SSE connections after server is down. *)
-      (try close_all_sse_connections ()
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | _ -> ());
-      Log.Server.info "MASC MCP: Server stopped, waiting for background fibers..."
+            in
+            Eio.Fiber.first
+            (fun () -> run_server ~sw ~env ~host ~port ~base_path)
+            await_shutdown_signal;
+            (* Server stopped; close SSE connections after server is down. *)
+            (try close_all_sse_connections ()
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> ());
+            Log.Server.info "MASC MCP: Server stopped, waiting for background fibers... [active conn: %d, ws: %d]"
+            (Masc_mcp.Server_mcp_transport_http_sse.active_session_count ())
+            (Masc_mcp.Server_mcp_transport_ws.session_count ())
+
     with
     | Eio.Cancel.Cancelled _ ->
         Log.Server.info "MASC MCP: Server cancelled, waiting for background fibers..."

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -261,6 +261,38 @@ let build
   |> Result.map_error Oas.Error.to_string
 
 (* ================================================================ *)
+(* Idle-detail enrichment                                           *)
+(* ================================================================ *)
+
+(** Enrich an [Oas.Error.to_string] detail with the name of the most
+    recently called tool when the error is an "Idle detected" failure.
+    For all other error strings the input is returned unchanged.
+
+    Exposed at module level so it can be unit-tested independently of
+    the network-bound [run] function. *)
+let enrich_idle_detail (detail : string) (messages : Oas.Types.message list) : string =
+  if String.starts_with ~prefix:"Idle detected" detail then
+    let last_tool =
+      let rec find = function
+        | [] -> None
+        | (m : Oas.Types.message) :: rest ->
+          let later = find rest in
+          if Option.is_some later then later
+          else if m.role = Oas.Types.Assistant then
+            List.find_map (function
+              | Oas.Types.ToolUse { name; _ } -> Some name
+              | _ -> None
+            ) m.content
+          else None
+      in
+      find messages
+    in
+    (match last_tool with
+     | Some name -> Printf.sprintf "%s (tool: %s)" detail name
+     | None -> detail)
+  else detail
+
+(* ================================================================ *)
 (* Run                                                               *)
 (* ================================================================ *)
 
@@ -367,29 +399,7 @@ let run
     | Error err ->
       let detail = Oas.Error.to_string err in
       let detail =
-        if String.starts_with ~prefix:"Idle detected" detail then
-          let state = Oas.Agent.state agent in
-          let messages = state.messages in
-          let last_tool =
-            let rec find = function
-              | [] -> None
-              | (m : Oas.Types.message) :: rest ->
-                let later = find rest in
-                if Option.is_some later then later
-                else if m.role = Oas.Types.Assistant then
-                  List.find_map (function
-                    | Oas.Types.ToolUse { name; _ } -> Some name
-                    | _ -> None
-                  ) m.content
-                else None
-            in
-            find messages
-          in
-          match last_tool with
-          | Some name ->
-            Printf.sprintf "%s (tool: %s)" detail name
-          | None -> detail
-        else detail
+        enrich_idle_detail detail (Oas.Agent.state agent).messages
       in
       (match proof with
        | Some p ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -366,6 +366,31 @@ let run
         }
     | Error err ->
       let detail = Oas.Error.to_string err in
+      let detail =
+        if String.starts_with ~prefix:"Idle detected" detail then
+          let state = Oas.Agent.state agent in
+          let messages = state.messages in
+          let last_tool =
+            let rec find = function
+              | [] -> None
+              | (m : Oas.Types.message) :: rest ->
+                let later = find rest in
+                if Option.is_some later then later
+                else if m.role = Oas.Types.Assistant then
+                  List.find_map (function
+                    | Oas.Types.ToolUse { name; _ } -> Some name
+                    | _ -> None
+                  ) m.content
+                else None
+            in
+            find messages
+          in
+          match last_tool with
+          | Some name ->
+            Printf.sprintf "%s (tool: %s)" detail name
+          | None -> detail
+        else detail
+      in
       (match proof with
        | Some p ->
          Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s error=%s"

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -82,6 +82,11 @@ let is_active_sse_session session_id =
   Eio.Mutex.use_ro sse_registry_mutex (fun () ->
     Hashtbl.mem sse_conn_by_session session_id)
 
+(** Number of active SSE connections. *)
+let active_session_count () =
+  Eio.Mutex.use_ro sse_registry_mutex (fun () ->
+    Hashtbl.length sse_conn_by_session)
+
 let reap_stale_guards () =
   Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
     let stale =

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -29,12 +29,14 @@ let run_all () =
   (* Close all SSE clients *)
   let t_sse = Unix.gettimeofday () in
   let sse_count = Sse.close_all_clients () in
-  Log.Server.info "Closed %d SSE clients (%.2fs)"
-    sse_count (Unix.gettimeofday () -. t_sse);
+  Log.Server.info "Closed %d SSE clients (%.2fs) [remaining conn: %d]"
+    sse_count (Unix.gettimeofday () -. t_sse)
+    (Server_mcp_transport_http_sse.active_session_count ());
   (* Close WebSocket sessions *)
   let t_ws = Unix.gettimeofday () in
   let ws_count = Server_mcp_transport_ws.close_all () in
-  Log.Server.info "Closed %d WebSocket sessions (%.2fs)"
-    ws_count (Unix.gettimeofday () -. t_ws);
+  Log.Server.info "Closed %d WebSocket sessions (%.2fs) [remaining ws: %d]"
+    ws_count (Unix.gettimeofday () -. t_ws)
+    (Server_mcp_transport_ws.session_count ());
   Log.Server.info "[Shutdown] hooks total: %.2fs"
     (Unix.gettimeofday () -. t0)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1314,6 +1314,68 @@ let test_restart_continuity_load_oas_non_empty () =
       | None -> Alcotest.fail "checkpoint must survive restart")
 
 (* ================================================================ *)
+(* enrich_idle_detail — unit tests (OAS #5020 regression)          *)
+(* ================================================================ *)
+
+(** Build a minimal assistant message that contains a single ToolUse. *)
+let make_assistant_tool_use_msg name : Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+    content =
+      [
+        Agent_sdk.Types.ToolUse
+          { id = "call-1"; name; input = `Assoc [] };
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
+(** Idle error with a preceding tool-use: should append "(tool: <name>)". *)
+let test_enrich_idle_detail_with_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages = [ make_assistant_tool_use_msg "my_tool" ] in
+  let result = Oas_worker_exec.enrich_idle_detail detail messages in
+  Alcotest.(check bool) "contains original prefix" true
+    (String.starts_with ~prefix:detail result);
+  Alcotest.(check bool) "appends tool name" true
+    (contains_substring ~needle:"(tool: my_tool)" result)
+
+(** Idle error with no tool use in messages: detail should be unchanged. *)
+let test_enrich_idle_detail_no_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages =
+    [ { Agent_sdk.Types.role = Agent_sdk.Types.User;
+        content = [ Agent_sdk.Types.Text "hello" ];
+        name = None; tool_call_id = None } ]
+  in
+  let result = Oas_worker_exec.enrich_idle_detail detail messages in
+  Alcotest.(check string) "unchanged when no tool" detail result
+
+(** Idle error with empty message list: detail should be unchanged. *)
+let test_enrich_idle_detail_empty_messages () =
+  let detail = "Idle detected: no progress" in
+  let result = Oas_worker_exec.enrich_idle_detail detail [] in
+  Alcotest.(check string) "unchanged with empty messages" detail result
+
+(** Non-idle error: detail must not be modified at all. *)
+let test_enrich_idle_detail_non_idle_error () =
+  let detail = "Rate limit exceeded" in
+  let messages = [ make_assistant_tool_use_msg "some_tool" ] in
+  let result = Oas_worker_exec.enrich_idle_detail detail messages in
+  Alcotest.(check string) "non-idle error unchanged" detail result
+
+(** Last tool in message list wins when multiple assistant messages are present. *)
+let test_enrich_idle_detail_picks_last_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages =
+    [ make_assistant_tool_use_msg "first_tool"
+    ; make_assistant_tool_use_msg "last_tool" ]
+  in
+  let expected = detail ^ " (tool: last_tool)" in
+  let result = Oas_worker_exec.enrich_idle_detail detail messages in
+  Alcotest.(check string) "exact string with last tool" expected result
+
+(* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
 
@@ -1410,5 +1472,17 @@ let () =
         test_same_trace_multi_turn_accumulation;
       Alcotest.test_case "restart continuity — load_oas returns non-empty messages" `Quick
         test_restart_continuity_load_oas_non_empty;
+    ];
+    "idle_detail_enrichment", [
+      Alcotest.test_case "idle error with tool appends tool name" `Quick
+        test_enrich_idle_detail_with_tool;
+      Alcotest.test_case "idle error with no tool is unchanged" `Quick
+        test_enrich_idle_detail_no_tool;
+      Alcotest.test_case "idle error with empty messages is unchanged" `Quick
+        test_enrich_idle_detail_empty_messages;
+      Alcotest.test_case "non-idle error is never modified" `Quick
+        test_enrich_idle_detail_non_idle_error;
+      Alcotest.test_case "last tool name wins over earlier ones" `Quick
+        test_enrich_idle_detail_picks_last_tool;
     ];
   ]


### PR DESCRIPTION
## Summary

- Adds `active_session_count` to SSE connection registry.
- Includes active connection counts (SSE and WS) in all shutdown phases.
- Enhances `Idle detected` error messages with the name of the repeated tool.
- Extracts idle-detail enrichment into a pure helper `enrich_idle_detail` in `lib/oas_worker_exec.ml` for independent testability.
- Adds 5 focused unit tests in `test/test_oas_worker.ml` covering idle-error string shaping.
- Provides better diagnostics for shutdown delays and agent loops.

## Product impact

- Promise affected: `ops visibility`
- User-visible change: No user-visible change; improves internal observability during shutdown and agent idle-loop failures.

## Evidence

- New `idle_detail_enrichment` test suite in `test/test_oas_worker.ml` with 5 tests covering all branches of `enrich_idle_detail`.

## Review evidence

- Copilot review: 1 comment (test coverage for idle string shaping). Addressed: Copilot SWE agent added `test_oas_worker.ml` (5 tests). Human reply: acknowledged test file does not exist, Copilot added it. No code correctness issues found.

## Linked issue

Follows up on #5014 (graceful shutdown improvements).