### PR TITLE
refactor: deprecate unused functions from keeper_exec_context public API

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -40,7 +40,6 @@ let serialize_context = Keeper_context_core.serialize_context
 let deserialize_context = Keeper_context_core.deserialize_context
 let context_to_json = Keeper_context_core.context_to_json
 let create_checkpoint = Keeper_context_core.create_checkpoint
-let restore_checkpoint = Keeper_context_core.restore_checkpoint
 let create_session = Keeper_context_core.create_session
 let persist_message = Keeper_context_core.persist_message
 
@@ -50,15 +49,12 @@ let usage_of_response = Keeper_context_core.usage_of_response
 let total_tokens = Keeper_context_core.total_tokens
 
 let save_session_checkpoint = Keeper_context_core.save_session_checkpoint
-let load_latest_checkpoint = Keeper_context_core.load_latest_checkpoint
 
 let log_keeper_exn = Keeper_context_core.log_keeper_exn
 let checkpoint_max_tokens = Keeper_context_core.checkpoint_max_tokens
 let context_of_oas_checkpoint = Keeper_context_core.context_of_oas_checkpoint
-let context_of_legacy_checkpoint = Keeper_context_core.context_of_legacy_checkpoint
 let checkpoint_model_of_meta = Keeper_context_core.checkpoint_model_of_meta
 let save_oas_checkpoint = Keeper_context_core.save_oas_checkpoint
-let checkpoint_generation = Keeper_context_core.checkpoint_generation
 let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpoint
 let save_checkpoint = Keeper_context_core.save_checkpoint
 

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -58,6 +58,11 @@ let save_oas_checkpoint = Keeper_context_core.save_oas_checkpoint
 let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpoint
 let save_checkpoint = Keeper_context_core.save_checkpoint
 
+let restore_checkpoint = Keeper_context_core.restore_checkpoint
+let load_latest_checkpoint = Keeper_context_core.load_latest_checkpoint
+let context_of_legacy_checkpoint = Keeper_context_core.context_of_legacy_checkpoint
+let checkpoint_generation = Keeper_context_core.checkpoint_generation
+
 (* ================================================================ *)
 (* Re-export from Keeper_rollover                                    *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -7,7 +7,6 @@
     are provided directly by this module. *)
 
 open Keeper_types
-open Keeper_memory
 
 (** {1 Working Context Types (re-exported from Keeper_types)} *)
 
@@ -38,7 +37,6 @@ val serialize_context : working_context -> string
 val deserialize_context : string -> max_tokens:int -> working_context
 val context_to_json : working_context -> Yojson.Safe.t
 val create_checkpoint : working_context -> generation:int -> checkpoint
-val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
 val create_session : session_id:string -> base_dir:string -> session_context
 val persist_message : ?source:string -> session_context -> Agent_sdk.Types.message -> unit
 
@@ -52,7 +50,6 @@ val total_tokens : Agent_sdk.Types.api_usage -> int
 (** {1 Checkpoint Store Delegation} *)
 
 val save_session_checkpoint : session_context -> checkpoint -> unit
-val load_latest_checkpoint : session_context -> checkpoint option
 
 (** {1 Keeper Context Lifecycle} *)
 
@@ -64,9 +61,6 @@ val checkpoint_max_tokens :
 val context_of_oas_checkpoint :
   Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
 
-val context_of_legacy_checkpoint :
-  checkpoint -> primary_model_max_tokens:int -> working_context
-
 val checkpoint_model_of_meta : keeper_meta -> string
 
 val save_oas_checkpoint :
@@ -76,9 +70,6 @@ val save_oas_checkpoint :
   ctx:working_context ->
   generation:int ->
   Agent_sdk.Checkpoint.t
-
-val checkpoint_generation :
-  Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 (** {1 Handoff Rollover} *)
 
@@ -214,18 +205,10 @@ val append_trait_clause : base:string -> clause:string -> string
 
 val strip_state_blocks_text : string -> string
 val trim_to_option : string -> string option
-val state_snapshot_reply_fallback : keeper_state_snapshot option -> string option
-val strip_internal_reply_markup : string -> string
 val user_visible_reply_text : ?fallback:string -> string -> string
-val normalize_proactive_text : string -> string
-val extract_checkin_text : string -> string option
 
 (** {1 Fragment Detection (used by dashboard)} *)
 
