### PR TITLE
refactor: consolidate local model label and elevenlabs URL to SSOT

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
 > Current package version: v2.244.0
-> Latest release: v2.243.0 (2026-04-05)
+> Latest release: v2.244.0 (2026-04-05)
 > Updated: 2026-04-05
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,7 +1,7 @@
 # Product Operating Plan
 
 > Current package version: v2.244.0
-> Latest release: v2.243.0 (2026-04-05)
+> Latest release: v2.244.0 (2026-04-05)
 > Updated: 2026-04-05
 
 Execution companion for capsule-only coordination hardening:

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -619,9 +619,10 @@ let release (lease : lease) ~success ?error ?latency_ms () =
         updated.total_success updated.total_failure
         (Option.value ~default:"" (trim_opt error))
 
-(** Return a parseable model label (e.g. "llama:qwen3.5") for an assignment. *)
+(** Return a parseable model label (e.g. "llama:qwen3.5") for an assignment.
+    Delegates to [Provider_adapter.make_local_label] for SSOT. *)
 let model_label_of_assignment (assignment : assignment) : string =
-  Printf.sprintf "llama:%s" assignment.model_name
+  Provider_adapter.make_local_label assignment.model_name
 
 let snapshot_to_yojson (snapshot : runtime_snapshot) =
   `Assoc

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -84,6 +84,16 @@ let cn_gemini = "gemini-api"
 let cn_glm = "glm"
 let cn_openrouter = "openrouter"
 
+(** SSOT cascade prefix for local llama-server instances.
+    All cascade label construction for local models must use this constant.
+    Format: [local_cascade_prefix ^ ":" ^ model_id] → e.g. "llama:qwen3.5" *)
+let local_cascade_prefix = cn_llama
+
+(** Build a cascade model label for a local model.
+    Single entry point — other modules must not concatenate prefix manually. *)
+let make_local_label (model_id : string) : string =
+  local_cascade_prefix ^ ":" ^ model_id
+
 (** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
     Note: OpenAI_compat maps to codex-api (cloud); llama (local) uses the
     same provider_kind but is identified by endpoint, not by this function. *)
@@ -474,7 +484,8 @@ let voice_endpoint_supports_http_tts (endpoint : Voice_config.endpoint) =
   voice_adapter_for_endpoint endpoint
   |> voice_transport_supports_http_tts
 
-let default_elevenlabs_base_url = "https://api.elevenlabs.io/v1"
+(** ElevenLabs base URL — SSOT is [Voice_config.default_elevenlabs_base_url]. *)
+let default_elevenlabs_base_url = Voice_config.default_elevenlabs_base_url
 
 let voice_endpoint_base_url (endpoint : Voice_config.endpoint) =
   match voice_adapter_for_endpoint endpoint with
@@ -662,7 +673,7 @@ let explicit_llama_model_id () =
   | Error msg -> invalid_arg msg
 
 let explicit_llama_model_label_result () =
-  Result.map (fun model_id -> "llama:" ^ model_id) (explicit_llama_model_id_result ())
+  Result.map make_local_label (explicit_llama_model_id_result ())
 
 let explicit_llama_model_label () =
   match explicit_llama_model_label_result () with

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -172,7 +172,7 @@ let default_configs = [
   });
   ("llama", {
     agent_name = "llama";
-    command = "llama:explicit-model-required";
+    command = Provider_adapter.make_local_label "explicit-model-required";
     timeout_seconds = Env_config.Spawn.timeout_seconds;
     working_dir = None;
     mcp_tools = masc_mcp_tools;

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -217,7 +217,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
         | "llama", None -> Error "model is required when agent_name=llama"
         | "llama", Some raw ->
             let spec_name =
-              if String.contains raw ':' then raw else "llama:" ^ raw
+              if String.contains raw ':' then raw else Provider_adapter.make_local_label raw
             in
             (* Validate the label parses without retaining model_spec *)
             (match Llm_provider.Cascade_config.parse_model_string spec_name with Some _ -> Ok () | None -> Error "invalid model spec")

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -232,7 +232,7 @@ let model_label_for_pool ~model_id runtime_pool =
   | Some pool ->
       let trimmed = String.trim pool in
       if is_oas_managed_runtime_pool (Some trimmed) then
-        Printf.sprintf "llama:%s" model_id
+        Provider_adapter.make_local_label model_id
       else
         let base_url =
           if
@@ -244,7 +244,7 @@ let model_label_for_pool ~model_id runtime_pool =
             runtime_base_url_for_pool runtime_pool
         in
         Printf.sprintf "custom:%s@%s" model_id base_url
-  | None -> Printf.sprintf "llama:%s" model_id
+  | None -> Provider_adapter.make_local_label model_id
 
 let ensure_runtime_reachable ?runtime_pool ~timeout_sec () =
   let base_url = runtime_base_url_for_pool runtime_pool |> String.trim in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -413,7 +413,7 @@ and resume_worker_via_oas
   let tool_names_ref, hooks = make_tool_tracking_hooks () in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
   let* resume_provider =
-    oas_provider_of_label (Printf.sprintf "llama:%s" resume_model_id)
+    oas_provider_of_label (Provider_adapter.make_local_label resume_model_id)
     |> Result.map_error (fun e ->
       Printf.sprintf "checkpoint resume (model %S): %s" resume_model_id e)
   in

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -175,6 +175,15 @@ let test_is_local_provider_cloud () =
   check bool "unknown is not local" false
     (Adapter.is_local_provider "unknown-provider")
 
+let test_make_local_label () =
+  check string "make_local_label basic" "llama:qwen3.5"
+    (Adapter.make_local_label "qwen3.5");
+  check string "make_local_label preserves model id" "llama:some-model"
+    (Adapter.make_local_label "some-model");
+  (* Verify make_local_label uses the same prefix as the llama adapter *)
+  check string "prefix matches cn_llama" Adapter.local_cascade_prefix
+    Adapter.cn_llama
+
 let test_default_local_fallback_label () =
   let label = Adapter.default_local_fallback_label () in
   check bool "fallback label contains colon" true
@@ -230,6 +239,7 @@ let () =
             test_is_local_provider_custom;
           test_case "is_local_provider cloud" `Quick
             test_is_local_provider_cloud;
