### PR TITLE
fix(keeper): address Copilot review on RFC-0002 Phase 1

### DIFF
--- a/docs/rfc/RFC-0002-keeper-state-machine.md
+++ b/docs/rfc/RFC-0002-keeper-state-machine.md
@@ -1,9 +1,9 @@
-# RFC-0002: Keeper 10-State Machine + Det/NonDet Boundary Formalization
+# RFC-0002: Keeper 11-State Machine + Det/NonDet Boundary Formalization
 
 **Status**: Draft
 **Date**: 2026-04-05
 **Scope**: `masc-mcp` keeper lifecycle state machine redesign
-**One sentence**: Keeper의 5-state 상태 머신을 10-state로 확장하고, 비결정론적 측정과 결정론적 전이 사이에 관찰 가능한 buffer state와 snapshot-at-decision 경계를 도입한다.
+**One sentence**: Keeper의 5-state 상태 머신을 11-state로 확장하고, 비결정론적 측정과 결정론적 전이 사이에 관찰 가능한 buffer state와 snapshot-at-decision 경계를 도입한다.
 
 ## Related Documents
 
@@ -57,7 +57,7 @@ Layer 1 (Storage)         Atomic registry updates + backward-compat projection
 
 ## State Definition
 
-### 10-State Phase Enum
+### 11-State Phase Enum
 
 ```ocaml
 type phase =
@@ -127,7 +127,7 @@ Terminal states: Stopped, Dead.
 ### Backward Compatibility
 
 ```ocaml
-(* 10-state -> 5-state projection *)
+(* 11-state -> 5-state projection *)
 let to_legacy = function
   | Offline       -> Stopped
   | Running       -> Running
@@ -202,7 +202,7 @@ val evaluate : measurement_snapshot -> event list
 | Risk | Mitigation |
 |------|-----------|
 | Eio fiber safety | conditions는 non-yielding 연산만 사용. 단일 fiber 소유 |
-| Dashboard backward compat | registry_state (5-state) 유지, phase (10-state) 추가 |
+| Dashboard backward compat | registry_state (5-state) 유지, phase (11-state) 추가 |
 | Transition table 복잡도 | derive_phase single pure function + property test 전수 검증 |
 | GADT 과잉 | Phase payload 차이가 작아 plain variant + exhaustive match 선택 |
 

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -62,7 +62,7 @@ let evaluate (s : measurement_snapshot) : event list =
   let compact_msg = s.context.message_count >= t.compaction_message_gate in
   let compact_tok = s.context.token_count >= t.compaction_token_gate in
   let cooldown_ok =
-    s.timing.since_last_compaction_ts >= float_of_int t.compaction_cooldown_sec
+    s.timing.since_last_compaction_sec >= float_of_int t.compaction_cooldown_sec
   in
   if (compact_ratio || compact_msg || compact_tok) && cooldown_ok then
     add Compaction_started;
@@ -70,7 +70,7 @@ let evaluate (s : measurement_snapshot) : event list =
   (* 5. Handoff: context ratio above threshold *)
   let handoff_threshold = t.handoff_threshold *. t.model_handoff_multiplier in
   let handoff_cooldown_ok =
-    s.timing.since_last_handoff_ts >= float_of_int t.handoff_cooldown_sec
+    s.timing.since_last_handoff_sec >= float_of_int t.handoff_cooldown_sec
   in
   if t.auto_handoff_enabled
      && s.context.context_ratio >= handoff_threshold
@@ -117,6 +117,7 @@ let evaluate (s : measurement_snapshot) : event list =
   List.sort (fun a b -> compare (event_priority a) (event_priority b))
     (List.rev !events)
 
-let prioritized_event = function
+let rec prioritized_event = function
   | [] -> Heartbeat_ok
+  | Context_measured _ :: rest -> prioritized_event rest
   | first :: _ -> first

--- a/lib/keeper/keeper_measurement.ml
+++ b/lib/keeper/keeper_measurement.ml
@@ -38,8 +38,8 @@ type similarity_measurement = {
 type timing_measurement = {
   now_ts : float;
   idle_seconds : int;
-  since_last_compaction_ts : float;
-  since_last_handoff_ts : float;
+  since_last_compaction_sec : float;
+  since_last_handoff_sec : float;
   proactive_warmup_elapsed : bool;
 }
 
@@ -103,8 +103,8 @@ let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
     "timing", `Assoc [
       "now_ts", `Float s.timing.now_ts;
       "idle_seconds", `Int s.timing.idle_seconds;
-      "since_last_compaction_ts", `Float s.timing.since_last_compaction_ts;
-      "since_last_handoff_ts", `Float s.timing.since_last_handoff_ts;
+      "since_last_compaction_sec", `Float s.timing.since_last_compaction_sec;
+      "since_last_handoff_sec", `Float s.timing.since_last_handoff_sec;
       "proactive_warmup_elapsed", `Bool s.timing.proactive_warmup_elapsed;
     ];
     "failures", `Assoc [

--- a/lib/keeper/keeper_measurement.mli
+++ b/lib/keeper/keeper_measurement.mli
@@ -51,8 +51,8 @@ type similarity_measurement = {
 type timing_measurement = {
   now_ts : float;
   idle_seconds : int;
-  since_last_compaction_ts : float;
-  since_last_handoff_ts : float;
+  since_last_compaction_sec : float;
+  since_last_handoff_sec : float;
   proactive_warmup_elapsed : bool;
 }
 

--- a/lib/keeper/keeper_state_compat.ml
+++ b/lib/keeper/keeper_state_compat.ml
@@ -23,14 +23,14 @@ let legacy_of_string = function
   | _ -> None
 
 let to_legacy : Keeper_state_machine.phase -> legacy_state = function
-  | Offline -> Stopped
-  | Running -> Running
-  | Failing -> Running
-  | Compacting -> Running
-  | HandingOff -> Running
-  | Draining -> Running
-  | Paused -> Paused
-  | Stopped -> Stopped
-  | Crashed -> Crashed
-  | Restarting -> Crashed
-  | Dead -> Dead
+  | Keeper_state_machine.Offline -> Stopped
+  | Keeper_state_machine.Running -> Running
+  | Keeper_state_machine.Failing -> Running
+  | Keeper_state_machine.Compacting -> Running
+  | Keeper_state_machine.HandingOff -> Running
+  | Keeper_state_machine.Draining -> Running
+  | Keeper_state_machine.Paused -> Paused
+  | Keeper_state_machine.Stopped -> Stopped
+  | Keeper_state_machine.Crashed -> Crashed
+  | Keeper_state_machine.Restarting -> Crashed
+  | Keeper_state_machine.Dead -> Dead

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -196,8 +196,8 @@ let can_transition ~from_phase ~to_phase =
   (* Terminal states accept nothing *)
   | Stopped, _ -> false
   | Dead, _ -> false
-  (* Offline -> Running | Stopped *)
-  | Offline, (Running | Stopped) -> true
+  (* Offline -> Running | Stopped | Draining (stop while not yet started) *)
+  | Offline, (Running | Stopped | Draining) -> true
   | Offline, _ -> false
   (* Running -> buffer states, Paused, Stopped, Crashed (fiber death) *)
   | Running, (Failing | Compacting | HandingOff | Draining | Paused | Stopped | Crashed) -> true
@@ -418,7 +418,60 @@ let conditions_to_json (c : conditions) =
     "drain_complete", `Bool c.drain_complete;
   ]
 
