### PR TITLE
fix: resolve model ID in oas_worker_exec failsafe

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -127,11 +127,19 @@ let resolve_provider_of_label (label : string) : Oas.Provider.config =
     match Llm_provider.Cascade_config.parse_model_string fallback with
     | Some pc -> Oas.Provider.config_of_provider_config pc
     | None ->
-      (* Failsafe: use "auto" sentinel rather than the unparseable label. *)
+      (* Failsafe: resolve model via Discovery or OLLAMA_DEFAULT_MODEL.
+         Ollama rejects literal "auto" — must resolve to a concrete ID. *)
+      let model_id =
+        match Llm_provider.Discovery.first_discovered_model_id () with
+        | Some id -> id
+        | None ->
+          Sys.getenv_opt "OLLAMA_DEFAULT_MODEL"
+          |> Option.value ~default:"auto"
+      in
       Oas.Provider.config_of_provider_config
         (Llm_provider.Provider_config.make
            ~kind:Llm_provider.Provider_config.OpenAI_compat
-           ~model_id:"auto"
+           ~model_id
            ~base_url:(Llm_provider.Provider_registry.next_llama_endpoint ())
            ~request_path:"/v1/chat/completions" ())
 


### PR DESCRIPTION
## Summary
- `oas_worker_exec.ml` failsafe에서 `model_id:"auto"` 하드코딩 제거
- Discovery.first_discovered_model_id → OLLAMA_DEFAULT_MODEL → "auto" fallback 체인

## Context
Ollama는 model 필드를 검증하여 literal "auto"를 거부:
`Invalid request: model 'auto' not found`

resolve_provider_of_label의 최종 failsafe 경로가 OpenAI_compat kind로 "auto"를 직접 전달하고 있었음.

관련: jeong-sik/oas PR (cascade_model_resolve + provider_bridge)

## Test plan
- [x] test_oas_worker 43 tests pass
- [x] dune build clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>