### PR TITLE
docs: sync ROADMAP version to v2.248.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.247.0
-> Latest release: v2.247.0 (2026-04-06)
+> Current package version: v2.248.0
+> Latest release: v2.248.0 (2026-04-06)
 > Updated: 2026-04-06
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.


### PR DESCRIPTION
## Summary
- Sync ROADMAP.md version from 2.247.0 to 2.248.0
- Missed in #5507 (SPEC-INDEX + PRODUCT-OPERATING-PLAN sync)
- Fixes Health check `front-door doc truth` assertion for all subsequent PRs

## Test plan
- [ ] `scripts/check-doc-truth.sh` passes locally (verified)
- [ ] Health CI check passes

Generated with [Claude Code](https://claude.com/claude-code)