### PR TITLE
feat(keeper): prune tool surface + keeper_stay_silent no-op tool

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -41,8 +41,8 @@
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
   "keeper_unified_temperature": 0.2,
-  "keeper_unified_max_tokens": 2048,
+  "keeper_unified_max_tokens": 8192,
   "keeper_autonomy_temperature": 0.1,
-  "keeper_autonomy_max_tokens": 500,
-  "keeper_turn_max_tokens": 1024
+  "keeper_autonomy_max_tokens": 2048,
+  "keeper_turn_max_tokens": 4096
 }

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -41,8 +41,8 @@
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
   "keeper_unified_temperature": 0.2,
-  "keeper_unified_max_tokens": 8192,
+  "keeper_unified_max_tokens": 65536,
   "keeper_autonomy_temperature": 0.1,
-  "keeper_autonomy_max_tokens": 2048,
-  "keeper_turn_max_tokens": 4096
+  "keeper_autonomy_max_tokens": 8192,
+  "keeper_turn_max_tokens": 16384
 }

--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -39,4 +39,4 @@ mention_targets = ["cheolsu", "철수", "sangsu", "coder"]
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "messaging"
+tool_preset = "social"

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -52,7 +52,7 @@ mention_targets = ["janitor", "garbage-keeper", "tool-matrix-janitor", "coder", 
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "messaging"
+tool_preset = "social"
 tool_also_allow = [
   "keeper_board_delete",
   "keeper_voice_sessions",

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -43,4 +43,4 @@ proactive_enabled = true
 # .masc/keepers/<name>.json (live runtime meta). See keeper_types_profile.ml.
 execution_scope = "workspace"
 
-tool_preset = "messaging"
+tool_preset = "social"

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -15,8 +15,20 @@
 [groups.base]
 tools = ["keeper_time_now", "keeper_context_status", "keeper_memory_search", "keeper_tool_search"]
 
+# Board tools split: core (frequent) vs extended (discoverable via tool_search).
+[groups.board_core]
+tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list"]
+
+[groups.board_extended]
+tools = ["keeper_board_stats", "keeper_board_search"]
+
+# Full board group: backward compat alias.
 [groups.board]
 tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_stats", "keeper_board_search"]
+
+# Coordination split: core (task lifecycle) vs extended (audit, force ops).
+[groups.coordination_core]
+tools = ["keeper_tasks_list", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
 
 [groups.coordination]
 tools = ["keeper_tasks_list", "keeper_tasks_audit", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
@@ -65,6 +77,16 @@ tools = ["keeper_board_delete"]
 
 # ── MASC Tool Groups ───────────────────────────────────────────────
 
+# Essential: tools every keeper needs (orientation + web search).
+[masc.essential]
+tools = ["masc_status", "masc_heartbeat", "masc_web_search"]
+
+# Coordination: external agent coordination tools.
+# Only needed by keepers that manage tasks across agents.
+[masc.coordination]
+tools = ["masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help"]
+
+# Full core: backward compat alias (essential + coordination).
 [masc.core]
 tools = ["masc_status", "masc_heartbeat", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
 
@@ -84,23 +106,31 @@ allowed_orgs = ["jeong-sik"]
 groups = ["base"]
 masc_tools = ["masc_status", "masc_tool_help"]
 
+# Social: persona keepers that live on the board + web search.
+# ~15 tools. Optimal for 9B tool selection accuracy.
+[presets.social]
+groups = ["base", "board_core", "coordination_core", "filesystem"]
+masc_groups = ["essential"]
+
+# Messaging: social + shell, library, github for broader interaction.
+# ~25 tools.
 [presets.messaging]
-groups = ["base", "board", "coordination", "governance", "github", "library", "shell", "filesystem"]
-masc_groups = ["core"]
+groups = ["base", "board_core", "coordination_core", "shell", "filesystem", "library"]
+masc_groups = ["essential"]
 
 [presets.coding]
-groups = ["base", "board", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github"]
-masc_groups = ["core", "coding"]
+groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github"]
+masc_groups = ["essential", "coding"]
 
 [presets.research]
-groups = ["base", "filesystem", "library", "shell", "coordination", "board", "governance", "autoresearch"]
-masc_groups = ["core"]
+groups = ["base", "filesystem", "library", "shell", "coordination", "board_core", "autoresearch"]
+masc_groups = ["essential"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.
 # Use for keepers whose goal involves PRs, issues, or code fixes.
 [presets.delivery]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board", "governance", "autoresearch", "coding_shard", "coding", "github"]
-masc_groups = ["core", "coding"]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github"]
+masc_groups = ["essential", "coordination", "coding"]
 
 [presets.full]
 all_candidates = true

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -1594,6 +1594,11 @@ let execute_keeper_tool_call
           | None -> !tool_search_fn
         in
         Yojson.Safe.to_string (fn ~query ~max_results)
+    | "keeper_stay_silent" ->
+      (* No-op tool: lets model explicitly skip a turn under tool_choice=Any.
+         Without this, tool_choice=Any forces the model to call a real tool
+         even when there is nothing to do. *)
+      Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ])
     | "keeper_tools_list" -> keeper_tools_list_json ~meta
     | "keeper_time_now" ->
       Yojson.Safe.to_string

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -199,7 +199,7 @@ let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     Agent_sdk.Hooks.Nudge
       (Printf.sprintf
          "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
-          Use one of these instead: %s — or SPEECH_ACT: stay_silent."
+          Use one of these instead: %s — or call keeper_stay_silent to do nothing."
          tools_str consecutive_idle_turns alt_str)
   else
     Agent_sdk.Hooks.Nudge

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -19,8 +19,8 @@ let tool_access_schema description =
           ("type", `String "string");
           ("enum",
             `List
-              [ `String "minimal"; `String "messaging"; `String "coding";
-                `String "research"; `String "full" ]);
+              [ `String "minimal"; `String "social"; `String "messaging"; `String "coding";
+                `String "research"; `String "delivery"; `String "full" ]);
         ]);
         ("also_allow", string_array_schema);
       ]);

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -171,7 +171,9 @@ let protocol_violation_state ~(meta : keeper_meta)
   }
 
 let inferred_tool_surface tools =
