### PR TITLE
refactor: remove deprecated keeper_state alias and dead state functions

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -289,7 +289,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             Keeper_registry.get ~base_path:config.base_path m.name in
           let registry_state =
             match registry_entry with
-            | Some entry -> Some (Keeper_registry.state_to_string entry.phase)
+            | Some entry -> Some (Keeper_state_machine.phase_to_string entry.phase)
             | None -> None
           in
           let phase =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -46,9 +46,6 @@ exception Keeper_heartbeat_failure of {
   keeper_name : string;
 }
 
-(** @deprecated Use [Keeper_state_machine.phase] directly. *)
-type keeper_state = Keeper_state_machine.phase
-
 type registry_entry = {
   base_path : string;
   name : string;
@@ -77,8 +74,6 @@ type registry_entry = {
   tool_usage : (string, tool_call_entry) Hashtbl.t;
 }
 
-(** @deprecated Use [Keeper_state_machine.phase_to_string]. *)
-let state_to_string = Keeper_state_machine.phase_to_string
 
 let registry : registry_entry StringMap.t ref = ref StringMap.empty
 let running_count_atomic = Atomic.make 0
@@ -262,9 +257,6 @@ let conditions_of_legacy_state (_prev : Keeper_state_machine.conditions) (state 
     }
   | Offline -> base
 
-(** @deprecated No external callers remain after Phase 3 migration.
-    Retained temporarily for mark_dead compatibility. Use [dispatch_event]. *)
-let _set_state_deprecated ~base_path:_ _name (_state : Keeper_state_machine.phase) = ()
 
 let mark_dead ~base_path name ~at =
   Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -148,7 +148,7 @@ let unregister ~base_path name =
          name (Atomic.get running_count_atomic)
    | Some entry ->
        Log.Keeper.debug "registry: unregistered non-running keeper name=%s state=%s"
-         name (state_to_string entry.phase)
+         name (Keeper_state_machine.phase_to_string entry.phase)
    | None ->
        Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name);
   registry := StringMap.remove key !registry
@@ -190,7 +190,7 @@ let () =
     All core conditions are set explicitly (not inherited from [prev])
     to prevent stale values from causing incorrect phase derivation.
     Phase 3-4 will migrate callers to [dispatch_event] directly. *)
-let conditions_of_legacy_state (_prev : Keeper_state_machine.conditions) (state : keeper_state)
+let conditions_of_legacy_state (_prev : Keeper_state_machine.conditions) (state : Keeper_state_machine.phase)
     : Keeper_state_machine.conditions =
   let base = Keeper_state_machine.default_conditions in
   match state with

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -26,9 +26,6 @@ exception Keeper_heartbeat_failure of {
   keeper_name : string;
 }
 
