### PR TITLE
feat(keeper): record tool call trajectory in guarded_execute

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -425,15 +425,41 @@ let guarded_execute
   let decision = pre_check ~config ~accumulated_cost ~trajectory_acc
     ~tool_name ~args_json in
 
+  let record_trajectory ~gate_decision ~result ~error ~duration_ms =
+    match trajectory_acc with
+    | None -> ()
+    | Some acc ->
+        let now = Time_compat.now () in
+        let entry : Trajectory.tool_call_entry = {
+          ts = now;
+          ts_iso = Types_core.iso8601_of_unix_seconds now;
+          turn = acc.turn;
+          round = Trajectory.calls_in_current_turn acc + 1;
+          tool_name;
+          args_json;
+          gate_decision;
+          result;
+          duration_ms;
+          error;
+          cost_usd = Trajectory.tool_cost_estimate tool_name;
+        } in
+        Trajectory.record_entry acc entry
+  in
+
   match decision with
   | Trajectory.Reject _reason ->
+      record_trajectory ~gate_decision:decision ~result:None ~error:None
+        ~duration_ms:0;
       (decision, None, None, 0)
   | Trajectory.Pass ->
       let t0 = Time_compat.now () in
+      let error_ref = ref None in
       let result =
         try execute ()
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Log.info "eval_gate tool %s failed: %s" tool_name (Printexc.to_string exn);
+          let msg = Printexc.to_string exn in
+          error_ref := Some msg;
+          Log.info "eval_gate tool %s failed: %s" tool_name msg;
           Yojson.Safe.to_string (`Assoc [
             ("error", `String "Tool execution failed (internal error)");
             ("tool", `String tool_name);
@@ -441,6 +467,9 @@ let guarded_execute
       in
       let t1 = Time_compat.now () in
       let duration_ms = int_of_float ((t1 -. t0) *. 1000.0) in
+
+      record_trajectory ~gate_decision:decision ~result:(Some result)
+        ~error:!error_ref ~duration_ms;
 
       let eval = post_eval ~config ~tool_name ~result ~duration_ms
         ~accumulated_cost in


### PR DESCRIPTION
## Summary
- `Eval_gate.guarded_execute`에 `Trajectory.record_entry` 호출 추가
- keeper tool 실행마다 JSONL trajectory entry 기록

## 배경
대시보드의 keeper 상세 모달 > "도구 텔레메트리" 섹션이 항상 빈칸.
원인: `Trajectory.record_entry`를 호출하는 곳이 없었음. accumulator는 이미 생성/전달되고 있었지만 기록이 누락.

## 변경 (eval_gate.ml, +30줄)
- `record_trajectory` 헬퍼: trajectory_acc 존재 시 entry 구성 + record
- **Reject 경로**: gate 거부 기록 (tool_name, gate_decision=Reject, duration=0)
- **Pass 경로**: 실행 결과 + 에러 + duration 기록
- 기존 반환 값/로직 변경 없음

## 데이터 흐름
```
keeper tool 호출
  → Eval_gate.guarded_execute
    → pre_check (gate decision)
    → execute() (tool 실행)
    → record_trajectory ← NEW
    → post_eval
  → JSONL: .masc/trajectories/{keeper}/{trace_id}.jsonl
  → Dashboard: GET /api/v1/keepers/{name}/tool-stats
```

## Test plan
- [ ] CI green
- [ ] keeper 실행 후 `.masc/trajectories/` 에 JSONL 파일 생성 확인
- [ ] 대시보드 keeper 상세 모달에서 도구 텔레메트리 데이터 표시 확인