### PR TITLE
feat(goal): add goal janitor for stale goal cleanup

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -483,6 +483,19 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ]
                 else
                   `Null );
+              ( "active_goals_tree",
+                if include_goals && m.active_goal_ids <> [] then
+                  let all_goals = Goal_store.list_goals config () in
+                  let linked = List.filter (fun (g : Goal_store.goal) ->
+                    List.mem g.id m.active_goal_ids) all_goals in
+                  let tasks = Room.get_tasks_safe config in
+                  let forest = Dashboard_goals.build_forest ~goals:linked ~tasks in
+                  `Assoc [
+                    ("count", `Int (List.length linked));
+                    ("nodes", `List (List.map Dashboard_goals.tree_node_to_json forest));
+                  ]
+                else
+                  `Null );
               ("soul_profile", `String m.soul_profile);
               ("will", if String.trim m.will = "" then `Null else `String m.will);
               ("needs", if String.trim m.needs = "" then `Null else `String m.needs);

--- a/lib/dune
+++ b/lib/dune
@@ -254,6 +254,7 @@
    relay
    goal_store
    goal_guard
+   goal_janitor
    goal_orchestrator
    goal_scheduler
    convergence

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -1,0 +1,134 @@
+(** Goal_janitor — Periodic cleanup of stale and dropped goals.
+
+    Three sweep rules:
+    1. Purge: delete Dropped goals older than [dropped_ttl_days].
+    2. Stagnate: mark Active goals with no update for [stagnant_days] as Dropped.
+    3. Orphan: remove active_goal_ids from keeper_meta that reference
+       non-existent goals in the Goal Store.
+
+    @since 2.236.0 *)
+
+type sweep_config = {
+  dropped_ttl_days : int;  (** Delete Dropped goals after this many days. Default 7. *)
+  stagnant_days : int;     (** Drop Active goals with no update after this many days. Default 30. *)
+}
+
+let default_config = {
+  dropped_ttl_days = 7;
+  stagnant_days = 30;
+}
+
+type sweep_result = {
+  purged : int;     (** Dropped goals deleted *)
+  stagnated : int;  (** Active goals marked Dropped *)
+  orphans : int;    (** Orphaned active_goal_ids cleaned *)
+}
+
+let sweep_result_to_yojson r =
+  `Assoc [
+    ("purged", `Int r.purged);
+    ("stagnated", `Int r.stagnated);
+    ("orphans", `Int r.orphans);
+  ]
+
+(** Parse ISO 8601 timestamp to Unix epoch seconds. *)
+let parse_iso_ts s =
+  try
+    Scanf.sscanf s "%d-%d-%dT%d:%d:%d" (fun y mo d h mi se ->
+      let tm = {
+        Unix.tm_sec = se; tm_min = mi; tm_hour = h;
+        tm_mday = d; tm_mon = mo - 1; tm_year = y - 1900;
+        tm_wday = 0; tm_yday = 0; tm_isdst = false;
+      } in
+      let epoch, _ = Unix.mktime tm in
+      Some epoch)
+  with _ -> None
+
+let days_since_update (goal : Goal_store.goal) ~now =
+  match parse_iso_ts goal.updated_at with
+  | Some ts -> Some (int_of_float ((now -. ts) /. 86400.0))
+  | None -> None
+
+(** Sweep goals: purge old Dropped, stagnate old Active.
+    Returns (updated_goals, sweep_result). Does NOT write state. *)
+let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
+  : Goal_store.goal list * sweep_result =
+  let now = Unix.gettimeofday () in
+  let iso_now = Types.now_iso () in
+  let purged = ref 0 in
+  let stagnated = ref 0 in
+  let result =
+    goals |> List.filter_map (fun (g : Goal_store.goal) ->
+      let age = days_since_update g ~now in
+      match g.status, age with
+      | Goal_store.Dropped, Some d when d >= config.dropped_ttl_days ->
+        incr purged;
+        Log.Misc.info "[GoalJanitor] purge: %s (%s, dropped %d days ago)"
+          g.id g.title d;
+        None
+      | Goal_store.Active, Some d when d >= config.stagnant_days ->
+        incr stagnated;
+        Log.Misc.info "[GoalJanitor] stagnate: %s (%s, no update for %d days)"
+          g.id g.title d;
+        Some { g with
+               status = Goal_store.Dropped;
+               last_review_note = Some (Printf.sprintf "auto-dropped: no update for %d days" d);
+               last_review_at = Some iso_now;
+               updated_at = iso_now }
+      | _ -> Some g)
+  in
+  (result, { purged = !purged; stagnated = !stagnated; orphans = 0 })
+
+(** Clean orphaned active_goal_ids from keeper meta.
+    Returns the pruned list and count of removed IDs. *)
+let prune_active_goal_ids ~(valid_goal_ids : string list)
+    (active_ids : string list) : string list * int =
+  let before = List.length active_ids in
+  let pruned =
+    List.filter (fun id -> List.mem id valid_goal_ids) active_ids
+  in
+  let removed = before - List.length pruned in
+  if removed > 0 then
+    Log.Misc.info "[GoalJanitor] pruned %d orphaned active_goal_ids" removed;
+  (pruned, removed)
+
+(** Run a full sweep: goals + keeper active_goal_ids.
+    Writes updated state to disk. *)
+let run ?(config = default_config) (room_config : Room.config) : sweep_result =
+  let st = Goal_store.read_state room_config in
+  let goals', partial = sweep_goals ~config st.goals in
+  let valid_ids = List.map (fun (g : Goal_store.goal) -> g.id) goals' in
+  (* Write updated goal state *)
+  if partial.purged > 0 || partial.stagnated > 0 then begin
+    Goal_store.write_state room_config
+      { goals = goals';
+        version = st.version + 1;
+        updated_at = Types.now_iso () }
+  end;
+  (* Prune active_goal_ids from all keeper metas *)
+  let total_orphans = ref 0 in
+  let keeper_dir =
+    Filename.concat (Room.masc_dir room_config) "keepers"
+  in
+  if Sys.file_exists keeper_dir && Sys.is_directory keeper_dir then
+    Sys.readdir keeper_dir
+    |> Array.iter (fun entry ->
+      if Filename.check_suffix entry ".json" then begin
+        let name = Filename.chop_suffix entry ".json" in
+        match Keeper_types.read_meta room_config name with
+        | Ok (Some meta) when meta.active_goal_ids <> [] ->
+          let pruned_ids, removed =
+            prune_active_goal_ids ~valid_goal_ids:valid_ids meta.active_goal_ids
+          in
+          if removed > 0 then begin
+            total_orphans := !total_orphans + removed;
+            let updated = { meta with active_goal_ids = pruned_ids } in
+            ignore (Keeper_types.write_meta room_config updated)
+          end
+        | _ -> ()
+      end);
+  let result = { partial with orphans = !total_orphans } in
+  if result.purged > 0 || result.stagnated > 0 || result.orphans > 0 then
+    Log.Misc.info "[GoalJanitor] sweep done: purged=%d stagnated=%d orphans=%d"
+      result.purged result.stagnated result.orphans;
+  result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -649,6 +649,17 @@ let rec add_routes ~sw ~clock router =
          )
        ) request reqd)
 
