### PR TITLE
fix(keeper): persist OAS Context.t across turns

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -296,6 +296,22 @@ let run_turn
       ~primary_model_max_tokens:max_context
       ~base_dir
   in
+  (* 2b. Load raw OAS checkpoint for Agent.resume path.
+     Preserves turn_count, usage_stats, and lifecycle state across turns.
+     Falls back to fresh build when unavailable (first turn, rollover). *)
+  let raw_oas_checkpoint =
+    match Keeper_checkpoint_store.load_oas
+            ~session_dir:session.session_dir
+            ~session_id:meta.runtime.trace_id with
+    | Ok cp -> Some cp
+    | Error _ -> None
+  in
+  (* Starting turn count for per-call budget calculation in hooks.
+     With Agent.resume, turn count is cumulative from checkpoint. *)
+  let start_turn_count = match raw_oas_checkpoint with
+    | Some cp -> cp.turn_count
+    | None -> 0
+  in
   (* 3. Build base system prompt from meta *)
   let persona_extended =
     Keeper_types_profile.load_persona_extended meta.name
@@ -843,8 +859,11 @@ let run_turn
            - Warning zone (2 turns before limit): inject budget warning
            - Last turn (1 turn before limit): restrict to safe tools + force [STATE]
            The keeper can still call extend_turns to escape the limit. *)
-        let is_last_turn = turn >= max_turns - 1 in
-        let is_warning_zone = turn >= max_turns - 2 in
+        (* With Agent.resume, turn is cumulative from checkpoint.
+           Use per-call turn count for budget calculations. *)
+        let per_call_turn = turn - start_turn_count in
+        let is_last_turn = per_call_turn >= max_turns - 1 in
+        let is_warning_zone = per_call_turn >= max_turns - 2 in
         let ctx =
           if is_last_turn then
             let warning =
@@ -1018,6 +1037,7 @@ let run_turn
           ~checkpoint_dir:session_dir
           ~context_injector
           ~context:shared_context
+          ?oas_checkpoint:raw_oas_checkpoint
           ()
       with
       | Error e -> Error e

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -249,6 +249,7 @@ let run_turn
     ?(tool_overlay : Agent_sdk.Tool_op.t ref option)
     ?priority
     ?(is_retry = false)
+    ?shared_context
     ()
   : (run_result, Oas.Error.sdk_error) result =
   (* 0. Resolve inference parameters via Cascade_inference *)
@@ -270,7 +271,16 @@ let run_turn
   (* 0b. Create context injector for temporal awareness *)
   let injector_config = Masc_context_injector.default_config () in
   let context_injector = Masc_context_injector.make ~config:injector_config () in
