### PR TITLE
chore: bump OAS pin 0.111.0, remove Collaboration bridge

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -23,8 +23,9 @@ let default_max_checkpoint_messages = 120
 
 (** Conservative context-window fallback used when a checkpoint carries
     neither [max_total_tokens] nor [max_input_tokens].  200K covers every
-    currently-supported large-context model and prevents division-by-zero
-    in [context_ratio] if neither field is populated. *)
+    currently-supported large-context model and provides a nonzero window
+    so [context_ratio] is still meaningful, avoiding a misleading 0.0 that
+    could suppress compaction or handoff decisions when limits are unknown. *)
 let default_context_window_tokens = 200_000
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -21,6 +21,12 @@ open Keeper_types
     Per-keeper override via [compaction_policy.max_checkpoint_messages]. *)
 let default_max_checkpoint_messages = 120
 
+(** Conservative context-window fallback used when a checkpoint carries
+    neither [max_total_tokens] nor [max_input_tokens].  200K covers every
+    currently-supported large-context model and prevents division-by-zero
+    in [context_ratio] if neither field is populated. *)
+let default_context_window_tokens = 200_000
+
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
 (* ================================================================ *)
@@ -249,24 +255,20 @@ let log_keeper_exn ~label exn =
 
 let checkpoint_generation_key = "keeper_generation"
 
-let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let open Yojson.Safe.Util in
+let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) : int =
   match cp.max_total_tokens with