-(** @deprecated Use [Keeper_state_machine.phase] directly. *)
-type keeper_state = Keeper_state_machine.phase
-
 type registry_entry = {
   base_path : string;
   name : string;
@@ -58,8 +55,6 @@ type registry_entry = {
   board_cursor_post_id : string option;
   tool_usage : (string, Keeper_types.tool_call_entry) Hashtbl.t;
 }
-
-val state_to_string : keeper_state -> string
 
 (** Register a keeper as running. Returns the new entry. *)
 val register : base_path:string -> string -> keeper_meta -> registry_entry

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -148,7 +148,7 @@ let runtime_surface_json config (meta : keeper_meta) =
   in
   let registry_state =
     match runtime_registry_entry config meta.name with
-    | Some entry -> Some (Keeper_registry.state_to_string entry.phase)
+    | Some entry -> Some (Keeper_state_machine.phase_to_string entry.phase)
     | None -> None
   in
   `Assoc

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -85,7 +85,7 @@ let test_crash_heartbeat_failure () =
   (match R.get ~base_path:bp "hb-crash" with
    | None -> fail "expected hb-crash in registry"
    | Some e ->
-     check string "state" "crashed" (R.state_to_string e.phase);
+     check string "state" "crashed" (KSM.phase_to_string e.phase);
      (match e.last_failure_reason with
       | Some (R.Heartbeat_consecutive_failures n) ->
         check int "failure count preserved" 5 n
@@ -116,7 +116,7 @@ let test_crash_generic_exception () =
   match R.get ~base_path:bp "exn-crash" with
   | None -> fail "expected exn-crash"
   | Some e ->
-    check string "state" "crashed" (R.state_to_string e.phase);
+    check string "state" "crashed" (KSM.phase_to_string e.phase);
     (match e.last_failure_reason with
      | Some (R.Exception s) ->
        check string "exception text" exn_str s
@@ -142,7 +142,7 @@ let test_crash_fiber_unresolved () =
     (match e.last_failure_reason with
      | Some R.Fiber_unresolved -> ()
      | _ -> fail "expected Fiber_unresolved reason");
-    check string "state" "crashed" (R.state_to_string e.phase)
+    check string "state" "crashed" (KSM.phase_to_string e.phase)
 
 (* ══════════════════════════════════════════════════════════
    2. Dead tombstone lifecycle
@@ -156,7 +156,7 @@ let test_dead_tombstone_full_lifecycle () =
   let meta = make_meta "mortal" in
   let reg = R.register ~base_path:bp "mortal" meta in
   check string "initially running" "running"
-    (R.state_to_string (Option.get (R.get ~base_path:bp "mortal")).phase);
+    (KSM.phase_to_string (Option.get (R.get ~base_path:bp "mortal")).phase);
   (* Crash *)
   Eio.Promise.resolve reg.done_r (`Crashed "test");
   ignore (R.dispatch_event ~base_path:bp "mortal"
@@ -178,14 +178,14 @@ let test_dead_tombstone_full_lifecycle () =
   ignore (R.dispatch_event ~base_path:bp "mortal" KSM.Fiber_started);
   (match R.get ~base_path:bp "mortal" with
    | Some e -> check string "still dead after Running attempt" "dead"
-       (R.state_to_string e.phase)
+       (KSM.phase_to_string e.phase)
    | None -> fail "expected mortal");
   (* Dead → Crashed blocked *)
   ignore (R.dispatch_event ~base_path:bp "mortal"
     (KSM.Fiber_terminated { outcome = "test" }));
   (match R.get ~base_path:bp "mortal" with
    | Some e -> check string "still dead after Crashed attempt" "dead"
-       (R.state_to_string e.phase)
+       (KSM.phase_to_string e.phase)
    | None -> fail "expected mortal");
   (* Only unregister removes Dead entry *)
   R.unregister ~base_path:bp "mortal";
@@ -275,7 +275,7 @@ let test_reconcile_predicate_sweep_owned () =
   let _e = R.register ~base_path:bp "r1" (make_meta "r1") in
   (match R.get ~base_path:bp "r1" with
    | Some e ->
-     check string "running" "running" (R.state_to_string e.phase);
+     check string "running" "running" (KSM.phase_to_string e.phase);
      check bool "sweep-owned" true
        (e.phase = KSM.Running || e.phase = KSM.Paused
         || e.phase = KSM.Crashed || e.phase = KSM.Dead)
@@ -303,7 +303,7 @@ let test_reconcile_predicate_stopped_resolved () =
   (* Stopped + resolved done_p = reconcile-eligible *)
   (match R.get ~base_path:bp "s1" with
    | Some e ->
-     check string "stopped" "stopped" (R.state_to_string e.phase);
+     check string "stopped" "stopped" (KSM.phase_to_string e.phase);
      check bool "done_p resolved" true
        (Option.is_some (Eio.Promise.peek e.done_p));
      (* dominated_by_sweep logic: Stopped with resolved → NOT dominated *)
@@ -325,7 +325,7 @@ let test_reconcile_predicate_stopped_unresolved () =
   (* Stopped + unresolved done_p = sweep will handle *)
   (match R.get ~base_path:bp "s2" with
    | Some e ->
-     check string "stopped" "stopped" (R.state_to_string e.phase);
+     check string "stopped" "stopped" (KSM.phase_to_string e.phase);
      check bool "done_p NOT resolved" true
        (Option.is_none (Eio.Promise.peek e.done_p));
      let dominated = match e.phase with
@@ -368,7 +368,7 @@ let test_restart_state_preservation () =
       (Option.is_none e.last_failure_reason);
     (* state should be Running after re-register *)
     check string "state running after restart" "running"
-      (R.state_to_string e.phase)
+      (KSM.phase_to_string e.phase)
 
 (* ══════════════════════════════════════════════════════════
    7. Turn failure → Crashed with Turn_consecutive_failures reason
@@ -391,7 +391,7 @@ let test_crash_turn_failures () =
   match R.get ~base_path:bp "turn-crash" with
   | None -> fail "expected turn-crash"
   | Some e ->
-    check string "state crashed" "crashed" (R.state_to_string e.phase);
+    check string "state crashed" "crashed" (KSM.phase_to_string e.phase);
     (match e.last_failure_reason with
      | Some (R.Turn_consecutive_failures n) ->
        check int "turn failure count" 10 n
@@ -445,7 +445,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       match R.get ~base_path:config.base_path keeper_name with
       | None -> fail "expected direct-lifecycle registry entry"
       | Some entry ->
-        check string "state stopped" "stopped" (R.state_to_string entry.phase);
+        check string "state stopped" "stopped" (KSM.phase_to_string entry.phase);
         check bool "done promise resolved eventually" true stopped_resolved;
         (match Eio.Promise.peek entry.done_p with
          | Some `Stopped -> ()
@@ -461,7 +461,7 @@ let test_stop_keepalive_resolves_running_entry_immediately () =
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected manual-stop-entry in registry"
   | Some entry ->
-    check string "state stopped immediately" "stopped" (R.state_to_string entry.phase);
+    check string "state stopped immediately" "stopped" (KSM.phase_to_string entry.phase);
     (match Eio.Promise.peek reg.done_p with
      | Some `Stopped -> ()
      | Some (`Crashed reason) ->
@@ -480,7 +480,7 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected crashed-before-stop in registry"
   | Some entry ->
-    check string "state remains crashed" "crashed" (R.state_to_string entry.phase);
+    check string "state remains crashed" "crashed" (KSM.phase_to_string entry.phase);
     (match Eio.Promise.peek entry.done_p with
      | Some (`Crashed msg) -> check string "crash reason preserved" reason msg
      | Some `Stopped -> fail "manual stop should not overwrite a crashed promise"

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -29,7 +29,7 @@ let test_register_and_get () =
   let meta = make_meta "k1" in
   let entry = R.register ~base_path:bp "k1" meta in
   check string "name" "k1" entry.name;
-  check string "state" "running" (R.state_to_string entry.phase);
+  check string "state" "running" (KSM.phase_to_string entry.phase);
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected entry for k1"
   | Some e -> check string "get name" "k1" e.name
@@ -66,7 +66,7 @@ let test_set_state () =
   check bool "not running after pause" false (R.is_running ~base_path:bp "k4");
   match R.get ~base_path:bp "k4" with
   | None -> fail "expected k4"
-  | Some e -> check string "state" "paused" (R.state_to_string e.phase)
+  | Some e -> check string "state" "paused" (KSM.phase_to_string e.phase)
 
 let test_extended_states () =
   R.clear ();
@@ -75,12 +75,12 @@ let test_extended_states () =
     (KSM.Fiber_terminated { outcome = "test" }));
   (match R.get ~base_path:bp "k4x" with
    | None -> fail "expected k4x"
-   | Some e -> check string "crashed string" "crashed" (R.state_to_string e.phase));
+   | Some e -> check string "crashed string" "crashed" (KSM.phase_to_string e.phase));
   R.mark_dead ~base_path:bp "k4x" ~at:123.0;
   match R.get ~base_path:bp "k4x" with
   | None -> fail "expected k4x"
   | Some e ->
-      check string "dead string" "dead" (R.state_to_string e.phase);
+      check string "dead string" "dead" (KSM.phase_to_string e.phase);
       check (option (float 0.01)) "dead_since set" (Some 123.0) e.dead_since_ts
 
 let test_count_running () =

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -35,7 +35,7 @@ let test_state_to_string_crashed () =
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "state is crashed" "crashed" (R.state_to_string e.phase)
+    check string "state is crashed" "crashed" (KSM.phase_to_string e.phase)
 
 let test_state_to_string_dead () =
   R.clear ();
@@ -44,7 +44,7 @@ let test_state_to_string_dead () =
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "state is dead" "dead" (R.state_to_string e.phase)
+    check string "state is dead" "dead" (KSM.phase_to_string e.phase)
 
 let test_running_count_crashed () =
   R.clear ();
@@ -146,7 +146,7 @@ let test_dead_to_running_blocked () =
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
-    check string "still dead" "dead" (R.state_to_string e.phase);
+    check string "still dead" "dead" (KSM.phase_to_string e.phase);
     check int "still 0 running" 0 (R.count_running ())
 
 (* ── Fix 1: last_failure_reason stored in registry ────── *)


### PR DESCRIPTION
## Summary
- `keeper_registry`의 deprecated 항목 완전 제거: `type keeper_state` alias, `val state_to_string`, dead no-op
- `keeper_registry.ml` 내부에 남아 있던 `keeper_state` 타입 참조(`conditions_of_legacy_state` 시그니처)를 `Keeper_state_machine.phase`로 교체
- `keeper_registry.ml` 내부에 남아 있던 `state_to_string` 호출(`unregister` 로깅)을 `Keeper_state_machine.phase_to_string`으로 교체
- `keeper_registry.mli`에서 `val state_to_string` 선언 및 `type keeper_state` alias 제거
- 2개 caller(`keeper_status_bridge`, `dashboard_http_keeper`)를 `Keeper_state_machine.phase_to_string` 직접 사용으로 전환

## Product impact

- Promise affected: `none/internal`
- User-visible change: 없음 (내부 타입/함수 정리)

## Evidence

- 제거된 심볼의 외부 참조 없음 확인 (`grep` 검사)
- Code review 및 CodeQL 스캔 통과

## Review evidence

- Copilot code review: no issues found
- CodeQL security scan: no issues found

## Linked issue