### PR TITLE
fix(keeper): propagate save_oas_checkpoint errors, abort handoff and keeper creation on failure, fix compaction inconsistency

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -302,7 +302,7 @@ let save_oas_checkpoint
     ~(model : string)
     ~(ctx : working_context)
     ~(generation : int)
-  : Agent_sdk.Checkpoint.t =
+  : (Agent_sdk.Checkpoint.t, string) result =
   let checkpoint_context = Agent_sdk.Context.copy ctx.context in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
@@ -340,10 +340,11 @@ let save_oas_checkpoint
       ~mcp_clients:[]
       ()
   in
-  (match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
-   | Ok () -> ()
-   | Error e -> Log.Keeper.error "save_oas_checkpoint failed: %s" e);
-  checkpoint
+  match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
+  | Ok () -> Ok checkpoint
+  | Error e ->
+      Log.Keeper.error "save_oas_checkpoint failed: %s" e;
+      Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -342,9 +342,7 @@ let save_oas_checkpoint
   in
   match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
   | Ok () -> Ok checkpoint
-  | Error e ->
-      Log.Keeper.error "save_oas_checkpoint failed: %s" e;
-      Error e
+  | Error e -> Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -69,7 +69,7 @@ val save_oas_checkpoint :
   model:string ->
   ctx:working_context ->
   generation:int ->
-  Agent_sdk.Checkpoint.t
+  (Agent_sdk.Checkpoint.t, string) result
 
 (** {1 Handoff Rollover} *)
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -113,10 +113,29 @@ let apply_post_turn_lifecycle
       let compacted_ctx, trigger, decision =
         Keeper_compact_policy.compact_if_needed ~meta:base_meta ~now_ts ctx
       in
-      let compaction_applied =
+      let compaction_decided =
         String.starts_with ~prefix:"applied:" decision
       in
-      let after_tokens = token_count compacted_ctx in
+      (* Attempt save before updating meta so that a save failure is treated as
+         compaction not applied — keeping ctx/checkpoint/metrics consistent. *)
+      let effective_compaction_applied, effective_ctx, checkpoint =
+        if not compaction_decided then (false, ctx, Some cp)
+        else
+          let session =
+            create_session ~session_id:base_meta.runtime.trace_id ~base_dir
+          in
+          (match save_oas_checkpoint ~session
+               ~agent_name:base_meta.agent_name
+               ~model ~ctx:compacted_ctx ~generation:current_generation
+          with
+          | Ok saved_cp -> (true, compacted_ctx, Some saved_cp)
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s compaction checkpoint save failed: %s"
+                base_meta.name e;
+              (false, ctx, Some cp))
+      in
+      let after_tokens = token_count effective_ctx in
       let saved_tokens = max 0 (before_tokens - after_tokens) in
       let meta_after_compaction =
         map_runtime
@@ -127,37 +146,21 @@ let apply_post_turn_lifecycle
                 {
                   count =
                     rt.compaction_rt.count
-                    + if compaction_applied then 1 else 0;
+                    + if effective_compaction_applied then 1 else 0;
                   last_ts =
-                    if compaction_applied then now_ts else rt.compaction_rt.last_ts;
+                    if effective_compaction_applied then now_ts
+                    else rt.compaction_rt.last_ts;
                   last_before_tokens =
-                    if compaction_applied then before_tokens
+                    if effective_compaction_applied then before_tokens
                     else rt.compaction_rt.last_before_tokens;
                   last_after_tokens =
-                    if compaction_applied then after_tokens
+                    if effective_compaction_applied then after_tokens
                     else rt.compaction_rt.last_after_tokens;
                   last_check_ts = now_ts;
                   last_decision = decision;
                 };
             })
           base_meta
-      in
-      let checkpoint =
-        if not compaction_applied then Some cp
-        else
-          let session =
-            create_session ~session_id:meta_after_compaction.runtime.trace_id ~base_dir
-          in
-          (match save_oas_checkpoint ~session
-               ~agent_name:meta_after_compaction.agent_name
-               ~model ~ctx:compacted_ctx ~generation:current_generation
-          with
-          | Ok saved_cp -> Some saved_cp
-          | Error e ->
-              Log.Keeper.error
-                "keeper:%s compaction checkpoint save failed: %s"
-                meta_after_compaction.agent_name e;
-              Some cp)
       in
       let rollover =
         Keeper_rollover.maybe_rollover_oas_handoff ~base_dir
