### PR TITLE
fix: add telemetry field to api_response record literals

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -517,6 +517,7 @@ let run
         content = [Oas.Types.Text (Printf.sprintf
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
         usage = None;
+        telemetry = None;
       } in
       Ok
         {

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -290,6 +290,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
           stop_reason = Oas.Types.EndTurn;
           content = [];
           usage = None;
+          telemetry = None;
         };
       checkpoint = None;
       session_id = "session-1";


### PR DESCRIPTION
## Summary
- OAS가 `api_response`에 `telemetry` 필드를 추가하면서 masc-mcp 빌드 깨짐
- `oas_worker_exec.ml`과 `test_team_session_oas_bridge.ml` 2곳에 `telemetry = None` 추가

## Test plan
- [x] 빌드 성공
- [x] keeper_state_machine 103/103 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)