### PR TITLE
feat(dashboard): server-side tool stats API with p95 latency and sparkline timeline

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -792,3 +792,41 @@ export function fetchKeeperTrajectory(
     `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${limit != null ? `?limit=${limit}` : ''}`,
   )
 }
+
+// ── Keeper tool stats (server-side aggregation) ──────────
+
+export type ToolStat = {
+  name: string
+  call_count: number
+  success_count: number
+  failure_count: number
+  avg_duration_ms: number
+  p95_duration_ms: number
+  max_duration_ms: number
+  total_cost_usd: number
+  last_used_at: string
+}
+
+export type HourlyBucket = {
+  hour: string
+  call_count: number
+  error_count: number
+}
+
+export type ToolStatsResponse = {
+  keeper: string
+  window_hours: number
+  total_entries: number
+  tools: ToolStat[]
+  timeline: HourlyBucket[]
+}
+
+export function fetchKeeperToolStats(
+  name: string,
+  windowHours?: number,
+): Promise<ToolStatsResponse> {
+  const params = windowHours != null ? `?window_hours=${windowHours}` : ''
+  return get<ToolStatsResponse>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/tool-stats${params}`,
+  )
+}

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -1,85 +1,80 @@
 // Keeper tool telemetry — per-keeper tool usage statistics panel.
-// Aggregates trajectory entries client-side: call count, success rate,
-// avg latency, cost breakdown. Horizontal bar charts.
+// Uses server-side aggregation (GET /tool-stats) for p95 latency,
+// cross-trace aggregation, and hourly timeline sparklines.
 
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
-import { fetchKeeperTrajectory } from '../api/dashboard'
-import type { TrajectoryEntry } from '../api/dashboard'
+import { fetchKeeperToolStats } from '../api/dashboard'
+import type { ToolStat, HourlyBucket, ToolStatsResponse } from '../api/dashboard'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 
 // ── Types ─────────────────────────────────────────────
 
-interface ToolStat {
-  name: string
-  callCount: number
-  successCount: number
-  failureCount: number
-  totalDurationMs: number
-  avgDurationMs: number
-  maxDurationMs: number
-  totalCostUsd: number
-}
-
 interface TelemetryState {
-  stats: ToolStat[]
+  tools: ToolStat[]
+  timeline: HourlyBucket[]
   loading: boolean
   error: string | null
-  totalCalls: number
-  totalCostUsd: number
+  totalEntries: number
+  windowHours: number
 }
 
-// ── Aggregation ───────────────────────────────────────
+// ── Sparkline ─────────────────────────────────────────
 
-function aggregateToolStats(entries: TrajectoryEntry[]): ToolStat[] {
-  const map = new Map<string, {
-    callCount: number
-    successCount: number
-    failureCount: number
-    totalDurationMs: number
-    maxDurationMs: number
-    totalCostUsd: number
-  }>()
+function Sparkline({ buckets, height = 32 }: { buckets: HourlyBucket[]; height?: number }) {
+  if (buckets.length === 0) return null
 
-  for (const e of entries) {
-    const existing = map.get(e.tool_name)
-    const isFailure = Boolean(e.error) || e.gate?.status === 'reject'
-    if (existing) {
-      existing.callCount++
-      if (isFailure) existing.failureCount++
-      else existing.successCount++
-      existing.totalDurationMs += e.duration_ms
-      existing.maxDurationMs = Math.max(existing.maxDurationMs, e.duration_ms)
-      existing.totalCostUsd += e.cost_usd
-    } else {
-      map.set(e.tool_name, {
-        callCount: 1,
-        successCount: isFailure ? 0 : 1,
-        failureCount: isFailure ? 1 : 0,
-        totalDurationMs: e.duration_ms,
-        maxDurationMs: e.duration_ms,
-        totalCostUsd: e.cost_usd,
-      })
-    }
-  }
+  const maxCount = Math.max(...buckets.map(b => b.call_count), 1)
+  const width = buckets.length * 14
+  const barW = 10
+  const gap = 4
 
-  const stats: ToolStat[] = []
-  for (const [name, s] of map) {
-    stats.push({
-      name,
-      ...s,
-      avgDurationMs: Math.round(s.totalDurationMs / s.callCount),
-    })
-  }
-  stats.sort((a, b) => b.callCount - a.callCount)
-  return stats
+  const bars = buckets.map((b, i) => {
+    const barH = Math.max(1, (b.call_count / maxCount) * (height - 4))
+    const errH = b.error_count > 0 ? Math.max(1, (b.error_count / maxCount) * (height - 4)) : 0
+    const x = i * (barW + gap)
+    const y = height - barH
+    return html`
+      <g key=${i}>
+        <rect x=${x} y=${y} width=${barW} height=${barH} rx="1.5"
+          fill="var(--accent)" opacity="0.5" />
+        ${errH > 0 ? html`
+          <rect x=${x} y=${height - errH} width=${barW} height=${errH} rx="1.5"
+            fill="var(--bad)" opacity="0.7" />
+        ` : null}
+      </g>
+    `
+  })
+
+  // Hour labels — show first, middle, last
+  const labelIndices = [0, Math.floor(buckets.length / 2), buckets.length - 1]
+    .filter((v, i, a) => a.indexOf(v) === i) // dedupe
+  const labels = labelIndices.map(i => {
+    const b = buckets[i]
+    if (!b) return null
+    const label = b.hour.slice(11, 16) // "HH:MM"
+    const x = i * (barW + gap) + barW / 2
+    return html`
+      <text key=${'lbl' + i} x=${x} y=${height + 10} text-anchor="middle"
+        fill="var(--text-dim)" font-size="8" font-family="monospace">
+        ${label}
+      </text>
+    `
+  })
+
+  return html`
+    <svg width=${width} height=${height + 14} class="overflow-visible">
+      ${bars}
+      ${labels}
+    </svg>
+  `
 }
 
 // ── Bar chart helpers ─────────────────────────────────
 
 function SuccessRateBar({ stat }: { stat: ToolStat }) {
-  const successPct = stat.callCount > 0 ? (stat.successCount / stat.callCount) * 100 : 100
+  const successPct = stat.call_count > 0 ? (stat.success_count / stat.call_count) * 100 : 100
   const barColor = successPct >= 95 ? 'var(--ok)' : successPct >= 80 ? 'var(--warn)' : 'var(--bad)'
 
   return html`
@@ -102,23 +97,27 @@ interface KeeperToolTelemetryProps {
 
 export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   const state = useSignal<TelemetryState>({
-    stats: [], loading: false, error: null, totalCalls: 0, totalCostUsd: 0,
+    tools: [], timeline: [], loading: false, error: null, totalEntries: 0, windowHours: 24,
   })
 
   useEffect(() => {
     state.value = { ...state.value, loading: true, error: null }
     void (async () => {
       try {
-        const data = await fetchKeeperTrajectory(keeperName, 200)
-        const stats = aggregateToolStats(data.entries)
-        const totalCalls = data.entries.length
-        const totalCostUsd = data.entries.reduce((sum, e) => sum + e.cost_usd, 0)
-        state.value = { stats, loading: false, error: null, totalCalls, totalCostUsd }
+        const data: ToolStatsResponse = await fetchKeeperToolStats(keeperName, 24)
+        state.value = {
+          tools: data.tools,
+          timeline: data.timeline,
+          loading: false,
+          error: null,
+          totalEntries: data.total_entries,
+          windowHours: data.window_hours,
+        }
       } catch (err) {
         state.value = {
-          stats: [], loading: false,
+          tools: [], timeline: [], loading: false,
           error: err instanceof Error ? err.message : 'fetch failed',
-          totalCalls: 0, totalCostUsd: 0,
+          totalEntries: 0, windowHours: 24,
         }
       }
     })()
@@ -144,16 +143,17 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
     return html`<div class="text-xs text-[var(--bad)] py-3 text-center">${s.error}</div>`
   }
 
-  if (s.stats.length === 0) {
+  if (s.tools.length === 0) {
     return html`<div class="text-xs text-[var(--text-muted)] py-3 text-center italic">도구 호출 데이터 없음</div>`
   }
 
-  const maxCount = s.stats[0]?.callCount ?? 1
+  const totalCost = s.tools.reduce((sum, t) => sum + t.total_cost_usd, 0)
+  const maxCount = s.tools[0]?.call_count ?? 1
 
-  // Find slowest 3 calls
+  // Find tools with highest p95
   const slowest = useMemo(() =>
-    [...s.stats].sort((a, b) => b.maxDurationMs - a.maxDurationMs).slice(0, 3),
-    [s.stats],
+    [...s.tools].sort((a, b) => b.p95_duration_ms - a.p95_duration_ms).slice(0, 3),
+    [s.tools],
   )
 
   return html`
@@ -162,24 +162,37 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       ${'' /* Summary row */}
       <div class="flex gap-3 flex-wrap text-[11px]">
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
-          <span class="font-mono font-medium text-[var(--text-strong)]">${s.stats.length}</span> 도구
+          <span class="font-mono font-medium text-[var(--text-strong)]">${s.tools.length}</span> 도구
         </span>
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
-          <span class="font-mono font-medium text-[var(--text-strong)]">${s.totalCalls}</span> 호출
+          <span class="font-mono font-medium text-[var(--text-strong)]">${s.totalEntries}</span> 호출
         </span>
-        ${s.totalCostUsd > 0 ? html`
+        ${totalCost > 0 ? html`
           <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--accent-12)] border border-[rgba(71,184,255,0.15)] text-[var(--text-muted)]">
-            <span class="font-mono font-medium text-[var(--accent)]">$${s.totalCostUsd.toFixed(3)}</span>
+            <span class="font-mono font-medium text-[var(--accent)]">$${totalCost.toFixed(3)}</span>
           </span>
         ` : null}
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-dim)]">
+          ${s.windowHours}h 기간
+        </span>
       </div>
+
+      ${'' /* Hourly timeline sparkline */}
+      ${s.timeline.length > 1 ? html`
+        <div class="flex flex-col gap-1">
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">시간대별 활동</div>
+          <div class="overflow-x-auto py-1">
+            <${Sparkline} buckets=${s.timeline} height=${28} />
+          </div>
+        </div>
+      ` : null}
 
       ${'' /* Per-tool bar chart */}
       <div class="flex flex-col gap-1">
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">호출 빈도</div>
-        ${s.stats.slice(0, 15).map(stat => {
+        ${s.tools.slice(0, 15).map(stat => {
           const cat = toolCategory(stat.name)
-          const barWidth = (stat.callCount / maxCount) * 100
+          const barWidth = (stat.call_count / maxCount) * 100
           return html`
             <div class="flex items-center gap-2 py-1 group">
               <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-[9px] font-mono font-bold ${cat.color}">
@@ -189,13 +202,13 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </div>
               <div class="flex-1 h-3 rounded bg-[var(--white-5)] overflow-hidden">
-                <div class="h-full rounded transition-all duration-300 ${stat.failureCount > 0 ? '' : ''}"
-                  style="width: ${barWidth}%; background: ${stat.failureCount > 0 ? 'var(--warn)' : 'var(--accent)'}; opacity: 0.7">
+                <div class="h-full rounded transition-all duration-300"
+                  style="width: ${barWidth}%; background: ${stat.failure_count > 0 ? 'var(--warn)' : 'var(--accent)'}; opacity: 0.7">
                 </div>
               </div>
-              <span class="w-8 text-right text-[11px] font-mono text-[var(--text-muted)]">${stat.callCount}</span>
-              <span class="w-14 text-right text-[10px] font-mono ${durationColor(stat.avgDurationMs)}">
-                ${formatDuration(stat.avgDurationMs)}
+              <span class="w-8 text-right text-[11px] font-mono text-[var(--text-muted)]">${stat.call_count}</span>
+              <span class="w-14 text-right text-[10px] font-mono ${durationColor(stat.avg_duration_ms)}">
+                ${formatDuration(stat.avg_duration_ms)}
               </span>
             </div>
           `
@@ -203,29 +216,32 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       </div>
 
       ${'' /* Success rate table */}
-      ${s.stats.some(st => st.failureCount > 0) ? html`
+      ${s.tools.some(st => st.failure_count > 0) ? html`
         <div class="flex flex-col gap-1.5">
           <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">성공률</div>
-          ${s.stats.filter(st => st.failureCount > 0).map(stat => html`
+          ${s.tools.filter(st => st.failure_count > 0).map(stat => html`
             <div class="flex items-center gap-2">
               <span class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate">
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </span>
               <${SuccessRateBar} stat=${stat} />
-              <span class="text-[10px] text-[var(--bad)] w-10 text-right">${stat.failureCount}err</span>
+              <span class="text-[10px] text-[var(--bad)] w-10 text-right">${stat.failure_count}err</span>
             </div>
           `)}
         </div>
       ` : null}
 
-      ${'' /* Slowest calls */}
-      ${slowest.length > 0 && (slowest[0]?.maxDurationMs ?? 0) > 500 ? html`
+      ${'' /* P95 latency (slowest tools) */}
+      ${slowest.length > 0 && slowest[0]!.p95_duration_ms > 500 ? html`
         <div class="flex flex-col gap-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">최대 소요 시간</div>
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">P95 지연 시간</div>
           ${slowest.map(stat => html`
             <div class="flex items-center justify-between py-1 px-2 rounded bg-[var(--white-3)]">
               <span class="text-[11px] font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
-              <span class="text-[11px] font-mono font-medium ${durationColor(stat.maxDurationMs)}">${formatDuration(stat.maxDurationMs)}</span>
+              <div class="flex items-center gap-3">
+                <span class="text-[10px] text-[var(--text-dim)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
+                <span class="text-[11px] font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatDuration(stat.p95_duration_ms)}</span>
+              </div>
             </div>
           `)}
         </div>

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -383,6 +383,38 @@ let handle_keeper_get_subroutes state req request reqd =
       in
       Http.Response.json ~status ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if ends_with "/tool-stats" then
+    let name = extract_name "/tool-stats" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else if not (Keeper_config.validate_name name) then
+      Http.Response.json ~status:`Bad_request
+        (Printf.sprintf {|{"error":"invalid keeper name: %S"}|}
+           (String.escaped name)) reqd
+    else
+      let config = state.Mcp_server.room_config in
+      let masc_root = Filename.concat config.base_path ".masc" in
+      let window_hours =
+        Server_utils.int_query_param req "window_hours"
+          ~default:24
+        |> max 1 |> min 168  (* 1h .. 7d *)
+      in
+      let since = Time_compat.now () -. (float_of_int window_hours *. 3600.0) in
+      let entries =
+        Trajectory.read_entries_since ~masc_root ~keeper_name:name ~since
+      in
+      let tools = Trajectory.aggregate_tool_stats entries in
+      let timeline = Trajectory.hourly_timeline entries in
+      let json = `Assoc [
+        ("keeper", `String name);
+        ("window_hours", `Int window_hours);
+        ("total_entries", `Int (List.length entries));
+        ("tools", `List (List.map Trajectory.tool_stat_to_json tools));
+        ("timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline));
+      ] in
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string json) reqd
   else if ends_with "/trajectory" then
     let name = extract_name "/trajectory" in
     if String.length name = 0 then

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -290,6 +290,168 @@ let calls_in_current_turn (acc : accumulator) : int =
   List.length (List.filter (fun (e : tool_call_entry) -> e.turn = acc.turn) acc.entries)
 
 (* ================================================================ *)
+(* Tool stats aggregation                                          *)
+(* ================================================================ *)
+
+type tool_stat = {
+  name : string;
+  call_count : int;
+  success_count : int;
+  failure_count : int;
+  avg_duration_ms : int;
+  p95_duration_ms : int;
+  max_duration_ms : int;
+  total_cost_usd : float;
+  last_used_at : string;
+}
+
+type hourly_bucket = {
+  hour : string;
+  call_count : int;
+  error_count : int;
+}
+
+(** Compute p95 from a sorted int array. *)
+let p95_of_sorted (durations : int array) : int =
+  let n = Array.length durations in
+  if n = 0 then 0
+  else
+    let idx = min (n - 1) (int_of_float (Float.round (float_of_int n *. 0.95))) in
+    durations.(idx)
+
+let aggregate_tool_stats (entries : tool_call_entry list) : tool_stat list =
+  let tbl : (string, int list * int * int * float * float * string) Hashtbl.t =
+    Hashtbl.create 32
+  in
+  List.iter (fun (e : tool_call_entry) ->
+    let is_failure = Option.is_some e.error || (match e.gate_decision with Reject _ -> true | Pass -> false) in
+    match Hashtbl.find_opt tbl e.tool_name with
+    | None ->
+      let succ = if is_failure then 0 else 1 in
+      let fail = if is_failure then 1 else 0 in
+      Hashtbl.replace tbl e.tool_name
+        ([e.duration_ms], succ, fail, e.cost_usd, e.ts, e.ts_iso)
+    | Some (durations, succ, fail, cost, max_ts, max_iso) ->
+      let succ' = if is_failure then succ else succ + 1 in
+      let fail' = if is_failure then fail + 1 else fail in
+      let (ts', iso') = if e.ts > max_ts then (e.ts, e.ts_iso) else (max_ts, max_iso) in
+      Hashtbl.replace tbl e.tool_name
+        (e.duration_ms :: durations, succ', fail', cost +. e.cost_usd, ts', iso')
+  ) entries;
+  let stats = Hashtbl.fold (fun name (durations, succ, fail, cost, _max_ts, last_iso) acc ->
+    let count = succ + fail in
+    let total_dur = List.fold_left (+) 0 durations in
+    let avg = if count > 0 then total_dur / count else 0 in
+    let sorted = Array.of_list durations in
+    Array.sort compare sorted;
+    let max_d = if Array.length sorted > 0 then sorted.(Array.length sorted - 1) else 0 in
+    { name;
+      call_count = count;
+      success_count = succ;
+      failure_count = fail;
+      avg_duration_ms = avg;
+      p95_duration_ms = p95_of_sorted sorted;
+      max_duration_ms = max_d;
+      total_cost_usd = cost;
+      last_used_at = last_iso;
+    } :: acc
+  ) tbl [] in
+  List.sort (fun (a : tool_stat) (b : tool_stat) -> compare b.call_count a.call_count) stats
+
+(** Truncate a Unix timestamp to the start of its UTC hour. *)
+let hour_start_iso (ts : float) : string =
+  let t = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:00:00Z"
+    (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday t.tm_hour
+
+let hourly_timeline (entries : tool_call_entry list) : hourly_bucket list =
+  let tbl : (string, int * int) Hashtbl.t = Hashtbl.create 24 in
+  List.iter (fun (e : tool_call_entry) ->
+    let hour = hour_start_iso e.ts in
+    let is_err = Option.is_some e.error in
+    match Hashtbl.find_opt tbl hour with
+    | None -> Hashtbl.replace tbl hour (1, if is_err then 1 else 0)
+    | Some (c, errs) -> Hashtbl.replace tbl hour (c + 1, errs + (if is_err then 1 else 0))
+  ) entries;
+  let buckets = Hashtbl.fold (fun hour (call_count, error_count) acc ->
+    { hour; call_count; error_count } :: acc
+  ) tbl [] in
+  List.sort (fun a b -> String.compare a.hour b.hour) buckets
+
+let tool_stat_to_json (s : tool_stat) : Yojson.Safe.t =
+  `Assoc [
+    ("name", `String s.name);
+    ("call_count", `Int s.call_count);
+    ("success_count", `Int s.success_count);
+    ("failure_count", `Int s.failure_count);
+    ("avg_duration_ms", `Int s.avg_duration_ms);
+    ("p95_duration_ms", `Int s.p95_duration_ms);
+    ("max_duration_ms", `Int s.max_duration_ms);
+    ("total_cost_usd", `Float s.total_cost_usd);
+    ("last_used_at", `String s.last_used_at);
+  ]
+
+let hourly_bucket_to_json (b : hourly_bucket) : Yojson.Safe.t =
+  `Assoc [
+    ("hour", `String b.hour);
+    ("call_count", `Int b.call_count);
+    ("error_count", `Int b.error_count);
+  ]
+
+(** Read all .jsonl trace files for a keeper. Filter entries with ts >= since.
+    Scans the keeper's trajectory directory for all trace files. *)
+let read_entries_since ~(masc_root : string) ~(keeper_name : string) ~(since : float)
+    : tool_call_entry list =
+  let dir = trajectories_dir masc_root keeper_name in
+  if not (Sys.file_exists dir) then []
+  else
+    let files = Sys.readdir dir in
+    let all_entries = ref [] in
+    Array.iter (fun fname ->
+      if Filename.check_suffix fname ".jsonl" then begin
+        let path = Filename.concat dir fname in
+        (try
+           let content = Fs_compat.load_file path in
+           String.split_on_char '\n' content
+           |> List.iter (fun line ->
+             if String.trim line <> "" then
+               try
+                 let json = Yojson.Safe.from_string line in
+                 let open Yojson.Safe.Util in
+                 (match member "type" json with
+                  | `String "trajectory_summary" -> ()
+                  | _ ->
+                    let ts = json |> member "ts" |> to_float in
+                    if ts >= since then
+                      let entry = {
+                        ts;
+                        ts_iso = json |> member "ts_iso" |> to_string;
+                        turn = json |> member "turn" |> to_int;
+                        round = json |> member "round" |> to_int;
+                        tool_name = json |> member "tool_name" |> to_string;
+                        args_json = json |> member "args" |> Yojson.Safe.to_string;
+                        gate_decision = Pass;
+                        result =
+                          (match json |> member "result" with
+                           | `Null -> None
+                           | `String s -> Some s
+                           | _ -> None);
+                        duration_ms = json |> member "duration_ms" |> to_int;
+                        error =
+                          (match json |> member "error" with
+                           | `Null -> None
+                           | `String s -> Some s
+                           | _ -> None);
+                        cost_usd = json |> member "cost_usd" |> to_float;
+                      } in
+                      all_entries := entry :: !all_entries)
+               with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ())
+         with Sys_error _ -> ())
+      end
+    ) files;
+    List.sort (fun a b -> compare a.ts b.ts) !all_entries
+
+(* ================================================================ *)
 (* Read trajectory from JSONL (for replay/eval)                     *)
 (* ================================================================ *)
 

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -109,3 +109,43 @@ val detect_entropy :
     If [args_json] is provided, only consecutive IDENTICAL calls (same tool and same args) are counted. *)
 
 val calls_in_current_turn : accumulator -> int
+
+(** {1 Tool stats aggregation}
+
+    Server-side aggregation for the keeper tool telemetry dashboard.
+    Computes per-tool call counts, latency percentiles, cost, and
+    hourly activity buckets from raw trajectory entries. *)
+
+type tool_stat = {
+  name : string;
+  call_count : int;
+  success_count : int;
+  failure_count : int;
+  avg_duration_ms : int;
+  p95_duration_ms : int;
+  max_duration_ms : int;
+  total_cost_usd : float;
+  last_used_at : string;
+}
+
+type hourly_bucket = {
+  hour : string;  (** ISO8601 hour start, e.g. "2026-04-06T10:00:00Z" *)
+  call_count : int;
+  error_count : int;
+}
+
+val aggregate_tool_stats : tool_call_entry list -> tool_stat list
+(** Aggregate per-tool statistics from a list of entries.
+    Results sorted by call_count descending. *)
+
+val hourly_timeline : tool_call_entry list -> hourly_bucket list
+(** Bucket entries by hour. Results sorted chronologically. *)
+
+val tool_stat_to_json : tool_stat -> Yojson.Safe.t
+val hourly_bucket_to_json : hourly_bucket -> Yojson.Safe.t
+
+val read_entries_since :
+  masc_root:string -> keeper_name:string -> since:float ->
+  tool_call_entry list
+(** Read entries from all trace files for a keeper with ts >= [since].
+    Results sorted chronologically. *)


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/keepers/:name/tool-stats` endpoint — server-side aggregation of per-tool call count, success rate, p95/avg/max latency, cost, and hourly activity buckets across all trajectory JSONL files
- Upgrade `keeper-tool-telemetry.ts` from client-side aggregation (fetching 200 raw entries) to server-computed data with SVG sparkline timeline and P95 latency display
- New OCaml functions: `aggregate_tool_stats`, `hourly_timeline`, `read_entries_since` in `trajectory.ml`

## Changes
| File | Change |
|------|--------|
| `lib/trajectory.mli` | New types (`tool_stat`, `hourly_bucket`) + aggregation/serialization functions |
| `lib/trajectory.ml` | P95 calculation, hourly bucketing, multi-trace file scanning |
| `lib/server/server_dashboard_http_keeper_api.ml` | `/tool-stats` GET route (window_hours param, 1h-168h) |
| `dashboard/src/api/dashboard.ts` | `ToolStat`, `HourlyBucket`, `ToolStatsResponse` types + `fetchKeeperToolStats` |
| `dashboard/src/components/keeper-tool-telemetry.ts` | Server data, SVG Sparkline, P95 display |

## Test plan
- [ ] OCaml build passes (`dune build --root .`)
- [ ] Dashboard build passes (`npm run build`)
- [ ] API returns correct JSON for a keeper with trajectory data
- [ ] Sparkline renders hourly buckets visually
- [ ] P95 latency section shows when tools have >500ms p95

🤖 Generated with [Claude Code](https://claude.com/claude-code)