### PR TITLE
feat(keeper): add keeper_pr_workflow composite tool for 9B models

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -34,7 +34,7 @@ tools = ["keeper_fs_edit"]
 tools = ["keeper_library_search", "keeper_library_read"]
 
 [groups.github]
-tools = ["keeper_github"]
+tools = ["keeper_github", "keeper_pr_workflow"]
 
 # Shard-backed groups: tool names resolved from Tool_shard at runtime.
 [groups.governance]

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -172,7 +172,7 @@ let privileged_public_tool_names : string list =
 
 let privileged_keeper_tool_names : string list =
   [ "keeper_bash"; "keeper_fs_edit"; "keeper_github";
-    "masc_worktree_create" ]
+    "keeper_pr_workflow"; "masc_worktree_create" ]
 
 (* Derived from Tool_catalog_surfaces.keeper_internal_replacement (SSOT).
    Returns the masc_* backend name for aliased tools, identity otherwise. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -440,6 +440,7 @@ let run_turn
     "keeper_shell_readonly", "명령어 조회 검색 탐색";
     "keeper_bash", "명령어 실행 쉘 빌드 테스트";
     "keeper_github", "깃허브 이슈 풀리퀘스트 PR CI";
+    "keeper_pr_workflow", "PR 생성 워크트리 커밋 푸시 풀리퀘스트 원���";
     "keeper_memory_search", "기억 검색 대화 이전 메시지";
     "keeper_library_search", "라이브러리 지식 문서 검색";
     "keeper_library_read", "라이브러리 문서 읽기 지식";

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -534,6 +534,144 @@ let handle_keeper_github
               ])))
 ;;
 
