### PR TITLE
fix/5069 5100 small fixes

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -125,7 +125,12 @@ let handle_keeper_status ctx args : tool_result =
                    | Anthropic -> "claude" | OpenAI_compat -> "openai"
                    | Gemini -> "gemini" | Glm -> "glm" | Claude_code -> "claude_code")
                  in
-                 if base = "openai" && (String.contains cfg.base_url "127.0.0.1" || String.contains cfg.base_url "localhost")
+                 let is_loopback url =
+                   match Uri.host (Uri.of_string url) with
+                   | Some "localhost" | Some "127.0.0.1" -> true
+                   | _ -> false
+                 in
+                 if base = "openai" && is_loopback cfg.base_url
                  then "llama" else base
              in
              Some (`Assoc [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -121,9 +121,12 @@ let handle_keeper_status ctx args : tool_result =
                | Some idx when idx > 0 ->
                  String.sub label 0 idx |> String.trim |> String.lowercase_ascii
                | _ ->
-                 Llm_provider.Provider_config.(match cfg.kind with
+                 let base = Llm_provider.Provider_config.(match cfg.kind with
                    | Anthropic -> "claude" | OpenAI_compat -> "openai"
                    | Gemini -> "gemini" | Glm -> "glm" | Claude_code -> "claude_code")
+                 in
+                 if base = "openai" && (String.contains cfg.base_url "127.0.0.1" || String.contains cfg.base_url "localhost")
+                 then "llama" else base
              in
              Some (`Assoc [
                ("provider", `String provider_name);

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -413,8 +413,11 @@ let run
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
+    let bt = Printexc.get_backtrace () in
     (try Oas.Agent.close agent with close_exn ->
       Log.Misc.warn "agent close failed during cleanup: %s" (Printexc.to_string close_exn));
+    Log.Misc.error "oas_worker %s: execution exception: %s\nBacktrace: %s"
+      config.name (Printexc.to_string exn) bt;
     Error (Printf.sprintf "Agent execution exception: %s" (Printexc.to_string exn)))
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

- **fix: resolve remaining small bugs and improve observability**
- **fix(oas): improve model resolution and error diagnostics**
- **fix(review): address compile errors, idempotency correctness, and TOML validity**

## Product impact

- Promise affected: `repo coordination` | `ops visibility`
- User-visible change: Keeper status detail now correctly classifies local llama providers; idempotent task claim/start transitions no longer emit spurious events or increment backlog versions; keeper TOML configs (`janitor`, `masc-improver`) now parse correctly with valid `instructions` key.

## Evidence

- `lib/oas_model_resolve.ml` (`max_context_of_label` and `resolve_primary_max_context`) and `lib/keeper/keeper_status_detail.ml`: replaced all invalid `String.contains` calls (which take `char`, not `string`) with `Uri.host (Uri.of_string url)`-based loopback detection, consistent with the pattern in `worker_runtime_docker.ml`. This also prevents false positives from substring matches on hostnames like `mylocalhost.example.com`.
- `lib/room/room_task.ml`: idempotent `Claim`/`Start` transitions now return `None` instead of `Some task_id`, preventing unnecessary backlog writes and re-emission of `task.claimed`/`task.started` events.
- `config/keepers/janitor.toml` and `config/keepers/masc-improver.toml`: fixed invalid TOML by assigning the multiline string to the `instructions` key (`instructions = """..."""`).

## Review evidence

Addressed all review comments including a second missed `String.contains` occurrence in `oas_model_resolve.ml:resolve_primary_max_context`. Changes validated via parallel code review and CodeQL scan (no new issues introduced).

## Linked issue