### PR TITLE
fix(keeper): add stop signal to keeper_tasks_audit response

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -736,8 +736,16 @@ let handle_keeper_task_tool
              ])
         orphans
     in
+    let action_hint =
+      if orphans = [] then
+        "ACTION: STOP calling keeper_tasks_audit — no orphans found. Move on to other work or end your turn."
+      else
+        Printf.sprintf "ACTION: %d orphan(s) found. Use keeper_task_force_release or keeper_task_force_done to resolve, then STOP re-auditing."
+          (List.length orphans)
+    in
     Yojson.Safe.to_string
-      (`Assoc [ "orphan_count", `Int (List.length orphans); "orphans", `List items ])
+      (`Assoc [ "orphan_count", `Int (List.length orphans); "orphans", `List items;
+                "action", `String action_hint ])
   | "keeper_task_force_release" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let reason = Safe_ops.json_string ~default:"" "reason" args in


### PR DESCRIPTION
## Summary
- `keeper_tasks_audit` 응답에 `action` 필드로 stop signal 추가
- orphan 0개: "STOP calling keeper_tasks_audit"
- orphan N개: "resolve with force_release/force_done, then STOP re-auditing"

## Context
서버 재시작 후 sangsu keeper가 8 turn 연속 `[board_post, tasks_audit x3]` 패턴 고정.
`keeper_tasks_list`에는 PR #5353에서 stop signal을 추가했지만 `tasks_audit`에는 누락.

## Test plan
- [x] `dune build` 통과
- [ ] 서버 재시작 후 tasks_audit 반복 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)