### PR TITLE
fix(ci): align agent_sdk floor with OAS pin v0.101.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.101.0))
+  (agent_sdk (>= 0.101.1))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.101.0"}
+  "agent_sdk" {>= "0.101.1"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
- `dune-project`와 `masc_mcp.opam`의 agent_sdk floor이 0.101.0으로 남아있어 Health check가 모든 branch에서 실패
- #5396에서 OAS SDK를 v0.101.1로 pin했지만 floor 업데이트가 누락됨

## Changes (2 files)
- `dune-project`: `(agent_sdk (>= 0.101.0))` → `(agent_sdk (>= 0.101.1))`
- `masc_mcp.opam`: `"agent_sdk" {>= "0.101.0"}` → `"agent_sdk" {>= "0.101.1"}`

## Test plan
- [ ] Health check `check-oas-pin.sh` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)