### PR TITLE
fix(boundary): extract cascade_name SSOT and fix silent role corruption

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
-> Current package version: v2.245.0
-> Latest release: v2.245.0 (2026-04-05)
-> Updated: 2026-04-05
+> Current package version: v2.246.0
+> Latest release: v2.246.0 (2026-04-06)
+> Updated: 2026-04-06
 
 Execution companion for capsule-only coordination hardening:
 [design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,8 +2,8 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-05
-> Snapshot baseline: `dune-project` version `2.245.0`
+> Last Updated: 2026-04-06
+> Snapshot baseline: `dune-project` version `2.246.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
 

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -2,6 +2,10 @@
 
 open Tool_args
 
+(** Default cascade name for keeper turns. SSOT — all keeper code must
+    reference this constant instead of using the string literal. *)
+let default_cascade_name = "keeper_unified"
+
 let bool_default_true_of_env name =
   match Sys.getenv_opt name with
   | None -> true

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -114,7 +114,10 @@ let role_to_string (r : Agent_sdk.Types.role) = match r with
 
 let role_of_string = function
   | "system" -> Agent_sdk.Types.System | "user" -> Agent_sdk.Types.User
-  | "assistant" -> Agent_sdk.Types.Assistant | _ -> Agent_sdk.Types.Tool
+  | "assistant" -> Agent_sdk.Types.Assistant | "tool" -> Agent_sdk.Types.Tool
+  | unknown ->
+    Log.Misc.warn "keeper_context_core: unknown role %S, defaulting to User" unknown;
+    Agent_sdk.Types.User
 
 let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
   let m = Inference_utils.sanitize_message_utf8 m in
@@ -291,7 +294,7 @@ let checkpoint_model_of_meta (meta : keeper_meta) =
     :: Oas_model_resolve.models_of_cascade_name meta.cascade_name
   in
   List.find_opt (fun value -> String.trim value <> "") candidates
-  |> Option.value ~default:"keeper_unified"
+  |> Option.value ~default:Keeper_config.default_cascade_name
 
 let save_oas_checkpoint
     ~(session : session_context)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -294,7 +294,7 @@ let checkpoint_model_of_meta (meta : keeper_meta) =
     :: Oas_model_resolve.models_of_cascade_name meta.cascade_name
   in
   List.find_opt (fun value -> String.trim value <> "") candidates
-  |> Option.value ~default:Keeper_config.default_cascade_name
+  |> Option.value ~default:(Provider_adapter.default_local_fallback_label ())
 
 let save_oas_checkpoint
     ~(session : session_context)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -183,7 +183,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ~fallback_message:env_message_gate
         ~fallback_token:env_token_gate
     in
-    let cascade_models = Oas_model_resolve.models_of_cascade_name "keeper_unified" in
+    let cascade_models = Oas_model_resolve.models_of_cascade_name Keeper_config.default_cascade_name in
     ignore (Oas_model_resolve.refresh_local_discovery_if_possible cascade_models);
     let primary_max_context =
       match p.max_context_override_opt with
@@ -227,7 +227,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         long_goal;
         
         social_model = default_social_model;
-        cascade_name = "keeper_unified";
+        cascade_name = Keeper_config.default_cascade_name;
         will;
         needs;
         desires;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -131,7 +131,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     long_goal;
     cascade_name =
       (if String.trim old.cascade_name <> "" then old.cascade_name
-       else "keeper_unified");
+       else Keeper_config.default_cascade_name);
     will =
       Option.value
         ~default:

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -703,7 +703,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : parsed_keeper_identity =
   in
   let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
   let pk_cascade_name =
-    Safe_ops.json_string ~default:default_cascade_name "cascade_name" json
+    Safe_ops.json_string ~default:Keeper_config.default_cascade_name "cascade_name" json
   in
   { pk_name
   ; pk_agent_name

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -703,7 +703,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : parsed_keeper_identity =
   in
   let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
   let pk_cascade_name =
-    Safe_ops.json_string ~default:"keeper_unified" "cascade_name" json
+    Safe_ops.json_string ~default:default_cascade_name "cascade_name" json
   in
   { pk_name
   ; pk_agent_name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -857,12 +857,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
       let temperature =
         Cascade_inference.resolve_temperature
-          ~cascade_name:"keeper_unified"
+          ~cascade_name:Keeper_config.default_cascade_name
           ~fallback:Keeper_config.keeper_unified_temperature
       in
       let max_tokens =
         Cascade_inference.resolve_max_tokens
-          ~cascade_name:"keeper_unified"
+          ~cascade_name:Keeper_config.default_cascade_name
           ~fallback:Keeper_config.keeper_unified_max_tokens
       in
       (* max_turns: defer to OAS default (Types.default_agent_config.max_turns).
@@ -887,7 +887,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             in
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
-              ~user_message ~cascade_name:"keeper_unified"
+              ~user_message ~cascade_name:Keeper_config.default_cascade_name
               ~generation:run_generation ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -87,7 +87,9 @@ let role_of_string = function
   | "user" -> Agent_sdk.Types.User
   | "assistant" -> Agent_sdk.Types.Assistant
   | "tool" -> Agent_sdk.Types.Tool
-  | _ -> Agent_sdk.Types.User
+  | unknown ->
+    Log.Misc.warn "tool_compact: unknown role %S, defaulting to User" unknown;
+    Agent_sdk.Types.User
 
 let string_of_role = function
   | Agent_sdk.Types.System -> "system"


### PR DESCRIPTION
## Summary
OAS 경계 재구현 패턴 2건 수정 + 리뷰 피드백 반영.

## Changes

### 1. cascade_name 하드코딩 산포 → SSOT 상수 추출
`"keeper_unified"` 리터럴이 8곳에 산재 → `Keeper_config.default_cascade_name` 상수로 통일.
- `keeper_types.ml`: 비한정 `default_cascade_name` → `Keeper_config.default_cascade_name` (스코프 오류 수정)
- `keeper_turn_up_update.ml`, `keeper_turn_up_create.ml` (2곳)
- `keeper_context_core.ml`, `keeper_unified_turn.ml` (3곳)

AI anti-pattern #1 (Scattered Hardcoded Defaults) 수정.

### 2. role_of_string unknown → Tool 기본값 수정
- `keeper_context_core.ml:115-117`: `| _ -> Tool` → `| "tool" -> Tool | unknown -> warn + User`
- `tool_compact.ml:85-90`: 동일 패턴 수정

unknown role이 Tool로 매핑되면 `message_of_json`이 ToolResult 구조체를 생성하여 텍스트 메시지가 tool result로 잘못 해석됨. checkpoint restore 시 데이터 손실 위험.

### 3. checkpoint_model_of_meta 폴백 값 수정
- `keeper_context_core.ml:297`: `Option.value` 폴백을 `Keeper_config.default_cascade_name`(cascade 이름)에서 `Provider_adapter.default_local_fallback_label()`(실제 모델 레이블)로 교체.
- `models_of_cascade_name`은 항상 non-empty 리스트를 반환하므로 이 경로는 실제로 도달 불가하지만, 트리거되더라도 올바른 모델 레이블을 반환하도록 수정.

### 4. main 브랜치 머지 및 충돌 해소
- `keeper_unified_turn.ml` 충돌 해소: `Keeper_config.default_cascade_name` 유지, `~max_turns` 명시 전달 제거(#5420에서 기본값으로 위임).

## Product impact

- Promise affected: `none/internal`
- User-visible change: 없음. checkpoint restore 시 role 오염 방지 및 내부 상수 정리.

## Evidence

- `keeper_types.ml:706` 컴파일 오류(unbound value) 수정 확인
- `checkpoint_model_of_meta` 폴백이 모델 레이블 타입과 일치하는지 확인
- main 머지 후 `keeper_unified_turn.ml` 충돌 해소 확인

## Review evidence

- Copilot code review 통과 (2건 지적 사항은 main 브랜치 머지 코드에 해당, 본 PR 변경과 무관)
- CodeQL Security Scan: 0 alerts

## Linked issue