### PR TITLE
fix(keeper): wire checkpoint_dir to OAS worker — restore continuity

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -920,6 +920,7 @@ let run_turn
           ~allowed_paths:oas_allowed_paths
           ~cache_system_prompt:true
           ~yield_on_tool
+          ~checkpoint_dir:session_dir
           ()
       with
       | Error e -> Error e

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -107,6 +107,7 @@ val run_named :
   ?cache_system_prompt:bool ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
+  ?checkpoint_dir:string ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -147,6 +147,7 @@ let run_named
     ?(cache_system_prompt = false)
     ?(yield_on_tool = false)
     ?compact_ratio
+    ?checkpoint_dir
     ?sw
     ?net
     ()
@@ -192,6 +193,7 @@ let run_named
       cache_system_prompt;
       compact_ratio;
       contract;
+      checkpoint_dir;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in


### PR DESCRIPTION
## Summary
- `run_named`에 `?checkpoint_dir` 파라미터 추가
- `keeper_agent_run.ml`에서 `~checkpoint_dir:session_dir` 전달
- OAS가 checkpoint를 실제로 저장하게 되어 `continuity_summary` 추출 가능

## Root Cause
`Oas_worker_named.run_named`의 config 빌드에서 `checkpoint_dir`이 누락.
`default_config`의 `checkpoint_dir = None`이 그대로 유지되어 OAS가 checkpoint를 절대 생성하지 않았음.
결과: `post_turn_lifecycle`에서 `checkpoint = None` → `apply_continuity_summary` 스킵 → 매 turn stateless.

## Impact
- Keeper가 이전 turn에서 뭘 했는지 기억
- Board post 반복 방지 (#5411 self-read + continuity 시너지)
- `tasks_audit` 반복 감소 (이전 감사 결과를 continuity에서 참조)

## Files Changed
| File | Change |
|------|--------|
| `lib/oas_worker_named.ml` | `?checkpoint_dir` 파라미터 추가 + config 전달 |
| `lib/oas_worker.mli` | 시그니처 업데이트 |
| `lib/keeper/keeper_agent_run.ml` | `~checkpoint_dir:session_dir` 전달 |

Closes #5421

## Test plan
- [x] `dune build` 통과
- [ ] 서버 재시작 후 checkpoint 파일 생성 확인
- [ ] `continuity_summary` 비어있지 않은지 확인
- [ ] Board post 반복 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)