### PR TITLE
fix(keeper): preserve proactive cooldown on transient network failures

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -41,7 +41,8 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
     These patterns match OAS cascade error messages for connection-level failures. *)
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
-    "connection closed"; "Connection refused" ]
+    "connection closed"; "Connection refused";
+    "Loading model"; "HTTP 503" ]
 
 let is_transient_network_error (msg : string) : bool =
   List.exists
@@ -674,7 +675,7 @@ let broadcast_lifecycle_events ~(name : string)
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
-    ~(reason : string) ?social_state () : keeper_meta =
+    ~(reason : string) ?(is_transient = false) ?social_state () : keeper_meta =
   let now_ts = Time_compat.now () in
   let is_scheduled_autonomous_cycle =
     is_scheduled_autonomous_cycle_of_observation observation
@@ -698,7 +699,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
           meta.runtime.proactive_rt.count_total
           + (if is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          if is_scheduled_autonomous_cycle then now_ts
+          if is_scheduled_autonomous_cycle && not is_transient then now_ts
           else meta.runtime.proactive_rt.last_ts;
         last_outcome =
           if is_scheduled_autonomous_cycle then Proactive_error
@@ -855,16 +856,18 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       in
       match run_result with
       | Error e ->
+          let is_transient = is_transient_network_error e in
           Log.Keeper.error
-            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms error=%s"
+            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name meta.cascade_name max_cascade_context latency_ms
+            (if is_transient then " (transient, cooldown preserved)" else "")
             (short_preview e);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e
           in
           let updated_meta =
             update_metrics_from_failure meta ~latency_ms ~observation ~reason:e
-              ~social_state ()
+              ~is_transient ~social_state ()
           in
           append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~outcome:"error" ~selected_mode:"error"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -42,7 +42,7 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
     "connection closed"; "Connection refused";
-    "Loading model"; "HTTP 503" ]
+    "unavailable_error"; "HTTP 503:" ]
 
 let is_transient_network_error (msg : string) : bool =
   List.exists

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -39,6 +39,7 @@ val update_metrics_from_failure :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   reason:string ->
+  ?is_transient:bool ->
   ?social_state:Keeper_social_model.social_state ->
   unit ->
   Keeper_types.keeper_meta

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2016,6 +2016,14 @@ let () =
             check bool "refused" true
               (UT.is_transient_network_error
                  "Eio.Io Net Connection refused"));
+          test_case "503 loading model detected" `Quick (fun () ->
+            check bool "503 loading" true
+              (UT.is_transient_network_error
+                 {|HTTP 503: {"error":{"message":"Loading model","type":"unavailable_error","code":503}}|}));
+          test_case "503 service unavailable detected" `Quick (fun () ->
+            check bool "503 plain" true
+              (UT.is_transient_network_error
+                 "Network error: All models failed: HTTP 503: Service Unavailable"));
           test_case "auth error not transient" `Quick (fun () ->
             check bool "auth 401" false
               (UT.is_transient_network_error

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2016,14 +2016,18 @@ let () =
             check bool "refused" true
               (UT.is_transient_network_error
                  "Eio.Io Net Connection refused"));
-          test_case "503 loading model detected" `Quick (fun () ->
-            check bool "503 loading" true
+          test_case "503 loading model (unavailable_error type)" `Quick (fun () ->
+            check bool "unavailable_error" true
               (UT.is_transient_network_error
                  {|HTTP 503: {"error":{"message":"Loading model","type":"unavailable_error","code":503}}|}));
-          test_case "503 service unavailable detected" `Quick (fun () ->
-            check bool "503 plain" true
+          test_case "503 service unavailable (HTTP 503: prefix)" `Quick (fun () ->
+            check bool "503 colon" true
               (UT.is_transient_network_error
                  "Network error: All models failed: HTTP 503: Service Unavailable"));
+          test_case "bare HTTP 503 without colon not transient" `Quick (fun () ->
+            check bool "bare 503" false
+              (UT.is_transient_network_error
+                 "expected HTTP 503 response"));
           test_case "auth error not transient" `Quick (fun () ->
             check bool "auth 401" false
               (UT.is_transient_network_error


### PR DESCRIPTION
## Summary
- Transient 네트워크 에러(Connection refused, HTTP 503, Loading model) 시 `proactive_rt.last_ts`를 갱신하지 않아 30분 cooldown 대신 다음 keepalive cycle에서 즉시 재시도
- HTTP 503과 "Loading model"을 transient error 패턴에 추가
- 기존 persistent failure(401, 429 등) 동작은 변경 없음

## Problem
llama-server 재시작 시 모든 keeper가 503/Connection refused로 실패 → `proactive_rt.last_ts = now` 갱신 → 30분 cooldown 대기 → 서버가 1초 만에 복귀해도 keeper가 30분간 침묵

## Fix
`update_metrics_from_failure`에 `~is_transient:bool` 파라미터 추가. Transient failure 시 `last_ts` 보존 → 이전 cooldown 타이머 유지 → 다음 keepalive cycle에서 재시도 가능.

## Test plan
- [x] `503 loading model detected` — HTTP 503 Loading model transient 인식
- [x] `503 service unavailable detected` — HTTP 503 일반 transient 인식
- [x] 기존 5개 transient 패턴 테스트 통과
- [x] auth/rate limit은 여전히 non-transient
- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)