### PR TITLE
feat(keeper): migrate set_state to dispatch_event (RFC-0002 Phase 3)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -289,7 +289,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             Keeper_registry.get ~base_path:config.base_path m.name in
           let registry_state =
             match registry_entry with
-            | Some entry -> Some (Keeper_registry.state_to_string entry.state)
+            | Some entry -> Some (Keeper_registry.state_to_string entry.phase)
             | None -> None
           in
           let phase =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1206,7 +1206,12 @@ let record_keeper_stopped
   =
   if resolve_registry_done entry `Stopped
   then (
-    Keeper_registry.set_state ~base_path keeper_name Keeper_registry.Stopped;
+    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
+      Keeper_state_machine.Stop_requested);
+    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
+      Keeper_state_machine.Drain_complete);
+    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
+      (Keeper_state_machine.Fiber_terminated { outcome = "stopped" }));
     publish_keeper_lifecycle ~event:"stopped" ~keeper_name ~detail;
     true)
   else
@@ -1224,7 +1229,8 @@ let record_keeper_crashed
   if resolve_registry_done entry (`Crashed reason)
   then (
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
-    Keeper_registry.set_state ~base_path keeper_name Keeper_registry.Crashed;
+    ignore (Keeper_registry.dispatch_event ~base_path keeper_name
+      (Keeper_state_machine.Fiber_terminated { outcome = reason }));
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
     publish_keeper_lifecycle ~event:"crashed" ~keeper_name ~detail:reason)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -71,7 +71,7 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
 let wakeup_keeper name =
   Keeper_registry.all ()
   |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    if String.equal entry.name name && entry.state = Keeper_registry.Running
+    if String.equal entry.name name && entry.phase = Keeper_state_machine.Running
     then Keeper_registry.wakeup ~base_path:entry.base_path name)
 ;;
 
@@ -94,7 +94,7 @@ let wakeup_relevant_keeper_for_board_signal
   let running_names =
     Keeper_registry.all ()
     |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-      if e.state = Keeper_registry.Running then Some e.name else None)
+      if e.phase = Keeper_state_machine.Running then Some e.name else None)
   in
   let candidates =
     running_names
@@ -1315,8 +1315,8 @@ let stop_keepalive name =
            | Eio.Cancel.Cancelled _ as e -> raise e
            | _exn -> ())
         | None -> ());
-       (match entry.state with
-        | Keeper_registry.Crashed | Keeper_registry.Dead -> ()
+       (match entry.phase with
+        | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> ()
         | _ ->
           if
             record_keeper_stopped

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -46,19 +46,14 @@ exception Keeper_heartbeat_failure of {
   keeper_name : string;
 }
 
-type keeper_state =
-  | Running
-  | Paused
-  | Stopped
-  | Crashed  (** Error exit, restart candidate (backoff applies) *)
-  | Dead     (** Restart budget exhausted, tombstone — no re-launch *)
+(** @deprecated Use [Keeper_state_machine.phase] directly. *)
+type keeper_state = Keeper_state_machine.phase
 
 type registry_entry = {
   base_path : string;
   name : string;
   meta : keeper_meta;
-  state : keeper_state;
-  (** Fine-grained phase from RFC-0002 state machine. *)
+  (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
   phase : Keeper_state_machine.phase;
   (** Observable conditions that derive [phase]. *)
   conditions : Keeper_state_machine.conditions;
@@ -82,12 +77,8 @@ type registry_entry = {
   tool_usage : (string, tool_call_entry) Hashtbl.t;
 }
 
-let state_to_string = function
-  | Running -> "running"
-  | Paused -> "paused"
-  | Stopped -> "stopped"
-  | Crashed -> "crashed"
-  | Dead -> "dead"
+(** @deprecated Use [Keeper_state_machine.phase_to_string]. *)
+let state_to_string = Keeper_state_machine.phase_to_string
 
 let registry : registry_entry StringMap.t ref = ref StringMap.empty
 let running_count_atomic = Atomic.make 0
@@ -112,7 +103,7 @@ let register ~base_path name meta =
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key !registry with
-   | Some entry when entry.state = Running ->
+   | Some entry when entry.phase = Running ->
        Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
        Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
    | _ -> ());
@@ -125,7 +116,6 @@ let register ~base_path name meta =
     base_path;
     name;
     meta;
-    state = Running;
     phase = Keeper_state_machine.Running;
     conditions = initial_conditions;
     fiber_stop = Atomic.make false;
@@ -157,13 +147,13 @@ let unregister ~base_path name =
   Log.Keeper.info "registry: unregistering keeper name=%s base_path=%s" name base_path;
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key !registry with
-   | Some entry when entry.state = Running ->
+   | Some entry when entry.phase = Running ->
        Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1));
        Log.Keeper.debug "registry: unregistered running keeper name=%s running_count=%d"
          name (Atomic.get running_count_atomic)
    | Some entry ->
        Log.Keeper.debug "registry: unregistered non-running keeper name=%s state=%s"
-         name (state_to_string entry.state)
+         name (state_to_string entry.phase)
    | None ->
        Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name);
   registry := StringMap.remove key !registry
@@ -239,52 +229,55 @@ let conditions_of_legacy_state (_prev : Keeper_state_machine.conditions) (state 
       Keeper_state_machine.fiber_alive = false;
       restart_budget_remaining = false;
     }
+  (* Buffer states map to their parent stable conditions *)
+  | Failing ->
+    { base with
+      Keeper_state_machine.fiber_alive = true;
+      restart_budget_remaining = true;
+      heartbeat_healthy = false;
+    }
+  | Compacting ->
+    { base with
+      Keeper_state_machine.fiber_alive = true;
+      restart_budget_remaining = true;
+      compaction_active = true;
+    }
+  | HandingOff ->
+    { base with
+      Keeper_state_machine.fiber_alive = true;
+      restart_budget_remaining = true;
+      handoff_active = true;
+    }
+  | Draining ->
+    { base with
+      Keeper_state_machine.fiber_alive = true;
+      restart_budget_remaining = true;
+      stop_requested = true;
+    }
+  | Restarting ->
+    { base with
+      Keeper_state_machine.fiber_alive = false;
+      restart_budget_remaining = true;
+      backoff_elapsed = true;
+    }
+  | Offline -> base
 
