### PR TITLE
feat(keeper): make max_checkpoint_messages configurable per keeper

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -388,6 +388,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
+                         ~max_checkpoint_messages:m.compaction.max_checkpoint_messages
                          ~trace_id:m.runtime.trace_id
                          ~primary_model_max_tokens:primary_max_context
                          ~base_dir

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -281,6 +281,7 @@ let run_turn
   (* 2. Load checkpoint *)
   let (session, ctx_opt) =
     Keeper_exec_context.load_context_from_checkpoint
+      ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
       ~trace_id:meta.runtime.trace_id
       ~primary_model_max_tokens:max_context
       ~base_dir

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -14,11 +14,12 @@ open Keeper_types
 (* Constants                                                         *)
 (* ================================================================ *)
 
-(** Maximum messages to retain in checkpoints (load and save).
+(** Default maximum messages to retain in checkpoints (load and save).
     Caps both load-time deserialization and save-time persistence to prevent
     unbounded memory growth.  The context_reducer (keep_last 30) trims
-    further during Agent.run, so 60 gives the reducer room to operate. *)
-let max_checkpoint_messages = 60
+    further during Agent.run, so 120 gives the reducer room to operate.
+    Per-keeper override via [compaction_policy.max_checkpoint_messages]. *)
+let default_max_checkpoint_messages = 120
 
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
@@ -260,14 +261,13 @@ let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
       | _ -> fallback)
 
 let context_of_oas_checkpoint
+    ~(max_checkpoint_messages : int)
     (cp : Agent_sdk.Checkpoint.t)
     ~(primary_model_max_tokens : int) : working_context =
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
     checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
   in
-  (* Cap loaded messages — see module-level max_checkpoint_messages. *)
-  let max_checkpoint_messages = max_checkpoint_messages in
   let messages =
     let n = List.length cp.messages in
     if n <= max_checkpoint_messages then cp.messages
@@ -297,6 +297,7 @@ let checkpoint_model_of_meta (meta : keeper_meta) =
   |> Option.value ~default:(Provider_adapter.default_local_fallback_label ())
 
 let save_oas_checkpoint
+    ~(max_checkpoint_messages : int)
     ~(session : session_context)
     ~(agent_name : string)
     ~(model : string)
@@ -363,7 +364,7 @@ let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
 (* Checkpoint Loading                                                *)
 (* ================================================================ *)
 
-let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
+let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_model_max_tokens ~base_dir =
   let session = create_session ~session_id:trace_id ~base_dir in
   let oas_result =
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
@@ -398,7 +399,7 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
   match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
   | (false, Some checkpoint, _) ->
       let ctx =
-        context_of_oas_checkpoint checkpoint ~primary_model_max_tokens
+        context_of_oas_checkpoint ~max_checkpoint_messages checkpoint ~primary_model_max_tokens
       in
       let ctx =
         if primary_model_max_tokens <= 0 then ctx

--- a/lib/keeper/keeper_coordination.mli
+++ b/lib/keeper/keeper_coordination.mli
@@ -5,6 +5,7 @@ open Keeper_types
 val log_keeper_exn : label:string -> exn -> unit
 
 val load_context_from_checkpoint :
+  max_checkpoint_messages:int ->
   trace_id:string ->
   primary_model_max_tokens:int ->
   base_dir:string ->

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -59,11 +59,13 @@ val checkpoint_max_tokens :
   Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint :
+  max_checkpoint_messages:int ->
   Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
 
 val checkpoint_model_of_meta : keeper_meta -> string
 
 val save_oas_checkpoint :
+  max_checkpoint_messages:int ->
   session:session_context ->
   agent_name:string ->
   model:string ->
@@ -120,6 +122,7 @@ val maybe_rollover_oas_handoff :
 (** {1 Checkpoint Loading and Saving} *)
 
 val load_context_from_checkpoint :
+  max_checkpoint_messages:int ->
   trace_id:string ->
   primary_model_max_tokens:int ->
   base_dir:string ->

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -17,6 +17,7 @@ val log_keeper_exn : label:string -> exn -> unit
 
 (** Load keeper context from checkpoint for resumption. *)
 val load_context_from_checkpoint :
+  max_checkpoint_messages:int ->
   trace_id:string ->
   primary_model_max_tokens:int ->
   base_dir:string ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -229,6 +229,7 @@ let write_heartbeat_snapshot
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir meta_current.runtime.trace_id));
   let _session, ctx_opt =
     load_context_from_checkpoint
+      ~max_checkpoint_messages:meta_current.compaction.max_checkpoint_messages
       ~trace_id:meta_current.runtime.trace_id
       ~primary_model_max_tokens:max_cascade_context
       ~base_dir

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -98,7 +98,7 @@ let apply_post_turn_lifecycle
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -124,7 +124,9 @@ let apply_post_turn_lifecycle
           let session =
             create_session ~session_id:base_meta.runtime.trace_id ~base_dir
           in
