### PR TITLE
refactor: externalize relay token estimation constants to Governance_registry

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -209,6 +209,62 @@ let keeper_handoff_pressure_threshold =
     ~deserialize:deserialize_float
     ()
 
+(* ── relay_heuristic surface (Low risk) ───────────────────────── *)
+
+let relay_tokens_per_user_msg =
+  Runtime_params.register ~key:"relay.tokens_per_user_msg"
+    ~default:(fun () -> 150)
+    ~validate:(validate_int_range ~min:10 ~max:5000 "relay.tokens_per_user_msg")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_assistant_msg =
+  Runtime_params.register ~key:"relay.tokens_per_assistant_msg"
+    ~default:(fun () -> 500)
+    ~validate:(validate_int_range ~min:10 ~max:10000 "relay.tokens_per_assistant_msg")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_tool_call =
+  Runtime_params.register ~key:"relay.tokens_per_tool_call"
+    ~default:(fun () -> 200)
+    ~validate:(validate_int_range ~min:10 ~max:5000 "relay.tokens_per_tool_call")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_tool_result =
+  Runtime_params.register ~key:"relay.tokens_per_tool_result"
+    ~default:(fun () -> 300)
+    ~validate:(validate_int_range ~min:10 ~max:10000 "relay.tokens_per_tool_result")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_large_file_read =
+  Runtime_params.register ~key:"relay.cost_large_file_read"
+    ~default:(fun () -> 10_000)
+    ~validate:(validate_int_range ~min:1000 ~max:100_000 "relay.cost_large_file_read")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_per_file_edit =
+  Runtime_params.register ~key:"relay.cost_per_file_edit"
+    ~default:(fun () -> 3_000)
+    ~validate:(validate_int_range ~min:500 ~max:50_000 "relay.cost_per_file_edit")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_long_running =
+  Runtime_params.register ~key:"relay.cost_long_running"
+    ~default:(fun () -> 20_000)
+    ~validate:(validate_int_range ~min:1000 ~max:200_000 "relay.cost_long_running")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_exploration =
+  Runtime_params.register ~key:"relay.cost_exploration"
+    ~default:(fun () -> 15_000)
+    ~validate:(validate_int_range ~min:1000 ~max:100_000 "relay.cost_exploration")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_simple =
+  Runtime_params.register ~key:"relay.cost_simple"
+    ~default:(fun () -> 1_000)
+    ~validate:(validate_int_range ~min:100 ~max:10_000 "relay.cost_simple")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
 (* ── keeper_diagnostics surface (Medium risk) ─────────────────── *)
 
 let keeper_snapshot_sec =
@@ -337,6 +393,17 @@ let surfaces =
         "keeper.work_as_hb_max_silence_sec";
         "keeper.smart_hb_enabled";
         "keeper.stage_timing_ring_size";
+      ];
+    };
+    {
+      id = "relay_heuristic";
+      description = "Relay token estimation and task cost heuristics (not calibrated)";
+      risk = "low";
+      param_keys = [
+        "relay.tokens_per_user_msg"; "relay.tokens_per_assistant_msg";
+        "relay.tokens_per_tool_call"; "relay.tokens_per_tool_result";
+        "relay.cost_large_file_read"; "relay.cost_per_file_edit";
+        "relay.cost_long_running"; "relay.cost_exploration"; "relay.cost_simple";
       ];
     };
   ]

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -130,18 +130,19 @@ let resolve_max_context model =
     No formal benchmark has validated these specific numbers.
 
     TODO(RFC-0001 Phase 0): Replace with empirical calibration once
-    heuristic_metrics.jsonl collects actual token counts per message type. *)
-let tokens_per_user_msg = 150
-let tokens_per_assistant_msg = 500
-let tokens_per_tool_call = 200
-let tokens_per_tool_result = 300
+    heuristic_metrics.jsonl collects actual token counts per message type.
+    Governable via [Governance_registry.relay_tokens_per_*]. *)
+let tokens_per_user_msg () = Runtime_params.get Governance_registry.relay_tokens_per_user_msg
+let tokens_per_assistant_msg () = Runtime_params.get Governance_registry.relay_tokens_per_assistant_msg
+let tokens_per_tool_call () = Runtime_params.get Governance_registry.relay_tokens_per_tool_call
+let tokens_per_tool_result () = Runtime_params.get Governance_registry.relay_tokens_per_tool_result
 
 (** Estimate context usage.
     Token-per-message estimates are rough heuristics, corrected by calibration. *)
 let estimate_context ~messages ~tool_calls ~model =
 
