### PR TITLE
feat(keeper): add metacognition signals to unified prompt

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -398,6 +398,64 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf "\n### Keeper Tools\n";
     Buffer.add_string ubuf (String.concat ", " keeper_tools);
     Buffer.add_string ubuf "\n");
+  (* Metacognition: show the keeper its own recent tool activity so it can
+     recognise patterns — thrashing, failure loops, tool over-reliance.
+     Data comes from Keeper_registry per-entry tool_usage Hashtbl. *)
+  let tool_activity =
+    Keeper_tools_oas.tool_usage_for_keeper meta.name
+    |> List.sort (fun (_, a) (_, b) ->
+      Float.compare b.Keeper_types.last_used_at a.Keeper_types.last_used_at)
+  in
+  let recent_activity = List.filteri (fun i _ -> i < 8) tool_activity in
+  if recent_activity <> [] then (
+    Buffer.add_string ubuf "\n### Recent Tool Activity\n";
+    List.iter (fun (name, (e : Keeper_types.tool_call_entry)) ->
+      let rate =
+        if e.count > 0
+        then float_of_int e.successes /. float_of_int e.count *. 100.0
+        else 0.0
+      in
+      let warning =
+        if e.count >= 3 && rate < 50.0 then " [LOW SUCCESS — try different approach]"
+        else ""
+      in
+      Buffer.add_string ubuf
+        (Printf.sprintf "- %s: %d calls (%d ok, %d fail, %.0f%% success)%s\n"
+           name e.count e.successes e.failures rate warning)
+    ) recent_activity;
+    (* Pattern detection: warn if recent activity is too homogeneous *)
+    let unique_tools = List.sort_uniq String.compare
+      (List.map fst recent_activity) in
+    if List.length recent_activity >= 4
+       && List.length unique_tools <= 2 then
+      Buffer.add_string ubuf
+        "NOTE: You are using very few distinct tools. Consider a different approach.\n");
+  (* Metacognition: last cycle outcome so keeper knows its own behavioral pattern *)
+  let prt = meta.runtime.proactive_rt in
+  let outcome_str = Keeper_types.proactive_cycle_outcome_to_string prt.last_outcome in
+  if prt.count_total > 0 then (
+    Buffer.add_string ubuf "\n### Last Cycle Outcome\n";
+    Buffer.add_string ubuf
+      (Printf.sprintf "- Result: %s\n" outcome_str);
+    if prt.last_reason <> "" then
+      Buffer.add_string ubuf
+        (Printf.sprintf "- Reason: %s\n" prt.last_reason);
+    Buffer.add_string ubuf
+      (Printf.sprintf "- Cycles total: %d (visible: %d, silent: %d)\n"
+         prt.count_total prt.visible_count_total
+         (prt.count_total - prt.visible_count_total));
+    (* Self-correction cues based on pattern *)
+    (match prt.last_outcome with
+     | Proactive_silent ->
+       Buffer.add_string ubuf
+         "SELF-CHECK: Last cycle was silent. If you have observations, act on them.\n"
+     | Proactive_error ->
+       Buffer.add_string ubuf
+         "SELF-CHECK: Last cycle ended in error. Diagnose before retrying the same approach.\n"
+     | Proactive_tool_use when prt.visible_count_total = 0 ->
+       Buffer.add_string ubuf
+         "SELF-CHECK: You have been using tools but never producing visible output. Consider sharing findings.\n"
+     | _ -> ()));
   (* Peer keepers — show other running keepers so this keeper can @mention them *)
   let peer_keepers =
     Keeper_registry.all ~base_path ()

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1829,6 +1829,45 @@ let test_normalize_override_passthrough () =
   | Ok text -> check string "passes through" override_text text
   | Error e -> fail ("unexpected error: " ^ e)
 
+(* ---------- Metacognition tests ---------- *)
+
+let meta_with_proactive_history outcome count visible =
+  let rt = minimal_meta.runtime in
+  let prt = { rt.proactive_rt with
+    last_outcome = outcome;
+    count_total = count;
+    visible_count_total = visible;
+    last_reason = "test-reason";
+  } in
+  { minimal_meta with runtime = { rt with proactive_rt = prt } }
+
+let test_prompt_includes_last_cycle_outcome () =
+  let meta = meta_with_proactive_history Masc_mcp.Keeper_types.Proactive_tool_use 5 3 in
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation in
+  check bool "has Last Cycle Outcome section"
+    true (contains_substring user "### Last Cycle Outcome");
+  check bool "shows tool_use result"
+    true (contains_substring user "tool_use");
+  check bool "shows cycle counts"
+    true (contains_substring user "Cycles total: 5")
+
+let test_prompt_self_check_after_silent () =
+  let meta = meta_with_proactive_history Masc_mcp.Keeper_types.Proactive_silent 3 1 in
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation in
+  check bool "has SELF-CHECK for silent"
+    true (contains_substring user "SELF-CHECK: Last cycle was silent")
+
+let test_prompt_self_check_after_error () =
+  let meta = meta_with_proactive_history Masc_mcp.Keeper_types.Proactive_error 2 1 in
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation in
+  check bool "has SELF-CHECK for error"
+    true (contains_substring user "SELF-CHECK: Last cycle ended in error")
+
+let test_prompt_no_outcome_for_fresh_keeper () =
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation in
+  check bool "no Last Cycle Outcome for fresh keeper"
+    false (contains_substring user "### Last Cycle Outcome")
+
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -1916,6 +1955,17 @@ let () =
             test_sanitize_messages_utf8_cleans_history_path;
           test_case "sanitize_messages_utf8 reuses clean history list" `Quick
             test_sanitize_messages_utf8_reuses_clean_history_list;
+        ] );
+      ( "metacognition",
+        [
+          test_case "includes last cycle outcome" `Quick
+            test_prompt_includes_last_cycle_outcome;
+          test_case "self-check after silent" `Quick
+            test_prompt_self_check_after_silent;
+          test_case "self-check after error" `Quick
+            test_prompt_self_check_after_error;
+          test_case "no outcome for fresh keeper" `Quick
+            test_prompt_no_outcome_for_fresh_keeper;
         ] );
       ( "config",
         [


### PR DESCRIPTION
## Summary
- Keeper unified prompt에 2개 메타인지 섹션 추가
- **Recent Tool Activity**: 최근 8개 도구 사용 이력 + 성공률 + 실패 경고 + 도구 다양성 경고
- **Last Cycle Outcome**: 이전 사이클 결과(silent/tool_use/error) + SELF-CHECK 자가 진단 큐

## Why
Keeper가 자기 행동 패턴(실패 루프, 도구 편중, 연속 침묵)을 인식하지 못해 기계적으로 동작.
기존 인프라(`Keeper_registry.tool_usage`, `proactive_rt`)의 데이터를 프롬프트에 주입하여
자기 교정 가능한 에이전트로 전환.

## Test plan
- [x] `dune build` 통과
- [x] `test_keeper_unified.exe` metacognition 4개 테스트 통과
  - includes last cycle outcome
  - self-check after silent
  - self-check after error
  - no outcome for fresh keeper
- [ ] CI Build and Test
- [ ] 실제 keeper 구동 후 프롬프트에 섹션 노출 확인

Closes #5308 (partial — metacognition facet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)