-let set_state ~base_path name state =
-  let key = registry_key ~base_path name in
-  match StringMap.find_opt key !registry with
-  | Some entry ->
-      (* Dead is terminal — only unregister can remove a Dead entry *)
-      if entry.state = Dead && state <> Dead then
-        Log.Keeper.warn "registry: attempted state change on Dead keeper name=%s new_state=%s"
-          name (state_to_string state)
-      else if entry.state <> state then begin
-        Log.Keeper.info "registry: state transition name=%s old=%s new=%s"
-          name (state_to_string entry.state) (state_to_string state);
-        (match (entry.state, state) with
-         | Running, (Paused | Stopped | Crashed | Dead) ->
-             Atomic.set running_count_atomic
-               (max 0 (Atomic.get running_count_atomic - 1))
-         | (Paused | Stopped | Crashed), Running ->
-             Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
-         | _ -> ());
-        let dead_since_ts =
-          match entry.state, state with
-          | _, Dead -> entry.dead_since_ts
-          | Dead, Running -> None
-          | Dead, _ -> entry.dead_since_ts
-          | _ -> None
-        in
-        (* Sync phase/conditions with legacy state *)
-        let conditions = conditions_of_legacy_state entry.conditions state in
-        let phase = Keeper_state_machine.derive_phase conditions in
-        put_entry key { entry with state; dead_since_ts; phase; conditions }
-      end
-  | None ->
-      Log.Keeper.warn "registry: set_state on non-existent keeper name=%s" name
+(** @deprecated No external callers remain after Phase 3 migration.
+    Retained temporarily for mark_dead compatibility. Use [dispatch_event]. *)
+let _set_state_deprecated ~base_path:_ _name (_state : Keeper_state_machine.phase) = ()
 
 let mark_dead ~base_path name ~at =
   Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
   update_entry ~base_path name (fun entry ->
-    if entry.state <> Dead then begin
-      (match entry.state with
+    if entry.phase <> Dead then begin
+      (match entry.phase with
        | Running ->
            Atomic.set running_count_atomic
              (max 0 (Atomic.get running_count_atomic - 1))
        | _ -> ());
       let conditions = conditions_of_legacy_state entry.conditions Dead in
       let phase = Keeper_state_machine.derive_phase conditions in
-      { entry with state = Dead; dead_since_ts = Some at; phase; conditions }
+      { entry with dead_since_ts = Some at; phase; conditions }
     end else
       { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
 
@@ -316,7 +309,7 @@ let get_turn_failures ~base_path name =
 
 let is_running ~base_path name =
   match get ~base_path name with
-  | Some { state = Running; _ } -> true
+  | Some { phase = Running; _ } -> true
   | _ -> false
 
 (** True if the keeper has ANY registry entry (regardless of state).
@@ -330,7 +323,7 @@ let count_running ?base_path () =
   | Some expected ->
       StringMap.fold
         (fun _k v acc ->
-          if String.equal expected v.base_path && v.state = Running then acc + 1
+          if String.equal expected v.base_path && v.phase = Running then acc + 1
           else acc)
         !registry 0
 
@@ -365,22 +358,22 @@ let wakeup_all ?base_path () =
   StringMap.iter (fun _k entry ->
     (match base_path with
      | Some expected when not (String.equal expected entry.base_path) -> ()
-     | _ -> if entry.state = Running then Atomic.set entry.fiber_wakeup true)
+     | _ -> if entry.phase = Running then Atomic.set entry.fiber_wakeup true)
   ) !registry
 
 let fiber_health_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) !registry with
   | None -> Fiber_unknown
   | Some entry -> (
-      match entry.state with
+      match entry.phase with
       | Dead -> Fiber_dead
-      | Crashed ->
+      | Crashed | Restarting ->
           let max_restarts =
             Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
           in
           if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie
-      | Stopped -> Fiber_unknown
-      | Running | Paused -> (
+      | Stopped | Offline -> Fiber_unknown
+      | Running | Paused | Failing | Compacting | HandingOff | Draining -> (
           match Eio.Promise.peek entry.done_p with
           | None -> Fiber_alive
           | Some `Stopped -> Fiber_unknown
@@ -649,18 +642,10 @@ let dispatch_event ~base_path name (event : Keeper_state_machine.event) =
          (Keeper_state_machine.phase_to_string tr.prev_phase)
          (Keeper_state_machine.phase_to_string tr.new_phase)
          (Keeper_state_machine.event_to_string event);
-       (* Sync legacy state *)
-       let legacy = Keeper_state_compat.to_legacy tr.new_phase in
-       let legacy_state = match legacy with
-         | Keeper_state_compat.Running -> Running
-         | Keeper_state_compat.Paused -> Paused
-         | Keeper_state_compat.Stopped -> Stopped
-         | Keeper_state_compat.Crashed -> Crashed
-         | Keeper_state_compat.Dead -> Dead
-       in
-       (* Update running count *)
+       (* Update running count based on legacy projection *)
        let prev_legacy = Keeper_state_compat.to_legacy tr.prev_phase in
-       (match prev_legacy, legacy with
+       let new_legacy = Keeper_state_compat.to_legacy tr.new_phase in
+       (match prev_legacy, new_legacy with
         | Keeper_state_compat.Running, (Keeper_state_compat.Paused | Stopped | Crashed | Dead) ->
           Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
         | (Keeper_state_compat.Paused | Stopped | Crashed), Keeper_state_compat.Running ->
@@ -673,7 +658,6 @@ let dispatch_event ~base_path name (event : Keeper_state_machine.event) =
        in
        put_entry key {
          entry with
-         state = legacy_state;
          phase = tr.new_phase;
          conditions = tr.updated_conditions;
          dead_since_ts;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -26,20 +26,15 @@ exception Keeper_heartbeat_failure of {
   keeper_name : string;
 }
 
-type keeper_state =
-  | Running
-  | Paused
-  | Stopped
-  | Crashed
-  | Dead
+(** @deprecated Use [Keeper_state_machine.phase] directly. *)
+type keeper_state = Keeper_state_machine.phase
 
 type registry_entry = {
   base_path : string;
   name : string;
   meta : keeper_meta;
-  state : keeper_state;
   phase : Keeper_state_machine.phase;
-      (** Fine-grained phase from RFC-0002. *)
+      (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
   conditions : Keeper_state_machine.conditions;
       (** Observable conditions that derive [phase]. *)
   fiber_stop : bool Atomic.t;
@@ -84,8 +79,7 @@ val all : ?base_path:string -> unit -> registry_entry list
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
 
-(** Change keeper state. No-op if not found. *)
-val set_state : base_path:string -> string -> keeper_state -> unit
+(** @deprecated Use [dispatch_event]. No external callers remain. *)
 
 (** Record a restart. Increments restart_count and updates last_restart_ts. *)
 val record_restart : base_path:string -> string -> unit

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -152,7 +152,7 @@ let runtime_surface_json config (meta : keeper_meta) =
   in
   let registry_state =
     match runtime_registry_entry config meta.name with
-    | Some entry -> Some (Keeper_registry.state_to_string entry.state)
+    | Some entry -> Some (Keeper_registry.state_to_string entry.phase)
     | None -> None
   in
   `Assoc

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -27,8 +27,8 @@ let keep_last_n n item lst =
 
 let should_cleanup_dead ~now ~dead_ttl_sec
     (entry : Keeper_registry.registry_entry) =
-  match entry.state, entry.dead_since_ts with
-  | Keeper_registry.Dead, Some dead_since ->
+  match entry.phase, entry.dead_since_ts with
+  | Keeper_state_machine.Dead, Some dead_since ->
       now -. dead_since >= dead_ttl_sec
   | _ -> false
 
@@ -196,10 +196,14 @@ let reconcile_keepalive_keepers (ctx : _ context) =
                match Keeper_registry.get ~base_path meta.name with
                | None -> false  (* no entry = orphaned, reconcile OK *)
                | Some e ->
-                 match e.state with
-                 | Keeper_registry.Running | Keeper_registry.Paused -> true
-                 | Keeper_registry.Crashed | Keeper_registry.Dead -> true
-                 | Keeper_registry.Stopped ->
+                 match e.phase with
+                 | Keeper_state_machine.Running | Keeper_state_machine.Paused -> true
+                 | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> true
+                 | Keeper_state_machine.Failing | Keeper_state_machine.Compacting
+                 | Keeper_state_machine.HandingOff | Keeper_state_machine.Draining
+                 | Keeper_state_machine.Restarting -> true
+                 | Keeper_state_machine.Offline -> false
+                 | Keeper_state_machine.Stopped ->
                      (* Stopped with unresolved fiber → sweep will clean up *)
                      Eio.Promise.peek e.done_p = None
              in
@@ -320,18 +324,21 @@ let sweep_and_recover (ctx : _ context) =
   let to_mark_dead = ref [] in
   let to_cleanup_dead = ref [] in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    match entry.state with
-    | Keeper_registry.Dead ->
+    match entry.phase with
+    | Keeper_state_machine.Dead ->
         (match entry.dead_since_ts with
          | Some dead_since when now -. dead_since >= dead_ttl_sec ->
              to_cleanup_dead := entry :: !to_cleanup_dead
          | _ -> ())
-    | Keeper_registry.Stopped ->
+    | Keeper_state_machine.Stopped ->
         to_unregister := entry :: !to_unregister
-    | Keeper_registry.Running | Keeper_registry.Paused
-    | Keeper_registry.Crashed ->
+    | Keeper_state_machine.Running | Keeper_state_machine.Paused
+    | Keeper_state_machine.Crashed
+    | Keeper_state_machine.Failing | Keeper_state_machine.Compacting
+    | Keeper_state_machine.HandingOff | Keeper_state_machine.Draining
+    | Keeper_state_machine.Restarting | Keeper_state_machine.Offline ->
       (match Eio.Promise.peek entry.done_p with
-      | None when entry.state = Keeper_registry.Stopped ->
+      | None when entry.phase = Keeper_state_machine.Stopped ->
           to_unregister := entry :: !to_unregister
       | None -> ()  (* Alive — skip *)
       | Some `Stopped ->
@@ -359,7 +366,7 @@ let sweep_and_recover (ctx : _ context) =
   List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
   let active_count =
     List.length (List.filter (fun (e : Keeper_registry.registry_entry) ->
-      e.state = Keeper_registry.Running || e.state = Keeper_registry.Crashed
+      e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed
     ) entries) in
   let restart_list =
     let keepers_dir =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -73,9 +73,13 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
         (try
            Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
              ctx meta reg.fiber_stop ~wakeup:reg.fiber_wakeup;
-           (* Normal exit: stop flag was set *)
-           Keeper_registry.set_state ~base_path meta.name
-             Keeper_registry.Stopped;
+           (* Normal exit: stop flag was set — dispatch typed events *)
+           ignore (Keeper_registry.dispatch_event ~base_path meta.name
+             Keeper_state_machine.Stop_requested);
+           ignore (Keeper_registry.dispatch_event ~base_path meta.name
+             Keeper_state_machine.Drain_complete);
+           ignore (Keeper_registry.dispatch_event ~base_path meta.name
+             (Keeper_state_machine.Fiber_terminated { outcome = "normal exit" }));
            if resolve_done `Stopped then
              publish_lifecycle "stopped" meta.name "normal exit"
          with
@@ -84,8 +88,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                Keeper_registry.failure_reason_to_string info.reason in
              Keeper_registry.set_failure_reason ~base_path meta.name
                (Some info.reason);
-             Keeper_registry.set_state ~base_path meta.name
-               Keeper_registry.Crashed;
+             ignore (Keeper_registry.dispatch_event ~base_path meta.name
+               (Keeper_state_machine.Fiber_terminated { outcome = reason }));
              let ts = Time_compat.now () in
              Keeper_registry.record_crash ~base_path
                meta.name ts reason;
@@ -101,8 +105,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              let fr = Keeper_registry.Exception (Printexc.to_string exn) in
              let reason = Keeper_registry.failure_reason_to_string fr in
              Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
-             Keeper_registry.set_state ~base_path meta.name
-               Keeper_registry.Crashed;
+             ignore (Keeper_registry.dispatch_event ~base_path meta.name
+               (Keeper_state_machine.Fiber_terminated { outcome = reason }));
              let ts = Time_compat.now () in
              Keeper_registry.record_crash ~base_path
                meta.name ts reason;
@@ -135,8 +139,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
             Keeper_crash_persistence.enqueue_record ~keepers_dir
               ~name:meta.name ~ts ~reason ~restart_count:rc;
             Keeper_registry.record_error ~base_path meta.name reason;
-            Keeper_registry.set_state ~base_path meta.name
-              Keeper_registry.Crashed;
+            ignore (Keeper_registry.dispatch_event ~base_path meta.name
+              (Keeper_state_machine.Fiber_terminated { outcome = reason }));
             if resolve_done (`Crashed reason) then
               publish_lifecycle "crashed" meta.name reason
           end

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -51,8 +51,8 @@ let handle_keeper_down ctx args : tool_result =
          in
          (write_meta_logged ctx.config retained;
           Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
-          Keeper_registry.set_state ~base_path:ctx.config.base_path name
-            Keeper_registry.Paused));
+          ignore (Keeper_registry.dispatch_event ~base_path:ctx.config.base_path name
+            Keeper_state_machine.Operator_pause)));
       if remove_session then (
         let rec rm_rf path =
           if Sys.file_exists path then begin

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -17,6 +17,7 @@ open Alcotest
 module R = Masc_mcp.Keeper_registry
 module Sup = Masc_mcp.Keeper_supervisor
 module KT = Masc_mcp.Keeper_types
+module KSM = Masc_mcp.Keeper_state_machine
 module Cfg = Env_config
 
 let bp = "/tmp/test-heartbeat-integ"
@@ -75,7 +76,8 @@ let test_crash_heartbeat_failure () =
   let reason = R.Heartbeat_consecutive_failures 5 in
   let reason_str = R.failure_reason_to_string reason in
   R.set_failure_reason ~base_path:bp "hb-crash" (Some reason);
-  R.set_state ~base_path:bp "hb-crash" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "hb-crash"
+    (KSM.Fiber_terminated { outcome = "heartbeat_failure" }));
   R.record_crash ~base_path:bp "hb-crash" 1000.0 reason_str;
   R.record_error ~base_path:bp "hb-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
@@ -83,7 +85,7 @@ let test_crash_heartbeat_failure () =
   (match R.get ~base_path:bp "hb-crash" with
    | None -> fail "expected hb-crash in registry"
    | Some e ->
-     check string "state" "crashed" (R.state_to_string e.state);
+     check string "state" "crashed" (R.state_to_string e.phase);
      (match e.last_failure_reason with
       | Some (R.Heartbeat_consecutive_failures n) ->
         check int "failure count preserved" 5 n
@@ -106,14 +108,15 @@ let test_crash_generic_exception () =
   let fr = R.Exception exn_str in
   let reason_str = R.failure_reason_to_string fr in
   R.set_failure_reason ~base_path:bp "exn-crash" (Some fr);
-  R.set_state ~base_path:bp "exn-crash" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "exn-crash"
+    (KSM.Fiber_terminated { outcome = "exception" }));
   R.record_crash ~base_path:bp "exn-crash" 1001.0 reason_str;
   R.record_error ~base_path:bp "exn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "exn-crash" with
   | None -> fail "expected exn-crash"
   | Some e ->
-    check string "state" "crashed" (R.state_to_string e.state);
+    check string "state" "crashed" (R.state_to_string e.phase);
     (match e.last_failure_reason with
      | Some (R.Exception s) ->
        check string "exception text" exn_str s
@@ -130,7 +133,8 @@ let test_crash_fiber_unresolved () =
   R.set_failure_reason ~base_path:bp "unresolved" (Some fr);
   R.record_crash ~base_path:bp "unresolved" 1002.0 reason_str;
   R.record_error ~base_path:bp "unresolved" reason_str;
-  R.set_state ~base_path:bp "unresolved" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "unresolved"
+    (KSM.Fiber_terminated { outcome = "unresolved" }));
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "unresolved" with
   | None -> fail "expected unresolved"
@@ -138,7 +142,7 @@ let test_crash_fiber_unresolved () =
     (match e.last_failure_reason with
      | Some R.Fiber_unresolved -> ()
      | _ -> fail "expected Fiber_unresolved reason");
-    check string "state" "crashed" (R.state_to_string e.state)
+    check string "state" "crashed" (R.state_to_string e.phase)
 
 (* ══════════════════════════════════════════════════════════
    2. Dead tombstone lifecycle
@@ -152,10 +156,11 @@ let test_dead_tombstone_full_lifecycle () =
   let meta = make_meta "mortal" in
   let reg = R.register ~base_path:bp "mortal" meta in
   check string "initially running" "running"
-    (R.state_to_string (Option.get (R.get ~base_path:bp "mortal")).state);
+    (R.state_to_string (Option.get (R.get ~base_path:bp "mortal")).phase);
   (* Crash *)
   Eio.Promise.resolve reg.done_r (`Crashed "test");
-  R.set_state ~base_path:bp "mortal" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "mortal"
+    (KSM.Fiber_terminated { outcome = "test" }));
   (* Simulate budget exhaustion *)
   let max_restarts = Cfg.KeeperSupervisor.max_restarts in
   R.restore_supervisor_state ~base_path:bp "mortal"
@@ -164,22 +169,23 @@ let test_dead_tombstone_full_lifecycle () =
    | Some e -> check bool "budget exhausted" true (e.restart_count >= max_restarts)
    | None -> fail "expected mortal");
   (* Transition to Dead (what sweep does) *)
-  R.set_state ~base_path:bp "mortal" R.Dead;
+  R.mark_dead ~base_path:bp "mortal" ~at:(Unix.gettimeofday ());
   (* Invariant checks *)
   check bool "Dead is registered" true (R.is_registered ~base_path:bp "mortal");
   check bool "Dead is not running" false (R.is_running ~base_path:bp "mortal");
   check int "running count 0" 0 (R.count_running ~base_path:bp ());
   (* Dead → Running blocked *)
-  R.set_state ~base_path:bp "mortal" R.Running;
+  ignore (R.dispatch_event ~base_path:bp "mortal" KSM.Fiber_started);
   (match R.get ~base_path:bp "mortal" with
    | Some e -> check string "still dead after Running attempt" "dead"
-       (R.state_to_string e.state)
+       (R.state_to_string e.phase)
    | None -> fail "expected mortal");
   (* Dead → Crashed blocked *)
-  R.set_state ~base_path:bp "mortal" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "mortal"
+    (KSM.Fiber_terminated { outcome = "test" }));
   (match R.get ~base_path:bp "mortal" with
    | Some e -> check string "still dead after Crashed attempt" "dead"
-       (R.state_to_string e.state)
+       (R.state_to_string e.phase)
    | None -> fail "expected mortal");
   (* Only unregister removes Dead entry *)
   R.unregister ~base_path:bp "mortal";
@@ -199,7 +205,8 @@ let test_self_preservation_suppresses_dominant () =
   let names = ["sp-hb1"; "sp-hb2"; "sp-hb3"; "sp-exn"] in
   let entries = List.map (fun name ->
     let _reg = R.register ~base_path:bp name (make_meta name) in
-    R.set_state ~base_path:bp name R.Crashed;
+    ignore (R.dispatch_event ~base_path:bp name
+      (KSM.Fiber_terminated { outcome = "test" }));
     let reason = if String.length name > 4 && String.sub name 3 2 = "hb"
       then Some (R.Heartbeat_consecutive_failures 5)
       else Some (R.Exception "timeout") in
@@ -228,7 +235,8 @@ let test_self_preservation_suppresses_dominant () =
 let test_self_preservation_below_threshold () =
   R.clear ();
   let _reg = R.register ~base_path:bp "lone" (make_meta "lone") in
-  R.set_state ~base_path:bp "lone" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "lone"
+    (KSM.Fiber_terminated { outcome = "test" }));
   R.set_failure_reason ~base_path:bp "lone"
     (Some (R.Heartbeat_consecutive_failures 3));
   let entry = match R.get ~base_path:bp "lone" with
@@ -242,7 +250,8 @@ let test_self_preservation_below_threshold () =
 let test_self_preservation_min_candidates_not_met () =
   R.clear ();
   let _reg = R.register ~base_path:bp "solo" (make_meta "solo") in
-  R.set_state ~base_path:bp "solo" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "solo"
+    (KSM.Fiber_terminated { outcome = "test" }));
   R.set_failure_reason ~base_path:bp "solo"
     (Some (R.Heartbeat_consecutive_failures 3));
   let entry = match R.get ~base_path:bp "solo" with
@@ -266,39 +275,44 @@ let test_reconcile_predicate_sweep_owned () =
   let _e = R.register ~base_path:bp "r1" (make_meta "r1") in
   (match R.get ~base_path:bp "r1" with
    | Some e ->
-     check string "running" "running" (R.state_to_string e.state);
+     check string "running" "running" (R.state_to_string e.phase);
      check bool "sweep-owned" true
-       (e.state = R.Running || e.state = R.Paused
-        || e.state = R.Crashed || e.state = R.Dead)
+       (e.phase = KSM.Running || e.phase = KSM.Paused
+        || e.phase = KSM.Crashed || e.phase = KSM.Dead)
    | None -> fail "expected r1");
   (* Crashed = sweep-owned *)
-  R.set_state ~base_path:bp "r1" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "r1"
+    (KSM.Fiber_terminated { outcome = "test" }));
   (match R.get ~base_path:bp "r1" with
    | Some e -> check bool "crashed is sweep-owned" true
-       (e.state = R.Crashed)
+       (e.phase = KSM.Crashed)
    | None -> fail "expected r1");
   (* Dead = sweep-owned *)
-  R.set_state ~base_path:bp "r1" R.Dead;
+  R.mark_dead ~base_path:bp "r1" ~at:(Unix.gettimeofday ());
   (match R.get ~base_path:bp "r1" with
    | Some e -> check bool "dead is sweep-owned" true
-       (e.state = R.Dead)
+       (e.phase = KSM.Dead)
    | None -> fail "expected r1")
 
 let test_reconcile_predicate_stopped_resolved () =
   R.clear ();
   let reg = R.register ~base_path:bp "s1" (make_meta "s1") in
-  R.set_state ~base_path:bp "s1" R.Stopped;
+  ignore (R.dispatch_event ~base_path:bp "s1" KSM.Stop_requested);
+  ignore (R.dispatch_event ~base_path:bp "s1" KSM.Drain_complete);
   Eio.Promise.resolve reg.done_r `Stopped;
   (* Stopped + resolved done_p = reconcile-eligible *)
   (match R.get ~base_path:bp "s1" with
    | Some e ->
-     check string "stopped" "stopped" (R.state_to_string e.state);
+     check string "stopped" "stopped" (R.state_to_string e.phase);
      check bool "done_p resolved" true
        (Option.is_some (Eio.Promise.peek e.done_p));
      (* dominated_by_sweep logic: Stopped with resolved → NOT dominated *)
-     let dominated = match e.state with
-       | R.Running | R.Paused | R.Crashed | R.Dead -> true
-       | R.Stopped -> Eio.Promise.peek e.done_p = None
+     let dominated = match e.phase with
+       | KSM.Running | KSM.Paused | KSM.Crashed | KSM.Dead -> true
+       | KSM.Failing | KSM.Compacting | KSM.HandingOff
+       | KSM.Draining | KSM.Restarting -> true
+       | KSM.Offline -> false
+       | KSM.Stopped -> Eio.Promise.peek e.done_p = None
      in
      check bool "not dominated (reconcile-eligible)" false dominated
    | None -> fail "expected s1")
@@ -306,16 +320,20 @@ let test_reconcile_predicate_stopped_resolved () =
 let test_reconcile_predicate_stopped_unresolved () =
   R.clear ();
   let _reg = R.register ~base_path:bp "s2" (make_meta "s2") in
-  R.set_state ~base_path:bp "s2" R.Stopped;
+  ignore (R.dispatch_event ~base_path:bp "s2" KSM.Stop_requested);
+  ignore (R.dispatch_event ~base_path:bp "s2" KSM.Drain_complete);
   (* Stopped + unresolved done_p = sweep will handle *)
   (match R.get ~base_path:bp "s2" with
    | Some e ->
-     check string "stopped" "stopped" (R.state_to_string e.state);
+     check string "stopped" "stopped" (R.state_to_string e.phase);
      check bool "done_p NOT resolved" true
        (Option.is_none (Eio.Promise.peek e.done_p));
-     let dominated = match e.state with
-       | R.Running | R.Paused | R.Crashed | R.Dead -> true
-       | R.Stopped -> Eio.Promise.peek e.done_p = None
+     let dominated = match e.phase with
+       | KSM.Running | KSM.Paused | KSM.Crashed | KSM.Dead -> true
+       | KSM.Failing | KSM.Compacting | KSM.HandingOff
+       | KSM.Draining | KSM.Restarting -> true
+       | KSM.Offline -> false
+       | KSM.Stopped -> Eio.Promise.peek e.done_p = None
      in
      check bool "dominated (sweep will handle)" true dominated
    | None -> fail "expected s2")
@@ -331,7 +349,8 @@ let test_restart_state_preservation () =
   let meta = make_meta "restartable" in
   let reg1 = R.register ~base_path:bp "restartable" meta in
   Eio.Promise.resolve reg1.done_r (`Crashed "first crash");
