### PR TITLE
refactor(keeper): use OAS on_idle Nudge instead of prompt SELF-CHECK

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -137,6 +137,24 @@ let emit_cost_event
     @param destructive_check Enable destructive pattern detection (default true)
     @param on_tool_executed Optional callback after each tool execution
     @param trajectory_acc Optional trajectory accumulator for cost attribution *)
+
+(** Pure decision logic for the on_idle hook.  Testable without Room.config.
+    Returns Nudge on first idle turn (resets idle counter in OAS), Skip on 2+. *)
+let on_idle_decision ~consecutive_idle_turns ~tool_names : Agent_sdk.Hooks.hook_decision =
+  let tools_str = match tool_names with
+    | [] -> "<none>"
+    | names -> String.concat ", " names
+  in
+  if consecutive_idle_turns >= 2 then
+    Agent_sdk.Hooks.Skip
+  else
+    Agent_sdk.Hooks.Nudge
+      (Printf.sprintf
+         "You have been repeating the same tools (%s) without making progress. \
+          Try a genuinely different approach: post findings to the board, \
+          claim a different task, or end your turn silently."
+         tools_str)
+
 let make_hooks
     ~config:(_config : Room.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
@@ -301,19 +319,17 @@ let make_hooks
     on_idle = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names; _ } ->
-        let tools_str = match tool_names with
-          | [] -> "<none>"
-          | names -> String.concat ", " names
-        in
-        if consecutive_idle_turns >= 2 then begin
-          Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop (threshold=2, max_idle_turns=3)"
-            (!meta_ref).name consecutive_idle_turns tools_str;
-          Agent_sdk.Hooks.Skip
-        end else begin
-          Log.Keeper.info "keeper:%s idle_turns=%d tools=[%s] — nudging via Continue"
-            (!meta_ref).name consecutive_idle_turns tools_str;
-          Agent_sdk.Hooks.Continue
-        end
+        let decision =
+          on_idle_decision ~consecutive_idle_turns ~tool_names in
+        (match decision with
+         | Agent_sdk.Hooks.Skip ->
+           Log.Keeper.warn "keeper:%s idle_turns=%d — requesting stop"
+             (!meta_ref).name consecutive_idle_turns
+         | Agent_sdk.Hooks.Nudge _ ->
+           Log.Keeper.info "keeper:%s idle_turns=%d — nudging LLM via Nudge"
+             (!meta_ref).name consecutive_idle_turns
+         | _ -> ());
+        decision
       | _ -> Agent_sdk.Hooks.Continue);
   }
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -321,13 +321,15 @@ let make_hooks
       | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names; _ } ->
         let decision =
           on_idle_decision ~consecutive_idle_turns ~tool_names in
+        let tools_str = match tool_names with
+          | [] -> "<none>" | names -> String.concat ", " names in
         (match decision with
          | Agent_sdk.Hooks.Skip ->
-           Log.Keeper.warn "keeper:%s idle_turns=%d — requesting stop"
-             (!meta_ref).name consecutive_idle_turns
+           Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop"
+             (!meta_ref).name consecutive_idle_turns tools_str
          | Agent_sdk.Hooks.Nudge _ ->
-           Log.Keeper.info "keeper:%s idle_turns=%d — nudging LLM via Nudge"
-             (!meta_ref).name consecutive_idle_turns
+           Log.Keeper.info "keeper:%s idle_turns=%d tools=[%s] — nudging LLM via Nudge"
+             (!meta_ref).name consecutive_idle_turns tools_str
          | _ -> ());
         decision
       | _ -> Agent_sdk.Hooks.Continue);

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -396,7 +396,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
      recognise patterns — thrashing, failure loops, tool over-reliance.
      Data comes from Keeper_registry per-entry tool_usage Hashtbl. *)
   let tool_activity =
-    Keeper_tools_oas.tool_usage_for_keeper meta.name
+    Keeper_registry.tool_usage_of ~base_path meta.name
     |> List.sort (fun (_, a) (_, b) ->
       Float.compare b.Keeper_types.last_used_at a.Keeper_types.last_used_at)
   in

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -417,14 +417,11 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
         (Printf.sprintf "- %s: %d calls (%d ok, %d fail, %.0f%% success)%s\n"
            name e.count e.successes e.failures rate warning)
     ) recent_activity;
