### PR TITLE
fix: silent defaults, missing testid, and bare exception catches

### DIFF
--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -93,7 +93,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
 export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
   return html`
-    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded-xl overflow-hidden flex flex-col max-h-[400px]">
+    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded-xl overflow-hidden flex flex-col max-h-[400px]" data-testid="json-viewer-card" data-title=${title ?? ''}>
       ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-[11px] uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
       <div class="p-3 overflow-y-auto min-h-0 w-full">
         <${JsonViewer} data=${data} />

--- a/lib/cdal_contract_bridge.ml
+++ b/lib/cdal_contract_bridge.ml
@@ -57,14 +57,19 @@ let of_delivery_contract
 let infer_keeper_risk_class ~(scope_kind : string) : Oas.Risk_class.t =
   match String.lowercase_ascii scope_kind with
   | "read_only" | "readonly" | "observe" -> Oas.Risk_class.Low
-  | "workspace" | "local" -> Oas.Risk_class.Medium
+  | "workspace" | "local" | "global" -> Oas.Risk_class.Medium
   | "full" | "unrestricted" -> Oas.Risk_class.Medium
-  | _ -> Oas.Risk_class.Medium
+  | unknown ->
+    Log.Misc.warn "infer_keeper_risk_class: unknown scope_kind %S, defaulting to Medium" unknown;
+    Oas.Risk_class.Medium
 
 let infer_keeper_execution_mode ~(scope_kind : string) : Oas.Execution_mode.t =
   match String.lowercase_ascii scope_kind with
   | "read_only" | "readonly" | "observe" -> Oas.Execution_mode.Diagnose
-  | _ -> Oas.Execution_mode.Execute
+  | "workspace" | "local" | "global" | "full" | "unrestricted" -> Oas.Execution_mode.Execute
+  | unknown ->
+    Log.Misc.warn "infer_keeper_execution_mode: unknown scope_kind %S, defaulting to Diagnose" unknown;
+    Oas.Execution_mode.Diagnose
 
 let infer_keeper_allowed_mutations ~(execution_scope : string) =
   match String.lowercase_ascii execution_scope with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -248,17 +248,31 @@ let write_heartbeat_snapshot
           (Filename.concat base_dir meta_current.runtime.trace_id)
           "history.jsonl"
       in
-      (try
-        read_file_tail_lines history_path ~max_bytes:max_history_read_bytes ~max_lines:max_history_read_lines
-        |> List.filter_map (fun line ->
-          try
-            let json = Yojson.Safe.from_string line in
-            Some (Keeper_context_core.message_of_json json)
-          with _ -> None)
-      with e ->
-        Log.Keeper.warn "write_heartbeat_snapshot: history.jsonl load error (%s): %s"
-          meta_current.name (Printexc.to_string e);
-        [])
+      (let parse_errors = ref 0 in
+       let messages =
+         try
+           read_file_tail_lines history_path ~max_bytes:max_history_read_bytes ~max_lines:max_history_read_lines
+           |> List.filter_map (fun line ->
+             try
+               let json = Yojson.Safe.from_string line in
+               Some (Keeper_context_core.message_of_json json)
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _exn ->
+               incr parse_errors;
+               None)
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Keeper.warn "write_heartbeat_snapshot: history.jsonl load error (%s): %s"
+             meta_current.name (Printexc.to_string exn);
+           []
+       in
+       if !parse_errors > 0 then
+         Log.Keeper.warn
+           "write_heartbeat_snapshot: failed to parse %d message(s) from history.jsonl for keeper=%s trace_id=%s path=%s"
+           !parse_errors meta_current.name meta_current.runtime.trace_id history_path;
+       messages)
   in
   let c_messages = messages_for_continuity in
   let latest_user_message =


### PR DESCRIPTION
## Summary
- `JsonViewerCard`에 `data-testid` + `data-title` 속성 추가 (테스트 용이성)
- `cdal_contract_bridge.ml`: `"global"` scope_kind 명시 처리 + unknown 입력 로깅 (silent permissive default 제거)
- `keeper_keepalive.ml`: history.jsonl 파싱에서 `Eio.Cancel.Cancelled` re-raise + 파싱 에러 집계 로그

Supersedes #5466 (closed: trajectory.ml 타입 충돌로 rebase 불가)

## Test plan
- [x] `dune build` 통과
- [x] dashboard TypeScript 변경은 기존 테스트 커버리지 유지

Generated with [Claude Code](https://claude.com/claude-code)