### PR TITLE
fix(keeper): add planning/ docs/ to workspace paths + shell timeout

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -114,7 +114,9 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
        let safe_name = sanitize_keeper_name meta.name in
        [ playground;
          Printf.sprintf ".masc/keepers/%s/" safe_name;
-         ".masc/traces/" ]
+         ".masc/traces/";
+         "planning/";
+         "docs/" ]
      | _ -> [ playground ])
 
 let truncate_tool_output ?(max_len = 12000) (s : string) : string =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -338,7 +338,7 @@ let handle_keeper_shell_readonly
     resolve_keeper_path ~config ~meta ~raw_path
   in
   let render_process_result ~cmd argv =
-    let st, out = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+    let st, out = Process_eio.run_argv_with_status ~timeout_sec:30.0 argv in
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool (st = Unix.WEXITED 0)
@@ -352,14 +352,14 @@ let handle_keeper_shell_readonly
   | "pwd" -> render_process_result ~cmd:"pwd" [ "/bin/pwd" ]
   | "git_status" ->
     render_process_result
-      ~cmd:"git -C <root> status --short --branch"
-      [ "git"; "-C"; root; "status"; "--short"; "--branch" ]
+      ~cmd:"git -C <root> --no-optional-locks status --short --branch"
+      [ "git"; "-C"; root; "--no-optional-locks"; "status"; "--short"; "--branch" ]
   | "ls" ->
     (match read_target () with
      | Error e -> error_json ~fields:[ "op", `String op ] e
      | Ok target ->
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:15.0 [ "/bin/ls"; "-la"; target ]
+         Process_eio.run_argv_with_status ~timeout_sec:30.0 [ "/bin/ls"; "-la"; target ]
        in
        let limit = shell_readonly_limit args in
        Yojson.Safe.to_string

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -41,7 +41,8 @@ let test_workspace_empty_paths_computed_default () =
       ~name:"sangsu" () in
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "workspace + [] = playground + computed default"
-    [".masc/playground/sangsu/"; ".masc/keepers/sangsu/"; ".masc/traces/"] effective
+    [".masc/playground/sangsu/"; ".masc/keepers/sangsu/"; ".masc/traces/";
+     "planning/"; "docs/"] effective
 
 let test_workspace_explicit_paths () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -92,7 +93,8 @@ let test_computed_default_uses_keeper_name () =
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "name embedded in path"
     [".masc/playground/cdal-formalist/";
-     ".masc/keepers/cdal-formalist/"; ".masc/traces/"] effective
+     ".masc/keepers/cdal-formalist/"; ".masc/traces/";
+     "planning/"; "docs/"] effective
 
 (* ── playground path ── *)
 


### PR DESCRIPTION
## Summary
- workspace scope keeper 기본 allowed_paths에 `planning/`과 `docs/` 추가
- `keeper_shell_readonly` 타임아웃 15s -> 30s (대규모 repo에서 git status 타임아웃)
- `git status`에 `--no-optional-locks` 추가 (index lock 경합 방지)

## Product impact
admin-keeper가 `planning/task-041/context.json` 접근 실패 -> Failing 전환하는 문제 해결.

## Evidence
- 로그: `path_not_in_allowed_paths: planning/task-041/context.json`
- 로그: `Timeout after 15s: 'git' '-C' '/Users/dancer/me' 'status'`

## Review evidence
- Alcotest 11/11 pass (test_keeper_allowed_paths.exe)

## Linked issue
- Supersedes #5380 (which adds `"."` - too broad)
- Refs #5376

## Test plan
- [x] test_keeper_allowed_paths 11/11 pass
- [x] 빌드 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)