### PR TITLE
refactor: remove dead code + dispatch compaction/handoff events to state machine

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -313,6 +313,21 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   ~primary_model_max_tokens:primary_max_context
                   ~checkpoint:result.checkpoint
               in
+              (* Dispatch compaction/handoff events to state machine *)
+              if lifecycle.compaction.applied then
+                ignore (Keeper_registry.dispatch_event ~base_path:base_dir meta.name
+                  (Compaction_completed {
+                    before_tokens = lifecycle.compaction.before_tokens;
+                    after_tokens = lifecycle.compaction.after_tokens;
+                  }));
+              (match lifecycle.handoff_json with
+               | Some _ ->
+                 ignore (Keeper_registry.dispatch_event ~base_path:base_dir meta.name
+                   (Handoff_completed {
+                     new_trace_id = lifecycle.updated_meta.runtime.trace_id;
+                     generation = lifecycle.turn_generation;
+                   }))
+               | None -> ());
               let updated_meta =
                 update_direct_turn_meta lifecycle.updated_meta ~latency_ms result
               in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1006,6 +1006,21 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~primary_model_max_tokens:primary_max_context
               ~checkpoint:result.checkpoint
           in
+          (* Dispatch compaction/handoff events to state machine *)
+          if lifecycle.compaction.applied then
+            ignore (Keeper_registry.dispatch_event ~base_path:base_dir meta.name
+              (Compaction_completed {
+                before_tokens = lifecycle.compaction.before_tokens;
+                after_tokens = lifecycle.compaction.after_tokens;
+              }));
+          (match lifecycle.handoff_json with
+           | Some _ ->
+             ignore (Keeper_registry.dispatch_event ~base_path:base_dir meta.name
+               (Handoff_completed {
+                 new_trace_id = lifecycle.updated_meta.runtime.trace_id;
+                 generation = lifecycle.turn_generation;
+               }))
+           | None -> ());
           let scope_only_reactive =
             observation.pending_scope_messages <> []
             && observation.pending_mentions = []

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -61,19 +61,6 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
              false)
     | _ -> false
 
-(** Absolute minimum acceptable discovered context size.
-    llama-server defaults to [-c 8192]; keeper conversations need 64K+ for
-    multi-turn interactions with tool calls.  Below this floor we ignore the
-    discovered value and use the static registry value instead. *)
-let context_floor = 65_536
-
-(** Select the effective discovered context, applying {!context_floor}.
-    Returns [discovered] when it is at least [context_floor]; otherwise
-    falls back to [static_ctx]. *)
-let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
-  match discovered with
-  | Some ctx when ctx >= context_floor -> ctx
-  | _ -> static_ctx
 
 (** Resolve max_context for a model label.
     Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -98,31 +98,6 @@ let test_max_context_of_label () =
       "nonexistent:model" in
   check int "fallback 128000" 128_000 fallback
 
-(* ── effective_discovered_ctx boundary tests ── *)
-
-let test_effective_ctx_below_floor () =
-  (* discovered=8192 (llama-server default) → static fallback *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 8_192) in
-  check int "below floor uses static" 128_000 result
-
-let test_effective_ctx_at_floor () =
-  (* discovered exactly at 65536 → accepted *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 65_536) in
-  check int "at floor uses discovered" 65_536 result
-
-let test_effective_ctx_above_floor () =
-  (* discovered=131072 (128K) → accepted *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:(Some 131_072) in
-  check int "above floor uses discovered" 131_072 result
-
-let test_effective_ctx_none () =
-  (* no discovered value → static fallback *)
-  let result = Masc_mcp.Oas_model_resolve.effective_discovered_ctx
-      ~static_ctx:128_000 ~discovered:None in
-  check int "none uses static" 128_000 result
 
 let test_labels_require_local_discovery () =
   check bool "llama labels refresh local discovery" true
@@ -229,14 +204,6 @@ let () =
           test_case "max context of label" `Quick test_max_context_of_label;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
-          test_case "effective ctx: below floor falls back" `Quick
-            test_effective_ctx_below_floor;
-          test_case "effective ctx: at floor accepted" `Quick
-            test_effective_ctx_at_floor;
-          test_case "effective ctx: above floor accepted" `Quick
-            test_effective_ctx_above_floor;
-          test_case "effective ctx: none falls back" `Quick
-            test_effective_ctx_none;
         ] );
       ( "dashboard_schema",
         [


### PR DESCRIPTION
## Summary

### #5274 — Dead code removal
- Remove `context_floor` and `effective_discovered_ctx` from `oas_model_resolve.ml` (0 production callers)
- Remove 4 corresponding tests (-46 lines)

### #5270 — Compaction/Handoff state machine events
- Dispatch `Compaction_completed` and `Handoff_completed` events at both `apply_post_turn_lifecycle` call sites
- Dashboard can now observe compaction/handoff via state machine conditions
- 2 files: `keeper_unified_turn.ml`, `keeper_turn.ml`

Closes #5274, closes #5270

## Test plan
- [ ] CI Build and Test passes
- [ ] `rg 'effective_discovered_ctx\|context_floor' lib/` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)