### PR TITLE
feat(tool): add keeper_board_cleanup composite tool

### DIFF
--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -43,5 +43,6 @@ execution_scope = "workspace"
 tool_preset = "social"
 tool_also_allow = [
   "keeper_board_delete",
+  "keeper_board_cleanup",
   "masc_cleanup_zombies",
 ]

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -73,7 +73,7 @@ tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "
 # Optional tools that require explicit opt-in via also_allow.
 # Excluded from all presets by default; a keeper must list them in also_allow.
 [groups.optional]
-tools = ["keeper_board_delete"]
+tools = ["keeper_board_delete", "keeper_board_cleanup"]
 
 # ── MASC Tool Groups ───────────────────────────────────────────────
 

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -259,6 +259,7 @@ let handle_keeper_board_tool
   | "keeper_board_stats" -> dispatch "masc_board_stats" args
   | "keeper_board_search" -> dispatch "masc_board_search" args
   | "keeper_board_delete" -> dispatch "masc_board_delete" args
+  | "keeper_board_cleanup" -> dispatch "masc_board_cleanup" args
   | other -> error_json ~fields:[ "tool", `String other ] "unknown_board_tool"
 ;;
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -786,7 +786,6 @@ let tools = [
   tool_profile;
   tool_hearth_list;
   tool_delete;
-  tool_board_cleanup;
 ]
 
 (** Tool dispatcher *)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -654,6 +654,70 @@ let handle_delete args =
     | Ok () -> (true, Printf.sprintf "Deleted post %s" post_id)
     | Error e -> (false, Printf.sprintf "Delete failed: %s" (board_error_to_string e))
 
+let handle_board_cleanup args =
+  let max_age_hours = get_int args "max_age_hours" 24 |> max 1 in
+  let require_no_comments = get_bool args "require_no_comments" true in
+  let require_no_votes = get_bool args "require_no_votes" true in
+  let dry_run = get_bool args "dry_run" true in
+  let limit = get_int args "limit" 10 |> max 1 |> min 50 in
+  let title_pattern = get_string_opt args "title_pattern" in
+  let author_pattern = get_string_opt args "author_pattern" in
+  let now = Time_compat.now () in
+  let age_threshold = now -. (float_of_int max_age_hours *. 3600.0) in
+  let title_re = Option.map (fun p ->
+    Re.str (String.lowercase_ascii p) |> Re.compile) title_pattern in
+  let author_re = Option.map (fun p ->
+    Re.str (String.lowercase_ascii p) |> Re.compile) author_pattern in
+  let matches_opt re s =
+    match re with
+    | None -> true
+    | Some compiled -> Re.execp compiled (String.lowercase_ascii s)
+  in
+  let all_posts =
+    Board_dispatch.list_posts ~sort_by:Recent ~limit:500 ()
+  in
+  let candidates =
+    List.filter (fun (p : Board.post) ->
+      p.created_at < age_threshold
+      && (not require_no_comments || p.reply_count = 0)
+      && (not require_no_votes || (p.votes_up = 0 && p.votes_down = 0))
+      && matches_opt title_re p.title
+      && matches_opt author_re (Board.Agent_id.to_string p.author))
+      all_posts
+  in
+  let targets = List.filteri (fun i _ -> i < limit) candidates in
+  if dry_run then begin
+    let count = List.length targets in
+    if count = 0 then
+      (true, Printf.sprintf "Scan complete: 0 candidates (scanned %d posts, age>%dh)"
+         (List.length all_posts) max_age_hours)
+    else
+      let lines = List.map (fun (p : Board.post) ->
+        Printf.sprintf "  - %s | %s | by %s | %s | replies=%d votes=%d"
+          (Board.Post_id.to_string p.id)
+          p.title
+          (Board.Agent_id.to_string p.author)
+          (format_timestamp_relative p.created_at)
+          p.reply_count
+          (p.votes_up + p.votes_down))
+        targets
+      in
+      (true, Printf.sprintf "Dry-run: %d candidates (scanned %d, age>%dh):\n%s"
+         count (List.length all_posts) max_age_hours
+         (String.concat "\n" lines))
+  end else begin
+    let deleted = ref 0 in
+    let failed = ref 0 in
+    List.iter (fun (p : Board.post) ->
+      let pid = Board.Post_id.to_string p.id in
+      match Board_dispatch.delete_post ~post_id:pid with
+      | Ok () -> incr deleted
+      | Error _ -> incr failed)
+      targets;
+    (true, Printf.sprintf "Cleanup done: %d deleted, %d failed (scanned %d, age>%dh)"
+       !deleted !failed (List.length all_posts) max_age_hours)
+  end
+
 let tool_delete : Types.tool_schema = {
   name = "masc_board_delete";
   description = "Delete a board post and its associated comments and votes. Use for cleanup of stale, test, or expired posts.";
@@ -663,6 +727,47 @@ let tool_delete : Types.tool_schema = {
       ("post_id", `Assoc [("type", `String "string"); ("description", `String "ID of the post to delete")]);
     ]);
     ("required", `List [`String "post_id"]);
