### PR TITLE
fix(keeper): patch OAS checkpoint with [STATE] block for continuity (#5431)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1050,25 +1050,11 @@ let run_turn
       with
       | Error e -> Error e
       | Ok result ->
-        (match result.checkpoint with
-         | Some checkpoint -> (
-             try
-               (* Unify session_id to trace_id so load_oas can find this
-                  checkpoint on the next turn. oas_worker generates a per-turn
-                  session_id that differs from trace_id, causing a load miss. *)
-               let checkpoint =
-                 { checkpoint with Agent_sdk.Checkpoint.session_id = meta.runtime.trace_id }
-               in
-               Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
-                 checkpoint
-             with
-             | Eio.Cancel.Cancelled _ as exn -> raise exn
-             | exn ->
-                 Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s"
-                   meta.name (Printexc.to_string exn))
-         | None ->
-             Log.Keeper.warn "keeper:%s missing OAS checkpoint after run"
-               meta.name);
+        (* Checkpoint save is deferred until after [STATE] synthesis so the
+           persisted checkpoint includes the synthesized continuity block.
+           Without this, read_continuity_summary finds no [STATE] in the
+           checkpoint messages and returns empty — causing keepers to lose
+           context across turns.  See #5431. *)
         let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
         let text = Agent_sdk.Types.text_of_content result.response.content in
         let model = result.response.model in
@@ -1122,6 +1108,35 @@ let run_turn
                ~source:history_assistant_source
                session assistant_msg;
              ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
+             (* Save checkpoint AFTER [STATE] synthesis.  Patch the last
+                assistant message in the OAS checkpoint so that the persisted
+                checkpoint contains the [STATE] block.  Without this patch,
+                read_continuity_summary would find no [STATE] in checkpoint
+                messages and return empty, causing context loss.  #5431 *)
+             let saved_checkpoint =
+               match result.checkpoint with
+               | Some checkpoint ->
+                   let patched =
+                     Keeper_context_core.patch_checkpoint_last_assistant
+                       checkpoint ~session_id:meta.runtime.trace_id
+                       ~response_text
+                   in
+                   (try
+                     Keeper_checkpoint_store.save_oas
+                       ~session_dir:session.session_dir patched
+                   with
+                   | Eio.Cancel.Cancelled _ as exn -> raise exn
+                   | exn ->
+                       Log.Keeper.error
+                         "keeper:%s OAS checkpoint save failed: %s"
+                         meta.name (Printexc.to_string exn));
+                   Some patched
+               | None ->
+                   Log.Keeper.warn
+                     "keeper:%s missing OAS checkpoint after run"
+                     meta.name;
+                   None
+             in
              (match result.proof with
              | Some p ->
                 log_keeper_proof ~keeper_name:meta.name p;
@@ -1165,7 +1180,7 @@ let run_turn
            tool_calls_made = List.length tool_names;
            usage;
            tools_used = tool_names;
-           checkpoint = result.checkpoint;
+           checkpoint = saved_checkpoint;
            proof = result.proof;
            stop_reason = result.stop_reason;
          }))

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -406,6 +406,31 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
          (session, None))
   | _ -> (session, None)
 
+(** Patch an OAS checkpoint: unify session_id and replace the last
+    assistant message's text content with [response_text] (which includes
+    MASC's [STATE] synthesis).  This ensures read_continuity_summary can
+    find the [STATE] block in checkpoint messages on the next turn.  #5431 *)
+let patch_checkpoint_last_assistant
+    (cp : Agent_sdk.Checkpoint.t) ~session_id ~response_text
+  : Agent_sdk.Checkpoint.t =
+  (* Find index of last assistant message. *)
+  let last_asst_idx = ref (-1) in
+  List.iteri
+    (fun i (msg : Agent_sdk.Types.message) ->
+      if msg.role = Agent_sdk.Types.Assistant then last_asst_idx := i)
+    cp.messages;
+  let messages =
+    if !last_asst_idx < 0 then cp.messages
+    else
+      List.mapi
+        (fun i msg ->
+          if i = !last_asst_idx then
+            Agent_sdk.Types.assistant_msg response_text
+          else msg)
+        cp.messages
+  in
+  { cp with Agent_sdk.Checkpoint.session_id; messages }
+
 let save_checkpoint session (ctx : working_context) ~generation =
   let ckpt = create_checkpoint ctx ~generation in
   save_session_checkpoint session ckpt;

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module KEC = Masc_mcp.Keeper_exec_context
+module KCC = Masc_mcp.Keeper_context_core
 module KT = Masc_mcp.Keeper_types
 
 let temp_dir prefix =
@@ -424,6 +425,97 @@ let test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_
           fail
             "expected overflow retry recovery to keep message history within budget even with a large checkpoint system prompt")
 
