### PR TITLE
chore: pin OAS Agent SDK to v0.101.2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.101.1))
+  (agent_sdk (>= 0.101.2))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.101.1"}
+  "agent_sdk" {>= "0.101.2"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.101.1"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.101.2"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="972b3ed0c1f109df36a4da127a58686191629315"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.101.1"
+readonly OAS_AGENT_SDK_SHA="94d32aeebd43683ad3de9e58e911779a6ea5f551"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.101.2"


### PR DESCRIPTION
## Summary
- `dune-project`, `masc_mcp.opam`: agent_sdk 최소 버전을 0.101.1 -> 0.101.2로 올림
- `scripts/oas-agent-sdk-pin.sh`: base tag, SHA, min version을 v0.101.2로 갱신
- v0.101.2에 포함된 idle hint dedup 변경 반영

## Test plan
- [ ] `dune build` 성공 확인
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>