### PR TITLE
refactor(context): remove dead token_count from compact() return type

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -38,21 +38,10 @@ type strategy =
       Resolves to a list of concrete strategies (no nested Dynamic).
       @since #3070 *)
 
-(* ================================================================ *)
-(* Token Estimation                                                  *)
-(* ================================================================ *)
-
-(** CJK-aware token estimate delegated to OAS Context_reducer. *)
-let msg_tokens (m : Agent_sdk.Types.message) : int =
-  let base = Agent_sdk.Context_reducer.estimate_message_tokens m in
-  if Agent_sdk.Types.text_of_message m = "" then 0 else base + 4
-
-let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
-  let sys_tokens =
-    if system_prompt = "" then 0
-    else Agent_sdk.Context_reducer.estimate_char_tokens system_prompt + 4
-  in
-  List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
+(* Token estimation lives in [Keeper_context_core] (authoritative, with 15%
+   safety buffer).  This module previously had its own msg_tokens/count_tokens
+   without the buffer, but they were only used by [compact]'s dead return value.
+   Removed in #5281 follow-up to consolidate to single estimation path. *)
 
 (* ================================================================ *)
 (* Importance Scoring (inlined from Context_scoring)                 *)
@@ -437,12 +426,12 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
       When a strategy list contains [Dynamic], this context determines
       which concrete strategies are applied. *)
 let compact
-    ~(system_prompt : string)
+    ~system_prompt:(_system_prompt : string)
     ~(messages : Agent_sdk.Types.message list)
     ~(strategies : strategy list)
     ?(observation : observation_context option)
     ()
-  : Agent_sdk.Types.message list * int =
+  : Agent_sdk.Types.message list =
   let resolved = resolve_strategies ~obs:observation strategies in
   let strategy_names = List.map strategy_name resolved in
   Log.Compact.info "[compact] strategies=[%s] %s"
@@ -451,6 +440,4 @@ let compact
   let oas_strategies = List.map oas_strategy_of resolved in
   let reducer = Agent_sdk.Context_reducer.compose
     (List.map (fun s -> { Agent_sdk.Context_reducer.strategy = s }) oas_strategies) in
-  let reduced = Agent_sdk.Context_reducer.reduce reducer messages in
-  let token_count = count_tokens system_prompt reduced in
-  (reduced, token_count)
+  Agent_sdk.Context_reducer.reduce reducer messages

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -114,7 +114,7 @@ let compact_if_needed
           Log.Harness.warn "[pre_compact] sse broadcast failed: %s"
             (Printexc.to_string exn));
       let messages =
-          let msgs_after_compact, _ =
+          let msgs_after_compact =
             Context_compact_oas.compact
               ~system_prompt:ctx.system_prompt
               ~messages:ctx.messages

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -152,7 +152,7 @@ let handle_compact args : result =
     let tokens_before = Keeper_exec_context.token_count ctx in
     let msg_count_before = List.length ctx.messages in
     (* Apply compaction *)
-    let messages, _ =
+    let messages =
       Context_compact_oas.compact
         ~system_prompt:ctx.system_prompt
         ~messages:ctx.messages

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -34,7 +34,7 @@ let test_merge_contiguous_still_merges_plain_user () =
     msg Agent_sdk.Types.User "World";
     msg Agent_sdk.Types.Assistant "Hi";
   ] in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous] () in
   let user_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
@@ -52,7 +52,7 @@ let test_compact_prune_tool_outputs () =
     tool_msg long_output;
     msg Agent_sdk.Types.Assistant "answer";
   ] in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.PruneToolOutputs] () in
   let tool_text = Agent_sdk.Types.text_of_message (List.nth result 1) in
@@ -60,15 +60,14 @@ let test_compact_prune_tool_outputs () =
     (String.length tool_text < String.length long_output)
 
 let test_compact_empty_messages () =
-  let result, tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:[]
     ~strategies:[Compact.PruneToolOutputs; Compact.MergeContiguous] () in
-  check int "empty input = empty output" 0 (List.length result);
-  check bool "tokens > 0 (system prompt)" true (tokens > 0)
+  check int "empty input = empty output" 0 (List.length result)
 
 let test_compact_single_message () =
   let msgs = [msg Agent_sdk.Types.User "hello"] in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous; Compact.DropLowImportance] () in
   check bool "single message survives" true (List.length result >= 1)
@@ -81,7 +80,7 @@ let test_compact_drop_low_importance () =
       msg Agent_sdk.Types.Assistant (Printf.sprintf "ok %d" i))
     @ [msg Agent_sdk.Types.User "latest question"]
   in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.DropLowImportance] () in
   check bool "some messages dropped" true
@@ -93,7 +92,7 @@ let test_compact_summarize_old () =
     msg (if i mod 2 = 0 then Agent_sdk.Types.User else Agent_sdk.Types.Assistant)
       (Printf.sprintf "message %d with enough content to be meaningful" i))
   in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.SummarizeOld] () in
   check bool "message count reduced" true
@@ -113,7 +112,7 @@ let test_summarize_old_masks_tool_results_but_preserves_pairing () =
     msg Agent_sdk.Types.User "Any tests exist?";
     msg Agent_sdk.Types.Assistant "Yes, there are focused compaction tests.";
   ] in
-  let result, _tokens = Compact.compact
+  let result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.SummarizeOld] () in
   check bool "message count reduced" true
@@ -235,7 +234,7 @@ let test_dynamic_high_pressure_multi_agent () =
     unclaimed_task_count = 2; is_single_focused_task = false;
     context_window = 200_000; is_local_model = false } in
   let msgs = [msg Agent_sdk.Types.User "test"] in
-  let _result, _tokens = Compact.compact
+  let _result = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.Dynamic Compact.default_dynamic_selector]
     ~observation:obs () in

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -77,7 +77,7 @@ let test_roundtrip_tool_msg () =
 (* Compaction tests (via Context_compact_oas directly) *)
 
 let compact_ctx (ctx : Keeper_exec_context.working_context) strategies =
-  let messages, _ =
+  let messages =
     Context_compact_oas.compact
       ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies () in
   Keeper_exec_context.sync_oas_context

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -108,7 +108,7 @@ let test_compact_syncs_oas_context () =
   let ctx = Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:1000 in
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "msg1") in
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "msg2") in
-  let messages, _ =
+  let messages =
     Context_compact_oas.compact
       ~system_prompt:ctx.system_prompt ~messages:ctx.messages
       ~strategies:[Context_compact_oas.MergeContiguous] () in


### PR DESCRIPTION
## Summary

- `compact()` return type: `message list * int` → `message list`
- Removed duplicate `msg_tokens`/`count_tokens` from `context_compact_oas.ml` (had ~11% discrepancy vs authoritative `Keeper_context_core` — fixed +4 vs 15% buffer)
- All 4 callers already discarded token_count with `_` and recalculated via `Keeper_context_core.token_count`
- Single token estimation authority: `Keeper_context_core`

## Changes

| File | Change |
|------|--------|
| `lib/context_compact_oas.ml` | Remove `msg_tokens`, `count_tokens`, simplify `compact` return |
| `lib/keeper/keeper_compact_policy.ml` | `msgs, _ =` → `msgs =` |
| `lib/tool_compact.ml` | `messages, _ =` → `messages =` |
| `test/test_oas_adapters.ml` | Same pattern |
| `test/test_oas_integration.ml` | Same pattern |

## Context

Follow-up to #5281 (context floor + fallback alignment). Deep scan found this dead code + estimation inconsistency.

## Test plan

- [ ] CI Build and Test
- [ ] CI Contract Harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)