### PR TITLE
perf(keeper): autonomous turn concurrency throttle

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
-> Current package version: v2.251.0
-> Latest release: v2.251.0 (2026-04-06)
-> Updated: 2026-04-06
+> Current package version: v2.252.0
+> Latest release: v2.252.0 (2026-04-07)
+> Updated: 2026-04-07
 
 Execution companion for capsule-only coordination hardening:
 [design/masc-capsule-execution-plan.md](design/masc-capsule-execution-plan.md)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -26,13 +26,8 @@ let bus_ref : Agent_sdk.Event_bus.t option Atomic.t = Atomic.make None
 let set_bus bus = Atomic.set bus_ref (Some bus)
 let get_bus () = Atomic.get bus_ref
 
-(* Concurrent keeper turn slots. This is NOT the LLM slot count —
-   it is the number of keeper fibers allowed to attempt a turn
-   simultaneously. The LLM's own slot limit (llama-server -np)
-   handles inference queuing. Setting this lower than the keeper
-   count causes starvation: reactive wakeups (explicit mentions)
-   queue behind long autonomous turns and never execute.
-   Default 12 = generous headroom for up to 12 keepers. *)
+(* Global turn slot cap. Safety ceiling for ALL keeper turns (autonomous
+   + reactive). Default 12 = headroom for up to 12 keepers. *)
 let keeper_turn_throttle_limit =
   Keeper_config.int_of_env_default
     "MASC_KEEPER_AUTOBOOT_MAX" ~default:12 ~min_v:1 ~max_v:20
@@ -40,9 +35,32 @@ let keeper_turn_throttle_limit =
 
 let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
 
-let with_keeper_turn_slot f =
+(* Autonomous turn concurrency cap. Prevents thundering-herd when all
+   keepers fire scheduled turns simultaneously on a shared LLM server.
+   Reactive turns (explicit mentions, board events) bypass this gate
+   so they are never starved by slow autonomous turns.
+   Default 3 = with 27B/8-slot each autonomous turn gets ~2-3 slots
+   of GPU throughput, completing in ~30-60s instead of 5min+. *)
+let autonomous_turn_limit =
+  Keeper_config.int_of_env_default
+    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:12
+;;
+
+let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
+
+let with_keeper_turn_slot ~channel f =
+  let is_autonomous =
+    match channel with
+    | Keeper_world_observation.Scheduled_autonomous -> true
+    | Keeper_world_observation.Reactive -> false
+  in
+  if is_autonomous then Eio.Semaphore.acquire autonomous_turn_semaphore;
   Eio.Semaphore.acquire turn_semaphore;
-  Fun.protect ~finally:(fun () -> Eio.Semaphore.release turn_semaphore) f
+  Fun.protect
+    ~finally:(fun () ->
+      Eio.Semaphore.release turn_semaphore;
+      if is_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
+    f
 ;;
 
 (** Optional gRPC client + env — WORM Atomic: set at server bootstrap
@@ -685,7 +703,7 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if should_run_turn
       then (
-        with_keeper_turn_slot (fun () ->
+        with_keeper_turn_slot ~channel:turn_decision.channel (fun () ->
           match
             Keeper_unified_turn.run_unified_turn
               ~config:ctx.config


### PR DESCRIPTION
## Summary
- Thundering-herd 방지: 8개 keeper가 동시에 스케줄된 autonomous turn을 발사하면 27B LLM 서버의 8 slot 전부 점유 → 각각 1/8 GPU → 전부 5분+ stuck
- Autonomous turn 전용 semaphore 추가 (`MASC_KEEPER_AUTONOMOUS_CONCURRENCY`, 기본 3)
- Reactive turn (멘션, 보드 이벤트)은 이 gate를 건너뜀 → starvation 없음
- 기존 global semaphore (`MASC_KEEPER_AUTOBOOT_MAX`, 기본 12) 유지

## Data Flow
```
8 keepers scheduled_autonomous
  → autonomous_semaphore (cap 3) → 3 pass, 5 wait
    → turn_semaphore (cap 12) → pass
      → LLM call (~30-60s each)
    ← release both semaphores
  → next 3 pass → ...

Reactive mention arrives
  → skip autonomous_semaphore
    → turn_semaphore → pass immediately
      → LLM call
```

## Expected Impact
| 지표 | Before | After |
|------|--------|-------|
| Autonomous turn latency | 5min+ (8-way GPU contention) | ~30-60s (3-way) |
| Reactive turn latency | Blocked behind autonomous queue | Immediate |
| Total throughput | ~Same | ~Same (batching is more efficient) |

## Test plan
- [ ] `dune build` pass
- [ ] `dune runtest` pass
- [ ] 서버 재시작 후 keeper decisions.jsonl 갱신 확인
- [ ] `MASC_KEEPER_AUTONOMOUS_CONCURRENCY=2` 환경변수 오버라이드 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)