### PR TITLE
fix(resolve): apply context_floor guard to discovered per-slot context

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -61,36 +61,47 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
              false)
     | _ -> false
 
+(** Minimum acceptable discovered per-slot context.  Below this floor
+    the discovered value is assumed to be a misconfigured endpoint
+    (e.g. llama-server with default [-c 8192] and 1 slot).  Legitimate
+    multi-slot setups (131K / 4 = 32K per slot) pass this threshold. *)
+let context_floor = 4_096
+
+(** Apply {!context_floor}: return [discovered] when it is at least
+    [context_floor]; otherwise fall back to [static_ctx]. *)
+let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
+  match discovered with
+  | Some ctx when ctx >= context_floor -> ctx
+  | _ -> static_ctx
 
 (** Resolve max_context for a model label.
     Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —
-    MASC does not guess which endpoint serves the request.
+    MASC does not guess which endpoint serves the request.  Discovered
+    values below {!context_floor} fall back to the static registry.
 
     Resolution chain:
-    1. OAS {!Llm_provider.Cascade_config.resolve_label_context}. Any intermediate OAS
-       fallbacks happen inside that function (for example, endpoint-specific
-       discovered context, per-slot /props results for local providers, or
-       broader discovered maxima used by the cascade resolver).
-    2. If {!Llm_provider.Cascade_config.resolve_label_context} returns [None], this
-       function falls back to the static OAS {!Llm_provider.Provider_registry} entry's
-       [max_context].
-    3. Final fallback: [128_000]. *)
+    1. OAS {!Llm_provider.Cascade_config.resolve_label_context} (model-aware
+       endpoint lookup for local providers, round-robin fallback).
+    2. Apply {!context_floor} guard on the discovered value.
+    3. If OAS returns [None], use static registry entry's [max_context].
+    4. Final fallback: [128_000]. *)
 let max_context_of_label (label : string) : int =
-  (* OAS owns routing resolution — we don't guess *)
-  match Llm_provider.Cascade_config.resolve_label_context label with
-  | Some ctx -> ctx
-  | None ->
-    (* Cloud provider or unresolved: use static registry *)
+  let static_ctx =
     match provider_name_of_label label with
     | None -> 128_000
     | Some pname ->
       match Llm_provider.Provider_registry.find default_registry pname with
       | Some entry -> entry.max_context
       | None -> 128_000
+  in
+  match Llm_provider.Cascade_config.resolve_label_context label with
+  | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
+  | None -> static_ctx
 
 (** Resolve max_context for the first available model in a label list.
     "Available" means the provider's API key env var is set (or not required).
     Per-label context resolved by OAS — no routing guess in MASC.
+    Applies {!context_floor} to discovered values.
     Falls back to 128_000 if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
   let rec find = function
@@ -103,10 +114,10 @@ let resolve_primary_max_context (labels : string list) : int =
         | None -> find rest
         | Some entry ->
           if entry.is_available () then
-            (* OAS resolves label → context. No routing guess in MASC. *)
+            let static_ctx = entry.max_context in
             match Llm_provider.Cascade_config.resolve_label_context label with
-            | Some ctx -> ctx
-            | None -> entry.max_context
+            | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
+            | None -> static_ctx
           else find rest
   in
   find labels

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -99,6 +99,21 @@ let test_max_context_of_label () =
   check int "fallback 128000" 128_000 fallback
 
 
+let test_effective_discovered_ctx () =
+  let edc = Masc_mcp.Oas_model_resolve.effective_discovered_ctx in
+  (* Below floor (4096) → use static *)
+  check int "below floor uses static" 128_000
+    (edc ~static_ctx:128_000 ~discovered:(Some 2048));
+  (* At floor → use discovered *)
+  check int "at floor uses discovered" 4_096
+    (edc ~static_ctx:128_000 ~discovered:(Some 4_096));
+  (* Above floor → use discovered *)
+  check int "above floor uses discovered" 32_768
+    (edc ~static_ctx:128_000 ~discovered:(Some 32_768));
+  (* None → use static *)
+  check int "none uses static" 128_000
+    (edc ~static_ctx:128_000 ~discovered:None)
+
 let test_labels_require_local_discovery () =
   check bool "llama labels refresh local discovery" true
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
@@ -202,6 +217,8 @@ let () =
             test_default_registry_populated;
           test_case "provider name of label" `Quick test_provider_name_of_label;
           test_case "max context of label" `Quick test_max_context_of_label;
+          test_case "effective discovered ctx floor" `Quick
+            test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
         ] );


### PR DESCRIPTION
## Summary
- `context_floor = 4_096` + `effective_discovered_ctx` 추가
- `max_context_of_label`과 `resolve_primary_max_context`에 floor guard 적용
- 4K 미만 discovered context는 static registry 값으로 fallback

## Problem
Discovery가 반환하는 per-slot context가 비정상적으로 낮을 때 (e.g. 잘못된 endpoint의 8192), keeper가 그 값을 그대로 사용하여 반복 overflow 발생.

Root cause fix는 jeong-sik/oas#628 (model-aware endpoint routing). 이 PR은 defense-in-depth guard.

## Test plan
- [x] `test_observability_provider_contracts` (18 pass, floor 테스트 포함)
- [x] `test_keeper_unified` (93 pass)
- [ ] 실행 검증: keeper 로그에서 `max_context` 값 확인

## Dependencies
- jeong-sik/oas#628 (OAS must be merged first for model-aware routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)