### PR TITLE
feat(dashboard): add ToolCallHealth panel and fix TypeScript schema

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -14,6 +14,7 @@ const refreshNamespaceTruth = vi.fn().mockResolvedValue(undefined)
 
 const topActiveAgents = { value: [] as unknown[] }
 const shellMetaCognition = { value: null as Record<string, unknown> | null }
+const serverStatus = { value: null as Record<string, unknown> | null }
 const navigate = vi.fn()
 const navigateToPost = vi.fn()
 const connected = { value: true }
@@ -42,6 +43,7 @@ async function loadOverview() {
   }))
   vi.doMock('../../store', () => ({
     shellMetaCognition,
+    serverStatus,
   }))
   vi.doMock('../../sse', () => ({
     journal: [],
@@ -52,6 +54,7 @@ async function loadOverview() {
   vi.doMock('../../router', () => ({
     navigate,
     navigateToPost,
+    hashForRoute: vi.fn().mockReturnValue('#'),
   }))
   vi.doMock('./situation-banner', () => ({
     SituationBanner: () => html`<div>Situation</div>`,
@@ -85,6 +88,7 @@ describe('Overview freshness strip', () => {
     namespaceTruthLoading.value = false
     topActiveAgents.value = []
     shellMetaCognition.value = null
+    serverStatus.value = null
     connected.value = true
     eventCount.value = 0
     lastEvent.value = null
@@ -215,5 +219,123 @@ describe('Overview freshness strip', () => {
     digestButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
     expect(navigateToPost).toHaveBeenCalledWith('post-meta-1')
+  }, 15000)
+})
+
+describe('ToolCallHealthPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-03-26T12:10:00Z').getTime())
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    missionLoading.value = false
+    namespaceTruthLoading.value = false
+    topActiveAgents.value = []
+    shellMetaCognition.value = null
+    serverStatus.value = null
+    connected.value = true
+    eventCount.value = 0
+    lastEvent.value = null
+    missionSnapshot.value = {
+      generated_at: '2026-03-26T12:09:00Z',
+      summary: {},
+      sessions: [],
+      session_briefs: [],
+      attention_queue: [],
+    }
+    namespaceTruth.value = {
+      generated_at: '2026-03-26T12:08:00Z',
+    }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../../mission-store')
+    vi.doUnmock('../../namespace-truth-store')
+    vi.doUnmock('../../observatory-store')
+    vi.doUnmock('../../store')
+    vi.doUnmock('../../sse')
+    vi.doUnmock('../../router')
+    vi.doUnmock('./situation-banner')
+    vi.doUnmock('./attention-spotlight')
+    vi.doUnmock('./narrative-timeline')
+    vi.doUnmock('./agent-avatar')
+    vi.doUnmock('../transport-health')
+    vi.doUnmock('../perf-snapshot')
+  })
+
+  it('hides the panel when serverStatus is null', async () => {
+    serverStatus.value = null
+
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('도구 호출')
+    expect(container.textContent).not.toContain('호출')
+  }, 15000)
+
+  it('hides the panel when tool_calls is 0', async () => {
+    serverStatus.value = {
+      tool_call_health: {
+        window_hours: 1,
+        tool_calls: 0,
+        failures: 0,
+        failure_rate: 0,
+        since_epoch: 1711454400,
+      },
+    }
+
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('도구 호출')
+  }, 15000)
+
+  it('shows the panel with correct counts and failure rate when tool_calls > 0', async () => {
+    serverStatus.value = {
+      tool_call_health: {
+        window_hours: 1,
+        tool_calls: 42,
+        failures: 3,
+        failure_rate: 0.0714,
+        since_epoch: 1711454400,
+      },
+    }
+
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('도구 호출')
+    expect(container.textContent).toContain('42')
+    expect(container.textContent).toContain('3')
+    expect(container.textContent).toContain('7.1%')
+  }, 15000)
+
+  it('shows 0.0% failure rate when there are no failures', async () => {
+    serverStatus.value = {
+      tool_call_health: {
+        window_hours: 1,
+        tool_calls: 10,
+        failures: 0,
+        failure_rate: 0,
+        since_epoch: 1711454400,
+      },
+    }
+
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('도구 호출')
+    expect(container.textContent).toContain('10')
+    expect(container.textContent).toContain('0.0%')
   }, 15000)
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -18,7 +18,7 @@ import { TransportHealthPanel } from '../transport-health'
 import { ConnectorStatusPanel } from '../connector-status'
 import { PerfSnapshotPanel } from '../perf-snapshot'
 import { RouteLink } from '../common/route-link'
-import { shellMetaCognition } from '../../store'
+import { serverStatus, shellMetaCognition } from '../../store'
 import { navigateToPost } from '../../router'
 import type { ObservatoryAgent } from '../../observatory-store'
 import type {
@@ -463,6 +463,38 @@ function AgentPulse() {
   `
 }
 
+// --- Tool Call Health ---
+
+function ToolCallHealthPanel() {
+  const status = serverStatus.value
+  const health = status?.tool_call_health
+  if (!health || health.tool_calls === 0) return null
+
+  const rate = health.failure_rate ?? 0
+  const rateColor = rate > 0.1 ? 'text-bad-light' : rate > 0.03 ? 'text-warn' : 'text-ok'
+  const ratePct = (rate * 100).toFixed(1)
+
+  return html`
+    <div>
+      <${HomeSectionHeader} label="도구 호출" linkLabel="도구 목록 ->" linkTab="monitoring" linkParams=${{ section: 'tools' }} />
+      <div class="grid grid-cols-3 gap-3 max-[640px]:grid-cols-1">
+        <div class="rounded-lg border border-card-border/30 bg-card/40 p-3 text-center">
+          <div class="text-[22px] font-bold text-text-strong">${health.tool_calls.toLocaleString()}</div>
+          <div class="text-[11px] text-text-muted mt-1">호출 (${health.window_hours}h)</div>
+        </div>
+        <div class="rounded-lg border border-card-border/30 bg-card/40 p-3 text-center">
+          <div class="text-[22px] font-bold text-text-strong">${health.failures}</div>
+          <div class="text-[11px] text-text-muted mt-1">실패</div>
+        </div>
+        <div class="rounded-lg border border-card-border/30 bg-card/40 p-3 text-center">
+          <div class="text-[22px] font-bold ${rateColor}">${ratePct}%</div>
+          <div class="text-[11px] text-text-muted mt-1">실패율</div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
 // --- Overview (Home) ---
 
 export function Overview() {
@@ -471,6 +503,7 @@ export function Overview() {
   const metaCognitionCard = MetaCognitionCard()
   const hotSessions = HotSessions()
   const agentPulse = AgentPulse()
+  const toolHealth = ToolCallHealthPanel()
   const journalEntries = (
     Array.isArray(journal as unknown)
       ? { value: journal as unknown as unknown[] }
@@ -498,6 +531,14 @@ export function Overview() {
         ? html`
             <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
               ${agentPulse}
+            </div>
+          `
+        : null}
+
+      ${toolHealth
+        ? html`
+            <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
+              ${toolHealth}
             </div>
           `
         : null}

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -437,9 +437,7 @@ export interface ServerStatus {
     window_hours: number
     tool_calls: number
     failures: number
-    timeouts: number | null
     failure_rate: number
-    p95_duration_ms: number | null
     since_epoch: number
   }
   alert_thresholds?: {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -434,9 +434,13 @@ export interface ServerStatus {
   tempo_interval_s?: number
   tempo?: string
   tool_call_health?: {
-    timeouts: number
-    p95_duration_ms: number | null
     window_hours: number
+    tool_calls: number
+    failures: number
+    timeouts: number | null
+    failure_rate: number
+    p95_duration_ms: number | null
+    since_epoch: number
   }
   alert_thresholds?: {
     proactive_fallback_warn: number

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -7,8 +7,11 @@ open Dashboard_http_helpers
 
 (** Compute tool-call health metrics from [Audit_log] entries within a
     configurable time window.  Reads the canonical date-split audit store
-    and counts [ToolCall _] actions, partitioned by outcome. *)
-let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
+    and counts [ToolCall _] actions, partitioned by outcome.
+
+    [~now_ts] is injectable for testing; defaults to wall-clock time. *)
+let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Room.config)
+    : Yojson.Safe.t =
   let window_hours =
     float_of_env_default
       "MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS"
@@ -16,8 +19,7 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
       ~min_v:0.1
       ~max_v:168.0
   in
-  let now = Unix.gettimeofday () in
-  let since = now -. (window_hours *. 3600.0) in
+  let since = now_ts -. (window_hours *. 3600.0) in
   let entries =
     try Audit_log.read_entries ~n:50_000 config
     with exn ->
@@ -25,20 +27,17 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
         (Printexc.to_string exn);
       []
   in
-  let is_tool_call (e : Audit_log.audit_entry) =
-    match e.action with Audit_log.ToolCall _ -> true | _ -> false
-  in
-  let in_window (e : Audit_log.audit_entry) = e.timestamp >= since in
-  let tool_entries =
-    entries |> List.filter (fun e -> is_tool_call e && in_window e)
-  in
-  let total = List.length tool_entries in
-  let failures =
-    List.length
-      (List.filter
-         (fun (e : Audit_log.audit_entry) ->
-           match e.outcome with Audit_log.Failure _ -> true | _ -> false)
-         tool_entries)
+  let total, failures =
+    List.fold_left
+      (fun (t, f) (e : Audit_log.audit_entry) ->
+        match e.action with
+        | Audit_log.ToolCall _ when e.timestamp >= since ->
+          let f =
+            match e.outcome with Audit_log.Failure _ -> f + 1 | _ -> f
+          in
+          (t + 1, f)
+        | _ -> (t, f))
+      (0, 0) entries
   in
   let failure_rate =
     if total = 0 then 0.0 else float_of_int failures /. float_of_int total
@@ -47,7 +46,9 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
     ("window_hours", `Float window_hours);
     ("tool_calls", `Int total);
     ("failures", `Int failures);
+    ("timeouts", `Null);
     ("failure_rate", `Float failure_rate);
+    ("p95_duration_ms", `Null);
     ("since_epoch", `Float since);
   ]
 

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -46,9 +46,7 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Room.config
     ("window_hours", `Float window_hours);
     ("tool_calls", `Int total);
     ("failures", `Int failures);
-    ("timeouts", `Null);
     ("failure_rate", `Float failure_rate);
-    ("p95_duration_ms", `Null);
     ("since_epoch", `Float since);
   ]
 


### PR DESCRIPTION
## Summary
- tool_call_health TypeScript 타입을 백엔드와 일치시킴 (#5356 follow-up)
- Overview에 ToolCallHealthPanel 추가: 도구 호출 수/실패/실패율 표시
- tool_calls > 0일 때만 렌더링 (데이터 없으면 비표시)
- 리뷰 피드백 반영: `timeouts`/`p95_duration_ms` null 필드 제거 (Audit_log에서 제공 불가), 테스트 목 및 커버리지 보완

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Overview 페이지에 도구 호출 수/실패 수/실패율 패널이 추가됩니다. tool_calls가 0이면 패널이 표시되지 않습니다.

## Evidence

- `dashboard/src/types/dashboard-execution.ts`: tool_call_health 필드를 백엔드 응답과 일치하도록 수정 (tool_calls, failures, failure_rate, since_epoch; timeouts/p95_duration_ms 제거)
- `dashboard/src/components/overview/overview.ts`: ToolCallHealthPanel 컴포넌트 + Overview에 배치
- `lib/dashboard/dashboard_http_monitoring.ml`: tool_call_health_json에서 `timeouts`/`p95_duration_ms` null 항목 제거
- `dashboard/src/components/overview/overview.test.ts`:
  - `../../store` 목에 `serverStatus` 시그널 추가 (모듈 로드 오류 수정)
  - 라우터 목에 `hashForRoute` 추가 (HomeSectionHeader → RouteLink 의존성)
  - ToolCallHealthPanel 테스트 4건 추가: serverStatus=null일 때 미표시, tool_calls=0일 때 미표시, tool_calls>0일 때 수치 표시, 실패 없을 때 0.0% 표시
- 전체 7개 테스트 통과, 대시보드 빌드 성공

## Review evidence

- CodeQL 스캔: 경고 없음
- 코드 리뷰: 지적 사항 없음

## Linked issue