### PR TITLE
fix(keeper): add project root to workspace allowed_paths (#5376)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -115,8 +115,7 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
        [ playground;
          Printf.sprintf ".masc/keepers/%s/" safe_name;
          ".masc/traces/";
-         "planning/";
-         "docs/" ]
+         "." ]
      | _ -> [ playground ])
 
 let truncate_tool_output ?(max_len = 12000) (s : string) : string =

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -41,8 +41,7 @@ let test_workspace_empty_paths_computed_default () =
       ~name:"sangsu" () in
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "workspace + [] = playground + computed default"
-    [".masc/playground/sangsu/"; ".masc/keepers/sangsu/"; ".masc/traces/";
-     "planning/"; "docs/"] effective
+    [".masc/playground/sangsu/"; ".masc/keepers/sangsu/"; ".masc/traces/"; "."] effective
 
 let test_workspace_explicit_paths () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -93,8 +92,7 @@ let test_computed_default_uses_keeper_name () =
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "name embedded in path"
     [".masc/playground/cdal-formalist/";
-     ".masc/keepers/cdal-formalist/"; ".masc/traces/";
-     "planning/"; "docs/"] effective
+     ".masc/keepers/cdal-formalist/"; ".masc/traces/"; "."] effective
 
 (* ── playground path ── *)
 


### PR DESCRIPTION
## Summary

Workspace scope keeper의 default `allowed_paths`에 프로젝트 루트(`"."`) 추가.

### Before

```
allowed_paths = [playground, keepers/<name>, traces]
```

keeper가 `.geminiignore`, `config/`, `lib/` 등 프로젝트 파일 접근 시 `path_not_in_allowed_paths` 에러 → tool retry 소진 → turn 실패.

### After

```
allowed_paths = [playground, keepers/<name>, traces, .]
```

프로젝트 파일 읽기 가능. 쓰기는 `tool_policy.toml`의 `filesystem_write` group으로 별도 제어.

## Evidence

- 2026-04-06 로그: `path_not_in_allowed_paths` 7건, tool retry 소진 1건
- 영향 keeper: admin-keeper (.geminiignore 읽기 실패)

## Test plan

- [x] `test_keeper_allowed_paths.ml` 업데이트
- [ ] CI green

Closes #5376

🤖 Generated with [Claude Code](https://claude.com/claude-code)