### PR TITLE
fix(keeper): add anti-repetition rules and delivery preset for autonomous keepers

### DIFF
--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -34,4 +34,7 @@ mention_targets = ["masc-improver", "improver"]
 execution_scope = "workspace"
 allowed_paths = ["*"]
 
+# Delivery preset: research + coding tools for keepers that produce code changes.
+tool_preset = "delivery"
+
 proactive_enabled = true

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -83,5 +83,11 @@ masc_groups = ["core", "coding"]
 groups = ["base", "filesystem", "library", "shell", "coordination", "board", "governance", "autoresearch"]
 masc_groups = ["core"]
 
+# Delivery preset: research + coding for keepers that need to produce code changes.
+# Use for keepers with soul_profile=delivery whose goal involves PRs, issues, or code fixes.
+[presets.delivery]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board", "governance", "autoresearch", "coding_shard", "coding"]
+masc_groups = ["core", "coding"]
+
 [presets.full]
 all_candidates = true

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -31,6 +31,7 @@ let preset_name_of_tool_preset = function
   | Messaging -> "messaging"
   | Coding -> "coding"
   | Research -> "research"
+  | Delivery -> "delivery"
   | Full -> "full"
 
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -39,6 +39,7 @@ type tool_preset =
   | Messaging
   | Coding
   | Research
+  | Delivery
   | Full
 
 type tool_access =
@@ -199,6 +200,7 @@ let tool_preset_to_string = function
   | Messaging -> "messaging"
   | Coding -> "coding"
   | Research -> "research"
+  | Delivery -> "delivery"
   | Full -> "full"
 ;;
 
@@ -208,6 +210,7 @@ let tool_preset_of_string raw =
   | "messaging" -> Some Messaging
   | "coding" -> Some Coding
   | "research" -> Some Research
+  | "delivery" -> Some Delivery
   | "full" -> Some Full
   | _ -> None
 ;;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -41,6 +41,7 @@ type tool_preset =
   | Messaging
   | Coding
   | Research
+  | Delivery
   | Full
 
 type tool_access =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -64,7 +64,7 @@ let normalize_name_list_opt items =
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
   match normalized with
-  | "minimal" | "messaging" | "coding" | "research" | "full" -> Some normalized
+  | "minimal" | "messaging" | "coding" | "research" | "delivery" | "full" -> Some normalized
   | _ -> None
 
 let first_some = Dashboard_utils.first_some
@@ -238,7 +238,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | _ ->
                 Error
                   (Printf.sprintf
-                     "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
+                     "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, delivery, full)"
                      raw))
         | None -> Ok ())
   in

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -104,7 +104,7 @@ let actionable_routes ~(allowed_tools : string list)
   if observation.failed_task_count > 0 then
     if can "keeper_tasks_audit" then
       add
-        "- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do."
+        "- Failed tasks: audit once with keeper_tasks_audit. If the audit returns no orphans or actionable items, do NOT call keeper_tasks_audit again — instead post a brief status summary to the board with keeper_board_post and end your turn."
     else
       add
         "- Failed tasks are actionable, but task-audit tooling is unavailable under the current tool policy.";
@@ -223,7 +223,15 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
      Unclaimed tasks in the backlog are actionable work — if your skills match, \
      claim one with keeper_task_claim and work on it.\n\
      When you have findings, opinions, or status updates worth sharing, post them to the board \
-     using keeper_board_post. When responding to board activity, use keeper_board_comment.\n\
+     using keeper_board_post. When responding to board activity, use keeper_board_comment.\n\n\
+     ## Anti-Repetition Rules\n\
+     CRITICAL: Never call the same tool with the same arguments twice in a row within a single turn.\n\
+     If a tool returned no actionable results (e.g. audit found no orphans, search found nothing), \
+     do NOT retry it. Instead choose one of:\n\
+     1. Post a status summary to the board (keeper_board_post)\n\
+     2. Claim a different task if available (keeper_task_claim)\n\
+     3. End your turn silently (DELIVERY_SURFACE: silent)\n\
+     Progress means doing something NEW each cycle, not re-checking the same state.\n\n\
      Every response must begin with these machine-readable headers exactly once:\n\
      SOCIAL_MODEL: bdi_speech_v1\n\
      BELIEF_SUMMARY: <short summary>\n\


### PR DESCRIPTION
## Summary
- Keeper들이 `keeper_tasks_audit`를 반복 호출하다 idle detection에 걸려 종료되는 문제 해결
- `turn_intent_block`에 **Anti-Repetition Rules** 추가: 같은 tool 연속 호출 금지, 대안 행동 3가지 제시
- `actionable_routes`의 failed_task route를 "audit once, then board post" 패턴으로 변경
- `Delivery` tool preset 신규 추가 (research + coding 결합)
- `masc-improver` keeper에 delivery preset 할당하여 goal에 맞는 도구 제공

## Root Cause
keeper가 "Failed tasks: audit them" 지시를 받고 audit 실행 → "no orphans" → 다음 turn에도 같은 지시 → 같은 호출 반복 → OAS idle detection kill (5 consecutive identical tool call turns)

## Test plan
- [x] `dune build --root .` 성공
- [x] `test_keeper_unified.exe` 94 tests pass
- [x] `test_keeper_tool_policy_config.exe` 1 test pass
- [x] `test_types.exe` 6 tests pass
- [ ] MASC 서버 재시작 후 keeper 자율 행동 실 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)