-  let message_tokens = messages * (tokens_per_user_msg + tokens_per_assistant_msg) in
-  let tool_tokens = tool_calls * (tokens_per_tool_call + tokens_per_tool_result) in
+  let message_tokens = messages * (tokens_per_user_msg () + tokens_per_assistant_msg ()) in
+  let tool_tokens = tool_calls * (tokens_per_tool_call () + tokens_per_tool_result ()) in
   let estimated_raw = message_tokens + tool_tokens in
   let factor = calibration.correction_factor in
   let estimated = int_of_float (float_of_int estimated_raw *. factor) in
@@ -165,19 +166,14 @@ type task_hint =
   | Simple_task                  (* Quick task, no relay needed *)
 
 (** Task cost estimates (tokens). Same heuristic caveat as above —
-    these are order-of-magnitude guesses, not measured values. *)
-let cost_large_file_read = 10_000
-let cost_per_file_edit   = 3_000
-let cost_long_running    = 20_000
-let cost_exploration     = 15_000
-let cost_simple          = 1_000
-
+    these are order-of-magnitude guesses, not measured values.
+    Governable via [Governance_registry.relay_cost_*]. *)
 let estimate_task_cost = function
-  | Large_file_read _ -> cost_large_file_read
-  | Multi_file_edit n -> n * cost_per_file_edit
-  | Long_running_task -> cost_long_running
-  | Exploration_task -> cost_exploration
-  | Simple_task -> cost_simple
+  | Large_file_read _ -> Runtime_params.get Governance_registry.relay_cost_large_file_read
+  | Multi_file_edit n -> n * Runtime_params.get Governance_registry.relay_cost_per_file_edit
+  | Long_running_task -> Runtime_params.get Governance_registry.relay_cost_long_running
+  | Exploration_task -> Runtime_params.get Governance_registry.relay_cost_exploration
+  | Simple_task -> Runtime_params.get Governance_registry.relay_cost_simple
 
 (** Proactive relay decision - key insight: predict before hitting limit *)
 let should_relay_proactive ~config ~metrics ~task_hint =

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -144,8 +144,8 @@ let test_estimate_context_honors_token_override () =
        | Ok () -> ()
        | Error msg -> failwith msg);
       let overridden = Relay.estimate_context ~messages:1 ~tool_calls:0 ~model:"claude" in
-      check bool "override changes estimated_tokens"
-        true (overridden.estimated_tokens <> default_metrics.estimated_tokens));
+      check bool "override increases estimated_tokens"
+        true (overridden.estimated_tokens > default_metrics.estimated_tokens));
   let cleared = Relay.estimate_context ~messages:1 ~tool_calls:0 ~model:"claude" in
   check int "clear reverts estimated_tokens"
     default_metrics.estimated_tokens cleared.estimated_tokens

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -11,6 +11,8 @@
 open Alcotest
 
 module Relay = Masc_mcp.Relay
