### PR TITLE
feat(keeper): Samchon verification loop for tool search errors

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -617,14 +617,12 @@ let run_turn
           | Some e -> `String e.when_to_use
           | None -> `Null
         in
-        (* Extract required params from MASC schema for immediate usability *)
-        let required_params =
+        (* Samchon verification principle: include full input_schema so
+           the LLM can construct a correct call on the first attempt.
+           "Schema drives both LLM guidance and validation." *)
+        let input_schema =
           match List.find_opt (fun (s : Types.tool_schema) -> s.name = name) masc_schemas with
-          | Some s ->
-            (try
-              let props = Yojson.Safe.Util.(member "required" s.input_schema |> to_list) in
-              `List (List.map (fun j -> j) props)
-            with _ -> `Null)
+          | Some s -> s.input_schema
           | None -> `Null
         in
         `Assoc [
@@ -632,7 +630,7 @@ let run_turn
           ("score", `Float score);
           ("description", desc);
           ("when_to_use", when_to_use);
-          ("required_params", required_params);
+          ("input_schema", input_schema);
         ]
       ) new_discoveries
     in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -966,8 +966,22 @@ let execute_keeper_tool_call
   let lookup = tool_access_lookup_of_meta meta in
   if not (can_execute ~lookup name)
   then
+    (* Samchon verification loop: structured rejection with actionable
+       guidance so the LLM can self-correct on the next attempt. *)
+    let reason =
+      if not (Hashtbl.mem lookup.candidate_set name)
+      then "not_in_candidate_set"
+      else if Hashtbl.mem lookup.deny_set name
+      then "denied_by_policy"
+      else "not_in_allow_set"
+    in
     Yojson.Safe.to_string
-      (`Assoc [ "error", `String "tool_not_allowed"; "tool", `String name ])
+      (`Assoc [
+        ("error", `String "tool_not_allowed");
+        ("tool", `String name);
+        ("reason", `String reason);
+        ("hint", `String "Use keeper_tool_search to find allowed alternatives.");
+      ])
   else (
     match name with
     | "keeper_tool_search" ->
@@ -1065,13 +1079,29 @@ let execute_keeper_tool_call
         in
         scored
       in
+      (* Samchon verification loop: include schema for suggested tools
+         so the LLM can self-correct in one step, not two. *)
+      let masc_schemas = !masc_schemas_ref in
+      let enrich_suggestion name =
+        let schema_opt =
+          List.find_opt (fun (s : Types.tool_schema) -> s.name = name) masc_schemas
+        in
+        match schema_opt with
+        | Some s ->
+          `Assoc [
+            ("name", `String name);
+            ("description", `String s.description);
+            ("input_schema", s.input_schema);
+          ]
+        | None -> `String name
+      in
       let fields =
         [ ("error", `String "unknown_tool"); ("tool", `String other) ]
         @ (match suggestion with
            | [] -> [("hint", `String "Use keeper_tool_search to find available tools.")]
            | names ->
-             [ ("did_you_mean", `List (List.map (fun n -> `String n) names));
-               ("hint", `String "Use keeper_tool_search to discover tools by description.") ])
+             [ ("did_you_mean", `List (List.map enrich_suggestion names));
+               ("hint", `String "Call one of these tools with the correct parameters.") ])
       in
       Yojson.Safe.to_string (`Assoc fields))
 ;;


### PR DESCRIPTION
## Summary
- Search results include full `input_schema` instead of `required_params` — LLM gets complete parameter specification for first-try correct calls
- `tool_not_allowed` returns structured `reason` (not_in_candidate_set / denied_by_policy / not_in_allow_set) with actionable hint
- `did_you_mean` suggestions include description + input_schema for 1-step self-correction

## Context
Samchon harness insight #4: "if you can verify, you converge." Structured error feedback enables LLM self-correction loops without additional search round-trips.

Reference: https://dev.to/samchon/qwen-meetup-function-calling-harness-from-675-to-100-3830

## Test plan
- [x] `dune build` clean
- [ ] Existing test suites pass (CI)
- [ ] Manual: trigger unknown tool → verify did_you_mean includes schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)