### PR TITLE
fix(security): harden gh safety gates — flag bypass, equals syntax, new cmd gates

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -420,8 +420,10 @@ let gh_blocked_operations =
 
 (** Extract the top-level command and its first subcommand from a gh
     command string (the portion after "gh ").
-    Flags (starting with '-') are skipped when looking for the subcommand.
-    Example: "pr view 123" -> (Some "pr", Some "view") *)
+    Flags (starting with '-') and their values are skipped when scanning
+    for the subcommand, preventing bypass via flag insertion.
+    Example: "pr view 123" -> (Some "pr", Some "view")
+    Example: "workflow --repo o/r disable" -> (Some "workflow", Some "disable") *)
 let extract_gh_command_pair cmd =
   let parts =
     String.split_on_char ' ' (String.trim cmd)
@@ -430,9 +432,16 @@ let extract_gh_command_pair cmd =
   match parts with
   | [] -> (None, None)
   | [ x ] -> (Some x, None)
-  | x :: y :: _ ->
-    if String.length y > 0 && y.[0] = '-' then (Some x, None)
-    else (Some x, Some y)
+  | x :: rest ->
+    let rec find_subcmd = function
+      | [] -> None
+      | tok :: tl ->
+        if String.length tok > 0 && tok.[0] = '-' then
+          if String.contains tok '=' then find_subcmd tl
+          else (match tl with _ :: rest' -> find_subcmd rest' | [] -> None)
+        else Some tok
+    in
+    (Some x, find_subcmd rest)
 
 (** Validate a gh CLI command string for safety.
     Checks: (1) shell metacharacters, (2) top-level command allowlist,
@@ -473,15 +482,30 @@ let gh_api_destructive_patterns =
   [ "/merge"; "/merges";
     "state=closed"; "state=\"closed\""; "state='closed'" ]
 
-(** Check if a gh API command uses a non-GET HTTP method.
-    Returns [true] for -X POST, -X PUT, -X PATCH, --method POST, etc. *)
+(** Check if a gh API command uses or implies a non-GET HTTP method.
+    Returns [true] for explicit mutating methods (-X POST, --method PATCH,
+    etc.) and for implicit POST via field flags (-f, -F, --field,
+    --raw-field), matching gh CLI behavior where field flags cause an
+    automatic POST. Handles both "--method POST" and "--method=POST". *)
 let has_mutating_http_method parts =
+  let is_mutating m =
+    let m = String.lowercase_ascii m in
+    m = "post" || m = "put" || m = "patch" || m = "delete"
+  in
   let rec check = function
     | [] -> false
-    | ("-x" | "--method") :: m :: _ ->
-      let m = String.lowercase_ascii m in
-      m = "post" || m = "put" || m = "patch" || m = "delete"
-    | _ :: rest -> check rest
+    | tok :: rest when tok = "-x" || tok = "--method" ->
+      (match rest with m :: _ -> is_mutating m | [] -> false)
+    | tok :: rest ->
+      if String.length tok > 10
+         && String.lowercase_ascii (String.sub tok 0 9) = "--method="
+      then is_mutating (String.sub tok 9 (String.length tok - 9))
+      else if String.length tok > 3
+              && String.lowercase_ascii (String.sub tok 0 3) = "-x="
+      then is_mutating (String.sub tok 3 (String.length tok - 3))
+      else if tok = "-f" || tok = "-F" || tok = "--field" || tok = "--raw-field"
+      then true
+      else check rest
   in
   check parts
 
@@ -500,6 +524,10 @@ let is_gh_destructive_operation cmd =
   | "release" :: sub :: _ -> List.mem sub [ "delete" ]
   | "repo" :: sub :: _ -> List.mem sub [ "archive"; "rename" ]
   | "label" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "cache" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "project" :: sub :: _ -> List.mem sub [ "close"; "delete" ]
+  | "workflow" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "ruleset" :: _ -> false
   | "api" :: _ ->
     let joined = String.concat " " parts in
     List.mem "delete" parts

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -108,6 +108,7 @@ let test_blocked_destructive_operations () =
       "Repo Delete owner/repo";
       "GIST DELETE abc123";
       "workflow disable deploy.yml";
+      "workflow --repo owner/repo disable deploy.yml";
     ]
   in
   List.iter
