### PR TITLE
perf(ci): drop --force from lint dune build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
 
       - name: Build with warnings as errors
         run: |
-          opam exec -- dune build @install --force
+          opam exec -- dune build @install
         env:
           OCAMLPARAM: "_,warn-error=+a"
 


### PR DESCRIPTION
## Summary
- Lint job의 `dune build @install --force`에서 `--force` 제거

## 배경
`--force`는 dune 캐시를 완전히 무시하고 전체 rebuild를 강제한다. 하지만 `OCAMLPARAM="_,warn-error=+a"` 환경변수가 설정되면 dune이 컴파일러 플래그 변경을 감지하여 자동으로 관련 타겟을 재빌드한다. `--force`는 불필요.

## 예상 효과
- Lint build step: ~52s → dune 캐시 히트 시 수초
- #5475 (SHA pin + contract 통합)과 함께 적용 시 Lint job 전체 시간 단축

## Test plan
- [ ] Lint job이 warning-as-error 모드에서 정상 통과하는지 확인
- [ ] Lint build step 시간 비교