### PR TITLE
fix(keeper): include [STATE] template in system prompt

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -100,7 +100,9 @@ let build_keeper_system_prompt
       profile_policy;
       "\n\
        \n\
-       <continuity>\n";
+       <continuity>\n\
+       Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
+       When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].\n";
       keeper_constitution ();
       "\n\
        </continuity>";

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -100,9 +100,9 @@ let build_keeper_system_prompt
       profile_policy;
       "\n\
        \n\
-       <continuity>\n\
-       This conversation may be compacted or handed off to a successor.\n\
-       Reply in the user's language. Keep replies concise.\n\
+       <continuity>\n";
+      keeper_constitution ();
+      "\n\
        </continuity>";
     ]
 


### PR DESCRIPTION
## Summary

- `keeper_constitution()`이 정의만 되고 `build_keeper_system_prompt`에서 호출되지 않던 버그 수정
- `<continuity>` 블록의 하드코딩 placeholder를 `keeper.constitution.md` 전체 내용으로 교체
- 모든 키퍼가 `[STATE] missing, synthesized from N tools` 로그를 100% 남기던 문제 해결
- `<continuity>` 블록에 조건부 한정 문구 추가: `direct_reply_mode` 존재 시 STATE 방출 억제 명시 (constitution의 "MUST emit" 지시와의 충돌 해소)

## Root Cause

| Before | After |
|--------|-------|
| `<continuity>` 블록에 2줄 placeholder | `keeper_constitution()` 호출로 전체 STATE 템플릿 포함 |
| LLM이 `[STATE]` 포맷을 모름 | Goal/Progress/Next/Decisions/OpenQuestions/Constraints 템플릿 수신 |
| 100% synthesized fallback | 모델이 직접 STATE 블록 출력 가능 |
| `direct_reply_mode`와 constitution 간 충돌 | `<continuity>` 블록에 명시적 우선순위 규칙 추가 |

## Impact

- 메모리 축적 품질 향상: synthesized fallback (도구 사용 패턴만)에서 모델 생성 STATE (목표/진척/결정/질문)로
- 키퍼 연속성 개선: compaction/handoff 시 더 풍부한 상태 정보 보존
- `direct_reply_mode` 충돌 해소: constitution의 "MUST emit STATE" 지시가 `direct_reply_mode` 턴에서 모호하게 적용되던 문제 수정 — `<continuity>` 블록이 `direct_reply_mode` 우선 적용을 명시

## Evidence

- `dune build --root .` 성공
- `test_keeper_prompt_metrics` 6/6 통과
- `test_prompt_registry_defaults` 11/11 통과
- `test_keeper_memory` 31/31 통과

## Review evidence

변경 사항은 CodeQL 및 코드 리뷰 자동화 도구로 검증됨. 보안 취약점 없음, 리뷰 코멘트 없음.

## Linked issue