### PR TITLE
fix(keeper): TOML denylist takes precedence over stale runtime state

### DIFF
--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -38,6 +38,6 @@ allowed_paths = ["*"]
 tool_preset = "delivery"
 
 # Deny tools that local models misuse in idle loops.
-tool_denylist = ["keeper_board_comment"]
+tool_denylist = ["keeper_board_comment", "keeper_board_post"]
 
 proactive_enabled = true

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -113,13 +113,16 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
             | None -> Custom names)
   in
   let tool_denylist =
-    let old_or_profile =
-      if old.tool_denylist <> [] then Some old.tool_denylist
-      else p.profile_defaults.tool_denylist
+    let profile_or_old =
+      match p.profile_defaults.tool_denylist with
+      | Some _ as toml -> toml
+      | None ->
+        if old.tool_denylist <> [] then Some old.tool_denylist
+        else None
     in
     resolve_tool_name_list
       ~preferred:p.tool_denylist_opt
-      ~fallback:old_or_profile
+      ~fallback:profile_or_old
   in
   let updated = { old with
     goal;


### PR DESCRIPTION
## Summary
- Fix priority inversion in `keeper_turn_up_update.ml` denylist resolution
- TOML `profile_defaults.tool_denylist` now always overrides stale runtime state
- Old state only used as fallback when no TOML default exists

## Problem
PR #5403 fixed the race condition where API-set denylist was overwritten, but the 3-level fallback still had a priority issue: if `old.tool_denylist` was non-empty (even if corrupted/incomplete), it took precedence over TOML defaults.

Observed: example keeper runtime had `['keeper_board_comment']` but TOML defines `["keeper_board_comment", "keeper_board_post"]`. The keeper kept calling `keeper_board_post` because the partial old state blocked TOML from being consulted.

## Fix
```
Before: API override > old state (if non-empty) > TOML defaults
After:  API override > TOML defaults > old state (only if no TOML default)
```

## Test plan
- [ ] Verify example keeper gets full TOML denylist after server restart
- [ ] Verify keepers without TOML denylist still use old state as fallback
- [ ] Check cheolsu still has all 3 denied tools
- [ ] Monitor for `keeper_board_post` calls from example

🤖 Generated with [Claude Code](https://claude.com/claude-code)