### PR TITLE
fix(keeper): replace internal Agent.set_state with public extend_turns API (P1)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.108.0))
+  (agent_sdk (>= 0.109.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -1,75 +1,24 @@
 (** Keeper_extend_turns — Self-extending turn budget tool for keeper Agent.run.
 
-    Creates an [extend_turns] {!Agent_sdk.Tool.t} that lets the keeper request
-    more turns at runtime.  The tool enforces a per-session extension limit
-    and an absolute ceiling on total turns. *)
+    Delegates to {!Agent_sdk.Agent.make_extend_turns_tool} which uses the
+    public [Agent.t] type and OAS-internal {!Agent_turn_budget} for
+    budget tracking, idle checks, and cost guards.
+
+    Previously this module reimplemented the budget logic and called the
+    internal [Agent.set_state] API.  Using the public wrapper avoids the
+    internal-API dependency and keeps budget enforcement in OAS. *)
 
 (** Default absolute ceiling on total turns.
     Keepers typically run 50-100 turns per session. 200 is ~2x the worst-case
-    observed session length, providing headroom while preventing runaway loops.
-    Above 200 turns, the keeper is likely stuck or in a degenerate retry pattern.
-    This value is the fallback when no explicit ceiling is provided by the caller. *)
+    observed session length, providing headroom while preventing runaway loops. *)
 let default_ceiling = 200
-
-(** Maximum turns that can be requested in a single [extend_turns] call.
-    Typical extension requests are 3-5 turns. 20 is generous enough for
-    burst work (e.g., processing multiple board posts in sequence) while
-    preventing a single request from consuming a large fraction of the ceiling. *)
-let max_per_request = 20
-
-(** Maximum number of extension requests per session.
-    Combined with [max_per_request], this caps total extensions at 10 * 20 = 200
-    turns, which aligns with [default_ceiling]. This prevents infinite
-    self-extension while allowing gradual budget growth as the keeper discovers
-    more work. Each extension also requires a [reason], creating an audit trail. *)
-let max_extensions_per_session = 10
 
 let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
   let ceiling = match ceiling with Some c -> c | None -> max max_turns default_ceiling in
-  let budget_current = ref max_turns in
-  let budget_extensions = ref 0 in
-  let open Agent_sdk in
-  Tool.create
-    ~name:"extend_turns"
-    ~description:"Request additional turns when you need more time. \
-                   Guardrails check cost and idle before granting."
-    ~parameters:[
-      { Types.name = "additional_turns";
-        description = Printf.sprintf "Number of additional turns (1-%d)" max_per_request;
-        param_type = Types.Integer; required = true };
-      { Types.name = "reason";
-        description = "Why more turns are needed";
-        param_type = Types.String; required = true };
-    ]
-    (fun input ->
-      let additional =
-        try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 5 in
-      let reason =
-        try Yojson.Safe.Util.(member "reason" input |> to_string)
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unspecified" in
-      let additional = max 1 (min additional max_per_request) in
-      if !budget_extensions >= max_extensions_per_session then
-        Ok { Types.content = Printf.sprintf
-          "Denied: extension limit (%d) reached. Budget: %d/%d."
-          max_extensions_per_session !budget_current ceiling }
-      else
-        let new_max = min (!budget_current + additional) ceiling in
-        let granted = new_max - !budget_current in
-        if granted <= 0 then
-          Ok { Types.content = Printf.sprintf
-            "Denied: at ceiling (%d/%d)." !budget_current ceiling }
-        else begin
-          budget_current := new_max;
-          incr budget_extensions;
-          (match !agent_ref with
-           | Some agent ->
-             let state = Agent_sdk.Agent.state agent in
-             Agent_sdk.Agent.set_state agent
-               { state with config =
-                   { state.config with max_turns = new_max } }
-           | None -> ());
-          Ok { Types.content = Printf.sprintf
-            "Granted %d turns. Budget: %d (ceiling: %d). Extensions: %d/%d. Reason: %s"
-            granted new_max ceiling !budget_extensions max_extensions_per_session reason }
-        end)
+  let budget =
+    Agent_sdk.Agent_turn_budget.create
+      ~initial:max_turns
+      ~ceiling
+      ()
+  in
+  Agent_sdk.Agent.make_extend_turns_tool ~agent_ref ~budget ()

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.108.0"}
+  "agent_sdk" {>= "0.109.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.108.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.109.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="96edc450bcc3b82d9155f809d6142176459575d7"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.108.0"
+readonly OAS_AGENT_SDK_SHA="aba035f535a1617c934f27797f9d22027c547f35"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.109.0"


### PR DESCRIPTION
## Summary
- `keeper_extend_turns.ml`이 OAS internal API `Agent.set_state`를 사용하던 문제 수정
- OAS#674에서 추가된 `Agent.make_extend_turns_tool`(public API)로 교체
- 76줄 → 24줄, 자체 budget 로직 제거, OAS `Agent_turn_budget`에 위임
- OAS pin bump 0.108.0 → 0.109.0
- doc comment의 odoc 링크 `{!Agent_turn_budget}` → `{!Agent_sdk.Agent_turn_budget}` 로 수정 (broken link 방지)

## Product impact

- Promise affected: `none/internal`
- User-visible change: 없음 — keeper 내부 API 의존성 제거 및 문서 링크 수정

## Evidence

- [x] `dune build` 통과
- [x] `test_oas_worker` 43/43 passed
- [x] `test_worker_safety_gates` 11/11 passed

## Review evidence

- Copilot PR reviewer 코멘트 반영: `keeper_extend_turns.ml:4` odoc 링크 수정

## Linked issue