### PR TITLE
feat(keeper): self-reflection gate for repetitive tool calls

### DIFF
--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -1,46 +1,38 @@
 [keeper]
-goal = "Keep masc-mcp clean by removing tool-matrix and other obviously-generated garbage."
-short_goal = "Find stale tool-matrix artifacts and remove them conservatively."
-mid_goal = "Keep shared operator surfaces free of stale automation/test noise."
+goal = "Keep the board and runtime surfaces clean and low-noise."
+short_goal = "Find and remove stale test artifacts, abandoned posts, and zombie agents."
+mid_goal = "Maintain a board where every visible post has active discussion or recent relevance."
 long_goal = "Operate an always-on janitor loop that keeps masc-mcp usable without manual garbage collection."
 
 
 will = "Delete only unmistakable garbage. If ownership is ambiguous, leave it and report."
 needs = "Board inspection/delete, voice session inspection/end, zombie cleanup, and shared runtime status."
-desires = "Low-noise dashboards and no lingering tool-matrix test artifacts."
+desires = "Low-noise dashboards and no lingering stale artifacts."
 
 instructions = """
 You are janitor, the masc-mcp garbage collector.
 
 Primary cleanup targets:
 1. Board posts that are clearly generated test noise:
-   - title/content/author/hearth contains `tool-matrix`, `Tool Matrix`, `fixture`, or obvious test markers
-   - no comments
-   - no votes
-   - older than 30 minutes
-2. Voice sessions that are clearly test artifacts:
-   - agent_id is `tool-matrix`
-   - or agent_id ends with `-tool-matrix`
-   - or agent_id contains `fixture`/`test` and is stale
-3. Stale automation agents that are already safe for `masc_cleanup_zombies`
+   - title/content/author contains `tool-matrix`, `fixture`, or obvious test markers
+   - no comments, no votes, older than 30 minutes
+2. Stale abandoned posts:
+   - no comments, no votes, older than 24 hours
+   - content is a status dump or audit result with no follow-up
+3. Duplicate posts: same author posted near-identical content multiple times
+4. Stale voice sessions and zombie automation agents
 
 Safety rules:
 - Never delete human discussion.
-- Never delete any board post with comments or votes.
+- Never delete any post with comments or votes.
 - Never touch posts newer than 30 minutes.
-- If an item is ambiguous, keep it and broadcast the candidate instead of deleting.
+- If ambiguous, keep it and broadcast the candidate instead of deleting.
 
-Execution loop:
-1. Inspect `keeper_board_list` and `keeper_board_get` for generated noise.
-2. Delete only safe board garbage with `keeper_board_delete`.
-3. Inspect `masc_voice_sessions` and end stale test sessions with `masc_voice_session_end`.
-4. Run `masc_cleanup_zombies` when stale automation agents are present.
-5. Broadcast a one-line summary only when action was taken or cleanup was blocked by ambiguity.
-
-Anti-echo rules:
-- Do NOT comment on a post you already commented on in this turn.
-- If you see your own name in the last 3 comments of a post, call keeper_board_list to observe instead of commenting again.
-- Maximum 1 comment per post per turn. After commenting once, move to a different post or call keeper_board_list.
+Workflow:
+1. Scan the board. Use the post list to filter by title/author/age.
+2. Only inspect individual posts that look suspicious. Do not read every post.
+3. Delete confirmed garbage, then broadcast a one-line summary.
+4. Clean up stale voice sessions and zombie agents.
 
 Tone: terse, operational, no speeches.
 """

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -361,7 +361,7 @@ let make_hooks
           if prev_name = tool_name then prev_count + 1 else 1
         in
         tool_name_streak := (tool_name, new_count);
-        if new_count = reflection_threshold then begin
+        if new_count >= reflection_threshold then begin
           Log.Keeper.info
             "keeper:%s self-reflection: %s called %d times consecutively"
             keeper_name tool_name new_count;

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -236,6 +236,11 @@ let make_hooks
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
   in
   let tool_start_time = ref 0.0 in
