### PR TITLE
fix(cascade): add glm:auto fallback to keeper_unified_models

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -36,7 +36,7 @@
   "auto_responder_gemini_models": ["llama:auto", "gemini:auto", "glm:auto"],
   "auto_responder_glm_models": ["llama:auto", "glm:auto"],
   "spawn_glm_models": ["llama:auto", "glm:auto"],
-  "keeper_unified_models": ["llama:auto"],
+  "keeper_unified_models": ["llama:auto", "glm:auto"],
   "research_models": ["llama:auto", "glm:auto"],
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",


### PR DESCRIPTION
## Summary
- `keeper_unified_models`에 `glm:auto` fallback 추가
- 이전: `["llama:auto"]` — llama 실패 시 cascade 종료, keeper 턴 실패
- 이후: `["llama:auto", "glm:auto"]` — 다른 모든 cascade와 동일한 fallback 경로

## Context
keeper_unified는 keeper 턴 실행의 핵심 cascade인데, 유일하게 glm fallback이 빠져있었음.
llama-server 재시작/장애 시 keeper가 전부 멈추는 원인.

## Test plan
- [ ] llama-server 중지 상태에서 keeper_msg 호출 → glm으로 fallback 확인
- [ ] llama-server 정상 상태에서 기존 동작 변화 없음 확인

Generated with [Claude Code](https://claude.com/claude-code)