### PR TITLE
fix: recover lost post-merge commit (OnIdle wildcard)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -290,7 +290,7 @@ let make_hooks
 
     on_idle = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names } ->
+      | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names; _ } ->
         let tools_str = match tool_names with
           | [] -> "<none>"
           | names -> String.concat ", " names


### PR DESCRIPTION
## Summary

Cherry-pick of `24e9633f0` from `fix/5020-idle-loop-logging` branch.
This commit was pushed after the PR was squash-merged, so it never reached main.

Change: add wildcard to OnIdle pattern for forward compatibility in `keeper_hooks_oas.ml`.

## Context

Scan of 100 merged PRs found 16 branches with post-merge commits.
This PR recovers the only commit that cherry-picks cleanly.
Remaining 4 branches with conflicts tracked in #5303.

## Test plan

- [ ] `dune build` passes
- [ ] OnIdle pattern matches forward-compatible events

Fixes #5303 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)