### PR TITLE
refactor(ssot): centralize prompt template names and port/host defaults

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -156,24 +156,26 @@ let sb_path () =
   | Ok path -> path
   | Error msg -> raise (Config_error msg)
 
+let default_http_port = "8935"
+let default_http_port_int = 8935
+
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
   | Some port -> port
-  | None -> "8935"
+  | None -> default_http_port
 
 let masc_http_port_int () =
-  Safe_ops.int_of_string_with_default ~default:8935 (masc_http_port ())
+  Safe_ops.int_of_string_with_default ~default:default_http_port_int (masc_http_port ())
 
 let masc_host_opt () =
   Sys.getenv_opt "MASC_HOST" |> trim_opt
 
-(** Centralized MASC_HOST reader.
-    Reads MASC_HOST env var.
-    Default: "127.0.0.1". *)
+let default_host = "127.0.0.1"
+
 let masc_host () =
   match masc_host_opt () with
   | Some host -> host
-  | None -> "127.0.0.1"
+  | None -> default_host
 
 (** Centralized MASC_ASSETS_DIR reader.
     Returns None when MASC_ASSETS_DIR is unset or empty. *)

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -157,7 +157,7 @@ let sb_path () =
   | Error msg -> raise (Config_error msg)
 
 let default_http_port = "8935"
-let default_http_port_int = 8935
+let default_http_port_int = int_of_string default_http_port
 
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
@@ -172,6 +172,9 @@ let masc_host_opt () =
 
 let default_host = "127.0.0.1"
 
+(** Centralized MASC_HOST reader.
+    Reads MASC_HOST env var.
+    Default: {!default_host} ("127.0.0.1"). *)
 let masc_host () =
   match masc_host_opt () with
   | Some host -> host

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -57,8 +57,8 @@ let category name entries =
 
 let server_entries =
   [
-    entry ~default:"8935" "MASC_HTTP_PORT" "HTTP server port";
-    entry ~default:"127.0.0.1" "MASC_HOST" "Server bind host";
+    entry ~default:Env_config_core.default_http_port "MASC_HTTP_PORT" "HTTP server port";
+    entry ~default:Env_config_core.default_host "MASC_HOST" "Server bind host";
     entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -713,9 +713,9 @@ let keeper_config_json (config : Room.config) (name : string)
           ( "system_prompt_blocks",
             `Assoc
               [
-                ("constitution", prompt_block_json "keeper.constitution");
-                ("world", prompt_block_json "keeper.world");
-                ("capabilities", prompt_block_json "keeper.capabilities");
+                ("constitution", prompt_block_json Keeper_prompt_names.constitution);
+                ("world", prompt_block_json Keeper_prompt_names.world);
+                ("capabilities", prompt_block_json Keeper_prompt_names.capabilities);
               ] );
           ("effective_system_prompt", `String effective_system_prompt);
         ]

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -146,18 +146,7 @@ let auth_kind_for_provider provider =
   | _ -> Provider_adapter.auth_kind_for_canonical_name provider
 
 let endpoint_url_for_provider provider =
-  match provider with
-  | "llama" -> Some Env_config_runtime.Llama.server_url
-  | "claude-api" -> Some "https://api.anthropic.com"
-  | "codex-api" -> Some "https://api.openai.com"
-  | "glm" -> Some Env_config_runtime.Glm.server_url
-  | "gemini-api" -> (
-      match Provider_adapter.resolve_gemini_direct_auth () with
-      | Provider_adapter.Gemini_vertex_adc { project; location } ->
-          Some
-            (Provider_adapter.gemini_vertex_openai_base_url ~project ~location)
-      | _ -> Some "https://generativelanguage.googleapis.com")
-  | _ -> None
+  Provider_adapter.endpoint_url_for_canonical_name provider
 
 let default_model_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with

--- a/lib/dune
+++ b/lib/dune
@@ -471,6 +471,7 @@
    keeper_unified_prompt
    keeper_unified_turn
 
