### PR TITLE
fix(keeper): use max cascade context for automatic overflow cascading

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -215,7 +215,7 @@ let write_heartbeat_snapshot
   let cascade_models =
     Oas_model_resolve.models_of_cascade_name meta_current.cascade_name
   in
-  let primary_max_context =
+  let max_cascade_context =
     match meta_current.max_context_override with
     | Some v -> v
     | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
@@ -225,7 +225,7 @@ let write_heartbeat_snapshot
   let _session, ctx_opt =
     load_context_from_checkpoint
       ~trace_id:meta_current.runtime.trace_id
-      ~primary_model_max_tokens:primary_max_context
+      ~primary_model_max_tokens:max_cascade_context
       ~base_dir
   in
   match ctx_opt with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -219,7 +219,7 @@ let write_heartbeat_snapshot
   let primary_max_context =
     match meta_current.max_context_override with
     | Some v -> v
-    | None -> Oas_model_resolve.resolve_primary_max_context cascade_models
+    | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
   in
   let base_dir = session_base_dir ctx.config in
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -37,7 +37,7 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = Oas_model_resolve.models_of_cascade_name m.cascade_name in
-      let primary_max_context = Oas_model_resolve.resolve_primary_max_context models in
+      let primary_max_context = Oas_model_resolve.resolve_max_cascade_context models in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -174,7 +174,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
        | Ok () ->
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Oas_model_resolve.refresh_local_discovery_if_possible effective_models);
-         let primary_max_context =
+         let max_cascade_context =
            match meta.max_context_override with
            | Some v ->
                Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
