### PR TITLE
fix(keeper): skip transient retry after side-effecting tool execution

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -791,7 +791,27 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         { system_prompt; dynamic_context = "" }
       in
       (* 5. Run via OAS Agent.run() with transient-error retry *)
+      (* Track whether side-effecting tool calls have been executed.
+         If a board_post/comment/shell succeeded and then a transient error
+         occurs, retrying would replay those tool calls and produce duplicates.
+         In that case, we propagate the error instead of retrying. *)
+      let side_effect_occurred = ref false in
+      let side_effect_tools =
+        [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote";
+          "keeper_board_delete";
+          "keeper_shell_exec"; "keeper_file_write"; "keeper_git_commit";
+          "keeper_npm_run"; "keeper_github" ]
+      in
+      let original_on_tool_call = !Keeper_exec_tools.on_keeper_tool_call in
+      Keeper_exec_tools.on_keeper_tool_call :=
+        (fun ~tool_name ~success ~duration_ms ->
+           if success && List.mem tool_name side_effect_tools then
+             side_effect_occurred := true;
+           original_on_tool_call ~tool_name ~success ~duration_ms);
       let run_result, latency_ms =
+        Fun.protect ~finally:(fun () ->
+          Keeper_exec_tools.on_keeper_tool_call := original_on_tool_call)
+        (fun () ->
         Keeper_exec_context.timed (fun () ->
           let do_run ~run_meta ~max_context ~run_generation ~is_retry =
             let max_idle_turns =
@@ -817,16 +837,23 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             | Ok _ as ok -> ok
             | Error e when is_transient_network_error e
                            && attempt <= max_transient_retries ->
-                let delay = transient_backoff_sec attempt in
-                Log.Keeper.warn
-                  "%s: transient network error cascade=%s max_context=%d retry=%d/%d backoff=%.0fs: %s"
-                  meta.name meta.cascade_name max_context
-                  attempt max_transient_retries delay
-                  (short_preview e);
-                Eio.Time.sleep (Eio_context.get_clock ()) delay;
-                retry_loop ~run_meta ~max_context ~run_generation
-                  ~attempt:(attempt + 1)
-                  ~is_retry:true ~overflow_retry_used
+                if !side_effect_occurred then begin
+                  Log.Keeper.warn
+                    "%s: transient error after side-effecting tool call — skipping retry to prevent duplicate (error: %s)"
+                    meta.name (short_preview e);
+                  Error e
+                end else begin
+                  let delay = transient_backoff_sec attempt in
+                  Log.Keeper.warn
+                    "%s: transient network error cascade=%s max_context=%d retry=%d/%d backoff=%.0fs: %s"
+                    meta.name meta.cascade_name max_context
+                    attempt max_transient_retries delay
+                    (short_preview e);
+                  Eio.Time.sleep (Eio_context.get_clock ()) delay;
+                  retry_loop ~run_meta ~max_context ~run_generation
+                    ~attempt:(attempt + 1)
+                    ~is_retry:true ~overflow_retry_used
+                end
             | Error e when (not overflow_retry_used)
                            && should_attempt_context_overflow_retry e -> (
                 match
@@ -853,7 +880,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           in
           retry_loop ~run_meta:meta ~max_context:max_cascade_context
             ~run_generation:generation ~attempt:1
-            ~is_retry:false ~overflow_retry_used:false)
+            ~is_retry:false ~overflow_retry_used:false))
       in
       match run_result with
       | Error e ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -529,7 +529,16 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
               (fst base_cursor, Option.value ~default:"" (snd base_cursor))
             > 0 ->
          Keeper_registry.set_board_cursor ~base_path meta.name ts (Some post_id)
-     | _ -> ());
+     | Some (ts, post_id) ->
+       Log.Keeper.debug
+         "board cursor not advanced for %s: new=(%f, %s) not greater than base=(%f, %s)"
+         meta.name ts post_id (fst base_cursor)
+         (Option.value ~default:"" (snd base_cursor))
+     | None ->
+       if final_events <> [] then
+         Log.Keeper.warn
+           "board cursor not updated for %s despite %d events processed"
+           meta.name (List.length final_events));
     (final_events, new_count, mention_count)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Summary
- Transient retry가 이미 실행된 side-effect tool(board_post, shell_exec 등)을 재실행하여 **중복 포스트**를 발생시키는 버그 수정
- `on_keeper_tool_call` 콜백을 임시 래핑하여 side-effect 발생을 추적
- Side-effect 발생 후 transient error 시 retry 대신 에러 전파
- Board cursor update의 silent failure에 진단 로그 추가

## Root cause
1. `keeper_unified_turn.ml`의 retry_loop이 `do_run`(OAS Agent.run)을 재실행
2. OAS가 checkpoint에서 재개하면서 동일 tool call 재실행
3. board_post에 idempotency guard 없음 → 중복 포스트

## Fix approach
비결정론적 경계(retry)에서 부작용 감지 후 retry 차단. Content hash dedup 같은 결정론적 레이어 땜빵 대신, 원인이 되는 retry 경로 자체를 guard.

## Test plan
- [x] `dune build` 통과
- [x] `test_keeper_state_machine` 66/66 통과
- [ ] 서버 재시작 후 keeper 중복 포스트 발생 여부 모니터링

Generated with [Claude Code](https://claude.com/claude-code)