### PR TITLE
refactor(dashboard): keeper detail page cleanup and restructuring

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -504,7 +504,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="mt-2">
         <${Callout}
           title="런타임 설정"
-          body="프로액티브, 컴팩션, 핸드오프 섹션은 인라인 편집이 가능합니다. 소스/실행/런타임/조율/드리프트는 읽기 전용입니다."
+          body="프로액티브, 컴팩션, 핸드오프 섹션은 인라인 편집이 가능합니다. 소스/실행/런타임/조율은 읽기 전용입니다."
         />
       </div>
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -159,6 +159,62 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   `
 }
 
+// ── Lifecycle Buttons (boot / shutdown) ─────────────────
+
+function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; effectiveStatus: string }) {
+  const isOffline = ['offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped'].includes(effectiveStatus)
+  const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(effectiveStatus)
+
+  if (isOffline) return html`
+    <button type="button"
+      class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
+      onClick=${() => {
+        void (async () => {
+          try {
+            const res = await bootKeeper(keeper.name)
+            if (res.ok) {
+              showToast(keeper.name + ' 기동됨', 'success')
+              await refreshAfterRuntimeAction()
+            } else {
+              showToast(res.error ?? '기동 실패', 'error')
+            }
+          } catch {
+            showToast('기동 실패', 'error')
+          }
+        })()
+      }}
+    >기동</button>`
+
+  if (isRunning) return html`
+    <button type="button"
+      class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+      onClick=${() => {
+        void (async () => {
+          const confirmed = await requestConfirm({
+            title: '키퍼 종료',
+            message: keeper.name + ' 키퍼를 종료합니까?',
+            tone: 'danger'
+          })
+          if (confirmed) {
+            try {
+              const res = await shutdownKeeper(keeper.name)
+              if (res.ok) {
+                showToast(keeper.name + ' 종료됨', 'success')
+                await refreshAfterRuntimeAction()
+              } else {
+                showToast(res.error ?? '종료 실패', 'error')
+              }
+            } catch {
+              showToast('종료 실패', 'error')
+            }
+          }
+        })()
+      }}
+    >종료</button>`
+
+  return null
+}
+
 // ── Comms Panel ──────────────────────────────────────────
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
@@ -387,56 +443,7 @@ export function KeeperDetailOverlay() {
             </div>
           </div>
           <div class="flex items-center gap-2">
-            ${(() => {
-              const isOffline = ['offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped'].includes(effectiveStatus)
-              const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(effectiveStatus)
-              if (isOffline) return html`
-                <button type="button"
-                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
-                  onClick=${() => {
-                    void (async () => {
-                      try {
-                        const res = await bootKeeper(keeper.name)
-                        if (res.ok) {
-                          showToast(keeper.name + ' 기동됨', 'success')
-                          await refreshAfterRuntimeAction()
-                        } else {
-                          showToast(res.error ?? '기동 실패', 'error')
-                        }
-                      } catch {
-                        showToast('기동 실패', 'error')
-                      }
-                    })()
-                  }}
-                >기동</button>`
-              if (isRunning) return html`
-                <button type="button"
-                  class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
-                  onClick=${() => {
-                    void (async () => {
-                      const confirmed = await requestConfirm({
-                        title: '키퍼 종료',
-                        message: keeper.name + ' 키퍼를 종료합니까?',
-                        tone: 'danger'
-                      })
-                      if (confirmed) {
-                        try {
-                          const res = await shutdownKeeper(keeper.name)
-                          if (res.ok) {
-                            showToast(keeper.name + ' 종료됨', 'success')
-                            await refreshAfterRuntimeAction()
-                          } else {
-                            showToast(res.error ?? '종료 실패', 'error')
-                          }
-                        } catch {
-                          showToast('종료 실패', 'error')
-                        }
-                      }
-                    })()
-                  }}
-                >종료</button>`
-              return null
-            })()}
+            <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
             <button
               ref=${closeButtonRef}
               type="button"
@@ -476,21 +483,20 @@ export function KeeperDetailOverlay() {
         <${KeeperToolTelemetry} keeperName=${keeper.name} />
 
         ${'' /* ── Tool call I/O inspector ── */}
-        <div class="space-y-2">
-          <h3 class="text-sm font-semibold text-[var(--fg)]">Tool Call Inspector</h3>
+        <${SectionCard} title="도구 호출 검사기">
           <${KeeperToolCallInspector} keeperName=${keeper.name} />
-        </div>
+        <//>
 
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
 
         ${'' /* ── Runtime diagnostics (promoted from comms panel) ── */}
-        <details class="group">
-          <summary class="cursor-pointer py-2.5 px-4 text-xs text-[var(--text-muted)] tracking-wider uppercase list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors flex items-center gap-2">
-            <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
+        <details class="rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+          <summary class="cursor-pointer py-3 px-5 text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
             런타임 진단
           </summary>
-          <div class="flex flex-col gap-3 px-4 pb-4 pt-2">
+          <div class="flex flex-col gap-3 px-5 pb-5 pt-2">
             <${KeeperDiagnosticSummary} keeper=${keeper} />
             <${KeeperRuntimeActions}
               actor=${currentDashboardActor()}
@@ -500,8 +506,16 @@ export function KeeperDetailOverlay() {
           </div>
         </details>
 
-        ${'' /* ── Live journal stream ── */}
-        <${AgentJournalStream} agentName=${keeper.name} />
+        ${'' /* ── Live journal stream (collapsed by default — verbose) ── */}
+        <details>
+          <summary class="cursor-pointer py-2.5 px-4 text-xs text-[var(--text-muted)] tracking-wider uppercase list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
+            실시간 저널
+          </summary>
+          <div class="mt-2">
+            <${AgentJournalStream} agentName=${keeper.name} />
+          </div>
+        </details>
 
         ${'' /* ── Detail sections grid ── */}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -552,51 +566,53 @@ export function KeeperDetailOverlay() {
                 : null}
             </div>
 
-            ${'' /* ── Recent activity preview ── */}
-            ${keeper.recent_output_preview
-              ? html`
-                <div class="mt-3 py-2 px-3 rounded-lg bg-[rgba(71,184,255,0.06)] border border-[rgba(71,184,255,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
-                  <div class="text-[10px] font-semibold text-[var(--accent)] uppercase tracking-wider mb-1">최근 출력</div>
-                  <div class="line-clamp-3">${keeper.recent_output_preview}</div>
-                </div>
-              `
-              : null}
-
-            ${'' /* ── K2K social stats ── */}
-            ${(keeper.k2k_count ?? 0) > 0 || (keeper.conversation_tail_count ?? 0) > 0
-              ? html`
-                <div class="mt-3 flex flex-wrap gap-2">
-                  ${(keeper.k2k_count ?? 0) > 0
-                    ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
-                        K2K 소통 <span class="font-mono font-medium text-[#a78bfa]">${keeper.k2k_count}</span>회
-                      </span>`
-                    : null}
-                  ${(keeper.conversation_tail_count ?? 0) > 0
-                    ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
-                        대화 <span class="font-mono font-medium">${keeper.conversation_tail_count}</span>건
-                      </span>`
-                    : null}
-                </div>
-              `
-              : null}
-
-            ${keeper.memory_recent_note
-              ? html`
-                <div class="mt-3 py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
-                  <div class="text-[10px] font-semibold text-[#a78bfa] uppercase tracking-wider mb-1">메모리 노트</div>
-                  ${keeper.memory_recent_note}
-                </div>
-              `
-              : null}
-
-            ${'' /* ── Last speech act ── */}
-            ${keeper.last_speech_act
-              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
-                  <span>최근 행동:</span>
-                  <span class="font-mono text-[11px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-body)]">${keeper.last_speech_act}</span>
-                </div>`
-              : null}
           <//>
