### PR TITLE
refactor(boundary): move vendor URLs to Provider_adapter, remove hardcoded model name

### DIFF
--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -146,18 +146,7 @@ let auth_kind_for_provider provider =
   | _ -> Provider_adapter.auth_kind_for_canonical_name provider
 
 let endpoint_url_for_provider provider =
-  match provider with
-  | "llama" -> Some Env_config_runtime.Llama.server_url
-  | "claude-api" -> Some "https://api.anthropic.com"
-  | "codex-api" -> Some "https://api.openai.com"
-  | "glm" -> Some Env_config_runtime.Glm.server_url
-  | "gemini-api" -> (
-      match Provider_adapter.resolve_gemini_direct_auth () with
-      | Provider_adapter.Gemini_vertex_adc { project; location } ->
-          Some
-            (Provider_adapter.gemini_vertex_openai_base_url ~project ~location)
-      | _ -> Some "https://generativelanguage.googleapis.com")
-  | _ -> None
+  Provider_adapter.endpoint_url_for_canonical_name provider
 
 let default_model_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -831,3 +831,24 @@ let gemini_vertex_openai_base_url ~project ~location =
   Printf.sprintf
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
     project location
+
+(** Resolve the base endpoint URL for a canonical provider name.
+    Returns the runtime-configured URL for local/dynamic providers,
+    or the well-known public API URL for direct-API providers.
+    Dashboard code should call this instead of hardcoding vendor URLs. *)
+let endpoint_url_for_canonical_name name =
+  match normalize_label name with
+  | "llama" | "llama.cpp" | "llamacpp" ->
+    Some Env_config_runtime.Llama.server_url
+  | "glm" ->
+    Some Env_config_runtime.Glm.server_url
+  | "claude-api" | "claude" | "anthropic" ->
+    Some "https://api.anthropic.com"
+  | "codex-api" | "codex" | "openai" ->
+    Some "https://api.openai.com"
+  | "gemini-api" | "gemini" -> (
+    match resolve_gemini_direct_auth () with
+    | Gemini_vertex_adc { project; location } ->
+      Some (gemini_vertex_openai_base_url ~project ~location)
+    | _ -> Some "https://generativelanguage.googleapis.com")
+  | _ -> None

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -832,21 +832,34 @@ let gemini_vertex_openai_base_url ~project ~location =
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
     project location
 
-(** Resolve the base endpoint URL for a canonical provider name.
-    Returns the runtime-configured URL for local/dynamic providers,
-    or the well-known public API URL for direct-API providers.
+(** Resolve the base endpoint URL for a provider name or alias.
+    The input is normalized with {!normalize_label}, so known aliases
+    (e.g. "llamacpp", "anthropic", "openai") are accepted in addition
+    to canonical labels.
+
+    Returns runtime-configured URLs for providers backed by local/runtime
+    config (llama, glm), well-known public API URLs for hosted providers
+    (claude-api, codex-api), and for gemini-api either a Vertex
+    OpenAI-compatible endpoint derived from runtime auth/config or the
+    public Generative Language API URL.
+
     Dashboard code should call this instead of hardcoding vendor URLs. *)
 let endpoint_url_for_canonical_name name =
-  match normalize_label name with
-  | "llama" | "llama.cpp" | "llamacpp" ->
+  let canonical =
+    match resolve_direct_canonical_name name with
+    | Some resolved -> resolved
+    | None -> normalize_label name
+  in
+  match canonical with
+  | "llama" ->
     Some Env_config_runtime.Llama.server_url
   | "glm" ->
     Some Env_config_runtime.Glm.server_url
-  | "claude-api" | "claude" | "anthropic" ->
+  | "claude-api" ->
     Some "https://api.anthropic.com"
-  | "codex-api" | "codex" | "openai" ->
+  | "codex-api" ->
     Some "https://api.openai.com"
-  | "gemini-api" | "gemini" -> (
+  | "gemini-api" -> (
     match resolve_gemini_direct_auth () with
     | Gemini_vertex_adc { project; location } ->
       Some (gemini_vertex_openai_base_url ~project ~location)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -207,7 +207,6 @@ let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->
     let author = String.lowercase_ascii (String.trim author) in
     author = "auto-researcher"
     || String.starts_with ~prefix:"qa-" author
-    || String.starts_with ~prefix:"qwen35-probe" author
     || ((not (String.contains author ' '))
         && String.ends_with ~suffix:"-probe" author)
   in


### PR DESCRIPTION
## Summary
- Add `Provider_adapter.endpoint_url_for_canonical_name` as SSOT for provider endpoint URLs
- Replace `dashboard_provider_runs.endpoint_url_for_provider` inline vendor URL hardcoding with `Provider_adapter` delegation (-12 lines)
- Remove redundant `qwen35-probe` prefix check in `room.ml` (already covered by generic `*-probe` suffix match)

## Boundary Impact
- `dashboard_provider_runs.ml` no longer contains vendor API URLs (`api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`)
- All vendor URL knowledge consolidated in `Provider_adapter` (MASC boundary adapter)

## Test plan
- [ ] `dune build` passes
- [ ] CI Build and Test green
- [ ] `rg "api.anthropic|api.openai|generativelanguage" lib/dashboard_provider_runs.ml` → 0 hits

Closes #5239

🤖 Generated with [Claude Code](https://claude.com/claude-code)