### PR TITLE
fix(dashboard): align trace entry test fixtures with detectContentHint thresholds

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -31,7 +31,7 @@ function sampleToolCallEvent(overrides: Partial<UnifiedTraceEvent> = {}): Unifie
     detail: {},
     toolName: 'demo_tool',
     toolArgs: '{"arg":true}',
-    toolResult: '{"ok":true}',
+    toolResult: '{"ok":true,"result":"success","detail":"completed normally"}',
     ...overrides,
   }
 }
@@ -48,6 +48,7 @@ describe('SessionTraceEntry', () => {
     expect(cards[0]?.textContent ?? '').toContain('"arg":true')
     expect(cards[1]?.getAttribute('data-title')).toBe('Result')
     expect(cards[1]?.textContent ?? '').toContain('"ok":true')
+    expect(cards[1]?.textContent ?? '').toContain('completed normally')
   })
 
   it('labels error payloads as Error when expanded', () => {
@@ -57,9 +58,11 @@ describe('SessionTraceEntry', () => {
 
     fireEvent.click(container.querySelector('summary') as HTMLElement)
 
+    // Args card renders as JsonViewerCard
     const cards = screen.getAllByTestId('json-viewer-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[1]?.getAttribute('data-title')).toBe('Error')
-    expect(cards[1]?.textContent ?? '').toContain('plain error')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.getAttribute('data-title')).toBe('Args')
+    // Error is plain text (<pre>), not JsonViewerCard — verify via text content
+    expect(container.textContent ?? '').toContain('plain error')
   })
 })


### PR DESCRIPTION
## Summary
- session-trace-entry 테스트 fixture의 toolResult가 11자로 detectContentHint의 JSON 최소 길이(20자) 미달
- JSON으로 분류되지 않아 ResultViewer가 JsonViewerCard 대신 pre 태그 렌더
- 전 PR의 Dashboard CI 실패 원인 (공통 blocker)

## Changes
- toolResult fixture: `{"ok":true}` → `{"ok":true,"result":"success","detail":"completed normally"}`
- error 테스트: plain text error는 pre 렌더가 정상 → 1 JsonViewerCard (Args만) 기대

## Test plan
- [x] vitest 로컬 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)