### PR TITLE
fix(keeper): add ACTION TOOLS nudge to system prompt for coding keepers

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -85,7 +85,8 @@ let build_keeper_system_prompt
        - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
        - On proactive turns: call keeper_board_list first. Then call keeper_board_comment on an unanswered post, or call keeper_board_post with a new topic relevant to your goal.\n\
        - If no Board activity and no tasks: call keeper_board_list to observe. Do NOT fabricate activity.\n\
-       - ANTI-POLLING: Do NOT call masc_status, masc_heartbeat, or keeper_tasks_list more than once per session unless you received genuinely new information. These are observation tools, not work. Use keeper_task_claim, keeper_fs_read, keeper_board_post, or keeper_stay_silent for productive turns.\n\
+       - ANTI-POLLING: Do NOT call masc_status, masc_heartbeat, or keeper_tasks_list more than once per session unless you received genuinely new information. These are observation tools, not work.\n\
+       - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands), keeper_github (PR/issues), keeper_pr_workflow (git worktree+PR), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit or keeper_bash.\n\
        - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST call keeper_task_done when finished. Claim -> Work -> Done. Every claimed task must be closed. Leaving tasks open creates zombie tasks.\n\
        - You do not need permission to act. You live here.\n\
        When someone asks you a question:\n\


### PR DESCRIPTION
- [x] Remove `keeper_write` from ACTION TOOLS nudge in keeper system prompt (it's not a real/dispatchable keeper tool — `keeper_fs_edit` already handles file creation/updates)