### PR TITLE
feat(transport): unified Transport_bridge provider interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,12 @@ dashboard/dist/
 assets/dashboard/
 viewer/dist-build/
 
+# TLC model checker artifacts
+specs/**/states/
+specs/**/*_TTrace_*.tla
+specs/**/TraceData.tla
+*.jar
+
 # Local Claude session scratch
 .claude/
 

--- a/lib/dune
+++ b/lib/dune
@@ -388,6 +388,7 @@
    heuristic_metrics
    agent_stress
    transport
+   transport_bridge
    transport_read_model
    transport_metrics
    ;; gRPC coordination transport (grpc-direct)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -679,6 +679,52 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         Server_webrtc_transport.set_connection_starter
           (fun peer_id ->
             Server_webrtc_transport.start_webrtc_connection ~sw ~env peer_id));
+      (* Register transport providers for unified bridge *)
+      Transport_bridge.register_provider (module struct
+        let name = "sse"
+        let protocol = Transport.Sse
+        let is_enabled () = true  (* SSE is always enabled *)
+        let session_count () = Sse.client_count ()
+        let status_json () = `Assoc [
+          "clients", `Int (Sse.client_count ());
+          "external_subscribers", `Int (Sse.external_subscriber_count ());
+        ]
+        let reap_stale () = List.length (Sse.cleanup_stale ())
+      end);
+      Transport_bridge.register_provider (module struct
+        let name = "ws"
+        let protocol = Transport.Ws
+        let is_enabled () = Server_ws_standalone.is_enabled ()
+        let session_count () = Server_mcp_transport_ws.session_count ()
+        let status_json () = `Assoc [
+          "port", `Int (Server_ws_standalone.configured_port ());
+          "sessions", `Int (Server_mcp_transport_ws.session_count ());
+        ]
+        let reap_stale () = 0  (* WS sessions self-clean on disconnect *)
+      end);
+      Transport_bridge.register_provider (module struct
+        let name = "grpc"
+        let protocol = Transport.Grpc
+        let is_enabled () = Masc_grpc_server.is_enabled ()
+        let session_count () = 0  (* gRPC uses per-call, no persistent sessions *)
+        let status_json () = `Assoc [
+          "port", `Int (Masc_grpc_server.configured_port ());
+          "service", `String Masc_grpc_service.service_name;
+        ]
+        let reap_stale () = 0
+      end);
+      Transport_bridge.register_provider (module struct
+        let name = "webrtc"
+        let protocol = Transport.Webrtc
+        let is_enabled () = Server_webrtc_transport.is_enabled ()
+        let session_count () = Server_webrtc_transport.live_webrtc_count ()
+        let status_json () = `Assoc [
+          "active_peers", `Int (Server_webrtc_transport.active_peer_count ());
+          "live_connections", `Int (Server_webrtc_transport.live_webrtc_count ());
+          "connected_channels", `Int (Server_webrtc_transport.connected_channel_count ());
+        ]
+        let reap_stale () = 0  (* WebRTC has its own ICE timeout *)
+      end);
       (* Cold-start warm-cache stagger is handled by warm_delay_s in each
          Proactive_refresh config. Heavy surfaces delay their initial warm
          compute to avoid concurrent CPU/PG contention.  Lightweight surfaces

--- a/lib/transport_bridge.ml
+++ b/lib/transport_bridge.ml
@@ -1,0 +1,89 @@
+(** Transport_bridge — Unified transport provider registry.
+
+    Pure registry module. Has no dependencies on specific transport
+    implementations — providers are registered via bootstrap. *)
+
+module type PROVIDER = sig
+  val name : string
+  val protocol : Transport.protocol
+  val is_enabled : unit -> bool
+  val session_count : unit -> int
+  val status_json : unit -> Yojson.Safe.t
+  val reap_stale : unit -> int
+end
+
+(* ── Registry ─────────────────────────────────────────── *)
+
+(* Providers stored in registration order. *)
+let registry : (module PROVIDER) list ref = ref []
+
+let register_provider (p : (module PROVIDER)) =
+  let module P = (val p : PROVIDER) in
+  (* Replace existing with same name *)
+  registry := List.filter (fun m ->
+    let module M = (val m : PROVIDER) in
+    M.name <> P.name
+  ) !registry;
+  registry := !registry @ [ p ]
+
+let providers () = !registry
+
+let provider_by_name name =
+  List.find_opt (fun m ->
+    let module M = (val m : PROVIDER) in
+    M.name = name
+  ) !registry
+
+(* ── Aggregate Operations ─────────────────────────────── *)
+
+let total_session_count () =
+  List.fold_left (fun acc m ->
+    let module M = (val m : PROVIDER) in
+    if M.is_enabled () then acc + M.session_count ()
+    else acc
+  ) 0 !registry
+
+let status_all_json () =
+  `Assoc (List.map (fun m ->
+    let module M = (val m : PROVIDER) in
+    (M.name, `Assoc [
+      "enabled", `Bool (M.is_enabled ());
+      "protocol", `String (Transport.protocol_to_string M.protocol);
+      "sessions", `Int (M.session_count ());
+      "detail", M.status_json ();
+    ])
+  ) !registry)
+
+let reap_all_stale () =
+  List.fold_left (fun acc m ->
+    let module M = (val m : PROVIDER) in
+    if M.is_enabled () then acc + M.reap_stale ()
+    else acc
+  ) 0 !registry
+
+let enabled_protocols () =
+  List.filter_map (fun m ->
+    let module M = (val m : PROVIDER) in
+    if M.is_enabled () then Some M.protocol
+    else None
+  ) !registry
+
+(* ── Agent Card ───────────────────────────────────────── *)
+
+let agent_card_transports_json ~host ~port =
+  let entries = List.filter_map (fun m ->
+    let module M = (val m : PROVIDER) in
+    if M.is_enabled () then
+      Some (`Assoc [
+        "protocol", `String (Transport.protocol_to_string M.protocol);
+        "name", `String M.name;
+        "sessions", `Int (M.session_count ());
+      ])
+    else None
+  ) !registry in
+  `Assoc [
+    "host", `String host;
+    "port", `Int port;
+    "active_transports", `List entries;
+    "total_sessions", `Int (total_session_count ());
+  ]

--- a/lib/transport_bridge.mli
+++ b/lib/transport_bridge.mli
@@ -1,0 +1,63 @@
+(** Transport_bridge — Unified transport provider interface.
+
+    Each transport (SSE, WS, gRPC, WebRTC) implements {!PROVIDER}
+    and registers at server bootstrap. The bridge centralizes:
+    - Discovery: protocol enumeration, Agent Card generation
+    - Lifecycle: session reaping across all transports
+    - Metrics: aggregate session/connection counts
+
+    Broadcast still flows through SSE's external_subscriber
+    pattern. This module does not replace that mechanism. *)
+
+(** Contract that every transport must satisfy. *)
+module type PROVIDER = sig
+  val name : string
+  (** Short identifier: "sse", "ws", "grpc", "webrtc". *)
+
+  val protocol : Transport.protocol
+  (** Which protocol enum this provider implements. *)
+
+  val is_enabled : unit -> bool
+  (** Whether this transport is currently accepting connections. *)
+
+  val session_count : unit -> int
+  (** Number of active sessions/connections right now. *)
+
+  val status_json : unit -> Yojson.Safe.t
+  (** Protocol-specific status for diagnostic endpoints. *)
+
+  val reap_stale : unit -> int
+  (** Clean up dead/idle sessions. Returns number reaped. *)
+end
+
+(** {1 Provider Registry} *)
+
+val register_provider : (module PROVIDER) -> unit
+(** Register a transport provider. Replaces any existing provider
+    with the same name. Called during server bootstrap. *)
+
+val providers : unit -> (module PROVIDER) list
+(** All registered providers, in registration order. *)
+
+val provider_by_name : string -> (module PROVIDER) option
+(** Lookup a provider by its [name] field. *)
+
+(** {1 Aggregate Operations} *)
+
+val total_session_count : unit -> int
+(** Sum of [session_count] across all enabled providers. *)
+
+val status_all_json : unit -> Yojson.Safe.t
+(** Assoc of provider name -> status_json for all providers. *)
+
+val reap_all_stale : unit -> int
+(** Reap stale sessions across all providers. Returns total reaped. *)
+
+val enabled_protocols : unit -> Transport.protocol list
+(** List of protocols with at least one enabled provider. *)
+
+(** {1 Agent Card} *)
+
+val agent_card_transports_json : host:string -> port:int -> Yojson.Safe.t
+(** Transport section for A2A Agent Card / MCP discovery.
+    Includes enabled protocols, endpoints, session counts. *)

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -193,4 +193,5 @@ let transport_status_json (ctx : http_context) =
               [ ("signaling_url", `String (ctx.base_url ^ "/webrtc")) ]
             else
               []) );
