### PR TITLE
arch(boundary): eliminate vendor/model knowledge in MASC core logic

### DIFF
--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -153,7 +153,7 @@ let default_model_for_provider provider =
   | Some { canonical_name; default_model_id; _ } when canonical_name = Provider_adapter.cn_llama -> (
       match Provider_adapter.explicit_llama_model_id_result () with
       | Ok model_id -> trim_nonempty model_id
-      | Error _ -> default_model_id)
+      | Error _ -> Option.bind default_model_id trim_nonempty)
   | Some { default_model_id; _ } -> default_model_id
   | None -> None
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -150,10 +150,10 @@ let endpoint_url_for_provider provider =
 
 let default_model_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with
-  | Some { canonical_name; default_model_id; _ } when canonical_name = Provider_adapter.cn_llama -> (
+  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_llama -> (
       match Provider_adapter.explicit_llama_model_id_result () with
       | Ok model_id -> trim_nonempty model_id
-      | Error _ -> Option.bind default_model_id trim_nonempty)
+      | Error _ -> None)
   | Some { default_model_id; _ } -> default_model_id
   | None -> None
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -150,20 +150,17 @@ let endpoint_url_for_provider provider =
 
 let default_model_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with
-  | Some { runtime_kind = Provider_adapter.Local; _ } ->
-    (match Provider_adapter.explicit_llama_model_id_result () with
-     | Ok model_id -> trim_nonempty model_id
-     | Error _ ->
-       (match trim_nonempty Env_config_runtime.Llama.default_model with
-        | Some value when value <> "explicit-model-required" -> Some value
-        | _ -> None))
-  | Some { runtime_kind = Provider_adapter.Direct_api; _ } -> Some "auto"
+  | Some { canonical_name; default_model_id; _ } when canonical_name = Provider_adapter.cn_llama -> (
+      match Provider_adapter.explicit_llama_model_id_result () with
+      | Ok model_id -> trim_nonempty model_id
+      | Error _ -> default_model_id)
+  | Some { default_model_id; _ } -> default_model_id
   | None -> None
 
 let candidate_models_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with
-  | Some { runtime_kind = Provider_adapter.Local; _ } -> []
-  | Some { runtime_kind = Provider_adapter.Direct_api; _ } -> ["auto"]
+  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_llama -> []
+  | Some _ -> [ "auto" ]
   | None -> []
 
 let llama_snapshot () =

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -405,18 +405,14 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
   | Error e, _ | _, Error e -> Error e
 
 (** Convert a model label to an OAS Provider.config.
-    Uses OAS Provider.config_of_provider_config directly.
-    Falls back to glm for unrecognized labels. *)
+    Uses OAS Provider.config_of_provider_config directly. *)
 let oas_provider_of_label (label : string) : Oas.Provider.config =
   match Llm_provider.Cascade_config.parse_model_string label with
   | Some pc -> Oas.Provider.config_of_provider_config pc
   | None ->
-    Oas.Provider.config_of_provider_config
-      (Llm_provider.Provider_config.make
-         ~kind:Llm_provider.Provider_config.Glm
-         ~model_id:label
-         ~base_url:(Env_config_runtime.Glm.server_url ^ "/api/coding/paas/v4")
-         ~request_path:"/chat/completions" ())
+    let msg = Printf.sprintf "Cannot parse model label: %s (expected provider:model)" label in
+    Log.Misc.error "%s" msg;
+    invalid_arg msg
 
 (** Resolve provider from a model label string.
     Returns the provider config and model_id on success. *)

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -405,14 +405,15 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
   | Error e, _ | _, Error e -> Error e
 
 (** Convert a model label to an OAS Provider.config.
-    Uses OAS Provider.config_of_provider_config directly. *)
-let oas_provider_of_label (label : string) : Oas.Provider.config =
+    Returns Error when the label cannot be parsed. *)
+let oas_provider_of_label (label : string) :
+    (Oas.Provider.config, string) result =
   match Llm_provider.Cascade_config.parse_model_string label with
-  | Some pc -> Oas.Provider.config_of_provider_config pc
+  | Some pc -> Ok (Oas.Provider.config_of_provider_config pc)
   | None ->
     let msg = Printf.sprintf "Cannot parse model label: %s (expected provider:model)" label in
     Log.Misc.error "%s" msg;
-    invalid_arg msg
+    Error msg
 
 (** Resolve provider from a model label string.
     Returns the provider config and model_id on success. *)
@@ -420,7 +421,10 @@ let resolve_oas_provider_of_label (label : string) :
     (Oas.Provider.config * string, string) result =
   match Llm_provider.Cascade_config.parse_model_string label with
   | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
