### PR TITLE
fix(keeper): true cross-generation memory search via trace_history

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -638,15 +638,42 @@ let keeper_memory_search_json
   let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
   let limit = max 1 (min 8 (Safe_ops.json_int ~default:5 "limit" args)) in
   (* Cross-generation search: merge current checkpoint messages with
-     persisted history.jsonl.  Checkpoint messages are prioritized;
-     history provides recall across earlier generations. *)
-  let history_path = keeper_history_path config meta.runtime.trace_id in
+     persisted history.jsonl from current AND previous generations.
+     trace_history contains trace_ids from earlier generations,
+     accumulated by keeper_rollover on each handoff. *)
+  let current_history =
+    load_history_user_messages
+      ~path:(keeper_history_path config meta.runtime.trace_id)
+      ~max_n:50
+  in
+  let prev_history =
+    meta.runtime.trace_history
+    |> List.concat_map (fun old_trace_id ->
+         load_history_user_messages
+           ~path:(keeper_history_path config old_trace_id)
+           ~max_n:20)
+  in
+  (* Checkpoint messages first (most recent), then current session
+     history, then previous generations.  Deduplicate by first 100 chars. *)
+  let checkpoint_user_msgs =
+    recent_user_messages ctx_work.messages ~max_n:100
+  in
+  let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
+  let key_of s =
+    let len = min 100 (String.length s) in
+    String.sub s 0 len
+  in
+  List.iter (fun s -> Hashtbl.replace seen (key_of s) ()) checkpoint_user_msgs;
+  let dedup lst =
+    List.filter (fun s ->
+      let k = key_of s in
+      if Hashtbl.mem seen k then false
+      else (Hashtbl.replace seen k (); true)) lst
+  in
   let all_candidates =
-    recall_candidates_with_history
-      ~checkpoint_messages:ctx_work.messages
-      ~history_path
-      ~max_checkpoint:100
-      ~max_history:50
+    checkpoint_user_msgs
+    @ dedup current_history
+    @ dedup prev_history
   in
   let matches =
     all_candidates

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -7,14 +7,15 @@ module Keeper_memory_recall = Masc_mcp.Keeper_memory_recall
 module Keeper_types = Masc_mcp.Keeper_types
 module Types = Types
 
-let keeper_meta ~name ~mention_targets =
+let keeper_meta ?(trace_id = "trace-1") ?(trace_history = []) ~name ~mention_targets () =
   let json =
     `Assoc
       [
         ("name", `String name);
