### PR TITLE
fix(dashboard): handle transient pipeline stages and nullish event labels

### DIFF
--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -43,7 +43,10 @@ function phaseBgClass(phase: string): string {
 // selected_event comes as object {type: "...", ...} from the server
 function eventLabel(event: unknown): string {
   if (typeof event === 'string') return event
-  if (event && typeof event === 'object' && 'type' in event) return String((event as Record<string, unknown>).type)
+  if (event && typeof event === 'object' && 'type' in event) {
+    const type = (event as Record<string, unknown>).type
+    if (type != null) return String(type)
+  }
   return '?'
 }
 

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -26,12 +26,12 @@ export function PipelineStageBar({ stage }: { stage?: PipelineStage | null }) {
   const current = stage ?? 'offline'
   const currentIdx = STAGE_ORDER[current] ?? -1
 
-  if (current === 'offline') {
+  if (current === 'offline' || currentIdx === -1) {
     return html`
       <div class="flex items-center py-1.5">
-        <div class="pipeline-stage-node active stage-offline">
+        <div class="pipeline-stage-node active stage-${current}">
           <span class="pipeline-stage-dot transition-all duration-300"></span>
-          <span class="pipeline-stage-label">offline</span>
+          <span class="pipeline-stage-label">${current}</span>
         </div>
       </div>
     `

--- a/dashboard/src/styles/pipeline.css
+++ b/dashboard/src/styles/pipeline.css
@@ -72,6 +72,24 @@
   border-color: rgba(75, 75, 85, 0.8);
 }
 
+/* Transient runtime states (failing, crashed, draining, paused, restarting) */
+.pipeline-stage-node.active.stage-failing .pipeline-stage-dot,
+.pipeline-stage-node.active.stage-crashed .pipeline-stage-dot {
+  background: rgba(239, 68, 68, 0.6);
+  border-color: rgba(239, 68, 68, 0.8);
+}
+
+.pipeline-stage-node.active.stage-draining .pipeline-stage-dot,
+.pipeline-stage-node.active.stage-restarting .pipeline-stage-dot {
+  background: rgba(251, 146, 60, 0.6);
+  border-color: rgba(251, 146, 60, 0.8);
+}
+
+.pipeline-stage-node.active.stage-paused .pipeline-stage-dot {
+  background: rgba(167, 139, 250, 0.6);
+  border-color: rgba(167, 139, 250, 0.8);
+}
+
 .pipeline-stage-node.passed .pipeline-stage-dot {
   background: rgba(100, 100, 120, 0.5);
   border-color: rgba(100, 100, 120, 0.7);
@@ -84,5 +102,8 @@
 /* ── Pipeline stage badge variants ── */
 @utility pipeline-stage-badge {
   &.stage-offline { color: rgba(100, 100, 110, 0.85); background: rgba(100, 100, 110, 0.12); border-color: rgba(100, 100, 110, 0.2); }
+  &.stage-failing, &.stage-crashed { color: rgba(239, 68, 68, 0.85); background: rgba(239, 68, 68, 0.12); border-color: rgba(239, 68, 68, 0.2); }
+  &.stage-draining, &.stage-restarting { color: rgba(251, 146, 60, 0.85); background: rgba(251, 146, 60, 0.12); border-color: rgba(251, 146, 60, 0.2); }
+  &.stage-paused { color: rgba(167, 139, 250, 0.85); background: rgba(167, 139, 250, 0.12); border-color: rgba(167, 139, 250, 0.2); }
 }
 


### PR DESCRIPTION
## Summary
- PipelineStageBar: unrecognized stages (failing, crashed, draining, paused, restarting) render as single-node fallback instead of empty bar (currentIdx=-1)
- eventLabel: guard against undefined type field returning literal "undefined" string
- pipeline.css: add dot and badge styles for transient runtime stages

## Review follow-up
Addresses review comments from #5683 (merged):
- [PipelineStage fallback](https://github.com/jeong-sik/masc-mcp/pull/5683#discussion_r3043361869)
- [eventLabel nullish](https://github.com/jeong-sik/masc-mcp/pull/5683#discussion_r3043361907)
- [PipelineStage CSS](https://github.com/jeong-sik/masc-mcp/pull/5683#discussion_r3043466825)

Refs #5683