### PR TITLE
feat(keeper): 3-layer defense for 9B tool calling accuracy

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -449,6 +449,7 @@
    keeper_tool_policy_config
    keeper_tool_policy
    keeper_discovered_tools
+   keeper_tool_affinity
    keeper_tag_dispatch
    keeper_exec_tools
    keeper_voice_local
@@ -601,6 +602,7 @@
   keeper_tool_policy_config
   keeper_tool_policy
   keeper_discovered_tools
+  keeper_tool_affinity
   keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -387,6 +387,30 @@ let run_turn
     | None -> 5
   in
   let discovered_ref = ref (Keeper_discovered_tools.create ~decay_turns) in
+  (* L1 Tool Affinity: pre-populate discovered tools from trajectory history.
+     Solves the 9B text_response trap by making proven tools visible at
+     turn 0 without requiring keeper_tool_search first.  #5566 *)
+  let affinity_k = Keeper_tool_affinity.configured_max_k () in
+  let _affinity_entries =
+    if affinity_k > 0 then begin
+      let masc_root = Filename.concat config.base_path ".masc" in
+      let allowed = Keeper_tool_policy.keeper_allowed_tool_names meta in
+      let core = Keeper_tool_registry.core_discovery_tools in
+      let entries =
+        Keeper_tool_affinity.pre_populate_from_history
+          ~masc_root ~keeper_name:meta.name
+          ~allowed_tool_names:allowed ~core_tool_names:core
+          ~discovered:!discovered_ref ~max_k:affinity_k
+      in
+      if entries <> [] then
+        Log.Keeper.info "keeper:%s affinity pre-populated %d tools: [%s]"
+          meta.name (List.length entries)
+          (String.concat ", "
+             (List.map (fun (e : Keeper_tool_affinity.affinity_entry) ->
+                Printf.sprintf "%s(%.1f)" e.tool_name e.score) entries));
+      entries
+    end else []
+  in
   let keeper_tools =
     Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
@@ -917,6 +941,19 @@ let run_turn
             all_allowed
         in
         let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
+        (* L2: Force tool calling on autonomous turn 0.
+           tool_choice=Any is deterministic — the API parser enforces tool call
+           format.  Prompt-level "MUST call a tool" is non-deterministic and
+           unreliable for 9B models.  See #5566. *)
+        let tool_choice =
+          let is_autonomous = history_user_source = "world_state_prompt" in
+          if is_autonomous && turn = 0 && List.length all_allowed > 0 then begin
+            Log.Keeper.info "keeper:%s L2 tool_choice=Any on autonomous turn 0"
+              meta.name;
+            Some Agent_sdk.Types.Any
+          end else
+            current_params.tool_choice
+        in
         (* Yield after CPU-bound tool filtering to let HTTP handlers run.
            Without this, N concurrent keeper fibers starve the Eio scheduler
            during turn setup (tool list construction + prompt building). *)
@@ -924,6 +961,7 @@ let run_turn
         Agent_sdk.Hooks.AdjustParams
           { current_params with
             extra_system_context = ctx;
+            tool_choice;
             tool_filter_override = Some tool_filter }
       | _ -> Agent_sdk.Hooks.Continue)
   } in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -391,7 +391,7 @@ let run_turn
      Solves the 9B text_response trap by making proven tools visible at
      turn 0 without requiring keeper_tool_search first.  #5566 *)
   let affinity_k = Keeper_tool_affinity.configured_max_k () in
-  let _affinity_entries =
+  let affinity_populated =
     if affinity_k > 0 then begin
       let masc_root = Filename.concat config.base_path ".masc" in
       let allowed = Keeper_tool_policy.keeper_allowed_tool_names meta in
@@ -947,9 +947,10 @@ let run_turn
            unreliable for 9B models.  See #5566. *)
         let tool_choice =
           let is_autonomous = history_user_source = "world_state_prompt" in
-          if is_autonomous && turn = 0 && List.length all_allowed > 0 then begin
-            Log.Keeper.info "keeper:%s L2 tool_choice=Any on autonomous turn 0"
-              meta.name;
+          if is_autonomous && turn = 0 && affinity_populated <> []
+             && List.length all_allowed > 0 then begin
+            Log.Keeper.info "keeper:%s L2 tool_choice=Any on autonomous turn 0 (%d affinity tools)"
+              meta.name (List.length affinity_populated);
             Some Agent_sdk.Types.Any
           end else
             current_params.tool_choice

