### PR TITLE
fix(release): align version truth docs with v2.241.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## [2.241.0] - 2026-04-05
+
+### Changed
+- **SSOT consolidation** -- centralize keeper prompt template names; extract port/host default constants (#5259).
+- **Boundary cleanup** -- move vendor endpoint URLs to Provider_adapter; remove redundant probe check (#5259).
+- **TOML multiline** -- support multi-line TOML arrays; enforce base_path in dashboard (#5255).
+- **Role catalog SSOT** -- consolidate tool names into Tool_catalog_surfaces (#5256).
+- **RFC-0002 Phase 3** -- migrate set_state to dispatch_event (#5250).
+
+### Fixed
+- **Memory growth** -- bound global mutable state to prevent growth on rerun (#5252).
+- **Dead code** -- remove apply_self_model_drift and exceeds_threshold stubs (#5253).
+
 ## [2.240.0] - 2026-04-05
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.240.0
-> Latest release: v2.240.0 (2026-04-05)
+> Current package version: v2.241.0
+> Latest release: v2.241.0 (2026-04-05)
 > Updated: 2026-04-05
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,7 +1,7 @@
 # Product Operating Plan
 
-> Current package version: v2.240.0
-> Latest release: v2.240.0 (2026-04-05)
+> Current package version: v2.241.0
+> Latest release: v2.241.0 (2026-04-05)
 > Updated: 2026-04-05
 
 Execution companion for capsule-only coordination hardening:


### PR DESCRIPTION
## Summary
- Update ROADMAP.md, CHANGELOG.md, PRODUCT-OPERATING-PLAN.md to v2.241.0
- Fixes Health CI failure from #5264 (version truth check: dune-project 2.241.0 != ROADMAP 2.240.0)

## Test plan
- [ ] Health CI version truth check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)