### PR TITLE
feat(keeper): record inference telemetry to decisions.jsonl and costs.jsonl

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -274,6 +274,87 @@ function miniSparkline(
   }).join(' ')
 }
 
+export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
+  const series = keeper.metrics_series ?? []
+  const telemetryPoints = series.filter(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second != null,
+  )
+  if (telemetryPoints.length === 0) return null
+
+  const tokPerSec = telemetryPoints.map(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second ?? 0,
+  )
+  const latencies = telemetryPoints.map(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.request_latency_ms ?? 0,
+  )
+  const cacheNs = telemetryPoints.map(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.cache_n ?? 0,
+  )
+  const reasoningTokens = telemetryPoints.map(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.reasoning_tokens ?? 0,
+  )
+
+  const W = SPARKLINE_W, H = SPARKLINE_H
+  const lastTps = tokPerSec[tokPerSec.length - 1] ?? 0
+  const avgTps = tokPerSec.reduce((a, b) => a + b, 0) / tokPerSec.length
+  const lastLatency = latencies[latencies.length - 1] ?? 0
+  const totalCacheN = cacheNs.reduce((a, b) => a + b, 0)
+  const totalReasoning = reasoningTokens.reduce((a, b) => a + b, 0)
+
+  const tpsLine = miniSparkline(tokPerSec)
+  const latencyLine = miniSparkline(latencies)
+
+  const lastFp = telemetryPoints[telemetryPoints.length - 1]?.inference_telemetry?.system_fingerprint
+
+  return html`
+    <div class="mb-5">
+      <div class="flex items-center gap-2 mb-2">
+        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Inference Telemetry</span>
+        <span class="text-[10px] text-[var(--text-dim)]">${telemetryPoints.length} points</span>
+        ${lastFp ? html`<span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
+      </div>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        ${'' /* tok/s sparkline */}
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">tok/s</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastTps.toFixed(1)}</span>
+          </div>
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
+            ${tpsLine ? html`<polyline points="${tpsLine}" fill="none" stroke="#4ade80" stroke-width="1.5"/>` : null}
+          </svg>
+          <div class="text-[9px] text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
+        </div>
+
+        ${'' /* request latency */}
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">API latency</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+          </div>
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
+            ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="#9ad9ff" stroke-width="1.5"/>` : null}
+          </svg>
+        </div>
+
+        ${'' /* cache hits */}
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--purple)]">${totalCacheN > 0 ? totalCacheN.toLocaleString() : '-'}</span>
+          <span class="text-[9px] text-[var(--text-dim)]">cumulative tokens</span>
+        </div>
+
+        ${'' /* reasoning tokens */}
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
+          <span class="text-[9px] text-[var(--text-dim)]">total tokens</span>
+        </div>
+      </div>
+    </div>
+  `
+}
+
 export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) return null

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -24,6 +24,7 @@ import { showToast } from './common/toast'
 import {
   ContextChart,
   EquipmentList,
+  InferenceTelemetryPanel,
   KpiGrid,
   MetricsCharts,
   RawDataDebug,
@@ -376,6 +377,8 @@ export function KeeperDetailOverlay() {
           `
           : null}
 
+        ${'' /* ── Inference Telemetry (tok/s, cache, reasoning) ── */}
+        <${InferenceTelemetryPanel} keeper=${keeper} />
         ${'' /* ── Per-keeper tool telemetry ── */}
         <${KeeperToolTelemetry} keeperName=${keeper.name} />
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -87,6 +87,22 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         handoffObj
           ? (typeof handoffObj.to_model === 'string' ? handoffObj.to_model : null)
           : (typeof item.handoff_to_model === 'string' ? item.handoff_to_model : null)
+      const rawTel = isRecord(item.inference_telemetry) ? item.inference_telemetry : null
+      const rawTimings = rawTel && isRecord(rawTel.timings) ? rawTel.timings : null
+      const inference_telemetry = rawTel ? {
+        system_fingerprint: typeof rawTel.system_fingerprint === 'string' ? rawTel.system_fingerprint : null,
+        timings: rawTimings ? {
+          prompt_n: asNumber(rawTimings.prompt_n) ?? null,
+          prompt_ms: asNumber(rawTimings.prompt_ms) ?? null,
+          prompt_per_second: asNumber(rawTimings.prompt_per_second) ?? null,
+          predicted_n: asNumber(rawTimings.predicted_n) ?? null,
+          predicted_ms: asNumber(rawTimings.predicted_ms) ?? null,
+          predicted_per_second: asNumber(rawTimings.predicted_per_second) ?? null,
+          cache_n: asNumber(rawTimings.cache_n) ?? null,
+        } : null,
+        reasoning_tokens: asNumber(rawTel.reasoning_tokens) ?? null,
+        request_latency_ms: asNumber(rawTel.request_latency_ms) ?? 0,
+      } : null
       return {
         ts,
         context_ratio: contextRatio,
@@ -103,6 +119,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         cost_usd: asNumber(item.cost_usd) ?? Number.NaN,
         handoff_to_model: handoffToModel,
         handoff_new_generation: handoffNewGeneration,
+        inference_telemetry,
       }
     })
     .filter((item): item is KeeperMetricPoint => item !== null)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -146,6 +146,21 @@ export interface BoardFlair {
 
 // --- Keeper Metrics ---
 
+export interface InferenceTelemetry {
+  system_fingerprint: string | null
+  timings: {
+    prompt_n: number | null
+    prompt_ms: number | null
+    prompt_per_second: number | null
+    predicted_n: number | null
+    predicted_ms: number | null
+    predicted_per_second: number | null
+    cache_n: number | null
+  } | null
+  reasoning_tokens: number | null
+  request_latency_ms: number
+}
+
 export interface KeeperMetricPoint {
   ts: number
   context_ratio: number
@@ -162,6 +177,7 @@ export interface KeeperMetricPoint {
   cost_usd: number
   handoff_to_model: string | null
   handoff_new_generation: number | null
+  inference_telemetry: InferenceTelemetry | null
 }
 
 export type KeeperLifecycleState =

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -521,6 +521,7 @@ let compute_metrics_window
                     ("memory_compaction_dropped_notes", `Int memory_compaction_dropped_notes_now);
                     ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
                     ("memory_expected_topic", Json_util.string_opt_to_json memory_expected_topic);
+                    ("inference_telemetry", j |> member "inference_telemetry");
                   ])
               with
               | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1461,7 +1461,13 @@ let run_turn
              "tools_used_count", `Int (List.length tool_names);
              "used_memory_search", `Bool used_search;
              "post_turn_ms", `Float post_turn_ms;
-           ] @ (match recall_eval with
+           ] @ (match result.response.telemetry with
+                | Some t -> [
+                    "inference_telemetry",
+                    Agent_sdk.Types.inference_telemetry_to_yojson t;
+                  ]
+                | None -> [])
+             @ (match recall_eval with
                 | Some e -> [
                     "memory_recall_performed", `Bool e.performed;
                     "memory_recall_passed", `Bool e.passed;

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -101,9 +101,22 @@ let emit_cost_event
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
-    : unit =
+    ?(telemetry : Agent_sdk.Types.inference_telemetry option)
+    () : unit =
   let path = Filename.concat masc_root "costs.jsonl" in
-  let entry = `Assoc [
+  let telemetry_fields = match telemetry with
+    | Some t ->
+      (match t.reasoning_tokens with
+       | Some n -> [("reasoning_tokens", `Int n)] | None -> [])
+      @ (match t.timings with
+         | Some tm ->
+           (match tm.cache_n with
+            | Some n -> [("cache_n", `Int n)] | None -> [])
+         | None -> [])
+      @ [("request_latency_ms", `Int t.request_latency_ms)]
+    | None -> []
+  in
+  let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
     ("model", `String model);
@@ -112,7 +125,7 @@ let emit_cost_event
     ("cost_usd", `Float cost_usd);
     ("timestamp", `String (Types.now_iso ()));
     ("source", `String "auto_trajectory");
-  ] in
+  ] @ telemetry_fields) in
   let line = Yojson.Safe.to_string entry ^ "\n" in
   (try Fs_compat.append_file path line
    with Eio.Cancel.Cancelled _ as e -> raise e
@@ -287,7 +300,7 @@ let make_hooks
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
              ~model ~input_tokens:input_tok ~output_tokens:output_tok
-             ~cost_usd:0.0
+             ~cost_usd:0.0 ?telemetry:response.telemetry ()
          | None -> ());
         let text = Agent_sdk.Types.text_of_content response.content in
         let has_state_block =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -685,6 +685,11 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
              ("mode_source", `String p.mode_decision_source);
            ]
          | None -> `Null);
+        ("inference_telemetry",
+         match result.inference_telemetry with
+         | Some t ->
+           Agent_sdk.Types.inference_telemetry_to_yojson t
+         | None -> `Null);
       ]
   in
   Dated_jsonl.append metrics_store snapshot