+  ];
+}
+
+let tool_board_cleanup : Types.tool_schema = {
+  name = "masc_board_cleanup";
+  description = "Scan board posts matching filter criteria and delete or report them. \
+Defaults to dry_run=true (report only). Set dry_run=false to delete. \
+Safety: never deletes posts with comments or votes unless filters are overridden.";
+  input_schema = `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc [
+      ("max_age_hours", `Assoc [
+        ("type", `String "integer");
+        ("description", `String "Only target posts older than this (default: 24)");
+      ]);
+      ("require_no_comments", `Assoc [
+        ("type", `String "boolean");
+        ("description", `String "Only target posts with 0 replies (default: true)");
+      ]);
+      ("require_no_votes", `Assoc [
+        ("type", `String "boolean");
+        ("description", `String "Only target posts with 0 votes (default: true)");
+      ]);
+      ("title_pattern", `Assoc [
+        ("type", `String "string");
+        ("description", `String "Substring filter on post title (case-insensitive)");
+      ]);
+      ("author_pattern", `Assoc [
+        ("type", `String "string");
+        ("description", `String "Substring filter on post author (case-insensitive)");
+      ]);
+      ("dry_run", `Assoc [
+        ("type", `String "boolean");
+        ("description", `String "If true (default), only report candidates without deleting");
+      ]);
+      ("limit", `Assoc [
+        ("type", `String "integer");
+        ("description", `String "Max posts to process (default: 10, max: 50)");
+      ]);
+    ]);
+    ("required", `List []);
   ];
 }
 
@@ -679,6 +784,7 @@ let tools = [
   tool_profile;
   tool_hearth_list;
   tool_delete;
+  tool_board_cleanup;
 ]
 
 (** Tool dispatcher *)
@@ -695,6 +801,7 @@ let handle_tool name args =
   | "masc_board_profile" -> handle_profile args
   | "masc_board_hearths" -> handle_hearth_list args
   | "masc_board_delete" -> handle_delete args
+  | "masc_board_cleanup" -> handle_board_cleanup args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)
 
 let register () =

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -710,9 +710,11 @@ let handle_board_cleanup args =
     let failed = ref 0 in
     List.iter (fun (p : Board.post) ->
       let pid = Board.Post_id.to_string p.id in
-      match Board_dispatch.delete_post ~post_id:pid with
-      | Ok () -> incr deleted
-      | Error _ -> incr failed)
+      (try
+        match Board_dispatch.delete_post ~post_id:pid with
+        | Ok () -> incr deleted
+        | Error _ -> incr failed
+      with _exn -> incr failed))
       targets;
     (true, Printf.sprintf "Cleanup done: %d deleted, %d failed (scanned %d, age>%dh)"
        !deleted !failed (List.length all_posts) max_age_hours)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -186,6 +186,39 @@ expired automation, or other explicitly-approved cleanup cases.";
       ("required", `List [`String "post_id"]);
     ];
   };
+  {
+    name = "keeper_board_cleanup";
+    description = "Batch scan and cleanup board posts matching filter criteria. \
+Defaults to dry_run=true (report candidates only). \
+Set dry_run=false to delete matched posts. \
+Safe defaults: only targets posts older than 24h with no comments and no votes.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("max_age_hours", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Only target posts older than this many hours (default: 24)");
+        ]);
+        ("title_pattern", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Substring filter on post title (case-insensitive)");
+        ]);
+        ("author_pattern", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Substring filter on post author (case-insensitive)");
+        ]);
+        ("dry_run", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true (default), report candidates without deleting");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Max posts to process (default: 10, max: 50)");
+        ]);
+      ]);
+      ("required", `List []);
+    ];
+  };
 ]
 
 let select_named_schemas (names : string list) (schemas : Types.tool_schema list) :


### PR DESCRIPTION
## Summary
- `keeper_board_cleanup` composite tool 추가: batch scan + filter + delete/report
- janitor가 3-5 tool call/post 대신 1-2 call/sweep으로 청소 가능
- dry_run=true 기본값 (안전: 먼저 후보 보고, 명시적으로 삭제)

## 변경 파일
- `lib/tool_board.ml` — handle_board_cleanup 핸들러
- `lib/tool_shard.ml` — keeper_board_cleanup 스키마
- `lib/keeper/keeper_exec_tools.ml` — 디스패치 추가
- `config/tool_policy.toml` — optional 그룹에 등록
- `config/keepers/janitor.toml` — tool_also_allow에 추가

## 파라미터
| 이름 | 타입 | 기본값 | 설명 |
|------|------|--------|------|
| max_age_hours | int | 24 | 이 시간보다 오래된 글만 대상 |
| require_no_comments | bool | true | 댓글 없는 글만 대상 |
| require_no_votes | bool | true | 투표 없는 글만 대상 |
| title_pattern | string? | - | 제목 substring 필터 |
| author_pattern | string? | - | 작성자 substring 필터 |
| dry_run | bool | true | true=보고만, false=삭제 |
| limit | int | 10 | 최대 처리 수 (max 50) |

## Product impact
repo coordination — janitor keeper 효율 개선, streak_gate 발동 감소

## Evidence
- 기존 board_get 20+ 반복 → streak_gate 발동 패턴 해소
- Board_dispatch.delete_posts_by_predicate 재사용 대신 직접 필터링 (더 세밀한 제어)

## Review evidence
빌드 통과 (`dune build` clean)

## Linked issue
Phase 3 of keeper autonomy improvement plan