### PR TITLE
feat(dashboard): add Mermaid state diagram to keeper detail

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -774,10 +774,17 @@ let keeper_config_json (config : Room.config) (name : string)
           ("compaction_count", `Int m.runtime.compaction_rt.count);
         ]
       in
+      let current_phase =
+        Keeper_registry.get_phase ~base_path:config.base_path m.name
+      in
       let pipeline_stage =
-        match Keeper_registry.get_phase ~base_path:config.base_path m.name with
+        match current_phase with
         | Some phase -> Keeper_exec_status.pipeline_stage_of_phase phase
         | None -> "offline"
+      in
+      let state_diagram =
+        Keeper_state_machine.phase_to_mermaid
+          ~current:(Option.value ~default:Keeper_state_machine.Offline current_phase)
       in
       let tools_access =
         let allowed = Keeper_exec_tools.keeper_allowed_tool_names m in
@@ -822,6 +829,7 @@ let keeper_config_json (config : Room.config) (name : string)
            `List (List.map (fun s -> `String s)
              (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
          ("pipeline_stage", `String pipeline_stage);
+         ("state_diagram", `String state_diagram);
          ("prompt", prompt);
          ("execution", execution);
          ("compaction", compaction);

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -516,3 +516,53 @@ let transition_result_to_json (tr : transition_result) =
     "event", event_to_json tr.event_applied;
     "timestamp", `Float tr.timestamp;
   ]
+
+(* ── Mermaid State Diagram ────────────────────────────── *)
+
+let phase_to_mermaid ~(current : phase) : string =
+  let b = Buffer.create 512 in
+  let p fmt = Printf.bprintf b fmt in
+  p "stateDiagram-v2\n";
+  (* Phase nodes with display names *)
+  p "    [*] --> Offline\n";
+  p "    Offline --> Running : Fiber_started\n";
+  p "    Running --> Failing : hb/turn fail\n";
+  p "    Running --> Compacting : compact start\n";
+  p "    Running --> HandingOff : handoff start\n";
+  p "    Running --> Draining : stop requested\n";
+  p "    Running --> Paused : operator pause\n";
+  p "    Failing --> Running : hb/turn ok\n";
+  p "    Failing --> Crashed : fiber death\n";
+  p "    Failing --> Draining : stop requested\n";
+  p "    Compacting --> Running : compact done\n";
+  p "    Compacting --> Failing : hb fail\n";
+  p "    Compacting --> Crashed : fiber death\n";
+  p "    HandingOff --> Running : handoff done\n";
+  p "    HandingOff --> Failing : hb fail\n";
+  p "    HandingOff --> Crashed : fiber death\n";
+  p "    Draining --> Stopped : drain done\n";
+  p "    Draining --> Crashed : fiber death\n";
+  p "    Paused --> Running : operator resume\n";
+  p "    Paused --> Draining : stop requested\n";
+  p "    Paused --> Crashed : fiber death\n";
+  p "    Crashed --> Restarting : backoff elapsed\n";
+  p "    Crashed --> Dead : budget exhausted\n";
+  p "    Restarting --> Running : fiber started\n";
+  p "    Restarting --> Crashed : launch fail\n";
+  p "    Restarting --> Dead : budget exhausted\n";
+  p "    Stopped --> [*]\n";
+  p "    Dead --> [*]\n";
+  (* Highlight current phase with classDef *)
+  p "\n";
+  p "    classDef active fill:#22c55e,stroke:#16a34a,color:#fff,stroke-width:3px\n";
+  p "    classDef terminal fill:#6b7280,stroke:#4b5563,color:#fff\n";
+  p "    classDef buffer fill:#f59e0b,stroke:#d97706,color:#fff\n";
+  (match current with
+   | Stopped | Dead ->
+     p "    class %s terminal\n" (phase_to_string current)
+   | Failing | Compacting | HandingOff | Draining | Restarting ->
+     p "    class %s buffer\n" (phase_to_string current);
+     p "    class %s active\n" (phase_to_string current)
+   | _ ->
+     p "    class %s active\n" (phase_to_string current));
+  Buffer.contents b

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -519,6 +519,20 @@ let transition_result_to_json (tr : transition_result) =
 
 (* ── Mermaid State Diagram ────────────────────────────── *)
 
+(** Maps a phase to the capitalized state ID used in the Mermaid diagram. *)
+let phase_to_mermaid_id = function
+  | Offline -> "Offline"
+  | Running -> "Running"
+  | Failing -> "Failing"
+  | Compacting -> "Compacting"
+  | HandingOff -> "HandingOff"
+  | Draining -> "Draining"
+  | Paused -> "Paused"
+  | Stopped -> "Stopped"
+  | Crashed -> "Crashed"
+  | Restarting -> "Restarting"
+  | Dead -> "Dead"
+
 let phase_to_mermaid ~(current : phase) : string =
   let b = Buffer.create 512 in
   let p fmt = Printf.bprintf b fmt in
@@ -526,30 +540,40 @@ let phase_to_mermaid ~(current : phase) : string =
   (* Phase nodes with display names *)
   p "    [*] --> Offline\n";
   p "    Offline --> Running : Fiber_started\n";
+  p "    Offline --> Draining : stop requested\n";
+  p "    Offline --> Stopped : stop while not started\n";
   p "    Running --> Failing : hb/turn fail\n";
   p "    Running --> Compacting : compact start\n";
   p "    Running --> HandingOff : handoff start\n";
   p "    Running --> Draining : stop requested\n";
   p "    Running --> Paused : operator pause\n";
+  p "    Running --> Stopped : stop requested\n";
+  p "    Running --> Crashed : fiber death\n";
   p "    Failing --> Running : hb/turn ok\n";
   p "    Failing --> Crashed : fiber death\n";
   p "    Failing --> Draining : stop requested\n";
+  p "    Failing --> Paused : operator pause\n";
   p "    Compacting --> Running : compact done\n";
   p "    Compacting --> Failing : hb fail\n";
   p "    Compacting --> Crashed : fiber death\n";
+  p "    Compacting --> Draining : stop requested\n";
   p "    HandingOff --> Running : handoff done\n";
   p "    HandingOff --> Failing : hb fail\n";
   p "    HandingOff --> Crashed : fiber death\n";
+  p "    HandingOff --> Draining : stop requested\n";
   p "    Draining --> Stopped : drain done\n";
   p "    Draining --> Crashed : fiber death\n";
   p "    Paused --> Running : operator resume\n";
   p "    Paused --> Draining : stop requested\n";
+  p "    Paused --> Stopped : stop requested\n";
   p "    Paused --> Crashed : fiber death\n";
   p "    Crashed --> Restarting : backoff elapsed\n";
   p "    Crashed --> Dead : budget exhausted\n";
   p "    Restarting --> Running : fiber started\n";
   p "    Restarting --> Crashed : launch fail\n";
   p "    Restarting --> Dead : budget exhausted\n";
+  p "    Restarting --> Draining : stop requested\n";
+  p "    Restarting --> Paused : operator pause\n";
   p "    Stopped --> [*]\n";
   p "    Dead --> [*]\n";
   (* Highlight current phase with classDef *)
@@ -559,10 +583,9 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    classDef buffer fill:#f59e0b,stroke:#d97706,color:#fff\n";
   (match current with
    | Stopped | Dead ->
-     p "    class %s terminal\n" (phase_to_string current)
+     p "    class %s terminal\n" (phase_to_mermaid_id current)
    | Failing | Compacting | HandingOff | Draining | Restarting ->
-     p "    class %s buffer\n" (phase_to_string current);
-     p "    class %s active\n" (phase_to_string current)
+     p "    class %s buffer\n" (phase_to_mermaid_id current)
    | _ ->
-     p "    class %s active\n" (phase_to_string current));
+     p "    class %s active\n" (phase_to_mermaid_id current));
   Buffer.contents b

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -185,3 +185,11 @@ val phase_to_json : phase -> Yojson.Safe.t
 val conditions_to_json : conditions -> Yojson.Safe.t
 val event_to_json : event -> Yojson.Safe.t
 val transition_result_to_json : transition_result -> Yojson.Safe.t
+
+(** {1 Mermaid Visualization} *)
+
+(** Generate a Mermaid stateDiagram-v2 string with the given phase
+    highlighted. The diagram shows the full 11-state transition graph
+    with the current phase visually distinguished (green for active,
+    amber for buffer, gray for terminal). *)
+val phase_to_mermaid : current:phase -> string

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -188,6 +188,10 @@ val transition_result_to_json : transition_result -> Yojson.Safe.t
 
 (** {1 Mermaid Visualization} *)
 
+(** Maps a phase to its Mermaid diagram state identifier (capitalized).
+    Use this to reference states in generated Mermaid `class` directives. *)
+val phase_to_mermaid_id : phase -> string
+
 (** Generate a Mermaid stateDiagram-v2 string with the given phase
     highlighted. The diagram visualizes the keeper phases and
     distinguishes the current phase visually (green for active,

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -189,7 +189,7 @@ val transition_result_to_json : transition_result -> Yojson.Safe.t
 (** {1 Mermaid Visualization} *)
 
 (** Generate a Mermaid stateDiagram-v2 string with the given phase
-    highlighted. The diagram shows the full 11-state transition graph
-    with the current phase visually distinguished (green for active,
+    highlighted. The diagram visualizes the keeper phases and
+    distinguishes the current phase visually (green for active,
     amber for buffer, gray for terminal). *)
 val phase_to_mermaid : current:phase -> string

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -1578,21 +1578,6 @@ let test_all_phases_covered () =
 let mermaid_lines phase =
   SM.phase_to_mermaid ~current:phase |> String.split_on_char '\n'
 
-(** The Mermaid state ID used in the diagram for each phase. *)
-let mermaid_id_of phase =
-  match phase with
-  | SM.Offline -> "Offline"
-  | SM.Running -> "Running"
-  | SM.Failing -> "Failing"
-  | SM.Compacting -> "Compacting"
-  | SM.HandingOff -> "HandingOff"
-  | SM.Draining -> "Draining"
-  | SM.Paused -> "Paused"
-  | SM.Stopped -> "Stopped"
-  | SM.Crashed -> "Crashed"
-  | SM.Restarting -> "Restarting"
-  | SM.Dead -> "Dead"
-
 (** Returns true if [needle] appears as a substring of [haystack]. *)
 let string_contains haystack needle =
   let hl = String.length haystack and nl = String.length needle in
@@ -1615,7 +1600,7 @@ let test_mermaid_header () =
 let test_mermaid_all_phases_appear () =
   List.iter (fun phase ->
     let diagram = SM.phase_to_mermaid ~current:phase in
-    let id = mermaid_id_of phase in
+    let id = SM.phase_to_mermaid_id phase in
     check bool (Printf.sprintf "phase %s appears in diagram" id)
       true (string_contains diagram id)
   ) SM.all_phases
@@ -1631,7 +1616,7 @@ let test_mermaid_active_class () =
   let active_phases = [ SM.Offline; SM.Running; SM.Paused ] in
   List.iter (fun phase ->
     let lines = mermaid_lines phase in
-    let id = mermaid_id_of phase in
+    let id = SM.phase_to_mermaid_id phase in
     let cls = class_lines_for lines id in
     check int
       (Printf.sprintf "phase %s has exactly one class line" id)
@@ -1646,7 +1631,7 @@ let test_mermaid_buffer_class () =
     [ SM.Failing; SM.Compacting; SM.HandingOff; SM.Draining; SM.Restarting ] in
   List.iter (fun phase ->
     let lines = mermaid_lines phase in
-    let id = mermaid_id_of phase in
+    let id = SM.phase_to_mermaid_id phase in
     let cls = class_lines_for lines id in
     check int
       (Printf.sprintf "phase %s has exactly one class line" id)
@@ -1660,7 +1645,7 @@ let test_mermaid_terminal_class () =
   let terminal_phases = [ SM.Stopped; SM.Dead ] in
   List.iter (fun phase ->
     let lines = mermaid_lines phase in
-    let id = mermaid_id_of phase in
+    let id = SM.phase_to_mermaid_id phase in
     let cls = class_lines_for lines id in
     check int
       (Printf.sprintf "phase %s has exactly one class line" id)

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -1572,6 +1572,104 @@ let test_invariant_priority_chain () =
 let test_all_phases_covered () =
   check int "11 phases" 11 (List.length SM.all_phases)
 
+(* ── Mermaid diagram tests ─────────────────────────────── *)
+
+(** Returns all lines of the Mermaid output for a given current phase. *)
+let mermaid_lines phase =
+  SM.phase_to_mermaid ~current:phase |> String.split_on_char '\n'
+
+(** The Mermaid state ID used in the diagram for each phase. *)
+let mermaid_id_of phase =
+  match phase with
+  | SM.Offline -> "Offline"
+  | SM.Running -> "Running"
+  | SM.Failing -> "Failing"
+  | SM.Compacting -> "Compacting"
+  | SM.HandingOff -> "HandingOff"
+  | SM.Draining -> "Draining"
+  | SM.Paused -> "Paused"
+  | SM.Stopped -> "Stopped"
+  | SM.Crashed -> "Crashed"
+  | SM.Restarting -> "Restarting"
+  | SM.Dead -> "Dead"
+
+(** Returns true if [needle] appears as a substring of [haystack]. *)
+let string_contains haystack needle =
+  let hl = String.length haystack and nl = String.length needle in
+  if nl = 0 then true
+  else if hl < nl then false
+  else begin
+    let found = ref false in
+    for i = 0 to hl - nl do
+      if not !found && String.sub haystack i nl = needle then
+        found := true
+    done;
+    !found
+  end
+
+let test_mermaid_header () =
+  let lines = mermaid_lines SM.Running in
+  check string "starts with stateDiagram-v2"
+    "stateDiagram-v2" (List.nth lines 0)
+
+let test_mermaid_all_phases_appear () =
+  List.iter (fun phase ->
+    let diagram = SM.phase_to_mermaid ~current:phase in
+    let id = mermaid_id_of phase in
+    check bool (Printf.sprintf "phase %s appears in diagram" id)
+      true (string_contains diagram id)
+  ) SM.all_phases
+
+let class_lines_for lines id =
+  let prefix = Printf.sprintf "    class %s " id in
+  List.filter (fun l ->
+    String.length l >= String.length prefix &&
+    String.sub l 0 (String.length prefix) = prefix
+  ) lines
+
+let test_mermaid_active_class () =
+  let active_phases = [ SM.Offline; SM.Running; SM.Paused ] in
+  List.iter (fun phase ->
+    let lines = mermaid_lines phase in
+    let id = mermaid_id_of phase in
+    let cls = class_lines_for lines id in
+    check int
+      (Printf.sprintf "phase %s has exactly one class line" id)
+      1 (List.length cls);
+    check bool
+      (Printf.sprintf "phase %s assigned active class" id)
+      true (List.mem (Printf.sprintf "    class %s active" id) cls)
+  ) active_phases
+
+let test_mermaid_buffer_class () =
+  let buffer_phases =
+    [ SM.Failing; SM.Compacting; SM.HandingOff; SM.Draining; SM.Restarting ] in
+  List.iter (fun phase ->
+    let lines = mermaid_lines phase in
+    let id = mermaid_id_of phase in
+    let cls = class_lines_for lines id in
+    check int
+      (Printf.sprintf "phase %s has exactly one class line" id)
+      1 (List.length cls);
+    check bool
+      (Printf.sprintf "phase %s assigned buffer class (not active)" id)
+      true (List.mem (Printf.sprintf "    class %s buffer" id) cls)
+  ) buffer_phases
+
+let test_mermaid_terminal_class () =
+  let terminal_phases = [ SM.Stopped; SM.Dead ] in
+  List.iter (fun phase ->
+    let lines = mermaid_lines phase in
+    let id = mermaid_id_of phase in
+    let cls = class_lines_for lines id in
+    check int
+      (Printf.sprintf "phase %s has exactly one class line" id)
+      1 (List.length cls);
+    check bool
+      (Printf.sprintf "phase %s assigned terminal class" id)
+      true (List.mem (Printf.sprintf "    class %s terminal" id) cls)
+  ) terminal_phases
+
 (* ── Test suite ────────────────────────────────────────── *)
 
 let () =
@@ -1693,5 +1791,12 @@ let () =
       test_case "INV-8: budget exhaustion permanent" `Quick test_invariant_budget_exhaustion_permanent;
       test_case "INV-9: derive matches matrix (180 combos)" `Quick test_invariant_derive_matches_matrix;
       test_case "INV-10: priority chain ordering" `Quick test_invariant_priority_chain;
+    ];
+    "mermaid", [
+      test_case "header is stateDiagram-v2" `Quick test_mermaid_header;
+      test_case "all phases appear in diagram" `Quick test_mermaid_all_phases_appear;
+      test_case "active phases get active class only" `Quick test_mermaid_active_class;
+      test_case "buffer phases get buffer class only" `Quick test_mermaid_buffer_class;
+      test_case "terminal phases get terminal class only" `Quick test_mermaid_terminal_class;
     ];
   ]


### PR DESCRIPTION
## Summary

- RFC-0002 마지막 항목: keeper detail API에 Mermaid stateDiagram-v2 추가
- `phase_to_mermaid ~current:phase` 함수가 모든 `can_transition` 엣지를 포함하는 전체 전이 그래프를 생성
- 현재 phase를 색상으로 구분: green(active), amber(buffer), gray(terminal)
- `phase_to_mermaid_id` 함수 추가: Mermaid 다이어그램에서 사용하는 대문자 상태 ID 반환 (`.mli` 공개)
- `state_diagram` JSON 필드로 포함, 프론트엔드에서 Mermaid.js로 렌더링 가능
- 리뷰 피드백 반영: `class` 지시문 상태 ID 불일치 수정, 버퍼 페이즈 이중 클래스 제거, 누락된 전이 엣지 추가

## Product impact

- Promise affected: `ops visibility`
- User-visible change: keeper detail API의 `state_diagram` 필드가 올바른 현재 페이즈 하이라이트와 완전한 전이 그래프를 반환

## Evidence

- `"mermaid"` 테스트 그룹 추가 (5개 케이스):
  - `stateDiagram-v2` 헤더 검증
  - 모든 11개 페이즈가 다이어그램에 등장하는지 검증
  - active 페이즈(Offline, Running, Paused)가 정확히 `active` 클래스 하나만 갖는지 검증
  - buffer 페이즈(Failing, Compacting, HandingOff, Draining, Restarting)가 정확히 `buffer` 클래스 하나만 갖는지 검증
  - terminal 페이즈(Stopped, Dead)가 정확히 `terminal` 클래스 하나만 갖는지 검증

## Review evidence

- Copilot code review 피드백 전체 반영

## Linked issue