### PR DESCRIPTION
## Summary

- `keeper_agent_run.ml`: `post_turn_eval` event에 `inference_telemetry` 블록 추가. OAS `api_response.telemetry`를 `inference_telemetry_to_yojson`으로 직렬화.
- `keeper_hooks_oas.ml`: `emit_cost_event`에 `?telemetry` optional 파라미터 추가. `reasoning_tokens`, `cache_n`, `request_latency_ms` 기록.

## Context

OAS v0.111.0에서 inference telemetry 파싱이 구현되었고 MASC가 `run_result.inference_telemetry`로 수신 중이지만, decisions.jsonl과 costs.jsonl에 기록되지 않았음. 이 PR은 기존 데이터 흐름의 "마지막 1마일"을 연결.

## Test plan

- [ ] CI 빌드 통과
- [ ] `dune runtest` 통과
- [ ] Keeper 실행 후 `jq 'select(.event=="post_turn_eval") | .inference_telemetry' .masc/keepers/<name>.decisions.jsonl` 로 telemetry 확인
- [ ] `jq 'select(.reasoning_tokens != null)' .masc/costs.jsonl` 로 costs 확인

## Related

- OAS PR jeong-sik/oas#701 (merged): `request_latency_ms` wiring + `PostToolUse.duration_ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)