### PR TITLE
fix(dashboard): update session-trace-entry tests for ResultViewer

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -37,17 +37,19 @@ function sampleToolCallEvent(overrides: Partial<UnifiedTraceEvent> = {}): Unifie
 }
 
 describe('SessionTraceEntry', () => {
-  it('renders tool results through JsonViewerCard and parses JSON-string payloads', () => {
+  it('renders tool args through JsonViewerCard and result through ResultViewer', () => {
     const { container } = render(h(SessionTraceEntry, { event: sampleToolCallEvent() }))
 
     fireEvent.click(container.querySelector('summary') as HTMLElement)
 
+    // Args still uses JsonViewerCard
     const cards = screen.getAllByTestId('json-viewer-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[0]?.getAttribute('data-title')).toBe('Args')
+    expect(cards.length).toBeGreaterThanOrEqual(1)
     expect(cards[0]?.textContent ?? '').toContain('"arg":true')
-    expect(cards[1]?.getAttribute('data-title')).toBe('Result')
-    expect(cards[1]?.textContent ?? '').toContain('"ok":true')
+
+    // Result is rendered by ResultViewer (may be pre or JsonViewerCard depending on content type)
+    const resultText = container.textContent ?? ''
+    expect(resultText).toContain('"ok":true')
   })
 
   it('labels error payloads as Error when expanded', () => {
@@ -57,9 +59,9 @@ describe('SessionTraceEntry', () => {
 
     fireEvent.click(container.querySelector('summary') as HTMLElement)
 
-    const cards = screen.getAllByTestId('json-viewer-card')
-    expect(cards).toHaveLength(2)
-    expect(cards[1]?.getAttribute('data-title')).toBe('Error')
-    expect(cards[1]?.textContent ?? '').toContain('plain error')
+    // Error is rendered through ResultViewer with isError flag
+    const resultText = container.textContent ?? ''
+    expect(resultText).toContain('plain error')
+    expect(resultText).toContain('Error')
   })
 })


### PR DESCRIPTION
## Summary
- #5452에서 도입된 ResultViewer 구조 변경으로 기존 테스트가 깨짐
- JsonViewerCard 개수 대신 콘텐츠 존재 여부로 assertion 변경

## Test plan
- [x] `vitest run session-trace-entry.test.ts` 통과 (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)