### PR TITLE
fix: remove fake replay_check stub and governance dead code

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -52,9 +52,6 @@ tools = ["keeper_library_search", "keeper_library_read"]
 tools = ["keeper_github", "keeper_pr_workflow"]
 
 # Shard-backed groups: tool names resolved from Tool_shard at runtime.
-[groups.governance]
-shard = "governance"
-
 [groups.coding_shard]
 shard = "coding"
 

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -24,10 +24,6 @@ let to_json (r : transition_record) : Yojson.Safe.t =
     "wall_clock_at_decision", `Float r.wall_clock_at_decision;
   ]
 
-(* Phase 1 stub: Keeper_guard not yet wired as consumer.
-   Phase 4 will implement actual replay by calling Keeper_guard.evaluate. *)
-let replay_check _snapshot _expected_events = true
-
 (* ================================================================ *)
 (* In-memory ring buffer for recent transitions                     *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -16,14 +16,6 @@ type transition_record = {
 (** Serialize a transition record for JSONL storage. *)
 val to_json : transition_record -> Yojson.Safe.t
 
-(** Given a historical snapshot, re-run [Keeper_guard.evaluate] (when available)
-    and verify the result matches the recorded events.
-    Phase 1: always returns [true] (stub). *)
-val replay_check :
-  Keeper_measurement.measurement_snapshot ->
-  Keeper_state_machine.event list ->
-  bool
-
 (** {1 In-memory Ring Buffer} *)
 
 (** Record a transition in the per-keeper ring buffer (last 50). *)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -226,9 +226,6 @@ let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->
          else removed)
        0)
 
-(* Governance stale case purge — retired, no-op *)
-let () = Room_hooks.governance_purge_fn := (fun _base_path -> (0, 0))
-
 (* Subscription auto-subscribe on join — wraps Subscriptions for room_eio *)
 let () = Room_hooks.subscribe_messages_fn := (fun ~subscriber ->
   let _ = Subscriptions.SubscriptionStore.subscribe

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -9,8 +9,7 @@ open Room_state
 
 (* Callback refs and types are now in Room_hooks. *)
 
-(* Board artifact cleanup and governance purge are now in Room_hooks callbacks.
-   The actual implementations are wired by room.ml at startup. *)
+(* Board artifact cleanup is wired via Room_hooks callbacks at startup. *)
 
 
 (* heartbeat_in_room removed — rooms are flattened (#4638). Use heartbeat. *)
@@ -390,11 +389,8 @@ let gc config ?(days=7) () =
   else
     results := "✅ No team sessions to archive" :: !results;
 
-  (* 7. Hard-delete board/governance artifacts (via hooks) *)
+  (* 7. Hard-delete board artifacts (via hooks) *)
   let board_artifact_count = !Room_hooks.cleanup_board_artifacts_fn () in
-  let governance_test_artifact_count, governance_artifact_count =
-    !Room_hooks.governance_purge_fn config.base_path
-  in
   if board_artifact_count > 0 then
     results :=
       Printf.sprintf "🧽 Removed %d board artifact post(s)"
@@ -402,13 +398,6 @@ let gc config ?(days=7) () =
       :: !results
   else
     results := "✅ No board artifacts" :: !results;
-  if governance_test_artifact_count > 0 || governance_artifact_count > 0 then
-    results :=
-      Printf.sprintf "⚖️ Removed %d governance artifact case(s) and %d stale test case(s)"
-        governance_artifact_count governance_test_artifact_count
-      :: !results
-  else
-    results := "✅ No governance artifacts" :: !results;
 
   (* 8. CP data cleanup (dead units, stale operations, orphaned detachments) *)
   if not !Room_hooks.cp_cleanup_connected then
@@ -442,9 +431,9 @@ let gc config ?(days=7) () =
   results := "✅ Rooms flattened (no room archival needed)" :: !results;
 
   log_event config (Printf.sprintf
-    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"board_artifacts\":%d,\"governance_test_artifacts\":%d,\"governance_artifacts\":%d,\"rooms_archived\":%d,\"cp_cleanup\":%s,\"days\":%d,\"ts\":\"%s\"}"
+    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"board_artifacts\":%d,\"rooms_archived\":%d,\"cp_cleanup\":%s,\"days\":%d,\"ts\":\"%s\"}"
     !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count
-    board_artifact_count governance_test_artifact_count governance_artifact_count
+    board_artifact_count
     0 cp_json days (now_iso ()));
 
   String.concat "\n" (List.rev !results)

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -125,12 +125,6 @@ let cleanup_board_artifacts_fn
   : (unit -> int) ref
   = ref (fun () -> 0)
 
-(** Governance stale case purge (retired, no-op stub).
-    Returns (test_cases_purged, artifact_cases_purged). *)
-let governance_purge_fn
-  : (string -> int * int) ref
-  = ref (fun _base_path -> (0, 0))
-
 (** Invalidate dashboard execution cache on task mutation (add, transition).
     Wired by server bootstrap to avoid circular dependency between
     Room sub-modules and server dashboard surfaces. *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -548,34 +548,11 @@ let shard_library : shard = {
   description = "Knowledge library: search, read documents";
 }
 
-let governance_keeper_tool_names : string list =
-  [
-    "masc_cases";
-    "masc_case_status";
-    "masc_ruling_status";
-    "masc_governance_status";
-    "masc_governance_feed";
-    "masc_case_brief_submit";
-    "masc_petition_submit";
-  ]
-
-let governance_tools : Types.tool_schema list =
-  (* Governance compatibility surface retained, but no governance tool schemas are exposed. *)
-  ignore governance_keeper_tool_names;
-  []
-
 let shard_taskboard : shard = {
   name = "taskboard";
   tools = taskboard_tools;
   removable = true;
   description = "Task board management: list, audit, force-release, force-done, broadcast";
-}
-
-let shard_governance : shard = {
-  name = "governance";
-  tools = governance_tools;
-  removable = true;
-  description = "Governance compatibility stub: no governance tools exposed";
 }
 
 (** Autoresearch tools: filtered subset for keeper use (excludes swarm_start). *)
@@ -603,7 +580,6 @@ let default_shard_names : string list = [
   "shell";
   "library";
   "taskboard";
-  "governance";
   "coding";
   "autoresearch";
 ]
@@ -629,7 +605,6 @@ let all_shards : shard StringMap.t =
     shard_voice;
     shard_library;
     shard_taskboard;
-    shard_governance;
     shard_autoresearch;
   ]
 
@@ -688,7 +663,7 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_tool_grant";
     description = "Grant a capability group to an agent. \
-Groups: base (core), board, filesystem, shell, governance, voice, taskboard, coding, autoresearch.";
+Groups: base (core), board, filesystem, shell, voice, taskboard, coding, autoresearch.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -698,7 +673,7 @@ Groups: base (core), board, filesystem, shell, governance, voice, taskboard, cod
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Group to grant: base, board, filesystem, shell, governance, voice, taskboard, coding, autoresearch");
+          ("description", `String "Group to grant: base, board, filesystem, shell, voice, taskboard, coding, autoresearch");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);
@@ -717,7 +692,7 @@ Cannot revoke 'base' (always present).";
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Group to revoke (must be removable). One of: board, filesystem, shell, governance, voice, taskboard, coding, autoresearch");
+          ("description", `String "Group to revoke (must be removable). One of: board, filesystem, shell, voice, taskboard, coding, autoresearch");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -24,9 +24,6 @@ val shard_filesystem : shard
 val shard_shell : shard
 (** Structured read-only shell access. *)
 
-val shard_governance : shard
-(** Governance workflow: cases, briefs, petitions, status/feed. *)
-
 (** {1 Lookup} *)
 
 val get_shard : string -> shard option
@@ -36,7 +33,7 @@ val get_shard : string -> shard option
 
 val default_shard_names : string list
 (** Default shards for a new keeper: base, board, filesystem, shell,
-    library, taskboard, governance. *)
+    library, taskboard, coding, autoresearch. *)
 
 val tools_of_shards : string list -> Types.tool_schema list
 (** Combine tools from multiple shard names. *)
@@ -77,9 +74,6 @@ val base_tools : Types.tool_schema list
 
 val board_tools : Types.tool_schema list
 (** Board tools: board_post, board_list, board_comment, board_vote. *)
-
-val governance_tools : Types.tool_schema list
-(** Governance tools exposed to keepers by default. *)
 
 (** {1 MCP Interface} *)
 

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -53,8 +53,6 @@ let has_keeper_prefix name =
     depends on inject_masc_schemas which runs after module init. *)
 let known_non_keeper_tool_names () : string list =
   List.concat [
-    Tool_shard.governance_tools
-    |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_shard.autoresearch_keeper_tools
     |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_shard.coding_tools

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -47,17 +47,9 @@ let test_shard_shell_exists () =
     Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1)
   | None -> Alcotest.fail "shell shard not found"
 
-let test_shard_governance_exists () =
-  match Tool_shard.get_shard "governance" with
-  | Some s ->
-    Alcotest.(check bool) "removable" true s.Tool_shard.removable;
-    (* Governance shard exists for compatibility but has 0 tools. *)
-    Alcotest.(check int) "no tools after governance tool retirement" 0
-      (List.length s.Tool_shard.tools);
-    Alcotest.(check string) "stub description"
-      "Governance compatibility stub: no governance tools exposed"
-      s.Tool_shard.description
-  | None -> Alcotest.fail "governance shard not found"
+let test_shard_governance_removed () =
+  Alcotest.(check bool) "governance shard removed" true
+    (Tool_shard.get_shard "governance" = None)
 
 let test_shard_coding_exists () =
   match Tool_shard.get_shard "coding" with
@@ -99,10 +91,10 @@ let test_all_shards_count () =
 let test_default_shard_names () =
   let defaults = Tool_shard.default_shard_names in
   (* All shards are now in defaults (mode removal: every keeper gets all tools) *)
-  Alcotest.(check bool) "at least 8 defaults" true (List.length defaults >= 8);
+  Alcotest.(check bool) "at least 7 defaults" true (List.length defaults >= 7);
   Alcotest.(check bool) "base in defaults" true (List.mem "base" defaults);
-  (* governance shard still in defaults but has 0 tools after tool retirement *)
-  Alcotest.(check bool) "governance in defaults" true
+  (* governance shard removed: empty stub deleted *)
+  Alcotest.(check bool) "governance removed from defaults" false
     (List.mem "governance" defaults);
   Alcotest.(check bool) "coding in defaults" true
     (List.mem "coding" defaults);
@@ -330,11 +322,6 @@ let test_board_tools_names () =
   Alcotest.(check bool) "has board_comment" true (List.mem "keeper_board_comment" names);
   Alcotest.(check bool) "has board_vote" true (List.mem "keeper_board_vote" names)
 
-let test_governance_tools_empty () =
-  (* Governance tools are retired, so governance_tools is empty. *)
-  Alcotest.(check int) "governance tools empty after retirement" 0
-    (List.length Tool_shard.governance_tools)
-
 (* ============================================================
    Voice tools content tests (#3: all 5 voice tools present)
    ============================================================ *)
@@ -497,7 +484,7 @@ let () =
       Alcotest.test_case "board" `Quick test_shard_board_exists;
       Alcotest.test_case "filesystem" `Quick test_shard_filesystem_exists;
       Alcotest.test_case "shell" `Quick test_shard_shell_exists;
-      Alcotest.test_case "governance" `Quick test_shard_governance_exists;
+      Alcotest.test_case "governance removed" `Quick test_shard_governance_removed;
       Alcotest.test_case "coding" `Quick test_shard_coding_exists;
       Alcotest.test_case "coding in defaults" `Quick test_coding_in_defaults;
       Alcotest.test_case "voice" `Quick test_shard_voice_exists;
@@ -571,7 +558,6 @@ let () =
     ("tool_content", [
       Alcotest.test_case "base tools" `Quick test_base_tools_names;
       Alcotest.test_case "board tools" `Quick test_board_tools_names;
-      Alcotest.test_case "governance tools empty" `Quick test_governance_tools_empty;
       Alcotest.test_case "voice tools" `Quick test_voice_tools_names;
       Alcotest.test_case "keeper_model excludes voice" `Quick
         test_keeper_model_excludes_voice_tools;


### PR DESCRIPTION
## Summary
- Remove `replay_check` function that always returned `true` (false safety confidence)
- Remove `shard_governance` compatibility stub (empty tool list, no tools exposed)
- Remove `governance_purge_fn` permanent no-op ref and GC step 7 that called it
- Remove governance group from `tool_policy.toml` (was causing `invalid_arg` at runtime)
- Update tests: removed governance shard/tool assertions, added governance-removed assertion

## Motivation
Product boundary audit (2026-04-07) identified these as lying implementations -- code that pretends to provide safety/functionality but actually does nothing.

A function named `replay_check` that always returns `true` is worse than not having the function. It gives false confidence in transition audit safety.

The `shard_governance` had an empty tool list with a description saying no governance tools exposed -- a compatibility stub that served no purpose. Its presence in `default_shard_names` and `tool_policy.toml` added config noise.

The `governance_purge_fn` was a permanent no-op wired in `room.ml` as `(fun _base_path -> (0, 0))`, called during GC with results that were always zero. Removed the hook, the GC step, and the wiring.

## Changes (10 files, -82 lines net)
| File | Change |
|------|--------|
| `lib/keeper/keeper_transition_audit.ml` | Remove `replay_check` stub |
| `lib/keeper/keeper_transition_audit.mli` | Remove `replay_check` signature |
| `lib/tool_shard.ml` | Remove `governance_tools`, `shard_governance`, `governance_keeper_tool_names` |
| `lib/tool_shard.mli` | Remove governance exports |
| `lib/room/room_hooks.ml` | Remove `governance_purge_fn` |
| `lib/room/room_gc.ml` | Remove GC step 7 governance purge logic |
| `lib/room.ml` | Remove governance_purge_fn wiring |
| `config/tool_policy.toml` | Remove governance group |
| `test/test_tool_shard_coverage.ml` | Update governance assertions |
| `test/test_keeper_agent_isolation.ml` | Remove governance_tools reference |

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` -- all tests pass except pre-existing `keeper_tool_matrix` failures (6 on main, same on branch + 1 flaky timeout)
- [x] Verified no remaining references to removed functions via `rg`
- [x] New test `test_shard_governance_removed` verifies governance shard is gone

Closes #5659
