### PR TITLE
fix(keeper): resolve tool_policy.toml path when base_path differs from project root

### DIFF
--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -110,14 +110,27 @@ let parse_presets
   ) names;
   tbl
 
+let project_root_from_executable () =
+  let exe = try Sys.executable_name with _ -> "" in
+  let rec walk_up dir =
+    if dir = "/" || dir = "." || dir = "" then None
+    else if Filename.basename dir = "_build" then Some (Filename.dirname dir)
+    else walk_up (Filename.dirname dir)
+  in
+  walk_up (Filename.dirname exe)
+
 let load ~base_path : (t, string) result =
   let rel = "config/tool_policy.toml" in
   let base_candidate = Filename.concat base_path rel in
   let cwd_candidate = Filename.concat (Sys.getcwd ()) rel in
-  (* Try base_path first, then cwd as fallback; skip cwd if identical to base_path *)
+  let exe_candidate = match project_root_from_executable () with
+    | Some root -> Some (Filename.concat root rel)
+    | None -> None
+  in
   let candidates =
-    if base_candidate = cwd_candidate then [ base_candidate ]
-    else [ base_candidate; cwd_candidate ]
+    [ base_candidate; cwd_candidate ]
+    @ (match exe_candidate with Some c -> [ c ] | None -> [])
+    |> List.sort_uniq String.compare
   in
   let rec try_candidates failures = function
     | [] ->


### PR DESCRIPTION
## Summary
- Add `project_root_from_executable()` to derive project root from `_build` directory in executable path
- Config load now tries 3 candidates: base_path, cwd, executable-derived project root

## Problem
When `MASC_BASE_PATH=/Users/dancer/me` (ME_ROOT), `init_policy_config` looks for `~/me/config/tool_policy.toml` which does not exist. The file is at `~/me/workspace/yousleepwhen/masc-mcp/config/tool_policy.toml`. Graceful fallback silently returns empty tool list, causing all keepers to have 0 allowed tools.

## Verification
- Dashboard keepers showed `allowed_tool_names: []` for all 12 keepers
- Server health confirmed `effective_base_path: /Users/dancer/me`
- Root cause: base_path != project root in production deployment

## Test plan
- [ ] `dune exec test/test_keeper_agent_isolation.exe` — 19 pass
- [ ] `dune exec test/test_keeper_tool_exposure.exe` — 47 pass
- [ ] Restart server, verify dashboard shows non-empty `allowed_tool_names`