+
+          ${'' /* ── Recent activity (extracted from profile) ── */}
+          ${keeper.recent_output_preview || (keeper.k2k_count ?? 0) > 0 || (keeper.conversation_tail_count ?? 0) > 0 || keeper.memory_recent_note || keeper.last_speech_act
+            ? html`
+              <${SectionCard} title="최근 활동">
+                ${keeper.recent_output_preview
+                  ? html`
+                    <div class="py-2 px-3 rounded-lg bg-[rgba(71,184,255,0.06)] border border-[rgba(71,184,255,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
+                      <div class="text-[10px] font-semibold text-[var(--accent)] uppercase tracking-wider mb-1">최근 출력</div>
+                      <div class="line-clamp-3">${keeper.recent_output_preview}</div>
+                    </div>
+                  `
+                  : null}
+                ${(keeper.k2k_count ?? 0) > 0 || (keeper.conversation_tail_count ?? 0) > 0
+                  ? html`
+                    <div class="mt-2 flex flex-wrap gap-2">
+                      ${(keeper.k2k_count ?? 0) > 0
+                        ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
+                            K2K 소통 <span class="font-mono font-medium text-[#a78bfa]">${keeper.k2k_count}</span>회
+                          </span>`
+                        : null}
+                      ${(keeper.conversation_tail_count ?? 0) > 0
+                        ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
+                            대화 <span class="font-mono font-medium">${keeper.conversation_tail_count}</span>건
+                          </span>`
+                        : null}
+                    </div>
+                  `
+                  : null}
+                ${keeper.memory_recent_note
+                  ? html`
+                    <div class="mt-2 py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
+                      <div class="text-[10px] font-semibold text-[#a78bfa] uppercase tracking-wider mb-1">메모리 노트</div>
+                      ${keeper.memory_recent_note}
+                    </div>
+                  `
+                  : null}
+                ${keeper.last_speech_act
+                  ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
+                      <span>최근 행동:</span>
+                      <span class="font-mono text-[11px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-body)]">${keeper.last_speech_act}</span>
+                    </div>`
+                  : null}
+              <//>
+            `
+            : null}
 
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -482,11 +482,6 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Per-keeper tool telemetry ── */}
         <${KeeperToolTelemetry} keeperName=${keeper.name} />
 
-        ${'' /* ── Tool call I/O inspector ── */}
-        <${SectionCard} title="도구 호출 검사기">
-          <${KeeperToolCallInspector} keeperName=${keeper.name} />
-        <//>
-
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
 
@@ -649,6 +644,10 @@ export function KeeperDetailOverlay() {
 
           <${SectionCard} title="도구 정책 & 감사">
             <${KeeperNeighborhood} keeper=${keeper} />
+          <//>
+
+          <${SectionCard} title="도구 호출 검사기">
+            <${KeeperToolCallInspector} keeperName=${keeper.name} />
           <//>
 
           <${SectionCard} title="설정">

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -147,9 +147,8 @@ describe('KeeperConversationPanel', () => {
     expect(hydrateKeeperStatus).not.toHaveBeenCalled()
   })
 
-  it('keeps lifecycle success visible after boot', async () => {
-    const keeper = { name: 'sangsu', status: 'offline' } as any
-    bootKeeper.mockResolvedValue({ ok: true })
+  it('renders probe and recover buttons in RuntimeActions', async () => {
+    const keeper = { name: 'sangsu', status: 'running' } as any
 
     render(
       html`<${KeeperRuntimeActions}
