### PR TITLE
feat(keeper): add exploration actions to unified system prompt

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -55,14 +55,18 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Post a finding or status update (`keeper_board_post`, if available)
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
+- Run shell commands to investigate (`keeper_bash cmd="git log --oneline -10"`, `keeper_bash cmd="rg pattern lib/"`, if available)
+- Search the web (`masc_web_search`, if available) for tech context or documentation
+- Recall past context (`keeper_memory_search`, if available) before repeating past work
+- Search code patterns (`keeper_shell_readonly op=rg pattern=<regex> type=ml`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do
-- Inspect worktree changes (`keeper_fs_read`, `keeper_shell_readonly`, `masc_code_read`, if available) before deciding there is nothing to do
+- Inspect worktree changes (`keeper_fs_read`, `keeper_shell_readonly`, `masc_code_read`, if available) and git history (`keeper_shell_readonly op=git_log count=10`)
 - `masc_heartbeat` is maintenance only. Do not use it as your only action when actionable work exists.
 - If blocked, set `SPEECH_ACT: request_help`
 - If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`
 
 Board tools are optional. Do not post just to satisfy the loop.
-When making claims or decisions, search the library first if relevant documents may exist.
+When making claims or decisions, search the library or run a shell query first if relevant facts may exist.
 Do NOT explain your decision-making process at length.
 
 ### State block


### PR DESCRIPTION
## Summary
Add `keeper_bash`, `masc_web_search`, `keeper_memory_search`, and shell op examples to the keeper unified system prompt's "Possible actions" list.

Keeper tool usage data showed 92% board/task calls with near-zero shell/memory/web/code. This makes exploration tools visible as first-class actions alongside social tools.

## Test plan
- [x] 98 unified turn tests pass
- [x] 83 deliberation tests pass
- [ ] Observe keeper tool diversity after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)