### PR TITLE
fix(config): remove dead CDAL flags, graduate room-signal, deprecate orchestrator

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -313,13 +313,6 @@ module Cdal = struct
   let enabled () =
     Feature_flag_registry.get_bool "MASC_CDAL_ENABLED"
 
-  (** Enforce contract risk violations. Default: false. *)
-  let risk_enforcement_enabled () =
-    Feature_flag_registry.get_bool "MASC_CDAL_RISK_ENFORCEMENT"
-
-  (** Aggregate proof bundles across turns. Default: false. *)
-  let proof_aggregation_enabled () =
-    Feature_flag_registry.get_bool "MASC_CDAL_PROOF_AGGREGATION"
 end
 
 (** {1 Slot Scheduling} *)

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -135,7 +135,7 @@ let all_flags : flag list = [
   { env_name = "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED";
     description = "Global override for keeper room-signal prompt injection";
     default = false; category = "keeper";
-    lifecycle = Experimental; since = "2.214.0" };
+    lifecycle = Active; since = "2.214.0" };
 
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_COMMAND_PLANE_SNAPSHOT_REFRESH_ENABLED";
@@ -171,9 +171,9 @@ let all_flags : flag list = [
 
   (* ── Runtime ──────────────────────────────────────────────── *)
   { env_name = "MASC_ORCHESTRATOR_ENABLED";
-    description = "Auto-orchestration background loop";
+    description = "Auto-orchestration background loop (superseded by zero-zombie cleanup)";
     default = false; category = "runtime";
-    lifecycle = Active; since = "2.0.0" };
+    lifecycle = Deprecated "superseded by zero-zombie cleanup since v2.130.0"; since = "2.0.0" };
 
   { env_name = "MASC_TEAM_SESSION_ROUTER_JUDGE";
     description = "Team session routing judge for dispatch";
@@ -195,16 +195,6 @@ let all_flags : flag list = [
     description = "Contract-driven agent loop: proof capture and verdict evaluation";
     default = true; category = "runtime";
     lifecycle = Active; since = "2.162.0" };
-
-  { env_name = "MASC_CDAL_RISK_ENFORCEMENT";
-    description = "Enforce risk_contract constraints (fail on violation)";
-    default = false; category = "runtime";
-    lifecycle = Experimental; since = "2.162.0" };
-
-  { env_name = "MASC_CDAL_PROOF_AGGREGATION";
-    description = "Aggregate proof bundles across multi-turn sessions";
-    default = false; category = "runtime";
-    lifecycle = Experimental; since = "2.162.0" };
 
 ]
 

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -142,8 +142,6 @@ end
 
 module Cdal : sig
   val enabled : unit -> bool
-  val risk_enforcement_enabled : unit -> bool
-  val proof_aggregation_enabled : unit -> bool
 end
 
 module Board : sig


### PR DESCRIPTION
## Summary
- `MASC_CDAL_RISK_ENFORCEMENT` + `MASC_CDAL_PROOF_AGGREGATION` 제거 — Experimental since v2.162.0, accessor 정의만 있고 호출처 0건 (dead code)
- `MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED` Experimental → Active 승격 — 9+ keeper 파일에서 활발 사용, 최근 2주 내 수정
- `MASC_ORCHESTRATOR_ENABLED` Active → Deprecated — v2.0.0부터 200+ 버전 동안 OFF, zero-zombie cleanup이 대체

Registry: 28 → 26 flags

## Test plan
- [x] `dune build` 성공 (exit 0)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)