### PR TITLE
refactor(dashboard): remove duplicate top-tools display in keeper detail

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -58,14 +58,6 @@ export function actionDescriptorLabel(actionType?: string): string {
   }
 }
 
-function keeperTopTools(keeper: Keeper): string[] {
-  const metrics = keeper.metrics_window
-  const topTools = Array.isArray(metrics?.top_tools) ? metrics.top_tools : []
-  return topTools
-    .map(item => (typeof item === 'object' && item !== null && 'tool' in item && typeof item.tool === 'string' ? item.tool : null))
-    .filter((item): item is string => item !== null)
-}
-
 export function resolveKeeperCurrentTaskLabel(
   keeper: Keeper | null | undefined,
 ): string {
@@ -363,7 +355,6 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const keeperConfig = peekLoadedKeeperConfig(keeper.name)
   const configLoadStatus = peekKeeperConfigLoadStatus(keeper.name)
   const namespaceStatus = operatorSnapshot.value?.namespace ?? {}
-  const topTools = keeperTopTools(keeper)
   const missionBrief = resolveKeeperMissionBrief(keeper)
   const toolPolicy = resolveKeeperToolPolicy(keeperConfig, configLoadStatus)
   const observedAudit = resolveKeeperObservedToolAudit(keeper, missionBrief)
@@ -485,9 +476,6 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-xs font-medium text-[var(--text-strong)]">${auditSource ?? metadataFallback}${auditAt ? html` · <${TimeAgo} timestamp=${auditAt} />` : ''}</span>
       </div>
 
-      ${topTools.length > 0
-        ? html`<${ToolSection} title="윈도우 상위 도구" tools=${topTools} fallback="" />`
-        : null}
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- KeeperNeighborhood의 "윈도우 상위 도구" ToolSection 제거 (동일 `metrics_window.top_tools` 데이터가 RuntimeSignals "주요 도구" DistributionBars에서 이미 표시)
- 미사용 `keeperTopTools` 함수 및 `topTools` 변수 정리
- **-12줄**, 정보 중복 제거

## Context
keeper detail page 내에서 `metrics_window.top_tools`가 두 곳에서 표시되었음:
1. KeeperNeighborhood → "윈도우 상위 도구" ToolSection (ToolChip 리스트)
2. RuntimeSignals → "주요 도구" DistributionBars (막대 그래프)

두 곳 모두 동일 데이터 소스를 사용하므로, 시각적으로 더 풍부한 DistributionBars만 유지.

## Test plan
- [ ] Dashboard 빌드 성공 (CI)
- [ ] Keeper detail 열기 → "윈도우 상위 도구" 섹션 미표시 확인
- [ ] "품질 시그널" → "주요 도구" DistributionBars 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)