### PR TITLE
feat(keeper): expand messaging preset with github, library, shell, filesystem

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -38,4 +38,3 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "messaging"
-tool_also_allow = ["keeper_library_search", "keeper_library_read"]

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -82,7 +82,7 @@ groups = ["base"]
 masc_tools = ["masc_status", "masc_tool_help"]
 
 [presets.messaging]
-groups = ["base", "board", "coordination", "governance"]
+groups = ["base", "board", "coordination", "governance", "github", "library", "shell", "filesystem"]
 masc_groups = ["core"]
 
 [presets.coding]

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -97,8 +97,12 @@ let test_messaging_preset_exposes_board () =
   (* Governance tools are no longer available *)
   Alcotest.(check bool) "no masc_governance_status" false
     (List.mem "masc_governance_status" names);
-  Alcotest.(check bool) "omits keeper_shell_readonly" false
-    (List.mem "keeper_shell_readonly" names)
+  Alcotest.(check bool) "has keeper_shell_readonly" true
+    (List.mem "keeper_shell_readonly" names);
+  Alcotest.(check bool) "has keeper_github" true
+    (List.mem "keeper_github" names);
+  Alcotest.(check bool) "has keeper_fs_read" true
+    (List.mem "keeper_fs_read" names)
 
 let test_custom_opens_specific_tools_only () =
   prime_keeper_bridge ();

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -217,7 +217,9 @@ let test_messaging_preset_tools () =
   let meta = make_meta ~preset:Keeper_types.Messaging () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has board tools" true (List.mem "keeper_board_post" tools);
-  check bool "omits keeper_fs_read" false (List.mem "keeper_fs_read" tools)
+  check bool "has keeper_fs_read" true (List.mem "keeper_fs_read" tools);
+  check bool "has keeper_shell_readonly" true (List.mem "keeper_shell_readonly" tools);
+  check bool "has keeper_github" true (List.mem "keeper_github" tools)
 
 let test_all_keepers_have_shell_and_coding () =
   let meta = make_meta ~preset:Keeper_types.Coding () in


### PR DESCRIPTION
## Summary
- messaging preset에 `github`, `library`, `shell`, `filesystem` groups 추가
- cheolsu, sangsu, janitor 등 social keeper가 `keeper_github`, `keeper_library_*`, `keeper_shell_readonly`, `keeper_fs_read` 사용 가능
- cheolsu.toml의 중복 `tool_also_allow` 제거

## Motivation
이전 세션에서 social keeper가 web search/github 접근이 안 되는 문제 확인. `masc_web_search`는 이미 `masc.core`에 포함되어 있었으나, keeper-level 도구(`keeper_github` 등)는 messaging preset에 없었음.

## Test plan
- [ ] `dune build` pass
- [ ] CI Build and Test pass
- [ ] 서버 재시작 후 cheolsu가 `keeper_github`, `keeper_fs_read` 사용 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)