--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -1,0 +1,130 @@
+(** Keeper_tool_affinity — History-based tool pre-population.
+
+    Reads trajectory JSONL and computes an affinity score for each tool.
+    Tools with high scores are pre-populated into the per-session
+    Keeper_discovered_tools so they are visible from turn 0.
+
+    Scoring:  score = call_count * success_rate * recency_weight
+      - success_rate = success_count / call_count  (threshold >= 0.3)
+      - recency_weight = exp(-lambda * age_hours)  (lambda = 0.01, ~3-day half-life)
+
+    @since 2.251.0
+    @see <https://github.com/jeong-sik/masc-mcp/issues/5566> *)
+
+(* ================================================================ *)
+(* Configuration                                                     *)
+(* ================================================================ *)
+
+let default_max_k = 5
+let default_lookback_days = 7
+let min_success_rate = 0.3
+let recency_lambda = 0.01
+
+let configured_max_k () =
+  match Sys.getenv_opt "MASC_KEEPER_TOOL_AFFINITY_K" with
+  | Some s -> (try max 0 (min 20 (int_of_string s)) with _ -> default_max_k)
+  | None -> default_max_k
+
+let configured_lookback_days () =
+  match Sys.getenv_opt "MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS" with
+  | Some s -> (try max 1 (min 30 (int_of_string s)) with _ -> default_lookback_days)
+  | None -> default_lookback_days
+
+(* ================================================================ *)
+(* Types                                                             *)
+(* ================================================================ *)
+
+type affinity_entry = {
+  tool_name : string;
+  score : float;
+  call_count : int;
+  success_rate : float;
+}
+
+(* ================================================================ *)
+(* ISO8601 timestamp parser (minimal)                                *)
+(* ================================================================ *)
+
+(** Parse "YYYY-MM-DDTHH:MM:SSZ" to Unix timestamp.
+    Returns [None] on parse failure. *)
+let unix_of_iso8601 (s : string) : float option =
+  try
+    Scanf.sscanf s "%d-%d-%dT%d:%d:%d"
+      (fun year mon day hour minute sec ->
+        let tm : Unix.tm = {
+          tm_sec = sec; tm_min = minute; tm_hour = hour;
+          tm_mday = day; tm_mon = mon - 1; tm_year = year - 1900;
+          tm_wday = 0; tm_yday = 0; tm_isdst = false;
+        } in
+        let (ts, _) = Unix.mktime tm in
+        Some ts)
+  with _ -> None
+
+(* ================================================================ *)
+(* Scoring                                                           *)
+(* ================================================================ *)
+
+let compute_affinity ~(tool_stats : Trajectory.tool_stat list)
+    ~(now : float) ~(max_k : int) : affinity_entry list =
+  if max_k <= 0 then []
+  else
+    tool_stats
+    |> List.filter_map (fun (s : Trajectory.tool_stat) ->
+      let success_rate =
+        if s.call_count > 0
+        then float_of_int s.success_count /. float_of_int s.call_count
+        else 0.0
+      in
+      if success_rate < min_success_rate then None
+      else
+        let age_hours =
+          match unix_of_iso8601 s.last_used_at with
+          | Some last_ts ->
+            let h = (now -. last_ts) /. 3600.0 in
+            Float.max 0.0 h
+          | None -> 168.0  (* 7 days fallback *)
+        in
+        let recency_weight = exp (-. recency_lambda *. age_hours) in
+        let score =
+          float_of_int s.call_count *. success_rate *. recency_weight
+        in
+        Some { tool_name = s.name; score; call_count = s.call_count;
+               success_rate })
+    |> List.sort (fun a b -> Float.compare b.score a.score)
+    |> List.filteri (fun i _ -> i < max_k)
+
+(* ================================================================ *)
+(* Main entry point                                                  *)
+(* ================================================================ *)
+
+let pre_populate_from_history
+    ~(masc_root : string) ~(keeper_name : string)
+    ~(allowed_tool_names : string list) ~(core_tool_names : string list)
+    ~(discovered : Keeper_discovered_tools.t) ~(max_k : int)
+    : affinity_entry list =
+  if max_k <= 0 then []
+  else
+    let now = Unix.gettimeofday () in
+    let lookback_days = configured_lookback_days () in
+    let since = now -. (float_of_int lookback_days *. 86400.0) in
+    let entries =
+      Trajectory.read_entries_since ~masc_root ~keeper_name ~since
+    in
+    if entries = [] then []
+    else
+      let tool_stats = Trajectory.aggregate_tool_stats entries in
+      let allowed_set = Hashtbl.create (List.length allowed_tool_names) in
+      List.iter (fun n -> Hashtbl.replace allowed_set n ()) allowed_tool_names;
+      let core_set = Hashtbl.create (List.length core_tool_names) in
+      List.iter (fun n -> Hashtbl.replace core_set n ()) core_tool_names;
+      let filtered_stats =
+        tool_stats
+        |> List.filter (fun (s : Trajectory.tool_stat) ->
+          Hashtbl.mem allowed_set s.name
+          && not (Hashtbl.mem core_set s.name))
+      in
+      let affinity = compute_affinity ~tool_stats:filtered_stats ~now ~max_k in
+      let names = List.map (fun a -> a.tool_name) affinity in
+      if names <> [] then
+        Keeper_discovered_tools.add discovered ~turn:0 ~names;
+      affinity

--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -45,8 +45,17 @@ type affinity_entry = {
 (* ISO8601 timestamp parser (minimal)                                *)
 (* ================================================================ *)
 
-(** Parse "YYYY-MM-DDTHH:MM:SSZ" to Unix timestamp.
-    Returns [None] on parse failure. *)
+(** Compute the local→UTC offset in seconds.
+    Cached once per process to avoid repeated syscalls. *)
+let utc_offset_sec : float =
+  let t = Unix.gettimeofday () in
+  let utc_tm = Unix.gmtime t in
+  let (local_as_utc, _) = Unix.mktime utc_tm in
+  t -. local_as_utc
+
+(** Parse "YYYY-MM-DDTHH:MM:SSZ" to Unix timestamp (UTC).
+    [Unix.mktime] interprets as local time, so we subtract [utc_offset_sec]
+    to convert to true UTC.  Returns [None] on parse failure. *)
 let unix_of_iso8601 (s : string) : float option =
   try
     Scanf.sscanf s "%d-%d-%dT%d:%d:%d"
@@ -57,7 +66,7 @@ let unix_of_iso8601 (s : string) : float option =
           tm_wday = 0; tm_yday = 0; tm_isdst = false;
         } in
         let (ts, _) = Unix.mktime tm in
-        Some ts)
+        Some (ts -. utc_offset_sec))
   with _ -> None
 
 (* ================================================================ *)
