### PR TITLE
fix(dashboard): consolidate streaming indicators and context ratio SSOT (#5397)

### DIFF
--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -11,9 +11,9 @@ import { truncate } from '../lib/truncate'
 import { TimeAgo } from './common/time-ago'
 import { toolCategory, durationColor, formatArgs, prettyArgs, formatDuration, summarizeEntries } from './tool-call-shared'
 import { keeperHeartbeats } from '../store'
+import { isConnected } from '../sse'
+import { TRAJECTORY_HEARTBEAT_STALE_MS, LIVENESS_TICK_MS, CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from '../config/constants'
 import type { Keeper } from '../types'
-
-const HEARTBEAT_STALE_MS = 30_000
 const OFFLINE_STATUSES = ['offline', 'inactive', 'dead', 'crashed'] as const
 const STAT_PILL = 'text-[10px] py-0.5 px-2 rounded-full bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)]'
 
@@ -274,9 +274,16 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
     const distinct = new Set(data.entries.filter(e => e.tool_name).map(e => e.tool_name)).size
     return { turns: sorted, allSummary: summary, distinctTools: distinct }
   }, [data.entries])
+  // Tick every LIVENESS_TICK_MS so isLive transitions from true→false
+  // when heartbeat goes stale while the component is mounted.
+  const now = useSignal(Date.now())
+  useEffect(() => {
+    const id = setInterval(() => { now.value = Date.now() }, LIVENESS_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
   const lastHb = keeperHeartbeats.value.get(keeperName)
-  const isLive = lastHb != null && (Date.now() - lastHb) < HEARTBEAT_STALE_MS
-  const isOnline = keeper && !OFFLINE_STATUSES.includes(keeper.status as typeof OFFLINE_STATUSES[number])
+  const isLive = isConnected.value && lastHb != null && (now.value - lastHb) < TRAJECTORY_HEARTBEAT_STALE_MS
+  const isOnline = keeper != null && !OFFLINE_STATUSES.includes(keeper.status as typeof OFFLINE_STATUSES[number])
   const contextRatio = keeper?.context_ratio
 
   return html`
@@ -295,7 +302,7 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
           <span class="text-[10px] font-mono text-[var(--text-dim)]">trace: ${data.trace_id.slice(0, 8)}</span>
           <span class="text-[10px] text-[var(--text-dim)]">gen ${data.generation}</span>
           ${contextRatio != null
-            ? html`<span class="text-[10px] font-mono ${contextRatio > 0.8 ? 'text-[var(--bad)]' : contextRatio > 0.6 ? 'text-[var(--warn)]' : 'text-[var(--text-dim)]'}">ctx ${(contextRatio * 100).toFixed(0)}%</span>`
+            ? html`<span class="text-[10px] font-mono ${contextRatio > CONTEXT_RATIO_CRITICAL ? 'text-[var(--bad)]' : contextRatio > CONTEXT_RATIO_WARN ? 'text-[var(--warn)]' : 'text-[var(--text-dim)]'}">ctx ${(contextRatio * 100).toFixed(0)}%</span>`
             : null}
         </div>
         <span class="text-[10px] text-[var(--text-dim)]">

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -2,10 +2,11 @@
 
 import { html } from 'htm/preact'
 import { keeperHealthSummary, type KeeperPressure } from '../../live-store'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from '../../config/constants'
 
 function pressureColor(ratio: number): string {
-  if (ratio > 0.85) return 'bg-[var(--bad)]'
-  if (ratio > 0.70) return 'bg-[var(--warn)]'
+  if (ratio > CONTEXT_RATIO_CRITICAL) return 'bg-[var(--bad)]'
+  if (ratio > CONTEXT_RATIO_WARN) return 'bg-[var(--warn)]'
   if (ratio > 0.50) return 'bg-[var(--warn)]'
   return 'bg-[var(--ok)]'
 }

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -34,6 +34,14 @@ export const SSE_RECONNECT_RETRY_MS = 3_000
 export const PERIODIC_REFRESH_DEV_MS = 180_000
 export const PERIODIC_REFRESH_PROD_MS = 120_000
 
+// --- Context ratio thresholds (SSOT: backend env_config_runtime.ml:496-499) ---
+export const CONTEXT_RATIO_CRITICAL = 0.85
+export const CONTEXT_RATIO_WARN = 0.70
+
+// --- Trajectory timeline ---
+export const TRAJECTORY_HEARTBEAT_STALE_MS = 30_000
+export const LIVENESS_TICK_MS = 5_000
+
 // --- Keeper UI/runtime limits ---
 export const KEEPER_STATUS_TAIL_MESSAGES = 50
 export const KEEPER_HISTORY_TAIL_MESSAGES = 200

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -6,6 +6,7 @@ import type {
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from './config/constants'
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
@@ -39,8 +40,8 @@ export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   if (latest.is_handoff) return 'handoff-imminent'
   if (latest.is_compaction) return 'compacting'
   const ratio = latest.context_ratio
-  if (ratio > 0.85) return 'handoff-imminent'
-  if (ratio > 0.70) return 'preparing'
+  if (ratio > CONTEXT_RATIO_CRITICAL) return 'handoff-imminent'
+  if (ratio > CONTEXT_RATIO_WARN) return 'preparing'
   if (ratio > 0.50) return 'compacting'
   return 'active'
 }

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -6,6 +6,7 @@ import type { JournalEntry } from './types'
 import type { PipelineStage } from './types/core'
 import { journal } from './sse'
 import { agents, agentMotionMap, keepers, staleKeepers } from './store'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from './config/constants'
 import type { AgentMotionSnapshot } from './components/common/agent-motion'
 
 // --- Filter toggles ---
@@ -169,8 +170,8 @@ export const keeperHealthSummary: ReadonlySignal<KeeperHealthSummary> = computed
 
   const pressures: KeeperPressure[] = active.map(k => {
     const ratio = k.context_ratio ?? 0
-    if (ratio > 0.85) criticalCount++
-    else if (ratio > 0.70 || stale.has(k.name)) warningCount++
+    if (ratio > CONTEXT_RATIO_CRITICAL) criticalCount++
+    else if (ratio > CONTEXT_RATIO_WARN || stale.has(k.name)) warningCount++
     return { name: k.name, ratio, stage: (k.pipeline_stage ?? 'idle') as PipelineStage }
   }).sort((a, b) => b.ratio - a.ratio)
 

--- a/dashboard/src/styles/a11y.css
+++ b/dashboard/src/styles/a11y.css
@@ -13,4 +13,5 @@
   [class*="avatar-pulse-glow"] { animation: none; }
   [style*="workingPulse"] { animation: none; }
   [style*="keeperPulse"] { animation: none; }
+  [style*="activityFadeIn"] { animation: none; }
 }


### PR DESCRIPTION
## Summary
- Extract `TRAJECTORY_HEARTBEAT_STALE_MS`, `CONTEXT_RATIO_CRITICAL`, `CONTEXT_RATIO_WARN`, `LIVENESS_TICK_MS` to `config/constants.ts` (SSOT)
- Replace hardcoded `0.8/0.6` thresholds in `keeper-trajectory-timeline.ts` with SSOT constants (aligned to backend `0.85/0.70`)
- Add ticking timer for `isLive` transition detection while component is mounted
- Use SSE `isConnected` signal alongside heartbeat for immediate disconnect feedback
- Add explicit `keeper != null` check for `isOnline`
- Add `activityFadeIn` to `prefers-reduced-motion` overrides in `a11y.css`
- Consolidate threshold constants across `keeper-store-normalize.ts`, `live-store.ts`, `keeper-health-strip.ts`

Closes #5397

## Test plan
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] Dashboard vitest passes (ops/ timeouts are pre-existing)
- [ ] Keeper trajectory timeline shows "live" indicator with ticking transition
- [ ] SSE disconnect immediately shows non-live state
- [ ] Context ratio colors match backend thresholds (85%/70%)
- [ ] `prefers-reduced-motion` disables `activityFadeIn` animation

Generated with [Claude Code](https://claude.com/claude-code)