### PR TITLE
fix(concurrency): re-raise Eio.Cancel.Cancelled in 3 I/O cleanup paths

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -314,7 +314,7 @@ let use_with_retry pool f =
     Log.Backend.warn "[EioPG] stale connection detected, draining pool and retrying: %s"
       (Caqti_error.show err);
     Eio.Mutex.use_rw ~protect:false _drain_mutex (fun () ->
-      try Caqti_eio.Pool.drain pool with _ -> ());
+      try Caqti_eio.Pool.drain pool with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
     Caqti_eio.Pool.use f pool
   | Error _ as err -> err
 

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -323,7 +323,7 @@ module Reflection_bridge = struct
       let process_loop () =
         Eio.Switch.run @@ fun loop_sw ->
         Eio.Switch.on_release loop_sw (fun () ->
-            (try Grpc_eio.Stream.close response_stream with _ -> ()));
+            (try Grpc_eio.Stream.close response_stream with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()));
             let rec loop () =
               let request_bytes = Grpc_eio.Stream.take request_stream in
               let services = Grpc_eio.Server.list_services !server_ref in

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -48,7 +48,7 @@ let make_closing_client ~sw ~net ~https =
     | None -> ()
     | Some sock ->
         last_sock := None;
-        (try Eio.Net.close sock with _ -> ()));
+        (try Eio.Net.close sock with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()));
   client
 
 (** POST with structured error handling.


### PR DESCRIPTION
## Summary
- Replace bare `with _ ->` in 3 Eio I/O contexts that could swallow cancellation
- `backend_pg.ml`: Caqti pool drain
- `masc_grpc_server.ml`: gRPC stream close
- `masc_http_client.ml`: Eio socket close
- Non-Eio sites (server_startup_takeover, masc_grpc_service) left as-is

Closes #5335

## Test plan
- [x] `dune build` passes
- [ ] CI `dune runtest` passes

Generated with [Claude Code](https://claude.com/claude-code)