### PR TITLE
test(trajectory): add unit tests for tool stats aggregation

### DIFF
--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -499,7 +499,7 @@ let read_entries_since ~(masc_root : string) ~(keeper_name : string) ~(since : f
          with Sys_error _ -> ())
       end
     ) files;
-    List.sort (fun a b -> compare a.ts b.ts) !all_entries
+    List.sort (fun (a : tool_call_entry) (b : tool_call_entry) -> compare a.ts b.ts) !all_entries
 
 (* ================================================================ *)
 (* Read trajectory from JSONL (for replay/eval)                     *)

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -275,6 +275,162 @@ let test_task_id_null_when_none () =
    deleted from Trajectory (#3029). Pricing belongs to OAS cascade. *)
 
 (* ================================================================ *)
+(* Test: aggregate_tool_stats                                        *)
+(* ================================================================ *)
+
+let mk_entry ?(error = None) ?(gate = Trajectory.Pass) name dur cost ts_iso =
+  { Trajectory.
+    ts = 1000.0; ts_iso; turn = 1; round = 0;
+    tool_name = name; args_json = "{}";
+    gate_decision = gate;
+    result = Some "ok"; duration_ms = dur;
+    error; cost_usd = cost;
+  }
+
+let test_aggregate_basic () =
+  let entries = [
+    mk_entry "keeper_bash" 100 0.001 "2026-04-06T10:00:00Z";
+    mk_entry "keeper_bash" 200 0.002 "2026-04-06T10:01:00Z";
+    mk_entry "keeper_bash" 300 0.001 "2026-04-06T10:02:00Z";
+    mk_entry "keeper_fs_read" 50 0.0 "2026-04-06T10:03:00Z";
+  ] in
+  let stats = Trajectory.aggregate_tool_stats entries in
+  Alcotest.(check int) "tool count" 2 (List.length stats);
+  (* keeper_bash has more calls, should be first *)
+  let bash = List.hd stats in
+  Alcotest.(check string) "first tool" "keeper_bash" bash.Trajectory.name;
+  Alcotest.(check int) "bash call count" 3 bash.Trajectory.call_count;
+  Alcotest.(check int) "bash success count" 3 bash.Trajectory.success_count;
+  Alcotest.(check int) "bash failure count" 0 bash.Trajectory.failure_count;
+  Alcotest.(check int) "bash avg duration" 200 bash.Trajectory.avg_duration_ms;
+  Alcotest.(check int) "bash max duration" 300 bash.Trajectory.max_duration_ms
+
+let test_aggregate_with_errors () =
+  let entries = [
+    mk_entry "keeper_bash" 100 0.001 "2026-04-06T10:00:00Z";
+    mk_entry ~error:(Some "timeout") "keeper_bash" 5000 0.001 "2026-04-06T10:01:00Z";
+    mk_entry ~gate:(Trajectory.Reject "denied") "keeper_bash" 0 0.0 "2026-04-06T10:02:00Z";
+  ] in
+  let stats = Trajectory.aggregate_tool_stats entries in
+  Alcotest.(check int) "tool count" 1 (List.length stats);
+  let s = List.hd stats in
+  Alcotest.(check int) "call count" 3 s.Trajectory.call_count;
+  Alcotest.(check int) "success" 1 s.Trajectory.success_count;
+  Alcotest.(check int) "failure" 2 s.Trajectory.failure_count
+
+let test_aggregate_empty () =
+  let stats = Trajectory.aggregate_tool_stats [] in
+  Alcotest.(check int) "empty" 0 (List.length stats)
+
+let test_aggregate_p95 () =
+  (* 20 entries: durations 100, 200, ..., 2000. p95 index = floor(20 * 0.95) = 19 -> 2000 *)
+  let entries = List.init 20 (fun i ->
+    mk_entry "keeper_bash" ((i + 1) * 100) 0.0
+      (Printf.sprintf "2026-04-06T10:%02d:00Z" i)
+  ) in
+  let stats = Trajectory.aggregate_tool_stats entries in
+  let s = List.hd stats in
+  (* p95 of [100..2000] with 20 items — idx 19 = 2000 *)
+  Alcotest.(check int) "p95" 2000 s.Trajectory.p95_duration_ms
+
+(* ================================================================ *)
+(* Test: hourly_timeline                                             *)
+(* ================================================================ *)
+
+let test_hourly_single_bucket () =
+  let entries = [
+    { (mk_entry "keeper_bash" 100 0.0 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
+    { (mk_entry "keeper_bash" 100 0.0 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
+  ] in
+  let timeline = Trajectory.hourly_timeline entries in
+  (* Both have the same ts so should be 1 bucket *)
+  Alcotest.(check int) "bucket count" 1 (List.length timeline);
+  let b = List.hd timeline in
+  Alcotest.(check int) "call count" 2 b.Trajectory.call_count;
+  Alcotest.(check int) "error count" 0 b.Trajectory.error_count
+
+let test_hourly_with_errors () =
+  let entries = [
+    { (mk_entry "keeper_bash" 100 0.0 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
+    { (mk_entry ~error:(Some "fail") "keeper_bash" 100 0.0 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
+  ] in
+  let timeline = Trajectory.hourly_timeline entries in
+  let b = List.hd timeline in
+  Alcotest.(check int) "error count" 1 b.Trajectory.error_count
+
+let test_hourly_empty () =
+  let timeline = Trajectory.hourly_timeline [] in
+  Alcotest.(check int) "empty" 0 (List.length timeline)
+
+(* ================================================================ *)
+(* Test: tool_stat_to_json / hourly_bucket_to_json                   *)
+(* ================================================================ *)
+
+let test_tool_stat_json_roundtrip () =
+  let stat : Trajectory.tool_stat = {
+    name = "keeper_bash";
+    call_count = 10;
+    success_count = 9;
+    failure_count = 1;
+    avg_duration_ms = 150;
+    p95_duration_ms = 500;
+    max_duration_ms = 800;
+    total_cost_usd = 0.01;
+    last_used_at = "2026-04-06T12:00:00Z";
+  } in
+  let json = Trajectory.tool_stat_to_json stat in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "name" "keeper_bash" (json |> member "name" |> to_string);
+  Alcotest.(check int) "call_count" 10 (json |> member "call_count" |> to_int);
+  Alcotest.(check int) "p95" 500 (json |> member "p95_duration_ms" |> to_int);
+  Alcotest.(check int) "failure" 1 (json |> member "failure_count" |> to_int)
+
+let test_hourly_bucket_json () =
+  let b : Trajectory.hourly_bucket = {
+    hour = "2026-04-06T10:00:00Z";
+    call_count = 5;
+    error_count = 1;
+  } in
+  let json = Trajectory.hourly_bucket_to_json b in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "hour" "2026-04-06T10:00:00Z" (json |> member "hour" |> to_string);
+  Alcotest.(check int) "calls" 5 (json |> member "call_count" |> to_int);
+  Alcotest.(check int) "errors" 1 (json |> member "error_count" |> to_int)
+
+(* ================================================================ *)
+(* Test: read_entries_since (file-based)                             *)
+(* ================================================================ *)
+
+let test_read_entries_since () =
+  with_tmpdir (fun dir ->
+    let masc_root = dir in
+    let keeper = "test-keeper" in
+    (* Create a trajectory file manually *)
+    let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
+    ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote traj_dir)));
+    let path = Filename.concat traj_dir "trace-100.jsonl" in
+    let entry_json ts = Printf.sprintf
+      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"keeper_bash","args":"{}","result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|}
+      ts
+    in
+    let oc = open_out path in
+    Printf.fprintf oc "%s\n" (entry_json 1000.0);
+    Printf.fprintf oc "%s\n" (entry_json 2000.0);
+    Printf.fprintf oc "%s\n" (entry_json 3000.0);
+    close_out oc;
+    (* Read since ts=1500 should get 2 entries *)
+    let entries = Trajectory.read_entries_since ~masc_root ~keeper_name:keeper ~since:1500.0 in
+    Alcotest.(check int) "entries since 1500" 2 (List.length entries);
+    (* Read since ts=0 should get all 3 *)
+    let all = Trajectory.read_entries_since ~masc_root ~keeper_name:keeper ~since:0.0 in
+    Alcotest.(check int) "all entries" 3 (List.length all))
+
+let test_read_entries_since_no_dir () =
+  with_tmpdir (fun dir ->
+    let entries = Trajectory.read_entries_since ~masc_root:dir ~keeper_name:"nonexistent" ~since:0.0 in
+    Alcotest.(check int) "no dir" 0 (List.length entries))
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -312,5 +468,24 @@ let () =
       Alcotest.test_case "finalize propagates" `Quick test_finalize_propagates_task_id;
       Alcotest.test_case "json with task_id" `Quick test_task_id_in_trajectory_json;
       Alcotest.test_case "json null when none" `Quick test_task_id_null_when_none;
+    ]);
+    ("aggregate_tool_stats", [
+      Alcotest.test_case "basic aggregation" `Quick test_aggregate_basic;
+      Alcotest.test_case "with errors and rejected gates" `Quick test_aggregate_with_errors;
+      Alcotest.test_case "empty input" `Quick test_aggregate_empty;
+      Alcotest.test_case "p95 calculation" `Quick test_aggregate_p95;
+    ]);
+    ("hourly_timeline", [
+      Alcotest.test_case "single bucket" `Quick test_hourly_single_bucket;
+      Alcotest.test_case "with errors" `Quick test_hourly_with_errors;
+      Alcotest.test_case "empty input" `Quick test_hourly_empty;
+    ]);
+    ("json_serialization", [
+      Alcotest.test_case "tool_stat to json" `Quick test_tool_stat_json_roundtrip;
+      Alcotest.test_case "hourly_bucket to json" `Quick test_hourly_bucket_json;
+    ]);
+    ("read_entries_since", [
+      Alcotest.test_case "filter by timestamp" `Quick test_read_entries_since;
+      Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
     ]);
   ]

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -278,9 +278,9 @@ let test_task_id_null_when_none () =
 (* Test: aggregate_tool_stats                                        *)
 (* ================================================================ *)
 
-let mk_entry ?(error = None) ?(gate = Trajectory.Pass) name dur cost ts_iso =
+let mk_entry ?(ts = 1000.0) ?(error = None) ?(gate = Trajectory.Pass) name dur cost ts_iso =
   { Trajectory.
-    ts = 1000.0; ts_iso; turn = 1; round = 0;
+    ts; ts_iso; turn = 1; round = 0;
     tool_name = name; args_json = "{}";
     gate_decision = gate;
     result = Some "ok"; duration_ms = dur;
@@ -323,7 +323,7 @@ let test_aggregate_empty () =
   Alcotest.(check int) "empty" 0 (List.length stats)
 
 let test_aggregate_p95 () =
-  (* 20 entries: durations 100, 200, ..., 2000. p95 index = floor(20 * 0.95) = 19 -> 2000 *)
+  (* 20 entries: durations 100, 200, ..., 2000. p95 index = round(20 * 0.95) = 19 -> 2000 *)
   let entries = List.init 20 (fun i ->
     mk_entry "keeper_bash" ((i + 1) * 100) 0.0
       (Printf.sprintf "2026-04-06T10:%02d:00Z" i)
@@ -343,7 +343,7 @@ let test_hourly_single_bucket () =
     { (mk_entry "keeper_bash" 100 0.0 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
   ] in
   let timeline = Trajectory.hourly_timeline entries in
-  (* Both have the same ts so should be 1 bucket *)
+  (* Both entries fall in the same hour bucket (25 min apart) *)
   Alcotest.(check int) "bucket count" 1 (List.length timeline);
   let b = List.hd timeline in
   Alcotest.(check int) "call count" 2 b.Trajectory.call_count;
@@ -410,7 +410,7 @@ let test_read_entries_since () =
     ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote traj_dir)));
     let path = Filename.concat traj_dir "trace-100.jsonl" in
     let entry_json ts = Printf.sprintf
-      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"keeper_bash","args":"{}","result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|}
+      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"keeper_bash","args":{},"result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|}
       ts
     in
     let oc = open_out path in


### PR DESCRIPTION
## Summary
- 11 new Alcotest cases for Phase 3 server-side aggregation functions
- Fix type annotation in `read_entries_since` sort (thinking_entry field collision after Phase 2 merge)

## Test plan
- [x] `dune exec test/test_trajectory.exe` — 30/30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)