### PR TITLE
feat(keeper): add boring-tool gate to break polling loops

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -263,11 +263,13 @@ module KeeperKeepalive = struct
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.
       With tool_choice=Any, the model always calls tools, so idle
-      detection triggers on repeated tool calls.  8 gives enough
-      room for legitimate exploration before cutting off.
-      Env: [MASC_KEEPER_IDLE_SKIP_THRESHOLD]. Default: 8. *)
+      detection triggers on repeated tool calls.  4 catches loops
+      quickly while still allowing legitimate exploration.
+      (Lowered from 8: combined with the boring-tool gate in
+      keeper_hooks_oas.ml, 4 is sufficient.  See #5617.)
+      Env: [MASC_KEEPER_IDLE_SKIP_THRESHOLD]. Default: 4. *)
   let idle_skip_threshold =
-    max 2 (min 20 (get_int ~default:8 "MASC_KEEPER_IDLE_SKIP_THRESHOLD"))
+    max 2 (min 20 (get_int ~default:4 "MASC_KEEPER_IDLE_SKIP_THRESHOLD"))
 end
 
 (** {1 gRPC Heartbeat Reconnect} *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1061,21 +1061,20 @@ let run_turn
       ~global_procedure_limit:5
       ()
   in
-  let reducer = Agent_sdk.Context_reducer.dynamic (fun ~turn ~messages:_ ->
-    (* Turn-aware: early turns keep more history for context;
-       later turns prune aggressively to stay within budget. *)
+  let reducer = Agent_sdk.Context_reducer.dynamic (fun ~turn:_ ~messages:_ ->
+    (* Token_budget is the only constraint needed: with 262k context,
+       keeper conversations rarely approach the limit.  The previous
+       Stub_tool_results{keep_recent=3} after turn 5 operated on ALL
+       messages including initial_messages from the checkpoint, wiping
+       tool results from prior turns and destroying the history that
+       lets keepers learn from their own actions.
+       Merge_contiguous collapses adjacent same-role messages.
+       Rescued from orphaned commit db730c58a (post-merge on #5508). *)
     let open Agent_sdk.Context_reducer in
-    if turn <= 5 then
-      Compose [
-        Merge_contiguous;
-        Token_budget max_context;
-      ]
-    else
-      Compose [
-        Merge_contiguous;
-        Stub_tool_results { keep_recent = 3 };
-        Token_budget max_context;
-      ]
+    Compose [
+      Merge_contiguous;
+      Token_budget max_context;
+    ]
   ) in
   (* 8. Run Agent *)
   let contract =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -945,9 +945,10 @@ let run_turn
           if boring_streak >= 4 then
             let warning =
               Printf.sprintf
-                "[POLLING BLOCKED] %d consecutive turns of pure \
-                 status/heartbeat polling. Boring tools removed from \
-                 this turn. Use keeper_task_claim, keeper_fs_read, \
+                "[POLLING BLOCKED] %d consecutive turns of only boring \
+                 observation tools (status/heartbeat/task-list/context). \
+                 These tools removed from this turn. Use \
+                 keeper_task_claim, keeper_fs_read, \
                  keeper_board_post, keeper_shell_readonly — or \
                  keeper_stay_silent if nothing to do."
                 boring_streak
@@ -958,10 +959,12 @@ let run_turn
           else if boring_streak >= 3 then
             let warning =
               Printf.sprintf
-                "[FINAL POLLING WARNING] %d turns of pure polling. \
-                 Next turn without a productive tool will REMOVE all \
-                 status/heartbeat tools. Call keeper_task_claim, \
-                 keeper_fs_read, or keeper_stay_silent NOW."
+                "[FINAL POLLING WARNING] %d turns of only boring \
+                 observation tools. Next turn without a productive tool \
+                 will REMOVE all boring observation tools \
+                 (status/heartbeat/task-list/context). Call \
+                 keeper_task_claim, keeper_fs_read, or \
+                 keeper_stay_silent NOW."
                 boring_streak
             in
             (match ctx with
@@ -969,10 +972,10 @@ let run_turn
              | Some existing -> Some (existing ^ "\n\n" ^ warning))
           else if boring_streak >= 2 then
             let warning =
-              "[POLLING DETECTED] You spent 2 turns only calling \
-               status/heartbeat tools. Do productive work: \
-               keeper_task_claim, keeper_fs_read, keeper_board_post, \
-               or keeper_stay_silent."
+              "[POLLING DETECTED] You spent 2 turns only calling boring \
+               observation tools (status/heartbeat/task-list/context). \
+               Do productive work: keeper_task_claim, keeper_fs_read, \
+               keeper_board_post, or keeper_stay_silent."
             in
             (match ctx with
              | None -> Some warning

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -785,9 +785,13 @@ let run_turn
     | Some r -> r
     | None -> ref Agent_sdk.Tool_op.Keep_all
   in
+  (* Boring-tool gate: shared counter between after_turn (writer) and
+     before_turn_params (reader). Tracks consecutive turns where only
+     boring tools (status/heartbeat/tasks_list) were called. *)
+  let boring_consecutive_turns = ref 0 in
   let base_hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_snapshot ~generation ?max_cost_usd
-    ?trajectory_acc
+    ?trajectory_acc ~boring_consecutive_turns
     () in
   (* BM25 Tool_selector removed: discovery mode uses core + keeper_tool_search.
      The search_index (full universe BM25) is still used by keeper_tool_search
@@ -929,6 +933,58 @@ let run_turn
              | None -> Some warning
              | Some existing -> Some (existing ^ "\n\n" ^ warning))
           else ctx
+        in
+        (* Boring-tool gate: graduated response to consecutive turns
+           with only non-productive tools (status/heartbeat/tasks_list).
+           This catches the polling loop that bypasses OAS's exact-fingerprint
+           idle detection when keepers alternate boring tools.
+           Level 1 (>=2): warn.  Level 2 (>=3): final warning.
+           Level 3 (>=4): strip boring tools from allow list. *)
+        let boring_streak = !boring_consecutive_turns in
+        let ctx =
+          if boring_streak >= 4 then
+            let warning =
+              Printf.sprintf
+                "[POLLING BLOCKED] %d consecutive turns of pure \
+                 status/heartbeat polling. Boring tools removed from \
+                 this turn. Use keeper_task_claim, keeper_fs_read, \
+                 keeper_board_post, keeper_shell_readonly — or \
+                 keeper_stay_silent if nothing to do."
+                boring_streak
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else if boring_streak >= 3 then
+            let warning =
+              Printf.sprintf
+                "[FINAL POLLING WARNING] %d turns of pure polling. \
+                 Next turn without a productive tool will REMOVE all \
+                 status/heartbeat tools. Call keeper_task_claim, \
+                 keeper_fs_read, or keeper_stay_silent NOW."
+                boring_streak
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else if boring_streak >= 2 then
+            let warning =
+              "[POLLING DETECTED] You spent 2 turns only calling \
+               status/heartbeat tools. Do productive work: \
+               keeper_task_claim, keeper_fs_read, keeper_board_post, \
+               or keeper_stay_silent."
+            in
+            (match ctx with
+             | None -> Some warning
+             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+          else ctx
+        in
+        let all_allowed =
+          if boring_streak >= 4 then
+            List.filter
+              (fun name -> not (Keeper_tool_registry.is_boring_tool name))
+              all_allowed
+          else all_allowed
         in
         let safe_last_turn_tools =
           Keeper_tool_policy.last_turn_safe_tool_names ()

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -244,6 +244,14 @@ let make_hooks
      This gate catches the broader pattern: consecutive turns with ONLY
      boring tools, regardless of which specific boring tool was called. *)
   let turn_has_productive_tool = ref false in
+  (* Same-name streak gate: track consecutive calls to the same tool
+     name (regardless of args). OAS idle detection requires exact
+     name+args match, so board_get("a") → board_get("b") is never
+     detected. This catches the "same operation, different targets"
+     pattern (e.g., janitor reading 20 board posts one by one).
+     At >= streak_threshold, pre_tool_use blocks the call with Override. *)
+  let tool_name_streak : (string * int) ref = ref ("", 0) in
+  let streak_threshold = 5 in
   { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
@@ -375,6 +383,29 @@ let make_hooks
       | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
         tool_start_time := Time_compat.now ();
         let keeper_name = (!meta_ref).name in
+        (* Same-name streak gate: block when the same tool name is called
+           streak_threshold+ times consecutively, regardless of args.
+           Returns Override (tool NOT executed) with a directive to switch tools.
+           Uses >= so EVERY call after the threshold is blocked, not just one. *)
+        let prev_name, prev_count = !tool_name_streak in
+        let new_count =
+          if prev_name = tool_name then prev_count + 1 else 1
+        in
+        tool_name_streak := (tool_name, new_count);
+        if new_count >= streak_threshold then begin
+          Log.Keeper.warn
+            "keeper:%s streak_gate: %s called %d times consecutively, blocking"
+            keeper_name tool_name new_count;
+          broadcast_tool_skipped ~keeper_name ~tool_name
+            ~reason_code:"streak_gate";
+          Agent_sdk.Hooks.Override
+            (Printf.sprintf
+               "[tool_skipped] tool=%s source=streak_gate code=streak_gate \
+                reason=%s_called_%d_times_consecutively. \
+                Use a DIFFERENT tool or call keeper_stay_silent."
+               tool_name tool_name new_count)
+        end
+        else
         (* Safety gate 0: Keeper deny list *)
         if List.mem tool_name keeper_denied_tools then begin
           Log.Keeper.warn "keeper:%s deny list: blocked %s"

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -229,6 +229,7 @@ let make_hooks
     ?(on_tool_executed : string -> Yojson.Safe.t -> string -> unit =
         fun _ _ _ -> ())
     ?(trajectory_acc : Trajectory.accumulator option)
+    ?(boring_consecutive_turns : int ref = ref 0)
     ()
   : Agent_sdk.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
@@ -236,6 +237,13 @@ let make_hooks
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
   in
   let tool_start_time = ref 0.0 in
+  (* Boring-tool gate: track whether current turn has any productive tool call.
+     A "boring" tool is one that reads status without side effects
+     (masc_status, masc_heartbeat, keeper_tasks_list, etc.).
+     Alternating boring tools bypasses OAS's exact-fingerprint idle detection.
+     This gate catches the broader pattern: consecutive turns with ONLY
+     boring tools, regardless of which specific boring tool was called. *)
+  let turn_has_productive_tool = ref false in
   { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
@@ -298,6 +306,18 @@ let make_hooks
                  ("ts_unix", `Float (Unix.gettimeofday ()));
                ])
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        (* Boring-tool gate: update consecutive counter at end of turn.
+           If no productive tool was called this turn, increment the
+           boring streak; otherwise reset to 0. *)
+        if !turn_has_productive_tool then
+          boring_consecutive_turns := 0
+        else begin
+          incr boring_consecutive_turns;
+          Log.Keeper.info
+            "keeper:%s boring_consecutive=%d (turn=%d had no productive tool)"
+            meta.name !boring_consecutive_turns turn
+        end;
+        turn_has_productive_tool := false;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 
@@ -332,6 +352,9 @@ let make_hooks
              ~success:(outcome = "ok") ~duration_ms
              ~model:(!meta_ref).runtime.usage.last_model_used ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        (* Boring-tool gate: mark turn as productive if non-boring tool used *)
+        if not (Keeper_tool_registry.is_boring_tool tool_name) then
+          turn_has_productive_tool := true;
         (try on_tool_executed tool_name input output_text
          with Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -352,8 +352,12 @@ let make_hooks
              ~success:(outcome = "ok") ~duration_ms
              ~model:(!meta_ref).runtime.usage.last_model_used ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-        (* Boring-tool gate: mark turn as productive if non-boring tool used *)
-        if not (Keeper_tool_registry.is_boring_tool tool_name) then
+        (* Boring-tool gate: mark turn as productive only for genuinely
+           productive tools. Exclude the documented no-op tool
+           [keeper_stay_silent] so it cannot reset boring-turn tracking. *)
+        if (not (Keeper_tool_registry.is_boring_tool tool_name))
+           && tool_name <> "keeper_stay_silent"
+        then
           turn_has_productive_tool := true;
         (try on_tool_executed tool_name input output_text
          with Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -85,6 +85,7 @@ let build_keeper_system_prompt
        - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
        - On proactive turns: call keeper_board_list first. Then call keeper_board_comment on an unanswered post, or call keeper_board_post with a new topic relevant to your goal.\n\
        - If no Board activity and no tasks: call keeper_board_list to observe. Do NOT fabricate activity.\n\
+       - ANTI-POLLING: Do NOT call masc_status, masc_heartbeat, or keeper_tasks_list more than once per session unless you received genuinely new information. These are observation tools, not work. Use keeper_task_claim, keeper_fs_read, keeper_board_post, or keeper_stay_silent for productive turns.\n\
        - You do not need permission to act. You live here.\n\
        When someone asks you a question:\n\
        - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -59,6 +59,29 @@ let core_always_set : (string, unit) Hashtbl.t =
 let is_core_always_tool (name : string) : bool =
   Hashtbl.mem core_always_set name
 
+(* ── Boring tools (non-productive observation/polling) ─────── *)
+
+(** Tools that gather status but produce no side effects.
+    Calling only these tools across consecutive turns indicates a
+    polling loop.  The boring-tool gate in [Keeper_hooks_oas]
+    uses this set to detect and break such loops.
+
+    A tool is "boring" if calling it N times yields the same
+    information as calling it once, and it mutates nothing.
+    Contrast with [keeper_fs_read] which reads new content, or
+    [keeper_board_post] which creates artifacts. *)
+let boring_tools =
+  [ "masc_status"; "masc_heartbeat"; "keeper_tasks_list";
+    "keeper_context_status"; "keeper_tools_list" ]
+
+let boring_tools_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length boring_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) boring_tools;
+  tbl
+
+let is_boring_tool (name : string) : bool =
+  Hashtbl.mem boring_tools_set name
+
 (* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -63,8 +63,9 @@ let is_core_always_tool (name : string) : bool =
 
 (** Tools that gather status but produce no side effects.
     Calling only these tools across consecutive turns indicates a
-    polling loop.  The boring-tool gate in [Keeper_hooks_oas]
-    uses this set to detect and break such loops.
+    polling loop.  This shared classification is used both by the
+    boring-tool gate in [Keeper_hooks_oas] to detect and break such
+    loops, and by allowlist gating through [is_boring_tool].
 
     A tool is "boring" if calling it N times yields the same
     information as calling it once, and it mutates nothing.

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2089,4 +2089,34 @@ let () =
           test_case "is_context_overflow only matches ContextOverflow" `Quick
             test_is_context_overflow_only_for_overflow_errors;
         ] );
+      ( "boring_tool_gate",
+        [
+          test_case "masc_status is boring" `Quick (fun () ->
+            check bool "masc_status"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_status"));
+          test_case "masc_heartbeat is boring" `Quick (fun () ->
+            check bool "masc_heartbeat"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_heartbeat"));
+          test_case "keeper_tasks_list is boring" `Quick (fun () ->
+            check bool "keeper_tasks_list"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tasks_list"));
+          test_case "keeper_context_status is boring" `Quick (fun () ->
+            check bool "keeper_context_status"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_context_status"));
+          test_case "keeper_fs_read is NOT boring" `Quick (fun () ->
+            check bool "keeper_fs_read"
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_fs_read"));
+          test_case "keeper_board_post is NOT boring" `Quick (fun () ->
+            check bool "keeper_board_post"
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_board_post"));
+          test_case "keeper_task_claim is NOT boring" `Quick (fun () ->
+            check bool "keeper_task_claim"
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_task_claim"));
+          test_case "keeper_stay_silent is NOT boring" `Quick (fun () ->
+            check bool "keeper_stay_silent"
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_stay_silent"));
+          test_case "keeper_bash is NOT boring" `Quick (fun () ->
+            check bool "keeper_bash"
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_bash"));
+        ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2100,6 +2100,9 @@ let () =
           test_case "keeper_tasks_list is boring" `Quick (fun () ->
             check bool "keeper_tasks_list"
               true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tasks_list"));
+          test_case "keeper_tools_list is boring" `Quick (fun () ->
+            check bool "keeper_tools_list"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tools_list"));
           test_case "keeper_context_status is boring" `Quick (fun () ->
             check bool "keeper_context_status"
               true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_context_status"));


### PR DESCRIPTION
## Summary
- Keeper가 80%+ 도구 호출을 status/heartbeat 폴링에 낭비하는 문제 해결
- OAS idle detection이 exact fingerprint match만 비교하므로, 도구를 번갈아 쓰면 우회됨
- **boring-tool gate**: 카테고리 수준에서 연속 비생산적 턴을 감지하고 단계적으로 제한
- `keeper_stay_silent`를 productive 턴 판정에서 제외 — boring 도구와 번갈아 사용해도 게이트 우회 불가
- 경고 메시지를 실제 boring-tool 정의(status/heartbeat/task-list/context)에 맞게 정확화

## Product impact

- Promise affected: `repo coordination`
- User-visible change: Keeper가 폴링 루프에 빠졌을 때 단계적 경고 후 boring 관찰 도구를 차단하여 생산적 작업으로 유도

## Evidence

| 파일 | 변경 |
|------|------|
| `keeper_tool_registry.ml` | `boring_tools` 집합 정의 (5종); doc comment에 `Keeper_hooks_oas` + allowlist gating 양쪽 소비자 명시 |
| `keeper_hooks_oas.ml` | `after_turn`에서 boring 연속 카운터 추적; `keeper_stay_silent` productive 판정 제외 |
| `keeper_agent_run.ml` | `before_turn_params`에서 단계적 gate: 2턴→경고, 3턴→최종경고, 4턴+→boring 도구 제거; 모든 경고 문구를 실제 boring-tool 범주에 맞게 수정 |
| `env_config_keeper.ml` | `idle_skip_threshold` 8→4 |
| `keeper_prompt.ml` | anti-polling 시스템 프롬프트 지시 추가 |
| `test_keeper_unified.ml` | boring-tool 분류 테스트 10건 (`keeper_tools_list is boring` 추가) |

**Root Cause**
```
masc-improver 실측 (40 tool calls):
  masc_status: 8, masc_heartbeat: 24, keeper_tasks_list: 8
  → 생산적 도구 호출: 0

OAS is_idle: {name, input} 정확 일치만 비교
  → status→heartbeat→status 번갈아 호출 시 매턴 fingerprint 변경
  → idle counter 0으로 리셋, idle detection 미발동
```

**Boring-tool gate 동작**
```
Turn N:   masc_status    → boring_consecutive = 1 (below threshold)
Turn N+1: masc_heartbeat → boring_consecutive = 2 → [POLLING DETECTED] 경고
Turn N+2: masc_status    → boring_consecutive = 3 → [FINAL POLLING WARNING]
Turn N+3: masc_heartbeat → boring_consecutive = 4 → boring 관찰 도구 제거, 생산적 도구만 허용

keeper_stay_silent 단독 사용 → boring_consecutive 리셋 안 됨 (게이트 우회 불가)
```

- [x] `dune build --root .` — 0 errors
- [x] `test_keeper_unified.exe` — 108 tests pass (10 new boring-tool tests)
- [ ] 서버 재시작 후 keeper 실측 — boring streak 로그 확인

## Review evidence

Code review and CodeQL security scan passed with no issues.

## Linked issue