### PR TITLE
feat(evidence): Phase 4 — unified turn evidence + chain validation in status

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -682,6 +682,13 @@ let handle_keeper_status ctx args : tool_result =
                  ~trace_id:m.runtime.trace_id with
                | Some ev -> ev
                | None -> `Null);
+             ("evidence_chain_valid",
+               match Keeper_evidence.verify_evidence_chain
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:m.name
+                 ~trace_id:m.runtime.trace_id with
+               | Ok () -> `Bool true
+               | Error _ -> `Bool false);
            ]);
          ] in
          let response = Yojson.Safe.pretty_to_string json in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -890,6 +890,11 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           side_effect_occurred := true
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;
+      let evidence_before_hash =
+        try Keeper_evidence.snapshot_before_turn
+          ~base_path:config.base_path ~keeper_name:meta.name
+        with _ -> None
+      in
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
           Keeper_exec_tools.remove_tool_call_observer side_effect_observer)
@@ -1158,6 +1163,21 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             ~selected_mode:(selected_mode_of_result result)
             ~social_state
             ~result:(Some result) ();
+          (* Post-turn evidence: deterministic git before/after delta *)
+          (try
+            ignore (Keeper_evidence.capture_turn_evidence
+              ~base_path:config.base_path
+              ~keeper_name:meta.name
+              ~trace_id:updated_meta.runtime.trace_id
+              ~turn_number:updated_meta.runtime.usage.total_turns
+              ~tool_calls_made:result.tool_calls_made
+              ~before_hash:evidence_before_hash
+              ())
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Keeper.warn "post-turn evidence capture failed (unified): %s"
+              (Printexc.to_string exn));
           Log.Keeper.info
             "%s: unified turn OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
             updated_meta.name result.model_used


### PR DESCRIPTION
## Summary
- Autonomous turns (keeper_unified_turn) now capture the same git evidence as direct turns
- `evidence_chain_valid` field added to `execution_context` in keeper_status response

## Changes (2 files)
| File | Change |
|------|--------|
| `keeper_unified_turn.ml` | before/after hash capture around Agent.run |
| `keeper_status_detail.ml` | `evidence_chain_valid` via `verify_evidence_chain` |

## Evidence Coverage

| Turn Path | Before | After |
|-----------|--------|-------|
| Direct (keeper_msg) | Phase 1 (#5621) | Phase 1 (#5621) |
| Autonomous (unified_turn) | **This PR** | **This PR** |

## Test Plan
- [x] `dune build` passes
- [ ] CI green
- [ ] `keeper_status` response includes `evidence_chain_valid: true`

Refs #5620

Generated with [Claude Code](https://claude.com/claude-code)