### PR TITLE
fix(dashboard): use tool_distribution from API instead of nonexistent tier_distribution

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -530,7 +530,6 @@ export interface DashboardToolInventoryResponse {
 export interface ToolMetricsTopEntry {
   name: string
   call_count: number
-  tier: string
 }
 
 export interface ToolMetricsResponse {
@@ -538,8 +537,6 @@ export interface ToolMetricsResponse {
   distinct_tools_called: number
   top_20: ToolMetricsTopEntry[]
   never_called_count: number
-  /** @deprecated Server never returns this field. Use tool_distribution instead. */
-  tier_distribution?: { essential: number; standard: number; full: number } | null
   tool_distribution?: { total: number; public: number; visible: number; hidden: number } | null
   dispatch_v2_enabled: boolean
   registered_count: number

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -538,6 +538,7 @@ export interface ToolMetricsResponse {
   distinct_tools_called: number
   top_20: ToolMetricsTopEntry[]
   never_called_count: number
+  /** @deprecated Server never returns this field. Use tool_distribution instead. */
   tier_distribution?: { essential: number; standard: number; full: number } | null
   tool_distribution?: { total: number; public: number; visible: number; hidden: number } | null
   dispatch_v2_enabled: boolean

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -538,7 +538,8 @@ export interface ToolMetricsResponse {
   distinct_tools_called: number
   top_20: ToolMetricsTopEntry[]
   never_called_count: number
-  tier_distribution: { essential: number; standard: number; full: number }
+  tier_distribution?: { essential: number; standard: number; full: number } | null
+  tool_distribution?: { total: number; public: number; visible: number; hidden: number } | null
   dispatch_v2_enabled: boolean
   registered_count: number
 }

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -73,31 +73,24 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
   `
 }
 
-function TierDistribution({ dist }: { dist: Record<string, number> | null | undefined }) {
-  if (!dist) return html`<div class="text-[11px] text-[var(--text-muted)] italic">서버에서 계층 분류 데이터를 제공하지 않습니다.</div>`
-  const total = dist.total ?? dist.full ?? 0
-  const essential = dist.essential ?? 0
-  const standardOnly = dist.standard_only ?? dist.standard ?? 0
-  const fullOnly = dist.full_only ?? (total - standardOnly)
-  const essentialPct = total > 0 ? ((essential / total) * 100).toFixed(1) : '0'
-  const standardPct = total > 0 ? ((standardOnly / total) * 100).toFixed(1) : '0'
-  const fullOnlyPct = total > 0 ? ((fullOnly / total) * 100).toFixed(1) : '0'
+function ToolDistribution({ dist }: { dist: { total: number; public: number; visible: number; hidden: number } | null | undefined }) {
+  if (!dist) return html`<div class="text-[11px] text-[var(--text-muted)] italic">도구 분포 데이터가 없습니다.</div>`
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-essential">필수</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${essential}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${essentialPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-essential">공개</span>
+        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.public / dist.total) * 100).toFixed(1) : '0'}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-standard">표준</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${standardOnly}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${standardPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-standard">표시</span>
+        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.visible}</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.visible / dist.total) * 100).toFixed(1) : '0'}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-full">전체 전용</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${fullOnly}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${fullOnlyPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-full">숨김</span>
+        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.hidden / dist.total) * 100).toFixed(1) : '0'}%</span>
       </div>
     </div>
   `
@@ -159,8 +152,8 @@ export function ToolMetrics() {
 
         <div class="tool-metrics-sections">
           <div>
-            <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">계층 분포</h4>
-            <${TierDistribution} dist=${data.tier_distribution} />
+            <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">도구 분포</h4>
+            <${ToolDistribution} dist=${data.tool_distribution} />
           </div>
           <div>
             <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -14,25 +14,6 @@ function loadMetrics() {
   return metricsResource.load(() => fetchToolMetrics())
 }
 
-function tierLabel(tier: string | null | undefined): string {
-  switch (tier) {
-    case 'essential': return '필수'
-    case 'standard': return '표준'
-    case 'full': return '전체'
-    case null: case undefined: return '-'
-    default: return tier
-  }
-}
-
-function tierBadgeClass(tier: string | null | undefined): string {
-  switch (tier) {
-    case 'essential': return 'badge-essential'
-    case 'standard': return 'badge-standard'
-    case 'full': return 'badge-full'
-    default: return 'bg-[var(--white-4)] text-[var(--text-dim)]'
-  }
-}
-
 /** Map category color CSS class (text-[...]) to a usable bar background color. */
 function categoryBarColor(colorClass: string): string {
   const match = colorClass.match(/text-\[(.*)\]/)
@@ -46,7 +27,6 @@ function categoryBarColor(colorClass: string): string {
 
 function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount: number }) {
   if (items.length === 0) return html`<p class="muted">아직 도구 호출 기록이 없습니다.</p>`
-  const hasTier = items.some(item => item.tier != null && item.tier !== '')
   return html`
     <div class="flex flex-col gap-1.5">
       ${items.map(item => {
@@ -59,9 +39,7 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
               <span class="flex-shrink-0 size-4 rounded text-[9px] font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
               <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px]" title=${item.name}>${item.name}</span>
             </div>
-            ${hasTier
-              ? html`<span class="px-1.5 py-px rounded-[3px] text-[10px] font-semibold text-center ${tierBadgeClass(item.tier)}">${tierLabel(item.tier)}</span>`
-              : html`<span class="px-1.5 py-px rounded-[3px] text-[10px] font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>`}
+            <span class="px-1.5 py-px rounded-[3px] text-[10px] font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>
             <div class="h-3.5 rounded-[3px] bg-[var(--white-6)] overflow-hidden">
               <div class="h-full rounded-[3px] min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%`, backgroundColor: barBg }} />
             </div>

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -75,23 +75,27 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
 
 function ToolDistribution({ dist }: { dist: { total: number; public: number; visible: number; hidden: number } | null | undefined }) {
   if (!dist) return html`<div class="text-[11px] text-[var(--text-muted)] italic">도구 분포 데이터가 없습니다.</div>`
+  // Mutually exclusive segments: public ⊂ visible, hidden = total - visible
+  const visibleExclusive = Math.max(0, dist.visible - dist.public)
+  const pct = (n: number) => dist.total > 0 ? ((n / dist.total) * 100).toFixed(1) : '0'
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-essential">공개</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-essential">공개 MCP</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.public / dist.total) * 100).toFixed(1) : '0'}%</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(dist.public)}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-standard">표시</span>
-        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.visible}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.visible / dist.total) * 100).toFixed(1) : '0'}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-standard">내부 전용</span>
+        <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${visibleExclusive}</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(visibleExclusive)}%</span>
       </div>
       <div class="flex items-center gap-3">
         <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-full">숨김</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${dist.total > 0 ? ((dist.hidden / dist.total) * 100).toFixed(1) : '0'}%</span>
