### PR TITLE
feat(dashboard): enhance keeper tool visibility and telemetry

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -45,6 +45,9 @@ import { KeeperTrajectoryTimeline } from './keeper-trajectory-timeline'
 import { DialogOverlay } from './common/dialog'
 import { CollapsibleSection } from './common/collapsible'
 import { SessionTraceView } from './session-trace/session-trace-view'
+import { SessionProgressHeader } from './session-progress-header'
+import { getTraceSummary } from './session-trace/session-trace-state'
+import { KeeperToolTelemetry } from './keeper-tool-telemetry'
 
 // ── Global overlay state ──────────────────────────────────
 
@@ -470,6 +473,9 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Pipeline stage indicator ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
 
+        ${'' /* ── Session progress header (Copilot-style) ── */}
+        <${SessionProgressHeader} keeper=${keeper} summary=${getTraceSummary(keeper.name)} />
+
         ${'' /* ── KPIs ── */}
         <${KpiGrid} keeper=${keeper} />
 
@@ -481,6 +487,11 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Latency / Cost / Model charts ── */}
         <${MetricsCharts} keeper=${keeper} />
+
+        ${'' /* ── Per-keeper tool telemetry ── */}
+        <${SectionCard} title="도구 텔레메트리">
+          <${KeeperToolTelemetry} keeperName=${keeper.name} />
+        <//>
 
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
@@ -599,15 +610,17 @@ export function KeeperDetailOverlay() {
             `
             : null}
 
+          ${'' /* ── Activity Trace (promoted to main view) ── */}
           <div class="md:col-span-2">
-            <${SectionCard} title="도구 호출 궤적">
-              <${KeeperTrajectoryTimeline} keeperName=${keeper.name} keeper=${keeper} />
+            <${SectionCard} title="활동 추적">
+              <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
           </div>
 
+          ${'' /* ── Tool-only trajectory (collapsed, for deep inspection) ── */}
           <div class="md:col-span-2">
-            <${CollapsibleSection} title="통합 활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">공지 + 태스크 + 도구 호출</span>`}>
-              <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
+            <${CollapsibleSection} title="도구 호출 상세" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">궤적 전용</span>`}>
+              <${KeeperTrajectoryTimeline} keeperName=${keeper.name} keeper=${keeper} />
             <//>
           </div>
 

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -1,0 +1,235 @@
+// Keeper tool telemetry — per-keeper tool usage statistics panel.
+// Aggregates trajectory entries client-side: call count, success rate,
+// avg latency, cost breakdown. Horizontal bar charts.
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import { fetchKeeperTrajectory } from '../api/dashboard'
+import type { TrajectoryEntry } from '../api/dashboard'
+import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
+
+// ── Types ─────────────────────────────────────────────
+
+interface ToolStat {
+  name: string
+  callCount: number
+  successCount: number
+  failureCount: number
+  totalDurationMs: number
+  avgDurationMs: number
+  maxDurationMs: number
+  totalCostUsd: number
+}
+
+interface TelemetryState {
+  stats: ToolStat[]
+  loading: boolean
+  error: string | null
+  totalCalls: number
+  totalCostUsd: number
+}
+
+// ── Aggregation ───────────────────────────────────────
+
+function aggregateToolStats(entries: TrajectoryEntry[]): ToolStat[] {
+  const map = new Map<string, {
+    callCount: number
+    successCount: number
+    failureCount: number
+    totalDurationMs: number
+    maxDurationMs: number
+    totalCostUsd: number
+  }>()
+
+  for (const e of entries) {
+    const existing = map.get(e.tool_name)
+    const isFailure = Boolean(e.error) || e.gate?.status === 'reject'
+    if (existing) {
+      existing.callCount++
+      if (isFailure) existing.failureCount++
+      else existing.successCount++
+      existing.totalDurationMs += e.duration_ms
+      existing.maxDurationMs = Math.max(existing.maxDurationMs, e.duration_ms)
+      existing.totalCostUsd += e.cost_usd
+    } else {
+      map.set(e.tool_name, {
+        callCount: 1,
+        successCount: isFailure ? 0 : 1,
+        failureCount: isFailure ? 1 : 0,
+        totalDurationMs: e.duration_ms,
+        maxDurationMs: e.duration_ms,
+        totalCostUsd: e.cost_usd,
+      })
+    }
+  }
+
+  const stats: ToolStat[] = []
+  for (const [name, s] of map) {
+    stats.push({
+      name,
+      ...s,
+      avgDurationMs: Math.round(s.totalDurationMs / s.callCount),
+    })
+  }
+  stats.sort((a, b) => b.callCount - a.callCount)
+  return stats
+}
+
+// ── Bar chart helpers ─────────────────────────────────
+
+function SuccessRateBar({ stat }: { stat: ToolStat }) {
+  const successPct = stat.callCount > 0 ? (stat.successCount / stat.callCount) * 100 : 100
+  const barColor = successPct >= 95 ? 'var(--ok)' : successPct >= 80 ? 'var(--warn)' : 'var(--bad)'
+
+  return html`
+    <div class="flex items-center gap-2 w-full">
+      <div class="flex-1 h-1.5 rounded-full bg-[var(--white-5)] overflow-hidden">
+        <div class="h-full rounded-full transition-all duration-300" style="width: ${successPct}%; background: ${barColor}"></div>
+      </div>
+      <span class="text-[10px] font-mono w-10 text-right" style="color: ${barColor}">
+        ${successPct === 100 ? '100%' : `${successPct.toFixed(0)}%`}
+      </span>
+    </div>
+  `
+}
+
+// ── Main component ────────────────────────────────────
+
+interface KeeperToolTelemetryProps {
+  keeperName: string
+}
+
+export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
+  const state = useSignal<TelemetryState>({
+    stats: [], loading: false, error: null, totalCalls: 0, totalCostUsd: 0,
+  })
+
+  useEffect(() => {
+    state.value = { ...state.value, loading: true, error: null }
+    void (async () => {
+      try {
+        const data = await fetchKeeperTrajectory(keeperName, 200)
+        const stats = aggregateToolStats(data.entries)
+        const totalCalls = data.entries.length
+        const totalCostUsd = data.entries.reduce((sum, e) => sum + e.cost_usd, 0)
+        state.value = { stats, loading: false, error: null, totalCalls, totalCostUsd }
+      } catch (err) {
+        state.value = {
+          stats: [], loading: false,
+          error: err instanceof Error ? err.message : 'fetch failed',
+          totalCalls: 0, totalCostUsd: 0,
+        }
+      }
+    })()
+  }, [keeperName])
+
+  const s = state.value
+
+  if (s.loading) {
+    return html`
+      <div class="flex flex-col gap-2 py-3" style="animation: loadingPulse 1.5s ease-in-out infinite">
+        ${[1, 2, 3].map(i => html`
+          <div key=${i} class="flex items-center gap-3 py-2 px-3">
+            <div class="size-5 rounded bg-[var(--white-8)]"></div>
+            <div class="flex-1 h-2 rounded bg-[var(--white-5)]"></div>
+            <div class="w-10 h-2 rounded bg-[var(--white-5)]"></div>
+          </div>
+        `)}
+      </div>
+    `
+  }
+
+  if (s.error) {
+    return html`<div class="text-xs text-[var(--bad)] py-3 text-center">${s.error}</div>`
+  }
+
+  if (s.stats.length === 0) {
+    return html`<div class="text-xs text-[var(--text-muted)] py-3 text-center italic">도구 호출 데이터 없음</div>`
+  }
+
+  const maxCount = s.stats[0]?.callCount ?? 1
+
+  // Find slowest 3 calls
+  const slowest = useMemo(() =>
+    [...s.stats].sort((a, b) => b.maxDurationMs - a.maxDurationMs).slice(0, 3),
+    [s.stats],
+  )
+
+  return html`
+    <div class="flex flex-col gap-4">
+
+      ${'' /* Summary row */}
+      <div class="flex gap-3 flex-wrap text-[11px]">
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
+          <span class="font-mono font-medium text-[var(--text-strong)]">${s.stats.length}</span> 도구
+        </span>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
+          <span class="font-mono font-medium text-[var(--text-strong)]">${s.totalCalls}</span> 호출
+        </span>
+        ${s.totalCostUsd > 0 ? html`
+          <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--accent-12)] border border-[rgba(71,184,255,0.15)] text-[var(--text-muted)]">
+            <span class="font-mono font-medium text-[var(--accent)]">$${s.totalCostUsd.toFixed(3)}</span>
+          </span>
+        ` : null}
+      </div>
+
+      ${'' /* Per-tool bar chart */}
+      <div class="flex flex-col gap-1">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">호출 빈도</div>
+        ${s.stats.slice(0, 15).map(stat => {
+          const cat = toolCategory(stat.name)
+          const barWidth = (stat.callCount / maxCount) * 100
+          return html`
+            <div class="flex items-center gap-2 py-1 group">
+              <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-[9px] font-mono font-bold ${cat.color}">
+                ${cat.icon}
+              </div>
+              <div class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate" title=${stat.name}>
+                ${stat.name.replace(/^(keeper_|masc_)/, '')}
+              </div>
+              <div class="flex-1 h-3 rounded bg-[var(--white-5)] overflow-hidden">
+                <div class="h-full rounded transition-all duration-300 ${stat.failureCount > 0 ? '' : ''}"
+                  style="width: ${barWidth}%; background: ${stat.failureCount > 0 ? 'var(--warn)' : 'var(--accent)'}; opacity: 0.7">
+                </div>
+              </div>
+              <span class="w-8 text-right text-[11px] font-mono text-[var(--text-muted)]">${stat.callCount}</span>
+              <span class="w-14 text-right text-[10px] font-mono ${durationColor(stat.avgDurationMs)}">
+                ${formatDuration(stat.avgDurationMs)}
+              </span>
+            </div>
+          `
+        })}
+      </div>
+
+      ${'' /* Success rate table */}
+      ${s.stats.some(st => st.failureCount > 0) ? html`
+        <div class="flex flex-col gap-1.5">
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">성공률</div>
+          ${s.stats.filter(st => st.failureCount > 0).map(stat => html`
+            <div class="flex items-center gap-2">
+              <span class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate">
+                ${stat.name.replace(/^(keeper_|masc_)/, '')}
+              </span>
+              <${SuccessRateBar} stat=${stat} />
+              <span class="text-[10px] text-[var(--bad)] w-10 text-right">${stat.failureCount}err</span>
+            </div>
+          `)}
+        </div>
+      ` : null}
+
+      ${'' /* Slowest calls */}
+      ${slowest.length > 0 && (slowest[0]?.maxDurationMs ?? 0) > 500 ? html`
+        <div class="flex flex-col gap-1.5">
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">최대 소요 시간</div>
+          ${slowest.map(stat => html`
+            <div class="flex items-center justify-between py-1 px-2 rounded bg-[var(--white-3)]">
+              <span class="text-[11px] font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
+              <span class="text-[11px] font-mono font-medium ${durationColor(stat.maxDurationMs)}">${formatDuration(stat.maxDurationMs)}</span>
+            </div>
+          `)}
+        </div>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/session-progress-header.ts
+++ b/dashboard/src/components/session-progress-header.ts
@@ -1,0 +1,162 @@
+// Session progress header — Copilot-style session summary bar
+// Shows total duration, status, generation, tool call stats, cost, context usage.
+
+import { html } from 'htm/preact'
+import { useEffect, useRef } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import type { Keeper } from '../types'
+import type { TraceSummary } from './session-trace/session-trace-state'
+import { formatDuration } from './tool-call-shared'
+
+// ── Helpers ──────────────────────────────────────────────
+
+function sessionDurationMs(keeper: Keeper): number | null {
+  if (!keeper.created_at) return null
+  const start = new Date(keeper.created_at).getTime()
+  if (Number.isNaN(start)) return null
+  return Date.now() - start
+}
+
+function isOnline(status: string): boolean {
+  return ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(
+    status.trim().toLowerCase(),
+  )
+}
+
+function isError(status: string): boolean {
+  return ['error', 'critical', 'crashed', 'dead'].includes(
+    status.trim().toLowerCase(),
+  )
+}
+
+function statusLabel(status: string): { text: string; color: string; bgColor: string } {
+  const s = status.trim().toLowerCase()
+  if (s === 'active' || s === 'running' || s === 'working')
+    return { text: '실행 중', color: 'text-[var(--ok)]', bgColor: 'bg-[rgba(74,222,128,0.12)]' }
+  if (s === 'idle' || s === 'quiet')
+    return { text: '대기', color: 'text-[var(--warn)]', bgColor: 'bg-[rgba(251,191,36,0.1)]' }
+  if (s === 'paused')
+    return { text: '일시정지', color: 'text-[var(--warn)]', bgColor: 'bg-[rgba(251,191,36,0.1)]' }
+  if (isError(s))
+    return { text: '오류', color: 'text-[var(--bad)]', bgColor: 'bg-[var(--bad-10)]' }
+  if (s === 'offline' || s === 'inactive' || s === 'stopped' || s === 'unbooted')
+    return { text: '오프라인', color: 'text-[#94a3b8]', bgColor: 'bg-[rgba(148,163,184,0.1)]' }
+  return { text: status, color: 'text-[#86a0cf]', bgColor: 'bg-[rgba(138,163,211,0.08)]' }
+}
+
+// ── Live elapsed timer ────────────────────────────────────
+
+function ElapsedTimer({ startMs }: { startMs: number }) {
+  const elapsed = useSignal(Date.now() - startMs)
+  const rafRef = useRef<number>(0)
+
+  useEffect(() => {
+    let mounted = true
+    const tick = () => {
+      if (!mounted) return
+      elapsed.value = Date.now() - startMs
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    // Update once per second instead of every frame
+    const interval = setInterval(() => { elapsed.value = Date.now() - startMs }, 1000)
+    tick()
+    return () => {
+      mounted = false
+      cancelAnimationFrame(rafRef.current)
+      clearInterval(interval)
+    }
+  }, [startMs])
+
+  return html`<span class="font-mono tabular-nums">${formatDuration(elapsed.value)}</span>`
+}
+
+// ── Main component ────────────────────────────────────────
+
+interface SessionProgressHeaderProps {
+  keeper: Keeper
+  summary: TraceSummary | null
+}
+
+export function SessionProgressHeader({ keeper, summary }: SessionProgressHeaderProps) {
+  const status = statusLabel(keeper.status)
+  const online = isOnline(keeper.status)
+  const gen = keeper.generation ?? 0
+  const ctxRatio = keeper.context_ratio ?? 0
+  const ctxPct = Math.round(ctxRatio * 100)
+  const ctxColor = ctxPct > 85 ? 'var(--bad)' : ctxPct > 70 ? 'var(--warn)' : 'var(--ok)'
+
+  const startMs = keeper.created_at ? new Date(keeper.created_at).getTime() : null
+  const durationMs = sessionDurationMs(keeper)
+
+  const toolCount = summary?.tool_call_count ?? keeper.latest_tool_call_count ?? 0
+  const cost = summary?.total_cost_usd ?? 0
+
+  return html`
+    <div class="flex flex-col gap-3 px-5 py-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] backdrop-blur-sm">
+
+      ${'' /* Row 1: Status + Duration + Generation */}
+      <div class="flex items-center justify-between flex-wrap gap-3">
+        <div class="flex items-center gap-3">
+          ${'' /* Status badge */}
+          <div class="flex items-center gap-1.5 px-3 py-1 rounded-full ${status.bgColor}">
+            ${online ? html`
+              <span class="relative flex size-2">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 ${status.color === 'text-[var(--ok)]' ? 'bg-[var(--ok)]' : 'bg-current'}"></span>
+                <span class="relative inline-flex size-2 rounded-full ${status.color === 'text-[var(--ok)]' ? 'bg-[var(--ok)]' : 'bg-current'}"></span>
+              </span>
+            ` : html`<span class="size-2 rounded-full bg-current ${status.color}"></span>`}
+            <span class="text-xs font-semibold ${status.color}">${status.text}</span>
+          </div>
+
+          ${'' /* Duration */}
+          ${startMs && !Number.isNaN(startMs) ? html`
+            <div class="flex items-center gap-1.5 text-sm ${online ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-60">
+                <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+              </svg>
+              ${online
+                ? html`<${ElapsedTimer} startMs=${startMs} />`
+                : durationMs != null
+                  ? html`<span class="font-mono">${formatDuration(durationMs)}</span>`
+                  : null
+              }
+            </div>
+          ` : null}
+
+          ${'' /* Generation */}
+          ${gen > 0 ? html`
+            <span class="text-[11px] font-mono px-2 py-0.5 rounded-md bg-[var(--white-5)] border border-[var(--white-8)] text-[var(--text-muted)]">
+              Gen ${gen}
+            </span>
+          ` : null}
+        </div>
+
+        ${'' /* Right: quick stats */}
+        <div class="flex items-center gap-3 text-[11px] text-[var(--text-muted)]">
+          ${toolCount > 0 ? html`
+            <span class="flex items-center gap-1">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-50">
+                <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+              </svg>
+              <span class="font-mono">${toolCount}</span> 호출
+            </span>
+          ` : null}
+          ${cost > 0 ? html`
+            <span class="font-mono text-[var(--accent)]">$${cost.toFixed(3)}</span>
+          ` : null}
+        </div>
+      </div>
+
+      ${'' /* Row 2: Context usage bar */}
+      ${ctxPct > 0 ? html`
+        <div class="flex items-center gap-3">
+          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] w-16 flex-shrink-0">컨텍스트</span>
+          <div class="flex-1 h-1.5 rounded-full bg-[var(--white-5)] overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-500" style="width: ${ctxPct}%; background: ${ctxColor}"></div>
+          </div>
+          <span class="text-[11px] font-mono w-10 text-right" style="color: ${ctxColor}">${ctxPct}%</span>
+        </div>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -2,6 +2,7 @@
 // Reuses tool category patterns from keeper-trajectory-timeline.ts.
 
 import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
 import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
@@ -12,6 +13,8 @@ import type { UnifiedTraceEvent, TraceEventKind } from './session-trace-state'
 // ── Constants ──────────────────────────────────────────
 
 const BROADCAST_PREVIEW_MAX = 160
+const RESULT_COLLAPSED_MAX_HEIGHT = 200 // px
+const RESULT_LINES_THRESHOLD = 12 // lines above which we collapse
 
 // ── Kind styling ───────────────────────────────────────
 
@@ -61,25 +64,123 @@ function taskColor(type: string): string {
   }
 }
 
