### PR TITLE
fix(cascade): correct key name for keeper_unified cascade

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,6 @@
 {
   "default_models": ["glm:auto"],
-  "keeper_ollama_models": ["ollama:qwen3.5:9b-nvfp4"],
+  "keeper_unified_models": ["ollama:auto", "glm:auto"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 


### PR DESCRIPTION
## Summary
- `keeper_ollama_models` → `keeper_unified_models` (OAS load_profile convention: `{cascade_name}_models`)
- `ollama:qwen3.5:9b-nvfp4` → `ollama:auto` (Discovery/env 기반 resolve)
- Without this fix, all keeper turns fallback to `default_models` (GLM only), skipping Ollama

## Root cause
OAS `Cascade_config_loader.load_profile` looks up `{name}_models` key in cascade.json.
Keeper cascade name is `keeper_unified`, so the key must be `keeper_unified_models`.
Previous commit (#5724) used `keeper_ollama_models` which never matched.

## Impact
- 1,007/1,597 (63%) of today's keeper failures were "model 'auto' not found" 
- 335/1,597 (21%) were "model 'qwen3.5-9b-local' not found" (llama-server ghost, now killed)
- Success rate was 2.1% (34/1,631 unified turns)

## Test plan
- [ ] Server restart with this config
- [ ] Verify keeper decisions show `model=qwen3.5:*` (Ollama) 
- [ ] Zero "model 'auto' not found" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)