+(** keeper_pr_workflow — deterministic pipeline: worktree → write → git → PR.
+    Reduces 4-step tool chain to a single call for 9B models that cannot
+    reliably chain multi-step tool sequences. *)
+let handle_keeper_pr_workflow
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
+  let file_path = Safe_ops.json_string ~default:"" "file_path" args |> String.trim in
+  let file_content = Safe_ops.json_string ~default:"" "file_content" args in
+  let commit_message = Safe_ops.json_string ~default:"" "commit_message" args |> String.trim in
+  let pr_title = Safe_ops.json_string ~default:"" "pr_title" args |> String.trim in
+  let pr_body = Safe_ops.json_string ~default:"" "pr_body" args |> String.trim in
+  let base_branch = Safe_ops.json_string ~default:"main" "base_branch" args |> String.trim in
+  (* Validate required fields *)
+  if branch = "" then error_json "branch_required"
+  else if file_path = "" then error_json "file_path_required"
+  else if commit_message = "" then error_json "commit_message_required"
+  else if pr_title = "" then error_json "pr_title_required"
+  else
+    (* Check preset: requires delivery or coding *)
+    let preset_ok =
+      match Keeper_types.tool_access_preset meta.tool_access with
+      | Some (Delivery | Coding | Full) -> true
+      | _ -> false
+    in
+    if not preset_ok then
+      Yojson.Safe.to_string
+        (`Assoc
+          [ "ok", `Bool false
+          ; "error", `String "preset_insufficient"
+          ; "reason", `String "keeper_pr_workflow requires delivery, coding, or full preset"
+          ])
+    else
+      let root = project_root_of_config config in
+      let task_id = Printf.sprintf "pr-%s" (String.sub branch 0 (min 20 (String.length branch))) in
+      let agent_name = Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name) in
+      let steps = Buffer.create 512 in
+      let step_ok = ref true in
+      let step_error = ref "" in
+      let run_step name f =
+        if !step_ok then begin
+          match f () with
+          | Ok msg ->
+            Buffer.add_string steps (Printf.sprintf "  %s: ok\n" name);
+            Log.Keeper.info "pr_workflow step %s ok (keeper=%s)" name meta.name;
+            Some msg
+          | Error msg ->
+            step_ok := false;
+            step_error := Printf.sprintf "%s failed: %s" name msg;
+            Buffer.add_string steps (Printf.sprintf "  %s: FAILED — %s\n" name msg);
+            Log.Keeper.warn "pr_workflow step %s failed: %s (keeper=%s)" name msg meta.name;
+            None
+        end else None
+      in
+      (* Step 1: Create worktree *)
+      let worktree_path = ref "" in
+      let _s1 = run_step "worktree_create" (fun () ->
+        match Room.worktree_create_r config ~agent_name ~task_id ~base_branch with
+        | Ok msg ->
+          (* Extract worktree path from message *)
+          let wt_dir = Filename.concat root
+            (Printf.sprintf ".worktrees/%s-%s" agent_name task_id) in
+          worktree_path := wt_dir;
+          Ok msg
+        | Error e -> Error (Types.masc_error_to_string e)
+      ) in
+      (* Step 2: Write file *)
+      let _s2 = run_step "file_write" (fun () ->
+        if !worktree_path = "" then Error "no worktree path"
+        else begin
+          let abs_path = Filename.concat !worktree_path file_path in
+          try
+            let dir = Filename.dirname abs_path in
+            Fs_compat.mkdir_p dir;
+            Fs_compat.save_file abs_path file_content;
+            Ok (Printf.sprintf "wrote %d bytes to %s" (String.length file_content) file_path)
+          with exn -> Error (Printexc.to_string exn)
+        end
+      ) in
+      (* Step 3: Git add + commit + push *)
+      let _s3 = run_step "git_commit_push" (fun () ->
+        if !worktree_path = "" then Error "no worktree path"
+        else begin
+          let run_git cmd =
+            let shell = Printf.sprintf "cd %s && git %s 2>&1"
+              (Filename.quote !worktree_path) cmd in
+            Process_eio.run_argv_with_status ~timeout_sec:30.0
+              [ "/bin/zsh"; "-lc"; shell ]
+          in
+          let st_add, out_add = run_git (Printf.sprintf "add %s" (Filename.quote file_path)) in
+          if st_add <> Unix.WEXITED 0 then
+            Error (Printf.sprintf "git add: %s" out_add)
+          else begin
+            let st_commit, out_commit = run_git
+              (Printf.sprintf "commit -m %s" (Filename.quote commit_message)) in
+            if st_commit <> Unix.WEXITED 0 then
+              Error (Printf.sprintf "git commit: %s" out_commit)
+            else begin
+              let st_push, out_push = run_git
+                (Printf.sprintf "push -u origin %s" (Filename.quote branch)) in
+              if st_push <> Unix.WEXITED 0 then
+                Error (Printf.sprintf "git push: %s" out_push)
+              else
+                Ok "committed and pushed"
+            end
+          end
+        end
+      ) in
+      (* Step 4: Create draft PR via gh CLI *)
+      let pr_url = ref "" in
+      let _s4 = run_step "gh_pr_create" (fun () ->
+        let body = if pr_body = "" then pr_title else pr_body in
+        let gh_cmd = Printf.sprintf
+          "cd %s && gh pr create --draft --title %s --body %s --base %s 2>&1"
+          (Filename.quote root) (Filename.quote pr_title) (Filename.quote body)
+          (Filename.quote base_branch) in
+        let st, out =
+          Process_eio.run_argv_with_status ~timeout_sec:30.0
+            [ "/bin/zsh"; "-lc"; gh_cmd ] in
+        if st <> Unix.WEXITED 0 then
+          Error (Printf.sprintf "gh pr create: %s" out)
+        else begin
+          pr_url := String.trim out;
+          Ok (Printf.sprintf "PR created: %s" (String.trim out))
+        end
+      ) in
+      Yojson.Safe.to_string
+        (`Assoc
+          [ "ok", `Bool !step_ok
+          ; "steps", `String (Buffer.contents steps)
+          ; "pr_url", `String !pr_url
+          ; "error", `String !step_error
+          ; "keeper", `String meta.name
+          ])
+;;
+
 let keeper_agent_sender ~(meta : keeper_meta) =
   Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name)
 
@@ -1094,6 +1232,7 @@ let execute_keeper_tool_call
     | "keeper_voice_session_start"
     | "keeper_voice_session_end" -> handle_keeper_voice_tool ~meta ~name ~args
     | "keeper_github" -> handle_keeper_github ~config ~meta ~args
