### PR TITLE
chore: bump version 2.252.0 → 2.253.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
 
+## [2.253.0] - 2026-04-07
+
+### Added
+- **Memory consolidation** -- short-term to long-term memory transfer. (#5588)
+- **SearXNG web search** -- add web search tool for keepers. (#5591)
+- **Slot pinning** -- llama-server KV cache reuse via slot_id. (#5583)
+- **Self-directed autonomy triggers** -- token budget fix and autonomy. (#5594)
+- **Per-turn wall-clock timeout** and slot yield. (#5603)
+
+### Changed
+- **Autonomous multi-step behavior** -- enable keeper multi-step. (#5592)
+- **Default max_turns** -- 50 to 200 for autonomous PR workflow. (#5585)
+
+### Fixed
+- **extend_turns API** -- replace internal Agent.set_state with public API. (#5580)
+- **Transient vs persistent failure** -- separate turn failure counting. (#5584)
+- **stderr capture** -- capture in run_argv_with_status. (#5586)
+- **fs_read hint** -- add parent directory hint on file-not-found. (#5589)
+
+### Performance
+- **Server-side cache** for keeper_status responses. (#5587)
+- **mtime-based guard** -- skip meta disk read when mtime unchanged. (#5590)
+
 ## [2.252.0] - 2026-04-07
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.252.0)
+(version 2.253.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
14 commits since v2.252.0.

### Highlights
- Memory consolidation (short-term → long-term)
- SearXNG web search for keepers
- llama-server slot pinning (KV cache reuse)
- Self-directed autonomy triggers
- Per-turn wall-clock timeout
- extend_turns public API (replace internal set_state)
- Server-side cache + mtime guard

## Test plan
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>