### PR TITLE
fix(keeper): address #5220 review — ceiling rounding, validation, log level

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -44,8 +44,9 @@ let ensure_dir path =
 (** CJK-aware token estimate delegated to OAS Context_reducer. *)
 let msg_tokens (m : Agent_sdk.Types.message) : int =
   let estimated = Agent_sdk.Context_reducer.estimate_message_tokens m in
-  (* Use 15% safety buffer for message estimation errors (#5053) *)
-  int_of_float (float_of_int estimated *. 1.15)
+  (* Use 15% safety buffer for message estimation errors (#5053).
+     Ceiling-based to avoid truncation erasing the buffer. *)
+  int_of_float (ceil (float_of_int estimated *. 1.15))
 
 let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
   let sys_tokens = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -177,7 +177,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          let primary_max_context =
            match meta.max_context_override with
            | Some v ->
-               Log.Keeper.info "%s: using max_context_override=%d (manual turn)" meta.name v;
+               Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
                v
            | None -> Oas_model_resolve.resolve_primary_max_context effective_models
          in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -187,7 +187,14 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let voice_channel_opt = get_string_opt args "voice_channel" in
     let voice_agent_id_opt = get_string_opt args "voice_agent_id" in
     let mention_targets_in = get_string_list args "mention_targets" in
-    let max_context_override_opt = Safe_ops.json_int_opt "max_context_override" args in
+    let max_context_override_opt =
+      match Safe_ops.json_int_opt "max_context_override" args with
+      | None -> None
+      | Some v when v > 0 && v <= 1_000_000 -> Some v
+      | Some v ->
+          Log.Misc.warn "max_context_override=%d out of range (1..1000000), ignored" v;
+          None
+    in
     let proactive_enabled_opt = get_bool_opt args "proactive_enabled" in
     let proactive_idle_sec_opt = Safe_ops.json_int_opt "proactive_idle_sec" args in
     let proactive_cooldown_sec_opt = Safe_ops.json_int_opt "proactive_cooldown_sec" args in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -147,9 +147,9 @@ type keeper_meta = {
   voice_channel: string;
   voice_agent_id: string;
   created_at: string;
-  updated_at : string;
-  max_context_override : int option;
-  continuity_summary : string;
+  updated_at: string;
+  max_context_override: int option;
+  continuity_summary: string;
   active_goal_ids: string list;
   active_team_session_id: string option;
   last_team_session_started_at: string;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -108,8 +108,10 @@ let overflow_retry_history_budget
       Agent_sdk.Context_reducer.estimate_char_tokens system_prompt
       + Agent_sdk.Context_reducer.estimate_char_tokens user_message
     in
-    (* Use 20% safety buffer for prompt estimation errors (#5053) *)
-    int_of_float (float_of_int estimated *. 1.2)
+    (* Use 20% safety buffer for prompt estimation errors (#5053).
+       Ceiling-based to avoid truncation erasing the buffer. *)
+    if estimated <= 0 then estimated
+    else estimated + ((estimated + 4) / 5)
   in
   let prompt_reserve = max 1024 prompt_tokens in
   let tool_reserve =
@@ -783,7 +785,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let primary_max_context =
         match meta.max_context_override with
         | Some v ->
-            Log.Keeper.info "%s: using max_context_override=%d" meta.name v;
+            Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
             v
         | None -> Oas_model_resolve.resolve_primary_max_context model_labels
       in


### PR DESCRIPTION
## Summary
- Use ceiling-based rounding for 20%/15% safety buffers to avoid truncation erasing the buffer on small values
- Add input validation for `max_context_override` (1..1_000_000 range, out-of-range values warned and ignored)
- Lower `max_context_override` log from info to debug to reduce per-turn noise
- Fix `.mli` spacing to match existing field style

Follow-up to #5220 review comments (Copilot round-1).

## Product impact
- Promise affected: `none/internal`
- User-visible change: None — correctness and noise reduction for keeper context override

## Evidence
- Cherry-picked from `c187cf5` (review fix commit on #5220 branch, pushed after merge)

## Test plan
- [ ] CI Build and Test passes
- [ ] Existing context override behavior unchanged (ceiling only increases estimates)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>