### PR TITLE
fix(keeper): preserve workspace defaults when explicit allowed_paths set

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -98,7 +98,10 @@ let render_timeout_s =
     "MASC_DASHBOARD_EXECUTION_RENDER_TIMEOUT_S"
     ~default:60.0 ~min_v:10.0 ~max_v:300.0
 
-let session_list_timeout_s = 5.0
+let session_list_timeout_s =
+  Dashboard_http_helpers.float_of_env_default
+    "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
+    ~default:5.0 ~min_v:1.0 ~max_v:30.0
 
 let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -87,12 +87,11 @@ let resolve_keeper_target_path ~(config : Room.config)
              "path_not_in_allowed_paths: %s (allowed: [%s])"
              raw (String.concat ", " allowed_norms))
 
-(** Compute effective allowed_paths from keeper meta, applying scope-based
-    defaults when the operator has not set an explicit list.
-    - ["*"]          → [] (full access, explicit opt-in)
-    - non-empty list → list as-is (explicit restriction)
-    - [] + workspace → keeper's own dirs (computed default)
-    - [] + otherwise → [] (observe_only blocks writes; local = full access) *)
+(** Compute effective allowed_paths from keeper meta.
+    Always prepends the keeper's playground path and, for workspace scope,
+    the workspace default dirs (.masc/keepers/<name>/, .masc/traces/, ".").
+    - ["*"]          → [] (full access, explicit opt-in bypasses path checks)
+    - other          → playground :: workspace_defaults @ explicit *)
 let sanitize_keeper_name (name : string) : string =
   String.map (fun c ->
     if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
@@ -105,18 +104,18 @@ let playground_path_of_keeper (name : string) : string =
 
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   let playground = playground_path_of_keeper meta.name in
+  let workspace_defaults =
+    match String.lowercase_ascii meta.execution_scope with
+    | "workspace" ->
+      let safe_name = sanitize_keeper_name meta.name in
+      [ Printf.sprintf ".masc/keepers/%s/" safe_name;
+        ".masc/traces/";
+        "." ]
+    | _ -> []
+  in
   match meta.allowed_paths with
   | ["*"] -> []
-  | _ :: _ as explicit -> playground :: explicit
-  | [] ->
-    (match String.lowercase_ascii meta.execution_scope with
-     | "workspace" ->
-       let safe_name = sanitize_keeper_name meta.name in
-       [ playground;
-         Printf.sprintf ".masc/keepers/%s/" safe_name;
-         ".masc/traces/";
-         "." ]
-     | _ -> [ playground ])
+  | explicit -> playground :: workspace_defaults @ explicit
 
 let truncate_tool_output ?(max_len = 12000) (s : string) : string =
   if String.length s <= max_len then s

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -47,8 +47,9 @@ let test_workspace_explicit_paths () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["src/"; "docs/"] ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "workspace + explicit = playground + explicit"
-    [".masc/playground/t/"; "src/"; "docs/"] effective
+  check (list string) "workspace + explicit = playground + ws defaults + explicit"
+    [".masc/playground/t/"; ".masc/keepers/t/"; ".masc/traces/";
+     "planning/"; "docs/"; "src/"; "docs/"] effective
 
 let test_workspace_star_wildcard () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -76,13 +77,21 @@ let test_star_wildcard_any_scope () =
 
 let test_explicit_paths_any_scope () =
   let paths = ["lib/keeper/"; "test/"] in
-  let expected = [".masc/playground/t/"; "lib/keeper/"; "test/"] in
-  let scopes = ["observe_only"; "workspace"; "local"] in
+  let non_ws_expected = [".masc/playground/t/"; "lib/keeper/"; "test/"] in
+  (* non-workspace scopes: playground + explicit only *)
   List.iter (fun scope ->
     let meta = make_meta ~execution_scope:scope ~allowed_paths:paths ~name:"t" () in
     let effective = KAP.effective_allowed_paths ~meta in
-    check (list string) (scope ^ " + explicit = playground + explicit") expected effective
-  ) scopes
+    check (list string) (scope ^ " + explicit = playground + explicit")
+      non_ws_expected effective
+  ) ["observe_only"; "local"];
+  (* workspace scope: playground + workspace defaults + explicit *)
+  let ws_meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:paths ~name:"t" () in
+  let ws_effective = KAP.effective_allowed_paths ~meta:ws_meta in
+  check (list string) "workspace + explicit = playground + ws defaults + explicit"
+    [".masc/playground/t/"; ".masc/keepers/t/"; ".masc/traces/";
+     "planning/"; "docs/"; "lib/keeper/"; "test/"] ws_effective
 
 (* ── keeper name in computed default ── *)
 

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -49,7 +49,7 @@ let test_workspace_explicit_paths () =
   let effective = KAP.effective_allowed_paths ~meta in
   check (list string) "workspace + explicit = playground + ws defaults + explicit"
     [".masc/playground/t/"; ".masc/keepers/t/"; ".masc/traces/";
-     "planning/"; "docs/"; "src/"; "docs/"] effective
+     "."; "src/"; "docs/"] effective
 
 let test_workspace_star_wildcard () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -91,7 +91,7 @@ let test_explicit_paths_any_scope () =
   let ws_effective = KAP.effective_allowed_paths ~meta:ws_meta in
   check (list string) "workspace + explicit = playground + ws defaults + explicit"
     [".masc/playground/t/"; ".masc/keepers/t/"; ".masc/traces/";
-     "planning/"; "docs/"; "lib/keeper/"; "test/"] ws_effective
+     "."; "lib/keeper/"; "test/"] ws_effective
 
 (* ── keeper name in computed default ── *)
 


### PR DESCRIPTION
## Summary
- workspace scope 키퍼가 explicit `allowed_paths` 설정 시 기본 경로(`.masc/keepers/<name>/`, `.masc/traces/`)를 유지하도록 수정
- `dashboard_execution.ml`의 하드코딩된 session list timeout(5s)을 `MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S` env var 패턴으로 통일
- 관련 테스트 갱신 (11/11 통과)

## Problem
admin-keeper가 `planning/task-041/context.json` 접근 시 `path_not_in_allowed_paths` 에러로 failing 상태 전환. 원인: `effective_allowed_paths`가 explicit paths 설정 시 workspace 기본값을 교체(replace)하는 설계. `allowed_paths = ["planning/"]` 설정 시 `.masc/keepers/<name>/`과 `.masc/traces/` 접근 불가.

## Changes
- `keeper_alerting_path.ml`: workspace defaults를 항상 포함하도록 로직 변경 (explicit paths는 defaults를 **확장**)
- `dashboard_execution.ml`: `session_list_timeout_s` → `Dashboard_http_helpers.float_of_env_default` 사용
- `test_keeper_allowed_paths.ml`: workspace + explicit 테스트 기대값 갱신, scope별 분리 검증 추가

## Test plan
- [x] `test_keeper_allowed_paths.exe` 11/11 통과
- [x] 빌드 성공 (`dune build --root`)
- [ ] admin-keeper 재시작 후 `planning/` 접근 검증

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>