### PR TITLE
refactor: remove dead code apply_self_model_drift and exceeds_threshold

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -455,7 +455,6 @@ Keeper는 idle 상태에서 주기적으로 자발적 행동을 생성한다.
 **소스**: `keeper_config.ml` (`compact_self_model_text`)
 
 Keeper는 자기 모델(will, needs, desires)의 텍스트를 상한 내로 유지한다.
-`apply_self_model_drift`는 unified turn 리팩터링에서 제거됨 (PR #5251).
 
 - `drift_enabled`: 드리프트 활성화 여부
 - `drift_max_clauses`: 최대 절 수 (기본 6개)

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -452,16 +452,16 @@ Keeper는 idle 상태에서 주기적으로 자발적 행동을 생성한다.
 
 ## 11. Self-Model Drift
 
-**소스**: `keeper_prompt.ml` (`apply_self_model_drift`)
+**소스**: `keeper_config.ml` (`compact_self_model_text`)
 
-Keeper는 작업 내용에 따라 자기 모델(will, needs, desires)을 점진적으로 변이시킨다.
+Keeper는 자기 모델(will, needs, desires)의 텍스트를 상한 내로 유지한다.
+`apply_self_model_drift`는 unified turn 리팩터링에서 제거됨 (PR #5251).
 
 - `drift_enabled`: 드리프트 활성화 여부
-- `drift_min_turn_gap`: 최소 턴 간격 (기본 6턴)
 - `drift_max_clauses`: 최대 절 수 (기본 6개)
 - `drift_max_chars`: 최대 문자 수 (기본 320자)
 
-Semicolon으로 구분된 절 목록에 새 절을 추가하고, 상한 초과 시 오래된 절을 제거(`take_last`).
+`compact_self_model_text`가 semicolon으로 구분된 절 목록을 상한 내로 유지하며, 초과 시 오래된 절을 제거(`take_last`).
 
 ---
 

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -91,7 +91,7 @@
 | Anti-Fake | Test quality scoring | IMPL | anti_fake.ml |
 | Hooks | Autonomy level gating (l3/l4/l5) | IMPL | keeper_hooks_oas.ml |
 | Proactive | Quality gate + similarity + 3-retry fallback | IMPL | keeper_prompt.ml |
-| Self-Model Drift | will/needs/desires gradual mutation | IMPL | keeper_prompt.ml |
+| Self-Model Drift | will/needs/desires compaction | IMPL | keeper_config.ml |
 | TOML Config | config/keepers/*.toml | IMPL | keeper_toml_loader.ml |
 | OAS Memory.t Bridge | 5-tier mapping (부분적) | CODE | memory_oas_bridge.ml (Long_term 불완전) |
 

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -65,9 +65,6 @@ let context_ratio (ctx : working_context) : float =
   if ctx.max_tokens = 0 then 0.0
   else float_of_int (token_count ctx) /. float_of_int ctx.max_tokens
 
-let exceeds_threshold ctx threshold =
-  context_ratio ctx >= threshold
-
 let create ~system_prompt ~max_tokens =
   let context = Agent_sdk.Context.create () in
   { system_prompt; messages = []; max_tokens; context }

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -25,7 +25,6 @@ val count_tokens : string -> Agent_sdk.Types.message list -> int
 val token_count : working_context -> int
 val message_count : working_context -> int
 val context_ratio : working_context -> float
-val exceeds_threshold : working_context -> float -> bool
 val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 val append : working_context -> Agent_sdk.Types.message -> working_context

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -94,14 +94,6 @@ val build_keeper_system_prompt :
 (** Append trait clause to existing trait string. *)
 val append_trait_clause : base:string -> clause:string -> string
 
-(** Apply self-model drift to keeper metadata.
-    Returns updated meta, whether drift occurred, and optional reason. *)
-val apply_self_model_drift :
-  meta:keeper_meta ->
-  user_message:string ->
-  work_kind:string ->
-  keeper_meta * bool * string option
-
 (** {1 Text Processing} *)
 
 (** Remove [STATE]..[/STATE] blocks from text. *)

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -142,11 +142,4 @@ let append_trait_clause ~(base : string) ~(clause : string) : string =
   else if contains_ci b c then b
   else Printf.sprintf "%s; %s" b c
 
-let apply_self_model_drift
-    ~(meta : keeper_meta)
-    ~(user_message : string)
-    ~(work_kind : string) : keeper_meta * bool * string option =
-  ignore (user_message, work_kind);
-  (meta, false, None)
-
 include Keeper_text_processing

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -26,12 +26,6 @@ val append_direct_reply_mode_prompt :
 
 val append_trait_clause : base:string -> clause:string -> string
 
-val apply_self_model_drift :
-  meta:Keeper_types.keeper_meta ->
-  user_message:string ->
-  work_kind:string ->
-  Keeper_types.keeper_meta * bool * string option
-
 (** {1 Text Processing}
 
     Re-exported from [Keeper_text_processing]. *)


### PR DESCRIPTION
## Summary

Dead code 제거 (-25줄) + 관련 spec 문서 업데이트.

| 함수 | 파일 | 이유 |
|------|------|------|
| `apply_self_model_drift` | keeper_prompt.ml | Stub (ignore + return). Caller 0건. |
| `exceeds_threshold` | keeper_exec_context.ml | `context_ratio >= threshold` 한 줄 wrapper. Caller 0건. |

`.mli` export 3곳도 함께 제거.

`docs/spec/05-keeper-agent.md` §11 Self-Model Drift 섹션에서 삭제된 `apply_self_model_drift` 참조를 제거하여 존재하지 않는 API를 문서가 기술하지 않도록 정리.

## Product impact

- Promise affected: `none/internal`
- User-visible change: 없음 (내부 dead code 및 문서 정리)

## Evidence

- `rg` 로 caller 0건 확인
- `dune build` 성공
- `docs/spec/05-keeper-agent.md` §11에서 `apply_self_model_drift` 참조 제거 확인

## Review evidence

<!-- Cross-model review result, reviewer model, and fallback reason if any. -->

## Linked issue