### PR TITLE
fix(boundary): remove dead code and consolidate role catalog SSOT

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -529,54 +529,16 @@ let admin_tool_names : string list =
   Tool_catalog.tools_for_surface Tool_catalog.Admin
 
 (** Role-catalog candidates for coordinators and fleet leaders.
-    These are curated subsets, not surface SSOTs. [build_tool_catalog]
-    filters them against surfaced tool names so stale hardcoded entries
-    cannot escape into prompts. *)
+    SSOT: Tool_catalog_surfaces.coordination_role_tools.
+    [build_tool_catalog] filters against surfaced tool names so stale
+    entries cannot escape into prompts. *)
 let coordination_tool_names : string list =
-  [
-    "masc_status";
-    "masc_tasks";
-    "masc_add_task";
-    "masc_broadcast";
-    "masc_join";
-    "masc_leave";
-    "masc_who";
-    "masc_heartbeat";
-    "masc_messages";
-    "masc_board_list";
-    "masc_board_post";
-    "masc_board_comment";
-    "masc_board_vote";
-    "masc_board_get";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_team_session_start";
-    "masc_team_session_status";
-    "masc_team_session_events";
-    "masc_team_session_report";
-    "masc_team_session_list";
-    "masc_spawn";
-  ]
+  Tool_catalog_surfaces.coordination_role_tools
 
 (** Role-catalog candidates for worker agents.
-    These are curated subsets, not surface SSOTs. *)
+    SSOT: Tool_catalog_surfaces.execution_role_tools. *)
 let execution_tool_names : string list =
-  [
-    "masc_heartbeat";
-    "masc_team_session_step";
-    "masc_team_session_status";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_broadcast";
-    "masc_code_search";
-    "masc_code_symbols";
-    "masc_code_read";
-    "masc_run_init";
-    "masc_run_log";
-    "masc_run_deliverable";
-    "masc_run_get";
-    "masc_tool_help";
-  ]
+  Tool_catalog_surfaces.execution_role_tools
 
 let filter_catalog_to_available ~available names =
   let available = SS.of_list available in

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -835,7 +835,7 @@ let forced_overflow_retry_meta
       };
   }
 
-let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
+let recover_latest_checkpoint_for_overflow_retry
     ~(base_dir : string)
     ~(meta : keeper_meta)
     ~(model : string)
@@ -907,7 +907,6 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
         compact_if_needed ~meta:retry_meta ~now_ts ctx
       in
       let after_tokens = token_count compacted_ctx in
-      let decision = base_decision in
       let compaction_applied =
         String.starts_with ~prefix:"applied:" base_decision
       in
@@ -918,7 +917,7 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
           {
             applied = true;
             trigger;
-            decision;
+            decision = base_decision;
             before_tokens;
             after_tokens;
             saved_tokens = max 0 (before_tokens - after_tokens);

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -55,9 +55,6 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
 let token_count (ctx : working_context) =
   count_tokens ctx.system_prompt ctx.messages
 
-let message_token_count (ctx : working_context) =
-  count_tokens "" ctx.messages
-
 let message_count (ctx : working_context) =
   List.length ctx.messages
 
@@ -647,10 +644,6 @@ let compact_if_needed
           let msgs_after_fold =
             Agent_sdk.Context_reducer.reduce fold_reducer msgs_after_compact
           in
-          let token_count =
-            Context_compact_oas.count_tokens ctx.system_prompt msgs_after_fold
-          in
-          let _ = token_count in
           msgs_after_fold
         in
         let compacted_ctx =
@@ -913,10 +906,6 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
       let compacted_ctx, trigger, base_decision =
         compact_if_needed ~meta:retry_meta ~now_ts ctx
       in
-      let strategy_after_message_tokens =
-        message_token_count compacted_ctx
-      in
-      let _ = strategy_after_message_tokens in
       let after_tokens = token_count compacted_ctx in
       let decision = base_decision in
       let compaction_applied =
@@ -925,7 +914,6 @@ let[@warning "-32"] recover_latest_checkpoint_for_overflow_retry
       let meaningful_reduction = after_tokens < before_tokens in
       if not (compaction_applied && meaningful_reduction) then None
       else
-        let _ = strategy_after_message_tokens in
         let compaction =
           {
             applied = true;

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -306,8 +306,8 @@ let system_internal_surface_tools =
 (* ================================================================ *)
 (* Role catalogs — curated subsets for agent role assignment.        *)
 (* These are NOT surfaces; they define what a role *should* see.    *)
-(* Consumers must filter against actual surfaced tools via          *)
-(* [filter_catalog_to_available] before exposing to agents.        *)
+(* Consumers must filter them against the tools actually surfaced   *)
+(* before exposing them to agents.                                 *)
 (* ================================================================ *)
 
 let coordination_role_tools : string list =

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -304,6 +304,57 @@ let system_internal_surface_tools =
   ]
 
 (* ================================================================ *)
+(* Role catalogs — curated subsets for agent role assignment.        *)
+(* These are NOT surfaces; they define what a role *should* see.    *)
+(* Consumers must filter against actual surfaced tools via          *)
+(* [filter_catalog_to_available] before exposing to agents.        *)
+(* ================================================================ *)
+
+let coordination_role_tools : string list =
+  [
+    "masc_status";
+    "masc_tasks";
+    "masc_add_task";
+    "masc_broadcast";
+    "masc_join";
+    "masc_leave";
+    "masc_who";
+    "masc_heartbeat";
+    "masc_messages";
+    "masc_board_list";
+    "masc_board_post";
+    "masc_board_comment";
+    "masc_board_vote";
+    "masc_board_get";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_team_session_start";
+    "masc_team_session_status";
+    "masc_team_session_events";
+    "masc_team_session_report";
+    "masc_team_session_list";
+    "masc_spawn";
+  ]
+
+let execution_role_tools : string list =
+  [
+    "masc_heartbeat";
+    "masc_team_session_step";
+    "masc_team_session_status";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_broadcast";
+    "masc_code_search";
+    "masc_code_symbols";
+    "masc_code_read";
+    "masc_run_init";
+    "masc_run_log";
+    "masc_run_deliverable";
+    "masc_run_get";
+    "masc_tool_help";
+  ]
+
+(* ================================================================ *)
 (* Surface query functions                                          *)
 (* ================================================================ *)
 


### PR DESCRIPTION
## Summary

- `keeper_exec_context.ml`에서 #5237 병합 잔여 dead code 제거 (unused `message_token_count` 함수 + 3개 `let _ =` 바인딩 + dead `token_count` 연산)
- `coordination_tool_names`/`execution_tool_names` 하드코딩 리스트를 `Tool_catalog_surfaces`로 이동하여 SSOT 통합 (#5247이 `local_worker`에 적용한 패턴과 동일)
- `agent_tool_surfaces.ml`은 이제 독립 리스트 대신 `Tool_catalog_surfaces` 참조

## Context

PR 병합 순서 분석에서 발견:
- #5201 → #5237 과정에서 budget trim 로직 삭제 시 dead code 잔존
- #5247이 `local_worker` SSOT를 수정했으나 role catalog은 여전히 하드코딩

## Test plan

- [x] `test_tool_surface_ssot.exe` 25개 테스트 통과
- [x] `test_keeper_lifecycle.exe` 6개 테스트 통과
- [x] `dune build @check` 경고 없이 컴파일
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)