### PR TITLE
chore: bump OAS agent_sdk pin 0.110.0 → 0.111.0

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -21,6 +21,12 @@ open Keeper_types
     Per-keeper override via [compaction_policy.max_checkpoint_messages]. *)
 let default_max_checkpoint_messages = 120
 
+(** Conservative context-window fallback used when a checkpoint carries
+    neither [max_total_tokens] nor [max_input_tokens].  200K covers every
+    currently-supported large-context model and prevents division-by-zero
+    in [context_ratio] if neither field is populated. *)
+let default_context_window_tokens = 200_000
+
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
 (* ================================================================ *)
@@ -249,24 +255,20 @@ let log_keeper_exn ~label exn =
 
 let checkpoint_generation_key = "keeper_generation"
 
-let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let open Yojson.Safe.Util in
+let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) : int =
   match cp.max_total_tokens with
-  | Some value -> value
-  | None -> (
-      match cp.working_context with
-      | Some (`Assoc _ as sidecar) ->
-          sidecar |> member "max_tokens" |> to_int_option
-          |> Option.value ~default:fallback
-      | _ -> fallback)
+  | Some n when n > 0 -> n
+  | _ -> (
+      match cp.max_input_tokens with
+      | Some n when n > 0 -> n
+      | _ -> default_context_window_tokens)
 
 let context_of_oas_checkpoint
     ~(max_checkpoint_messages : int)
-    (cp : Agent_sdk.Checkpoint.t)
-    ~(primary_model_max_tokens : int) : working_context =
+    (cp : Agent_sdk.Checkpoint.t) : working_context =
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
-    checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
+    checkpoint_max_tokens cp
   in
   let messages =
     let n = List.length cp.messages in
@@ -399,7 +401,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
   match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
   | (false, Some checkpoint, _) ->
       let ctx =
-        context_of_oas_checkpoint ~max_checkpoint_messages checkpoint ~primary_model_max_tokens
+        context_of_oas_checkpoint ~max_checkpoint_messages checkpoint
       in
       let ctx =
         if primary_model_max_tokens <= 0 then ctx

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -56,11 +56,11 @@ val save_session_checkpoint : session_context -> checkpoint -> unit
 val log_keeper_exn : label:string -> exn -> unit
 
 val checkpoint_max_tokens :
-  Agent_sdk.Checkpoint.t -> fallback:int -> int
+  Agent_sdk.Checkpoint.t -> int
 
 val context_of_oas_checkpoint :
   max_checkpoint_messages:int ->
-  Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
+  Agent_sdk.Checkpoint.t -> working_context
 
 val checkpoint_model_of_meta : keeper_meta -> string
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -98,7 +98,7 @@ let apply_post_turn_lifecycle
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -270,7 +270,7 @@ let recover_latest_checkpoint_for_overflow_retry
           checkpoint_generation checkpoint ~fallback:meta.runtime.generation
         in
         Some
-          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint ~primary_model_max_tokens,
+          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint,
             turn_generation )
     | _, _, Some checkpoint ->
         (try
@@ -291,8 +291,7 @@ let recover_latest_checkpoint_for_overflow_retry
                       ~fallback:meta.runtime.generation
                   in
                   Some
-                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint
-                        ~primary_model_max_tokens,
+                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint,
                       turn_generation )
               | None -> None))
     | _ -> None

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -35,7 +35,7 @@ let maybe_rollover_oas_handoff
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -276,7 +276,7 @@ let build
     match config.compact_ratio with
     | Some ratio ->
       Oas.Builder.with_context_thresholds ~compact_ratio:ratio
-        ?context_window_tokens:config.max_input_tokens builder
+        ?max_tokens:config.max_input_tokens builder
     | None -> builder
   in
   let builder = match config.context_injector with

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -274,7 +274,9 @@ let build
   in
   let builder =
     match config.compact_ratio with
-    | Some ratio -> Oas.Builder.with_context_thresholds ~compact_ratio:ratio builder
+    | Some ratio ->
+      Oas.Builder.with_context_thresholds ~compact_ratio:ratio
+        ?context_window_tokens:config.max_input_tokens builder
     | None -> builder
   in
   let builder = match config.context_injector with

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.110.0"}
+  "agent_sdk" {>= "0.111.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.110.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.111.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ff2ba4ee6cbf8f67f4f2f734419451277160bdb6"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.110.0"
+readonly OAS_AGENT_SDK_SHA="707cf7ef21c6f5e6f1a6a41b6a8474b3e2b30c4e"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.111.0"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.111.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="707cf7ef21c6f5e6f1a6a41b6a8474b3e2b30c4e"
+readonly OAS_AGENT_SDK_SHA="91c47c8c682692df1b59a4f8d22bf2719507471f"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.111.0"

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -127,7 +127,7 @@ let test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit () =
       in
       let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
       check int "stored checkpoint max preserved in checkpoint helper" 4096
-        (KEC.checkpoint_max_tokens checkpoint ~fallback:32768);
+        (KEC.checkpoint_max_tokens checkpoint);
       match
         load_context ~base_dir ~trace_id:meta.runtime.trace_id
           ~max_tokens:32768


### PR DESCRIPTION
## Summary
- OAS pin bump to v0.111.0 (oas#696)
- `with_context_thresholds`에 `?context_window_tokens` 파라미터 추가 (`config.max_input_tokens`로 실제 모델 window 전달)
- `checkpoint_max_tokens` fallback 순서 통일: `max_total_tokens` (n>0) → `max_input_tokens` (n>0) → `default_context_window_tokens` (200K); 레거시 `working_context` JSON sidecar 경로 제거
- n > 0 guard 추가 (division-by-zero 방지)
- `context_of_oas_checkpoint`에서 불필요해진 `~primary_model_max_tokens` 파라미터 제거 및 전체 call site 업데이트

## Product impact
- Promise affected: `repo coordination`
- User-visible change: keeper context budget이 실제 모델 window (262K)에 맞춰짐 — OAS가 compaction 결정 시 올바른 context window를 사용

## Evidence
빌드 통과 (`dune build` clean with OAS 0.111.0); `test_keeper_lifecycle` 업데이트 및 통과 확인

## Review evidence
GLM 리뷰 완료. fallback 순서 불일치 + n>0 guard 누락 수정 반영. Copilot code review: magic number → named constant (`default_context_window_tokens`), unused parameter 제거 반영.

## Linked issue