-          (match save_oas_checkpoint ~session
+          (match save_oas_checkpoint
+               ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
+               ~session
                ~agent_name:base_meta.agent_name
                ~model ~ctx:compacted_ctx ~generation:current_generation
           with
@@ -268,7 +270,7 @@ let recover_latest_checkpoint_for_overflow_retry
           checkpoint_generation checkpoint ~fallback:meta.runtime.generation
         in
         Some
-          ( context_of_oas_checkpoint checkpoint ~primary_model_max_tokens,
+          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint ~primary_model_max_tokens,
             turn_generation )
     | _, _, Some checkpoint ->
         (try
@@ -289,7 +291,7 @@ let recover_latest_checkpoint_for_overflow_retry
                       ~fallback:meta.runtime.generation
                   in
                   Some
-                    ( context_of_oas_checkpoint checkpoint
+                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint
                         ~primary_model_max_tokens,
                       turn_generation )
               | None -> None))
@@ -328,7 +330,9 @@ let recover_latest_checkpoint_for_overflow_retry
           }
         in
         try
-          (match save_oas_checkpoint ~session
+          (match save_oas_checkpoint
+              ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+              ~session
               ~agent_name:retry_meta.agent_name
               ~model ~ctx:compacted_ctx ~generation:turn_generation
           with

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -35,7 +35,7 @@ let maybe_rollover_oas_handoff
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -74,7 +74,9 @@ let maybe_rollover_oas_handoff
           let new_session =
             create_session ~session_id:new_trace_id ~base_dir
           in
-          match save_oas_checkpoint ~session:new_session
+          match save_oas_checkpoint
+                  ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
+                  ~session:new_session
                   ~agent_name:base_meta.agent_name
                   ~model ~ctx ~generation:next_generation with
           | Error e ->

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -43,6 +43,7 @@ let handle_keeper_status ctx args : tool_result =
            if include_context then
              let (_session, ctx_opt) =
                load_context_from_checkpoint
+                 ~max_checkpoint_messages:m.compaction.max_checkpoint_messages
                  ~trace_id:m.runtime.trace_id
                  ~primary_model_max_tokens:primary_max_context
                  ~base_dir

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -257,6 +257,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           message_gate = compaction_message_gate;
           token_gate = compaction_token_gate;
           cooldown_sec = continuity_compaction_cooldown_sec;
+          max_checkpoint_messages = 120;
         };
         auto_handoff;
         handoff_threshold;
@@ -324,6 +325,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       let init_save_result =
         try
           Keeper_exec_context.save_oas_checkpoint
+            ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
             ~session
             ~agent_name:meta.agent_name
             ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -196,6 +196,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
           ~default:old.compaction.cooldown_sec
           p.continuity_compaction_cooldown_sec_opt
         |> normalize_continuity_compaction_cooldown_sec;
+      max_checkpoint_messages = old.compaction.max_checkpoint_messages;
     };
     auto_handoff = Option.value ~default:old.auto_handoff p.auto_handoff_opt;
     handoff_threshold = Option.value ~default:old.handoff_threshold p.handoff_threshold_opt;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -13,6 +13,7 @@ type compaction_policy =
   ; message_gate : int
   ; token_gate : int
   ; cooldown_sec : int
+  ; max_checkpoint_messages : int
   }
 
 type proactive_policy =
@@ -552,6 +553,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "compaction_message_gate", `Int m.compaction.message_gate
     ; "compaction_token_gate", `Int m.compaction.token_gate
     ; "continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec
+    ; "max_checkpoint_messages", `Int m.compaction.max_checkpoint_messages
     ; "auto_handoff", `Bool m.auto_handoff
     ; "handoff_threshold", `Float m.handoff_threshold
     ; "handoff_cooldown_sec", `Int m.handoff_cooldown_sec
@@ -847,6 +849,8 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
           ; message_gate = compaction_message_gate
           ; token_gate = compaction_token_gate
           ; cooldown_sec = continuity_compaction_cooldown_sec
