### PR TITLE
fix(keeper): increase default max_turns 50 → 200

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -236,7 +236,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 50) (* generous budget for multi-step tool chains *)
+    ?(max_turns : int = 200) (* large budget: keeper needs research + code + PR in one cycle *)
     ?(max_idle_turns : int = 3)
     ?(history_user_source = "direct_user")
     ?(history_assistant_source = "direct_assistant")


### PR DESCRIPTION
## Summary
- keeper가 15턴 budget에서 research(shell_readonly + web_search)만 하다가 소진
- code mutation/PR 생성까지 도달하지 못함
- 200턴으로 올려서 research → edit → commit → PR 전체 사이클 가능하게

## 근거
- masc-improver 로그: 15턴 중 12턴 research, 0턴 code mutation
- keeper_config.ml 주석: "1000 turns → 787s latency, 20 turns → 6.7GB RSS"
- 200은 안전 범위 내 (cost_max_usd=$1.0이 별도 guard)

## Test plan
- [x] dune build clean
- [ ] 서버 재시작 후 masc-improver turn budget 200 확인