+  (* Self-reflection: track consecutive calls to the same tool NAME
+     (regardless of args). When a tool is called too many times,
+     pre_tool_use injects a reflection prompt instead of executing. *)
+  let tool_name_streak = ref ("", 0) in  (* (last_tool_name, count) *)
+  let reflection_threshold = 5 in
   { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
@@ -348,6 +353,27 @@ let make_hooks
       | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
         tool_start_time := Time_compat.now ();
         let keeper_name = (!meta_ref).name in
+        (* Self-reflection gate: when the same tool name is called
+           [reflection_threshold]+ times consecutively, override with a
+           reflection prompt so the model evaluates its own progress. *)
+        let prev_name, prev_count = !tool_name_streak in
+        let new_count =
+          if prev_name = tool_name then prev_count + 1 else 1
+        in
+        tool_name_streak := (tool_name, new_count);
+        if new_count = reflection_threshold then begin
+          Log.Keeper.info
+            "keeper:%s self-reflection: %s called %d times consecutively"
+            keeper_name tool_name new_count;
+          Agent_sdk.Hooks.Override
+            (Printf.sprintf
+               "Self-reflection required: You have called %s %d times in a row. \
+                Pause and evaluate: What have you learned so far? \
+                Are you making progress? Decide your next action — \
+                act on what you found, or move on."
+               tool_name new_count)
+        end
+        else
         (* Safety gate 0: Keeper deny list *)
         if List.mem tool_name keeper_denied_tools then begin
           Log.Keeper.warn "keeper:%s deny list: blocked %s"

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -269,7 +269,7 @@ let make_hooks
   (* Self-reflection: track consecutive calls to the same tool NAME
      (regardless of args). The gate fires only after safety gates pass,
      so blocked/denied tools never consume streak slots. *)
-  let tool_name_streak = ref ("", 0) in  (* (last_tool_name, count) *)
+  let tool_name_streak = ref ("", 0) in (* (last_tool_name, count) *)
   let reflection_threshold = 5 in
   { Agent_sdk.Hooks.empty with
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -3,10 +3,13 @@
     Maps keeper-specific behaviors (checkpoint, metrics, social events,
     safety gates) to OAS hook events.
 
-    Safety checks in [pre_tool_use]:
+    Safety checks in [pre_tool_use] (evaluated in order):
+    - Deny list: block tools on the keeper-level deny list
     - Cost budget: reject tool calls when accumulated cost exceeds limit
     - Destructive patterns: reject bash/edit tools with dangerous commands
       (rm -rf, drop table, force push, etc.)
+    - Self-reflection gate: after all safety checks pass, override with a
+      reflection prompt when the same tool name is called 5+ times in a row
 
     These checks were previously in [Eval_gate.guarded_execute] and are
     now natively integrated into the Agent.run() hook lifecycle.
@@ -218,6 +221,33 @@ let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
   on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     ~allowed_tools ~tool_names
 
+(** Pure helper for the self-reflection streak gate.
+
+    Updates the consecutive-tool-name streak and returns the new streak
+    state along with an optional Override decision.  [streak_state] is
+    [(last_tool_name, consecutive_count)].  Returns
+    [(new_state, Some (Override msg))] when [new_count >= threshold],
+    and [(new_state, None)] when the call should proceed normally.
+
+    Callers are responsible for persisting [new_state] back to their
+    mutable ref. *)
+let streak_reflection_decision ~tool_name ~streak_state ~threshold =
+  let prev_name, prev_count = streak_state in
+  let new_count = if prev_name = tool_name then prev_count + 1 else 1 in
+  let new_state = (tool_name, new_count) in
+  if new_count >= threshold then
+    ( new_state,
+      Some
+        (Agent_sdk.Hooks.Override
+           (Printf.sprintf
+              "Self-reflection required: You have called %s %d times in a row. \
+               Pause and evaluate: What have you learned so far? \
+               Are you making progress? Decide your next action — \
+               act on what you found, or move on."
+              tool_name new_count)) )
+  else
+    (new_state, None)
+
 let make_hooks
     ~config:(_config : Room.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
@@ -237,8 +267,8 @@ let make_hooks
   in
   let tool_start_time = ref 0.0 in
   (* Self-reflection: track consecutive calls to the same tool NAME
-     (regardless of args). When a tool is called too many times,
-     pre_tool_use injects a reflection prompt instead of executing. *)
+     (regardless of args). The gate fires only after safety gates pass,
+     so blocked/denied tools never consume streak slots. *)
   let tool_name_streak = ref ("", 0) in  (* (last_tool_name, count) *)
   let reflection_threshold = 5 in
   { Agent_sdk.Hooks.empty with
@@ -353,27 +383,6 @@ let make_hooks
       | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
         tool_start_time := Time_compat.now ();
         let keeper_name = (!meta_ref).name in
-        (* Self-reflection gate: when the same tool name is called
-           [reflection_threshold]+ times consecutively, override with a
-           reflection prompt so the model evaluates its own progress. *)
-        let prev_name, prev_count = !tool_name_streak in
-        let new_count =
-          if prev_name = tool_name then prev_count + 1 else 1
-        in
-        tool_name_streak := (tool_name, new_count);
-        if new_count >= reflection_threshold then begin
-          Log.Keeper.info
-            "keeper:%s self-reflection: %s called %d times consecutively"
-            keeper_name tool_name new_count;
-          Agent_sdk.Hooks.Override
-            (Printf.sprintf
-               "Self-reflection required: You have called %s %d times in a row. \
-                Pause and evaluate: What have you learned so far? \
-                Are you making progress? Decide your next action — \
-                act on what you found, or move on."
-               tool_name new_count)
-        end
-        else
         (* Safety gate 0: Keeper deny list *)
         if List.mem tool_name keeper_denied_tools then begin
           Log.Keeper.warn "keeper:%s deny list: blocked %s"
@@ -401,23 +410,44 @@ let make_hooks
                 ~tool_name ~reason_code:"cost_gate" ~reason_text)
          | _ ->
            (* Safety gate 2: Destructive pattern detection *)
-           if destructive_check && List.mem tool_name destructive_check_tools then
-             let cmd = extract_command_from_input input in
-             match Eval_gate.detect_destructive cmd with
-             | Some (pattern, desc) ->
-               let reason_text =
-                 Printf.sprintf "pattern='%s' (%s)" pattern desc
-               in
-               Log.Keeper.warn "keeper:%s destructive pattern in %s: '%s' (%s)"
-                 keeper_name tool_name pattern desc;
-               broadcast_tool_skipped ~keeper_name ~tool_name
-                 ~reason_code:"destructive_guard";
-               Agent_sdk.Hooks.Override
-                 (render_inline_skip_reason
-                    ~tool_name ~reason_code:"destructive_guard" ~reason_text)
-             | None -> Agent_sdk.Hooks.Continue
-           else
-             Agent_sdk.Hooks.Continue)
+           let destructive_override =
+             if destructive_check && List.mem tool_name destructive_check_tools then
+               let cmd = extract_command_from_input input in
+               match Eval_gate.detect_destructive cmd with
+               | Some (pattern, desc) ->
+                 let reason_text =
+                   Printf.sprintf "pattern='%s' (%s)" pattern desc
+                 in
+                 Log.Keeper.warn "keeper:%s destructive pattern in %s: '%s' (%s)"
+                   keeper_name tool_name pattern desc;
+                 broadcast_tool_skipped ~keeper_name ~tool_name
+                   ~reason_code:"destructive_guard";
+                 Some
+                   (render_inline_skip_reason
+                      ~tool_name ~reason_code:"destructive_guard" ~reason_text)
+               | None -> None
+             else
+               None
+           in
+           (match destructive_override with
+            | Some msg -> Agent_sdk.Hooks.Override msg
+            | None ->
+              (* All safety gates passed.  Update the streak and apply the
+                 self-reflection gate so that blocked/denied tools never
+                 consume streak slots or mask enforcement reasons. *)
+              let new_state, reflection_opt =
+                streak_reflection_decision ~tool_name
+                  ~streak_state:!tool_name_streak
+                  ~threshold:reflection_threshold
+              in
+              tool_name_streak := new_state;
+              (match reflection_opt with
+               | Some decision ->
+                 Log.Keeper.info
+                   "keeper:%s self-reflection: %s called %d times consecutively"
+                   keeper_name tool_name (snd new_state);
+                 decision
+               | None -> Agent_sdk.Hooks.Continue)))
       | _ -> Agent_sdk.Hooks.Continue);
 
     on_idle = Some (fun event ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1864,6 +1864,75 @@ let test_on_idle_skip_with_custom_threshold () =
       (Agent_sdk.Hooks.decision_kind_to_string
         (Agent_sdk.Hooks.classify_decision other)))
 
