### PR TITLE
build: bump agent_sdk pin 0.101.2 → 0.103.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.101.2))
+  (agent_sdk (>= 0.103.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.101.2"}
+  "agent_sdk" {>= "0.103.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.101.2"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.103.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="971007cf674efb476339054d8790276d3a2cdd79"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.101.2"
+readonly OAS_AGENT_SDK_SHA="4ab03a6fa8353965542a2ef96b5a9715cd3aef99"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.103.0"


### PR DESCRIPTION
## Summary
- Bumps OAS (agent_sdk) from 0.101.2 to 0.103.0
- Picks up oas#644: Nudge hook stops resetting idle counter, fixing infinite nudge loops

## Context
Observed in production: admin-keeper looped `keeper_tools_list` indefinitely, example looped `keeper_board_list`. Nudge reset `consecutive_idle_turns` to 0 each time, preventing Skip (threshold=3) from firing.

## Test plan
- [x] `dune build` passes locally
- [ ] CI green
- [ ] Deploy and verify keepers exit idle loops within 3 turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)