### PR TITLE
feat(context): integrate OAS context_injector for temporal awareness

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -221,6 +221,7 @@
    mcp_server_eio_resource
    mcp_server_eio_execute
    mcp_server_eio_call_tool
+   masc_context_injector
    masc_error_recovery
    mcp_server_eio_tool_profile
    mcp_server_eio_protocol

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -267,6 +267,10 @@ let run_turn
         (* Keep under Cloudflare tunnel 100s timeout: 2048 / 35 tok/s ~ 59s *)
         ~fallback:(fun () -> 2048)
   in
+  (* 0b. Create context injector for temporal awareness *)
+  let injector_config = Masc_context_injector.default_config () in
+  let context_injector = Masc_context_injector.make ~config:injector_config () in
+  let shared_context = Oas.Context.create () in
   (* 1. Ensure session directory tree exists.
      Both the base traces dir AND the trace-specific session dir must
      exist before any file I/O (checkpoint load, history persist).
@@ -759,6 +763,15 @@ let run_turn
             | None -> Some dynamic_context
             | Some existing -> Some (existing ^ "\n\n" ^ dynamic_context)
         in
+        (* 1b. Temporal context from context_injector (turn 1+) *)
+        let ctx =
+          match Masc_context_injector.render_temporal_summary shared_context with
+          | None -> ctx
+          | Some temporal ->
+            (match ctx with
+             | None -> Some temporal
+             | Some existing -> Some (existing ^ "\n\n" ^ temporal))
+        in
         (* 2. Progressive tool disclosure via OAS Tool_selector.
            Extract context from last user message for relevance scoring. *)
         let last_user_text =
@@ -992,6 +1005,8 @@ let run_turn
           ~cache_system_prompt:true
           ~yield_on_tool
           ~checkpoint_dir:session_dir
+          ~context_injector
+          ~context:shared_context
           ()
       with
       | Error e -> Error e

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -1,0 +1,102 @@
+(** Masc_context_injector — OAS context_injector for MASC agents.
+
+    @since context_injector integration *)
+
+(* ================================================================ *)
+(* Configuration                                                     *)
+(* ================================================================ *)
+
+type config = {
+  start_time : float;
+}
+
+let default_config () : config =
+  { start_time = Unix.gettimeofday () }
+
+(* ================================================================ *)
+(* Context keys                                                      *)
+(* ================================================================ *)
+
+let key_wall_time = "session:wall_time"
+let key_elapsed_seconds = "session:elapsed_seconds"
+let key_tool_call_count = "session:tool_call_count"
+let key_last_tool_name = "session:last_tool_name"
+let key_last_tool_outcome = "session:last_tool_outcome"
+let key_tool_success_count = "session:tool_success_count"
+let key_tool_error_count = "session:tool_error_count"
+
+(* ================================================================ *)
+(* ISO 8601 formatting                                               *)
+(* ================================================================ *)
+
+let iso8601_of_float (t : float) : string =
+  let open Unix in
+  let tm = gmtime t in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+    tm.tm_hour tm.tm_min tm.tm_sec
+
+(* ================================================================ *)
+(* Injector factory                                                  *)
+(* ================================================================ *)
+
+let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
+  let call_count = Atomic.make 0 in
+  let success_count = Atomic.make 0 in
+  let error_count = Atomic.make 0 in
+  fun ~tool_name ~input:_ ~output ->
+    let now = Unix.gettimeofday () in
+    let is_ok = match output with Ok _ -> true | Error _ -> false in
+    let _ = Atomic.fetch_and_add call_count 1 in
+    if is_ok then ignore (Atomic.fetch_and_add success_count 1)
+    else ignore (Atomic.fetch_and_add error_count 1);
+    let outcome_str = if is_ok then "ok" else "error" in
+    let elapsed = now -. config.start_time in
+    Some Agent_sdk.Hooks.{
+      context_updates = [
+        (key_wall_time, `String (iso8601_of_float now));
+        (key_elapsed_seconds, `Float elapsed);
+        (key_tool_call_count, `Int (Atomic.get call_count));
+        (key_last_tool_name, `String tool_name);
+        (key_last_tool_outcome, `String outcome_str);
+        (key_tool_success_count, `Int (Atomic.get success_count));
+        (key_tool_error_count, `Int (Atomic.get error_count));
+      ];
+      extra_messages = [];
+    }
+
+(* ================================================================ *)
+(* Temporal summary renderer                                         *)
+(* ================================================================ *)
+
+let get_string ctx key =
+  match Agent_sdk.Context.get ctx key with
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let get_float ctx key =
+  match Agent_sdk.Context.get ctx key with
+  | Some (`Float f) -> Some f
+  | Some (`Int i) -> Some (float_of_int i)
+  | _ -> None
+
+let get_int ctx key =
+  match Agent_sdk.Context.get ctx key with
+  | Some (`Int i) -> Some i
+  | _ -> None
+
+let render_temporal_summary (ctx : Agent_sdk.Context.t) : string option =
+  match get_string ctx key_wall_time with
+  | None -> None
+  | Some wall_time ->
+    let elapsed =
+      get_float ctx key_elapsed_seconds |> Option.value ~default:0.0 in
+    let tool_count =
+      get_int ctx key_tool_call_count |> Option.value ~default:0 in
+    let last_tool =
+      get_string ctx key_last_tool_name |> Option.value ~default:"none" in
+    let outcome =
+      get_string ctx key_last_tool_outcome |> Option.value ~default:"unknown" in
+    Some (Printf.sprintf
+      "[Temporal] time=%s elapsed=%.0fs tools=%d last=%s(%s)"
+      wall_time elapsed tool_count last_tool outcome)

--- a/lib/masc_context_injector.mli
+++ b/lib/masc_context_injector.mli
@@ -1,0 +1,57 @@
+(** Masc_context_injector — OAS context_injector for MASC agents.
+
+    Writes temporal and tool metadata to {!Agent_sdk.Context.t} after each
+    tool execution.  Shared between Keeper and Worker paths.
+
+    The write path:
+    {[
+      context_injector (after tool exec)
+        → Context.set key value  (via OAS Pipeline Stage 5)
+    ]}
+
+    The read path (caller must wire):
+    {[
+      render_temporal_summary ctx
+        → "[Temporal] time=... elapsed=... tools=... last=...(ok)"
+        → append to extra_system_context in before_turn_params hook
+    ]}
+
+    @since context_injector integration *)
+
+type config = {
+  start_time : float;
+  (** [Unix.gettimeofday ()] at agent creation.
+      Used to compute elapsed seconds. *)
+}
+
+val default_config : unit -> config
+(** Create a config with [start_time = Unix.gettimeofday ()]. *)
+
+val make : config:config -> unit -> Agent_sdk.Hooks.context_injector
+(** Build an OAS [context_injector] function.
+
+    Thread-safe: uses {!Atomic} counters internally.
+    Returns [Some injection] for every tool call (never [None]). *)
+
+val render_temporal_summary : Agent_sdk.Context.t -> string option
+(** Read temporal keys from [Context.t] and render a one-line summary.
+
+    Returns [None] when no tool has executed yet (turn 0).
+    Format: [[Temporal] time=<ISO8601> elapsed=<N>s tools=<N> last=<name>(<outcome>)] *)
+
+val iso8601_of_float : float -> string
+(** Format a Unix timestamp as ISO 8601 UTC string. *)
+
+(** {2 Context keys}
+
+    Constants for the keys written by {!make} and read by
+    {!render_temporal_summary}.  Useful for testing and
+    [AppendInstruction.FromContext] wiring. *)
+
+val key_wall_time : string
+val key_elapsed_seconds : string
+val key_tool_call_count : string
+val key_last_tool_name : string
+val key_last_tool_outcome : string
+val key_tool_success_count : string
+val key_tool_error_count : string

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -108,6 +108,8 @@ val run_named :
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
   ?checkpoint_dir:string ->
+  ?context_injector:Oas.Hooks.context_injector ->
+  ?context:Oas.Context.t ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -43,6 +43,8 @@ type config = {
   cache_system_prompt : bool;
   yield_on_tool : bool;
   compact_ratio : float option;
+  context_injector : Oas.Hooks.context_injector option;
+  context : Oas.Context.t option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -73,6 +75,8 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     cache_system_prompt = false;
     yield_on_tool = false;
     compact_ratio = None;
+    context_injector = None;
+    context = None;
   }
 
 (* ================================================================ *)
@@ -269,6 +273,14 @@ let build
   let builder =
     match config.compact_ratio with
     | Some ratio -> Oas.Builder.with_context_thresholds ~compact_ratio:ratio builder
+    | None -> builder
+  in
+  let builder = match config.context_injector with
+    | Some injector -> Oas.Builder.with_context_injector injector builder
+    | None -> builder
+  in
+  let builder = match config.context with
+    | Some ctx -> Oas.Builder.with_context ctx builder
     | None -> builder
   in
   Oas.Builder.build_safe builder

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -148,6 +148,8 @@ let run_named
     ?(yield_on_tool = false)
     ?compact_ratio
     ?checkpoint_dir
+    ?context_injector
+    ?context
     ?sw
     ?net
     ()
@@ -194,6 +196,8 @@ let run_named
       compact_ratio;
       contract;
       checkpoint_dir;
+      context_injector;
+      context;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -234,6 +234,8 @@ let build_agent
     ~(raw_trace : Oas.Raw_trace.t)
     ~(heartbeat_callbacks : Oas.Agent.periodic_callback list)
     ?(gate_config : Eval_gate.gate_config option)
+    ?context_injector
+    ?context
     () : (Oas.Agent.t, string) result =
   let config = agent_config_of_worker_meta meta ~system_prompt in
   let tool_names =
@@ -271,6 +273,14 @@ let build_agent
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)
   in
+  let builder = match context_injector with
+    | Some ci -> Oas.Builder.with_context_injector ci builder
+    | None -> builder
+  in
+  let builder = match context with
+    | Some ctx -> Oas.Builder.with_context ctx builder
+    | None -> builder
+  in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string
 
@@ -304,9 +314,9 @@ let make_heartbeat_callbacks
       };
     ]
 
