### PR TITLE
fix(boundary): enforce OAS estimation facade and remove provider_kind from keeper

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -39,6 +39,16 @@ let text_of_message = Agent_sdk.Types.text_of_message
 let ensure_dir path =
   ignore (Keeper_fs.ensure_dir path)
 
+(** {1 Token Estimation Facade}
+
+    All OAS Context_reducer estimation calls in MASC pass through this
+    module.  Other keeper modules must NOT call
+    [Agent_sdk.Context_reducer.estimate_*] directly for decision-making. *)
+
+(** Estimate token count for a raw string (CJK-aware). *)
+let estimate_char_tokens (s : string) : int =
+  Agent_sdk.Context_reducer.estimate_char_tokens s
+
 (** CJK-aware token estimate delegated to OAS Context_reducer. *)
 let msg_tokens (m : Agent_sdk.Types.message) : int =
   let estimated = Agent_sdk.Context_reducer.estimate_message_tokens m in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -114,14 +114,13 @@ let handle_keeper_status ctx args : tool_result =
            | None -> None
            | Some cfg ->
              let pricing = Llm_provider.Pricing.pricing_for_model cfg.model_id in
-             (* Extract provider name from label directly to avoid
-                OpenAI_compat conflating llama/openrouter *)
+             (* Extract provider name from cascade label prefix.
+                Keeper must not reference OAS provider_kind directly. *)
              let provider_name =
                match String.index_opt label ':' with
                | Some idx when idx > 0 ->
                  String.sub label 0 idx |> String.trim |> String.lowercase_ascii
-               | _ ->
-                 Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+               | _ -> "unknown"
              in
              Some (`Assoc [
                ("provider", `String provider_name);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -146,8 +146,10 @@ let overflow_retry_history_budget
     ~(user_message : string) : int =
   let prompt_tokens =
     let estimated =
-      Agent_sdk.Context_reducer.estimate_char_tokens system_prompt
-      + Agent_sdk.Context_reducer.estimate_char_tokens user_message
+      (* Route through Keeper_context_core facade — MASC must not call
+         Agent_sdk.Context_reducer directly for its own decisions. *)
+      Keeper_context_core.estimate_char_tokens system_prompt
+      + Keeper_context_core.estimate_char_tokens user_message
     in
     (* Use 20% safety buffer for prompt estimation errors (#5053).
        Ceiling-based to avoid truncation erasing the buffer. *)


### PR DESCRIPTION
## Summary
- `estimate_char_tokens` 퍼사드를 `keeper_context_core`에 추가
- `keeper_unified_turn`의 OAS 직접 호출을 퍼사드 경유로 교체
- `keeper_status_detail`에서 `string_of_provider_kind` 제거 — cascade label prefix가 SSOT

## Boundary Verification
- `rg 'Agent_sdk.Context_reducer.estimate' lib/keeper/` → `keeper_context_core.ml`만
- `rg 'string_of_provider_kind' lib/keeper/` → 0 hits

## Test plan
- [x] `dune build --root .` 통과
- [ ] 기존 테스트 회귀 없음

Partial fix for #5045

🤖 Generated with [Claude Code](https://claude.com/claude-code)