### PR TITLE
fix: enforce OAS boundary facade + shutdown Cancelled re-raise

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -39,6 +39,17 @@ let text_of_message = Agent_sdk.Types.text_of_message
 let ensure_dir path =
   ignore (Keeper_fs.ensure_dir path)
 
+(** {1 Token Estimation Facade}
+
+    All OAS Context_reducer calls in MASC pass through this module.
+    Other keeper modules must NOT call Agent_sdk.Context_reducer directly
+    for their own decision-making. *)
+
+(** Estimate token count for a raw string (CJK-aware).
+    Single entry point for char-based estimation in MASC. *)
+let estimate_char_tokens (s : string) : int =
+  Agent_sdk.Context_reducer.estimate_char_tokens s
+
 (** CJK-aware token estimate delegated to OAS Context_reducer. *)
 let msg_tokens (m : Agent_sdk.Types.message) : int =
   let estimated = Agent_sdk.Context_reducer.estimate_message_tokens m in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -114,14 +114,13 @@ let handle_keeper_status ctx args : tool_result =
            | None -> None
            | Some cfg ->
              let pricing = Llm_provider.Pricing.pricing_for_model cfg.model_id in
-             (* Extract provider name from label directly to avoid
-                OpenAI_compat conflating llama/openrouter *)
+             (* Extract provider name from cascade label prefix.
+                Keeper must not reference OAS provider_kind directly. *)
              let provider_name =
                match String.index_opt label ':' with
                | Some idx when idx > 0 ->
                  String.sub label 0 idx |> String.trim |> String.lowercase_ascii
-               | _ ->
-                 Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+               | _ -> "unknown"
              in
              Some (`Assoc [
                ("provider", `String provider_name);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -146,8 +146,10 @@ let overflow_retry_history_budget
     ~(user_message : string) : int =
   let prompt_tokens =
     let estimated =
-      Agent_sdk.Context_reducer.estimate_char_tokens system_prompt
-      + Agent_sdk.Context_reducer.estimate_char_tokens user_message
+      (* Route through Keeper_context_core facade — MASC must not call
+         Agent_sdk.Context_reducer directly for its own decisions. *)
+      Keeper_context_core.estimate_char_tokens system_prompt
+      + Keeper_context_core.estimate_char_tokens user_message
     in
     (* Use 20% safety buffer for prompt estimation errors (#5053).
        Ceiling-based to avoid truncation erasing the buffer. *)

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -40,12 +40,15 @@ let run_all () =
     (Server_mcp_transport_ws.session_count ());
   (* Flush metric/stress buffers to prevent data loss *)
   (try Heuristic_metrics.flush ()
-   with _ -> Log.Server.warn "[Shutdown] heuristic_metrics flush failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] heuristic_metrics flush failed");
   (try Agent_stress.flush ()
-   with _ -> Log.Server.warn "[Shutdown] agent_stress flush failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] agent_stress flush failed");
   (* Clear transient A2A state to free memory *)
   (try A2a_tools.clear_transient_state ()
-   with _ -> Log.Server.warn "[Shutdown] a2a_tools clear failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] a2a_tools clear failed");
   (* Clear session identity caches *)
   Agent_registry_eio.clear_session_caches ();
   Log.Server.info "[Shutdown] hooks total: %.2fs"


### PR DESCRIPTION
## Summary
경계 수정 + 안전성 수정 4건:

### 1. OAS 토큰 추정 퍼사드 (`keeper_context_core.ml`)
- `estimate_char_tokens` 퍼사드 함수 추가
- MASC keeper 모듈이 OAS `Context_reducer.estimate_*`를 직접 호출하지 않도록 단일 진입점 강제

### 2. 경계 침범 수정 (`keeper_unified_turn.ml`)
- `Agent_sdk.Context_reducer.estimate_char_tokens` 직접 호출 → `Keeper_context_core.estimate_char_tokens` 경유

### 3. Provider 경계 수정 (`keeper_status_detail.ml`)
- `Llm_provider.Provider_config.string_of_provider_kind` 참조 제거
- Keeper는 OAS provider_kind 타입을 모름. Cascade label prefix가 SSOT.

### 4. shutdown_hooks Cancelled 수정
- `with _ ->` 3곳에서 `Eio.Cancel.Cancelled` re-raise 추가
- 구조적 동시성 취소 신호가 삼켜지는 회귀 수정

## Verification
- `rg 'string_of_provider_kind' lib/keeper/` = 0 hits
- `rg 'Agent_sdk.Context_reducer.estimate' lib/keeper/` = `keeper_context_core.ml`만
- [x] `dune build --root .` 통과

Partial fix for #5045, closes #5311

🤖 Generated with [Claude Code](https://claude.com/claude-code)