### PR TITLE
fix(security): close gh api bypass for destructive POST/PATCH/PUT (#5370, #5371)

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -404,8 +404,9 @@ let truncate_for_log ?(max_len = 240) s =
     Commands not in this list are rejected at the allowlist gate. *)
 let gh_allowed_commands =
   [
-    "api"; "gist"; "issue"; "label"; "pr"; "release";
-    "repo"; "run"; "search"; "status";
+    "api"; "cache"; "gist"; "issue"; "label"; "pr"; "project";
+    "release"; "repo"; "ruleset"; "run"; "search"; "status";
+    "workflow";
   ]
 
 (** Specific (command, subcommand) pairs that are always blocked
@@ -414,6 +415,7 @@ let gh_blocked_operations =
   [
     ("repo", "delete");
     ("gist", "delete");
+    ("workflow", "disable");
   ]
 
 (** Extract the top-level command and its first subcommand from a gh
@@ -464,6 +466,25 @@ let validate_gh_command cmd =
             (Printf.sprintf "gh %s %s is blocked for safety" command sub)
         else Ok ()
 
+(** Known destructive API endpoint patterns.
+    Each pattern is checked as a substring of the full command.
+    Covers merge, state-closing, and branch-merge endpoints. *)
+let gh_api_destructive_patterns =
+  [ "/merge"; "/merges";
+    "state=closed"; "state=\"closed\""; "state='closed'" ]
+
+(** Check if a gh API command uses a non-GET HTTP method.
+    Returns [true] for -X POST, -X PUT, -X PATCH, --method POST, etc. *)
+let has_mutating_http_method parts =
+  let rec check = function
+    | [] -> false
+    | ("-x" | "--method") :: m :: _ ->
+      let m = String.lowercase_ascii m in
+      m = "post" || m = "put" || m = "patch" || m = "delete"
+    | _ :: rest -> check rest
+  in
+  check parts
+
 (** Check if a gh command is a destructive mutation that should be gated.
     Returns [true] for high-risk operations like merge, close, delete.
     Low-risk writes (create, comment) return [false] and are allowed. *)
@@ -479,7 +500,12 @@ let is_gh_destructive_operation cmd =
   | "release" :: sub :: _ -> List.mem sub [ "delete" ]
   | "repo" :: sub :: _ -> List.mem sub [ "archive"; "rename" ]
   | "label" :: sub :: _ -> List.mem sub [ "delete" ]
-  | "api" :: _ -> List.mem "delete" parts
+  | "api" :: _ ->
+    let joined = String.concat " " parts in
+    List.mem "delete" parts
+    || (has_mutating_http_method parts
+        && List.exists (fun pat -> contains_substring joined pat)
+             gh_api_destructive_patterns)
   | _ -> false
 
 (* --- Recursive mkdir --- *)

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -6,7 +6,9 @@
     3. Destructive operations (repo delete, gist delete) are blocked
     4. Shell metacharacters are rejected
     5. Destructive mutations (pr merge, pr close, etc.) are detected
-    6. Low-risk writes (pr create, pr comment, etc.) are not flagged *)
+    6. Low-risk writes (pr create, pr comment, etc.) are not flagged
+    7. gh api bypass via POST/PATCH/PUT to destructive endpoints is detected
+    8. Newly allowed commands (workflow, project, cache, ruleset) pass *)
 
 let validate = Masc_mcp.Worker_dev_tools.validate_gh_command
 
@@ -39,6 +41,12 @@ let test_allowed_read_commands () =
       "label list";
       "status";
       "api repos/owner/repo/pulls/123/comments";
+      "workflow list";
+      "workflow view deploy.yml";
+      "project list";
+      "project view 1";
+      "cache list";
+      "ruleset list";
     ]
   in
   List.iter
@@ -62,6 +70,7 @@ let test_allowed_write_commands () =
       "issue reopen 456";
       "gist create file.txt";
       "gist edit abc123";
+      "workflow run deploy.yml";
     ]
   in
   List.iter
@@ -98,6 +107,7 @@ let test_blocked_destructive_operations () =
       "gist delete abc123";
       "Repo Delete owner/repo";
       "GIST DELETE abc123";
