### PR TITLE
fix(transport): seal registry after bootstrap for fiber safety

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -725,6 +725,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         ]
         let reap_stale () = 0  (* WebRTC has its own ICE timeout *)
       end);
+      Transport_bridge.seal ();
       (* Cold-start warm-cache stagger is handled by warm_delay_s in each
          Proactive_refresh config. Heavy surfaces delay their initial warm
          compute to avoid concurrent CPU/PG contention.  Lightweight surfaces

--- a/lib/transport_bridge.ml
+++ b/lib/transport_bridge.ml
@@ -14,17 +14,28 @@ end
 
 (* ── Registry ─────────────────────────────────────────── *)
 
-(* Providers stored in registration order. *)
+(* Providers stored in registration order.
+   The registry is mutable only during bootstrap (single fiber).
+   After [seal] is called, further registration raises [Failure].
+   Reads from multiple fibers are safe because OCaml ref reads are
+   atomic at the word level, and the list is never mutated post-seal. *)
 let registry : (module PROVIDER) list ref = ref []
+let sealed = ref false
+
+let seal () = sealed := true
 
 let register_provider (p : (module PROVIDER)) =
-  let module P = (val p : PROVIDER) in
-  (* Replace existing with same name *)
-  registry := List.filter (fun m ->
-    let module M = (val m : PROVIDER) in
-    M.name <> P.name
-  ) !registry;
-  registry := !registry @ [ p ]
+  if !sealed then
+    failwith "Transport_bridge: registry sealed after bootstrap"
+  else begin
+    let module P = (val p : PROVIDER) in
+    (* Replace existing with same name *)
+    registry := List.filter (fun m ->
+      let module M = (val m : PROVIDER) in
+      M.name <> P.name
+    ) !registry;
+    registry := !registry @ [ p ]
+  end
 
 let providers () = !registry
 

--- a/lib/transport_bridge.mli
+++ b/lib/transport_bridge.mli
@@ -34,7 +34,13 @@ end
 
 val register_provider : (module PROVIDER) -> unit
 (** Register a transport provider. Replaces any existing provider
-    with the same name. Called during server bootstrap. *)
+    with the same name. Called during server bootstrap.
+    @raise Failure if called after {!seal}. *)
+
+val seal : unit -> unit
+(** Freeze the registry. Must be called after all providers are
+    registered (end of bootstrap). Post-seal reads from multiple
+    fibers are safe without synchronization. *)
 
 val providers : unit -> (module PROVIDER) list
 (** All registered providers, in registration order. *)


### PR DESCRIPTION
## Summary
Follow-up to #5726. Adds `seal()` pattern to `Transport_bridge` registry.

- `register_provider` raises `Failure` if called after `seal()`
- `seal()` called at end of bootstrap after all 4 providers registered
- Post-seal reads from multiple fibers are safe (immutable list)

## Why
Review identified that `list ref` registry was not fiber-safe for concurrent reads during mutation. The seal pattern makes the immutable-after-bootstrap invariant explicit with zero runtime cost on reads.

## Test plan
- [x] `dune build @check` passes
- [x] Existing PBT tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)