### PR TITLE
refactor(boundary): add cascade_prefix to adapter record

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -21,6 +21,7 @@ type adapter = {
   auth_mode : auth_mode;
   aliases : string list;
   spawn_key : string option;       (** Key into Spawn.default_configs. None = not spawnable via CLI. *)
+  cascade_prefix : string;         (** OAS cascade model prefix (e.g. "claude", "openai"). Used in "prefix:model_id" labels. *)
   default_voice : string option;   (** Default TTS voice name. None = no voice assignment. *)
   endpoint_url : string option;    (** Base URL for the provider API. *)
   default_model_id : string option; (** Default model ID for the provider. *)
@@ -72,17 +73,6 @@ let string_of_voice_transport = function
   | Voice_elevenlabs_direct -> "elevenlabs_direct"
   | Voice_mcp -> "voice_mcp"
 
-(** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
-    TODO: remove after OAS exports string_of_provider_kind (oas#623 pin). *)
-let string_of_provider_kind
-    : Llm_provider.Provider_config.provider_kind -> string
-  = function
-  | Anthropic -> "claude-api"
-  | OpenAI_compat -> "codex-api"
-  | Gemini -> "gemini-api"
-  | Glm -> "glm"
-  | Claude_code -> "claude-code"
-
 let normalize_label label = String.trim label |> String.lowercase_ascii
 
 (* ── Canonical adapter names (single definition point) ──────── *)
@@ -93,6 +83,18 @@ let cn_codex = "codex-api"
 let cn_gemini = "gemini-api"
 let cn_glm = "glm"
 let cn_openrouter = "openrouter"
+
+(** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
+    Note: OpenAI_compat maps to codex-api (cloud); llama (local) uses the
+    same provider_kind but is identified by endpoint, not by this function. *)
+let string_of_provider_kind
+    : Llm_provider.Provider_config.provider_kind -> string
+  = function
+  | Anthropic -> cn_claude
+  | OpenAI_compat -> cn_codex
+  | Gemini -> cn_gemini
+  | Glm -> cn_glm
+  | Claude_code -> "claude-code"
 
 (** Single source of truth for all agent adapters.
     spawn_key maps to Spawn.default_configs keys.
@@ -106,6 +108,7 @@ let direct_adapters =
       auth_mode = No_auth;
       aliases = [ cn_llama; "llama.cpp"; "llamacpp" ];
       spawn_key = Some "llama";
+      cascade_prefix = "llama";
       default_voice = Some "Laura";
       endpoint_url = Some Env_config_runtime.Llama.server_url;
       default_model_id =
@@ -118,6 +121,7 @@ let direct_adapters =
       auth_mode = Api_key "ANTHROPIC_API_KEY";
       aliases = [ cn_claude; "claude"; "anthropic"; "claude-code"; "claude-api" ];
       spawn_key = Some "claude";
+      cascade_prefix = "claude";
       default_voice = Some "Sarah";
       endpoint_url = Some "https://api.anthropic.com";
       default_model_id = Some "auto";
@@ -128,6 +132,7 @@ let direct_adapters =
       auth_mode = Api_key "OPENAI_API_KEY";
       aliases = [ cn_codex; "codex"; "openai"; "codex-cli"; "codex-api" ];
       spawn_key = Some "codex";
+      cascade_prefix = "openai";
       default_voice = Some "George";
       endpoint_url = Some "https://api.openai.com";
       default_model_id = Some "auto";
@@ -143,6 +148,7 @@ let direct_adapters =
           };
       aliases = [ cn_gemini; "gemini"; "google"; "gemini-cli"; "gemini-api" ];
       spawn_key = Some "gemini";
+      cascade_prefix = "gemini";
       default_voice = Some "Roger";
       endpoint_url = None; (** Resolved dynamically for Gemini *)
       default_model_id = Some "auto";
@@ -153,6 +159,7 @@ let direct_adapters =
       auth_mode = Api_key "ZAI_API_KEY";
       aliases = [ cn_glm; "glm_cloud"; "zai" ];
       spawn_key = None;
+      cascade_prefix = "glm";
       default_voice = None;
       endpoint_url = Some Env_config_runtime.Glm.server_url;
       default_model_id = Some "auto";
@@ -163,6 +170,7 @@ let direct_adapters =
       auth_mode = Api_key "OPENROUTER_API_KEY";
       aliases = [ cn_openrouter ];
       spawn_key = None;
+      cascade_prefix = "openrouter";
       default_voice = None;
       endpoint_url = Some "https://openrouter.ai/api/v1";
       default_model_id = None;
@@ -851,14 +859,8 @@ type auth_detail = {
   note : string option;
 }
 
-(** Map adapter canonical_name to the cascade config prefix.
-    E.g. "claude-api" -> "claude", "codex-api" -> "openai". *)
-let cascade_prefix_of_adapter (adapter : adapter) =
-  match adapter.canonical_name with
-  | v when v = cn_claude -> "claude"
-  | v when v = cn_codex -> "openai"
-  | v when v = cn_gemini -> "gemini"
-  | _ -> adapter.canonical_name
+(** Cascade config prefix from adapter record. No match needed. *)
+let cascade_prefix_of_adapter (adapter : adapter) = adapter.cascade_prefix
 
 let endpoint_url_of_adapter (adapter : adapter) =
   match adapter.canonical_name with


### PR DESCRIPTION
## Summary

Provider 이름이 3개의 독립적 namespace로 하드코딩되어 있던 근본 문제 수정.

- adapter record에 `cascade_prefix` 필드 추가
- `cascade_prefix_of_adapter`: 4-branch match → `adapter.cascade_prefix` 필드 접근
- `string_of_provider_kind`: 문자열 리터럴 → `cn_*` 상수 참조
- 새 provider 추가 시 adapter 정의 1곳만 수정하면 됨

## Root cause

3중 이름 체계가 5+곳의 match문으로 독립 관리되어 drift 위험:
1. MASC canonical: `claude-api`, `codex-api`
2. OAS registry prefix: `claude`, `openai`  
3. OAS provider_kind: `anthropic`, `openai_compat`

#5262에서 OAS `string_of_provider_kind`로 위임 시도했으나,
OAS는 "anthropic" 반환 / MASC는 "claude-api" 기대 → silent breaking change.
`OpenAI_compat`이 llama와 codex 양쪽에 매핑되므로 OAS 위임 자체가 불가.

## Test plan

- [x] `test_tool_surface_ssot.exe` 25개 통과
- [x] `test_observability_provider_contracts.exe` 17개 통과
- [x] `dune build @check` 경고 없음
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)