### PR TITLE
fix(keeper): remove keeper_* prefix filter from world state prompt

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -386,14 +386,13 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  (* Keeper tool inventory — show the keeper_* subset available this cycle *)
+  (* Keeper tool inventory — show all allowed tools this cycle.
+     Previously filtered to keeper_* prefix only, hiding masc_web_search
+     and other masc_* tools the keeper can actually call. *)
   let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
-  let keeper_tools =
-    List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
-  in
-  if keeper_tools <> [] then (
+  if allowed_tools <> [] then (
     Buffer.add_string ubuf "\n### Keeper Tools\n";
-    Buffer.add_string ubuf (String.concat ", " keeper_tools);
+    Buffer.add_string ubuf (String.concat ", " allowed_tools);
     Buffer.add_string ubuf "\n");
   (* Metacognition: show the keeper its own recent tool activity so it can
      recognise patterns — thrashing, failure loops, tool over-reliance.

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -216,6 +216,22 @@ let test_sufficient_tool_count () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "tool count from shards" true (List.length tools >= 20)
 
+(* Verify masc_web_search survives inject_masc_schemas after
+   tag_registry initialization. This catches missing Mod_misc entries
+   in tool_tag_init.ml — the bug where lookup_tag returns None and
+   supported_in_keeper rejects the tool at runtime. *)
+let test_web_search_survives_tag_registry () =
+  check bool "tag_registry is initialized" true
+    (Tool_dispatch.is_tag_registry_initialized ());
+  let injected = !Keeper_exec_tools.masc_schemas_ref in
+  let names = List.map (fun (s : Types.tool_schema) -> s.name) injected in
+  check bool "masc_web_search in injected schemas" true
+    (List.mem "masc_web_search" names);
+  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "delivery preset has masc_web_search" true
+    (has_tool "masc_web_search" tools)
+
 (* ============================================================
    8. Combined profiles
    ============================================================ *)
@@ -547,6 +563,15 @@ let test_keeper_reported_observe_only_scope () =
 
 let () =
   let base_path = Masc_test_deps.find_project_root () in
+  (* Reproduce server boot sequence: tag registration must precede injection
+     so that inject_masc_schemas filters via lookup_tag after initialization.
+     Without this, is_tag_registry_initialized returns false and the tag
+     check is bypassed — hiding missing tag entries. *)
+  Tool_dispatch.register_module_tag
+    ~schemas:Tool_schemas_inline.schemas ~tag:Tool_dispatch.Mod_inline;
+  Tool_tag_init.register_all ();
+  Tool_board.register ();
+  Tool_dispatch.mark_tag_registry_initialized ();
   Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
   Keeper_exec_tools.init_policy_config ~base_path;
   run "Keeper_tool_exposure" [
@@ -589,6 +614,10 @@ let () =
       test_case "coding has coordination tools" `Quick test_coding_preset_has_coordination_tools;
       test_case "messaging legacy governance tools removed" `Quick test_messaging_preset_has_no_legacy_governance_tools;
       test_case "sufficient tool count" `Quick test_sufficient_tool_count;
+    ]);
+    ("tag_registry_integration", [
+      test_case "masc_web_search survives tag registry" `Quick
+        test_web_search_survives_tag_registry;
     ]);
     ("combined_profiles", [
       test_case "research plus also_allow override" `Quick test_research_plus_also_allow_combined;


### PR DESCRIPTION
## Summary
- Keeper world state prompt의 "Keeper Tools" 섹션이 `keeper_*` 접두사로 필터링하여 `masc_web_search` 등 `masc_*` 도구를 숨기던 문제 수정
- 테스트 초기화에서 서버 부트 순서(tag registry 초기화)를 재현하여 환경 차이 버그 방지
- #5535의 후속 — #5535는 `tool_tag_init.ml` 중복 등록만 포함, 실제 prompt fix는 이 PR

## Root cause
```ocaml
(* keeper_unified_prompt.ml:392 — 이전 코드 *)
List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
```
이 필터가 `masc_web_search`, `masc_code_*`, `masc_autoresearch_*` 등을 prompt에서 제외.

## Changes
1. `keeper_unified_prompt.ml` — `keeper_*` prefix 필터 제거, `allowed_tools` 전체 노출
2. `test_keeper_tool_exposure.ml` — tag registry 초기화 후 `masc_web_search` injection 검증 추가

## Test plan
- [x] `dune build` 통과
- [x] 47개 테스트 전부 통과 (기존 46 + 신규 1)
- [ ] 서버 재시작 후 keeper trace "Keeper Tools"에 `masc_web_search` 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)