### PR TITLE
fix(keeper): report actual usage in heartbeat snapshot

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -442,10 +442,13 @@ let write_heartbeat_snapshot
         ; "model_used", `String meta_current.runtime.usage.last_model_used
         ; ( "usage"
           , `Assoc
-              [ "input_tokens", `Int 0; "output_tokens", `Int 0; "total_tokens", `Int 0 ]
+              [ "input_tokens", `Int meta_current.runtime.usage.last_input_tokens
+              ; "output_tokens", `Int meta_current.runtime.usage.last_output_tokens
+              ; "total_tokens", `Int meta_current.runtime.usage.last_total_tokens
+              ]
           )
-        ; "latency_ms", `Int 0
-        ; "cost_usd", `Float 0.0
+        ; "latency_ms", `Int meta_current.runtime.usage.last_latency_ms
+        ; "cost_usd", `Float meta_current.runtime.usage.total_cost_usd
         ; "context_ratio", `Float context_ratio_v
         ; "context_tokens", `Int token_count_v
         ; "context_max", `Int (match ctx_opt with Some c -> c.max_tokens | None -> max_cascade_context)


### PR DESCRIPTION
## Summary
- Heartbeat metrics snapshot was hardcoding `usage: {0, 0, 0}`, `latency_ms: 0`, `cost_usd: 0.0`
- `meta.runtime.usage` already tracks per-turn and cumulative values — just not wired to the snapshot
- Now reports `last_input_tokens`/`last_output_tokens`/`last_total_tokens` from the most recent LLM turn
- `latency_ms` reports actual last turn latency, `cost_usd` reports cumulative total

## Evidence
Before: every heartbeat snapshot shows `input_tokens: 0, output_tokens: 0` regardless of actual LLM activity
After: heartbeat reflects last turn's actual token counts

## Test plan
- [ ] Start keeper, observe heartbeat JSONL after first LLM turn
- [ ] Verify dashboard shows non-zero usage for active keepers
- [ ] Verify fresh keepers (no turns yet) still show 0 correctly