-  | Some value -> value
-  | None -> (
-      match cp.working_context with
-      | Some (`Assoc _ as sidecar) ->
-          sidecar |> member "max_tokens" |> to_int_option
-          |> Option.value ~default:fallback
-      | _ -> fallback)
+  | Some n when n > 0 -> n
+  | _ -> (
+      match cp.max_input_tokens with
+      | Some n when n > 0 -> n
+      | _ -> default_context_window_tokens)
 
 let context_of_oas_checkpoint
     ~(max_checkpoint_messages : int)
-    (cp : Agent_sdk.Checkpoint.t)
-    ~(primary_model_max_tokens : int) : working_context =
+    (cp : Agent_sdk.Checkpoint.t) : working_context =
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
-    checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
+    checkpoint_max_tokens cp
   in
   let messages =
     let n = List.length cp.messages in
@@ -399,7 +401,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
   match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
   | (false, Some checkpoint, _) ->
       let ctx =
-        context_of_oas_checkpoint ~max_checkpoint_messages checkpoint ~primary_model_max_tokens
+        context_of_oas_checkpoint ~max_checkpoint_messages checkpoint
       in
       let ctx =
         if primary_model_max_tokens <= 0 then ctx

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -56,11 +56,11 @@ val save_session_checkpoint : session_context -> checkpoint -> unit
 val log_keeper_exn : label:string -> exn -> unit
 
 val checkpoint_max_tokens :
-  Agent_sdk.Checkpoint.t -> fallback:int -> int
+  Agent_sdk.Checkpoint.t -> int
 
 val context_of_oas_checkpoint :
   max_checkpoint_messages:int ->
-  Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
+  Agent_sdk.Checkpoint.t -> working_context
 
 val checkpoint_model_of_meta : keeper_meta -> string
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -98,7 +98,7 @@ let apply_post_turn_lifecycle
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -270,7 +270,7 @@ let recover_latest_checkpoint_for_overflow_retry
           checkpoint_generation checkpoint ~fallback:meta.runtime.generation
         in
         Some
-          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint ~primary_model_max_tokens,
+          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint,
             turn_generation )
     | _, _, Some checkpoint ->
         (try
@@ -291,8 +291,7 @@ let recover_latest_checkpoint_for_overflow_retry
                       ~fallback:meta.runtime.generation
                   in
                   Some
-                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint
-                        ~primary_model_max_tokens,
+                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint,
                       turn_generation )
               | None -> None))
     | _ -> None

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -35,7 +35,7 @@ let maybe_rollover_oas_handoff
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -276,7 +276,7 @@ let build
     match config.compact_ratio with
     | Some ratio ->
       Oas.Builder.with_context_thresholds ~compact_ratio:ratio
-        ?context_window_tokens:config.max_input_tokens builder
+        ?max_tokens:config.max_input_tokens builder
     | None -> builder
   in
   let builder = match config.context_injector with

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -276,7 +276,7 @@ let build
     match config.compact_ratio with
     | Some ratio ->
       Oas.Builder.with_context_thresholds ~compact_ratio:ratio
-        ?max_tokens:config.max_input_tokens builder
+        ?context_window_tokens:config.max_input_tokens builder
     | None -> builder
   in
   let builder = match config.context_injector with

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -275,9 +275,8 @@ let build
   let builder =
     match config.compact_ratio with
     | Some ratio ->
-      let ctx_window = config.max_input_tokens in
       Oas.Builder.with_context_thresholds ~compact_ratio:ratio
-        ?context_window_tokens:ctx_window builder
+        ?context_window_tokens:config.max_input_tokens builder
     | None -> builder
   in
   let builder = match config.context_injector with

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -289,8 +289,9 @@ git_log/git_diff for repo history, bash for curl/jq/env/which.";
 let coding_keeper_bridge_tools : Types.tool_schema list = [
   {
     name = "keeper_bash";
-    description = "Run a shell command by cmd (builds, tests, git, file edits) — \
-returns exit_code and output. For read-only ops prefer keeper_shell_readonly, \
+    description = "Run a single shell command by cmd (builds, tests, git, file edits) — \
+returns exit_code and output. ONE command only: no &&, ||, |, ;, or > chaining. \
+For read-only ops prefer keeper_shell_readonly, \
 for file writes prefer keeper_fs_edit, for worktree-isolated code prefer masc_code_shell.";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -289,9 +289,9 @@ git_log/git_diff for repo history, bash for curl/jq/env/which.";
 let coding_keeper_bridge_tools : Types.tool_schema list = [
   {
     name = "keeper_bash";
-    description = "Run a single shell command by cmd (builds, tests, git, file edits) — \
-returns exit_code and output. ONE command only: no &&, ||, |, ;, or > chaining. \
-For read-only ops prefer keeper_shell_readonly, \
+    description = "Run a shell command by cmd (builds, tests, git, file edits) — \
+returns exit_code and output. Use a single shell command string; validation determines \
+which shell constructs are allowed. For read-only ops prefer keeper_shell_readonly, \
 for file writes prefer keeper_fs_edit, for worktree-isolated code prefer masc_code_shell.";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.111.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="15bef576ff65dc7e455dfcb2e2aa4bdfeb26a3b1"
+readonly OAS_AGENT_SDK_SHA="15bef57d9964fe844d910480eae2ee0e04ad95ac"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.111.0"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.111.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="91c47c8c682692df1b59a4f8d22bf2719507471f"
+readonly OAS_AGENT_SDK_SHA="15bef576ff65dc7e455dfcb2e2aa4bdfeb26a3b1"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.111.0"

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -127,7 +127,7 @@ let test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit () =
       in
       let checkpoint = save_checkpoint ~base_dir ~meta ~ctx in
       check int "stored checkpoint max preserved in checkpoint helper" 4096
-        (KEC.checkpoint_max_tokens checkpoint ~fallback:32768);
+        (KEC.checkpoint_max_tokens checkpoint);
       match
         load_context ~base_dir ~trace_id:meta.runtime.trace_id
           ~max_tokens:32768

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1096,7 +1096,6 @@ let test_overflow_retry_legacy_restore_failure_falls_back_to_oas () =
             Keeper_exec_context.context_of_oas_checkpoint
               ~max_checkpoint_messages:120
               recovery.checkpoint
-              ~primary_model_max_tokens:512
           in
           Alcotest.(check int) "fallback uses OAS generation" 11
             recovery.turn_generation;
@@ -1203,7 +1202,6 @@ let test_overflow_retry_saves_compacted_checkpoint () =
             Keeper_exec_context.context_of_oas_checkpoint
               ~max_checkpoint_messages:120
               recovery.checkpoint
-              ~primary_model_max_tokens:512
           in
           Alcotest.(check bool) "token count reduced" true
             (Keeper_exec_context.token_count recovered_ctx < before_tokens);


### PR DESCRIPTION
## Summary
- Bump OAS agent_sdk pin to 0.111.0 (SHA 15bef57d)
- Remove Agent_sdk.Collaboration dependency (retired in OAS 0.111.0)
- Convert team_context_oas_adapter to produce opaque Yojson.Safe.t for swarm_config.collaboration_context
- Align keeper context checkpoint logic with OAS 0.111.0 fallback chain
- Remove `~primary_model_max_tokens` from `context_of_oas_checkpoint` call sites in tests; recovery checkpoint already embeds the clamped `max_total_tokens` value
- Align `keeper_bash` tool description with actual `validate_command_coding` behavior (pipes and fd-redirects are permitted)
- Reword `default_context_window_tokens` comment to reflect the actual motivation (avoid misleading 0.0 context ratio) rather than division-by-zero prevention

## Product impact

- Promise affected: `none/internal`
- User-visible change: None — internal OAS SDK version alignment and code correctness fixes only

## Evidence

- Code review and CodeQL scan both pass
- `context_of_oas_checkpoint` call sites updated to match the new signature; checkpoint carries clamped `max_total_tokens` so test assertions remain valid

## Review evidence

- Reviewed by copilot-pull-request-reviewer; all flagged issues addressed

## Linked issue