### PR TITLE
fix(keeper): add parent directory hint on fs_read file-not-found

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -220,7 +220,25 @@ let handle_keeper_fs_read
   | Error e -> error_json e
   | Ok target ->
     (match Safe_ops.read_file_safe target with
-     | Error e -> error_json ~fields:[ "path", `String target ] e
+     | Error e ->
+       let parent = Filename.dirname target in
+       let siblings =
+         try
+           Sys.readdir parent
+           |> Array.to_list
+           |> List.sort String.compare
+           |> (fun l -> if List.length l > 20 then List.filteri (fun i _ -> i < 20) l @ ["..."] else l)
+         with _ -> []
+       in
+       let fields =
+         ("path", `String target)
+         :: (if siblings <> [] then
+               [ "hint", `String "File not found. Check available entries in parent directory.";
+                 "parent", `String parent;
+                 "entries", `List (List.map (fun s -> `String s) siblings) ]
+             else [])
+       in
+       error_json ~fields e
      | Ok content ->
        let total = String.length content in
        let truncated = total > max_bytes in


### PR DESCRIPTION
## Summary
- `keeper_fs_read`에서 파일 미발견 시 부모 디렉토리 listing을 에러 응답에 포함
- LLM이 잘못된 경로를 hallucinate했을 때 자체 교정할 수 있도록 힌트 제공
- 최대 20개 엔트리로 제한하여 응답 크기 통제

## Test plan
- [x] 빌드 성공
- [x] keeper_state_machine 103/103 pass
- [x] heartbeat_integration 19/19 pass

Closes #5531

🤖 Generated with [Claude Code](https://claude.com/claude-code)