+// ── Content type detection ─────────────────────────────
+
+type ContentHint = 'plain' | 'code' | 'diff' | 'json'
+
+function detectContentHint(text: string): ContentHint {
+  if (!text || text.length < 10) return 'plain'
+  const trimmed = text.trimStart()
+  // Diff detection: unified diff markers
+  if (trimmed.startsWith('@@') || trimmed.startsWith('---') || trimmed.startsWith('+++')
+    || /^[-+] /m.test(trimmed.slice(0, 500))) return 'diff'
+  // JSON detection
+  if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && trimmed.length > 20) {
+    try { JSON.parse(trimmed); return 'json' } catch { /* not json */ }
+  }
+  // Code detection: indentation patterns or common code markers
+  const lines = trimmed.split('\n').slice(0, 20)
+  const indentedLines = lines.filter(l => /^[ \t]{2,}/.test(l)).length
+  if (indentedLines > lines.length * 0.4) return 'code'
+  if (/^(def |fn |let |const |import |function |class |module |type )/.test(trimmed)) return 'code'
+  return 'plain'
+}
+
+function isLongContent(text: string): boolean {
+  if (!text) return false
+  return text.split('\n').length > RESULT_LINES_THRESHOLD || text.length > 1500
+}
+
+// ── Diff renderer ─────────────────────────────────────
+
+function DiffBlock({ text }: { text: string }) {
+  const lines = text.split('\n')
+  return html`
+    <div class="font-mono text-[11px] leading-[1.6] overflow-x-auto">
+      ${lines.map((line: string) => {
+        const cls =
+          line.startsWith('+') && !line.startsWith('+++') ? 'text-[var(--ok)] bg-[rgba(74,222,128,0.06)]'
+          : line.startsWith('-') && !line.startsWith('---') ? 'text-[var(--bad)] bg-[rgba(239,68,68,0.06)]'
+          : line.startsWith('@@') ? 'text-[var(--accent)] font-semibold'
+          : 'text-[var(--text-body)]'
+        return html`<div class="${cls} px-2 min-h-[1.6em]">${line || ' '}</div>`
+      })}
+    </div>
+  `
+}
+
+// ── Collapsible result viewer ─────────────────────────
+
+function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: ContentHint; isError: boolean }) {
+  const expanded = useSignal(false)
+  const needsCollapse = isLongContent(text)
+  const shouldCollapse = needsCollapse && !expanded.value
+
+  const titleLabel = isErr ? 'Error' : 'Result'
+  const titleColor = isErr ? 'text-[var(--bad)]' : 'text-[var(--text-muted)]'
+  const borderColor = isErr ? 'border-[rgba(239,68,68,0.2)]' : 'border-[var(--white-8)]'
+  const bgColor = isErr ? 'bg-[rgba(239,68,68,0.04)]' : 'bg-[var(--white-3)]'
+
+  return html`
+    <div>
+      <div class="flex items-center justify-between mb-1">
+        <span class="text-[10px] font-semibold uppercase tracking-wider ${titleColor}">${titleLabel}</span>
+        ${hint !== 'plain' ? html`
+          <span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
+        ` : null}
+      </div>
+      <div class="rounded-lg border ${borderColor} ${bgColor} overflow-hidden">
+        <div class="${shouldCollapse ? `max-h-[${RESULT_COLLAPSED_MAX_HEIGHT}px] overflow-hidden relative` : ''}"
+             style=${shouldCollapse ? `max-height: ${RESULT_COLLAPSED_MAX_HEIGHT}px` : ''}>
+          ${hint === 'diff' ? html`<${DiffBlock} text=${text} />`
+            : hint === 'json' ? html`<${JsonViewerCard} data=${parseJsonLikeData(text)} />`
+            : html`<pre class="m-0 text-[11px] font-mono ${isErr ? 'text-[var(--bad)]' : 'text-[var(--text-body)]'} p-3 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">${text}</pre>`}
+          ${shouldCollapse ? html`
+            <div class="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t ${isErr ? 'from-[rgba(239,68,68,0.08)]' : 'from-[var(--white-3)]'} to-transparent pointer-events-none"></div>
+          ` : null}
+        </div>
+        ${needsCollapse ? html`
+          <button
+            type="button"
+            class="w-full py-1.5 text-[10px] font-medium text-[var(--accent)] hover:text-[var(--text-strong)] hover:bg-[var(--white-5)] transition-colors cursor-pointer border-t border-[var(--white-6)] bg-transparent"
+            onClick=${() => { expanded.value = !expanded.value }}
+          >
+            ${expanded.value ? '접기' : `전체 보기 (${text.split('\n').length}줄)`}
+          </button>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
 // ── Components ─────────────────────────────────────────
 
 function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
   const gateRejected = event.gate?.status === 'reject'
+  const resultText = event.error ?? event.toolResult ?? null
+  const hint = resultText ? detectContentHint(resultText) : 'plain'
+
   return html`
-    <div class="mt-2 space-y-1.5">
+    <div class="mt-2 space-y-2">
       ${event.toolArgs ? html`
-        <div class="mt-1">
-          <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} title="Args" />
+        <div>
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Args</div>
+          <${JsonViewerCard} data=${parseJsonLikeData(event.toolArgs)} />
         </div>
       ` : null}
-      ${event.toolResult || event.error ? html`
-        <div class="mt-1">
-          <${JsonViewerCard} data=${parseJsonLikeData(event.error ?? event.toolResult)} title=${event.error ? 'Error' : 'Result'} />
-        </div>
+      ${resultText ? html`
+        <${ResultViewer} text=${resultText} hint=${hint} isError=${Boolean(event.error)} />
       ` : null}
       ${gateRejected ? html`
         <div class="text-[10px] px-2 py-1 rounded bg-[var(--bad-10)] text-[var(--bad)] inline-block">
           거부: ${event.gate?.reason ?? ''}
+        </div>
+      ` : null}
+      ${'' /* Metadata row */}
+      ${event.cost_usd != null && event.cost_usd > 0 ? html`
+        <div class="flex gap-3 text-[10px] text-[var(--text-dim)]">
+          <span>비용: <span class="font-mono text-[var(--accent)]">$${event.cost_usd.toFixed(4)}</span></span>
+          ${event.duration_ms != null ? html`<span>소요: <span class="font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span></span>` : null}
         </div>
       ` : null}
     </div>
@@ -151,8 +252,13 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
               ${taskIcon(String(event.detail.type))}
             </span>
           ` : null}