+   keeper_prompt_names
    keeper_prompt
    keeper_coordination
    keeper_execution

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -384,7 +384,7 @@ let build_deliberation_prompt
 {"action":"multi_step","params":{"steps":[{"action":"task_claim","params":{"task_id":"task-1","reason":"urgent"}},{"action":"broadcast","params":{"message":"Claimed task-1"}}]},"reasoning":"Claim and announce","confidence":0.7}|}
   in
   match
-    Prompt_registry.render_prompt_template "keeper.deliberation"
+    Prompt_registry.render_prompt_template Keeper_prompt_names.deliberation
       [
         ("keeper_name", keeper_name);
         ("soul_profile", soul_profile);
@@ -396,7 +396,7 @@ let build_deliberation_prompt
       ]
   with
   | Ok value -> value
-  | Error _ -> Prompt_registry.get_prompt "keeper.deliberation"
+  | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.deliberation
 
 type structured_result = {
   action: deliberation_action;

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -11,7 +11,7 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
   Mention.any_mentioned ~targets content
 
 let keeper_constitution () =
-  Prompt_registry.get_prompt "keeper.constitution"
+  Prompt_registry.get_prompt Keeper_prompt_names.constitution
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~soul_profile ~will ~needs ~desires
@@ -55,7 +55,7 @@ let build_keeper_system_prompt
     [
       persona_block;
       "<world>\n";
-      Prompt_registry.get_prompt "keeper.world";
+      Prompt_registry.get_prompt Keeper_prompt_names.world;
       "\n</world>\n\
        \n\
        <identity>\n\
@@ -105,7 +105,7 @@ let build_keeper_system_prompt
       desires;
       "\n\
        <capabilities>\n";
-      Prompt_registry.get_prompt "keeper.capabilities";
+      Prompt_registry.get_prompt Keeper_prompt_names.capabilities;
       "\n</capabilities>\n\
        \n\
        ";

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -1,0 +1,11 @@
+(** Keeper_prompt_names — SSOT for Prompt_registry template keys
+    used by keeper modules.
+
+    All keeper prompt lookups must reference these constants
+    instead of string literals. *)
+
+let constitution = "keeper.constitution"
+let world = "keeper.world"
+let capabilities = "keeper.capabilities"
+let deliberation = "keeper.deliberation"
+let unified_system = "keeper.unified.system"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -203,7 +203,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
   in
   let base_system_prompt =
     match
-      Prompt_registry.render_prompt_template "keeper.unified.system"
+      Prompt_registry.render_prompt_template Keeper_prompt_names.unified_system
         [
           ("identity_header", Printf.sprintf "You are %s, a keeper agent." meta.name);
           ("trait_lines", trait_lines);
@@ -212,7 +212,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
         ]
     with
     | Ok value -> value
-    | Error _ -> Prompt_registry.get_prompt "keeper.unified.system"
+    | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.unified_system
   in
   let turn_intent_block =
     "Use the world state below as raw context.\n\

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -831,3 +831,19 @@ let gemini_vertex_openai_base_url ~project ~location =
   Printf.sprintf
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
     project location
+
+(** Resolve the API endpoint URL for a canonical provider name.
+    Local and runtime-configured providers use Env_config_runtime.
+    Cloud API providers return their well-known base URLs. *)
+let endpoint_url_for_canonical_name name =
+  match name with
+  | "llama" -> Some Env_config_runtime.Llama.server_url
+  | "glm" -> Some Env_config_runtime.Glm.server_url
+  | "claude-api" -> Some "https://api.anthropic.com"
+  | "codex-api" -> Some "https://api.openai.com"
+  | "gemini-api" -> (
+      match resolve_gemini_direct_auth () with
+      | Gemini_vertex_adc { project; location } ->
+          Some (gemini_vertex_openai_base_url ~project ~location)
+      | _ -> Some "https://generativelanguage.googleapis.com")
+  | _ -> None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -837,11 +837,11 @@ let gemini_vertex_openai_base_url ~project ~location =
     Cloud API providers return their well-known base URLs. *)
 let endpoint_url_for_canonical_name name =
   match name with
-  | "llama" -> Some Env_config_runtime.Llama.server_url
-  | "glm" -> Some Env_config_runtime.Glm.server_url
-  | "claude-api" -> Some "https://api.anthropic.com"
-  | "codex-api" -> Some "https://api.openai.com"
-  | "gemini-api" -> (
+  | s when s = cn_llama -> Some Env_config_runtime.Llama.server_url
+  | s when s = cn_glm -> Some Env_config_runtime.Glm.server_url
+  | s when s = cn_claude -> Some "https://api.anthropic.com"
+  | s when s = cn_codex -> Some "https://api.openai.com"
+  | s when s = cn_gemini -> (
       match resolve_gemini_direct_auth () with
       | Gemini_vertex_adc { project; location } ->
           Some (gemini_vertex_openai_base_url ~project ~location)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -207,7 +207,6 @@ let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->
     let author = String.lowercase_ascii (String.trim author) in
     author = "auto-researcher"
     || String.starts_with ~prefix:"qa-" author
-    || String.starts_with ~prefix:"qwen35-probe" author
     || ((not (String.contains author ' '))
         && String.ends_with ~suffix:"-probe" author)
   in


### PR DESCRIPTION
## Summary

Addresses #5240 (SSOT consolidation) and #5239 (MASC-OAS boundary violations).

### #5240 — SSOT Consolidation
- **Part A**: Extract 5 keeper prompt template keys into `Keeper_prompt_names` module. 9 call sites across 4 files now reference constants instead of string literals.
- **Part B**: Extract `default_http_port` / `default_host` constants in `Env_config_core`. `Env_config_snapshot` references these instead of duplicating values.
- **Part C deferred**: 300s timeout values have different semantics per call site — consolidation would introduce coupling.

### #5239 — MASC-OAS Boundary Violations
- **A**: Already resolved in prior PR (spawnable_agents removed from mention.ml).
- **B**: Move vendor API endpoint URLs from `dashboard_provider_runs.ml` to `Provider_adapter.endpoint_url_for_canonical_name`. Dashboard delegates instead of hardcoding.
- **C**: Remove redundant `qwen35-probe` prefix check — generic `*-probe` suffix already covers it.

## Changes
| File | Change |
|------|--------|
| `lib/keeper/keeper_prompt_names.ml` | **New** — 5 prompt template key constants |
| `lib/keeper/keeper_prompt.ml` | Replace 3 string literals with constants |
| `lib/keeper/keeper_unified_prompt.ml` | Replace 2 string literals |
| `lib/keeper/keeper_deliberation.ml` | Replace 2 string literals |
| `lib/dashboard/dashboard_http_keeper.ml` | Replace 3 string literals |
| `lib/config/env_config_core.ml` | Extract port/host default constants |
| `lib/config/env_config_snapshot.ml` | Reference constants |
| `lib/provider_adapter.ml` | Add `endpoint_url_for_canonical_name` |
| `lib/dashboard_provider_runs.ml` | Delegate to Provider_adapter |
| `lib/room.ml` | Remove redundant probe check |
| `lib/dune` | Register `keeper_prompt_names` |

## Verification
- `dune build` passes (exit 0)
- `rg '"keeper\.(constitution|world|capabilities|deliberation|unified\.system)"' lib/ --type ocaml` → only `keeper_prompt_names.ml`
- `rg 'anthropic\.com|openai\.com' lib/ --type ocaml --glob '!**/provider_adapter.ml'` → 0 hits

## Test plan
- [ ] CI Build and Test passes
- [ ] Keeper prompts load correctly
- [ ] Dashboard provider runs endpoint URLs resolve

Closes #5240 (A+B), closes #5239 (B+C; A was prior PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)