### PR TITLE
fix(context): raise small-local floor from 32K to 64K, align fallback to 128K, and fix token-count buffer

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -364,10 +364,11 @@ let resolve_strategies
       let obs_val = match obs with
         | Some o -> o
         | None ->
-          (* Fallback: minimal observation when none provided *)
+          (* Fallback: minimal observation when none provided.
+             128_000 matches OAS resolve_primary_max_context fallback. *)
           { context_ratio = 0.5; active_agent_count = 1;
             unclaimed_task_count = 0; is_single_focused_task = true;
-            context_window = 100_000; is_local_model = false }
+            context_window = 128_000; is_local_model = false }
       in
       (* Resolve once — no recursive Dynamic *)
       selector obs_val
@@ -410,8 +411,10 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
   else if obs.context_ratio >= dynamic_focused_ctx && obs.is_single_focused_task then
     (* Focused work near budget: summarize old context *)
     [PruneToolOutputs; SummarizeOld]
-  else if obs.is_local_model && obs.context_window < 32_000 then
-    (* Small local models: lightweight compaction only *)
+  else if obs.is_local_model && obs.context_window < 64_000 then
+    (* Small local models (< 64K): lightweight compaction only.
+       64K floor matches OAS context_floor — llama-server default 8K is
+       unsuitable for multi-turn keeper conversations. *)
     [PruneToolOutputs; MergeContiguous]
   else if obs.context_window >= 500_000 then
     (* Large-context cloud: invest in quality-preserving strategies *)

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -413,7 +413,7 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
     [PruneToolOutputs; SummarizeOld]
   else if obs.is_local_model && obs.context_window < 64_000 then
     (* Small local models (< 64K): lightweight compaction only.
-       64K floor matches OAS context_floor — llama-server default 8K is
+       Uses an approximate 64K floor here; llama-server default 8K is
        unsuitable for multi-turn keeper conversations. *)
     [PruneToolOutputs; MergeContiguous]
   else if obs.context_window >= 500_000 then

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -203,7 +203,7 @@ let pre_compact_event_of_json json =
         token_count = Safe_ops.json_int ~default:0 "token_count" json;
         strategies = Safe_ops.json_string_list "strategies" json;
         model_family = string_field json "model_family";
-        context_window = Safe_ops.json_int ~default:100_000 "context_window" json;
+        context_window = Safe_ops.json_int ~default:128_000 "context_window" json;
         is_local_model = Safe_ops.json_bool ~default:false "is_local_model" json;
         trigger = string_field json "trigger";
       }
@@ -394,7 +394,7 @@ let overview_json
 let record_pre_compact_at ~timestamp ~keeper_name ~context_ratio ~message_count
     ~token_count ~strategies ~context_window ~is_local_model ~trigger =
   let model_family =
-    if is_local_model && context_window < 32_000 then "small_local"
+    if is_local_model && context_window < 64_000 then "small_local"
     else if context_window >= 200_000 then "large_cloud"
     else "medium_cloud"
   in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -49,14 +49,11 @@ let tag_dispatch_fn
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
 ;;
 
-(** Estimate total token count for a working context (system prompt + messages).
-    Mirrors [Keeper_exec_context.token_count] but avoids a dependency cycle. *)
+(** Delegate to [Keeper_exec_context.token_count] for consistent 15% safety
+    buffer (#5053).  Previous inline version lacked the buffer, causing
+    context_ratio in masc_status to be ~13% lower than the authoritative value. *)
 let count_context_tokens (ctx : working_context) =
-  Agent_sdk.Context_reducer.estimate_char_tokens ctx.system_prompt
-  + List.fold_left
-      (fun acc m -> acc + Agent_sdk.Context_reducer.estimate_message_tokens m)
-      0
-      ctx.messages
+  Keeper_exec_context.token_count ctx
 ;;
 
 let ensure_keeper_board_post_args ~author ~source = function

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -279,13 +279,16 @@ let keeper_reflection_payload_of_auto_rules (e : keeper_auto_rule_eval) : Yojson
     Uses concrete parameters (context_window, is_local) from
     [Llm_provider.Model_meta] instead of tier classification.
 
-    - Local models with small context (< 32K): (0.75, 0.75) — earlier handoff.
+    - Local models with small context (< 64K): (0.75, 0.75) — earlier handoff.
     - Models with large context (>= 200K): (1.15, 1.10) — prefer compaction.
-    - Everything else: (1.0, 1.0) (no adjustment). *)
+    - Everything else: (1.0, 1.0) (no adjustment).
+
+    64K floor: llama-server default 8K is too small for keeper sessions.
+    Models below 64K get early-handoff to avoid context overflow. *)
 let model_threshold_multipliers_of_model_id (model_id : string) : float * float =
   let meta = Llm_provider.Model_meta.for_model_id model_id in
   let ctx = meta.context_window in
-  if meta.is_local && ctx < 32_000 then
+  if meta.is_local && ctx < 64_000 then
     (0.75, 0.75)
   else if ctx >= 200_000 then
     (1.15, 1.10)

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -183,8 +183,8 @@ let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ~context_ratio ~strategy_names ~active_agent_count ~context_window
     ~is_local_model =
   let model_family =
