### PR TITLE
fix(dashboard): align pipeline stage colors (scheduled_autonomous + restarting)

### DIFF
--- a/dashboard/src/styles/pipeline.css
+++ b/dashboard/src/styles/pipeline.css
@@ -62,7 +62,8 @@
   border-color: rgba(168, 85, 247, 0.9);
 }
 
-.pipeline-stage-node.active.stage-proactive .pipeline-stage-dot {
+.pipeline-stage-node.active.stage-proactive .pipeline-stage-dot,
+.pipeline-stage-node.active.stage-scheduled_autonomous .pipeline-stage-dot {
   background: rgba(74, 222, 128, 0.7);
   border-color: rgba(74, 222, 128, 0.9);
 }
@@ -79,10 +80,14 @@
   border-color: rgba(239, 68, 68, 0.8);
 }
 
-.pipeline-stage-node.active.stage-draining .pipeline-stage-dot,
-.pipeline-stage-node.active.stage-restarting .pipeline-stage-dot {
+.pipeline-stage-node.active.stage-draining .pipeline-stage-dot {
   background: rgba(251, 146, 60, 0.6);
   border-color: rgba(251, 146, 60, 0.8);
+}
+
+.pipeline-stage-node.active.stage-restarting .pipeline-stage-dot {
+  background: rgba(56, 189, 248, 0.6);
+  border-color: rgba(56, 189, 248, 0.8);
 }
 
 .pipeline-stage-node.active.stage-paused .pipeline-stage-dot {
@@ -103,7 +108,9 @@
 @utility pipeline-stage-badge {
   &.stage-offline { color: rgba(100, 100, 110, 0.85); background: rgba(100, 100, 110, 0.12); border-color: rgba(100, 100, 110, 0.2); }
   &.stage-failing, &.stage-crashed { color: rgba(239, 68, 68, 0.85); background: rgba(239, 68, 68, 0.12); border-color: rgba(239, 68, 68, 0.2); }
-  &.stage-draining, &.stage-restarting { color: rgba(251, 146, 60, 0.85); background: rgba(251, 146, 60, 0.12); border-color: rgba(251, 146, 60, 0.2); }
+  &.stage-draining { color: rgba(251, 146, 60, 0.85); background: rgba(251, 146, 60, 0.12); border-color: rgba(251, 146, 60, 0.2); }
+  &.stage-restarting { color: rgba(56, 189, 248, 0.85); background: rgba(56, 189, 248, 0.12); border-color: rgba(56, 189, 248, 0.2); }
+  &.stage-scheduled_autonomous { color: rgba(74, 222, 128, 0.85); background: rgba(74, 222, 128, 0.12); border-color: rgba(74, 222, 128, 0.2); }
   &.stage-paused { color: rgba(167, 139, 250, 0.85); background: rgba(167, 139, 250, 0.12); border-color: rgba(167, 139, 250, 0.2); }
 }
 


### PR DESCRIPTION
## Summary
- Add missing `stage-scheduled_autonomous` CSS (dot + badge) — same green as `proactive`
- Change `restarting` stage from orange to blue, matching `keeper-phase-strip.ts` and `keeper-fleet-overview.ts`

Addresses review comments from #5700.

## Test plan
- [ ] Dashboard loads without CSS errors
- [ ] Pipeline stage bar shows correct colors for restarting (blue) and scheduled_autonomous (green)