@@ -283,7 +283,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               Keeper_exec_context.timed (fun () ->
                   Keeper_agent_run.run_turn
                     ~config:ctx.config ~meta ~base_dir
-                    ~max_context:primary_max_context
+                    ~max_context:max_cascade_context
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:turn_cascade_name
@@ -310,7 +310,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 Keeper_exec_context.apply_post_turn_lifecycle ~base_dir
                   ~meta
                   ~model:result.model_used
-                  ~primary_model_max_tokens:primary_max_context
+                  ~primary_model_max_tokens:max_cascade_context
                   ~checkpoint:result.checkpoint
               in
               (* RFC-0002: dispatch buffer state events after lifecycle *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -179,7 +179,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
            | Some v ->
                Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
                v
-           | None -> Oas_model_resolve.resolve_primary_max_context effective_models
+           | None -> Oas_model_resolve.resolve_max_cascade_context effective_models
          in
             let base_dir = session_base_dir ctx.config in
             let effective_no_skill_route = no_skill_route || direct_reply in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -184,7 +184,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let primary_max_context =
       match p.max_context_override_opt with
       | Some v -> v
-      | None -> Oas_model_resolve.resolve_primary_max_context cascade_models
+      | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
     in
     Progress.Tracker.step tracker ~message:"Initializing session directory" ();
     let trace_id = generate_trace_id () in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -164,7 +164,7 @@ let overflow_retry_history_budget
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
-    ~(primary_max_context : int)
+    ~(max_cascade_context : int)
     ~(system_prompt : string)
     ~(user_message : string)
     ~(error : string) : overflow_retry_plan option =
@@ -172,8 +172,8 @@ let recover_context_overflow_retry
   | None -> None
   | Some actual_limit ->
       let retry_max_context =
-        if primary_max_context <= 0 then actual_limit
-        else min primary_max_context actual_limit
+        if max_cascade_context <= 0 then actual_limit
+        else min max_cascade_context actual_limit
       in
       let retry_history_budget =
         overflow_retry_history_budget ~available_context:retry_max_context
@@ -823,12 +823,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   | Error e -> Error e
   | Ok () ->
       ignore (Oas_model_resolve.refresh_local_discovery_if_possible model_labels);
-      let primary_max_context =
+      let max_cascade_context =
         match meta.max_context_override with
         | Some v ->
             Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
             v
-        | None -> Oas_model_resolve.resolve_primary_max_context model_labels
+        | None -> Oas_model_resolve.resolve_max_cascade_context model_labels
       in
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
@@ -898,7 +898,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                            && should_attempt_context_overflow_retry e -> (
                 match
                   recover_context_overflow_retry ~meta ~base_dir
-                    ~primary_max_context ~system_prompt ~user_message ~error:e
+                    ~max_cascade_context ~system_prompt ~user_message ~error:e
                 with
                 | Some retry_plan ->
                     let retry_meta =
@@ -918,7 +918,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 | None -> Error e)
             | Error e -> Error e
           in
-          retry_loop ~run_meta:meta ~max_context:primary_max_context
+          retry_loop ~run_meta:meta ~max_context:max_cascade_context
             ~run_generation:generation ~attempt:1
             ~is_retry:false ~overflow_retry_used:false)
       in
@@ -926,7 +926,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       | Error e ->
           Log.Keeper.error
             "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms error=%s"
-            meta.name meta.cascade_name primary_max_context latency_ms
+            meta.name meta.cascade_name max_cascade_context latency_ms
             (short_preview e);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e
@@ -1003,7 +1003,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             apply_post_turn_lifecycle ~base_dir
               ~meta
               ~model:result.model_used
-              ~primary_model_max_tokens:primary_max_context
+              ~primary_model_max_tokens:max_cascade_context
               ~checkpoint:result.checkpoint
           in
           (* RFC-0002: dispatch buffer state events after lifecycle *)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -262,7 +262,7 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
   try
     let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
     let primary_max_context =
-      Oas_model_resolve.resolve_primary_max_context cascade_models
+      Oas_model_resolve.resolve_max_cascade_context cascade_models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
@@ -282,7 +282,7 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
   try
     let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
     let primary_max_context =
-      Oas_model_resolve.resolve_primary_max_context cascade_models
+      Oas_model_resolve.resolve_max_cascade_context cascade_models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -122,6 +122,33 @@ let resolve_primary_max_context (labels : string list) : int =
   in
   find labels
 
+(** Maximum context across all available models in a label list.
+    Returns the largest context window that any model in the cascade can
+    handle.  This is the value MASC should use for [max_input_tokens]:
+    OAS cascade will try providers in order — if the primary overflows,
+    the cascade fails over to the next provider that can handle the
+    prompt size.  Falls back to [128_000] if no model is available. *)
+let resolve_max_cascade_context (labels : string list) : int =
+  let contexts = List.filter_map (fun label ->
+    match provider_name_of_label label with
+    | None -> None
+    | Some pname ->
+      match Llm_provider.Provider_registry.find default_registry pname with
+      | None -> None
+      | Some entry ->
+        if entry.is_available () then
+          let static_ctx = entry.max_context in
+          let ctx = match Llm_provider.Cascade_config.resolve_label_context label with
+            | Some discovered -> effective_discovered_ctx ~static_ctx ~discovered:(Some discovered)
+            | None -> static_ctx
+          in
+          Some ctx
+        else None
+  ) labels in
+  match contexts with
+  | [] -> 128_000
+  | ctxs -> List.fold_left max 0 ctxs
+
 (** Resolve model_id for the first available model in a label list.
     Returns the model_id portion of "provider:model_id".
     Falls back to empty string if no model is available. *)

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -98,29 +98,35 @@ let max_context_of_label (label : string) : int =
   | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
   | None -> static_ctx
 
+(** Resolve context for a label if its provider is available; returns [None]
+    if the provider is unknown, unavailable, or the label is malformed.
+    Applies {!context_floor} to discovered values. *)
+let context_if_available (label : string) : int option =
+  match provider_name_of_label label with
+  | None -> None
+  | Some pname ->
+    match Llm_provider.Provider_registry.find default_registry pname with
+    | None -> None
+    | Some entry ->
+      if entry.is_available () then
+        let static_ctx = entry.max_context in
+        let ctx =
+          match Llm_provider.Cascade_config.resolve_label_context label with
+          | Some discovered -> effective_discovered_ctx ~static_ctx ~discovered:(Some discovered)
+          | None -> static_ctx
+        in
+        Some ctx
+      else None
+
 (** Resolve max_context for the first available model in a label list.
     "Available" means the provider's API key env var is set (or not required).
     Per-label context resolved by OAS — no routing guess in MASC.
     Applies {!context_floor} to discovered values.
     Falls back to 128_000 if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
-  let rec find = function
-    | [] -> 128_000
-    | label :: rest ->
-      match provider_name_of_label label with
-      | None -> find rest
-      | Some pname ->
-        match Llm_provider.Provider_registry.find default_registry pname with
-        | None -> find rest
-        | Some entry ->
-          if entry.is_available () then
-            let static_ctx = entry.max_context in
-            match Llm_provider.Cascade_config.resolve_label_context label with
-            | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
-            | None -> static_ctx
-          else find rest
-  in
-  find labels
+  match List.find_map context_if_available labels with
+  | Some ctx -> ctx
+  | None -> 128_000
 
 (** Maximum context across all available models in a label list.
     Returns the largest context window that any model in the cascade can
@@ -129,23 +135,7 @@ let resolve_primary_max_context (labels : string list) : int =
     the cascade fails over to the next provider that can handle the
     prompt size.  Falls back to [128_000] if no model is available. *)
 let resolve_max_cascade_context (labels : string list) : int =
-  let contexts = List.filter_map (fun label ->
-    match provider_name_of_label label with
-    | None -> None
-    | Some pname ->
-      match Llm_provider.Provider_registry.find default_registry pname with
-      | None -> None
-      | Some entry ->
-        if entry.is_available () then
-          let static_ctx = entry.max_context in
-          let ctx = match Llm_provider.Cascade_config.resolve_label_context label with
-            | Some discovered -> effective_discovered_ctx ~static_ctx ~discovered:(Some discovered)
-            | None -> static_ctx
-          in
-          Some ctx
-        else None
-  ) labels in
-  match contexts with
+  match List.filter_map context_if_available labels with
   | [] -> 128_000
   | ctxs -> List.fold_left max 0 ctxs
 

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -114,6 +114,22 @@ let test_effective_discovered_ctx () =
   check int "none uses static" 128_000
     (edc ~static_ctx:128_000 ~discovered:None)
 
+let test_resolve_max_cascade_context () =
+  (* Empty list → 128_000 fallback *)
+  check int "empty labels fallback 128000" 128_000
+    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context []);
+  (* Unknown provider → fallback *)
+  check int "unknown provider fallback 128000" 128_000
+    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context
+       [ "nonexistent:model" ]);
+  (* Malformed label (no colon) → fallback *)
+  check int "malformed label fallback 128000" 128_000
+    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context [ "nocolonlabel" ]);
+  (* Known provider with available key returns max context > 0 *)
+  let ctx = Masc_mcp.Oas_model_resolve.resolve_max_cascade_context
+      [ "claude:claude-sonnet-4-6" ] in
+  check bool "known provider returns positive context" true (ctx > 0)
+
 let test_labels_require_local_discovery () =
   check bool "llama labels refresh local discovery" true
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
@@ -221,6 +237,8 @@ let () =
             test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
