### PR TITLE
fix(keeper): return structured errors from load_oas instead of option

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -151,25 +151,42 @@ let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
 (* Delta Checkpoint Shadow-Apply removed: Agent_sdk.Checkpoint.delta
    type was removed upstream. Functions had zero callers. *)
 
+type checkpoint_load_error =
+  | Not_found
+  | Store_error of string
+  | Parse_error of string
+  | Io_error of string
+
+let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
+  match e with
+  | Io (FileOpFailed _) -> Not_found
+  | Io (ValidationFailed r) -> Store_error r.detail
+  | Serialization (JsonParseError r) -> Parse_error r.detail
+  | Serialization (VersionMismatch r) ->
+      Parse_error (sprintf "version mismatch: expected %d, got %d" r.expected r.got)
+  | Serialization (UnknownVariant r) ->
+      Parse_error (sprintf "unknown variant %s: %s" r.type_name r.value)
+  | _ -> Io_error (Agent_sdk.Error.to_string e)
+
 let load_oas ~(session_dir : string) ~(session_id : string) :
-    Agent_sdk.Checkpoint.t option =
+    (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
   match Fs_compat.get_fs_opt () with
   | Some fs ->
       let dir = Eio.Path.(fs / session_dir) in
       (match Agent_sdk.Checkpoint_store.create dir with
        | Ok store -> (
            match Agent_sdk.Checkpoint_store.load store session_id with
-           | Ok ckpt -> Some ckpt
-           | Error _ -> None)
-       | Error _ -> None)
+           | Ok ckpt -> Ok ckpt
+           | Error e -> Error (classify_sdk_error e))
+       | Error e -> Error (Store_error (Agent_sdk.Error.to_string e)))
   | None ->
       let path = oas_checkpoint_path ~session_dir ~session_id in
       if Sys.file_exists path then
         try
           match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
-          | Ok ckpt -> Some ckpt
-          | Error _ -> None
+          | Ok ckpt -> Ok ckpt
+          | Error e -> Error (classify_sdk_error e)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
-        | _ -> None
-      else None
+        | exn -> Error (Io_error (Printexc.to_string exn))
+      else Error Not_found

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -157,9 +157,17 @@ type checkpoint_load_error =
   | Parse_error of string
   | Io_error of string
 
+let is_not_found_detail (detail : string) : bool =
+  let d = String.lowercase_ascii detail in
+  String.starts_with ~prefix:"no_such_file" d  (* Eio.Fs.Not_found *)
+  || String.starts_with ~prefix:"no such file" d
+  || String.starts_with ~prefix:"unix_error (enoent" d  (* POSIX *)
+
 let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   match e with
-  | Io (FileOpFailed _) -> Not_found
+  | Io (FileOpFailed r) ->
+      if is_not_found_detail r.detail then Not_found
+      else Io_error (sprintf "file %s failed on %s: %s" r.op r.path r.detail)
   | Io (ValidationFailed r) -> Store_error r.detail
   | Serialization (JsonParseError r) -> Parse_error r.detail
   | Serialization (VersionMismatch r) ->

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -302,7 +302,7 @@ let save_oas_checkpoint
     ~(model : string)
     ~(ctx : working_context)
     ~(generation : int)
-  : Agent_sdk.Checkpoint.t =
+  : (Agent_sdk.Checkpoint.t, string) result =
   let checkpoint_context = Agent_sdk.Context.copy ctx.context in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
@@ -340,10 +340,11 @@ let save_oas_checkpoint
       ~mcp_clients:[]
       ()
   in
-  (match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
-   | Ok () -> ()
-   | Error e -> Log.Keeper.error "save_oas_checkpoint failed: %s" e);
-  checkpoint
+  match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
+  | Ok () -> Ok checkpoint
+  | Error e ->
+      Log.Keeper.error "save_oas_checkpoint failed: %s" e;
+      Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -367,10 +367,20 @@ let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
 
 let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
   let session = create_session ~session_id:trace_id ~base_dir in
