### PR TITLE
feat(keeper): async keeper_msg — fire-and-forget with poll

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -310,7 +310,7 @@ let legacy_permission_for_tool = function
   | "channel_gate"
   | "masc_register_capabilities" | "masc_find_by_capability"
   | "masc_agent_update" | "masc_operator_action"
-  | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_msg"
+  | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_repair"
   | "masc_keeper_create_from_persona"
   | "masc_operator_confirm" | "masc_unit_define"

--- a/lib/dune
+++ b/lib/dune
@@ -499,6 +499,7 @@
    keeper_turn_up
    keeper_turn_lifecycle
    keeper_turn
+   keeper_msg_async
    keeper_status_detail
    keeper_status
    keeper_status_bridge
@@ -625,6 +626,7 @@
   keeper_turn_up_update
   keeper_turn_up
   keeper_turn_lifecycle
+  keeper_msg_async
   team_session_engine_helpers
   team_session_engine_status
   team_session_engine_policy

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -1,0 +1,133 @@
+(** Keeper_msg_async — fire-and-forget keeper message execution.
+
+    Manages background fibers for keeper_msg turns.
+    MCP tool returns immediately with a request_id;
+    clients poll keeper_msg_result for completion.
+
+    Entries auto-expire after [max_age_sec] to prevent memory leaks. *)
+
+open Keeper_types
+
+type request_status =
+  | Queued
+  | Running
+  | Done of { ok : bool; body : string }
+
+type entry = {
+  request_id : string;
+  keeper_name : string;
+  status : request_status;
+  submitted_at : float;
+  completed_at : float option;
+}
+
+let mu = Mutex.create ()
+let pending : (string, entry) Hashtbl.t = Hashtbl.create 16
+let counter = Atomic.make 0
+
+let max_age_sec = 3600.0
+
+let generate_request_id ~keeper_name =
+  let n = Atomic.fetch_and_add counter 1 in
+  Printf.sprintf "kmsg_%s_%d_%d" keeper_name n
+    (int_of_float (Unix.gettimeofday () *. 1000.0))
+
+let with_lock f =
+  Mutex.lock mu;
+  Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+
+let gc_stale () =
+  let now = Unix.gettimeofday () in
+  let stale = with_lock (fun () ->
+    Hashtbl.fold (fun id entry acc ->
+      if now -. entry.submitted_at > max_age_sec then id :: acc
+      else acc
+    ) pending []
+  ) in
+  List.iter (fun id ->
+    with_lock (fun () -> Hashtbl.remove pending id)
+  ) stale
+
+let set_status request_id status =
+  with_lock (fun () ->
+    match Hashtbl.find_opt pending request_id with
+    | Some entry ->
+      let completed_at = match status with
+        | Done _ -> Some (Unix.gettimeofday ())
+        | _ -> None
+      in
+      Hashtbl.replace pending request_id { entry with status; completed_at }
+    | None -> ()
+  )
+
+(** Submit a keeper_msg turn for async execution.
+    Forks a background fiber on [sw], returns the request_id immediately. *)
+let submit ~sw ~(f : unit -> tool_result) ~keeper_name : string =
+  gc_stale ();
+  let request_id = generate_request_id ~keeper_name in
+  let entry = {
+    request_id;
+    keeper_name;
+    status = Queued;
+    submitted_at = Unix.gettimeofday ();
+    completed_at = None;
+  } in
+  with_lock (fun () -> Hashtbl.replace pending request_id entry);
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    set_status request_id Running;
+    let result =
+      try
+        let (ok, body) = f () in
+        Done { ok; body }
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Done { ok = false; body = Printf.sprintf "keeper_msg failed: %s" (Printexc.to_string exn) }
+    in
+    set_status request_id result;
+    `Stop_daemon
+  );
+  request_id
+
+(** Poll for the result of an async keeper_msg request. *)
+let poll request_id : entry option =
+  with_lock (fun () -> Hashtbl.find_opt pending request_id)
+
+(** List all pending/running requests for a keeper. *)
+let list_for_keeper ~keeper_name : entry list =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _id entry acc ->
+      if entry.keeper_name = keeper_name then entry :: acc
+      else acc
+    ) pending []
+  )
+  |> List.sort (fun a b -> compare b.submitted_at a.submitted_at)
+
+let status_to_string = function
+  | Queued -> "queued"
+  | Running -> "running"
+  | Done { ok = true; _ } -> "done"
+  | Done { ok = false; _ } -> "error"
+
+let entry_to_json (e : entry) : Yojson.Safe.t =
+  let fields = [
+    ("request_id", `String e.request_id);
+    ("keeper_name", `String e.keeper_name);
+    ("status", `String (status_to_string e.status));
+    ("submitted_at", `Float e.submitted_at);
+  ] in
+  let fields = match e.completed_at with
+    | Some t -> fields @ [("completed_at", `Float t)]
+    | None ->
+      let elapsed = Unix.gettimeofday () -. e.submitted_at in
+      fields @ [("elapsed_sec", `Float elapsed)]
+  in
+  let fields = match e.status with
+    | Done { ok; body } ->
+      fields @ [
+        ("ok", `Bool ok);
+        ("result", (try Yojson.Safe.from_string body with _ -> `String body));
+      ]
+    | _ -> fields
+  in
+  `Assoc fields

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -325,7 +325,7 @@ let keeper_schemas : tool_schema list = [
 
   {
     name = "masc_keeper_msg";
-    description = "Send a message to an existing keeper and get a reply. Use masc_keeper_up for keeper creation or persisted updates.";
+    description = "Send a message to a keeper (async). Returns immediately with a request_id. Poll masc_keeper_msg_result for the response.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -351,6 +351,21 @@ let keeper_schemas : tool_schema list = [
         ]);
       ]);
       ("required", `List [`String "name"; `String "message"]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_msg_result";
+    description = "Poll the result of an async keeper_msg request. Returns status (queued/running/done/error) and the result when complete.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("request_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Request ID returned by masc_keeper_msg");
+        ]);
+      ]);
+      ("required", `List [`String "request_id"]);
     ];
   };
 

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -79,6 +79,7 @@ let worker_only_tools =
     "masc_keeper_up";
     "masc_keeper_down";
     "masc_keeper_msg";
+    "masc_keeper_msg_result";
     "masc_keeper_repair";
     "masc_keeper_create_from_persona";
     (* CanBroadcast — org units *)

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -122,7 +122,7 @@ let public_mcp_surface_tools =
     (* Heartbeat *)
     "masc_heartbeat";
     (* Keeper interaction *)
-    "masc_keeper_msg"; "masc_keeper_list"; "masc_keeper_status";
+    "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -241,18 +241,34 @@ let handle_keeper_msg ctx args : tool_result =
   | Error err -> (false, err)
   | Ok _ ->
       let name = get_string args "name" "" in
-      let ok, body = Turn.handle_keeper_msg ctx args in
-      if not ok then (ok, body)
-      else begin
-        invalidate_keeper_list_cache ();
-        invalidate_status_cache name;
-        let json =
-          try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
-        in
-        (true,
-         Yojson.Safe.pretty_to_string
-           (annotate_keeper_json ~runtime_class:"keeper" json))
-      end
+      let request_id = Keeper_msg_async.submit ~sw:ctx.sw
+        ~keeper_name:name
+        ~f:(fun () ->
+          let ok, body = Turn.handle_keeper_msg ctx args in
+          if ok then begin
+            invalidate_keeper_list_cache ();
+            invalidate_status_cache name
+          end;
+          (ok, body))
+      in
+      let json = `Assoc [
+        ("request_id", `String request_id);
+        ("keeper_name", `String name);
+        ("status", `String "queued");
+        ("message", `String "Keeper turn submitted. Poll with keeper_msg_result.");
+      ] in
+      (true, Yojson.Safe.pretty_to_string json)
+
+let handle_keeper_msg_result _ctx args : tool_result =
+  let request_id = get_string args "request_id" "" in
+  if request_id = "" then
+    (false, {|{"error":"request_id is required"}|})
+  else
+    match Keeper_msg_async.poll request_id with
+    | None ->
+      (false, Printf.sprintf {|{"error":"request_id not found","request_id":"%s"}|} request_id)
+    | Some entry ->
+      (true, Yojson.Safe.pretty_to_string (Keeper_msg_async.entry_to_json entry))
 
 let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   match ensure_keeper_exists ctx args with
@@ -467,6 +483,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_up" -> Some (handle_keeper_up ctx args)
   | "masc_keeper_status" -> Some (handle_keeper_status ctx args)
   | "masc_keeper_msg" -> Some (handle_keeper_msg ctx args)
+  | "masc_keeper_msg_result" -> Some (handle_keeper_msg_result ctx args)
   | "masc_keeper_repair" -> Some (handle_keeper_repair ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)


### PR DESCRIPTION
## Summary
- `keeper_msg` returns immediately with `request_id` instead of blocking 6-21 minutes
- New `keeper_msg_result` tool polls for completion status
- Background fiber executes the agent turn asynchronously
- Auto-cleanup of stale entries after 1 hour

## Before/After

| | Before | After |
|--|--------|-------|
| `keeper_msg` latency | 8.4 min avg (6-21 min range) | <10ms |
| MCP timeout risk | high (5 min default) | eliminated |
| Parallel messages | impossible (blocks caller) | supported |

## Usage
```
# 1. Send message (returns immediately)
keeper_msg(name="dreamer", message="analyze the code")
→ {request_id: "kmsg_dreamer_0_1712...", status: "queued"}

# 2. Poll for result
keeper_msg_result(request_id="kmsg_dreamer_0_1712...")
→ {status: "running", elapsed_sec: 12.3}
→ {status: "done", ok: true, result: {...}}
```

## Files Changed (7)
- `lib/keeper/keeper_msg_async.ml` (NEW): async request tracking
- `lib/tool_keeper.ml`: async dispatch + result handler
- `lib/keeper/keeper_schema.ml`: updated descriptions + new tool
- `lib/tool_access_role.ml`, `lib/auth.ml`, `lib/tool_catalog_surfaces.ml`: tool registration
- `lib/dune`: module registration

## Test Plan
- [x] `dune build` passes
- [x] operator control tests pass (41/41)
- [ ] CI green

Closes #5577

🤖 Generated with [Claude Code](https://claude.com/claude-code)