### PR TITLE
fix(keeper): lower proactive defaults 900/1800 → 120/300 and add TOML support

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -38,8 +38,8 @@ let validate_name name =
 
 let default_execution_scope = "workspace"
 let default_proactive_enabled = true
-let default_proactive_idle_sec = 900
-let default_proactive_cooldown_sec = 1800
+let default_proactive_idle_sec = 120
+let default_proactive_cooldown_sec = 300
 let default_keeper_will = ""
 let default_keeper_needs = ""
 let default_keeper_desires = ""

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -28,6 +28,16 @@ let ensure_keeper_meta config name =
       | Some v -> v
       | None -> Keeper_config.default_proactive_enabled
     in
+    let target_idle_sec =
+      match defaults.proactive_idle_sec with
+      | Some v -> v
+      | None -> Keeper_config.default_proactive_idle_sec
+    in
+    let target_cooldown_sec =
+      match defaults.proactive_cooldown_sec with
+      | Some v -> v
+      | None -> Keeper_config.default_proactive_cooldown_sec
+    in
     let target_room_signal_prompt_enabled =
       match Keeper_config.keeper_room_signal_prompt_enabled_override () with
       | Some override -> override
@@ -41,16 +51,27 @@ let ensure_keeper_meta config name =
       | None -> meta.tool_denylist
     in
     let denylist_changed = meta.tool_denylist <> target_denylist in
+    let proactive_timers_changed =
+      meta.proactive.idle_sec <> target_idle_sec
+      || meta.proactive.cooldown_sec <> target_cooldown_sec
+    in
     if meta.proactive.enabled <> target_proactive
+       || proactive_timers_changed
        || meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled
        || denylist_changed then begin
       Log.Keeper.info
-        "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b, room_signal_prompt_enabled %b -> %b, denylist_changed %b for %s"
+        "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b, idle_sec %d -> %d, cooldown_sec %d -> %d, room_signal_prompt_enabled %b -> %b, denylist_changed %b for %s"
         meta.proactive.enabled target_proactive
+        meta.proactive.idle_sec target_idle_sec
+        meta.proactive.cooldown_sec target_cooldown_sec
         meta.room_signal_prompt_enabled target_room_signal_prompt_enabled
         denylist_changed meta.name;
       let updated = { meta with
-        proactive = { meta.proactive with enabled = target_proactive };
+        proactive = {
+          enabled = target_proactive;
+          idle_sec = target_idle_sec;
+          cooldown_sec = target_cooldown_sec;
+        };
         room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
         updated_at = now_iso ();

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -101,11 +101,17 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         p.proactive_enabled_opt
     in
     let proactive_idle_sec =
-      Option.value ~default:default_proactive_idle_sec p.proactive_idle_sec_opt
+      Option.value
+        ~default:
+          (Option.value ~default:default_proactive_idle_sec p.profile_defaults.proactive_idle_sec)
+        p.proactive_idle_sec_opt
       |> normalize_proactive_idle_sec
     in
     let proactive_cooldown_sec =
-      Option.value ~default:default_proactive_cooldown_sec p.proactive_cooldown_sec_opt
+      Option.value
+        ~default:
+          (Option.value ~default:default_proactive_cooldown_sec p.profile_defaults.proactive_cooldown_sec)
+        p.proactive_cooldown_sec_opt
       |> normalize_proactive_cooldown_sec
     in
     let auto_handoff = Option.value ~default:true p.auto_handoff_opt in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -134,6 +134,8 @@ type keeper_profile_defaults = {
   scope_kind : string option;
   mention_targets : string list;
   proactive_enabled : bool option;
+  proactive_idle_sec : int option;
+  proactive_cooldown_sec : int option;
   room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
@@ -167,6 +169,8 @@ let empty_keeper_profile_defaults = {
   scope_kind = None;
   mention_targets = [];
   proactive_enabled = None;
+  proactive_idle_sec = None;
+  proactive_cooldown_sec = None;
   room_signal_prompt_enabled = None;
   shards = None;
   allowed_paths = None;
@@ -214,6 +218,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let k key = "keeper." ^ key in
   let str key = Keeper_toml_loader.toml_string_opt doc (k key) in
   let bool_ key = Keeper_toml_loader.toml_bool_opt doc (k key) in
+  let int_ key = Keeper_toml_loader.toml_int_opt doc (k key) in
   let strs key = Keeper_toml_loader.toml_string_list doc (k key) in
   let removed_present =
     removed_keeper_input_key_names
@@ -267,6 +272,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         scope_kind = str "scope_kind";
         mention_targets = strs "mention_targets";
         proactive_enabled = bool_ "proactive_enabled";
+        proactive_idle_sec = int_ "proactive_idle_sec";
+        proactive_cooldown_sec = int_ "proactive_cooldown_sec";
         room_signal_prompt_enabled = bool_ "room_signal_prompt_enabled";
         shards =
           (match strs "shards" with
@@ -364,6 +371,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 scope_kind = Safe_ops.json_string_opt "scope_kind" keeper_json;
                 mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
+                proactive_idle_sec = Safe_ops.json_int_opt "proactive_idle_sec" keeper_json;
+                proactive_cooldown_sec = Safe_ops.json_int_opt "proactive_cooldown_sec" keeper_json;
                 room_signal_prompt_enabled =
                   Safe_ops.json_bool_opt "room_signal_prompt_enabled" keeper_json;
                 shards =


### PR DESCRIPTION
## Summary
- Keeper proactive 기본값이 idle=900s, cooldown=1800s로 너무 높아 키퍼가 restart 후 15-30분간 자율 턴을 스케줄하지 못하는 문제 수정
- 기본값을 idle=120s, cooldown=300s로 변경
- `proactive_idle_sec` / `proactive_cooldown_sec`를 TOML config에서 파싱 가능하게 추가
- `ensure_keeper_meta` bootstrap 시 TOML 값을 disk meta에 동기화

## 변경 파일 (4개)
| 파일 | 변경 |
|------|------|
| `keeper_config.ml` | 기본값 `900/1800` → `120/300` |
| `keeper_types_profile.ml` | type + TOML/JSON 파싱에 `proactive_idle_sec`, `proactive_cooldown_sec` 추가 |
| `keeper_turn_up_create.ml` | fallback 체인: MCP arg > TOML > default |
| `keeper_runtime.ml` | bootstrap re-sync에 idle/cooldown 동기화 추가 |

## Fallback 체인 (우선순위)
```
MCP tool arg (masc_keeper_up)  >  TOML (config/keepers/*.toml)  >  default (120/300)
```

## Test plan
- [x] `test_keeper_toml` — 49 tests pass
- [x] `test_keeper_toml_config_validation` — 1 test pass
- [x] `test_keeper_state_machine` — 98 tests pass
- [x] `test_keeper_unified` — 98 tests pass
- [x] `dune build` — clean

Closes #5537

🤖 Generated with [Claude Code](https://claude.com/claude-code)