### PR TITLE
refactor: externalize relay token estimation constants to Governance_registry

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -209,6 +209,62 @@ let keeper_handoff_pressure_threshold =
     ~deserialize:deserialize_float
     ()
 
+(* ── relay_heuristic surface (Low risk) ───────────────────────── *)
+
+let relay_tokens_per_user_msg =
+  Runtime_params.register ~key:"relay.tokens_per_user_msg"
+    ~default:(fun () -> 150)
+    ~validate:(validate_int_range ~min:10 ~max:5000 "relay.tokens_per_user_msg")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_assistant_msg =
+  Runtime_params.register ~key:"relay.tokens_per_assistant_msg"
+    ~default:(fun () -> 500)
+    ~validate:(validate_int_range ~min:10 ~max:10000 "relay.tokens_per_assistant_msg")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_tool_call =
+  Runtime_params.register ~key:"relay.tokens_per_tool_call"
+    ~default:(fun () -> 200)
+    ~validate:(validate_int_range ~min:10 ~max:5000 "relay.tokens_per_tool_call")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_tokens_per_tool_result =
+  Runtime_params.register ~key:"relay.tokens_per_tool_result"
+    ~default:(fun () -> 300)
+    ~validate:(validate_int_range ~min:10 ~max:10000 "relay.tokens_per_tool_result")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_large_file_read =
+  Runtime_params.register ~key:"relay.cost_large_file_read"
+    ~default:(fun () -> 10_000)
+    ~validate:(validate_int_range ~min:1000 ~max:100_000 "relay.cost_large_file_read")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_per_file_edit =
+  Runtime_params.register ~key:"relay.cost_per_file_edit"
+    ~default:(fun () -> 3_000)
+    ~validate:(validate_int_range ~min:500 ~max:50_000 "relay.cost_per_file_edit")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_long_running =
+  Runtime_params.register ~key:"relay.cost_long_running"
+    ~default:(fun () -> 20_000)
+    ~validate:(validate_int_range ~min:1000 ~max:200_000 "relay.cost_long_running")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_exploration =
+  Runtime_params.register ~key:"relay.cost_exploration"
+    ~default:(fun () -> 15_000)
+    ~validate:(validate_int_range ~min:1000 ~max:100_000 "relay.cost_exploration")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
+let relay_cost_simple =
+  Runtime_params.register ~key:"relay.cost_simple"
+    ~default:(fun () -> 1_000)
+    ~validate:(validate_int_range ~min:100 ~max:10_000 "relay.cost_simple")
+    ~serialize:(fun v -> `Int v) ~deserialize:deserialize_int ()
+
 (* ── keeper_diagnostics surface (Medium risk) ─────────────────── *)
 
 let keeper_snapshot_sec =
@@ -337,6 +393,17 @@ let surfaces =
         "keeper.work_as_hb_max_silence_sec";
         "keeper.smart_hb_enabled";
         "keeper.stage_timing_ring_size";
+      ];
+    };
+    {
+      id = "relay_heuristic";
+      description = "Relay token estimation and task cost heuristics (not calibrated)";
+      risk = "low";
+      param_keys = [
+        "relay.tokens_per_user_msg"; "relay.tokens_per_assistant_msg";
+        "relay.tokens_per_tool_call"; "relay.tokens_per_tool_result";
+        "relay.cost_large_file_read"; "relay.cost_per_file_edit";
+        "relay.cost_long_running"; "relay.cost_exploration"; "relay.cost_simple";
       ];
     };
   ]

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -130,18 +130,19 @@ let resolve_max_context model =
     No formal benchmark has validated these specific numbers.
 
     TODO(RFC-0001 Phase 0): Replace with empirical calibration once
-    heuristic_metrics.jsonl collects actual token counts per message type. *)
-let tokens_per_user_msg = 150
-let tokens_per_assistant_msg = 500
-let tokens_per_tool_call = 200
-let tokens_per_tool_result = 300
+    heuristic_metrics.jsonl collects actual token counts per message type.
+    Governable via [Governance_registry.relay_tokens_per_*]. *)
+let tokens_per_user_msg () = Runtime_params.get Governance_registry.relay_tokens_per_user_msg
+let tokens_per_assistant_msg () = Runtime_params.get Governance_registry.relay_tokens_per_assistant_msg
+let tokens_per_tool_call () = Runtime_params.get Governance_registry.relay_tokens_per_tool_call
+let tokens_per_tool_result () = Runtime_params.get Governance_registry.relay_tokens_per_tool_result
 
 (** Estimate context usage.
     Token-per-message estimates are rough heuristics, corrected by calibration. *)
 let estimate_context ~messages ~tool_calls ~model =
 
-  let message_tokens = messages * (tokens_per_user_msg + tokens_per_assistant_msg) in
-  let tool_tokens = tool_calls * (tokens_per_tool_call + tokens_per_tool_result) in
+  let message_tokens = messages * (tokens_per_user_msg () + tokens_per_assistant_msg ()) in
+  let tool_tokens = tool_calls * (tokens_per_tool_call () + tokens_per_tool_result ()) in
   let estimated_raw = message_tokens + tool_tokens in
   let factor = calibration.correction_factor in
   let estimated = int_of_float (float_of_int estimated_raw *. factor) in
@@ -165,19 +166,14 @@ type task_hint =
   | Simple_task                  (* Quick task, no relay needed *)
 
 (** Task cost estimates (tokens). Same heuristic caveat as above —
-    these are order-of-magnitude guesses, not measured values. *)
-let cost_large_file_read = 10_000
-let cost_per_file_edit   = 3_000
-let cost_long_running    = 20_000
-let cost_exploration     = 15_000
-let cost_simple          = 1_000
-
+    these are order-of-magnitude guesses, not measured values.
+    Governable via [Governance_registry.relay_cost_*]. *)
 let estimate_task_cost = function
-  | Large_file_read _ -> cost_large_file_read
-  | Multi_file_edit n -> n * cost_per_file_edit
-  | Long_running_task -> cost_long_running
-  | Exploration_task -> cost_exploration
-  | Simple_task -> cost_simple
+  | Large_file_read _ -> Runtime_params.get Governance_registry.relay_cost_large_file_read
+  | Multi_file_edit n -> n * Runtime_params.get Governance_registry.relay_cost_per_file_edit
+  | Long_running_task -> Runtime_params.get Governance_registry.relay_cost_long_running
+  | Exploration_task -> Runtime_params.get Governance_registry.relay_cost_exploration
+  | Simple_task -> Runtime_params.get Governance_registry.relay_cost_simple
 
 (** Proactive relay decision - key insight: predict before hitting limit *)
 let should_relay_proactive ~config ~metrics ~task_hint =


### PR DESCRIPTION
## Summary
- Relay token estimation constants (`tokens_per_user_msg`, `cost_large_file_read`, etc.) 를 Governance_registry로 이동
- Runtime_params를 통해 런타임 변경 가능
- 기존 하드코딩 상수 9개 → governable 파라미터로 전환

Re-created from closed #5330 (rebase + CI retrigger issue).

## Test plan
- [ ] `dune build` 성공
- [ ] relay 토큰 추정이 기본값으로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)