### PR TITLE
feat(dashboard): keeper fleet overview with pipeline stage and context comparison

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -13,6 +13,7 @@ import { AgentProfile } from './agent-profile'
 import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
+import { KeeperFleetOverview } from './keeper-fleet-overview'
 
 type AgentsView = 'all' | 'agents' | 'keepers'
 
@@ -111,6 +112,10 @@ export function AgentsUnified() {
       </details>
 
       ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
+
+      ${currentView !== 'agents' && keepers.value.length > 0 ? html`
+        <${KeeperFleetOverview} keepers=${keepers.value} />
+      ` : null}
 
       <${AgentRoster}
         keeperFilter=${currentView === 'keepers' ? 'keeper-only'

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -149,8 +149,8 @@ export function KeeperFleetOverview({ keepers: allKeepers }: { keepers: Keeper[]
 
   // Sort: active first, then by recency
   const sorted = [...allKeepers].sort((a, b) => {
-    const aActive = a.pipeline_stage === 'thinking' || a.pipeline_stage === 'tool_use' ? 1 : 0
-    const bActive = b.pipeline_stage === 'thinking' || b.pipeline_stage === 'tool_use' ? 1 : 0
+    const aActive = ACTIVE_STAGES.has(a.pipeline_stage ?? '') ? 1 : 0
+    const bActive = ACTIVE_STAGES.has(b.pipeline_stage ?? '') ? 1 : 0
     if (aActive !== bActive) return bActive - aActive
     return (a.last_activity_ago_s ?? 9999) - (b.last_activity_ago_s ?? 9999)
   })

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -25,6 +25,8 @@ const STAGE_STYLES: Record<string, StageStyle> = {
   offline:              { label: '오프',    color: 'var(--text-dim)', bg: 'var(--white-3)',        pulse: false },
 }
 
+const ACTIVE_STAGES = new Set<string>(['thinking', 'tool_use', 'compacting', 'handoff', 'scheduled_autonomous'])
+
 function stageStyle(stage?: PipelineStage): StageStyle {
   if (!stage) return STAGE_STYLES['offline']!
   return STAGE_STYLES[stage] ?? STAGE_STYLES['offline']!
@@ -62,7 +64,7 @@ function formatRecency(agoS: number | undefined): string {
 
 function KeeperRow({ keeper }: { keeper: Keeper }) {
   const stage = stageStyle(keeper.pipeline_stage)
-  const isActive = keeper.pipeline_stage === 'thinking' || keeper.pipeline_stage === 'tool_use'
+  const isActive = ACTIVE_STAGES.has(keeper.pipeline_stage ?? '')
   const toolCount = keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0
 
   return html`
@@ -104,7 +106,7 @@ function KeeperRow({ keeper }: { keeper: Keeper }) {
 // ── Fleet summary bar ─────────────────────────────────
 
 function FleetSummary({ keepers }: { keepers: Keeper[] }) {
-  const active = keepers.filter(k => k.pipeline_stage === 'thinking' || k.pipeline_stage === 'tool_use').length
+  const active = keepers.filter(k => ACTIVE_STAGES.has(k.pipeline_stage ?? '')).length
   const idle = keepers.filter(k => k.pipeline_stage === 'idle').length
   const offline = keepers.length - active - idle
   const avgCtx = keepers.reduce((s, k) => s + (k.context_ratio ?? 0), 0) / (keepers.length || 1)

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -1,0 +1,164 @@
+// Keeper fleet overview — compact comparison grid showing all keepers
+// at a glance: pipeline stage, context ratio, tool calls, generation,
+// and activity recency. Designed for the Agents tab header.
+
+import { html } from 'htm/preact'
+import { navigate } from '../router'
+import type { Keeper, PipelineStage } from '../types/core'
+
+// ── Pipeline stage styling ────────────────────────────
+
+interface StageStyle {
+  label: string
+  color: string
+  bg: string
+  pulse: boolean
+}
+
+const STAGE_STYLES: Record<string, StageStyle> = {
+  thinking:             { label: '사고',    color: 'var(--accent)',  bg: 'rgba(71,184,255,0.12)', pulse: true },
+  tool_use:             { label: '도구',    color: 'var(--ok)',      bg: 'rgba(52,211,153,0.12)', pulse: true },
+  compacting:           { label: '압축',    color: '#a855f7',        bg: 'rgba(168,85,247,0.12)', pulse: true },
+  handoff:              { label: '승계',    color: '#ef4444',        bg: 'rgba(239,68,68,0.12)',  pulse: true },
+  scheduled_autonomous: { label: '자율',    color: 'var(--accent)',  bg: 'rgba(71,184,255,0.08)', pulse: true },
+  idle:                 { label: '대기',    color: 'var(--text-dim)', bg: 'var(--white-5)',        pulse: false },
+  offline:              { label: '오프',    color: 'var(--text-dim)', bg: 'var(--white-3)',        pulse: false },
+}
+
+function stageStyle(stage?: PipelineStage): StageStyle {
+  if (!stage) return STAGE_STYLES['offline']!
+  return STAGE_STYLES[stage] ?? STAGE_STYLES['offline']!
+}
+
+// ── Context bar ───────────────────────────────────────
+
+function ContextBar({ ratio }: { ratio: number | undefined }) {
+  const pct = (ratio ?? 0) * 100
+  const color = pct > 85 ? 'var(--bad)' : pct > 60 ? 'var(--warn)' : 'var(--ok)'
+  return html`
+    <div class="flex items-center gap-1.5">
+      <div class="flex-1 h-1.5 rounded-full bg-[var(--white-6)] overflow-hidden">
+        <div class="h-full rounded-full transition-all duration-500"
+          style="width: ${pct.toFixed(0)}%; background: ${color}"></div>
+      </div>
+      <span class="text-[10px] font-mono w-8 text-right" style="color: ${color}">
+        ${pct > 0 ? `${pct.toFixed(0)}%` : '-'}
+      </span>
+    </div>
+  `
+}
+
+// ── Activity recency ──────────────────────────────────
+
+function formatRecency(agoS: number | undefined): string {
+  if (agoS == null) return '-'
+  if (agoS < 60) return `${Math.round(agoS)}초`
+  if (agoS < 3600) return `${Math.floor(agoS / 60)}분`
+  if (agoS < 86400) return `${Math.floor(agoS / 3600)}시간`
+  return `${Math.floor(agoS / 86400)}일`
+}
+
+// ── Keeper row ────────────────────────────────────────
+
+function KeeperRow({ keeper }: { keeper: Keeper }) {
+  const stage = stageStyle(keeper.pipeline_stage)
+  const isActive = keeper.pipeline_stage === 'thinking' || keeper.pipeline_stage === 'tool_use'
+  const toolCount = keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0
+
+  return html`
+    <div
+      class="flex items-center gap-3 py-2 px-3 rounded-lg cursor-pointer hover:bg-[var(--white-5)] transition-colors ${isActive ? 'ring-1 ring-[var(--accent-30)]' : ''}"
+      onClick=${() => navigate('monitoring', { section: 'agents', agent: keeper.name })}
+    >
+      ${'' /* Stage badge */}
+      <div
+        class="flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider text-center w-12"
+        style="color: ${stage.color}; background: ${stage.bg}; ${stage.pulse ? 'animation: loadingPulse 2s ease-in-out infinite;' : ''}"
+      >
+        ${stage.label}
+      </div>
+
+      ${'' /* Name */}
+      <div class="w-28 flex-shrink-0 truncate">
+        <span class="text-[12px] font-mono font-medium text-[var(--text-strong)]">${keeper.name}</span>
+      </div>
+
+      ${'' /* Context bar */}
+      <div class="flex-1 min-w-20 max-w-40">
+        <${ContextBar} ratio=${keeper.context_ratio} />
+      </div>
+
+      ${'' /* Stats */}
+      <div class="flex items-center gap-4 flex-shrink-0 text-[10px] font-mono text-[var(--text-muted)]">
+        <span title="세대">G${keeper.generation ?? 0}</span>
+        <span title="턴">${keeper.turn_count ?? 0}t</span>
+        <span title="도구 호출">${toolCount > 0 ? `${toolCount}c` : '-'}</span>
+        <span title="마지막 활동" class="${(keeper.last_activity_ago_s ?? 999) < 120 ? 'text-[var(--ok)]' : ''}">
+          ${formatRecency(keeper.last_activity_ago_s)}
+        </span>
+      </div>
+    </div>
+  `
+}
+
+// ── Fleet summary bar ─────────────────────────────────
+
+function FleetSummary({ keepers }: { keepers: Keeper[] }) {
+  const active = keepers.filter(k => k.pipeline_stage === 'thinking' || k.pipeline_stage === 'tool_use').length
+  const idle = keepers.filter(k => k.pipeline_stage === 'idle').length
+  const offline = keepers.length - active - idle
+  const avgCtx = keepers.reduce((s, k) => s + (k.context_ratio ?? 0), 0) / (keepers.length || 1)
+  const totalTools = keepers.reduce((s, k) => s + (k.latest_tool_call_count ?? k.metrics_window?.tool_call_count ?? 0), 0)
+
+  return html`
+    <div class="flex gap-3 flex-wrap text-[11px] mb-3">
+      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
+        <span class="font-mono font-medium text-[var(--ok)]">${active}</span>
+        <span class="text-[var(--text-dim)]">활성</span>
+      </span>
+      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
+        <span class="font-mono font-medium text-[var(--text-muted)]">${idle}</span>
+        <span class="text-[var(--text-dim)]">대기</span>
+      </span>
+      ${offline > 0 ? html`
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
+          <span class="font-mono font-medium text-[var(--text-dim)]">${offline}</span>
+          <span class="text-[var(--text-dim)]">오프</span>
+        </span>
+      ` : null}
+      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
+        <span class="text-[var(--text-dim)]">평균 컨텍스트</span>
+        <span class="font-mono font-medium ${avgCtx > 0.85 ? 'text-[var(--bad)]' : avgCtx > 0.6 ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${(avgCtx * 100).toFixed(0)}%</span>
+      </span>
+      ${totalTools > 0 ? html`
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
+          <span class="font-mono font-medium text-[var(--text-strong)]">${totalTools}</span>
+          <span class="text-[var(--text-dim)]">총 도구 호출</span>
+        </span>
+      ` : null}
+    </div>
+  `
+}
+
+// ── Main component ────────────────────────────────────
+
+export function KeeperFleetOverview({ keepers: allKeepers }: { keepers: Keeper[] }) {
+  if (allKeepers.length === 0) return null
+
+  // Sort: active first, then by recency
+  const sorted = [...allKeepers].sort((a, b) => {
+    const aActive = a.pipeline_stage === 'thinking' || a.pipeline_stage === 'tool_use' ? 1 : 0
+    const bActive = b.pipeline_stage === 'thinking' || b.pipeline_stage === 'tool_use' ? 1 : 0
+    if (aActive !== bActive) return bActive - aActive
+    return (a.last_activity_ago_s ?? 9999) - (b.last_activity_ago_s ?? 9999)
+  })
+
+  return html`
+    <div class="mb-6">
+      <${FleetSummary} keepers=${allKeepers} />
+      <div class="flex flex-col gap-0.5 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-2">
+        ${sorted.map(k => html`<${KeeperRow} key=${k.name} keeper=${k} />`)}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -65,7 +65,26 @@ export function clearTrajectory(keeperName: string): void {
 
 // ── Components ───────────────────────────────────────────
 
+function ThinkingEntryRow({ entry }: { entry: TrajectoryEntry }) {
+  const len = entry.content_length ?? entry.content?.length ?? 0
+  return html`
+    <div class="flex items-center gap-3 py-2 px-3 rounded-lg opacity-60">
+      <div class="flex-shrink-0 flex items-center gap-1.5">
+        <span class="text-[10px] text-[var(--text-dim)] w-3"></span>
+        <div class="size-7 rounded-md bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[11px]">💭</div>
+      </div>
+      <div class="flex-1 min-w-0 flex items-center gap-2">
+        <span class="text-xs font-mono text-[var(--text-muted)]">${entry.redacted ? '사고 (비공개)' : '사고'}</span>
+        <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}</span>
+        ${len > 0 ? html`<span class="text-[10px] text-[var(--text-dim)]">${len}자</span>` : null}
+      </div>
+    </div>
+  `
+}
+
 function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
+  if (entry.type === 'thinking') return html`<${ThinkingEntryRow} entry=${entry} />`
+
   const expanded = useSignal(false)
   const gateRejected = entry.gate?.status === 'reject'
   const cat = toolCategory(entry.tool_name ?? 'unknown')

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -68,7 +68,7 @@ export function clearTrajectory(keeperName: string): void {
 function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
   const expanded = useSignal(false)
   const gateRejected = entry.gate?.status === 'reject'
-  const cat = toolCategory(entry.tool_name ?? '')
+  const cat = toolCategory(entry.tool_name ?? 'unknown')
   const toggle = () => { expanded.value = !expanded.value }
 
   return html`
@@ -92,9 +92,9 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
         ${'' /* Content */}
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 flex-wrap">
-            <span class="text-xs font-mono font-medium ${cat.color}" title=${entry.tool_name}>${entry.tool_name}</span>
+            <span class="text-xs font-mono font-medium ${cat.color}" title=${entry.tool_name ?? ''}>${entry.tool_name ?? 'unknown'}</span>
             <span class="text-[10px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
-            <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}R${entry.round}</span>
+            <span class="text-[10px] text-[var(--text-dim)]">T${entry.turn}R${entry.round ?? 0}</span>
             ${(entry.cost_usd ?? 0) > 0
               ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)]">$${(entry.cost_usd ?? 0).toFixed(4)}</span>`
               : null}
@@ -160,7 +160,7 @@ function TrajectoryEntryRow({ entry }: { entry: TrajectoryEntry }) {
           <div class="flex gap-4 flex-wrap text-[10px] text-[var(--text-dim)]">
             ${(entry.cost_usd ?? 0) > 0 ? html`<span>Cost: $${(entry.cost_usd ?? 0).toFixed(6)}</span>` : null}
             <span>Duration: ${entry.duration_ms ?? 0}ms</span>
-            <span>Turn ${entry.turn}, Round ${entry.round}</span>
+            <span>Turn ${entry.turn}, Round ${entry.round ?? 0}</span>
             <span class="font-mono">${entry.ts_iso ?? new Date(entry.ts * 1000).toISOString()}</span>
           </div>
         </div>

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -229,11 +229,11 @@ function trajectoryEntryToTrace(entry: TrajectoryEntry, index: number): UnifiedT
   }
 
   return {
-    id: `tj-${ts}-${entry.tool_name}-T${entry.turn}R${entry.round}-${index}`,
+    id: `tj-${ts}-${entry.tool_name ?? 'unknown'}-T${entry.turn}R${entry.round ?? 0}-${index}`,
     ts,
     ts_iso: entry.ts_iso,
     kind: 'tool_call',
-    summary: entry.tool_name ?? '',
+    summary: entry.tool_name ?? 'unknown',
     detail: {},
     toolName: entry.tool_name,
     toolArgs: entry.args,


### PR DESCRIPTION
## Summary
- New `KeeperFleetOverview` component: compact grid showing all keepers with pipeline stage badge, context ratio bar, generation/turn/tool counts, and activity recency
- Active keepers sorted first, clickable rows navigate to keeper detail
- Fleet summary bar: active/idle/offline counts, average context ratio, total tool calls
- Fix Phase 2 TypeScript type compat: optional fields in `TrajectoryEntry` (thinking entries)

## Changes
| File | Change |
|------|--------|
| `keeper-fleet-overview.ts` | **NEW** — fleet comparison grid |
| `agents-unified.ts` | Integrate fleet overview into Agents tab |
| `keeper-trajectory-timeline.ts` | Fix optional field access for Phase 2 thinking entries |
| `session-trace-state.ts` | Fix optional tool_name/round in trajectory conversion |
| `tool-call-shared.ts` | Make summarizeEntries accept optional duration_ms/error |

## Test plan
- [x] Dashboard build passes (`npm run build`)
- [ ] Agents tab shows fleet overview when keepers exist
- [ ] Clicking a keeper row navigates to its detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)