### PR TITLE
chore: bump agent_sdk pin 0.105.0 → 0.106.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.105.0))
+  (agent_sdk (>= 0.106.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.105.0"}
+  "agent_sdk" {>= "0.106.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.105.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.106.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
 readonly OAS_AGENT_SDK_SHA="3e165bd41deea6c5a2b66beecfdc2c212cd261a7"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.105.0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.106.0"


### PR DESCRIPTION
## Summary
- `oas-agent-sdk-pin.sh`: BASE_TAG v0.105.0 → v0.106.0, MIN_VERSION 0.105.0 → 0.106.0
- `dune-project` + `masc_mcp.opam`: agent_sdk >= 0.106.0

OAS v0.106.0 includes:
- #650: lifecycle transition guards
- #651: inference profiles (worker_default, deterministic) + context_metrics
- #652: Collaboration/Plan transition guards
- #649: Constants.Endpoints consolidation

Generated with [Claude Code](https://claude.com/claude-code)