### PR TITLE
fix(keeper): downgrade social keepers from delivery to messaging preset

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -37,5 +37,5 @@ mention_targets = ["cheolsu", "철수", "sangsu", "coder"]
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "delivery"
-tool_denylist = []
+tool_preset = "messaging"
+tool_also_allow = ["keeper_library_search", "keeper_library_read"]

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -47,11 +47,10 @@ mention_targets = ["janitor", "garbage-keeper", "tool-matrix-janitor", "coder", 
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "delivery"
+tool_preset = "messaging"
 tool_also_allow = [
   "keeper_board_delete",
-  "masc_voice_sessions",
-  "masc_voice_session_end",
+  "keeper_voice_sessions",
+  "keeper_voice_session_end",
   "masc_cleanup_zombies",
 ]
-tool_denylist = []

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -43,5 +43,4 @@ proactive_enabled = true
 # .masc/keepers/<name>.json (live runtime meta). See keeper_types_profile.ml.
 execution_scope = "workspace"
 
-tool_preset = "delivery"
-tool_denylist = []
+tool_preset = "messaging"

--- a/config/personas/sangsu/profile.json
+++ b/config/personas/sangsu/profile.json
@@ -73,7 +73,7 @@
       "상수",
       "홍상수"
     ],
-    "tool_preset": "research",
+    "tool_preset": "messaging",
     "presence_keepalive": true,
     "presence_keepalive_sec": 30,
     "proactive_enabled": true


### PR DESCRIPTION
## Summary

- sangsu/cheolsu/janitor 모두 `delivery` preset (45+ tools) → 실제 역할에 맞는 preset으로 축소
- janitor의 ghost tool reference 수정 (`masc_voice_*` → `keeper_voice_*`)
- persona/sangsu의 tool_preset을 TOML과 일치시킴

## 변경 상세

| Keeper | Before | After | 감소율 |
|--------|--------|-------|--------|
| sangsu | delivery (45+) | messaging (28) | -38% |
| cheolsu | delivery (45+) | messaging + library (30) | -33% |
| janitor | delivery (45+) | messaging + cleanup (32) | -29% |

## 근거

Samchon Function Calling Harness 원칙: **도구 수와 9B 모델 선택 정확도는 반비례**. 21 essential tool에서 42.9%, BM25 pre-filter로 5~8개 축소 시 83.3%. 불필요한 도구를 물리적으로 제거하는 것이 가장 직접적인 선택 정확도 향상 방법.

### 발견된 버그
- janitor `also_allow`에 `masc_voice_sessions`/`masc_voice_session_end` — 실제 도구명은 `keeper_voice_*`. Ghost reference로 도구가 동작하지 않았음.

## 영향 범위
- Config 파일 4개만 수정, OCaml 코드 변경 없음
- 서버 재시작 시 keeper가 새 preset으로 부팅됨

## Test plan
- [x] `dune build` 통과
- [ ] 서버 재시작 후 sangsu/cheolsu가 board 도구만 사용하는지 확인
- [ ] janitor가 voice session cleanup을 실제로 수행하는지 확인
- [ ] dashboard에서 keeper별 visible tool count 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)