### PR TITLE
fix(keeper): recover from token budget overflow

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -244,15 +244,18 @@ let log_keeper_exn ~label exn =
 let checkpoint_generation_key = "keeper_generation"
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let open Yojson.Safe.Util in
-  match cp.max_total_tokens with
-  | Some value -> value
-  | None -> (
-      match cp.working_context with
-      | Some (`Assoc _ as sidecar) ->
-          sidecar |> member "max_tokens" |> to_int_option
-          |> Option.value ~default:fallback
-      | _ -> fallback)
+  let stored_limit =
+    let open Yojson.Safe.Util in
+    match cp.max_total_tokens with
+    | Some value when value > 0 -> Some value
+    | _ -> (
+        match cp.working_context with
+        | Some (`Assoc _ as sidecar) ->
+            sidecar |> member "max_tokens" |> to_int_option
+        | _ -> None)
+  in
+  if fallback > 0 then fallback
+  else Option.value ~default:fallback stored_limit
 
 let context_of_oas_checkpoint
     (cp : Agent_sdk.Checkpoint.t)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -244,18 +244,15 @@ let log_keeper_exn ~label exn =
 let checkpoint_generation_key = "keeper_generation"
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let stored_limit =
-    let open Yojson.Safe.Util in
-    match cp.max_total_tokens with
-    | Some value when value > 0 -> Some value
-    | _ -> (
-        match cp.working_context with
-        | Some (`Assoc _ as sidecar) ->
-            sidecar |> member "max_tokens" |> to_int_option
-        | _ -> None)
-  in
-  if fallback > 0 then fallback
-  else Option.value ~default:fallback stored_limit
+  let open Yojson.Safe.Util in
+  match cp.max_total_tokens with
+  | Some value -> value
+  | None -> (
+      match cp.working_context with
+      | Some (`Assoc _ as sidecar) ->
+          sidecar |> member "max_tokens" |> to_int_option
+          |> Option.value ~default:fallback
+      | _ -> fallback)
 
 let context_of_oas_checkpoint
     (cp : Agent_sdk.Checkpoint.t)
@@ -513,9 +510,14 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
       trace_id;
   match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
   | (false, Some checkpoint, _) ->
-      ( session,
-        Some
-          (context_of_oas_checkpoint checkpoint ~primary_model_max_tokens) )
+      let ctx =
+        context_of_oas_checkpoint checkpoint ~primary_model_max_tokens
+      in
+      let ctx =
+        if primary_model_max_tokens <= 0 then ctx
+        else sync_oas_context { ctx with max_tokens = primary_model_max_tokens }
+      in
+      (session, Some ctx)
   | (_, _, Some ckpt) ->
       (try
          let ctx =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -71,25 +71,66 @@ let transient_backoff_sec (attempt : int) : float =
   Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
 
 let context_overflow_anchor = "available context size ("
+let input_budget_exceeded_anchor = "input token budget exceeded:"
 
-let context_overflow_limit (msg : string) : int option =
-  let lowered = String.lowercase_ascii msg in
-  match find_substring ~needle:context_overflow_anchor lowered with
+let is_ascii_whitespace = function
+  | ' ' | '\n' | '\r' | '\t' -> true
+  | _ -> false
+
+let skip_ascii_whitespace (text : string) idx =
+  let rec loop i =
+    if i >= String.length text then i
+    else if is_ascii_whitespace text.[i] then loop (i + 1)
+    else i
+  in
+  loop idx
+
+let int_run_from (text : string) start_idx : (int * int) option =
+  let rec consume_digits idx =
+    if idx >= String.length text then idx
+    else
+      match text.[idx] with
+      | '0' .. '9' -> consume_digits (idx + 1)
+      | _ -> idx
+  in
+  let end_idx = consume_digits start_idx in
+  if end_idx = start_idx then None
+  else
+    String.sub text start_idx (end_idx - start_idx)
+    |> int_of_string_opt
+    |> Option.map (fun value -> (value, end_idx))
+
+let parse_available_context_limit (msg : string) : int option =
+  match find_substring ~needle:context_overflow_anchor msg with
   | None -> None
   | Some anchor_idx ->
       let start_idx = anchor_idx + String.length context_overflow_anchor in
-      let rec consume_digits idx =
-        if idx >= String.length lowered then idx
-        else
-          match lowered.[idx] with
-          | '0' .. '9' -> consume_digits (idx + 1)
-          | _ -> idx
+      int_run_from msg start_idx |> Option.map fst
+
+let parse_input_budget_exceeded_limit (msg : string) : int option =
+  match find_substring ~needle:input_budget_exceeded_anchor msg with
+  | None -> None
+  | Some anchor_idx ->
+      let used_start =
+        skip_ascii_whitespace msg
+          (anchor_idx + String.length input_budget_exceeded_anchor)
       in
-      let end_idx = consume_digits start_idx in
-      if end_idx = start_idx then None
-      else
-        String.sub lowered start_idx (end_idx - start_idx)
-        |> int_of_string_opt
+      match int_run_from msg used_start with
+      | None -> None
+      | Some (_, used_end) ->
+          let slash_idx = skip_ascii_whitespace msg used_end in
+          if slash_idx >= String.length msg || msg.[slash_idx] <> '/' then None
+          else
+            let limit_start =
+              skip_ascii_whitespace msg (slash_idx + 1)
+            in
+            int_run_from msg limit_start |> Option.map fst
+
+let context_overflow_limit (msg : string) : int option =
+  let lowered = String.lowercase_ascii msg in
+  match parse_available_context_limit lowered with
+  | Some limit -> Some limit
+  | None -> parse_input_budget_exceeded_limit lowered
 
 let should_attempt_context_overflow_retry (msg : string) : bool =
   Option.is_some (context_overflow_limit msg)

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -118,8 +118,8 @@ let test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit () =
           ~state_reply:"[STATE]\nGoal: test\nProgress: saved\n[/STATE]"
       in
       let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
-      check int "stored checkpoint max used when fallback missing" 4096
-        (KEC.checkpoint_max_tokens checkpoint ~fallback:0);
+      check int "stored checkpoint max preserved in checkpoint helper" 4096
+        (KEC.checkpoint_max_tokens checkpoint ~fallback:32768);
       match
         load_context ~base_dir ~trace_id:meta.runtime.trace_id
           ~max_tokens:32768

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -106,6 +106,29 @@ let test_apply_post_turn_lifecycle_without_checkpoint_records_skip () =
       check int "turn generation unchanged" meta.runtime.generation
         lifecycle.turn_generation)
 