+module Runtime_params = Masc_mcp.Runtime_params
+module Governance_registry = Masc_mcp.Governance_registry
 
 (* ============================================================
    relay_config Tests
@@ -126,6 +128,41 @@ let test_task_cost_exploration () =
 let test_task_cost_simple () =
   let cost = Relay.estimate_task_cost Relay.Simple_task in
   check int "simple cost" 1000 cost
+
+(* ============================================================
+   Runtime_params override Tests (estimate_context / estimate_task_cost)
+   ============================================================ *)
+
+let test_estimate_context_honors_token_override () =
+  let default_metrics = Relay.estimate_context ~messages:1 ~tool_calls:0 ~model:"claude" in
+  let default_tpu = Runtime_params.get Governance_registry.relay_tokens_per_user_msg in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime_params.clear Governance_registry.relay_tokens_per_user_msg)
+    (fun () ->
+      (match Runtime_params.set Governance_registry.relay_tokens_per_user_msg (default_tpu + 17) with
+       | Ok () -> ()
+       | Error msg -> failwith msg);
+      let overridden = Relay.estimate_context ~messages:1 ~tool_calls:0 ~model:"claude" in
+      check bool "override changes estimated_tokens"
+        true (overridden.estimated_tokens <> default_metrics.estimated_tokens));
+  let cleared = Relay.estimate_context ~messages:1 ~tool_calls:0 ~model:"claude" in
+  check int "clear reverts estimated_tokens"
+    default_metrics.estimated_tokens cleared.estimated_tokens
+
+let test_estimate_task_cost_honors_simple_override () =
+  let default_cost = Relay.estimate_task_cost Relay.Simple_task in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime_params.clear Governance_registry.relay_cost_simple)
+    (fun () ->
+      (match Runtime_params.set Governance_registry.relay_cost_simple (default_cost + 123) with
+       | Ok () -> ()
+       | Error msg -> failwith msg);
+      check int "override changes cost"
+        (default_cost + 123) (Relay.estimate_task_cost Relay.Simple_task));
+  check int "clear reverts cost"
+    default_cost (Relay.estimate_task_cost Relay.Simple_task)
 
 (* ============================================================
    should_relay (Reactive) Tests
@@ -886,6 +923,10 @@ let () =
       test_case "long running" `Quick test_task_cost_long_running;
       test_case "exploration" `Quick test_task_cost_exploration;
       test_case "simple" `Quick test_task_cost_simple;
+    ];
+    "relay_params_override", [
+      test_case "estimate_context token override" `Quick test_estimate_context_honors_token_override;
+      test_case "estimate_task_cost simple override" `Quick test_estimate_task_cost_honors_simple_override;
     ];
     "should_relay.reactive", [
       test_case "below threshold" `Quick test_should_relay_below_threshold;


### PR DESCRIPTION
## Summary
- relay.ml의 9개 토큰 추정/task cost 상수를 `Governance_registry`로 이동
- alert keyword weights는 RFC-0001 Phase 3 TODO로 유지 (구조체 직렬화 복잡)
- `test_relay_coverage.ml`에 Runtime_params 오버라이드 검증 테스트 추가 (`relay_params_override` suite)

## Constants Externalized
| 상수 | 기본값 | 비고 |
|------|--------|------|
| `tokens_per_user_msg` | 150 | NOT calibrated |
| `tokens_per_assistant_msg` | 500 | NOT calibrated |
| `tokens_per_tool_call` | 200 | NOT calibrated |
| `tokens_per_tool_result` | 300 | NOT calibrated |
| `cost_large_file_read` | 10000 | task hint |
| `cost_per_file_edit` | 3000 | per file |
| `cost_long_running` | 20000 | task hint |
| `cost_exploration` | 15000 | task hint |
| `cost_simple` | 1000 | task hint |

## Product impact

- Promise affected: `none/internal`
- User-visible change: none — internal governance wiring only

## Evidence

- `test_estimate_context_honors_token_override`: `relay_tokens_per_user_msg`를 default+17로 오버라이드 후 `estimate_context` 반환값이 증가하고, clear 후 원래 값으로 복원됨을 검증
- `test_estimate_task_cost_honors_simple_override`: `relay_cost_simple`을 default+123으로 오버라이드 후 `estimate_task_cost Simple_task`가 정확한 오버라이드 값을 반환하고, clear 후 기본값으로 복원됨을 검증
- 두 테스트 모두 `Fun.protect ~finally:Runtime_params.clear`로 실패 시에도 파라미터 상태 누출 방지

## Review evidence

- Copilot code review 반영: `estimate_context` 어설션을 `<>`에서 `>`(방향성 검증)으로 강화 — calibration correction_factor 적용 시 정수 반올림으로 인한 정확한 델타 계산이 비결정적이므로

## Linked issue