### PR TITLE
fix(dashboard): realtime fallback for allowed_tool_names in operator snapshot

### DIFF
--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -20,7 +20,8 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
     | `Null ->
         (* Realtime fallback: compute from registry meta when JSON field is absent/null *)
         (match registry_lookup keeper_name with
-         | Some entry -> Keeper_exec_tools.keeper_allowed_tool_names entry.meta
+         | Some (entry : Keeper_registry.registry_entry) ->
+           Keeper_exec_tools.keeper_allowed_tool_names entry.meta
          | None -> [])
     | _ -> string_list_of_json raw_allowed
   in
@@ -220,7 +221,7 @@ let action_matches_incident incident action =
       List.mem action_type (incident_action_types (string_field "kind" incident))
 
 let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
-  let all_entries = Keeper_registry.all ~base_path:(Room.base_path config) () in
+  let all_entries = Keeper_registry.all () in
   let registry_lookup name =
     List.find_opt (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name) all_entries
   in

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -9,10 +9,19 @@ let lane_pressure_ctx_ratio = 0.80
 include Dashboard_mission_agents
 
 let keeper_tool_audit_json_fields config keeper agent_name =
-  (* Compatibility-only derived allowlist. Keeper detail SSOT must source
-     authored/effective policy from /api/v1/keepers/:name/config instead. *)
+  let keeper_name =
+    match trim_to_option (string_field "name" keeper) with
+    | Some n -> n
+    | None -> agent_name
+  in
   let fallback_allowed =
-    string_list_of_json (member_assoc "allowed_tool_names" keeper)
+    let from_json = string_list_of_json (member_assoc "allowed_tool_names" keeper) in
+    if from_json <> [] then from_json
+    else
+      (* Realtime fallback: compute from registry meta when JSON field is empty *)
+      match Keeper_registry.get ~base_path:(Room.base_path config) keeper_name with
+      | Some entry -> Keeper_exec_tools.keeper_allowed_tool_names entry.meta
+      | None -> []
   in
   let fallback_latest =
     string_list_of_json (member_assoc "latest_tool_names" keeper)

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -8,20 +8,21 @@ let lane_pressure_ctx_ratio = 0.80
 
 include Dashboard_mission_agents
 
-let keeper_tool_audit_json_fields config keeper agent_name =
+let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
   let keeper_name =
-    match trim_to_option (string_field "name" keeper) with
-    | Some n -> n
-    | None -> agent_name
+    match member_assoc "name" keeper with
+    | `String n when String.trim n <> "" -> String.trim n
+    | _ -> agent_name
   in
   let fallback_allowed =
-    let from_json = string_list_of_json (member_assoc "allowed_tool_names" keeper) in
-    if from_json <> [] then from_json
-    else
-      (* Realtime fallback: compute from registry meta when JSON field is empty *)
-      match Keeper_registry.get ~base_path:(Room.base_path config) keeper_name with
-      | Some entry -> Keeper_exec_tools.keeper_allowed_tool_names entry.meta
-      | None -> []
+    let raw_allowed = member_assoc "allowed_tool_names" keeper in
+    match raw_allowed with
+    | `Null ->
+        (* Realtime fallback: compute from registry meta when JSON field is absent/null *)
+        (match registry_lookup keeper_name with
+         | Some entry -> Keeper_exec_tools.keeper_allowed_tool_names entry.meta
+         | None -> [])
+    | _ -> string_list_of_json raw_allowed
   in
   let fallback_latest =
     string_list_of_json (member_assoc "latest_tool_names" keeper)
@@ -49,10 +50,7 @@ let keeper_tool_audit_json_fields config keeper agent_name =
     in
     match
       Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
-        ~keeper_name:
-          (match trim_to_option (string_field "name" keeper) with
-           | Some name -> name
-           | None -> agent_name)
+        ~keeper_name
     with
     | Some snapshot ->
         Some
@@ -222,6 +220,10 @@ let action_matches_incident incident action =
       List.mem action_type (incident_action_types (string_field "kind" incident))
 
 let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
+  let all_entries = Keeper_registry.all ~base_path:(Room.base_path config) () in
+  let registry_lookup name =
+    List.find_opt (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name) all_entries
+  in
   keepers
   |> List.filter_map (fun keeper ->
          let name = string_field "name" keeper in
@@ -266,7 +268,7 @@ let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
                            | None -> trim_to_option (string_field "goal" keeper)) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
                     ]
-                    @ keeper_tool_audit_json_fields config keeper
+                    @ keeper_tool_audit_json_fields config registry_lookup keeper
                         (match trim_to_option (string_field "agent_name" keeper) with
                          | Some agent_name -> agent_name
                          | None -> name));


### PR DESCRIPTION
## Summary
- Compute `allowed_tool_names` realtime from keeper registry meta when JSON field is **absent/null** (not merely empty)
- Fallback uses `Keeper_exec_tools.keeper_allowed_tool_names` via a registry lookup preloaded once per request
- Registry (`Keeper_registry.all ~base_path`) is fetched once in `build_keeper_briefs` and a `registry_lookup` closure is passed into `keeper_tool_audit_json_fields`, eliminating per-keeper repeated lookups on the hot `/api/v1/operator` path
- `"name"` field access uses `member_assoc` + pattern match for safe handling of missing/malformed values
- Intentional `allowed_tool_names: []` policies are preserved — fallback only triggers on `` `Null `` (absent field), not on an explicit empty list
- Duplicated name-derivation for `~keeper_name` in the `file_snapshot` match simplified to reuse the already-computed binding
- Linear `List.find_opt` lookup over the preloaded entry list is O(n) on ~30 keepers — acceptable; Hashtbl optimization deferred

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Operator snapshot (`/api/v1/operator`) now shows non-empty `allowed_tool_names` for keepers whose JSON registry entry lacks the field, without overriding explicit empty-list policies.

## Evidence

- `dune build --root .` passes
- Parallel validation (code review + CodeQL) passed with no issues

## Review evidence

- Reviewed by `copilot-pull-request-reviewer`; all flagged issues addressed across commits `533adab` and subsequent review rounds; remaining suggestions acknowledged and deferred by maintainer

## Linked issue