### PR TITLE
fix(worker): pass shared_context to Agent.resume for temporal awareness

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
-> Current package version: v2.249.0
-> Latest release: v2.249.0 (2026-04-06)
+> Current package version: v2.250.0
+> Latest release: v2.250.0 (2026-04-06)
 > Updated: 2026-04-06
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,7 +1,7 @@
 # Product Operating Plan
 
-> Current package version: v2.249.0
-> Latest release: v2.249.0 (2026-04-06)
+> Current package version: v2.250.0
+> Latest release: v2.250.0 (2026-04-06)
 > Updated: 2026-04-06
 
 Execution companion for capsule-only coordination hardening:

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -606,8 +606,7 @@ and resume_worker_via_oas
     Option.value ~default:false meta.thinking_enabled
   in
   let guardrails =
-    gate_config_of_execution_scope meta.execution_scope
-    |> Verifier_oas.eval_gate_to_oas_guardrails
+    Verifier_oas.eval_gate_to_oas_guardrails gate_config
   in
   let config, options =
     Worker_container.build_resume_config ~worker_name
@@ -633,7 +632,8 @@ and resume_worker_via_oas
         | Error e -> raise (Failure ("worker join failed: " ^ e))
       in
       let agent =
-        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
+        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config
+          ~context:shared_context ()
       in
       let workspace_path =
         if String.trim meta.workspace_path <> "" then meta.workspace_path


### PR DESCRIPTION
## Summary
- `resume_worker_via_oas`에서 `Agent.resume` 호출 시 `~context:shared_context` 누락 → resume된 Worker의 temporal awareness가 작동하지 않던 버그 수정
- `gate_config_of_execution_scope` 이중 호출 제거 (동일 결과의 redundant 계산)

## Test plan
- [x] `test_worker_safety_gates.exe` 11개 통과
- [x] `dune build` 성공
- [ ] CI green

Closes #5546

🤖 Generated with [Claude Code](https://claude.com/claude-code)