### PR TITLE
fix(config): add board group to coding preset

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -76,7 +76,7 @@ groups = ["base", "board", "coordination", "voice", "governance"]
 masc_groups = ["core"]
 
 [presets.coding]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding"]
+groups = ["base", "board", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding"]
 masc_groups = ["core", "coding"]
 
 [presets.research]

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -242,7 +242,7 @@ let test_all_keepers_have_shell_and_coding () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "keeper_shell_readonly included" true (List.mem "keeper_shell_readonly" tools);
   check bool "keeper_fs_read included" true (List.mem "keeper_fs_read" tools);
-  check bool "keeper_board_get omitted" false (List.mem "keeper_board_get" tools)
+  check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 
 let test_all_modes_produce_same_tools () =
   let meta_a = make_meta ~preset:Keeper_types.Minimal () in


### PR DESCRIPTION
Coding keepers need board access for posting/commenting.