### PR TITLE
fix(keeper): remove stale soul_profile ref and add broadcast fallback (#5398)

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -94,7 +94,7 @@ groups = ["base", "filesystem", "library", "shell", "coordination", "board", "go
 masc_groups = ["core"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.
-# Use for keepers with soul_profile=delivery whose goal involves PRs, issues, or code fixes.
+# Use for keepers whose goal involves PRs, issues, or code fixes.
 [presets.delivery]
 groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board", "governance", "autoresearch", "coding_shard", "coding", "github"]
 masc_groups = ["core", "coding"]

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -127,6 +127,9 @@ let actionable_routes ~(allowed_tools : string list)
       add
         "- No reactive work. Share an observation, thought, or question on the Board \
          using keeper_board_post (set hearth to your name).";
+    if can "keeper_broadcast" then
+      add
+        "- No reactive work. Share a brief status update using keeper_broadcast.";
     if can "keeper_board_list" then
       add
         "- Browse recent Board posts with keeper_board_list to look for topics \


### PR DESCRIPTION
## Summary
- Remove outdated `soul_profile=delivery` reference from `tool_policy.toml` delivery preset comment
- Add `keeper_broadcast` as proactive fallback route when `keeper_board_post` is unavailable in `keeper_unified_prompt.ml`
- Sub-item 2/3 (rule text "within single turn") already removed on main — no action needed

Closes #5398

## Test plan
- [ ] `dune build` passes
- [ ] `dune test` passes
- [ ] Keeper without `keeper_board_post` access gets `keeper_broadcast` suggestion

Generated with [Claude Code](https://claude.com/claude-code)