### PR TITLE
chore: bump OAS pin 0.110.0 → 0.111.0 (ollama provider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## [2.256.0] - 2026-04-07
+
+### Changed
+- **OAS agent_sdk pin** -- bump 0.110.0 to 0.111.0 (ollama provider).
+
 ## [2.255.0] - 2026-04-07
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 2.255.0)
+(version 2.256.0)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.110.0))
+  (agent_sdk (>= 0.111.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))


### PR DESCRIPTION
## Summary

- Bump agent_sdk dependency 0.110.0 → 0.111.0
- OAS v0.111.0 adds `ollama` provider to cascade registry
- Enables `ollama:auto` in cascade.json for Ollama MLX server
- Version bump 2.255.0 → 2.256.0

## Test plan

- [ ] CI Build and Test
- [ ] CI Lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)