### PR TITLE
fix(keeper): persist shared_context across turns

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.249.0
-> Latest release: v2.249.0 (2026-04-06)
+> Current package version: v2.250.0
+> Latest release: v2.250.0 (2026-04-06)
 > Updated: 2026-04-06
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,7 +1,7 @@
 # Product Operating Plan
 
-> Current package version: v2.249.0
-> Latest release: v2.249.0 (2026-04-06)
+> Current package version: v2.250.0
+> Latest release: v2.250.0 (2026-04-06)
 > Updated: 2026-04-06
 
 Execution companion for capsule-only coordination hardening:

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -271,12 +271,14 @@ let run_turn
   (* 0b. Create context injector for temporal awareness *)
   let injector_config = Masc_context_injector.default_config () in
   let context_injector = Masc_context_injector.make ~config:injector_config () in
-  (* Use caller-provided Context.t for cross-turn state persistence.
-     OAS Context.t is a mutable cross-turn container; creating a fresh
-     instance per turn loses accumulated temporal state (elapsed time,
-     tool call counts) that hooks and context_injector depend on.
-     Callers that manage a persistent lifecycle (keeper heartbeat loop)
-     should pass a long-lived instance via ~shared_context. *)
+  (* Use caller-provided Context.t for cross-turn OAS context persistence.
+     OAS Context.t is a mutable container, so reusing it preserves any
+     state stored in that context across keeper turns. Note, however, that
+     this function creates a fresh [context_injector] on each call, so any
+     injector-local elapsed-time or tool-call counters do not accumulate
+     across turns merely by sharing [~shared_context]. Callers that manage
+     a persistent lifecycle (keeper heartbeat loop) should pass a long-lived
+     [~shared_context] when they need cross-turn OAS context continuity. *)
   let shared_context = match shared_context with
     | Some ctx -> ctx
     | None -> Oas.Context.create ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -249,6 +249,7 @@ let run_turn
     ?(tool_overlay : Agent_sdk.Tool_op.t ref option)
     ?priority
     ?(is_retry = false)
+    ?shared_context
     ()
   : (run_result, Oas.Error.sdk_error) result =
   (* 0. Resolve inference parameters via Cascade_inference *)
@@ -270,7 +271,16 @@ let run_turn
   (* 0b. Create context injector for temporal awareness *)
   let injector_config = Masc_context_injector.default_config () in
   let context_injector = Masc_context_injector.make ~config:injector_config () in
-  let shared_context = Oas.Context.create () in
+  (* Use caller-provided Context.t for cross-turn state persistence.
+     OAS Context.t is a mutable cross-turn container; creating a fresh
+     instance per turn loses accumulated temporal state (elapsed time,
+     tool call counts) that hooks and context_injector depend on.
+     Callers that manage a persistent lifecycle (keeper heartbeat loop)
+     should pass a long-lived instance via ~shared_context. *)
+  let shared_context = match shared_context with
+    | Some ctx -> ctx
+    | None -> Oas.Context.create ()
+  in
   (* 1. Ensure session directory tree exists.
      Both the base traces dir AND the trace-specific session dir must
      exist before any file I/O (checkpoint load, history persist).

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -938,8 +938,8 @@ let run_heartbeat_loop
      OAS Context.t is designed as a mutable cross-turn state container.
      Hooks and context_injector accumulate temporal state (elapsed time,
      tool call counts, etc.) into this instance across turns.
-     Previously, a fresh Context.create() was called per turn in run_turn,
-     losing all accumulated state.  See docs/analysis/2026-04-06-keeper-lifecycle-analysis.md *)
+     Previously, a fresh Context.create () was called per turn in
+     run_turn, losing all accumulated state. *)
   let shared_context = Agent_sdk.Context.create () in
   let rec loop () =
     if Atomic.get stop

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -935,11 +935,11 @@ let run_heartbeat_loop
   let smart_hb_config = Heartbeat_smart.default_config in
   let last_heartbeat_cycle_ts = ref 0.0 in
   (* Persistent OAS Context.t — created once per keeper lifecycle.
-     OAS Context.t is designed as a mutable cross-turn state container.
-     Hooks and context_injector accumulate temporal state (elapsed time,
-     tool call counts, etc.) into this instance across turns.
-     Previously, a fresh Context.create () was called per turn in
-     run_turn, losing all accumulated state. *)
+     OAS Context.t is a mutable cross-turn state container for values
+     written directly into the shared context. This preserves shared
+     metadata across turns, but per-turn context_injector-local timing
+     and tool-call counters are recreated inside run_turn and therefore
+     do not accumulate for the full keeper lifecycle. *)
   let shared_context = Agent_sdk.Context.create () in
   let rec loop () =
     if Atomic.get stop

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -635,6 +635,7 @@ let run_keepalive_unified_turn
       ~pending_board_events
       ~(stop : bool Atomic.t)
       ~(proactive_warmup_elapsed : bool)
+      ~(shared_context : Agent_sdk.Context.t)
   : keeper_meta
   =
   if not proactive_warmup_elapsed
