### PR TITLE
fix(boundary): delete string_of_provider_kind, delegate to OAS

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -121,7 +121,7 @@ let handle_keeper_status ctx args : tool_result =
                | Some idx when idx > 0 ->
                  String.sub label 0 idx |> String.trim |> String.lowercase_ascii
                | _ ->
-                 Provider_adapter.string_of_provider_kind cfg.kind
+                 Llm_provider.Provider_config.string_of_provider_kind cfg.kind
              in
              Some (`Assoc [
                ("provider", `String provider_name);

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -84,18 +84,6 @@ let cn_gemini = "gemini-api"
 let cn_glm = "glm"
 let cn_openrouter = "openrouter"
 
-(** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
-    Note: OpenAI_compat maps to codex-api (cloud); llama (local) uses the
-    same provider_kind but is identified by endpoint, not by this function. *)
-let string_of_provider_kind
-    : Llm_provider.Provider_config.provider_kind -> string
-  = function
-  | Anthropic -> cn_claude
-  | OpenAI_compat -> cn_codex
-  | Gemini -> cn_gemini
-  | Glm -> cn_glm
-  | Claude_code -> "claude-code"
-
 (** Single source of truth for all agent adapters.
     spawn_key maps to Spawn.default_configs keys.
     default_voice maps to TTS voice names.


### PR DESCRIPTION
## Summary
- Delete `string_of_provider_kind` from `provider_adapter.ml` (13 lines removed)
- Update sole caller in `keeper_status_detail.ml` to use OAS `Provider_config.string_of_provider_kind`

## Context
OAS 0.101.0 exports this function. The MASC duplicate survived squash merge of #5262 because the review bot kept restoring it. This PR completes the deletion.

## Test plan
- [x] `dune build` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)