### PR TITLE
feat(keeper): expose lifecycle observability — transitions API, state diagram, phase SSE

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -38,7 +38,7 @@ function eventMatchesFilter(entry: JournalEntry, filter: FilterKind): boolean {
     case 'error':
       return et === 'keeper_guardrail' || isErrorJournalEntry(entry)
     case 'lifecycle':
-      return et === 'agent_joined' || et === 'agent_left' || et === 'keeper_handoff' || et === 'keeper_compaction'
+      return et === 'agent_joined' || et === 'agent_left' || et === 'keeper_handoff' || et === 'keeper_compaction' || et === 'keeper_phase_changed'
     default:
       return true
   }

--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -94,6 +94,7 @@ export function classifyJournalKind(entry: JournalEntry): 'board' | 'tasks' | 'k
     case 'keeper_handoff':
     case 'keeper_compaction':
     case 'keeper_guardrail':
+    case 'keeper_phase_changed':
       return 'keepers'
     default:
       return 'system'

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -207,6 +207,7 @@ export function eventKindLabel(entry: JournalEntry): string {
   if (type === 'keeper_handoff') return 'handoff'
   if (type === 'keeper_compaction') return 'compact'
   if (type === 'keeper_guardrail') return 'guardrail'
+  if (type === 'keeper_phase_changed') return 'phase'
   if (entry.kind === 'board') return 'board'
   if (entry.kind === 'tasks') return 'task'
   if (entry.kind === 'keepers') return 'keeper'

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -106,6 +106,7 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   keeper_handoff:        { target: 'execution' },
   keeper_compaction:     { target: 'execution' },
   keeper_guardrail:      { target: 'execution' },
+  keeper_phase_changed:  { target: 'execution' },
   // Client input
   client_input_approved:  { target: 'operator', debounceMs: SSE_OPERATOR_DEBOUNCE_MS },
   client_input_rejected:  { target: 'operator', debounceMs: SSE_OPERATOR_DEBOUNCE_MS },
@@ -141,7 +142,7 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
 // --- Named handlers for complex events ---
 
 const KEEPER_LIFECYCLE_EVENTS = new Set([
-  'keeper_handoff', 'keeper_compaction', 'keeper_guardrail', 'keeper_turn_complete',
+  'keeper_handoff', 'keeper_compaction', 'keeper_guardrail', 'keeper_turn_complete', 'keeper_phase_changed',
   'masc/keeper_handoff', 'masc/keeper_compaction', 'masc/keeper_guardrail', 'masc/keeper_turn_complete',
 ])
 

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -384,6 +384,19 @@ function handleEvent(event: SSEEvent): void {
         },
       )
       break
