### PR TITLE
refactor: re-raise Eio.Cancel.Cancelled in 6 bare with-wildcard I/O sites

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -314,7 +314,8 @@ let use_with_retry pool f =
     Log.Backend.warn "[EioPG] stale connection detected, draining pool and retrying: %s"
       (Caqti_error.show err);
     Eio.Mutex.use_rw ~protect:false _drain_mutex (fun () ->
-      try Caqti_eio.Pool.drain pool with _ -> ());
+      try Caqti_eio.Pool.drain pool
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
     Caqti_eio.Pool.use f pool
   | Error _ as err -> err
 

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -68,7 +68,8 @@ let set_board_sse_hook hook =
 
 let emit_board_sse_event event =
   match Atomic.get board_sse_hook with
-  | Some hook -> (try hook event with _ -> ())
+  | Some hook -> (try hook event
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
   | None -> ()
 
 let is_initialized () =

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -323,7 +323,8 @@ module Reflection_bridge = struct
       let process_loop () =
         Eio.Switch.run @@ fun loop_sw ->
         Eio.Switch.on_release loop_sw (fun () ->
-            (try Grpc_eio.Stream.close response_stream with _ -> ()));
+            (try Grpc_eio.Stream.close response_stream
+             with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()));
             let rec loop () =
               let request_bytes = Grpc_eio.Stream.take request_stream in
               let services = Grpc_eio.Server.list_services !server_ref in

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -48,7 +48,8 @@ let make_closing_client ~sw ~net ~https =
     | None -> ()
     | Some sock ->
         last_sock := None;
-        (try Eio.Net.close sock with _ -> ()));
+        (try Eio.Net.close sock
+         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()));
   client
 
 (** POST with structured error handling.

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -53,7 +53,8 @@ let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn 
 
 let notify_error config exn =
   match config.on_error with
-  | Some f -> (try f exn with _ -> ())
+  | Some f -> (try f exn
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
   | None -> ()
 
 let start ~sw ~clock ~config ~compute ~on_result =
@@ -93,7 +94,8 @@ let start ~sw ~clock ~config ~compute ~on_result =
       Eio.Time.sleep clock (!current_interval +. jitter);
       let health_ok = match config.health_check with
         | None -> true
-        | Some check -> (try check () with _ -> false)
+        | Some check -> (try check ()
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false)
       in
       if not health_ok then begin
         incr consecutive_failures;


### PR DESCRIPTION
## Summary

`with _ ->` 패턴 중 Eio I/O/callback context에서 `Eio.Cancel.Cancelled`를 삼킬 수 있는 6곳을 수정.

### 수정 대상 (6곳, 5파일)

| 파일 | 컨텍스트 |
|------|----------|
| `backend_pg.ml:317` | Caqti pool drain (stale connection retry) |
| `masc_grpc_server.ml:326` | gRPC response stream close (Switch.on_release) |
| `masc_http_client.ml:51` | Socket close (Switch.on_release) |
| `board_dispatch.ml:71` | SSE hook callback dispatch |
| `proactive_refresh.ml:56` | on_error callback |
| `proactive_refresh.ml:96` | health_check probe |

### 제외 대상 (무해)

- `masc_grpc_service.ml:243,258` — 순수 JSON 파싱, Eio context 없음
- `server_startup_takeover.ml` — startup 전 Unix I/O, `at_exit` 콜백

### 패턴

```ocaml
(* before *)
try f () with _ -> default

(* after *)
try f ()
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> default
```

## Related

- Closes #5335
- Depends on: #5336 (shutdown_hooks.ml 수정)

## Test plan

- [x] `dune build` — 컴파일 성공
- [ ] CI green 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)