### PR TITLE
fix(dashboard): lower detectContentHint thresholds for short JSON

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -69,13 +69,13 @@ function taskColor(type: string): string {
 type ContentHint = 'plain' | 'code' | 'diff' | 'json'
 
 function detectContentHint(text: string): ContentHint {
-  if (!text || text.length < 10) return 'plain'
+  if (!text || text.length < 5) return 'plain'
   const trimmed = text.trimStart()
   // Diff detection: unified diff markers
   if (trimmed.startsWith('@@') || trimmed.startsWith('---') || trimmed.startsWith('+++')
     || /^[-+] /m.test(trimmed.slice(0, 500))) return 'diff'
   // JSON detection
-  if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && trimmed.length > 20) {
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
     try { JSON.parse(trimmed); return 'json' } catch { /* not json */ }
   }
   // Code detection: indentation patterns or common code markers


### PR DESCRIPTION
## Summary
- `detectContentHint` had two thresholds preventing short JSON payloads from being classified as JSON:
  1. Early return `text.length < 10` — blocked `'{"ok":true}'` (9 chars)
  2. JSON detection guard `trimmed.length > 20` — blocked all short JSON even if early return passed
- Lowered early return to `< 5` and removed the `> 20` length guard (JSON.parse already validates)
- Fixed test error payload to use JSON string for consistent JsonViewerCard testing

## Root Cause
Dashboard CI failure across all open PRs — `session-trace-entry.test.ts` expected 2 json-viewer-card elements but only got 1 because `'{"ok":true}'` (test data for toolResult) was too short to trigger JSON detection.

## Test plan
- [x] `session-trace-entry.test.ts` — both tests pass locally (2/2)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)