-    (* Pattern detection: warn if recent activity is too homogeneous *)
-    let unique_tools = List.sort_uniq String.compare
-      (List.map fst recent_activity) in
-    if List.length recent_activity >= 4
-       && List.length unique_tools <= 2 then
-      Buffer.add_string ubuf
-        "NOTE: You are using very few distinct tools. Consider a different approach.\n");
-  (* Metacognition: last cycle outcome so keeper knows its own behavioral pattern *)
+    );
+  (* Metacognition: last cycle outcome so keeper knows its own behavioral pattern.
+     This is MASC domain data (proactive_rt) not available in OAS.
+     Per-turn behavioral correction (idle loops, tool repetition) is handled by
+     OAS on_idle → Nudge hook in keeper_hooks_oas.ml — not here. *)
   let prt = meta.runtime.proactive_rt in
   let outcome_str = Keeper_types.proactive_cycle_outcome_to_string prt.last_outcome in
   if prt.count_total > 0 then (
@@ -437,19 +434,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf
       (Printf.sprintf "- Cycles total: %d (visible: %d, silent: %d)\n"
          prt.count_total prt.visible_count_total
-         (prt.count_total - prt.visible_count_total));
-    (* Self-correction cues based on pattern *)
-    (match prt.last_outcome with
-     | Proactive_silent ->
-       Buffer.add_string ubuf
-         "SELF-CHECK: Last cycle was silent. If you have observations, act on them.\n"
-     | Proactive_error ->
-       Buffer.add_string ubuf
-         "SELF-CHECK: Last cycle ended in error. Diagnose before retrying the same approach.\n"
-     | Proactive_tool_use when prt.visible_count_total = 0 ->
-       Buffer.add_string ubuf
-         "SELF-CHECK: You have been using tools but never producing visible output. Consider sharing findings.\n"
-     | _ -> ()));
+         (prt.count_total - prt.visible_count_total)));
   (* Peer keepers — show other running keepers so this keeper can @mention them *)
   let peer_keepers =
     Keeper_registry.all ~base_path ()

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1850,17 +1850,36 @@ let test_prompt_includes_last_cycle_outcome () =
   check bool "shows cycle counts"
     true (contains_substring user "Cycles total: 5")
 
-let test_prompt_self_check_after_silent () =
+let test_prompt_no_self_check_in_prompt () =
+  (* SELF-CHECK cues were removed; per-turn correction is done via OAS on_idle Nudge *)
   let meta = meta_with_proactive_history Masc_mcp.Keeper_types.Proactive_silent 3 1 in
   let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation in
-  check bool "has SELF-CHECK for silent"
-    true (contains_substring user "SELF-CHECK: Last cycle was silent")
+  check bool "no SELF-CHECK in prompt (moved to OAS hook)"
+    false (contains_substring user "SELF-CHECK")
 
-let test_prompt_self_check_after_error () =
-  let meta = meta_with_proactive_history Masc_mcp.Keeper_types.Proactive_error 2 1 in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation in
-  check bool "has SELF-CHECK for error"
-    true (contains_substring user "SELF-CHECK: Last cycle ended in error")
+let test_on_idle_nudge_at_first_idle () =
+  let decision = HK.on_idle_decision
+    ~consecutive_idle_turns:1
+    ~tool_names:["keeper_board_list"; "keeper_tasks_list"] in
+  match decision with
+  | Agent_sdk.Hooks.Nudge msg ->
+    check bool "nudge mentions repeated tools"
+      true (contains_substring msg "keeper_board_list")
+  | other ->
+    fail (Printf.sprintf "expected Nudge, got %s"
+      (Agent_sdk.Hooks.decision_kind_to_string
+        (Agent_sdk.Hooks.classify_decision other)))
+
+let test_on_idle_skip_at_repeated_idle () =
+  let decision = HK.on_idle_decision
+    ~consecutive_idle_turns:2
+    ~tool_names:["keeper_board_list"] in
+  match decision with
+  | Agent_sdk.Hooks.Skip -> ()
+  | other ->
+    fail (Printf.sprintf "expected Skip, got %s"
+      (Agent_sdk.Hooks.decision_kind_to_string
+        (Agent_sdk.Hooks.classify_decision other)))
 
 let test_prompt_no_outcome_for_fresh_keeper () =
   let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation in
@@ -1959,12 +1978,14 @@ let () =
         [
           test_case "includes last cycle outcome" `Quick
             test_prompt_includes_last_cycle_outcome;
-          test_case "self-check after silent" `Quick
-            test_prompt_self_check_after_silent;
-          test_case "self-check after error" `Quick
-            test_prompt_self_check_after_error;
+          test_case "no SELF-CHECK in prompt (OAS hook)" `Quick
+            test_prompt_no_self_check_in_prompt;
           test_case "no outcome for fresh keeper" `Quick
             test_prompt_no_outcome_for_fresh_keeper;
+          test_case "on_idle nudge at first idle" `Quick
+            test_on_idle_nudge_at_first_idle;
+          test_case "on_idle skip at repeated idle" `Quick
+            test_on_idle_skip_at_repeated_idle;
         ] );
       ( "config",
         [


### PR DESCRIPTION
## Summary
- #5422에서 추가한 SELF-CHECK 프롬프트 큐를 OAS hook API 소비로 전환
- `on_idle` hook에서 `Nudge` 결정 사용 — 첫 idle 턴에서 LLM에 교정 메시지 직접 주입
- 정적 프롬프트 문자열(SELF-CHECK, 도구 다양성 경고)을 제거
- MASC 도메인 데이터(Last Cycle Outcome, Recent Tool Activity)는 유지

## Why
OAS가 제공하는 hook API를 무시하고 프롬프트 레벨에서 재구현하는 것은 경계 위반.
`on_idle → Nudge`는 OAS가 idle 감지 시 대화에 메시지를 주입하는 공식 메커니즘.

## Test plan
- [x] `dune build @check` 통과
- [ ] CI Build and Test
- [x] `on_idle_decision` 순수 함수 테스트 추가 (Nudge/Skip 검증)
- [x] SELF-CHECK 제거 확인 테스트

Refs #5422

🤖 Generated with [Claude Code](https://claude.com/claude-code)