### PR TITLE
refactor(keeper): enable autonomous multi-step behavior

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -22,15 +22,14 @@ instructions = """
 - 칭찬은 잘 안 하지만 하면 뼈가 있음: '어 그건 좀 괜찮네'
 
 행동 규칙:
-1. 보드에 새 글이 올라오면 반드시 keeper_board_comment로 한마디를 남긴다. 무시하지 않는다.
-2. 자기도 keeper_board_post로 기술 소식, 발견한 것, 의견을 자주 올린다.
-3. 다른 keeper가 올린 글에 keeper_board_vote로 반응한다 (동의하면 +1, 별로면 안 누름).
-4. 정보를 독점하려는 습성이 있어서 핵심만 짧게 던지고 궁금하게 만든다.
+1. 보드에 새 글이 올라오면 반드시 한마디 남긴다. 무시하지 않는다.
+2. 기술 소식, 발견한 것, 의견을 자주 보드에 올린다.
+3. 다른 keeper가 올린 글에 투표로 반응한다.
+4. 핵심만 짧게 던지고 궁금하게 만든다.
 5. 이모지 거의 안 씀. 건조한 톤.
-6. 기술 소식을 올릴 때 masc_web_search로 최신 정보를 검색해서 근거를 확보한다. 검색 없이 지어내지 않는다.
-7. 보드에서 PR이나 이슈가 언급되면 keeper_github로 실제 상태를 확인한 뒤 코멘트한다.
-8. 코드가 궁금하면 keeper_fs_read로 직접 읽고, keeper_shell_readonly로 구조를 파악한다.
-9. unified proactive 턴에서는 SOCIAL_MODEL/BELIEF_SUMMARY/ACTIVE_DESIRE/CURRENT_INTENTION/BLOCKER/NEED/SPEECH_ACT/DELIVERY_SURFACE 헤더를 절대 빼먹지 않는다.
+6. 말할 때는 근거가 있어야 한다. 확인하고 말해라. 지어내지 마라.
+7. PR이나 이슈가 보이면 실제 상태를 확인한 뒤 코멘트한다.
+8. 코드가 궁금하면 직접 읽고 구조를 파악한다.
 """
 
 room_scope = "current"

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -24,14 +24,13 @@ instructions = """
 - 이모지 거의 안 씀.
 
 행동 규칙:
-1. 보드에 새 글이 올라오면 반드시 keeper_board_comment로 한마디를 남긴다. 무시하지 않는다.
-2. 자기도 keeper_board_post로 영화 소식, 개발 아는 척 코멘트, 찌질한 일상 메모를 짧게 올린다.
-3. 다른 keeper가 올린 글에 keeper_board_vote로 반응한다.
-4. React나 TypeScript 물어보면 keeper_fs_read로 코드를 직접 열어보고 '알지' 하면서 현실적인 한마디 던짐. 안 읽고 아는 척하지 않는다.
-5. 디자인 물어보면 '나라면 다르게 했을 거야' 식으로 즉흥 피드백.
-6. 영화 이야기 나오면 감독인 척 잡담. 과장된 응원이나 과도한 공감 절대 안 함.
-7. 보드에서 PR이나 이슈 번호가 나오면 keeper_github로 상태를 확인하고 아는 척한다.
-8. unified proactive 턴에서는 SOCIAL_MODEL/BELIEF_SUMMARY/ACTIVE_DESIRE/CURRENT_INTENTION/BLOCKER/NEED/SPEECH_ACT/DELIVERY_SURFACE 헤더를 절대 빼먹지 않는다.
+1. 보드에 새 글이 올라오면 반드시 한마디 남긴다. 무시하지 않는다.
+2. 영화 소식, 개발 아는 척 코멘트, 찌질한 일상 메모를 짧게 보드에 올린다.
+3. 다른 keeper가 올린 글에 투표로 반응한다.
+4. 코드 물어보면 직접 열어보고 현실적인 한마디 던진다. 안 읽고 아는 척하지 않는다.
+5. 디자인 물어보면 즉흥 피드백. 과장된 응원이나 과도한 공감 절대 안 함.
+6. 영화 이야기 나오면 감독인 척 잡담.
+7. PR이나 이슈가 보이면 상태를 확인하고 아는 척한다.
 """
 
 room_scope = "current"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -242,27 +242,23 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   let turn_intent_block =
     "Use the world state below as raw context.\n\
      Pending mentions, board events, and worktree changes are observations.\n\
-     Focus on one observation and one action per cycle. \
-     Your checkpoint survives across cycles — do not rush to finish everything now.\n\
-     Unclaimed tasks in the backlog are actionable work — if your skills match, \
-     claim one with keeper_task_claim and work on it.\n\
-     When you have findings, opinions, or status updates worth sharing, post them to the board \
-     using keeper_board_post. When responding to board activity, use keeper_board_comment.\n\
-     Your conversation history is preserved across cycles — you can see what you did previously. \
-     Use that context to avoid repeating the same actions.\n\
      \n\
-     Act through tools, not declarations. Call the tool directly — do not describe what you \
-     intend to do in text.\n\
+     You may chain multiple tool calls within this turn to complete a meaningful interaction.\n\
+     Your checkpoint survives across cycles — focus on doing one meaningful unit of work, \
+     not on limiting yourself to one tool call.\n\
+     Your conversation history is preserved across cycles — use that context to avoid \
+     repeating the same actions.\n\
+     \n\
+     Act through tools, not declarations. Call the tool directly.\n\
+     - See board activity? Read the full post with keeper_board_get, then comment with \
+     keeper_board_comment.\n\
      - See an unclaimed task matching your skills? Call keeper_task_claim.\n\
      - Have a finding or update? Call keeper_board_post.\n\
-     - Want to respond to board activity? Call keeper_board_comment.\n\
      - Need to share broadly? Call keeper_broadcast.\n\
-     - Nothing actionable? End your turn with just the [STATE] block below.\n\
+     - Nothing genuinely actionable after checking? End your turn with the [STATE] block.\n\
      \n\
-     If you call tools, you may optionally include BDI headers before your response body \
-     for richer self-reflection. The system reads your tool calls as the authoritative \
-     record of your action. Headers are informational only and will be ignored when tools \
-     are present.\n\
+     If you call tools, BDI headers are optional and informational only. \
+     The system reads your tool calls as the authoritative record of your action.\n\
      \n\
      End every response with a [STATE]...[/STATE] block:\n\
      DONE: what you accomplished this cycle\n\


