### PR TITLE
fix(keeper): surface web_search and shell_readonly to all keeper turns

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -47,6 +47,7 @@ let core_discovery_tools =
     "keeper_fs_read";
     "keeper_board_get"; "keeper_board_post";
     "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list";
+    "masc_web_search"; "keeper_shell_readonly";
   ]
 
 let effective_core_tools () = core_discovery_tools


### PR DESCRIPTION
## Summary
Root cause of keepers never using `masc_web_search` autonomously:
- Tool was in preset allowlist but **BM25 progressive disclosure never surfaced it**
- `world_state_prompt` contains task counts and agent status, not "search" or "web" keywords
- BM25 scored `masc_web_search` too low to appear in the turn's tool list

Fix: Add `masc_web_search` and `keeper_shell_readonly` to `core_discovery_tools` — these are now visible on every keeper turn regardless of BM25 scoring.

## Test plan
- [x] 29 retrieval quality tests pass
- [ ] Restart server, observe keeper calling `masc_web_search` with `engine:searxng`

🤖 Generated with [Claude Code](https://claude.com/claude-code)