@@ -692,6 +693,7 @@ let run_keepalive_unified_turn
               ~observation:obs
               ~generation:meta_after_observe.runtime.generation
               ~channel:turn_decision.channel
+              ~shared_context
               ()
           with
           | Error err ->
@@ -932,6 +934,13 @@ let run_heartbeat_loop
   in
   let smart_hb_config = Heartbeat_smart.default_config in
   let last_heartbeat_cycle_ts = ref 0.0 in
+  (* Persistent OAS Context.t — created once per keeper lifecycle.
+     OAS Context.t is designed as a mutable cross-turn state container.
+     Hooks and context_injector accumulate temporal state (elapsed time,
+     tool call counts, etc.) into this instance across turns.
+     Previously, a fresh Context.create() was called per turn in run_turn,
+     losing all accumulated state.  See docs/analysis/2026-04-06-keeper-lifecycle-analysis.md *)
+  let shared_context = Agent_sdk.Context.create () in
   let rec loop () =
     if Atomic.get stop
     then ()
@@ -1015,6 +1024,7 @@ let run_heartbeat_loop
             ~pending_board_events
             ~stop
             ~proactive_warmup_elapsed
+            ~shared_context
         in
         (* Turn failure threshold: registry tracks count (via unified_turn),
                  keepalive raises to terminate the fiber for supervisor restart. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -740,6 +740,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int)
     ?(channel : Keeper_world_observation.unified_turn_channel = Scheduled_autonomous)
+    ?shared_context
     () : (keeper_meta, Oas.Error.sdk_error) result =
   (* 1. Check API keys *)
   let model_labels = Keeper_coordination.effective_model_labels_for_turn meta in
@@ -840,6 +841,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~temperature ~max_tokens
               ~max_cost_usd
               ~is_retry
+              ?shared_context
               ()
           in
           let rec retry_loop ~run_meta ~max_context ~run_generation

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -84,5 +84,6 @@ val run_unified_turn :
   observation:Keeper_world_observation.world_observation ->
   generation:int ->
   ?channel:Keeper_world_observation.unified_turn_channel ->
+  ?shared_context:Agent_sdk.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -587,7 +587,7 @@ and resume_worker_via_oas
   in
   let injector_config = Masc_context_injector.default_config () in
   let context_injector = Masc_context_injector.make ~config:injector_config () in
-  let shared_context = Oas.Context.create () in
+  let shared_context = Oas.Context.copy checkpoint.context in
   let gate_config = gate_config_of_execution_scope meta.execution_scope in
   let tool_names_ref, hooks = make_tool_tracking_hooks ~gate_config ~context:shared_context () in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -606,8 +606,7 @@ and resume_worker_via_oas
     Option.value ~default:false meta.thinking_enabled
   in
   let guardrails =
-    gate_config_of_execution_scope meta.execution_scope
-    |> Verifier_oas.eval_gate_to_oas_guardrails
+    Verifier_oas.eval_gate_to_oas_guardrails gate_config
   in
   let config, options =
     Worker_container.build_resume_config ~worker_name
@@ -633,7 +632,8 @@ and resume_worker_via_oas
         | Error e -> raise (Failure ("worker join failed: " ^ e))
       in
       let agent =
-        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
+        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config
+          ~context:shared_context ()
       in
       let workspace_path =
         if String.trim meta.workspace_path <> "" then meta.workspace_path


### PR DESCRIPTION
## Summary
- OAS `Context.t`를 turn마다 새로 생성하던 것을 keeper lifecycle 단위로 1회 생성 후 재사용
- `keeper_keepalive` → `run_keepalive_unified_turn` → `run_turn` 경로로 persistent context 전달
- `Agent.resume`에도 동일한 `shared_context` 전달하여 resume 시 상태 유지
- `resume_worker_via_oas`에서 `shared_context`를 `Oas.Context.copy checkpoint.context`로 초기화하여 checkpoint에 저장된 cross-run mutable state를 resume 시 복원
- `keeper_keepalive.ml` 주석 수정: `Context.t` 공유가 보존하는 것(shared context에 직접 쓰인 값)과 보존하지 않는 것(per-turn `context_injector`-local 타이밍/툴 호출 카운터)을 정확히 기술
- `keeper_agent_run.ml` 주석 수정: `context_injector`가 매 호출마다 새로 생성되므로 injector-local elapsed/counter가 `~shared_context` 공유만으로는 누적되지 않음을 명시
- `keeper_keepalive.ml` 주석에서 존재하지 않는 문서(`docs/analysis/2026-04-06-keeper-lifecycle-analysis.md`) 참조 제거

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — internal context persistence improvement and comment accuracy fixes only

## Evidence

- `dune build` 통과 (parallel_validation ✅)
- `keeper_context_core.ml`에서 `Agent_sdk.Context.copy cp.context` 패턴으로 동일 용법 확인

## Review evidence

- Copilot code review 피드백 반영: dead doc reference 제거, resume 시 checkpoint context 복원, `context_injector` lifecycle 관련 주석 정확도 개선

## Linked issue