### PR TITLE
feat(dashboard): expand tool categories and improve tool call display UX

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -7,7 +7,7 @@ import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { agentTimeline } from './agent-detail-state'
 import { trimText } from '../lib/truncate'
-import { toolCategory, durationColor } from './tool-call-shared'
+import { toolCategory, durationColor, formatDuration, formatArgs } from './tool-call-shared'
 import type { AgentTimelineEvent } from '../api'
 
 function timelineEventIcon(type: string): string {
@@ -37,19 +37,34 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
   const success = d.success !== false
   const durationMs = (d.duration_ms as number) ?? 0
   const errorMsg = d.error as string | null
+  const args = d.args as Record<string, unknown> | string | undefined
   const cat = toolCategory(toolName)
 
   return html`
-    <div class="flex items-center gap-2 py-1.5 px-2 text-[13px] rounded hover:bg-[var(--white-4)] transition-colors" key=${idx}>
-      <div class="flex-shrink-0 size-5 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[9px] font-mono font-bold ${cat.color}">
-        ${cat.icon}
+    <div class="flex flex-col py-1.5 px-2 rounded hover:bg-[var(--white-4)] transition-colors" key=${idx}>
+      <div class="flex items-center gap-2 text-[13px]">
+        <div class="flex-shrink-0 size-6 rounded-md bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[10px] font-mono font-bold ${cat.color}">
+          ${cat.icon}
+        </div>
+        <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[200px]" title=${toolName}>${toolName}</span>
+        <span class="text-[9px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
+        <span class="text-[11px] font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>
+        ${success
+          ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">ok</span>`
+          : html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">err</span>`}
+        <span class="flex-1"></span>
+        ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
       </div>
-      <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[180px]">${toolName}</span>
-      <span class="text-[11px] font-mono ${durationColor(durationMs)}">${durationMs}ms</span>
-      ${!success ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">실패</span>` : null}
-      ${errorMsg ? html`<span class="text-[10px] text-[var(--text-dim)] truncate max-w-[120px]" title=${errorMsg}>${trimText(errorMsg, 30)}</span>` : null}
-      <span class="flex-1"></span>
-      ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+      ${args ? html`
+        <div class="ml-8 mt-0.5 text-[10px] text-[var(--text-dim)] font-mono truncate">
+          ${typeof args === 'string' ? trimText(args, 60) : formatArgs(args)}
+        </div>
+      ` : null}
+      ${errorMsg ? html`
+        <div class="ml-8 mt-0.5 text-[10px] text-[var(--bad)] font-mono truncate" title=${errorMsg}>
+          ${trimText(errorMsg, 60)}
+        </div>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useState } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
+import { toolCategory } from './tool-call-shared'
 import type { Keeper } from '../types'
 import { serverStatus } from '../store'
 import { operatorSnapshot } from '../operator-store'
@@ -99,12 +100,16 @@ function SignalRow({ label, value }: { label: string; value: string | number }) 
 // ── Tool chip badge ──────────────────────────────────────
 
 function ToolChip({ name }: { name: string }) {
+  const cat = toolCategory(name)
   return html`
     <button type="button"
-      class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
-      title="클릭하여 도구 상세 보기"
+      class="inline-flex items-center gap-1 py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
+      title=${`${cat.label}: ${name}`}
       onClick=${() => openToolsInventory(name)}
-    >${name}</button>
+    >
+      <span class="font-mono font-bold ${cat.color}">${cat.icon}</span>
+      <span>${name}</span>
+    </button>
   `
 }
 

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -9,7 +9,7 @@ import { fetchKeeperTrajectory } from '../api/dashboard'
 import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
 import { truncate } from '../lib/truncate'
 import { TimeAgo } from './common/time-ago'
-import { toolCategory, durationColor, formatArgs, prettyArgs } from './tool-call-shared'
+import { toolCategory, durationColor, formatArgs, prettyArgs, formatDuration, summarizeEntries } from './tool-call-shared'
 import type { Keeper } from '../types'
 
 // ── Constants ────────────────────────────────────────────
@@ -87,7 +87,8 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
         ${'' /* Content */}
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 flex-wrap">
-            <span class="text-xs font-mono font-medium ${cat.color}">${entry.tool_name}</span>
+            <span class="text-xs font-mono font-medium ${cat.color}" title=${entry.tool_name}>${entry.tool_name}</span>
+            <span class="text-[10px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
             <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}R${entry.round}</span>
             ${entry.cost_usd > 0
               ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)]">$${entry.cost_usd.toFixed(4)}</span>`
@@ -97,7 +98,9 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
               : null}
             ${entry.error
               ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>`
-              : null}
+              : !gateRejected
+                ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">완료</span>`
+                : null}
           </div>
 
           ${'' /* Args preview (collapsed) */}
@@ -110,7 +113,7 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
 
         ${'' /* Duration + timestamp */}
         <div class="flex-shrink-0 flex flex-col items-end gap-0.5">
-          <span class="text-[11px] font-mono ${durationColor(entry.duration_ms)}">${entry.duration_ms}ms</span>
+          <span class="text-[11px] font-mono ${durationColor(entry.duration_ms)}">${formatDuration(entry.duration_ms)}</span>
           <${TimeAgo} timestamp=${entry.ts} class="text-[10px] text-[var(--text-dim)]" />
         </div>
       </div>
@@ -244,16 +247,25 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
       </div>
 
       ${'' /* Turn groups */}
-      ${turns.map(([turnNum, entries]) => html`
-        <div class="mb-2">
-          <div class="flex items-center gap-2 mb-1">
-            <div class="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-wider">Turn ${turnNum}</div>
-            <div class="flex-1 h-px bg-[var(--border-slate-12)]"></div>
-            <div class="text-[10px] text-[var(--text-dim)]">${entries.length} call${entries.length > 1 ? 's' : ''}</div>
+      ${turns.map(([turnNum, entries]) => {
+        const summary = summarizeEntries(entries)
+        return html`
+          <div class="mb-3">
+            <div class="flex items-center gap-2 mb-1.5 px-1">
+              <div class="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-wider">Turn ${turnNum}</div>
+              <div class="flex-1 h-px bg-[var(--border-slate-12)]"></div>
+              <div class="flex items-center gap-2 text-[10px] text-[var(--text-dim)]">
+                ${summary.errorCount > 0
+                  ? html`<span class="text-[var(--bad)]">${summary.errorCount} err</span>`
+                  : null}
+                <span>${summary.successCount}/${entries.length}</span>
+                <span class="font-mono ${durationColor(summary.totalMs)}">${formatDuration(summary.totalMs)}</span>
+              </div>
+            </div>
+            ${entries.map((e: TrajectoryEntry) => html`<${TrajectoryEntryRow} entry=${e} />`)}
           </div>
-          ${entries.map((e: TrajectoryEntry) => html`<${TrajectoryEntryRow} entry=${e} />`)}
-        </div>
-      `)}
+        `
+      })}
     </div>
   `
 }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -6,6 +6,7 @@ import type { LogEntry } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
 import { TextInput } from './common/input'
 import { createAsyncResource, loaded } from '../lib/async-state'
+import { toolCategory } from './tool-call-shared'
 
 interface LogData {
   entries: LogEntry[]
@@ -236,7 +237,7 @@ function renderLogRow(entry: LogEntry) {
           ? html`<span class="rounded-full border border-[rgba(71,184,255,0.16)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
-          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${toolName}</span>`
+          ? html`<span class="inline-flex items-center gap-1 rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px]"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
           : null}
         ${phase
           ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { StatusChip } from './common/status-chip'
+import { toolCategory } from './tool-call-shared'
 import type {
   DashboardProofActorContribution,
   DashboardProofArtifactRef,
@@ -133,7 +134,10 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
         ? html`<div class="flex flex-col gap-2 mt-2 pt-3 border-t border-card-border/50">
             <strong class="text-[11px] font-semibold uppercase tracking-widest text-text-muted">실행 도구</strong>
             <div class="flex flex-wrap gap-2">
-              ${toolNames.map(name => html`<span class="px-2 py-1 rounded-md text-[10px] font-medium bg-[var(--accent-10)] text-accent border border-accent/20 shadow-sm">${name}</span>`)}
+              ${toolNames.map(name => {
+                const cat = toolCategory(name)
+                return html`<span class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium bg-[var(--accent-10)] text-accent border border-accent/20 shadow-sm"><span class="font-mono font-bold ${cat.color}">${cat.icon}</span>${name}</span>`
+              })}
             </div>
           </div>`
         : null}
@@ -219,7 +223,10 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
         : null}
       ${Array.isArray(item.recent_tool_names) && item.recent_tool_names.length > 0
         ? html`<div class="flex flex-wrap gap-1.5 mb-3">