-let make_tool_tracking_hooks () =
+let make_tool_tracking_hooks ?context () =
   let tool_names_ref = ref [] in
-  let hooks =
+  let tracking =
     {
       Oas.Hooks.empty with
       pre_tool_use =
@@ -317,6 +327,28 @@ let make_tool_tracking_hooks () =
                 Oas.Hooks.Continue
             | _ -> Oas.Hooks.Continue);
     }
+  in
+  let hooks = match context with
+    | Some ctx ->
+      let temporal =
+        { Oas.Hooks.empty with
+          before_turn_params =
+            Some (function
+              | Oas.Hooks.BeforeTurnParams { current_params; _ } ->
+                (match Masc_context_injector.render_temporal_summary ctx with
+                 | None -> Oas.Hooks.Continue
+                 | Some summary ->
+                   let ctx_str = match current_params.Oas.Hooks.extra_system_context with
+                     | None -> summary
+                     | Some prev -> prev ^ "\n\n" ^ summary
+                   in
+                   Oas.Hooks.AdjustParams { current_params with
+                     extra_system_context = Some ctx_str })
+              | _ -> Oas.Hooks.Continue);
+        }
+      in
+      Oas.Hooks.compose ~outer:temporal ~inner:tracking
+    | None -> tracking
   in
   (tool_names_ref, hooks)
 
