### PR TITLE
fix(config): split cascade models — glm default, ollama per-keeper

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,6 @@
 {
-  "default_models": ["ollama:qwen3.5:9b-nvfp4", "glm:auto"],
+  "default_models": ["glm:auto"],
+  "keeper_ollama_models": ["ollama:qwen3.5:9b-nvfp4"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 


### PR DESCRIPTION
## Summary
- `ollama:auto`가 llama-server discovery에서 모델명을 가져오지만 Ollama endpoint로 라우팅하여 전 keeper "model not found" 에러 발생
- `default_models`를 `glm:auto`로 변경하여 즉시 언블록
- `keeper_ollama_models`를 별도 cascade로 분리, opt-in 방식으로 Ollama 사용 가능

## 변경
- `config/cascade.json`: default → glm:auto, keeper_ollama → ollama:qwen3.5:9b-nvfp4
- Runtime: keeper JSON에 `cascade_name: "keeper_ollama"` 설정으로 Ollama 사용

## Root Cause (OAS discovery bug, 별도 이슈)
`cascade_config.ml:100`의 `first_discovered_model_id()`가 provider별 필터 없이 전체 endpoint에서 모델을 반환하여 cross-provider 오염 발생. 이 PR은 config 우회로 즉시 해결.

## Test plan
- [ ] MASC 서버 재시작 후 keeper 정상 턴 확인
- [ ] example keeper가 Ollama 모델로 턴 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)