### PR TITLE
fix(tool): default code_search to literal match and add OAS telemetry field

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.109.0))
+  (agent_sdk (>= 0.110.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -517,6 +517,7 @@ let run
         content = [Oas.Types.Text (Printf.sprintf
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
         usage = None;
+        telemetry = None;
       } in
       Ok
         {

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -92,6 +92,7 @@ let handle_code_search ctx args =
   let path = get_string args "path" "." in
   let file_pattern = get_string args "file_pattern" "" in
   let case_insensitive = get_bool args "case_insensitive" true in
+  let is_regex = get_bool args "is_regex" false in
   let max_results = get_int args "max_results" 50 in
 
   if query = "" then
@@ -120,6 +121,10 @@ let handle_code_search ctx args =
     (* File pattern if specified: -g PATTERN *)
     if file_pattern <> "" then
       rg_args_list := file_pattern :: "-g" :: !rg_args_list;
+
+    (* Fixed-strings mode (default): treat query as literal, not regex *)
+    if not is_regex then
+      rg_args_list := "--fixed-strings" :: !rg_args_list;
 
     (* Case insensitive flag: -i *)
     if case_insensitive then
@@ -329,15 +334,19 @@ let schemas : Types.tool_schema list = [
   (* masc_code_search *)
   {
     name = "masc_code_search";
-    description = "Search code by query using ripgrep with regex, returning structured results (file, line, content). \
-Use when finding function names, patterns, or text across the codebase from within MASC. \
-Pair with masc_code_symbols for file-level symbol outlines or masc_code_read for targeted line ranges.";
+    description = "Search code by query using ripgrep. Default is literal string match; set is_regex=true for regex. \
+Returns structured results (file, line, content).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("query", `Assoc [
           ("type", `String "string");
-          ("description", `String "Search pattern (supports regex)");
+          ("description", `String "Search pattern (literal by default, regex if is_regex=true)");
+        ]);
+        ("is_regex", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Treat query as regex instead of literal string (default: false)");
+          ("default", `Bool false);
         ]);
         ("path", `Assoc [
           ("type", `String "string");

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.109.0"}
+  "agent_sdk" {>= "0.110.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.109.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ae17471564e3f712f8e3d53d6a3cf4b984a1b262"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.109.0"
+readonly OAS_AGENT_SDK_SHA="e9d0bfdcad3573801e7a293d5ce8a2315a0af9c1"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e9d0bfdcad3573801e7a293d5ce8a2315a0af9c1"
+readonly OAS_AGENT_SDK_SHA="ff2ba4ee6cbf8f67f4f2f734419451277160bdb6"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -290,6 +290,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
           stop_reason = Oas.Types.EndTurn;
           content = [];
           usage = None;
+          telemetry = None;
         };
       checkpoint = None;
       session_id = "session-1";


### PR DESCRIPTION
## Summary
- `masc_code_search` now uses `--fixed-strings` by default. LLM-generated queries with regex special chars (`(`, `[`, `{`) no longer cause silent `exit 2` failures.
- New `is_regex` parameter (default `false`) for opt-in regex mode.
- Adds `telemetry = None` to `api_response` constructors for OAS 0.110.0 compatibility.

## Motivation
Keeper `cheolsu` hit repeated `masc_code_search` failures with empty error. Root cause: query contained regex metacharacters → rg exit 2 → `"ripgrep failed: "`. Literal matching is the safe default for LLM tool calls.

## Test plan
- [x] Build clean
- [ ] Runtime: verify code_search works with queries like `foo(bar)` without errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>