-  let shared_context = Oas.Context.create () in
+  (* Use caller-provided Context.t for cross-turn state persistence.
+     OAS Context.t is a mutable cross-turn container; creating a fresh
+     instance per turn loses accumulated temporal state (elapsed time,
+     tool call counts) that hooks and context_injector depend on.
+     Callers that manage a persistent lifecycle (keeper heartbeat loop)
+     should pass a long-lived instance via ~shared_context. *)
+  let shared_context = match shared_context with
+    | Some ctx -> ctx
+    | None -> Oas.Context.create ()
+  in
   (* 1. Ensure session directory tree exists.
      Both the base traces dir AND the trace-specific session dir must
      exist before any file I/O (checkpoint load, history persist).

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -635,6 +635,7 @@ let run_keepalive_unified_turn
       ~pending_board_events
       ~(stop : bool Atomic.t)
       ~(proactive_warmup_elapsed : bool)
+      ~(shared_context : Agent_sdk.Context.t)
   : keeper_meta
   =
   if not proactive_warmup_elapsed
@@ -692,6 +693,7 @@ let run_keepalive_unified_turn
               ~observation:obs
               ~generation:meta_after_observe.runtime.generation
               ~channel:turn_decision.channel
+              ~shared_context
               ()
           with
           | Error err ->
@@ -932,6 +934,13 @@ let run_heartbeat_loop
   in
   let smart_hb_config = Heartbeat_smart.default_config in
   let last_heartbeat_cycle_ts = ref 0.0 in
+  (* Persistent OAS Context.t — created once per keeper lifecycle.
+     OAS Context.t is designed as a mutable cross-turn state container.
+     Hooks and context_injector accumulate temporal state (elapsed time,
+     tool call counts, etc.) into this instance across turns.
+     Previously, a fresh Context.create() was called per turn in run_turn,
+     losing all accumulated state.  See docs/analysis/2026-04-06-keeper-lifecycle-analysis.md *)
+  let shared_context = Agent_sdk.Context.create () in
   let rec loop () =
     if Atomic.get stop
     then ()
@@ -1015,6 +1024,7 @@ let run_heartbeat_loop
             ~pending_board_events
             ~stop
             ~proactive_warmup_elapsed
+            ~shared_context
         in
         (* Turn failure threshold: registry tracks count (via unified_turn),
                  keepalive raises to terminate the fiber for supervisor restart. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -740,6 +740,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int)
     ?(channel : Keeper_world_observation.unified_turn_channel = Scheduled_autonomous)
+    ?shared_context
     () : (keeper_meta, Oas.Error.sdk_error) result =
   (* 1. Check API keys *)
   let model_labels = Keeper_coordination.effective_model_labels_for_turn meta in
@@ -840,6 +841,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~temperature ~max_tokens
               ~max_cost_usd
               ~is_retry
+              ?shared_context
               ()
           in
           let rec retry_loop ~run_meta ~max_context ~run_generation

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -84,5 +84,6 @@ val run_unified_turn :
   observation:Keeper_world_observation.world_observation ->
   generation:int ->
   ?channel:Keeper_world_observation.unified_turn_channel ->
+  ?shared_context:Agent_sdk.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -110,6 +110,7 @@ val run_named :
   ?checkpoint_dir:string ->
   ?context_injector:Oas.Hooks.context_injector ->
   ?context:Oas.Context.t ->
+  ?oas_checkpoint:Oas.Checkpoint.t ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -438,7 +438,9 @@ let run
   let agent_result = match oas_checkpoint with
     | Some checkpoint ->
       (try Ok (resume_from_checkpoint ~net ~config ~checkpoint)
-       with exn ->
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
          Log.Misc.warn "oas_worker %s: resume_from_checkpoint failed (%s), falling back to build"
            config.name (Printexc.to_string exn);
          build ~net ~config)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -318,6 +318,91 @@ let enrich_idle_detail (detail : string) (messages : Oas.Types.message list) : s
   else detail
 
 (* ================================================================ *)
+(* Resume from checkpoint                                            *)
+(* ================================================================ *)
+
+(** Build an Agent.t from a checkpoint via [Agent.resume], overriding
+    per-turn config values from the MASC config.
+
+    The checkpoint provides: messages, turn_count, usage_stats.
+    The MASC config provides: provider, model_id, system_prompt,
+    max_turns, temperature, tools, hooks, guardrails, etc.
+
+    [max_turns] and [max_cost_usd] are adjusted to account for
+    cumulative values in the checkpoint — the keeper's per-call budget
+    is added on top of the checkpoint's accumulated state. *)
+let resume_from_checkpoint
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ~(checkpoint : Oas.Checkpoint.t)
+  : Oas.Agent.t =
+  (* Adjust budgets: max_turns and max_cost_usd are per-call, but
+     Agent.resume restores turn_count/usage from checkpoint. Without
+     adjustment the loop guard fires immediately on resumed agents. *)
+  let effective_max_turns = checkpoint.turn_count + config.max_turns in
+  let effective_max_cost_usd = match config.max_cost_usd with
+    | Some budget ->
+      Some (checkpoint.usage.estimated_cost_usd +. budget)
+    | None -> None
+  in
+  (* Patch checkpoint fields that MASC controls per-turn.
+     OAS build_resume copies checkpoint.model/system_prompt/temperature
+     over the base config, so we align the checkpoint with MASC intent. *)
+  let patched_checkpoint = { checkpoint with
+    Oas.Checkpoint.model = config.model_id;
+    system_prompt = Some config.system_prompt;
+    temperature = Some config.temperature;
+    enable_thinking = config.enable_thinking;
+    cache_system_prompt = config.cache_system_prompt;
+    max_input_tokens = config.max_input_tokens;
+    max_total_tokens = Some config.max_tokens;
+  } in
+  let agent_config : Oas.Types.agent_config = {
+    Oas.Types.default_config with
+    name = config.name;
+    model = config.model_id;
+    system_prompt = Some config.system_prompt;
+    max_tokens = config.max_tokens;
+    max_turns = effective_max_turns;
+    temperature = Some config.temperature;
+    enable_thinking = config.enable_thinking;
+    cache_system_prompt = config.cache_system_prompt;
+    max_input_tokens = config.max_input_tokens;
+    max_cost_usd = effective_max_cost_usd;
+    yield_on_tool = config.yield_on_tool;
+    context_compact_ratio = config.compact_ratio;
+    priority = config.priority;
+  } in
+  let tool_names =
+    List.map (fun (t : Oas.Tool.t) -> t.schema.name) config.tools in
+  let guardrails = match config.guardrails with
+    | Some g -> g
+    | None ->
+      { Oas.Guardrails.default with
+        tool_filter =
+          if tool_names <> [] then Oas.Guardrails.AllowList tool_names
+          else Oas.Guardrails.AllowAll }
+  in
+  let options : Oas.Agent.options = {
+    Oas.Agent.default_options with
+    provider = Some config.provider;
+    hooks = Option.value ~default:Oas.Hooks.empty config.hooks;
+    max_idle_turns = config.max_idle_turns;
+    guardrails;
+    context_reducer = config.context_reducer;
+    context_injector = config.context_injector;
+    event_bus = config.event_bus;
+    memory = config.memory;
+    raw_trace = config.raw_trace;
+    tool_retry_policy = config.tool_retry_policy;
+    allowed_paths = config.allowed_paths;
+    description = config.description;
+  } in
+  Oas.Agent.resume ~net ~checkpoint:patched_checkpoint ~tools:config.tools
+    ?context:config.context ?named_cascade:config.named_cascade
+    ~options ~config:agent_config ()
+
+(* ================================================================ *)
 (* Run                                                               *)
 (* ================================================================ *)
 
@@ -325,6 +410,7 @@ let run
     ~(sw : Eio.Switch.t)
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
+    ?oas_checkpoint
     ?(on_event : (Oas.Types.sse_event -> unit) option)
     ?(on_yield : (unit -> unit) option)
     ?(on_resume : (unit -> unit) option)
@@ -349,7 +435,16 @@ let run
   Option.iter (fun bus ->
     publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal
   ) config.event_bus;
-  match build ~net ~config with
+  let agent_result = match oas_checkpoint with
+    | Some checkpoint ->
+      (try Ok (resume_from_checkpoint ~net ~config ~checkpoint)
+       with exn ->
+         Log.Misc.warn "oas_worker %s: resume_from_checkpoint failed (%s), falling back to build"
+           config.name (Printexc.to_string exn);
+         build ~net ~config)
+    | None -> build ~net ~config
+  in
+  match agent_result with
   | Error e ->
     Option.iter (fun bus ->
       publish_lifecycle bus ~name:config.name ~event:"build_error"

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -150,6 +150,7 @@ let run_named
     ?checkpoint_dir
     ?context_injector
     ?context
+    ?oas_checkpoint
     ?sw
     ?net
     ()
@@ -202,7 +203,7 @@ let run_named
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in
-  match Oas_worker_exec.run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?agent_ref ?proof_ref ?contract goal with
+  match Oas_worker_exec.run ~sw ~net ~config ?oas_checkpoint ?on_event ?on_yield ?on_resume ?agent_ref ?proof_ref ?contract goal with
   | Ok result when accept result.response ->
     let observation =
       Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels


### PR DESCRIPTION
## Summary

Keeper의 cross-turn 상태 유실 문제를 근본적으로 수정. 두 가지 변경:

1. **Context.t 영속화**: `run_heartbeat_loop`에서 `Context.t`를 한 번만 생성, turn 간 재사용
2. **Agent.resume 경로 도입**: OAS checkpoint 존재 시 `Agent.resume`으로 agent 복원 (usage_stats, turn_count, lifecycle 보존)

## Background

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| Context.t | 매 turn `Context.create()` → 유실 | heartbeat loop에서 1회 생성, 재사용 |
| Agent 생성 | 매 turn `Builder.create` → fresh agent | `Agent.resume(checkpoint)` → 상태 복원 |
| usage_stats | 매 turn 리셋 | checkpoint에서 누적 |
| turn_count | 항상 0 | checkpoint에서 연속 |

## Changes (8파일)

### Commit 1: Context.t persistence
| File | Change |
|------|--------|
| `keeper_agent_run.ml` | `?shared_context` optional parameter |
| `keeper_unified_turn.ml/mli` | threading |
| `keeper_keepalive.ml` | `Context.create()` 1회, lifecycle 전체 재사용 |

### Commit 2: Agent.resume integration
| File | Change |
|------|--------|
| `oas_worker_exec.ml` | `resume_from_checkpoint` 함수 추가, `?oas_checkpoint` to `run` |
| `oas_worker_named.ml` | `?oas_checkpoint` threading |
| `oas_worker.mli` | export |
| `keeper_agent_run.ml` | raw checkpoint 로드, `run_named`에 전달, per-call turn budget 조정 |

## Edge Cases
- 첫 turn/rollover: checkpoint 없음 → 기존 Builder 경로 (backward-compatible)
- Checkpoint 손상: resume 실패 catch → Builder fallback + warn 로그
- Model 변경: checkpoint 패칭으로 MASC config 값 적용
- max_turns 조정: `checkpoint.turn_count + per_call_max_turns`

## Test plan
- [x] `dune build --root .` 통과
- [x] `test_worker_safety_gates` 11/11 passed
- [x] `test_oas_worker` 43/43 passed
- [ ] CI checks green
- [ ] keeper 실행 후 turn_count/usage_stats 누적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)