### PR TITLE
revert: remove resolve_max_cascade_context (unintended cloud cascade)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -215,17 +215,17 @@ let write_heartbeat_snapshot
   let cascade_models =
     Oas_model_resolve.models_of_cascade_name meta_current.cascade_name
   in
-  let max_cascade_context =
+  let primary_max_context =
     match meta_current.max_context_override with
     | Some v -> v
-    | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+    | None -> Oas_model_resolve.resolve_primary_max_context cascade_models
   in
   let base_dir = session_base_dir ctx.config in
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));
   let _session, ctx_opt =
     load_context_from_checkpoint
       ~trace_id:meta_current.runtime.trace_id
-      ~primary_model_max_tokens:max_cascade_context
+      ~primary_model_max_tokens:primary_max_context
       ~base_dir
   in
   match ctx_opt with

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -37,7 +37,7 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = Oas_model_resolve.models_of_cascade_name m.cascade_name in
-      let primary_max_context = Oas_model_resolve.resolve_max_cascade_context models in
+      let primary_max_context = Oas_model_resolve.resolve_primary_max_context models in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -174,12 +174,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
        | Ok () ->
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Oas_model_resolve.refresh_local_discovery_if_possible effective_models);
-         let max_cascade_context =
+         let primary_max_context =
            match meta.max_context_override with
            | Some v ->
                Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
                v
-           | None -> Oas_model_resolve.resolve_max_cascade_context effective_models
+           | None -> Oas_model_resolve.resolve_primary_max_context effective_models
          in
             let base_dir = session_base_dir ctx.config in
             let effective_no_skill_route = no_skill_route || direct_reply in
@@ -283,7 +283,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               Keeper_exec_context.timed (fun () ->
                   Keeper_agent_run.run_turn
                     ~config:ctx.config ~meta ~base_dir
-                    ~max_context:max_cascade_context
+                    ~max_context:primary_max_context
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:turn_cascade_name
@@ -310,7 +310,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 Keeper_exec_context.apply_post_turn_lifecycle ~base_dir
                   ~meta
                   ~model:result.model_used
-                  ~primary_model_max_tokens:max_cascade_context
+                  ~primary_model_max_tokens:primary_max_context
                   ~checkpoint:result.checkpoint
               in
               (* RFC-0002: dispatch buffer state events after lifecycle *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -184,7 +184,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let primary_max_context =
       match p.max_context_override_opt with
       | Some v -> v
-      | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+      | None -> Oas_model_resolve.resolve_primary_max_context cascade_models
     in
     Progress.Tracker.step tracker ~message:"Initializing session directory" ();
     let trace_id = generate_trace_id () in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -164,7 +164,7 @@ let overflow_retry_history_budget
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)
-    ~(max_cascade_context : int)
+    ~(primary_max_context : int)
     ~(system_prompt : string)
     ~(user_message : string)
     ~(error : string) : overflow_retry_plan option =
@@ -172,8 +172,8 @@ let recover_context_overflow_retry
   | None -> None
   | Some actual_limit ->
       let retry_max_context =
-        if max_cascade_context <= 0 then actual_limit
-        else min max_cascade_context actual_limit
+        if primary_max_context <= 0 then actual_limit
+        else min primary_max_context actual_limit
       in
       let retry_history_budget =
         overflow_retry_history_budget ~available_context:retry_max_context
@@ -823,12 +823,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   | Error e -> Error e
   | Ok () ->
       ignore (Oas_model_resolve.refresh_local_discovery_if_possible model_labels);
-      let max_cascade_context =
+      let primary_max_context =
         match meta.max_context_override with
         | Some v ->
             Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
             v
-        | None -> Oas_model_resolve.resolve_max_cascade_context model_labels
+        | None -> Oas_model_resolve.resolve_primary_max_context model_labels
       in
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
@@ -898,7 +898,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                            && should_attempt_context_overflow_retry e -> (
                 match
                   recover_context_overflow_retry ~meta ~base_dir
-                    ~max_cascade_context ~system_prompt ~user_message ~error:e
+                    ~primary_max_context ~system_prompt ~user_message ~error:e
                 with
                 | Some retry_plan ->
                     let retry_meta =
@@ -918,7 +918,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 | None -> Error e)
             | Error e -> Error e
           in
-          retry_loop ~run_meta:meta ~max_context:max_cascade_context
+          retry_loop ~run_meta:meta ~max_context:primary_max_context
             ~run_generation:generation ~attempt:1
             ~is_retry:false ~overflow_retry_used:false)
       in
@@ -926,7 +926,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       | Error e ->
           Log.Keeper.error
             "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms error=%s"
-            meta.name meta.cascade_name max_cascade_context latency_ms
+            meta.name meta.cascade_name primary_max_context latency_ms
             (short_preview e);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e
@@ -1003,7 +1003,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             apply_post_turn_lifecycle ~base_dir
               ~meta
               ~model:result.model_used