-            ${item.recent_tool_names.map(name => html`<span class="semantic-tag">${name}</span>`)}
+            ${item.recent_tool_names.map(name => {
+              const cat = toolCategory(name)
+              return html`<span class="semantic-tag inline-flex items-center gap-1"><span class="font-mono font-bold ${cat.color}">${cat.icon}</span>${name}</span>`
+            })}
           </div>`
         : null}
     </article>

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -6,13 +6,11 @@ import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { truncate } from '../../lib/truncate'
+import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import type { UnifiedTraceEvent, TraceEventKind } from './session-trace-state'
 
 // ── Constants ──────────────────────────────────────────
 
-const ARGS_PREVIEW_MAX = 80
-const ARGS_VALUE_MAX = 30
-const ARGS_MAX_KEYS = 3
 const BROADCAST_PREVIEW_MAX = 160
 
 // ── Kind styling ───────────────────────────────────────
@@ -31,39 +29,16 @@ const KIND_STYLES: Record<TraceEventKind, KindStyle> = {
   lifecycle:  { icon: 'L', color: 'text-[var(--warn)]', label: '생명주기' },
 }
 
-// Tool-specific icon/color overrides (same categories as keeper-trajectory-timeline)
-const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; color: string }> = [
-  { match: n => n.includes('bash'),                          icon: '>', color: 'text-[var(--ok)]' },
-  { match: n => n.includes('edit') || n.includes('fs'),      icon: 'E', color: 'text-[var(--warn)]' },
-  { match: n => n.includes('board') || n.includes('social'), icon: 'B', color: 'text-[var(--purple)]' },
-  { match: n => n.includes('github'),                        icon: 'G', color: 'text-[var(--accent)]' },
-  { match: n => n.includes('search') || n.includes('read'),  icon: 'R', color: 'text-[#60a5fa]' },
-]
-
+// Use shared tool category from tool-call-shared (SSOT)
 function toolStyle(name: string): { icon: string; color: string } {
-  return TOOL_CATEGORIES.find(c => c.match(name)) ?? { icon: '>', color: 'text-[var(--ok)]' }
-}
-
-function durationColor(ms: number): string {
-  if (ms < 500) return 'text-[var(--ok)]'
-  if (ms < 2000) return 'text-[var(--warn)]'
-  return 'text-[var(--bad)]'
+  return toolCategory(name)
 }
 
 // ── Formatters ─────────────────────────────────────────
 
+// formatArgs delegated to shared module (SSOT: tool-call-shared.ts)
 function formatArgs(args: Record<string, unknown> | string): string {
-  if (typeof args === 'string') return truncate(args, ARGS_PREVIEW_MAX)
-  const keys = Object.keys(args)
-  if (keys.length === 0) return '{}'
-  const preview = keys.slice(0, ARGS_MAX_KEYS).map(k => {
-    const v = args[k]
-    const vs = typeof v === 'string'
-      ? truncate(v, ARGS_VALUE_MAX)
-      : truncate(JSON.stringify(v) ?? '', ARGS_VALUE_MAX)
-    return `${k}: ${vs}`
-  }).join(', ')
-  return keys.length > ARGS_MAX_KEYS ? `{${preview}, …}` : `{${preview}}`
+  return sharedFormatArgs(args)
 }
 
 // ── Task event helpers ─────────────────────────────────
@@ -187,7 +162,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
       ${'' /* Right side: duration + time */}
       <div class="flex-shrink-0 flex flex-col items-end gap-0.5">
         ${event.duration_ms != null ? html`
