### PR TITLE
feat(keeper): make tool discovery default, remove MASC_KEEPER_TOOL_DISCOVERY flag

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -374,7 +374,6 @@ let run_turn
     Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
-        if Keeper_exec_tools.tool_discovery_enabled () then
           Keeper_discovered_tools.mark_used !discovered_ref
             ~turn:!current_turn_ref ~name)
       ()
@@ -838,20 +837,17 @@ let run_turn
             ~tools:scoped_tools
           |> Tool_portal.filter_visible_tool_names portal_ctx
         in
-        (* In discovery mode, bypass Tool_selector BM25 and use only
-           core + actively discovered tools.  The keeper discovers tools
-           on demand via keeper_tool_search. *)
+        (* Core + discovered tools: the keeper discovers additional tools
+           on demand via keeper_tool_search.  BM25 auto-selection is replaced
+           by explicit discovery — only tools the keeper asked for appear. *)
         let effective_selected =
-          if Keeper_exec_tools.tool_discovery_enabled () then
-            let core = Keeper_exec_tools.effective_core_tools () in
-            let discovered =
-              Keeper_discovered_tools.active_names !discovered_ref ~turn
-            in
-            let _ = Keeper_discovered_tools.decay !discovered_ref ~turn in
-            Keeper_types.dedupe_keep_order (core @ discovered)
-            |> Tool_portal.filter_visible_tool_names portal_ctx
-          else
-            selected_names
+          let core = Keeper_exec_tools.effective_core_tools () in
+          let discovered =
+            Keeper_discovered_tools.active_names !discovered_ref ~turn
+          in
+          let _ = Keeper_discovered_tools.decay !discovered_ref ~turn in
+          Keeper_types.dedupe_keep_order (core @ discovered)
+          |> Tool_portal.filter_visible_tool_names portal_ctx
         in
         (* Apply runtime tool overlay (masc_tool_grant/revoke) and
            intersect with the full dispatch universe. *)

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -34,9 +34,6 @@ val core_discovery_tools : string list
 (** Returns [core_discovery_tools] when discovery enabled, else [core_always_tools]. *)
 val effective_core_tools : unit -> string list
 
-(** Whether MASC_KEEPER_TOOL_DISCOVERY env var is set. *)
-val tool_discovery_enabled : unit -> bool
-
 (** Schema for the keeper_tool_search tool. *)
 val keeper_tool_search_schema : Types.tool_schema
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -34,34 +34,19 @@ let core_always_tools =
   [ "keeper_context_status"; "keeper_tools_list";
     "masc_status"; "masc_heartbeat"; "extend_turns" ]
 
-(** Expanded core set for tool-discovery mode.  These tools are always
-    visible when [MASC_KEEPER_TOOL_DISCOVERY=true]; all other tools are
-    discoverable via [keeper_tool_search]. *)
+(** Core tools always visible to the LLM.  All other tools are
+    discoverable on demand via [keeper_tool_search]. *)
 let core_discovery_tools =
-  (* Explicit superset of core_always_tools: all always-visible tools are
-     present here so discovery mode preserves their always-visible guarantee. *)
   core_always_tools @
-  [ (* Search / discovery entry point *)
-    "keeper_tool_search";
-    (* Coordination essentials *)
+  [ "keeper_tool_search";
     "keeper_broadcast"; "keeper_tasks_list";
     "keeper_task_claim"; "keeper_task_done";
-    (* Knowledge *)
     "keeper_memory_search"; "keeper_time_now";
-    (* Filesystem *)
     "keeper_fs_read";
-    (* Board essentials *)
     "keeper_board_get"; "keeper_board_post"; "keeper_board_comment";
   ]
 
-let tool_discovery_enabled () : bool =
-  match Sys.getenv_opt "MASC_KEEPER_TOOL_DISCOVERY" with
-  | Some ("true" | "1") -> true
-  | _ -> false
-
-let effective_core_tools () =
-  if tool_discovery_enabled () then core_discovery_tools
-  else core_always_tools
+let effective_core_tools () = core_discovery_tools
 
 let core_always_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length core_always_tools) in


### PR DESCRIPTION
## Summary
- `MASC_KEEPER_TOOL_DISCOVERY` 환경변수 제거
- Tool discovery (core 15개 + keeper_tool_search)가 기본 모드
- BM25 auto-selection 대신 명시적 discovery 모델로 전환
- `-36줄, +14줄` — flag 분기 제거로 코드 단순화

## Motivation
Tool search는 기본 기능이다. Feature flag로 게이팅하는 건 과잉 방어.
- keeper_tool_search E2E 동작 확인됨 (sangsu 2회 호출)
- Samchon harness 원칙 기반 structured feedback 이미 내장
- core tools 15개가 생존 필수 도구 커버

## Before/After
| | Before | After |
|---|---|---|
| 기본 모드 | BM25 ~25 tools/turn | core 15 + discovered |
| Flag 필요 | `MASC_KEEPER_TOOL_DISCOVERY=true` | 없음 |
| 코드 경로 | if/else 분기 3곳 | 단일 경로 |

## Test plan
- [x] `dune build --root . lib/keeper` 성공
- [x] `tool_discovery_enabled` 참조 0건 확인
- [ ] 서버 재시작 후 keeper가 core+discovered 모드로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)