+let test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit () =
+  let base_dir = temp_dir "keeper_lifecycle_live_limit" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let meta = make_keeper_meta ~trace_id:"trace-live-limit" () in
+      let ctx =
+        build_dense_context ~turns:4 ~max_tokens:4096
+          ~state_reply:"[STATE]\nGoal: test\nProgress: saved\n[/STATE]"
+      in
+      let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
+      check int "stored checkpoint max used when fallback missing" 4096
+        (KEC.checkpoint_max_tokens checkpoint ~fallback:0);
+      match
+        load_context ~base_dir ~trace_id:meta.runtime.trace_id
+          ~max_tokens:32768
+      with
+      | Some loaded ->
+          check int "restore uses live primary max tokens" 32768
+            loaded.max_tokens
+      | None -> fail "expected checkpoint context to load")
+
 let test_apply_post_turn_lifecycle_compacts_and_updates_continuity () =
   let base_dir = temp_dir "keeper_lifecycle_compact" in
   Fun.protect
@@ -355,6 +378,8 @@ let () =
         [
           test_case "no checkpoint records skip state" `Quick
             test_apply_post_turn_lifecycle_without_checkpoint_records_skip;
+          test_case "restore prefers live primary max tokens" `Quick
+            test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit;
           test_case "compaction persists checkpoint and continuity" `Quick
             test_apply_post_turn_lifecycle_compacts_and_updates_continuity;
           test_case "handoff runs after compaction" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1195,6 +1195,9 @@ let test_context_overflow_limit_parses_common_oas_errors () =
   check (option int) "available context size extracted" (Some 159671)
     (UT.context_overflow_limit
        "OpenAI returned 400: This model's maximum context length is 128000 tokens. However, your messages resulted in 193217 tokens. available context size (159671)");
+  check (option int) "input budget exceeded extracted" (Some 8192)
+    (UT.context_overflow_limit
+       "Agent run failed: Input token budget exceeded:\n  10847/8192");
   check (option int) "missing digits" None
     (UT.context_overflow_limit
        "available context size () but message malformed");
@@ -1206,6 +1209,9 @@ let test_should_attempt_context_overflow_retry_only_for_overflow_errors () =
   check bool "overflow string retries" true
     (UT.should_attempt_context_overflow_retry
        "provider error: available context size (32768) exceeded");
+  check bool "input budget exceeded retries" true
+    (UT.should_attempt_context_overflow_retry
+       "Agent run failed: Input token budget exceeded:\n  11010/8192");
   check bool "non-overflow string skips retry" false
     (UT.should_attempt_context_overflow_retry
        "Network error: Connection_reset")

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -850,7 +850,7 @@ let test_keeper_checkpoint_prefers_oas_checkpoint () =
       | Some loaded ->
           Alcotest.(check string) "system prompt from OAS checkpoint"
             "oas system" loaded.system_prompt;
-          Alcotest.(check int) "max_tokens from OAS checkpoint" 4096
+          Alcotest.(check int) "max_tokens from live primary context" 1024
             loaded.max_tokens;
           Alcotest.(check string) "loaded OAS message" "oas"
             (Agent_sdk.Types.text_of_message (List.hd loaded.messages))


### PR DESCRIPTION
## Summary

- parse keeper overflow failures reported as `Input token budget exceeded: used/max`
- prefer the live primary context limit when restoring keeper checkpoints
- add regression coverage for overflow parsing and checkpoint max token restore

## Verification

- `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-context-limit --display short @runtest-test_oas_worker @runtest-test_keeper_unified @runtest-test_keeper_lifecycle`
