### PR TITLE
fix(security): detect destructive GraphQL mutations in keeper_github (#5386)

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -482,6 +482,13 @@ let gh_api_destructive_patterns =
   [ "/merge"; "/merges";
     "state=closed"; "state=\"closed\""; "state='closed'" ]
 
+(** Known destructive GraphQL mutation names (lowercase).
+    Used to detect bypass via "gh api graphql -f query='mutation ...'". *)
+let gh_graphql_destructive_mutations =
+  [ "mergepullrequest"; "closepullrequest"; "closeissue";
+    "deleteissue"; "deleteref"; "deletebranch";
+    "deletebranchprotectionrule"; "deleteproject" ]
+
 (** Check if a gh API command uses or implies a non-GET HTTP method.
     Returns [true] for explicit mutating methods (-X POST, --method PATCH,
     etc.) and for implicit POST via field flags (-f, -F, --field,
@@ -549,6 +556,9 @@ let is_gh_destructive_operation cmd =
     || (has_mutating_http_method parts
         && List.exists (fun pat -> contains_substring joined pat)
              gh_api_destructive_patterns)
+    || (List.mem "graphql" parts
+        && List.exists (fun m -> contains_substring joined m)
+             gh_graphql_destructive_mutations)
   | _ -> false
 
 (* --- Recursive mkdir --- *)

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -196,6 +196,39 @@ let test_api_bypass_detected () =
         true (is_destructive cmd))
     api_destructive
 
+let test_graphql_mutation_detected () =
+  let graphql_destructive =
+    [
+      "api graphql -f query=mergePullRequest";
+      "api graphql -f query=closePullRequest";
+      "api graphql -f query=closeIssue";
+      "api graphql -f query=deleteIssue";
+      "api graphql -f query=deleteRef";
+      "api graphql -f query=deleteBranch";
+      "api graphql -f query=deleteProject";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "graphql destructive: gh %s" cmd)
+        true (is_destructive cmd))
+    graphql_destructive;
+  let graphql_safe =
+    [
+      "api graphql -f query=repository";
+      "api graphql -f query=pullRequest";
+      "api graphql -f query=addComment";
+      "api graphql -f query=createPullRequest";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "graphql safe: gh %s" cmd)
+        false (is_destructive cmd))
+    graphql_safe
+
 let test_api_safe_methods_not_flagged () =
   let safe_api =
     [
@@ -304,6 +337,8 @@ let () =
             test_destructive_ops_detected;
           Alcotest.test_case "api bypass via POST/PATCH/PUT detected" `Quick
             test_api_bypass_detected;
+          Alcotest.test_case "graphql destructive mutations detected" `Quick
+            test_graphql_mutation_detected;
           Alcotest.test_case "safe api methods not flagged" `Quick
             test_api_safe_methods_not_flagged;
           Alcotest.test_case "new commands destructive ops" `Quick


### PR DESCRIPTION
## Summary

Close the last known bypass vector in keeper_github: GraphQL mutations via `gh api graphql`.

## Problem

`gh api graphql -f query='mutation { mergePullRequest(...) }'` bypassed the destructive gate because:
1. The endpoint is always `/graphql` — doesn't match `/merge` or `/merges`
2. `-f` triggers implicit POST detection, but the endpoint pattern check fails
3. Shell chars `{` and `}` are not in the forbidden list (they're valid in gh API queries)

## Fix

Add `gh_graphql_destructive_mutations` list with 8 known destructive GitHub GraphQL mutations. The `api` branch in `is_gh_destructive_operation` now also checks if "graphql" appears in the command and any destructive mutation name is found as a substring.

### Detected mutations
`mergePullRequest`, `closePullRequest`, `closeIssue`, `deleteIssue`, `deleteRef`, `deleteBranch`, `deleteBranchProtectionRule`, `deleteProject`

### Not flagged (safe)
`repository`, `pullRequest`, `addComment`, `createPullRequest`

## Test plan
- [x] 12/12 github safety tests pass (was 11, added graphql mutation test)
- [x] 7 destructive GraphQL mutations correctly detected
- [x] 4 safe GraphQL queries not flagged

## Related
- #5370, #5372, #5392, #5395 (previous iterations)
- Closes #5386