### PR TITLE
chore: bump OAS agent_sdk pin 0.109.0 → 0.110.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.109.0))
+  (agent_sdk (>= 0.110.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -517,6 +517,7 @@ let run
         content = [Oas.Types.Text (Printf.sprintf
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
         usage = None;
+        telemetry = None;
       } in
       Ok
         {

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.109.0"}
+  "agent_sdk" {>= "0.110.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="55cb482eeaeb2b32ddcf9e83e7e9e5e9daa5f938"
+readonly OAS_AGENT_SDK_SHA="e9d0bfdcad3573801e7a293d5ce8a2315a0af9c1"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.109.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ae17471564e3f712f8e3d53d6a3cf4b984a1b262"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.109.0"
+readonly OAS_AGENT_SDK_SHA="55cb482eeaeb2b32ddcf9e83e7e9e5e9daa5f938"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e9d0bfdcad3573801e7a293d5ce8a2315a0af9c1"
+readonly OAS_AGENT_SDK_SHA="ff2ba4ee6cbf8f67f4f2f734419451277160bdb6"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -290,6 +290,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
           stop_reason = Oas.Types.EndTurn;
           content = [];
           usage = None;
+          telemetry = None;
         };
       checkpoint = None;
       session_id = "session-1";


### PR DESCRIPTION
## Summary
- OAS pin bump: ae17471 (v0.109.0) → 55cb482 (v0.110.0)
- Picks up: inference telemetry types, tool_choice propagation, proactive watermark compaction, cascade fallback/timeout fixes
- Adds `telemetry = None` to api_response record literals to satisfy new field from OAS #685

## Test plan
- [x] `dune build --root .` passes
- [x] `test_oas_worker.exe` — 43 tests pass
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>