-let event_to_json ev = `String (event_to_string ev)
+let event_to_json (ev : event) : Yojson.Safe.t =
+  let obj typ fields = `Assoc (("type", `String typ) :: fields) in
+  match ev with
+  | Heartbeat_ok -> obj "heartbeat_ok" []
+  | Heartbeat_failed r ->
+    obj "heartbeat_failed" [
+      "consecutive", `Int r.consecutive;
+      "max_allowed", `Int r.max_allowed;
+    ]
+  | Turn_succeeded -> obj "turn_succeeded" []
+  | Turn_failed r ->
+    obj "turn_failed" [
+      "consecutive", `Int r.consecutive;
+      "max_allowed", `Int r.max_allowed;
+    ]
+  | Context_measured r ->
+    obj "context_measured" [
+      "context_ratio", `Float r.context_ratio;
+      "message_count", `Int r.message_count;
+      "token_count", `Int r.token_count;
+      "auto_rules", `Assoc [
+        "reflect", `Bool r.auto_rules.reflect;
+        "plan", `Bool r.auto_rules.plan;
+        "compact", `Bool r.auto_rules.compact;
+        "handoff", `Bool r.auto_rules.handoff;
+        "guardrail_stop", `Bool r.auto_rules.guardrail_stop;
+        "goal_drift", `Float r.auto_rules.goal_drift;
+      ];
+    ]
+  | Compaction_started -> obj "compaction_started" []
+  | Compaction_completed r ->
+    obj "compaction_completed" [
+      "before_tokens", `Int r.before_tokens;
+      "after_tokens", `Int r.after_tokens;
+    ]
+  | Compaction_failed r -> obj "compaction_failed" ["reason", `String r.reason]
+  | Handoff_started -> obj "handoff_started" []
+  | Handoff_completed r ->
+    obj "handoff_completed" [
+      "new_trace_id", `String r.new_trace_id;
+      "generation", `Int r.generation;
+    ]
+  | Handoff_failed r -> obj "handoff_failed" ["reason", `String r.reason]
+  | Operator_pause -> obj "operator_pause" []
+  | Operator_resume -> obj "operator_resume" []
+  | Operator_stop r -> obj "operator_stop" ["remove_meta", `Bool r.remove_meta]
+  | Stop_requested -> obj "stop_requested" []
+  | Drain_complete -> obj "drain_complete" []
+  | Fiber_started -> obj "fiber_started" []
+  | Fiber_terminated r -> obj "fiber_terminated" ["outcome", `String r.outcome]
+  | Supervisor_restart_attempt r ->
+    obj "supervisor_restart_attempt" ["attempt", `Int r.attempt]
+  | Restart_budget_exhausted -> obj "restart_budget_exhausted" []
+  | Guardrail_stop r -> obj "guardrail_stop" ["reason", `String r.reason]
 
 let transition_result_to_json (tr : transition_result) =
   `Assoc [

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -446,8 +446,8 @@ let healthy_snapshot : Meas.measurement_snapshot = {
   timing = {
     now_ts = 1000.0;
     idle_seconds = 10;
-    since_last_compaction_ts = 600.0;
-    since_last_handoff_ts = 600.0;
+    since_last_compaction_sec = 600.0;
+    since_last_handoff_sec = 600.0;
     proactive_warmup_elapsed = true;
   };
   failures = {


### PR DESCRIPTION
## Summary

#5229 Copilot 리뷰 8개 코멘트 대응. 6개 수정, 2개 인지(Phase 2 defer).

- 11-state 용어 통일
- Offline -> Draining 전이 허용
- `prioritized_event` audit-only event 스킵
- `since_last_*_sec` 필드명 명확화
- `event_to_json` 구조화된 JSON (payload 보존)
- `keeper_state_compat.ml` 명시적 module qualifier

## Test Plan

- [x] 50 tests, all green
- [x] Full `dune build` pass

Follows up: #5229