### PR TITLE
fix(concurrency): replace option ref with Atomic.t for multi-domain safety

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -49,25 +49,25 @@ let board_mu = Eio.Mutex.create ()
 let with_board_rw f = Eio_guard.with_mutex board_mu f
 let with_board_ro f = Eio_guard.with_mutex_ro board_mu f
 
-let keeper_board_signal_hook : (keeper_board_signal -> unit) option ref = ref None
+(* Hooks are WORM Atomic: set once at server bootstrap, read from any fiber.
+   No mutex needed — Atomic.get/set are single-instruction operations. *)
+let keeper_board_signal_hook : (keeper_board_signal -> unit) option Atomic.t = Atomic.make None
 
 let set_keeper_board_signal_hook hook =
-  with_board_rw (fun () -> keeper_board_signal_hook := Some hook)
+  Atomic.set keeper_board_signal_hook (Some hook)
 
 let emit_keeper_board_signal signal =
-  let hook_opt = with_board_ro (fun () -> !keeper_board_signal_hook) in
-  match hook_opt with
+  match Atomic.get keeper_board_signal_hook with
   | Some hook -> hook signal
   | None -> ()
 
-let board_sse_hook : (board_sse_event -> unit) option ref = ref None
+let board_sse_hook : (board_sse_event -> unit) option Atomic.t = Atomic.make None
 
 let set_board_sse_hook hook =
-  with_board_rw (fun () -> board_sse_hook := Some hook)
+  Atomic.set board_sse_hook (Some hook)
 
 let emit_board_sse_event event =
-  let hook_opt = with_board_ro (fun () -> !board_sse_hook) in
-  match hook_opt with
+  match Atomic.get board_sse_hook with
   | Some hook -> (try hook event with _ -> ())
   | None -> ()
 

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -83,15 +83,13 @@ let [@warning "-32"] cleanup_expired () =
     List.iter (fun key -> Hashtbl.remove table key) victims;
     List.length victims)
 