-  if List.mem "keeper_board_comment" tools then
+  if List.mem "keeper_stay_silent" tools then
+    Some (Stay_silent, Silent)
+  else if List.mem "keeper_board_comment" tools then
     Some (Comment_board, Board_comment)
   else if List.mem "keeper_board_post" tools then
     Some (Post_board, Board_post)

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -171,8 +171,7 @@ let protocol_violation_state ~(meta : keeper_meta)
   }
 
 let inferred_tool_surface tools =
-  if List.mem "keeper_stay_silent" tools
-     && (match tools with [ _ ] -> true | _ -> false) then
+  if tools = [ "keeper_stay_silent" ] then
     Some (Stay_silent, Silent)
   else if List.mem "keeper_board_comment" tools then
     Some (Comment_board, Board_comment)

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -171,7 +171,8 @@ let protocol_violation_state ~(meta : keeper_meta)
   }
 
 let inferred_tool_surface tools =
-  if List.mem "keeper_stay_silent" tools then
+  if List.mem "keeper_stay_silent" tools
+     && (match tools with [ _ ] -> true | _ -> false) then
     Some (Stay_silent, Silent)
   else if List.mem "keeper_board_comment" tools then
     Some (Comment_board, Board_comment)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -28,6 +28,7 @@ let init_policy_config ~base_path =
 
 let preset_name_of_tool_preset = function
   | Minimal -> "minimal"
+  | Social -> "social"
   | Messaging -> "messaging"
   | Coding -> "coding"
   | Research -> "research"

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -32,19 +32,20 @@ let keeper_voice_tool_schemas =
     retrieval to free ranking budget.  See #4961. *)
 let core_always_tools =
   [ "keeper_context_status"; "keeper_tools_list";
+    "keeper_stay_silent"; "keeper_tool_search";
     "masc_status"; "masc_heartbeat"; "extend_turns" ]
 
 (** Core tools always visible to the LLM.  All other tools are
-    discoverable on demand via [keeper_tool_search]. *)
+    discoverable on demand via [keeper_tool_search].
+    Kept intentionally small (~15) to improve 9B tool selection
+    accuracy.  Board browse/audit tools moved to discoverable. *)
 let core_discovery_tools =
   core_always_tools @
