### PR TITLE
refactor(keeper): simplify anti-polling gate per review

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -897,41 +897,32 @@ let run_turn
         let per_call_turn = turn - start_turn_count in
         let is_last_turn = per_call_turn >= max_turns - 1 in
         let is_warning_zone = per_call_turn >= max_turns - 2 in
+        let append_ctx ctx text =
+          Some (match ctx with None -> text | Some e -> e ^ "\n\n" ^ text)
+        in
         let ctx =
           if is_last_turn then
-            let warning =
-              Printf.sprintf
-                "[LAST TURN] Turn %d/%d. This is your final turn. \
-                 You MUST emit a [STATE]...[/STATE] block now summarizing \
-                 what you accomplished and what the next generation should do. \
-                 Do NOT start new tool work. If you need more turns, call extend_turns."
-                turn max_turns
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+            append_ctx ctx
+              (Printf.sprintf
+                 "[LAST TURN] Turn %d/%d. This is your final turn. \
+                  You MUST emit a [STATE]...[/STATE] block now summarizing \
+                  what you accomplished and what the next generation should do. \
+                  Do NOT start new tool work. If you need more turns, call extend_turns."
+                 turn max_turns)
           else if is_retry then
-            let warning =
-              Printf.sprintf
-                "[RETRY] The previous attempt overflowed the model context. \
-                 Stay concise, prefer already-loaded context, and only use the \
-                 smallest essential tool set if a tool call is strictly necessary. \
-                 Current tool budget: %d."
-                max_tools
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+            append_ctx ctx
+              (Printf.sprintf
+                 "[RETRY] The previous attempt overflowed the model context. \
+                  Stay concise, prefer already-loaded context, and only use the \
+                  smallest essential tool set if a tool call is strictly necessary. \
+                  Current tool budget: %d."
+                 max_tools)
           else if is_warning_zone then
