### PR TITLE
fix(dashboard): show completed tasks and tool usage in planning view

### DIFF
--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -132,7 +132,7 @@ export function KanbanCard({ task }: { task: Task }) {
       `}
 
       <div class="flex flex-wrap items-center gap-2 text-[11px] text-text-muted">
-        ${task.created_at ? html`<span class="rounded-md border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>` : null}
+        ${task.completed_at ? html`<span class="rounded-md border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완료 <${TimeAgo} timestamp=${task.completed_at} /></span>` : task.created_at ? html`<span class="rounded-md border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>` : null}
         ${task.assignee ? html`<span class="rounded-md border border-accent/20 bg-[var(--accent-10)] px-2 py-1 text-accent">@${task.assignee}</span>` : null}
         <a
           href=${link.href}

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -132,7 +132,13 @@ export function KanbanCard({ task }: { task: Task }) {
       `}
 
       <div class="flex flex-wrap items-center gap-2 text-[11px] text-text-muted">
-        ${task.completed_at ? html`<span class="rounded-md border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완료 <${TimeAgo} timestamp=${task.completed_at} /></span>` : task.created_at ? html`<span class="rounded-md border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>` : null}
+        ${task.completed_at && task.status === 'done'
+          ? html`<span class="rounded-md border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완�� <${TimeAgo} timestamp=${task.completed_at} /></span>`
+          : task.completed_at && task.status === 'cancelled'
+            ? html`<span class="rounded-md border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[var(--bad-light)]">취소 <${TimeAgo} timestamp=${task.completed_at} /></span>`
+            : task.created_at
+              ? html`<span class="rounded-md border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>`
+              : null}
         ${task.assignee ? html`<span class="rounded-md border border-accent/20 bg-[var(--accent-10)] px-2 py-1 text-accent">@${task.assignee}</span>` : null}
         <a
           href=${link.href}

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { useMemo } from 'preact/hooks'
 import { EmptyState } from '../common/empty-state'
 import { ActionButton } from '../common/button'
 import {
@@ -12,7 +13,6 @@ import {
   keepers,
 } from '../../store'
 import { navigate } from '../../router'
-import type { MetricsWindowTopItem } from '../../types'
 import {
   groupedByHorizon,
 } from './goal-helpers'
@@ -107,29 +107,36 @@ function GuideCard({
 }
 
 function KeeperToolActivity() {
-  const activeKeepers = keepers.value.filter(k => {
-    const stage = k.pipeline_stage ?? 'idle'
-    return stage !== 'offline' && stage !== 'idle'
-  })
+  const keeperList = keepers.value
+  if (keeperList.length === 0) return null
 
-  // Aggregate top tools across all active keepers
-  const toolCounts = new Map<string, number>()
-  let totalToolTurns = 0
-  for (const k of keepers.value) {
-    totalToolTurns += k.autonomous_tool_turn_count ?? 0
-    const topTools = (k as Record<string, unknown>).top_tools as MetricsWindowTopItem[] | undefined
-    if (topTools) {
-      for (const t of topTools) {
-        const name = t.tool ?? ''
-        if (name) toolCounts.set(name, (toolCounts.get(name) ?? 0) + (t.count ?? 1))
+  const activeKeepers = useMemo(() =>
+    keeperList.filter(k => {
+      const stage = k.pipeline_stage ?? 'idle'
+      return stage !== 'offline' && stage !== 'idle'
+    }),
+    [keeperList],
+  )
+
+  // Aggregate top tools across all keepers (memoized)
+  const { topTools, totalToolTurns } = useMemo(() => {
+    const toolCounts = new Map<string, number>()
+    let turns = 0
+    for (const k of keeperList) {
+      turns += k.autonomous_tool_turn_count ?? 0
+      const items = k.metrics_window?.top_tools
+      if (items) {
+        for (const t of items) {
+          const name = t.tool ?? ''
+          if (name) toolCounts.set(name, (toolCounts.get(name) ?? 0) + (t.count ?? 1))
+        }
       }
     }
-  }
-  const topTools = [...toolCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-
-  if (keepers.value.length === 0) return null
+    return {
+      topTools: [...toolCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8),
+      totalToolTurns: turns,
+    }
+  }, [keeperList])
 
   return html`
     <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)]" open=${true}>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -3,19 +3,19 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { EmptyState } from '../common/empty-state'
-import { LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import {
   goals,
   goalsLoading,
   refreshGoals,
   tasksByStatus,
+  keepers,
 } from '../../store'
+import { navigate } from '../../router'
+import type { MetricsWindowTopItem } from '../../types'
 import {
-  filteredGoals,
   groupedByHorizon,
 } from './goal-helpers'
-import { GoalsSummary, FilterBar, HorizonGroup } from './goal-components'
 import { TaskBacklog } from './kanban-components'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 
@@ -106,6 +106,84 @@ function GuideCard({
   `
 }
 
+function KeeperToolActivity() {
+  const activeKeepers = keepers.value.filter(k => {
+    const stage = k.pipeline_stage ?? 'idle'
+    return stage !== 'offline' && stage !== 'idle'
+  })
+
+  // Aggregate top tools across all active keepers
+  const toolCounts = new Map<string, number>()
+  let totalToolTurns = 0
+  for (const k of keepers.value) {
+    totalToolTurns += k.autonomous_tool_turn_count ?? 0
+    const topTools = (k as Record<string, unknown>).top_tools as MetricsWindowTopItem[] | undefined
+    if (topTools) {
+      for (const t of topTools) {
+        const name = t.tool ?? ''
+        if (name) toolCounts.set(name, (toolCounts.get(name) ?? 0) + (t.count ?? 1))
+      }
+    }
+  }
+  const topTools = [...toolCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+
+  if (keepers.value.length === 0) return null
+
+  return html`
+    <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)]" open=${true}>
+      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-white/3">
+        <div class="min-w-0">
+          <div>도구 활동 요약</div>
+          <div class="mt-1 text-[12px] font-normal text-text-muted">
+            keeper가 최근 사용한 도구와 활동 현황. 상세는 keeper 클릭.
+          </div>
+        </div>
+        <span class="ml-auto inline-flex items-center rounded-lg border border-card-border/70 bg-white/4 px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-body font-semibold">
+          ${totalToolTurns} calls
+        </span>
+      </summary>
+      <div class="p-5">
+        ${activeKeepers.length > 0 ? html`
+          <div class="mb-4">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">활성 keeper</div>
+            <div class="flex flex-wrap gap-2">
+              ${activeKeepers.map(k => html`
+                <button
+                  key=${k.name}
+                  type="button"
+                  class="inline-flex items-center gap-1.5 rounded-lg border border-card-border/60 bg-white/4 px-3 py-1.5 text-[12px] text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+                  onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
+                >
+                  ${k.emoji ?? ''} ${k.koreanName ?? k.name}
+                  <span class="text-[10px] font-mono text-text-dim">${k.turn_count ?? 0}t</span>
+                </button>
+              `)}
+            </div>
+          </div>
+        ` : null}
+
+        ${topTools.length > 0 ? html`
+          <div>
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">최근 자주 사용된 도구</div>
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1.5">
+              ${topTools.map(([name, count]) => html`
+                <div key=${name} class="flex items-center justify-between rounded-lg bg-white/3 px-3 py-1.5 text-[12px]">
+                  <span class="font-mono text-text-body truncate">${name.replace(/^(keeper_|masc_)/, '')}</span>
+                  <span class="ml-2 flex-shrink-0 font-mono text-text-dim">${count}</span>
+                </div>
+              `)}
+            </div>
+          </div>
+        ` : html`
+          <${EmptyState} message="도구 호출 데이터가 아직 없습니다" compact />
+        `}
+      </div>
+    </details>
+  `
+}
+
 export function Planning() {
   const { todo, inProgress, done } = tasksByStatus.value
   const totalTasks = todo.length + inProgress.length + done.length
@@ -179,47 +257,47 @@ export function Planning() {
 
       <${TaskBacklog} />
 
-      <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)]" open=${true}>
-        <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-white/3">
-          <div class="min-w-0">
-            <div>장기 목표 파이프라인</div>
-            <div class="mt-1 text-[12px] font-normal text-text-muted">
-              goal은 자동 생성되지 않습니다. 등록된 항목만 여기에 보입니다.
-            </div>
+      <${KeeperToolActivity} />
+
+      <section class="rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Goal Pipeline</div>
+            <h3 class="mt-1 text-[15px] font-semibold text-text-strong">
+              장기 목표 ${hasGoals ? `(${goals.value.length})` : ''}
+            </h3>
           </div>
-          <span class="ml-auto inline-flex items-center rounded-lg border border-card-border/70 bg-white/4 px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-body font-semibold">${goals.value.length}</span>
-        </summary>
-        <div class="p-5">
-          ${hasGoals ? html`
-            <div class="mb-4 text-[12px] leading-relaxed text-text-muted">
-              단기/중기/장기 목표를 메트릭 기준으로 구조화해 보여 줍니다.
-            </div>
-            <${GoalsSummary} />
-            <${FilterBar} />
-            ${goalsLoading.value && goals.value.length === 0
-              ? html`<${LoadingState}>목표 불러오는 중...<//>`
-              : filteredGoals.value.length === 0
-                ? html`<${EmptyState} message="현재 필터에 맞는 목표가 없습니다" compact />`
-                : html`
-                    <div class="mt-3 flex flex-col gap-5">
-                      <${HorizonGroup} horizon="short" items=${grouped.short ?? []} />
-                      <${HorizonGroup} horizon="mid" items=${grouped.mid ?? []} />
-                      <${HorizonGroup} horizon="long" items=${grouped.long ?? []} />
-                    </div>
-                  `}
-          ` : html`
-            <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
-              <div class="text-[14px] font-semibold text-text-strong">등록된 장기 목표가 없습니다</div>
-              <div class="mt-2 text-[13px] leading-relaxed text-text-muted">
-                backlog 태스크와 목표 파이프라인은 별개입니다. 장기 계획이 필요하면 목표를 등록하세요.
-              </div>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <${ExternalDocLink} href=${COMMAND_PLANE_DOC_URL} label="goal 등록 가이드" />
-              </div>
-            </div>
-          `}
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-accent/25 bg-[var(--accent-12)] px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:border-accent/40 hover:bg-[var(--accent-15)]"
+            onClick=${() => navigate('workspace', { section: 'goals' })}
+          >
+            목표 트리에서 보기
+            <span aria-hidden="true">\u2192</span>
+          </button>
         </div>
-      </details>
+        ${hasGoals ? html`
+          <div class="mt-3 flex flex-wrap gap-2">
+            ${(grouped.short ?? []).length > 0 ? html`
+              <span class="rounded-md border border-ok/25 bg-ok/10 px-2 py-0.5 text-[11px] text-ok">
+                단기 ${(grouped.short ?? []).length}
+              </span>
+            ` : null}
+            ${(grouped.mid ?? []).length > 0 ? html`
+              <span class="rounded-md border border-warn/25 bg-warn/10 px-2 py-0.5 text-[11px] text-warn">
+                중기 ${(grouped.mid ?? []).length}
+              </span>
+            ` : null}
+            ${(grouped.long ?? []).length > 0 ? html`
+              <span class="rounded-md border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-[11px] text-accent">
+                장기 ${(grouped.long ?? []).length}
+              </span>
+            ` : null}
+          </div>
+        ` : html`
+          <p class="mt-2 text-[13px] text-text-muted">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>
+        `}
+      </section>
     </div>
   `
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -34,6 +34,7 @@ export interface Task {
   description?: string
   created_at?: string
   updated_at?: string
+  completed_at?: string
   contract?: TaskContract | null
   handoff_context?: TaskHandoffContext | null
   gate?: TaskGateSnapshot | null

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -50,7 +50,7 @@ let messages_safe config =
 
 
 let task_json (task : Types.task) =
-  `Assoc
+  let base =
     [
       ("id", `String task.id);
       ("title", `String task.title);
@@ -60,6 +60,15 @@ let task_json (task : Types.task) =
       ("assignee", Json_util.string_opt_to_json (task_assignee task));
       ("created_at", `String task.created_at);
     ]
+  in
+  let extra = match task.task_status with
+    | Types.Done { completed_at; _ } ->
+      [("completed_at", `String completed_at)]
+    | Types.Cancelled { cancelled_at; _ } ->
+      [("completed_at", `String cancelled_at)]
+    | _ -> []
+  in
+  `Assoc (base @ extra)
 
 let agent_json (agent : Types.agent) =
   let (emoji, korean_name) = get_agent_identity agent.name in
@@ -272,16 +281,34 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           ("keepers", `List keepers);
         ]
       in
+      let now = Time_compat.now () in
+      let recent_cutoff = now -. 86400.0 in (* 24 hours *)
       let active_tasks = List.filter (fun (t : Types.task) ->
         match t.task_status with
         | Types.Done _ | Types.Cancelled _ -> false
         | _ -> true
       ) tasks in
-      let limited_tasks = take 50 active_tasks in
+      let recent_done = tasks
+        |> List.filter (fun (t : Types.task) ->
+          match t.task_status with
+          | Types.Done { completed_at; _ } ->
+            (match Types.parse_iso8601_opt completed_at with
+             | Some ts -> ts >= recent_cutoff
+             | None -> false)
+          | Types.Cancelled { cancelled_at; _ } ->
+            (match Types.parse_iso8601_opt cancelled_at with
+             | Some ts -> ts >= recent_cutoff
+             | None -> false)
+          | _ -> false)
+        |> take 20
+      in
+      let all_visible = active_tasks @ recent_done in
+      let limited_tasks = take 50 all_visible in
       let task_fields = [
         ("tasks", `List (List.map task_json limited_tasks));
         ("task_counts", `Assoc [
           ("active", `Int (List.length active_tasks));
+          ("done_recent", `Int (List.length recent_done));
           ("total", `Int (List.length tasks));
           ("shown", `Int (List.length limited_tasks));
         ]);


### PR DESCRIPTION
## Summary
- Done 태스크가 Kanban에서 사라지는 버그 수정: 24h 이내 완료 태스크 포함 (최대 20개)
- 계획 섹션에 도구 활동 요약 추가: keeper top_tools 집계, 활성 keeper 칩 클릭으로 상세 이동
- 장기목표 파이프라인 인라인 렌더링 → 요약 + "목표 트리에서 보기" 링크로 대체

## Changes
| File | Change |
|------|--------|
| `lib/dashboard/dashboard_execution.ml` | Include recent done tasks (24h, max 20), add `completed_at` field |
| `dashboard/src/types/core.ts` | Add `completed_at` to Task interface |
| `dashboard/src/components/goals/kanban-components.ts` | Show "완료 N분 전" for done tasks |
| `dashboard/src/components/goals/planning.ts` | Add KeeperToolActivity, replace inline goal pipeline with summary |

## Test plan
- [ ] 대시보드 계획 화면에서 완료된 태스크가 "완료" 컬럼에 표시되는지 확인
- [ ] 완료 태스크에 "완료 N분 전" 시간 표시 확인
- [ ] 도구 활동 요약 섹션에 keeper 활동/top tools 표시 확인
- [ ] 목표 트리 링크 클릭 시 올바른 섹션으로 이동 확인
- [ ] OCaml 빌드 성공 (10/10 dashboard tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)