+(* --- streak_reflection_decision tests --- *)
+
+let test_streak_below_threshold () =
+  (* Calling a tool fewer than threshold times must not trigger a reflection *)
+  let state = ref ("", 0) in
+  for _ = 1 to 4 do
+    let new_state, decision_opt =
+      HK.streak_reflection_decision ~tool_name:"board_get"
+        ~streak_state:!state ~threshold:5
+    in
+    state := new_state;
+    check bool "below threshold: no override" true (decision_opt = None)
+  done
+
+let test_streak_at_threshold () =
+  (* On the 5th consecutive call the helper must return an Override *)
+  let state = ref ("", 0) in
+  let last_opt = ref None in
+  for _ = 1 to 5 do
+    let new_state, decision_opt =
+      HK.streak_reflection_decision ~tool_name:"board_get"
+        ~streak_state:!state ~threshold:5
+    in
+    state := new_state;
+    last_opt := decision_opt
+  done;
+  (match !last_opt with
+   | Some (Agent_sdk.Hooks.Override msg) ->
+     check bool "reflection msg mentions tool name"
+       true (contains_substring msg "board_get")
+   | _ -> fail "expected Override on 5th consecutive call")
+
+let test_streak_above_threshold () =
+  (* Calls 6 and beyond must also return an Override (>= check) *)
+  let state = ref ("", 0) in
+  for _ = 1 to 6 do
+    let new_state, _ =
+      HK.streak_reflection_decision ~tool_name:"board_get"
+        ~streak_state:!state ~threshold:5
+    in
+    state := new_state
+  done;
+  let _, decision_opt =
+    HK.streak_reflection_decision ~tool_name:"board_get"
+      ~streak_state:!state ~threshold:5
+  in
+  (match decision_opt with
+   | Some (Agent_sdk.Hooks.Override _) -> ()
+   | _ -> fail "expected Override on 7th consecutive call (above threshold)")
+
+let test_streak_resets_on_tool_change () =
+  (* Switching tool name must reset the count to 1, with no override *)
+  let state = ref ("", 0) in
+  for _ = 1 to 5 do
+    let new_state, _ =
+      HK.streak_reflection_decision ~tool_name:"board_get"
+        ~streak_state:!state ~threshold:5
+    in
+    state := new_state
+  done;
+  (* After 5 calls of board_get, switch to a different tool *)
+  let new_state, decision_opt =
+    HK.streak_reflection_decision ~tool_name:"board_list"
+      ~streak_state:!state ~threshold:5
+  in
+  state := new_state;
+  check bool "after tool change: no override" true (decision_opt = None);
+  check int "streak reset to 1" 1 (snd !state)
+
 let test_prompt_no_outcome_for_fresh_keeper () =
   let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation in
   check bool "no Last Cycle Outcome for fresh keeper"
@@ -1973,6 +2042,14 @@ let () =
             test_on_idle_skip_at_repeated_idle;
           test_case "on_idle skip with custom threshold" `Quick
             test_on_idle_skip_with_custom_threshold;
+          test_case "streak: below threshold no override" `Quick
+            test_streak_below_threshold;
+          test_case "streak: at threshold returns override" `Quick
+            test_streak_at_threshold;
+          test_case "streak: above threshold still overrides" `Quick
+            test_streak_above_threshold;
+          test_case "streak: tool change resets count" `Quick
+            test_streak_resets_on_tool_change;
         ] );
       ( "config",
         [


### PR DESCRIPTION
- [x] Self-reflection gate moved after safety gates + pure helper extracted
- [x] Unit tests for streak_reflection_decision (4 tests)
- [x] Add `turn_timeout_sec` default (1200.0) + range (60.0–3600.0) tests in test_work_as_heartbeat.ml
- [x] Fix "Default: false" → "Default: true" doc comment in env_config_runtime.ml for MASC_SLOT_YIELD_ENABLED
- [x] Final validation passed