### PR TITLE
fix(keeper): run Failing recovery even when presence_fresh is true

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -473,6 +473,28 @@ let keeper_agent_status (meta : keeper_meta) =
     | None -> Types.Active)
 ;;
 
+(** Reset stale turn failures so the keeper can exit Failing phase.
+    Called unconditionally after presence sync (whether I/O was skipped or not).
+    If the underlying issue persists, the next turn will re-fail. *)
+let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
+  let stale_turn_failures =
+    Keeper_registry.get_turn_failures
+      ~base_path:ctx.config.base_path meta.name
+  in
+  if stale_turn_failures > 0 then begin
+    Keeper_registry.reset_turn_failures
+      ~base_path:ctx.config.base_path meta.name;
+    ignore (Keeper_registry.dispatch_event
+      ~base_path:ctx.config.base_path meta.name
+      Keeper_state_machine.Heartbeat_ok);
+    ignore (Keeper_registry.dispatch_event
+      ~base_path:ctx.config.base_path meta.name
+      Keeper_state_machine.Turn_succeeded);
+    Log.Keeper.info
+      "heartbeat recovery: reset %d stale turn failures for %s"
+      stale_turn_failures meta.name
+  end
+
 let sync_keeper_presence
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
@@ -491,6 +513,7 @@ let sync_keeper_presence
     Log.Keeper.debug
       "presence sync skipped: fresh heartbeat %.0fs ago"
       (t_presence_start -. !last_successful_heartbeat_ts);
+    maybe_recover_from_failing ~ctx ~meta:meta_current;
     meta_current)
   else (
     try
@@ -527,25 +550,7 @@ let sync_keeper_presence
           Keeper_state_machine.Heartbeat_ok);
         Prometheus.inc_counter "masc_keeper_heartbeat_successes_total"
           ~labels:[("keeper", meta_current.name)] ();
-        (* Failing recovery: heartbeat success proves infrastructure is healthy.
-           Reset stale turn failures so the keeper can exit Failing phase.
-           Without this, a single turn failure traps the keeper in Failing forever
-           because no new turn runs → Turn_succeeded never dispatches → turn_healthy
-           stays false. If the underlying issue persists, the next turn will re-fail. *)
-        let stale_turn_failures =
-          Keeper_registry.get_turn_failures
-            ~base_path:ctx.config.base_path meta_current.name
-        in
-        if stale_turn_failures > 0 then begin
-          Keeper_registry.reset_turn_failures
-            ~base_path:ctx.config.base_path meta_current.name;
-          ignore (Keeper_registry.dispatch_event
-            ~base_path:ctx.config.base_path meta_current.name
-            Keeper_state_machine.Turn_succeeded);
-          Log.Keeper.info
-            "heartbeat recovery: reset %d stale turn failures for %s"
-            stale_turn_failures meta_current.name
-        end);
+        maybe_recover_from_failing ~ctx ~meta:meta_current);
       match write_meta ctx.config synced with
       | Ok () -> synced
       | Error e ->


### PR DESCRIPTION
## Summary
- `presence_fresh` 최적화가 Room.heartbeat() I/O뿐 아니라 Failing phase recovery(turn_failures reset + Heartbeat_ok)도 skip해서 keeper가 Failing에 무한 정체
- 복구 시간이 `max_silence()` 타이밍에 의존해 수분~수시간 불확정
- PR #5455 (online/offline 불일치)와 동일 근본 원인: `presence_fresh` 최적화의 부작용

## Root cause
```
presence_fresh = true
  → skip Room.heartbeat()
  → skip Heartbeat_ok dispatch    ← recovery 차단
  → skip turn_failures reset      ← Failing 탈출 불가
  → keeper stuck in Failing
```

## Fix
`presence_fresh` 브랜치 안에서도 `stale_turn_failures > 0`이면 recovery 실행:
- `reset_turn_failures` + `Heartbeat_ok` + `Turn_succeeded` dispatch
- Room.heartbeat() I/O는 여전히 skip (최적화 유지)

## Test plan
- [x] keeper_state_machine: 66/66 pass
- [x] keeper_unified: 95/95 pass
- [x] keeper_exec_status: 12/12 pass
- [ ] CI checks
- [ ] 서버 재빌드 후 Failing→Running 즉시 복구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)