### PR TITLE
feat(provider): add Ollama as first-class local adapter

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -173,6 +173,14 @@ end
     continue to compile without changes. *)
 module Llama = Local_runtime
 
+module Ollama = struct
+  let server_url =
+    get_string ~default:Masc_network_defaults.ollama_default_url "OLLAMA_SERVER_URL"
+
+  let default_model =
+    get_string ~default:"" "OLLAMA_DEFAULT_MODEL"
+end
+
 module Glm = struct
   let server_url = Env_config_core.get_string ~default:"https://api.z.ai" "ZAI_BASE_URL"
 end

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -16,6 +16,13 @@ let local_llm_default_port = 8085
 let local_llm_default_url =
   Printf.sprintf "http://127.0.0.1:%d" local_llm_default_port
 
+(** Default port for Ollama (OpenAI-compatible at /v1). *)
+let ollama_default_port = 11434
+
+(** Default URL for Ollama. *)
+let ollama_default_url =
+  Printf.sprintf "http://127.0.0.1:%d" ollama_default_port
+
 (** Default port for the MASC HTTP server. *)
 let masc_http_default_port = 8935
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -81,6 +81,7 @@ let normalize_label label = String.trim label |> String.lowercase_ascii
 (* ── Canonical adapter names (single definition point) ──────── *)
 
 let cn_llama = "llama"
+let cn_ollama = "ollama"
 let cn_claude = "claude-api"
 let cn_codex = "codex-api"
 let cn_gemini = "gemini-api"
@@ -146,6 +147,19 @@ let direct_adapters =
       default_model_id =
         (let m = Env_config_runtime.Llama.default_model in
          if m = "" || m = "explicit-model-required" then None else Some m);
+    };
+    {
+      canonical_name = cn_ollama;
+      runtime_kind = Local;
+      auth_mode = No_auth;
+      aliases = [ cn_ollama; "ollama-local" ];
+      spawn_key = None;
+      cascade_prefix = "ollama";
+      default_voice = None;
+      endpoint_url = Some Env_config_runtime.Ollama.server_url;
+      default_model_id =
+        (let m = Env_config_runtime.Ollama.default_model in
+         if m = "" then None else Some m);
     };
     {
       canonical_name = cn_claude;
@@ -669,10 +683,12 @@ let auth_kind_for_canonical_name name =
   | None -> "unknown"
 
 let bare_ollama_migration_message () =
-  "Bare `ollama` is no longer supported. Use `default` for normal selection, or `llama:<model>` / another explicit provider:model label as an override."
+  "Bare `ollama` without a model requires OLLAMA_DEFAULT_MODEL env var. Use `ollama:<model>` for explicit selection."
 
 let is_bare_ollama_label label =
-  String.equal (normalize_label label) "ollama"
+  let normalized = normalize_label label in
+  String.equal normalized "ollama"
+  && Env_config_runtime.Ollama.default_model = ""
 
 let explicit_llama_model_id_result () =
   match nonempty_env "LLAMA_DEFAULT_MODEL" with


### PR DESCRIPTION
## Summary
Ollama를 정식 로컬 프로바이더로 등록. cascade.json의 `"ollama:auto"`가 동작하도록 합니다.

### 변경 사항
- **`masc_network_defaults.ml`**: `ollama_default_port` (11434) + `ollama_default_url` 추가
- **`env_config_runtime.ml`**: `Ollama` 모듈 — `OLLAMA_SERVER_URL`, `OLLAMA_DEFAULT_MODEL` env var
- **`provider_adapter.ml`**: `cn_ollama` 상수 + `direct_adapters` 엔트리 (Local, No_auth, cascade_prefix "ollama")
  - `is_bare_ollama_label`: `OLLAMA_DEFAULT_MODEL` 미설정 시에만 bare 차단

### 설계 근거
- `requires_discovery` 주석이 이미 예상: "Adding a new local provider (ollama, ...) only requires adding an entry with [runtime_kind = Local]"
- llama 어댑터와 동일 패턴 (Local runtime, OpenAI 호환 API)
- `auto` 모델 해석: `OLLAMA_DEFAULT_MODEL` env var → `default_model_id`

### 사용법
```bash
export OLLAMA_DEFAULT_MODEL="qwen3.5:9b-nvfp4"
# OLLAMA_SERVER_URL 기본값: http://127.0.0.1:11434
```

cascade.json은 기존 `"ollama:auto"` 그대로 동작.

Closes #5680

## Test plan
- [x] 수정 모듈 3개 dune 컴파일 성공
- [ ] `OLLAMA_DEFAULT_MODEL=qwen3.5:9b-nvfp4` 설정 후 서버 재시작
- [ ] keeper 턴 성공 확인 (`model 'auto' not found` 에러 사라짐)
- [ ] `ollama:qwen3.5:27b-nvfp4` 등 명시적 모델 라벨 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)