### PR TITLE
feat(keeper): phase-level telemetry for turn cycle

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -446,6 +446,7 @@
    keeper_skill_routing
    keeper_alerting
    keeper_alerting_path
+   keeper_timing
    keeper_tool_registry
    keeper_tool_policy_config
    keeper_tool_policy

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -957,28 +957,6 @@ let run_turn
             (Keeper_config.keeper_llm_rerank_enabled ())
             (List.length all_allowed)
             (String.length query_text);
-        (* Tool disclosure telemetry: log which tools the keeper sees each turn.
-           Deterministic measurement — counts only, no thresholds or judgments. *)
-        (let hook_elapsed_ms =
-           Keeper_timing.round1 ((Time_compat.now () -. hook_t0) *. 1000.0)
-         in
-         let disclosure_json = `Assoc [
-           "ts_unix", `Float (Time_compat.now ());
-           "event", `String "tool_disclosure";
-           "keeper_name", `String meta.name;
-           "turn", `Int turn;
-           "core_count", `Int core_count;
-           "discovered_count", `Int discovered_count;
-           "final_visible", `Int (List.length all_allowed);
-           "hook_ms", `Float hook_elapsed_ms;
-         ] in
-         (try
-           Keeper_types_support.append_jsonl_line
-             (Keeper_types_support.keeper_decision_log_path config meta.name)
-             disclosure_json
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | _ -> ()));
         (* 3. Graceful last-turn: inject budget warnings and restrict
            tools when approaching the turn limit.
            - Warning zone (2 turns before limit): inject budget warning
@@ -1107,6 +1085,31 @@ let run_turn
           else
             Some Agent_sdk.Types.Any  (* all other turns: force tool use *)
         in
+        (* Tool disclosure telemetry: emitted after all allow-list rewrites
+           (boring-tool gate, last-turn intersect, max_tools cap) so that
+           final_visible and hook_ms reflect the actual state sent to AdjustParams.
+           Capture now once so ts_unix and hook_ms are consistent. *)
+        (let now = Time_compat.now () in
+         let hook_elapsed_ms =
+           Keeper_timing.round1 ((now -. hook_t0) *. 1000.0)
+         in
+         let disclosure_json = `Assoc [
+           "ts_unix", `Float now;
+           "event", `String "tool_disclosure";
+           "keeper_name", `String meta.name;
+           "turn", `Int turn;
+           "core_count", `Int core_count;
+           "discovered_count", `Int discovered_count;
+           "final_visible", `Int (List.length all_allowed);
+           "hook_ms", `Float hook_elapsed_ms;
+         ] in
+         (try
+           Keeper_types_support.append_jsonl_line
+             (Keeper_types_support.keeper_decision_log_path config meta.name)
+             disclosure_json
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> ()));
         (* Yield after CPU-bound tool filtering to let HTTP handlers run.
            Without this, N concurrent keeper fibers starve the Eio scheduler
            during turn setup (tool list construction + prompt building). *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -800,7 +800,7 @@ let run_turn
     before_turn_params = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.BeforeTurnParams { turn; current_params; messages; _ } ->
-        let hook_t0 = Unix.gettimeofday () in
+        let hook_t0 = Time_compat.now () in
         (* Update current_turn_ref so session-scoped callbacks
            (keeper_tool_search, on_tool_called) use the correct turn. *)
         current_turn_ref := turn;
@@ -960,7 +960,7 @@ let run_turn
         (* Tool disclosure telemetry: log which tools the keeper sees each turn.
            Deterministic measurement — counts only, no thresholds or judgments. *)
         (let hook_elapsed_ms =
-           Keeper_timing.round1 ((Unix.gettimeofday () -. hook_t0) *. 1000.0)
+           Keeper_timing.round1 ((Time_compat.now () -. hook_t0) *. 1000.0)
          in
          let disclosure_json = `Assoc [
            "ts_unix", `Float (Time_compat.now ());
@@ -972,9 +972,13 @@ let run_turn
            "final_visible", `Int (List.length all_allowed);
            "hook_ms", `Float hook_elapsed_ms;
          ] in
-         Keeper_types_support.append_jsonl_line
-           (Keeper_types_support.keeper_decision_log_path config meta.name)
-           disclosure_json);
+         (try
+           Keeper_types_support.append_jsonl_line
+             (Keeper_types_support.keeper_decision_log_path config meta.name)
+             disclosure_json
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> ()));
         (* 3. Graceful last-turn: inject budget warnings and restrict
            tools when approaching the turn limit.
            - Warning zone (2 turns before limit): inject budget warning
@@ -1213,7 +1217,7 @@ let run_turn
       with
       | Error e -> Error e
       | Ok result ->
-        let post_turn_t0 = Unix.gettimeofday () in
+        let post_turn_t0 = Time_compat.now () in
         (* Checkpoint save is deferred until after [STATE] synthesis so the
            persisted checkpoint includes the synthesized continuity block.
            Without this, read_continuity_summary finds no [STATE] in the
@@ -1413,7 +1417,7 @@ let run_turn
            in
            let post_turn_ms =
              Keeper_timing.round1
-               ((Unix.gettimeofday () -. post_turn_t0) *. 1000.0)
+               ((Time_compat.now () -. post_turn_t0) *. 1000.0)
            in
            let eval_json = `Assoc ([
              "ts_unix", `Float (Time_compat.now ());

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -800,6 +800,7 @@ let run_turn
     before_turn_params = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.BeforeTurnParams { turn; current_params; messages; _ } ->
+        let hook_t0 = Unix.gettimeofday () in
         (* Update current_turn_ref so session-scoped callbacks
            (keeper_tool_search, on_tool_called) use the correct turn. *)
         current_turn_ref := turn;
@@ -945,15 +946,35 @@ let run_turn
           end;
           validated
         in
+        let core_count = List.length (Keeper_exec_tools.effective_core_tools ()) in
+        let discovered_count =
+          List.length (Keeper_discovered_tools.active_names !discovered_ref ~turn)
+        in
         if Keeper_types_profile.keeper_debug then
           Log.Keeper.info
             "tool_disclosure keeper=%s core=%d discovered=%d llm_rerank=%b allowed=%d query_len=%d"
-            meta.name
-            (List.length (Keeper_exec_tools.effective_core_tools ()))
-            (List.length (Keeper_discovered_tools.active_names !discovered_ref ~turn))
+            meta.name core_count discovered_count
             (Keeper_config.keeper_llm_rerank_enabled ())
             (List.length all_allowed)
             (String.length query_text);
+        (* Tool disclosure telemetry: log which tools the keeper sees each turn.
+           Deterministic measurement — counts only, no thresholds or judgments. *)
+        (let hook_elapsed_ms =
+           Keeper_timing.round1 ((Unix.gettimeofday () -. hook_t0) *. 1000.0)
+         in
+         let disclosure_json = `Assoc [
+           "ts_unix", `Float (Time_compat.now ());
+           "event", `String "tool_disclosure";
+           "keeper_name", `String meta.name;
+           "turn", `Int turn;
+           "core_count", `Int core_count;
+           "discovered_count", `Int discovered_count;
+           "final_visible", `Int (List.length all_allowed);
+           "hook_ms", `Float hook_elapsed_ms;
+         ] in
+         Keeper_types_support.append_jsonl_line
+           (Keeper_types_support.keeper_decision_log_path config meta.name)
+           disclosure_json);
         (* 3. Graceful last-turn: inject budget warnings and restrict
            tools when approaching the turn limit.
            - Warning zone (2 turns before limit): inject budget warning
@@ -1192,6 +1213,7 @@ let run_turn
       with
       | Error e -> Error e
       | Ok result ->
+        let post_turn_t0 = Unix.gettimeofday () in
         (* Checkpoint save is deferred until after [STATE] synthesis so the
            persisted checkpoint includes the synthesized continuity block.
            Without this, read_continuity_summary finds no [STATE] in the
@@ -1389,6 +1411,10 @@ let run_turn
                  ~candidates)
              else None
            in
+           let post_turn_ms =
+             Keeper_timing.round1
+               ((Unix.gettimeofday () -. post_turn_t0) *. 1000.0)
+           in
            let eval_json = `Assoc ([
              "ts_unix", `Float (Time_compat.now ());
              "event", `String "post_turn_eval";
@@ -1397,6 +1423,7 @@ let run_turn
              "goal_alignment", `Float goal_score;
              "tools_used_count", `Int (List.length tool_names);
              "used_memory_search", `Bool used_search;
+             "post_turn_ms", `Float post_turn_ms;
            ] @ (match recall_eval with
                 | Some e -> [
                     "memory_recall_performed", `Bool e.performed;

--- a/lib/keeper/keeper_timing.ml
+++ b/lib/keeper/keeper_timing.ml
@@ -3,3 +3,11 @@
 (** Round to 1 decimal place for compact JSON output. *)
 let round1 (v : float) : float =
   Float.round (v *. 10.0) /. 10.0
+
+(** [timed f] runs [f ()], returning its result and elapsed time in ms.
+    Uses [Time_compat.now] as the single timing source. *)
+let timed (f : unit -> 'a) : 'a * float =
+  let t0 = Time_compat.now () in
+  let result = f () in
+  let elapsed_ms = (Time_compat.now () -. t0) *. 1000.0 in
+  (result, elapsed_ms)

--- a/lib/keeper/keeper_timing.ml
+++ b/lib/keeper/keeper_timing.ml
@@ -1,0 +1,5 @@
+(** Keeper_timing — deterministic timing helpers for turn cycle telemetry. *)
+
+(** Round to 1 decimal place for compact JSON output. *)
+let round1 (v : float) : float =
+  Float.round (v *. 10.0) /. 10.0

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -239,19 +239,6 @@ let make_tools
                     ("ts_unix", `Float ts);
                   ])
                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                (try
-                  Keeper_types_support.append_jsonl_line
-                    (Keeper_types_support.keeper_decision_log_path config meta.name)
-                    (`Assoc [
-                      "ts_unix", `Float ts;
-                      "event", `String "tool_exec";
-                      "keeper_name", `String meta.name;
-                      "tool", `String td.name;
-                      "duration_ms", `Int duration_ms;
-                      "result_bytes", `Int (String.length result);
-                      "ok", `Bool true;
-                    ])
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 (* Notify session callback (e.g., mark_used for discovered tools) *)
                 (match on_tool_called with Some f -> f td.name | None -> ());
                 (* PR#814 Gap 1: Capture git status delta after successful tool execution.
@@ -282,6 +269,19 @@ let make_tools
                        | _ -> normalized
                      with Yojson.Json_error _ -> normalized)
                 in
+                (try
+                  Keeper_types_support.append_jsonl_line
+                    (Keeper_types_support.keeper_decision_log_path config meta.name)
+                    (`Assoc [
+                      "ts_unix", `Float ts;
+                      "event", `String "tool_exec";
+                      "keeper_name", `String meta.name;
+                      "tool", `String td.name;
+                      "duration_ms", `Int duration_ms;
+                      "result_bytes", `Int (String.length final_result);
+                      "ok", `Bool true;
+                    ])
+                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 (true, final_result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -228,6 +228,7 @@ let make_tools
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:true ~duration_ms;
                 Keeper_exec_tools.notify_tool_call_observers ~tool_name:td.name ~success:true;
+                let ts = Time_compat.now () in
                 (try Sse.broadcast
                   (`Assoc [
                     ("type", `String "keeper_tool_call");
@@ -235,9 +236,22 @@ let make_tools
                     ("tool_name", `String td.name);
                     ("duration_ms", `Int duration_ms);
                     ("success", `Bool true);
-                    ("ts_unix", `Float (Time_compat.now ()));
+                    ("ts_unix", `Float ts);
                   ])
                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+                (try
+                  Keeper_types_support.append_jsonl_line
+                    (Keeper_types_support.keeper_decision_log_path config meta.name)
+                    (`Assoc [
+                      "ts_unix", `Float ts;
+                      "event", `String "tool_exec";
+                      "keeper_name", `String meta.name;
+                      "tool", `String td.name;
+                      "duration_ms", `Int duration_ms;
+                      "result_bytes", `Int (String.length result);
+                      "ok", `Bool true;
+                    ])
+                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 (* Notify session callback (e.g., mark_used for discovered tools) *)
                 (match on_tool_called with Some f -> f td.name | None -> ());
                 (* PR#814 Gap 1: Capture git status delta after successful tool execution.
@@ -271,9 +285,11 @@ let make_tools
                 (true, final_result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+              let ts = Time_compat.now () in
               let duration_ms =
-                int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+                int_of_float ((ts -. t0) *. 1000.0) in
               let count = prior_fails + 1 in
+              let error_text = Printexc.to_string exn in
               Hashtbl.replace failure_counts key count;
               Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
               !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
@@ -285,10 +301,23 @@ let make_tools
                   ("tool_name", `String td.name);
                   ("duration_ms", `Int duration_ms);
                   ("success", `Bool false);
-                  ("error_text", `String (Printexc.to_string exn));
-                  ("ts_unix", `Float (Time_compat.now ()));
+                  ("error_text", `String error_text);
+                  ("ts_unix", `Float ts);
                 ])
                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+              (try
+                Keeper_types_support.append_jsonl_line
+                  (Keeper_types_support.keeper_decision_log_path config meta.name)
+                  (`Assoc [
+                    "ts_unix", `Float ts;
+                    "event", `String "tool_exec";
+                    "keeper_name", `String meta.name;
+                    "tool", `String td.name;
+                    "duration_ms", `Int duration_ms;
+                    "ok", `Bool false;
+                    "error", `String error_text;
+                  ])
+              with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
               let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
                 td.name count max_consecutive_failures
                 (Printexc.to_string exn) in

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -208,6 +208,7 @@ let make_tools
                   if String.length s <= 300 then s
                   else String.sub s 0 300 ^ "..."
                 in
+                let ts = Time_compat.now () in
                 (try Sse.broadcast
                   (`Assoc [
                     ("type", `String "keeper_tool_call");
@@ -216,13 +217,27 @@ let make_tools
                     ("duration_ms", `Int duration_ms);
                     ("success", `Bool false);
                     ("error_text", `String detail);
-                    ("ts_unix", `Float (Time_compat.now ()));
+                    ("ts_unix", `Float ts);
                   ])
                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 Log.Keeper.warn
                   "tool %s returned error result (%d/%d): %s"
                   td.name count max_consecutive_failures detail;
-                (false, normalize_tool_result ~success:false result)
+                let normalized_error = normalize_tool_result ~success:false result in
+                (try
+                  Keeper_types_support.append_jsonl_line
+                    (Keeper_types_support.keeper_decision_log_path config meta.name)
+                    (`Assoc [
+                      "ts_unix", `Float ts;
+                      "event", `String "tool_exec";
+                      "keeper_name", `String meta.name;
+                      "tool", `String td.name;
+                      "duration_ms", `Int duration_ms;
+                      "result_bytes", `Int (String.length normalized_error);
+                      "ok", `Bool false;
+                    ])
+                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+                (false, normalized_error)
               end else begin
                 Hashtbl.remove failure_counts key;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
@@ -305,6 +320,11 @@ let make_tools
                   ("ts_unix", `Float ts);
                 ])
                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+              let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
+                td.name count max_consecutive_failures
+                (Printexc.to_string exn) in
+              Log.Keeper.error "%s" msg;
+              let normalized_exn = normalize_tool_result ~success:false msg in
               (try
                 Keeper_types_support.append_jsonl_line
                   (Keeper_types_support.keeper_decision_log_path config meta.name)
@@ -314,14 +334,11 @@ let make_tools
                     "keeper_name", `String meta.name;
                     "tool", `String td.name;
                     "duration_ms", `Int duration_ms;
+                    "result_bytes", `Int (String.length normalized_exn);
                     "ok", `Bool false;
                     "error", `String error_text;
                   ])
               with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-              let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
-                td.name count max_consecutive_failures
-                (Printexc.to_string exn) in
-              Log.Keeper.error "%s" msg;
-              (false, normalize_tool_result ~success:false msg)))
+              (false, normalized_exn)))
     else None
   ) tool_defs


### PR DESCRIPTION
- [x] Round 1 & 2 review feedback addressed
- [x] `keeper_tools_oas.ml`: Add `error` field to is-failure branch `tool_exec` event (schema consistency with exception path)
- [x] `keeper_agent_run.ml`: Move `hook_t0` to after `effective_selected` (exclude OAS rerank LLM latency from `hook_ms`)
- [x] `keeper_agent_run.ml`: Lift `core`/`discovered` outside `effective_selected`; reuse for `core_count`/`discovered_count`
- [x] `test_keeper_tools_oas.ml`: Add `tool_exec_telemetry` test group (success + error-result paths)
- [x] Code review and CodeQL validation: pass