### PR TITLE
refactor: remove 15% token buffer and extract compaction threshold

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -303,6 +303,7 @@ module ContextCompact = struct
   let dynamic_multi_agent_ratio = get_float ~default:0.80 "MASC_COMPACT_DYN_MULTI_AGENT_RATIO"
   let dynamic_focused_ratio = get_float ~default:0.70 "MASC_COMPACT_DYN_FOCUSED_RATIO"
   let small_local_floor = get_int ~default:64_000 "MASC_COMPACT_SMALL_LOCAL_FLOOR"
+  let large_cloud_floor = get_int ~default:500_000 "MASC_COMPACT_LARGE_CLOUD_FLOOR"
 end
 
 (** {1 Dashboard Health Thresholds}

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -409,7 +409,7 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
        Uses an approximate 64K floor here; llama-server default 8K is
        unsuitable for multi-turn keeper conversations. *)
     [PruneToolOutputs; MergeContiguous]
-  else if obs.context_window >= 500_000 then
+  else if obs.context_window >= Env_config.ContextCompact.large_cloud_floor then
     (* Large-context cloud: invest in quality-preserving strategies *)
     [DropLowImportance; SummarizeOld]
   else

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -49,12 +49,12 @@ let ensure_dir path =
 let estimate_char_tokens (s : string) : int =
   Agent_sdk.Context_reducer.estimate_char_tokens s
 
-(** CJK-aware token estimate delegated to OAS Context_reducer. *)
+(** CJK-aware token estimate delegated to OAS Context_reducer.
+    OAS estimator is already conservative (CJK-aware, ceil-based).
+    Prior 15% buffer (#5053) removed — it caused premature compaction
+    and masked the OAS estimator's actual accuracy. *)
 let msg_tokens (m : Agent_sdk.Types.message) : int =
-  let estimated = Agent_sdk.Context_reducer.estimate_message_tokens m in
-  (* Use 15% safety buffer for message estimation errors (#5053).
-     Ceiling-based to avoid truncation erasing the buffer. *)
-  int_of_float (ceil (float_of_int estimated *. 1.15))
+  Agent_sdk.Context_reducer.estimate_message_tokens m
 
 let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
   let sys_tokens = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in


### PR DESCRIPTION
## Summary

- `keeper_context_core.ml` 15% safety buffer 제거 — OAS 추정기 직접 위임
- `context_compact_oas.ml` 500K 하드코딩 → `MASC_COMPACT_LARGE_CLOUD_FLOOR` 환경변수

## 변경하지 않는 것

- `relay.ml` context 해상도 — OAS `Model_meta.for_model_id`가 base-provider-name lookup을 지원하지 않으므로 기존 3-layer 해상도 유지. 이건 OAS 쪽 개선이 필요한 별도 작업.

## 행동 변경

- 토큰 추정값 ~13% 감소 → keeper 컴팩션 빈도 감소, context 활용 효율 증가
- overflow 시 `Oas.Retry.is_context_overflow_message`로 자동 복구

## Test plan

- [x] `dune build` 통과
- [x] 3파일, 7+/6- (relay.ml 미변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)