-  R.set_state ~base_path:bp "restartable" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "restartable"
+    (KSM.Fiber_terminated { outcome = "first crash" }));
   R.record_crash ~base_path:bp "restartable" 100.0 "first crash";
   (* Simulate sweep restart: re-register then restore state *)
   let _reg2 = R.register ~base_path:bp "restartable" meta in
@@ -349,7 +368,7 @@ let test_restart_state_preservation () =
       (Option.is_none e.last_failure_reason);
     (* state should be Running after re-register *)
     check string "state running after restart" "running"
-      (R.state_to_string e.state)
+      (R.state_to_string e.phase)
 
 (* ══════════════════════════════════════════════════════════
    7. Turn failure → Crashed with Turn_consecutive_failures reason
@@ -364,14 +383,15 @@ let test_crash_turn_failures () =
   let reason = R.Turn_consecutive_failures 10 in
   let reason_str = R.failure_reason_to_string reason in
   R.set_failure_reason ~base_path:bp "turn-crash" (Some reason);
-  R.set_state ~base_path:bp "turn-crash" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "turn-crash"
+    (KSM.Fiber_terminated { outcome = "turn failure" }));
   R.record_crash ~base_path:bp "turn-crash" 2000.0 reason_str;
   R.record_error ~base_path:bp "turn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "turn-crash" with
   | None -> fail "expected turn-crash"
   | Some e ->