+    case 'keeper_phase_changed':
+      addTypedJournalEntry(
+        event.name ?? agent,
+        `Phase: ${event.prev_phase ?? '?'} → ${event.new_phase ?? '?'} (${event.event ?? '?'})`,
+        'keepers',
+        'keeper_phase_changed',
+        {
+          severity: (event.new_phase === 'Failing' || event.new_phase === 'Crashed' || event.new_phase === 'Dead') ? 'error' : 'info',
+          source: event.source,
+          narrativeText: `${actorLabel(event.name ?? agent)}의 상태가 ${event.prev_phase ?? '?'}에서 ${event.new_phase ?? '?'}로 전이되었습니다`,
+        },
+      )
+      break
     case 'keeper_tool_call': {
       const toolName = event.tool_name ?? '?'
       const durationMs = event.duration_ms ?? 0

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -213,6 +213,15 @@ export interface KeeperGuardrailEvent {
   ts_unix: number
 }
 
+export interface KeeperPhaseChangedEvent {
+  type: 'keeper_phase_changed'
+  name: string
+  prev_phase: string
+  new_phase: string
+  event: string
+  ts_unix: number
+}
+
 export interface Goal {
   id: string
   horizon: 'short' | 'mid' | 'long'

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -17,6 +17,7 @@ export type SSEEventType =
   | 'masc/keeper_compaction'
   | 'keeper_guardrail'
   | 'masc/keeper_guardrail'
+  | 'keeper_phase_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
   | 'keeper_turn_complete'
@@ -76,6 +77,10 @@ export interface SSEEvent {
   saved_tokens?: number
   trigger?: string
   reason?: string
+  // Keeper phase transition fields
+  prev_phase?: string
+  new_phase?: string
+  event?: string
   // Keeper tool call fields
   tool_name?: string
   duration_ms?: number
@@ -99,6 +104,7 @@ export type JournalEventType =
   | 'keeper_handoff'
   | 'keeper_compaction'
   | 'keeper_guardrail'
+  | 'keeper_phase_changed'
   | 'keeper_tool_call'
   | 'oas_keeper_snapshot'
   | 'oas_event'

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -566,6 +566,20 @@ let dispatch_event ~base_path name (event : Keeper_state_machine.event) =
          transition_outcome = "applied";
          wall_clock_at_decision = now;
        };
+       (* Broadcast phase transition to SSE subscribers *)
+       (try
+          Sse.broadcast
+            (`Assoc [
+               "type", `String "keeper_phase_changed";
+               "name", `String name;
+               "prev_phase", `String (Keeper_state_machine.phase_to_string tr.prev_phase);
+               "new_phase", `String (Keeper_state_machine.phase_to_string tr.new_phase);
+               "event", `String (Keeper_state_machine.event_to_string event);
+               "ts_unix", `Float now;
+             ])
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _exn -> ());
        (* Update running count based on phase transition *)
        (match tr.prev_phase, tr.new_phase with
         | Running, phase when phase <> Running ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -508,6 +508,52 @@ let handle_keeper_get_subroutes state req request reqd =
          ] in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd)
+  else if ends_with "/transitions" then
+    let name = extract_name "/transitions" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:20
+        |> max 1 |> min 50
+      in
+      let base_path = state.Mcp_server.room_config.base_path in
+      let phase = Keeper_registry.get_phase ~base_path name in
+      let phase_str = match phase with
+        | Some p -> `String (Keeper_state_machine.phase_to_string p)
+        | None -> `Null
+      in
+      let transitions =
+        Keeper_transition_audit.recent_transitions_json
+          ~keeper_name:name ~limit
+      in
+      let json = `Assoc [
+        "keeper", `String name;
+        "current_phase", phase_str;
+        "count", `Int (match transitions with `List l -> List.length l | _ -> 0);
+        "transitions", transitions;
+      ] in
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string json) reqd
+  else if ends_with "/state-diagram" then
+    let name = extract_name "/state-diagram" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let base_path = state.Mcp_server.room_config.base_path in
+      let phase = Keeper_registry.get_phase ~base_path name in
+      let current = match phase with Some p -> p | None -> Keeper_state_machine.Offline in
+      let mermaid = Keeper_state_machine.phase_to_mermaid ~current in
+      let phase_str = Keeper_state_machine.phase_to_string current in
+      let json = `Assoc [
+        "keeper", `String name;
+        "current_phase", `String phase_str;
+        "mermaid", `String mermaid;
+      ] in
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string json) reqd
   else
     Http.Response.json ~status:`Not_found
       {|{"error":"not found"}|} reqd


### PR DESCRIPTION
## Summary
- `GET /api/v1/keepers/:name/transitions` — FSM phase transition audit ring (up to 50 entries, current phase, events, timestamps)
- `GET /api/v1/keepers/:name/state-diagram` — Mermaid stateDiagram-v2 with current phase highlighted
- SSE `keeper_phase_changed` event — broadcast on every phase transition, handled by dashboard journal + live-timeline + SSE store

All three features were already **implemented** in `keeper_transition_audit.ml` and `keeper_state_machine.ml` but never exposed via HTTP or SSE. This PR adds the "last mile" plumbing.

## Files changed (9)
- `lib/keeper/keeper_registry.ml` — SSE broadcast on phase transition
- `lib/server/server_dashboard_http_keeper_api.ml` — two new GET subroutes
- `dashboard/src/types/sse.ts` — SSEEventType + SSEEvent fields + JournalEventType
- `dashboard/src/types/core.ts` — KeeperPhaseChangedEvent interface
- `dashboard/src/sse.ts` — journal entry creation for phase events
- `dashboard/src/sse-store.ts` — SIMPLE_ROUTES + KEEPER_LIFECYCLE_EVENTS
- `dashboard/src/live-store.ts` — event kind label
- `dashboard/src/journal-entry.ts` — journal category mapping
- `dashboard/src/components/agent-monitor/live-timeline.ts` — lifecycle filter

## Test plan
- [x] `dune build --root .` passes
- [x] `npx tsc --noEmit` passes
- [x] `test_keeper_unified.exe` — 108 tests pass
- [ ] CI green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>