-    if is_local_model then "small_local"
-    else if context_window >= 128_000 then "large_cloud"
+    if is_local_model && context_window < 64_000 then "small_local"
+    else if context_window >= 200_000 then "large_cloud"
     else "medium_cloud"
   in
   let payload = `Assoc [

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -88,7 +88,7 @@ let default_registry = Llm_provider.Provider_registry.default ()
     Resolution order:
     1. Capabilities.for_model_id — per-model override (e.g. "claude-opus-4-6" -> 1M)
     2. Provider_registry.find — provider-level default (e.g. "claude" -> 200K)
-    3. 100_000 conservative fallback *)
+    3. 128_000 fallback (matches Oas_model_resolve.resolve_primary_max_context) *)
 let resolve_max_context model =
   (* Layer 1: per-model capabilities (e.g. "claude-opus-4-6" -> 1M) *)
   let from_caps =
@@ -116,8 +116,8 @@ let resolve_max_context model =
        if base <> "" then
          match Llm_provider.Provider_registry.find default_registry base with
          | Some entry -> entry.Llm_provider.Provider_registry.max_context
-         | None -> 100_000
-       else 100_000)
+         | None -> 128_000
+       else 128_000)
 
 (** {1 Token estimation constants}
 

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -68,15 +68,15 @@ let test_estimate_context_gemini () =
   check int "max tokens gemini" 1000000 m.max_tokens
 
 let test_estimate_context_codex () =
-  (* "codex" not in OAS Provider_registry; conservative fallback.
-     TODO: register "openai" provider in OAS to cover codex/gpt. *)
+  (* "codex" not in OAS Provider_registry; 128K fallback
+     (matches Oas_model_resolve.resolve_primary_max_context). *)
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"codex" in
-  check int "max tokens codex" 100000 m.max_tokens
+  check int "max tokens codex" 128000 m.max_tokens
 
 let test_estimate_context_gpt () =
-  (* "gpt" not in OAS Provider_registry; same as codex. *)
+  (* "gpt" not in OAS Provider_registry; same 128K fallback. *)
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"gpt" in
-  check int "max tokens gpt" 100000 m.max_tokens
+  check int "max tokens gpt" 128000 m.max_tokens
 
 let test_estimate_context_claude_opus () =
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"claude-opus" in
@@ -84,7 +84,7 @@ let test_estimate_context_claude_opus () =
 
 let test_estimate_context_unknown_model () =
   let m = Relay.estimate_context ~messages:10 ~tool_calls:5 ~model:"unknown" in
-  check int "max tokens unknown" 100000 m.max_tokens
+  check int "max tokens unknown" 128000 m.max_tokens
 
 let test_estimate_context_usage_ratio () =
   let m = Relay.estimate_context ~messages:100 ~tool_calls:50 ~model:"claude" in


### PR DESCRIPTION
## Summary

- Small-local context threshold 32K → 64K (3 files). 32K was llama-server default; keeper sessions need 64K+ for multi-turn tool calls.
- Context fallback SSOT: 100K → 128K (3 files). Aligns relay/compact/dashboard with OAS `resolve_primary_max_context`.
- `oas_events.ml` model_family bug: all local models classified as "small_local" regardless of context window; "large_cloud" threshold 128K → 200K to match dashboard.
- `keeper_exec_tools.ml` token-count bug: `count_context_tokens` was re-implementing token estimation without the 15% safety buffer, causing `context_ratio` in `masc_status` to read ~13% lower than the authoritative value from `Keeper_exec_context`. Delegated to `Keeper_exec_context.token_count` for a consistent buffered count.

| File | Change | Reason |
|------|--------|--------|
| `lib/context_compact_oas.ml` | 32K→64K, 100K→128K | floor + SSOT |
| `lib/keeper/keeper_memory_recall.ml` | 32K→64K | floor alignment |
| `lib/dashboard/dashboard_harness_health.ml` | 32K→64K, 100K→128K | floor + SSOT |
| `lib/oas_events.ml` | `is_local → is_local && <64K`, 128K→200K | classification bug |
| `lib/relay.ml` | 100K→128K | SSOT alignment |
| `lib/keeper/keeper_exec_tools.ml` | delegate to `Keeper_exec_context.token_count` (15% buffer) | token-count undercount bug |

## Product impact

- Promise affected: `ops visibility`
- User-visible change: `masc_status` `context_ratio` now correctly reflects the 15% safety buffer, preventing keepers from believing they have ~13% more context budget than is actually available. Compaction and recall thresholds align with OAS-resolved values.

## Evidence

- [x] `test_dynamic_small_local_model` uses `context_window = 8_192` (< 64K, still hits small-local branch)
- [x] `test_dynamic_medium_cloud_default` uses `context_window = 128_000` (unchanged behavior)
- [ ] CI Build and Test
- [ ] CI Contract Harness

## Review evidence

Copilot reviewer flagged missing `keeper_exec_tools.ml` entry in PR table (review thread on `c6bf448`). Addressed by adding the file to the change table and summary.

## Linked issue

- Relates #5274
- Relates #5266