+(* --- patch_checkpoint_last_assistant tests (#5431) --- *)
+
+let make_test_checkpoint ?(session_id = "old-session")
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Checkpoint.t =
+  {
+    Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
+    session_id;
+    agent_name = "patch-test";
+    model = "test-model";
+    system_prompt = None;
+    messages;
+    usage = Agent_sdk.Types.empty_usage;
+    turn_count = List.length messages;
+    created_at = 0.0;
+    tools = [];
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = Some 4096;
+    context = Agent_sdk.Context.create ();
+    mcp_sessions = [];
+    working_context = None;
+  }
+
+let test_patch_checkpoint_replaces_last_assistant () =
+  let msgs =
+    [ Agent_sdk.Types.user_msg "hello";
+      Agent_sdk.Types.assistant_msg "raw response without STATE" ]
+  in
+  let cp = make_test_checkpoint msgs in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"new-session"
+      ~response_text:"patched response\n[STATE]\nprogress: done\n[/STATE]"
+  in
+  let last_msg = List.nth patched.messages 1 in
+  let text = Agent_sdk.Types.text_of_message last_msg in
+  check bool "contains STATE block" true (contains_substring text "[STATE]");
+  check bool "contains patched text" true
+    (contains_substring text "patched response");
+  check string "session_id updated" "new-session" patched.session_id
+
+let test_patch_checkpoint_preserves_non_assistant () =
+  let msgs =
+    [ Agent_sdk.Types.user_msg "question 1";
+      Agent_sdk.Types.assistant_msg "answer 1";
+      Agent_sdk.Types.user_msg "question 2";
+      Agent_sdk.Types.assistant_msg "answer 2 raw" ]
+  in
+  let cp = make_test_checkpoint msgs in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"s" ~response_text:"answer 2 with STATE"
+  in
+  (* First user message preserved *)
+  let first_text = Agent_sdk.Types.text_of_message (List.nth patched.messages 0) in
+  check string "first user preserved" "question 1" first_text;
+  (* First assistant preserved (only LAST assistant is patched) *)
+  let second_text = Agent_sdk.Types.text_of_message (List.nth patched.messages 1) in
+  check string "first assistant preserved" "answer 1" second_text;
+  (* Last assistant patched *)
+  let last_text = Agent_sdk.Types.text_of_message (List.nth patched.messages 3) in
+  check string "last assistant patched" "answer 2 with STATE" last_text
+
+let test_patch_checkpoint_updates_session_id () =
+  let cp = make_test_checkpoint ~session_id:"old" [] in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"new-trace-id" ~response_text:"unused"
+  in
+  check string "session_id" "new-trace-id" patched.session_id
+
+let test_patch_checkpoint_no_assistant_noop () =
+  let msgs = [ Agent_sdk.Types.user_msg "only user" ] in
+  let cp = make_test_checkpoint msgs in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"s" ~response_text:"should not appear"
+  in
+  check int "message count unchanged" 1 (List.length patched.messages);
+  let text = Agent_sdk.Types.text_of_message (List.hd patched.messages) in
+  check string "user msg unchanged" "only user" text
+
 let () =
   run "keeper_lifecycle"
     [
@@ -447,5 +539,16 @@ let () =
             "overflow retry history budget ignores checkpoint system prompt"
             `Quick
             test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_prompt_in_history_budget;
+        ] );
+      ( "checkpoint_patch",
+        [
+          test_case "patch replaces last assistant text" `Quick
+            test_patch_checkpoint_replaces_last_assistant;
+          test_case "patch preserves non-assistant messages" `Quick
+            test_patch_checkpoint_preserves_non_assistant;
+          test_case "patch updates session_id" `Quick
+            test_patch_checkpoint_updates_session_id;
+          test_case "patch with no assistant is noop" `Quick
+            test_patch_checkpoint_no_assistant_noop;
         ] );
     ]


### PR DESCRIPTION
## Summary
- OAS checkpoint이 `[STATE]` 합성 **이전**에 저장되어, `read_continuity_summary`가 checkpoint 메시지에서 `[STATE]` 블록을 찾지 못함
- keeper가 매 턴마다 컨텍스트를 잃고 처음부터 시작하는 근본 원인
- checkpoint 저장을 `[STATE]` 합성 이후로 이동하고, `patch_checkpoint_last_assistant` 헬퍼로 마지막 assistant 메시지를 패치

## Changes
- `keeper_agent_run.ml`: checkpoint 저장을 `[STATE]` 합성 이후로 재배치
- `keeper_context_core.ml`: `patch_checkpoint_last_assistant` 헬퍼 추가
- `test_keeper_lifecycle.ml`: 4개 단위 테스트 추가 (12/12 통과)

## Test plan
- [x] `dune build` 성공
- [x] `test_keeper_lifecycle` 12/12 통과
- [ ] CI Build and Test
- [ ] 서버 재시작 후 keeper continuity_summary 비어있지 않은지 확인

Closes #5431

🤖 Generated with [Claude Code](https://claude.com/claude-code)