### PR TITLE
fix(dashboard): align session-trace-entry tests with content hint threshold

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -31,7 +31,7 @@ function sampleToolCallEvent(overrides: Partial<UnifiedTraceEvent> = {}): Unifie
     detail: {},
     toolName: 'demo_tool',
     toolArgs: '{"arg":true}',
-    toolResult: '{"ok":true}',
+    toolResult: '{"ok":true,"detail":"completed"}',
     ...overrides,
   }
 }
@@ -48,6 +48,7 @@ describe('SessionTraceEntry', () => {
     expect(cards[0]?.textContent ?? '').toContain('"arg":true')
     expect(cards[1]?.getAttribute('data-title')).toBe('Result')
     expect(cards[1]?.textContent ?? '').toContain('"ok":true')
+    expect(cards[1]?.textContent ?? '').toContain('"detail":"completed"')
   })
 
   it('labels error payloads as Error when expanded', () => {
@@ -57,9 +58,14 @@ describe('SessionTraceEntry', () => {
 
     fireEvent.click(container.querySelector('summary') as HTMLElement)
 
+    // Args card is always rendered via JsonViewerCard
     const cards = screen.getAllByTestId('json-viewer-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[1]?.getAttribute('data-title')).toBe('Error')
-    expect(cards[1]?.textContent ?? '').toContain('plain error')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.getAttribute('data-title')).toBe('Args')
+
+    // Plain-text errors render through ResultViewer <pre>, not JsonViewerCard
+    // (detectContentHint returns 'plain' for non-JSON strings)
+    const errorPre = container.querySelector('pre')
+    expect(errorPre?.textContent ?? '').toContain('plain error')
   })
 })

--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -64,8 +64,11 @@ describe('SessionTraceEntry', () => {
     expect(cards[0]?.getAttribute('data-title')).toBe('Args')
 
     // Plain-text errors render through ResultViewer <pre>, not JsonViewerCard
-    // (detectContentHint returns 'plain' for non-JSON strings)
+    // (this specific 'plain error' payload is classified as 'plain')
     const errorPre = container.querySelector('pre')
     expect(errorPre?.textContent ?? '').toContain('plain error')
+
+    // ResultViewer should display the "Error" title label
+    expect(screen.getByText('Error')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- Dashboard CI가 main에서 실패하는 문제 수정
- `session-trace-entry.test.ts`가 2개의 `JsonViewerCard`를 기대했지만 `detectContentHint`가 20자 미만 JSON을 'plain'으로 분류하여 1개만 렌더링됨
- `toolResult` fixture를 20자 이상 JSON으로 확장하고, plain-text error 테스트의 기대값을 `<pre>` 렌더링에 맞게 수정
- 리뷰 피드백 반영: `ResultViewer`가 `isError=true`일 때 "Error" 타이틀 레이블을 렌더링하는지 검증하는 assertion 추가
- 리뷰 피드백 반영: 부정확한 인라인 주석 수정 ("detectContentHint returns 'plain' for non-JSON strings" → "this specific 'plain error' payload is classified as 'plain'")

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — test-only fix

## Evidence

- `vitest run session-trace-entry` — 2/2 pass

## Review evidence

N/A

## Linked issue