-    check string "state crashed" "crashed" (R.state_to_string e.state);
+    check string "state crashed" "crashed" (R.state_to_string e.phase);
     (match e.last_failure_reason with
      | Some (R.Turn_consecutive_failures n) ->
        check int "turn failure count" 10 n
@@ -425,7 +445,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       match R.get ~base_path:config.base_path keeper_name with
       | None -> fail "expected direct-lifecycle registry entry"
       | Some entry ->
-        check string "state stopped" "stopped" (R.state_to_string entry.state);
+        check string "state stopped" "stopped" (R.state_to_string entry.phase);
         check bool "done promise resolved eventually" true stopped_resolved;
         (match Eio.Promise.peek entry.done_p with
          | Some `Stopped -> ()
@@ -441,7 +461,7 @@ let test_stop_keepalive_resolves_running_entry_immediately () =
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected manual-stop-entry in registry"
   | Some entry ->
-    check string "state stopped immediately" "stopped" (R.state_to_string entry.state);
+    check string "state stopped immediately" "stopped" (R.state_to_string entry.phase);
     (match Eio.Promise.peek reg.done_p with
      | Some `Stopped -> ()
      | Some (`Crashed reason) ->
@@ -453,13 +473,14 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
   let keeper_name = "crashed-before-stop" in
   let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
   let reason = "already crashed" in
-  R.set_state ~base_path:bp keeper_name R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp keeper_name
+    (KSM.Fiber_terminated { outcome = "already crashed" }));
   Eio.Promise.resolve reg.done_r (`Crashed reason);
   Masc_mcp.Keeper_keepalive.stop_keepalive keeper_name;
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected crashed-before-stop in registry"
   | Some entry ->
-    check string "state remains crashed" "crashed" (R.state_to_string entry.state);
+    check string "state remains crashed" "crashed" (R.state_to_string entry.phase);
     (match Eio.Promise.peek entry.done_p with
      | Some (`Crashed msg) -> check string "crash reason preserved" reason msg
      | Some `Stopped -> fail "manual stop should not overwrite a crashed promise"

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module R = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
+module KSM = Masc_mcp.Keeper_state_machine
 
 let bp = "/tmp/test"
 
@@ -28,7 +29,7 @@ let test_register_and_get () =
   let meta = make_meta "k1" in
   let entry = R.register ~base_path:bp "k1" meta in
   check string "name" "k1" entry.name;
-  check string "state" "running" (R.state_to_string entry.state);
+  check string "state" "running" (R.state_to_string entry.phase);
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected entry for k1"
   | Some e -> check string "get name" "k1" e.name
@@ -61,24 +62,25 @@ let test_set_state () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k4" (make_meta "k4") in
   check bool "running" true (R.is_running ~base_path:bp "k4");
-  R.set_state ~base_path:bp "k4" R.Paused;
+  ignore (R.dispatch_event ~base_path:bp "k4" KSM.Operator_pause);
   check bool "not running after pause" false (R.is_running ~base_path:bp "k4");
   match R.get ~base_path:bp "k4" with
   | None -> fail "expected k4"
-  | Some e -> check string "state" "paused" (R.state_to_string e.state)
+  | Some e -> check string "state" "paused" (R.state_to_string e.phase)
 
 let test_extended_states () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k4x" (make_meta "k4x") in
-  R.set_state ~base_path:bp "k4x" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "k4x"
+    (KSM.Fiber_terminated { outcome = "test" }));
   (match R.get ~base_path:bp "k4x" with
    | None -> fail "expected k4x"
-   | Some e -> check string "crashed string" "crashed" (R.state_to_string e.state));
+   | Some e -> check string "crashed string" "crashed" (R.state_to_string e.phase));
   R.mark_dead ~base_path:bp "k4x" ~at:123.0;
   match R.get ~base_path:bp "k4x" with
   | None -> fail "expected k4x"
   | Some e ->
-      check string "dead string" "dead" (R.state_to_string e.state);
+      check string "dead string" "dead" (R.state_to_string e.phase);
       check (option (float 0.01)) "dead_since set" (Some 123.0) e.dead_since_ts
 
 let test_count_running () =
@@ -87,7 +89,7 @@ let test_count_running () =
   let _e2 = R.register ~base_path:bp "r2" (make_meta "r2") in
   let _e3 = R.register ~base_path:bp "r3" (make_meta "r3") in
   check int "3 running" 3 (R.count_running ());
-  R.set_state ~base_path:bp "r2" R.Paused;
+  ignore (R.dispatch_event ~base_path:bp "r2" KSM.Operator_pause);
   check int "2 running" 2 (R.count_running ());
   R.unregister ~base_path:bp "r1";
   check int "1 running" 1 (R.count_running ())
@@ -99,7 +101,7 @@ let test_count_running_atomic_transitions () =
   ignore (R.register ~base_path:bp2 "fast2" (make_meta "fast2"));
   check int "global fast-path count" 2 (R.count_running ());
   check int "scoped count stays exact" 1 (R.count_running ~base_path:bp ());
-  R.set_state ~base_path:bp2 "fast2" R.Paused;
+  ignore (R.dispatch_event ~base_path:bp2 "fast2" KSM.Operator_pause);
   check int "pause decrements global fast-path" 1 (R.count_running ());
   ignore (R.register ~base_path:bp "fast1" (make_meta "fast1"));
   check int "replacing running entry keeps count stable" 1 (R.count_running ());
@@ -150,7 +152,7 @@ let test_get_exn_not_found () =
 let test_noop_on_missing () =
   R.clear ();
   R.update_meta ~base_path:bp "ghost" (make_meta "ghost");
-  R.set_state ~base_path:bp "ghost" R.Paused;
+  ignore (R.dispatch_event ~base_path:bp "ghost" KSM.Operator_pause);
   R.record_restart ~base_path:bp "ghost";
   R.record_error ~base_path:bp "ghost" "err";
   R.record_crash ~base_path:bp "ghost" 0.0 "crash";
@@ -221,8 +223,9 @@ let test_wakeup_all () =
   let e2 = R.register ~base_path:bp "wa2" (make_meta "wa2") in
   let e3 = R.register ~base_path:bp "wa3" (make_meta "wa3") in
   let e4 = R.register ~base_path:bp "wa4" (make_meta "wa4") in
-  R.set_state ~base_path:bp "wa3" R.Stopped;
-  R.set_state ~base_path:bp "wa4" R.Paused;
+  ignore (R.dispatch_event ~base_path:bp "wa3" KSM.Stop_requested);
+  ignore (R.dispatch_event ~base_path:bp "wa3" KSM.Drain_complete);
+  ignore (R.dispatch_event ~base_path:bp "wa4" KSM.Operator_pause);
   R.wakeup_all ();
   check bool "wa1 woken" true (Atomic.get e1.fiber_wakeup);
   check bool "wa2 woken" true (Atomic.get e2.fiber_wakeup);
@@ -261,7 +264,8 @@ let test_fiber_health_crashed () =
 let test_fiber_health_crashed_state_without_done_signal () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fh3-state" (make_meta "fh3-state") in
-  R.set_state ~base_path:bp "fh3-state" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "fh3-state"
+    (KSM.Fiber_terminated { outcome = "test" }));
   match R.fiber_health_of ~base_path:bp "fh3-state" with
   | Keeper_types.Fiber_zombie -> ()
   | _ -> fail "expected Fiber_zombie for explicit crashed state"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -154,7 +154,8 @@ let test_self_preservation_subset () =
   let names = ["a"; "b"; "c"; "d"; "e"] in
   let entries = List.map (fun name ->
     let _reg = Reg.register ~base_path:bp name (make_meta name) in
-    Reg.set_state ~base_path:bp name Reg.Crashed;
+    ignore (Reg.dispatch_event ~base_path:bp name
+      (Masc_mcp.Keeper_state_machine.Fiber_terminated { outcome = "test" }));
     Reg.set_failure_reason ~base_path:bp name
       (Some (Reg.Heartbeat_consecutive_failures 3));
     match Reg.get ~base_path:bp name with

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -5,6 +5,7 @@ open Alcotest
 
 module R = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
+module KSM = Masc_mcp.Keeper_state_machine
 module Cfg = Env_config
 
 let bp = "/tmp/test-phase2"
@@ -29,29 +30,31 @@ let eio_test name fn =
 let test_state_to_string_crashed () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "k1"
+    (KSM.Fiber_terminated { outcome = "test" }));
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "state is crashed" "crashed" (R.state_to_string e.state)
+    check string "state is crashed" "crashed" (R.state_to_string e.phase)
 
 let test_state_to_string_dead () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Dead;
+  R.mark_dead ~base_path:bp "k1" ~at:(Unix.gettimeofday ());
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "state is dead" "dead" (R.state_to_string e.state)
+    check string "state is dead" "dead" (R.state_to_string e.phase)
 
 let test_running_count_crashed () =
   R.clear ();
   let _e1 = R.register ~base_path:bp "a" (make_meta "a") in
   let _e2 = R.register ~base_path:bp "b" (make_meta "b") in
   check int "2 running" 2 (R.count_running ());
-  R.set_state ~base_path:bp "a" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "a"
+    (KSM.Fiber_terminated { outcome = "test" }));
   check int "1 running after crash" 1 (R.count_running ());
