### PR TITLE
fix(policy): add keeper_github to coding and delivery presets

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -36,6 +36,9 @@ tools = ["keeper_fs_edit"]
 [groups.library]
 tools = ["keeper_library_search", "keeper_library_read"]
 
+[groups.github]
+tools = ["keeper_github"]
+
 # Shard-backed groups: tool names resolved from Tool_shard at runtime.
 [groups.governance]
 shard = "governance"
@@ -86,7 +89,7 @@ groups = ["base", "board", "coordination", "voice", "governance"]
 masc_groups = ["core"]
 
 [presets.coding]
-groups = ["base", "board", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding"]
+groups = ["base", "board", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github"]
 masc_groups = ["core", "coding"]
 
 [presets.research]
@@ -96,7 +99,7 @@ masc_groups = ["core"]
 # Delivery preset: research + coding for keepers that need to produce code changes.
 # Use for keepers with soul_profile=delivery whose goal involves PRs, issues, or code fixes.
 [presets.delivery]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board", "governance", "autoresearch", "coding_shard", "coding"]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board", "governance", "autoresearch", "coding_shard", "coding", "github"]
 masc_groups = ["core", "coding"]
 
 [presets.full]


### PR DESCRIPTION
## Summary
- `keeper_github` (gh CLI 래퍼)가 `tool_policy.toml` 어떤 group에도 없어 keeper가 GitHub 접근 불가
- `[groups.github]` 추가, `coding`과 `delivery` preset에 포함

## Evidence
- 서버 로그 (2026-04-06): keeper_github 호출 0건
- `rg keeper_github config/tool_policy.toml` → no matches

Closes #5478

## Test plan
- [x] `test_tool_surface_ssot` 25/25 통과
- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)