### PR TITLE
fix(memory): bound global mutable state to prevent memory growth on rerun

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -161,9 +161,37 @@ let heartbeat_mutex = Eio.Mutex.create ()
 
 let heartbeat_snapshot_seq = ref 0
 
+(** Maximum agent entries in heartbeat snapshot maps.
+    Beyond this, oldest entries (by timestamp) are evicted on write. *)
+let max_heartbeat_agents = 128
+
 let next_heartbeat_snapshot_seq () =
   heartbeat_snapshot_seq := !heartbeat_snapshot_seq + 1;
   !heartbeat_snapshot_seq
+
+(** Evict oldest entries from a heartbeat SMap when it exceeds [max_heartbeat_agents].
+    [get_ts] extracts the ISO8601 timestamp string from a snapshot value.
+    Keeps the [max_heartbeat_agents] most recent entries. *)
+let evict_heartbeat_map ~get_ts (m : 'a SMap.t) : 'a SMap.t =
+  if SMap.cardinal m <= max_heartbeat_agents then m
+  else begin
+    let entries = SMap.bindings m in
+    let sorted = List.sort (fun (_, a) (_, b) ->
+      String.compare (get_ts b) (get_ts a)
+    ) entries in
+    let kept = List.filteri (fun i _ -> i < max_heartbeat_agents) sorted in
+    List.fold_left (fun acc (k, v) -> SMap.add k v acc) SMap.empty kept
+  end
+
+(** Clear all transient in-memory state (heartbeat snapshots + event buffers).
+    Call on shutdown or between flow runs to prevent memory accumulation. *)
+let clear_transient_state () =
+  Eio.Mutex.use_rw ~protect:true heartbeat_mutex (fun () ->
+    latest_heartbeat_tasks := SMap.empty;
+    latest_heartbeat_results := SMap.empty;
+    heartbeat_snapshot_seq := 0);
+  Eio.Mutex.use_rw ~protect:true event_buffers_mutex (fun () ->
+    event_buffers := SMap.empty)
 
 let latest_heartbeat_task agent =
   Eio_guard.with_mutex heartbeat_mutex (fun () ->
@@ -612,7 +640,7 @@ let emit_heartbeat_task
     ?(auth_token : string option)
     () : unit =
   Eio.Mutex.use_rw ~protect:true heartbeat_mutex (fun () ->
-    latest_heartbeat_tasks := SMap.add agent
+    let m = SMap.add agent
       {
         seq = next_heartbeat_snapshot_seq ();
         goal;
@@ -621,7 +649,9 @@ let emit_heartbeat_task
         allowed_tools;
         decision_reason;
         created_at = now_iso8601 ();
-      } !latest_heartbeat_tasks);
+      } !latest_heartbeat_tasks in
+    latest_heartbeat_tasks :=
+      evict_heartbeat_map ~get_ts:(fun s -> s.created_at) m);
   let data = `Assoc ([
     ("agent", `String agent);
     ("goal", `String goal);
@@ -707,7 +737,7 @@ let submit_heartbeat_result
   (match result with
    | Ok _ ->
        Eio.Mutex.use_rw ~protect:true heartbeat_mutex (fun () ->
-         latest_heartbeat_results := SMap.add agent
+         let m = SMap.add agent
            {
              seq = next_heartbeat_snapshot_seq ();
              status = normalized_status;
@@ -719,7 +749,9 @@ let submit_heartbeat_result
              decision_confidence;
              failure_reason;
              updated_at = now_iso8601 ();
-           } !latest_heartbeat_results);
+           } !latest_heartbeat_results in
+         latest_heartbeat_results :=
+           evict_heartbeat_map ~get_ts:(fun s -> s.updated_at) m);
        notify_event ~event_type:Completion ~agent
          ~data:(`Assoc [
            ("worker", `String worker_name);

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -55,9 +55,28 @@ let session_identity_map : (string, string) Hashtbl.t = Hashtbl.create 64
     ~180 lines of identity resolution on 2nd+ calls. *)
 let resolved_names : (string, string) Hashtbl.t = Hashtbl.create 64
 
+(** Maximum session cache entries before forced eviction.
+    Prevents unbounded growth when many MCP sessions connect over time. *)
+let max_session_cache_entries = 1024
+
 let clear_session_caches () =
   Hashtbl.clear session_identity_map;
   Hashtbl.clear resolved_names
+
+(** Evict all session cache entries if either cache exceeds [max_session_cache_entries].
+    A simple full-clear is safe because the caches are write-through
+    (identity is reconstructed from params on the next call). *)
+let maybe_evict_session_caches () =
+  if Hashtbl.length session_identity_map > max_session_cache_entries
+     || Hashtbl.length resolved_names > max_session_cache_entries
+  then begin
+    Log.Identity.info
+      "[AgentRegistry] session cache eviction: identity=%d resolved=%d (max=%d)"
+      (Hashtbl.length session_identity_map)
+      (Hashtbl.length resolved_names)
+      max_session_cache_entries;
+    clear_session_caches ()
+  end
 
 (** Reset registry for testing *)
 let reset_for_testing () =
@@ -118,6 +137,7 @@ let get_or_create_identity ?mcp_session_id params =
         (String.sub registered.session_key 0 8)
         (Option.value mcp_session_id ~default:"none");
 
+      maybe_evict_session_caches ();
       registered
 
 (** Get identity by agent name (for backward compatibility) *)

--- a/lib/agent_registry_eio.mli
+++ b/lib/agent_registry_eio.mli
@@ -27,5 +27,6 @@ val list_active : ?within_seconds:float -> unit -> Agent_identity.t list
 
 (** {1 Cleanup} *)
 
+val clear_session_caches : unit -> unit
 val cleanup_stale_sessions : unit -> int
 val unregister : string -> unit

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -38,5 +38,15 @@ let run_all () =
   Log.Server.info "Closed %d WebSocket sessions (%.2fs) [remaining ws: %d]"
     ws_count (Unix.gettimeofday () -. t_ws)
     (Server_mcp_transport_ws.session_count ());
+  (* Flush metric/stress buffers to prevent data loss *)
+  (try Heuristic_metrics.flush ()
+   with _ -> Log.Server.warn "[Shutdown] heuristic_metrics flush failed");
+  (try Agent_stress.flush ()
+   with _ -> Log.Server.warn "[Shutdown] agent_stress flush failed");
+  (* Clear transient A2A state to free memory *)
+  (try A2a_tools.clear_transient_state ()
+   with _ -> Log.Server.warn "[Shutdown] a2a_tools clear failed");
+  (* Clear session identity caches *)
+  Agent_registry_eio.clear_session_caches ();
   Log.Server.info "[Shutdown] hooks total: %.2fs"
     (Unix.gettimeofday () -. t0)


### PR DESCRIPTION
## Summary
- A2A heartbeat maps (`latest_heartbeat_tasks/results`): evict oldest entries when exceeding 128 agents
- Agent registry session caches: auto-clear when either cache exceeds 1024 entries  
- Shutdown hooks: flush `Heuristic_metrics`/`Agent_stress` buffers + clear A2A transient state + clear session caches
- Expose `clear_session_caches` in `.mli` for shutdown hook access

## Root Cause
Global mutable SMap refs and Hashtbls accumulated entries across flow reruns without eviction, causing RSS to grow monotonically. Shutdown hooks did not flush metric buffers or clear transient state.

## Test plan
- [ ] `dune build` passes (warn-error=+a)
- [ ] `dune test` passes
- [ ] CI Build and Test green
- [ ] Manual: run target flow twice, observe RSS stays stable

Closes #4890

🤖 Generated with [Claude Code](https://claude.com/claude-code)