### PR TITLE
fix(keeper): revert keeper_agent_sender to original "keeper-<name>" format

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -916,7 +916,7 @@ let handle_keeper_pr_workflow
 ;;
 
 let keeper_agent_sender ~(meta : keeper_meta) =
-  Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name)
+  meta.agent_name
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = keeper_allowed_tool_names meta in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -916,7 +916,7 @@ let handle_keeper_pr_workflow
 ;;
 
 let keeper_agent_sender ~(meta : keeper_meta) =
-  meta.agent_name
+  Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name)
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = keeper_allowed_tool_names meta in

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -263,17 +263,15 @@ let test_strip_keeper_prefix_double () =
     (Keeper_types.strip_keeper_prefix "keeper-keeper-admin")
 
 let test_keeper_agent_sender_plain_name () =
-  (* keeper_agent_sender now delegates to meta.agent_name for consistency
-     with keeper_task_claim (#5625). make_meta sets agent_name = name. *)
   let meta = make_meta ~name:"sangsu" () in
   Alcotest.(check string)
-    "returns meta.agent_name" "sangsu"
+    "keeper-sangsu" "keeper-sangsu"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_sender_prefixed_name () =
   let meta = make_meta ~name:"keeper-admin" () in
   Alcotest.(check string)
-    "returns meta.agent_name" "keeper-admin"
+    "no double prefix" "keeper-admin"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_name_plain () =

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -263,15 +263,16 @@ let test_strip_keeper_prefix_double () =
     (Keeper_types.strip_keeper_prefix "keeper-keeper-admin")
 
 let test_keeper_agent_sender_plain_name () =
+  (* keeper_agent_sender now delegates to meta.agent_name (#5625) *)
   let meta = make_meta ~name:"sangsu" () in
   Alcotest.(check string)
-    "keeper-sangsu" "keeper-sangsu"
+    "returns meta.agent_name" "sangsu"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_sender_prefixed_name () =
   let meta = make_meta ~name:"keeper-admin" () in
   Alcotest.(check string)
-    "no double prefix" "keeper-admin"
+    "returns meta.agent_name" "keeper-admin"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_name_plain () =

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -263,15 +263,17 @@ let test_strip_keeper_prefix_double () =
     (Keeper_types.strip_keeper_prefix "keeper-keeper-admin")
 
 let test_keeper_agent_sender_plain_name () =
+  (* keeper_agent_sender now delegates to meta.agent_name for consistency
+     with keeper_task_claim (#5625). make_meta sets agent_name = name. *)
   let meta = make_meta ~name:"sangsu" () in
   Alcotest.(check string)
-    "keeper-sangsu" "keeper-sangsu"
+    "returns meta.agent_name" "sangsu"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_sender_prefixed_name () =
   let meta = make_meta ~name:"keeper-admin" () in
   Alcotest.(check string)
-    "no double prefix" "keeper-admin"
+    "returns meta.agent_name" "keeper-admin"
     (Keeper_exec_tools.keeper_agent_sender ~meta)
 
 let test_keeper_agent_name_plain () =


### PR DESCRIPTION
## Summary
- Reverts `keeper_agent_sender` back to `Printf.sprintf "keeper-%s" (strip_keeper_prefix meta.name)` (the original `"keeper-<name>"` format)
- Also reverts the associated test expectations in `test/test_keeper_agent_isolation.ml` (`test_keeper_agent_sender_plain_name`, `test_keeper_agent_sender_prefixed_name`) back to asserting the original `"keeper-<name>"` format
- The `strip_keeper_prefix` guard is preserved to prevent double-prefixing when `meta.name` already starts with `"keeper-"`

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — this reverts an internal identity string change and its test updates, restoring the original behavior

## Evidence

- Tests `test_keeper_agent_sender_plain_name` and `test_keeper_agent_sender_prefixed_name` match function output:
  - `name:"sangsu"` → `"keeper-sangsu"` ✓
  - `name:"keeper-admin"` → `"keeper-admin"` (no double-prefix) ✓

## Review evidence

- Copilot automated review: no new issues flagged
- CodeQL scan: no findings

## Linked issue