-          ${event.error ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>` : null}
-          ${gateRejected ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">거부</span>` : null}
+          ${event.error
+            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>`
+            : gateRejected
+              ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">거부</span>`
+              : event.kind === 'tool_call'
+                ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">완료</span>`
+                : null}
         </div>
         <div class="mt-0.5 text-[11px] text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
           ${summaryText}


### PR DESCRIPTION
## Summary
- 세션 진행률 헤더 추가 (실시간 경과 시간, 상태 badge, 도구 호출 수, 비용, 컨텍스트 사용률)
- SessionTraceView를 숨겨진 CollapsibleSection에서 메인 활동 뷰로 승격
- Per-keeper 도구 텔레메트리 패널 추가 (호출 빈도 bar chart, 성공률, 최대 소요 시간)
- 도구 호출 결과 렌더링 개선 (diff/code/json 감지, 긴 결과 접기, 성공 badge)

## Changes
| File | Type |
|------|------|
| `dashboard/src/components/session-progress-header.ts` | New |
| `dashboard/src/components/keeper-tool-telemetry.ts` | New |
| `dashboard/src/components/keeper-detail.ts` | Modified |
| `dashboard/src/components/session-trace/session-trace-entry.ts` | Modified |

## Test plan
- [ ] `tsc --noEmit` 통과
- [ ] `vite build` 성공
- [ ] 브라우저에서 keeper detail 열어 SessionProgressHeader 표시 확인
- [ ] SessionTraceView가 메인 뷰에 바로 보이는지 확인
- [ ] 도구 호출 entry 확장 시 diff/code 감지 동작 확인
- [ ] KeeperToolTelemetry 패널에 per-tool 통계 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)