### PR TITLE
feat(metrics): instrument 4 heuristic decision sites (RFC-0001 Phase 0.1)

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -81,8 +81,18 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
               || contains_substring hearth "harness")
   then
     Automation_post
-  else if legacy_author_looks_automation author then
+  else if legacy_author_looks_automation author then begin
+    Heuristic_metrics.record {
+      module_name = "board_core_classify";
+      site = "legacy_migrate_post_kind";
+      raw_value = 1.0;
+      threshold = 0.5;
+      triggered = true;
+      provenance = Board_classify ("author_heuristic:" ^ author);
+      timestamp = Unix.gettimeofday ();
+    };
     Automation_post
+  end
   else
     Human_post
 

--- a/lib/goal/goal_orchestrator.ml
+++ b/lib/goal/goal_orchestrator.ml
@@ -132,6 +132,17 @@ let estimate_reversibility description =
   else if has "test" || has "lint" || has "format" then 0.9
   else if has "read" || has "search" || has "query" || has "list" || has "view" then 1.0
   else 0.7  (* unknown defaults to moderately reversible *)
+  |> fun score ->
+    Heuristic_metrics.record {
+      module_name = "goal_orchestrator";
+      site = "estimate_reversibility";
+      raw_value = score;
+      threshold = 0.5;
+      triggered = score < 0.5;
+      provenance = Reversibility (Printf.sprintf "%.1f" score);
+      timestamp = Unix.gettimeofday ();
+    };
+    score
 
 type task_complexity = {
   estimated_turns : int;

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -11,6 +11,11 @@ type provenance =
   | Drift_guard of string
   | Anti_rationalization of string
   | Agent_reputation of string
+  | Relay of string
+  | Alert_scoring of string
+  | Pipeline_stage of string
+  | Board_classify of string
+  | Reversibility of string
 
 type event = {
   module_name : string;
@@ -37,6 +42,16 @@ let provenance_to_json = function
     `Assoc [("type", `String "anti_rationalization"); ("detail", `String gate)]
   | Agent_reputation metric ->
     `Assoc [("type", `String "agent_reputation"); ("detail", `String metric)]
+  | Relay site ->
+    `Assoc [("type", `String "relay"); ("detail", `String site)]
+  | Alert_scoring signal ->
+    `Assoc [("type", `String "alert_scoring"); ("detail", `String signal)]
+  | Pipeline_stage stage ->
+    `Assoc [("type", `String "pipeline_stage"); ("detail", `String stage)]
+  | Board_classify kind ->
+    `Assoc [("type", `String "board_classify"); ("detail", `String kind)]
+  | Reversibility est ->
+    `Assoc [("type", `String "reversibility"); ("detail", `String est)]
 
 let event_to_json (e : event) : Yojson.Safe.t =
   `Assoc [

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -15,6 +15,11 @@ type provenance =
   | Drift_guard of string     (** drift type, e.g. "factual" *)
   | Anti_rationalization of string  (** gate name, e.g. "length" / "excuse" / "llm" / "fallback" *)
   | Agent_reputation of string      (** metric name, e.g. "overall_score" *)
+  | Relay of string                 (** relay decision site, e.g. "estimate_context" / "should_relay" *)
+  | Alert_scoring of string         (** alert keyword/signal, e.g. "keyword_match" / "signal_bonus" *)
+  | Pipeline_stage of string        (** stage inference, e.g. "recency_threshold" *)
+  | Board_classify of string        (** board classification, e.g. "author_heuristic" *)
+  | Reversibility of string         (** Karpathy reversibility, e.g. "estimate" *)
 
 (** A single heuristic observation.  All fields are informational. *)
 type event = {

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -216,6 +216,15 @@ let keeper_alert_signal
   end;
   let score = max 0.0 (min 1.0 !score) in
   let keywords = keyword_hits |> List.map fst |> dedup_strings in
+  Heuristic_metrics.record {
+    module_name = "keeper_alerting";
+    site = "keeper_alert_signal";
+    raw_value = score;
+    threshold = 0.0;
+    triggered = score > 0.0;
+    provenance = Alert_scoring (String.concat "," (List.rev !reasons));
+    timestamp = Unix.gettimeofday ();
+  };
   (score, List.rev !reasons, keywords)
 
 let keeper_alert_text

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -487,11 +487,25 @@ let derive_pipeline_stage
     (* Pick the most recent activity within the recency window.
        Priority order when multiple are recent:
        handoff > compacting > scheduled autonomous > thinking *)
-    if handoff_ago < recency_threshold then "handoff"
-    else if compaction_ago < recency_threshold then "compacting"
-    else if scheduled_autonomous_ago < recency_threshold then "scheduled_autonomous"
-    else if turn_ago < recency_threshold then "thinking"
-    else "idle"
+    let result =
+      if handoff_ago < recency_threshold then "handoff"
+      else if compaction_ago < recency_threshold then "compacting"
+      else if scheduled_autonomous_ago < recency_threshold then "scheduled_autonomous"
+      else if turn_ago < recency_threshold then "thinking"
+      else "idle"
+    in
+    let min_ago = Float.min turn_ago (Float.min compaction_ago
+        (Float.min handoff_ago scheduled_autonomous_ago)) in
+    Heuristic_metrics.record {
+      module_name = "keeper_exec_status";
+      site = "derive_pipeline_stage";
+      raw_value = min_ago;
+      threshold = recency_threshold;
+      triggered = min_ago < recency_threshold;
+      provenance = Pipeline_stage result;
+      timestamp = now_ts;
+    };
+    result
 
 (** RFC-0002: derive pipeline stage directly from phase.
     Replaces the heuristic-based [derive_pipeline_stage] with a


### PR DESCRIPTION
## Summary
RFC-0001 Phase 0.1 데이터 수집을 위해 4개 휴리스틱 결정 사이트에 계측 삽입.

## Instrumented Sites
| 사이트 | Provenance | 기록 내용 |
|--------|-----------|----------|
| `keeper_exec_status.derive_pipeline_stage` | Pipeline_stage | recency vs threshold, 결과 stage |
| `keeper_alerting.keeper_alert_signal` | Alert_scoring | 최종 score, trigger reasons |
| `board_core_classify.legacy_migrate_post_kind` | Board_classify | author heuristic 분류 |
| `goal_orchestrator.estimate_reversibility` | Reversibility | Karpathy score |

## New Provenance Variants
`Relay`, `Alert_scoring`, `Pipeline_stage`, `Board_classify`, `Reversibility`

## Test plan
- [x] `dune build --root .` 통과
- [ ] `.masc/heuristic_metrics.jsonl`에 새 provenance 이벤트 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)