### PR TITLE
chore: add .ci_build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ sidecars/**/.venv/
 issue*.md
 .nvimlog
 config/personas/uranium666
+.ci_build/


### PR DESCRIPTION
## Summary
- `.ci_build/` 빌드 캐시 디렉토리를 `.gitignore`에 추가

## Product impact
none/internal

## Evidence
main에 28MB `.ci_build/` 아티팩트가 untracked로 남아있었음

## Review evidence
단일 라인 .gitignore 추가

## Linked issue
N/A - housekeeping