### PR TITLE
fix(keeper): separate transient vs persistent turn failure counting (P3)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -923,14 +923,26 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                Log.Keeper.error
                  "write_meta failed after unified turn failure: %s" msg);
           let base_path = config.base_path in
-          Keeper_registry.increment_turn_failures ~base_path meta.name;
+          (* Transient errors (429 rate limit, 503 overloaded, network
+             timeout) do not count toward the consecutive failure threshold.
+             They are already retried at the turn level with backoff; killing
+             the keeper fiber for a transient API blip is an overreaction
+             that causes unnecessary restarts and context loss.
+             Only persistent errors (auth failure, config error, context
+             overflow after compaction) increment the crash counter. *)
+          if not is_transient then
+            Keeper_registry.increment_turn_failures ~base_path meta.name
+          else
+            Log.Keeper.info
+              "%s: transient turn failure (not counted toward crash threshold): %s"
+              meta.name (short_preview e_str);
           let count = Keeper_registry.get_turn_failures ~base_path meta.name in
           let threshold =
             Runtime_params.get Governance_registry.keeper_max_turn_failures
           in
           if count >= threshold then begin
             Log.Keeper.error
-              "%s: %d consecutive turn failures (threshold=%d), escalating to supervisor crash path"
+              "%s: %d consecutive persistent turn failures (threshold=%d), escalating to supervisor crash path"
               meta.name count threshold;
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name


### PR DESCRIPTION
## Summary
- Transient 네트워크 에러(429, 503, timeout)가 consecutive turn failure 카운터를 올려 keeper fiber를 죽이던 문제 수정
- `is_transient` 플래그가 이미 계산되고 있었으나 카운터 증가에 사용되지 않았음
- Transient 에러: 카운터 미증가 + info 로그
- Persistent 에러: 기존 동작 유지 (카운터 증가 → threshold 도달 시 crash)
- `RateLimited` (HTTP 429) 에러를 `is_transient_network_error`에 추가하여 실제 동작과 문서가 일치하도록 수정

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Keeper fiber가 429 rate-limit 에러로 인해 불필요하게 재시작되지 않음

## Evidence

- `dune build` 통과
- `test_oas_worker` 43/43 passed
- `test_worker_safety_gates` 11/11 passed
- `test_keeper_unified` — `RateLimited is transient` 케이스 추가 및 통과

## Review evidence

N/A

## Linked issue