@@ -110,8 +119,9 @@ let pre_populate_from_history
     let entries =
       Trajectory.read_entries_since ~masc_root ~keeper_name ~since
     in
-    if entries = [] then []
-    else
+    match entries with
+    | [] -> []
+    | _ ->
       let tool_stats = Trajectory.aggregate_tool_stats entries in
       let allowed_set = Hashtbl.create (List.length allowed_tool_names) in
       List.iter (fun n -> Hashtbl.replace allowed_set n ()) allowed_tool_names;

--- a/lib/keeper/keeper_tool_affinity.mli
+++ b/lib/keeper/keeper_tool_affinity.mli
@@ -1,0 +1,47 @@
+(** Keeper_tool_affinity — History-based tool pre-population for small models.
+
+    Reads trajectory JSONL for a keeper, scores tools by usage frequency,
+    success rate, and recency, and returns the top-K tool names to
+    pre-populate into {!Keeper_discovered_tools} at session start.
+
+    Solves the "text_response trap" where 9B models write text about
+    actions instead of calling tools, because the discovered set is empty
+    on a fresh generation.
+
+    @since 2.251.0
+    @see <https://github.com/jeong-sik/masc-mcp/issues/5566> *)
+
+type affinity_entry = {
+  tool_name : string;
+  score : float;
+  call_count : int;
+  success_rate : float;
+}
+
+val compute_affinity :
+  tool_stats:Trajectory.tool_stat list ->
+  now:float ->
+  max_k:int ->
+  affinity_entry list
+(** [compute_affinity ~tool_stats ~now ~max_k] scores tools from
+    trajectory stats and returns the top-[max_k] entries sorted by
+    descending score.  Tools with success_rate below the threshold
+    (default 0.3) are excluded. *)
+
+val pre_populate_from_history :
+  masc_root:string ->
+  keeper_name:string ->
+  allowed_tool_names:string list ->
+  core_tool_names:string list ->
+  discovered:Keeper_discovered_tools.t ->
+  max_k:int ->
+  affinity_entry list
+(** [pre_populate_from_history] is the main entry point.
+    Reads recent trajectory, computes affinity, filters by allowed/core,
+    and calls {!Keeper_discovered_tools.add} for the top-K tools.
+    Returns the affinity entries that were added (for logging/metrics).
+    Returns [[]] if no trajectory data exists or [max_k = 0]. *)
+
+val configured_max_k : unit -> int
+(** Read max_k from [MASC_KEEPER_TOOL_AFFINITY_K] env, clamped to [0, 20].
+    Default: 5.  Set to 0 to disable affinity. *)

--- a/test/dune
+++ b/test/dune
@@ -67,6 +67,7 @@
         test_keeper_toml_config_validation
         test_keeper_bash_safety
         test_keeper_discovered_tools
+        test_keeper_tool_affinity
         test_keeper_github_safety
         test_worktree_live_context
         test_tool_input_validation
@@ -128,6 +129,7 @@
           test_keeper_toml_config_validation
           test_keeper_bash_safety
           test_keeper_discovered_tools
+          test_keeper_tool_affinity
           test_keeper_github_safety
           test_worktree_live_context
           test_tool_input_validation

--- a/test/test_keeper_tool_affinity.ml
+++ b/test/test_keeper_tool_affinity.ml
@@ -1,0 +1,111 @@
+(** Tests for Keeper_tool_affinity — trajectory-based tool pre-population. *)
+
+module Affinity = Masc_mcp.Keeper_tool_affinity
+module Trajectory = Masc_mcp.Trajectory
+module Discovered = Masc_mcp.Keeper_discovered_tools
+
+(* Helper: build a tool_stat record *)
+let stat ?(successes = 5) ?(failures = 0) ?(last = "2026-04-06T12:00:00Z") name =
+  let count = successes + failures in
+  { Trajectory.name;
+    call_count = count;
+    success_count = successes;
+    failure_count = failures;
+    avg_duration_ms = 100;
+    p95_duration_ms = 200;
+    max_duration_ms = 300;
+    total_cost_usd = 0.01;
+    last_used_at = last }
+
+(* now = 2026-04-06T14:00:00Z in Unix time (approx) *)
+let now = 1775397600.0
+
+let test_empty_stats () =
+  let result = Affinity.compute_affinity ~tool_stats:[] ~now ~max_k:5 in
+  Alcotest.(check int) "empty stats → empty result" 0 (List.length result)
+
+let test_filters_low_success () =
+  let stats = [
+    stat ~successes:1 ~failures:9 "bad_tool";   (* 10% success *)
+    stat ~successes:8 ~failures:2 "good_tool";  (* 80% success *)
+  ] in
+  let result = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:5 in
+  Alcotest.(check int) "only good_tool passes" 1 (List.length result);
+  Alcotest.(check string) "good_tool selected"
+    "good_tool" (List.hd result).tool_name
+
+let test_respects_max_k () =
+  let stats = List.init 10 (fun i ->
+    stat ~successes:(10 - i) (Printf.sprintf "tool_%d" i)
+  ) in
+  let result = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:3 in
+  Alcotest.(check int) "max_k=3 returns 3" 3 (List.length result)
+
+let test_score_ordering () =
+  let stats = [
+    stat ~successes:2 ~failures:0 "low_count";    (* 2 calls, 100% *)
+    stat ~successes:10 ~failures:0 "high_count";   (* 10 calls, 100% *)
+    stat ~successes:5 ~failures:0 "mid_count";     (* 5 calls, 100% *)
+  ] in
+  let result = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:10 in
+  let names = List.map (fun (e : Affinity.affinity_entry) -> e.tool_name) result in
+  Alcotest.(check (list string)) "ordered by score desc"
+    [ "high_count"; "mid_count"; "low_count" ] names
+
+let test_recency_decay () =
+  let stats = [
+    (* 1 hour ago *)
+    stat ~successes:5 ~last:"2026-04-06T13:00:00Z" "recent_tool";
+    (* 7 days ago *)
+    stat ~successes:5 ~last:"2026-03-30T12:00:00Z" "old_tool";
+  ] in
+  let result = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:10 in
+  Alcotest.(check int) "both pass" 2 (List.length result);
+  Alcotest.(check string) "recent_tool ranked first"
+    "recent_tool" (List.hd result).tool_name;
+  Alcotest.(check bool) "recent has higher score"
+    true ((List.hd result).score > (List.nth result 1).score)
+
+let test_max_k_zero () =
+  let stats = [ stat "some_tool" ] in
+  let result = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:0 in
+  Alcotest.(check int) "max_k=0 → empty" 0 (List.length result)
+
+let test_populates_discovered () =
+  let discovered = Discovered.create ~decay_turns:5 in
+  let stats = [
+    stat ~successes:5 "keeper_board_post";
+    stat ~successes:3 "keeper_board_comment";
+  ] in
+  (* Simulate pre_populate_from_history logic inline
+     (can't call pre_populate_from_history without real trajectory files) *)
+  let affinity = Affinity.compute_affinity ~tool_stats:stats ~now ~max_k:5 in
+  let names = List.map (fun (e : Affinity.affinity_entry) -> e.tool_name) affinity in
+  Discovered.add discovered ~turn:0 ~names;
+  let active = Discovered.active_names discovered ~turn:0 in
+  Alcotest.(check int) "2 tools in discovered" 2 (List.length active);
+  Alcotest.(check bool) "board_post present" true
+    (List.mem "keeper_board_post" active);
+  Alcotest.(check bool) "board_comment present" true
+    (List.mem "keeper_board_comment" active)
+
+let test_configured_max_k_default () =
+  (* Without env var, should return default 5 *)
+  let k = Affinity.configured_max_k () in
+  Alcotest.(check bool) "default max_k in [0,20]" true (k >= 0 && k <= 20)
+
+let () =
+  Alcotest.run "Keeper tool affinity" [
+    ("compute_affinity", [
+      Alcotest.test_case "empty stats" `Quick test_empty_stats;
+      Alcotest.test_case "filters low success rate" `Quick test_filters_low_success;
+      Alcotest.test_case "respects max_k" `Quick test_respects_max_k;
+      Alcotest.test_case "score ordering" `Quick test_score_ordering;
+      Alcotest.test_case "recency decay" `Quick test_recency_decay;
+      Alcotest.test_case "max_k=0 disables" `Quick test_max_k_zero;
+    ]);
+    ("integration", [
+      Alcotest.test_case "populates discovered" `Quick test_populates_discovered;
+      Alcotest.test_case "configured_max_k default" `Quick test_configured_max_k_default;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- **L1 Tool Affinity**: trajectory JSONL에서 과거 성공 도구를 읽어 `discovered_ref`에 사전 채우기. Turn 0부터 proven tools 즉시 가용
- **L2 tool_choice=Any**: 자율 턴 0에서 API 파서 레벨로 tool call 강제. 프롬프트 "MUST call a tool"보다 결정론적
- 8개 유닛 테스트 전부 통과

## Problem
cheolsu(Qwen3.5-9B) 자율 턴에서 74% text_response (19턴 중 14턴). 
- Cold start: `discovered_ref` 비어있어 핵심 도구 미노출
- 프롬프트 강제 비결정론적 (Qwen 공식: "not guaranteed")

## Research
- Agent Skill Framework (arxiv 2602.16653): 9B는 20+ tool에서 정확도 하락
- AutoTool (AAAI 2026): tool usage inertia, 30% 추론 비용 감소
- Qwen3.5 chat template bugs (QwenLM/Qwen3#1831): 별도 L0 이슈로 추적

## Changes
| 파일 | Layer | 변경 |
|------|-------|------|
| `keeper_tool_affinity.ml` + `.mli` | L1 | 신규 — trajectory scoring + pre-populate |
| `keeper_agent_run.ml` | L1+L2 | affinity 호출 (15줄) + tool_choice=Any 주입 (10줄) |
| `lib/dune` | L1 | 모듈 등록 (2줄) |
| `test_keeper_tool_affinity.ml` | 테스트 | 8개 유닛 테스트 |
| `test/dune` | 테스트 | 테스트 등록 |

## Measurement Plan
| 지표 | Before | After (목표) |
|------|--------|-------------|
| text_response rate | 74% | <10% |
| Turn 0 visible tools | 17 | 17-22 |
| first_turn_tool_use | 0% | >90% |

Closes #5566

## Test plan
- [x] `dune build` clean
- [x] `test_keeper_tool_affinity.exe` — 8 tests pass
- [x] `test_keeper_discovered_tools.exe` — 8 tests pass (no regression)
- [ ] 서버 재시작 후 cheolsu/sangsu autonomous turn에서 tool call 발생 확인
- [ ] Trajectory에서 text_response vs tool_use 비율 측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)