### PR TITLE
fix(keeper): abort creation on save failure, fix compaction consistency

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -342,9 +342,7 @@ let save_oas_checkpoint
   in
   match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
   | Ok () -> Ok checkpoint
-  | Error e ->
-      Log.Keeper.error "save_oas_checkpoint failed: %s" e;
-      Error e
+  | Error e -> Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -113,10 +113,29 @@ let apply_post_turn_lifecycle
       let compacted_ctx, trigger, decision =
         Keeper_compact_policy.compact_if_needed ~meta:base_meta ~now_ts ctx
       in
-      let compaction_applied =
+      let compaction_decided =
         String.starts_with ~prefix:"applied:" decision
       in
-      let after_tokens = token_count compacted_ctx in
+      (* Attempt save before updating meta so that a save failure is treated as
+         compaction not applied — keeping ctx/checkpoint/metrics consistent. *)
+      let effective_compaction_applied, effective_ctx, checkpoint =
+        if not compaction_decided then (false, ctx, Some cp)
+        else
+          let session =
+            create_session ~session_id:base_meta.runtime.trace_id ~base_dir
+          in
+          (match save_oas_checkpoint ~session
+               ~agent_name:base_meta.agent_name
+               ~model ~ctx:compacted_ctx ~generation:current_generation
+          with
+          | Ok saved_cp -> (true, compacted_ctx, Some saved_cp)
+          | Error e ->
+              Log.Keeper.error
+                "keeper:%s compaction checkpoint save failed: %s"
+                base_meta.name e;
+              (false, ctx, Some cp))
+      in
+      let after_tokens = token_count effective_ctx in
       let saved_tokens = max 0 (before_tokens - after_tokens) in
       let meta_after_compaction =
         map_runtime
@@ -127,37 +146,21 @@ let apply_post_turn_lifecycle
                 {
                   count =
                     rt.compaction_rt.count
-                    + if compaction_applied then 1 else 0;
+                    + if effective_compaction_applied then 1 else 0;
                   last_ts =
-                    if compaction_applied then now_ts else rt.compaction_rt.last_ts;
+                    if effective_compaction_applied then now_ts
+                    else rt.compaction_rt.last_ts;
                   last_before_tokens =
-                    if compaction_applied then before_tokens
+                    if effective_compaction_applied then before_tokens
                     else rt.compaction_rt.last_before_tokens;
                   last_after_tokens =
-                    if compaction_applied then after_tokens
+                    if effective_compaction_applied then after_tokens
                     else rt.compaction_rt.last_after_tokens;
                   last_check_ts = now_ts;
                   last_decision = decision;
                 };
             })
           base_meta
-      in
-      let checkpoint =
-        if not compaction_applied then Some cp
-        else
-          let session =
-            create_session ~session_id:meta_after_compaction.runtime.trace_id ~base_dir
-          in
-          (match save_oas_checkpoint ~session
-               ~agent_name:meta_after_compaction.agent_name
-               ~model ~ctx:compacted_ctx ~generation:current_generation
-          with
-          | Ok saved_cp -> Some saved_cp
-          | Error e ->
-              Log.Keeper.error
-                "keeper:%s compaction checkpoint save failed: %s"
-                meta_after_compaction.agent_name e;
-              Some cp)
       in
       let rollover =
         Keeper_rollover.maybe_rollover_oas_handoff ~base_dir
@@ -169,7 +172,7 @@ let apply_post_turn_lifecycle
       let continuity_meta =
         apply_continuity_summary
           ~meta:rollover.updated_meta
-          ~ctx:compacted_ctx
+          ~ctx:effective_ctx
       in
       {
         updated_meta = continuity_meta;
@@ -177,7 +180,7 @@ let apply_post_turn_lifecycle
         handoff_json = rollover.handoff_json;
         compaction =
           {
-            applied = compaction_applied;
+            applied = effective_compaction_applied;
             trigger;
             decision;
             before_tokens;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -321,21 +321,28 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         };
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
-      (try
-         (match Keeper_exec_context.save_oas_checkpoint
-              ~session
-              ~agent_name:meta.agent_name
-              ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
-              ~ctx:ctx0
-              ~generation:0
-          with
-          | Ok _ -> ()
-          | Error e ->
-              Log.Keeper.error "save_oas_checkpoint (init) failed: %s" e)
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-           log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn);
+      let init_save_result =
+        try
+          Keeper_exec_context.save_oas_checkpoint
+            ~session
+            ~agent_name:meta.agent_name
+            ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+            ~ctx:ctx0
+            ~generation:0
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            log_keeper_exn ~label:"save_oas_checkpoint (init) exception" exn;
+            Error (Printexc.to_string exn)
+      in
+      match init_save_result with
+      | Error e ->
+        Log.Keeper.error
+          "create_keeper failed: initial checkpoint save error for name=%s: %s"
+          p.name e;
+        Progress.stop_tracking task_id;
+        (false, Printf.sprintf "initial checkpoint save failed: %s" e)
+      | Ok _ ->
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_meta ctx.config meta with
       | Error e ->


### PR DESCRIPTION
## Summary
PR #5517 의 rebase 후 재생성. 핵심 변경만 포함 (3개 파일).

- `keeper_context_core.ml`: save_oas_checkpoint Error 경로에서 중복 로그 제거
- `keeper_post_turn.ml`: compaction save 실패 시 메타도 not-applied로 처리 (일관성)
- `keeper_turn_up_create.ml`: init checkpoint save 실패 시 keeper 생성 자체를 실패 처리

### Base
#5523 (load structured errors) 머지 후 기반.

## Test plan
- [x] 로컬 빌드 성공
- [x] test_oas_worker 43/43 통과
- [ ] CI checks green

Closes #5514
