### PR TITLE
fix(board): add stop signals to non-retryable board errors

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -64,14 +64,14 @@ let format_ttl_remaining expires_at =
   else Printf.sprintf "%dd left" (int_of_float (remaining /. 86400.0))
 
 let board_error_to_string = function
-  | Board.Invalid_id s -> Printf.sprintf "Invalid ID: %s" s
-  | Board.Post_not_found s -> Printf.sprintf "Post not found: %s" s
-  | Board.Comment_not_found s -> Printf.sprintf "Comment not found: %s" s
+  | Board.Invalid_id s -> Printf.sprintf "Invalid ID: %s. ACTION: Do not retry — check the ID format." s
+  | Board.Post_not_found s -> Printf.sprintf "Post not found: %s. ACTION: Do not retry — the post does not exist." s
+  | Board.Comment_not_found s -> Printf.sprintf "Comment not found: %s. ACTION: Do not retry — the comment does not exist." s
   | Board.Rate_limited { retry_after } -> Printf.sprintf "Rate limited. Retry after %.1fs" retry_after
   | Board.Capacity_exceeded { current; max } -> Printf.sprintf "Capacity exceeded: %d/%d" current max
   | Board.Io_error s -> Printf.sprintf "I/O error: %s" s
   | Board.Validation_error s -> Printf.sprintf "Validation error: %s" s
-  | Board.Already_voted s -> Printf.sprintf "Already voted: %s" s
+  | Board.Already_voted s -> Printf.sprintf "Already voted: %s. ACTION: Do not retry — vote is already recorded." s
 
 let visibility_of_string = function
   | "public" -> Some Board.Public


### PR DESCRIPTION
## Summary

Board tool의 비재시도 에러에 `ACTION: Do not retry` 신호 추가.

### 문제

`cheolsu` keeper가 이미 투표한 게시글에 반복 투표 → tool retry 2/2 소진 → turn 실패. 10분 간격으로 4회 반복 (40분 낭비).

```
Tool retry budget exhausted after 2/2 retries:
  keeper_board_vote: Already voted: cheolsu already voted up on p-3d8b8bec
```

### 수정

| 에러 | 변경 |
|------|------|
| `Already_voted` | + "ACTION: Do not retry — vote is already recorded." |
| `Invalid_id` | + "ACTION: Do not retry — check the ID format." |
| `Post_not_found` | + "ACTION: Do not retry — the post does not exist." |
| `Comment_not_found` | + "ACTION: Do not retry — the comment does not exist." |

`#5353`의 Swiss Cheese 패턴과 동일 — tool 응답에 terminal signal 삽입.

## Test plan

- [x] `dune build` 성공
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)