+    | "keeper_pr_workflow" -> handle_keeper_pr_workflow ~config ~meta ~args
     | "keeper_tasks_list"
     | "keeper_tasks_audit"
     | "keeper_task_force_release"

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -569,9 +569,23 @@ let handle_keeper_pr_workflow
           ; "reason", `String "keeper_pr_workflow requires delivery, coding, or full preset"
           ])
     else
+      (* Sanitize branch/task_id: reject path traversal chars *)
+      let safe_name s =
+        String.to_seq s
+        |> Seq.filter (fun c ->
+          (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '/')
+        |> String.of_seq
+      in
+      let branch_safe = safe_name branch in
+      if branch_safe <> branch then
+        error_json "branch_contains_invalid_chars"
+      else
       let root = project_root_of_config config in
-      let task_id = Printf.sprintf "pr-%s" (String.sub branch 0 (min 20 (String.length branch))) in
-      let agent_name = Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name) in
+      let task_id = Printf.sprintf "pr-%s"
+        (safe_name (String.sub branch 0 (min 20 (String.length branch)))) in
+      let agent_name = Printf.sprintf "keeper-%s"
+        (safe_name (strip_keeper_prefix meta.name)) in
       let steps = Buffer.create 512 in
       let step_ok = ref true in
       let step_error = ref "" in
@@ -595,24 +609,44 @@ let handle_keeper_pr_workflow
       let _s1 = run_step "worktree_create" (fun () ->
         match Room.worktree_create_r config ~agent_name ~task_id ~base_branch with
         | Ok msg ->
-          (* Extract worktree path from message *)
+          (* Derive worktree path from known naming convention, then verify it exists *)
           let wt_dir = Filename.concat root
             (Printf.sprintf ".worktrees/%s-%s" agent_name task_id) in
-          worktree_path := wt_dir;
-          Ok msg
+          if Sys.file_exists wt_dir && Sys.is_directory wt_dir then begin
+            worktree_path := wt_dir;
+            Ok msg
+          end else
+            Error (Printf.sprintf "worktree created but path not found: %s" wt_dir)
         | Error e -> Error (Types.masc_error_to_string e)
       ) in
-      (* Step 2: Write file *)
+      (* Step 2: Write file — with path traversal guard *)
       let _s2 = run_step "file_write" (fun () ->
         if !worktree_path = "" then Error "no worktree path"
         else begin
           let abs_path = Filename.concat !worktree_path file_path in
-          try
-            let dir = Filename.dirname abs_path in
-            Fs_compat.mkdir_p dir;
-            Fs_compat.save_file abs_path file_content;
-            Ok (Printf.sprintf "wrote %d bytes to %s" (String.length file_content) file_path)
-          with exn -> Error (Printexc.to_string exn)
+          (* Resolve symlinks and normalize to catch ../.. traversal *)
+          let canonical =
+            try Some (Unix.realpath abs_path)
+            with Unix.Unix_error _ ->
+              (* File doesn't exist yet: check parent dir *)
+              try
+                let parent = Unix.realpath (Filename.dirname abs_path) in
+                Some (Filename.concat parent (Filename.basename abs_path))
+              with Unix.Unix_error _ -> None
+          in
+          match canonical with
+          | None -> Error (Printf.sprintf "cannot resolve path: %s" file_path)
+          | Some resolved ->
+            if not (String.starts_with ~prefix:(!worktree_path ^ "/") resolved) then
+              Error (Printf.sprintf "path escapes worktree boundary: %s" file_path)
+            else begin
+              try
+                let dir = Filename.dirname resolved in
+                Fs_compat.mkdir_p dir;
+                Fs_compat.save_file resolved file_content;
+                Ok (Printf.sprintf "wrote %d bytes to %s" (String.length file_content) file_path)
+              with exn -> Error (Printexc.to_string exn)
+            end
         end
       ) in
       (* Step 3: Git add + commit + push *)
@@ -644,13 +678,13 @@ let handle_keeper_pr_workflow
           end
         end
       ) in
-      (* Step 4: Create draft PR via gh CLI *)
+      (* Step 4: Create draft PR — run from worktree for correct branch context *)
       let pr_url = ref "" in
       let _s4 = run_step "gh_pr_create" (fun () ->
         let body = if pr_body = "" then pr_title else pr_body in
         let gh_cmd = Printf.sprintf
           "cd %s && gh pr create --draft --title %s --body %s --base %s 2>&1"
-          (Filename.quote root) (Filename.quote pr_title) (Filename.quote body)
+          (Filename.quote !worktree_path) (Filename.quote pr_title) (Filename.quote body)
           (Filename.quote base_branch) in
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec:30.0

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -16,7 +16,7 @@
 
 (** Bash-like tools that need destructive pattern screening. *)
 let destructive_check_tools =
-  [ "keeper_bash"; "keeper_fs_edit"; "keeper_github" ]
+  [ "keeper_bash"; "keeper_fs_edit"; "keeper_github"; "keeper_pr_workflow" ]
 
 (** Keeper deny list — derived from Tool_catalog surface SSOT.
     Administrative/destructive operations that should only be invoked

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -812,7 +812,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let side_effect_tools =
         [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote";
           "keeper_board_delete";
-          "keeper_bash"; "keeper_fs_edit"; "keeper_github" ]
+          "keeper_bash"; "keeper_fs_edit"; "keeper_github";
+          "keeper_pr_workflow" ]
       in
       let side_effect_observer ~tool_name ~success =
         if success && List.mem tool_name side_effect_tools then

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -46,6 +46,7 @@ let keeper_internal_tools =
     "keeper_shell_readonly";
     "keeper_bash";
     "keeper_github";
+    "keeper_pr_workflow";
     "keeper_voice_speak";
     (* keeper_voice_listen is keeper-only; there is no public masc_voice_listen
        counterpart on MCP surfaces. *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -265,6 +265,25 @@ Returns gh command output. Example: cmd='pr list --state open'.";
       ]);
     ];
   };
+  {
+    name = "keeper_pr_workflow";
+    description = "One-shot PR pipeline: creates worktree, writes file, commits, pushes, \
+and opens a draft PR. Use this instead of chaining worktree_create + code_write + code_git + \
+keeper_github manually. Requires delivery or coding preset.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("branch", `Assoc [("type", `String "string"); ("description", `String "Branch name for the PR (e.g. fix/changelog-unreleased)")]);
+        ("file_path", `Assoc [("type", `String "string"); ("description", `String "File path to create or overwrite, relative to repo root")]);
+        ("file_content", `Assoc [("type", `String "string"); ("description", `String "Full file content to write")]);
+        ("commit_message", `Assoc [("type", `String "string"); ("description", `String "Git commit message")]);
+        ("pr_title", `Assoc [("type", `String "string"); ("description", `String "PR title")]);
+        ("pr_body", `Assoc [("type", `String "string"); ("description", `String "PR body/description (optional, defaults to pr_title)")]);
+        ("base_branch", `Assoc [("type", `String "string"); ("description", `String "Base branch to target (default: main)")]);
+      ]);
+      ("required", `List [`String "branch"; `String "file_path"; `String "file_content"; `String "commit_message"; `String "pr_title"]);
+    ];
+  };
 ]
 
 let coding_workspace_tool_names : string list =


