### PR TITLE
test(context): add 64K boundary tests for small-local classification

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -404,6 +404,10 @@ let observation_summary = function
 let dynamic_multi_agent_ctx = 0.80
 let dynamic_focused_ctx = 0.70
 
+(** Context window floor (in tokens) below which a local model is classified
+    as "small-local", triggering lightweight compaction strategies. *)
+let small_local_ctx_floor = 64_000
+
 let default_dynamic_selector (obs : observation_context) : strategy list =
   if obs.context_ratio >= dynamic_multi_agent_ctx && obs.active_agent_count > 1 then
     (* Dense coordination: preserve recent turns, aggressive pruning *)
@@ -411,7 +415,7 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
   else if obs.context_ratio >= dynamic_focused_ctx && obs.is_single_focused_task then
     (* Focused work near budget: summarize old context *)
     [PruneToolOutputs; SummarizeOld]
-  else if obs.is_local_model && obs.context_window < 64_000 then
+  else if obs.is_local_model && obs.context_window < small_local_ctx_floor then
     (* Small local models (< 64K): lightweight compaction only.
        Uses an approximate 64K floor here; llama-server default 8K is
        unsuitable for multi-turn keeper conversations. *)

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -269,11 +269,11 @@ let test_dynamic_small_local_model () =
     ["PruneToolOutputs"; "MergeContiguous"] names
 
 let test_dynamic_local_at_64k_boundary () =
-  (* Local model at exactly 64K: NOT small — gets standard compaction *)
+  (* Local model at exactly the small_local_ctx_floor: NOT small — gets standard compaction *)
   let obs : Compact.observation_context = {
     context_ratio = 0.50; active_agent_count = 1;
     unclaimed_task_count = 0; is_single_focused_task = false;
-    context_window = 64_000; is_local_model = true } in
+    context_window = Compact.small_local_ctx_floor; is_local_model = true } in
   let resolved = Compact.resolve_strategies ~obs:(Some obs)
     [Compact.Dynamic Compact.default_dynamic_selector] in
   let names = strategy_names resolved in
@@ -281,11 +281,11 @@ let test_dynamic_local_at_64k_boundary () =
     ["DropLowImportance"] names
 
 let test_dynamic_local_below_64k () =
-  (* Local model at 63K: small — lightweight compaction *)
+  (* Local model at 63,999 (just below small_local_ctx_floor): small — lightweight compaction *)
   let obs : Compact.observation_context = {
     context_ratio = 0.50; active_agent_count = 1;
     unclaimed_task_count = 0; is_single_focused_task = false;
-    context_window = 63_999; is_local_model = true } in
+    context_window = Compact.small_local_ctx_floor - 1; is_local_model = true } in
   let resolved = Compact.resolve_strategies ~obs:(Some obs)
     [Compact.Dynamic Compact.default_dynamic_selector] in
   let names = strategy_names resolved in

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -268,6 +268,30 @@ let test_dynamic_small_local_model () =
   check (list string) "small local strategies"
     ["PruneToolOutputs"; "MergeContiguous"] names
 
+let test_dynamic_local_at_64k_boundary () =
+  (* Local model at exactly 64K: NOT small — gets standard compaction *)
+  let obs : Compact.observation_context = {
+    context_ratio = 0.50; active_agent_count = 1;
+    unclaimed_task_count = 0; is_single_focused_task = false;
+    context_window = 64_000; is_local_model = true } in
+  let resolved = Compact.resolve_strategies ~obs:(Some obs)
+    [Compact.Dynamic Compact.default_dynamic_selector] in
+  let names = strategy_names resolved in
+  check (list string) "local 64K gets default strategies"
+    ["DropLowImportance"] names
+
+let test_dynamic_local_below_64k () =
+  (* Local model at 63K: small — lightweight compaction *)
+  let obs : Compact.observation_context = {
+    context_ratio = 0.50; active_agent_count = 1;
+    unclaimed_task_count = 0; is_single_focused_task = false;
+    context_window = 63_999; is_local_model = true } in
+  let resolved = Compact.resolve_strategies ~obs:(Some obs)
+    [Compact.Dynamic Compact.default_dynamic_selector] in
+  let names = strategy_names resolved in
+  check (list string) "local below 64K gets small local strategies"
+    ["PruneToolOutputs"; "MergeContiguous"] names
+
 let test_dynamic_large_context_cloud () =
   let obs : Compact.observation_context = {
     context_ratio = 0.50; active_agent_count = 1;
@@ -328,6 +352,8 @@ let () =
       test_case "high pressure multi-agent" `Quick test_dynamic_high_pressure_multi_agent;
       test_case "single focused task" `Quick test_dynamic_single_focused_task;
       test_case "small local model" `Quick test_dynamic_small_local_model;
+      test_case "local at 64K boundary" `Quick test_dynamic_local_at_64k_boundary;
+      test_case "local below 64K" `Quick test_dynamic_local_below_64k;
       test_case "large context cloud" `Quick test_dynamic_large_context_cloud;
       test_case "medium cloud default" `Quick test_dynamic_medium_cloud_default;
       test_case "no observation fallback" `Quick test_dynamic_no_observation;


### PR DESCRIPTION
## Summary

- Adds boundary value tests for the 32K→64K small-local threshold change (#5281)
- Local model at exactly `small_local_ctx_floor` (64,000) → standard compaction (DropLowImportance)
- Local model at `small_local_ctx_floor - 1` (63,999, just below the floor) → lightweight compaction (PruneToolOutputs + MergeContiguous)
- Introduces `small_local_ctx_floor = 64_000` named constant in `context_compact_oas.ml` so tests and implementation stay in sync if the threshold changes again

Follow-up to #5281. Addresses cross-model review feedback (GLM-5.1).

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — test and refactor only; no behaviour change.

## Evidence

- Boundary tests reference `Compact.small_local_ctx_floor` directly, eliminating hardcoded literals
- Test comment corrected from "63K" to "63,999 (just below small_local_ctx_floor)"

## Review evidence

- Cross-model review (copilot-pull-request-reviewer): suggested shared constant and accurate comment — both addressed.

## Linked issue