### PR TITLE
fix(dashboard): sync keeper meta from disk to registry on heartbeat (#5364)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -938,6 +938,12 @@ let run_heartbeat_loop
         | Ok (Some latest) -> latest
         | _ -> m
       in
+      (* Sync disk meta to registry so dashboard reads live values.  #5364.
+         Physical inequality: read_meta returns a fresh record when the JSON
+         file changed; same pointer means no disk change occurred. *)
+      if meta_current != m then
+        Keeper_registry.update_meta
+          ~base_path:ctx.config.base_path meta_current.name meta_current;
       if
         run_smart_heartbeat_gate
           ~clock:ctx.clock


### PR DESCRIPTION
## Summary
- Keeper heartbeat loop now syncs disk meta to `Keeper_registry` when JSON file changes are detected
- Dashboard HTTP endpoints (`Keeper_registry.get`) immediately reflect live values
- No restart required after editing keeper JSON files (goal, instructions, tool_access, etc.)

Closes #5364

## Test plan
- [ ] `dune build` passes
- [ ] `dune test` passes
- [ ] Edit keeper JSON `goal` field → wait 1 heartbeat cycle → dashboard shows updated value

Generated with [Claude Code](https://claude.com/claude-code)