### PR TITLE
fix(cascade): use explicit ollama model name instead of 'auto'

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,5 @@
 {
-  "default_models": ["ollama:auto", "glm:auto"],
+  "default_models": ["ollama:qwen3.5:9b-nvfp4", "glm:auto"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 


### PR DESCRIPTION
## Summary
- `ollama:auto` → `ollama:qwen3.5:9b-nvfp4` in `config/cascade.json`
- Ollama API does not support `auto` as a model identifier — it requires explicit model tags
- This caused 573+ `model 'auto' not found` errors and all 8 keepers failed since PR #5685 was merged

## Root cause
PR #5685 migrated from `llama:auto` to `ollama:auto`, but OAS passes the model name literally to the provider API. llama-server may have resolved `auto` internally, but Ollama does not.

## Test plan
- [ ] Server restart with updated cascade.json
- [ ] Verify keeper turns succeed (no `model 'auto' not found` in logs)
- [ ] Confirm ollama:qwen3.5:9b-nvfp4 is used as primary model

🤖 Generated with [Claude Code](https://claude.com/claude-code)