### PR TITLE
feat(keeper): extract pure capture into Keeper_measurement

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -272,6 +272,63 @@ let write_heartbeat_snapshot
         ~response_alignment
         ()
     in
+    (* RFC-0002: build measurement_snapshot via pure capture function.
+       Timing/failure fields not yet wired from heartbeat loop context
+       use defaults; a follow-up PR will thread them through. *)
+    let thresholds : Keeper_measurement.threshold_params =
+      { compaction_ratio_gate = meta_current.compaction.ratio_gate
+      ; compaction_message_gate = meta_current.compaction.message_gate
+      ; compaction_token_gate = meta_current.compaction.token_gate
+      ; compaction_cooldown_sec = meta_current.compaction.cooldown_sec
+      ; handoff_threshold = meta_current.handoff_threshold
+      ; handoff_cooldown_sec = meta_current.handoff_cooldown_sec
+      ; auto_handoff_enabled = meta_current.auto_handoff
+      ; reflect_repetition_threshold =
+          Keeper_config.keeper_rule_reflect_repetition_threshold ()
+      ; plan_goal_alignment_threshold =
+          Keeper_config.keeper_rule_plan_goal_alignment_threshold ()
+      ; plan_response_alignment_threshold =
+          Keeper_config.keeper_rule_plan_response_alignment_threshold ()
+      ; guardrail_repetition_threshold =
+          Keeper_config.keeper_rule_guardrail_repetition_threshold ()
+      ; guardrail_goal_alignment_threshold =
+          Keeper_config.keeper_rule_guardrail_goal_alignment_threshold ()
+      ; guardrail_response_alignment_threshold =
+          Keeper_config.keeper_rule_guardrail_response_alignment_threshold ()
+      ; guardrail_context_threshold =
+          Keeper_config.keeper_rule_guardrail_context_threshold ()
+      ; max_consecutive_hb_failures = max_consecutive_heartbeat_failures ()
+      ; max_consecutive_turn_failures = max_consecutive_turn_failures ()
+      ; model_ratio_multiplier = 1.0
+      ; model_handoff_multiplier = 1.0
+      }
+    in
+    let _measurement =
+      Keeper_measurement.capture
+        ~snapshot_id:
+          (Printf.sprintf "msnap-%s-%Ld"
+             meta_current.name
+             (Int64.of_float (now_ts *. 1000.0)))
+        ~keeper_name:meta_current.name
+        ~generation:meta_current.runtime.generation
+        ~timestamp:now_ts
+        ~thresholds
+        ~context_ratio:(Keeper_exec_context.context_ratio c)
+        ~message_count:(Keeper_exec_context.message_count c)
+        ~token_count:(Keeper_exec_context.token_count c)
+        ~max_tokens:c.max_tokens
+        ~repetition_risk
+        ~goal_alignment
+        ~response_alignment
+        ~now_ts
+        ~idle_seconds:0
+        ~since_last_compaction_sec:0.0
+        ~since_last_handoff_sec:0.0
+        ~proactive_warmup_elapsed:false
+        ~consecutive_hb_failures:0
+        ~consecutive_turn_failures:0
+        ()
+    in
     (* RFC-0002: dispatch Context_measured event through state machine *)
     let _dispatch_result =
       Keeper_registry.dispatch_event

--- a/lib/keeper/keeper_measurement.ml
+++ b/lib/keeper/keeper_measurement.ml
@@ -1,5 +1,6 @@
 (** Keeper Measurement — Det/NonDet Boundary Types (RFC-0002).
-    Phase 1: types and serialization only. *)
+    Phase 1: types and serialization.
+    Phase 4: pure [capture] function. *)
 
 type threshold_params = {
   compaction_ratio_gate : float;
@@ -81,6 +82,58 @@ let threshold_params_to_json (t : threshold_params) : Yojson.Safe.t =
     "model_ratio_multiplier", `Float t.model_ratio_multiplier;
     "model_handoff_multiplier", `Float t.model_handoff_multiplier;
   ]
