### PR TITLE
feat(keeper): auto-inject tool hints from schema descriptions

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -390,3 +390,33 @@ let keeper_universe_model_tools (meta : keeper_meta) : Types.tool_schema list =
   all_schemas
   |> List.filter (fun tool -> List.mem tool.Types.name universe)
   |> dedupe_tool_schemas
+
+(* ── Tool description lookup (for prompt auto-hints) ─────────── *)
+
+(** Extract the first sentence from a tool description.
+    Truncates at the first period+space or 80 chars, whichever is shorter. *)
+let first_sentence desc =
+  let max_len = 80 in
+  let len = String.length desc in
+  let cutoff =
+    match String.index_opt desc '.' with
+    | Some i when i < max_len -> i + 1
+    | _ -> min len max_len
+  in
+  let s = String.sub desc 0 cutoff in
+  if cutoff < len then String.trim s else s
+
+(** Lookup tool description by name from all available schema sources.
+    Returns [Some first_sentence] if found, [None] otherwise.
+    Searches shard-resolved tools, inline schemas, injected masc_* schemas,
+    and code-write schemas. *)
+let tool_hint_of (name : string) : string option =
+  let all_schemas =
+    Tool_shard.keeper_model_tools
+    @ Tool_schemas_inline.schemas
+    @ !masc_schemas_ref
+    @ Tool_code_write.schemas
+  in
+  match List.find_opt (fun (s : Types.tool_schema) -> s.name = name) all_schemas with
+  | Some s -> Some (first_sentence s.description)
+  | None -> None

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -386,15 +386,20 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  (* Keeper tool inventory — show the keeper_* subset available this cycle *)
+  (* Keeper tool inventory — show allowed tools with auto-generated hints
+     from schema descriptions.  This is the SSOT for tool discovery:
+     keepers see what they can use and why, without manual duplication
+     in instructions. *)
   let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
-  let keeper_tools =
-    List.filter (fun n -> String.starts_with ~prefix:"keeper_" n) allowed_tools
-  in
-  if keeper_tools <> [] then (
-    Buffer.add_string ubuf "\n### Keeper Tools\n";
-    Buffer.add_string ubuf (String.concat ", " keeper_tools);
-    Buffer.add_string ubuf "\n");
+  if allowed_tools <> [] then (
+    Buffer.add_string ubuf "\n### Available Tools\n";
+    List.iter (fun name ->
+      match Keeper_tool_policy.tool_hint_of name with
+      | Some hint ->
+        Buffer.add_string ubuf (Printf.sprintf "- %s — %s\n" name hint)
+      | None ->
+        Buffer.add_string ubuf (Printf.sprintf "- %s\n" name))
+      allowed_tools);
   (* Metacognition: show the keeper its own recent tool activity so it can
      recognise patterns — thrashing, failure loops, tool over-reliance.
      Data comes from Keeper_registry per-entry tool_usage Hashtbl. *)

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -641,6 +641,37 @@ let () =
         check bool "non-empty" true (n > 0);
         check bool "5-30 range" true (n >= 5 && n <= 30));
     ]);
+    ("auto_tool_hints", [
+      test_case "known tool has hint" `Quick (fun () ->
+        match Keeper_tool_policy.tool_hint_of "keeper_board_post" with
+        | Some hint ->
+          check bool "hint non-empty" true (String.length hint > 0);
+          check bool "hint max 80 chars" true (String.length hint <= 81)
+        | None -> fail "keeper_board_post should have a hint");
+      test_case "unknown tool has no hint" `Quick (fun () ->
+        check (option string) "no hint for unknown"
+          None (Keeper_tool_policy.tool_hint_of "totally_fake_tool"));
+      test_case "masc tool has hint" `Quick (fun () ->
+        match Keeper_tool_policy.tool_hint_of "masc_web_search" with
+        | Some hint ->
+          check bool "hint non-empty" true (String.length hint > 0)
+        | None -> fail "masc_web_search should have a hint");
+      test_case "all allowed tools have hints" `Quick (fun () ->
+        let meta = make_meta ~preset:Keeper_types.Messaging () in
+        let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+        let missing = List.filter (fun name ->
+          Keeper_tool_policy.tool_hint_of name = None) tools in
+        (* Some shard-resolved or governance tools may not have schemas
+           in the static list. Log them but don't fail — the important
+           thing is that the majority of tools have hints. *)
+        if missing <> [] then
+          Printf.eprintf "[info] tools without hints: %s\n"
+            (String.concat ", " missing);
+        let total = List.length tools in
+        let with_hints = total - List.length missing in
+        check bool "at least 80%% of tools have hints" true
+          (with_hints * 100 / (max total 1) >= 80));
+    ]);
     ("tool_access_of_meta_json_validation", [
       test_case "string tools field returns error" `Quick (fun () ->
         let json = `Assoc [


### PR DESCRIPTION
## Summary
- keeper prompt에 tool name만 나열하던 것을 `name — description` 형태로 자동 주입
- `tool_hint_of` 함수가 schema description에서 첫 문장(max 80자)을 추출
- `keeper_*` 필터 제거 → 모든 allowed_tools를 hint와 함께 표시

## Before/After

**Before:**
```
### Keeper Tools
keeper_board_post, keeper_board_comment, keeper_board_vote, keeper_github, ...
```

**After:**
```
### Available Tools
- keeper_board_post — Post a new item to the keeper board.
- keeper_board_comment — Add a comment to an existing board post.
- keeper_github — Run gh CLI commands for GitHub operations.
- masc_web_search — Search the web using a query string.
...
```

## Motivation
9B 모델은 도구 이름만 보고 언제 써야 하는지 판단하기 어려움. schema description을 prompt에 자동 주입하면:
1. **Drift 제거**: instructions에 도구명을 수동 기술할 필요 없음
2. **SSOT**: tool_policy.toml + schema description이 유일한 진실의 원천
3. **자동화**: 새 도구 추가 시 prompt에 자동 반영

## Test plan
- [x] `dune build` pass
- [x] auto_tool_hints 4개 테스트 추가 및 pass
- [x] test_keeper_safety_gates 52개 pass
- [x] test_keeper_masc_bridge 28개 pass
- [x] test_keeper_tool_exposure 50개 pass
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)