### PR TITLE
fix(keeper): handle escaped quotes in array splitter and rename cwd function

### DIFF
--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -165,29 +165,38 @@ let parse_value (raw : string) : (toml_value, string) result =
         (* Split on commas outside quotes *)
         let items = ref [] in
         let buf = Buffer.create 64 in
-        let in_str = ref false in
         let ok = ref true in
-        for i = 0 to String.length inner - 1 do
-          let c = inner.[i] in
-          if !in_str then begin
-            Buffer.add_char buf c;
-            if c = '"' then in_str := false
-            else if c = '\\' && i + 1 < String.length inner then
-              () (* next char consumed naturally *)
-          end
-          else if c = ',' then begin
-            items := Buffer.contents buf :: !items;
-            Buffer.clear buf
-          end
-          else if c = '"' then begin
-            in_str := true;
-            Buffer.add_char buf c
-          end
-          else if is_ws c then ()
-          else begin
-            ok := false
-          end
-        done;
+        let ilen = String.length inner in
+        let rec split i in_str =
+          if i >= ilen then ()
+          else
+            let c = inner.[i] in
+            if in_str then begin
+              Buffer.add_char buf c;
+              if c = '\\' && i + 1 < ilen then begin
+                (* Escaped char: add next char and skip it *)
+                Buffer.add_char buf inner.[i + 1];
+                split (i + 2) true
+              end
+              else if c = '"' then split (i + 1) false
+              else split (i + 1) true
+            end
+            else if c = ',' then begin
+              items := Buffer.contents buf :: !items;
+              Buffer.clear buf;
+              split (i + 1) false
+            end
+            else if c = '"' then begin
+              Buffer.add_char buf c;
+              split (i + 1) true
+            end
+            else if is_ws c then split (i + 1) false
+            else begin
+              ok := false;
+              split (i + 1) false
+            end
+        in
+        split 0 false;
         if Buffer.length buf > 0 then
           items := Buffer.contents buf :: !items;
         if not !ok then

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -88,7 +88,7 @@ let me_root_voice_config_path_opt () =
   trim_opt (Env_config_core.me_root_opt ())
   |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
 
-let cwd_voice_config_path () =
+let fallback_voice_config_path () =
   let root =
     match Env_config_core.base_path_opt () with
     | Some bp -> bp
@@ -101,7 +101,7 @@ let config_path_candidates () =
     base_path_voice_config_path_opt ();
     repo_voice_config_path_opt ();
     me_root_voice_config_path_opt ();
-    Some (cwd_voice_config_path ());
+    Some (fallback_voice_config_path ());
   ]
   |> List.filter_map Fun.id
   |> dedupe_keep_order
@@ -111,7 +111,7 @@ let config_path () =
   match List.find_opt Sys.file_exists candidates, candidates with
   | Some path, _ -> path
   | None, path :: _ -> path
-  | None, [] -> cwd_voice_config_path ()
+  | None, [] -> fallback_voice_config_path ()
 
 let trim_nonempty = function
   | `String value ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -93,6 +93,18 @@ let test_parse_string_array () =
      | _ -> fail "expected Toml_string_array")
   | Error e -> fail e
 
+let test_parse_string_array_escaped_quotes () =
+  let input = {|tags = ["a\"b", "c\\d"]|} in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "tags" doc with
+     | Some (TL.Toml_string_array xs) ->
+       check int "array length" 2 (List.length xs);
+       check string "escaped quote" "a\"b" (List.nth xs 0);
+       check string "escaped backslash" "c\\d" (List.nth xs 1)
+     | _ -> fail "expected Toml_string_array")
+  | Error e -> fail e
+
 let test_parse_empty_array () =
   let input = "items = []" in
   match TL.parse_toml input with
@@ -771,6 +783,8 @@ let () =
           test_case "float value" `Quick test_parse_float_value;
           test_case "bool values" `Quick test_parse_bool_values;
           test_case "string array" `Quick test_parse_string_array;
+          test_case "string array escaped quotes" `Quick
+            test_parse_string_array_escaped_quotes;
           test_case "empty array" `Quick test_parse_empty_array;
           test_case "table" `Quick test_parse_table;
           test_case "inline comment" `Quick test_parse_inline_comment;


### PR DESCRIPTION
## Summary
- TOML array splitter에서 escaped quotes(`\"`) 처리 수정: `for` loop → `rec` loop 변환으로 backslash 다음 문자를 2칸 건너뜀
- `cwd_voice_config_path` → `fallback_voice_config_path` rename (base_path 우선이므로 이름 불일치 해소)

## Context
#5255 머지 후 Copilot 리뷰에서 두 가지 추가 이슈 발견:
1. `parse_value`의 array splitter가 `for` loop에서 `\"` escaped quote를 처리 못함 (backslash 뒤 `"`가 문자열 종료로 처리됨)
2. `cwd_voice_config_path`가 base_path를 우선 사용하도록 변경되었으나 함수명이 여전히 cwd를 암시

Refs #5255

## Test plan
- [x] `test_parse_string_array_escaped_quotes` — escaped `\"`, `\\` 포함 배열 파싱 검증
- [x] 54 TOML 파서 테스트 + 1 config 전수 검증 테스트 통과
- [x] `dune build --root .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)