-  | Some pc -> Ok (oas_provider_of_label label, pc.Llm_provider.Provider_config.model_id)
+  | Some pc ->
+    Ok
+      ( Oas.Provider.config_of_provider_config pc,
+        pc.Llm_provider.Provider_config.model_id )
 
 let oas_tool_names (tools : Oas.Tool.t list) =
   List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -411,7 +411,7 @@ let oas_provider_of_label (label : string) :
   match Llm_provider.Cascade_config.parse_model_string label with
   | Some pc -> Ok (Oas.Provider.config_of_provider_config pc)
   | None ->
-    let msg = Printf.sprintf "Cannot parse model label: %s (expected provider:model)" label in
+    let msg = Printf.sprintf "Cannot parse model label: %S (expected provider:model)" label in
     Log.Misc.error "%s" msg;
     Error msg
 

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -112,17 +112,22 @@ let proof_result_status_to_string status =
 
 (** Resolve a model label string to an OAS Provider.config.
     Uses OAS Cascade_config.parse_model_string (Provider_registry SSOT).
-    Falls back to glm when parsing fails. *)
+    Falls back to default local provider when parsing fails. *)
 let resolve_provider_of_label (label : string) : Oas.Provider.config =
   match Llm_provider.Cascade_config.parse_model_string label with
   | Some pc -> Oas.Provider.config_of_provider_config pc
   | None ->
-    Oas.Provider.config_of_provider_config
-      (Llm_provider.Provider_config.make
-         ~kind:Llm_provider.Provider_config.OpenAI_compat
-         ~model_id:"auto"
-         ~base_url:(Llm_provider.Provider_registry.next_llama_endpoint ())
-         ~request_path:"/v1/chat/completions" ())
+    let fallback = Provider_adapter.default_local_fallback_label () in
+    match Llm_provider.Cascade_config.parse_model_string fallback with
+    | Some pc -> Oas.Provider.config_of_provider_config pc
+    | None ->
+      (* Failsafe for "auto" or other weirdness *)
+      Oas.Provider.config_of_provider_config
+        (Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id:label
+           ~base_url:(Llm_provider.Provider_registry.next_llama_endpoint ())
+           ~request_path:"/v1/chat/completions" ())
 
 (* ================================================================ *)
 (* Internal: event publishing                                        *)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -121,11 +121,11 @@ let resolve_provider_of_label (label : string) : Oas.Provider.config =
     match Llm_provider.Cascade_config.parse_model_string fallback with
     | Some pc -> Oas.Provider.config_of_provider_config pc
     | None ->
-      (* Failsafe for "auto" or other weirdness *)
+      (* Failsafe: use "auto" sentinel rather than the unparseable label. *)
       Oas.Provider.config_of_provider_config
         (Llm_provider.Provider_config.make
            ~kind:Llm_provider.Provider_config.OpenAI_compat
-           ~model_id:label
+           ~model_id:"auto"
            ~base_url:(Llm_provider.Provider_registry.next_llama_endpoint ())
            ~request_path:"/v1/chat/completions" ())
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -18,15 +18,12 @@ let default_config_path () : string option =
     and the cascade name has no "{name}_models" entry.
     All profiles are now in config/cascade.json (hot-reloadable). *)
 let default_model_strings ~cascade_name:_ =
-  let llama_model = Env_config.Llama.default_model in
-  let models =
-    if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else []
-  in
-  if models = [] then
-    match Provider_adapter.preferred_execution_model_labels () with
-    | [] -> [ "llama:auto" ]
-    | labels -> labels
-  else models
+  match Provider_adapter.explicit_llama_model_label_result () with
+  | Ok label -> [ label ]
+  | Error _ -> (
+      match Provider_adapter.preferred_execution_model_labels () with
+      | [] -> [ Provider_adapter.default_local_fallback_label () ]
+      | labels -> labels)
 
 (* ================================================================ *)
 (* Named model execution                                            *)
@@ -168,16 +165,11 @@ let run_named
   let named_cascade = Agent_sdk.Api.named_cascade ?config_path
     ~metrics ~name:cascade_name ~defaults () in
   let name = Printf.sprintf "oas-%s" cascade_name in