@@ -360,10 +392,14 @@ let rec run_worker_via_oas
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
-  let tool_names_ref, hooks = make_tool_tracking_hooks () in
+  let injector_config = Masc_context_injector.default_config () in
+  let context_injector = Masc_context_injector.make ~config:injector_config () in
+  let shared_context = Oas.Context.create () in
+  let tool_names_ref, hooks = make_tool_tracking_hooks ~context:shared_context () in
   let* agent =
     build_agent ~net ~meta ~provider ~system_prompt ~tools ~hooks
-      ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ?gate_config ()
+      ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ?gate_config
+      ~context_injector ~context:shared_context ()
   in
   let* () =
     Worker_container.save_worker_meta ~base_path
@@ -410,7 +446,8 @@ and resume_worker_via_oas
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
-  let tool_names_ref, hooks = make_tool_tracking_hooks () in
+  let shared_context = Oas.Context.create () in
+  let tool_names_ref, hooks = make_tool_tracking_hooks ~context:shared_context () in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
   let* resume_provider =
     oas_provider_of_label (Provider_adapter.make_local_label resume_model_id)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -446,6 +446,8 @@ and resume_worker_via_oas
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
+  let injector_config = Masc_context_injector.default_config () in
+  let context_injector = Masc_context_injector.make ~config:injector_config () in
   let shared_context = Oas.Context.create () in
   let tool_names_ref, hooks = make_tool_tracking_hooks ~context:shared_context () in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
