### PR TITLE
feat(keeper): activate TopK_llm tool selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [2.255.0] - 2026-04-07
+
+### Added
+- **TopK_llm tool selection** -- activate OAS Tool_selector.TopK_llm in keeper
+  before_turn_hook. 2-stage selection: BM25 pre-filter then LLM reranking via
+  `default_rerank_fn`. Gated by `MASC_KEEPER_LLM_RERANK=true` (default off).
+  Self-healing fallback to BM25 on LLM failure. 8 new tests.
+
 ## [2.254.0] - 2026-04-07
 
 ### Added

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -38,8 +38,11 @@
   "spawn_glm_models": ["llama:auto", "glm:auto"],
   "keeper_unified_models": ["llama:auto", "glm:auto"],
   "research_models": ["llama:auto", "glm:auto"],
+  "tool_rerank_models": ["llama:auto", "glm:auto"],
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
+  "tool_rerank_temperature": 0.0,
+  "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,
   "keeper_unified_max_tokens": 65536,
   "keeper_autonomy_temperature": 0.1,

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.254.0)
+(version 2.255.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -868,9 +868,11 @@ let run_turn
                 let preset_names =
                   Keeper_tool_policy.keeper_preset_universe_tool_names meta
                 in
+                let preset_set = Hashtbl.create (List.length preset_names) in
+                List.iter (fun n -> Hashtbl.replace preset_set n true) preset_names;
                 let preset_tools =
                   List.filter (fun (t : Agent_sdk.Tool.t) ->
-                    List.mem t.schema.name preset_names
+                    Hashtbl.mem preset_set t.schema.name
                   ) keeper_tools
                 in
                 let strategy = Agent_sdk.Tool_selector.TopK_llm {

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -840,17 +840,68 @@ let run_turn
         let visible_always_include_tools =
           Tool_portal.filter_visible_tool_names portal_ctx always_include_tools
         in
-        (* Core + discovered tools: the keeper discovers additional tools
-           on demand via keeper_tool_search.  BM25 auto-selection (previously
-           computed here via Tool_selector.select_names) was removed — only
-           tools explicitly requested via keeper_tool_search appear. *)
+        (* Progressive tool disclosure: core tools are always visible;
+           additional tools are selected by BM25 + optional LLM reranking
+           (TopK_llm, gated by MASC_KEEPER_LLM_RERANK env var).
+           When LLM rerank is disabled, only tools explicitly discovered
+           via keeper_tool_search appear alongside core. *)
         let effective_selected =
           let core = Keeper_exec_tools.effective_core_tools () in
           let discovered =
             Keeper_discovered_tools.active_names !discovered_ref ~turn
           in
           let _ = Keeper_discovered_tools.decay !discovered_ref ~turn in
-          Keeper_types.dedupe_keep_order (core @ discovered)
+          let llm_selected =
+            if Keeper_config.keeper_llm_rerank_enabled () then
+              match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+              | Some sw, Some net ->
+                let rerank_cascade = Keeper_config.keeper_llm_rerank_cascade () in
+                let defaults = Oas_worker.default_model_strings ~cascade_name:rerank_cascade in
+                let config_path = Oas_worker.default_config_path () in
+                let named_cascade = Agent_sdk.Api.named_cascade
+                  ?config_path ~name:rerank_cascade ~defaults () in
+                let k = min max_tools 10 in
+                let rerank_fn = Agent_sdk.Tool_selector.default_rerank_fn
+                  ~sw ~net ~named_cascade ~k () in
+                (* Preset-scoped tools: filter keeper_tools to the current
+                   preset universe so BM25 ranks within relevant tools only. *)
+                let preset_names =
+                  Keeper_tool_policy.keeper_preset_universe_tool_names meta
+                in
+                let preset_tools =
+                  List.filter (fun (t : Agent_sdk.Tool.t) ->
+                    List.mem t.schema.name preset_names
+                  ) keeper_tools
+                in
+                let strategy = Agent_sdk.Tool_selector.TopK_llm {
+                  k;
+                  bm25_prefilter_n = min 30 (List.length preset_tools);
+                  always_include = core;
+                  confidence_threshold = 0.3;
+                  rerank_fn;
+                } in
+                (try
+                  let selected = Agent_sdk.Tool_selector.select_names
+                    ~strategy ~context:query_text ~tools:preset_tools in
+                  if Keeper_types_profile.keeper_debug then
+                    Log.Keeper.info
+                      "keeper:%s TopK_llm selected %d tools (query_len=%d, candidates=%d)"
+                      meta.name (List.length selected)
+                      (String.length query_text) (List.length preset_tools);
+                  selected
+                with exn ->
+                  Log.Keeper.warn
+                    "keeper:%s TopK_llm failed (%s), falling back to core+discovered"
+                    meta.name (Printexc.to_string exn);
+                  [])
+              | _ ->
+                Log.Keeper.warn
+                  "keeper:%s TopK_llm: Eio context unavailable, falling back"
+                  meta.name;
+                []
+            else []
+          in
+          Keeper_types.dedupe_keep_order (core @ llm_selected @ discovered)
           |> Tool_portal.filter_visible_tool_names portal_ctx
         in
         (* Apply runtime tool overlay (masc_tool_grant/revoke) and
@@ -890,10 +941,11 @@ let run_turn
         in
         if Keeper_types_profile.keeper_debug then
           Log.Keeper.info
-            "tool_disclosure keeper=%s core=%d discovered=%d allowed=%d query_len=%d"
+            "tool_disclosure keeper=%s core=%d discovered=%d llm_rerank=%b allowed=%d query_len=%d"
             meta.name
             (List.length (Keeper_exec_tools.effective_core_tools ()))
             (List.length (Keeper_discovered_tools.active_names !discovered_ref ~turn))
+            (Keeper_config.keeper_llm_rerank_enabled ())
             (List.length all_allowed)
             (String.length query_text);
         (* 3. Graceful last-turn: inject budget warnings and restrict

--- a/test/dune
+++ b/test/dune
@@ -95,7 +95,8 @@
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
-        test_telemetry_unified)
+        test_telemetry_unified
+        test_keeper_topk_llm)
  (modules test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -158,7 +159,8 @@
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine
-          test_telemetry_unified)
+          test_telemetry_unified
+          test_keeper_topk_llm)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -1,0 +1,232 @@
+(** test_keeper_topk_llm — Verify TopK_llm integration in keeper tool selection.
+
+    Tests the OAS Tool_selector.TopK_llm strategy as wired by the keeper's
+    before_turn_hook. Uses mock rerank_fn closures (no LLM calls).
+
+    @since 2.255.0 — PR-4: TopK_llm activation *)
+
+open Masc_mcp
+
+(* ── Helpers ─────────────────────────────────────────────── *)
+
+(** Create a minimal OAS Tool.t from name and description. *)
+let make_tool name description : Agent_sdk.Tool.t =
+  Agent_sdk.Tool.create ~name ~description ~parameters:[]
+    (fun _input -> Ok { content = "ok" })
+
+(** A mock rerank_fn that returns the first [k] candidates in order. *)
+let mock_rerank_passthrough ~context:_ ~candidates =
+  List.map fst candidates
+
+(** A mock rerank_fn that reverses candidate order (verifies reranking effect). *)
+let mock_rerank_reverse ~context:_ ~candidates =
+  List.rev_map fst candidates
+
+(** A mock rerank_fn that always selects tools containing a keyword. *)
+let mock_rerank_keyword keyword ~context:_ ~candidates =
+  List.filter_map (fun (name, _desc) ->
+    if String.length name >= String.length keyword
+       && let found = ref false in
+          for i = 0 to String.length name - String.length keyword do
+            if String.sub name i (String.length keyword) = keyword then
+              found := true
+          done;
+          !found
+    then Some name
+    else None
+  ) candidates
+
+(** A mock rerank_fn that always raises. *)
+let mock_rerank_failing ~context:_ ~candidates:_ =
+  failwith "LLM unavailable"
+
+(* ── Test tools ──────────────────────────────────────────── *)
+
+let test_tools = [
+  make_tool "keeper_board_post" "Post a message to the board";
+  make_tool "keeper_board_get" "Read a board post by ID";
+  make_tool "keeper_board_list" "List recent board posts";
+  make_tool "keeper_fs_read" "Read a file from the filesystem";
+  make_tool "keeper_fs_edit" "Edit a file on the filesystem";
+  make_tool "keeper_shell_readonly" "Execute a read-only shell command";
+  make_tool "keeper_bash" "Execute a shell command";
+  make_tool "keeper_github" "Interact with GitHub API";
+  make_tool "keeper_memory_search" "Search agent memory";
+  make_tool "keeper_broadcast" "Broadcast a message to all agents";
+  make_tool "keeper_tasks_list" "List all tasks";
+  make_tool "keeper_task_claim" "Claim a task";
+  make_tool "keeper_task_done" "Mark a task as done";
+  make_tool "keeper_context_status" "Check context window usage";
+  make_tool "keeper_tools_list" "List available tools";
+  make_tool "keeper_stay_silent" "Do nothing (no-op tool)";
+  make_tool "keeper_tool_search" "Search for tools by keyword";
+  make_tool "masc_code_search" "Search code in the repository";
+  make_tool "masc_code_edit" "Edit code files";
+  make_tool "masc_worktree_create" "Create a git worktree";
+]
+
+(* ── Tests ───────────────────────────────────────────────── *)
+
+let test_topk_llm_basic_selection () =
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 5;
+    bm25_prefilter_n = 15;
+    always_include = ["keeper_context_status"];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_passthrough;
+  } in
+  let selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"post a message on the board" ~tools:test_tools in
+  Alcotest.(check bool) "non-empty result" true (selected <> []);
+  Alcotest.(check bool) "always_include present"
+    true (List.mem "keeper_context_status" selected);
+  Alcotest.(check bool) "at most k+always results"
+    true (List.length selected <= 6)
+
+let test_topk_llm_rerank_effect () =
+  let passthrough_strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 3;
+    bm25_prefilter_n = 10;
+    always_include = [];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_passthrough;
+  } in
+  let reverse_strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 3;
+    bm25_prefilter_n = 10;
+    always_include = [];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_reverse;
+  } in
+  let context = "read a file from disk" in
+  let pass_names = Agent_sdk.Tool_selector.select_names
+    ~strategy:passthrough_strategy ~context ~tools:test_tools in
+  let rev_names = Agent_sdk.Tool_selector.select_names
+    ~strategy:reverse_strategy ~context ~tools:test_tools in
+  (* Reranking should change the result set when candidates > k *)
+  Alcotest.(check bool) "reranking changes results"
+    true (pass_names <> rev_names || List.length test_tools <= 3)
+
+let test_topk_llm_fallback_on_failure () =
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 3;
+    bm25_prefilter_n = 10;
+    always_include = ["keeper_stay_silent"];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_failing;
+  } in
+  (* Should not raise — OAS catches the exception and falls back to BM25 *)
+  let selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"search code" ~tools:test_tools in
+  Alcotest.(check bool) "fallback returns results" true (selected <> []);
+  Alcotest.(check bool) "always_include survives failure"
+    true (List.mem "keeper_stay_silent" selected)
+
+let test_topk_llm_confidence_gate () =
+  let call_count = ref 0 in
+  let counting_rerank ~context:_ ~candidates =
+    incr call_count;
+    List.map fst candidates
+  in
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 3;
+    bm25_prefilter_n = 10;
+    always_include = [];
+    confidence_threshold = 999.0;  (* Impossibly high — will always skip LLM *)
+    rerank_fn = counting_rerank;
+  } in
+  let _selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"anything" ~tools:test_tools in
+  Alcotest.(check int) "LLM not called when confidence below threshold"
+    0 !call_count
+
+let test_topk_llm_empty_tools () =
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 5;
+    bm25_prefilter_n = 10;
+    always_include = [];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_passthrough;
+  } in
+  let selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"anything" ~tools:[] in
+  Alcotest.(check (list string)) "empty tools -> empty result" [] selected
+
+let test_topk_llm_keyword_rerank () =
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 5;
+    bm25_prefilter_n = 20;
+    always_include = [];
+    confidence_threshold = 0.0;
+    rerank_fn = mock_rerank_keyword "board";
+  } in
+  let selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"board post message" ~tools:test_tools in
+  (* All selected should contain "board" *)
+  List.iter (fun name ->
+    Alcotest.(check bool)
+      (Printf.sprintf "%s contains 'board'" name)
+      true
+      (String.length name >= 5
+       && let found = ref false in
+          for i = 0 to String.length name - 5 do
+            if String.sub name i 5 = "board" then found := true
+          done;
+          !found)
+  ) selected
+
+let test_topk_llm_always_include_survives () =
+  let strategy = Agent_sdk.Tool_selector.TopK_llm {
+    k = 2;
+    bm25_prefilter_n = 5;
+    always_include = ["keeper_stay_silent"; "keeper_context_status"];
+    confidence_threshold = 0.0;
+    rerank_fn = (fun ~context:_ ~candidates ->
+      (* Return only board tools — always_include should still appear *)
+      List.filter_map (fun (name, _) ->
+        if String.length name > 6 && String.sub name 0 6 = "keeper" then Some name
+        else None
+      ) candidates
+      |> List.filteri (fun i _ -> i < 1));
+  } in
+  let selected = Agent_sdk.Tool_selector.select_names
+    ~strategy ~context:"do something" ~tools:test_tools in
+  Alcotest.(check bool) "always_include[0] present"
+    true (List.mem "keeper_stay_silent" selected);
+  Alcotest.(check bool) "always_include[1] present"
+    true (List.mem "keeper_context_status" selected)
+
+let test_keeper_config_defaults () =
+  (* Default: LLM rerank disabled *)
+  Alcotest.(check bool) "llm_rerank disabled by default"
+    false (Keeper_config.keeper_llm_rerank_enabled ());
+  (* Default cascade name *)
+  let cascade = Keeper_config.keeper_llm_rerank_cascade () in
+  Alcotest.(check string) "default cascade name"
+    "tool_rerank" cascade
+
+(* ── Suite ───────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "keeper_topk_llm" [
+    "topk_llm_selection", [
+      Alcotest.test_case "basic selection" `Quick
+        test_topk_llm_basic_selection;
+      Alcotest.test_case "rerank effect" `Quick
+        test_topk_llm_rerank_effect;
+      Alcotest.test_case "fallback on rerank failure" `Quick
+        test_topk_llm_fallback_on_failure;
+      Alcotest.test_case "confidence gate skips LLM" `Quick
+        test_topk_llm_confidence_gate;
+      Alcotest.test_case "empty tools" `Quick
+        test_topk_llm_empty_tools;
+      Alcotest.test_case "keyword reranker" `Quick
+        test_topk_llm_keyword_rerank;
+      Alcotest.test_case "always_include survives" `Quick
+        test_topk_llm_always_include_survives;
+    ];
+    "keeper_config", [
+      Alcotest.test_case "config defaults" `Quick
+        test_keeper_config_defaults;
+    ];
+  ]

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -24,16 +24,16 @@ let mock_rerank_reverse ~context:_ ~candidates =
 
 (** A mock rerank_fn that always selects tools containing a keyword. *)
 let mock_rerank_keyword keyword ~context:_ ~candidates =
+  let klen = String.length keyword in
   List.filter_map (fun (name, _desc) ->
-    if String.length name >= String.length keyword
-       && let found = ref false in
-          for i = 0 to String.length name - String.length keyword do
-            if String.sub name i (String.length keyword) = keyword then
-              found := true
-          done;
-          !found
-    then Some name
-    else None
+    let nlen = String.length name in
+    if nlen < klen then None
+    else
+      let found = ref false in
+      for i = 0 to nlen - klen do
+        if String.sub name i klen = keyword then found := true
+      done;
+      if !found then Some name else None
   ) candidates
 
 (** A mock rerank_fn that always raises. *)
@@ -163,16 +163,20 @@ let test_topk_llm_keyword_rerank () =
   let selected = Agent_sdk.Tool_selector.select_names
     ~strategy ~context:"board post message" ~tools:test_tools in
   (* All selected should contain "board" *)
+  let contains_board name =
+    let nlen = String.length name in
+    if nlen < 5 then false
+    else
+      let found = ref false in
+      for i = 0 to nlen - 5 do
+        if String.sub name i 5 = "board" then found := true
+      done;
+      !found
+  in
   List.iter (fun name ->
     Alcotest.(check bool)
       (Printf.sprintf "%s contains 'board'" name)
-      true
-      (String.length name >= 5
-       && let found = ref false in
-          for i = 0 to String.length name - 5 do
-            if String.sub name i 5 = "board" then found := true
-          done;
-          !found)
+      true (contains_board name)
   ) selected
 
 let test_topk_llm_always_include_survives () =


### PR DESCRIPTION
## Summary

- Wire OAS `Tool_selector.TopK_llm` into keeper `before_turn_hook`
- 2-stage selection: BM25 pre-filter (preset-scoped) → LLM reranking via `default_rerank_fn`
- Gated by `MASC_KEEPER_LLM_RERANK=true` (default off for safe rollout)
- Self-healing: LLM failure → BM25 top-k fallback (OAS built-in)
- Confidence gate: low BM25 score → skip LLM, use BM25 directly
- 8 new tests with mock rerank closures (no LLM calls)
- Existing `keeper_llm_rerank_enabled` / `keeper_llm_rerank_cascade` config now wired

## Changed files

| File | Change |
|------|--------|
| `lib/keeper/keeper_agent_run.ml` | TopK_llm in before_turn_hook (+51 lines) |
| `test/test_keeper_topk_llm.ml` | 8 new tests (new file) |
| `test/dune` | Register new test |
| `dune-project` | 2.254.0 → 2.255.0 |
| `CHANGELOG.md` | Document TopK_llm activation |

## Architecture

```
before_turn_hook (per turn)
├── core_tools (always visible, ~7)
├── llm_selected (NEW, when MASC_KEEPER_LLM_RERANK=true)
│   ├── BM25 pre-filter (preset-scoped tools, top 30)
│   ├── confidence gate (skip LLM if top_score < 0.3)
│   └── LLM rerank via Cascade_config (tool_rerank cascade)
├── discovered_tools (from keeper_tool_search)
└── overlay (masc_tool_grant/revoke)
```

## Test plan

- [x] 8 unit tests pass (mock rerank, no LLM)
- [ ] CI Build and Test
- [ ] CI Lint
- [ ] Integration: `MASC_KEEPER_LLM_RERANK=true` with live keeper

🤖 Generated with [Claude Code](https://claude.com/claude-code)