-  let primary_provider = match candidate_cfgs with
-    | cfg :: _ -> cfg
-    | [] ->
-      Llm_provider.Provider_config.make
-        ~kind:Llm_provider.Provider_config.Glm
-        ~model_id:"auto"
-        ~base_url:(Env_config_runtime.Glm.server_url ^ "/api/coding/paas/v4")
-        ~request_path:"/chat/completions"
-        ()
-  in
+  match candidate_cfgs with
+  | [] ->
+    Log.Misc.error "cascade %s: no callable models available" cascade_name;
+    Error (Printf.sprintf "cascade %s: no callable models available" cascade_name)
+  | primary_provider :: _ ->
   let provider : Agent_sdk.Provider.config =
     Agent_sdk.Provider.config_of_provider_config primary_provider
   in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -22,6 +22,8 @@ type adapter = {
   aliases : string list;
   spawn_key : string option;       (** Key into Spawn.default_configs. None = not spawnable via CLI. *)
   default_voice : string option;   (** Default TTS voice name. None = no voice assignment. *)
+  endpoint_url : string option;    (** Base URL for the provider API. *)
+  default_model_id : string option; (** Default model ID for the provider. *)
 }
 
 type voice_adapter = {
@@ -104,6 +106,8 @@ let direct_adapters =
       aliases = [ cn_llama; "llama.cpp"; "llamacpp" ];
       spawn_key = Some "llama";
       default_voice = Some "Laura";
+      endpoint_url = Some Env_config_runtime.Llama.server_url;
+      default_model_id = Some Env_config_runtime.Llama.default_model;
     };
     {
       canonical_name = cn_claude;
@@ -112,6 +116,8 @@ let direct_adapters =
       aliases = [ cn_claude; "claude"; "anthropic"; "claude-code"; "claude-api" ];
       spawn_key = Some "claude";
       default_voice = Some "Sarah";
+      endpoint_url = Some "https://api.anthropic.com";
+      default_model_id = None;
     };
     {
       canonical_name = cn_codex;
@@ -120,6 +126,8 @@ let direct_adapters =
       aliases = [ cn_codex; "codex"; "openai"; "codex-cli"; "codex-api" ];
       spawn_key = Some "codex";
       default_voice = Some "George";
+      endpoint_url = Some "https://api.openai.com";
+      default_model_id = None;
     };
     {
       canonical_name = cn_gemini;
@@ -133,6 +141,8 @@ let direct_adapters =
       aliases = [ cn_gemini; "gemini"; "google"; "gemini-cli"; "gemini-api" ];
       spawn_key = Some "gemini";
       default_voice = Some "Roger";
+      endpoint_url = None; (** Resolved dynamically for Gemini *)
+      default_model_id = None;
     };
     {
       canonical_name = cn_glm;
@@ -141,6 +151,8 @@ let direct_adapters =
       aliases = [ cn_glm; "glm_cloud"; "zai" ];
       spawn_key = None;
       default_voice = None;
+      endpoint_url = Some Env_config_runtime.Glm.server_url;
+      default_model_id = Some "auto";
     };
     {
       canonical_name = cn_openrouter;
@@ -149,6 +161,8 @@ let direct_adapters =
       aliases = [ cn_openrouter ];
       spawn_key = None;
       default_voice = None;
+      endpoint_url = Some "https://openrouter.ai/api/v1";
+      default_model_id = None;
     };
   ]
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -117,7 +117,7 @@ let direct_adapters =
       spawn_key = Some "claude";
       default_voice = Some "Sarah";
       endpoint_url = Some "https://api.anthropic.com";
-      default_model_id = None;
+      default_model_id = Some "auto";
     };
     {
       canonical_name = cn_codex;
@@ -127,7 +127,7 @@ let direct_adapters =
       spawn_key = Some "codex";
       default_voice = Some "George";
       endpoint_url = Some "https://api.openai.com";
-      default_model_id = None;
+      default_model_id = Some "auto";
     };
     {
       canonical_name = cn_gemini;
@@ -142,7 +142,7 @@ let direct_adapters =
       spawn_key = Some "gemini";
       default_voice = Some "Roger";
       endpoint_url = None; (** Resolved dynamically for Gemini *)
-      default_model_id = None;
+      default_model_id = Some "auto";
     };
     {
       canonical_name = cn_glm;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -107,7 +107,9 @@ let direct_adapters =
       spawn_key = Some "llama";
       default_voice = Some "Laura";
       endpoint_url = Some Env_config_runtime.Llama.server_url;
-      default_model_id = Some Env_config_runtime.Llama.default_model;
+      default_model_id =
+        (let m = Env_config_runtime.Llama.default_model in
+         if m = "" || m = "explicit-model-required" then None else Some m);
     };
     {
       canonical_name = cn_claude;

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -412,8 +412,10 @@ and resume_worker_via_oas
   in
   let tool_names_ref, hooks = make_tool_tracking_hooks () in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
-  let resume_provider =
+  let* resume_provider =
     oas_provider_of_label (Printf.sprintf "llama:%s" resume_model_id)
+    |> Result.map_error (fun e ->
+      Printf.sprintf "checkpoint resume (model %S): %s" resume_model_id e)
   in
   let system_prompt =
     Worker_container_types.default_system_prompt ~worker_name

--- a/lib/worker_run_once.ml
+++ b/lib/worker_run_once.ml
@@ -27,13 +27,15 @@ let contract_of_spec ~execution_scope (spec : Worker_execution_spec.t) =
              (spec.allowed_tools @ spec.allowed_shell_tools)))
     spec.delivery_contract
 
