### PR TITLE
refactor(keeper): remove max_turns hardcoding, defer to OAS default

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -254,7 +254,7 @@ let log_keeper_memory_write
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
     @param generation Current generation counter
-    @param max_turns Maximum agent turns (default 50)
+    @param max_turns Maximum agent turns (default: OAS default, currently 10)
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature MODEL temperature override; when omitted, resolved
            from [Cascade_inference] with a 0.3 fallback
@@ -275,7 +275,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 50)
+    ?(max_turns : int = 10) (* align with OAS Types.default_agent_config.max_turns *)
     ?(max_idle_turns : int = 3)
     ?(history_user_source = "direct_user")
     ?(history_assistant_source = "direct_assistant")

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -553,5 +553,10 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (* max_turns removed: agent turn budgets belong in OAS
-   (Types.default_agent_config.max_turns). MASC must not hardcode
-   agent runtime parameters. See OAS types.ml:79. *)
+   (Types.default_agent_config.max_turns = 10). MASC must not hardcode
+   agent runtime parameters.
+   Known constraints (retain for future OAS tuning):
+   - 1000 turns caused 787s+ latency per turn
+   - 20 turns caused 6.7GB RSS in 2 minutes with 3 concurrent keepers
+   - 3 turns left keepers unable to do meaningful work (board_post x3 only)
+   If OAS default needs adjustment, change it in OAS types.ml. *)

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -553,14 +553,15 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 3.
-    Previous default (1000) caused 787s+ latency per turn.
-    20 caused 6.7GB RSS in 2 minutes with 3 concurrent keepers.
+    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 8.
+    History: 1000 caused 787s+ latency; 20 caused 6.7GB RSS with 3 keepers;
+    3 left keepers unable to do meaningful work (board_post x3 only).
+    8 allows observe-reason-act-report chains without runaway resource use.
     This value is the fallback; channel-aware functions below are preferred. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:3
+    ~default:8
     ~min_v:1
     ~max_v:50
 

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -552,35 +552,6 @@ let keeper_unified_max_tokens () : int =
     ~min_v:256
     ~max_v:16000
 
-(** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 8.
-    History: 1000 caused 787s+ latency; 20 caused 6.7GB RSS with 3 keepers;
-    3 left keepers unable to do meaningful work (board_post x3 only).
-    8 allows observe-reason-act-report chains without runaway resource use.
-    This value is the fallback; channel-aware functions below are preferred. *)
-let keeper_unified_max_turns () : int =
-  int_of_env_default
-    "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:8
-    ~min_v:1
-    ~max_v:50
-
-(** Max turns for reactive channel (responding to mentions, board events, messages).
-    Reactive turns need more budget: read context -> reason -> act -> report.
-    Env: [MASC_KEEPER_REACTIVE_MAX_TURNS]. Default: 8. *)
-let keeper_reactive_max_turns () : int =
-  int_of_env_default
-    "MASC_KEEPER_REACTIVE_MAX_TURNS"
-    ~default:8
-    ~min_v:2
-    ~max_v:30
-
-(** Max turns for scheduled autonomous channel (proactive check-ins).
-    Autonomous turns are "observe one thing, do one thing" cycles.
-    Env: [MASC_KEEPER_AUTONOMOUS_MAX_TURNS]. Default: 5. *)
-let keeper_autonomous_max_turns () : int =
-  int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_MAX_TURNS"
-    ~default:5
-    ~min_v:1
-    ~max_v:20
+(* max_turns removed: agent turn budgets belong in OAS
+   (Types.default_agent_config.max_turns). MASC must not hardcode
+   agent runtime parameters. See OAS types.ml:79. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -865,13 +865,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           ~cascade_name:"keeper_unified"
           ~fallback:Keeper_config.keeper_unified_max_tokens
       in
-      let max_turns =
-        match channel with
-        | Keeper_world_observation.Reactive ->
-            Keeper_config.keeper_reactive_max_turns ()
-        | Keeper_world_observation.Scheduled_autonomous ->
-            Keeper_config.keeper_autonomous_max_turns ()
-      in
+      (* max_turns: defer to OAS default (Types.default_agent_config.max_turns).
+         MASC does not hardcode agent runtime budgets. *)
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)
       let build_turn_prompt ~base_system_prompt:_ ~messages:_
@@ -893,7 +888,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
-              ~generation:run_generation ~max_turns ~max_idle_turns
+              ~generation:run_generation ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -871,13 +871,11 @@ let test_prompt_includes_room_signal_when_flag_enabled () =
 let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_TEMP" "" (fun () ->
   with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
-  with_env "MASC_KEEPER_UNIFIED_MAX_TURNS" "" (fun () ->
     check (float 0.01) "unified temp default" 0.4
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
-      (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 3
-      (KC.keeper_unified_max_turns ()))))
+      (KC.keeper_unified_max_tokens ())
+    (* max_turns removed: agent turn budgets belong in OAS *)))
 
 let test_meta_defaults_social_model () =
   check string "default social model" "bdi_speech_v1"


### PR DESCRIPTION
## Summary
- Remove `keeper_unified_max_turns` (3), `keeper_reactive_max_turns` (8), `keeper_autonomous_max_turns` (5) from keeper_config.ml
- Remove `~max_turns` override in `keeper_unified_turn.ml` — OAS `Types.default_agent_config.max_turns` (10) now applies
- MASC was violating the OAS layer boundary by hardcoding agent runtime parameters

## Root cause
`max_turns=3` caused all keepers to perform exactly 3 tool calls per turn (board_post×3), unable to execute observe-reason-act-report chains. 2 keepers died from the cascade: trivial turns → context waste → handoff failures → crash → restart budget exhaustion → Dead.

## Boundary principle
Agent turn budgets belong in OAS (`Types.default_agent_config`), not MASC. MASC passes abstract signals (ratio, status), OAS owns raw infrastructure (token counts, turn limits, context size).

## Changes
- `lib/keeper/keeper_config.ml` — remove 3 `keeper_*_max_turns` functions (-30 lines)
- `lib/keeper/keeper_unified_turn.ml` — remove channel-specific max_turns override
- `test/test_keeper_unified.ml` — remove max_turns assertion

## Test plan
- [x] `dune build` clean
- [x] `test_keeper_state_machine.exe` 66/66 pass
- [x] `test_keeper_unified.exe` 94/94 pass
- [ ] After deploy: verify keepers execute more than 3 tool calls per turn
- [ ] Monitor that OAS default (10) is reasonable for keeper workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)