@@ -169,7 +172,7 @@ let apply_post_turn_lifecycle
       let continuity_meta =
         apply_continuity_summary
           ~meta:rollover.updated_meta
-          ~ctx:compacted_ctx
+          ~ctx:effective_ctx
       in
       {
         updated_meta = continuity_meta;
@@ -177,7 +180,7 @@ let apply_post_turn_lifecycle
         handoff_json = rollover.handoff_json;
         compaction =
           {
-            applied = compaction_applied;
+            applied = effective_compaction_applied;
             trigger;
             decision;
             before_tokens;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -148,10 +148,16 @@ let apply_post_turn_lifecycle
           let session =
             create_session ~session_id:meta_after_compaction.runtime.trace_id ~base_dir
           in
-          Some
-            (save_oas_checkpoint ~session
+          (match save_oas_checkpoint ~session
                ~agent_name:meta_after_compaction.agent_name
-               ~model ~ctx:compacted_ctx ~generation:current_generation)
+               ~model ~ctx:compacted_ctx ~generation:current_generation
+          with
+          | Ok saved_cp -> Some saved_cp
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s compaction checkpoint save failed: %s"
+                meta_after_compaction.agent_name e;
+              Some cp)
       in
       let rollover =
         Keeper_rollover.maybe_rollover_oas_handoff ~base_dir
@@ -313,16 +319,20 @@ let recover_latest_checkpoint_for_overflow_retry
           }
         in
         try
-          let checkpoint =
-            save_oas_checkpoint ~session
+          (match save_oas_checkpoint ~session
               ~agent_name:retry_meta.agent_name
               ~model ~ctx:compacted_ctx ~generation:turn_generation
-          in
-          Some { checkpoint; compaction; turn_generation }
+          with
+          | Ok checkpoint ->
+              Some { checkpoint; compaction; turn_generation }
+          | Error e ->
+              Log.Keeper.error
+                "overflow retry checkpoint save failed: %s" e;
+              None)
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             log_keeper_exn
-              ~label:"overflow retry checkpoint save failed"
+              ~label:"overflow retry checkpoint save exception"
               exn;
             None

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -70,10 +70,10 @@ let maybe_rollover_oas_handoff
         let prev_trace_id = base_meta.runtime.trace_id in
         let new_trace_id = Keeper_identity.generate_trace_id () in
         let next_generation = current_generation + 1 in
-        let new_session =
-          create_session ~session_id:new_trace_id ~base_dir
-        in
         (try
+          let new_session =
+            create_session ~session_id:new_trace_id ~base_dir
+          in
           match save_oas_checkpoint ~session:new_session
                   ~agent_name:base_meta.agent_name
                   ~model ~ctx ~generation:next_generation with

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -73,44 +73,49 @@ let maybe_rollover_oas_handoff
         let new_session =
           create_session ~session_id:new_trace_id ~base_dir
         in
-        try
-          ignore
-            (save_oas_checkpoint ~session:new_session
-               ~agent_name:base_meta.agent_name
-               ~model ~ctx ~generation:next_generation);
-          let updated_meta =
-            {
-              base_meta with
-              updated_at = now_iso ();
-              runtime = { base_meta.runtime with
-                trace_id = new_trace_id;
-                trace_history =
-                  dedupe_keep_order (prev_trace_id :: base_meta.runtime.trace_history);
-                generation = next_generation;
-                last_handoff_ts = now_ts;
-              };
-            }
-          in
-          let handoff_json =
-            `Assoc
-              [
-                ("performed", `Bool true);
-                ("from_generation", `Int current_generation);
-                ("to_generation", `Int next_generation);
-                ("new_generation", `Int next_generation);
-                ("prev_trace_id", `String prev_trace_id);
-                ("new_trace_id", `String new_trace_id);
-                ("to_model", `String model);
-                ("context_ratio", `Float ratio);
-              ]
-          in
-          Log.Keeper.info
-            "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f"
-            base_meta.name prev_trace_id new_trace_id current_generation
-            next_generation ratio;
-          { rollover_base with updated_meta; handoff_json = Some handoff_json }
+        (try
+          match save_oas_checkpoint ~session:new_session
+                  ~agent_name:base_meta.agent_name
+                  ~model ~ctx ~generation:next_generation with
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s OAS handoff rollover ABORTED — checkpoint save failed: %s"
+                base_meta.name e;
+              rollover_base
+          | Ok _checkpoint ->
+              let updated_meta =
+                {
+                  base_meta with
+                  updated_at = now_iso ();
+                  runtime = { base_meta.runtime with
+                    trace_id = new_trace_id;
+                    trace_history =
+                      dedupe_keep_order (prev_trace_id :: base_meta.runtime.trace_history);
+                    generation = next_generation;
+                    last_handoff_ts = now_ts;
+                  };
+                }
+              in
+              let handoff_json =
+                `Assoc
+                  [
+                    ("performed", `Bool true);
+                    ("from_generation", `Int current_generation);
+                    ("to_generation", `Int next_generation);
+                    ("new_generation", `Int next_generation);
+                    ("prev_trace_id", `String prev_trace_id);
+                    ("new_trace_id", `String new_trace_id);
+                    ("to_model", `String model);
+                    ("context_ratio", `Float ratio);
+                  ]
+              in
+              Log.Keeper.info
+                "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f"
+                base_meta.name prev_trace_id new_trace_id current_generation
+                next_generation ratio;
+              { rollover_base with updated_meta; handoff_json = Some handoff_json }
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
             log_keeper_exn ~label:"keeper OAS handoff rollover failed" exn;
-            rollover_base
+            rollover_base)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -322,17 +322,20 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
       (try
-         ignore
-           (Keeper_exec_context.save_oas_checkpoint
+         (match Keeper_exec_context.save_oas_checkpoint
               ~session
               ~agent_name:meta.agent_name
               ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
               ~ctx:ctx0
-              ~generation:0)
+              ~generation:0
+          with
+          | Ok _ -> ()
+          | Error e ->
+              Log.Keeper.error "save_oas_checkpoint (init) failed: %s" e)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           log_keeper_exn ~label:"save_oas_checkpoint (init) failed" exn);
+           log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn);
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_meta ctx.config meta with
       | Error e ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -321,21 +321,28 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         };
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
-      (try
-         (match Keeper_exec_context.save_oas_checkpoint
-              ~session
-              ~agent_name:meta.agent_name
-              ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
-              ~ctx:ctx0
-              ~generation:0
-          with
-          | Ok _ -> ()
-          | Error e ->
-              Log.Keeper.error "save_oas_checkpoint (init) failed: %s" e)
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-           log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn);
+      let init_save_result =
+        try
+          Keeper_exec_context.save_oas_checkpoint
+            ~session
+            ~agent_name:meta.agent_name
+            ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+            ~ctx:ctx0
+            ~generation:0
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn;
+            Error (Printexc.to_string exn)
+      in
+      match init_save_result with
+      | Error e ->
+        Log.Keeper.error
+          "create_keeper failed: initial checkpoint save error for name=%s: %s"
+          p.name e;
+        Progress.stop_tracking task_id;
+        (false, Printf.sprintf "initial checkpoint save failed: %s" e)
+      | Ok _ ->
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_meta ctx.config meta with
       | Error e ->

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -70,11 +70,14 @@ let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
   let session =
     KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
   in
