### PR TITLE
fix(tool): include exit code in masc_code_search error messages

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -173,8 +173,15 @@ let handle_code_search ctx args =
           ("results", `List []);
         ] in
         (true, Yojson.Safe.pretty_to_string response)
-    | _, output ->
-        (false, Printf.sprintf "❌ ripgrep failed: %s" output)
+    | status, output ->
+        let code = match status with
+          | Unix.WEXITED n -> Printf.sprintf "exit %d" n
+          | Unix.WSIGNALED n -> Printf.sprintf "signal %d" n
+          | Unix.WSTOPPED n -> Printf.sprintf "stopped %d" n
+        in
+        (false, Printf.sprintf "ripgrep failed (%s): %s" code
+           (if output = "" then "(no output — check rg is in PATH and query is valid)"
+            else output))
   end
 
 (* Handler: masc_code_symbols - Extract file symbols using heuristics *)


### PR DESCRIPTION
## Summary
- When ripgrep fails with empty stdout/stderr, the error message was just `"ripgrep failed: "` with no diagnostic info.
- Now includes the exit/signal code and a hint about possible causes (PATH, invalid query).

## Motivation
Keeper `cheolsu` hit `masc_code_search` returning `{"error":"❌ ripgrep failed: "}` — impossible to diagnose without the exit code. This is a silent failure that wastes keeper turns (retries 3x with no useful info).

## Test plan
- [x] Build clean
- [ ] Runtime: trigger a code_search error and verify the new message format

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>