### PR TITLE
feat(keeper): add keeper_bash to shell group for all presets

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -22,7 +22,7 @@ tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keepe
 tools = ["keeper_tasks_list", "keeper_tasks_audit", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
 
 [groups.shell]
-tools = ["keeper_shell_readonly"]
+tools = ["keeper_bash", "keeper_shell_readonly"]
 
 [groups.filesystem]
 tools = ["keeper_fs_read"]


### PR DESCRIPTION
## Summary

- `keeper_bash`를 `groups.shell`에 추가하여 messaging preset 이상 모든 keeper에서 사용 가능
- 기존 `keeper_shell_readonly`(hardcoded ops: pwd/ls/cat/rg)와 달리 임의 shell 명령 실행 가능
- 3-layer safety는 이미 구현됨: `validate_command` + `destructive_guard` + `write_gate`
- Write gate가 preset별로 자동 분기: messaging=readonly, coding/delivery=write 허용

### 배경

OpenClaw, Codex CLI, OpenHands 등 유사 제품 분석 결과:
- Codex CLI: 3-tier permission (read/workspace/danger) + sandbox
- OpenHands: Docker sandbox + 무제한 루프
- MASC: 6-tier preset + validate_command → 업계 대비 세밀한 제어

keeper가 `curl`, `jq`, `gh`, `find`, `sb search --grep` 등을 자유롭게 쓸 수 있어야 자율성이 높아짐.

## Changes

| 파일 | 변경 |
|------|------|
| `config/tool_policy.toml` | `groups.shell`에 `keeper_bash` 추가 |
| `lib/keeper/keeper_unified_prompt.ml` | worktree delta 검사 도구 후보에 `keeper_bash` 추가 |

## Test plan

- [ ] messaging preset keeper가 `keeper_bash`에 접근 가능한지 확인
- [ ] messaging preset keeper에서 write 명령(`git push` 등)이 차단되는지 확인
- [ ] coding/delivery preset에서 write 명령이 허용되는지 확인
- [ ] `keeper_shell_readonly` 기존 동작에 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)