### PR TITLE
fix(keeper): lower on_idle skip threshold 3→2

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -295,8 +295,8 @@ let make_hooks
           | [] -> "<none>"
           | names -> String.concat ", " names
         in
-        if consecutive_idle_turns >= 3 then begin
-          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop"
+        if consecutive_idle_turns >= 2 then begin
+          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop (threshold=2, max_idle_turns=3)"
             (!meta_ref).name consecutive_idle_turns tools_str;
           Agent_sdk.Hooks.Skip
         end else begin


### PR DESCRIPTION
## Summary
- `on_idle` hook의 Skip threshold를 `>= 3`에서 `>= 2`로 변경
- `max_idle_turns=3` 전에 1턴 안전 마진 확보
- 로그 메시지에 threshold/max 값 명시

## Problem
OAS의 idle detection early-exit와 연동하여, keeper가 2회 연속 동일 도구 호출 시
graceful exit. `max_idle_turns=3` hard limit에 도달하기 전에 soft exit.

## Test plan
- [x] `dune build` 통과

Depends on: jeong-sik/oas fix/idle-loop-prevention (skip tool execution on idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)