### PR TITLE
chore: pin OAS Agent SDK to v0.101.1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.101.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.101.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="a5060a6454cd4a1c0cf99fecf858306f48c9da95"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.101.0"
+readonly OAS_AGENT_SDK_SHA="7b6f38d33d8c54b70e1c48ee2aba2f47096cbdd1"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.101.1"


### PR DESCRIPTION
## Summary
- Updates OAS Agent SDK pin from v0.101.0 (`a5060a6`) to v0.101.1 (`7b6f38d`)
- Includes Nudge decision (#634) and idle-loop-prevention (#635)
- Required for #5377 to compile

## Test plan
- [ ] CI passes with new pin
- [ ] Dependent PRs (#5377) can rebase on this after merge

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>