-            let warning =
-              Printf.sprintf
-                "[BUDGET] %d/%d turns used. Wrap up current work and emit \
-                 a [STATE] block. Call extend_turns if you need more time."
-                turn max_turns
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+            append_ctx ctx
+              (Printf.sprintf
+                 "[BUDGET] %d/%d turns used. Wrap up current work and emit \
+                  a [STATE] block. Call extend_turns if you need more time."
+                 turn max_turns)
           else ctx
         in
         (* Boring-tool gate: graduated response to consecutive turns
@@ -943,43 +934,31 @@ let run_turn
         let boring_streak = !boring_consecutive_turns in
         let ctx =
           if boring_streak >= 4 then
-            let warning =
-              Printf.sprintf
-                "[POLLING BLOCKED] %d consecutive turns of only boring \
-                 observation tools (status/heartbeat/task-list/context). \
-                 These tools removed from this turn. Use \
-                 keeper_task_claim, keeper_fs_read, \
-                 keeper_board_post, keeper_shell_readonly — or \
-                 keeper_stay_silent if nothing to do."
-                boring_streak
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+            append_ctx ctx
+              (Printf.sprintf
+                 "[POLLING BLOCKED] %d consecutive turns of only boring \
+                  observation tools (status/heartbeat/task-list/context). \
+                  These tools removed from this turn. Use \
+                  keeper_task_claim, keeper_fs_read, \
+                  keeper_board_post, keeper_shell_readonly — or \
+                  keeper_stay_silent if nothing to do."
+                 boring_streak)
           else if boring_streak >= 3 then
-            let warning =
-              Printf.sprintf
-                "[FINAL POLLING WARNING] %d turns of only boring \
-                 observation tools. Next turn without a productive tool \
-                 will REMOVE all boring observation tools \
-                 (status/heartbeat/task-list/context). Call \
-                 keeper_task_claim, keeper_fs_read, or \
-                 keeper_stay_silent NOW."
-                boring_streak
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
+            append_ctx ctx
+              (Printf.sprintf
+                 "[FINAL POLLING WARNING] %d turns of only boring \
+                  observation tools. Next turn without a productive tool \
+                  will REMOVE all boring observation tools \
+                  (status/heartbeat/task-list/context). Call \
+                  keeper_task_claim, keeper_fs_read, or \
+                  keeper_stay_silent NOW."
+                 boring_streak)
           else if boring_streak >= 2 then
-            let warning =
+            append_ctx ctx
               "[POLLING DETECTED] You spent 2 turns only calling boring \
                observation tools (status/heartbeat/task-list/context). \
                Do productive work: keeper_task_claim, keeper_fs_read, \
                keeper_board_post, or keeper_stay_silent."
-            in
-            (match ctx with
-             | None -> Some warning
-             | Some existing -> Some (existing ^ "\n\n" ^ warning))
           else ctx
         in
         let all_allowed =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -147,14 +147,12 @@ let suggest_alternatives ~(allowed_tools : string list)
     ~(repeated_tools : string list) ~(max_suggestions : int) : string list =
   let repeated_set = Hashtbl.create (List.length repeated_tools) in
   List.iter (fun t -> Hashtbl.replace repeated_set t ()) repeated_tools;
-  (* Exclude core/meta tools that don't produce useful autonomous actions *)
-  let boring_tools = [ "keeper_time_now"; "keeper_context_status";
-    "keeper_tools_list"; "masc_heartbeat"; "masc_status"; "masc_tool_help" ] in
-  let boring_set = Hashtbl.create (List.length boring_tools) in
-  List.iter (fun t -> Hashtbl.replace boring_set t ()) boring_tools;
+  (* Exclude boring/meta tools — uses Keeper_tool_registry SSOT *)
   allowed_tools
   |> List.filter (fun t ->
-       not (Hashtbl.mem repeated_set t) && not (Hashtbl.mem boring_set t))
+       not (Hashtbl.mem repeated_set t)
+       && not (Keeper_tool_registry.is_boring_tool t)
+       && t <> "keeper_stay_silent")
   |> fun candidates ->
      let len = List.length candidates in
      if len <= max_suggestions then candidates
@@ -314,6 +312,10 @@ let make_hooks
                  ("ts_unix", `Float (Unix.gettimeofday ()));
                ])
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        (* Reset same-name streak at turn boundary so it doesn't
+           carry across turns (e.g., 4 calls in turn N + 1 in turn N+1
+           should not hit threshold 5). *)
+        tool_name_streak := ("", 0);
         (* Boring-tool gate: update consecutive counter at end of turn.
            If no productive tool was called this turn, increment the
            boring streak; otherwise reset to 0. *)
@@ -361,11 +363,8 @@ let make_hooks
              ~model:(!meta_ref).runtime.usage.last_model_used ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (* Boring-tool gate: mark turn as productive only for genuinely
-           productive tools. Exclude the documented no-op tool
-           [keeper_stay_silent] so it cannot reset boring-turn tracking. *)
-        if (not (Keeper_tool_registry.is_boring_tool tool_name))
-           && tool_name <> "keeper_stay_silent"
-        then
+           productive tools. keeper_stay_silent is in the boring set. *)
+        if not (Keeper_tool_registry.is_boring_tool tool_name) then
           turn_has_productive_tool := true;
         (try on_tool_executed tool_name input output_text
          with Eio.Cancel.Cancelled _ as e -> raise e
@@ -399,11 +398,12 @@ let make_hooks
           broadcast_tool_skipped ~keeper_name ~tool_name
             ~reason_code:"streak_gate";
           Agent_sdk.Hooks.Override
-            (Printf.sprintf
-               "[tool_skipped] tool=%s source=streak_gate code=streak_gate \
-                reason=%s_called_%d_times_consecutively. \
-                Use a DIFFERENT tool or call keeper_stay_silent."
-               tool_name tool_name new_count)
+            (render_inline_skip_reason
+               ~tool_name
+               ~reason_code:"streak_gate"
+               ~reason_text:(Printf.sprintf
+                 "%s called %d times consecutively. Use a DIFFERENT tool or keeper_stay_silent"
+                 tool_name new_count))
         end
         else
         (* Safety gate 0: Keeper deny list *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -70,11 +70,14 @@ let is_core_always_tool (name : string) : bool =
 
     A tool is "boring" if calling it N times yields the same
     information as calling it once, and it mutates nothing.
+    [keeper_stay_silent] is included: it is a no-op by design
+    and must not reset the boring-turn counter.
     Contrast with [keeper_fs_read] which reads new content, or
     [keeper_board_post] which creates artifacts. *)
 let boring_tools =
   [ "masc_status"; "masc_heartbeat"; "keeper_tasks_list";
-    "keeper_context_status"; "keeper_tools_list" ]
+    "keeper_context_status"; "keeper_tools_list";
+    "keeper_stay_silent" ]
 
 let boring_tools_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length boring_tools) in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2115,9 +2115,9 @@ let () =
           test_case "keeper_task_claim is NOT boring" `Quick (fun () ->
             check bool "keeper_task_claim"
               false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_task_claim"));
-          test_case "keeper_stay_silent is NOT boring" `Quick (fun () ->
+          test_case "keeper_stay_silent IS boring (no-op)" `Quick (fun () ->
             check bool "keeper_stay_silent"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_stay_silent"));
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_stay_silent"));
           test_case "keeper_bash is NOT boring" `Quick (fun () ->
             check bool "keeper_bash"
               false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_bash"));


### PR DESCRIPTION
## Summary
`/simplify` 3-agent 리뷰 결과 반영. #5623 후속.

## Fixes
1. **BUG**: `tool_name_streak` 턴 경계에서 리셋 안 됨 — turn N에서 4회 + turn N+1에서 1회 = 5회로 잘못 차단
2. **SSOT**: `suggest_alternatives`의 inline boring list 제거 → `Keeper_tool_registry.is_boring_tool` SSOT 사용
3. **DRY**: `append_ctx` 헬퍼 추출 — 6x 반복 `match ctx` 패턴 제거 (-18줄)
4. **일관성**: streak gate `Override` → `render_inline_skip_reason` 사용 (dashboard 파서 호환)
5. **분류 통합**: `keeper_stay_silent` → `boring_tools`에 추가, 별도 문자열 비교 제거

## Stats
+63/-81 — 코드량 감소

## Test plan
- [x] 107 tests pass (keeper_stay_silent assertion 업데이트)

Generated with [Claude Code](https://claude.com/claude-code)