-let provider_and_model_id_of_label model_label =
-  let provider = Worker_container.oas_provider_of_label model_label in
-  let model_id =
-    match Llm_provider.Cascade_config.parse_model_string model_label with
-    | Some cfg -> cfg.Llm_provider.Provider_config.model_id
-    | None -> model_label
-  in
+let model_id_of_label label =
+  match Llm_provider.Cascade_config.parse_model_string label with
+  | Some cfg -> cfg.Llm_provider.Provider_config.model_id
+  | None -> label
+
+let provider_and_model_id_of_label model_label :
+    (Oas.Provider.config * string, string) result =
+  let+ provider = Worker_container.oas_provider_of_label model_label in
+  let model_id = model_id_of_label model_label in
   (provider, model_id)
 
 let execute_spec ~sw ?net ~room_config (spec : Worker_execution_spec.t) :
@@ -50,9 +52,7 @@ let execute_spec ~sw ?net ~room_config (spec : Worker_execution_spec.t) :
       ~worker_name:spec.worker_name ~mcp_session_id ~role:spec.role
       ~selection_note:spec.selection_note ~execution_scope
       ~worker_class:spec.worker_class
-      ~effective_model:
-        (match provider_and_model_id_of_label spec.model_label with
-        | _provider, model_id -> model_id)
+      ~effective_model:(model_id_of_label spec.model_label)
       ~thinking_enabled:spec.thinking_enabled
       ~max_turns_override:(Some spec.max_turns)
       ~timeout_seconds:(Some spec.timeout_sec)
@@ -66,8 +66,12 @@ let execute_spec ~sw ?net ~room_config (spec : Worker_execution_spec.t) :
       let evidence_session_id =
         Worker_container.evidence_session_id_of_worker_run spec.worker_run_id
       in
-      let _provider, model_id = provider_and_model_id_of_label spec.model_label in
-      let provider = Worker_container.oas_provider_of_label spec.model_label in
+      let* provider, model_id =
+        provider_and_model_id_of_label spec.model_label
+        |> Result.map_error (fun e ->
+          Printf.sprintf "worker %s: model label %S: %s"
+            spec.worker_name spec.model_label e)
+      in
       let system_prompt =
         Worker_container.default_system_prompt ~worker_name:spec.worker_name
           ~model_id ?session_id:spec.team_session_id ?role:spec.role


### PR DESCRIPTION
## Summary

- Move endpoint URL and default model metadata to Provider_adapter
- Refactor dashboard_provider_runs to use Provider_adapter abstractions
- Remove hardcoded GLM fallbacks in oas_worker_exec and oas_worker_named
- Ensure MASC business logic is vendor-agnostic, delegating to OAS Cascade
- Set `default_model_id = Some "auto"` for Claude, Codex/OpenAI, and Gemini so dashboard_provider_runs correctly identifies them as runnable providers
- Refactor `oas_provider_of_label` to return `(Oas.Provider.config, string) result` instead of raising `invalid_arg` on unparseable labels; callers propagate structured errors with context
- Fix failsafe branch in `oas_worker_exec` to use sentinel `model_id:"auto"` instead of the raw unparseable label string
- Normalize llama's `default_model_id` to `None` when `LLAMA_DEFAULT_MODEL` is unset or equals the sentinel `"explicit-model-required"`, preventing the sentinel from surfacing as a real model ID
- Guard `default_model_for_provider` in dashboard against sentinel/empty fallback values via `Option.bind` with `trim_nonempty`
- Use `%S` (quoted format) and `(expected provider:model)` suffix consistently in both `oas_provider_of_label` and `resolve_oas_provider_of_label` error messages to handle labels with spaces or special characters unambiguously

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Claude, Codex/OpenAI, and Gemini now correctly appear as runnable providers in the dashboard when API keys are configured; previously they were incorrectly shown as non-runnable due to `default_model_id = None`. Llama no longer appears as having a configured default model when `LLAMA_DEFAULT_MODEL` is unset, preventing `supports_single_agent_run` from being incorrectly set to true for unconfigured local providers.

## Evidence

## Review evidence

Cross-model review by GLM-5.1: all 5 original Copilot review items addressed — APPROVE (commit 1b19f0a). Second-round Copilot review (3 items on sentinel normalization, dashboard fallback filtering, and log quoting) addressed in commit b1d4b32. Third-round Copilot review (consistent `%S`/format in `resolve_oas_provider_of_label`) addressed in commit 8bbea31.

## Linked issue