### PR TITLE
fix(keeper): trust keepalive fiber over stale last_seen for health state

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -264,19 +264,22 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   in
   if not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive"
   then "offline"
-  (* H-4 fix: report zombie/stale keepers regardless of keepalive state *)
-  else if is_zombie || last_seen_ago_s > stale_threshold_s then
-    "stale"
-  else if not keepalive_running then
-    "offline"
-  else
-    match quiet_reason with
+  (* H-4 fix: true zombies are stale regardless of keepalive state *)
+  else if is_zombie then "stale"
+  else if keepalive_running then
+    (* Keepalive fiber is alive — trust it over last_seen.
+       presence_fresh optimization may skip Room.heartbeat(),
+       causing last_seen to drift without the keeper actually being stale. *)
+    (match quiet_reason with
     | Some "graphql_error" | Some "model_error" -> "degraded"
     | _ ->
         if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then "idle"
         else if last_turn_ago_s > float_of_int (max meta.proactive.idle_sec 900)
         then "idle"
-        else "healthy"
+        else "healthy")
+  (* Keepalive NOT running — fall back to last_seen for stale detection *)
+  else if last_seen_ago_s > stale_threshold_s then "stale"
+  else "offline"
 
 let keeper_next_action_path ~health_state ~quiet_reason =
   match health_state with

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -23,6 +23,16 @@ val augment_keeper_diagnostic_json :
   Yojson.Safe.t ->
   Yojson.Safe.t
 
+val keeper_health_state :
+  ?fiber_health:fiber_health ->
+  meta:keeper_meta ->
+  keepalive_running:bool ->
+  agent_status:Yojson.Safe.t ->
+  quiet_reason:string option ->
+  now_ts:float ->
+  unit ->
+  string
+
 val keeper_surface_status :
   agent_status:Yojson.Safe.t ->
   diagnostic:Yojson.Safe.t ->

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -88,6 +88,73 @@ let test_derive_pipeline_stage_treats_inactive_as_offline () =
   check string "inactive keeper does not advertise a live pipeline stage"
     "offline" stage
 
+(* --- keeper_health_state tests (online/offline mismatch fix) --- *)
+
+let make_agent_status ?(exists = true) ?(status = "active")
+    ?(last_seen_ago_s = 10.0) ?(is_zombie = false) () : Yojson.Safe.t =
+  `Assoc [
+    ("exists", `Bool exists);
+    ("status", `String status);
+    ("last_seen_ago_s", `Float last_seen_ago_s);
+    ("is_zombie", `Bool is_zombie);
+  ]
+
+let test_health_keepalive_running_overrides_stale_last_seen () =
+  let meta = make_meta () in
+  let agent_status = make_agent_status ~last_seen_ago_s:600.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  (* keepalive is running — last_seen staleness should NOT make it "stale" *)
+  check bool "keepalive running + stale last_seen is NOT stale"
+    true (health <> "stale");
+  check bool "keepalive running + stale last_seen is NOT offline"
+    true (health <> "offline")
+
+let test_health_keepalive_not_running_respects_stale_last_seen () =
+  let meta = make_meta () in
+  let agent_status = make_agent_status ~last_seen_ago_s:600.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:false
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "no keepalive + stale last_seen → stale" "stale" health
+
+let test_health_zombie_overrides_keepalive () =
+  let meta = make_meta () in
+  let agent_status = make_agent_status ~is_zombie:true ~last_seen_ago_s:10.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "zombie overrides keepalive" "stale" health
+
+let test_health_keepalive_running_fresh_is_healthy () =
+  let meta =
+    let base = make_meta () in
+    { base with runtime = { base.runtime with
+        usage = { base.runtime.usage with
+          total_turns = 5;
+          last_turn_ts = Time_compat.now () };
+      }}
+  in
+  let agent_status = make_agent_status ~last_seen_ago_s:10.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "keepalive + fresh + turns → healthy" "healthy" health
+
+let test_health_keepalive_not_running_not_stale_is_offline () =
+  let meta = make_meta () in
+  let agent_status = make_agent_status ~last_seen_ago_s:50.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:false
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "no keepalive + not stale → offline" "offline" health
+
 let test_derive_pipeline_stage_prefers_scheduled_autonomous () =
   let meta =
     let base = make_meta () in
@@ -113,6 +180,19 @@ let test_derive_pipeline_stage_prefers_scheduled_autonomous () =
 let () =
   run "keeper_exec_status"
     [
+      ( "health_state",
+        [
+          test_case "keepalive running overrides stale last_seen" `Quick
+            test_health_keepalive_running_overrides_stale_last_seen;
+          test_case "no keepalive respects stale last_seen" `Quick
+            test_health_keepalive_not_running_respects_stale_last_seen;
+          test_case "zombie overrides keepalive" `Quick
+            test_health_zombie_overrides_keepalive;
+          test_case "keepalive + fresh turns → healthy" `Quick
+            test_health_keepalive_running_fresh_is_healthy;
+          test_case "no keepalive + not stale → offline" `Quick
+            test_health_keepalive_not_running_not_stale_is_offline;
+        ] );
       ( "surface_status",
         [
           test_case "preserves live agent states" `Quick


### PR DESCRIPTION
## Summary
- keeper_health_state()가 last_seen_ago_s > 120s로 keeper를 "stale"로 표시하는데, keepalive fiber가 살아있어도 무시했음
- presence_fresh 최적화가 Room.heartbeat()를 skip하면서 last_seen이 drift → "stale" → "inactive" → "offline"로 3단 cascade
- 리스트는 "active", 상세는 "offline"로 표시되는 불일치의 근본 원인

## Changes
- `keeper_exec_status.ml`: keepalive_running=true이면 last_seen 기반 stale 판정 skip. zombie는 항상 우선
- `keeper_exec_status.mli`: keeper_health_state 함수 expose (테스트 접근)
- `test_keeper_exec_status.ml`: 5개 health_state 테스트 추가 (12 total)

## Cascade fix
```
Before: keeper_health_state → "stale" → surface_status "inactive" → pipeline "offline"
After:  keeper_health_state → "healthy"/"idle" → surface_status "active" → pipeline correct
```

## Test plan
- [x] keeper_exec_status: 12/12 pass
- [x] keeper_state_machine: 66/66 pass
- [x] keeper_unified: 98/98 pass
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)