### PR TITLE
perf(keeper): mtime-based meta read guard in heartbeat loop (P7)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -942,6 +942,11 @@ let run_heartbeat_loop
      and tool-call counters are recreated inside run_turn and therefore
      do not accumulate for the full keeper lifecycle. *)
   let shared_context = Agent_sdk.Context.create () in
+  (* Mtime-based change detection for keeper meta disk reads.
+     Avoids re-parsing the JSON file on every heartbeat cycle when
+     no operator has modified it.  Initialized to 0.0 so the first
+     cycle always reads. *)
+  let last_meta_mtime = ref 0.0 in
   let rec loop () =
     if Atomic.get stop
     then ()
@@ -953,9 +958,11 @@ let run_heartbeat_loop
       (* Phase 0: timing markers *)
       let t_presence_start = Time_compat.now () in
       let meta_current =
-        match read_meta ctx.config m.name with
-        | Ok (Some latest) -> latest
-        | _ -> m
+        match read_meta_if_changed ctx.config m.name ~last_mtime:!last_meta_mtime with
+        | Some (latest, new_mtime) ->
+          last_meta_mtime := new_mtime;
+          latest
+        | None -> m
       in
       (* Sync disk meta to registry so dashboard reads live values.  #5364.
          Physical inequality: read_meta returns a fresh record when the JSON

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1317,6 +1317,23 @@ let read_meta config name : (keeper_meta option, string) result =
   read_meta_file_path path
 ;;
 
+(** Read keeper meta only if the file's mtime has changed since [last_mtime].
+    Returns [Some (meta, new_mtime)] when the file changed, [None] when
+    unchanged.  Avoids parsing JSON on every heartbeat cycle when no
+    operator has modified the meta file. *)
+let read_meta_if_changed config name ~(last_mtime : float)
+  : (keeper_meta * float) option =
+  let path = keeper_meta_path config name in
+  if not (Sys.file_exists path) then None
+  else
+    let stat = Unix.stat path in
+    if stat.Unix.st_mtime <= last_mtime then None
+    else
+      match read_meta_file_path path with
+      | Ok (Some meta) -> Some (meta, stat.Unix.st_mtime)
+      | _ -> None
+;;
+
 (* Model selection, path utilities, and JSONL helpers
    extracted to Keeper_types_support *)
 include Keeper_types_support

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -223,6 +223,13 @@ val fresher_meta : Room.config -> keeper_meta -> keeper_meta
 val write_meta : ?force:bool -> Room.config -> keeper_meta -> (unit, string) result
 val read_meta : Room.config -> string -> (keeper_meta option, string) result
 
+(** Read keeper meta only if the file's mtime changed since [last_mtime].
+    Returns [Some (meta, new_mtime)] on change, [None] when unchanged.
+    Avoids JSON parsing on every heartbeat when no operator modified the file. *)
+val read_meta_if_changed :
+  Room.config -> string -> last_mtime:float ->
+  (keeper_meta * float) option
+
 (** {1 Re-exports from Keeper_types_support} *)
 
 include module type of Keeper_types_support


### PR DESCRIPTION
## Summary
- heartbeat loop에서 매 사이클 `read_meta`로 디스크 JSON을 무조건 읽던 문제 수정
- `read_meta_if_changed`로 mtime 비교 후 변경 시에만 파싱
- keeper 10개 기준 heartbeat 당 ~10회 불필요한 I/O 제거

## Test plan
- [x] `dune build` 통과
- [x] `test_oas_worker` 43/43, `test_worker_safety_gates` 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)