-              ~primary_model_max_tokens:max_cascade_context
+              ~primary_model_max_tokens:primary_max_context
               ~checkpoint:result.checkpoint
           in
           (* RFC-0002: dispatch buffer state events after lifecycle *)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -262,7 +262,7 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
   try
     let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
     let primary_max_context =
-      Oas_model_resolve.resolve_max_cascade_context cascade_models
+      Oas_model_resolve.resolve_primary_max_context cascade_models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
@@ -282,7 +282,7 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
   try
     let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
     let primary_max_context =
-      Oas_model_resolve.resolve_max_cascade_context cascade_models
+      Oas_model_resolve.resolve_primary_max_context cascade_models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -98,46 +98,29 @@ let max_context_of_label (label : string) : int =
   | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
   | None -> static_ctx
 
-(** Resolve context for a label if its provider is available; returns [None]
-    if the provider is unknown, unavailable, or the label is malformed.
-    Applies {!context_floor} to discovered values. *)
-let context_if_available (label : string) : int option =
-  match provider_name_of_label label with
-  | None -> None
-  | Some pname ->
-    match Llm_provider.Provider_registry.find default_registry pname with
-    | None -> None
-    | Some entry ->
-      if entry.is_available () then
-        let static_ctx = entry.max_context in
-        let ctx =
-          match Llm_provider.Cascade_config.resolve_label_context label with
-          | Some discovered -> effective_discovered_ctx ~static_ctx ~discovered:(Some discovered)
-          | None -> static_ctx
-        in
-        Some ctx
-      else None
-
 (** Resolve max_context for the first available model in a label list.
     "Available" means the provider's API key env var is set (or not required).
     Per-label context resolved by OAS — no routing guess in MASC.
     Applies {!context_floor} to discovered values.
     Falls back to 128_000 if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
-  match List.find_map context_if_available labels with
-  | Some ctx -> ctx
-  | None -> 128_000
-
-(** Maximum context across all available models in a label list.
-    Returns the largest context window that any model in the cascade can
-    handle.  This is the value MASC should use for [max_input_tokens]:
-    OAS cascade will try providers in order — if the primary overflows,
-    the cascade fails over to the next provider that can handle the
-    prompt size.  Falls back to [128_000] if no model is available. *)
-let resolve_max_cascade_context (labels : string list) : int =
-  match List.filter_map context_if_available labels with
-  | [] -> 128_000
-  | ctxs -> List.fold_left max 0 ctxs
+  let rec find = function
+    | [] -> 128_000
+    | label :: rest ->
+      match provider_name_of_label label with
+      | None -> find rest
+      | Some pname ->
+        match Llm_provider.Provider_registry.find default_registry pname with
+        | None -> find rest
+        | Some entry ->
+          if entry.is_available () then
+            let static_ctx = entry.max_context in
+            match Llm_provider.Cascade_config.resolve_label_context label with
+            | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
+            | None -> static_ctx
+          else find rest
+  in
+  find labels
 
 (** Resolve model_id for the first available model in a label list.
     Returns the model_id portion of "provider:model_id".

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -114,22 +114,6 @@ let test_effective_discovered_ctx () =
   check int "none uses static" 128_000
     (edc ~static_ctx:128_000 ~discovered:None)
 
-let test_resolve_max_cascade_context () =
-  (* Empty list → 128_000 fallback *)
-  check int "empty labels fallback 128000" 128_000
-    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context []);
-  (* Unknown provider → fallback *)
-  check int "unknown provider fallback 128000" 128_000
-    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context
-       [ "nonexistent:model" ]);
-  (* Malformed label (no colon) → fallback *)
-  check int "malformed label fallback 128000" 128_000
-    (Masc_mcp.Oas_model_resolve.resolve_max_cascade_context [ "nocolonlabel" ]);
-  (* Known provider with available key returns max context > 0 *)
-  let ctx = Masc_mcp.Oas_model_resolve.resolve_max_cascade_context
-      [ "claude:claude-sonnet-4-6" ] in
-  check bool "known provider returns positive context" true (ctx > 0)
-
 let test_labels_require_local_discovery () =
   check bool "llama labels refresh local discovery" true
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
@@ -237,8 +221,6 @@ let () =
             test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
-          test_case "resolve max cascade context" `Quick
-            test_resolve_max_cascade_context;
         ] );
       ( "dashboard_schema",
         [


### PR DESCRIPTION
## Summary
Reverts #5305. `resolve_max_cascade_context`가 cloud provider context(200K)까지 포함하여 max를 계산하면서, 의도하지 않은 cloud cascade 발생 가능성이 생겼다. `resolve_primary_max_context`로 복원.

인프라 fix(llama-server `-c 262144`)로 per_slot context를 올리면 primary가 올바른 값을 반환하므로 max cascade가 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)