### PR TITLE
chore: bump agent_sdk pin 0.107.0 → 0.108.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.107.0))
+  (agent_sdk (>= 0.108.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.107.0"}
+  "agent_sdk" {>= "0.108.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.107.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.108.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ba1dc674aed553550542524cb7b28fc63c8bdc82"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.107.0"
+readonly OAS_AGENT_SDK_SHA="96edc450bcc3b82d9155f809d6142176459575d7"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.108.0"


### PR DESCRIPTION
## Summary
- OAS v0.108.0: lifecycle Running→Ready + BeforeTurnParams.max_turns
- keeper multi-turn 안정성 향상 (매 턴 WARN 제거)

## Test plan
- [x] `opam install agent_sdk.0.108.0` 성공
- [x] `dune build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)