### PR TITLE
fix: disambiguate tool_call_entry.ts in trajectory sort comparator

### DIFF
--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -499,7 +499,7 @@ let read_entries_since ~(masc_root : string) ~(keeper_name : string) ~(since : f
          with Sys_error _ -> ())
       end
     ) files;
-    List.sort (fun a b -> compare a.ts b.ts) !all_entries
+    List.sort (fun (a : tool_call_entry) (b : tool_call_entry) -> compare a.ts b.ts) !all_entries
 
 (* ================================================================ *)
 (* Read trajectory from JSONL (for replay/eval)                     *)


### PR DESCRIPTION
## Summary
- thinking_entry (#5461)가 tool_call_entry와 동일한 `ts` 필드를 가지면서, OCaml 레코드 필드 해석 규칙(마지막 정의 우선)에 의해 `read_entries_since`의 sort lambda가 `thinking_entry list`로 추론됨
- main 빌드가 깨진 상태 — 타입 어노테이션 추가로 수정

## Change
`List.sort (fun a b -> ...)` → `List.sort (fun (a : tool_call_entry) (b : tool_call_entry) -> ...)`

## Test plan
- [x] `dune build` 통과
- [x] `test_keeper_state_machine` 66개 테스트 전부 통과

Generated with [Claude Code](https://claude.com/claude-code)