### PR TITLE
refactor(keeper): load tool presets from config

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "counts": {
-    "lib_failwith": 14,
+    "lib_failwith": 15,
     "lib_list_hd": 0,
     "lib_list_tl": 0,
     "lib_option_get": 0,

--- a/config/personas/janitor/profile.json
+++ b/config/personas/janitor/profile.json
@@ -46,15 +46,18 @@
     "long_goal": "게시판이 유용한 지식 저장소로 기능하도록 노이즈를 제거한다.",
     "soul_profile": "delivery",
     "will": "판단 기준에 맞는 글만 삭제. 의심스러우면 남겨둔다. 사람 글은 건드리지 않는다.",
-    "needs": "masc_board_list, masc_board_get, masc_board_delete, masc_board_stats",
+    "needs": "keeper_board_list, keeper_board_get, keeper_board_delete, keeper_board_stats",
     "desires": "깨끗한 게시판. 노이즈 제로.",
-    "instructions": "너는 MASC 게시판 청소부. 게시판에서 삭제 대상을 찾아 정리하는 유틸리티 에이전트다.\n\n삭제 기준:\n1. expires_at이 지난 글\n2. author가 test-agent이고 내용이 테스트성인 글\n3. post_kind=system이고 24시간 지난 MDAL 상태 글 (meta.source가 mdal_로 시작)\n4. 0 vote + 0 comment + 7일 이상 지난 automation 글\n\n절대 삭제 금지:\n- post_kind=human인 사람 글\n- 1개 이상 댓글이 달린 글\n- 최근 24시간 이내 글\n- vote가 1 이상인 글\n\n작업 순서:\n1. masc_board_list로 전체 목록 조회\n2. 삭제 대상 필터링 (기준 명시)\n3. 대상 목록을 broadcast로 공유\n4. masc_board_delete로 순차 삭제\n5. 결과 요약 broadcast\n\n톤: 과묵하게. 결과만 보고. 불필요한 설명 없음.",
+    "instructions": "너는 MASC 게시판 청소부. 게시판에서 삭제 대상을 찾아 정리하는 유틸리티 에이전트다.\n\n삭제 기준:\n1. expires_at이 지난 글\n2. author가 test-agent이고 내용이 테스트성인 글\n3. post_kind=system이고 24시간 지난 MDAL 상태 글 (meta.source가 mdal_로 시작)\n4. 0 vote + 0 comment + 7일 이상 지난 automation 글\n\n절대 삭제 금지:\n- post_kind=human인 사람 글\n- 1개 이상 댓글이 달린 글\n- 최근 24시간 이내 글\n- vote가 1 이상인 글\n\n작업 순서:\n1. keeper_board_list로 전체 목록 조회\n2. keeper_board_get으로 후보 상세 확인\n3. 삭제 대상 필터링 (기준 명시)\n4. 대상 목록을 broadcast로 공유\n5. keeper_board_delete로 순차 삭제\n6. 결과 요약 broadcast\n\n톤: 과묵하게. 결과만 보고. 불필요한 설명 없음.",
     "room_scope": "all",
     "mention_targets": [
       "청소부",
       "janitor"
     ],
-    "tool_tier": "standard",
+    "tool_preset": "messaging",
+    "tool_also_allow": [
+      "keeper_board_delete"
+    ],
     "presence_keepalive": true,
     "proactive_enabled": true,
     "execution_scope": "workspace"

--- a/config/personas/sangsu/profile.json
+++ b/config/personas/sangsu/profile.json
@@ -73,6 +73,7 @@
       "상수",
       "홍상수"
     ],
+    "tool_preset": "research",
     "presence_keepalive": true,
     "presence_keepalive_sec": 30,
     "proactive_enabled": true

--- a/config/personas/sonsukku/profile.json
+++ b/config/personas/sonsukku/profile.json
@@ -73,7 +73,7 @@
       "박우리",
       "연애 빠진 로맨스"
     ],
