### PR TITLE
refactor(ssot): consolidate prompt names and port/host defaults

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -156,24 +156,28 @@ let sb_path () =
   | Ok path -> path
   | Error msg -> raise (Config_error msg)
 
+let default_masc_http_port = "8935"
+let default_masc_host = "127.0.0.1"
+
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
   | Some port -> port
-  | None -> "8935"
+  | None -> default_masc_http_port
 
 let masc_http_port_int () =
-  Safe_ops.int_of_string_with_default ~default:8935 (masc_http_port ())
+  Safe_ops.int_of_string_with_default
+    ~default:(int_of_string default_masc_http_port) (masc_http_port ())
 
 let masc_host_opt () =
   Sys.getenv_opt "MASC_HOST" |> trim_opt
 
 (** Centralized MASC_HOST reader.
     Reads MASC_HOST env var.
-    Default: "127.0.0.1". *)
+    Default: {!default_masc_host}. *)
 let masc_host () =
   match masc_host_opt () with
   | Some host -> host
-  | None -> "127.0.0.1"
+  | None -> default_masc_host
 
 (** Centralized MASC_ASSETS_DIR reader.
     Returns None when MASC_ASSETS_DIR is unset or empty. *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -57,8 +57,8 @@ let category name entries =
 
 let server_entries =
   [
-    entry ~default:"8935" "MASC_HTTP_PORT" "HTTP server port";
-    entry ~default:"127.0.0.1" "MASC_HOST" "Server bind host";
+    entry ~default:Env_config_core.default_masc_http_port "MASC_HTTP_PORT" "HTTP server port";
+    entry ~default:Env_config_core.default_masc_host "MASC_HOST" "Server bind host";
     entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -713,9 +713,9 @@ let keeper_config_json (config : Room.config) (name : string)
           ( "system_prompt_blocks",
             `Assoc
               [
-                ("constitution", prompt_block_json "keeper.constitution");
-                ("world", prompt_block_json "keeper.world");
-                ("capabilities", prompt_block_json "keeper.capabilities");
+                ("constitution", prompt_block_json Keeper_prompt_names.constitution);
+                ("world", prompt_block_json Keeper_prompt_names.world);
+                ("capabilities", prompt_block_json Keeper_prompt_names.capabilities);
               ] );
           ("effective_system_prompt", `String effective_system_prompt);
         ]

--- a/lib/dune
+++ b/lib/dune
@@ -472,6 +472,7 @@
    keeper_unified_turn
 
    keeper_prompt
+   keeper_prompt_names
    keeper_coordination
    keeper_execution
    keeper_keepalive

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -384,7 +384,7 @@ let build_deliberation_prompt
 {"action":"multi_step","params":{"steps":[{"action":"task_claim","params":{"task_id":"task-1","reason":"urgent"}},{"action":"broadcast","params":{"message":"Claimed task-1"}}]},"reasoning":"Claim and announce","confidence":0.7}|}
   in
   match
-    Prompt_registry.render_prompt_template "keeper.deliberation"
+    Prompt_registry.render_prompt_template Keeper_prompt_names.deliberation
       [
         ("keeper_name", keeper_name);
         ("soul_profile", soul_profile);
@@ -396,7 +396,7 @@ let build_deliberation_prompt
       ]
   with
   | Ok value -> value
-  | Error _ -> Prompt_registry.get_prompt "keeper.deliberation"
+  | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.deliberation
 
 type structured_result = {
   action: deliberation_action;

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -11,7 +11,7 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
   Mention.any_mentioned ~targets content
 
 let keeper_constitution () =
-  Prompt_registry.get_prompt "keeper.constitution"
+  Prompt_registry.get_prompt Keeper_prompt_names.constitution
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~soul_profile ~will ~needs ~desires
@@ -55,7 +55,7 @@ let build_keeper_system_prompt
     [
       persona_block;
       "<world>\n";
-      Prompt_registry.get_prompt "keeper.world";
+      Prompt_registry.get_prompt Keeper_prompt_names.world;
       "\n</world>\n\
        \n\
        <identity>\n\
@@ -105,7 +105,7 @@ let build_keeper_system_prompt
       desires;
       "\n\
        <capabilities>\n";
-      Prompt_registry.get_prompt "keeper.capabilities";
+      Prompt_registry.get_prompt Keeper_prompt_names.capabilities;
       "\n</capabilities>\n\
        \n\
        ";

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -1,0 +1,10 @@
+(** Keeper_prompt_names — SSOT for keeper prompt template identifiers.
+
+    All prompt names used with [Prompt_registry.get_prompt] or
+    [Prompt_registry.render_prompt_template] are defined here.
+    Callers must reference these constants instead of string literals. *)
+
+let constitution = "keeper.constitution"
+let world = "keeper.world"
+let capabilities = "keeper.capabilities"
+let deliberation = "keeper.deliberation"


### PR DESCRIPTION
## Summary
**Part A: Prompt template name constants**
- New `Keeper_prompt_names` module as SSOT for `keeper.constitution`, `keeper.world`, `keeper.capabilities`, `keeper.deliberation`
- Replace string literals in 3 consumer files with module references

**Part B: Port/host default deduplication**
- Extract `default_masc_http_port`/`default_masc_host` in `Env_config_core`
- `env_config_snapshot.ml` now references SSOT instead of duplicate literals

## Verification
- `rg '"keeper\.(constitution|world|capabilities|deliberation)"' lib/` → 0 hits (only constant references)
- `rg '"8935"' lib/config/` → `env_config_core.ml` only (SSOT)

## Test plan
- [ ] `dune build` passes
- [ ] CI Build and Test green

Closes #5240

🤖 Generated with [Claude Code](https://claude.com/claude-code)