### PR TITLE
fix(keeper): add workspace path and PR workflow to capabilities prompt

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -13,7 +13,7 @@ File operations:
 - View file (raw): keeper_shell_readonly with op=cat, path=<file>
 - Git history: keeper_shell_readonly with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell_readonly with op=git_status
-- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding preset)
+- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Full preset)
 - Write or create a file: keeper_fs_edit (Coding/Delivery). Writable path: .masc/playground/<your-name>/
 - Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title. Handles worktree, commit, and draft PR.
 - GitHub CLI: keeper_github with cmd="pr comment 123 --body 'text'"

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -14,13 +14,13 @@ File operations:
 - Git history: keeper_shell_readonly with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell_readonly with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding preset)
-- Write or create a file: keeper_fs_edit (Coding preset only). Writable path: .masc/playground/<your-name>/
-- Create a PR in one step: keeper_pr_workflow (Delivery/Coding). Provide branch, file_path, file_content, commit_message, pr_title. Handles worktree, commit, and draft PR.
+- Write or create a file: keeper_fs_edit (Coding/Delivery). Writable path: .masc/playground/<your-name>/
+- Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title. Handles worktree, commit, and draft PR.
 - GitHub CLI: keeper_github with cmd="pr comment 123 --body 'text'"
 
 Workspace:
 - Your writable workspace is .masc/playground/<your-name>/. Use keeper_fs_edit to write files there.
-- To produce a PR: use keeper_pr_workflow (single call, handles everything) or work in your playground then commit manually via keeper_bash.
+- To produce a PR: use keeper_pr_workflow (single call, handles everything). Delivery keepers should use keeper_pr_workflow for PR creation; manual commit/push via keeper_bash is Coding/Full only.
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -14,7 +14,13 @@ File operations:
 - Git history: keeper_shell_readonly with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell_readonly with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding preset)
-- Write or create a file: keeper_fs_edit (Coding preset only)
+- Write or create a file: keeper_fs_edit (Coding preset only). Writable path: .masc/playground/<your-name>/
+- Create a PR in one step: keeper_pr_workflow (Delivery/Coding). Provide branch, file_path, file_content, commit_message, pr_title. Handles worktree, commit, and draft PR.
+- GitHub CLI: keeper_github with cmd="pr comment 123 --body 'text'"
+
+Workspace:
+- Your writable workspace is .masc/playground/<your-name>/. Use keeper_fs_edit to write files there.
+- To produce a PR: use keeper_pr_workflow (single call, handles everything) or work in your playground then commit manually via keeper_bash.
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -14,13 +14,13 @@ File operations:
 - Git history: keeper_shell_readonly with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell_readonly with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Full preset)
-- Write or create a file: keeper_fs_edit (Coding/Delivery). Writable path: .masc/playground/<your-name>/
-- Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title. Handles worktree, commit, and draft PR.
-- GitHub CLI: keeper_github with cmd="pr comment 123 --body 'text'"
+- Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable path: .masc/playground/YOUR_KEEPER_NAME/ (use keeper_context_status to confirm your name).
+- Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title (optional: base_branch, default "main"). Handles worktree, commit, and draft PR for a single file.
+- GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
 
 Workspace:
-- Your writable workspace is .masc/playground/<your-name>/. Use keeper_fs_edit to write files there.
-- To produce a PR: use keeper_pr_workflow (single call, handles everything). Delivery keepers should use keeper_pr_workflow for PR creation; manual commit/push via keeper_bash is Coding/Full only.
+- Your writable workspace is .masc/playground/YOUR_KEEPER_NAME/. Use keeper_fs_edit to write files there.
+- To produce a PR: use keeper_pr_workflow (single call, handles everything) — this is the preferred path for all coding/delivery keepers.
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search


### PR DESCRIPTION
## Summary
Keepers had no guidance about where to write files or how to create PRs.
coder tried `.worktrees/` via `keeper_fs_edit` (rejected) instead of `.masc/playground/<name>/` or `keeper_pr_workflow`.

Adds to `keeper.capabilities.md`:
- Writable path (`.masc/playground/<name>/`) for `keeper_fs_edit`
- `keeper_pr_workflow` tool (single-call PR creation)
- `keeper_github` tool
- Workspace section clarifying PR paths per preset

Corrects preset labels based on review feedback:
- `keeper_fs_edit` available to **Coding/Delivery** (not Coding only)
- `keeper_pr_workflow` available to **Delivery/Coding/Full**
- `keeper_bash` write access (including `git commit`/`git push`) is **Coding/Full only** — this is now stated consistently in both the file operations list and the workspace guidance
- Delivery keepers are directed to use `keeper_pr_workflow` for PR creation

## Product impact

- Promise affected: `none/internal`
- User-visible change: No user-visible change; affects keeper agent behaviour only.

## Evidence

Config-only change. No runtime logic altered.

## Review evidence

Reviewer suggestions from `copilot-pull-request-reviewer` applied verbatim. Follow-up consistency fix applied to align `keeper_bash` write-access preset label ("Coding/Full") across both occurrences in the file.

## Linked issue