### PR TITLE
refactor(dashboard): extract shared session list timeout constant

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -99,9 +99,7 @@ let render_timeout_s =
     ~default:60.0 ~min_v:10.0 ~max_v:300.0
 
 let session_list_timeout_s =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
-    ~default:5.0 ~min_v:1.0 ~max_v:30.0
+  Dashboard_http_helpers.dashboard_session_list_timeout_s ()
 
 let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -39,6 +39,10 @@ let dashboard_session_list_limit () =
   int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
     ~default:20 ~min_v:5 ~max_v:200
 
+let dashboard_session_list_timeout_s () =
+  float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
+    ~default:5.0 ~min_v:1.0 ~max_v:30.0
+
 let operator_snapshot_session_window_seconds () =
   float_of_env_default "MASC_OPERATOR_SNAPSHOT_SESSION_WINDOW_SECONDS"
     ~default:86400.0 ~min_v:300.0 ~max_v:(7.0 *. 86400.0)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -70,9 +70,8 @@ let _dashboard_mission_timeout_s =
   float_of_env_default "MASC_DASHBOARD_MISSION_TIMEOUT_S"
     ~default:25.0 ~min_v:10.0 ~max_v:120.0
 
-let dashboard_session_list_timeout_s =
-  float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
-    ~default:5.0 ~min_v:1.0 ~max_v:30.0
+let _session_list_timeout_s =
+  dashboard_session_list_timeout_s ()
 
 let dashboard_active_or_recent_sessions ~clock config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
@@ -80,7 +79,7 @@ let dashboard_active_or_recent_sessions ~clock config =
   let limit = dashboard_session_list_limit () in
   let sessions =
     match
-      Eio.Time.with_timeout clock dashboard_session_list_timeout_s (fun () ->
+      Eio.Time.with_timeout clock _session_list_timeout_s (fun () ->
           Ok
             (Team_session_store.list_sessions ~since_unix:cutoff_unix
                ~limit config))
@@ -89,7 +88,7 @@ let dashboard_active_or_recent_sessions ~clock config =
     | Error `Timeout ->
         Log.Dashboard.warn
           "dashboard session list timed out after %.0fs (limit=%d); serving without session rows"
-          dashboard_session_list_timeout_s limit;
+          _session_list_timeout_s limit;
         []
   in
   sessions


### PR DESCRIPTION
## Summary
- `MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S`가 2곳에서 독립적으로 정의되어 있던 문제 수정
- SSOT를 `dashboard_http_helpers.ml`에 배치, 두 소비처(`dashboard_execution.ml`, `server_dashboard_http_core.ml`)가 참조

## Changes
- `dashboard_http_helpers.ml`: `dashboard_session_list_timeout_s()` SSOT 함수 추가
- `dashboard_execution.ml`: 로컬 정의 → SSOT 호출로 교체
- `server_dashboard_http_core.ml`: 로컬 정의 → SSOT 호출로 교체

Closes #5393

## Test plan
- [x] `dune build --root .` passes
- [ ] CI Build and Test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)