-          <span class="text-[11px] font-mono ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>
+          <span class="text-[11px] font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span>
         ` : null}
         <${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-[var(--text-dim)]" />
       </div>

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -13,20 +13,94 @@ const ARGS_VALUE_MAX_CHARS = 30
 const ARGS_MAX_KEYS = 3
 
 // ── Tool categories ─────────────────────────────────────
+// Order matters: first match wins. More specific patterns before general ones.
 
-export const TOOL_CATEGORIES: Array<{ match: (n: string) => boolean; icon: string; color: string }> = [
-  { match: n => n.includes('bash'),                          icon: '>', color: 'text-[var(--ok)]' },
-  { match: n => n.includes('edit') || n.includes('fs'),      icon: 'E', color: 'text-[var(--warn)]' },
-  { match: n => n.includes('board') || n.includes('social'), icon: 'B', color: 'text-[var(--purple)]' },
-  { match: n => n.includes('github'),                        icon: 'G', color: 'text-[var(--accent)]' },
-  { match: n => n.includes('search') || n.includes('read'),  icon: 'R', color: 'text-[#60a5fa]' },
+export type ToolCategoryEntry = {
+  match: (n: string) => boolean
+  icon: string
+  color: string
+  label: string
+}
+
+export const TOOL_CATEGORIES: ToolCategoryEntry[] = [
+  // Shell / Bash — execution tools
+  { match: n => n.includes('bash') || n.includes('shell'),
+    icon: '>', color: 'text-[var(--ok)]', label: 'shell' },
+  // Git / GitHub / Worktree — version control
+  { match: n => n.includes('github') || n.includes('git') || n.includes('worktree'),
+    icon: 'G', color: 'text-[var(--accent)]', label: 'git' },
+  // File write / edit — mutations
+  { match: n => n.includes('edit') || n.includes('write') || n.includes('delete'),
+    icon: 'E', color: 'text-[var(--warn)]', label: 'edit' },
+  // File read / filesystem
+  { match: n => n.includes('fs_read') || n.includes('code_read'),
+    icon: 'F', color: 'text-[#a78bfa]', label: 'file' },
+  // Board / Social — community interaction
+  { match: n => n.includes('board') || n.includes('social'),
+    icon: 'B', color: 'text-[var(--purple)]', label: 'board' },
+  // Search / Read / Library / Symbols
+  { match: n => n.includes('search') || n.includes('symbols') || n.includes('library'),
+    icon: 'S', color: 'text-[#60a5fa]', label: 'search' },
+  // Voice — audio/speech
+  { match: n => n.includes('voice'),
+    icon: 'V', color: 'text-[#f472b6]', label: 'voice' },
+  // Web — network access
+  { match: n => n.includes('web') || n.includes('fetch'),
+    icon: 'W', color: 'text-[#38bdf8]', label: 'web' },
+  // Coordination — tasks, transitions, heartbeat
+  { match: n => n.includes('task') || n.includes('transition') || n.includes('claim') || n.includes('heartbeat') || n.includes('broadcast'),
+    icon: 'C', color: 'text-[#fbbf24]', label: 'coord' },
+  // Memory — recall, context, memory search
+  { match: n => n.includes('memory') || n.includes('recall') || n.includes('context'),
+    icon: 'M', color: 'text-[#34d399]', label: 'memory' },
+  // Status / Dashboard — observability
+  { match: n => n.includes('status') || n.includes('dashboard') || n.includes('agents') || n.includes('agent_card'),
+    icon: 'D', color: 'text-[#c084fc]', label: 'status' },
+  // Playwright / Browser — browser automation
+  { match: n => n.includes('playwright') || n.includes('browser') || n.includes('navigate'),
+    icon: 'P', color: 'text-[#fb923c]', label: 'browser' },
+  // Read (generic, after more specific patterns)
+  { match: n => n.includes('read'),
+    icon: 'R', color: 'text-[#60a5fa]', label: 'read' },
 ]
-export const DEFAULT_TOOL_STYLE = { icon: 'T', color: 'text-[#94a3b8]' }
+export const DEFAULT_TOOL_STYLE: Omit<ToolCategoryEntry, 'match'> = { icon: 'T', color: 'text-[#94a3b8]', label: 'tool' }
 
 // ── Functions ───────────────────────────────────────────
 
-export function toolCategory(name: string): { icon: string; color: string } {
-  return TOOL_CATEGORIES.find(c => c.match(name)) ?? DEFAULT_TOOL_STYLE
+export type ToolCategoryResult = { icon: string; color: string; label: string }
+
+export function toolCategory(name: string): ToolCategoryResult {
+  const found = TOOL_CATEGORIES.find(c => c.match(name))
+  return found ?? DEFAULT_TOOL_STYLE
+}
+
+/** Human-readable tool name: strip common prefixes, replace underscores. */
+export function humanToolName(name: string): string {
+  return name
+    .replace(/^(keeper_|masc_|mcp__[a-z_-]+__)/i, '')
+    .replace(/_/g, ' ')
+}
+
+/** Format duration as human-readable string with unit. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  return `${(ms / 60_000).toFixed(1)}m`
+}
+
+/** Summarize a list of trajectory entries: total duration, success count, error count. */
+export function summarizeEntries(entries: Array<{ duration_ms: number; error: string | null }>): {
+  totalMs: number
+  successCount: number
+  errorCount: number
+} {
+  let totalMs = 0
+  let errorCount = 0
+  for (const e of entries) {
+    totalMs += e.duration_ms
+    if (e.error) errorCount++
+  }
+  return { totalMs, successCount: entries.length - errorCount, errorCount }
 }
 
 export function durationColor(ms: number): string {

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { fetchToolMetrics, type ToolMetricsResponse, type ToolMetricsTopEntry } from '../api'
 import { createAsyncResource } from '../lib/async-state'
+import { toolCategory } from './tool-call-shared'
 
 const metricsResource = createAsyncResource<ToolMetricsResponse>()
 
@@ -29,18 +30,34 @@ function tierBadgeClass(tier: string): string {
   }
 }
 
+/** Map category color CSS class (text-[...]) to a usable bar background color. */
+function categoryBarColor(colorClass: string): string {
+  const match = colorClass.match(/text-\[(.*)\]/)
+  if (!match) return 'var(--accent)'
+  const val = match[1]!
+  // CSS variable references
+  if (val.startsWith('var(')) return val
+  // Direct hex/rgb
+  return val
+}
+
 function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount: number }) {
   if (items.length === 0) return html`<p class="muted">아직 도구 호출 기록이 없습니다.</p>`
   return html`
     <div class="flex flex-col gap-1.5">
       ${items.map(item => {
         const pct = maxCount > 0 ? (item.call_count / maxCount) * 100 : 0
+        const cat = toolCategory(item.name)
+        const barBg = categoryBarColor(cat.color)
         return html`
           <div class="tool-bar-row" key=${item.name}>
-            <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px]">${item.name}</span>
+            <div class="flex items-center gap-1.5 overflow-hidden">
+              <span class="flex-shrink-0 size-4 rounded text-[9px] font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
+              <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px]" title=${item.name}>${item.name}</span>
+            </div>
             <span class="px-1.5 py-px rounded-[3px] text-[10px] font-semibold text-center ${tierBadgeClass(item.tier)}">${tierLabel(item.tier)}</span>
             <div class="h-3.5 rounded-[3px] bg-[var(--white-6)] overflow-hidden">
-              <div class="h-full rounded-[3px] bg-[var(--accent)] min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%` }} />
+              <div class="h-full rounded-[3px] min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%`, backgroundColor: barBg }} />
             </div>
             <span class="text-[var(--text-muted)] text-[11px] text-right font-mono">${item.call_count}</span>
           </div>


### PR DESCRIPTION
## Summary

- 도구 카테고리를 5개에서 13개로 확장 (shell, git, edit, file, board, search, voice, web, coord, memory, status, browser, read)
- 각 카테고리에 고유 아이콘/색상/레이블 부여로 도구 유형 즉시 식별 가능
- tool call 행에 성공/실패 뱃지(ok/err) 추가
- turn 헤더에 요약 정보(성공/총 횟수 + 총 소요시간) 추가
- duration 표시를 raw ms에서 human-readable(ms/s/m)로 변환
- agent timeline에 args 미리보기 추가
- session-trace-entry의 중복 카테고리를 tool-call-shared SSOT로 통합

## Test plan

- [x] TypeScript type check 통과 (`pnpm typecheck`)
- [ ] 대시보드 로컬 실행 후 keeper detail trajectory에서 카테고리 아이콘/레이블 확인
- [ ] agent timeline에서 tool call 행의 ok/err 뱃지, args 미리보기 확인
- [ ] session trace에서 기존과 동일한 도구 분류 동작 확인

Generated with [Claude Code](https://claude.com/claude-code)