### PR TITLE
perf(ci): pin floating deps to SHA and merge contract into build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,35 +246,6 @@ jobs:
           opam exec -- dune fmt 2>&1 || true
           # Note: dune fmt may not be available, skip if so
 
-      - name: Verification matrix summary
-        run: |
-          echo "::notice::Required CI gates: dune test, test_sse_storm_e2e, transport harness suite (contract harness runs in dedicated job)"
-          echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN/TURN/browser interop, viewer-local-e2e-check, swarm/team-session workload harnesses"
-
-  contract:
-    name: Contract Harness
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: [pr-sync-check, release-train]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup OCaml toolchain
-        uses: ./.github/actions/setup-ocaml-toolchain
-
-      - name: Pin external OCaml dependencies
-        uses: ./.github/actions/pin-ocaml-deps
-
-      - name: Install system and OCaml dependencies
-        uses: ./.github/actions/install-ocaml-deps
-
-      - name: Build server executable
-        run: |
-          opam exec -- dune build ./bin/main_eio.exe
-
       - name: Run contract harness suite
         env:
           ME_ROOT: /tmp/me
@@ -289,8 +260,8 @@ jobs:
 
       - name: Verification matrix summary
         run: |
-          echo "::notice::Required CI gates: contract harness suite"
-          echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN, viewer-local-e2e-check, swarm/team-session workload harnesses"
+          echo "::notice::Required CI gates: dune test, test_sse_storm_e2e, transport harness, contract harness"
+          echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN/TURN/browser interop, viewer-local-e2e-check, swarm/team-session workload harnesses"
 
   lint:
     name: Lint

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env bash
 # Pin private/external opam dependencies that are not published on opam-repository.
 #
-# NOTE: Most first-party packages here intentionally float on #main. OAS does
-# not float at install time, and mcp_protocol is pinned to the current released
-# single-package line so local setup does not drift across packaging changes.
-# OAS itself is ratcheted to the current upstream main commit in one shared
-# place so CI/runtime stay reproducible while still consuming the latest
-# required OAS feature set. Set AGENT_SDK_PIN_URL to a local checkout/worktree
-# path when validating unreleased OAS changes locally. If you need reproducible
-# builds for the remaining dependencies, pin them to specific commit SHAs
-# instead:
-#   opam pin add <pkg> <url>#<commit-sha> -n -y
+# All first-party packages are pinned to specific commit SHAs so that the
+# opam cache in CI stays stable across runs. When upstream changes are needed,
+# bump the SHA constants below and in oas-agent-sdk-pin.sh.
+#
+# To bump a pin:
+#   git ls-remote https://github.com/jeong-sik/<repo>.git HEAD
+#   # update the readonly SHA below, commit, push
+#
+# For local development against an unreleased checkout:
+#   AGENT_SDK_PIN_URL=/path/to/local/oas opam-pin-external-deps.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
+
+# --- Pin SHAs (bump these when upstream changes are needed) ---
+readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
+readonly GRPC_DIRECT_SHA="840b6cd6fe822d3577aa26147e7dc71ca25abecc"
+readonly NEO4J_BOLT_SHA="a1ca30c1247db5c58934e99306fe330419f7b21a"
 
 include_bisect=false
 include_compact_protocol=false
@@ -43,13 +48,13 @@ fi
 # as sub-libraries (mcp-protocol-sdk#60). Pin the released single-package line.
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0 -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
-opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-opam pin add neo4j_bolt_common https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+opam pin add ocaml-webrtc "https://github.com/jeong-sik/ocaml-webrtc.git#${WEBRTC_SHA}" -n -y
+opam pin add grpc-direct-core "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
+opam pin add grpc-direct "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
+opam pin add neo4j_packstream "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam pin add neo4j_bolt_common "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam pin add neo4j_bolt "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam pin add neo4j_bolt_eio "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
 
 if $include_bisect; then
   # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.4 by pinning.


### PR DESCRIPTION
## Summary
- floating `#main` pin 7개를 specific commit SHA로 고정 → opam 캐시 히트율 향상
- Contract Harness job을 Build and Test job에 통합 → setup 중복 제거

## 배경
CI에서 4개 OCaml job이 각각 독립적으로 `opam install . --deps-only`를 실행 (각 ~3분).
floating `#main` pin은 매 run마다 upstream fetch가 필요해서 캐시 효과 감소.

## 변경 상세

### 1. SHA 고정 (`scripts/opam-pin-external-deps.sh`)
| Package | Before | After |
|---------|--------|-------|
| ocaml-webrtc | `#main` | `#1b79936...` |
| grpc-direct, grpc-direct-core | `#main` | `#840b6cd...` |
| neo4j_* (4 packages) | `#main` | `#a1ca30c...` |

pin 업데이트: `git ls-remote <url> HEAD` → SHA 상수 수정 → commit

### 2. Contract → Build 통합 (`ci.yml`)
- Contract Harness job 삭제 (42s build + 14s test인데 4분 setup)
- Build and Test job에 step으로 추가
- Branch protection은 `Build and Test` + `Lint`만 required → 안전

## 예상 효과
- **Billable minutes**: -5min/run (contract setup 제거)
- **Cache hit runs**: opam install 3min → 수초 (SHA 불변 시)
- **Critical path**: +1min (contract step 추가) / -3min (opam cache hit) = net -2min

## Test plan
- [ ] CI가 green인지 확인 (특히 contract harness가 Build job 안에서 통과하는지)
- [ ] opam install step 시간 비교 (이전 run vs 이 PR의 run)