-  let oas_checkpoint =
+  let oas_result =
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:trace_id
   in
+  (* Log non-trivial load errors (Not_found is normal on first boot) *)
+  (match oas_result with
+   | Error (Parse_error detail) ->
+       Log.Keeper.error "keeper:%s OAS checkpoint parse error: %s" trace_id detail
+   | Error (Store_error detail) ->
+       Log.Keeper.error "keeper:%s OAS checkpoint store error: %s" trace_id detail
+   | Error (Io_error detail) ->
+       Log.Keeper.error "keeper:%s OAS checkpoint I/O error: %s" trace_id detail
+   | Error Not_found | Ok _ -> ());
+  let oas_checkpoint = Result.to_option oas_result in
   let legacy_checkpoint =
     try load_latest_checkpoint session
     with ex ->
@@ -407,7 +417,21 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
          Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
            trace_id (Printexc.to_string ex);
          (session, None))
-  | _ -> (session, None)
+  | _ ->
+      (* Both OAS and legacy checkpoints unavailable *)
+      (match oas_result with
+       | Error Not_found -> ()
+       | Error e ->
+           Log.Keeper.warn
+             "keeper:%s no checkpoint available (oas=%s, legacy=none)"
+             trace_id
+             (match e with
+              | Parse_error d -> "parse_error:" ^ d
+              | Store_error d -> "store_error:" ^ d
+              | Io_error d -> "io_error:" ^ d
+              | Not_found -> "not_found")
+       | Ok _ -> ());
+      (session, None)
 
 (** Patch an OAS checkpoint: unify session_id and replace the last
     assistant message's text content with [response_text] (which includes

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -418,19 +418,8 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
            trace_id (Printexc.to_string ex);
          (session, None))
   | _ ->
-      (* Both OAS and legacy checkpoints unavailable *)
-      (match oas_result with
-       | Error Not_found -> ()
-       | Error e ->
-           Log.Keeper.warn
-             "keeper:%s no checkpoint available (oas=%s, legacy=none)"
-             trace_id
-             (match e with
-              | Parse_error d -> "parse_error:" ^ d
-              | Store_error d -> "store_error:" ^ d
-              | Io_error d -> "io_error:" ^ d
-              | Not_found -> "not_found")
-       | Ok _ -> ());
+      (* Both OAS and legacy checkpoints unavailable.
+         Non-trivial OAS errors were already logged above at error level. *)
       (session, None)
 
 (** Patch an OAS checkpoint: unify session_id and replace the last

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -69,7 +69,7 @@ val save_oas_checkpoint :
   model:string ->
   ctx:working_context ->
   generation:int ->
-  Agent_sdk.Checkpoint.t
+  (Agent_sdk.Checkpoint.t, string) result
 
 (** {1 Handoff Rollover} *)
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -148,10 +148,16 @@ let apply_post_turn_lifecycle
           let session =
             create_session ~session_id:meta_after_compaction.runtime.trace_id ~base_dir
           in
-          Some
-            (save_oas_checkpoint ~session
+          (match save_oas_checkpoint ~session
                ~agent_name:meta_after_compaction.agent_name
-               ~model ~ctx:compacted_ctx ~generation:current_generation)
+               ~model ~ctx:compacted_ctx ~generation:current_generation
+          with
+          | Ok saved_cp -> Some saved_cp
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s compaction checkpoint save failed: %s"
+                meta_after_compaction.agent_name e;
+              Some cp)
       in
       let rollover =
         Keeper_rollover.maybe_rollover_oas_handoff ~base_dir
@@ -313,16 +319,20 @@ let recover_latest_checkpoint_for_overflow_retry
           }
         in
         try
