### PR TITLE
feat(keeper): log tool call params and outcome (#5373)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -227,6 +227,16 @@ let make_hooks
           | Error { Agent_sdk.Types.message; _ } ->
             Printf.sprintf "error: %s" message
         in
+        let input_keys = match input with
+          | `Assoc pairs -> String.concat "," (List.map fst pairs)
+          | _ -> "-"
+        in
+        let outcome, out_len = match output with
+          | Ok { Agent_sdk.Types.content; _ } -> "ok", String.length content
+          | Error { Agent_sdk.Types.message; _ } -> "error", String.length message
+        in
+        Log.Keeper.info "keeper:%s tool_call tool=%s params=[%s] outcome=%s out_len=%d"
+          (!meta_ref).name tool_name input_keys outcome out_len;
         (try on_tool_executed tool_name input output_text
          with Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->


### PR DESCRIPTION
## Summary

PostToolUse hook에 구조화된 tool call 로그 추가.

### 로그 형식

```
keeper:sangsu tool_call tool=keeper_board_comment params=[board_id,content] outcome=ok out_len=245
keeper:admin tool_call tool=keeper_fs_read params=[path] outcome=error out_len=87
```

### 분석 가능 항목

- tool별 호출 빈도
- 파라미터 다양성 (같은 tool, 다른 params = 정상 / 같은 params = idle 후보)
- outcome 비율 (ok vs error per tool)
- output 크기 분포

## Evidence

- 기존 로그: tool_name만 기록, 파라미터/결과 추적 불가
- idle loop 디버깅 시 "어떤 파라미터로 반복 호출했는지" 확인 불가능했음

## Test plan

- [x] `dune build` 성공
- [ ] CI green
- [ ] 서버 재시작 후 로그에서 tool_call 라인 확인

Refs #5373

🤖 Generated with [Claude Code](https://claude.com/claude-code)