+  |> Http.Router.post "/api/v1/dashboard/goals/sweep" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         let config = state.Mcp_server.room_config in
+         let result = Goal_janitor.run config in
+         Http.Response.json ~compress:true ~request
+           (Yojson.Safe.to_string
+              (`Assoc [("ok", `Bool true);
+                       ("result", Goal_janitor.sweep_result_to_yojson result)]))
+           reqd
+       ) request reqd)
+
   |> Http.Router.post "/api/v1/keepers/chat/stream" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_keeper_msg" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->

--- a/test/dune
+++ b/test/dune
@@ -324,7 +324,8 @@
         test_cdal_friction_projection
         test_task_sandbox
         test_governance_yojson_roundtrip
-        test_eval_calibration)
+        test_eval_calibration
+        test_goal_janitor)
  (modules
         test_runtime_params
         test_config_dir_resolver
@@ -465,7 +466,8 @@
         test_cdal_friction_projection
         test_task_sandbox
         test_governance_yojson_roundtrip
-        test_eval_calibration)
+        test_eval_calibration
+        test_goal_janitor)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -1,0 +1,117 @@
+(** Tests for Goal_janitor — stale goal cleanup. *)
+
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let path = Filename.temp_file "goal_janitor_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let with_room f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
+    let config = Room.default_config dir in
+    ignore (Room.init config ~agent_name:(Some "test"));
+    f config)
+
+let old_iso days_ago =
+  let ts = Unix.gettimeofday () -. (float_of_int days_ago *. 86400.0) in
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let make_goal ?(status = Goal_store.Active) ?(days_ago = 0) id title =
+  let ts = old_iso days_ago in
+  {
+    Goal_store.id; horizon = Short; title;
+    metric = None; target_value = None; due_date = None;
+    priority = 3; status; parent_goal_id = None;
+    last_review_note = None; last_review_at = None;
+    created_at = ts; updated_at = ts;
+  }
+
+let test_purge_old_dropped () =
+  with_room @@ fun config ->
+  let g1 = make_goal ~status:Dropped ~days_ago:10 "g1" "Old dropped" in
+  let g2 = make_goal ~status:Dropped ~days_ago:3 "g2" "Recent dropped" in
+  let g3 = make_goal ~status:Active ~days_ago:1 "g3" "Active" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Types.now_iso ();
+      goals = [g1; g2; g3] };
+  let result = Goal_janitor.run config in
+  check int "purged old dropped" 1 result.purged;
+  check int "no stagnation" 0 result.stagnated;
+  let remaining = Goal_store.list_goals config () in
+  check int "2 goals remain" 2 (List.length remaining);
+  check bool "g1 purged" false
+    (List.exists (fun (g : Goal_store.goal) -> g.id = "g1") remaining);
+  check bool "g2 kept" true
+    (List.exists (fun (g : Goal_store.goal) -> g.id = "g2") remaining)
+
+let test_stagnate_old_active () =
+  with_room @@ fun config ->
+  let g1 = make_goal ~status:Active ~days_ago:35 "g1" "Stale active" in
+  let g2 = make_goal ~status:Active ~days_ago:5 "g2" "Fresh active" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Types.now_iso ();
+      goals = [g1; g2] };
+  let result = Goal_janitor.run config in
+  check int "stagnated 1" 1 result.stagnated;
+  check int "no purge" 0 result.purged;
+  let goals = Goal_store.list_goals config () in
+  let g1' = List.find (fun (g : Goal_store.goal) -> g.id = "g1") goals in
+  check string "g1 now dropped"
+    "dropped" (match g1'.status with Dropped -> "dropped" | _ -> "not dropped");
+  let g2' = List.find (fun (g : Goal_store.goal) -> g.id = "g2") goals in
+  check string "g2 still active"
+    "active" (match g2'.status with Active -> "active" | _ -> "not active")
+
+let test_no_changes_when_clean () =
+  with_room @@ fun config ->
+  let g1 = make_goal ~status:Active ~days_ago:1 "g1" "Fresh" in
+  let g2 = make_goal ~status:Done ~days_ago:60 "g2" "Done long ago" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Types.now_iso ();
+      goals = [g1; g2] };
+  let result = Goal_janitor.run config in
+  check int "no purge" 0 result.purged;
+  check int "no stagnation" 0 result.stagnated;
+  check int "no orphans" 0 result.orphans
+
+let test_prune_orphaned_ids () =
+  let valid = ["g1"; "g2"; "g3"] in
+  let active = ["g1"; "g4"; "g5"; "g2"] in
+  let pruned, removed = Goal_janitor.prune_active_goal_ids ~valid_goal_ids:valid active in
+  check int "removed 2 orphans" 2 removed;
+  check int "2 remaining" 2 (List.length pruned);
+  check bool "g1 kept" true (List.mem "g1" pruned);
+  check bool "g2 kept" true (List.mem "g2" pruned)
+
+let () =
+  run "Goal_janitor" [
+    "sweep", [
+      test_case "purge old dropped goals" `Quick test_purge_old_dropped;
+      test_case "stagnate old active goals" `Quick test_stagnate_old_active;
+      test_case "no changes when clean" `Quick test_no_changes_when_clean;
+    ];
+    "prune", [
+      test_case "prune orphaned active_goal_ids" `Quick test_prune_orphaned_ids;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Goal 시스템에 자동 정리 기능 추가 (C → B → A 로드맵의 첫 단계).

### Sweep Rules
1. **Purge**: `status=Dropped` + 7일 경과 → 삭제
2. **Stagnate**: `status=Active` + 30일 업데이트 없음 → Dropped 전환 (자동 리뷰 기록)
3. **Orphan**: keeper_meta의 `active_goal_ids`에서 존재하지 않는 goal ID 제거

### Endpoints
- `POST /api/v1/dashboard/goals/sweep` — 수동 트리거, `{ok, result: {purged, stagnated, orphans}}` 반환

### Files
| File | Change |
|------|--------|
| `lib/goal/goal_janitor.ml` | 새 모듈: sweep_goals, prune_active_goal_ids, run |
| `lib/dune` | goal_janitor 모듈 등록 |
| `lib/server/server_routes_http_routes_dashboard.ml` | sweep 엔드포인트 |
| `test/test_goal_janitor.ml` | 4개 테스트 |
| `test/dune` | 테스트 등록 |

### 다음 단계 (B: 대시보드 표시 통합)
- "계획 및 매트릭"의 목표 텍스트를 Goal Tree로 리다이렉트
- Goal Tree에 keeper horizon goals 주석 표시

## Test plan
- [x] 4개 테스트 통과 (purge, stagnate, no-op, orphan prune)
- [x] 빌드 성공
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)