### PR TITLE
fix(keeper): add byte budget to lines_to_json and raise turn timeout

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -253,10 +253,12 @@ module KeeperKeepalive = struct
   (** Wall-clock timeout in seconds for a single unified turn (including all
       retries and cascade fallbacks). Prevents indefinite blocking when an
       upstream LLM hangs at the TCP level.
-      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 1800]. *)
+      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 1200. Range: [60, 3600].
+      Raised from 600 to 1200: keepers using GLM-5.1 + local 27B need more
+      wall-clock time for multi-turn research cycles. *)
   let turn_timeout_sec =
-    Float.max 60.0 (Float.min 1800.0
-      (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+    Float.max 60.0 (Float.min 3600.0
+      (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -132,13 +132,27 @@ let shell_readonly_cat_max_bytes args =
   max 256 (min 100000 (Safe_ops.json_int ~default:4000 "max_bytes" args))
 ;;
 
-let lines_to_json ?(limit = max_int) (text : string) : Yojson.Safe.t =
-  let lines =
+let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yojson.Safe.t =
+  let all_lines =
     String.split_on_char '\n' text
     |> List.filter (fun line -> line <> "")
     |> fun rows -> if List.length rows > limit then take limit rows else rows
   in
-  `List (List.map (fun line -> `String line) lines)
+  (* Byte-budget: accumulate lines until max_bytes is reached.
+     This prevents 200 long lines from producing 500KB+ JSON arrays
+     that stall the LLM context window. *)
+  let rec collect acc bytes_used = function
+    | [] -> List.rev acc, 0
+    | line :: rest ->
+      let line_len = String.length line + 4 (* JSON overhead: quotes, comma *) in
+      if bytes_used + line_len > max_bytes && acc <> []
+      then List.rev acc, List.length rest + 1
+      else collect (`String line :: acc) (bytes_used + line_len) rest
+  in
+  let kept, omitted = collect [] 0 all_lines in
+  if omitted > 0
+  then `List (kept @ [ `String (Printf.sprintf "...[%d more lines omitted — narrow your search pattern or add --glob/--type filter]" omitted) ])
+  else `List kept
 ;;
 
 let error_json ?(fields = []) (message : string) =


### PR DESCRIPTION
## Summary

- `lines_to_json`에 `max_bytes` 파라미터 추가 (default 32KB)
- 기존: 줄 수만 제한 → 200줄 × 2.6KB = 527KB 발생 가능
- 변경: 바이트 예산 도달 시 줄 추가 중단 + 힌트 메시지 append
- 줄 내용은 자르지 않음 (mid-line truncation 없음)
- wall-clock timeout: 600s → 1200s (max 3600s)

### 배경

masc-improver가 `keeper_shell_readonly` rg로 CHANGELOG 검색 시 527KB 출력 → LLM 컨텍스트 폭발 → 600s timeout 2회 연속 히트.

| 변경 | 이전 | 이후 |
|------|------|------|
| `lines_to_json` 바이트 제한 | 없음 | 32KB |
| `turn_timeout_sec` default | 600s | 1200s |
| `turn_timeout_sec` max | 1800s | 3600s |

## Test plan

- [ ] rg 결과가 32KB 초과 시 줄이 잘리고 힌트 메시지가 포함되는지 확인
- [ ] 짧은 rg 결과(32KB 미만)는 기존과 동일하게 전체 반환되는지 확인
- [ ] keeper turn이 600s에서 timeout되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)