### PR TITLE
feat(keeper): terminate idle loop at 3 turns via Skip

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -295,13 +295,15 @@ let make_hooks
           | [] -> "<none>"
           | names -> String.concat ", " names
         in
-        if consecutive_idle_turns >= 3 then
-          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s]"
-            (!meta_ref).name consecutive_idle_turns tools_str
-        else
+        if consecutive_idle_turns >= 3 then begin
+          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop"
+            (!meta_ref).name consecutive_idle_turns tools_str;
+          Agent_sdk.Hooks.Skip
+        end else begin
           Log.Keeper.debug "keeper:%s idle_turns=%d tools=[%s]"
             (!meta_ref).name consecutive_idle_turns tools_str;
-        Agent_sdk.Hooks.Continue
+          Agent_sdk.Hooks.Continue
+        end
       | _ -> Agent_sdk.Hooks.Continue);
   }
 


### PR DESCRIPTION
## Summary

Keeper의 `on_idle` hook이 `consecutive_idle_turns >= 3`에서 `Skip`을 반환하여 idle loop을 즉시 종료.

### Before

```
턴 1-2: idle 감지 → debug 로그
턴 3-4: idle 감지 → warn 로그 → Continue (계속 실행)
턴 5: OAS max_idle_turns 도달 → IdleDetected 에러
```

27s~112s 낭비 (턴당 LLM 호출 포함).

### After

```
턴 1-2: idle 감지 → debug 로그
턴 3: idle 감지 → warn 로그 → Skip → IdleDetected 에러 (즉시 종료)
```

### 의존성

- [jeong-sik/oas#631](https://github.com/jeong-sik/oas/pull/631): OAS `on_idle`에 `Skip` 허용
- OAS#631 머지 전: OAS가 `Skip`을 불법 결정으로 판단 → `Continue`로 fallback (기존 동작 유지, fail-safe)

## Test plan

- [x] `dune build` 성공
- [ ] OAS#631 머지 후 통합 테스트
- [ ] CI green

Depends on jeong-sik/oas#631

🤖 Generated with [Claude Code](https://claude.com/claude-code)