### PR TITLE
refactor(ssot): migrate last-turn and optional tool lists to tool_policy.toml

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -51,7 +51,7 @@ shard = "autoresearch"
 tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_shell", "masc_code_git"]
 
 # Tools allowed on the keeper's last turn (safety constraint).
-# Only these tools remain visible when turn >= max_turns - 1.
+# On last turn, visible tools are intersected with this set.
 [groups.last_turn_safe]
 tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_broadcast"]
 

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -50,6 +50,16 @@ shard = "autoresearch"
 [groups.coding]
 tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_shell", "masc_code_git"]
 
+# Tools allowed on the keeper's last turn (safety constraint).
+# Only these tools remain visible when turn >= max_turns - 1.
+[groups.last_turn_safe]
+tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_broadcast"]
+
+# Optional tools that require explicit opt-in via also_allow.
+# Excluded from all presets by default; a keeper must list them in also_allow.
+[groups.optional]
+tools = ["keeper_board_delete"]
+
 # ── MASC Tool Groups ───────────────────────────────────────────────
 
 [masc.core]

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -787,9 +787,7 @@ let run_turn
           else ctx
         in
         let safe_last_turn_tools =
-          [ "keeper_board_post"; "keeper_board_comment";
-            "keeper_context_status"; "extend_turns";
-            "keeper_time_now"; "keeper_broadcast" ]
+          Keeper_tool_policy.last_turn_safe_tool_names ()
         in
         let all_allowed =
           if is_last_turn then

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -119,11 +119,33 @@ let keeper_base_candidate_tool_names () =
     @ keeper_internal_candidate_tool_names
     @ injected_masc_tool_names () )
 
+(** Resolve a named group from tool_policy.toml.  Returns the hardcoded
+    fallback when config is not loaded. *)
+let resolve_policy_group ~(fallback : string list) (group_name : string) : string list =
+  match !policy_config with
+  | Some cfg ->
+    (match Keeper_tool_policy_config.resolve_group cfg group_name with
+     | Some tools -> tools
+     | None ->
+       Log.Keeper.warn "tool_policy group %S not found, using fallback (%d tools)"
+         group_name (List.length fallback);
+       fallback)
+  | None -> fallback
+
 (** Optional tools that require explicit opt-in via also_allow.
-    Kept separate from config groups because they are deliberately
-    excluded from all presets by default. *)
-let keeper_optional_tool_names =
-  [ "keeper_board_delete" ]
+    Reads [groups.optional] from tool_policy.toml; falls back to
+    hardcoded list when config is absent. *)
+let keeper_optional_tool_names () =
+  resolve_policy_group ~fallback:[ "keeper_board_delete" ] "optional"
+
+(** Tools allowed on the keeper's last turn.
+    Reads [groups.last_turn_safe] from tool_policy.toml. *)
+let last_turn_safe_tool_names () =
+  resolve_policy_group
+    ~fallback:[ "keeper_board_post"; "keeper_board_comment";
+                "keeper_context_status"; "extend_turns";
+                "keeper_time_now"; "keeper_broadcast" ]
+    "last_turn_safe"
 
 let explicit_optional_candidate_tool_names (meta : keeper_meta) =
   let requested =
@@ -132,7 +154,7 @@ let explicit_optional_candidate_tool_names (meta : keeper_meta) =
     | Custom allowlist -> allowlist
   in
   requested
-  |> List.filter (fun name -> List.mem name keeper_optional_tool_names)
+  |> List.filter (fun name -> List.mem name (keeper_optional_tool_names ()))
   |> dedupe_tool_names
 
 (* ── Presets (config-driven) ───────────────────────────────────── *)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -125,7 +125,7 @@ let resolve_policy_group ~(fallback : string list) (group_name : string) : strin
   match !policy_config with
   | Some cfg ->
     (match Keeper_tool_policy_config.resolve_group cfg group_name with
-     | Some tools -> tools
+     | Some tools -> dedupe_tool_names tools
      | None ->
        Log.Keeper.warn "tool_policy group %S not found, using fallback (%d tools)"
          group_name (List.length fallback);
@@ -153,8 +153,9 @@ let explicit_optional_candidate_tool_names (meta : keeper_meta) =
     | Preset { also_allow; _ } -> also_allow
     | Custom allowlist -> allowlist
   in
+  let optional = keeper_optional_tool_names () in
   requested
-  |> List.filter (fun name -> List.mem name (keeper_optional_tool_names ()))
+  |> List.filter (fun name -> List.mem name optional)
   |> dedupe_tool_names
 
 (* ── Presets (config-driven) ───────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- `safe_last_turn_tools` (keeper_agent_run.ml) → `[groups.last_turn_safe]` in tool_policy.toml
- `keeper_optional_tool_names` (keeper_tool_policy.ml) → `[groups.optional]` in tool_policy.toml
- `resolve_policy_group` helper: config에서 그룹을 읽되, 미로딩 시 하드코딩 fallback 유지

## Changes (3 files)
- `config/tool_policy.toml`: +2 groups (last_turn_safe, optional)
- `lib/keeper/keeper_tool_policy.ml`: resolve_policy_group + keeper_optional_tool_names()를 함수로 변경 + last_turn_safe_tool_names() 추가
- `lib/keeper/keeper_agent_run.ml`: 하드코딩 → `Keeper_tool_policy.last_turn_safe_tool_names()` 호출

## Test plan
- [ ] `dune build` 통과
- [ ] 기존 테스트 통과 (preset allowlist에 영향 없음)
- [ ] config 미로딩 시 fallback으로 기존 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)