### PR TITLE
fix(cascade): remove hardcoded gemini:auto, respect cascade.json order

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -784,10 +784,10 @@ let preferred_execution_model_labels () =
     (match explicit_llama_model_label_result () with
     | Ok label -> Some label
     | Error _ -> None);
-    (* Provider auto-detection: iterate adapters, check auth
-       availability from config, delegate model selection to
-       OAS cascade via "provider:auto". *)
-    (if gemini_direct_available () then Some "gemini:auto" else None);
+    (* No hardcoded provider preference here.  Model order is determined
+       by cascade.json (OAS Cascade_config), not by MASC.  The auto_detect
+       list below only serves as a last-resort fallback when cascade.json
+       is missing entirely. *)
   ] in
   Json_util.dedupe_keep_order
     (List.filter_map Fun.id explicit
@@ -801,7 +801,6 @@ let preferred_verifier_model_labels () =
     (match explicit_llama_model_label_result () with
     | Ok label -> Some label
     | Error _ -> None);
-    (if gemini_direct_available () then Some "gemini:auto" else None);
   ] in
   Json_util.dedupe_keep_order
     (List.filter_map Fun.id explicit


### PR DESCRIPTION
## Summary
- `preferred_execution_model_labels()`에서 `gemini:auto` 하드코딩 제거
- `preferred_verifier_model_labels()`에서 동일 하드코딩 제거
- 모델 순서는 이제 `cascade.json`이 결정 (OAS Cascade_config)

## Root Cause
`~/.masc/cascade.json`이 없어서 OAS cascade가 `Hardcoded_defaults` 경로를 탔고, 거기서 MASC `provider_adapter.ml`이 `gemini:auto`를 하드코딩으로 끼워넣어 `glm:auto`보다 앞에 배치됨.

## Fix
1. `gemini:auto` 하드코딩 제거 (이 PR)
2. `~/.masc/cascade.json` → `config/cascade.json` 심볼릭 링크 (수동, 서버 재시작 필요)

## Tracking
- Phase 1 of #5554 (provider_adapter.ml 전체 제거 로드맵)

## Test plan
- [ ] `dune build` 통과
- [ ] 서버 재시작 후 cascade 순서 확인: `llama → glm` (gemini 없음)
- [ ] tool call log에서 glm:auto 모델 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)