+          test_case "make_local_label" `Quick test_make_local_label;
           test_case "default_local_fallback_label" `Quick
             test_default_local_fallback_label;
         ] );


### PR DESCRIPTION
## Summary
- `"llama:"` 문자열 리터럴 6곳을 `Provider_adapter.make_local_label` SSOT로 통합
- `default_elevenlabs_base_url` 중복 제거 (provider_adapter → Voice_config 참조)

## MASC 모델 무지 원칙
MASC는 cascade label 형식 자체를 모르고, `Provider_adapter`가 label 생성의 유일한 진입점.
다른 모듈이 `"prefix:model"` 형식을 직접 구성하지 않음.

## Changes
| 파일 | 변경 |
|------|------|
| `provider_adapter.ml` | `make_local_label`, `local_cascade_prefix` 추가. elevenlabs URL → Voice_config 참조 |
| `local_runtime_pool.ml` | `"llama:%s"` → `Provider_adapter.make_local_label` |
| `tool_inline_dispatch.ml` | `"llama:" ^ raw` → `Provider_adapter.make_local_label raw` |
| `tool_local_runtime_bench.ml` | 2곳 `"llama:%s"` → `Provider_adapter.make_local_label` |
| `worker_oas.ml` | `"llama:%s"` → `Provider_adapter.make_local_label` |

## Test plan
- [x] `dune build --root .` 통과
- [x] `rg '"llama:' lib/ --glob '*.ml' | grep -v provider_adapter` = doc comment만
- [ ] 기존 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)