### PR TITLE
fix(ops): add error logging to silent failure hotspots (#5627)

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -105,7 +105,8 @@ let capabilities_of_json (json : Yojson.Safe.t) : agent_capabilities =
   | `Assoc _ ->
     (match agent_capabilities_of_yojson json with
      | Ok c -> c
-     | Error _ ->
+     | Error msg ->
+       Log.Misc.warn "[agent_card] capabilities_of_json parse error: %s" msg;
        { streaming = false; push_notifications = false; extended_agent_card = false })
   | `List strs ->
     (* Backward compat: parse old string list format *)
@@ -125,7 +126,9 @@ let signature_to_json = agent_card_signature_to_yojson
 let signature_of_json (json : Yojson.Safe.t) : agent_card_signature option =
   match agent_card_signature_of_yojson json with
   | Ok s -> Some s
-  | Error _ -> None
+  | Error msg ->
+    Log.Misc.warn "[agent_card] signature_of_json parse error: %s" msg;
+    None
 
 (** Convert agent_card to JSON (A2A v0.3 spec format) *)
 let to_json (card : agent_card) : Yojson.Safe.t =
@@ -175,7 +178,9 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
       | p ->
         match provider_of_yojson p with
         | Ok v -> Some v
-        | Error _ -> None
+        | Error msg ->
+          Log.Misc.warn "[agent_card] provider parse error: %s" msg;
+          None
     in
 
     let protocol_versions =
@@ -192,7 +197,9 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
       |> List.filter_map (fun s ->
         match skill_of_yojson s with
         | Ok v -> Some v
-        | Error _ -> None)
+        | Error msg ->
+          Log.Misc.warn "[agent_card] skill parse error: %s" msg;
+          None)
     in
 
     (* Accept both "supportedInterfaces" (v0.3) and "bindings" (legacy) *)
@@ -207,7 +214,9 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
       |> List.filter_map (fun b ->
         match binding_of_yojson b with
         | Ok v -> Some v
-        | Error _ -> None)
+        | Error msg ->
+          Log.Misc.warn "[agent_card] binding parse error: %s" msg;
+          None)
     in
 
     let security_schemes =
@@ -216,7 +225,9 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
         List.filter_map (fun (k, v) ->
           match security_scheme_of_yojson v with
           | Ok scheme -> Some (k, scheme)
-          | Error _ -> None) pairs
+          | Error msg ->
+            Log.Misc.warn "[agent_card] security_scheme parse error for %s: %s" k msg;
+            None) pairs
       | _ -> []
     in
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -75,7 +75,9 @@ let load_auth_config config : auth_config =
       let json = Yojson.Safe.from_string content in
       match auth_config_of_yojson json with
       | Ok cfg -> cfg
-      | Error _ -> default_auth_config
+      | Error msg ->
+        Log.Auth.warn "[load_auth_config] parse error for %s: %s" file msg;
+        default_auth_config
     with Sys_error _ | Yojson.Json_error _ -> default_auth_config
   else
     default_auth_config
@@ -104,7 +106,9 @@ let load_credential config agent_name : agent_credential option =
       let json = Yojson.Safe.from_string content in
       match agent_credential_of_yojson json with
       | Ok cred -> Some cred
-      | Error _ -> None
+      | Error msg ->
+        Log.Auth.warn "[load_credential] parse error for %s: %s" agent_name msg;
+        None
     with Sys_error _ | Yojson.Json_error _ -> None
   else
     None
@@ -493,7 +497,9 @@ let enable_auth config ~require_token ~agent_name : string * string option =
       write_initial_admin config agent_name;
       match create_token config ~agent_name ~role:Admin with
       | Ok (token, _cred) -> Some token
-      | Error _ -> None
+      | Error e ->
+        Log.Auth.warn "[enable_auth] bootstrap token creation failed for %s: %s" agent_name (Types.show_masc_error e);
+        None
     end else None
   in
   (secret, bootstrap_token)

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -102,10 +102,14 @@ let entry_of_json (json : Yojson.Safe.t) : cache_entry option =
 
 let read_entry_file path =
   match Safe_ops.read_file_safe path with
