### PR TITLE
refactor: remove dead code context_floor and effective_discovered_ctx

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -61,20 +61,6 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
              false)
     | _ -> false
 
-(** Absolute minimum acceptable discovered context size.
-    llama-server defaults to [-c 8192]; keeper conversations need 64K+ for
-    multi-turn interactions with tool calls.  Below this floor we ignore the
-    discovered value and use the static registry value instead. *)
-let context_floor = 65_536
-
-(** Select the effective discovered context, applying {!context_floor}.
-    Returns [discovered] when it is at least [context_floor]; otherwise
-    falls back to [static_ctx]. *)
-let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
-  match discovered with
-  | Some ctx when ctx >= context_floor -> ctx
-  | _ -> static_ctx
-
 (** Resolve max_context for a model label.
     Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —
     MASC does not guess which endpoint serves the request.

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -98,32 +98,6 @@ let test_max_context_of_label () =
       "nonexistent:model" in
   check int "fallback 128000" 128_000 fallback
 
-(* ── effective_discovered_ctx boundary tests ── *)
-
-let test_effective_ctx_below_floor () =
-  (* discovered=8192 (llama-server default) → static fallback *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 8_192) in
-  check int "below floor uses static" 128_000 result
-
-let test_effective_ctx_at_floor () =
-  (* discovered exactly at 65536 → accepted *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 65_536) in
-  check int "at floor uses discovered" 65_536 result
-
-let test_effective_ctx_above_floor () =
-  (* discovered=131072 (128K) → accepted *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 131_072) in
-  check int "above floor uses discovered" 131_072 result
-
-let test_effective_ctx_none () =
-  (* no discovered value → static fallback *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:None in
-  check int "none uses static" 128_000 result
-
 let test_labels_require_local_discovery () =
   check bool "llama labels refresh local discovery" true
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
@@ -229,14 +203,6 @@ let () =
           test_case "max context of label" `Quick test_max_context_of_label;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
-          test_case "effective ctx: below floor falls back" `Quick
-            test_effective_ctx_below_floor;
-          test_case "effective ctx: at floor accepted" `Quick
-            test_effective_ctx_at_floor;
-          test_case "effective ctx: above floor accepted" `Quick
-            test_effective_ctx_above_floor;
-          test_case "effective ctx: none falls back" `Quick
-            test_effective_ctx_none;
         ] );
       ( "dashboard_schema",
         [


### PR DESCRIPTION
## Summary

Remove `context_floor` (65536) and `effective_discovered_ctx` from `oas_model_resolve.ml` — neither is called anywhere. `resolve_primary_max_context` delegates directly to OAS `resolve_label_context`.

Also removes the corresponding `effective_discovered_ctx` boundary tests from `test/test_observability_provider_contracts.ml` to restore compilability after the function was removed from the module's public surface.

Discovered during #5100 verification (chain trace showed these were bypassed).

## Product impact

- Promise affected: `none/internal`
- User-visible change: none — dead code removal only; runtime context resolution behaviour is unchanged.

## Evidence

- No remaining references to `effective_discovered_ctx` or `context_floor` in the codebase.
- `dune build` passes.

## Review evidence

Automated code review (Copilot) — no issues found.

## Linked issue