### PR TITLE
fix(dashboard): refine keeper offline into unbooted/stopped

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -4,6 +4,7 @@
 
 import { html } from 'htm/preact'
 import { isOfflineStatus } from '../lib/status-utils'
+import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
 import { useRef } from 'preact/hooks'
 import { requestConfirm } from './common/confirm-dialog'
@@ -103,6 +104,10 @@ function statusColor(status: string): { bg: string; text: string; dot: string } 
     case 'offline':
     case 'inactive':
       return { bg: 'bg-[rgba(148,163,184,0.12)]', text: 'text-[#94a3b8]', dot: 'bg-[#64748b]' }
+    case 'unbooted':
+      return { bg: 'bg-[rgba(148,163,184,0.08)]', text: 'text-[#64748b]', dot: 'bg-[#475569]' }
+    case 'stopped':
+      return { bg: 'bg-[rgba(239,68,68,0.08)]', text: 'text-[#fb7185]', dot: 'bg-[#f43f5e]' }
     case 'error':
     case 'critical':
       return { bg: 'bg-[rgba(239,68,68,0.12)]', text: 'text-[var(--bad)]', dot: 'bg-[var(--bad)]' }
@@ -361,7 +366,7 @@ export function KeeperDetailOverlay() {
   const keeper = findKeeper(selected.name) ?? selected
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const titleId = `keeper-detail-title-${keeper.name}`
-  const effectiveStatus = keeper.paused ? 'paused' : keeper.status
+  const effectiveStatus = keeperDisplayStatus(keeper)
 
   return html`
     <${DialogOverlay}
@@ -396,8 +401,8 @@ export function KeeperDetailOverlay() {
           </div>
           <div class="flex items-center gap-2">
             ${(() => {
-              const isOffline = ['offline', 'inactive', 'dead', 'crashed'].includes(keeper.status)
-              const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(keeper.status)
+              const isOffline = ['offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped'].includes(effectiveStatus)
+              const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(effectiveStatus)
               if (isOffline) return html`
                 <button type="button"
                   class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -4,7 +4,35 @@ import { relativeTime } from './format-time'
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
   if (keeper?.paused) return 'paused'
   const status = keeper?.status ?? fallbackStatus
+  const normalized = (status ?? '').trim().toLowerCase()
+
+  // Refine generic offline/inactive into specific sub-states
+  if (normalized === 'offline' || normalized === 'inactive') {
+    return refineOfflineStatus(keeper)
+  }
+
   return status && status.trim() !== '' ? status : 'unknown'
+}
+
+/** Distinguish "never booted" from "was running but stopped" keepers. */
+function refineOfflineStatus(keeper: Keeper | null | undefined): string {
+  if (!keeper) return 'offline'
+
+  const generation = keeper.generation ?? 0
+  const turnCount = keeper.turn_count ?? 0
+  const agentExists = keeper.agent?.exists ?? false
+
+  // Never ran a single turn or generation — registered but never booted
+  if (generation === 0 && turnCount === 0 && !agentExists) {
+    return 'unbooted'
+  }
+
+  // Had activity before but now offline — stopped/crashed
+  if (generation > 0 || turnCount > 0) {
+    return 'stopped'
+  }
+
+  return 'offline'
 }
 
 export function keeperRecentHeartbeatLabel(keeper: Keeper | null | undefined): string {

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -39,6 +39,10 @@ export function statusLabel(value?: string | null): string {
     case 'offline':
     case 'inactive':
       return '오프라인'
+    case 'unbooted':
+      return '미기동'
+    case 'stopped':
+      return '중단됨'
     case 'idle':
       return '대기'
     case 'quiet':
@@ -68,8 +72,6 @@ export function statusLabel(value?: string | null): string {
       return '완료'
     case 'cancelled':
       return '취소됨'
-    case 'stopped':
-      return '문제'
     case 'retired':
       return '은퇴'
     case 'spawned':

--- a/dashboard/src/lib/status-utils.ts
+++ b/dashboard/src/lib/status-utils.ts
@@ -1,7 +1,7 @@
 // Status classification utilities for keeper/agent status strings.
 
-/** True when the status indicates the process is not running (offline or inactive). */
+/** True when the status indicates the process is not running. */
 export function isOfflineStatus(status: string | undefined | null): boolean {
   const s = (status ?? '').toLowerCase()
-  return s === 'offline' || s === 'inactive'
+  return s === 'offline' || s === 'inactive' || s === 'unbooted' || s === 'stopped'
 }

--- a/dashboard/src/lib/tone.ts
+++ b/dashboard/src/lib/tone.ts
@@ -10,6 +10,7 @@ export function toneClass(tone?: string | null): string {
     || tone === 'failed'
     || tone === 'fatal'
     || tone === 'offline'
+    || tone === 'stopped'
     || tone === 'critical'
     || tone === 'risk'
   ) {
@@ -24,6 +25,7 @@ export function toneClass(tone?: string | null): string {
     || tone === 'watch'
     || tone === 'paused'
     || tone === 'blocked'
+    || tone === 'unbooted'
   ) {
     return 'warn'
   }


### PR DESCRIPTION
## Summary
- 백엔드가 보내는 generic `offline` 상태를 프론트엔드에서 keeper 메타데이터로 세분화
  - **미기동 (unbooted)**: 등록만 되고 한 번도 실행 안 됨 (generation=0, agent 없음)
  - **중단됨 (stopped)**: 이전에 활동했으나 현재 offline (generation>0)
  - **오프라인 (offline)**: 기존 fallback
- 각 상태에 고유 색상, 톤(warn/bad), 한글 레이블 지정
- `status-label.ts`의 dead-code 중복 (`stopped` → `문제`) 정리

## Changes
| 파일 | 변경 |
|------|------|
| `keeper-runtime-display.ts` | `refineOfflineStatus()` 함수 추가 |
| `status-label.ts` | `unbooted` → 미기동, `stopped` → 중단됨 (기존 중복 제거) |
| `tone.ts` | `stopped` → bad, `unbooted` → warn |
| `status-utils.ts` | `isOfflineStatus`에 새 상태 포함 |
| `keeper-detail.ts` | `statusColor` + `effectiveStatus`를 `keeperDisplayStatus()` 경유로 변경 |

## Test plan
- [x] TypeScript typecheck 통과
- [x] Vite build 성공 (중복 case 경고 해소)
- [x] 전체 테스트 315건 통과
- [ ] 실제 대시보드에서 미기동/중단됨/오프라인 구분 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)