### PR TITLE
feat(keeper): 10-state machine with det/nondet boundary (RFC-0002 Phase 1)

### DIFF
--- a/docs/rfc/RFC-0002-keeper-state-machine.md
+++ b/docs/rfc/RFC-0002-keeper-state-machine.md
@@ -1,0 +1,213 @@
+# RFC-0002: Keeper 10-State Machine + Det/NonDet Boundary Formalization
+
+**Status**: Draft
+**Date**: 2026-04-05
+**Scope**: `masc-mcp` keeper lifecycle state machine redesign
+**One sentence**: Keeper의 5-state 상태 머신을 10-state로 확장하고, 비결정론적 측정과 결정론적 전이 사이에 관찰 가능한 buffer state와 snapshot-at-decision 경계를 도입한다.
+
+## Related Documents
+
+- `RFC-0001-det-nondet-boundary-harness.md` — Design Principle 1 (Det/NonDet Rules)
+- `../../archive/trpg/lib/trpg/engine_state_machine.mli` — Result-based transition pattern
+- `../../docs/design/adr-masc-oas-boundary-ssot.md` — MASC/OAS boundary rules
+
+## Problem Statement
+
+현재 `keeper_registry.ml:49-54`의 상태 머신:
+
+```ocaml
+type keeper_state = Running | Paused | Stopped | Crashed | Dead
+```
+
+세 가지 구조적 문제:
+
+1. **관찰 불가능한 전이**: compaction, handoff, failure 누적, drain이 진행되는 동안 외부에서 "Running"으로만 보인다. `derive_pipeline_stage` (keeper_exec_status.ml)는 30초 recency window heuristic으로 추론하지만 정확하지 않다.
+
+2. **재현 불가능한 crash**: `context_ratio >= threshold`가 compaction을 트리거하고 실패하면 즉시 Crashed로 전이. 판단 시점의 threshold 값, context_ratio 값, timing이 기록되지 않아 재현할 수 없다.
+
+3. **산재된 상태 변경**: `set_state` 호출이 keeper_keepalive.ml, keeper_supervisor.ml, keeper_turn_lifecycle.ml 세 곳에 분산. 중앙 집중화된 transition validation이 없다.
+
+## Design Anchors
+
+| 패턴 | 출처 | 적용 |
+|------|------|------|
+| Deterministic Core, Agentic Shell | Morissette 2026 | 3-layer 아키텍처 기본 원칙 |
+| Phase vs Conditions | Kubernetes Pod Lifecycle | Conditions(bool) primitive, Phase 파생 |
+| state_enter callback | Erlang gen_statem | Buffer state entry/exit action |
+| Half-Open probe | Circuit Breaker (Resilience4j) | Failing state = controlled probe |
+| Guard conditions | Hybrid Automata | NonDet measurement -> Det guard evaluation |
+| Result-based transition | TRPG engine_state_machine.mli | `can_transition` + typed error |
+
+## Architecture: 3-Layer
+
+```
+Layer 3 (NonDet Shell)    Measurements -> Typed Events
+                          keeper_keepalive.ml, keeper_memory_recall.ml
+                              |  capture() — 유일한 NonDet 경계
+                              v
+Layer 2 (Det Core)        Events x Conditions -> Phase transitions
+                          keeper_state_machine.ml (NEW)
+                              |  derive_phase() — pure function
+                              v
+Layer 1 (Storage)         Atomic registry updates + backward-compat projection
+                          keeper_registry.ml + keeper_state_compat.ml
+```
+
+핵심 불변량: **snapshot 이후 모든 것은 결정론적**. 같은 snapshot이면 같은 transition.
+
+## State Definition
+
+### 10-State Phase Enum
+
+```ocaml
+type phase =
+  | Offline       (* Registered, no heartbeat fiber yet *)
+  | Running       (* Healthy heartbeat loop *)
+  | Failing       (* Consecutive failures detected, probing recovery *)
+  | Compacting    (* Context compaction in progress *)
+  | HandingOff    (* Generation rollover in progress *)
+  | Draining      (* Graceful shutdown: completing current turn *)
+  | Paused        (* Operator-paused *)
+  | Stopped       (* Clean exit *)
+  | Crashed       (* Unrecoverable error, restart candidate *)
+  | Restarting    (* Supervisor backoff wait before re-launch *)
+  | Dead          (* Restart budget exhausted, tombstone *)
+```
+
+### Observable Conditions (Kubernetes Pattern)
+
+```ocaml
+type conditions = {
+  fiber_alive : bool;
+  heartbeat_healthy : bool;
+  turn_healthy : bool;
+  context_within_budget : bool;
+  context_handoff_needed : bool;
+  compaction_active : bool;
+  handoff_active : bool;
+  operator_paused : bool;
+  stop_requested : bool;
+  restart_budget_remaining : bool;
+  backoff_elapsed : bool;
+  guardrail_triggered : bool;
+  drain_complete : bool;
+}
+```
+
+Phase는 conditions로부터 단일 pure function `derive_phase`로 파생된다.
+
+### Transition Matrix
+
+| From\To | Off | Run | Fail | Comp | Hand | Drain | Pause | Stop | Crash | Restart | Dead |
+|---------|-----|-----|------|------|------|-------|-------|------|-------|---------|------|
+| Offline |     | Y   |      |      |      |       |       | Y    |       |         |      |
+| Running |     |     | Y    | Y    | Y    | Y     | Y     | Y    |       |         |      |
+| Failing |     | Y   |      |      |      | Y     |       |      | Y     |         |      |
+| Compact |     | Y   | Y    |      |      |       |       |      | Y     |         |      |
+| HandOff |     | Y   | Y    |      |      |       |       |      | Y     |         |      |
+| Draining|     |     |      |      |      |       |       | Y    | Y     |         |      |
+| Paused  |     | Y   |      |      |      | Y     |       | Y    |       |         |      |
+| Stopped |     |     |      |      |      |       |       |      |       |         |      |
+| Crashed |     |     |      |      |      |       |       |      |       | Y       | Y    |
+| Restart |     | Y   |      |      |      |       |       |      | Y     |         | Y    |
+| Dead    |     |     |      |      |      |       |       |      |       |         |      |
+
+Terminal states: Stopped, Dead.
+
+### Buffer State Behavior
+
+| State | Entry Trigger | Exit to Running | Exit to Crashed | Timeout |
+|-------|--------------|-----------------|-----------------|---------|
+| Failing | Heartbeat_failed (count < max) | Heartbeat_ok (counter reset) | count >= max | none |
+| Compacting | Compaction_started | Compaction_completed | Compaction_failed | 60s |
+| HandingOff | Handoff_started | Handoff_completed (gen++) | Handoff_failed | 30s |
+| Draining | Stop_requested (turn active) | n/a | Drain timeout | 120s |
+| Restarting | Supervisor_restart_attempt | Fiber launch success | Launch fail | backoff delay |
+
+### Backward Compatibility
+
+```ocaml
+(* 10-state -> 5-state projection *)
+let to_legacy = function
+  | Offline       -> Stopped
+  | Running       -> Running
+  | Failing       -> Running   (* Still attempting recovery *)
+  | Compacting    -> Running   (* Sub-activity of running *)
+  | HandingOff    -> Running   (* Sub-activity of running *)
+  | Draining      -> Running   (* Still completing work *)
+  | Paused        -> Paused
+  | Stopped       -> Stopped
+  | Crashed       -> Crashed
+  | Restarting    -> Crashed   (* Awaiting restart *)
+  | Dead          -> Dead
+```
+
+## Det/NonDet Boundary
+
+### Measurement Snapshot
+
+모든 비결정론적 값(context_ratio, similarity scores, wall-clock, Runtime_params thresholds)을 한 번에 캡처하는 immutable record.
+
+```ocaml
+type measurement_snapshot = {
+  snapshot_id : string;
+  keeper_name : string;
+  timestamp : float;           (* single clock read *)
+  thresholds : threshold_params;  (* frozen Runtime_params *)
+  context : context_measurement;
+  similarity : similarity_measurement;
+  timing : timing_measurement;
+  failures : failure_measurement;
+}
+```
+
+### Guard Evaluation
+
+```ocaml
+val evaluate : measurement_snapshot -> event list
+(* Pure function. No I/O, no clock, no mutable reads. *)
+(* Same snapshot -> same events. *)
+```
+
+### Audit Trail
+
+모든 transition은 (snapshot, events_fired, selected_event, outcome)을 기록한다. `replay_check`로 historical snapshot을 재평가하여 동일 결과를 검증할 수 있다.
+
+## Implementation Phases
+
+### Phase 1: New Modules, Zero Consumers (1 PR)
+- `keeper_state_machine.ml/.mli` — phase, conditions, events, derive_phase, apply_event
+- `keeper_measurement.ml/.mli` — snapshot types (no capture impl yet)
+- `keeper_guard.ml/.mli` — pure guard evaluation
+- `keeper_transition_audit.ml/.mli` — audit record types
+- `keeper_state_compat.ml/.mli` — legacy projection
+- `test_keeper_state_machine.ml` — exhaustive pure tests
+
+### Phase 2: Registry Integration (1 PR)
+- `keeper_registry.ml` — conditions field, dispatch_event, set_state deprecated
+
+### Phase 3: Supervisor Migration (1 PR)
+- `keeper_supervisor.ml` — event-based crash/restart handling
+
+### Phase 4: Keepalive Migration (1 PR)
+- `keeper_keepalive.ml` — snapshot capture + event dispatch
+- `keeper_memory_recall.ml` — guard wrapper
+
+### Phase 5: Cleanup + Dashboard (1 PR)
+- Remove deprecated set_state, derive_pipeline_stage heuristic
+- Dashboard phase rendering
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Eio fiber safety | conditions는 non-yielding 연산만 사용. 단일 fiber 소유 |
+| Dashboard backward compat | registry_state (5-state) 유지, phase (10-state) 추가 |
+| Transition table 복잡도 | derive_phase single pure function + property test 전수 검증 |
+| GADT 과잉 | Phase payload 차이가 작아 plain variant + exhaustive match 선택 |
+
+## Scope Exclusion
+
+- RFC-0001의 Emotional Recovery Loop, Thompson rehabilitation (별도 구현)
+- Adversarial harness (Phase 5 이후)
+- failure_reason ADT 변경 없음 (self-preservation과 직교)

--- a/lib/dune
+++ b/lib/dune
@@ -478,6 +478,11 @@
    keeper_chat_store
    keeper_recurring
    keeper_registry
