### PR TITLE
fix(boundary): externalize scattered thresholds and align dashboard types

### DIFF
--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -439,6 +439,9 @@ export interface ServerStatus {
     failures: number
     failure_rate: number
     since_epoch: number
+    distinct_tools?: number
+    top_failures?: Array<{ tool: string; calls: number; failures: number }>
+    top_active?: Array<{ tool: string; calls: number; failures: number }>
   }
   alert_thresholds?: {
     proactive_fallback_warn: number

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -270,6 +270,15 @@ module KeeperToolExec = struct
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
 end
 
+(** {1 Context Ratio Hard Cap}
+
+    Absolute ceiling for compaction ratio_gate and handoff threshold after
+    multiplier adjustment.  Prevents runaway values from disabling
+    compaction/handoff.  Default: 0.95. Range: [0.80, 0.99]. *)
+
+let context_ratio_hard_cap =
+  Float.max 0.80 (Float.min 0.99 (get_float ~default:0.95 "MASC_CONTEXT_RATIO_HARD_CAP"))
+
 (** {1 Context Compaction (OAS)} *)
 
 module ContextCompact = struct
@@ -294,6 +303,20 @@ module ContextCompact = struct
   let dynamic_multi_agent_ratio = get_float ~default:0.80 "MASC_COMPACT_DYN_MULTI_AGENT_RATIO"
   let dynamic_focused_ratio = get_float ~default:0.70 "MASC_COMPACT_DYN_FOCUSED_RATIO"
   let small_local_floor = get_int ~default:64_000 "MASC_COMPACT_SMALL_LOCAL_FLOOR"
+end
+
+(** {1 Dashboard Health Thresholds}
+
+    Thresholds used by the dashboard keeper health scorer and harness health
+    panels.  Distinct from compaction triggers — these affect UI display only. *)
+
+module DashboardHealth = struct
+  let ctx_critical = get_float ~default:0.9 "MASC_DASHBOARD_HEALTH_CTX_CRITICAL"
+  let ctx_warn = get_float ~default:0.8 "MASC_DASHBOARD_HEALTH_CTX_WARN"
+  let penalty_critical = get_float ~default:20.0 "MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL"
+  let penalty_warn = get_float ~default:10.0 "MASC_DASHBOARD_HEALTH_PENALTY_WARN"
+  let runtime_warning_ctx_ratio = get_float ~default:0.95 "MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO"
+  let runtime_warning_token_count = get_int ~default:50_000 "MASC_DASHBOARD_RUNTIME_WARNING_TOKEN_COUNT"
 end
 
 (** Print configuration summary for debugging *)

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -50,9 +50,10 @@ let max_signal_scan = 500
 let runtime_stale_after_s = 30. *. 60.
 let evaluator_stale_after_s = 12. *. 3600.
 
-(** Runtime health warning thresholds. Distinct from compaction thresholds. *)
-let runtime_warning_ctx_ratio = 0.95
-let runtime_warning_token_count = 50_000
+(** Runtime health warning thresholds. Distinct from compaction thresholds.
+    Values sourced from [Env_config_keeper.DashboardHealth]. *)
+let runtime_warning_ctx_ratio = Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
+let runtime_warning_token_count = Env_config_keeper.DashboardHealth.runtime_warning_token_count
 
 let pre_compact_store_ref : Dated_jsonl.t option ref = ref None
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -12,11 +12,12 @@ include Dashboard_http_keeper_detail
 
 (** Context-ratio thresholds for keeper health scoring.
     These are distinct from Dashboard.ctx_* (compaction triggers) —
-    health scoring penalizes keepers approaching context limits. *)
-let health_ctx_critical = 0.9
-let health_ctx_warn = 0.8
-let health_penalty_critical = 20.0
-let health_penalty_warn = 10.0
+    health scoring penalizes keepers approaching context limits.
+    Values sourced from [Env_config_keeper.DashboardHealth]. *)
+let health_ctx_critical = Env_config_keeper.DashboardHealth.ctx_critical
+let health_ctx_warn = Env_config_keeper.DashboardHealth.ctx_warn
+let health_penalty_critical = Env_config_keeper.DashboardHealth.penalty_critical
+let health_penalty_warn = Env_config_keeper.DashboardHealth.penalty_warn
 
 (** Compute keeper health score (0-100). Pure function.
     Inputs: restart_count, max_restarts, recent_crash_count,

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -310,7 +310,7 @@ let evaluate_keeper_auto_rules
     | Some id -> model_threshold_multipliers_of_model_id id
     | None -> (1.0, 1.0)
   in
-  let ratio_gate = Float.min 0.95 (meta.compaction.ratio_gate *. ratio_mult) in
+  let ratio_gate = Float.min Env_config_keeper.context_ratio_hard_cap (meta.compaction.ratio_gate *. ratio_mult) in
   let message_gate = meta.compaction.message_gate in
   let token_gate = meta.compaction.token_gate in
   let reflect_threshold = keeper_rule_reflect_repetition_threshold () in
@@ -337,7 +337,7 @@ let evaluate_keeper_auto_rules
     || (message_gate > 0 && message_count >= message_gate)
     || (token_gate > 0 && token_count >= token_gate)
   in
-  let adjusted_handoff_threshold = Float.min 0.95 (meta.handoff_threshold *. handoff_mult) in
+  let adjusted_handoff_threshold = Float.min Env_config_keeper.context_ratio_hard_cap (meta.handoff_threshold *. handoff_mult) in
   let handoff = meta.auto_handoff && context_ratio >= adjusted_handoff_threshold in
   let guardrail_stop =
     repetition_risk >= guardrail_repetition_threshold
@@ -474,7 +474,7 @@ let learned_policy_auto_rules
     | Some id -> model_threshold_multipliers_of_model_id id
     | None -> (1.0, 1.0)
   in
-  let ratio_gate = Float.min 0.95 (meta.compaction.ratio_gate *. ratio_mult) in
+  let ratio_gate = Float.min Env_config_keeper.context_ratio_hard_cap (meta.compaction.ratio_gate *. ratio_mult) in
   let message_gate = meta.compaction.message_gate in
   let token_gate = meta.compaction.token_gate in
   let goal_drift =
@@ -487,7 +487,7 @@ let learned_policy_auto_rules
     || (message_gate > 0 && message_count >= message_gate)
     || (token_gate > 0 && token_count >= token_gate)
   in
-  let adjusted_handoff_threshold = Float.min 0.95 (meta.handoff_threshold *. handoff_mult) in
+  let adjusted_handoff_threshold = Float.min Env_config_keeper.context_ratio_hard_cap (meta.handoff_threshold *. handoff_mult) in
   let handoff = meta.auto_handoff && context_ratio >= adjusted_handoff_threshold in
   {
     repetition_risk;


### PR DESCRIPTION
## Summary
- `keeper_memory_recall.ml`의 하드코딩된 `0.95` context ratio hard cap 4개소를 `Env_config_keeper.context_ratio_hard_cap` (`MASC_CONTEXT_RATIO_HARD_CAP`) 단일 상수로 추출
- Dashboard health 임계값 6개를 `Env_config_keeper.DashboardHealth` 모듈로 외부화 (env var로 런타임 조정 가능)
- `tool_call_health` TypeScript 타입에 backend가 보내지만 누락된 `distinct_tools`, `top_failures`, `top_active` 필드 추가

## Why
1. **산포된 하드코딩 (AI anti-pattern #1)**: 동일 임계값 `0.95`가 4개소에 리터럴로 존재. 한 곳만 바꾸면 drift 발생.
2. **API 계약 불일치**: PR #5391이 backend에 `top_failures`/`top_active`를 추가했지만 TypeScript 타입이 미갱신. 타입 안전성 위반.
3. **Dashboard 임계값 불투명성**: health scoring과 runtime warning의 정책 값이 코드에 묻혀 있어 운영 시 튜닝 불가.

## Changed files
| File | Change |
|------|--------|
| `lib/config/env_config_keeper.ml` | `context_ratio_hard_cap` + `DashboardHealth` 모듈 추가 |
| `lib/keeper/keeper_memory_recall.ml` | 4x `0.95` → `Env_config_keeper.context_ratio_hard_cap` |
| `lib/dashboard/dashboard_http_keeper.ml` | 4 literals → `DashboardHealth.*` |
| `lib/dashboard/dashboard_harness_health.ml` | 2 literals → `DashboardHealth.*` |
| `dashboard/src/types/dashboard-execution.ts` | `tool_call_health` 3 optional fields 추가 |

## Test plan
- [x] OCaml 빌드 성공 (`dune build`)
- [x] Dashboard vitest 341/344 passed (3 pre-existing `session-trace-entry` failures, 내 변경 무관)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)