+          test_case "resolve max cascade context" `Quick
+            test_resolve_max_cascade_context;
         ] );
       ( "dashboard_schema",
         [


### PR DESCRIPTION
## Summary
- `context_if_available` 공통 헬퍼 추가: provider 가용 여부 확인 + context 해석 로직을 단일 함수로 추출
- `resolve_primary_max_context`, `resolve_max_cascade_context` 모두 `context_if_available`을 재사용하도록 리팩토링 (중복 제거)
- `keeper_unified_turn.ml`에서도 `resolve_primary_max_context` → `resolve_max_cascade_context`로 교체 (unified turn 경로 포함 전체 적용)
- `primary_max_context` → `max_cascade_context`로 변수명 일괄 변경 (`keeper_turn.ml`, `keeper_keepalive.ml`, `keeper_unified_turn.ml`, `recover_context_overflow_retry` 파라미터 포함)
- `test_observability_provider_contracts`에 `test_resolve_max_cascade_context` 테스트 추가: 빈 목록 fallback, 미지 provider fallback, colon 없는 label fallback, known provider 양수 context 검증

## Product impact

- Promise affected: `repo coordination` | `delivery swarm` | `ops visibility` | `none/internal`
- User-visible change: cascade failover가 모든 keeper 실행 경로(manual turn, unified turn, keepalive)에서 일관되게 동작. prompt가 primary 모델의 context를 초과해도 cascade 내 더 큰 context 모델로 failover 가능.

## Evidence

- `test_observability_provider_contracts` — `resolve_max_cascade_context` 신규 테스트 포함 통과
- `test_keeper_unified` (93 pass)

## Review evidence

- Copilot code review 피드백 반영: 중복 로직 추출, 미테스트 함수 커버리지 추가, 남은 callsite 일괄 교체, 오해 유발 변수명 정정

## Linked issue