### PR TITLE
feat(keeper): allow git clone for allowed GitHub orgs

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -58,6 +58,13 @@ tools = ["masc_status", "masc_heartbeat", "masc_tasks", "masc_claim_next", "masc
 [masc.coding]
 tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktree_create", "masc_worktree_remove", "masc_worktree_list"]
 
+# ── Git Clone Policy ────────────────────────────────────────────────
+# GitHub org names allowed for masc_code_git clone action.
+# URLs not matching any org here are rejected.
+
+[git_clone]
+allowed_orgs = ["jeong-sik"]
+
 # ── Presets ─────────────────────────────────────────────────────────
 
 [presets.minimal]

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -4,6 +4,7 @@
     - All write operations restricted to .worktrees/ directories
     - Shell commands restricted to allowlist
     - Git push to main/master blocked
+    - Git clone restricted to allowed GitHub orgs (config/tool_policy.toml)
     - File size limit: 1MB for writes
     - Binary file extension check inherited from Tool_code
 
@@ -54,6 +55,7 @@ let allowed_shell_commands = [
 let allowed_git_actions = [
   "add"; "commit"; "push"; "diff"; "status";
   "log"; "branch"; "checkout"; "stash"; "fetch";
+  "clone";
 ]
 
 let max_output_bytes = 10 * 1024 (* 10KB output limit *)
@@ -62,6 +64,84 @@ let truncate_output s =
   if String.length s > max_output_bytes then
     String.sub s 0 max_output_bytes ^ "\n... (truncated)"
   else s
+
+(* ── Git clone org allowlist ─────────────────────────────────────── *)
+
+(* Cached clone allowed orgs loaded from config/tool_policy.toml.
+   Loaded once per process; config changes require restart. *)
+let clone_allowed_orgs_cache : string list option ref = ref None
+
+let load_clone_allowed_orgs ~base_path =
+  match !clone_allowed_orgs_cache with
+  | Some orgs -> orgs
+  | None ->
+    let rel = "config/tool_policy.toml" in
+    let path = Filename.concat base_path rel in
+    let orgs = match Safe_ops.read_file_safe path with
+      | Error _ -> []
+      | Ok content ->
+        match Keeper_toml_loader.parse_toml content with
+        | Error _ -> []
+        | Ok doc -> Keeper_toml_loader.toml_string_list doc "git_clone.allowed_orgs"
+    in
+    clone_allowed_orgs_cache := Some orgs;
+    orgs
+
+(** Extract GitHub org from clone URL.
+    Handles:
+    - [https://github.com/ORG/repo\[.git\]]
+    - [git@github.com:ORG/repo\[.git\]]
+    - [ssh://git@github.com/ORG/repo\[.git\]] *)
+let extract_github_org url =
+  let prefixes = [
+    "https://github.com/";
+    "git@github.com:";
+    "ssh://git@github.com/";
+  ] in
+  let after_prefix =
+    List.find_map (fun prefix ->
+      if String.starts_with ~prefix url then
+        let len = String.length prefix in
+        Some (String.sub url len (String.length url - len))
+      else None
+    ) prefixes
+  in
+  match after_prefix with
+  | None -> None
+  | Some rest ->
+    match String.index_opt rest '/' with
+    | None -> None
+    | Some idx -> Some (String.sub rest 0 idx)
+
+let validate_clone_url ~base_path url =
+  let allowed = load_clone_allowed_orgs ~base_path in
+  if allowed = [] then
+    Error "No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_policy.toml)"
+  else
+    match extract_github_org url with
+    | None ->
+      Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
+    | Some org ->
+      if List.mem org allowed then Ok ()
+      else Error (Printf.sprintf
+        "GitHub org '%s' not in allowed list: %s" org (String.concat ", " allowed))
+
+(** Validate cwd for clone: allows .worktrees/ itself (not just subdirs). *)
+let validate_clone_cwd config cwd =
+  match Tool_code.validate_path config cwd with
+  | Error e -> Error e
+  | Ok canonical_path ->
+    match Room_git.git_root ~base_path:config.Room.base_path with
+    | None -> Error (IoError "Not in a git repository")
+    | Some root ->
+      let worktree_prefix = Tool_code.normalize_path
+        (Filename.concat root ".worktrees") in
+      if canonical_path = worktree_prefix ||
+         String.starts_with ~prefix:(worktree_prefix ^ "/") canonical_path then
+        Ok canonical_path
+      else
+        Error (IoError (Printf.sprintf
+          "Clone restricted to .worktrees/ directory (got: %s)" canonical_path))
 
 (* Handler: masc_code_write — Create or overwrite a file *)
 let handle_code_write ctx args =
@@ -282,8 +362,41 @@ let handle_code_git ctx args =
   else if not (List.mem action allowed_git_actions) then
     (false, Printf.sprintf "Git action '%s' not allowed. Allowed: %s"
        action (String.concat ", " allowed_git_actions))
+  else if action = "clone" then begin
+    (* Clone: validate org allowlist + cwd within .worktrees/ *)
+    let url = match git_args with url :: _ -> url | [] -> "" in
+    if url = "" then
+      (false, "clone requires a repository URL as first argument")
+    else if cwd = "" then
+      (false, "cwd parameter required for clone")
+    else
+      match validate_clone_url ~base_path:ctx.config.Room.base_path url with
+      | Error msg -> (false, msg)
+      | Ok () ->
+        match validate_clone_cwd ctx.config cwd with
+        | Error e -> (false, Types.masc_error_to_string e)
+        | Ok abs_cwd ->
+          let cmd = ["sh"; "-c";
+                     Printf.sprintf "cd %s && git clone %s"
+                       (Filename.quote abs_cwd)
+                       (String.concat " " (List.map Filename.quote git_args))]
+          in
+          match Process_eio.run_argv_with_status ~timeout_sec:120.0 cmd with
+          | Unix.WEXITED code, output ->
+            let response = `Assoc [
+              ("status", `String (if code = 0 then "ok" else "error"));
+              ("exit_code", `Int code);
+              ("output", `String (truncate_output output));
+              ("action", `String "clone");
+              ("url", `String url);
+              ("agent", `String ctx.agent_name);
+            ] in
+            (code = 0, Yojson.Safe.pretty_to_string response)
+          | _, output ->
+            (false, Printf.sprintf "Git clone failed: %s" (truncate_output output))
+  end
   else begin
-    (* Block dangerous operations *)
+    (* Non-clone actions: existing validation *)
     let is_dangerous =
       (action = "push" && List.mem "--force" git_args) ||
       (action = "push" && List.mem "-f" git_args) ||
@@ -296,7 +409,6 @@ let handle_code_git ctx args =
     if is_dangerous then
       (false, "Dangerous git operation blocked (force push, main push, or checkout .)")
     else begin
-      (* Validate cwd *)
       let cwd_result =
         if cwd = "" then (false, "cwd parameter required for git operations") |> fun (ok, msg) ->
           if ok then Ok None else Error (IoError msg)
@@ -448,14 +560,15 @@ Returns exit_code and stdout (truncated at 10KB).";
     name = "masc_code_git";
     description = "Run git commands in a worktree (.worktrees/ only). Structured alternative \
 to masc_code_shell for git operations. Supports: add, commit, push, diff, status, \
-log, branch, checkout, stash, fetch. Force push and push to main/master are blocked. \
+log, branch, checkout, stash, fetch, clone. Force push and push to main/master are blocked. \
+Clone is restricted to allowed GitHub orgs (configured in config/tool_policy.toml). \
 Returns git command output.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("action", `Assoc [
           ("type", `String "string");
-          ("description", `String "Git action: add, commit, push, diff, status, log, branch, checkout, stash, fetch");
+          ("description", `String "Git action: add, commit, push, diff, status, log, branch, checkout, stash, fetch, clone");
         ]);
         ("args", `Assoc [
           ("type", `String "array");

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -78,10 +78,14 @@ let load_clone_allowed_orgs ~base_path =
     let rel = "config/tool_policy.toml" in
     let path = Filename.concat base_path rel in
     let orgs = match Safe_ops.read_file_safe path with
-      | Error _ -> []
+      | Error msg ->
+        Log.Keeper.warn "git_clone: cannot read %s: %s" path msg;
+        []
       | Ok content ->
         match Keeper_toml_loader.parse_toml content with
-        | Error _ -> []
+        | Error msg ->
+          Log.Keeper.warn "git_clone: TOML parse error in %s: %s" path msg;
+          []
         | Ok doc -> Keeper_toml_loader.toml_string_list doc "git_clone.allowed_orgs"
     in
     clone_allowed_orgs_cache := Some orgs;

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -87,12 +87,15 @@ let load_clone_allowed_orgs ~base_path =
     clone_allowed_orgs_cache := Some orgs;
     orgs
 
-(** Extract GitHub org from clone URL.
+(** Extract GitHub org from clone URL (case-normalized to lowercase).
+    Strict matching: URL must start with an exact known prefix to prevent
+    authority spoofing (e.g. github.com.evil.com).
     Handles:
     - [https://github.com/ORG/repo\[.git\]]
     - [git@github.com:ORG/repo\[.git\]]
     - [ssh://git@github.com/ORG/repo\[.git\]] *)
 let extract_github_org url =
+  let lc = String.lowercase_ascii url in
   let prefixes = [
     "https://github.com/";
     "git@github.com:";
@@ -100,18 +103,28 @@ let extract_github_org url =
   ] in
   let after_prefix =
     List.find_map (fun prefix ->
-      if String.starts_with ~prefix url then
+      if String.starts_with ~prefix lc then
         let len = String.length prefix in
-        Some (String.sub url len (String.length url - len))
+        Some (String.sub lc len (String.length lc - len))
       else None
     ) prefixes
   in
   match after_prefix with
   | None -> None
   | Some rest ->
+    (* rest must be "org/repo[.git]" — reject if org contains suspicious chars *)
     match String.index_opt rest '/' with
     | None -> None
-    | Some idx -> Some (String.sub rest 0 idx)
+    | Some idx ->
+      let org = String.sub rest 0 idx in
+      (* GitHub org names: alphanumeric + hyphens only *)
+      let valid_org_char c =
+        (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '-'
+      in
+      if org = "" || not (String.to_seq org |> Seq.for_all valid_org_char) then
+        None
+      else
+        Some org
 
 let validate_clone_url ~base_path url =
   let allowed = load_clone_allowed_orgs ~base_path in
@@ -122,7 +135,9 @@ let validate_clone_url ~base_path url =
     | None ->
       Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
     | Some org ->
-      if List.mem org allowed then Ok ()
+      (* Case-insensitive comparison: org is already lowercase from extract *)
+      let allowed_lc = List.map String.lowercase_ascii allowed in
+      if List.mem org allowed_lc then Ok ()
       else Error (Printf.sprintf
         "GitHub org '%s' not in allowed list: %s" org (String.concat ", " allowed))
 
@@ -363,10 +378,14 @@ let handle_code_git ctx args =
     (false, Printf.sprintf "Git action '%s' not allowed. Allowed: %s"
        action (String.concat ", " allowed_git_actions))
   else if action = "clone" then begin
-    (* Clone: validate org allowlist + cwd within .worktrees/ *)
+    (* Clone: validate org allowlist + cwd within .worktrees/.
+       Block all flag-like args to prevent --upload-pack injection (CVE-like). *)
     let url = match git_args with url :: _ -> url | [] -> "" in
+    let has_flag_args = List.exists (fun a -> String.length a > 0 && a.[0] = '-') git_args in
     if url = "" then
       (false, "clone requires a repository URL as first argument")
+    else if has_flag_args then
+      (false, "clone does not accept flags (security: --upload-pack injection blocked)")
     else if cwd = "" then
       (false, "cwd parameter required for clone")
     else
@@ -376,10 +395,11 @@ let handle_code_git ctx args =
         match validate_clone_cwd ctx.config cwd with
         | Error e -> (false, Types.masc_error_to_string e)
         | Ok abs_cwd ->
+          (* Only pass the validated URL — no extra args allowed *)
           let cmd = ["sh"; "-c";
                      Printf.sprintf "cd %s && git clone %s"
                        (Filename.quote abs_cwd)
-                       (String.concat " " (List.map Filename.quote git_args))]
+                       (Filename.quote url)]
           in
           match Process_eio.run_argv_with_status ~timeout_sec:120.0 cmd with
           | Unix.WEXITED code, output ->

--- a/test/dune
+++ b/test/dune
@@ -510,6 +510,7 @@
         test_tool_control_coverage test_tool_misc_coverage
         test_ag_ui_coverage test_tool_verification_coverage
         test_tool_suspend_coverage test_tool_code_coverage
+        test_tool_code_write_coverage
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)
@@ -543,6 +544,7 @@
         test_tool_control_coverage test_tool_misc_coverage
         test_ag_ui_coverage test_tool_verification_coverage
         test_tool_suspend_coverage test_tool_code_coverage
+        test_tool_code_write_coverage
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -98,6 +98,44 @@ let () = check "validate_clone_url: empty allowlist rejected"
       with Not_found -> false)
    | Ok () -> false)
 
+(* ── Security: authority spoofing ─────────────────────────────────── *)
+
+let () = check "extract_github_org: domain spoofing github.com.evil.com rejected"
+  (Tool_code_write.extract_github_org
+     "https://github.com.evil.com/jeong-sik/repo.git"
+   = None)
+
+let () = check "extract_github_org: authority spoofing via @ rejected"
+  (Tool_code_write.extract_github_org
+     "https://jeong-sik@evil.com/repo"
+   = None)
+
+(* ── Security: case-insensitive org matching ─────────────────────── *)
+
+let () =
+  Tool_code_write.clone_allowed_orgs_cache := Some ["jeong-sik"]
+
+let () = check "validate_clone_url: mixed-case org passes (case-insensitive)"
+  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "https://github.com/Jeong-Sik/repo.git" = Ok ())
+
+let () = check "extract_github_org: uppercase normalized to lowercase"
+  (Tool_code_write.extract_github_org
+     "https://github.com/JEONG-SIK/repo.git"
+   = Some "jeong-sik")
+
+(* ── Security: org name validation ───────────────────────────────── *)
+
+let () = check "extract_github_org: percent-encoded org rejected"
+  (Tool_code_write.extract_github_org
+     "https://github.com/jeong%2Dsik/repo.git"
+   = None)
+
+let () = check "extract_github_org: org with dots rejected"
+  (Tool_code_write.extract_github_org
+     "https://github.com/jeong.sik/repo.git"
+   = None)
+
 (* ── Summary ─────────────────────────────────────────────────────── *)
 
 let () =

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -1,143 +1,168 @@
-(** Coverage tests for Tool_code_write — git clone org validation.
+(** Coverage tests for Tool_code_write — git clone URL parsing
+    and org allowlist validation. Pure function tests only. *)
 
-    Tests extract_github_org, validate_clone_url, and clone dispatch
-    error paths. Pure function tests do not require Eio or file I/O.
-*)
+open Alcotest
 
 module Tool_code_write = Masc_mcp.Tool_code_write
 
-let test_counter = ref 0
-let pass = ref 0
-let fail = ref 0
-
-let check name cond =
-  incr test_counter;
-  if cond then (
-    incr pass;
-    Printf.printf "\027[32mPASS\027[0m %s\n" name)
-  else (
-    incr fail;
-    Printf.printf "\027[31mFAIL\027[0m %s\n" name)
-
 (* ── extract_github_org ──────────────────────────────────────────── *)
 
-let () = check "extract_github_org: https URL with .git"
-  (Tool_code_write.extract_github_org
-     "https://github.com/jeong-sik/masc-mcp.git"
-   = Some "jeong-sik")
+let test_https_url () =
+  (check (option string)) "https with .git"
+    (Some "jeong-sik")
+    (Tool_code_write.extract_github_org
+       "https://github.com/jeong-sik/masc-mcp.git")
 
-let () = check "extract_github_org: https URL without .git"
-  (Tool_code_write.extract_github_org
-     "https://github.com/jeong-sik/masc-mcp"
-   = Some "jeong-sik")
+let test_https_url_no_git () =
+  (check (option string)) "https without .git"
+    (Some "jeong-sik")
+    (Tool_code_write.extract_github_org
+       "https://github.com/jeong-sik/masc-mcp")
 
-let () = check "extract_github_org: ssh URL"
-  (Tool_code_write.extract_github_org
-     "git@github.com:jeong-sik/oas.git"
-   = Some "jeong-sik")
+let test_ssh_url () =
+  (check (option string)) "ssh URL"
+    (Some "jeong-sik")
+    (Tool_code_write.extract_github_org
+       "git@github.com:jeong-sik/oas.git")
 
-let () = check "extract_github_org: ssh protocol URL"
-  (Tool_code_write.extract_github_org
-     "ssh://git@github.com/jeong-sik/oas.git"
-   = Some "jeong-sik")
+let test_ssh_protocol_url () =
+  (check (option string)) "ssh protocol URL"
+    (Some "jeong-sik")
+    (Tool_code_write.extract_github_org
+       "ssh://git@github.com/jeong-sik/oas.git")
 
-let () = check "extract_github_org: non-github URL returns None"
-  (Tool_code_write.extract_github_org
-     "https://gitlab.com/someone/repo.git"
-   = None)
+let test_non_github_url () =
+  (check (option string)) "non-github returns None"
+    None
+    (Tool_code_write.extract_github_org
+       "https://gitlab.com/someone/repo.git")
 
-let () = check "extract_github_org: bare string returns None"
-  (Tool_code_write.extract_github_org "not-a-url" = None)
+let test_bare_string () =
+  (check (option string)) "bare string returns None"
+    None
+    (Tool_code_write.extract_github_org "not-a-url")
 
-let () = check "extract_github_org: different org"
-  (Tool_code_write.extract_github_org
-     "https://github.com/kidsnote/backend.git"
-   = Some "kidsnote")
+let test_different_org () =
+  (check (option string)) "different org"
+    (Some "kidsnote")
+    (Tool_code_write.extract_github_org
+       "https://github.com/kidsnote/backend.git")
 
-let () = check "extract_github_org: empty string returns None"
-  (Tool_code_write.extract_github_org "" = None)
+let test_empty_string () =
+  (check (option string)) "empty string returns None"
+    None
+    (Tool_code_write.extract_github_org "")
 
-let () = check "extract_github_org: URL with no path after org"
-  (Tool_code_write.extract_github_org
-     "https://github.com/jeong-sik"
-   = None)
+let test_no_repo_path () =
+  (check (option string)) "URL with no path after org"
+    None
+    (Tool_code_write.extract_github_org
+       "https://github.com/jeong-sik")
+
+(* ── Security: authority spoofing ──────────────────────────────── *)
+
+let test_domain_spoofing () =
+  (check (option string)) "github.com.evil.com rejected"
+    None
+    (Tool_code_write.extract_github_org
+       "https://github.com.evil.com/jeong-sik/repo.git")
+
+let test_authority_spoofing () =
+  (check (option string)) "authority via @ rejected"
+    None
+    (Tool_code_write.extract_github_org
+       "https://jeong-sik@evil.com/repo")
+
+let test_uppercase_normalized () =
+  (check (option string)) "uppercase normalized to lowercase"
+    (Some "jeong-sik")
+    (Tool_code_write.extract_github_org
+       "https://github.com/JEONG-SIK/repo.git")
+
+let test_percent_encoded_org () =
+  (check (option string)) "percent-encoded org rejected"
+    None
+    (Tool_code_write.extract_github_org
+       "https://github.com/jeong%2Dsik/repo.git")
+
+let test_org_with_dots () =
+  (check (option string)) "org with dots rejected"
+    None
+    (Tool_code_write.extract_github_org
+       "https://github.com/jeong.sik/repo.git")
 
 (* ── validate_clone_url ──────────────────────────────────────────── *)
 
-let () =
-  (* Inject cache to avoid file I/O *)
-  Tool_code_write.clone_allowed_orgs_cache := Some ["jeong-sik"]
+let with_cache orgs f =
+  Tool_code_write.clone_allowed_orgs_cache := Some orgs;
+  f ()
 
-let () = check "validate_clone_url: allowed org passes"
-  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "https://github.com/jeong-sik/masc-mcp.git" = Ok ())
+let test_allowed_org () = with_cache ["jeong-sik"] @@ fun () ->
+  (check (result unit string)) "allowed org passes"
+    (Ok ())
+    (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+       "https://github.com/jeong-sik/masc-mcp.git")
 
-let () = check "validate_clone_url: disallowed org rejected"
-  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "https://github.com/other-org/repo.git" with
-   | Error _ -> true | Ok () -> false)
+let test_disallowed_org () = with_cache ["jeong-sik"] @@ fun () ->
+  match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+    "https://github.com/other-org/repo.git" with
+  | Error _ -> ()
+  | Ok () -> fail "expected error for disallowed org"
 
-let () = check "validate_clone_url: non-github URL rejected"
-  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "https://gitlab.com/jeong-sik/repo.git" with
-   | Error _ -> true | Ok () -> false)
+let test_non_github_rejected () = with_cache ["jeong-sik"] @@ fun () ->
+  match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+    "https://gitlab.com/jeong-sik/repo.git" with
+  | Error _ -> ()
+  | Ok () -> fail "expected error for non-github URL"
 
-let () = check "validate_clone_url: ssh allowed org passes"
-  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "git@github.com:jeong-sik/oas.git" = Ok ())
+let test_ssh_allowed () = with_cache ["jeong-sik"] @@ fun () ->
+  (check (result unit string)) "ssh allowed org passes"
+    (Ok ())
+    (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+       "git@github.com:jeong-sik/oas.git")
 
-let () =
-  Tool_code_write.clone_allowed_orgs_cache := Some []
+let test_empty_allowlist () = with_cache [] @@ fun () ->
+  match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+    "https://github.com/jeong-sik/repo.git" with
+  | Error msg ->
+    (check bool) "mentions 'No allowed orgs'" true
+      (String.starts_with ~prefix:"No allowed orgs" msg)
+  | Ok () -> fail "expected error for empty allowlist"
 
-let () = check "validate_clone_url: empty allowlist rejected"
-  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "https://github.com/jeong-sik/repo.git" with
-   | Error msg ->
-     let needle = "No allowed orgs" in
-     (try ignore (Str.search_forward (Str.regexp_string needle) msg 0); true
-      with Not_found -> false)
-   | Ok () -> false)
+let test_mixed_case_org () = with_cache ["jeong-sik"] @@ fun () ->
+  (check (result unit string)) "mixed-case org passes"
+    (Ok ())
+    (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+       "https://github.com/Jeong-Sik/repo.git")
 
-(* ── Security: authority spoofing ─────────────────────────────────── *)
-
-let () = check "extract_github_org: domain spoofing github.com.evil.com rejected"
-  (Tool_code_write.extract_github_org
-     "https://github.com.evil.com/jeong-sik/repo.git"
-   = None)
-
-let () = check "extract_github_org: authority spoofing via @ rejected"
-  (Tool_code_write.extract_github_org
-     "https://jeong-sik@evil.com/repo"
-   = None)
-
-(* ── Security: case-insensitive org matching ─────────────────────── *)
+(* ── Runner ──────────────────────────────────────────────────────── *)
 
 let () =
-  Tool_code_write.clone_allowed_orgs_cache := Some ["jeong-sik"]
-
-let () = check "validate_clone_url: mixed-case org passes (case-insensitive)"
-  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
-     "https://github.com/Jeong-Sik/repo.git" = Ok ())
-
-let () = check "extract_github_org: uppercase normalized to lowercase"
-  (Tool_code_write.extract_github_org
-     "https://github.com/JEONG-SIK/repo.git"
-   = Some "jeong-sik")
-
-(* ── Security: org name validation ───────────────────────────────── *)
-
-let () = check "extract_github_org: percent-encoded org rejected"
-  (Tool_code_write.extract_github_org
-     "https://github.com/jeong%2Dsik/repo.git"
-   = None)
-
-let () = check "extract_github_org: org with dots rejected"
-  (Tool_code_write.extract_github_org
-     "https://github.com/jeong.sik/repo.git"
-   = None)
-
-(* ── Summary ─────────────────────────────────────────────────────── *)
-
-let () =
-  Printf.printf "\n%d/%d tests passed\n" !pass !test_counter;
-  if !fail > 0 then exit 1
+  Alcotest.run "Tool_code_write" [
+    ("extract_github_org", [
+      test_case "https with .git" `Quick test_https_url;
+      test_case "https without .git" `Quick test_https_url_no_git;
+      test_case "ssh URL" `Quick test_ssh_url;
+      test_case "ssh protocol URL" `Quick test_ssh_protocol_url;
+      test_case "non-github URL" `Quick test_non_github_url;
+      test_case "bare string" `Quick test_bare_string;
+      test_case "different org" `Quick test_different_org;
+      test_case "empty string" `Quick test_empty_string;
+      test_case "no repo path" `Quick test_no_repo_path;
+    ]);
+    ("security", [
+      test_case "domain spoofing" `Quick test_domain_spoofing;
+      test_case "authority spoofing" `Quick test_authority_spoofing;
+      test_case "uppercase normalized" `Quick test_uppercase_normalized;
+      test_case "percent-encoded org" `Quick test_percent_encoded_org;
+      test_case "org with dots" `Quick test_org_with_dots;
+    ]);
+    ("validate_clone_url", [
+      test_case "allowed org" `Quick test_allowed_org;
+      test_case "disallowed org" `Quick test_disallowed_org;
+      test_case "non-github rejected" `Quick test_non_github_rejected;
+      test_case "ssh allowed" `Quick test_ssh_allowed;
+      test_case "empty allowlist" `Quick test_empty_allowlist;
+      test_case "mixed-case org" `Quick test_mixed_case_org;
+    ]);
+  ]

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -1,0 +1,105 @@
+(** Coverage tests for Tool_code_write — git clone org validation.
+
+    Tests extract_github_org, validate_clone_url, and clone dispatch
+    error paths. Pure function tests do not require Eio or file I/O.
+*)
+
+module Tool_code_write = Masc_mcp.Tool_code_write
+
+let test_counter = ref 0
+let pass = ref 0
+let fail = ref 0
+
+let check name cond =
+  incr test_counter;
+  if cond then (
+    incr pass;
+    Printf.printf "\027[32mPASS\027[0m %s\n" name)
+  else (
+    incr fail;
+    Printf.printf "\027[31mFAIL\027[0m %s\n" name)
+
+(* ── extract_github_org ──────────────────────────────────────────── *)
+
+let () = check "extract_github_org: https URL with .git"
+  (Tool_code_write.extract_github_org
+     "https://github.com/jeong-sik/masc-mcp.git"
+   = Some "jeong-sik")
+
+let () = check "extract_github_org: https URL without .git"
+  (Tool_code_write.extract_github_org
+     "https://github.com/jeong-sik/masc-mcp"
+   = Some "jeong-sik")
+
+let () = check "extract_github_org: ssh URL"
+  (Tool_code_write.extract_github_org
+     "git@github.com:jeong-sik/oas.git"
+   = Some "jeong-sik")
+
+let () = check "extract_github_org: ssh protocol URL"
+  (Tool_code_write.extract_github_org
+     "ssh://git@github.com/jeong-sik/oas.git"
+   = Some "jeong-sik")
+
+let () = check "extract_github_org: non-github URL returns None"
+  (Tool_code_write.extract_github_org
+     "https://gitlab.com/someone/repo.git"
+   = None)
+
+let () = check "extract_github_org: bare string returns None"
+  (Tool_code_write.extract_github_org "not-a-url" = None)
+
+let () = check "extract_github_org: different org"
+  (Tool_code_write.extract_github_org
+     "https://github.com/kidsnote/backend.git"
+   = Some "kidsnote")
+
+let () = check "extract_github_org: empty string returns None"
+  (Tool_code_write.extract_github_org "" = None)
+
+let () = check "extract_github_org: URL with no path after org"
+  (Tool_code_write.extract_github_org
+     "https://github.com/jeong-sik"
+   = None)
+
+(* ── validate_clone_url ──────────────────────────────────────────── *)
+
+let () =
+  (* Inject cache to avoid file I/O *)
+  Tool_code_write.clone_allowed_orgs_cache := Some ["jeong-sik"]
+
+let () = check "validate_clone_url: allowed org passes"
+  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "https://github.com/jeong-sik/masc-mcp.git" = Ok ())
+
+let () = check "validate_clone_url: disallowed org rejected"
+  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "https://github.com/other-org/repo.git" with
+   | Error _ -> true | Ok () -> false)
+
+let () = check "validate_clone_url: non-github URL rejected"
+  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "https://gitlab.com/jeong-sik/repo.git" with
+   | Error _ -> true | Ok () -> false)
+
+let () = check "validate_clone_url: ssh allowed org passes"
+  (Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "git@github.com:jeong-sik/oas.git" = Ok ())
+
+let () =
+  Tool_code_write.clone_allowed_orgs_cache := Some []
+
+let () = check "validate_clone_url: empty allowlist rejected"
+  (match Tool_code_write.validate_clone_url ~base_path:"/tmp"
+     "https://github.com/jeong-sik/repo.git" with
+   | Error msg ->
+     let needle = "No allowed orgs" in
+     (try ignore (Str.search_forward (Str.regexp_string needle) msg 0); true
+      with Not_found -> false)
+   | Ok () -> false)
+
+(* ── Summary ─────────────────────────────────────────────────────── *)
+
+let () =
+  Printf.printf "\n%d/%d tests passed\n" !pass !test_counter;
+  if !fail > 0 then exit 1


### PR DESCRIPTION
## Summary
- `masc_code_git`에 `clone` 액션 추가. GitHub org 단위 allowlist로 제한.
- `config/tool_policy.toml`의 `[git_clone] allowed_orgs`에서 허용 org 관리 (현재: `jeong-sik`).
- URL 파싱: HTTPS, SSH (`git@`), SSH protocol 3가지 형식 지원.
- clone cwd는 `.worktrees/` 자체 또는 하위 디렉토리 허용 (기존 git 액션보다 완화).
- 타임아웃 120초 (기존 30초 대비 네트워크 지연 고려).

## Security
- 허용되지 않은 org → 거부
- GitHub 외 URL (gitlab, bitbucket 등) → 거부
- `.worktrees/` 외 경로 → 거부
- 플래그 형태(`-`로 시작) 인자 전체 차단 — `--upload-pack`, `--config`, `--separate-git-dir` 등 injection 방지; URL만 전달
- `load_clone_allowed_orgs` 파일 읽기/TOML 파싱 실패 시 `Log.Keeper.warn`으로 경고 로깅 (기존: 묵시적 `[]` 반환)

## Product impact

- Promise affected: `none/internal`
- User-visible change: keeper agent가 허용된 GitHub org의 레포를 `.worktrees/` 내로 clone할 수 있음

## Evidence
- [x] `extract_github_org` 9개 케이스 (HTTPS, SSH, non-github, edge cases) — Alcotest
- [x] `validate_clone_url` 6개 케이스 (allowed/disallowed/empty/non-github/mixed-case) — Alcotest
- [x] security 케이스 5개 (domain spoofing, authority spoofing, percent-encoding, dots, uppercase normalization) — Alcotest
- [x] 빌드 통과
- [x] CI green (0 failed jobs)

## Review evidence

- Copilot code review: 4 threads resolved (git_args injection, silent config load, test comment, test harness)
- CodeQL scan: no issues detected

## Linked issue