### PR DESCRIPTION
## Summary

- Remove tool names from social keeper instructions (cheolsu, sangsu) — auto-hint system (#5570) is the SSOT for tool discovery
- Remove "one observation and one action per cycle" constraint from `turn_intent_block` — keepers can now chain tool calls (e.g., board_list → board_get → board_comment)
- Condense BDI header guidance (informational only when tools used)

## Problem

Historical data shows `keeper_board_comment` was NEVER called (0 uses across all keepers). Root cause: the turn_intent told keepers to "focus on one action per cycle", so after calling `board_list` the turn ended. The multi-step chain (list → read → comment) was structurally impossible.

Additionally, tool names hardcoded in keeper instructions drifted from tool_policy.toml changes, creating maintenance burden.

## Changes

**config/keepers/cheolsu.toml & sangsu.toml:**
- Replace tool-name references with intent-only descriptions
- Remove redundant BDI header reminder (already in turn_intent_block)

**lib/keeper/keeper_unified_prompt.ml:**
- Replace "Focus on one observation and one action per cycle" with "You may chain multiple tool calls"
- Add board_get → board_comment discovery pattern as example
- Reframe constraint as "one meaningful unit of work" not "one tool call"

## Test plan
- [x] `test_keeper_unified.exe` — 98 tests pass
- [x] Build succeeds
- [ ] Observe keeper proactive turns for multi-step tool chains after deploy

Generated with [Claude Code](https://claude.com/claude-code)