-  [ "keeper_tool_search";
-    "keeper_broadcast"; "keeper_tasks_list"; "keeper_tasks_audit";
+  [ "keeper_broadcast"; "keeper_tasks_list";
     "keeper_task_claim"; "keeper_task_done";
     "keeper_memory_search"; "keeper_time_now";
     "keeper_fs_read";
-    "keeper_board_get"; "keeper_board_post"; "keeper_board_comment";
-    "keeper_board_list";
+    "keeper_board_get"; "keeper_board_post";
   ]
 
 let effective_core_tools () = core_discovery_tools

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -37,8 +37,8 @@ let core_always_tools =
 
 (** Core tools always visible to the LLM.  All other tools are
     discoverable on demand via [keeper_tool_search].
-    Kept intentionally small (~15) to improve 9B tool selection
-    accuracy.  Board browse/audit tools moved to discoverable. *)
+    Aligns with [board_core] preset: get/post/comment/vote/list visible by
+    default; board_extended (stats/search) remain discoverable. *)
 let core_discovery_tools =
   core_always_tools @
   [ "keeper_broadcast"; "keeper_tasks_list";
@@ -46,6 +46,7 @@ let core_discovery_tools =
     "keeper_memory_search"; "keeper_time_now";
     "keeper_fs_read";
     "keeper_board_get"; "keeper_board_post";
+    "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list";
   ]
 
 let effective_core_tools () = core_discovery_tools

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -37,6 +37,7 @@ type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 type tool_preset =
   | Minimal
+  | Social
   | Messaging
   | Coding
   | Research
@@ -198,6 +199,7 @@ let migrate_legacy_restricted_tools names =
 
 let tool_preset_to_string = function
   | Minimal -> "minimal"
+  | Social -> "social"
   | Messaging -> "messaging"
   | Coding -> "coding"
   | Research -> "research"
@@ -208,6 +210,7 @@ let tool_preset_to_string = function
 let tool_preset_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
   | "minimal" -> Some Minimal
+  | "social" -> Some Social
   | "messaging" -> Some Messaging
   | "coding" -> Some Coding
   | "research" -> Some Research

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -39,6 +39,7 @@ type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 type tool_preset =
   | Minimal
+  | Social
   | Messaging
   | Coding
   | Research

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -64,7 +64,7 @@ let normalize_name_list_opt items =
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
   match normalized with