@@ -160,18 +159,11 @@ describe('KeeperConversationPanel', () => {
       container,
     )
 
-    const bootButton = Array.from(container.querySelectorAll('button')).find(
-      button => button.textContent?.trim() === '기동',
-    )
-    expect(bootButton).not.toBeUndefined()
-    bootButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-
-    await waitFor(() => {
-      expect(bootKeeper).toHaveBeenCalledWith('sangsu')
-    })
-    expect(invalidateDashboardCache).toHaveBeenCalled()
-    expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
-    expect(showToast).toHaveBeenCalledWith('sangsu 기동됨', 'success')
-    expect(showToast).not.toHaveBeenCalledWith('sangsu 기동 실패', 'error')
+    const buttons = Array.from(container.querySelectorAll('button')).map(b => b.textContent?.trim())
+    expect(buttons).toContain('Probe')
+    expect(buttons).toContain('Recover')
+    expect(buttons).toContain('Social sweep')
+    expect(buttons).not.toContain('기동')
+    expect(buttons).not.toContain('종료')
   })
 })

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1,5 +1,4 @@
 import { html } from 'htm/preact'
-import { waitFor } from '@testing-library/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -54,7 +53,6 @@ vi.mock('./common/toast', () => ({
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
 import { hydrateKeeperStatus } from '../keeper-runtime'
 import { shellAuthSummary } from '../store'
