### PR TITLE
chore(release): bump version to 2.243.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## [2.243.0] - 2026-04-05
+
+### Changed
+- **Tool index** -- migrate korean_keywords from description concatenation to Tool_index.entry.aliases field (OAS 0.101.0). BM25 behavior preserved (#5295).
+- **OAS pin** -- bump agent_sdk dependency to >= 0.101.0.
+
 ## [2.242.0] - 2026-04-05
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.242.0
-> Latest release: v2.242.0 (2026-04-05)
+> Current package version: v2.243.0
+> Latest release: v2.243.0 (2026-04-05)
 > Updated: 2026-04-05
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.


### PR DESCRIPTION
## Summary
- ROADMAP.md와 CHANGELOG.md를 dune-project 2.243.0에 맞춤
- #5295 (korean_keywords → aliases) 머지 후 누락된 release metadata

## Test plan
- [ ] Health CI check passes (version truth check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)