### PR TITLE
chore: bump version 2.251.0 → 2.252.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## [2.252.0] - 2026-04-07
+
+### Added
+- **3-layer defense for 9B tool calling** -- trajectory affinity pre-population (L1) + tool_choice=Any on autonomous turn 0 (L2). (#5568)
+- **Composite PR workflow tool** -- keeper_pr_workflow for 9B models to reduce multi-step tool failures. (#5561)
+- **Auto tool hints** -- inject schema descriptions into keeper prompt for tool discovery. (#5570)
+
+### Fixed
+- **Memory bank search** -- search structured memory bank instead of raw history, improve description for retrieval quality. (#5571)
+- **Tool call authority** -- make tool calls authoritative over BDI text headers. (#5573)
+- **Max tokens budget** -- prevent max_tokens output limit from poisoning cumulative token budget. (#5574)
+- **Keeper tool autonomy** -- expand autonomous tool access for keeper agents. (#5575)
+
 ## [2.251.0] - 2026-04-06
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.251.0)
+(version 2.252.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Version bump for 11 commits since v2.251.0
- CHANGELOG updated with #5568, #5561, #5570, #5571, #5573, #5574, #5575