### PR TITLE
fix(keeper): stop infinite retry on Eio context errors (CI timeout fix)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -509,7 +509,14 @@ let run_keepalive_unified_turn
               ~generation:meta_after_observe.runtime.generation
           with
           | Error e ->
-            Log.Keeper.error "unified turn failed: %s" e;
+            Log.Keeper.error "%s: unified turn failed: %s"
+              meta_after_observe.name e;
+            if String_util.contains_substring e "Eio switch not available"
+               || String_util.contains_substring e "Eio net not available"
+            then
+              raise (Keeper_registry.Keeper_heartbeat_failure
+                (Printf.sprintf "%s: fatal environment error: %s"
+                   meta_after_observe.name e));
             (match read_meta ctx.config meta_after_observe.name with
              | Ok (Some latest) -> latest
              | _ -> meta_after_observe)
@@ -522,7 +529,8 @@ let run_keepalive_unified_turn
     | Eio.Cancel.Cancelled _ as e -> raise e
     | Keeper_registry.Keeper_heartbeat_failure _ as e -> raise e
     | exn ->
-      Log.Keeper.error "unified turn exception: %s" (Printexc.to_string exn);
+      Log.Keeper.error "%s: unified turn exception: %s"
+        meta_after_observe.name (Printexc.to_string exn);
       meta_after_triage)
 ;;
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -514,9 +514,11 @@ let run_keepalive_unified_turn
             if String_util.contains_substring e "Eio switch not available"
                || String_util.contains_substring e "Eio net not available"
             then
-              raise (Keeper_registry.Keeper_heartbeat_failure
-                (Printf.sprintf "%s: fatal environment error: %s"
-                   meta_after_observe.name e));
+              raise (Keeper_registry.Keeper_heartbeat_failure {
+                reason = Keeper_registry.Exception
+                  (Printf.sprintf "fatal environment error: %s" e);
+                keeper_name = meta_after_observe.name;
+              });
             (match read_meta ctx.config meta_after_observe.name with
              | Ok (Some latest) -> latest
              | _ -> meta_after_observe)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -532,7 +532,7 @@ let run_keepalive_unified_turn
     | Keeper_registry.Keeper_heartbeat_failure _ as e -> raise e
     | exn ->
       Log.Keeper.error "%s: unified turn exception: %s"
-        meta_after_observe.name (Printexc.to_string exn);
+        meta_after_triage.name (Printexc.to_string exn);
       meta_after_triage)
 ;;
 


### PR DESCRIPTION
## Summary
Raise Keeper_heartbeat_failure on unrecoverable Eio context errors instead of retrying every keepalive cycle.

## Root Cause
CI Build and Test times out at 900s because keeper E2E tests run without server context. Keeper gets "Eio switch not available" and retries indefinitely.

## Fix
- Detect "Eio switch/net not available" errors in keepalive turn loop
- Raise fatal Keeper_heartbeat_failure to stop the loop immediately
- Include keeper name in all error/exception logs

Fixes #5197