### PR TITLE
fix: OAS 0.110.0 telemetry field compat

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -517,6 +517,7 @@ let run
         content = [Oas.Types.Text (Printf.sprintf
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
         usage = None;
+        telemetry = None;
       } in
       Ok
         {

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -290,6 +290,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
           stop_reason = Oas.Types.EndTurn;
           content = [];
           usage = None;
+          telemetry = None;
         };
       checkpoint = None;
       session_id = "session-1";


### PR DESCRIPTION
OAS api_response에 telemetry 필드 추가 대응. 2곳 telemetry=None 추가.