-(** Background revalidation switch — must be set via [set_sw] before
-    stale-while-revalidate can fork background fibers. *)
-let _bg_sw : Eio.Switch.t option ref = ref None
-
 (* clock_ref removed: Time_compat.sleep is the single sleep path
    since the Fiber.yield spin-loop fix (#4948). *)
 let set_clock _clk = ()
 
-let set_sw sw = _bg_sw := Some sw
+(* _bg_sw removed: uses Eio_context.get_switch_opt() directly.
+   set_sw retained as no-op for backward compat with server_runtime_bootstrap. *)
+let set_sw _sw = ()
 
 let now () = Time_compat.now ()
 
@@ -246,7 +244,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
       (* Background revalidation: fork on the main domain's switch if available.
          When called from Executor_pool (different domain), fork would raise
          "Switch accessed from wrong domain!" — fall back to inline compute. *)
-      (match !_bg_sw with
+      (match Eio_context.get_switch_opt () with
        | Some sw ->
            (try Eio.Fiber.fork ~sw (fun () ->
               try do_bg_compute ()

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -23,7 +23,8 @@ let global_fs : Eio.Fs.dir_ty Eio.Path.t option Atomic.t = Atomic.make None
 let set_fs fs =
   Atomic.set global_fs (Some fs)
 
-(** Clear the global fs (for testing or shutdown) *)
+(** Clear the global fs (testing/shutdown only — not called in production).
+    Safe because test runners and shutdown are single-fiber sequential. *)
 let clear_fs () =
   Atomic.set global_fs None
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -13,24 +13,26 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
-(** Global fs reference - set at Eio_main.run startup *)
-let global_fs : Eio.Fs.dir_ty Eio.Path.t option ref = ref None
+(** Global fs — WORM Atomic (write-once at startup, read from any domain).
+    Using Atomic.t is required for OCaml 5 multi-domain safety:
+    Executor_pool workers run on a separate domain and read this value. *)
+let global_fs : Eio.Fs.dir_ty Eio.Path.t option Atomic.t = Atomic.make None
 
 (** Set the global Eio filesystem. Call once at server startup.
     @param fs The Eio fs from [Eio.Stdenv.fs env] *)
 let set_fs fs =
-  global_fs := Some fs
+  Atomic.set global_fs (Some fs)
 
 (** Clear the global fs (for testing or shutdown) *)
 let clear_fs () =
-  global_fs := None
+  Atomic.set global_fs None
 
 let get_fs_opt () =
-  !global_fs
+  Atomic.get global_fs
 
 (** Check if Eio fs is available *)
 let has_fs () =
-  Option.is_some !global_fs
+  Option.is_some (Atomic.get global_fs)
 
 (** Normalize [Eio.Io] to [Sys_error] so callers only need one catch.
     Eio operations raise [Eio.Io _] on permission errors, missing files, etc.
@@ -42,7 +44,7 @@ let with_io ~path f =
     raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
 
 let with_fs_or_fallback ~path ~fallback f =
-  match !global_fs with
+  match Atomic.get global_fs with
   | Some fs -> (
       try with_io ~path (fun () -> f fs)
       with Stdlib.Effect.Unhandled _ -> fallback ())

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -6,18 +6,18 @@
     @since 0.5.0
 *)
 
-(** Registered cancel function for orchestrator *)
-let cancel_orchestrator_ref : (unit -> unit) option ref = ref None
+(** Registered cancel function for orchestrator — WORM Atomic. *)
+let cancel_orchestrator_ref : (unit -> unit) option Atomic.t = Atomic.make None
 
 (** Register the orchestrator cancel function *)
 let register_cancel_orchestrator (f : unit -> unit) =
-  cancel_orchestrator_ref := Some f
+  Atomic.set cancel_orchestrator_ref (Some f)
 
 (** Call all registered shutdown hooks with per-hook timing. *)
 let run_all () =
   let t0 = Unix.gettimeofday () in
   (* Cancel orchestrator first *)
-  (match !cancel_orchestrator_ref with
+  (match Atomic.get cancel_orchestrator_ref with
    | Some cancel ->
      let t_start = Unix.gettimeofday () in
      Log.Server.info "Cancelling orchestrator...";

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -83,10 +83,10 @@ let visibility_of_string = function
 (** Agent lookup callback — set once at server startup with the real
     Room.is_agent_joined check so that board posts are auto-classified
     without requiring callers to pass config or post_kind. *)
-let agent_lookup_hook : (string -> bool) option ref = ref None
+let agent_lookup_hook : (string -> bool) option Atomic.t = Atomic.make None
 
-let set_agent_lookup f = agent_lookup_hook := Some f
-let set_agent_lookup_none () = agent_lookup_hook := None
+let set_agent_lookup f = Atomic.set agent_lookup_hook (Some f)
+let set_agent_lookup_none () = Atomic.set agent_lookup_hook None
 
 
 
@@ -94,7 +94,7 @@ let set_agent_lookup_none () = agent_lookup_hook := None
     lookup (Room.is_agent_joined) when available via [agent_lookup_hook];
     returns [false] when no hook is installed. *)
 let is_agent name =
-  match !agent_lookup_hook with
+  match Atomic.get agent_lookup_hook with
   | Some lookup -> lookup name
   | None -> false
 
@@ -114,7 +114,7 @@ let resolve_board_post_kind ~author (raw_kind : string option) :
            automation to prevent misleading direct-attributed posts (#4604). *)
         Ok Board.Automation_post
       else
-        (match !agent_lookup_hook with
+        (match Atomic.get agent_lookup_hook with
          | Some _ when is_agent author_lc -> Ok Board.Automation_post
          | _ -> Ok Board.Human_post)
 
@@ -407,10 +407,10 @@ type evolution_callback = {
   record_feedback: name:string -> dimension:string -> is_positive:bool -> unit;
 }
 
-let evolution_hook : evolution_callback option ref = ref None
+let evolution_hook : evolution_callback option Atomic.t = Atomic.make None
 
 let register_evolution_callback cb =
-  evolution_hook := Some cb
+  Atomic.set evolution_hook (Some cb)
 
 let handle_vote args =
   let post_id = get_string args "post_id" "" in
@@ -427,7 +427,7 @@ let handle_vote args =
       let arrow = if direction = Board.Up then "↑" else "↓" in
       (* SOUL Evolution via callback (breaks compile-time dependency cycle) *)
       let evolution_msg =
-        match !evolution_hook with
+        match Atomic.get evolution_hook with
         | None -> ""  (* Not initialized yet *)
         | Some cb ->
             match Board_dispatch.get_post ~post_id with


### PR DESCRIPTION
## Summary

OCaml 5 memory model에서 `option ref`를 다른 domain에서 읽으면 **UB(정의되지 않은 동작)**. `Executor_pool`이 2 domain으로 실행되므로 `Fs_compat.global_fs` 등이 영향 받음. `Atomic.t`로 전환하여 cross-domain 가시성을 보장.

### 변환 대상 (모두 WORM — Write-Once-Read-Many)

| 파일 | ref | 변환 |
|------|-----|------|
| `lib/fs_compat/fs_compat.ml` | `global_fs` | `option ref` → `option Atomic.t` (정확성 수정) |
| `lib/board_dispatch.ml` | `keeper_board_signal_hook`, `board_sse_hook` | mutex 래퍼 제거 + Atomic |
| `lib/tool_board.ml` | `agent_lookup_hook`, `evolution_hook` | `option ref` → `option Atomic.t` |
| `lib/shutdown_hooks.ml` | `cancel_orchestrator_ref` | `option ref` → `option Atomic.t` |
| `lib/dashboard/dashboard_cache.ml` | `_bg_sw` | 제거, `Eio_context.get_switch_opt()` 사용 |

### API 영향
Zero — 모든 public 시그니처 유지. caller 변경 없음.

### Phase 2 (후속)
`keeper_keepalive.ml`의 `bus_ref`, `grpc_client_ref`, `grpc_env_ref` → keeper context record.

Closes #3158 (Phase 1)

## Test plan
- [x] `dune build` passes
- [x] `rg 'option ref' <target files>` → 0 hits
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)