### PR TITLE
fix(keeper): log repeated tool names on idle loop detection

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -290,9 +290,17 @@ let make_hooks
 
     on_idle = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; _ } ->
-        Log.Keeper.debug "keeper:%s idle_turns=%d"
-          (!meta_ref).name consecutive_idle_turns;
+      | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names } ->
+        let tools_str = match tool_names with
+          | [] -> "<none>"
+          | names -> String.concat ", " names
+        in
+        if consecutive_idle_turns >= 3 then
+          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s]"
+            (!meta_ref).name consecutive_idle_turns tools_str
+        else
+          Log.Keeper.debug "keeper:%s idle_turns=%d tools=[%s]"
+            (!meta_ref).name consecutive_idle_turns tools_str;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
   }


### PR DESCRIPTION
## Summary
- Extract `tool_names` from `OnIdle` event (was previously discarded via `_`)
- Log tool names at debug level for idle_turns < 3
- Escalate to warn level at 3+ consecutive idle turns for operational visibility
- Enables diagnosing which tool an agent is stuck repeating

## Root Cause
The `on_idle` hook was matching `{ consecutive_idle_turns; _ }`, discarding the `tool_names` field that tells you exactly which tools are being repeated.

## Test plan
- [ ] `dune build` passes
- [ ] CI Build and Test green

Closes #5020

🤖 Generated with [Claude Code](https://claude.com/claude-code)