-  KEC.save_oas_checkpoint ~session
+  match KEC.save_oas_checkpoint ~session
     ~agent_name:meta.agent_name
     ~model:"llama:auto"
     ~ctx
     ~generation:meta.runtime.generation
+  with
+  | Ok cp -> cp
+  | Error e -> Alcotest.fail (Printf.sprintf "save_oas_checkpoint failed: %s" e)
 
 let load_context ~base_dir ~trace_id ~max_tokens =
   let (_session, loaded_opt) =

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -322,6 +322,64 @@ let test_apply_post_turn_lifecycle_handoffs_after_compaction () =
             (List.length loaded.messages > 0)
       | None -> fail "expected rollover checkpoint in new trace")
 
+let test_rollover_aborts_on_save_failure () =
+  let base_dir = temp_dir "keeper_lifecycle_rollover_abort" in
+  Fun.protect
+    ~finally:(fun () ->
+      (* Restore write permissions for cleanup *)
+      (try Unix.chmod base_dir 0o755 with _ -> ());
+      cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let now_ts = Time_compat.now () in
+      let original_trace = "trace-rollover-abort" in
+      let meta =
+        let base = make_keeper_meta ~trace_id:original_trace () in
+        {
+          base with
+          auto_handoff = true;
+          handoff_threshold = 0.0;
+          handoff_cooldown_sec = 0;
+          compaction =
+            {
+              base.compaction with
+              ratio_gate = 1.0;
+              message_gate = 0;
+              token_gate = 0;
+              cooldown_sec = 0;
+            };
+          runtime =
+            {
+              base.runtime with
+              last_continuity_update_ts = now_ts -. 60.0;
+            };
+        }
+      in
+      let ctx =
+        build_dense_context ~turns:10 ~max_tokens:256
+          ~state_reply:
+            "done\n\n[STATE]\nGoal: test abort\nProgress: saved\n[/STATE]"
+      in
+      let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
+      (* Make base_dir read-only so new session dir creation fails *)
+      Unix.chmod base_dir 0o555;
+      let rollover =
+        KEC.maybe_rollover_oas_handoff ~base_dir ~meta
+          ~model:"llama:auto"
+          ~primary_model_max_tokens:256
+          ~checkpoint:(Some checkpoint)
+      in
+      (* Restore permissions before assertions *)
+      Unix.chmod base_dir 0o755;
+      check bool "handoff NOT emitted on save failure" false
+        (Option.is_some rollover.handoff_json);
+      check string "trace_id unchanged" original_trace
+        rollover.updated_meta.runtime.trace_id;
+      check int "generation unchanged" 0
+        rollover.updated_meta.runtime.generation)
+
 let test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint () =
   let base_dir = temp_dir "keeper_lifecycle_overflow_retry_oas" in
   Fun.protect