-          let checkpoint =
-            save_oas_checkpoint ~session
+          (match save_oas_checkpoint ~session
               ~agent_name:retry_meta.agent_name
               ~model ~ctx:compacted_ctx ~generation:turn_generation
-          in
-          Some { checkpoint; compaction; turn_generation }
+          with
+          | Ok checkpoint ->
+              Some { checkpoint; compaction; turn_generation }
+          | Error e ->
+              Log.Keeper.error
+                "overflow retry checkpoint save failed: %s" e;
+              None)
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             log_keeper_exn
-              ~label:"overflow retry checkpoint save failed"
+              ~label:"overflow retry checkpoint save exception"
               exn;
             None

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -234,10 +234,16 @@ let recover_latest_checkpoint_for_overflow_retry
     ~(model : string)
     ~(primary_model_max_tokens : int) : overflow_retry_recovery option =
   let session = create_session ~session_id:meta.runtime.trace_id ~base_dir in
-  let oas_checkpoint =
+  let oas_result =
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:meta.runtime.trace_id
   in
+  (match oas_result with
+   | Error (Parse_error d | Store_error d | Io_error d) ->
+       Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
+         meta.runtime.trace_id d
+   | Error Not_found | Ok _ -> ());
+  let oas_checkpoint = Result.to_option oas_result in
   let legacy_checkpoint =
     (try load_latest_checkpoint session
      with

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -70,10 +70,10 @@ let maybe_rollover_oas_handoff
         let prev_trace_id = base_meta.runtime.trace_id in
         let new_trace_id = Keeper_identity.generate_trace_id () in
         let next_generation = current_generation + 1 in
-        let new_session =
-          create_session ~session_id:new_trace_id ~base_dir
-        in
         (try
+          let new_session =
+            create_session ~session_id:new_trace_id ~base_dir
+          in
           match save_oas_checkpoint ~session:new_session
                   ~agent_name:base_meta.agent_name
                   ~model ~ctx ~generation:next_generation with

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -73,44 +73,49 @@ let maybe_rollover_oas_handoff
         let new_session =
           create_session ~session_id:new_trace_id ~base_dir
         in
-        try
-          ignore
-            (save_oas_checkpoint ~session:new_session
-               ~agent_name:base_meta.agent_name
-               ~model ~ctx ~generation:next_generation);
-          let updated_meta =
-            {
-              base_meta with
-              updated_at = now_iso ();
-              runtime = { base_meta.runtime with
-                trace_id = new_trace_id;
-                trace_history =
-                  dedupe_keep_order (prev_trace_id :: base_meta.runtime.trace_history);
-                generation = next_generation;
-                last_handoff_ts = now_ts;
-              };
-            }
-          in
-          let handoff_json =
-            `Assoc
-              [
-                ("performed", `Bool true);
-                ("from_generation", `Int current_generation);
-                ("to_generation", `Int next_generation);
-                ("new_generation", `Int next_generation);
-                ("prev_trace_id", `String prev_trace_id);
-                ("new_trace_id", `String new_trace_id);
-                ("to_model", `String model);
-                ("context_ratio", `Float ratio);
-              ]
-          in
-          Log.Keeper.info
-            "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f"
-            base_meta.name prev_trace_id new_trace_id current_generation
-            next_generation ratio;
-          { rollover_base with updated_meta; handoff_json = Some handoff_json }
+        (try
+          match save_oas_checkpoint ~session:new_session
+                  ~agent_name:base_meta.agent_name
+                  ~model ~ctx ~generation:next_generation with
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s OAS handoff rollover ABORTED — checkpoint save failed: %s"
+                base_meta.name e;
+              rollover_base
+          | Ok _checkpoint ->
+              let updated_meta =
+                {
+                  base_meta with
+                  updated_at = now_iso ();
+                  runtime = { base_meta.runtime with
+                    trace_id = new_trace_id;
+                    trace_history =
+                      dedupe_keep_order (prev_trace_id :: base_meta.runtime.trace_history);
+                    generation = next_generation;
+                    last_handoff_ts = now_ts;
+                  };
+                }
+              in
+              let handoff_json =
+                `Assoc
+                  [
+                    ("performed", `Bool true);
+                    ("from_generation", `Int current_generation);
+                    ("to_generation", `Int next_generation);
+                    ("new_generation", `Int next_generation);
+                    ("prev_trace_id", `String prev_trace_id);
+                    ("new_trace_id", `String new_trace_id);
+                    ("to_model", `String model);
+                    ("context_ratio", `Float ratio);
+                  ]
+              in
+              Log.Keeper.info
+                "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f"
+                base_meta.name prev_trace_id new_trace_id current_generation
+                next_generation ratio;
+              { rollover_base with updated_meta; handoff_json = Some handoff_json }
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
             log_keeper_exn ~label:"keeper OAS handoff rollover failed" exn;
-            rollover_base
+            rollover_base)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -322,17 +322,20 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
       (try
-         ignore
-           (Keeper_exec_context.save_oas_checkpoint
+         (match Keeper_exec_context.save_oas_checkpoint
               ~session
               ~agent_name:meta.agent_name
               ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
               ~ctx:ctx0
-              ~generation:0)
+              ~generation:0
+          with
+          | Ok _ -> ()
+          | Error e ->
+              Log.Keeper.error "save_oas_checkpoint (init) failed: %s" e)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           log_keeper_exn ~label:"save_oas_checkpoint (init) failed" exn);
+           log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn);
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_meta ctx.config meta with
       | Error e ->

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -70,11 +70,14 @@ let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
   let session =
     KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
   in
