### PR TITLE
fix(security): remove auth_token SSE leak + re-raise Eio.Cancel in shutdown

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -637,7 +637,6 @@ let emit_heartbeat_task
     ?(session_id : string option)
     ?(decision_reason : string option)
     ?(decision_confidence : float option)
-    ?(auth_token : string option)
     () : unit =
   Eio.Mutex.use_rw ~protect:true heartbeat_mutex (fun () ->
     let m = SMap.add agent
@@ -673,9 +672,7 @@ let emit_heartbeat_task
   @ (match decision_confidence with
     | Some confidence -> [("decision_confidence", `Float confidence)]
     | None -> [])
-  @ (match auth_token with
-    | Some token -> [("auth_token", `String token)]
-    | None -> []))
+  )
   in
   notify_event ~event_type:HeartbeatTask ~agent ~data;
   Log.info ~ctx:"heartbeat"

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -40,12 +40,15 @@ let run_all () =
     (Server_mcp_transport_ws.session_count ());
   (* Flush metric/stress buffers to prevent data loss *)
   (try Heuristic_metrics.flush ()
-   with _ -> Log.Server.warn "[Shutdown] heuristic_metrics flush failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] heuristic_metrics flush failed");
   (try Agent_stress.flush ()
-   with _ -> Log.Server.warn "[Shutdown] agent_stress flush failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] agent_stress flush failed");
   (* Clear transient A2A state to free memory *)
   (try A2a_tools.clear_transient_state ()
-   with _ -> Log.Server.warn "[Shutdown] a2a_tools clear failed");
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> Log.Server.warn "[Shutdown] a2a_tools clear failed");
   (* Clear session identity caches *)
   Agent_registry_eio.clear_session_caches ();
   Log.Server.info "[Shutdown] hooks total: %.2fs"


### PR DESCRIPTION
## Summary

- **#5310 (security)**: `emit_heartbeat_task`에서 `auth_token`을 SSE broadcast payload에 포함하고 있었음. 모든 SSE 구독자(대시보드 포함)에게 토큰 유출. `~auth_token` 파라미터 자체를 제거 (caller에서 전달하는 곳 0건 확인).
- **#5311 (regression)**: `shutdown_hooks.ml`의 bare `with _ ->`가 `Eio.Cancel.Cancelled`를 삼켜 structured cancellation이 깨짐. PR #5286 리베이스 과정에서 회귀. 3곳 모두 `Eio.Cancel.Cancelled _ as e -> raise e` 패턴으로 수정.

## Related

- Closes #5310
- Closes #5311
- Follow-up: #5335 (나머지 ~12곳 `with _ ->` I/O sweep)

## Test plan

- [x] `dune build` — 컴파일 성공
- [x] `test_dashboard_mission.exe` — 7/7 통과 (emit_heartbeat_task 사용 테스트)
- [ ] CI green 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)