### PR TITLE
fix(test): handle null latest_tool_call_count in snapshot audit test

### DIFF
--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -383,8 +383,11 @@ let test_snapshot_keeper_tool_audit_fallback () =
         (match tool_audit_source with
          | None -> true  (* null before first turn — expected *)
          | Some s -> List.mem s [ "keeper_metrics"; "keeper_decision_log" ]);
-      Alcotest.(check int) "tool audit count exposed as zero" 0
-        (keeper |> member "latest_tool_call_count" |> to_int);
+      Alcotest.(check bool) "tool audit count zero or absent before first turn" true
+        (match keeper |> member "latest_tool_call_count" with
+         | `Null -> true  (* None before any turn — expected *)
+         | `Int 0 -> true
+         | _ -> false);
       Alcotest.(check bool) "tool audit names remain empty" true
         ((keeper |> member "latest_tool_names" |> to_list) = []);
       Alcotest.(check bool) "diagnostic removed from snapshot" true


### PR DESCRIPTION
## Summary
- `latest_tool_call_count`는 `int option` — keeper_up 직후 첫 turn 전에는 `None`(null)
- test 34가 `to_int`를 사용해 null에서 crash
- `match` 패턴으로 변경: `Null` 또는 `Int 0` 모두 허용

## Impact
모든 열린 PR (#5459, #5460, #5440, #5461-5465)의 CI blocker 해결.

## Test plan
- [x] test 34 로컬 통과 확인
- [ ] CI Build and Test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)