+        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(dist.hidden)}%</span>
       </div>
+      <div class="text-[10px] text-[var(--text-dim)] mt-1">전체 ${dist.total}개 (공개 ${dist.public} + 내부 ${visibleExclusive} + 숨김 ${dist.hidden})</div>
     </div>
   `
 }

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
-> Current package version: v2.245.0
-> Latest release: v2.245.0 (2026-04-05)
-> Updated: 2026-04-05
+> Current package version: v2.246.0
+> Latest release: v2.246.0 (2026-04-06)
+> Updated: 2026-04-06
 
 Execution companion for capsule-only coordination hardening:
 [design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,8 +2,8 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-05
-> Snapshot baseline: `dune-project` version `2.245.0`
+> Last Updated: 2026-04-06
+> Snapshot baseline: `dune-project` version `2.246.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
 


### PR DESCRIPTION
## Summary

서버 API와 대시보드 간 **키 이름 불일치** 수정.

서버(`tool_unified.ml`)는 `tool_distribution`(total/public/visible/hidden)을 반환하지만, 대시보드는 `tier_distribution`(essential/standard/full)을 읽고 있어서 항상 null → 0/0/0 표시.

- `TierDistribution` → `ToolDistribution` 컴포넌트 교체
- 실제 서버 데이터를 세 가지 **상호 배타적** 범주로 표시: 공개 / 비공개 표시(`visible - public`) / 숨김 → 퍼센트 합 100%
- 섹션 제목: "계층 분포" → "도구 분포"
- `ToolMetricsResponse`에서 서버에 존재하지 않고 사용되지 않는 `tier_distribution` 필드 제거

## Product impact

- Promise affected: `ops visibility`
- User-visible change: 도구 분포 섹션에 실제 공개/비공개 표시/숨김 수치가 올바른 비율(합계 100%)로 표시됨

## Evidence

```
curl localhost:8935/api/v1/tool-metrics | jq '.tool_distribution'
# {"total":232,"public":48,"visible":136,"hidden":96}

curl localhost:8935/api/v1/tool-metrics | jq '.tier_distribution'
# null (필드 자체가 없음)
```

도구 분포 표시 (total=232 기준):
- 공개: 48 (20.7%)
- 비공개 표시: 88 (37.9%)  ← visible(136) - public(48)
- 숨김: 96 (41.4%)

## Review evidence

- TypeScript type check 통과 (수정 파일 대상)
- CodeQL 스캔: 0건 알림

## Linked issue