+      ("bridge", Transport_bridge.status_all_json ());
     ]


### PR DESCRIPTION
## Summary
- Introduces `Transport_bridge.PROVIDER` module type — contract for all transport implementations
- Pure registry module (no dependencies on specific transports)
- 4 providers registered at bootstrap: SSE, WS, gRPC, WebRTC
- Aggregate operations: `total_session_count`, `status_all_json`, `reap_all_stale`, `enabled_protocols`
- Agent Card generation: `agent_card_transports_json`
- `.gitignore`: TLC model checker artifacts (TraceData.tla, states/, jars)

## Context
Part of the Transport layer unification effort. Currently each transport (SSE, WS, gRPC, WebRTC) has its own ad-hoc interface. SSE's `external_subscriber` pattern handles outbound broadcast, but inbound discovery and lifecycle management are fragmented.

This module type formalizes the contract without rewriting existing transports — they're wrapped as inline modules at bootstrap time.

## Changes
| File | Change |
|------|--------|
| `lib/transport_bridge.ml/.mli` | New: PROVIDER module type + registry |
| `lib/server/server_runtime_bootstrap.ml` | 4 provider registrations (SSE/WS/gRPC/WebRTC) |
| `lib/transport_read_model.ml` | Bridge status in transport_status_json |
| `.gitignore` | TLC artifacts |

## Test plan
- [x] `dune build @check` passes
- [x] PBT tests pass (20,000 sequences)
- [ ] Verify `transport_status` tool shows bridge section after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)