### PR TITLE
feat(keeper): consume OAS inference telemetry + semaphore timing

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -34,6 +34,7 @@ type run_result = {
   checkpoint : Agent_sdk.Checkpoint.t option;
   proof : Agent_sdk.Cdal_proof.t option;
   stop_reason : Oas_worker.stop_reason;
+  inference_telemetry : Agent_sdk.Types.inference_telemetry option;
 }
 
 let keeper_tool_usage_snapshot ~base_path ~keeper_name : (string * int) list =
@@ -1355,4 +1356,5 @@ let run_turn
            checkpoint = saved_checkpoint;
            proof = result.proof;
            stop_reason = result.stop_reason;
+           inference_telemetry = result.response.telemetry;
          }))

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -53,13 +53,16 @@ let with_keeper_turn_slot ~channel f =
     | Keeper_world_observation.Scheduled_autonomous -> true
     | Keeper_world_observation.Reactive -> false
   in
+  let t0 = Time_compat.now () in
   if is_autonomous then Eio.Semaphore.acquire autonomous_turn_semaphore;
   Eio.Semaphore.acquire turn_semaphore;
+  let semaphore_wait_ms =
+    int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
   Fun.protect
     ~finally:(fun () ->
       Eio.Semaphore.release turn_semaphore;
       if is_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
-    f
+    (fun () -> f ~semaphore_wait_ms)
 ;;
 
 (** Optional gRPC client + env — WORM Atomic: set at server bootstrap
@@ -702,7 +705,7 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if should_run_turn
       then (
-        with_keeper_turn_slot ~channel:turn_decision.channel (fun () ->
+        with_keeper_turn_slot ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
           match
             Keeper_unified_turn.run_unified_turn
               ~config:ctx.config
@@ -710,6 +713,7 @@ let run_keepalive_unified_turn
               ~observation:obs
               ~generation:meta_after_observe.runtime.generation
               ~channel:turn_decision.channel
+              ~semaphore_wait_ms:semaphore_wait_ms
               ~shared_context
               ()
           with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -209,6 +209,7 @@ let append_decision_record
     ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(latency_ms : int)
+    ?(semaphore_wait_ms : int = 0)
     ~(outcome : string)
     ~(selected_mode : string)
     ?social_state
@@ -279,6 +280,7 @@ let append_decision_record
         ("selected_mode", `String selected_mode);
         ("selected_mode_source", `String "observed_result");
         ("latency_ms", `Int latency_ms);
+        ("semaphore_wait_ms", `Int semaphore_wait_ms);
         ("trigger_signals", `List (List.map (fun s -> `String s) trigger_signals));
         ("observed_affordances", `List (List.map (fun s -> `String s) affordances));
         ( "observation",
@@ -361,6 +363,28 @@ let append_decision_record
                 | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
                     Printf.sprintf "turn_budget_exhausted(%d/%d)" turns_used limit
               in
+              let inference_fields =
+                match r.inference_telemetry with
+                | Some t ->
+                    let timings_fields =
+                      match t.timings with
+                      | Some ti ->
+                          [
+                            ("prompt_ms", match ti.prompt_ms with Some v -> `Float v | None -> `Null);
+                            ("predicted_ms", match ti.predicted_ms with Some v -> `Float v | None -> `Null);
+                            ("provider_tokens_per_second", match ti.predicted_per_second with Some v -> `Float v | None -> `Null);
+                            ("prompt_per_second", match ti.prompt_per_second with Some v -> `Float v | None -> `Null);
+                            ("cache_n", match ti.cache_n with Some v -> `Int v | None -> `Null);
+                          ]
+                      | None -> []
+                    in
+                    [
+                      ("system_fingerprint", match t.system_fingerprint with Some s -> `String s | None -> `Null);
+                      ("reasoning_tokens", match t.reasoning_tokens with Some n -> `Int n | None -> `Null);
+                      ("request_latency_ms", `Int t.request_latency_ms);
+                    ] @ timings_fields
+                | None -> []
+              in
               `Assoc ([
                 ("model_used", `String r.model_used);
                 ("turn_count", `Int r.turn_count);
@@ -374,7 +398,7 @@ let append_decision_record
                   if latency_ms > 0 then
                     `Float (float_of_int r.usage.output_tokens /. (float_of_int latency_ms /. 1000.0))
                   else `Null);
-              ] @ cascade_fields)
+              ] @ inference_fields @ cascade_fields)
           | None -> `Null );
       ]
       @ social_fields)
@@ -785,6 +809,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int)
     ?(channel : Keeper_world_observation.unified_turn_channel = Scheduled_autonomous)
+    ?(semaphore_wait_ms = 0)
     ?shared_context
     () : (keeper_meta, Oas.Error.sdk_error) result =
   (* 1. Check API keys *)
@@ -977,7 +1002,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_transient ~social_state ()
           in
           append_decision_record ~config ~meta:updated_meta ~observation
-            ~latency_ms ~outcome:"error" ~selected_mode:"error"
+            ~latency_ms ~semaphore_wait_ms ~outcome:"error" ~selected_mode:"error"
             ~social_state
             ~error:e_str ();
           (match write_meta config updated_meta with
@@ -1129,7 +1154,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             ~compaction:lifecycle.compaction
             ~handoff_json:lifecycle.handoff_json;
           append_decision_record ~config ~meta:updated_meta ~observation
-            ~latency_ms ~outcome:"success"
+            ~latency_ms ~semaphore_wait_ms ~outcome:"success"
             ~selected_mode:(selected_mode_of_result result)
             ~social_state
             ~result:(Some result) ();

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -84,6 +84,7 @@ val run_unified_turn :
   observation:Keeper_world_observation.world_observation ->
   generation:int ->
   ?channel:Keeper_world_observation.unified_turn_channel ->
+  ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -897,6 +897,7 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     checkpoint = None;
     proof = None;
     stop_reason = Masc_mcp.Oas_worker.Completed;
+    inference_telemetry = None;
   }
 
 let test_metrics_text_response () =


### PR DESCRIPTION
## Summary
- OAS `inference_telemetry` (timings, system_fingerprint, reasoning_tokens)를 decision record에 소비
- `semaphore_wait_ms` 추가 — autonomous turn throttle 대기 시간 관측
- 7파일, +40/-5

## Decision record 새 필드
```json
{
  "telemetry": {
    "system_fingerprint": "b1-25eec6f",
    "reasoning_tokens": null,
    "request_latency_ms": 0,
    "prompt_ms": 572.6,
    "predicted_ms": 1443.1,
    "provider_tokens_per_second": 6.9,
    "prompt_per_second": 22.7,
    "cache_n": 0
  },
  "semaphore_wait_ms": 12
}
```

## 의존
- OAS #685 (merged) — inference_telemetry types + parsing

## Test plan
- [ ] `dune build` pass
- [ ] `dune runtest` pass
- [ ] 서버 재시작 후 decisions.jsonl에 timings 필드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)