### PR TITLE
fix(dashboard): enrich keeper detail profile and empty states

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -206,6 +206,17 @@ function SectionCard({ title, children }: { title: string; children: preact.Comp
   `
 }
 
+// ── Profile field (label + value inline) ────────────────
+
+function ProfileField({ label, value, color }: { label: string; value: string; color: string }) {
+  return html`
+    <div class="flex items-start gap-2 text-xs text-[var(--text-muted)]">
+      <span class="flex-shrink-0">${label}:</span>
+      <span class="font-medium leading-relaxed" style="color: ${color}">${value}</span>
+    </div>
+  `
+}
+
 // ── Supervisor Diagnostics Panel ────────────────────────
 
 function registryStateBadge(state: string | null) {
@@ -493,18 +504,77 @@ export function KeeperDetailOverlay() {
             ${keeper.skill_reason
               ? html`<div class="text-[11px] text-[var(--text-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
-            ${keeper.last_heartbeat
-              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
-                  <span>마지막 하트비트:</span>
-                  <${TimeAgo} timestamp=${keeper.last_heartbeat} />
-                </div>`
+
+            ${'' /* ── Identity: will / needs / desires ── */}
+            ${keeper.will || keeper.needs || keeper.desires
+              ? html`
+                <div class="mt-3 flex flex-col gap-1.5">
+                  ${keeper.will ? html`<${ProfileField} label="의지" value=${keeper.will} color="var(--cyan)" />` : null}
+                  ${keeper.needs ? html`<${ProfileField} label="필요" value=${keeper.needs} color="var(--warn)" />` : null}
+                  ${keeper.desires ? html`<${ProfileField} label="열망" value=${keeper.desires} color="var(--purple)" />` : null}
+                </div>
+              `
               : null}
+
+            ${'' /* ── Timestamps ── */}
+            <div class="mt-3 flex flex-col gap-1">
+              ${keeper.last_heartbeat
+                ? html`<div class="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+                    <span>마지막 하트비트:</span>
+                    <${TimeAgo} timestamp=${keeper.last_heartbeat} />
+                  </div>`
+                : null}
+              ${keeper.created_at
+                ? html`<div class="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+                    <span>생성일:</span>
+                    <${TimeAgo} timestamp=${keeper.created_at} />
+                  </div>`
+                : null}
+            </div>
+
+            ${'' /* ── Recent activity preview ── */}
+            ${keeper.recent_output_preview
+              ? html`
+                <div class="mt-3 py-2 px-3 rounded-lg bg-[rgba(71,184,255,0.06)] border border-[rgba(71,184,255,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
+                  <div class="text-[10px] font-semibold text-[var(--accent)] uppercase tracking-wider mb-1">최근 출력</div>
+                  <div class="line-clamp-3">${keeper.recent_output_preview}</div>
+                </div>
+              `
+              : null}
+
+            ${'' /* ── K2K social stats ── */}
+            ${(keeper.k2k_count ?? 0) > 0 || (keeper.conversation_tail_count ?? 0) > 0
+              ? html`
+                <div class="mt-3 flex flex-wrap gap-2">
+                  ${(keeper.k2k_count ?? 0) > 0
+                    ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
+                        K2K 소통 <span class="font-mono font-medium text-[#a78bfa]">${keeper.k2k_count}</span>회
+                      </span>`
+                    : null}
+                  ${(keeper.conversation_tail_count ?? 0) > 0
+                    ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
+                        대화 <span class="font-mono font-medium">${keeper.conversation_tail_count}</span>건
+                      </span>`
+                    : null}
+                </div>
+              `
+              : null}
+
             ${keeper.memory_recent_note
               ? html`
                 <div class="mt-3 py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
+                  <div class="text-[10px] font-semibold text-[#a78bfa] uppercase tracking-wider mb-1">메모리 노트</div>
                   ${keeper.memory_recent_note}
                 </div>
               `
+              : null}
+
+            ${'' /* ── Last speech act ── */}
+            ${keeper.last_speech_act
+              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
+                  <span>최근 행동:</span>
+                  <span class="font-mono text-[11px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-body)]">${keeper.last_speech_act}</span>
+                </div>`
               : null}
           <//>
 
@@ -526,13 +596,13 @@ export function KeeperDetailOverlay() {
 
           <div class="md:col-span-2">
             <${SectionCard} title="도구 호출 궤적">
-              <${KeeperTrajectoryTimeline} keeperName=${keeper.name} />
+              <${KeeperTrajectoryTimeline} keeperName=${keeper.name} keeper=${keeper} />
             <//>
           </div>
 
           <div class="md:col-span-2">
             <${CollapsibleSection} title="통합 활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">공지 + 태스크 + 도구 호출</span>`}>
-              <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} />
+              <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
           </div>
 

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -10,6 +10,7 @@ import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
 import { truncate } from '../lib/truncate'
 import { TimeAgo } from './common/time-ago'
 import { toolCategory, durationColor, formatArgs, prettyArgs } from './tool-call-shared'
+import type { Keeper } from '../types'
 
 // ── Constants ────────────────────────────────────────────
 
@@ -160,6 +161,38 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
   `
 }
 
+function TrajectoryEmptyState({ keeper }: { keeper?: Keeper }) {
+  const isOffline = keeper && ['offline', 'inactive', 'dead', 'crashed'].includes(keeper.status)
+  const toolNames = keeper?.recent_tool_names ?? keeper?.latest_tool_names ?? []
+  const toolCount = keeper?.latest_tool_call_count ?? 0
+  const generation = keeper?.generation ?? 0
+
+  return html`
+    <div class="py-4 flex flex-col items-center gap-3">
+      <div class="text-xs text-[var(--text-muted)] text-center">
+        ${isOffline
+          ? '키퍼가 오프라인입니다. 기동하면 도구 호출 내역이 기록됩니다.'
+          : generation === 0
+            ? '아직 시작되지 않은 키퍼입니다.'
+            : '현재 세대에서 기록된 도구 호출이 없습니다.'}
+      </div>
+      ${toolNames.length > 0 ? html`
+        <div class="w-full max-w-md">
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1.5">이전 사용 도구</div>
+          <div class="flex flex-wrap gap-1.5">
+            ${toolNames.map((name: string) => html`
+              <span class="inline-flex items-center text-[11px] font-mono px-2 py-0.5 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">${name}</span>
+            `)}
+          </div>
+          ${toolCount > 0 ? html`
+            <div class="text-[10px] text-[var(--text-dim)] mt-1.5">누적 호출 ${toolCount}회</div>
+          ` : null}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]> {
   const groups = new Map<number, TrajectoryEntry[]>()
   for (const e of entries) {
@@ -173,7 +206,7 @@ function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]>
   return groups
 }
 
-export function KeeperTrajectoryTimeline({ keeperName }: { keeperName: string }) {
+export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: string; keeper?: Keeper }) {
   useEffect(() => {
     void loadTrajectory(keeperName)
     return () => clearTrajectory(keeperName)
@@ -191,7 +224,7 @@ export function KeeperTrajectoryTimeline({ keeperName }: { keeperName: string })
 
   const data = state.data
   if (!data || data.entries.length === 0) {
-    return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">이 세션에 기록된 도구 호출이 없습니다.</div>`
+    return html`<${TrajectoryEmptyState} keeper=${keeper} />`
   }
 
   const turnGroups = groupByTurn(data.entries)

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -69,9 +69,11 @@ function LiveIndicator({ events }: { events: readonly { ts: number }[] }) {
 interface SessionTraceViewProps {
   agentName: string
   isKeeper: boolean
+  keeperStatus?: string
+  keeperGeneration?: number
 }
 
-export function SessionTraceView({ agentName, isKeeper }: SessionTraceViewProps) {
+export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGeneration }: SessionTraceViewProps) {
   const listRef = useRef<HTMLDivElement>(null)
 
   // Load on first mount. Clean up only when agentName changes (overlay closes).
@@ -123,11 +125,17 @@ export function SessionTraceView({ agentName, isKeeper }: SessionTraceViewProps)
     `
   }
 
-  // Empty state
+  // Empty state — contextual message based on keeper status
   if (events.length === 0) {
+    const isOffline = keeperStatus && ['offline', 'inactive', 'dead', 'crashed'].includes(keeperStatus)
+    const msg = isOffline
+      ? '키퍼가 오프라인입니다. 기동하면 활동이 기록됩니다.'
+      : (keeperGeneration ?? 0) === 0
+        ? '아직 시작되지 않은 키퍼입니다. 활동 기록이 없습니다.'
+        : '현재 세대에서 기록된 활동이 없습니다.'
     return html`
       <div class="py-4">
-        <${EmptyState} message="기록된 활동이 없습니다" compact />
+        <${EmptyState} message=${msg} compact />
       </div>
     `
   }


### PR DESCRIPTION
## Summary
- 프로필 섹션에 keeper 타입에 존재하지만 미노출되던 필드 추가: 의지/필요/열망, 생성일, 최근 출력 미리보기, K2K 소통 통계, 최근 행동 유형, 메모리 노트 레이블
- 도구 호출 궤적 빈 상태에 keeper 컨텍스트 기반 메시지 (offline/미시작/현재 세대 데이터 없음) 및 이전 사용 도구 목록 fallback 표시
- 통합 활동 추적 빈 상태에 keeper 상태/세대 기반 구체적 안내 메시지

## Changes
- `keeper-detail.ts`: ProfileField 헬퍼 추가, 프로필 섹션 강화 (will/needs/desires, created_at, recent_output_preview, k2k stats, last_speech_act)
- `keeper-trajectory-timeline.ts`: TrajectoryEmptyState 컴포넌트 추가, keeper prop 수용
- `session-trace-view.ts`: keeperStatus/keeperGeneration props 추가, 조건부 empty 메시지

## Test plan
- [x] TypeScript typecheck 통과
- [x] 전체 테스트 315건 통과
- [x] Vite 빌드 성공
- [ ] 실제 대시보드에서 offline/active keeper 상세 페이지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)