-  R.set_state ~base_path:bp "b" R.Dead;
+  R.mark_dead ~base_path:bp "b" ~at:(Unix.gettimeofday ());
   check int "0 running after dead" 0 (R.count_running ())
 
 (* ── is_registered ────────────────────────────────────── *)
@@ -64,13 +67,14 @@ let test_is_registered_running () =
 let test_is_registered_crashed () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "k1"
+    (KSM.Fiber_terminated { outcome = "test" }));
   check bool "crashed → still registered" true (R.is_registered ~base_path:bp "k1")
 
 let test_is_registered_dead () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Dead;
+  R.mark_dead ~base_path:bp "k1" ~at:(Unix.gettimeofday ());
   check bool "dead → still registered" true (R.is_registered ~base_path:bp "k1")
 
 let test_is_registered_unregistered () =
@@ -121,7 +125,8 @@ let test_state_transition_running_crashed_running () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
   check int "1 running" 1 (R.count_running ());
-  R.set_state ~base_path:bp "k1" R.Crashed;
+  ignore (R.dispatch_event ~base_path:bp "k1"
+    (KSM.Fiber_terminated { outcome = "test" }));
   check int "0 running" 0 (R.count_running ());
   check bool "is_running false" false (R.is_running ~base_path:bp "k1");
   check bool "is_registered true" true (R.is_registered ~base_path:bp "k1");
