### PR TITLE
refactor(keeper): replace mutable ctx_ref with immutable snapshot

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -348,7 +348,7 @@ let run_turn
   if not is_retry then
     Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
   (* 7. Set up agent *)
-  let ctx_ref = ref ctx_work in
+  let ctx_snapshot = ctx_work in
   let agent_name = meta.agent_name in
   let meta_ref = ref meta in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in
@@ -375,7 +375,7 @@ let run_turn
   in
   let discovered_ref = ref (Keeper_discovered_tools.create ~decay_turns) in
   let keeper_tools =
-    Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref
+    Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
           Keeper_discovered_tools.mark_used !discovered_ref
@@ -730,7 +730,7 @@ let run_turn
     | None -> ref Agent_sdk.Tool_op.Keep_all
   in
   let base_hooks = Keeper_hooks_oas.make_hooks
-    ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd
+    ~config ~meta_ref ~session ~ctx_snapshot ~generation ?max_cost_usd
     ?trajectory_acc
     () in
   (* BM25 Tool_selector removed: discovery mode uses core + keeper_tool_search.
@@ -1115,7 +1115,10 @@ let run_turn
              Keeper_exec_context.persist_message
                ~source:history_assistant_source
                session assistant_msg;
-             ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
+             (* ctx_snapshot is immutable — assistant message is persisted
+                via checkpoint (OAS) and persist_message (history file).
+                No in-memory mutation needed; next turn reconstructs
+                context from checkpoint. *)
              (* Save checkpoint AFTER [STATE] synthesis.  Patch the last
                 assistant message in the OAS checkpoint so that the persisted
                 checkpoint contains the [STATE] block.  Without this patch,

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -131,7 +131,7 @@ let emit_cost_event
     @param config Room configuration
     @param meta_ref Mutable ref to keeper metadata
     @param session Session context for checkpoint persistence
-    @param ctx_ref Mutable ref to current working context
+    @param ctx_snapshot Immutable snapshot of working context (reserved, unused)
     @param generation Current generation counter
     @param max_cost_usd Optional cost budget (rejects tool calls above limit)
     @param destructive_check Enable destructive pattern detection (default true)
@@ -159,7 +159,7 @@ let make_hooks
     ~config:(_config : Room.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
     ~session:(_session : Keeper_exec_context.session_context)
-    ~ctx_ref:(_ctx_ref : Keeper_exec_context.working_context ref)
+    ~ctx_snapshot:(_ctx_snapshot : Keeper_exec_context.working_context)
     ~(generation : int)
     ?(max_cost_usd : float option)
     ?(destructive_check : bool = true)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -3,7 +3,7 @@
     Bridges [Keeper_exec_tools.execute_keeper_tool_call] dispatch
     to [Agent_sdk.Tool.t] list via [Tool_bridge.oas_tool_of_masc].
 
-    Tool execution reads current context from [ctx_ref] (mutable ref),
+    Tool execution reads current context from [ctx_snapshot] (immutable),
     enabling Agent.run() to manage messages while keeper tools
     access the working context for status/metrics.
 
@@ -51,12 +51,12 @@ let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
 (** Build OAS Tool.t list from keeper's allowed tools.
 
     Each tool delegates to [execute_keeper_tool_call] with the current
-    [ctx_ref] snapshot. Tools that raise exceptions return error results
+    [ctx_snapshot] value. Tools that raise exceptions return error results
     instead of crashing the agent loop.
 
     @param config Room configuration for tool dispatch
     @param meta Keeper metadata (determines which tools are allowed)
-    @param ctx_ref Mutable ref to current working context *)
+    @param ctx_snapshot Immutable snapshot of current working context *)
 (** Repeated-failure guardrail: blocks a tool after [max_consecutive]
     consecutive failures with the same (tool_name, args_hash) key.
     Resets on success. Prevents infinite retry loops (e.g. keeper
@@ -148,7 +148,7 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
 let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
-    ~(ctx_ref : Keeper_types.working_context ref)
+    ~(ctx_snapshot : Keeper_types.working_context)
     ?search_fn
     ?on_tool_called
     ()
@@ -192,7 +192,7 @@ let make_tools
               let (result, duration_ms) =
                 Inference_utils.timed (fun () ->
                   Keeper_exec_tools.execute_keeper_tool_call
-                    ~config ~meta ~ctx_work:(!ctx_ref)
+                    ~config ~meta ~ctx_work:ctx_snapshot
                     ?search_fn
                     ~name:td.name ~input ())
               in

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -24,7 +24,7 @@ and fixture = {
   generic : Generic.fixture;
   config : Masc_mcp.Room.config;
   meta : Masc_mcp.Keeper_types.keeper_meta;
-  ctx_ref : Masc_mcp.Keeper_types.working_context ref;
+  ctx_snapshot : Masc_mcp.Keeper_types.working_context;
   tools : Agent_sdk.Tool.t list;
 }
 
@@ -127,16 +127,16 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
     Masc_mcp.Keeper_exec_context.append ctx
       (Agent_sdk.Types.user_msg "tool matrix memory needle")
   in
-  let ctx_ref = ref ctx in
+  let ctx_snapshot = ctx in
   let meta = make_meta () in
-  let tools = KTO.make_tools ~config ~meta ~ctx_ref () in
+  let tools = KTO.make_tools ~config ~meta ~ctx_snapshot () in
   (match init_mode with
    | Init_joined ->
        ignore
          (Masc_mcp.Room.join config ~agent_name:("keeper-" ^ meta.name)
             ~capabilities:[] ())
    | Fresh | Init_only -> ());
-  { generic; config; meta; ctx_ref; tools }
+  { generic; config; meta; ctx_snapshot; tools }
 
 let keeper_agent_name fixture = "keeper-" ^ fixture.meta.name
 
@@ -189,10 +189,9 @@ let prepare_keeper_name fixture name =
   then
     ensure_keeper_claim fixture;
   if name = "keeper_voice_session_end" then ensure_voice_session fixture;
-  if name = "keeper_memory_search" then
-    fixture.ctx_ref :=
-      Masc_mcp.Keeper_exec_context.append !(fixture.ctx_ref)
-        (Agent_sdk.Types.user_msg "keeper tool matrix memory needle")
+  (* keeper_memory_search: needle "tool matrix memory needle" is already
+     in ctx_snapshot from fixture creation (line ~128). No mutation needed. *)
+  ignore (name = "keeper_memory_search")
 
 let keeper_arguments fixture (schema : Types.tool_schema) =
   let name = schema.name in

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -30,7 +30,7 @@ let make_test_ctx () =
 
 let test_make_tools_returns_nonempty () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -43,12 +43,12 @@ let test_make_tools_returns_nonempty () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       check bool "tools nonempty" true (List.length tools > 0))
 
 let test_tools_have_valid_schemas () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_schema_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -61,7 +61,7 @@ let test_tools_have_valid_schemas () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       List.iter (fun (tool : Agent_sdk.Tool.t) ->
         check bool (Printf.sprintf "tool %s has name" tool.schema.name)
           true (String.length tool.schema.name > 0);
@@ -71,7 +71,7 @@ let test_tools_have_valid_schemas () =
 
 let test_tool_count_matches_allowed () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_count_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -84,7 +84,7 @@ let test_tool_count_matches_allowed () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
       let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
       check bool "all tools are in allowed list" true
@@ -110,7 +110,7 @@ let is_guardrail_message message =
 
 let test_error_json_is_returned_as_tool_error () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_error_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -123,7 +123,7 @@ let test_error_json_is_returned_as_tool_error () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       match Tool.execute tool
               (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
@@ -142,7 +142,7 @@ let test_error_json_is_returned_as_tool_error () =
 
 let test_repeated_error_results_are_blocked () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_guard_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -155,7 +155,7 @@ let test_repeated_error_results_are_blocked () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       let args =
         `Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")]
@@ -173,7 +173,7 @@ let test_repeated_error_results_are_blocked () =
 
 let test_failure_count_resets_after_success () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_reset_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -188,7 +188,7 @@ let test_failure_count_resets_after_success () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       let path = "reset-after-success.txt" in
       let args = `Assoc [("path", `String path)] in
@@ -219,7 +219,7 @@ let test_failure_count_resets_after_success () =
 
 let test_failure_tracking_is_independent_per_args () =
   let meta = make_test_meta () in
-  let ctx_ref = ref (make_test_ctx ()) in
+  let ctx_snapshot = make_test_ctx () in
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_tools_independent_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -232,7 +232,7 @@ let test_failure_tracking_is_independent_per_args () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref () in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       let args_a = `Assoc [("path", `String "missing-a.txt")] in
       let args_b = `Assoc [("path", `String "missing-b.txt")] in


### PR DESCRIPTION
## Summary
- Remove `ctx_ref : working_context ref` from keeper tool execution path
- Tools now capture an immutable `ctx_snapshot` value via closure — physically unable to mutate conversation state
- The previous `ctx_ref :=` mutation was a dead write (value never read again after mutation)
- Context continuity is maintained through OAS checkpoints, not in-memory mutation

## Motivation
Mutable refs for shared state break:
- **Determinism**: tool execution order affects what state tools see
- **Testability**: impossible to reproduce exact state at tool call time
- **Reasoning**: cannot determine what messages a tool saw without tracing ref mutations

Follows Anthropic Claude SDK pattern: tools receive parameters only, pipeline owns state transitions.

## Changes
| File | Change |
|------|--------|
| `keeper_tools_oas.ml` | `~ctx_ref` → `~ctx_snapshot` (value, not ref) |
| `keeper_hooks_oas.ml` | `~ctx_ref` → `~ctx_snapshot` (was already unused `_ctx_ref`) |
| `keeper_agent_run.ml` | Remove `ref` creation, remove dead `ctx_ref :=` mutation |
| Tests (2 files) | Replace `ref` with value, remove mid-test mutations |

## Test plan
- [x] `dune build` clean
- [ ] CI (Build & Test, Lint, Health)

Generated with [Claude Code](https://claude.com/claude-code)