### PR TITLE
fix(dashboard): restore tool_call_health from Audit_log entries

### DIFF
--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -21,7 +21,7 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
   let entries =
     try Audit_log.read_entries ~n:50_000 config
     with exn ->
-      Log.Misc.warn "tool_call_health: read_entries failed: %s"
+      Log.Dashboard.warn "tool_call_health: read_entries failed: %s"
         (Printexc.to_string exn);
       []
   in

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -5,9 +5,10 @@
 
 open Dashboard_http_helpers
 
-(* Tool_audit module removed — audit-based tool call health is retired.
-   Returns zeroed metrics so dashboard consumers degrade gracefully. *)
-let tool_call_health_json (_config : Room.config) : Yojson.Safe.t =
+(** Compute tool-call health metrics from [Audit_log] entries within a
+    configurable time window.  Reads the canonical date-split audit store
+    and counts [ToolCall _] actions, partitioned by outcome. *)
+let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
   let window_hours =
     float_of_env_default
       "MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS"
@@ -15,13 +16,39 @@ let tool_call_health_json (_config : Room.config) : Yojson.Safe.t =
       ~min_v:0.1
       ~max_v:168.0
   in
+  let now = Unix.gettimeofday () in
+  let since = now -. (window_hours *. 3600.0) in
+  let entries =
+    try Audit_log.read_entries ~n:50_000 config
+    with exn ->
+      Log.Misc.warn "tool_call_health: read_entries failed: %s"
+        (Printexc.to_string exn);
+      []
+  in
+  let is_tool_call (e : Audit_log.audit_entry) =
+    match e.action with Audit_log.ToolCall _ -> true | _ -> false
+  in
+  let in_window (e : Audit_log.audit_entry) = e.timestamp >= since in
+  let tool_entries =
+    entries |> List.filter (fun e -> is_tool_call e && in_window e)
+  in
+  let total = List.length tool_entries in
+  let failures =
+    List.length
+      (List.filter
+         (fun (e : Audit_log.audit_entry) ->
+           match e.outcome with Audit_log.Failure _ -> true | _ -> false)
+         tool_entries)
+  in
+  let failure_rate =
+    if total = 0 then 0.0 else float_of_int failures /. float_of_int total
+  in
   `Assoc [
     ("window_hours", `Float window_hours);
-    ("tool_calls", `Int 0);
-    ("failures", `Int 0);
-    ("timeouts", `Int 0);
-    ("failure_rate", `Float 0.0);
-    ("p95_duration_ms", `Null);
+    ("tool_calls", `Int total);
+    ("failures", `Int failures);
+    ("failure_rate", `Float failure_rate);
+    ("since_epoch", `Float since);
   ]
 
 let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =


### PR DESCRIPTION
## Summary
- `tool_call_health_json`이 #4782에서 Tool_audit 모듈 삭제 시 all-zero stub으로 대체됨
- Audit_log는 여전히 모든 tool call을 기록 중이므로, `Audit_log.read_entries`에서 직접 집계하도록 복원
- configurable time window 내의 ToolCall action을 count하여 total/failures/failure_rate 반환
- JSON shape에서 `timeouts`와 `p95_duration_ms` 제거 (Audit_log 소스는 타이밍 데이터를 포함하지 않음 — 이전에 0을 반환하던 것보다 필드를 생략하는 것이 더 정확함)

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Dashboard `tool_call_health` 패널이 실제 집계 데이터를 표시. `timeouts` 및 `p95_duration_ms` 필드가 응답에서 제거됨 (해당 데이터를 소스에서 사용할 수 없음)

## Evidence

- `dune build` 통과
- `/api/v1/dashboard/shell` 호출 시 `tool_call_health.tool_calls > 0` 확인 (keeper 활성 상태에서)
- `MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS` 환경변수 변경 시 window 반영 확인

## Review evidence

- Copilot PR reviewer feedback addressed: log routing (`Log.Misc.warn` → `Log.Dashboard.warn`) applied in 69dc592; JSON shape and 50K read cap decisions confirmed intentional.

## Linked issue