### PR TITLE
chore(ci): update OAS agent SDK pin SHA to track upstream main

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.101.0))
+  (agent_sdk (>= 0.101.1))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.101.0"}
+  "agent_sdk" {>= "0.101.1"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.101.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7b6f38d33d8c54b70e1c48ee2aba2f47096cbdd1"
+readonly OAS_AGENT_SDK_SHA="972b3ed0c1f109df36a4da127a58686191629315"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.101.1"


### PR DESCRIPTION
## Summary
- OAS pin SHA 업데이트: `7b6f38d` → `972b3ed` (upstream main 추적)
- Health check "OAS main drift" 에러로 모든 open PR의 CI가 실패하는 상황 해결

## Test plan
- [x] Health check에서 pin SHA 일치 확인
- [ ] 이 PR merge 후 #5375, #5385 CI 재실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)