### PR TITLE
fix(dashboard): stop displaying missing API data as fake zero values

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -35,7 +35,7 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
   const d = evt.detail as Record<string, unknown>
   const toolName = (d.tool_name as string) ?? 'unknown'
   const success = d.success !== false
-  const durationMs = (d.duration_ms as number) ?? 0
+  const durationMs = d.duration_ms as number | undefined
   const errorMsg = d.error as string | null
   const args = d.args as Record<string, unknown> | string | undefined
   const cat = toolCategory(toolName)
@@ -48,7 +48,9 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
         </div>
         <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[200px]" title=${toolName}>${toolName}</span>
         <span class="text-[9px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
-        <span class="text-[11px] font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>
+        ${durationMs != null
+          ? html`<span class="text-[11px] font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
+          : null}
         ${success
           ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">ok</span>`
           : html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">err</span>`}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -473,7 +473,7 @@ function ToolCallHealthPanel() {
   const rate = health.failure_rate
   const hasRate = rate != null
   const rateColor = hasRate ? (rate > 0.1 ? 'text-bad-light' : rate > 0.03 ? 'text-warn' : 'text-ok') : 'text-text-dim'
-  const ratePct = hasRate ? (rate * 100).toFixed(1) : '-'
+  const ratePct = hasRate ? `${(rate * 100).toFixed(1)}%` : '-'
 
   return html`
     <div>
@@ -488,7 +488,7 @@ function ToolCallHealthPanel() {
           <div class="text-[11px] text-text-muted mt-1">실패</div>
         </div>
         <div class="rounded-lg border border-card-border/30 bg-card/40 p-3 text-center">
-          <div class="text-[22px] font-bold ${rateColor}">${ratePct}%</div>
+          <div class="text-[22px] font-bold ${rateColor}">${ratePct}</div>
           <div class="text-[11px] text-text-muted mt-1">실패율</div>
         </div>
       </div>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -312,7 +312,7 @@ function MetaCognitionCard() {
                   ${belief?.claim ?? '아직 강한 belief가 드러나지 않았습니다.'}
                 </div>
                 <div class="mt-2 text-[11px] text-[var(--text-muted)]">
-                  ${belief ? `${beliefStatusLabel(belief.status)} · ${belief.support_agent_count ?? 0}명 지지` : '공감대 형성 전'}
+                  ${belief ? `${beliefStatusLabel(belief.status)}${belief.support_agent_count != null ? ` · ${belief.support_agent_count}명 지지` : ''}` : '공감대 형성 전'}
                 </div>
               </div>
 
@@ -470,9 +470,10 @@ function ToolCallHealthPanel() {
   const health = status?.tool_call_health
   if (!health || health.tool_calls === 0) return null
 
-  const rate = health.failure_rate ?? 0
-  const rateColor = rate > 0.1 ? 'text-bad-light' : rate > 0.03 ? 'text-warn' : 'text-ok'
-  const ratePct = (rate * 100).toFixed(1)
+  const rate = health.failure_rate
+  const hasRate = rate != null
+  const rateColor = hasRate ? (rate > 0.1 ? 'text-bad-light' : rate > 0.03 ? 'text-warn' : 'text-ok') : 'text-text-dim'
+  const ratePct = hasRate ? (rate * 100).toFixed(1) : '-'
 
   return html`
     <div>

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -14,20 +14,22 @@ function loadMetrics() {
   return metricsResource.load(() => fetchToolMetrics())
 }
 
-function tierLabel(tier: string | undefined): string {
+function tierLabel(tier: string | null | undefined): string {
   switch (tier) {
     case 'essential': return '필수'
     case 'standard': return '표준'
     case 'full': return '전체'
-    default: return tier ?? '-'
+    case null: case undefined: return '-'
+    default: return tier
   }
 }
 
-function tierBadgeClass(tier: string): string {
+function tierBadgeClass(tier: string | null | undefined): string {
   switch (tier) {
     case 'essential': return 'badge-essential'
     case 'standard': return 'badge-standard'
-    default: return 'badge-full'
+    case 'full': return 'badge-full'
+    default: return 'bg-[var(--white-4)] text-[var(--text-dim)]'
   }
 }
 

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -14,11 +14,12 @@ function loadMetrics() {
   return metricsResource.load(() => fetchToolMetrics())
 }
 
-function tierLabel(tier: string): string {
+function tierLabel(tier: string | undefined): string {
   switch (tier) {
     case 'essential': return '필수'
     case 'standard': return '표준'
-    default: return '전체'
+    case 'full': return '전체'
+    default: return tier ?? '-'
   }
 }
 


### PR DESCRIPTION
## Summary

API 필드가 null/undefined일 때 대시보드가 거짓 값을 표시하던 3곳 수정:

- **agent timeline**: duration_ms 부재 시 "0ms" 대신 숨김
- **overview**: failure_rate null → "0.0%" 대신 "-" 표시
- **overview**: support_agent_count null → "0명 지지" 대신 생략
- **tool-metrics**: unknown tier → "전체" 대신 raw 값 또는 "-"

## Evidence

```bash
curl localhost:8935/api/v1/tool-metrics | jq '.top_20[0].tier'
# null (필드 없음)
```

## Test plan

- [x] TypeScript type check 통과
- [ ] tier 없는 API 응답에서 "-" 표시 확인
- [ ] failure_rate null에서 "-" 표시 확인

Generated with [Claude Code](https://claude.com/claude-code)