### PR TITLE
fix(security): close boolean flag bypass and --field= implicit POST

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -497,36 +497,51 @@ let has_mutating_http_method parts =
     | tok :: rest when tok = "-x" || tok = "--method" ->
       (match rest with m :: _ -> is_mutating m | [] -> false)
     | tok :: rest ->
-      if String.length tok > 10
+      if String.length tok >= 10
          && String.lowercase_ascii (String.sub tok 0 9) = "--method="
       then is_mutating (String.sub tok 9 (String.length tok - 9))
       else if String.length tok > 3
               && String.lowercase_ascii (String.sub tok 0 3) = "-x="
       then is_mutating (String.sub tok 3 (String.length tok - 3))
-      else if tok = "-f" || tok = "-F" || tok = "--field" || tok = "--raw-field"
-      then true
-      else check rest
+      else
+        let tok_lower = String.lowercase_ascii tok in
+        if tok = "-f" || tok = "-F" || tok = "--field" || tok = "--raw-field"
+           || String.length tok_lower > 3 && String.sub tok_lower 0 3 = "-f="
+           || String.length tok_lower > 8 && String.sub tok_lower 0 8 = "--field="
+           || String.length tok_lower > 12 && String.sub tok_lower 0 12 = "--raw-field="
+        then true
+        else check rest
   in
   check parts
 
+(** Filter out flag-like tokens, keeping only positional args.
+    Handles boolean flag bypass (e.g. "workflow -q delete"). *)
+let positional_tokens parts =
+  List.filter (fun s -> String.length s = 0 || s.[0] <> '-') parts
+
 (** Check if a gh command is a destructive mutation that should be gated.
     Returns [true] for high-risk operations like merge, close, delete.
-    Low-risk writes (create, comment) return [false] and are allowed. *)
+    Low-risk writes (create, comment) return [false] and are allowed.
+    Scans positional tokens to handle boolean flag insertion bypass. *)
 let is_gh_destructive_operation cmd =
   let parts =
     String.split_on_char ' ' (String.trim cmd)
     |> List.filter (fun s -> s <> "")
     |> List.map String.lowercase_ascii
   in
+  let has_positional_subcmd subcmds rest =
+    let positionals = positional_tokens rest in
+    List.exists (fun s -> List.mem s subcmds) positionals
+  in
   match parts with
-  | "pr" :: sub :: _ -> List.mem sub [ "merge"; "close" ]
-  | "issue" :: sub :: _ -> List.mem sub [ "close"; "delete"; "transfer" ]
-  | "release" :: sub :: _ -> List.mem sub [ "delete" ]
-  | "repo" :: sub :: _ -> List.mem sub [ "archive"; "rename" ]
-  | "label" :: sub :: _ -> List.mem sub [ "delete" ]
-  | "cache" :: sub :: _ -> List.mem sub [ "delete" ]
-  | "project" :: sub :: _ -> List.mem sub [ "close"; "delete" ]
-  | "workflow" :: sub :: _ -> List.mem sub [ "delete" ]
+  | "pr" :: rest -> has_positional_subcmd [ "merge"; "close" ] rest
+  | "issue" :: rest -> has_positional_subcmd [ "close"; "delete"; "transfer" ] rest
+  | "release" :: rest -> has_positional_subcmd [ "delete" ] rest
+  | "repo" :: rest -> has_positional_subcmd [ "archive"; "rename" ] rest
+  | "label" :: rest -> has_positional_subcmd [ "delete" ] rest
+  | "cache" :: rest -> has_positional_subcmd [ "delete" ] rest
+  | "project" :: rest -> has_positional_subcmd [ "close"; "delete" ] rest
+  | "workflow" :: rest -> has_positional_subcmd [ "delete" ] rest
   | "ruleset" :: _ -> false
   | "api" :: _ ->
     let joined = String.concat " " parts in

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -158,6 +158,11 @@ let test_destructive_ops_detected () =
       "PR Merge 123";
       "Issue CLOSE 456";
       "api -X DeLeTe repos/owner/repo";
+      "workflow -q delete deploy.yml";
+      "pr --verbose merge 123";
+      "issue -R owner/repo --json id close 456";
+      "cache --repo o/r delete";
+      "project -q close 1";
     ]
   in
   List.iter
@@ -180,6 +185,8 @@ let test_api_bypass_detected () =
       "api /repos/o/r/merges -F base=main -F head=feat";
       "api --method=POST /repos/o/r/pulls/1/merge";
       "api -x=put /repos/o/r/pulls/1/merge";
+      "api /repos/o/r/pulls/1/merge --field=sha=abc123";
+      "api /repos/o/r/merges -f=base=main";
     ]
   in
   List.iter


### PR DESCRIPTION
## Summary

GLM review of #5392 found two remaining bypass vectors in keeper_github safety gates.

## Changes

### 1. Boolean Flag Bypass (Critical)
`is_gh_destructive_operation` used positional matching (`"workflow" :: sub :: _`), which was defeated by boolean flags:
```
workflow -q delete deploy.yml  → sub = "-q", "delete" missed
pr --verbose merge 123        → sub = "--verbose", "merge" missed
```

Fix: `positional_tokens` helper filters out flag-like tokens (starting with `-`), then checks if any remaining positional arg matches a destructive subcmd.

### 2. `--field=` Implicit POST
`has_mutating_http_method` only matched exact tokens (`-f`, `--field`), missing equals-joined form:
```
api /repos/.../merge --field=sha=abc  → implicit POST, not detected
api /repos/.../merges -f=base=main    → implicit POST, not detected
```

Fix: also check prefixes `-f=`, `--field=`, `--raw-field=`.

### 3. Minor: `--method=` guard
Changed `> 10` to `>= 10` for correct minimum length check.

## Test plan
- [x] 11/11 github safety tests pass (7 new cases added)
- [x] Boolean flag insertion correctly detected for all commands
- [x] `--field=` form correctly triggers implicit POST detection

## Related
- #5372 (original API bypass fix)
- #5392 (followup — merged, missing these fixes)
- #5386 (GraphQL bypass — separate)