@@ -534,6 +592,8 @@ let () =
             test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips;
           test_case "handoff runs after compaction" `Quick
             test_apply_post_turn_lifecycle_handoffs_after_compaction;
+          test_case "rollover aborts on save failure" `Quick
+            test_rollover_aborts_on_save_failure;
           test_case "overflow retry compacts OAS checkpoint" `Quick
             test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint;
           test_case "overflow retry falls back to legacy checkpoint" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -839,11 +839,11 @@ let test_keeper_checkpoint_prefers_oas_checkpoint () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "oas")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
-           ~ctx:oas_ctx ~generation:7);
+           ~ctx:oas_ctx ~generation:7
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       let (_session, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id
           ~primary_model_max_tokens:1024 ~base_dir
@@ -947,10 +947,11 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
+        with Ok cp -> cp | Error e -> Alcotest.fail e
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -1013,10 +1014,11 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
+        with Ok cp -> cp | Error e -> Alcotest.fail e
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -1050,11 +1052,11 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
         Keeper_exec_context.append ctx (tool_result_msg noisy_tool_output)
         |> Keeper_exec_context.sync_oas_context
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:11);
+           ~generation:11
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       let bad_legacy =
         {
           (Keeper_exec_context.create_checkpoint ctx ~generation:19) with
@@ -1130,11 +1132,11 @@ let test_overflow_retry_requires_meaningful_reduction () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "short")
         |> Keeper_exec_context.sync_oas_context
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:meta.runtime.generation);
+           ~generation:meta.runtime.generation
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
@@ -1165,11 +1167,11 @@ let test_overflow_retry_saves_compacted_checkpoint () =
         |> Keeper_exec_context.sync_oas_context
       in
       let before_tokens = Keeper_exec_context.token_count ctx in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:meta.runtime.generation);
+           ~generation:meta.runtime.generation
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
@@ -1215,10 +1217,10 @@ let test_same_trace_multi_turn_accumulation () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "turn 1 reply")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx:ctx_turn1 ~generation:0);
+           ~model:"llama:auto" ~ctx:ctx_turn1 ~generation:0
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Turn 2: load checkpoint, verify messages, add more *)
       let (_session2, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id
@@ -1241,10 +1243,10 @@ let test_same_trace_multi_turn_accumulation () =
       let session2 =
         Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session:session2
+      (match Keeper_exec_context.save_oas_checkpoint ~session:session2
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx:ctx_turn2 ~generation:1);
+           ~model:"llama:auto" ~ctx:ctx_turn2 ~generation:1
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Immediate verify: reload right after second save to isolate
          save correctness from load correctness (GLM-5 review finding) *)
       let (_session_imm, immediate_opt) =
@@ -1297,10 +1299,10 @@ let test_restart_continuity_load_oas_non_empty () =
         Keeper_exec_context.append c (Agent_sdk.Types.user_msg "msg3")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx ~generation:5);
+           ~model:"llama:auto" ~ctx ~generation:5
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Simulate restart: fresh load with no runtime state *)
       let (_fresh_session, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id


### PR DESCRIPTION
## Summary
- `save_oas_checkpoint` 반환 타입을 `Checkpoint.t` → `(Checkpoint.t, string) result`로 변경하여 저장 실패를 호출자에게 전파
- **handoff rollover에서 save 실패 시 handoff를 중단** (`rollover_base` 반환, `meta.trace_id` 불변) — context 소실의 핵심 원인 차단
- **keeper 생성 시 초기 checkpoint save 실패 시 keeper 생성 중단** — 복구 불가능한 상태(persisted checkpoint 없음)로 keeper가 시작되는 것을 방지. `write_meta` 실패와 동일하게 `(false, error)` 반환 + `Progress.stop_tracking` 호출
- **compaction save 실패 시 compaction을 미적용으로 처리** — save 결과를 먼저 확인 후 `meta_after_compaction` 갱신, `effective_ctx`/`effective_compaction_applied`/`checkpoint`를 일관되게 downstream에 전달. 이전 코드는 save 실패 시 `compacted_ctx`로 계속 진행하여 checkpoint와 context/metrics 간 불일치 발생
- `save_oas_checkpoint` 내부의 중복 `Log.Keeper.error` 제거 — 모든 call site가 이미 `Error` 시 로깅하므로 동일 실패에 대해 이중 로그 방지
- compaction save 실패 로그의 `keeper:%s` prefix를 `agent_name` → `name`으로 수정 — keeper 로그 컨벤션 준수
- 모든 production call site(5곳) + test call site에서 result 처리

### 근본원인
OAS의 `Checkpoint_store.save`는 이미 `(unit, Error.sdk_error) result`를 반환하지만, MASC 래퍼 `save_oas_checkpoint`가 에러를 로그만 찍고 `Checkpoint.t`를 항상 반환. `keeper_rollover.ml`에서 `ignore(save_oas_checkpoint ...)`로 호출하여 저장 실패해도 `meta.trace_id`를 새 값으로 갱신 → 다음 턴에서 빈 session_dir 로드 → context 전부 소실.

### OAS 경계
OAS 변경 없음. MASC 래퍼의 result 소비 방식만 수정.

## Product impact

- Promise affected: `repo coordination` | `none/internal`
- User-visible change: 없음. checkpoint 저장 실패 시 context 소실 방지 및 invalid 상태 keeper 생성 방지 (내부 안정성 개선)

## Evidence

- `dune build` 성공
- `test_keeper_lifecycle` 12/12 통과
- `test_oas_worker` 43/43 통과
- `test_rollover_aborts_on_save_failure` 추가 — read-only base_dir로 save 실패 유발, handoff 중단 + `meta.trace_id` 불변 검증

## Review evidence

- Copilot PR reviewer (4-comment thread) 피드백 전체 반영: 중복 로그 제거, compaction 일관성 수정, 로그 prefix 수정, keeper 생성 중단 추가
- GLM-5.1 리뷰: Finding 1/2/3 의도적 동작 확인, Finding 4 테스트 추가로 수정 완료

## Linked issue