### PR TITLE
feat(config): add tool_rerank cascade profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
 
-## [2.245.0] - 2026-04-06
+## [Unreleased]
 
 ### Added
-- **Git clone for keepers** -- `masc_code_git` now supports `clone` action, restricted to allowed GitHub orgs via `config/tool_policy.toml` `[git_clone]` section. URL parsing supports HTTPS, SSH, SSH protocol formats. Security: flag args blocked, case-insensitive org matching, domain spoofing prevention. Closes #5341.
 - **tool_rerank cascade profile** -- add `tool_rerank_models` to `config/cascade.json`, required for `MASC_KEEPER_LLM_RERANK=true` to use an explicit model list instead of silent defaults fallback.
 
 ## [2.244.0] - 2026-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 
 ## [2.245.0] - 2026-04-06
 
-### Changed
-- TBD
-
-### Deprecated
-- TBD
+### Added
+- **Git clone for keepers** -- `masc_code_git` now supports `clone` action, restricted to allowed GitHub orgs via `config/tool_policy.toml` `[git_clone]` section. URL parsing supports HTTPS, SSH, SSH protocol formats. Security: flag args blocked, case-insensitive org matching, domain spoofing prevention. Closes #5341.
+- **tool_rerank cascade profile** -- add `tool_rerank_models` to `config/cascade.json`, required for `MASC_KEEPER_LLM_RERANK=true` to use an explicit model list instead of silent defaults fallback.
 
 ## [2.244.0] - 2026-04-05
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # masc-mcp Roadmap
 
 > Current package version: v2.245.0
-> Latest release: v2.245.0 (2026-04-05)
-> Updated: 2026-04-05
+> Latest release: v2.245.0 (2026-04-06)
+> Updated: 2026-04-06
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -38,6 +38,7 @@
   "spawn_glm_models": ["llama:auto", "glm:auto"],
   "keeper_unified_models": ["llama:auto"],
   "research_models": ["llama:auto", "glm:auto"],
+  "tool_rerank_models": ["llama:auto", "glm:auto"],
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
   "keeper_unified_temperature": 0.2,

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
 > Current package version: v2.245.0
-> Latest release: v2.245.0 (2026-04-05)
-> Updated: 2026-04-05
+> Latest release: v2.245.0 (2026-04-06)
+> Updated: 2026-04-06
 
 Execution companion for capsule-only coordination hardening:
 [design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)


### PR DESCRIPTION
## Summary
- cascade.json에 `tool_rerank_models` 프로파일 추가
- `MASC_KEEPER_LLM_RERANK=true` 활성화 시 `default_rerank_fn`이 이 프로파일로 LLM을 호출
- 없으면 init 실패 → BM25 fallback (silent degradation)
- CHANGELOG에 `tool_rerank` config 추가 내용 및 관련 변경사항 함께 기록

## Product impact

- Promise affected: `repo coordination`
- User-visible change: Keeper tool selection의 LLM reranking 기능이 실제로 동작할 수 있게 하는 필수 설정.

## Evidence

- `keeper_agent_run.ml:611`: `Keeper_config.keeper_llm_rerank_cascade()` → default "tool_rerank"
- `tool_selector.ml:197`: `complete_named` with `temperature:0.0, max_tokens:200`
- CI green
- `MASC_KEEPER_LLM_RERANK=true`로 keeper 시작 → rerank init 로그 확인

## Review evidence

<!-- Cross-model review result, reviewer model, and fallback reason if any. -->

## Linked issue

- Relates #5301