### PR TITLE
feat(keeper): allow workflow ops (merge/close) for coding preset keepers

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -452,18 +452,38 @@ let handle_keeper_github
             ; "reason", `String reason
             ])
     | Ok () ->
-      if Worker_dev_tools.is_gh_destructive_operation gh_raw
+      let preset_allows_workflow =
+        match Keeper_types.tool_access_preset meta.tool_access with
+        | Some (Coding | Full) -> true
+        | _ -> false
+      in
+      if Worker_dev_tools.is_gh_dangerous_operation gh_raw
       then (
-        Log.Keeper.info "keeper_github destructive-gate: %s (keeper=%s)" gh_raw meta.name;
+        Log.Keeper.info "keeper_github dangerous-gate: %s (keeper=%s)" gh_raw meta.name;
         Yojson.Safe.to_string
           (`Assoc
               [ "ok", `Bool false
-              ; "error", `String "destructive_operation_gated"
+              ; "error", `String "dangerous_operation_gated"
               ; ( "reason"
                 , `String
-                    "This gh command performs a destructive mutation \
-                     (merge/close/delete/archive). Use read-only commands \
-                     (view/list/diff/checks) or request operator approval." )
+                    "This gh command performs an irreversible operation \
+                     (delete/archive/transfer). Request operator approval." )
+              ; "cmd", `String ("gh " ^ gh_raw)
+              ]))
+      else if (not preset_allows_workflow)
+              && Worker_dev_tools.is_gh_workflow_operation gh_raw
+      then (
+        Log.Keeper.info "keeper_github workflow-gate: %s (keeper=%s, preset not coding/full)"
+          gh_raw meta.name;
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool false
+              ; "error", `String "workflow_operation_gated"
+              ; ( "reason"
+                , `String
+                    "This gh command performs a workflow mutation \
+                     (merge/close). Upgrade to coding or full preset, \
+                     or request operator approval." )
               ; "cmd", `String ("gh " ^ gh_raw)
               ]))
       else (

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -526,40 +526,58 @@ let has_mutating_http_method parts =
 let positional_tokens parts =
   List.filter (fun s -> String.length s = 0 || s.[0] <> '-') parts
 
-(** Check if a gh command is a destructive mutation that should be gated.
-    Returns [true] for high-risk operations like merge, close, delete.
-    Low-risk writes (create, comment) return [false] and are allowed.
-    Scans positional tokens to handle boolean flag insertion bypass. *)
-let is_gh_destructive_operation cmd =
-  let parts =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
-    |> List.map String.lowercase_ascii
-  in
-  let has_positional_subcmd subcmds rest =
-    let positionals = positional_tokens rest in
-    List.exists (fun s -> List.mem s subcmds) positionals
-  in
+(** Shared tokenizer for destructive-operation checks. *)
+let gh_op_parts cmd =
+  String.split_on_char ' ' (String.trim cmd)
+  |> List.filter (fun s -> s <> "")
+  |> List.map String.lowercase_ascii
+
+let has_positional_subcmd subcmds rest =
+  let positionals = positional_tokens rest in
+  List.exists (fun s -> List.mem s subcmds) positionals
+
+(** Check if a gh command is a normal workflow mutation (merge, close).
+    These are legitimate for coding-preset keepers but should still be
+    gated for lower-privilege presets. *)
+let is_gh_workflow_operation cmd =
+  let parts = gh_op_parts cmd in
   match parts with
   | "pr" :: rest -> has_positional_subcmd [ "merge"; "close" ] rest
-  | "issue" :: rest -> has_positional_subcmd [ "close"; "delete"; "transfer" ] rest
+  | "issue" :: rest -> has_positional_subcmd [ "close" ] rest
+  | "project" :: rest -> has_positional_subcmd [ "close" ] rest
+  | "api" :: _ ->
+    let joined = String.concat " " parts in
+    has_mutating_http_method parts
+    && List.exists (fun pat -> contains_substring joined pat)
+         [ "/merge"; "/merges"; "state=closed"; "state=\"closed\""; "state='closed'" ]
+  | _ -> false
+
+(** Check if a gh command is a dangerous irreversible operation (delete,
+    archive, transfer). Always gated regardless of preset. *)
+let is_gh_dangerous_operation cmd =
+  let parts = gh_op_parts cmd in
+  match parts with
+  | "issue" :: rest -> has_positional_subcmd [ "delete"; "transfer" ] rest
   | "release" :: rest -> has_positional_subcmd [ "delete" ] rest
   | "repo" :: rest -> has_positional_subcmd [ "archive"; "rename" ] rest
   | "label" :: rest -> has_positional_subcmd [ "delete" ] rest
   | "cache" :: rest -> has_positional_subcmd [ "delete" ] rest
-  | "project" :: rest -> has_positional_subcmd [ "close"; "delete" ] rest
+  | "project" :: rest -> has_positional_subcmd [ "delete" ] rest
   | "workflow" :: rest -> has_positional_subcmd [ "delete" ] rest
   | "ruleset" :: _ -> false
   | "api" :: _ ->
     let joined = String.concat " " parts in
     List.mem "delete" parts
-    || (has_mutating_http_method parts
-        && List.exists (fun pat -> contains_substring joined pat)
-             gh_api_destructive_patterns)
     || (List.mem "graphql" parts
         && List.exists (fun m -> contains_substring joined m)
              gh_graphql_destructive_mutations)
   | _ -> false
+
+(** Combined check: returns [true] for any destructive mutation.
+    Use [is_gh_dangerous_operation] for always-gated ops, or
+    [is_gh_workflow_operation] for preset-dependent gating. *)
+let is_gh_destructive_operation cmd =
+  is_gh_workflow_operation cmd || is_gh_dangerous_operation cmd
 
 (* --- Recursive mkdir --- *)
 

--- a/test/test_keeper_github_safety.ml
+++ b/test/test_keeper_github_safety.ml
@@ -16,6 +16,8 @@ let is_ok = function Ok () -> true | Error _ -> false
 let is_error = function Error _ -> true | Ok () -> false
 
 let is_destructive = Masc_mcp.Worker_dev_tools.is_gh_destructive_operation
+let is_workflow = Masc_mcp.Worker_dev_tools.is_gh_workflow_operation
+let is_dangerous = Masc_mcp.Worker_dev_tools.is_gh_dangerous_operation
 
 let test_allowed_read_commands () =
   let allowed =
@@ -312,6 +314,54 @@ let test_non_destructive_ops () =
         false (is_destructive cmd))
     safe
 