@@ -134,14 +139,14 @@ let test_state_transition_running_crashed_running () =
 let test_dead_to_running_blocked () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Dead;
+  R.mark_dead ~base_path:bp "k1" ~at:(Unix.gettimeofday ());
   check int "0 running" 0 (R.count_running ());
   (* Attempt to transition Dead → Running via set_state *)
-  R.set_state ~base_path:bp "k1" R.Running;
+  ignore (R.dispatch_event ~base_path:bp "k1" KSM.Fiber_started);
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "still dead" "dead" (R.state_to_string e.state);
+    check string "still dead" "dead" (R.state_to_string e.phase);
     check int "still 0 running" 0 (R.count_running ())
 
 (* ── Fix 1: last_failure_reason stored in registry ────── *)
@@ -205,8 +210,9 @@ let test_cohort_key_none () =
 let test_dead_tombstone_is_registered () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
-  R.set_state ~base_path:bp "k1" R.Crashed;
-  R.set_state ~base_path:bp "k1" R.Dead;
+  ignore (R.dispatch_event ~base_path:bp "k1"
+    (KSM.Fiber_terminated { outcome = "test" }));
+  R.mark_dead ~base_path:bp "k1" ~at:(Unix.gettimeofday ());
   (* Dead keeper is still registered — reconcile must skip *)
   check bool "Dead is registered" true (R.is_registered ~base_path:bp "k1");
   check bool "Dead is not running" false (R.is_running ~base_path:bp "k1")

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -875,8 +875,12 @@ let test_keepalive_gap_reports_not_running_instead_of_disabled () =
         | Some entry -> entry
         | None -> fail "missing registry entry after keeper_down"
       in
