### PR TITLE
feat(keeper): structured feedback for empty tool search results

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -589,12 +589,15 @@ let run_turn
         not (List.mem name core)
         && name <> "keeper_tool_search")
     in
-    let new_discoveries =
+    let after_policy_filter =
       after_core_filter
       |> List.filter (fun (name, _) -> Hashtbl.mem allowed_set name)
+    in
+    let new_discoveries =
+      after_policy_filter
       |> List.filteri (fun i _ -> i < max_results)
     in
-    let filtered_by_policy = List.length after_core_filter - List.length new_discoveries in
+    let filtered_by_policy = List.length after_core_filter - List.length after_policy_filter in
     (* Register discovered tools for discovery-mode before_turn_hook
        using the actual current turn so decay/visibility stay aligned. *)
     let discovered_names = List.map fst new_discoveries in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -582,14 +582,19 @@ let run_turn
       let tbl = Hashtbl.create (List.length allowed) in
       List.iter (fun n -> Hashtbl.replace tbl n ()) allowed; tbl
     in
-    let new_discoveries =
+    let raw_hit_count = List.length retrieved in
+    let after_core_filter =
       retrieved
       |> List.filter (fun (name, _) ->
         not (List.mem name core)
-        && name <> "keeper_tool_search"
-        && Hashtbl.mem allowed_set name)
+        && name <> "keeper_tool_search")
+    in
+    let new_discoveries =
+      after_core_filter
+      |> List.filter (fun (name, _) -> Hashtbl.mem allowed_set name)
       |> List.filteri (fun i _ -> i < max_results)
     in
+    let filtered_by_policy = List.length after_core_filter - List.length new_discoveries in
     (* Register discovered tools for discovery-mode before_turn_hook
        using the actual current turn so decay/visibility stay aligned. *)
     let discovered_names = List.map fst new_discoveries in
@@ -627,11 +632,26 @@ let run_turn
         ]
       ) new_discoveries
     in
+    let hint = match results with
+      | [] when raw_hit_count = 0 ->
+        "No tools match this query. Try different keywords (e.g., 'worktree', 'board', 'github')."
+      | [] when filtered_by_policy > 0 ->
+        Printf.sprintf "Found %d matches but all filtered (already visible or policy-denied). Your current tools may already cover this need." filtered_by_policy
+      | [] ->
+        Printf.sprintf "Found %d raw BM25 hits but all are already in your core tool set." raw_hit_count
+      | _ -> "Call any of these tools by name in this or a future turn."
+    in
     `Assoc [
       ("ok", `Bool true);
       ("query", `String query);
       ("results", `List results);
