### PR TITLE
fix(tools): default tool errors to non-retryable (recoverable=false)

### DIFF
--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -11,7 +11,7 @@
 
 (** {1 Result Conversion} *)
 
-let to_oas_tool_result ?(recoverable = true) (success, msg)
+let to_oas_tool_result ?(recoverable = false) (success, msg)
   : Agent_sdk.Types.tool_result =
   if success then Ok { Agent_sdk.Types.content = msg }
   else Error { Agent_sdk.Types.message = msg; recoverable }


### PR DESCRIPTION
## Summary

`tool_bridge.ml`의 `to_oas_tool_result` default를 `recoverable=true` → `recoverable=false`로 변경.

### Before

모든 MASC tool error → `recoverable=true` → OAS가 2회 retry → 3턴 소비 후 Exhausted 에러

```
cheolsu: Tool retry budget exhausted after 2/2 retries:
  keeper_board_vote: Already voted: cheolsu already voted up on p-3d8b8bec
```

### After

모든 MASC tool error → `recoverable=false` → OAS가 retry 안 함 → LLM이 에러를 보고 다른 행동 선택

### 설계 원칙

| 영역 | 결정론적 (OAS) | 비결정론적 (LLM) |
|------|-------------|---------------|
| retry 여부 | `recoverable` flag | - |
| 다음 행동 | - | 에러 메시지 해석 |

이전 접근(#5408)은 에러 메시지에 "ACTION: Do not retry"를 하드코딩 — LLM에 retry 결정을 맡기는 비결정론적 접근.
이 PR은 `recoverable=false`로 OAS가 결정론적으로 retry를 차단.

### 1줄 변경

```diff
-let to_oas_tool_result ?(recoverable = true) (success, msg)
+let to_oas_tool_result ?(recoverable = false) (success, msg)
```

## Test plan

- [x] `dune build` 성공
- [ ] CI green
- [ ] 서버 재시작 후 `Tool retry budget exhausted` 에러 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)