### PR TITLE
perf: server-side response cache for masc_keeper_status

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1,5 +1,9 @@
 (** Keeper_status_detail — single-keeper detailed status handler.
-    Split from keeper_status.ml. *)
+    Split from keeper_status.ml.
+
+    Server-side response cache: keyed on (name, updated_at, args_hash).
+    Avoids expensive JSONL parsing and checkpoint loading when keeper
+    state has not changed between consecutive status polls. *)
 
 open Tool_args
 open Keeper_types
@@ -13,6 +17,38 @@ open Keeper_status_bridge
 
 type tool_result = Keeper_types.tool_result
 
+(* ── Response cache ──────────────────────────────────── *)
+
+type cache_entry = {
+  updated_at : string;
+  args_hash : string;
+  response : string;
+}
+
+let _cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 8
+
+let invalidate_status_cache_for name =
+  Hashtbl.remove _cache name
+
+let invalidate_status_cache_all () =
+  Hashtbl.clear _cache
+
+(** Hash the status-affecting args so different parameter combos
+    get separate cache entries (e.g. fast=true vs fast=false). *)
+let hash_status_args args =
+  let parts = [
+    get_string args "name" "";
+    string_of_bool (get_bool args "fast" false);
+    string_of_bool (get_bool args "include_context" false);
+    string_of_bool (get_bool args "include_metrics_overview" false);
+    string_of_bool (get_bool args "include_memory_bank" false);
+    string_of_bool (get_bool args "include_history_tail" false);
+    string_of_bool (get_bool args "include_compaction_history" false);
+    string_of_int (get_int args "tail_turns" 3);
+    string_of_int (get_int args "tail_messages" 5);
+  ] in
+  Digest.string (String.concat "|" parts) |> Digest.to_hex
+
 let handle_keeper_status ctx args : tool_result =
   let name = get_string args "name" "" in
   if not (validate_name name) then
@@ -22,6 +58,14 @@ let handle_keeper_status ctx args : tool_result =
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (false, Printf.sprintf "❌ keeper not found: %s" name)
     | Ok (Some m) ->
+      let args_hash = hash_status_args args in
+      (* Cache hit: same updated_at + same args → return cached response *)
+      (match Hashtbl.find_opt _cache name with
+       | Some entry
+         when entry.updated_at = m.updated_at
+           && entry.args_hash = args_hash ->
+         (true, entry.response)
+       | _ ->
       let tail_turns = max 0 (get_int args "tail_turns" 3) in
       let tail_messages = max 0 (get_int args "tail_messages" 5) in
       let tail_compactions = max 0 (get_int args "tail_compactions" 10) in
@@ -614,4 +658,7 @@ let handle_keeper_status ctx args : tool_result =
              ("history", `String history_path);
            ]);
          ] in
-         (true, Yojson.Safe.pretty_to_string json)
+         let response = Yojson.Safe.pretty_to_string json in
+         Hashtbl.replace _cache name
+           { updated_at = m.updated_at; args_hash; response };
+         (true, response))

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -166,6 +166,9 @@ let keeper_list_row_json ~runtime_class config name =
             ("updated_at", `String meta.updated_at);
           ])
 
+let invalidate_status_cache name =
+  Keeper_status_detail.invalidate_status_cache_for name
+
 let handle_keeper_create_from_persona ctx args : tool_result =
   match Keeper_exec_persona.resolved_keeper_args_from_persona args with
   | Error e -> (false, "❌ " ^ e)
@@ -199,6 +202,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
               ]
           in
           invalidate_keeper_list_cache ();
+          invalidate_status_cache (get_string resolved_args "name" "");
           (true, Yojson.Safe.pretty_to_string json)
 
 let handle_keeper_up ctx args : tool_result =
@@ -209,6 +213,7 @@ let handle_keeper_up ctx args : tool_result =
       try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
     in
     invalidate_keeper_list_cache ();
+    invalidate_status_cache (get_string args "name" "");
     (true,
      Yojson.Safe.pretty_to_string
        (annotate_keeper_json ~runtime_class:"keeper" json))
@@ -235,10 +240,12 @@ let handle_keeper_msg ctx args : tool_result =
   match ensure_keeper_exists ctx args with
   | Error err -> (false, err)
   | Ok _ ->
+      let name = get_string args "name" "" in
       let ok, body = Turn.handle_keeper_msg ctx args in
       if not ok then (ok, body)
       else begin
         invalidate_keeper_list_cache ();
+        invalidate_status_cache name;
         let json =
           try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
         in
@@ -251,10 +258,12 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   match ensure_keeper_exists ctx args with
   | Error err -> (false, err)
   | Ok _ ->
+      let name = get_string args "name" "" in
       let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx args in
       if not ok then (ok, body)
       else begin
         invalidate_keeper_list_cache ();
+        invalidate_status_cache name;
         let json =
           try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
         in
@@ -373,10 +382,12 @@ let handle_keeper_repair ctx args : tool_result =
                       ~sw:ctx.sw ~clock:ctx.clock ~config:ctx.config
                       (`Assoc fields)
                   in
+                  invalidate_status_cache meta.name;
                   (ok, annotate_keeper_repair_json ~keeper_name:meta.name body)
 
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();
+  invalidate_status_cache (get_string args "name" "");
   Turn.handle_keeper_down ctx args
 
 let handle_keeper_list ctx args : tool_result =


### PR DESCRIPTION
## Summary

- `masc_keeper_status`가 전체 MCP 호출의 55% (86/157)를 차지하며, 매 호출마다 JSONL 파싱, checkpoint 로딩, 메모리 뱅크 읽기 등 비싼 I/O를 반복
- keeper_meta의 `updated_at` 필드를 version key로 사용하는 서버 캐시 추가
- 상태 변경 없으면 캐시 반환 (read_meta만 ~1-5ms), 변경 시 full 연산 후 캐시 갱신
- 모든 상태 변경 함수(up/down/msg/msg_stream/repair/create_from_persona)에서 캐시 무효화

## Changes

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_status_detail.ml` | response cache (Hashtbl), `invalidate_status_cache_for/all`, `hash_status_args` |
| `lib/tool_keeper.ml` | 상태 변경 handler들에 `invalidate_status_cache` 호출 추가 |

## Cache design

- Key: keeper name
- Version: `updated_at` + args hash (fast/include_context 등 파라미터 조합별 별도 캐시)
- Invalidation: 명시적 (모든 상태 변경 시) — TTL 없음, stale 데이터 불가

## Expected improvement

- 연속 폴링 시 p50: 22ms → ~2ms (read_meta만)
- p95: 374ms → ~5ms
- JSONL/checkpoint I/O 횟수: 86회 → 첫 1회 + 상태 변경 횟수

## Test plan

- [x] `dune build` 성공
- [ ] CI green

Closes #5578

🤖 Generated with [Claude Code](https://claude.com/claude-code)