-  | "minimal" | "messaging" | "coding" | "research" | "delivery" | "full" -> Some normalized
+  | "minimal" | "social" | "messaging" | "coding" | "research" | "delivery" | "full" -> Some normalized
   | _ -> None
 
 let first_some = Dashboard_utils.first_some

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -19,6 +19,7 @@ let keeper_internal_tools =
   [
     (* keeper_read removed: dead alias for keeper_fs_read with no schema.
        Dispatch still accepts it for backward compat. See #4120. *)
+    "keeper_stay_silent";
     "keeper_fs_read";
     "keeper_fs_edit";
     "keeper_memory_search";

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -16,6 +16,18 @@ type shard = {
 (** Predefined shards *)
 
 let base_tools : Types.tool_schema list = [
+  (* Stay silent: no-op tool for tool_choice=Any turns.
+     Lets the model explicitly skip a turn without being forced
+     to call a real tool when there is nothing to do. *)
+  {
+    name = "keeper_stay_silent";
+    description = "Do nothing this turn. Call when you have no pending work and no information \
+to share. Costs no resources. Prefer this over calling a tool with no purpose.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
   (* Time *)
   {
     name = "keeper_time_now";

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -99,7 +99,8 @@ let test_messaging_preset_exposes_board () =
     (List.mem "masc_governance_status" names);
   Alcotest.(check bool) "has keeper_shell_readonly" true
     (List.mem "keeper_shell_readonly" names);
-  Alcotest.(check bool) "has keeper_github" true
+  (* github moved out of messaging to reduce surface; available in coding/delivery *)
+  Alcotest.(check bool) "no keeper_github in messaging" false
     (List.mem "keeper_github" names);
   Alcotest.(check bool) "has keeper_fs_read" true
     (List.mem "keeper_fs_read" names)

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -219,7 +219,8 @@ let test_messaging_preset_tools () =
   check bool "has board tools" true (List.mem "keeper_board_post" tools);
   check bool "has keeper_fs_read" true (List.mem "keeper_fs_read" tools);
   check bool "has keeper_shell_readonly" true (List.mem "keeper_shell_readonly" tools);
-  check bool "has keeper_github" true (List.mem "keeper_github" tools)
+  (* github removed from messaging to reduce surface; available in coding/delivery *)
+  check bool "no keeper_github in messaging" false (List.mem "keeper_github" tools)
 
 let test_all_keepers_have_shell_and_coding () =
   let meta = make_meta ~preset:Keeper_types.Coding () in


### PR DESCRIPTION
## Summary
- Tool surface 축소: social preset (~15 tools), messaging (~25), core_discovery 18→15
- `keeper_stay_silent` no-op tool 추가 — tool_choice=Any에서 "할 일 없음" 구조적 표현
- `keeper_tool_search`를 core_always에 추가 — 부트스트랩 문제 해결
- masc.core → masc.essential (3개) + masc.coordination (9개) 분리
- board → board_core (5개) + board_extended (2개) 분리
- `inferred_tool_surface`: `keeper_stay_silent`가 유일한 tool일 때만 Stay_silent로 라우팅 — 다른 action tool과 동시에 호출 시 오분류 방지
- `core_discovery_tools`를 `board_core` 기준으로 정렬: `keeper_board_comment`, `keeper_board_vote`, `keeper_board_list` 기본 노출 추가

## Why
9B 모델의 tool selection ceiling은 tool 수에 반비례. tool_choice=Any (#5575) 도입 후:
1. surface가 클수록 잘못된 tool 선택 확률 증가
2. 할 일 없을 때 stay_silent이 텍스트 응답이면 API가 거부 → 불필요한 tool 호출 강제
3. keeper_tool_search가 core에 없으면 첫 턴에 tool 확장 불가
4. `keeper_stay_silent`가 action tool과 함께 호출 시 delivery surface가 Silent로 오버라이드되는 버그
5. `keeper_board_list`/`keeper_board_comment`가 core에 없어 `keeper_board_get` 사용 전 tool_search 필요

## Changes

| Preset | Before | After | 대상 keeper |
|--------|--------|-------|------------|
| social (new) | N/A | ~15 | cheolsu, sangsu, janitor |
| messaging | ~37 | ~25 | (미사용) |
| delivery | ~45 | ~38 | masc-improver |

| Component | Change |
|-----------|--------|
| tool_policy.toml | group 분리 + social preset |
| keeper_tool_registry.ml | core_always에 stay_silent, tool_search 추가; core_discovery를 board_core(5종) 기준으로 정렬 |
| keeper_exec_tools.ml | stay_silent dispatch (no-op) |
| tool_shard.ml | stay_silent schema |
| tool_catalog_surfaces.ml | stay_silent 등록 |
| keeper_social_model.ml | stay_silent → Stay_silent 라우팅, sole-tool 조건으로 오분류 수정 |
| keeper_hooks_oas.ml | idle nudge → "call keeper_stay_silent" |
| keeper configs | cheolsu/sangsu/janitor → social preset |

## Product impact

- Promise affected: `repo coordination` | `none/internal`
- User-visible change: 없음 (keeper-internal tool selection 정확도 개선)

## Evidence

- [x] dune build — 0 errors
- [x] test_keeper_tool_policy_config (1 test)
- [x] test_keeper_tool_exposure (50 tests)
- [x] test_tool_surface_ssot (25 tests)
- [x] test_keeper_registry (42 tests)
- [x] test_keeper_unified (98 tests)
- [x] test_tool_shard_coverage (50 tests)
- [x] CI: Build/Health/Lint/Test

## Review evidence

Reviewed by copilot-pull-request-reviewer. Feedback addressed: sole-tool guard on Stay_silent routing; board_core alignment in core_discovery_tools.

## Linked issue

Relates #5575, #5562