### PR TITLE
feat(telemetry): record phase transitions in audit ring buffer

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -642,6 +642,16 @@ let dispatch_event ~base_path name (event : Keeper_state_machine.event) =
          (Keeper_state_machine.phase_to_string tr.prev_phase)
          (Keeper_state_machine.phase_to_string tr.new_phase)
          (Keeper_state_machine.event_to_string event);
+       (* Record transition in audit ring buffer for dashboard API *)
+       Keeper_transition_audit.record_transition ~keeper_name:name {
+         snapshot = None;
+         events_fired = [event];
+         selected_event = event;
+         prev_phase = tr.prev_phase;
+         new_phase = tr.new_phase;
+         transition_outcome = "applied";
+         wall_clock_at_decision = now;
+       };
        (* Update running count based on legacy projection *)
        let prev_legacy = Keeper_state_compat.to_legacy tr.prev_phase in
        let new_legacy = Keeper_state_compat.to_legacy tr.new_phase in

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -1,7 +1,7 @@
 (** Keeper Transition Audit — Structured audit trail (RFC-0002). *)
 
 type transition_record = {
-  snapshot : Keeper_measurement.measurement_snapshot;
+  snapshot : Keeper_measurement.measurement_snapshot option;
   events_fired : Keeper_state_machine.event list;
   selected_event : Keeper_state_machine.event;
   prev_phase : Keeper_state_machine.phase;
@@ -12,7 +12,9 @@ type transition_record = {
 
 let to_json (r : transition_record) : Yojson.Safe.t =
   `Assoc [
-    "snapshot", Keeper_measurement.measurement_snapshot_to_json r.snapshot;
+    "snapshot", (match r.snapshot with
+      | Some s -> Keeper_measurement.measurement_snapshot_to_json s
+      | None -> `Null);
     "events_fired",
       `List (List.map Keeper_state_machine.event_to_json r.events_fired);
     "selected_event", Keeper_state_machine.event_to_json r.selected_event;
@@ -25,3 +27,51 @@ let to_json (r : transition_record) : Yojson.Safe.t =
 (* Phase 1 stub: Keeper_guard not yet wired as consumer.
    Phase 4 will implement actual replay by calling Keeper_guard.evaluate. *)
 let replay_check _snapshot _expected_events = true
+
+(* ================================================================ *)
+(* In-memory ring buffer for recent transitions                     *)
+(* ================================================================ *)
+
+(** Per-keeper ring buffer: stores the last N transition records.
+    Thread-safe via non-yielding StringMap + Array mutation in single-domain Eio. *)
+
+type ring = {
+  buf : transition_record option array;
+  mutable pos : int;
+  mutable count : int;
+}
+
+let ring_capacity = 50
+
+let rings : (string, ring) Hashtbl.t = Hashtbl.create 16
+
+let get_or_create_ring name =
+  match Hashtbl.find_opt rings name with
+  | Some r -> r
+  | None ->
+    let r = { buf = Array.make ring_capacity None; pos = 0; count = 0 } in
+    Hashtbl.replace rings name r;
+    r
+
+let record_transition ~keeper_name (rec_ : transition_record) =
+  let ring = get_or_create_ring keeper_name in
+  ring.buf.(ring.pos) <- Some rec_;
+  ring.pos <- (ring.pos + 1) mod ring_capacity;
+  ring.count <- ring.count + 1
+
+let recent_transitions ~keeper_name ~limit : transition_record list =
+  match Hashtbl.find_opt rings keeper_name with
+  | None -> []
+  | Some ring ->
+    let n = min limit (min ring.count ring_capacity) in
+    let result = ref [] in
+    for i = 0 to n - 1 do
+      let idx = (ring.pos - 1 - i + ring_capacity) mod ring_capacity in
+      match ring.buf.(idx) with
+      | Some r -> result := r :: !result
+      | None -> ()
+    done;
+    !result
+
+let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
+  `List (List.map to_json (recent_transitions ~keeper_name ~limit))

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -4,7 +4,7 @@
 
 (** A single transition decision record. *)
 type transition_record = {
-  snapshot : Keeper_measurement.measurement_snapshot;
+  snapshot : Keeper_measurement.measurement_snapshot option;
   events_fired : Keeper_state_machine.event list;
   selected_event : Keeper_state_machine.event;
   prev_phase : Keeper_state_machine.phase;
@@ -23,3 +23,17 @@ val replay_check :
   Keeper_measurement.measurement_snapshot ->
   Keeper_state_machine.event list ->
   bool
+
+(** {1 In-memory Ring Buffer} *)
+
+(** Record a transition in the per-keeper ring buffer (last 50). *)
+val record_transition :
+  keeper_name:string -> transition_record -> unit
+
+(** Retrieve recent transitions for a keeper, newest first. *)
+val recent_transitions :
+  keeper_name:string -> limit:int -> transition_record list
+
+(** JSON array of recent transitions. *)
+val recent_transitions_json :
+  keeper_name:string -> limit:int -> Yojson.Safe.t


### PR DESCRIPTION
## Summary
- `Keeper_transition_audit`에 per-keeper ring buffer (cap 50) 추가
- `keeper_registry.dispatch_event`에서 phase 전이 시 자동 기록
- `transition_record.snapshot`을 optional로 변경 (dispatch_event에서 full snapshot 불필요)

## API
- `record_transition ~keeper_name record` — 전이 기록
- `recent_transitions ~keeper_name ~limit` — 최근 N개 조회
- `recent_transitions_json ~keeper_name ~limit` — JSON 직렬화

## Next
이 데이터를 소비하는 `/api/keepers/:name/transitions` HTTP 엔드포인트는 별도 PR.

## Test plan
- [x] `dune build --root .` 통과
- [ ] keeper 전이 시 ring buffer에 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)