### PR TITLE
fix(keeper): graceful idle exit + Failing deadlock recovery + 64K context floor

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -295,13 +295,16 @@ let make_hooks
           | [] -> "<none>"
           | names -> String.concat ", " names
         in
-        if consecutive_idle_turns >= 3 then
-          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s]"
-            (!meta_ref).name consecutive_idle_turns tools_str
-        else
+        if consecutive_idle_turns >= 3 then begin
+          Log.Keeper.info
+            "keeper:%s idle_turns=%d repeated_tools=[%s] — graceful exit (Skip)"
+            (!meta_ref).name consecutive_idle_turns tools_str;
+          Agent_sdk.Hooks.Skip
+        end else begin
           Log.Keeper.debug "keeper:%s idle_turns=%d tools=[%s]"
             (!meta_ref).name consecutive_idle_turns tools_str;
-        Agent_sdk.Hooks.Continue
+          Agent_sdk.Hooks.Continue
+        end
       | _ -> Agent_sdk.Hooks.Continue);
   }
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -491,7 +491,26 @@ let sync_keeper_presence
         (* RFC-0002: dispatch heartbeat success *)
         ignore (Keeper_registry.dispatch_event
           ~base_path:ctx.config.base_path meta_current.name
-          Keeper_state_machine.Heartbeat_ok));
+          Keeper_state_machine.Heartbeat_ok);
+        (* Failing recovery: heartbeat success proves infrastructure is healthy.
+           Reset stale turn failures so the keeper can exit Failing phase.
+           Without this, a single turn failure traps the keeper in Failing forever
+           because no new turn runs → Turn_succeeded never dispatches → turn_healthy
+           stays false. If the underlying issue persists, the next turn will re-fail. *)
+        let stale_turn_failures =
+          Keeper_registry.get_turn_failures
+            ~base_path:ctx.config.base_path meta_current.name
+        in
+        if stale_turn_failures > 0 then begin
+          Keeper_registry.reset_turn_failures
+            ~base_path:ctx.config.base_path meta_current.name;
+          ignore (Keeper_registry.dispatch_event
+            ~base_path:ctx.config.base_path meta_current.name
+            Keeper_state_machine.Turn_succeeded);
+          Log.Keeper.info
+            "heartbeat recovery: reset %d stale turn failures for %s"
+            stale_turn_failures meta_current.name
+        end);
       match write_meta ctx.config synced with
       | Ok () -> synced
       | Error e ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -216,9 +216,12 @@ let write_heartbeat_snapshot
     Oas_model_resolve.models_of_cascade_name meta_current.cascade_name
   in
   let max_cascade_context =
-    match meta_current.max_context_override with
-    | Some v -> v
-    | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+    let min_keeper_context = 65_536 in
+    let raw = match meta_current.max_context_override with
+      | Some v -> v
+      | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+    in
+    max min_keeper_context raw
   in
   let base_dir = session_base_dir ctx.config in
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -175,11 +175,19 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Oas_model_resolve.refresh_local_discovery_if_possible effective_models);
          let max_cascade_context =
-           match meta.max_context_override with
-           | Some v ->
-               Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
-               v
-           | None -> Oas_model_resolve.resolve_max_cascade_context effective_models
+           let min_keeper_context = 65_536 in
+           let raw =
+             match meta.max_context_override with
+             | Some v ->
+                 Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
+                 v
+             | None -> Oas_model_resolve.resolve_max_cascade_context effective_models
+           in
+           if raw < min_keeper_context then begin
+             Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"
+               meta.name raw min_keeper_context;
+             min_keeper_context
+           end else raw
          in
             let base_dir = session_base_dir ctx.config in
             let effective_no_skill_route = no_skill_route || direct_reply in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -188,11 +188,18 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let voice_agent_id_opt = get_string_opt args "voice_agent_id" in
     let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
+      let min_keeper_context = 65_536 in
       match Safe_ops.json_int_opt "max_context_override" args with
       | None -> None
-      | Some v when v > 0 && v <= 1_000_000 -> Some v
+      | Some v when v >= min_keeper_context && v <= 1_000_000 -> Some v
+      | Some v when v > 0 && v < min_keeper_context ->
+          Log.Misc.warn
+            "max_context_override=%d below minimum %d, clamped to %d"
+            v min_keeper_context min_keeper_context;
+          Some min_keeper_context
       | Some v ->
-          Log.Misc.warn "max_context_override=%d out of range (1..1000000), ignored" v;
+          Log.Misc.warn "max_context_override=%d out of range (%d..1000000), ignored"
+            v min_keeper_context;
           None
     in
     let proactive_enabled_opt = get_bool_opt args "proactive_enabled" in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -824,11 +824,19 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   | Ok () ->
       ignore (Oas_model_resolve.refresh_local_discovery_if_possible model_labels);
       let max_cascade_context =
-        match meta.max_context_override with
-        | Some v ->
-            Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
-            v
-        | None -> Oas_model_resolve.resolve_max_cascade_context model_labels
+        let min_keeper_context = 65_536 in
+        let raw =
+          match meta.max_context_override with
+          | Some v ->
+              Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
+              v
+          | None -> Oas_model_resolve.resolve_max_cascade_context model_labels
+        in
+        if raw < min_keeper_context then begin
+          Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"
+            meta.name raw min_keeper_context;
+          min_keeper_context
+        end else raw
       in
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)


### PR DESCRIPTION
## Summary

keeper 안정성 3-in-1 수정. 세 변경 모두 개별 PR로 이미 `main`에 병합됨 (#5320, #5346, #5348). 이 번들 PR은 병합 충돌 해소 검토용으로만 존재하며, 고유한 기능 변경은 없음.

### 1. 64K context floor
max_context가 8192 같은 작은 값일 때 즉시 overflow. 모든 context resolution에 65536 floor guard 적용. → merged via #5320

### 2. Failing phase deadlock recovery
turn 실패 → turn_healthy=false → Failing → turn 미실행 → 영구 교착.
heartbeat 성공 시 stale turn_failures를 리셋하여 recovery 트리거. → merged via #5346

### 3. Graceful idle exit
idle 감지 시 Continue 대신 Skip 반환 → 에러가 아닌 정상 종료.
keeper_tasks_list 반복 호출 같은 패턴에서 turn_failure 증가 방지. → merged via #5348

### Merge conflict note
`keeper_hooks_oas.ml`의 on_idle 핸들러에서 log level/message 차이(branch: `Log.Keeper.info "… graceful exit (Skip)"` vs main: `Log.Keeper.warn "… requesting stop"`)로 인한 단일 충돌. #5353 이후 main에서 문구가 변경됨. 고유 변경 없음 — 이 PR은 종료해도 안전.

## Product impact

- Promise affected: `none/internal`
- User-visible change: None. All functional changes already shipped via individual PRs.

## Evidence

- [x] `dune build` clean
- [x] CI green
- All 3 fixes verified in individual PRs: #5320, #5346, #5348

## Review evidence

All 5 review threads resolved. 65K floor clamp is by design (RFC-0001 Phase 0 minimum). Recovery timing is correct (presence sync is periodic). Turn failure reset is tested via keeper lifecycle harness.

## Linked issue

- Relates #5320
- Relates #5346
- Relates #5348