+   keeper_state_machine
+   keeper_state_compat
+   keeper_measurement
+   keeper_guard
+   keeper_transition_audit
    keeper_supervisor
    keeper_runtime
    keeper_turn_session

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -95,7 +95,7 @@ let evaluate (s : measurement_snapshot) : event list =
       plan =
         s.similarity.goal_alignment <= t.plan_goal_alignment_threshold
         || s.similarity.response_alignment <= t.plan_response_alignment_threshold;
-      compact = compact_ratio || compact_msg || compact_tok;
+      compact = (compact_ratio || compact_msg || compact_tok) && cooldown_ok;
       handoff =
         t.auto_handoff_enabled
         && s.context.context_ratio >= handoff_threshold;

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -1,0 +1,122 @@
+(** Keeper Guard — Pure guard evaluation (RFC-0002).
+    See .mli for documentation.
+
+    This module replaces the inline threshold checks currently scattered
+    across keeper_memory_recall.ml, keeper_keepalive.ml, and
+    keeper_supervisor.ml. All decisions are made against a frozen
+    [measurement_snapshot] — no Runtime_params re-reads, no clock queries. *)
+
+open Keeper_measurement
+open Keeper_state_machine
+
+(** Priority levels for event ordering (lower = higher priority). *)
+let event_priority = function
+  | Guardrail_stop _ -> 0
+  | Heartbeat_failed _ -> 1
+  | Turn_failed _ -> 2
+  | Compaction_started -> 3
+  | Handoff_started -> 4
+  | Context_measured _ -> 5
+  | Heartbeat_ok -> 10
+  | Turn_succeeded -> 10
+  | _ -> 10
+
+let evaluate (s : measurement_snapshot) : event list =
+  let t = s.thresholds in
+  let events = ref [] in
+  let add ev = events := ev :: !events in
+
+  (* 1. Guardrail: 4-way AND gate *)
+  let guardrail_fired =
+    s.similarity.repetition_risk >= t.guardrail_repetition_threshold
+    && s.similarity.goal_alignment <= t.guardrail_goal_alignment_threshold
+    && s.similarity.response_alignment <= t.guardrail_response_alignment_threshold
+    && s.context.context_ratio >= t.guardrail_context_threshold
+  in
+  if guardrail_fired then
+    add (Guardrail_stop {
+      reason = Printf.sprintf
+        "rep=%.2f goal=%.2f resp=%.2f ratio=%.3f"
+        s.similarity.repetition_risk
+        s.similarity.goal_alignment
+        s.similarity.response_alignment
+        s.context.context_ratio;
+    });
+
+  (* 2. Crash: heartbeat failure threshold *)
+  if s.failures.consecutive_hb_failures >= t.max_consecutive_hb_failures then
+    add (Heartbeat_failed {
+      consecutive = s.failures.consecutive_hb_failures;
+      max_allowed = t.max_consecutive_hb_failures;
+    });
+
+  (* 3. Crash: turn failure threshold *)
+  if s.failures.consecutive_turn_failures >= t.max_consecutive_turn_failures then
+    add (Turn_failed {
+      consecutive = s.failures.consecutive_turn_failures;
+      max_allowed = t.max_consecutive_turn_failures;
+    });
+
+  (* 4. Compaction: any of 3 gates *)
+  let compact_ratio = s.context.context_ratio >= t.compaction_ratio_gate in
+  let compact_msg = s.context.message_count >= t.compaction_message_gate in
+  let compact_tok = s.context.token_count >= t.compaction_token_gate in
+  let cooldown_ok =
+    s.timing.since_last_compaction_ts >= float_of_int t.compaction_cooldown_sec
+  in
+  if (compact_ratio || compact_msg || compact_tok) && cooldown_ok then
+    add Compaction_started;
+
+  (* 5. Handoff: context ratio above threshold *)
+  let handoff_threshold = t.handoff_threshold *. t.model_handoff_multiplier in
+  let handoff_cooldown_ok =
+    s.timing.since_last_handoff_ts >= float_of_int t.handoff_cooldown_sec
+  in
+  if t.auto_handoff_enabled
+     && s.context.context_ratio >= handoff_threshold
+     && handoff_cooldown_ok then
+    add Handoff_started;
+
+  (* 6. Heartbeat health: if below threshold, report ok *)
+  if s.failures.consecutive_hb_failures > 0
+     && s.failures.consecutive_hb_failures < t.max_consecutive_hb_failures then
+    add (Heartbeat_failed {
+      consecutive = s.failures.consecutive_hb_failures;
+      max_allowed = t.max_consecutive_hb_failures;
+    });
+
+  (* 7. Context measurement (always emitted for audit trail) *)
+  add (Context_measured {
+    context_ratio = s.context.context_ratio;
+    message_count = s.context.message_count;
+    token_count = s.context.token_count;
+    auto_rules = {
+      reflect = s.similarity.repetition_risk >= t.reflect_repetition_threshold;
+      plan =
+        s.similarity.goal_alignment <= t.plan_goal_alignment_threshold
+        || s.similarity.response_alignment <= t.plan_response_alignment_threshold;
+      compact = compact_ratio || compact_msg || compact_tok;
+      handoff =
+        t.auto_handoff_enabled
+        && s.context.context_ratio >= handoff_threshold;
+      guardrail_stop = guardrail_fired;
+      guardrail_reason =
+        if guardrail_fired then
+          Some (Printf.sprintf "rep=%.2f goal=%.2f resp=%.2f ratio=%.3f"
+            s.similarity.repetition_risk
+            s.similarity.goal_alignment
+            s.similarity.response_alignment
+            s.context.context_ratio)
+        else None;
+      goal_drift =
+        1.0 -. s.similarity.goal_alignment;
+    };
+  });
+
+  (* Sort by priority (highest first) and return *)
+  List.sort (fun a b -> compare (event_priority a) (event_priority b))
+    (List.rev !events)
+
+let prioritized_event = function
+  | [] -> Heartbeat_ok
+  | first :: _ -> first

--- a/lib/keeper/keeper_guard.mli
+++ b/lib/keeper/keeper_guard.mli
@@ -1,0 +1,23 @@
+(** Keeper Guard — Pure guard evaluation (RFC-0002).
+
+    Evaluates a [measurement_snapshot] against frozen thresholds
+    and returns typed events. This is the bridge between the NonDet
+    boundary (measurement capture) and the Det core (state machine).
+
+    INVARIANT: [evaluate] is a pure function.
+    Given the same [measurement_snapshot], it MUST return the same events.
+    No I/O, no mutable state reads, no clock queries. *)
+
+(** Evaluate all guard conditions against a frozen measurement snapshot.
+    Returns all events that fire, ordered by priority (highest first).
+    The caller decides whether to act on the first or process all. *)
+val evaluate :
+  Keeper_measurement.measurement_snapshot ->
+  Keeper_state_machine.event list
+
+(** Select the highest-priority event from the guard output.
+    Priority: Guardrail > Crash > Compact > Handoff > No_transition.
+    Returns [Heartbeat_ok] if the list is empty (no transitions needed). *)
+val prioritized_event :
+  Keeper_state_machine.event list ->
+  Keeper_state_machine.event

