### PR TITLE
refactor: remove dead code (apply_self_model_drift + exceeds_threshold)

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -65,9 +65,6 @@ let context_ratio (ctx : working_context) : float =
   if ctx.max_tokens = 0 then 0.0
   else float_of_int (token_count ctx) /. float_of_int ctx.max_tokens
 
-let exceeds_threshold ctx threshold =
-  context_ratio ctx >= threshold
-
 let create ~system_prompt ~max_tokens =
   let context = Agent_sdk.Context.create () in
   { system_prompt; messages = []; max_tokens; context }

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -25,7 +25,6 @@ val count_tokens : string -> Agent_sdk.Types.message list -> int
 val token_count : working_context -> int
 val message_count : working_context -> int
 val context_ratio : working_context -> float
-val exceeds_threshold : working_context -> float -> bool
 val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 val append : working_context -> Agent_sdk.Types.message -> working_context

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -94,14 +94,6 @@ val build_keeper_system_prompt :
 (** Append trait clause to existing trait string. *)
 val append_trait_clause : base:string -> clause:string -> string
 
-(** Apply self-model drift to keeper metadata.
-    Returns updated meta, whether drift occurred, and optional reason. *)
-val apply_self_model_drift :
-  meta:keeper_meta ->
-  user_message:string ->
-  work_kind:string ->
-  keeper_meta * bool * string option
-
 (** {1 Text Processing} *)
 
 (** Remove [STATE]..[/STATE] blocks from text. *)

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -142,11 +142,4 @@ let append_trait_clause ~(base : string) ~(clause : string) : string =
   else if contains_ci b c then b
   else Printf.sprintf "%s; %s" b c
 
-let apply_self_model_drift
-    ~(meta : keeper_meta)
-    ~(user_message : string)
-    ~(work_kind : string) : keeper_meta * bool * string option =
-  ignore (user_message, work_kind);
-  (meta, false, None)
-
 include Keeper_text_processing

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -26,12 +26,6 @@ val append_direct_reply_mode_prompt :
 
 val append_trait_clause : base:string -> clause:string -> string
 
-val apply_self_model_drift :
-  meta:Keeper_types.keeper_meta ->
-  user_message:string ->
-  work_kind:string ->
-  Keeper_types.keeper_meta * bool * string option
-
 (** {1 Text Processing}
 
     Re-exported from [Keeper_text_processing]. *)


### PR DESCRIPTION
## Summary
Remove 2 dead code functions with zero callers since the unified turn transition.

- `apply_self_model_drift` in keeper_prompt.ml — stub returning `(meta, false, None)` with `ignore()`
- `exceeds_threshold` in keeper_exec_context.ml — trivial `context_ratio >= threshold` wrapper

## Verification
- `dune build @install` passes
- `rg "apply_self_model_drift|exceeds_threshold" lib/ test/ --type ocaml` → 0 hits
- -25 lines removed across 5 files (.ml + .mli)

Closes #5238

🤖 Generated with [Claude Code](https://claude.com/claude-code)