-      check string "registry state paused" "paused"
-        (Masc_mcp.Keeper_registry.state_to_string entry.state))
+      (* After stop_keepalive → Stopped (terminal), keeper_down's
+         Operator_pause is rejected by the state machine. The registry
+         phase stays "stopped"; the meta.paused flag carries the
+         "paused for later resume" semantic instead. *)
+      check string "registry state stopped (terminal)" "stopped"
+        (Masc_mcp.Keeper_registry.state_to_string entry.phase))
 
 let test_keeper_msg_missing_keeper_fails_without_bootstrap () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

RFC-0002 Phase 3: 모든 `set_state` 호출자(6곳)를 `dispatch_event`로 마이그레이션.

- `keeper_supervisor.ml`: 4곳 (Stopped, Crashed x3)
- `keeper_keepalive.ml`: 2곳 (record_keeper_stopped, record_keeper_crashed)
- `keeper_turn_lifecycle.ml`: 1곳 (Paused -> Operator_pause)

`set_state`는 이제 외부 호출자 0개. 내부 backward-compat shim으로만 남음.

## Test Plan

- [x] 115 tests pass (state machine 50 + registry 42 + supervisor 17 + lifecycle 6)
- [x] Full `dune build` pass

Refs: RFC-0002, #5229, #5243