### PR TITLE
feat: capture and display LLM thinking blocks in trajectory

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -766,14 +766,15 @@ export type TrajectoryEntry = {
   ts: number
   ts_iso: string
   turn: number
-  round: number
-  tool_name: string
-  args: Record<string, unknown> | string
-  gate: TrajectoryGate
-  result: string | null
-  duration_ms: number
-  error: string | null
-  cost_usd: number
+  // Tool-call fields (absent on thinking entries)
+  round?: number
+  tool_name?: string
+  args?: Record<string, unknown> | string
+  gate?: TrajectoryGate
+  result?: string | null
+  duration_ms?: number
+  error?: string | null
+  cost_usd?: number
   // Thinking-specific fields
   content?: string
   content_length?: number
@@ -796,7 +797,9 @@ export function fetchKeeperTrajectory(
 ): Promise<TrajectoryResponse> {
   const params = new URLSearchParams()
   if (limit != null) params.set('limit', String(limit))
-  if (includeThinking) params.set('include_thinking', 'true')
+  // Always send include_thinking explicitly — backend defaults to false,
+  // so omitting the param means "don't include".
+  params.set('include_thinking', includeThinking ? 'true' : 'false')
   const qs = params.toString()
   return get<TrajectoryResponse>(
     `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${qs ? `?${qs}` : ''}`,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -762,6 +762,7 @@ export type TrajectoryGate = {
 }
 
 export type TrajectoryEntry = {
+  type?: 'thinking'  // absent for tool calls, 'thinking' for thinking blocks
   ts: number
   ts_iso: string
   turn: number
@@ -773,6 +774,10 @@ export type TrajectoryEntry = {
   duration_ms: number
   error: string | null
   cost_usd: number
+  // Thinking-specific fields
+  content?: string
+  content_length?: number
+  redacted?: boolean
 }
 
 export type TrajectoryResponse = {
@@ -787,8 +792,13 @@ export type TrajectoryResponse = {
 export function fetchKeeperTrajectory(
   name: string,
   limit?: number,
+  includeThinking = true,
 ): Promise<TrajectoryResponse> {
+  const params = new URLSearchParams()
+  if (limit != null) params.set('limit', String(limit))
+  if (includeThinking) params.set('include_thinking', 'true')
+  const qs = params.toString()
   return get<TrajectoryResponse>(
-    `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${limit != null ? `?limit=${limit}` : ''}`,
+    `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${qs ? `?${qs}` : ''}`,
   )
 }

--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -51,18 +51,19 @@ function sampleThinkingEvent(overrides: Partial<UnifiedTraceEvent> = {}): Unifie
 }
 
 describe('SessionTraceEntry', () => {
-  it('renders tool results through JsonViewerCard and parses JSON-string payloads', () => {
+  it('renders tool args through JsonViewerCard and result through ResultViewer', () => {
     const { container } = render(h(SessionTraceEntry, { event: sampleToolCallEvent() }))
 
     fireEvent.click(container.querySelector('summary') as HTMLElement)
 
+    // Args still uses JsonViewerCard
     const cards = screen.getAllByTestId('json-viewer-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[0]?.getAttribute('data-title')).toBe('Args')
+    expect(cards.length).toBeGreaterThanOrEqual(1)
     expect(cards[0]?.textContent ?? '').toContain('"arg":true')
-    expect(cards[1]?.getAttribute('data-title')).toBe('Result')
-    expect(cards[1]?.textContent ?? '').toContain('"ok":true')
-    expect(cards[1]?.textContent ?? '').toContain('"detail":"completed"')
+
+    // Result is rendered by ResultViewer (may be pre or JsonViewerCard depending on content type)
+    const resultText = container.textContent ?? ''
+    expect(resultText).toContain('"ok":true')
   })
 
   it('labels error payloads as Error when expanded', () => {

--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -36,6 +36,20 @@ function sampleToolCallEvent(overrides: Partial<UnifiedTraceEvent> = {}): Unifie
   }
 }
 
+function sampleThinkingEvent(overrides: Partial<UnifiedTraceEvent> = {}): UnifiedTraceEvent {
+  return {
+    id: 'thinking-1',
+    ts: 2,
+    ts_iso: '2026-04-03T00:01:00Z',
+    kind: 'thinking',
+    summary: 'thinking block (120 chars)',
+    detail: {},
+    thinkingContent: 'The user wants to refactor the module. I should check the dependency graph first.',
+    thinkingRedacted: false,
+    ...overrides,
+  }
+}
+
 describe('SessionTraceEntry', () => {
   it('renders tool results through JsonViewerCard and parses JSON-string payloads', () => {
     const { container } = render(h(SessionTraceEntry, { event: sampleToolCallEvent() }))
@@ -64,11 +78,39 @@ describe('SessionTraceEntry', () => {
     expect(cards[0]?.getAttribute('data-title')).toBe('Args')
 
     // Plain-text errors render through ResultViewer <pre>, not JsonViewerCard
-    // (this specific 'plain error' payload is classified as 'plain')
     const errorPre = container.querySelector('pre')
     expect(errorPre?.textContent ?? '').toContain('plain error')
 
     // ResultViewer should display the "Error" title label
     expect(screen.getByText('Error')).toBeTruthy()
+  })
+
+  it('renders ThinkingDetail with markdown content when expanded', () => {
+    const { container } = render(h(SessionTraceEntry, {
+      event: sampleThinkingEvent(),
+    }))
+
+    fireEvent.click(container.querySelector('summary') as HTMLElement)
+
+    const mdBlocks = screen.getAllByTestId('markdown')
+    expect(mdBlocks.length).toBeGreaterThanOrEqual(1)
+    const thinkingMd = mdBlocks.find(el =>
+      (el.textContent ?? '').includes('refactor the module'),
+    )
+    expect(thinkingMd).toBeDefined()
+  })
+
+  it('renders redacted ThinkingDetail with placeholder text', () => {
+    const { container } = render(h(SessionTraceEntry, {
+      event: sampleThinkingEvent({
+        thinkingRedacted: true,
+        thinkingContent: undefined,
+      }),
+    }))
+
+    fireEvent.click(container.querySelector('summary') as HTMLElement)
+
+    // The redacted placeholder should be visible (Korean text)
+    expect(container.textContent).toContain('비공개 처리')
   })
 })

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -30,6 +30,7 @@ const KIND_STYLES: Record<TraceEventKind, KindStyle> = {
   tool_call:  { icon: '>', color: 'text-[var(--ok)]', label: '도구 호출' },
   heartbeat:  { icon: 'H', color: 'text-[#94a3b8]', label: '하트비트' },
   lifecycle:  { icon: 'L', color: 'text-[var(--warn)]', label: '생명주기' },
+  thinking:   { icon: '\u{1F4AD}', color: 'text-[#c084fc]', label: '내부 사고' },
 }
 
 // Use shared tool category from tool-call-shared (SSOT)
@@ -211,6 +212,25 @@ function TaskDetail({ event }: { event: UnifiedTraceEvent }) {
   `
 }
 
+function ThinkingDetail({ event }: { event: UnifiedTraceEvent }) {
+  if (event.thinkingRedacted) {
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(192,132,252,0.06)] border border-[rgba(192,132,252,0.15)] text-xs text-[#c084fc] italic">
+        이 사고 과정은 비공개 처리되었습니다.
+      </div>
+    `
+  }
+  const content = event.thinkingContent ?? ''
+  if (!content) return null
+  return html`
+    <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(192,132,252,0.04)] border border-[rgba(192,132,252,0.12)]">
+      <div class="text-[13px] leading-relaxed text-[var(--text-body)]">
+        <${Markdown} text=${content} />
+      </div>
+    </div>
+  `
+}
+
 export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
   const kindStyle = KIND_STYLES[event.kind]
   // For tool_call, use tool-specific icon/color
@@ -232,6 +252,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
   const hasDetail = event.kind === 'tool_call'
     || (event.kind === 'broadcast' && typeof event.detail.content === 'string' && event.detail.content.length > BROADCAST_PREVIEW_MAX)
     || event.kind === 'task'
+    || event.kind === 'thinking'
 
   const row = html`
     <div class="flex items-start gap-3 py-2 px-3 rounded-lg ${gateRejected ? 'opacity-50' : ''}">
@@ -284,6 +305,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
         ${event.kind === 'tool_call' ? html`<${ToolCallDetail} event=${event} />` : null}
         ${event.kind === 'broadcast' ? html`<${BroadcastDetail} event=${event} />` : null}
         ${event.kind === 'task' ? html`<${TaskDetail} event=${event} />` : null}
+        ${event.kind === 'thinking' ? html`<${ThinkingDetail} event=${event} />` : null}
       </div>
     </details>
   `

--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -11,6 +11,7 @@ type FilterKey = TraceEventKind | 'all'
 const CHIP_DEFS: Array<{ key: FilterKey; label: string }> = [
   { key: 'all',        label: '전체' },
   { key: 'tool_call',  label: '도구 호출' },
+  { key: 'thinking',   label: '내부 사고' },
   { key: 'broadcast',  label: '브로드캐스트' },
   { key: 'task',       label: '태스크' },
   { key: 'heartbeat',  label: '하트비트' },

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -10,7 +10,7 @@ import type { AgentTimelineEvent, AgentTimelineResponse, TrajectoryEntry, Trajec
 
 // ── Types ──────────────────────────────────────────────
 
-export type TraceEventKind = 'broadcast' | 'task' | 'tool_call' | 'heartbeat' | 'lifecycle'
+export type TraceEventKind = 'broadcast' | 'task' | 'tool_call' | 'heartbeat' | 'lifecycle' | 'thinking'
 
 export interface UnifiedTraceEvent {
   id: string
@@ -29,6 +29,9 @@ export interface UnifiedTraceEvent {
   round?: number
   cost_usd?: number
   error?: string | null
+  // thinking fields
+  thinkingContent?: string
+  thinkingRedacted?: boolean
 }
 
 export interface TraceSummary {
@@ -38,6 +41,7 @@ export interface TraceSummary {
   task_claimed_count: number
   heartbeat_count: number
   lifecycle_count: number
+  thinking_count: number
   total_cost_usd: number
 }
 
@@ -100,6 +104,7 @@ export function getTraceSummary(agent: string): TraceSummary {
   let task_claimed_count = 0
   let heartbeat_count = 0
   let lifecycle_count = 0
+  let thinking_count = 0
   let total_cost_usd = 0
 
   for (const e of events) {
@@ -121,15 +126,18 @@ export function getTraceSummary(agent: string): TraceSummary {
       case 'lifecycle':
         lifecycle_count++
         break
+      case 'thinking':
+        thinking_count++
+        break
     }
   }
 
-  return { tool_call_count, broadcast_count, task_completed_count, task_claimed_count, heartbeat_count, lifecycle_count, total_cost_usd }
+  return { tool_call_count, broadcast_count, task_completed_count, task_claimed_count, heartbeat_count, lifecycle_count, thinking_count, total_cost_usd }
 }
 
 export function getKindCounts(agent: string): Record<TraceEventKind | 'all', number> {
   const events = getTraceEvents(agent)
-  const counts: Record<string, number> = { all: events.length, broadcast: 0, task: 0, tool_call: 0, heartbeat: 0, lifecycle: 0 }
+  const counts: Record<string, number> = { all: events.length, broadcast: 0, task: 0, tool_call: 0, heartbeat: 0, lifecycle: 0, thinking: 0 }
   for (const e of events) counts[e.kind] = (counts[e.kind] ?? 0) + 1
   return counts as Record<TraceEventKind | 'all', number>
 }
@@ -204,6 +212,22 @@ function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTr
 
 function trajectoryEntryToTrace(entry: TrajectoryEntry, index: number): UnifiedTraceEvent {
   const ts = typeof entry.ts === 'number' ? entry.ts : safeTimestamp(entry.ts_iso)
+
+  // Handle thinking entries (type === 'thinking')
+  if (entry.type === 'thinking') {
+    return {
+      id: `tj-${ts}-thinking-T${entry.turn}-${index}`,
+      ts,
+      ts_iso: entry.ts_iso,
+      kind: 'thinking',
+      summary: entry.redacted ? '[비공개 사고]' : (entry.content?.slice(0, 120) ?? ''),
+      detail: {},
+      turn: entry.turn,
+      thinkingContent: entry.content,
+      thinkingRedacted: entry.redacted,
+    }
+  }
+
   return {
     id: `tj-${ts}-${entry.tool_name}-T${entry.turn}R${entry.round}-${index}`,
     ts,

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1037,7 +1037,11 @@ let run_turn
         let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
         let text = Agent_sdk.Types.text_of_content result.response.content in
         let model = result.response.model in
-        (* Extract and persist thinking blocks to trajectory JSONL *)
+        (* Extract and persist thinking blocks to trajectory JSONL.
+           NOTE: turn = acc.turn stays at 0 in the keeper path because
+           Trajectory.increment_turn is never called here — the keeper
+           uses OAS Agent.run which manages its own internal call count.
+           Consumers should treat turn=0 as "turn not tracked in keeper path". *)
         (match trajectory_acc with
          | Some acc ->
            let now = Time_compat.now () in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1037,6 +1037,49 @@ let run_turn
         let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
         let text = Agent_sdk.Types.text_of_content result.response.content in
         let model = result.response.model in
+        (* Extract and persist thinking blocks to trajectory JSONL *)
+        (match trajectory_acc with
+         | Some acc ->
+           let now = Time_compat.now () in
+           let now_iso = Types.now_iso () in
+           List.iter (function
+             | Agent_sdk.Types.Thinking { content; _ } ->
+               let entry : Trajectory.thinking_entry = {
+                 ts = now;
+                 ts_iso = now_iso;
+                 turn = acc.Trajectory.turn;
+                 content;
+                 content_length = String.length content;
+                 redacted = false;
+               } in
+               (try Trajectory.append_thinking
+                      ~masc_root:acc.Trajectory.masc_root
+                      ~keeper_name:acc.Trajectory.keeper_name
+                      ~trace_id:acc.Trajectory.trace_id entry
+                with Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Keeper.error "keeper:%s thinking persist failed: %s"
+                    meta.name (Printexc.to_string exn))
+             | Agent_sdk.Types.RedactedThinking _ ->
+               let entry : Trajectory.thinking_entry = {
+                 ts = now;
+                 ts_iso = now_iso;
+                 turn = acc.Trajectory.turn;
+                 content = "[redacted]";
+                 content_length = 0;
+                 redacted = true;
+               } in
+               (try Trajectory.append_thinking
+                      ~masc_root:acc.Trajectory.masc_root
+                      ~keeper_name:acc.Trajectory.keeper_name
+                      ~trace_id:acc.Trajectory.trace_id entry
+                with Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Keeper.error "keeper:%s redacted thinking persist failed: %s"
+                    meta.name (Printexc.to_string exn))
+             | _ -> ())
+             result.response.content
+         | None -> ());
         let reported_tool_names =
           List.filter_map (function
             | Agent_sdk.Types.ToolUse { name; _ } -> Some name | _ -> None)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -420,7 +420,7 @@ let handle_keeper_get_subroutes state req request reqd =
          in
          let include_thinking =
            Server_utils.bool_query_param req "include_thinking"
-             ~default:true
+             ~default:false
          in
          let masc_root = Filename.concat config.base_path ".masc" in
          let all_lines =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -418,17 +418,28 @@ let handle_keeper_get_subroutes state req request reqd =
              ~default:2000
            |> max 0 |> min 10000
          in
+         let include_thinking =
+           Server_utils.bool_query_param req "include_thinking"
+             ~default:true
+         in
          let masc_root = Filename.concat config.base_path ".masc" in
-         let entries =
-           Trajectory.read_entries ~masc_root ~keeper_name:m.name
+         let all_lines =
+           Trajectory.read_all_lines ~masc_root ~keeper_name:m.name
              ~trace_id:m.runtime.trace_id
          in
-         let total = List.length entries in
+         (* Filter out thinking entries if not requested *)
+         let lines =
+           if include_thinking then all_lines
+           else List.filter (function
+             | Trajectory.Tool_call _ -> true
+             | Trajectory.Thinking _ -> false) all_lines
+         in
+         let total = List.length lines in
          let recent =
-           if total <= limit then entries
+           if total <= limit then lines
            else
              let drop = total - limit in
-             List.filteri (fun i _e -> i >= drop) entries
+             List.filteri (fun i _e -> i >= drop) lines
          in
          let json = `Assoc [
            ("keeper", `String name);
@@ -436,7 +447,8 @@ let handle_keeper_get_subroutes state req request reqd =
            ("generation", `Int m.runtime.generation);
            ("total_entries", `Int total);
            ("showing", `Int (List.length recent));
-           ("entries", `List (List.map (Trajectory.entry_to_json ~result_max_len) recent));
+           ("entries", `List (List.map
+             (Trajectory.trajectory_line_to_json ~result_max_len) recent));
          ] in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd)

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -59,6 +59,23 @@ type trajectory = {
 }
 
 (* ================================================================ *)
+(* Thinking entries                                                  *)
+(* ================================================================ *)
+
+type thinking_entry = {
+  ts : float;
+  ts_iso : string;
+  turn : int;
+  content : string;
+  content_length : int;
+  redacted : bool;
+}
+
+type trajectory_line =
+  | Tool_call of tool_call_entry
+  | Thinking of thinking_entry
+
+(* ================================================================ *)
 (* Cost estimation                                                  *)
 (* ================================================================ *)
 
@@ -125,6 +142,29 @@ let entry_to_json ?(result_max_len = default_result_truncation) (e : tool_call_e
     ("cost_usd", `Float e.cost_usd);
   ]
 
+let default_thinking_truncation = 2000
+
+let thinking_entry_to_json ?(content_max_len = default_thinking_truncation) (e : thinking_entry) : Yojson.Safe.t =
+  let content =
+    if content_max_len > 0 && String.length e.content > content_max_len then
+      String.sub e.content 0 content_max_len ^ "..."
+    else e.content
+  in
+  `Assoc [
+    ("type", `String "thinking");
+    ("ts", `Float e.ts);
+    ("ts_iso", `String e.ts_iso);
+    ("turn", `Int e.turn);
+    ("content", `String content);
+    ("content_length", `Int e.content_length);
+    ("redacted", `Bool e.redacted);
+  ]
+
+let trajectory_line_to_json ?(result_max_len = default_result_truncation)
+    ?(content_max_len = default_thinking_truncation) = function
+  | Tool_call e -> entry_to_json ~result_max_len e
+  | Thinking e -> thinking_entry_to_json ~content_max_len e
+
 let trajectory_to_json (t : trajectory) : Yojson.Safe.t =
   `Assoc [
     ("scenario_id", Json_util.string_opt_to_json t.scenario_id);
@@ -161,6 +201,16 @@ let append_entry ~(masc_root : string) ~(keeper_name : string) ~(trace_id : stri
   ensure_dir dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let json = entry_to_json entry in
+  let line = Yojson.Safe.to_string json ^ "\n" in
+  Fs_compat.append_file path line
+
+(** Append a thinking block entry to the JSONL trajectory file. *)
+let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
+    (entry : thinking_entry) : unit =
+  let dir = trajectories_dir masc_root keeper_name in
+  ensure_dir dir;
+  let path = trajectory_path masc_root keeper_name trace_id in
+  let json = thinking_entry_to_json entry in
   let line = Yojson.Safe.to_string json ^ "\n" in
   Fs_compat.append_file path line
 
@@ -330,4 +380,52 @@ let read_entries ~(masc_root : string) ~(keeper_name : string) ~(trace_id : stri
                    | _ -> None);
                 cost_usd = json |> member "cost_usd" |> to_float;
               }
+        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
+
+(** Read all trajectory lines including thinking entries. *)
+let read_all_lines ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
+    : trajectory_line list =
+  let path = trajectory_path masc_root keeper_name trace_id in
+  if not (Sys.file_exists path) then []
+  else
+    let content = Fs_compat.load_file path in
+    String.split_on_char '\n' content
+    |> List.filter (fun line -> String.trim line <> "")
+    |> List.filter_map (fun line ->
+        try
+          let json = Yojson.Safe.from_string line in
+          let open Yojson.Safe.Util in
+          match json |> member "type" with
+          | `String "trajectory_summary" -> None
+          | `String "thinking" ->
+              Some (Thinking {
+                ts = json |> member "ts" |> to_float;
+                ts_iso = json |> member "ts_iso" |> to_string;
+                turn = json |> member "turn" |> to_int;
+                content = json |> member "content" |> to_string;
+                content_length = json |> member "content_length" |> to_int;
+                redacted = (match json |> member "redacted" with `Bool b -> b | _ -> false);
+              })
+          | _ ->
+              Some (Tool_call {
+                ts = json |> member "ts" |> to_float;
+                ts_iso = json |> member "ts_iso" |> to_string;
+                turn = json |> member "turn" |> to_int;
+                round = json |> member "round" |> to_int;
+                tool_name = json |> member "tool_name" |> to_string;
+                args_json = json |> member "args" |> Yojson.Safe.to_string;
+                gate_decision = Pass;
+                result =
+                  (match json |> member "result" with
+                   | `Null -> None
+                   | `String s -> Some s
+                   | _ -> None);
+                duration_ms = json |> member "duration_ms" |> to_int;
+                error =
+                  (match json |> member "error" with
+                   | `Null -> None
+                   | `String s -> Some s
+                   | _ -> None);
+                cost_usd = json |> member "cost_usd" |> to_float;
+              })
         with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -45,6 +45,25 @@ type trajectory = {
   task_id : string option;
 }
 
+(** {1 Thinking entries}
+
+    Thinking blocks from LLM responses, persisted alongside tool call entries
+    in the same JSONL file with [type = "thinking"]. *)
+
+type thinking_entry = {
+  ts : float;
+  ts_iso : string;
+  turn : int;
+  content : string;
+  content_length : int;
+  redacted : bool;
+}
+
+(** Tagged union for reading mixed JSONL (tool calls + thinking). *)
+type trajectory_line =
+  | Tool_call of tool_call_entry
+  | Thinking of thinking_entry
+
 (** {1 Cost estimation} *)
 
 val tool_cost_estimate : string -> float
@@ -57,6 +76,8 @@ val outcome_to_json : trajectory_outcome -> Yojson.Safe.t
 val outcome_to_string : trajectory_outcome -> string
 val default_result_truncation : int
 val entry_to_json : ?result_max_len:int -> tool_call_entry -> Yojson.Safe.t
+val thinking_entry_to_json : ?content_max_len:int -> thinking_entry -> Yojson.Safe.t
+val trajectory_line_to_json : ?result_max_len:int -> ?content_max_len:int -> trajectory_line -> Yojson.Safe.t
 val trajectory_to_json : trajectory -> Yojson.Safe.t
 
 (** {1 Persistence} *)
@@ -72,9 +93,18 @@ val append_summary :
   masc_root:string -> keeper_name:string -> trace_id:string ->
   trajectory -> unit
 
+val append_thinking :
+  masc_root:string -> keeper_name:string -> trace_id:string ->
+  thinking_entry -> unit
+
 val read_entries :
   masc_root:string -> keeper_name:string -> trace_id:string ->
   tool_call_entry list
+
+val read_all_lines :
+  masc_root:string -> keeper_name:string -> trace_id:string ->
+  trajectory_line list
+(** Read all entries (tool calls + thinking) from JSONL. *)
 
 (** {1 Accumulator}
 


### PR DESCRIPTION
## Summary
- OAS 응답의 Thinking/RedactedThinking 블록을 trajectory JSONL에 기록
- trajectory API(`GET /api/v1/keepers/:name/trajectory`)는 `include_thinking=true`를 명시해야 thinking 항목을 반환 (기본값 `false`로 개인정보 보호 opt-in)
- `fetchKeeperTrajectory`는 `include_thinking` 파라미터를 항상 명시적으로 전송 (`true`/`false`)
- thinking 블록의 turn 번호는 `!current_turn_ref`로 정확히 추적 (이전: 항상 0이었던 `acc.Trajectory.turn`)
- `TrajectoryEntry` 타입을 discriminated union으로 리팩터링: `ToolCallTrajectoryEntry | ThinkingTrajectoryEntry` — TypeScript가 `type` 필드로 정확히 narrowing
- `keeper-trajectory-timeline.ts`, `keeper-tool-telemetry.ts` 컴포넌트에서 thinking 항목 필터링 및 `ToolCallTrajectoryEntry` 타입 적용
- 대시보드 활동 추적에서 "내부 사고" 블록을 Markdown으로 렌더링
- 필터 칩에 "내부 사고" 추가
- `ThinkingDetail` 렌더링 테스트 추가 (비공개/비-비공개 두 케이스 모두)

## Product impact

- Promise affected: `ops visibility`
- User-visible change: 대시보드 세션 추적에 LLM 내부 사고 블록이 보라색 아이콘으로 표시되며, `include_thinking=true` 쿼리 파라미터를 통해 명시적으로 요청해야 반환됨

## Evidence

- `dune build --root .` 성공
- `tsc --noEmit` 통과 (변경된 파일 기준)
- Vitest 4개 테스트 통과 (`session-trace-entry.test.ts`): 기존 tool-call 2개 + 신규 ThinkingDetail 2개
- CodeQL 보안 스캔 이상 없음

## Review evidence

- Copilot code review 통과 (코드 리뷰 코멘트 없음)
- CodeQL Security Scan: 0 alerts

## Linked issue