### PR TITLE
fix(config): increase default tool timeout 30s → 60s for local models

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -152,7 +152,7 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(arguments : Yojson.Safe.t) : fl
         float_of_int
           (int_of_env_default
              "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
-             ~default:30
+             ~default:60
              ~min_v:5
              ~max_v:300)
       in


### PR DESCRIPTION
## Summary

`MASC_TOOL_TIMEOUT_DEFAULT_SEC` default를 30s → 60s로 증가.

### 근거

Local qwen3.5-9b 운영 시 tool 호출 latency가 30-90s. 30s timeout으로 `masc_dashboard` 등이 premature timeout 발생 (오늘 로그 2건).

### 변경

`mcp_server_eio_call_tool.ml:155` — `~default:30` → `~default:60`

env var `MASC_TOOL_TIMEOUT_DEFAULT_SEC`로 런타임 override 가능 (range: 5-300s).

## Test plan

- [x] `dune build` 성공
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)