-      ("hint", `String "Call any of these tools by name in this or a future turn.");
+      ("result_count", `Int (List.length results));
+      ("diagnostics", `Assoc [
+        ("raw_bm25_hits", `Int raw_hit_count);
+        ("filtered_by_core", `Int (raw_hit_count - List.length after_core_filter));
+        ("filtered_by_policy", `Int filtered_by_policy);
+      ]);
+      ("hint", `String hint);
     ]
   );
   (* Visibility measurement (#4961): log universe size vs BM25 scope *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -41,7 +41,8 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
     These patterns match OAS cascade error messages for connection-level failures. *)
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
-    "connection closed"; "Connection refused" ]
+    "connection closed"; "Connection refused";
+    "Loading model"; "HTTP 503" ]
 
 let is_transient_network_error (msg : string) : bool =
   List.exists
@@ -674,7 +675,7 @@ let broadcast_lifecycle_events ~(name : string)
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
-    ~(reason : string) ?social_state () : keeper_meta =
+    ~(reason : string) ?(is_transient = false) ?social_state () : keeper_meta =
   let now_ts = Time_compat.now () in
   let is_scheduled_autonomous_cycle =
     is_scheduled_autonomous_cycle_of_observation observation
@@ -698,7 +699,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
           meta.runtime.proactive_rt.count_total
           + (if is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          if is_scheduled_autonomous_cycle then now_ts
+          if is_scheduled_autonomous_cycle && not is_transient then now_ts
           else meta.runtime.proactive_rt.last_ts;
         last_outcome =
           if is_scheduled_autonomous_cycle then Proactive_error
@@ -855,16 +856,18 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       in
       match run_result with
       | Error e ->
+          let is_transient = is_transient_network_error e in
           Log.Keeper.error
-            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms error=%s"
+            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name meta.cascade_name max_cascade_context latency_ms
+            (if is_transient then " (transient, cooldown preserved)" else "")
             (short_preview e);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e
           in
           let updated_meta =
             update_metrics_from_failure meta ~latency_ms ~observation ~reason:e
-              ~social_state ()
+              ~is_transient ~social_state ()
           in
           append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~outcome:"error" ~selected_mode:"error"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -42,7 +42,7 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
 let transient_error_patterns =
   [ "Connection_reset"; "Broken pipe"; "End_of_file";
     "connection closed"; "Connection refused";
-    "Loading model"; "HTTP 503" ]
+    "unavailable_error"; "HTTP 503:" ]
 
 let is_transient_network_error (msg : string) : bool =
   List.exists

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -39,6 +39,7 @@ val update_metrics_from_failure :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   reason:string ->
+  ?is_transient:bool ->
   ?social_state:Keeper_social_model.social_state ->
   unit ->
   Keeper_types.keeper_meta

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2016,6 +2016,14 @@ let () =
             check bool "refused" true
               (UT.is_transient_network_error
                  "Eio.Io Net Connection refused"));
+          test_case "503 loading model detected" `Quick (fun () ->
+            check bool "503 loading" true
+              (UT.is_transient_network_error
+                 {|HTTP 503: {"error":{"message":"Loading model","type":"unavailable_error","code":503}}|}));
+          test_case "503 service unavailable detected" `Quick (fun () ->
+            check bool "503 plain" true
+              (UT.is_transient_network_error
+                 "Network error: All models failed: HTTP 503: Service Unavailable"));
           test_case "auth error not transient" `Quick (fun () ->
             check bool "auth 401" false
               (UT.is_transient_network_error

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2016,14 +2016,18 @@ let () =
             check bool "refused" true
               (UT.is_transient_network_error
                  "Eio.Io Net Connection refused"));
-          test_case "503 loading model detected" `Quick (fun () ->
-            check bool "503 loading" true
+          test_case "503 loading model (unavailable_error type)" `Quick (fun () ->
+            check bool "unavailable_error" true
               (UT.is_transient_network_error
                  {|HTTP 503: {"error":{"message":"Loading model","type":"unavailable_error","code":503}}|}));
-          test_case "503 service unavailable detected" `Quick (fun () ->
-            check bool "503 plain" true
+          test_case "503 service unavailable (HTTP 503: prefix)" `Quick (fun () ->
+            check bool "503 colon" true
               (UT.is_transient_network_error
                  "Network error: All models failed: HTTP 503: Service Unavailable"));
+          test_case "bare HTTP 503 without colon not transient" `Quick (fun () ->
+            check bool "bare 503" false
+              (UT.is_transient_network_error
+                 "expected HTTP 503 response"));
           test_case "auth error not transient" `Quick (fun () ->
             check bool "auth 401" false
               (UT.is_transient_network_error


### PR DESCRIPTION
## Summary
- keeper_tool_search 빈 결과 시 structured diagnostics 추가 (Samchon harness 원칙 #4)
- `raw_bm25_hits`, `filtered_by_core`, `filtered_by_policy` 진단 정보 포함
- 빈 결과 사유별 다른 hint 메시지 제공

## Problem
keeper가 `keeper_tool_search`를 호출하고 빈 결과를 받으면 "Call any of these tools..." hint만 나옴. LLM이 왜 결과가 없는지 알 수 없어 같은 검색을 반복하고 idle_turns 증가.

## Samchon Harness Synergy
> "when verification fails, provide structured error feedback" (Principle #4)

빈 결과의 3가지 사유를 구분:
1. `raw_bm25_hits=0` → "No tools match. Try different keywords."
2. `filtered_by_policy>0` → "Found N matches but all filtered by policy."
3. 기타 → "All matches already in your core tool set."

## Test plan
- [x] `dune build --root .` 성공
- [ ] keeper 실제 호출 시 diagnostics 포함 확인 (서버 재시작 후)

Depends on: #5472 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)