### PR TITLE
fix(security): remove auth_token from SSE broadcast (#5310)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -637,7 +637,6 @@ let emit_heartbeat_task
     ?(session_id : string option)
     ?(decision_reason : string option)
     ?(decision_confidence : float option)
-    ?(auth_token : string option)
     () : unit =
   Eio.Mutex.use_rw ~protect:true heartbeat_mutex (fun () ->
     let m = SMap.add agent
@@ -673,9 +672,7 @@ let emit_heartbeat_task
   @ (match decision_confidence with
     | Some confidence -> [("decision_confidence", `Float confidence)]
     | None -> [])
-  @ (match auth_token with
-    | Some token -> [("auth_token", `String token)]
-    | None -> []))
+  )
   in
   notify_event ~event_type:HeartbeatTask ~agent ~data;
   Log.info ~ctx:"heartbeat"


### PR DESCRIPTION
## Summary

`emit_heartbeat_task`의 `~auth_token` 파라미터가 SSE broadcast payload에 포함되어 모든 구독자에게 토큰이 유출되던 보안 취약점 수정.

### 접근 방식

파라미터 자체를 제거. caller 중 `~auth_token`을 전달하는 곳이 0건이므로 하위 호환성 문제 없음. 타입 시스템이 재도입을 방지.

### 이전 시도

- #5323: `ignore auth_token` + 회귀 테스트 (타입 에러로 CLOSED)
- #5325: 파라미터 제거 + runtime guard (순환 supersede로 CLOSED)
- #5336: 이 세션 초기 시도 (CLOSED)

세 PR 모두 main에 도달하지 못함.

## Product impact

- SSE endpoint를 관찰하는 모든 클라이언트에게 auth_token 유출 차단

## Evidence

- `grep -r '~auth_token' lib/ test/` — emit_heartbeat_task에 전달하는 caller 0건
- `dune build` 성공, `test_dashboard_mission.exe` 7/7 통과

Closes #5310

🤖 Generated with [Claude Code](https://claude.com/claude-code)