### PR TITLE
fix(keeper): show all allowed tools in world state prompt

### DIFF
--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -85,6 +85,7 @@ let register_all () =
     "masc_dashboard"; "masc_verify_handoff";
     "masc_gc"; "masc_cleanup_zombies";
     "masc_tool_stats"; "masc_tool_help";
+    "masc_web_search";
     "masc_tool_admin_snapshot"; "masc_tool_admin_update";
     "masc_keeper_tool_catalog";
     "masc_feature_flags";


### PR DESCRIPTION
## Summary
- keeper의 world state prompt가 `keeper_*` 접두사로 필터링하여 `masc_web_search` 등 `masc_*` 도구를 숨기던 문제 수정
- `masc_*` 도구는 OAS schema에 정상 전달되어 호출 가능하지만, prompt hint에서 누락되어 LLM이 발견하지 못함
- 테스트 초기화에 서버 부트 순서(tag registry 초기화)를 재현하여 환경 차이 버그를 방지

## Root cause
```
keeper_unified_prompt.ml:392
List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
```
이 필터가 `masc_web_search`, `masc_status` 등을 prompt에서 제외.

## Changes
1. `keeper_unified_prompt.ml` — `keeper_*` prefix 필터 제거, 전체 allowed tools 노출
2. `test_keeper_tool_exposure.ml` — tag registry 초기화 후 `masc_web_search` injection 검증 테스트 추가

## Test plan
- [x] `dune build` 통과
- [x] 47개 테스트 전부 통과 (기존 46 + 신규 1)
- [ ] 서버 재시작 후 keeper trace "Keeper Tools"에 `masc_web_search` 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)