### PR TITLE
fix(dashboard): wire refineOfflineStatus into lifecycle signals

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -5,6 +5,7 @@ import type {
 } from './types'
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
+import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
@@ -15,6 +16,8 @@ function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
     || raw === 'idle'
     || raw === 'inactive'
     || raw === 'offline'
+    || raw === 'unbooted'
+    || raw === 'stopped'
   ) {
     return raw
   }
@@ -25,7 +28,7 @@ function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
 
 export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   const status = keeper.status?.toLowerCase() ?? ''
-  if (isOfflineStatus(status)) return 'offline'
+  if (isOfflineStatus(status)) return keeperDisplayStatus(keeper) as KeeperLifecycleState
 
   const series = keeper.metrics_series
   if (!series || series.length === 0) {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -4,6 +4,7 @@
 
 import { signal, computed, type ReadonlySignal } from '@preact/signals'
 import { isOfflineStatus } from './lib/status-utils'
+import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import type {
   Agent,
   Task,
@@ -238,7 +239,8 @@ export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>>
   for (const k of keepers.value) {
     const status = k.status?.toLowerCase() ?? ''
     if (isOfflineStatus(status)) {
-      map.set(k.name, 'offline')
+      const refined = keeperDisplayStatus(k) as KeeperLifecycleState
+      map.set(k.name, refined)
       continue
     }
     if (!k.metrics_series || k.metrics_series.length === 0) continue

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -170,6 +170,8 @@ export type KeeperLifecycleState =
   | 'handoff-imminent'
   | 'idle'
   | 'offline'
+  | 'unbooted'
+  | 'stopped'
 
 // --- Keeper SSE Events ---
 


### PR DESCRIPTION
## Summary
- `keeperLifecycles` signal과 `deriveLifecycleState`에서 모든 offline 키퍼를 `'offline'`로 하드코딩하던 버그 수정
- PR #5345에서 도입한 `unbooted`/`stopped` 구분이 lifecycle signal에 반영되지 않던 문제 해결

## Problem
PR #5345가 `refineOfflineStatus()`로 offline 상태를 세분화했지만, 이 함수가 `keeperLifecycles` computed signal과 `deriveLifecycleState()`에서는 호출되지 않았음. 대시보드 전역에서 모든 비활성 키퍼가 동일한 'offline'으로 표시.

## Changes
- `KeeperLifecycleState` 타입에 `'unbooted'` | `'stopped'` 추가
- `store.ts`: `keeperLifecycles`에서 `keeperDisplayStatus()` 사용
- `keeper-store-normalize.ts`: `deriveLifecycleState`에서 `keeperDisplayStatus()` 사용, `normalizeKeeperAgentStatus`에 `unbooted`/`stopped` 인식 추가

## Test plan
- [x] TypeScript type check 통과 (`tsc --noEmit`)
- [x] Dashboard tests 332/333 통과 (1 flaky: mcp.test.ts 네트워크 타임아웃, 기존)
- [ ] 실제 대시보드에서 unbooted/stopped 키퍼 구분 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>