+
+let capture
+      ~snapshot_id
+      ~keeper_name
+      ~generation
+      ~timestamp
+      ~thresholds
+      ~context_ratio
+      ~message_count
+      ~token_count
+      ~max_tokens
+      ~repetition_risk
+      ~goal_alignment
+      ~response_alignment
+      ~now_ts
+      ~idle_seconds
+      ~since_last_compaction_sec
+      ~since_last_handoff_sec
+      ~proactive_warmup_elapsed
+      ~consecutive_hb_failures
+      ~consecutive_turn_failures
+      ()
+    : measurement_snapshot
+  =
+  { snapshot_id
+  ; keeper_name
+  ; generation
+  ; timestamp
+  ; thresholds
+  ; context =
+      { context_ratio
+      ; message_count
+      ; token_count
+      ; max_tokens
+      }
+  ; similarity =
+      { repetition_risk
+      ; goal_alignment
+      ; response_alignment
+      }
+  ; timing =
+      { now_ts
+      ; idle_seconds
+      ; since_last_compaction_sec
+      ; since_last_handoff_sec
+      ; proactive_warmup_elapsed
+      }
+  ; failures =
+      { consecutive_hb_failures
+      ; consecutive_turn_failures
+      }
+  }
 
 let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
   `Assoc [

--- a/lib/keeper/keeper_measurement.mli
+++ b/lib/keeper/keeper_measurement.mli
@@ -4,8 +4,9 @@
     boundary. The [measurement_snapshot] is an immutable record captured once per
     decision cycle. Everything downstream of this record is deterministic.
 
-    Phase 1: types only (no [capture] implementation yet).
-    Phase 4 will add the [capture] function that performs I/O. *)
+    Phase 1: types and serialization.
+    Phase 4: pure [capture] function — accepts pre-computed values,
+    returns [measurement_snapshot]. All I/O happens upstream in the caller. *)
 
 (** {1 Threshold Parameters} *)
 
@@ -78,6 +79,34 @@ type measurement_snapshot = {
   timing : timing_measurement;
   failures : failure_measurement;
 }
+
+(** {1 Capture} *)
+
+(** Pure snapshot constructor — the det/nondet boundary.
+    All I/O (clock reads, file reads, Runtime_params queries) must happen
+    before calling [capture]. The returned record is fully deterministic. *)
+val capture :
+  snapshot_id:string ->
+  keeper_name:string ->
+  generation:int ->
+  timestamp:float ->
+  thresholds:threshold_params ->
+  context_ratio:float ->
+  message_count:int ->
+  token_count:int ->
+  max_tokens:int ->
+  repetition_risk:float ->
+  goal_alignment:float ->
+  response_alignment:float ->
+  now_ts:float ->
+  idle_seconds:int ->
+  since_last_compaction_sec:float ->
+  since_last_handoff_sec:float ->
+  proactive_warmup_elapsed:bool ->
+  consecutive_hb_failures:int ->
+  consecutive_turn_failures:int ->
+  unit ->
+  measurement_snapshot
 
 (** {1 Serialization} *)
 


### PR DESCRIPTION
## Summary
- Add `Keeper_measurement.capture` as a pure function (det/nondet boundary) that accepts pre-computed labeled parameters and returns `measurement_snapshot`
- Wire `write_heartbeat_snapshot` in `keeper_keepalive.ml` to call `Keeper_measurement.capture`, building `threshold_params` from `keeper_meta` and `Keeper_config`
- Timing/failure fields use defaults (0) pending follow-up wiring from heartbeat loop context

## Test plan
- [ ] `dune build` passes (verified locally)
- [ ] CI checks green
- [ ] Existing keeper heartbeat tests unaffected (no behavioral change, `_measurement` is unused for now)
- [ ] Follow-up PR will thread timing/failure values from heartbeat loop and use the snapshot downstream

Closes #5271

🤖 Generated with [Claude Code](https://claude.com/claude-code)