### PR TITLE
fix(keeper): add per-turn wall-clock timeout and enable slot yield

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -250,6 +250,14 @@ module KeeperKeepalive = struct
   let max_idle_turns_reactive =
     max 2 (min 50 (get_int ~default:15 "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE"))
 
+  (** Wall-clock timeout in seconds for a single unified turn (including all
+      retries and cascade fallbacks). Prevents indefinite blocking when an
+      upstream LLM hangs at the TCP level.
+      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 1800]. *)
+  let turn_timeout_sec =
+    Float.max 60.0 (Float.min 1800.0
+      (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.
       With tool_choice=Any, the model always calls tools, so idle

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -187,7 +187,7 @@ let all_flags : flag list = [
 
   { env_name = "MASC_SLOT_YIELD_ENABLED";
     description = "Release LLM slot during tool execution so other agents can use it";
-    default = false; category = "runtime";
+    default = true; category = "runtime";
     lifecycle = Active; since = "2.208.0" };
 
   (* ── CDAL (Contract-Driven Agent Loop) ───────────────────── *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -893,9 +893,26 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 | None -> Error err)
             | Error err -> Error err
           in
-          retry_loop ~run_meta:meta ~max_context:max_cascade_context
-            ~run_generation:generation ~attempt:1
-            ~is_retry:false ~overflow_retry_used:false))
+          (* Wall-clock timeout guards against indefinite TCP-level hangs
+             from upstream LLM providers. Without this, a single stalled
+             connection blocks the keeper fiber forever. *)
+          let timeout_sec =
+            Env_config_keeper.KeeperKeepalive.turn_timeout_sec
+          in
+          (try
+            Eio.Time.with_timeout_exn (Eio_context.get_clock ()) timeout_sec
+              (fun () ->
+                retry_loop ~run_meta:meta ~max_context:max_cascade_context
+                  ~run_generation:generation ~attempt:1
+                  ~is_retry:false ~overflow_retry_used:false)
+          with Eio.Time.Timeout ->
+            let msg =
+              Printf.sprintf
+                "Turn wall-clock timeout after %.0fs (MASC_KEEPER_TURN_TIMEOUT_SEC)"
+                timeout_sec
+            in
+            Log.Keeper.error "%s: %s" meta.name msg;
+            Error (Oas.Error.Internal msg))))
       in
       match run_result with
       | Error err ->


### PR DESCRIPTION
## Summary

- Add wall-clock timeout (default 600s) around the entire retry_loop in `keeper_unified_turn.ml`, preventing indefinite fiber blocking when upstream LLMs hang at TCP level
- Enable `MASC_SLOT_YIELD_ENABLED` by default (was `false`), releasing LLM slots during tool execution for better inter-keeper fairness

## Problem

Observed in logs (2026-04-07):
- **cheolsu**: turn scheduled but never started — GLM TCP stall blocked the fiber for 16 minutes
- **sangsu/example/uranium666**: 5-12 minute gaps between tool calls — GLM API saturation caused cascade fallback delays
- **Root cause**: `Oas_worker.run_named` has no wall-clock timeout. A single stalled LLM connection blocks the Eio fiber indefinitely.

## Changes

**lib/keeper/keeper_unified_turn.ml:**
- Wrap `retry_loop` with `Eio.Time.with_timeout_exn` using configurable timeout
- On timeout: log error, return `Oas.Error.Internal` (handled by existing consecutive-failure counter)

**lib/config/env_config_keeper.ml:**
- Add `MASC_KEEPER_TURN_TIMEOUT_SEC` (default 600, range [60, 1800])

**lib/config/feature_flag_registry.ml:**
- Change `MASC_SLOT_YIELD_ENABLED` default: `false` → `true`

## Test plan
- [x] `test_keeper_unified.exe` — 98 tests pass
- [x] Build succeeds
- [ ] Observe keeper turns completing within timeout after deploy
- [ ] Verify slot yield improves inter-keeper fairness

Generated with [Claude Code](https://claude.com/claude-code)