### PR TITLE
feat(keeper): post-turn evidence capture + execution context tracking

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -500,6 +500,7 @@
    keeper_turn_lifecycle
    keeper_turn
    keeper_msg_async
+   keeper_file_tracker
    keeper_evidence
    keeper_status_detail
    keeper_status
@@ -628,6 +629,7 @@
   keeper_turn_up
   keeper_turn_lifecycle
   keeper_msg_async
+  keeper_file_tracker
   keeper_evidence
   team_session_engine_helpers
   team_session_engine_status

--- a/lib/dune
+++ b/lib/dune
@@ -500,6 +500,7 @@
    keeper_turn_lifecycle
    keeper_turn
    keeper_msg_async
+   keeper_evidence
    keeper_status_detail
    keeper_status
    keeper_status_bridge
@@ -627,6 +628,7 @@
   keeper_turn_up
   keeper_turn_lifecycle
   keeper_msg_async
+  keeper_evidence
   team_session_engine_helpers
   team_session_engine_status
   team_session_engine_policy

--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -1,54 +1,91 @@
-(** Keeper_evidence — deterministic post-turn evidence capture.
+(** Keeper_evidence — deterministic turn-level git evidence.
 
-    After each keeper turn, captures git diff/status as immutable
-    evidence of what actually changed. No LLM interpretation —
-    git commands only.
+    Captures git state transitions (before/after) for each keeper turn.
+    No LLM interpretation — git commands only. Hash chain ensures
+    tamper-evident ordering.
 
-    Evidence is persisted to:
-      .masc/evidence/<keeper_name>/<trace_id>/turn_<N>.jsonl
+    Evidence path: .masc/evidence/<keeper_name>/<trace_id>/turn_<N>.json
 
     @since 2.254.0 — execution evidence system (#5620) *)
+
+(* ── Git helpers (delegate to Worktree_live_context) ─────────── *)
 
 let run_git ~workdir args =
   Worktree_live_context.run_git_capture_lines ~workdir args
 
-(** Capture post-turn evidence snapshot.
-    Returns the evidence JSON and persists it to disk. *)
-let capture_post_turn_evidence
-    ~base_path
-    ~keeper_name
-    ~trace_id
-    ~turn_number
-    ~tool_calls_made
+let repo_root ~base_path =
+  match Worktree_live_context.repo_root_for ~base_path with
+  | Some r -> r
+  | None -> base_path
+
+let git_status_lines ~repo_root =
+  Worktree_live_context.current_status_lines ~repo_root
+
+let hash_lines lines =
+  Worktree_live_context.hash_lines lines
+
+(* ── Hash chain state (process-scoped) ───────────────────────── *)
+
+let chain_mu = Mutex.create ()
+let chain_latest : (string, string) Hashtbl.t = Hashtbl.create 8
+
+let chain_key ~keeper_name ~trace_id =
+  Printf.sprintf "%s/%s" keeper_name trace_id
+
+let get_prev_hash ~keeper_name ~trace_id =
+  Mutex.lock chain_mu;
+  let result =
+    match Hashtbl.find_opt chain_latest (chain_key ~keeper_name ~trace_id) with
+    | Some h -> h
+    | None -> "genesis"
+  in
+  Mutex.unlock chain_mu;
+  result
+
+let set_latest_hash ~keeper_name ~trace_id hash =
+  Mutex.lock chain_mu;
+  Hashtbl.replace chain_latest (chain_key ~keeper_name ~trace_id) hash;
+  Mutex.unlock chain_mu
+
+(* ── Phase 1: Turn-level evidence capture ────────────────────── *)
+
+(** Snapshot git status before a turn. Returns hash of status lines. *)
+let snapshot_before_turn ~base_path ~keeper_name:_ : string option =
+  try
+    let root = repo_root ~base_path in
+    let lines = git_status_lines ~repo_root:root in
+    Some (hash_lines lines)
+  with _ -> None
+
+(** Capture turn evidence after a turn completes.
+    Compares before_hash with current state to detect delta. *)
+let capture_turn_evidence
+    ~base_path ~keeper_name ~trace_id
+    ~turn_number ~tool_calls_made
+    ~(before_hash : string option)
     ()
   : Yojson.Safe.t option =
-  let repo_root =
-    match Worktree_live_context.repo_root_for ~base_path with
-    | Some r -> r
-    | None -> base_path
-  in
+  let root = repo_root ~base_path in
+  let status_lines = git_status_lines ~repo_root:root in
+  let after_hash = hash_lines status_lines in
+  let before_h = Option.value ~default:"unknown" before_hash in
+  let delta_detected = before_h <> after_hash in
   let diff_stat =
-    run_git ~workdir:repo_root [ "diff"; "--stat" ]
+    run_git ~workdir:root [ "diff"; "--stat" ]
     |> Option.value ~default:[]
   in
   let shortstat =
-    run_git ~workdir:repo_root [ "diff"; "--shortstat" ]
+    run_git ~workdir:root [ "diff"; "--shortstat" ]
     |> Option.value ~default:[]
     |> String.concat " " |> String.trim
   in
   let branch =
-    run_git ~workdir:repo_root [ "branch"; "--show-current" ]
+    run_git ~workdir:root [ "branch"; "--show-current" ]
     |> Option.value ~default:["(detached)"]
-    |> List.hd
-    |> String.trim
-  in
-  let status_lines =
-    run_git ~workdir:repo_root [ "status"; "--porcelain" ]
-    |> Option.value ~default:[]
-    |> List.filter (fun l -> not (String_util.contains_substring l ".masc/"))
+    |> (fun l -> match l with h :: _ -> String.trim h | [] -> "(detached)")
   in
   let worktrees =
-    run_git ~workdir:repo_root [ "worktree"; "list"; "--porcelain" ]
+    run_git ~workdir:root [ "worktree"; "list"; "--porcelain" ]
     |> Option.value ~default:[]
     |> List.filter_map (fun line ->
       if String.length line > 9 && String.sub line 0 9 = "worktree " then
@@ -56,47 +93,126 @@ let capture_post_turn_evidence
       else None)
   in
   let files_changed = List.length status_lines in
-  if files_changed = 0 && diff_stat = [] then
-    None
-  else
-    let ts = Types.now_iso () in
-    let evidence = `Assoc [
-      ("timestamp", `String ts);
-      ("keeper_name", `String keeper_name);
-      ("trace_id", `String trace_id);
-      ("turn", `Int turn_number);
-      ("tool_calls_made", `Int tool_calls_made);
-      ("branch", `String branch);
-      ("files_changed", `Int files_changed);
-      ("shortstat", `String shortstat);
-      ("diff_stat", `List (List.map (fun l -> `String l) diff_stat));
-      ("dirty_files", `List (List.map (fun l -> `String l) status_lines));
-      ("active_worktrees", `List (List.map (fun w -> `String w) worktrees));
-    ] in
-    (* Persist to disk *)
-    (try
-      let evidence_dir =
-        Filename.concat base_path
-          (Printf.sprintf ".masc/evidence/%s/%s"
-            (Room_utils.safe_filename keeper_name)
-            (Room_utils.safe_filename trace_id))
-      in
-      Fs_compat.mkdir_p evidence_dir;
-      let evidence_file = Filename.concat evidence_dir
-        (Printf.sprintf "turn_%03d.json" turn_number)
-      in
-      Fs_compat.save_file evidence_file
-        (Yojson.Safe.pretty_to_string evidence);
-      Log.Keeper.debug "evidence captured: %s turn=%d files=%d"
-        keeper_name turn_number files_changed
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Keeper.warn "evidence capture failed for %s turn %d: %s"
-        keeper_name turn_number (Printexc.to_string exn));
-    Some evidence
+  (* Collision detection *)
+  let collision_warnings =
+    if files_changed > 0 then
+      Keeper_file_tracker.record_turn_files ~keeper_name ~files:status_lines
+    else []
+  in
+  let prev_evidence_hash = get_prev_hash ~keeper_name ~trace_id in
+  let ts = Types.now_iso () in
+  let evidence_body = `Assoc ([
+    ("timestamp", `String ts);
+    ("keeper_name", `String keeper_name);
+    ("trace_id", `String trace_id);
+    ("turn", `Int turn_number);
+    ("tool_calls_made", `Int tool_calls_made);
+    ("branch", `String branch);
+    ("files_changed", `Int files_changed);
+    ("shortstat", `String shortstat);
+    ("delta_detected", `Bool delta_detected);
+    ("before_hash", `String before_h);
+    ("after_hash", `String after_hash);
+    ("diff_stat", `List (List.map (fun l -> `String l) diff_stat));
+    ("dirty_files", `List (List.map (fun l -> `String l) status_lines));
+    ("active_worktrees", `List (List.map (fun w -> `String w) worktrees));
+    ("prev_evidence_hash", `String prev_evidence_hash);
+  ] @ (if collision_warnings <> [] then
+    [("collision_warnings", `List (List.map Keeper_file_tracker.collision_to_json collision_warnings))]
+  else [])) in
+  (* Compute this entry's hash *)
+  let turn_evidence_hash =
+    Digest.string (Yojson.Safe.to_string evidence_body) |> Digest.to_hex
+  in
+  let evidence = match evidence_body with
+    | `Assoc fields -> `Assoc (fields @ [("turn_evidence_hash", `String turn_evidence_hash)])
+    | other -> other
+  in
+  set_latest_hash ~keeper_name ~trace_id turn_evidence_hash;
+  (* Persist *)
+  (try
+    let evidence_dir =
+      Filename.concat base_path
+        (Printf.sprintf ".masc/evidence/%s/%s"
+          (Room_utils.safe_filename keeper_name)
+          (Room_utils.safe_filename trace_id))
+    in
+    Fs_compat.mkdir_p evidence_dir;
+    let evidence_file = Filename.concat evidence_dir
+      (Printf.sprintf "turn_%03d.json" turn_number)
+    in
+    Fs_compat.save_file evidence_file (Yojson.Safe.pretty_to_string evidence);
+    Log.Keeper.debug "evidence: %s turn=%d delta=%b files=%d chain=%s"
+      keeper_name turn_number delta_detected files_changed
+      (String.sub turn_evidence_hash 0 8)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn "evidence capture failed for %s turn %d: %s"
+      keeper_name turn_number (Printexc.to_string exn));
+  Some evidence
 
-(** Read the latest evidence snapshot for a keeper. *)
+(* ── Phase 3: Hash chain verification ────────────────────────── *)
+
+let verify_evidence_chain ~base_path ~keeper_name ~trace_id
+  : (unit, int * string * string) result =
+  let evidence_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/evidence/%s/%s"
+        (Room_utils.safe_filename keeper_name)
+        (Room_utils.safe_filename trace_id))
+  in
+  if not (Fs_compat.file_exists evidence_dir) then Ok ()
+  else
+    let entries = Sys.readdir evidence_dir |> Array.to_list in
+    let json_files =
+      List.filter (fun f -> Filename.check_suffix f ".json") entries
+      |> List.sort String.compare
+    in
+    let rec check ~expected_prev = function
+      | [] -> Ok ()
+      | file :: rest ->
+        let path = Filename.concat evidence_dir file in
+        let content = Fs_compat.load_file path in
+        let json = Yojson.Safe.from_string content in
+        let get key = match json with
+          | `Assoc fields ->
+            (match List.assoc_opt key fields with
+             | Some (`String s) -> s
+             | _ -> "")
+          | _ -> ""
+        in
+        let turn = match json with
+          | `Assoc fields ->
+            (match List.assoc_opt "turn" fields with
+             | Some (`Int n) -> n
+             | _ -> 0)
+          | _ -> 0
+        in
+        let actual_prev = get "prev_evidence_hash" in
+        if actual_prev <> expected_prev then
+          Error (turn, expected_prev, actual_prev)
+        else
+          let stored_hash = get "turn_evidence_hash" in
+          (* Recompute hash from body without turn_evidence_hash *)
+          let body_fields = match json with
+            | `Assoc fields ->
+              List.filter (fun (k, _) -> k <> "turn_evidence_hash") fields
+            | _ -> []
+          in
+          let recomputed =
+            Digest.string (Yojson.Safe.to_string (`Assoc body_fields))
+            |> Digest.to_hex
+          in
+          if stored_hash <> recomputed then
+            Error (turn, stored_hash, recomputed)
+          else
+            check ~expected_prev:stored_hash rest
+    in
+    check ~expected_prev:"genesis" json_files
+
+(* ── Query ───────────────────────────────────────────────────── *)
+
 let latest_evidence ~base_path ~keeper_name ~trace_id
   : Yojson.Safe.t option =
   let evidence_dir =

--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -1,0 +1,122 @@
+(** Keeper_evidence — deterministic post-turn evidence capture.
+
+    After each keeper turn, captures git diff/status as immutable
+    evidence of what actually changed. No LLM interpretation —
+    git commands only.
+
+    Evidence is persisted to:
+      .masc/evidence/<keeper_name>/<trace_id>/turn_<N>.jsonl
+
+    @since 2.254.0 — execution evidence system (#5620) *)
+
+let run_git ~workdir args =
+  Worktree_live_context.run_git_capture_lines ~workdir args
+
+(** Capture post-turn evidence snapshot.
+    Returns the evidence JSON and persists it to disk. *)
+let capture_post_turn_evidence
+    ~base_path
+    ~keeper_name
+    ~trace_id
+    ~turn_number
+    ~tool_calls_made
+    ()
+  : Yojson.Safe.t option =
+  let repo_root =
+    match Worktree_live_context.repo_root_for ~base_path with
+    | Some r -> r
+    | None -> base_path
+  in
+  let diff_stat =
+    run_git ~workdir:repo_root [ "diff"; "--stat" ]
+    |> Option.value ~default:[]
+  in
+  let shortstat =
+    run_git ~workdir:repo_root [ "diff"; "--shortstat" ]
+    |> Option.value ~default:[]
+    |> String.concat " " |> String.trim
+  in
+  let branch =
+    run_git ~workdir:repo_root [ "branch"; "--show-current" ]
+    |> Option.value ~default:["(detached)"]
+    |> List.hd
+    |> String.trim
+  in
+  let status_lines =
+    run_git ~workdir:repo_root [ "status"; "--porcelain" ]
+    |> Option.value ~default:[]
+    |> List.filter (fun l -> not (String_util.contains_substring l ".masc/"))
+  in
+  let worktrees =
+    run_git ~workdir:repo_root [ "worktree"; "list"; "--porcelain" ]
+    |> Option.value ~default:[]
+    |> List.filter_map (fun line ->
+      if String.length line > 9 && String.sub line 0 9 = "worktree " then
+        Some (String.sub line 9 (String.length line - 9))
+      else None)
+  in
+  let files_changed = List.length status_lines in
+  if files_changed = 0 && diff_stat = [] then
+    None
+  else
+    let ts = Types.now_iso () in
+    let evidence = `Assoc [
+      ("timestamp", `String ts);
+      ("keeper_name", `String keeper_name);
+      ("trace_id", `String trace_id);
+      ("turn", `Int turn_number);
+      ("tool_calls_made", `Int tool_calls_made);
+      ("branch", `String branch);
+      ("files_changed", `Int files_changed);
+      ("shortstat", `String shortstat);
+      ("diff_stat", `List (List.map (fun l -> `String l) diff_stat));
+      ("dirty_files", `List (List.map (fun l -> `String l) status_lines));
+      ("active_worktrees", `List (List.map (fun w -> `String w) worktrees));
+    ] in
+    (* Persist to disk *)
+    (try
+      let evidence_dir =
+        Filename.concat base_path
+          (Printf.sprintf ".masc/evidence/%s/%s"
+            (Room_utils.safe_filename keeper_name)
+            (Room_utils.safe_filename trace_id))
+      in
+      Fs_compat.mkdir_p evidence_dir;
+      let evidence_file = Filename.concat evidence_dir
+        (Printf.sprintf "turn_%03d.json" turn_number)
+      in
+      Fs_compat.save_file evidence_file
+        (Yojson.Safe.pretty_to_string evidence);
+      Log.Keeper.debug "evidence captured: %s turn=%d files=%d"
+        keeper_name turn_number files_changed
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.warn "evidence capture failed for %s turn %d: %s"
+        keeper_name turn_number (Printexc.to_string exn));
+    Some evidence
+
+(** Read the latest evidence snapshot for a keeper. *)
+let latest_evidence ~base_path ~keeper_name ~trace_id
+  : Yojson.Safe.t option =
+  let evidence_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/evidence/%s/%s"
+        (Room_utils.safe_filename keeper_name)
+        (Room_utils.safe_filename trace_id))
+  in
+  if not (Fs_compat.file_exists evidence_dir) then None
+  else
+    try
+      let entries = Sys.readdir evidence_dir |> Array.to_list in
+      let json_files =
+        List.filter (fun f -> Filename.check_suffix f ".json") entries
+        |> List.sort (fun a b -> compare b a)
+      in
+      match json_files with
+      | [] -> None
+      | latest :: _ ->
+        let path = Filename.concat evidence_dir latest in
+        let content = Fs_compat.load_file path in
+        Some (Yojson.Safe.from_string content)
+    with _ -> None

--- a/lib/keeper/keeper_file_tracker.ml
+++ b/lib/keeper/keeper_file_tracker.ml
@@ -1,0 +1,87 @@
+(** Keeper_file_tracker — cross-keeper file collision detection.
+
+    Process-scoped tracker that records which keeper modified which
+    files. Detects when two different keepers touch the same file
+    within a time window.
+
+    Non-yielding Hashtbl operations only — single-domain Eio safe.
+
+    @since 2.254.0 — execution evidence system (#5620) *)
+
+type collision_warning = {
+  file_path : string;
+  other_keeper : string;
+  other_ts : float;
+}
+
+type file_entry = {
+  keeper_name : string;
+  ts : float;
+}
+
+let collision_window_sec = 300.0
+
+let mu = Mutex.create ()
+let tracker : (string, file_entry) Hashtbl.t = Hashtbl.create 64
+
+let with_lock f =
+  Mutex.lock mu;
+  Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+
+let gc_stale () =
+  let now = Unix.gettimeofday () in
+  let stale = Hashtbl.fold (fun path entry acc ->
+    if now -. entry.ts > collision_window_sec *. 2.0 then path :: acc
+    else acc
+  ) tracker [] in
+  List.iter (Hashtbl.remove tracker) stale
+
+(** Record files from a turn's git status output. Returns collision warnings.
+    Each status line is e.g. " M lib/foo.ml" — extract file path. *)
+let record_turn_files ~keeper_name ~files : collision_warning list =
+  let now = Unix.gettimeofday () in
+  let extract_path line =
+    let trimmed = String.trim line in
+    if String.length trimmed > 3 then
+      String.sub trimmed 3 (String.length trimmed - 3)
+      |> String.trim
+    else trimmed
+  in
+  with_lock (fun () ->
+    gc_stale ();
+    let warnings = ref [] in
+    List.iter (fun raw_line ->
+      let path = extract_path raw_line in
+      if path <> "" then begin
+        (match Hashtbl.find_opt tracker path with
+         | Some entry
+           when entry.keeper_name <> keeper_name
+                && now -. entry.ts < collision_window_sec ->
+           warnings := { file_path = path;
+                         other_keeper = entry.keeper_name;
+                         other_ts = entry.ts } :: !warnings
+         | _ -> ());
+        Hashtbl.replace tracker path { keeper_name; ts = now }
+      end
+    ) files;
+    List.rev !warnings)
+
+(** Recent collisions involving a specific keeper. *)
+let recent_collisions ~keeper_name : collision_warning list =
+  let now = Unix.gettimeofday () in
+  with_lock (fun () ->
+    Hashtbl.fold (fun path entry acc ->
+      if entry.keeper_name <> keeper_name
+         && now -. entry.ts < collision_window_sec then
+        { file_path = path;
+          other_keeper = entry.keeper_name;
+          other_ts = entry.ts } :: acc
+      else acc
+    ) tracker [])
+
+let collision_to_json (w : collision_warning) : Yojson.Safe.t =
+  `Assoc [
+    ("file_path", `String w.file_path);
+    ("other_keeper", `String w.other_keeper);
+    ("other_ts", `Float w.other_ts);
+  ]

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -656,6 +656,24 @@ let handle_keeper_status ctx args : tool_result =
              ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
              ("session_dir", `String session_dir);
              ("history", `String history_path);
+             ("evidence_dir", `String
+               (Filename.concat ctx.config.base_path
+                 (Printf.sprintf ".masc/evidence/%s/%s"
+                   (Room_utils.safe_filename m.name)
+                   (Room_utils.safe_filename m.runtime.trace_id))));
+           ]);
+           ("execution_context", `Assoc [
+             ("playground_path", `String
+               (Keeper_alerting_path.playground_path_of_keeper m.name));
+             ("execution_scope", `String m.execution_scope);
+             ("allowed_paths", string_list_to_json m.allowed_paths);
+             ("last_evidence",
+               match Keeper_evidence.latest_evidence
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:m.name
+                 ~trace_id:m.runtime.trace_id with
+               | Some ev -> ev
+               | None -> `Null);
            ]);
          ] in
          let response = Yojson.Safe.pretty_to_string json in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -288,6 +288,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             in
             Progress.Tracker.step turn_tracker
               ~message:(Printf.sprintf "Executing Agent.run for %s" name) ();
+            let evidence_before_hash =
+              try Keeper_evidence.snapshot_before_turn
+                ~base_path:ctx.config.base_path ~keeper_name:name
+              with _ -> None
+            in
             let run_result, latency_ms =
               Keeper_exec_context.timed (fun () ->
                   Keeper_agent_run.run_turn
@@ -383,15 +388,16 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~turn_generation:lifecycle.turn_generation
                 ~compaction:lifecycle.compaction
                 ~handoff_json:lifecycle.handoff_json;
-              (* Post-turn evidence capture: deterministic git snapshot *)
+              (* Post-turn evidence: deterministic git before/after delta *)
               let evidence =
                 try
-                  Keeper_evidence.capture_post_turn_evidence
+                  Keeper_evidence.capture_turn_evidence
                     ~base_path:ctx.config.base_path
                     ~keeper_name:name
                     ~trace_id:updated_meta.runtime.trace_id
                     ~turn_number:updated_meta.runtime.usage.total_turns
                     ~tool_calls_made:result.tool_calls_made
+                    ~before_hash:evidence_before_hash
                     ()
                 with
                 | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -383,17 +383,39 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~turn_generation:lifecycle.turn_generation
                 ~compaction:lifecycle.compaction
                 ~handoff_json:lifecycle.handoff_json;
+              (* Post-turn evidence capture: deterministic git snapshot *)
+              let evidence =
+                try
+                  Keeper_evidence.capture_post_turn_evidence
+                    ~base_path:ctx.config.base_path
+                    ~keeper_name:name
+                    ~trace_id:updated_meta.runtime.trace_id
+                    ~turn_number:updated_meta.runtime.usage.total_turns
+                    ~tool_calls_made:result.tool_calls_made
+                    ()
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Keeper.warn "post-turn evidence capture failed: %s"
+                    (Printexc.to_string exn);
+                  None
+              in
               start_keepalive ctx updated_meta;
               Progress.Tracker.complete turn_tracker
                 ~message:(Printf.sprintf "Turn completed: %d tool calls" result.tool_calls_made) ();
               let reply_json =
-                `Assoc
-                  [
+                let base = [
                     ("reply", `String result.response_text);
                     ("model", `String result.model_used);
                     ("turns", `Int result.turn_count);
                     ("tool_calls", `Int result.tool_calls_made);
                   ]
+                in
+                let with_evidence = match evidence with
+                  | Some ev -> base @ [("evidence", ev)]
+                  | None -> base
+                in
+                `Assoc with_evidence
               in
               (true, Yojson.Safe.to_string reply_json)
 


### PR DESCRIPTION
## Summary
- Post-turn evidence capture: deterministic git snapshot after every keeper turn
- `execution_context` block in `keeper_status` response
- Evidence persisted to `.masc/evidence/<name>/<trace_id>/turn_NNN.json`

## What Gets Captured (automatically, every turn)

```json
{
  "timestamp": "2026-04-07T09:30:00Z",
  "keeper_name": "dreamer",
  "turn": 5,
  "tool_calls_made": 3,
  "branch": "fix/dreamer-task",
  "files_changed": 2,
  "shortstat": "2 files changed, 15 insertions(+), 3 deletions(-)",
  "diff_stat": ["lib/foo.ml | 12 ++++++---", "test/test_foo.ml | 6 +++"],
  "dirty_files": ["M lib/foo.ml", "M test/test_foo.ml"],
  "active_worktrees": ["/path/to/repo", "/path/to/.worktrees/fix-task"]
}
```

## Why This Matters

LLM says "I fixed the bug" but git shows no file was modified = hallucination caught deterministically. No LLM interpretation in the evidence chain — git commands only.

## Files Changed (4)
- `lib/keeper/keeper_evidence.ml` (NEW): capture + persistence + query
- `lib/keeper/keeper_turn.ml`: post-turn evidence hook after lifecycle
- `lib/keeper/keeper_status_detail.ml`: execution_context in status response
- `lib/dune`: module registration

## Test Plan
- [x] `dune build` passes
- [ ] CI green

Refs #5620

Generated with [Claude Code](https://claude.com/claude-code)