-  KEC.save_oas_checkpoint ~session
+  match KEC.save_oas_checkpoint ~session
     ~agent_name:meta.agent_name
     ~model:"llama:auto"
     ~ctx
     ~generation:meta.runtime.generation
+  with
+  | Ok cp -> cp
+  | Error e -> Alcotest.fail (Printf.sprintf "save_oas_checkpoint failed: %s" e)
 
 let load_context ~base_dir ~trace_id ~max_tokens =
   let (_session, loaded_opt) =

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -322,6 +322,64 @@ let test_apply_post_turn_lifecycle_handoffs_after_compaction () =
             (List.length loaded.messages > 0)
       | None -> fail "expected rollover checkpoint in new trace")
 
+let test_rollover_aborts_on_save_failure () =
+  let base_dir = temp_dir "keeper_lifecycle_rollover_abort" in
+  Fun.protect
+    ~finally:(fun () ->
+      (* Restore write permissions for cleanup *)
+      (try Unix.chmod base_dir 0o755 with _ -> ());
+      cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let now_ts = Time_compat.now () in
+      let original_trace = "trace-rollover-abort" in
+      let meta =
+        let base = make_keeper_meta ~trace_id:original_trace () in
+        {
+          base with
+          auto_handoff = true;
+          handoff_threshold = 0.0;
+          handoff_cooldown_sec = 0;
+          compaction =
+            {
+              base.compaction with
+              ratio_gate = 1.0;
+              message_gate = 0;
+              token_gate = 0;
+              cooldown_sec = 0;
+            };
+          runtime =
+            {
+              base.runtime with
+              last_continuity_update_ts = now_ts -. 60.0;
+            };
+        }
+      in
+      let ctx =
+        build_dense_context ~turns:10 ~max_tokens:256
+          ~state_reply:
+            "done\n\n[STATE]\nGoal: test abort\nProgress: saved\n[/STATE]"
+      in
+      let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
+      (* Make base_dir read-only so new session dir creation fails *)
+      Unix.chmod base_dir 0o555;
+      let rollover =
+        KEC.maybe_rollover_oas_handoff ~base_dir ~meta
+          ~model:"llama:auto"
+          ~primary_model_max_tokens:256
+          ~checkpoint:(Some checkpoint)
+      in
+      (* Restore permissions before assertions *)
+      Unix.chmod base_dir 0o755;
+      check bool "handoff NOT emitted on save failure" false
+        (Option.is_some rollover.handoff_json);
+      check string "trace_id unchanged" original_trace
+        rollover.updated_meta.runtime.trace_id;
+      check int "generation unchanged" 0
+        rollover.updated_meta.runtime.generation)
+
 let test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint () =
   let base_dir = temp_dir "keeper_lifecycle_overflow_retry_oas" in
   Fun.protect
