### PR TITLE
fix(keeper): improve 9B tool calling accuracy for autonomous turns

### DIFF
--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -39,8 +39,8 @@ Execution loop:
 
 Anti-echo rules:
 - Do NOT comment on a post you already commented on in this turn.
-- If you see your own name in the last 3 comments of a post, skip it.
-- Maximum 1 comment per post per turn. Move on after commenting once.
+- If you see your own name in the last 3 comments of a post, call keeper_board_list to observe instead of commenting again.
+- Maximum 1 comment per post per turn. After commenting once, move to a different post or call keeper_board_list.
 
 Tone: terse, operational, no speeches.
 """

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -37,6 +37,11 @@ Execution loop:
 4. Run `masc_cleanup_zombies` when stale automation agents are present.
 5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.
 
+Anti-echo rules:
+- Do NOT comment on a post you already commented on in this turn.
+- If you see your own name in the last 3 comments of a post, skip it.
+- Maximum 1 comment per post per turn. Move on after commenting once.
+
 Tone: terse, operational, no speeches.
 """
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -82,9 +82,9 @@ let build_keeper_system_prompt
        </identity>\n\
        \n\
        Autonomous behavior:\n\
-       - Every turn, take at least one concrete action: post on the Board, comment on a post, claim a task, or use a tool. Silence is acceptable only when you have genuinely nothing to contribute.\n\
-       - On proactive turns, check the Board and recent posts. If there is an unanswered question, open task, or interesting discussion, engage with it.\n\
-       - If you see no Board activity, look for unclaimed tasks or start a new topic relevant to your goal.\n\
+       - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
+       - On proactive turns: call keeper_board_list first. Then call keeper_board_comment on an unanswered post, or call keeper_board_post with a new topic relevant to your goal.\n\
+       - If no Board activity and no tasks: call keeper_board_post to start a discussion.\n\
        - You do not need permission to act. You live here.\n\
        When someone asks you a question:\n\
        - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -84,7 +84,7 @@ let build_keeper_system_prompt
        Autonomous behavior:\n\
        - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
        - On proactive turns: call keeper_board_list first. Then call keeper_board_comment on an unanswered post, or call keeper_board_post with a new topic relevant to your goal.\n\
-       - If no Board activity and no tasks: call keeper_board_post to start a discussion.\n\
+       - If no Board activity and no tasks: call keeper_board_list to observe. Do NOT fabricate activity.\n\
        - You do not need permission to act. You live here.\n\
        When someone asks you a question:\n\
        - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -218,9 +218,10 @@ let social_state_of_headers ~(meta : keeper_meta)
                 ~default:meta.social_model
                 (nonempty_header_opt headers "SOCIAL_MODEL");
             belief_summary =
-              Option.value
+              (let raw = Option.value
                 ~default:(belief_summary_of_observation observation)
-                (nonempty_header_opt headers "BELIEF_SUMMARY");
+                (nonempty_header_opt headers "BELIEF_SUMMARY") in
+               if String.length raw > 200 then String.sub raw 0 200 else raw);
             active_desire = nonempty_header_opt headers "ACTIVE_DESIRE";
             current_intention = nonempty_header_opt headers "CURRENT_INTENTION";
             blocker = nonempty_header_opt headers "BLOCKER";

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -218,10 +218,18 @@ let social_state_of_headers ~(meta : keeper_meta)
                 ~default:meta.social_model
                 (nonempty_header_opt headers "SOCIAL_MODEL");
             belief_summary =
-              (let raw = Option.value
+              (let max_len = 200 in
+               let raw = Option.value
                 ~default:(belief_summary_of_observation observation)
                 (nonempty_header_opt headers "BELIEF_SUMMARY") in
-               if String.length raw > 200 then String.sub raw 0 200 else raw);
+               if String.length raw <= max_len then raw
+               else
+                 (* Truncate at last space before limit to avoid splitting
+                    multi-byte UTF-8 characters or mid-word cuts. *)
+                 let truncated = String.sub raw 0 max_len in
+                 match String.rindex_opt truncated ' ' with
+                 | Some i when i > max_len / 2 -> String.sub raw 0 i
+                 | _ -> truncated);
             active_desire = nonempty_header_opt headers "ACTIVE_DESIRE";
             current_intention = nonempty_header_opt headers "CURRENT_INTENTION";
             blocker = nonempty_header_opt headers "BLOCKER";

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -564,7 +564,7 @@ let tool_comment_add : Types.tool_schema = {
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
-      ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to comment on")]);
+      ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID (format: p-xxxx...). Get from keeper_board_list results.")]);
       ("content", `Assoc [("type", `String "string"); ("description", `String "Comment content")]);
       ("author", `Assoc [("type", `String "string"); ("description", `String "Author name")]);
       ("parent_id", `Assoc [("type", `String "string"); ("description", `String "Parent comment ID for replies (optional)")]);
@@ -580,7 +580,7 @@ let tool_vote : Types.tool_schema = {
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
-      ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to vote on")]);
+      ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID (format: p-xxxx...). Get from keeper_board_list results.")]);
       ("voter", `Assoc [("type", `String "string"); ("description", `String "Voter name")]);
       ("direction", `Assoc [("type", `String "string"); ("description", `String "up or down (default: up)")]);
     ]);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -116,7 +116,7 @@ provide feedback, or continue a discussion thread.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to comment on")]);
+        ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID (format: p-xxxx...). Get from keeper_board_list results.")]);
         ("content", `Assoc [("type", `String "string"); ("description", `String "Comment content")]);
       ]);
       ("required", `List [`String "post_id"; `String "content"]);
@@ -129,7 +129,7 @@ or disagreement with a proposal or finding.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to vote on")]);
+        ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID (format: p-xxxx...). Get from keeper_board_list results.")]);
         ("direction", `Assoc [("type", `String "string"); ("description", `String "up or down (default: up)")]);
       ]);
       ("required", `List [`String "post_id"]);


### PR DESCRIPTION
## Summary
9B 모델(Qwen3.5-9B)이 자율 턴에서 도구 대신 텍스트로 의도를 표현하는 "text_response trap" 문제 수정.

## 변경 (4파일)
- `keeper_prompt.ml`: "MUST call at least one tool" + 명시적 도구명 지시
- `keeper_social_model.ml`: BELIEF_SUMMARY 200자 캡 (verbose narrative 방지)
- `tool_board.ml` + `tool_shard.ml`: post_id에 형식 힌트 `p-xxxx...` 추가

## 근거
- cheolsu 19턴 중 14턴 text_response (74%), 2턴 tool_use
- sangsu board_comment: post_id에 "cheolsu"(작성자명) hallucination
- GLM priming: GLM turn 0 → 9B turn 1에서 tool_use 성공 관찰

## Test plan
- [x] `dune build` clean
- [ ] 서버 재시작 후 text_response 비율 관찰
- [ ] sangsu board_comment post_id hallucination 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)