@@ -175,6 +176,10 @@ let test_api_bypass_detected () =
       "api --method POST /repos/o/r/merges -f base=main";
       "api -X POST /repos/o/r/merges -f base=main -f head=feat";
       "api -X PATCH /repos/o/r/issues/1 -f state=closed";
+      "api /repos/o/r/pulls/1/merge -f sha=abc123";
+      "api /repos/o/r/merges -F base=main -F head=feat";
+      "api --method=POST /repos/o/r/pulls/1/merge";
+      "api -x=put /repos/o/r/pulls/1/merge";
     ]
   in
   List.iter
@@ -201,6 +206,40 @@ let test_api_safe_methods_not_flagged () =
         (Printf.sprintf "api safe: gh %s" cmd)
         false (is_destructive cmd))
     safe_api
+
+let test_new_command_destructive_ops () =
+  let destructive =
+    [
+      "cache delete --all";
+      "project delete 1";
+      "project close 1";
+      "workflow delete deploy.yml";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "new cmd destructive: gh %s" cmd)
+        true (is_destructive cmd))
+    destructive;
+  let safe =
+    [
+      "cache list";
+      "project list";
+      "project view 1";
+      "workflow list";
+      "workflow view deploy.yml";
+      "workflow run deploy.yml";
+      "ruleset list";
+      "ruleset view 1";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "new cmd safe: gh %s" cmd)
+        false (is_destructive cmd))
+    safe
 
 let test_non_destructive_ops () =
   let safe =
@@ -260,6 +299,8 @@ let () =
             test_api_bypass_detected;
           Alcotest.test_case "safe api methods not flagged" `Quick
             test_api_safe_methods_not_flagged;
+          Alcotest.test_case "new commands destructive ops" `Quick
+            test_new_command_destructive_ops;
           Alcotest.test_case "safe ops not flagged" `Quick
             test_non_destructive_ops;
         ] );


### PR DESCRIPTION
## Summary

Follow-up to #5372 (merged with only the first commit due to post-squash-merge push — see #5303 pattern). This PR applies the improvements that were lost.

## Changes

### 1. Flag Insertion Bypass Prevention
`extract_gh_command_pair` now scans past flags to find the actual subcommand:
- Before: `workflow --repo o/r disable` → subcmd = `--repo` (missed `disable`)
- After: `workflow --repo o/r disable` → subcmd = `disable` (correctly detected)

### 2. Equals Syntax for HTTP Methods
`has_mutating_http_method` now handles:
- `--method=POST` (was only `--method POST`)
- `-x=put` (was only `-x put`)

### 3. Implicit POST Detection
Field flags (`-f`, `-F`, `--field`, `--raw-field`) trigger implicit POST in gh CLI. Now detected:
- `gh api /repos/o/r/pulls/1/merge -f sha=abc` → destructive

### 4. New Command Destructive Gates
- `cache delete` → gated
- `project close/delete` → gated
- `workflow delete` → gated (separate from `workflow disable` which is blocked at allowlist)

## Test plan
- [x] 11/11 github safety tests pass
- [x] 54/54 keeper safety gates pass (no regression)
- [x] Flag insertion bypass correctly blocked
- [x] Equals syntax correctly detected
- [x] Implicit POST correctly detected
- [x] New command destructive ops correctly classified

## Related
- #5372 (original fix, merged partially)
- #5370 (API bypass issue — closed)
- #5371 (new commands — closes with this PR)
- #5386 (GraphQL bypass — separate follow-up)