--- a/lib/keeper/keeper_measurement.ml
+++ b/lib/keeper/keeper_measurement.ml
@@ -1,0 +1,114 @@
+(** Keeper Measurement — Det/NonDet Boundary Types (RFC-0002).
+    Phase 1: types and serialization only. *)
+
+type threshold_params = {
+  compaction_ratio_gate : float;
+  compaction_message_gate : int;
+  compaction_token_gate : int;
+  compaction_cooldown_sec : int;
+  handoff_threshold : float;
+  handoff_cooldown_sec : int;
+  auto_handoff_enabled : bool;
+  reflect_repetition_threshold : float;
+  plan_goal_alignment_threshold : float;
+  plan_response_alignment_threshold : float;
+  guardrail_repetition_threshold : float;
+  guardrail_goal_alignment_threshold : float;
+  guardrail_response_alignment_threshold : float;
+  guardrail_context_threshold : float;
+  max_consecutive_hb_failures : int;
+  max_consecutive_turn_failures : int;
+  model_ratio_multiplier : float;
+  model_handoff_multiplier : float;
+}
+
+type context_measurement = {
+  context_ratio : float;
+  message_count : int;
+  token_count : int;
+  max_tokens : int;
+}
+
+type similarity_measurement = {
+  repetition_risk : float;
+  goal_alignment : float;
+  response_alignment : float;
+}
+
+type timing_measurement = {
+  now_ts : float;
+  idle_seconds : int;
+  since_last_compaction_ts : float;
+  since_last_handoff_ts : float;
+  proactive_warmup_elapsed : bool;
+}
+
+type failure_measurement = {
+  consecutive_hb_failures : int;
+  consecutive_turn_failures : int;
+}
+
+type measurement_snapshot = {
+  snapshot_id : string;
+  keeper_name : string;
+  generation : int;
+  timestamp : float;
+  thresholds : threshold_params;
+  context : context_measurement;
+  similarity : similarity_measurement;
+  timing : timing_measurement;
+  failures : failure_measurement;
+}
+
+let threshold_params_to_json (t : threshold_params) : Yojson.Safe.t =
+  `Assoc [
+    "compaction_ratio_gate", `Float t.compaction_ratio_gate;
+    "compaction_message_gate", `Int t.compaction_message_gate;
+    "compaction_token_gate", `Int t.compaction_token_gate;
+    "compaction_cooldown_sec", `Int t.compaction_cooldown_sec;
+    "handoff_threshold", `Float t.handoff_threshold;
+    "handoff_cooldown_sec", `Int t.handoff_cooldown_sec;
+    "auto_handoff_enabled", `Bool t.auto_handoff_enabled;
+    "reflect_repetition_threshold", `Float t.reflect_repetition_threshold;
+    "plan_goal_alignment_threshold", `Float t.plan_goal_alignment_threshold;
+    "plan_response_alignment_threshold", `Float t.plan_response_alignment_threshold;
+    "guardrail_repetition_threshold", `Float t.guardrail_repetition_threshold;
+    "guardrail_goal_alignment_threshold", `Float t.guardrail_goal_alignment_threshold;
+    "guardrail_response_alignment_threshold", `Float t.guardrail_response_alignment_threshold;
+    "guardrail_context_threshold", `Float t.guardrail_context_threshold;
+    "max_consecutive_hb_failures", `Int t.max_consecutive_hb_failures;
+    "max_consecutive_turn_failures", `Int t.max_consecutive_turn_failures;
+    "model_ratio_multiplier", `Float t.model_ratio_multiplier;
+    "model_handoff_multiplier", `Float t.model_handoff_multiplier;
+  ]
+
+let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
+  `Assoc [
+    "snapshot_id", `String s.snapshot_id;
+    "keeper_name", `String s.keeper_name;
+    "generation", `Int s.generation;
+    "timestamp", `Float s.timestamp;
+    "thresholds", threshold_params_to_json s.thresholds;
+    "context", `Assoc [
+      "context_ratio", `Float s.context.context_ratio;
+      "message_count", `Int s.context.message_count;
+      "token_count", `Int s.context.token_count;
+      "max_tokens", `Int s.context.max_tokens;
+    ];
+    "similarity", `Assoc [
+      "repetition_risk", `Float s.similarity.repetition_risk;
+      "goal_alignment", `Float s.similarity.goal_alignment;
+      "response_alignment", `Float s.similarity.response_alignment;
+    ];
+    "timing", `Assoc [
+      "now_ts", `Float s.timing.now_ts;
+      "idle_seconds", `Int s.timing.idle_seconds;
+      "since_last_compaction_ts", `Float s.timing.since_last_compaction_ts;
+      "since_last_handoff_ts", `Float s.timing.since_last_handoff_ts;
+      "proactive_warmup_elapsed", `Bool s.timing.proactive_warmup_elapsed;
+    ];
+    "failures", `Assoc [
+      "consecutive_hb_failures", `Int s.failures.consecutive_hb_failures;
+      "consecutive_turn_failures", `Int s.failures.consecutive_turn_failures;
+    ];
+  ]

--- a/lib/keeper/keeper_measurement.mli
+++ b/lib/keeper/keeper_measurement.mli
@@ -1,0 +1,85 @@
+(** Keeper Measurement — Det/NonDet Boundary Types (RFC-0002).
+
+    This module defines the snapshot types for the deterministic/non-deterministic
+    boundary. The [measurement_snapshot] is an immutable record captured once per
+    decision cycle. Everything downstream of this record is deterministic.
+
+    Phase 1: types only (no [capture] implementation yet).
+    Phase 4 will add the [capture] function that performs I/O. *)
+
+(** {1 Threshold Parameters} *)
+
+(** Frozen snapshot of all runtime-configurable thresholds.
+    Captured once per decision cycle to eliminate TOCTOU windows
+    where [Runtime_params.get] could return different values. *)
+type threshold_params = {
+  compaction_ratio_gate : float;
+  compaction_message_gate : int;
+  compaction_token_gate : int;
+  compaction_cooldown_sec : int;
+  handoff_threshold : float;
+  handoff_cooldown_sec : int;
+  auto_handoff_enabled : bool;
+  reflect_repetition_threshold : float;
+  plan_goal_alignment_threshold : float;
+  plan_response_alignment_threshold : float;
+  guardrail_repetition_threshold : float;
+  guardrail_goal_alignment_threshold : float;
+  guardrail_response_alignment_threshold : float;
+  guardrail_context_threshold : float;
+  max_consecutive_hb_failures : int;
+  max_consecutive_turn_failures : int;
+  model_ratio_multiplier : float;
+  model_handoff_multiplier : float;
+}
+
+(** {1 Sub-measurements} *)
+
+type context_measurement = {
+  context_ratio : float;
+  message_count : int;
+  token_count : int;
+  max_tokens : int;
+}
+
+type similarity_measurement = {
+  repetition_risk : float;
+  goal_alignment : float;
+  response_alignment : float;
+}
+
+type timing_measurement = {
+  now_ts : float;
+  idle_seconds : int;
+  since_last_compaction_ts : float;
+  since_last_handoff_ts : float;
+  proactive_warmup_elapsed : bool;
+}
+
+type failure_measurement = {
+  consecutive_hb_failures : int;
+  consecutive_turn_failures : int;
+}
+
+(** {1 Measurement Snapshot} *)
+
+(** Immutable snapshot of all non-deterministic values at a single decision point.
+    This record IS the det/nondet boundary.
+    Everything upstream is impure measurement;
+    everything downstream is pure guard evaluation. *)
+type measurement_snapshot = {
+  snapshot_id : string;
+  keeper_name : string;
+  generation : int;
+  timestamp : float;
+  thresholds : threshold_params;
+  context : context_measurement;
+  similarity : similarity_measurement;
+  timing : timing_measurement;
+  failures : failure_measurement;
+}
+
+(** {1 Serialization} *)
+
+val threshold_params_to_json : threshold_params -> Yojson.Safe.t
+val measurement_snapshot_to_json : measurement_snapshot -> Yojson.Safe.t

--- a/lib/keeper/keeper_state_compat.ml
+++ b/lib/keeper/keeper_state_compat.ml
@@ -1,0 +1,36 @@
+(** Keeper State Compat — Backward-compatible 5-state projection (RFC-0002). *)
+
+type legacy_state =
+  | Running
+  | Paused
+  | Stopped
+  | Crashed
+  | Dead
+
+let legacy_to_string = function
+  | Running -> "running"
+  | Paused -> "paused"
+  | Stopped -> "stopped"
+  | Crashed -> "crashed"
+  | Dead -> "dead"
+
+let legacy_of_string = function
+  | "running" -> Some Running
+  | "paused" -> Some Paused
+  | "stopped" -> Some Stopped
+  | "crashed" -> Some Crashed
+  | "dead" -> Some Dead
+  | _ -> None
+
+let to_legacy : Keeper_state_machine.phase -> legacy_state = function
+  | Offline -> Stopped
+  | Running -> Running
+  | Failing -> Running
+  | Compacting -> Running
+  | HandingOff -> Running
+  | Draining -> Running
+  | Paused -> Paused
+  | Stopped -> Stopped
+  | Crashed -> Crashed
+  | Restarting -> Crashed
+  | Dead -> Dead

--- a/lib/keeper/keeper_state_compat.mli
+++ b/lib/keeper/keeper_state_compat.mli
@@ -1,0 +1,22 @@
+(** Keeper State Compat — Backward-compatible 5-state projection (RFC-0002).
+
+    Maps the 10-state [Keeper_state_machine.phase] to the legacy 5-state enum
+    that existing API consumers expect. *)
+
+(** The legacy 5-state enum matching the original [keeper_state]. *)
+type legacy_state =
+  | Running
+  | Paused
+  | Stopped
+  | Crashed
+  | Dead
+
+val legacy_to_string : legacy_state -> string
+val legacy_of_string : string -> legacy_state option
+
+(** Project a fine-grained phase to the legacy 5-state enum.
+    Buffer states map to their "parent" stable state:
+    - [Failing | Compacting | HandingOff | Draining] -> [Running]
+    - [Restarting] -> [Crashed]
+    - [Offline] -> [Stopped] *)
+val to_legacy : Keeper_state_machine.phase -> legacy_state

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -228,18 +228,37 @@ let can_transition ~from_phase ~to_phase =
 
 let derive_phase (c : conditions) : phase =
   (* Priority order: first match wins.
-     Terminal/lifecycle checks first, then buffer states, then healthy. *)
-  if not c.fiber_alive && not c.restart_budget_remaining then Dead
+
+     Design note: stop_requested + drain_complete -> Stopped is checked
+     BEFORE fiber_alive checks. This means a keeper that completed its
+     drain cleanly (drain_complete=true) reaches Stopped even if the
+     fiber subsequently exits. This is correct: the drain succeeded,
+     so the keeper should be Stopped, not Crashed.
+
+     However, if the fiber dies DURING drain (drain_complete=false),
+     the fiber_alive checks fire first and the keeper goes to Crashed.
+     This is also correct: the drain did not complete. *)
+
+  (* 1. Completed stop always wins — drain succeeded *)
+  if c.stop_requested && c.drain_complete then Stopped
+  (* 2. Fiber lifecycle — Dead / Restarting / Crashed *)
+  else if not c.fiber_alive && not c.restart_budget_remaining then Dead
   else if not c.fiber_alive && c.restart_budget_remaining && c.backoff_elapsed then Restarting
-  else if not c.fiber_alive && c.restart_budget_remaining && not c.backoff_elapsed then Crashed
-  else if c.stop_requested && c.drain_complete then Stopped
-  else if c.stop_requested && not c.drain_complete then Draining
+  else if not c.fiber_alive && c.restart_budget_remaining then Crashed
+  (* 3. In-progress stop — still draining *)
+  else if c.stop_requested then Draining
+  (* 4. Guardrail -> Failing *)
   else if c.guardrail_triggered then Failing
+  (* 5. Operator control *)
   else if c.operator_paused then Paused
+  (* 6. Buffer states: in-progress operations *)
   else if c.handoff_active then HandingOff
   else if c.compaction_active then Compacting
+  (* 7. Health degradation *)
   else if not c.heartbeat_healthy || not c.turn_healthy then Failing
+  (* 8. Healthy running *)
   else if c.fiber_alive then Running
+  (* 9. Initial / unreachable fallback *)
   else Offline
 
 (* ── Condition Updaters ────────────────────────────────── *)
@@ -250,11 +269,15 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Heartbeat_ok ->
     { c with heartbeat_healthy = true }
   | Heartbeat_failed { consecutive; max_allowed } ->
-    { c with heartbeat_healthy = consecutive < max_allowed }
+    (* Any failure makes heartbeat unhealthy. Recovery requires Heartbeat_ok.
+       The consecutive count is for audit/logging, not for health determination. *)
+    let _ = max_allowed in
+    { c with heartbeat_healthy = consecutive = 0 }
   | Turn_succeeded ->
     { c with turn_healthy = true }
   | Turn_failed { consecutive; max_allowed } ->
-    { c with turn_healthy = consecutive < max_allowed }
+    let _ = max_allowed in
+    { c with turn_healthy = consecutive = 0 }
   | Context_measured { auto_rules; _ } ->
     { c with
       guardrail_triggered = auto_rules.guardrail_stop;

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -1,0 +1,407 @@
+(** Keeper State Machine — Deterministic Core (RFC-0002).
+    See .mli for documentation. *)
+
+(* ── Phase ─────────────────────────────────────────────── *)
+
+type phase =
+  | Offline
+  | Running
+  | Failing
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Stopped
+  | Crashed
+  | Restarting
+  | Dead
+
+let phase_to_string = function
+  | Offline -> "offline"
+  | Running -> "running"
+  | Failing -> "failing"
+  | Compacting -> "compacting"
+  | HandingOff -> "handing_off"
+  | Draining -> "draining"
+  | Paused -> "paused"
+  | Stopped -> "stopped"
+  | Crashed -> "crashed"
+  | Restarting -> "restarting"
+  | Dead -> "dead"
+
+let phase_of_string = function
+  | "offline" -> Some Offline
+  | "running" -> Some Running
+  | "failing" -> Some Failing
+  | "compacting" -> Some Compacting
+  | "handing_off" -> Some HandingOff
+  | "draining" -> Some Draining
+  | "paused" -> Some Paused
+  | "stopped" -> Some Stopped
+  | "crashed" -> Some Crashed
+  | "restarting" -> Some Restarting
+  | "dead" -> Some Dead
+  | _ -> None
+
+let all_phases =
+  [ Offline; Running; Failing; Compacting; HandingOff;
+    Draining; Paused; Stopped; Crashed; Restarting; Dead ]
+
+(* ── Conditions ────────────────────────────────────────── *)
+
+type conditions = {
+  fiber_alive : bool;
+  heartbeat_healthy : bool;
+  turn_healthy : bool;
+  context_within_budget : bool;
+  context_handoff_needed : bool;
+  compaction_active : bool;
+  handoff_active : bool;
+  operator_paused : bool;
+  stop_requested : bool;
+  restart_budget_remaining : bool;
+  backoff_elapsed : bool;
+  guardrail_triggered : bool;
+  drain_complete : bool;
+}
+
+let default_conditions = {
+  fiber_alive = false;
+  heartbeat_healthy = true;
+  turn_healthy = true;
+  context_within_budget = true;
+  context_handoff_needed = false;
+  compaction_active = false;
+  handoff_active = false;
+  operator_paused = false;
+  stop_requested = false;
+  restart_budget_remaining = false;
+  backoff_elapsed = false;
+  guardrail_triggered = false;
+  drain_complete = false;
+}
+
+(* ── Events ────────────────────────────────────────────── *)
+
+type auto_rule_summary = {
+  reflect : bool;
+  plan : bool;
+  compact : bool;
+  handoff : bool;
+  guardrail_stop : bool;
+  guardrail_reason : string option;
+  goal_drift : float;
+}
+
+type event =
+  | Heartbeat_ok
+  | Heartbeat_failed of { consecutive : int; max_allowed : int }
+  | Turn_succeeded
+  | Turn_failed of { consecutive : int; max_allowed : int }
+  | Context_measured of {
+      context_ratio : float;
+      message_count : int;
+      token_count : int;
+      auto_rules : auto_rule_summary;
+    }
+  | Compaction_started
+  | Compaction_completed of { before_tokens : int; after_tokens : int }
+  | Compaction_failed of { reason : string }
+  | Handoff_started
+  | Handoff_completed of { new_trace_id : string; generation : int }
+  | Handoff_failed of { reason : string }
+  | Operator_pause
+  | Operator_resume
+  | Operator_stop of { remove_meta : bool }
+  | Stop_requested
+  | Drain_complete
+  | Fiber_started
+  | Fiber_terminated of { outcome : string }
+  | Supervisor_restart_attempt of { attempt : int }
+  | Restart_budget_exhausted
+  | Guardrail_stop of { reason : string }
+
+let event_to_string = function
+  | Heartbeat_ok -> "heartbeat_ok"
+  | Heartbeat_failed r ->
+    Printf.sprintf "heartbeat_failed(%d/%d)" r.consecutive r.max_allowed
+  | Turn_succeeded -> "turn_succeeded"
+  | Turn_failed r ->
+    Printf.sprintf "turn_failed(%d/%d)" r.consecutive r.max_allowed
+  | Context_measured r ->
+    Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
+  | Compaction_started -> "compaction_started"
+  | Compaction_completed r ->
+    Printf.sprintf "compaction_completed(%d->%d)" r.before_tokens r.after_tokens
+  | Compaction_failed r ->
+    Printf.sprintf "compaction_failed(%s)" r.reason
+  | Handoff_started -> "handoff_started"
+  | Handoff_completed r ->
+    Printf.sprintf "handoff_completed(gen=%d)" r.generation
+  | Handoff_failed r ->
+    Printf.sprintf "handoff_failed(%s)" r.reason
+  | Operator_pause -> "operator_pause"
+  | Operator_resume -> "operator_resume"
+  | Operator_stop r ->
+    Printf.sprintf "operator_stop(remove_meta=%b)" r.remove_meta
+  | Stop_requested -> "stop_requested"
+  | Drain_complete -> "drain_complete"
+  | Fiber_started -> "fiber_started"
+  | Fiber_terminated r ->
+    Printf.sprintf "fiber_terminated(%s)" r.outcome
+  | Supervisor_restart_attempt r ->
+    Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
+  | Restart_budget_exhausted -> "restart_budget_exhausted"
+  | Guardrail_stop r ->
+    Printf.sprintf "guardrail_stop(%s)" r.reason
+
+(* ── Entry Actions ─────────────────────────────────────── *)
+
+type entry_action =
+  | Start_compaction
+  | Start_handoff
+  | Start_drain
+  | Schedule_restart of { delay_sec : float }
+  | Publish_lifecycle of { event_name : string; detail : string }
+  | Mark_dead_tombstone
+  | Cleanup_and_unregister
+
+(* ── Transition Types ──────────────────────────────────── *)
+
+type transition_result = {
+  prev_phase : phase;
+  new_phase : phase;
+  updated_conditions : conditions;
+  entry_actions : entry_action list;
+  event_applied : event;
+  timestamp : float;
+}
+
+type transition_error =
+  | Terminal_state of { current : phase; attempted_event : string }
+  | Invalid_transition of { from_phase : phase; to_phase : phase; reason : string }
+
+let transition_error_to_string = function
+  | Terminal_state r ->
+    Printf.sprintf "terminal_state: %s cannot accept %s"
+      (phase_to_string r.current) r.attempted_event
+  | Invalid_transition r ->
+    Printf.sprintf "invalid_transition: %s -> %s (%s)"
+      (phase_to_string r.from_phase) (phase_to_string r.to_phase) r.reason
+
+(* ── Transition Matrix ─────────────────────────────────── *)
+
+let can_transition ~from_phase ~to_phase =
+  match from_phase, to_phase with
+  (* Terminal states accept nothing *)
+  | Stopped, _ -> false
+  | Dead, _ -> false
+  (* Offline -> Running | Stopped *)
+  | Offline, (Running | Stopped) -> true
+  | Offline, _ -> false
+  (* Running -> buffer states, Paused, Stopped, Crashed (fiber death) *)
+  | Running, (Failing | Compacting | HandingOff | Draining | Paused | Stopped | Crashed) -> true
+  | Running, _ -> false
+  (* Failing -> Running (recovery) | Crashed (threshold) | Draining (stop) *)
+  | Failing, (Running | Crashed | Draining) -> true
+  | Failing, _ -> false
+  (* Compacting -> Running (done) | Failing (hb fail during) | Crashed (fatal) *)
+  | Compacting, (Running | Failing | Crashed) -> true
+  | Compacting, _ -> false
+  (* HandingOff -> Running (done) | Failing | Crashed *)
+  | HandingOff, (Running | Failing | Crashed) -> true
+  | HandingOff, _ -> false
+  (* Draining -> Stopped (done) | Crashed (fatal during drain) *)
+  | Draining, (Stopped | Crashed) -> true
+  | Draining, _ -> false
+  (* Paused -> Running (resume) | Draining (stop) | Stopped (remove) *)
+  | Paused, (Running | Draining | Stopped) -> true
+  | Paused, _ -> false
+  (* Crashed -> Restarting (backoff done) | Dead (budget exhausted) *)
+  | Crashed, (Restarting | Dead) -> true
+  | Crashed, _ -> false
+  (* Restarting -> Running (success) | Crashed (fail) | Dead (budget) *)
+  | Restarting, (Running | Crashed | Dead) -> true
+  | Restarting, _ -> false
+
+(* ── derive_phase ──────────────────────────────────────── *)
+
+let derive_phase (c : conditions) : phase =
+  (* Priority order: first match wins.
+     Terminal/lifecycle checks first, then buffer states, then healthy. *)
+  if not c.fiber_alive && not c.restart_budget_remaining then Dead
+  else if not c.fiber_alive && c.restart_budget_remaining && c.backoff_elapsed then Restarting
+  else if not c.fiber_alive && c.restart_budget_remaining && not c.backoff_elapsed then Crashed
+  else if c.stop_requested && c.drain_complete then Stopped
+  else if c.stop_requested && not c.drain_complete then Draining
+  else if c.guardrail_triggered then Failing
+  else if c.operator_paused then Paused
+  else if c.handoff_active then HandingOff
+  else if c.compaction_active then Compacting
+  else if not c.heartbeat_healthy || not c.turn_healthy then Failing
+  else if c.fiber_alive then Running
+  else Offline
+
+(* ── Condition Updaters ────────────────────────────────── *)
+
+(** Update conditions based on an event. Returns new conditions. *)
+let update_conditions (c : conditions) (ev : event) : conditions =
+  match ev with
+  | Heartbeat_ok ->
+    { c with heartbeat_healthy = true }
+  | Heartbeat_failed { consecutive; max_allowed } ->
+    { c with heartbeat_healthy = consecutive < max_allowed }
+  | Turn_succeeded ->
+    { c with turn_healthy = true }
+  | Turn_failed { consecutive; max_allowed } ->
+    { c with turn_healthy = consecutive < max_allowed }
+  | Context_measured { auto_rules; _ } ->
+    { c with
+      guardrail_triggered = auto_rules.guardrail_stop;
+      context_handoff_needed = auto_rules.handoff;
+    }
+  | Compaction_started ->
+    { c with compaction_active = true }
+  | Compaction_completed _ ->
+    { c with compaction_active = false }
+  | Compaction_failed _ ->
+    { c with compaction_active = false }
+  | Handoff_started ->
+    { c with handoff_active = true }
+  | Handoff_completed _ ->
+    { c with handoff_active = false }
+  | Handoff_failed _ ->
+    { c with handoff_active = false }
+  | Operator_pause ->
+    { c with operator_paused = true }
+  | Operator_resume ->
+    { c with operator_paused = false }
+  | Operator_stop _ ->
+    { c with stop_requested = true }
+  | Stop_requested ->
+    { c with stop_requested = true }
+  | Drain_complete ->
+    { c with drain_complete = true }
+  | Fiber_started ->
+    { c with fiber_alive = true }
+  | Fiber_terminated _ ->
+    { c with fiber_alive = false }
+  | Supervisor_restart_attempt _ ->
+    { c with backoff_elapsed = true }
+  | Restart_budget_exhausted ->
+    { c with restart_budget_remaining = false }
+  | Guardrail_stop _ ->
+    { c with guardrail_triggered = true }
+
+(** Compute entry actions for a phase transition. *)
+let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action list =
+  let lifecycle name detail =
+    Publish_lifecycle { event_name = name; detail }
+  in
+  match prev_phase, new_phase with
+  | _, Compacting ->
+    [ Start_compaction; lifecycle "compaction_started" "" ]
+  | _, HandingOff ->
+    [ Start_handoff; lifecycle "handoff_started" "" ]
+  | _, Draining ->
+    [ Start_drain; lifecycle "draining" "" ]
+  | _, Dead ->
+    [ Mark_dead_tombstone; lifecycle "dead" "restart budget exhausted" ]
+  | _, Stopped ->
+    [ Cleanup_and_unregister;
+      lifecycle "stopped"
+        (match event with
+         | Operator_stop { remove_meta } ->
+           Printf.sprintf "remove_meta=%b" remove_meta
+         | _ -> "drain_complete") ]
+  | Crashed, Restarting ->
+    [ lifecycle "restarting" "backoff elapsed" ]
+  | Restarting, Running ->
+    [ lifecycle "restarted" "fiber launched" ]
+  | _, Failing ->
+    [ lifecycle "failing" (event_to_string event) ]
+  | Failing, Running ->
+    [ lifecycle "recovered" "failure counters reset" ]
+  | _, Paused ->
+    [ lifecycle "paused" "operator request" ]
+  | Paused, Running ->
+    [ lifecycle "resumed" "operator request" ]
+  | _ -> []
+
+(* ── apply_event ───────────────────────────────────────── *)
+
+let apply_event ~current_phase ~conditions ~event ~now =
+  (* Terminal states reject all events *)
+  match current_phase with
+  | Stopped | Dead ->
+    Error (Terminal_state {
+      current = current_phase;
+      attempted_event = event_to_string event;
+    })
+  | _ ->
+    let updated_conditions = update_conditions conditions event in
+    let new_phase = derive_phase updated_conditions in
+    (* Validate transition is allowed *)
+    if new_phase = current_phase then
+      (* No transition — still valid *)
+      Ok {
+        prev_phase = current_phase;
+        new_phase;
+        updated_conditions;
+        entry_actions = [];
+        event_applied = event;
+        timestamp = now;
+      }
+    else if can_transition ~from_phase:current_phase ~to_phase:new_phase then
+      Ok {
+        prev_phase = current_phase;
+        new_phase;
+        updated_conditions;
+        entry_actions = entry_actions_for ~prev_phase:current_phase ~new_phase ~event;
+        event_applied = event;
+        timestamp = now;
+      }
+    else
+      (* derive_phase produced a phase that can_transition rejects.
+         This indicates a logic error between derive_phase and the matrix. *)
+      Error (Invalid_transition {
+        from_phase = current_phase;
+        to_phase = new_phase;
+        reason = Printf.sprintf "event %s caused derive_phase to produce %s from %s, \
+                                 but this transition is not in the matrix"
+          (event_to_string event)
+          (phase_to_string new_phase)
+          (phase_to_string current_phase);
+      })
+
+(* ── JSON Serialization ────────────────────────────────── *)
+
+let phase_to_json p = `String (phase_to_string p)
+
+let conditions_to_json (c : conditions) =
+  `Assoc [
+    "fiber_alive", `Bool c.fiber_alive;
+    "heartbeat_healthy", `Bool c.heartbeat_healthy;
+    "turn_healthy", `Bool c.turn_healthy;
+    "context_within_budget", `Bool c.context_within_budget;
+    "context_handoff_needed", `Bool c.context_handoff_needed;
+    "compaction_active", `Bool c.compaction_active;
+    "handoff_active", `Bool c.handoff_active;
+    "operator_paused", `Bool c.operator_paused;
+    "stop_requested", `Bool c.stop_requested;
+    "restart_budget_remaining", `Bool c.restart_budget_remaining;
+    "backoff_elapsed", `Bool c.backoff_elapsed;
+    "guardrail_triggered", `Bool c.guardrail_triggered;
+    "drain_complete", `Bool c.drain_complete;
+  ]
+
+let event_to_json ev = `String (event_to_string ev)
+
+let transition_result_to_json (tr : transition_result) =
+  `Assoc [
+    "prev_phase", phase_to_json tr.prev_phase;
+    "new_phase", phase_to_json tr.new_phase;
+    "conditions", conditions_to_json tr.updated_conditions;
+    "event", event_to_json tr.event_applied;
+    "timestamp", `Float tr.timestamp;
+  ]

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -1,0 +1,187 @@
+(** Keeper State Machine — Deterministic Core (RFC-0002).
+
+    This module defines the 10-state keeper lifecycle as a pure state machine.
+    All functions are deterministic: no I/O, no clock reads, no mutable state.
+
+    Architecture:
+    - Layer 3 (NonDet Shell): measurements captured via [Keeper_measurement]
+    - Layer 2 (Det Core): THIS MODULE — events x conditions -> phase transitions
+    - Layer 1 (Storage): [Keeper_registry] applies transitions atomically
+
+    Key invariant: given the same [conditions] and [event], [apply_event]
+    always produces the same [transition_result]. *)
+
+(** {1 Phase (10-State Enum)} *)
+
+(** Fine-grained keeper lifecycle phase.
+    Buffer states ([Failing], [Compacting], [HandingOff], [Draining],
+    [Restarting]) are observable intermediaries between stable states. *)
+type phase =
+  | Offline       (** Registered but no heartbeat fiber started *)
+  | Running       (** Healthy heartbeat loop executing *)
+  | Failing       (** Consecutive failures detected, probing recovery *)
+  | Compacting    (** Context compaction in progress *)
+  | HandingOff    (** Generation rollover in progress *)
+  | Draining      (** Graceful shutdown: completing current turn *)
+  | Paused        (** Operator-paused, fiber sleeping *)
+  | Stopped       (** Clean exit, terminal *)
+  | Crashed       (** Unrecoverable error, restart candidate *)
+  | Restarting    (** Supervisor backoff wait before re-launch *)
+  | Dead          (** Restart budget exhausted, tombstone, terminal *)
+
+val phase_to_string : phase -> string
+val phase_of_string : string -> phase option
+val all_phases : phase list
+
+(** {1 Observable Conditions (Kubernetes Pattern)} *)
+
+(** Observable boolean conditions computed from keeper state.
+    Phase is DERIVED from conditions via [derive_phase].
+    Conditions are the primitive; phase is the projection. *)
+type conditions = {
+  fiber_alive : bool;
+  (** [done_p] unresolved AND [fiber_stop] not set *)
+  heartbeat_healthy : bool;
+  (** [consecutive_failures < max_hb_failures] *)
+  turn_healthy : bool;
+  (** [turn_consecutive_failures < max_turn_failures] *)
+  context_within_budget : bool;
+  (** [context_ratio < compaction.ratio_gate] *)
+  context_handoff_needed : bool;
+  (** [auto_handoff AND context_ratio >= handoff_threshold] *)
+  compaction_active : bool;
+  (** Set true on compaction entry, false on exit *)
+  handoff_active : bool;
+  (** Set true on handoff entry, false on exit *)
+  operator_paused : bool;
+  (** [meta.paused = true] *)
+  stop_requested : bool;
+  (** [Atomic.get fiber_stop = true] *)
+  restart_budget_remaining : bool;
+  (** [restart_count < max_restarts] *)
+  backoff_elapsed : bool;
+  (** [now - last_restart_ts >= backoff_delay(restart_count)] *)
+  guardrail_triggered : bool;
+  (** [auto_rules.guardrail_stop = true] *)
+  drain_complete : bool;
+  (** Current turn finished, no pending work *)
+}
+
+val default_conditions : conditions
+(** All false — the "zero state" for initialization. *)
+
+(** {1 Events (Det/NonDet Boundary Output)} *)
+
+(** Auto-rule evaluation summary, captured at the boundary. *)
+type auto_rule_summary = {
+  reflect : bool;
+  plan : bool;
+  compact : bool;
+  handoff : bool;
+  guardrail_stop : bool;
+  guardrail_reason : string option;
+  goal_drift : float;
+}
+
+(** Typed events that trigger condition re-evaluation.
+    These are the ONLY inputs to the deterministic state machine.
+    Non-deterministic measurements become typed events at the boundary. *)
+type event =
+  | Heartbeat_ok
+  | Heartbeat_failed of { consecutive : int; max_allowed : int }
+  | Turn_succeeded
+  | Turn_failed of { consecutive : int; max_allowed : int }
+  | Context_measured of {
+      context_ratio : float;
+      message_count : int;
+      token_count : int;
+      auto_rules : auto_rule_summary;
+    }
+  | Compaction_started
+  | Compaction_completed of { before_tokens : int; after_tokens : int }
+  | Compaction_failed of { reason : string }
+  | Handoff_started
+  | Handoff_completed of { new_trace_id : string; generation : int }
+  | Handoff_failed of { reason : string }
+  | Operator_pause
+  | Operator_resume
+  | Operator_stop of { remove_meta : bool }
+  | Stop_requested
+  | Drain_complete
+  | Fiber_started
+  | Fiber_terminated of { outcome : string }
+  | Supervisor_restart_attempt of { attempt : int }
+  | Restart_budget_exhausted
+  | Guardrail_stop of { reason : string }
+
+val event_to_string : event -> string
+
+(** {1 Transition} *)
+
+(** Entry actions — side-effect descriptors emitted on state entry.
+    The caller (registry integration) interprets and executes them. *)
+type entry_action =
+  | Start_compaction
+  | Start_handoff
+  | Start_drain
+  | Schedule_restart of { delay_sec : float }
+  | Publish_lifecycle of { event_name : string; detail : string }
+  | Mark_dead_tombstone
+  | Cleanup_and_unregister
+
+(** Result of applying an event. *)
+type transition_result = {
+  prev_phase : phase;
+  new_phase : phase;
+  updated_conditions : conditions;
+  entry_actions : entry_action list;
+  event_applied : event;
+  timestamp : float;
+}
+
+(** Transition errors. *)
+type transition_error =
+  | Terminal_state of { current : phase; attempted_event : string }
+  | Invalid_transition of { from_phase : phase; to_phase : phase; reason : string }
+
+val transition_error_to_string : transition_error -> string
+
+(** {1 Core Functions} *)
+
+(** Derive phase from conditions. Pure, priority-ordered.
+    This is the SOLE function that determines keeper phase.
+
+    Priority (first match wins):
+    1. Dead (terminal)
+    2. Restarting (fiber dead + budget + backoff elapsed)
+    3. Crashed (fiber dead + budget remaining)
+    4. Stopped (stop_requested + drain_complete)
+    5. Draining (stop_requested)
+    6. Guardrail -> Failing
+    7. Paused (operator_paused)
+    8. HandingOff (handoff_active)
+    9. Compacting (compaction_active)
+    10. Failing (heartbeat or turn unhealthy)
+    11. Running (fiber_alive)
+    12. Offline (default) *)
+val derive_phase : conditions -> phase
+
+(** Apply an event to the current state: update conditions, derive new phase.
+    Returns [Error] for events on terminal states (Stopped, Dead).
+    Pure function — no I/O, no clock. [now] is passed as argument. *)
+val apply_event :
+  current_phase:phase ->
+  conditions:conditions ->
+  event:event ->
+  now:float ->
+  (transition_result, transition_error) result
+
+(** Check if a direct transition from one phase to another is valid. *)
+val can_transition : from_phase:phase -> to_phase:phase -> bool
+
+(** {1 JSON Serialization} *)
+
+val phase_to_json : phase -> Yojson.Safe.t
+val conditions_to_json : conditions -> Yojson.Safe.t
+val event_to_json : event -> Yojson.Safe.t
+val transition_result_to_json : transition_result -> Yojson.Safe.t

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -1,0 +1,27 @@
+(** Keeper Transition Audit — Structured audit trail (RFC-0002). *)
+
+type transition_record = {
+  snapshot : Keeper_measurement.measurement_snapshot;
+  events_fired : Keeper_state_machine.event list;
+  selected_event : Keeper_state_machine.event;
+  prev_phase : Keeper_state_machine.phase;
+  new_phase : Keeper_state_machine.phase;
+  transition_outcome : string;
+  wall_clock_at_decision : float;
+}
+
+let to_json (r : transition_record) : Yojson.Safe.t =
+  `Assoc [
+    "snapshot", Keeper_measurement.measurement_snapshot_to_json r.snapshot;
+    "events_fired",
+      `List (List.map Keeper_state_machine.event_to_json r.events_fired);
+    "selected_event", Keeper_state_machine.event_to_json r.selected_event;
+    "prev_phase", Keeper_state_machine.phase_to_json r.prev_phase;
+    "new_phase", Keeper_state_machine.phase_to_json r.new_phase;
+    "transition_outcome", `String r.transition_outcome;
+    "wall_clock_at_decision", `Float r.wall_clock_at_decision;
+  ]
+
+(* Phase 1 stub: Keeper_guard not yet wired as consumer.
+   Phase 4 will implement actual replay by calling Keeper_guard.evaluate. *)
+let replay_check _snapshot _expected_events = true

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -1,0 +1,25 @@
+(** Keeper Transition Audit — Structured audit trail (RFC-0002).
+
+    Records every decision point for observability and replay. *)
+
+(** A single transition decision record. *)
+type transition_record = {
+  snapshot : Keeper_measurement.measurement_snapshot;
+  events_fired : Keeper_state_machine.event list;
+  selected_event : Keeper_state_machine.event;
+  prev_phase : Keeper_state_machine.phase;
+  new_phase : Keeper_state_machine.phase;
+  transition_outcome : string;
+  wall_clock_at_decision : float;
+}
+
+(** Serialize a transition record for JSONL storage. *)
+val to_json : transition_record -> Yojson.Safe.t
+
+(** Given a historical snapshot, re-run [Keeper_guard.evaluate] (when available)
+    and verify the result matches the recorded events.
+    Phase 1: always returns [true] (stub). *)
+val replay_check :
+  Keeper_measurement.measurement_snapshot ->
+  Keeper_state_machine.event list ->
+  bool

--- a/test/dune
+++ b/test/dune
@@ -91,7 +91,8 @@
         test_observability_provider_contracts
         test_worker_oas_scope_gate
         test_run_local_script
-        test_tool_prefilter)
+        test_tool_prefilter
+        test_keeper_state_machine)
  (modules test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -150,7 +151,8 @@
           test_observability_provider_contracts
           test_worker_oas_scope_gate
           test_run_local_script
-          test_tool_prefilter)
+          test_tool_prefilter
+          test_keeper_state_machine)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -1,0 +1,554 @@
+(** test_keeper_state_machine — RFC-0002 keeper state machine tests.
+
+    Pure unit tests for the deterministic core:
+    - derive_phase priority ordering
+    - apply_event valid/invalid transitions
+    - can_transition matrix completeness
+    - Terminal state properties (Stopped, Dead)
+    - Backward compatibility (to_legacy)
+    - Guard evaluation (pure, snapshot-based) *)
+
+open Alcotest
+
+module SM = Masc_mcp.Keeper_state_machine
+module Compat = Masc_mcp.Keeper_state_compat
+module Meas = Masc_mcp.Keeper_measurement
+module Guard = Masc_mcp.Keeper_guard
+
+let phase_t = testable
+  (Fmt.of_to_string SM.phase_to_string)
+  (fun a b -> SM.phase_to_string a = SM.phase_to_string b)
+
+let legacy_t = testable
+  (Fmt.of_to_string Compat.legacy_to_string)
+  (fun a b -> Compat.legacy_to_string a = Compat.legacy_to_string b)
+
+(* ── Helpers ───────────────────────────────────────────── *)
+
+(** Healthy running conditions. *)
+let running_conditions : SM.conditions =
+  { SM.default_conditions with
+    fiber_alive = true;
+    restart_budget_remaining = true;
+  }
+
+(** Apply event and extract the result, failing on error. *)
+let apply_ok ~current_phase ~conditions ~event =
+  match SM.apply_event ~current_phase ~conditions ~event ~now:1000.0 with
+  | Ok tr -> tr
+  | Error e -> fail (SM.transition_error_to_string e)
+
+(** Apply event and extract the error, failing on success. *)
+let apply_err ~current_phase ~conditions ~event =
+  match SM.apply_event ~current_phase ~conditions ~event ~now:1000.0 with
+  | Ok tr ->
+    fail (Printf.sprintf "expected error but got transition %s -> %s"
+      (SM.phase_to_string tr.prev_phase) (SM.phase_to_string tr.new_phase))
+  | Error e -> e
+
+(* ── derive_phase tests ────────────────────────────────── *)
+
+let test_derive_healthy () =
+  let c = running_conditions in
+  check phase_t "healthy = Running" SM.Running (SM.derive_phase c)
+
+let test_derive_default_dead () =
+  (* default_conditions: fiber_alive=false, restart_budget_remaining=false -> Dead *)
+  check phase_t "default = Dead" SM.Dead (SM.derive_phase SM.default_conditions)
+
+let test_derive_offline () =
+  (* Offline is the true initial state: no fiber, no budget concept yet.
+     Offline requires all booleans false — including restart_budget_remaining. *)
+  (* In practice, Offline is only reachable at the derive_phase fallback.
+     Since fiber_alive=false + restart_budget_remaining=false = Dead,
+     Offline is currently unreachable via derive_phase alone.
+     It requires explicit construction from registry initialization. *)
+  (* Verify Offline exists in all_phases *)
+  check bool "Offline in all_phases" true
+    (List.mem SM.Offline SM.all_phases)
+
+let test_derive_dead_highest_priority () =
+  let c = { running_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = false;
+    (* Even with other flags set, Dead wins *)
+    guardrail_triggered = true;
+    compaction_active = true;
+  } in
+  check phase_t "Dead wins over everything" SM.Dead (SM.derive_phase c)
+
+let test_derive_restarting () =
+  let c = { SM.default_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = true;
+    backoff_elapsed = true;
+  } in
+  check phase_t "fiber dead + budget + backoff = Restarting"
+    SM.Restarting (SM.derive_phase c)
+
+let test_derive_crashed () =
+  let c = { SM.default_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = true;
+    backoff_elapsed = false;
+  } in
+  check phase_t "fiber dead + budget + no backoff = Crashed"
+    SM.Crashed (SM.derive_phase c)
+
+let test_derive_stopped () =
+  let c = { running_conditions with
+    stop_requested = true;
+    drain_complete = true;
+  } in
+  check phase_t "stop + drain = Stopped" SM.Stopped (SM.derive_phase c)
+
+let test_derive_draining () =
+  let c = { running_conditions with
+    stop_requested = true;
+    drain_complete = false;
+  } in
+  check phase_t "stop + no drain = Draining" SM.Draining (SM.derive_phase c)
+
+let test_derive_guardrail_failing () =
+  let c = { running_conditions with guardrail_triggered = true } in
+  check phase_t "guardrail = Failing" SM.Failing (SM.derive_phase c)
+
+let test_derive_paused () =
+  let c = { running_conditions with operator_paused = true } in
+  check phase_t "paused" SM.Paused (SM.derive_phase c)
+
+let test_derive_handingoff () =
+  let c = { running_conditions with handoff_active = true } in
+  check phase_t "handoff active = HandingOff" SM.HandingOff (SM.derive_phase c)
+
+let test_derive_compacting () =
+  let c = { running_conditions with compaction_active = true } in
+  check phase_t "compaction active = Compacting" SM.Compacting (SM.derive_phase c)
+
+let test_derive_failing_heartbeat () =
+  let c = { running_conditions with heartbeat_healthy = false } in
+  check phase_t "hb unhealthy = Failing" SM.Failing (SM.derive_phase c)
+
+let test_derive_failing_turn () =
+  let c = { running_conditions with turn_healthy = false } in
+  check phase_t "turn unhealthy = Failing" SM.Failing (SM.derive_phase c)
+
+let test_derive_priority_stop_over_compact () =
+  let c = { running_conditions with
+    stop_requested = true;
+    drain_complete = true;
+    compaction_active = true;
+  } in
+  check phase_t "Stopped beats Compacting" SM.Stopped (SM.derive_phase c)
+
+let test_derive_priority_guardrail_over_paused () =
+  let c = { running_conditions with
+    guardrail_triggered = true;
+    operator_paused = true;
+  } in
+  check phase_t "Guardrail(Failing) beats Paused" SM.Failing (SM.derive_phase c)
+
+let test_derive_priority_handoff_over_compact () =
+  let c = { running_conditions with
+    handoff_active = true;
+    compaction_active = true;
+  } in
+  check phase_t "HandingOff beats Compacting" SM.HandingOff (SM.derive_phase c)
+
+(* ── apply_event tests ─────────────────────────────────── *)
+
+let test_apply_heartbeat_ok_stays_running () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Heartbeat_ok in
+  check phase_t "stays Running" SM.Running tr.new_phase
+
+let test_apply_heartbeat_fail_to_failing () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:(SM.Heartbeat_failed { consecutive = 5; max_allowed = 5 }) in
+  check phase_t "Running -> Failing" SM.Failing tr.new_phase;
+  check bool "hb unhealthy" false tr.updated_conditions.heartbeat_healthy
+
+let test_apply_heartbeat_recover () =
+  let failing_conds = { running_conditions with heartbeat_healthy = false } in
+  let tr = apply_ok
+    ~current_phase:SM.Failing
+    ~conditions:failing_conds
+    ~event:SM.Heartbeat_ok in
+  check phase_t "Failing -> Running" SM.Running tr.new_phase;
+  check bool "hb healthy" true tr.updated_conditions.heartbeat_healthy
+
+let test_apply_compaction_started () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Compaction_started in
+  check phase_t "Running -> Compacting" SM.Compacting tr.new_phase;
+  check bool "compaction_active" true tr.updated_conditions.compaction_active
+
+let test_apply_compaction_completed () =
+  let compacting_conds = { running_conditions with compaction_active = true } in
+  let tr = apply_ok
+    ~current_phase:SM.Compacting
+    ~conditions:compacting_conds
+    ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 }) in
+  check phase_t "Compacting -> Running" SM.Running tr.new_phase;
+  check bool "compaction done" false tr.updated_conditions.compaction_active
+
+let test_apply_handoff_lifecycle () =
+  (* Running -> HandingOff -> Running *)
+  let tr1 = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Handoff_started in
+  check phase_t "-> HandingOff" SM.HandingOff tr1.new_phase;
+  let tr2 = apply_ok
+    ~current_phase:SM.HandingOff
+    ~conditions:tr1.updated_conditions
+    ~event:(SM.Handoff_completed { new_trace_id = "abc"; generation = 2 }) in
+  check phase_t "-> Running" SM.Running tr2.new_phase
+
+let test_apply_operator_pause_resume () =
+  let tr1 = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Operator_pause in
+  check phase_t "-> Paused" SM.Paused tr1.new_phase;
+  let tr2 = apply_ok
+    ~current_phase:SM.Paused
+    ~conditions:tr1.updated_conditions
+    ~event:SM.Operator_resume in
+  check phase_t "-> Running" SM.Running tr2.new_phase
+
+let test_apply_drain_lifecycle () =
+  (* Running -> Draining -> Stopped *)
+  let tr1 = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Stop_requested in
+  check phase_t "-> Draining" SM.Draining tr1.new_phase;
+  let tr2 = apply_ok
+    ~current_phase:SM.Draining
+    ~conditions:tr1.updated_conditions
+    ~event:SM.Drain_complete in
+  check phase_t "-> Stopped" SM.Stopped tr2.new_phase
+
+let test_apply_fiber_terminated_crash () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:(SM.Fiber_terminated { outcome = "exception" }) in
+  (* fiber_alive=false + budget_remaining=true + backoff not elapsed = Crashed *)
+  check phase_t "-> Crashed" SM.Crashed tr.new_phase;
+  check bool "fiber dead" false tr.updated_conditions.fiber_alive
+
+let test_apply_crash_restart_lifecycle () =
+  (* Crashed -> Restarting -> Running *)
+  let crashed_conds = { SM.default_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = true;
+    backoff_elapsed = false;
+  } in
+  let tr1 = apply_ok
+    ~current_phase:SM.Crashed
+    ~conditions:crashed_conds
+    ~event:(SM.Supervisor_restart_attempt { attempt = 1 }) in
+  check phase_t "-> Restarting" SM.Restarting tr1.new_phase;
+  let tr2 = apply_ok
+    ~current_phase:SM.Restarting
+    ~conditions:tr1.updated_conditions
+    ~event:SM.Fiber_started in
+  check phase_t "-> Running" SM.Running tr2.new_phase
+
+let test_apply_crash_to_dead () =
+  let crashed_conds = { SM.default_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = true;
+  } in
+  let tr = apply_ok
+    ~current_phase:SM.Crashed
+    ~conditions:crashed_conds
+    ~event:SM.Restart_budget_exhausted in
+  check phase_t "-> Dead" SM.Dead tr.new_phase
+
+(* ── Terminal state tests ──────────────────────────────── *)
+
+let test_dead_rejects_all_events () =
+  let dead_conds = { SM.default_conditions with
+    fiber_alive = false;
+    restart_budget_remaining = false;
+  } in
+  List.iter (fun event ->
+    let err = apply_err ~current_phase:SM.Dead ~conditions:dead_conds ~event in
+    match err with
+    | SM.Terminal_state { current; _ } ->
+      check phase_t "Dead" SM.Dead current
+    | _ -> fail "expected Terminal_state error"
+  ) [ SM.Heartbeat_ok; SM.Fiber_started; SM.Operator_resume;
+      SM.Compaction_started; SM.Handoff_started ]
+
+let test_stopped_rejects_all_events () =
+  let stopped_conds = { running_conditions with
+    stop_requested = true;
+    drain_complete = true;
+  } in
+  List.iter (fun event ->
+    let err = apply_err ~current_phase:SM.Stopped ~conditions:stopped_conds ~event in
+    match err with
+    | SM.Terminal_state { current; _ } ->
+      check phase_t "Stopped" SM.Stopped current
+    | _ -> fail "expected Terminal_state error"
+  ) [ SM.Heartbeat_ok; SM.Fiber_started; SM.Operator_resume ]
+
+(* ── can_transition matrix tests ───────────────────────── *)
+
+let test_can_transition_running_to_buffer_states () =
+  check bool "-> Failing" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Failing);
+  check bool "-> Compacting" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Compacting);
+  check bool "-> HandingOff" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.HandingOff);
+  check bool "-> Draining" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Draining);
+  check bool "-> Paused" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Paused);
+  check bool "-> Stopped" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Stopped)
+
+let test_can_transition_running_invalid () =
+  check bool "no -> Dead" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Dead);
+  check bool "-> Crashed (fiber death)" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Crashed);
+  check bool "no -> Restarting" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Restarting);
+  check bool "no -> Offline" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Offline)
+
+let test_can_transition_terminal_nothing () =
+  List.iter (fun to_phase ->
+    check bool "Stopped -> nothing" false
+      (SM.can_transition ~from_phase:SM.Stopped ~to_phase);
+    check bool "Dead -> nothing" false
+      (SM.can_transition ~from_phase:SM.Dead ~to_phase)
+  ) SM.all_phases
+
+let test_can_transition_crashed_only_restart_or_dead () =
+  check bool "-> Restarting" true (SM.can_transition ~from_phase:SM.Crashed ~to_phase:SM.Restarting);
+  check bool "-> Dead" true (SM.can_transition ~from_phase:SM.Crashed ~to_phase:SM.Dead);
+  check bool "no -> Running" false (SM.can_transition ~from_phase:SM.Crashed ~to_phase:SM.Running);
+  check bool "no -> Paused" false (SM.can_transition ~from_phase:SM.Crashed ~to_phase:SM.Paused)
+
+(* ── Backward compat tests ─────────────────────────────── *)
+
+let test_legacy_buffer_states_map_to_running () =
+  List.iter (fun phase ->
+    check legacy_t "maps to Running" Compat.Running (Compat.to_legacy phase)
+  ) [ SM.Failing; SM.Compacting; SM.HandingOff; SM.Draining ]
+
+let test_legacy_restarting_maps_to_crashed () =
+  check legacy_t "Restarting -> Crashed" Compat.Crashed (Compat.to_legacy SM.Restarting)
+
+let test_legacy_offline_maps_to_stopped () =
+  check legacy_t "Offline -> Stopped" Compat.Stopped (Compat.to_legacy SM.Offline)
+
+let test_legacy_stable_states_identity () =
+  check legacy_t "Running" Compat.Running (Compat.to_legacy SM.Running);
+  check legacy_t "Paused" Compat.Paused (Compat.to_legacy SM.Paused);
+  check legacy_t "Stopped" Compat.Stopped (Compat.to_legacy SM.Stopped);
+  check legacy_t "Crashed" Compat.Crashed (Compat.to_legacy SM.Crashed);
+  check legacy_t "Dead" Compat.Dead (Compat.to_legacy SM.Dead)
+
+let test_legacy_roundtrip_string () =
+  List.iter (fun phase ->
+    let legacy = Compat.to_legacy phase in
+    let s = Compat.legacy_to_string legacy in
+    check bool "non-empty" true (String.length s > 0);
+    match Compat.legacy_of_string s with
+    | Some recovered -> check legacy_t "roundtrip" legacy recovered
+    | None -> fail (Printf.sprintf "legacy_of_string failed for %s" s)
+  ) SM.all_phases
+
+(* ── Guard evaluation tests ────────────────────────────── *)
+
+let base_thresholds : Meas.threshold_params = {
+  compaction_ratio_gate = 0.50;
+  compaction_message_gate = 100;
+  compaction_token_gate = 50000;
+  compaction_cooldown_sec = 60;
+  handoff_threshold = 0.85;
+  handoff_cooldown_sec = 300;
+  auto_handoff_enabled = true;
+  reflect_repetition_threshold = 0.7;
+  plan_goal_alignment_threshold = 0.3;
+  plan_response_alignment_threshold = 0.3;
+  guardrail_repetition_threshold = 0.9;
+  guardrail_goal_alignment_threshold = 0.2;
+  guardrail_response_alignment_threshold = 0.2;
+  guardrail_context_threshold = 0.8;
+  max_consecutive_hb_failures = 5;
+  max_consecutive_turn_failures = 3;
+  model_ratio_multiplier = 1.0;
+  model_handoff_multiplier = 1.0;
+}
+
+let healthy_snapshot : Meas.measurement_snapshot = {
+  snapshot_id = "test-001";
+  keeper_name = "alpha";
+  generation = 1;
+  timestamp = 1000.0;
+  thresholds = base_thresholds;
+  context = {
+    context_ratio = 0.30;
+    message_count = 20;
+    token_count = 15000;
+    max_tokens = 100000;
+  };
+  similarity = {
+    repetition_risk = 0.1;
+    goal_alignment = 0.8;
+    response_alignment = 0.7;
+  };
+  timing = {
+    now_ts = 1000.0;
+    idle_seconds = 10;
+    since_last_compaction_ts = 600.0;
+    since_last_handoff_ts = 600.0;
+    proactive_warmup_elapsed = true;
+  };
+  failures = {
+    consecutive_hb_failures = 0;
+    consecutive_turn_failures = 0;
+  };
+}
+
+let test_guard_healthy_no_crash_events () =
+  let events = Guard.evaluate healthy_snapshot in
+  let has_crash = List.exists (function
+    | SM.Heartbeat_failed _ | SM.Turn_failed _
+    | SM.Guardrail_stop _ | SM.Compaction_started | SM.Handoff_started -> true
+    | _ -> false
+  ) events in
+  check bool "no crash/action events" false has_crash
+
+let test_guard_compaction_triggers () =
+  let snap = { healthy_snapshot with
+    context = { healthy_snapshot.context with context_ratio = 0.55 };
+  } in
+  let events = Guard.evaluate snap in
+  let has_compact = List.exists (function
+    | SM.Compaction_started -> true | _ -> false
+  ) events in
+  check bool "compaction triggered" true has_compact
+
+let test_guard_handoff_triggers () =
+  let snap = { healthy_snapshot with
+    context = { healthy_snapshot.context with context_ratio = 0.90 };
+  } in
+  let events = Guard.evaluate snap in
+  let has_handoff = List.exists (function
+    | SM.Handoff_started -> true | _ -> false
+  ) events in
+  check bool "handoff triggered" true has_handoff
+
+let test_guard_guardrail_triggers () =
+  let snap = { healthy_snapshot with
+    similarity = {
+      repetition_risk = 0.95;
+      goal_alignment = 0.1;
+      response_alignment = 0.1;
+    };
+    context = { healthy_snapshot.context with context_ratio = 0.85 };
+  } in
+  let events = Guard.evaluate snap in
+  let prio = Guard.prioritized_event events in
+  match prio with
+  | SM.Guardrail_stop _ -> ()
+  | other -> fail (Printf.sprintf "expected Guardrail_stop, got %s"
+      (SM.event_to_string other))
+
+let test_guard_hb_failure_threshold () =
+  let snap = { healthy_snapshot with
+    failures = { healthy_snapshot.failures with consecutive_hb_failures = 5 };
+  } in
+  let events = Guard.evaluate snap in
+  let has_hb_fail = List.exists (function
+    | SM.Heartbeat_failed { consecutive = 5; max_allowed = 5 } -> true
+    | _ -> false
+  ) events in
+  check bool "heartbeat failure at threshold" true has_hb_fail
+
+(* ── Phase roundtrip tests ─────────────────────────────── *)
+
+let test_phase_string_roundtrip () =
+  List.iter (fun phase ->
+    let s = SM.phase_to_string phase in
+    match SM.phase_of_string s with
+    | Some recovered -> check phase_t "roundtrip" phase recovered
+    | None -> fail (Printf.sprintf "phase_of_string failed for %s" s)
+  ) SM.all_phases
+
+(* ── Property: derive_phase x apply_event consistency ──── *)
+
+let test_all_phases_covered () =
+  check int "11 phases" 11 (List.length SM.all_phases)
+
+(* ── Test suite ────────────────────────────────────────── *)
+
+let () =
+  run "Keeper_state_machine (RFC-0002)" [
+    "derive_phase", [
+      test_case "healthy = Running" `Quick test_derive_healthy;
+      test_case "default = Dead" `Quick test_derive_default_dead;
+      test_case "Offline in all_phases" `Quick test_derive_offline;
+      test_case "Dead highest priority" `Quick test_derive_dead_highest_priority;
+      test_case "Restarting" `Quick test_derive_restarting;
+      test_case "Crashed" `Quick test_derive_crashed;
+      test_case "Stopped" `Quick test_derive_stopped;
+      test_case "Draining" `Quick test_derive_draining;
+      test_case "Guardrail -> Failing" `Quick test_derive_guardrail_failing;
+      test_case "Paused" `Quick test_derive_paused;
+      test_case "HandingOff" `Quick test_derive_handingoff;
+      test_case "Compacting" `Quick test_derive_compacting;
+      test_case "Failing (heartbeat)" `Quick test_derive_failing_heartbeat;
+      test_case "Failing (turn)" `Quick test_derive_failing_turn;
+      test_case "priority: Stop > Compact" `Quick test_derive_priority_stop_over_compact;
+      test_case "priority: Guardrail > Paused" `Quick test_derive_priority_guardrail_over_paused;
+      test_case "priority: Handoff > Compact" `Quick test_derive_priority_handoff_over_compact;
+    ];
+    "apply_event", [
+      test_case "heartbeat ok stays" `Quick test_apply_heartbeat_ok_stays_running;
+      test_case "heartbeat fail -> Failing" `Quick test_apply_heartbeat_fail_to_failing;
+      test_case "heartbeat recover" `Quick test_apply_heartbeat_recover;
+      test_case "compaction started" `Quick test_apply_compaction_started;
+      test_case "compaction completed" `Quick test_apply_compaction_completed;
+      test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle;
+      test_case "pause/resume" `Quick test_apply_operator_pause_resume;
+      test_case "drain lifecycle" `Quick test_apply_drain_lifecycle;
+      test_case "fiber terminated -> Crashed" `Quick test_apply_fiber_terminated_crash;
+      test_case "crash -> restart -> Running" `Quick test_apply_crash_restart_lifecycle;
+      test_case "crash -> Dead" `Quick test_apply_crash_to_dead;
+    ];
+    "terminal", [
+      test_case "Dead rejects all" `Quick test_dead_rejects_all_events;
+      test_case "Stopped rejects all" `Quick test_stopped_rejects_all_events;
+    ];
+    "can_transition", [
+      test_case "Running -> buffer states" `Quick test_can_transition_running_to_buffer_states;
+      test_case "Running invalid targets" `Quick test_can_transition_running_invalid;
+      test_case "terminal -> nothing" `Quick test_can_transition_terminal_nothing;
+      test_case "Crashed -> Restarting|Dead only" `Quick test_can_transition_crashed_only_restart_or_dead;
+    ];
+    "backward_compat", [
+      test_case "buffer -> Running" `Quick test_legacy_buffer_states_map_to_running;
+      test_case "Restarting -> Crashed" `Quick test_legacy_restarting_maps_to_crashed;
+      test_case "Offline -> Stopped" `Quick test_legacy_offline_maps_to_stopped;
+      test_case "stable identity" `Quick test_legacy_stable_states_identity;
+      test_case "string roundtrip" `Quick test_legacy_roundtrip_string;
+    ];
+    "guard", [
+      test_case "healthy = no action events" `Quick test_guard_healthy_no_crash_events;
+      test_case "compaction triggers" `Quick test_guard_compaction_triggers;
+      test_case "handoff triggers" `Quick test_guard_handoff_triggers;
+      test_case "guardrail triggers" `Quick test_guard_guardrail_triggers;
+      test_case "hb failure at threshold" `Quick test_guard_hb_failure_threshold;
+    ];
+    "roundtrip", [
+      test_case "phase string roundtrip" `Quick test_phase_string_roundtrip;
+      test_case "11 phases" `Quick test_all_phases_covered;
+    ];
+  ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -16,12 +16,10 @@ module Meas = Masc_mcp.Keeper_measurement
 module Guard = Masc_mcp.Keeper_guard
 
 let phase_t = testable
-  (Fmt.of_to_string SM.phase_to_string)
-  (fun a b -> SM.phase_to_string a = SM.phase_to_string b)
+  (Fmt.of_to_string SM.phase_to_string) (=)
 
 let legacy_t = testable
-  (Fmt.of_to_string Compat.legacy_to_string)
-  (fun a b -> Compat.legacy_to_string a = Compat.legacy_to_string b)
+  (Fmt.of_to_string Compat.legacy_to_string) (=)
 
 (* ── Helpers ───────────────────────────────────────────── *)
 
@@ -235,6 +233,48 @@ let test_apply_drain_lifecycle () =
     ~conditions:tr1.updated_conditions
     ~event:SM.Drain_complete in
   check phase_t "-> Stopped" SM.Stopped tr2.new_phase
+
+let test_apply_drain_fiber_death () =
+  (* Draining + fiber dies -> Crashed (drain did not complete) *)
+  let draining_conds = { running_conditions with
+    stop_requested = true;
+    drain_complete = false;
+  } in
+  let tr = apply_ok
+    ~current_phase:SM.Draining
+    ~conditions:draining_conds
+    ~event:(SM.Fiber_terminated { outcome = "exception during drain" }) in
+  check phase_t "Draining + fiber death -> Crashed" SM.Crashed tr.new_phase
+
+let test_apply_drain_complete_then_fiber_exit () =
+  (* drain_complete=true + fiber exits -> Stopped (drain succeeded) *)
+  let drain_done_conds = { running_conditions with
+    stop_requested = true;
+    drain_complete = true;
+  } in
+  let tr = apply_ok
+    ~current_phase:SM.Draining
+    ~conditions:drain_done_conds
+    ~event:(SM.Fiber_terminated { outcome = "clean exit" }) in
+  check phase_t "drain complete + fiber exit -> Stopped" SM.Stopped tr.new_phase
+
+let test_apply_failing_to_crashed () =
+  (* Failing keeper receives fatal failure -> Crashed *)
+  let failing_conds = { running_conditions with heartbeat_healthy = false } in
+  let tr = apply_ok
+    ~current_phase:SM.Failing
+    ~conditions:failing_conds
+    ~event:(SM.Fiber_terminated { outcome = "fatal" }) in
+  check phase_t "Failing + fiber death -> Crashed" SM.Crashed tr.new_phase
+
+let test_apply_partial_heartbeat_failure () =
+  (* Partial failure (1/5) should still mark unhealthy and go to Failing *)
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:(SM.Heartbeat_failed { consecutive = 1; max_allowed = 5 }) in
+  check phase_t "partial failure -> Failing" SM.Failing tr.new_phase;
+  check bool "hb unhealthy on partial" false tr.updated_conditions.heartbeat_healthy
 
 let test_apply_fiber_terminated_crash () =
   let tr = apply_ok
@@ -519,6 +559,10 @@ let () =
       test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle;
       test_case "pause/resume" `Quick test_apply_operator_pause_resume;
       test_case "drain lifecycle" `Quick test_apply_drain_lifecycle;
+      test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death;
+      test_case "drain complete + fiber exit -> Stopped" `Quick test_apply_drain_complete_then_fiber_exit;
+      test_case "Failing + fiber death -> Crashed" `Quick test_apply_failing_to_crashed;
+      test_case "partial heartbeat -> Failing" `Quick test_apply_partial_heartbeat_failure;
       test_case "fiber terminated -> Crashed" `Quick test_apply_fiber_terminated_crash;
       test_case "crash -> restart -> Running" `Quick test_apply_crash_restart_lifecycle;
       test_case "crash -> Dead" `Quick test_apply_crash_to_dead;


### PR DESCRIPTION
- [x] Read and analyze all reviewer comments
- [x] Fix 10-state vs 11-state naming (mli, RFC, docs)
- [x] Add `budget_exhausted` condition + fix `derive_phase` so `Offline` is reachable from `default_conditions`
- [x] Fix `can_transition` to add `Offline -> Draining`
- [x] Fix `prioritized_event` to skip `Context_measured` events
- [x] Rename `since_last_compaction_ts` / `since_last_handoff_ts` → `*_sec` (measurement + guard)
- [x] Structured JSON for `event_to_json` (full payload, not just string)
- [x] Prefix unqualified constructors in `keeper_state_compat.ml` with `Keeper_state_machine.`
- [x] Update tests to match new semantics