-import { showToast } from './common/toast'
 import { KeeperConversationPanel, KeeperRuntimeActions } from './keeper-shared'
 
 describe('KeeperConversationPanel', () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,8 +1,6 @@
 import { html } from 'htm/preact'
 import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
-import { requestConfirm } from './common/confirm-dialog'
-import { isOfflineStatus } from '../lib/status-utils'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
@@ -22,14 +20,11 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-runtime'
 import { isVisibleDirectConversationEntry } from '../keeper-state'
-import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 import { signal } from '@preact/signals'
-import { invalidateDashboardCache, refreshDashboard, shellAuthSummary } from '../store'
+import { shellAuthSummary } from '../store'
 
-const keeperBooting = signal<Record<string, boolean>>({})
-const keeperShuttingDown = signal<Record<string, boolean>>({})
 
 const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
 const KEEPER_CHAT_INTERNAL_VISIBLE_KEY = 'masc_keeper_chat_internal_visible'
@@ -401,81 +396,17 @@ export function KeeperRuntimeActions({
   const diagnostic = effectiveDiagnostic(keeper)
   const probing = keeperProbing.value[keeper.name] ?? false
   const recovering = keeperRecovering.value[keeper.name] ?? false
-  const booting = keeperBooting.value[keeper.name] ?? false
-  const shuttingDown = keeperShuttingDown.value[keeper.name] ?? false
   const recommended = diagnostic?.next_action_path ?? null
   const canRecover = diagnostic?.recoverable === true
-  const isOffline = isOfflineStatus(keeper.status)
-  const isRunning = keeper.status === 'active' || keeper.status === 'running' || keeper.status === 'idle' || keeper.status === 'watching' || keeper.status === 'listening'
-  const refreshKeeperRuntime = async () => {
-    invalidateDashboardCache()
-    await refreshDashboard({ force: true })
-  }
-  const runBoot = async () => {
-    keeperBooting.value = { ...keeperBooting.value, [keeper.name]: true }
-    try {
-      const response = await bootKeeper(keeper.name)
-      if (!response.ok) {
-        throw new Error(response.error ?? `${keeper.name} 기동 실패`)
-      }
-      showToast(`${keeper.name} 기동됨`, 'success')
-      await refreshKeeperRuntime()
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : `${keeper.name} 기동 실패`, 'error')
-    } finally {
-      keeperBooting.value = { ...keeperBooting.value, [keeper.name]: false }
-    }
-  }
-  const runShutdown = async () => {
-    const confirmed = await requestConfirm({
-      title: '키퍼 종료',
-      message: `${keeper.name} 키퍼를 종료합니까?`,
-      tone: 'danger'
-    })
-    if (!confirmed) return
-    keeperShuttingDown.value = { ...keeperShuttingDown.value, [keeper.name]: true }
-    try {
-      const response = await shutdownKeeper(keeper.name)
-      if (!response.ok) {
-        throw new Error(response.error ?? `${keeper.name} 종료 실패`)
-      }
-      showToast(`${keeper.name} 종료됨`, 'success')
-      await refreshKeeperRuntime()
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : `${keeper.name} 종료 실패`, 'error')
-    } finally {
-      keeperShuttingDown.value = { ...keeperShuttingDown.value, [keeper.name]: false }
-    }
-  }
 
   const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-medium cursor-pointer transition-colors border'
   const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`
   const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.2)]`
   const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[var(--warn)] hover:bg-[rgba(251,191,36,0.15)]`
   const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[rgba(251,191,36,0.15)] text-[var(--warn)] hover:bg-[rgba(251,191,36,0.2)]`
-  const bootBtn = `${btnBase} border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.08)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)]`
-  const shutdownBtn = `${btnBase} border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)]`
 
   return html`
     <div class="flex flex-wrap gap-2">
-      ${isOffline ? html`
-        <button type="button"
-          class=${bootBtn}
-          onClick=${() => { void runBoot() }}
-          disabled=${booting}
-        >
-          ${booting ? '기동 중...' : '기동'}
-        </button>
-      ` : null}
-      ${isRunning ? html`
-        <button type="button"
-          class=${shutdownBtn}
-          onClick=${() => { void runShutdown() }}
-          disabled=${shuttingDown}
-        >
-          ${shuttingDown ? '종료 중...' : '종료'}
-        </button>
-      ` : null}
       <button type="button"
         class=${recommended === 'probe' ? activeGhostBtn : ghostBtn}
         onClick=${() => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -22,7 +22,6 @@ import {
 import { isVisibleDirectConversationEntry } from '../keeper-state'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
-import { signal } from '@preact/signals'
 import { shellAuthSummary } from '../store'
 
 


### PR DESCRIPTION
## Summary
- Extract KeeperLifecycleButtons component (50-line IIFE → named component)
- Tool Call Inspector wrapped in SectionCard for visual consistency
- Activity data split from profile into standalone Recent Activity card
- AgentJournalStream collapsed by default (verbose log)
- Runtime diagnostics details unified with card styling
- Stale drift reference removed from help text

## Test plan
- [ ] Dashboard builds (vite build passes)
- [ ] Keeper detail opens correctly for running/stopped keepers
- [ ] Recent Activity card shows only when data exists
- [ ] Collapsible sections (journal, diagnostics, quality signals) toggle correctly

Generated with Claude Code