-  | Error _ -> None
+  | Error msg ->
+    Log.Misc.warn "[cache_entry_read] failed to read %s: %s" path msg;
+    None
   | Ok content ->
       match Safe_ops.parse_json_safe ~context:"cache_entry_read" content with
-      | Error _ -> None
+      | Error msg ->
+        Log.Misc.warn "[cache_entry_read] %s" msg;
+        None
       | Ok json -> entry_of_json json
 
 let read_matching_entry path ~key =
@@ -200,10 +204,14 @@ let evict_expired config =
     let evicted = List.fold_left (fun count filename ->
       let path = Filename.concat dir filename in
       match Safe_ops.read_file_safe path with
-      | Error _ -> count
+      | Error msg ->
+        Log.Misc.warn "[cache_evict] failed to read %s: %s" path msg;
+        count
       | Ok content ->
         match Safe_ops.parse_json_safe ~context:"cache_evict" content with
-        | Error _ -> count
+        | Error msg ->
+          Log.Misc.warn "[cache_evict] %s" msg;
+          count
         | Ok json ->
           match entry_of_json json with
           | Some entry when is_expired entry ->
@@ -240,10 +248,14 @@ let maybe_evict_expired config =
         let expired_count = List.fold_left (fun acc filename ->
           let path = Filename.concat dir filename in
           match Safe_ops.read_file_safe path with
-          | Error _ -> acc
+          | Error msg ->
+            Log.Misc.warn "[cache_maybe_evict] failed to read %s: %s" path msg;
+            acc
           | Ok content ->
             match Safe_ops.parse_json_safe ~context:"cache_maybe_evict" content with
-            | Error _ -> acc
+            | Error msg ->
+              Log.Misc.warn "[cache_maybe_evict] %s" msg;
+              acc
             | Ok json ->
               match entry_of_json json with
               | Some entry when is_expired entry -> acc + 1
@@ -408,11 +420,12 @@ let list config ?(tag : string option) () : cache_entry list =
       List.iter (fun filename ->
         let path = Filename.concat dir filename in
         match Safe_ops.read_file_safe path with
-        | Error _ -> ()
+        | Error msg ->
+          Log.Misc.warn "[cache_get_all] failed to read %s: %s" path msg
         | Ok content ->
             match Safe_ops.parse_json_safe ~context:"cache_get_all" content with
             | Error msg ->
-                Log.Misc.info "%s" msg
+                Log.Misc.warn "[cache_get_all] %s" msg
             | Ok json ->
                 match entry_of_json json with
                 | Some entry ->
@@ -474,10 +487,14 @@ let stats config : (int * int * float, string) result =
           let file_size = (Unix.stat path).st_size in
           let is_exp =
             match Safe_ops.read_file_safe path with
-            | Error _ -> false
+            | Error msg ->
+              Log.Misc.warn "[cache_stats] failed to read %s: %s" path msg;
+              false
             | Ok content ->
               match Safe_ops.parse_json_safe ~context:"cache_stats" content with
-              | Error _ -> false
+              | Error msg ->
+                Log.Misc.warn "[cache_stats] %s" msg;
+                false
               | Ok json ->
                 match entry_of_json json with
                 | Some entry -> is_expired entry

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -85,6 +85,16 @@ let read_json_file_safe path : (Yojson.Safe.t, string) result =
   | Error e -> Error e
   | Ok content -> parse_json_safe ~context:path content
 
+(** Read JSON file safely, logging errors instead of silently discarding them.
+    Returns [Some json] on success, [None] on failure with a warning log.
+    Use this as a drop-in replacement for [read_json_file_safe |> Error _ -> None]. *)
+let read_json_file_logged ~label path : Yojson.Safe.t option =
+  match read_json_file_safe path with
+  | Ok json -> Some json
+  | Error msg ->
+    Log.Misc.warn "[%s] failed to read JSON from %s: %s" label path msg;
+    None
+
 (** Read JSON file via Eio-native I/O (Fs_compat).
     Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts.
     Falls back to blocking I/O when Eio fs is not set. *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -31,6 +31,10 @@ val read_file_safe : string -> (string, string) result
 val read_json_file_safe : string -> (Yojson.Safe.t, string) result
 (** Read JSON file safely. *)
 
+val read_json_file_logged : label:string -> string -> Yojson.Safe.t option
+(** Read JSON file safely, logging errors instead of silently discarding them.
+    Returns [Some json] on success, [None] on failure with a warning log. *)
+
 val read_json_eio : string -> Yojson.Safe.t
 (** Read JSON file via Eio-native I/O (Fs_compat).
     Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts. *)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -341,9 +341,9 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
   match persona_profile_path_opt name with
   | None -> empty_keeper_profile_defaults
   | Some path -> (
-      match Safe_ops.read_json_file_safe path with
-      | Error _ -> empty_keeper_profile_defaults
-      | Ok json ->
+      match Safe_ops.read_json_file_logged ~label:"load_keeper_profile_defaults" path with
+      | None -> empty_keeper_profile_defaults
+      | Some json ->
           let keeper_json = Yojson.Safe.Util.member "keeper" json in
           match keeper_json with
           | `Assoc _ ->
@@ -464,7 +464,9 @@ let load_persona_extended ?(max_chars = persona_description_max_chars) name : st
       let path = Filename.concat (Filename.concat root name) "AGENT.md" in
       if Sys.file_exists path then
         match Safe_ops.read_file_safe path with
-        | Error _ -> None
+        | Error msg ->
+          Log.Keeper.warn "[load_agent_md] failed to read %s: %s" path msg;
+          None
         | Ok content ->
           let trimmed = String.trim content in
           if String.length trimmed = 0 then None
@@ -476,9 +478,9 @@ let load_persona_summary name : persona_summary option =
   match persona_profile_path_opt name with
   | None -> None
   | Some path -> (
-      match Safe_ops.read_json_file_safe path with
-      | Error _ -> None
-      | Ok json ->
+      match Safe_ops.read_json_file_logged ~label:"load_persona_summary" path with
+      | None -> None
+      | Some json ->
           let display_name =
             Safe_ops.json_string_opt "name" json |> Option.value ~default:name
           in
@@ -500,9 +502,9 @@ let load_persona_summary name : persona_summary option =
             })
 
 let load_persona_summary_from_path name profile_path : persona_summary option =
-  match Safe_ops.read_json_file_safe profile_path with
-  | Error _ -> None
-  | Ok json ->
+  match Safe_ops.read_json_file_logged ~label:"load_persona_summary_from_path" profile_path with
+  | None -> None
+  | Some json ->
       let display_name =
         Safe_ops.json_string_opt "name" json |> Option.value ~default:name
       in

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -116,7 +116,9 @@ let mkdir_p path =
 let read_json_local path =
   match Safe_ops.read_json_file_safe path with
   | Ok json -> json
-  | Error _ -> `Assoc []
+  | Error msg ->
+    Log.Misc.warn "[read_json_local] %s" msg;
+    `Assoc []
 
 let write_json_local path json =
   mkdir_p (Filename.dirname path);
@@ -138,9 +140,13 @@ let read_json_root config path =
            if trimmed = "" then `Assoc []
            else match Safe_ops.parse_json_safe ~context:"read_json_root" trimmed with
            | Ok json -> json
-           | Error _ -> `Assoc [])
+           | Error msg ->
+             Log.Misc.warn "[read_json_root] %s" msg;
+             `Assoc [])
       | Ok None -> `Assoc []
-      | Error _ -> `Assoc []
+      | Error e ->
+        Log.Misc.warn "[read_json_root] backend_get failed for %s: %s" key (Backend_types.show_error e);
+        `Assoc []
     end
   | None -> read_json_local path
 
@@ -185,11 +191,15 @@ let read_json config path =
       | Ok (Some content) ->
           (let trimmed = String.trim content in
            if trimmed = "" then `Assoc []
-           else match Safe_ops.parse_json_safe ~context:"read_json_root" trimmed with
+           else match Safe_ops.parse_json_safe ~context:"read_json" trimmed with
            | Ok json -> json
-           | Error _ -> `Assoc [])
+           | Error msg ->
+             Log.Misc.warn "[read_json] %s" msg;
+             `Assoc [])
       | Ok None -> `Assoc []
-      | Error _ -> `Assoc []
+      | Error e ->
+        Log.Misc.warn "[read_json] backend_get failed for %s: %s" key (Backend_types.show_error e);
+        `Assoc []
     end
   | None -> read_json_local path
 
@@ -198,7 +208,10 @@ let read_text config path =
   | Some key -> begin
       match backend_get config ~key with
       | Ok (Some content) -> content
-      | Ok None | Error _ -> ""
+      | Ok None -> ""
+      | Error e ->
+        Log.Misc.warn "[read_text] backend_get failed for %s: %s" key (Backend_types.show_error e);
+        ""
     end
   | None ->
       if Fs_compat.file_exists path then Fs_compat.load_file path
@@ -270,7 +283,10 @@ let append_text config path content =
       let existing =
         match backend_get config ~key with
         | Ok (Some value) -> value
-        | Ok None | Error _ -> ""
+        | Ok None -> ""
+        | Error e ->
+          Log.Misc.warn "[append_text] backend_get failed for %s: %s" key (Backend_types.show_error e);
+          ""
       in
       (match backend_set config ~key ~value:(existing ^ content) with
        | Ok () -> ()
@@ -291,9 +307,13 @@ let read_json_opt config path =
           else (
             match Safe_ops.parse_json_safe ~context:"read_json_opt" trimmed with
             | Ok json -> Some json
-            | Error _ -> None)
+            | Error msg ->
+              Log.Misc.warn "[read_json_opt] %s" msg;
+              None)
       | Ok None -> None
-      | Error _ -> None)
+      | Error e ->
+        Log.Misc.warn "[read_json_opt] backend_get failed for %s: %s" key (Backend_types.show_error e);
+        None)
   | None ->
       if Sys.file_exists path then Some (read_json_local path)
       else None


### PR DESCRIPTION
## Summary
- Add `Safe_ops.read_json_file_logged` as a reusable logged wrapper for the common `read_json_file_safe |> Error _ -> None` pattern
- Replace `Error _ -> None/[]/default` silent-swallow patterns with `Log.warn` calls in the **top 5 hotspot files** identified in #5627:
  - `cache_eio.ml` (10 branches) -- `Log.Misc.warn`
  - `room/room_utils_ops.ml` (9 branches) -- `Log.Misc.warn`
  - `keeper/keeper_types_profile.ml` (4 branches) -- `Log.Keeper.warn` + `read_json_file_logged`
  - `agent_card.ml` (6 branches) -- `Log.Misc.warn`
  - `auth.ml` (3 branches) -- `Log.Auth.warn`
- No control flow or return type changes -- only adds logging before the existing fallback return
- Also fixed a copy-paste context label in `read_json` (was `"read_json_root"`)

## Motivation
Issue #5627 tracked 147 HIGH-severity `Error _ -> None/[]` patterns that silently swallow errors. The trigger was #5608 where `read_json_file_safe` returning `Error` was converted to `None`, hiding a malformed JSON bug for days.

## Test plan
- [ ] `dune build` passes (pre-existing `oas_worker_exec.ml` error from OAS SDK field addition is unrelated)
- [ ] Verify log output appears when JSON files are malformed (manual test with corrupt `.json`)
- [ ] No behavior change -- only logging added to existing error branches

## Files changed (7)
| File | Changes |
|------|---------|
| `lib/core/safe_ops.ml` | New `read_json_file_logged` function |
| `lib/core/safe_ops.mli` | Expose `read_json_file_logged` |
| `lib/cache_eio.ml` | 10 `Error _` branches now log |
| `lib/room/room_utils_ops.ml` | 9 `Error _` branches now log |
| `lib/keeper/keeper_types_profile.ml` | 4 branches use `read_json_file_logged` or `Log.Keeper.warn` |
| `lib/agent_card.ml` | 6 `Error _` branches now log |
| `lib/auth.ml` | 3 `Error _` branches now log |

Closes #5627

Generated with [Claude Code](https://claude.com/claude-code)