### PR TITLE
feat(keeper): non-heuristic board repetition awareness via self-reflection

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -424,6 +424,39 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       "You can interact with these keepers by mentioning them in board posts.\n";
     Buffer.add_string ubuf (String.concat "\n" peer_keepers);
     Buffer.add_string ubuf "\n");
+  (* Self-awareness: show this keeper its own recent board posts so it can
+     recognize repetitive patterns.  Non-heuristic: the model decides whether
+     its behavior is repetitive, not a hardcoded similarity check. *)
+  let own_recent_posts =
+    let posts_path =
+      Filename.concat (Filename.concat base_path ".masc") "board_posts.jsonl"
+    in
+    (try
+       Fs_compat.load_jsonl posts_path
+       |> List.filter_map Board.post_of_yojson
+       |> List.filter (fun (p : Board_types.post) ->
+         String.equal (Board_types.Agent_id.to_string p.author) meta.name)
+       |> List.rev
+       |> (fun posts ->
+         if List.length posts > 5
+         then List.filteri (fun i _ -> i < 5) posts
+         else posts)
+       |> List.map (fun (p : Board_types.post) ->
+         let title = p.title in
+         let truncated =
+           if String.length title <= 60 then title
+           else String.sub title 0 57 ^ "..."
+         in
+         Printf.sprintf "- \"%s\"" truncated)
+     with _ -> [])
+  in
+  if own_recent_posts <> [] then (
+    Buffer.add_string ubuf "\n### Your Recent Board Posts\n";
+    Buffer.add_string ubuf
+      "Review these before posting. If you see a repetitive pattern, \
+       do something genuinely different this turn.\n";
+    Buffer.add_string ubuf (String.concat "\n" own_recent_posts);
+    Buffer.add_string ubuf "\n");
   let routes = actionable_routes ~allowed_tools observation in
   if routes <> [] then (
     Buffer.add_string ubuf "\n### Actionable Routes\n";


### PR DESCRIPTION
## Summary
- Keeper user_message에 자기 최근 board post 5개 제목을 표시
- 모델이 자기 행동 패턴을 보고 비결정론적으로 반복 여부를 판단
- 하드코딩 유사도/regex/규칙 없음 — 순수 프롬프트 엔지니어링

## Problem
keeper들이 board에 같은 글을 10-19회 반복 도배:
- admin-keeper: "📊 Admin Tool Policy Test Update" x19
- sangsu: "📊 System Status Update" x10
- janitor: "Meta-cognition signal received" x4

원인: keeper가 자기 이전 출력을 볼 수 없어서 반복인지 인지 불가.

## Solution
`build_prompt`에 `### Your Recent Board Posts` 섹션 추가:
```
### Your Recent Board Posts
Review these before posting. If you see a repetitive pattern,
do something genuinely different this turn.
- "📊 Admin Tool Policy Test Update: Context at 80%..."
- "📊 Admin Tool Policy Test Update: Context at 80%..."
- "📊 Admin Tool Policy Test Update: Context at 80%..."
```

모델이 이걸 보면 "같은 글 3번 연속" → 스스로 다른 행동 선택.

## Test plan
- [x] `dune build` 성공
- [ ] 서버 재시작 후 반복 게시물 빈도 감소 확인
- [ ] keeper가 이전과 다른 제목/내용의 글을 쓰는지 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)