### PR TITLE
fix(scripts): validate PR body hygiene sections

### DIFF
--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -30,6 +30,36 @@ require_cmd() {
   }
 }
 
+validate_pr_body_file() {
+  local path="$1"
+  local missing=()
+  local heading
+
+  if [[ ! -f "$path" ]]; then
+    echo "body file not found: $path" >&2
+    exit 1
+  fi
+
+  for heading in \
+    "## Summary" \
+    "## Product impact" \
+    "## Evidence" \
+    "## Review evidence" \
+    "## Linked issue"
+  do
+    if ! grep -Fq "$heading" "$path"; then
+      missing+=("$heading")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "body file is missing required PR hygiene sections:" >&2
+    printf '  - %s\n' "${missing[@]}" >&2
+    echo "expected headings from .github/pull_request_template.md" >&2
+    exit 1
+  fi
+}
+
 is_doc_path() {
   case "$1" in
     docs/*|examples/trpg-mvp/*|README.md|*.md) return 0 ;;
@@ -74,6 +104,10 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "refusing to open PR from branch '$branch'" >&2
   exit 1
+fi
+
+if [[ -n "$body_file" ]]; then
+  validate_pr_body_file "$body_file"
 fi
 
 if [[ -z "$repo" ]]; then

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -47,7 +47,7 @@ validate_pr_body_file() {
     "## Review evidence" \
     "## Linked issue"
   do
-    if ! grep -Fq "$heading" "$path"; then
+    if ! grep -Fq -- "$heading" "$path"; then
       missing+=("$heading")
     fi
   done

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -167,7 +167,8 @@ let test_script_runs_under_system_bash_without_watch () =
       let gh_log = Filename.concat dir "gh.log" in
       let gh_labels = Filename.concat dir "gh-labels.json" in
       let body_file = Filename.concat dir "body.md" in
-      write_file body_file "## Summary\nTest body\n";
+      write_file body_file
+        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
       let path =
         Printf.sprintf "%s:%s" fake_gh_dir
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -203,6 +204,44 @@ let test_script_runs_under_system_bash_without_watch () =
       check bool "does not add docs label for code-only change" false
         (contains_substring labels "\"docs\""))
 
+let test_script_rejects_body_missing_required_sections () =
+  with_temp_dir "pr-open-script-missing-sections" (fun dir ->
+      init_repo_with_remote dir;
+      let fake_gh_dir = make_fake_gh dir in
+      let gh_log = Filename.concat dir "gh.log" in
+      let gh_labels = Filename.concat dir "gh-labels.json" in
+      let body_file = Filename.concat dir "body.md" in
+      write_file body_file "## Summary\nOnly summary present\n";
+      let path =
+        Printf.sprintf "%s:%s" fake_gh_dir
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_GH_LOG", gh_log);
+          ("FAKE_GH_LABELS", gh_labels);
+        ]
+      in
+      let cmd =
+        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
+          (quote (script_path ()))
+          (quote "example/test")
+          (quote "fix: reject incomplete PR body")
+          (quote body_file)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
+      check bool "command fails" true (code <> 0);
+      check bool "stdout empty" true (String.trim stdout = "");
+      check bool "mentions hygiene failure" true
+        (contains_substring stderr "body file is missing required PR hygiene sections:");
+      check bool "mentions product impact heading" true
+        (contains_substring stderr "## Product impact");
+      check bool "mentions linked issue heading" true
+        (contains_substring stderr "## Linked issue");
+      check bool "gh never invoked before validation" false
+        (Sys.file_exists gh_log))
+
 let () =
   run "pr_open_script"
     [
@@ -212,5 +251,7 @@ let () =
             test_source_avoids_mapfile_only_bash4_features;
           test_case "runs under system bash without watch" `Quick
             test_script_runs_under_system_bash_without_watch;
+          test_case "rejects body missing required sections" `Quick
+            test_script_rejects_body_missing_required_sections;
         ] );
     ]


### PR DESCRIPTION
## Summary

- reject `scripts/pr-open.sh --body-file` inputs that omit required PR hygiene headings
- keep the existing success path intact when the body file already matches the template
- add a regression test for the failure path before any `gh` call runs

## Product impact

- Promise affected: `repo coordination`
- User-visible change:
  `scripts/pr-open.sh` now fails fast with a clear error if the supplied PR body is missing the required planning sections

## Evidence

- `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-pr-open-hygiene --display short @runtest-test_pr_open_script`

## Review evidence

- Direct `sb glm-text` (`GLM-5.1`, `--no-thinking`) on 2026-04-05 10:18:29 UTC
- Result: `No findings.`
- Follow-up Copilot inline comment on `grep -Fq` option parsing addressed in head `60659e0c23250638327c63ffeca2e6c3a13c017b`

## Linked issue

- Refs #5254
