### PR TITLE
fix(boundary): use cascade format for model names in fixtures and tests

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -24,8 +24,8 @@ const mocks = vi.hoisted(() => ({
       effective_system_prompt: 'full prompt',
     },
     execution: {
-      models: ['gpt-5.4'],
-      active_model: 'gpt-5.4',
+      models: ['llama:test-balanced'],
+      active_model: 'llama:test-balanced',
       verify: true,
     },
     compaction: {
@@ -86,7 +86,7 @@ const mocks = vi.hoisted(() => ({
       total_output_tokens: 800,
       total_tokens: 2000,
       total_cost_usd: 0.12,
-      last_model_used: 'gpt-5.4',
+      last_model_used: 'llama:test-balanced',
       last_input_tokens: 120,
       last_output_tokens: 80,
       last_total_tokens: 200,

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -52,12 +52,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
             latency_ms: 140,
             generation: 5,
             channel: 'turn',
-            model_used: 'gpt-5.4',
+            model_used: 'llama:test-balanced',
             cost_usd: 0.2,
             compacted: false,
             handoff: {
               performed: true,
-              to_model: 'gpt-5.4',
+              to_model: 'llama:test-balanced',
               to_generation: 6,
             },
           },
@@ -69,7 +69,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     const metric = keeper!.metrics_series![0]
     expect(metric).toMatchObject({
       is_handoff: true,
-      handoff_to_model: 'gpt-5.4',
+      handoff_to_model: 'llama:test-balanced',
       handoff_new_generation: 6,
     })
     expect(deriveLifecycleState(keeper!)).toBe('handoff-imminent')

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -225,7 +225,7 @@ let execution_smoke_fixture_json () =
                 ("related_operation_id", `String "op-runtime-001");
                 ("emoji", `String "🤖");
                 ("korean_name", `String "local-alpha");
-                ("model", `String Env_config.Llama.default_model);
+                ("model", `String (Provider_adapter.make_local_label Env_config.Llama.default_model));
                 ("recent_output_preview", `String "manager synthesized runtime visibility and handed next checks to beta");
                 ("recent_event", `String "manager handoff");
               ];
@@ -247,7 +247,7 @@ let execution_smoke_fixture_json () =
                 ("related_operation_id", `String "op-runtime-001");
                 ("emoji", `String "🤖");
                 ("korean_name", `String "local-beta");
-                ("model", `String "qwen27-balanced");
+                ("model", `String (Provider_adapter.make_local_label "qwen27-balanced"));
                 ("recent_output_preview", `String "secondary runtime is quiet; watching queue depth before escalation");
                 ("recent_event", `String "secondary runtime probe");
               ];
@@ -269,7 +269,7 @@ let execution_smoke_fixture_json () =
                 ("related_operation_id", `String "op-runtime-003");
                 ("emoji", `String "🤖");
                 ("korean_name", `String "local-gamma");
-                ("model", `String "qwen9-swarm");
+                ("model", `String (Provider_adapter.make_local_label "qwen9-swarm"));
                 ("recent_output_preview", `Null);
                 ("recent_event", `String "idle");
               ];
@@ -328,7 +328,7 @@ let execution_smoke_fixture_json () =
                 ("continuity", `String "Gen 2 · Turns 84 · Goals 2");
                 ("lifecycle", `String "handoff-imminent");
                 ("related_session_id", `Null);
-                ("model", `String "qwen27-balanced");
+                ("model", `String (Provider_adapter.make_local_label "qwen27-balanced"));
                 ("emoji", `String "🤖");
                 ("korean_name", `String "dm-keeper");
                 ("recent_input_preview", `String "Player asked to continue the next scene without breaking continuity");
@@ -366,7 +366,7 @@ let execution_smoke_fixture_json () =
                 ("related_operation_id", `String "op-runtime-001");
                 ("emoji", `String "🤖");
                 ("korean_name", `String "local-delta");
-                ("model", `String "qwen9-swarm");
+                ("model", `String (Provider_adapter.make_local_label "qwen9-swarm"));
                 ("recent_output_preview", `Null);
                 ("recent_event", `String "missing heartbeat");
               ];
@@ -490,8 +490,8 @@ let execution_smoke_fixture_json () =
                 ("last_autonomous_action_at", `String generated_at);
                 ("autonomous_action_count", `Int 11);
                 ("active_goal_ids", `List [ `String "goal-runtime"; `String "goal-story" ]);
-                ("model", `String "qwen27-balanced");
-                ("active_model", `String "qwen27-balanced");
+                ("model", `String (Provider_adapter.make_local_label "qwen27-balanced"));
+                ("active_model", `String (Provider_adapter.make_local_label "qwen27-balanced"));
                 ("goal", `String "masc-keeper-autonomy");
                 ("short_goal", `String "masc-keeper-autonomy");
                 ("updated_at", `String generated_at);


### PR DESCRIPTION
## Summary
- OCaml fixture (`dashboard_execution_fixture.ml`)의 bare model name 7개소를 `Provider_adapter.make_local_label` SSOT 경유로 변경
- TS 테스트 (`keeper-config-panel.test.ts`, `keeper-store-normalize.test.ts`)의 vendor-specific `gpt-5.4`를 cascade format `llama:test-balanced`로 변경

## Why
MASC는 model/vendor를 직접 알면 안 된다. cascade abstraction layer가 유일한 경로. fixture 데이터가 bare model name을 사용하면 대시보드가 이를 그대로 렌더링하여 경계 위반이 사용자에게 노출된다.

## What was checked
- 최근 병합된 ~50 PR 전수 확인 (#5414, #5436, #5438, #5447, #5452 등)
- `cascade_name` SSOT: `keeper_config.ml:7` 단일 정의 확인
- `credits_dashboard.ml`: 과금 대시보드로 vendor 참조 정당 (수정 불필요)
- `relay.ml`: 주석 내 model name 참조 → 라우팅 설명 목적으로 정당

## Test plan
- [x] TS 테스트 통과 (vitest: 7 passed)
- [ ] OCaml 빌드 확인 (CI)
- [ ] 대시보드 fixture smoke test에서 cascade format 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)