+          ; max_checkpoint_messages =
+              Safe_ops.json_int ~default:120 "max_checkpoint_messages" json
           }
       ; pp_auto_handoff
       ; pp_handoff_threshold

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -15,6 +15,7 @@ type compaction_policy = {
   message_gate: int;
   token_gate: int;
   cooldown_sec: int;
+  max_checkpoint_messages: int;
 }
 
 type proactive_policy = {

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -269,7 +269,9 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
-      load_context_from_checkpoint ~trace_id:meta.runtime.trace_id
+      load_context_from_checkpoint
+        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+        ~trace_id:meta.runtime.trace_id
         ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
@@ -289,7 +291,9 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
-      load_context_from_checkpoint ~trace_id:meta.runtime.trace_id
+      load_context_from_checkpoint
+        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+        ~trace_id:meta.runtime.trace_id
         ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -70,7 +70,9 @@ let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
   let session =
     KEC.create_session ~session_id:meta.runtime.trace_id ~base_dir
   in
-  match KEC.save_oas_checkpoint ~session
+  match KEC.save_oas_checkpoint
+    ~max_checkpoint_messages:120
+    ~session
     ~agent_name:meta.agent_name
     ~model:"llama:auto"
     ~ctx
@@ -81,7 +83,9 @@ let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
 
 let load_context ~base_dir ~trace_id ~max_tokens =
   let (_session, loaded_opt) =
-    KEC.load_context_from_checkpoint ~trace_id
+    KEC.load_context_from_checkpoint
+      ~max_checkpoint_messages:120
+      ~trace_id
       ~primary_model_max_tokens:max_tokens
       ~base_dir
   in

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -845,13 +845,17 @@ let test_keeper_checkpoint_prefers_oas_checkpoint () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "oas")
       in
       let meta = make_keeper_meta ~trace_id () in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint
+           ~max_checkpoint_messages:120
+           ~session
            ~agent_name:meta.agent_name
            ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
            ~ctx:oas_ctx ~generation:7
        with Ok _ -> () | Error e -> Alcotest.fail e);
       let (_session, loaded_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint
+          ~max_checkpoint_messages:120
+          ~trace_id
           ~primary_model_max_tokens:1024 ~base_dir
       in
       match loaded_opt with
@@ -880,7 +884,9 @@ let test_keeper_checkpoint_legacy_fallback () =
       in
       ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:2);
       let (_session, loaded_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint
+          ~max_checkpoint_messages:120
+          ~trace_id
           ~primary_model_max_tokens:1024 ~base_dir
       in
       match loaded_opt with
@@ -917,7 +923,9 @@ let test_keeper_checkpoint_prefers_newer_legacy_during_migration () =
       in
       ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:9);
       let (_session, loaded_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint
+          ~max_checkpoint_messages:120
+          ~trace_id
           ~primary_model_max_tokens:1024 ~base_dir
       in
       match loaded_opt with
@@ -953,7 +961,9 @@ let test_keeper_oas_handoff_rollover_increments_generation () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        match Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
@@ -1020,7 +1030,9 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
         |> Keeper_exec_context.sync_oas_context
       in
       let checkpoint =
-        match Keeper_exec_context.save_oas_checkpoint ~session
+        match Keeper_exec_context.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
           ~agent_name:meta.agent_name
           ~model:"llama:auto"
           ~ctx ~generation:meta.runtime.generation
@@ -1058,7 +1070,7 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
         Keeper_exec_context.append ctx (tool_result_msg noisy_tool_output)
         |> Keeper_exec_context.sync_oas_context
       in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
            ~generation:11
@@ -1081,7 +1093,9 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
             "expected overflow retry recovery to fall back to OAS checkpoint"
       | Some recovery ->
           let recovered_ctx =
-            Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
+            Keeper_exec_context.context_of_oas_checkpoint
+              ~max_checkpoint_messages:120
+              recovery.checkpoint
               ~primary_model_max_tokens:512
           in
           Alcotest.(check int) "fallback uses OAS generation" 11
@@ -1138,7 +1152,7 @@ let test_overflow_retry_requires_meaningful_reduction () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "short")
         |> Keeper_exec_context.sync_oas_context
       in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
            ~generation:meta.runtime.generation
@@ -1173,7 +1187,7 @@ let test_overflow_retry_saves_compacted_checkpoint () =
         |> Keeper_exec_context.sync_oas_context
       in
       let before_tokens = Keeper_exec_context.token_count ctx in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx
            ~generation:meta.runtime.generation
@@ -1186,7 +1200,9 @@ let test_overflow_retry_saves_compacted_checkpoint () =
       | None -> Alcotest.fail "expected overflow retry recovery to compact"
       | Some recovery ->
           let recovered_ctx =
-            Keeper_exec_context.context_of_oas_checkpoint recovery.checkpoint
+            Keeper_exec_context.context_of_oas_checkpoint
+              ~max_checkpoint_messages:120
+              recovery.checkpoint
               ~primary_model_max_tokens:512
           in
           Alcotest.(check bool) "token count reduced" true