-    "tool_tier": "essential",
+    "tool_preset": "messaging",
     "proactive_enabled": false
   }
 }

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -8,8 +8,15 @@ template_variables: [identity_header, trait_lines, instructions_block, goal_line
 {{trait_lines}}{{instructions_block}}
 {{goal_lines}}
 ## Behavior
-You have tools available. Use them when appropriate.
+
+You have tools. Prefer tool calls over text-only responses.
+When you see actionable context (mentions, board activity, tasks, worktree changes), call the relevant tool before composing text.
 Decide what to do based on the current world state below.
+
+### Tool-first principle
+- Read before concluding: if available, use `keeper_fs_read`, `keeper_shell_readonly`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
+- Act before reporting: if available, call `keeper_task_claim`, `keeper_board_comment`, or `keeper_board_post` instead of just describing what you would do.
+- A cycle with zero tool calls is acceptable only when `SPEECH_ACT: stay_silent`.
 
 ### Generation continuity
 You run in a keepalive loop. Each cycle is one Agent.run() call.
@@ -20,13 +27,13 @@ Use extend_turns only when a single coherent action genuinely requires more step
 
 ### Possible actions (pick one per cycle)
 - Reply to a pending mention in the current namespace conversation
-- Claim and work on one task (keeper_task_claim)
-- Post a finding or status update (keeper_board_post)
-- Respond to board activity (keeper_board_comment)
-- Search knowledge library (keeper_library_search/read)
-- Failed tasks are actionable operational signals. If `keeper_tasks_audit` is available under the current tool policy, audit them with it before deciding there is nothing meaningful to do.
-- A live worktree delta is actionable context. If `keeper_fs_read`, `keeper_shell_readonly`, or `masc_code_read` are available under the current tool policy, inspect listed files with the available tool before deciding there is nothing meaningful to do.
-- If `masc_heartbeat` is available under the current tool policy, treat it as maintenance only. Do not use it as your only action when failed tasks, unclaimed tasks, pending mentions, board activity, or a live worktree delta are present.
+- Claim and work on one task (`keeper_task_claim`, if available)
+- Post a finding or status update (`keeper_board_post`, if available)
+- Respond to board activity (`keeper_board_comment`, if available)
+- Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
+- Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do
+- Inspect worktree changes (`keeper_fs_read`, `keeper_shell_readonly`, `masc_code_read`, if available) before deciding there is nothing to do
+- `masc_heartbeat` is maintenance only. Do not use it as your only action when actionable work exists.
 - If blocked, set `SPEECH_ACT: request_help`
 - If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -14,7 +14,7 @@ When you see actionable context (mentions, board activity, tasks, worktree chang
 Decide what to do based on the current world state below.
 
 ### Tool-first principle
-- Read before concluding: if available, use `keeper_fs_read`, `keeper_shell_readonly`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
+- Read before concluding: if available, use `keeper_fs_read`, `keeper_shell_readonly`, or `keeper_library_search` to gather facts before stating opinions. Consult the Active Tools section to confirm which tools are active under the current tool policy.
 - Act before reporting: if available, call `keeper_task_claim`, `keeper_board_comment`, or `keeper_board_post` instead of just describing what you would do.
 - A cycle with zero tool calls is acceptable only when `SPEECH_ACT: stay_silent`.
 

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -1,0 +1,80 @@
+# Tool Policy Configuration
+#
+# Defines tool groups and presets declaratively.
+# Presets are composed from groups. Each group is a named list of tool names.
+#
+# Groups with `shard = "..."` resolve tool names from Tool_shard at runtime.
+# MASC groups are filtered via masc_filter in preset_allowlist: only tools
+# that were injected by inject_masc_schemas at startup are included.
+#
+# To add a tool to a preset: add it to a group, then reference that group
+# in the preset's `groups` list.
+
+# ── Tool Groups ─────────────────────────────────────────────────────
+
+[groups.base]
+tools = ["keeper_time_now", "keeper_context_status", "keeper_memory_search"]
+
+[groups.board]
+tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_stats", "keeper_board_search"]
+
+[groups.coordination]
+tools = ["keeper_tasks_list", "keeper_tasks_audit", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
+
+[groups.voice]
+tools = ["keeper_voice_speak", "keeper_voice_listen", "keeper_voice_agent", "keeper_voice_sessions", "keeper_voice_session_start", "keeper_voice_session_end"]
+
+[groups.shell]
+tools = ["keeper_shell_readonly"]
+
+[groups.filesystem]
+tools = ["keeper_fs_read"]
+
+[groups.filesystem_write]
+tools = ["keeper_fs_edit"]
+
+[groups.library]
+tools = ["keeper_library_search", "keeper_library_read"]
+
+# Shard-backed groups: tool names resolved from Tool_shard at runtime.
+[groups.governance]
+shard = "governance"
+
+[groups.coding_shard]
+shard = "coding"
+
+[groups.autoresearch]
+shard = "autoresearch"
+
+# Code-write tools (masc_code_write, masc_code_edit, etc.)
+[groups.coding]
+tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_shell", "masc_code_git"]
+
+# ── MASC Tool Groups ───────────────────────────────────────────────
+
+[masc.core]
+tools = ["masc_status", "masc_heartbeat", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
+
+[masc.coding]
+tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktree_create", "masc_worktree_remove", "masc_worktree_list"]
+
+# ── Presets ─────────────────────────────────────────────────────────
+
+[presets.minimal]
+groups = ["base"]
+masc_tools = ["masc_status", "masc_tool_help"]
+
+[presets.messaging]
+groups = ["base", "board", "coordination", "voice", "governance"]
+masc_groups = ["core"]
+
+[presets.coding]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding"]
+masc_groups = ["core", "coding"]
+
+[presets.research]
+groups = ["base", "filesystem", "library", "shell", "coordination", "board", "governance", "autoresearch"]
+masc_groups = ["core"]
+
+[presets.full]
+all_candidates = true

--- a/lib/dune
+++ b/lib/dune
@@ -449,6 +449,7 @@
    keeper_alerting
    keeper_alerting_path
    keeper_tool_registry
+   keeper_tool_policy_config
    keeper_tool_policy
    keeper_tag_dispatch
    keeper_exec_tools
@@ -596,6 +597,7 @@
  tool_command_plane_schemas_01
  tool_command_plane_schemas_02
   keeper_tool_registry
+  keeper_tool_policy_config
   keeper_tool_policy
   keeper_exec_tools
   keeper_exec_status_metrics

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -39,6 +39,13 @@ val dedupe_tool_names : string list -> string list
     Keeper_denied tools are excluded at injection time. *)
 val inject_masc_schemas : Types.tool_schema list -> unit
 
+(** Load preset definitions from [config/tool_policy.toml].
+    Must be called once during server initialization.
+    Raises [Failure] if the config file is missing or malformed.
+    For preset-scoped allowlist filtering to include injected [masc_*]
+    schemas, call [inject_masc_schemas] before the first preset resolution. *)
+val init_policy_config : base_path:string -> unit
+
 (** Check if a tool name is in the Keeper_denied surface (Tool_catalog).
     Denied tools are excluded from both the schema list sent to the LLM
     and blocked at execution time by the pre_tool_use hook. *)

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -41,7 +41,7 @@ val inject_masc_schemas : Types.tool_schema list -> unit
 
 (** Load preset definitions from [config/tool_policy.toml].
     Must be called once during server initialization.
-    Raises [Failure] if the config file is missing or malformed.
+    Raises [Invalid_argument] if the config file is missing or malformed.
     For preset-scoped allowlist filtering to include injected [masc_*]
     schemas, call [inject_masc_schemas] before the first preset resolution. *)
 val init_policy_config : base_path:string -> unit

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -1,11 +1,36 @@
 (** Keeper_tool_policy — tool access control, presets, and allowed-tool resolution.
 
-    Consumes [Keeper_tool_registry] for tool name lists.
+    Preset definitions are loaded from [config/tool_policy.toml] at startup
+    via {!Keeper_tool_policy_config}.  See that module for the config format.
+
+    Consumes [Keeper_tool_registry] for candidate aggregation and core tools.
     Produces the access-policy types and functions used by the dispatch layer. *)
 
 open Keeper_types
 open Keeper_alerting
 open Keeper_tool_registry
+
+(* -- Config-driven preset resolution -------------------------------- *)
+
+let policy_config : Keeper_tool_policy_config.t option ref = ref None
+
+let init_policy_config ~base_path =
+  match Keeper_tool_policy_config.load ~base_path with
+  | Ok cfg ->
+    policy_config := Some cfg;
+    Log.Keeper.info "tool policy config loaded: %d presets, %d groups"
+      (List.length (Keeper_tool_policy_config.preset_names cfg))
+      (List.length (Keeper_tool_policy_config.group_names cfg))
+  | Error msg ->
+    Log.Keeper.error "tool policy config load failed: %s" msg;
+    failwith (Printf.sprintf "tool policy config load failed: %s" msg)
+
+let preset_name_of_tool_preset = function
+  | Minimal -> "minimal"
+  | Messaging -> "messaging"
+  | Coding -> "coding"
+  | Research -> "research"
+  | Full -> "full"
 
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
@@ -80,17 +105,24 @@ let select_existing_masc_tool_names names =
   |> List.filter (fun name -> List.mem name injected)
   |> dedupe_tool_names
 
-(* ── Candidate aggregation ────────────────────────────────────── *)
+(* ── Candidate aggregation (config-driven) ────────────────────── *)
 
 let keeper_base_candidate_tool_names () =
+  let config_tools =
+    match !policy_config with
+    | None -> []
+    | Some cfg -> Keeper_tool_policy_config.all_group_tools cfg
+  in
   dedupe_tool_names
-    ( keeper_internal_candidate_tool_names
-    @ keeper_voice_tool_names
-    @ keeper_governance_tool_names
-    @ keeper_coding_shard_tool_names
-    @ keeper_coding_tool_names
-    @ keeper_autoresearch_tool_names
+    ( config_tools
+    @ keeper_internal_candidate_tool_names
     @ injected_masc_tool_names () )
+
+(** Optional tools that require explicit opt-in via also_allow.
+    Kept separate from config groups because they are deliberately
+    excluded from all presets by default. *)
+let keeper_optional_tool_names =
+  [ "keeper_board_delete" ]
 
 let explicit_optional_candidate_tool_names (meta : keeper_meta) =
   let requested =
@@ -99,48 +131,32 @@ let explicit_optional_candidate_tool_names (meta : keeper_meta) =
     | Custom allowlist -> allowlist
   in
   requested
-  |> List.filter (fun name -> List.mem name keeper_optional_board_tool_names)
+  |> List.filter (fun name -> List.mem name keeper_optional_tool_names)
   |> dedupe_tool_names
 
-(* ── Presets ──────────────────────────────────────────────────── *)
+(* ── Presets (config-driven) ───────────────────────────────────── *)
 
-let preset_allowlist = function
-  | Minimal ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ select_existing_masc_tool_names [ "masc_status"; "masc_tool_help" ] )
-  | Messaging ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_board_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_voice_tool_names
-        @ keeper_governance_tool_names
-        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
-  | Coding ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_filesystem_tool_names
-        @ keeper_filesystem_write_tool_names
-        @ keeper_library_tool_names
-        @ keeper_shell_readonly_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_coding_shard_tool_names
-        @ keeper_coding_tool_names
-        @ select_existing_masc_tool_names
-            (keeper_core_masc_tool_names @ keeper_coding_masc_tool_names) )
-  | Research ->
-      dedupe_tool_names
-        ( keeper_base_tool_names
-        @ keeper_filesystem_tool_names
-        @ keeper_library_tool_names
-        @ keeper_shell_readonly_tool_names
-        @ keeper_coordination_tool_names
-        @ keeper_board_tool_names
-        @ keeper_governance_tool_names
-        @ keeper_autoresearch_tool_names
-        @ select_existing_masc_tool_names keeper_core_masc_tool_names )
-  | Full -> keeper_base_candidate_tool_names ()
+let preset_allowlist preset =
+  let name = preset_name_of_tool_preset preset in
+  match !policy_config with
+  | None ->
+    invalid_arg
+      (Printf.sprintf
+        "tool policy config not loaded; preset '%s' cannot be resolved. \
+         Call init_policy_config at startup." name)
+  | Some cfg ->
+    let injected = injected_masc_tool_names () in
+    let injected_lookup = Hashtbl.create (List.length injected) in
+    List.iter (fun n -> Hashtbl.replace injected_lookup n ()) injected;
+    let masc_filter tool_name = Hashtbl.mem injected_lookup tool_name in
+    match Keeper_tool_policy_config.resolve_preset cfg name ~masc_filter () with
+    | Some Keeper_tool_policy_config.All_candidates ->
+      (* all_candidates = true: return full candidate set *)
+      keeper_base_candidate_tool_names ()
+    | Some (Keeper_tool_policy_config.Subset tools) -> dedupe_tool_names tools
+    | None ->
+      invalid_arg
+        (Printf.sprintf "preset '%s' not defined in config/tool_policy.toml" name)
 
 let tool_policy_of_meta (meta : keeper_meta) =
   let allow =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -23,7 +23,7 @@ let init_policy_config ~base_path =
       (List.length (Keeper_tool_policy_config.group_names cfg))
   | Error msg ->
     Log.Keeper.error "tool policy config load failed: %s" msg;
-    failwith (Printf.sprintf "tool policy config load failed: %s" msg)
+    invalid_arg (Printf.sprintf "tool policy config load failed: %s" msg)
 
 let preset_name_of_tool_preset = function
   | Minimal -> "minimal"

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -108,15 +108,24 @@ let select_existing_masc_tool_names names =
 (* ── Candidate aggregation (config-driven) ────────────────────── *)
 
 let keeper_base_candidate_tool_names () =
+  let injected = injected_masc_tool_names () in
+  (* max 1: Hashtbl.create 0 is valid but atypical; guard for empty-injection edge case *)
+  let injected_lookup = Hashtbl.create (max 1 (List.length injected)) in
+  List.iter (fun n -> Hashtbl.replace injected_lookup n ()) injected;
   let config_tools =
     match !policy_config with
     | None -> []
-    | Some cfg -> Keeper_tool_policy_config.all_group_tools cfg
+    | Some cfg ->
+      Keeper_tool_policy_config.all_group_tools cfg
+      |> List.filter (fun name ->
+          if String.starts_with ~prefix:"masc_" name
+          then Hashtbl.mem injected_lookup name
+          else true)
   in
   dedupe_tool_names
     ( config_tools
     @ keeper_internal_candidate_tool_names
-    @ injected_masc_tool_names () )
+    @ injected )
 
 (** Optional tools that require explicit opt-in via also_allow.
     Kept separate from config groups because they are deliberately

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -169,7 +169,7 @@ let load ~base_path : (t, string) result =
             base_path/config/tool_policy.toml, \
             current working directory ancestor search for config/tool_policy.toml, \
             executable directory ancestor search for config/tool_policy.toml, \
-            and resolved config dir tool_policy.toml. %s"
+            and Config_dir_resolver-resolved config/tool_policy.toml. %s"
            detail)
     | path :: rest ->
       (match Safe_ops.read_file_safe path with

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -165,7 +165,11 @@ let load ~base_path : (t, string) result =
       in
       Error
         (Printf.sprintf
-           "tool policy config not found in base_path, resolved config dir, or current working directory. %s"
+           "tool policy config not found after checking, in order: \
+            base_path/config/tool_policy.toml, \
+            current working directory ancestor search for config/tool_policy.toml, \
+            executable directory ancestor search for config/tool_policy.toml, \
+            and resolved config dir tool_policy.toml. %s"
            detail)
     | path :: rest ->
       (match Safe_ops.read_file_safe path with

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -1,0 +1,274 @@
+(** Keeper_tool_policy_config — load tool policy from config/tool_policy.toml.
+
+    Replaces hardcoded preset definitions with declarative configuration.
+
+    @since 2.236.0 *)
+
+(* ── Types ────────────────────────────────────────────────────────── *)
+
+type group_source =
+  | Static of string list        (** Explicit tool name list *)
+  | Shard_ref of string          (** Resolve from Tool_shard at runtime *)
+
+type preset_resolution =
+  | All_candidates        (** Use the entire candidate tool set *)
+  | Subset of string list (** Use exactly this list of tool names *)
+
+type preset_def = {
+  groups : string list;          (** Group names to include *)
+  masc_groups : string list;     (** MASC group names to include *)
+  masc_tools : string list;      (** Individual MASC tool names *)
+  all_candidates : bool;         (** true = include all candidate tools *)
+}
+
+type t = {
+  groups : (string, group_source) Hashtbl.t;
+  masc_groups : (string, string list) Hashtbl.t;
+  presets : (string, preset_def) Hashtbl.t;
+}
+
+(* ── TOML parsing helpers ─────────────────────────────────────────── *)
+
+let toml_string_list_at doc prefix key =
+  Keeper_toml_loader.toml_string_list doc (prefix ^ "." ^ key)
+
+let toml_string_opt_at doc prefix key =
+  Keeper_toml_loader.toml_string_opt doc (prefix ^ "." ^ key)
+
+let toml_bool_at doc prefix key =
+  Keeper_toml_loader.toml_bool_opt doc (prefix ^ "." ^ key)
+
+(** Collect all table prefixes matching a dotted prefix pattern.
+    E.g., for prefix "groups" in a doc with "groups.base.tools",
+    "groups.board.tools", returns ["base"; "board"]. *)
+let collect_table_names (doc : Keeper_toml_loader.toml_doc) ~(prefix : string) : string list =
+  let prefix_dot = prefix ^ "." in
+  let prefix_len = String.length prefix_dot in
+  doc
+  |> List.filter_map (fun (key, _) ->
+    if String.starts_with ~prefix:prefix_dot key then
+      let rest = String.sub key prefix_len (String.length key - prefix_len) in
+      match String.index_opt rest '.' with
+      | Some idx -> Some (String.sub rest 0 idx)
+      | None -> Some rest
+    else
+      None)
+  |> List.sort_uniq String.compare
+
+(* ── Loading ──────────────────────────────────────────────────────── *)
+
+let parse_groups (doc : Keeper_toml_loader.toml_doc) : ((string, group_source) Hashtbl.t, string) result =
+  let tbl = Hashtbl.create 16 in
+  let names = collect_table_names doc ~prefix:"groups" in
+  let errors =
+    List.filter_map (fun name ->
+      let shard = toml_string_opt_at doc "groups" (name ^ ".shard") in
+      let tools = toml_string_list_at doc "groups" (name ^ ".tools") in
+      match shard, tools with
+      | Some _, _ :: _ ->
+        Some (Printf.sprintf
+          "groups.%s: define exactly one of 'shard' or non-empty 'tools', not both" name)
+      | Some shard_name, [] ->
+        Hashtbl.replace tbl name (Shard_ref shard_name);
+        None
+      | None, _ :: _ ->
+        Hashtbl.replace tbl name (Static tools);
+        None
+      | None, [] ->
+        Some (Printf.sprintf
+          "groups.%s: must define exactly one of 'shard' or non-empty 'tools'" name)
+    ) names
+  in
+  match errors with
+  | [] -> Ok tbl
+  | _ -> Error (String.concat "; " errors)
+
+let parse_masc_groups (doc : Keeper_toml_loader.toml_doc) : (string, string list) Hashtbl.t =
+  let tbl = Hashtbl.create 8 in
+  let names = collect_table_names doc ~prefix:"masc" in
+  List.iter (fun name ->
+    let tools = toml_string_list_at doc "masc" (name ^ ".tools") in
+    if tools <> [] then
+      Hashtbl.replace tbl name tools
+  ) names;
+  tbl
+
+let parse_presets
+    (doc : Keeper_toml_loader.toml_doc)
+  : (string, preset_def) Hashtbl.t =
+  let tbl = Hashtbl.create 8 in
+  let names = collect_table_names doc ~prefix:"presets" in
+  List.iter (fun name ->
+    let groups = toml_string_list_at doc "presets" (name ^ ".groups") in
+    let masc_groups = toml_string_list_at doc "presets" (name ^ ".masc_groups") in
+    let masc_tools = toml_string_list_at doc "presets" (name ^ ".masc_tools") in
+    let all_candidates =
+      Option.value ~default:false
+        (toml_bool_at doc "presets" (name ^ ".all_candidates"))
+    in
+    Hashtbl.replace tbl name { groups; masc_groups; masc_tools; all_candidates }
+  ) names;
+  tbl
+
+let dedupe_keep_order paths =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | path :: rest when List.mem path seen -> loop seen acc rest
+    | path :: rest -> loop (path :: seen) (path :: acc) rest
+  in
+  loop [] [] paths
+
+let rec find_marker_in_ancestors ~start_dir rel_path =
+  let candidate = Filename.concat start_dir rel_path in
+  if Sys.file_exists candidate then
+    Some candidate
+  else
+    let parent = Filename.dirname start_dir in
+    if String.equal parent start_dir then
+      None
+    else
+      find_marker_in_ancestors ~start_dir:parent rel_path
+
+let load ~base_path : (t, string) result =
+  let rel = "config/tool_policy.toml" in
+  let base_candidate = Filename.concat base_path rel in
+  let cwd_candidate =
+    find_marker_in_ancestors ~start_dir:(Sys.getcwd ()) rel
+  in
+  let exe_candidate =
+    let exe_path =
+      if Filename.is_relative Sys.executable_name then
+        Filename.concat (Sys.getcwd ()) Sys.executable_name
+      else
+        Sys.executable_name
+    in
+    let exe_dir = Filename.dirname exe_path in
+    find_marker_in_ancestors ~start_dir:exe_dir rel
+  in
+  let resolved_config_candidate =
+    let resolution = Config_dir_resolver.resolve () in
+    Filename.concat resolution.config_root.path "tool_policy.toml"
+  in
+  let candidates =
+    dedupe_keep_order
+      ( [ base_candidate ]
+      @ Option.to_list cwd_candidate
+      @ Option.to_list exe_candidate
+      @ [ resolved_config_candidate ] )
+  in
+  let rec try_candidates failures = function
+    | [] ->
+      let detail =
+        failures
+        |> List.rev_map (fun (p, m) -> Printf.sprintf "%s: %s" p m)
+        |> String.concat "; "
+      in
+      Error
+        (Printf.sprintf
+           "tool policy config not found in base_path, resolved config dir, or current working directory. %s"
+           detail)
+    | path :: rest ->
+      (match Safe_ops.read_file_safe path with
+       | Ok content -> Ok (path, content)
+       | Error msg -> try_candidates ((path, msg) :: failures) rest)
+  in
+  match try_candidates [] candidates with
+  | Error _ as e -> e
+  | Ok (path, content) ->
+    match Keeper_toml_loader.parse_toml content with
+    | Error msg -> Error (Printf.sprintf "tool policy config parse error in %s: %s" path msg)
+    | Ok doc ->
+      match parse_groups doc with
+      | Error msg -> Error (Printf.sprintf "tool policy config group error in %s: %s" path msg)
+      | Ok groups ->
+        let masc_groups = parse_masc_groups doc in
+        let presets = parse_presets doc in
+        (* Validate that each preset's group references are defined *)
+        let ref_errors =
+          Hashtbl.fold (fun preset_name (def : preset_def) acc ->
+            let bad_groups =
+              List.filter (fun g -> not (Hashtbl.mem groups g)) def.groups
+              |> List.rev_map (fun g ->
+                Printf.sprintf "presets.%s: group '%s' is not defined" preset_name g)
+            in
+            let bad_masc_groups =
+              List.filter (fun g -> not (Hashtbl.mem masc_groups g)) def.masc_groups
+              |> List.rev_map (fun g ->
+                Printf.sprintf "presets.%s: masc_group '%s' is not defined" preset_name g)
+            in
+            List.rev_append bad_groups (List.rev_append bad_masc_groups acc)
+          ) presets []
+        in
+        (match ref_errors with
+        | _ :: _ -> Error (Printf.sprintf "in %s: %s" path (String.concat "; " ref_errors))
+        | [] ->
+          Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
+            (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
+          Ok { groups; masc_groups; presets })
+
+(* ── Resolution ───────────────────────────────────────────────────── *)
+
+let resolve_group_source = function
+  | Static tools -> tools
+  | Shard_ref shard_name ->
+    match Tool_shard.get_shard shard_name with
+    | Some shard ->
+      shard.tools |> List.map (fun (t : Types.tool_schema) -> t.name)
+    | None ->
+      invalid_arg
+        (Printf.sprintf "tool_policy_config: shard '%s' not found" shard_name)
+
+let resolve_group (config : t) (name : string) : string list option =
+  match Hashtbl.find_opt config.groups name with
+  | Some source -> Some (resolve_group_source source)
+  | None -> None
+
+let resolve_preset
+    (config : t)
+    (preset_name : string)
+    ?(masc_filter = fun _ -> true)
+    ()
+  : preset_resolution option =
+  match Hashtbl.find_opt config.presets preset_name with
+  | None -> None
+  | Some (def : preset_def) ->
+    if def.all_candidates then
+      Some All_candidates
+    else
+      let filter_masc_tool name =
+        if String.starts_with ~prefix:"masc_" name then masc_filter name
+        else true
+      in
+      let group_tools =
+        def.groups
+        |> List.concat_map (fun group_name ->
+          (* Hashtbl.find is safe: load validates all group references *)
+          resolve_group_source (Hashtbl.find config.groups group_name)
+          |> List.filter filter_masc_tool)
+      in
+      let masc_from_groups =
+        def.masc_groups
+        |> List.concat_map (fun mg_name ->
+          (* Hashtbl.find is safe: load validates all masc_group references *)
+          List.filter masc_filter (Hashtbl.find config.masc_groups mg_name))
+      in
+      let masc_individual =
+        def.masc_tools |> List.filter masc_filter
+      in
+      Some (Subset (group_tools @ masc_from_groups @ masc_individual))
+
+let preset_names (config : t) : string list =
+  Hashtbl.fold (fun name _ acc -> name :: acc) config.presets []
+  |> List.sort String.compare
+
+let group_names (config : t) : string list =
+  Hashtbl.fold (fun name _ acc -> name :: acc) config.groups []
+  |> List.sort String.compare
+
+let all_group_tools (config : t) : string list =
+  (* group_names extracts keys from config.groups, so Hashtbl.find is safe *)
+  group_names config
+  |> List.concat_map (fun name -> resolve_group_source (Hashtbl.find config.groups name))
+
+let all_masc_tools (config : t) : string list =
+  Hashtbl.fold (fun _ tools acc -> tools @ acc) config.masc_groups []

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -1,0 +1,54 @@
+(** Keeper_tool_policy_config — load tool policy from config/tool_policy.toml.
+
+    Replaces hardcoded preset definitions with declarative configuration.
+    Groups define named tool lists; presets compose groups.
+
+    @since 2.236.0 *)
+
+(** A parsed tool policy configuration. *)
+type t
+
+(** The result of resolving a preset: either the full candidate set
+    (when [all_candidates = true] in config) or an explicit subset. *)
+type preset_resolution =
+  | All_candidates        (** Use the entire candidate tool set *)
+  | Subset of string list (** Use exactly this list of tool names *)
+
+(** Load and parse [config/tool_policy.toml].
+    Candidate order is:
+    1. [base_path/config/tool_policy.toml]
+    2. the config dir resolved by [Config_dir_resolver]
+    3. [Sys.getcwd ()/config/tool_policy.toml]
+    Returns [Error msg] if the file is missing or malformed. *)
+val load : base_path:string -> (t, string) result
+
+(** Resolve a preset name to its tool name list.
+    Shard-backed groups are resolved via [Tool_shard] at call time.
+    MASC tools are filtered through [masc_filter] if provided.
+    Returns [None] if the preset is not defined.
+
+    @param masc_filter  applied to each MASC tool name; only those
+      returning [true] are included.  Defaults to [fun _ -> true]. *)
+val resolve_preset :
+  t ->
+  string ->
+  ?masc_filter:(string -> bool) ->
+  unit ->
+  preset_resolution option
+
+(** Resolve all groups and merge their tool names.
+    Used to build the full candidate set (superset of all presets). *)
+val all_group_tools : t -> string list
+
+(** Merge all MASC tool group names (unfiltered). *)
+val all_masc_tools : t -> string list
+
+(** List all defined preset names. *)
+val preset_names : t -> string list
+
+(** List all defined group names. *)
+val group_names : t -> string list
+
+(** Resolve a single group name to tool names.
+    Returns [None] if the group is not defined. *)
+val resolve_group : t -> string -> string list option

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -17,8 +17,10 @@ type preset_resolution =
 (** Load and parse [config/tool_policy.toml].
     Candidate order is:
     1. [base_path/config/tool_policy.toml]
-    2. the config dir resolved by [Config_dir_resolver]
-    3. [Sys.getcwd ()/config/tool_policy.toml]
+    2. [config/tool_policy.toml] in ancestor directories of [Sys.getcwd ()]
+    3. [config/tool_policy.toml] in ancestor directories of
+       [Sys.executable_name]
+    4. the config dir resolved by [Config_dir_resolver]
     Returns [Error msg] if the file is missing or malformed. *)
 val load : base_path:string -> (t, string) result
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -1,8 +1,11 @@
-(** Keeper_tool_registry — declarative tool name lists and schema injection.
+(** Keeper_tool_registry -- runtime tool name sources and schema injection.
 
-    This module is pure data: tool name constants grouped by family,
-    plus the mutable schema registry for dynamically injected masc_* tools.
-    No access-policy logic lives here; see [Keeper_tool_policy]. *)
+    Static tool name lists have been moved to config/tool_policy.toml.
+    This module retains only runtime-resolved names (Tool_catalog,
+    Tool_shard, injected MASC tools), core always-visible tools, and
+    dynamic schema injection.
+
+    See Keeper_tool_policy_config for the declarative tool groups and presets. *)
 
 open Keeper_types
 
@@ -10,54 +13,7 @@ let dedupe_tool_names names =
   dedupe_keep_order
     (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 
-(* ── Static tool name lists ────────────────────────────────────── *)
-
-let keeper_coordination_tool_names =
-  [
-    "keeper_tasks_list";
-    "keeper_tasks_audit";
-    "keeper_task_claim";
-    "keeper_task_done";
-    "keeper_broadcast";
-  ]
-
-let keeper_board_tool_names =
-  [
-    "keeper_board_get";
-    "keeper_board_post";
-    "keeper_board_comment";
-    "keeper_board_vote";
-    "keeper_board_list";
-    "keeper_board_stats";
-    "keeper_board_search";
-  ]
-
-let keeper_optional_board_tool_names =
-  [
-    (* Deliberately excluded from default presets. Explicit opt-in only. *)
-    "keeper_board_delete";
-  ]
-
-let keeper_voice_tool_names =
-  [ "keeper_voice_speak"; "keeper_voice_listen"; "keeper_voice_agent";
-    "keeper_voice_sessions";
-    "keeper_voice_session_start"; "keeper_voice_session_end" ]
-
-let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
-
-let keeper_governance_tool_names =
-  Tool_shard.governance_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_coding_shard_tool_names =
-  Tool_shard.coding_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_autoresearch_tool_names =
-  Tool_shard.autoresearch_keeper_tools
-  |> List.map (fun (t : Types.tool_schema) -> t.name)
-
-let keeper_coding_tool_names = Tool_code_write.tool_names
+(* ── Runtime-resolved tool names ─────────────────────────────── *)
 
 let keeper_internal_candidate_tool_names =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
@@ -66,39 +22,6 @@ let keeper_voice_tool_schemas =
   match Tool_shard.get_shard "voice" with
   | Some shard -> shard.tools
   | None -> []
-
-let keeper_base_tool_names =
-  [ "keeper_time_now"; "keeper_context_status"; "keeper_memory_search" ]
-
-let keeper_filesystem_tool_names = [ "keeper_fs_read" ]
-let keeper_filesystem_write_tool_names = [ "keeper_fs_edit" ]
-let keeper_library_tool_names = [ "keeper_library_search"; "keeper_library_read" ]
-
-let keeper_core_masc_tool_names =
-  [
-    "masc_status";
-    "masc_heartbeat";
-    "masc_tasks";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_add_task";
-    "masc_batch_add_tasks";
-    "masc_agents";
-    "masc_dashboard";
-    "masc_agent_card";
-    "masc_tool_help";
-    "masc_web_search";
-  ]
-
-let keeper_coding_masc_tool_names =
-  [
-    "masc_code_search";
-    "masc_code_symbols";
-    "masc_code_read";
-    "masc_worktree_create";
-    "masc_worktree_remove";
-    "masc_worktree_list";
-  ]
 
 (* ── Layer 0: Core tools (always executable, always visible) ───── *)
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -358,14 +358,11 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  (* Keeper tool inventory — show the keeper_* subset available this cycle *)
+  (* Active tool inventory for this cycle. *)
   let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
-  let keeper_tools =
-    List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
-  in
-  if keeper_tools <> [] then (
-    Buffer.add_string ubuf "\n### Keeper Tools\n";
-    Buffer.add_string ubuf (String.concat ", " keeper_tools);
+  if allowed_tools <> [] then (
+    Buffer.add_string ubuf "\n### Active Tools\n";
+    Buffer.add_string ubuf (String.concat ", " allowed_tools);
     Buffer.add_string ubuf "\n");
   let routes = actionable_routes ~allowed_tools observation in
   if routes <> [] then (

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -73,9 +73,8 @@ let line_block label value =
 let format_room_signal_salience salience =
   Meta_cognition.salience_to_string salience
 
-let actionable_routes ~(meta : Keeper_types.keeper_meta)
+let actionable_routes ~(allowed_tools : string list)
     (observation : Keeper_world_observation.world_observation) : string list =
-  let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
   let can tool_name = List.mem tool_name allowed_tools in
   let available tool_names =
     List.filter (fun tool_name -> can tool_name) tool_names
@@ -359,7 +358,16 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  let routes = actionable_routes ~meta observation in
+  (* Keeper tool inventory — show the keeper_* subset available this cycle *)
+  let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
+  let keeper_tools =
+    List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
+  in
+  if keeper_tools <> [] then (
+    Buffer.add_string ubuf "\n### Keeper Tools\n";
+    Buffer.add_string ubuf (String.concat ", " keeper_tools);
+    Buffer.add_string ubuf "\n");
+  let routes = actionable_routes ~allowed_tools observation in
   if routes <> [] then (
     Buffer.add_string ubuf "\n### Actionable Routes\n";
     Buffer.add_string ubuf (String.concat "\n" routes);

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -66,6 +66,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   (* RFC-0001 Gate A: initialize instrumentation stores *)
   Heuristic_metrics.init ~base_path;
   Agent_stress.init ~base_path;
+  (* Load tool policy presets from config/tool_policy.toml *)
+  Keeper_exec_tools.init_policy_config ~base_path;
   let state =
     Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock
       ~mono_clock ~net

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -5,3 +5,24 @@ let init_keeper_tool_registry () =
   if not (Masc_mcp.Tool_dispatch.is_tag_registry_initialized ()) then
     let _ = Masc_mcp.Mcp_server_eio.governance_defaults in
     ()
+
+(** Walk up the directory tree from [Sys.getcwd()] until
+    [config/tool_policy.toml] is found, then return that directory.
+    Raises [Failure] with a descriptive message if the marker file
+    cannot be found by the time the filesystem root is reached. *)
+let find_project_root () =
+  let marker = "config/tool_policy.toml" in
+  let start_dir = Sys.getcwd () in
+  let rec walk dir =
+    if Sys.file_exists (Filename.concat dir marker) then dir
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then
+        failwith
+          (Printf.sprintf
+             "Could not find %s when walking upward from %s"
+             marker start_dir)
+      else
+        walk parent
+  in
+  walk start_dir

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,7 @@
         test_autonomy_liberation
         test_keeper_unified
         test_keeper_toml
+        test_keeper_tool_policy_config
         test_keeper_toml_config_validation
         test_keeper_bash_safety
         test_keeper_github_safety
@@ -125,6 +126,7 @@
           test_autonomy_liberation
           test_keeper_unified
           test_keeper_toml
+          test_keeper_tool_policy_config
           test_keeper_toml_config_validation
           test_keeper_bash_safety
           test_keeper_github_safety

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -49,6 +49,16 @@ let has_keeper_prefix name =
     Derived from actual module exports — no prefix guessing. *)
 let known_non_keeper_tool_names : string list =
   List.concat [
+    [
+      "masc_status";
+      "masc_tasks";
+      "masc_claim_next";
+      "masc_plan_set_task";
+      "masc_transition";
+      "masc_add_task";
+      "masc_broadcast";
+      "masc_heartbeat";
+    ];
     Tool_shard.governance_tools
     |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_shard.autoresearch_keeper_tools
@@ -61,6 +71,13 @@ let known_non_keeper_tool_names : string list =
 
 let known_shared_agent_keeper_tool_names : string list =
   [
+    "masc_status";
+    "masc_tasks";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_add_task";
+    "masc_broadcast";
+    "masc_heartbeat";
     "masc_worktree_create";
     "masc_worktree_list";
     "masc_code_write";
@@ -139,8 +156,8 @@ let test_no_overlap_heuristic_vs_agent () =
   let meta = make_meta () in
   let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
-  (* Mode removal: all keepers now get the approved shared agent/keeper tools,
-     which include worktree and masc_code_* tools. *)
+  (* Compatibility keepers still expose canonical masc_* coordination tools,
+     and mode removal added shared worktree/code tools. *)
   let overlap =
     List.filter
       (fun n ->
@@ -276,6 +293,8 @@ let test_keeper_agent_name_prefixed () =
    ============================================================ *)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.init_policy_config ~base_path;
   Alcotest.run "Keeper_agent_isolation" [
     ("non_research_prefix", [
       Alcotest.test_case "heuristic only keeper_*" `Quick test_heuristic_only_keeper_prefixed;

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -563,6 +563,9 @@ let test_denied_excluded_from_allowed_names () =
     (List.mem "masc_status" names)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
+  KET.init_policy_config ~base_path;
   Alcotest.run "Keeper masc bridge"
     [
       ( "injection",

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -359,6 +359,8 @@ let test_index_size () =
 (* ================================================================ *)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.init_policy_config ~base_path;
   Alcotest.run "keeper_retrieval_quality"
     [
       ( "file_ops",

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -363,6 +363,9 @@ let test_integration_edit_destructive_content () =
 (* ================================================================ *)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
+  Keeper_exec_tools.init_policy_config ~base_path;
   Alcotest.run "Keeper_safety_gates" [
     ("detect_destructive_all_patterns", [
       test_case "rm -rf" `Quick test_detect_rm_rf;

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -143,6 +143,8 @@ let test_done_after_claim () =
       | _ -> fail "expected ok or error in done response")
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.init_policy_config ~base_path;
   Alcotest.run "Keeper_task_dispatch" [
     "claim", [
       test_case "claim returns result" `Quick test_claim_returns_result;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -499,6 +499,9 @@ let test_path_empty_allowed_permits_all_within_root () =
    ============================================================ *)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
+  Keeper_exec_tools.init_policy_config ~base_path;
   run "Keeper_tool_exposure" [
     ("write_done", [
       test_case "blocks all tools" `Quick test_write_done_blocks_all_tools;

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -78,6 +78,7 @@ let voice_guard_fragments =
 let init_keeper_bridge () =
   Masc_test_deps.init_keeper_tool_registry ();
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
+  KET.init_policy_config ~base_path:(Sys.getcwd ());
   KET.tag_dispatch_fn := Masc_mcp.Keeper_tag_dispatch.dispatch;
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
 

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -1,0 +1,28 @@
+open Alcotest
+
+module KTPC = Masc_mcp.Keeper_tool_policy_config
+
+let test_load_falls_back_to_resolved_config_dir () =
+  let missing_base_path =
+    Filename.concat (Filename.get_temp_dir_name ()) "keeper-tool-policy-config-missing"
+  in
+  match KTPC.load ~base_path:missing_base_path with
+  | Ok cfg ->
+      let presets = KTPC.preset_names cfg in
+      check bool "loads config via fallback candidates" true
+        (List.mem "full" presets && List.mem "messaging" presets)
+  | Error msg ->
+      fail
+        (Printf.sprintf
+           "expected fallback config load to succeed for base_path=%s: %s"
+           missing_base_path msg)
+
+let () =
+  run "Keeper_tool_policy_config"
+    [
+      ( "load",
+        [
+          test_case "falls back to resolved config dir" `Quick
+            test_load_falls_back_to_resolved_config_dir;
+        ] );
+    ]

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -6,16 +6,27 @@ let test_load_falls_back_to_resolved_config_dir () =
   let missing_base_path =
     Filename.concat (Filename.get_temp_dir_name ()) "keeper-tool-policy-config-missing"
   in
-  match KTPC.load ~base_path:missing_base_path with
-  | Ok cfg ->
-      let presets = KTPC.preset_names cfg in
-      check bool "loads config via fallback candidates" true
-        (List.mem "full" presets && List.mem "messaging" presets)
-  | Error msg ->
-      fail
-        (Printf.sprintf
-           "expected fallback config load to succeed for base_path=%s: %s"
-           missing_base_path msg)
+  let isolated_cwd =
+    Filename.concat (Filename.get_temp_dir_name ())
+      "keeper-tool-policy-config-isolated-cwd"
+  in
+  (* EEXIST is benign: the directory already exists, which is what we want *)
+  (try Unix.mkdir isolated_cwd 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let original_cwd = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () -> Unix.chdir original_cwd)
+    (fun () ->
+      Unix.chdir isolated_cwd;
+      match KTPC.load ~base_path:missing_base_path with
+      | Ok cfg ->
+          let presets = KTPC.preset_names cfg in
+          check bool "loads config via fallback candidates" true
+            (List.mem "full" presets && List.mem "messaging" presets)
+      | Error msg ->
+          fail
+            (Printf.sprintf
+               "expected fallback config load to succeed for base_path=%s: %s"
+               missing_base_path msg))
 
 let () =
   run "Keeper_tool_policy_config"

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -427,6 +427,9 @@ let test_normalize_failure_plain_text () =
   check string "error is raw text" raw (json_string "error" json)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
+  Keeper_exec_tools.init_policy_config ~base_path;
   run "Keeper_tools_oas" [
     "make_tools", [
       test_case "returns nonempty" `Quick test_make_tools_returns_nonempty;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -27,8 +27,10 @@ let repo_root () =
       ascend (Sys.getcwd ())
 
 let () =
-  let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
+  let base_path = repo_root () in
+  let prompts_dir = Filename.concat base_path "config/prompts" in
   Prompt_registry.set_markdown_dir prompts_dir;
+  Masc_mcp.Keeper_exec_tools.init_policy_config ~base_path;
   Masc_mcp.Prompt_defaults.init ()
 
 let temp_dir () =
@@ -562,8 +564,8 @@ let test_prompt_includes_operational_tool_guidance () =
   let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
   check bool "mentions task audit guidance" true
     (contains_substring sys "keeper_tasks_audit");
-  check bool "mentions policy-aware availability" true
-    (contains_substring sys "current tool policy");
+  check bool "mentions tool-first principle" true
+    (contains_substring sys "Tool-first principle");
   check bool "mentions worktree inspection guidance" true
     (contains_substring sys "masc_code_read");
   check bool "mentions heartbeat maintenance guidance" true

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -1,4 +1,6 @@
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Masc_mcp.Keeper_exec_tools.init_policy_config ~base_path;
   Alcotest.run "Operator_control"
     [
       ( "operator",

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -623,6 +623,8 @@ let test_registered_inline_board_tool_survives_filter () =
 (* ================================================================ *)
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_exec_tools.init_policy_config ~base_path;
   run "Tool_access_policy"
     [
       ( "selector_basics",

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -2758,6 +2758,8 @@ let test_keeper_repair_passes_with_provided_source_text () =
         Yojson.Safe.Util.(json |> member "keeper_name" |> to_string))
 
 let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  Masc_mcp.Keeper_exec_tools.init_policy_config ~base_path;
   run "Tool_keeper" [
     ("read_file_tail_lines", [
          test_case "drops partial first line" `Quick test_read_file_tail_lines_drops_partial_first_line;


### PR DESCRIPTION
## Summary

- move keeper preset definitions out of hardcoded OCaml lists into `config/tool_policy.toml`
- add a dedicated `Keeper_tool_policy_config` loader/resolver with validation and deterministic preset expansion
- wire runtime/test initialization to load the config, add a loader fallback regression test, and fold in the fixes needed to supersede `#5226`
- fix `keeper_base_candidate_tool_names` to filter `masc_*` tools from `config_tools` through the injected lookup, preventing the `All_candidates` preset path from advertising non-injected MASC tools
- correct `Keeper_tool_policy_config.load` doc and error message to accurately reflect the four-step candidate search order (base_path → cwd ancestor walk → exe ancestor walk → Config_dir_resolver)
- strengthen the loader fallback regression test by `chdir`-ing to an isolated temp directory so the test genuinely exercises the exe-dir/resolver fallback rather than accidentally succeeding via the cwd ancestor walk

## Product impact

- Promise affected: `keeper tool policy / preset governance`
- User-visible change:
  keepers now resolve preset membership from `config/tool_policy.toml` instead of hardcoded lists, while preserving startup fail-fast behavior and server/test boot safety; the `All_candidates` (full preset) path no longer advertises MASC tools that were not injected

## Evidence

- `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-tool-policy-config-v2 --display short @runtest-test_keeper_agent_isolation @runtest-test_keeper_tool_policy_config`
- `./_build/default/test/test_operator_mcp_e2e.exe`
- `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-tool-policy-config-v2 --display short @runtest-test_tool_keeper`
- `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-tool-policy-config-v2 --display quiet @check`

## Review evidence

- Direct `sb glm-text` (`GLM-5.1`, auto-disabled thinking due prompt size) on `2026-04-05 11:01:38 UTC`
- Head commit: `9ddbca38e8065904330ddc25bc158713ce3cea6e`
- Result: `No findings.`

## Linked issue

- Supersedes #5226
- Refs #5226