@@ -474,6 +476,8 @@ and resume_worker_via_oas
       ~periodic_callbacks:heartbeat_cbs ~guardrails
       ~tool_retry_policy:default_internal_tool_retry_policy ()
   in
+  let options = { options with
+    Oas.Agent_types.context_injector = Some context_injector } in
   Fun.protect
     ~finally:(fun () ->
       ignore

--- a/test/dune
+++ b/test/dune
@@ -813,6 +813,11 @@
  (libraries masc_test_deps))
 
 (executable
+ (name test_masc_context_injector)
+ (modules test_masc_context_injector)
+ (libraries masc_test_deps))
+
+(executable
  (name tool_matrix_manifest)
  (modules tool_matrix_manifest test_mcp_tool_matrix_cases)
  (libraries masc_test_deps))

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -1,0 +1,139 @@
+(** Tests for MCI. *)
+
+open Alcotest
+module MCI = Masc_mcp.Masc_context_injector
+
+(* ── Helpers ──────────────────────────────────────────── *)
+
+let ok_output content : Agent_sdk.Types.tool_result =
+  Ok { Agent_sdk.Types.content }
+
+let err_output message : Agent_sdk.Types.tool_result =
+  Error { Agent_sdk.Types.message; recoverable = true }
+
+(* ── Unit tests: injector function ──────────────────── *)
+
+let test_injector_returns_some_on_success () =
+  let config = MCI.default_config () in
+  let injector = MCI.make ~config () in
+  match injector ~tool_name:"read_file" ~input:`Null ~output:(ok_output "data") with
+  | Some inj ->
+    check bool "has context_updates" true
+      (List.length inj.Agent_sdk.Hooks.context_updates > 0);
+    check bool "no extra_messages" true
+      (inj.extra_messages = [])
+  | None -> fail "expected Some injection"
+
+let test_injector_returns_some_on_error () =
+  let config = MCI.default_config () in
+  let injector = MCI.make ~config () in
+  match injector ~tool_name:"read_file" ~input:`Null ~output:(err_output "not found") with
+  | Some inj ->
+    let last_outcome =
+      List.assoc MCI.key_last_tool_outcome
+        inj.Agent_sdk.Hooks.context_updates
+    in
+    check (of_pp Yojson.Safe.pp) "outcome is error"
+      (`String "error") last_outcome
+  | None -> fail "expected Some injection"
+
+let test_injector_increments_counts () =
+  let config = MCI.default_config () in
+  let injector = MCI.make ~config () in
+  ignore (injector ~tool_name:"t1" ~input:`Null ~output:(ok_output "ok"));
+  ignore (injector ~tool_name:"t2" ~input:`Null ~output:(ok_output "ok"));
+  match injector ~tool_name:"t3" ~input:`Null ~output:(err_output "err") with
+  | Some inj ->
+    let updates = inj.Agent_sdk.Hooks.context_updates in
+    let count = List.assoc MCI.key_tool_call_count updates in
+    check (of_pp Yojson.Safe.pp) "3 total calls" (`Int 3) count;
+    let success = List.assoc MCI.key_tool_success_count updates in
+    check (of_pp Yojson.Safe.pp) "2 successes" (`Int 2) success;
+    let errors = List.assoc MCI.key_tool_error_count updates in
+    check (of_pp Yojson.Safe.pp) "1 error" (`Int 1) errors
+  | None -> fail "expected Some injection"
+
+(* ── Context.t integration ──────────────────────────── *)
+
+let test_context_populated_after_injection () =
+  let config = MCI.default_config () in
+  let injector = MCI.make ~config () in
+  let ctx = Agent_sdk.Context.create () in
+  match injector ~tool_name:"bash" ~input:`Null ~output:(ok_output "done") with
+  | Some inj ->
+    List.iter (fun (k, v) -> Agent_sdk.Context.set ctx k v)
+      inj.Agent_sdk.Hooks.context_updates;
+    (match Agent_sdk.Context.get ctx MCI.key_last_tool_name with
+     | Some (`String "bash") -> ()
+     | _ -> fail "last_tool_name not set");
+    (match Agent_sdk.Context.get ctx MCI.key_wall_time with
+     | Some (`String s) ->
+       check bool "ends with Z" true (String.length s > 0 && s.[String.length s - 1] = 'Z')
+     | _ -> fail "wall_time not set")
+  | None -> fail "expected Some injection"
+
+(* ── Temporal summary rendering ─────────────────────── *)
+
+let test_render_temporal_summary_empty () =
+  let ctx = Agent_sdk.Context.create () in
+  check (option string) "no summary before any tool"
+    None (MCI.render_temporal_summary ctx)
+
+let test_render_temporal_summary_populated () =
+  let ctx = Agent_sdk.Context.create () in
+  Agent_sdk.Context.set ctx
+    MCI.key_wall_time (`String "2026-04-06T12:00:00Z");
+  Agent_sdk.Context.set ctx
+    MCI.key_elapsed_seconds (`Float 42.5);
+  Agent_sdk.Context.set ctx
+    MCI.key_tool_call_count (`Int 3);
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_name (`String "keeper_bash");
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_outcome (`String "ok");
+  match MCI.render_temporal_summary ctx with
+  | Some summary ->
+    check bool "contains time" true
+      (Astring.String.is_prefix ~affix:"[Temporal]" summary);
+    check bool "contains tool name" true
+      (Astring.String.is_infix ~affix:"keeper_bash" summary);
+    check bool "contains elapsed" true
+      (Astring.String.is_infix ~affix:"elapsed=42s" summary)
+  | None -> fail "expected Some summary"
+
+(* ── ISO 8601 formatting ────────────────────────────── *)
+
+let test_iso8601_format () =
+  let result = MCI.iso8601_of_float 1712404800.0 in
+  check bool "ends with Z" true
+    (String.length result > 0 && result.[String.length result - 1] = 'Z');
+  check bool "contains T" true
+    (Astring.String.is_infix ~affix:"T" result);
+  check bool "length is 20" true (String.length result = 20)
+
+(* ── Runner ─────────────────────────────────────────── *)
+
+let () =
+  run "Masc_context_injector" [
+    "injector", [
+      test_case "returns Some on success" `Quick
+        test_injector_returns_some_on_success;
+      test_case "returns Some on error" `Quick
+        test_injector_returns_some_on_error;
+      test_case "increments counts" `Quick
+        test_injector_increments_counts;
+    ];
+    "context", [
+      test_case "populated after injection" `Quick
+        test_context_populated_after_injection;
+    ];
+    "temporal_summary", [
+      test_case "empty context" `Quick
+        test_render_temporal_summary_empty;
+      test_case "populated context" `Quick
+        test_render_temporal_summary_populated;
+    ];
+    "iso8601", [
+      test_case "format" `Quick test_iso8601_format;
+    ];
+  ]


### PR DESCRIPTION
- [x] Fix `resume_worker_via_oas` to pass `shared_context` to agent options (`context = Some shared_context`) so `context_injector` and `before_turn_params` hook use the same `Context.t` object
- [x] Fix test `test_render_temporal_summary_populated` to use `42.1` instead of tie-breaking `42.5` for platform-consistent `%.0f` rounding