+let test_workflow_vs_dangerous () =
+  let workflow_ops =
+    [
+      "pr merge 123";
+      "pr close 123";
+      "issue close 456";
+      "project close 1";
+      "api -X POST /repos/o/r/pulls/1/merge";
+      "api -X PATCH /repos/o/r/pulls/1 -f state=closed";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "workflow: gh %s" cmd)
+        true (is_workflow cmd);
+      Alcotest.(check bool)
+        (Printf.sprintf "not dangerous: gh %s" cmd)
+        false (is_dangerous cmd);
+      Alcotest.(check bool)
+        (Printf.sprintf "still destructive: gh %s" cmd)
+        true (is_destructive cmd))
+    workflow_ops;
+  let dangerous_ops =
+    [
+      "issue delete 456";
+      "issue transfer 456 owner/other";
+      "repo archive owner/repo";
+      "repo rename owner/repo new-name";
+      "release delete v1.0";
+      "label delete bug";
+      "cache delete --all";
+      "project delete 1";
+      "workflow delete deploy.yml";
+      "api -X DELETE repos/owner/repo/issues/1";
+      "api graphql -f query=mergePullRequest";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        (Printf.sprintf "dangerous: gh %s" cmd)
+        true (is_dangerous cmd);
+      Alcotest.(check bool)
+        (Printf.sprintf "not workflow: gh %s" cmd)
+        false (is_workflow cmd))
+    dangerous_ops
+
 let () =
   Alcotest.run "Keeper github safety"
     [
@@ -345,6 +395,11 @@ let () =
             test_new_command_destructive_ops;
           Alcotest.test_case "safe ops not flagged" `Quick
             test_non_destructive_ops;
+        ] );
+      ( "tier_split",
+        [
+          Alcotest.test_case "workflow ops classified correctly" `Quick
+            test_workflow_vs_dangerous;
         ] );
       ( "edge",
         [


### PR DESCRIPTION
## Summary

Coding preset keepers can create PRs and write code but cannot merge or close them — breaking the end-to-end workflow. This PR splits the destructive operation gate into two tiers to allow normal workflow operations for capable presets.

## Design

### Two-tier destructive classification

| Tier | Operations | Coding/Full | Other presets |
|------|-----------|-------------|---------------|
| **Workflow** | `pr merge`, `pr close`, `issue close`, `project close`, API merge/close | Allowed | Gated |
| **Dangerous** | `*delete`, `archive`, `rename`, `transfer`, GraphQL mutations | Gated | Gated |

### Implementation

- `is_gh_workflow_operation` — merge, close, state=closed patterns
- `is_gh_dangerous_operation` — delete, archive, transfer, rename, GraphQL destructive
- `is_gh_destructive_operation` — union of both (backward compat)
- `handle_keeper_github` checks `meta.tool_access` preset before gating

## Test plan
- [x] 13/13 github safety tests pass (added tier_split test)
- [x] 54/54 keeper safety gates pass
- [x] Workflow ops correctly classified (6 cases)
- [x] Dangerous ops correctly classified (11 cases)
- [x] Workflow ops are destructive but not dangerous
- [x] Dangerous ops are not workflow

## Keeper workflow (before → after)

```
Before: create PR → write code → push → ❌ merge blocked
After:  create PR → write code → push → ✅ merge allowed (coding preset)
```