@@ -1223,13 +1239,13 @@ let test_same_trace_multi_turn_accumulation () =
         Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "turn 1 reply")
       in
       let meta = make_keeper_meta ~trace_id () in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx:ctx_turn1 ~generation:0
        with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Turn 2: load checkpoint, verify messages, add more *)
       let (_session2, loaded_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint ~max_checkpoint_messages:120 ~trace_id
           ~primary_model_max_tokens:4096 ~base_dir
       in
       let ctx_turn2 = match loaded_opt with
@@ -1249,14 +1265,14 @@ let test_same_trace_multi_turn_accumulation () =
       let session2 =
         Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
       in
-      (match Keeper_exec_context.save_oas_checkpoint ~session:session2
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session:session2
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx:ctx_turn2 ~generation:1
        with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Immediate verify: reload right after second save to isolate
          save correctness from load correctness (GLM-5 review finding) *)
       let (_session_imm, immediate_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint ~max_checkpoint_messages:120 ~trace_id
           ~primary_model_max_tokens:4096 ~base_dir
       in
       (match immediate_opt with
@@ -1267,7 +1283,7 @@ let test_same_trace_multi_turn_accumulation () =
        | None -> Alcotest.fail "second save produced no loadable checkpoint");
       (* Final verify: full roundtrip content check *)
       let (_session3, final_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint ~max_checkpoint_messages:120 ~trace_id
           ~primary_model_max_tokens:4096 ~base_dir
       in
       match final_opt with
@@ -1305,13 +1321,13 @@ let test_restart_continuity_load_oas_non_empty () =
         Keeper_exec_context.append c (Agent_sdk.Types.user_msg "msg3")
       in
       let meta = make_keeper_meta ~trace_id () in
-      (match Keeper_exec_context.save_oas_checkpoint ~session
+      (match Keeper_exec_context.save_oas_checkpoint ~max_checkpoint_messages:120 ~session
            ~agent_name:meta.agent_name
            ~model:"llama:auto" ~ctx ~generation:5
        with Ok _ -> () | Error e -> Alcotest.fail e);
       (* Simulate restart: fresh load with no runtime state *)
       let (_fresh_session, loaded_opt) =
-        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+        Keeper_exec_context.load_context_from_checkpoint ~max_checkpoint_messages:120 ~trace_id
           ~primary_model_max_tokens:4096 ~base_dir
       in
       match loaded_opt with


### PR DESCRIPTION
## Summary
- `max_checkpoint_messages`를 `compaction_policy`에 configurable 필드로 추가 (기본값 60→120)
- 모듈 상수 제거, `~max_checkpoint_messages` required param으로 전체 call chain에 전달
- `save_oas_checkpoint`, `context_of_oas_checkpoint`, `load_context_from_checkpoint` 모두 keeper별 설정값 사용
- 15개 파일 수정, 10개 call site에서 `meta.compaction.max_checkpoint_messages` 전달

### 근본 개선
이전: 60 하드코딩 → 장기 실행 keeper의 앞쪽 context가 매 handoff마다 영구 삭제
이후: keeper별 설정 가능, 기본값 120으로 2배 여유. Silent failure 아닌 명시적 파라미터 전달.

### 리뷰 피드백 반영 (follow-up)
- **JSON key 명칭 통일**: `max_checkpoint_messages` → `compaction_max_checkpoint_messages` (기존 `compaction_*` 패턴 준수). 구 key는 파싱 시 backward-compat fallback으로 계속 수용.
- **단일 소스**: `default_max_checkpoint_messages = 120`과 `normalize_max_checkpoint_messages` (clamp `[1..10000]`)를 `keeper_config.ml`에 추가, 중복 상수 제거 (`keeper_context_core.ml`의 미사용 바인딩 삭제).
- **정규화 적용**: parse 경로에 `normalize_max_checkpoint_messages` 적용 — 음수·비정상 값 차단.
- **allowlist 동기화**: `fallback_canonical_keeper_meta_key_names`에 신규 key 및 구 key 모두 추가하여 unknown-key 경고 방지.
- **keeper_up tool 지원**: `continuity_compaction_max_checkpoint_messages_opt`를 `parsed_args`에 추가, `compaction_max_checkpoint_messages` 인자로 create/update 경로 모두에 전달 — 도구를 통한 per-keeper 설정 변경 가능.

## Product impact

- Promise affected: `ops visibility` | `none/internal`
- User-visible change: keeper 생성·수정 시 `compaction_max_checkpoint_messages` 파라미터로 checkpoint 메시지 보존 수를 직접 지정할 수 있음. 기존 저장된 keeper meta는 구 key(`max_checkpoint_messages`) fallback 파싱으로 하위 호환 유지.

## Evidence

- [x] `dune build` 성공
- [x] `test_keeper_lifecycle` 13/13 통과
- [x] `test_oas_worker` 43/43 통과
- [ ] CI checks green

## Review evidence

Code review (Copilot): no issues found after follow-up changes applied.

## Linked issue