-        ("trace_id", `String "trace-1");
+        ("trace_id", `String trace_id);
         ("goal", `String "keep continuity");
         ("mention_targets", `List (List.map (fun target -> `String target) mention_targets));
+        ("trace_history", `List (List.map (fun s -> `String s) trace_history));
       ]
   in
   match Keeper_types.meta_of_json json with
@@ -40,7 +41,7 @@ let test_any_mentioned_ambient_message () =
     (Mention.any_mentioned ~targets:[ "sangsu" ] "hello everyone, just chatting")
 
 let test_keeper_policy_observation_direct_mention () =
-  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] in
+  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] () in
   let obs =
     Keeper_memory.keeper_policy_observation_of_room_message
       ~meta ~room_id:"default" (room_message "@director, what do you think?")
@@ -48,7 +49,7 @@ let test_keeper_policy_observation_direct_mention () =
   check bool "keeper observation uses mention targets" true obs.direct_mention
 
 let test_keeper_policy_observation_non_mention () =
-  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] in
+  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] () in
   let obs =
     Keeper_memory.keeper_policy_observation_of_room_message
       ~meta ~room_id:"default" (room_message "ambient room chatter")
@@ -268,7 +269,7 @@ let test_memory_write_then_recall_with_state_block () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let config = make_test_room_config dir in
-    let meta = keeper_meta ~name:"e2e-keeper" ~mention_targets:["e2e-keeper"] in
+    let meta = keeper_meta ~name:"e2e-keeper" ~mention_targets:["e2e-keeper"] () in
 
     (* Simulate a keeper reply with [STATE] block *)
     let reply =
@@ -304,7 +305,7 @@ let test_memory_write_then_recall_meta_fallback () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let config = make_test_room_config dir in
-    let meta = keeper_meta ~name:"fallback-keeper" ~mention_targets:["fallback-keeper"] in
+    let meta = keeper_meta ~name:"fallback-keeper" ~mention_targets:["fallback-keeper"] () in
 
     (* Reply WITHOUT [STATE] block — should trigger meta-based fallback *)
     let reply = "네, 이해했습니다. 바로 작업을 시작하겠습니다." in
@@ -352,7 +353,7 @@ let test_memory_search_cross_generation () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
     let config = make_test_room_config dir in
-    let meta = keeper_meta ~name:"cross-gen-keeper" ~mention_targets:["cross-gen-keeper"] in
+    let meta = keeper_meta ~name:"cross-gen-keeper" ~mention_targets:["cross-gen-keeper"] () in
     let trace_id = meta.runtime.trace_id in
     (* Write history.jsonl with messages from previous generations *)
     let history_path = Keeper_types.keeper_history_path config trace_id in
@@ -384,7 +385,7 @@ let test_memory_search_checkpoint_only () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
     let config = make_test_room_config dir in
-    let meta = keeper_meta ~name:"ckpt-keeper" ~mention_targets:["ckpt-keeper"] in
+    let meta = keeper_meta ~name:"ckpt-keeper" ~mention_targets:["ckpt-keeper"] () in
     (* No history.jsonl — only checkpoint messages *)
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let ctx_work = KEC.append ctx_work
@@ -402,7 +403,7 @@ let test_memory_search_dedup () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
     let config = make_test_room_config dir in
-    let meta = keeper_meta ~name:"dedup-keeper" ~mention_targets:["dedup-keeper"] in
+    let meta = keeper_meta ~name:"dedup-keeper" ~mention_targets:["dedup-keeper"] () in
     let trace_id = meta.runtime.trace_id in
     let history_path = Keeper_types.keeper_history_path config trace_id in
     write_lines history_path [
@@ -419,6 +420,56 @@ let test_memory_search_dedup () =
     let json = Yojson.Safe.from_string result in
     let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
     check int "2 unique matches (deduped)" 2 match_count)
+
+(** Test: keeper_memory_search finds messages from a PREVIOUS generation's
+    history.jsonl via trace_history.  This is the true cross-generation test. *)
+let test_memory_search_prev_generation () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
+    let config = make_test_room_config dir in
+    let prev_trace = "gen-0-trace" in
+    let curr_trace = "gen-1-trace" in
+    let meta = keeper_meta
+      ~trace_id:curr_trace
+      ~trace_history:[prev_trace]
+      ~name:"multi-gen-keeper"
+      ~mention_targets:["multi-gen-keeper"]
+      () in
+    (* Previous generation's history — different trace_id directory *)
+    let prev_history_path = Keeper_types.keeper_history_path config prev_trace in
+    write_lines prev_history_path [
+      {|{"role":"user","content":"migrate the postgres schema to v3"}|};
+      {|{"role":"user","content":"rollback the failed deployment"}|};
+    ];
+    (* Current generation's history — empty (just started) *)
+    let curr_history_path = Keeper_types.keeper_history_path config curr_trace in
+    write_lines curr_history_path [
+      {|{"role":"user","content":"check cluster health"}|};
+    ];
+    (* Checkpoint has only new-gen messages *)
+    let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
+    let ctx_work = KEC.append ctx_work
+      (Agent_sdk.Types.text_message Agent_sdk.Types.User "status report") in
+    (* Search for "postgres" — only in previous generation's history *)
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+      ~name:"keeper_memory_search"
+      ~input:(`Assoc [ ("query", `String "postgres"); ("limit", `Int 5) ])
+      () in
+    let json = Yojson.Safe.from_string result in
+    let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
+    check bool "found postgres from previous generation" true (match_count > 0);
+    let matches = Yojson.Safe.Util.(json |> member "matches" |> to_list
+      |> List.map to_string) in
+    check bool "match references schema migration" true
+      (List.exists (fun m -> Re.execp (Re.str "postgres" |> Re.compile) m) matches);
+    (* Also verify current generation is searchable *)
+    let result2 = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+      ~name:"keeper_memory_search"
+      ~input:(`Assoc [ ("query", `String "cluster"); ("limit", `Int 5) ])
+      () in
+    let json2 = Yojson.Safe.from_string result2 in
+    let match2 = Yojson.Safe.Util.(json2 |> member "match_count" |> to_int) in
+    check bool "found cluster from current generation" true (match2 > 0))
 
 let () =
   run "Keeper_memory"
@@ -473,5 +524,7 @@ let () =
             test_memory_search_checkpoint_only;
           test_case "deduplicates checkpoint and history" `Quick
             test_memory_search_dedup;
+          test_case "finds messages from previous generation via trace_history" `Quick
+            test_memory_search_prev_generation;
         ] );
     ]


### PR DESCRIPTION
## Summary
- #5552가 "cross-generation"이라고 했지만 실제로는 현재 trace_id의 history.jsonl만 읽었음 (구라였음)
- rollover 시 새 trace_id가 생기므로 이전 세대의 history.jsonl은 다른 디렉토리에 존재
- 이제 `meta.runtime.trace_history`를 순회하여 이전 세대들의 history.jsonl도 검색
- 우선순위: checkpoint 메시지 > 현재 세대 history > 이전 세대들 history
- 100자 prefix 기반 dedup으로 중복 제거

## Changes
| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_exec_tools.ml` | `recall_candidates_with_history` 제거, 직접 3-layer 병합 (checkpoint + current history + prev history via trace_history) |
| `test/test_keeper_memory.ml` | `keeper_meta` helper에 `~trace_id`, `~trace_history` 옵션 추가. `test_memory_search_prev_generation` 테스트 추가 — 이전 세대 trace_id의 history.jsonl에서 검색 증명 |

## Test plan
- [x] `test_keeper_memory.exe` — 24 tests pass (4 cross-gen tests, 신규 1개)
- [x] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)