### PR TITLE
feat(keeper): add proactive board and web search routes for autonomous behavior

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -118,6 +118,15 @@ let actionable_routes ~(allowed_tools : string list)
            (Printf.sprintf
               "- Live worktree delta: inspect changed files with %s if you need to understand whether action is required."
               (String.concat ", " tools)));
+  (* Proactive routes: only when nothing reactive is pending *)
+  if !routes = [] then begin
+    if can "keeper_board_post" then
+      add
+        "- Proactive: post an observation, commentary, or finding to the board using keeper_board_post.";
+    if can "masc_web_search" then
+      add
+        "- Proactive: use masc_web_search to find something relevant to share or investigate.";
+  end;
   if !routes = [] then
     add "- No actionable work. Emit your [STATE] block and end your turn.";
   List.rev !routes

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -406,9 +406,9 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
   in
   if tasks = [] then
     if backlog.tasks = [] then
-      "📋 No tasks. ACTION: Do not re-check — the backlog is empty."
+      "📋 No tasks. ACTION: STOP calling keeper_tasks_list — the backlog is empty. Move on to other work or end your turn."
     else
-      "📋 No active tasks (all done/cancelled). ACTION: Do not re-check."
+      "📋 No active tasks (all done/cancelled). ACTION: STOP calling keeper_tasks_list — do not re-check. Move on to other work or end your turn."
   else begin
     let buf = Buffer.create 256 in
     Buffer.add_string buf "📋 Quest Board\n";

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -778,13 +778,13 @@ let test_prompt_actionable_routes_respect_tool_policy () =
     (contains_substring user "file-inspection tools are unavailable")
 
 let test_prompt_no_actionable_work_fallback () =
+  (* minimal_policy_meta has Minimal preset — no board/web-search tools *)
   let obs = base_observation in
-  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  let _sys, user = UP.build_prompt ~meta:minimal_policy_meta ~observation:obs in
   check bool "has actionable routes section" true
     (contains_substring user "Actionable Routes");
-  (* With research preset, proactive routes should appear instead of no-actionable-work *)
-  check bool "has proactive board route" true
-    (contains_substring user "Proactive")
+  check bool "has no-actionable-work fallback" true
+    (contains_substring user "No actionable work")
 
 let research_meta =
   { minimal_meta with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -782,8 +782,34 @@ let test_prompt_no_actionable_work_fallback () =
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
   check bool "has actionable routes section" true
     (contains_substring user "Actionable Routes");
-  check bool "has no-actionable-work fallback" true
-    (contains_substring user "No actionable work")
+  (* With research preset, proactive routes should appear instead of no-actionable-work *)
+  check bool "has proactive board route" true
+    (contains_substring user "Proactive")
+
+let research_meta =
+  { minimal_meta with
+    tool_access =
+      Preset { preset = Research; also_allow = [] };
+  }
+
+let test_prompt_proactive_board_route () =
+  let obs = base_observation in
+  let _sys, user = UP.build_prompt ~meta:research_meta ~observation:obs in
+  check bool "has proactive board post route" true
+    (contains_substring user "keeper_board_post");
+  (* masc_web_search is injected at runtime, not available in test env *)
+  check bool "has proactive route section" true
+    (contains_substring user "Proactive")
+
+let test_prompt_proactive_routes_suppressed_when_reactive () =
+  let obs =
+    { base_observation with unclaimed_task_count = 3 }
+  in
+  let _sys, user = UP.build_prompt ~meta:research_meta ~observation:obs in
+  check bool "has task claim route" true
+    (contains_substring user "keeper_task_claim");
+  check bool "no proactive board route when reactive" true
+    (not (contains_substring user "Proactive"))
 
 let test_prompt_omits_room_signal_when_flag_disabled () =
   let interpretation : Masc_mcp.Meta_cognition.interpretation =
@@ -1897,6 +1923,10 @@ let () =
             test_prompt_actionable_routes_respect_tool_policy;
           test_case "no actionable work fallback" `Quick
             test_prompt_no_actionable_work_fallback;
+          test_case "proactive board route when idle" `Quick
+            test_prompt_proactive_board_route;
+          test_case "proactive routes suppressed when reactive" `Quick
+            test_prompt_proactive_routes_suppressed_when_reactive;
           test_case "omits room signal when disabled" `Quick
             test_prompt_omits_room_signal_when_flag_disabled;
           test_case "includes room signal when enabled" `Quick

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1494,8 +1494,8 @@ let test_heartbeat_concurrent_start_stop () =
 let test_empty_backlog_stop_signal () =
   with_test_env (fun config ->
     let result = Room.list_tasks config in
-    Alcotest.(check bool) "contains ACTION stop signal"
-      true (str_contains result "ACTION: Do not re-check"))
+    Alcotest.(check bool) "contains STOP signal"
+      true (str_contains result "STOP calling keeper_tasks_list"))
 
 let test_no_active_tasks_stop_signal () =
   with_test_env (fun config ->
@@ -1503,8 +1503,8 @@ let test_no_active_tasks_stop_signal () =
     let _ = Room.claim_task config ~agent_name:"alice" ~task_id:"task-001" in
     let _ = Room.complete_task config ~agent_name:"alice" ~task_id:"task-001" ~notes:"done" in
     let result = Room.list_tasks config in
-    Alcotest.(check bool) "contains ACTION stop signal"
-      true (str_contains result "ACTION: Do not re-check"))
+    Alcotest.(check bool) "contains STOP signal"
+      true (str_contains result "STOP calling keeper_tasks_list"))
 
 let test_no_unclaimed_tasks_stop_signal () =
   with_test_env (fun config ->


### PR DESCRIPTION
## Summary
- Keeper가 idle일 때 proactive board posting과 web search route를 actionable_routes에 추가
- `keeper_tasks_list` 빈 응답의 stop signal을 "STOP calling" 수준으로 강화하여 반복 호출 방지
- Reactive signal이 있을 때는 proactive route가 억제되어 LLM 혼란 방지

## Context
- PR #5353에서 idle loop의 terminal signal 부재 문제를 수정했으나, proactive board/web-search 경로가 여전히 없어 keeper가 task 관련 도구만 반복 사용
- sangsu keeper의 최근 decision에서 `keeper_tasks_list` 5회 반복 호출 관찰
- 이 PR은 keeper가 할 일이 없을 때 board posting이나 web search 같은 자율 행동을 할 수 있도록 유도

## Changes
| File | Change |
|------|--------|
| `keeper_unified_prompt.ml` | proactive board/web-search routes 추가 (reactive 없을 때만) |
| `room_query.ml` | empty task list stop signal 강화 ("STOP calling keeper_tasks_list") |
| `test_keeper_unified.ml` | proactive route 존재/억제 테스트 3개 |
| `test_room.ml` | stop signal 테스트 assertion 업데이트 |

## Test plan
- [x] `test_keeper_unified.exe` — 96 tests passed
- [x] `test_room.exe` — idle_stop_signals 3 tests passed, 0 failures
- [ ] Keeper 재시작 후 board posting 확인 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)