### PR TITLE
fix(dashboard): board title markdown, author nav, comment rendering

### DIFF
--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -9,6 +9,7 @@ import { LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate } from '../router'
+import { navigateToAuthor } from '../lib/board-utils'
 import {
   detailComments,
   detailLoading,
@@ -82,14 +83,14 @@ function CommentItem({
       <div class="board-comment rounded-lg p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
           <span class="text-[12px]">${authorAvatar(comment.author)}</span>
-          <a class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('monitoring', { section: 'agents', agent: comment.author })}>${comment.author}</a>
+          <a class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</a>
           <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <button type="button"
             class="text-[11px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}</button>
         </div>
-        <div class="text-[13px] text-[var(--text-body)] leading-[1.55] whitespace-pre-wrap">${displayText}</div>
+        <div class="text-[13px] text-[var(--text-body)] leading-[1.55]"><${Markdown} text=${displayText} /></div>
         ${needsTruncation ? html`
           <button type="button"
             class="mt-1 text-[11px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
@@ -224,7 +225,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-[13px]">${authorAvatar(post.author)}</span>
-            <a class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('monitoring', { section: 'agents', agent: post.author })}>${post.author}</a>
+            <a class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigateToAuthor(post.author)}>${post.author}</a>
             <span class="text-[11px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
             <span class="text-[11px] text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
           </div>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -11,6 +11,7 @@ import { TextInput, TextArea } from './common/input'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate, navigateToPost, route } from '../router'
 import { PostDetail } from './memory-post-detail'
+import { stripInlineMarkdown, navigateToAuthor } from '../lib/board-utils'
 import {
   boardPosts,
   boardSortMode,
@@ -336,7 +337,7 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Post body -->
       <div class="flex-1 min-w-0">
         <!-- Title -->
-        <div class="text-[15px] font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${post.title}</div>
+        <div class="text-[15px] font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${stripInlineMarkdown(post.title)}</div>
 
         <!-- Content preview: rendered markdown, height-capped -->
         <div class="board-post-preview text-[13px] text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
@@ -350,7 +351,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <span class="text-[12px] text-[var(--text-muted)]">${authorAvatar(post.author)}</span>
           <a
             class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
-            onClick=${(e: Event) => { e.stopPropagation(); navigate('monitoring', { section: 'agents', agent: post.author }) }}
+            onClick=${(e: Event) => navigateToAuthor(post.author, e)}
           >${post.author}</a>
           <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
           ${isUpdated(post) ? html`<span class="text-[10px] text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}

--- a/dashboard/src/lib/board-utils.test.ts
+++ b/dashboard/src/lib/board-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { stripInlineMarkdown } from './board-utils'
+
+describe('stripInlineMarkdown', () => {
+  it('strips bold markers', () => {
+    expect(stripInlineMarkdown('**Hello World**')).toBe('Hello World')
+  })
+
+  it('strips underscore bold markers', () => {
+    expect(stripInlineMarkdown('__Hello World__')).toBe('Hello World')
+  })
+
+  it('strips italic markers', () => {
+    expect(stripInlineMarkdown('*italic text*')).toBe('italic text')
+  })
+
+  it('strips underscore italic markers', () => {
+    expect(stripInlineMarkdown('_italic text_')).toBe('italic text')
+  })
+
+  it('strips inline code markers', () => {
+    expect(stripInlineMarkdown('`code`')).toBe('code')
+  })
+
+  it('strips mixed formatting', () => {
+    expect(stripInlineMarkdown('**Bold** and *italic* and `code`'))
+      .toBe('Bold and italic and code')
+  })
+
+  it('preserves plain text', () => {
+    expect(stripInlineMarkdown('plain text')).toBe('plain text')
+  })
+
+  it('handles empty string', () => {
+    expect(stripInlineMarkdown('')).toBe('')
+  })
+})

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -1,0 +1,26 @@
+// Board display utilities — shared between memory.ts and memory-post-detail.ts
+
+import { navigate } from '../router'
+import { findKeeper } from './keeper-utils'
+import { openKeeperDetail } from '../components/keeper-detail'
+
+/** Strip inline markdown formatting from title text (bold, italic, code). */
+export function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/_(.+?)_/g, '$1')
+    .replace(/`(.+?)`/g, '$1')
+}
+
+/** Navigate to keeper detail if author is a keeper, otherwise agent profile. */
+export function navigateToAuthor(authorName: string, event?: Event) {
+  event?.stopPropagation()
+  const keeper = findKeeper(authorName)
+  if (keeper) {
+    openKeeperDetail(keeper)
+  } else {
+    navigate('monitoring', { section: 'agents', agent: authorName })
+  }
+}


### PR DESCRIPTION
## Summary
- 게시판 제목에서 `**Title**` 같은 inline markdown이 raw 텍스트로 표시되던 문제 수정 (stripInlineMarkdown)
- 작성자 이름 클릭 시 agent summary가 아닌 keeper detail overlay로 이동하도록 수정 (keeper인 경우)
- 댓글 본문이 plain text로 표시되어 코드 블럭/서식이 무시되던 문제 수정 (Markdown 컴포넌트 적용)

## Changes
- `dashboard/src/lib/board-utils.ts`: `stripInlineMarkdown` + `navigateToAuthor` 공유 유틸
- `dashboard/src/components/memory.ts`: title strip + author nav 적용
- `dashboard/src/components/memory-post-detail.ts`: comment Markdown + author nav 적용

## Test plan
- [x] `board-utils.test.ts` 8개 테스트 통과
- [x] `memory.test.ts`, `memory-post-detail.test.ts` 기존 8개 테스트 통과
- [x] `tsc --noEmit` 타입 체크 통과
- [x] `vite build` 성공
- [ ] 대시보드에서 `**제목**` 포맷 게시글이 깔끔하게 표시되는지 확인
- [ ] keeper 작성자 클릭 시 keeper detail overlay 열리는지 확인
- [ ] 댓글에 코드 블럭이 syntax highlighting과 함께 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)