### PR DESCRIPTION
## Summary
- 9B 모델이 4단계 도구 체이닝(worktree→write→git→PR)을 수행하지 못하는 문제를 해결
- `keeper_pr_workflow` 단일 도구로 전체 파이프라인을 결정론적 실행
- delivery/coding/full preset 필요, 각 단계 실패 시 즉시 중단 + 단계별 trace 반환

## 변경 (7파일, +164/-3)
- `keeper_exec_tools.ml`: `handle_keeper_pr_workflow` 핸들러 (worktree→write→git→PR)
- `tool_shard.ml`: tool schema 등록
- `tool_policy.toml`: github 그룹에 등록
- `keeper_unified_turn.ml`, `keeper_hooks_oas.ml`: side-effect/destructive 목록 등록
- `keeper_agent_run.ml`: tool search index 등록
- `tool_catalog_surfaces.ml`: catalog 등록

## 근거
- coder keeper trace: 5회 사용자 프롬프트에도 PR 워크플로 미완주 (autonomous_action_count=0)
- 9B tool selection benchmark: 21 tool 기준 42.9% ceiling → 복합 도구로 판단 부담 감소

## Test plan
- [x] `dune build` clean
- [ ] 서버 재시작 후 keeper가 keeper_pr_workflow를 호출하는지 관찰
- [ ] delivery preset keeper에서 실제 PR 생성 E2E 테스트