@@ -534,6 +592,8 @@ let () =
             test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips;
           test_case "handoff runs after compaction" `Quick
             test_apply_post_turn_lifecycle_handoffs_after_compaction;
+          test_case "rollover aborts on save failure" `Quick
+            test_rollover_aborts_on_save_failure;
           test_case "overflow retry compacts OAS checkpoint" `Quick
             test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint;
           test_case "overflow retry falls back to legacy checkpoint" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -839,11 +839,11 @@ let test_keeper_checkpoint_prefers_oas_checkpoint () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "oas")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
-           ~ctx:oas_ctx ~generation:7);
+           ~ctx:oas_ctx ~generation:7
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       let (_session, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id
           ~primary_model_max_tokens:1024 ~base_dir
@@ -947,10 +947,11 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
+        with Ok cp -> cp | Error e -> Alcotest.fail e
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -1013,10 +1014,11 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
+        with Ok cp -> cp | Error e -> Alcotest.fail e
       in
       let rollover =
         Keeper_exec_context.maybe_rollover_oas_handoff ~base_dir ~meta
@@ -1050,11 +1052,11 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
         Keeper_exec_context.append ctx (tool_result_msg noisy_tool_output)
         |> Keeper_exec_context.sync_oas_context
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:11);
+           ~generation:11
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       let bad_legacy =
         {
           (Keeper_exec_context.create_checkpoint ctx ~generation:19) with
@@ -1130,11 +1132,11 @@ let test_overflow_retry_requires_meaningful_reduction () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "short")
         |> Keeper_exec_context.sync_oas_context
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:meta.runtime.generation);
+           ~generation:meta.runtime.generation
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
@@ -1165,11 +1167,11 @@ let test_overflow_retry_saves_compacted_checkpoint () =
         |> Keeper_exec_context.sync_oas_context
       in
       let before_tokens = Keeper_exec_context.token_count ctx in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
-           ~generation:meta.runtime.generation);
+           ~generation:meta.runtime.generation
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       match
         Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
           ~base_dir ~meta ~model:"llama:auto"
@@ -1215,10 +1217,10 @@ let test_same_trace_multi_turn_accumulation () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "turn 1 reply")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx:ctx_turn1 ~generation:0);
+           ~model:"llama:auto" ~ctx:ctx_turn1 ~generation:0
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Turn 2: load checkpoint, verify messages, add more *)
       let (_session2, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id
@@ -1241,10 +1243,10 @@ let test_same_trace_multi_turn_accumulation () =
       let session2 =
         Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
       in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session:session2
+      (match Keeper_exec_context.save_oas_checkpoint ~session:session2
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx:ctx_turn2 ~generation:1);
+           ~model:"llama:auto" ~ctx:ctx_turn2 ~generation:1
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Immediate verify: reload right after second save to isolate
          save correctness from load correctness (GLM-5 review finding) *)
       let (_session_imm, immediate_opt) =
@@ -1297,10 +1299,10 @@ let test_restart_continuity_load_oas_non_empty () =
         Keeper_exec_context.append c (Agent_sdk.Types.user_msg "msg3")
       in
       let meta = make_keeper_meta ~trace_id () in
-      ignore
-        (Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~session
            ~agent_name:meta.agent_name
-           ~model:"llama:auto" ~ctx ~generation:5);
+           ~model:"llama:auto" ~ctx ~generation:5
+       with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Simulate restart: fresh load with no runtime state *)
       let (_fresh_session, loaded_opt) =
         Keeper_exec_context.load_context_from_checkpoint ~trace_id

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -789,7 +789,7 @@ let test_keeper_checkpoint_store_oas_roundtrip () =
       match
         Keeper_checkpoint_store.load_oas ~session_dir ~session_id:"trace-store"
       with
-      | Some loaded ->
+      | Ok loaded ->
           Alcotest.(check (float 0.000001)) "created_at preserved"
             checkpoint.created_at
             loaded.created_at;
@@ -803,7 +803,7 @@ let test_keeper_checkpoint_store_oas_roundtrip () =
           Alcotest.(check (option int)) "sidecar max_tokens preserved"
             (Some 4096)
             sidecar_max_tokens
-      | None -> Alcotest.fail "expected OAS checkpoint roundtrip")
+      | Error _ -> Alcotest.fail "expected OAS checkpoint roundtrip")
 
 let test_keeper_checkpoint_store_oas_missing_returns_none () =
   let base_dir = temp_dir "keeper_oas_store_missing" in
@@ -812,11 +812,17 @@ let test_keeper_checkpoint_store_oas_missing_returns_none () =
     (fun () ->
       Fs_compat.clear_fs ();
       let session_dir = Filename.concat base_dir "missing-session" in
-      Alcotest.(check (option string)) "missing checkpoint"
-        None
-        (Keeper_checkpoint_store.load_oas ~session_dir
-           ~session_id:"missing-session"
-         |> Option.map (fun (cp : Agent_sdk.Checkpoint.t) -> cp.session_id)))
+      (match Keeper_checkpoint_store.load_oas ~session_dir
+               ~session_id:"missing-session" with
+       | Error Not_found -> ()
+       | Ok _ -> Alcotest.fail "expected Not_found for missing checkpoint"
+       | Error e ->
+           Alcotest.fail (Printf.sprintf "expected Not_found, got other error: %s"
+             (match e with
+              | Parse_error d -> "parse:" ^ d
+              | Store_error d -> "store:" ^ d
+              | Io_error d -> "io:" ^ d
+              | Not_found -> "not_found"))))
 
 let test_keeper_checkpoint_prefers_oas_checkpoint () =
   let base_dir = temp_dir "keeper_oas_checkpoint" in
@@ -976,7 +982,7 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         Keeper_checkpoint_store.load_oas ~session_dir:new_session.session_dir
           ~session_id:rollover.updated_meta.runtime.trace_id
       with
-      | Some loaded ->
+      | Ok loaded ->
           let generation =
             Agent_sdk.Context.get_scoped loaded.context Agent_sdk.Context.Session
               "keeper_generation"
@@ -987,7 +993,7 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
               | `Int value -> Some value
               | `Intlit raw -> int_of_string_opt raw
               | _ -> None))
-      | None -> Alcotest.fail "expected rollover checkpoint")
+      | Error _ -> Alcotest.fail "expected rollover checkpoint")
 
 let test_keeper_oas_handoff_rollover_below_threshold_noop () =
   let base_dir = temp_dir "keeper_oas_handoff_noop" in


### PR DESCRIPTION
## Summary
- `load_oas` 반환 타입을 `option` → `(Checkpoint.t, checkpoint_load_error) result`로 변경
- 새 에러 타입: `Not_found | Store_error | Parse_error | Io_error`
- `classify_sdk_error`로 OAS `sdk_error` variant를 구조화된 에러로 매핑
- `load_context_from_checkpoint`에서 `Parse_error`/`Store_error`/`Io_error`를 error 로그로 출력
- `Not_found`는 첫 부팅 시 정상 → 로그 불필요
- 기존 silent `None` → 이제 원인 진단 가능

### Base
PR1 (#5517) 기반. main 머지 후 rebase 필요.

## Test plan
- [x] `dune build` 성공
- [x] `test_keeper_lifecycle` 13/13 통과
- [x] `test_oas_worker` 43/43 통과
- [ ] CI checks green

Closes #5515