+      "workflow disable deploy.yml";
     ]
   in
   List.iter
@@ -156,6 +166,42 @@ let test_destructive_ops_detected () =
         true (is_destructive cmd))
     destructive
 
+let test_api_bypass_detected () =
+  let api_destructive =
+    [
+      "api -X POST /repos/o/r/pulls/1/merge";
+      "api -X PUT /repos/o/r/pulls/1/merge";
+      "api -X PATCH /repos/o/r/pulls/1 -f state=closed";
+      "api --method POST /repos/o/r/merges -f base=main";
+      "api -X POST /repos/o/r/merges -f base=main -f head=feat";
+      "api -X PATCH /repos/o/r/issues/1 -f state=closed";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "api bypass detected: gh %s" cmd)
+        true (is_destructive cmd))
+    api_destructive
+
+let test_api_safe_methods_not_flagged () =
+  let safe_api =
+    [
+      "api repos/owner/repo/pulls";
+      "api -X GET repos/owner/repo";
+      "api repos/owner/repo/pulls/123/comments";
+      "api -X POST /repos/o/r/issues/1/comments -f body=ok";
+      "api -X POST /repos/o/r/pulls -f title=fix -f head=feat -f base=main";
+      "api -X PATCH /repos/o/r/pulls/1 -f title=newtitle";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "api safe: gh %s" cmd)
+        false (is_destructive cmd))
+    safe_api
+
 let test_non_destructive_ops () =
   let safe =
     [
@@ -173,6 +219,11 @@ let test_non_destructive_ops () =
       "api -X GET repos/owner/repo";
       "search issues 'query'";
       "status";
+      "workflow list";
+      "workflow view deploy.yml";
+      "project list";
+      "cache list";
+      "ruleset list";
     ]
   in
   List.iter
@@ -205,6 +256,10 @@ let () =
         [
           Alcotest.test_case "destructive mutations detected" `Quick
             test_destructive_ops_detected;
+          Alcotest.test_case "api bypass via POST/PATCH/PUT detected" `Quick
+            test_api_bypass_detected;
+          Alcotest.test_case "safe api methods not flagged" `Quick
+            test_api_safe_methods_not_flagged;
           Alcotest.test_case "safe ops not flagged" `Quick
             test_non_destructive_ops;
         ] );


### PR DESCRIPTION
## Summary
- Close security gap where `gh api -X POST/PATCH/PUT` could bypass the destructive operation gate
- Add `workflow`, `project`, `cache`, `ruleset` to `gh_allowed_commands`
- Block `workflow disable` as a destructive operation

## Changes

### Security Fix (#5370)
`is_gh_destructive_operation` only checked for `"delete"` in `gh api` commands. This allowed:
- `gh api -X POST .../pulls/N/merge` → merge a PR
- `gh api -X PATCH .../pulls/N -f state=closed` → close a PR/issue
- `gh api -X PUT .../pulls/N/merge` → merge a PR
- `gh api -X POST .../merges` → merge branches

Now detects mutating HTTP methods (POST/PATCH/PUT) targeting known destructive endpoints (`/merge`, `/merges`, `state=closed`).

### Feature (#5371)
Added `workflow`, `project`, `cache`, `ruleset` to the allowed gh commands list. Added `workflow disable` to blocked operations.

## Test plan
- [x] All 10 github safety tests pass (was 8, added 2 new)
- [x] All 54 keeper safety gates tests pass (no regression)
- [x] API bypass scenarios correctly detected as destructive
- [x] Safe API operations (comments, PR creation, title updates) not flagged
- [x] New commands (workflow list, project list, etc.) pass validation
- [x] workflow disable correctly blocked

## Verified edge cases
| Command | Before | After |
|---------|--------|-------|
| `gh api -X POST .../merge` | PASS (gap) | Destructive gate |
| `gh api -X PATCH ... state=closed` | PASS (gap) | Destructive gate |
| `gh workflow list` | BLOCKED | PASS |
| `gh project list` | BLOCKED | PASS |
| `gh workflow disable` | N/A | BLOCKED |