-val proactive_has_terminal_punct : string -> bool
-val proactive_has_terminal_korean_ending : string -> bool
-val proactive_has_terminal_ending : string -> bool
-val proactive_looks_fragmentary : string -> bool
 val looks_fragmentary_history_text : string -> bool
 
 (** {1 Memory Check} *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -128,6 +128,21 @@ val load_context_from_checkpoint :
 val save_checkpoint :
   session_context -> working_context -> generation:int -> checkpoint
 
+(** {1 Deprecated Checkpoint Helpers} *)
+
+val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
+[@@deprecated "Use Keeper_context_core.restore_checkpoint directly; this re-export will be removed in a future release."]
+
+val load_latest_checkpoint : session_context -> checkpoint option
+[@@deprecated "Use Keeper_context_core.load_latest_checkpoint directly; this re-export will be removed in a future release."]
+
+val context_of_legacy_checkpoint :
+  checkpoint -> primary_model_max_tokens:int -> working_context
+[@@deprecated "Use Keeper_context_core.context_of_legacy_checkpoint directly; this re-export will be removed in a future release."]
+
+val checkpoint_generation : Agent_sdk.Checkpoint.t -> fallback:int -> int
+[@@deprecated "Use Keeper_context_core.checkpoint_generation directly; this re-export will be removed in a future release."]
+
 (** {1 Compaction} *)
 
 val compaction_policy_of_keeper : keeper_meta -> float * int * int
@@ -206,6 +221,35 @@ val append_trait_clause : base:string -> clause:string -> string
 val strip_state_blocks_text : string -> string
 val trim_to_option : string -> string option
 val user_visible_reply_text : ?fallback:string -> string -> string
+
+(** {1 Deprecated Text Processing Helpers} *)
+
+val state_snapshot_reply_fallback :
+  Keeper_memory_policy.keeper_state_snapshot option -> string option
+[@@deprecated "Use Keeper_text_processing.state_snapshot_reply_fallback directly; this re-export will be removed in a future release."]
+
+val strip_internal_reply_markup : string -> string
+[@@deprecated "Use Keeper_text_processing.strip_internal_reply_markup directly; this re-export will be removed in a future release."]
+
+val normalize_proactive_text : string -> string
+[@@deprecated "Use Keeper_text_processing.normalize_proactive_text directly; this re-export will be removed in a future release."]
+
+val extract_checkin_text : string -> string option
+[@@deprecated "Use Keeper_text_processing.extract_checkin_text directly; this re-export will be removed in a future release."]
+
+(** {1 Deprecated Proactive Terminal-Ending Detection} *)
+
+val proactive_has_terminal_punct : string -> bool
+[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_punct directly; this re-export will be removed in a future release."]
+
+val proactive_has_terminal_korean_ending : string -> bool
+[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_korean_ending directly; this re-export will be removed in a future release."]
+
+val proactive_has_terminal_ending : string -> bool
+[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_ending directly; this re-export will be removed in a future release."]
+
+val proactive_looks_fragmentary : string -> bool
+[@@deprecated "Use Keeper_text_processing.proactive_looks_fragmentary directly; this re-export will be removed in a future release."]
 
 (** {1 Fragment Detection (used by dashboard)} *)
 


### PR DESCRIPTION
## Summary
- Deprecate 4 checkpoint functions (`restore_checkpoint`, `load_latest_checkpoint`, `context_of_legacy_checkpoint`, `checkpoint_generation`) in the public API with `[@@deprecated]` attributes pointing to `Keeper_context_core`
- Deprecate 8 text-processing functions (`normalize_proactive_text`, `extract_checkin_text`, `state_snapshot_reply_fallback`, `strip_internal_reply_markup`, and 4 `proactive_*` terminal-ending detection functions) with `[@@deprecated]` attributes pointing to `Keeper_text_processing`
- Functions remain callable during the deprecation period; implementations stay in sub-modules for internal use
- Re-exports for the 4 checkpoint functions added back to `keeper_exec_context.ml`; text-processing functions already exposed via `include Keeper_text_processing`
- 2 files changed

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — internal OCaml module surface change only; deprecated functions remain callable

## Evidence

- Code review validation passed with no issues

## Review evidence

- Automated code review: no comments
- CodeQL security scan: no findings

## Linked issue