### PR TITLE
fix(keeper): add secondary timeout for stuck keepalive fiber, based on configured interval (#5474)

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -267,10 +267,13 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   (* H-4 fix: true zombies are stale regardless of keepalive state *)
   else if is_zombie then "stale"
   else if keepalive_running then
-    (* Keepalive fiber is alive — trust it over last_seen.
-       presence_fresh optimization may skip Room.heartbeat(),
-       causing last_seen to drift without the keeper actually being stale. *)
-    (match quiet_reason with
+    (* Secondary timeout: if the fiber is stuck and not heartbeating, flag as stale *)
+    if last_seen_ago_s > 2.0 *. stale_threshold_s then "stale"
+    else
+      (* Keepalive fiber is alive — trust it over last_seen.
+         presence_fresh optimization may skip Room.heartbeat(),
+         causing last_seen to drift without the keeper actually being stale. *)
+      (match quiet_reason with
     | Some "graphql_error" | Some "model_error" -> "degraded"
     | _ ->
         if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then "idle"

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -241,6 +241,7 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
         else None
 
 let keeper_health_state ?(fiber_health = Fiber_unknown)
+    ?(keepalive_interval_s = 300.0)
     ~meta ~keepalive_running ~agent_status ~quiet_reason ~now_ts () =
   (* Supervisor-level health takes priority *)
   match fiber_health with
@@ -267,8 +268,10 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   (* H-4 fix: true zombies are stale regardless of keepalive state *)
   else if is_zombie then "stale"
   else if keepalive_running then
-    (* Secondary timeout: if the fiber is stuck and not heartbeating, flag as stale *)
-    if last_seen_ago_s > 2.0 *. stale_threshold_s then "stale"
+    (* Secondary timeout: if the fiber is stuck and not heartbeating, flag as stale.
+       Use 2x the configured keepalive interval (default: max 300s) so that keepers
+       with a long heartbeat cadence are not incorrectly classified. *)
+    if last_seen_ago_s > 2.0 *. keepalive_interval_s then "stale"
     else
       (* Keepalive fiber is alive — trust it over last_seen.
          presence_fresh optimization may skip Room.heartbeat(),

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -25,6 +25,7 @@ val augment_keeper_diagnostic_json :
 
 val keeper_health_state :
   ?fiber_health:fiber_health ->
+  ?keepalive_interval_s:float ->
   meta:keeper_meta ->
   keepalive_running:bool ->
   agent_status:Yojson.Safe.t ->

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -82,16 +82,48 @@ let make_agent_status ?(exists = true) ?(status = "active")
 
 let test_health_keepalive_running_overrides_stale_last_seen () =
   let meta = make_meta () in
+  (* 600.0 is at the boundary of 2 * 300.0 (default interval); > is strict so NOT stale *)
   let agent_status = make_agent_status ~last_seen_ago_s:600.0 () in
   let health =
     ES.keeper_health_state ~meta ~keepalive_running:true
       ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
   in
-  (* keepalive is running — last_seen staleness should NOT make it "stale" *)
-  check bool "keepalive running + stale last_seen is NOT stale"
+  (* keepalive is running and last_seen has not exceeded 2x the max keepalive interval *)
+  check bool "keepalive running + last_seen at boundary is NOT stale"
     true (health <> "stale");
-  check bool "keepalive running + stale last_seen is NOT offline"
+  check bool "keepalive running + last_seen at boundary is NOT offline"
     true (health <> "offline")
+
+let test_health_keepalive_stuck_secondary_timeout () =
+  let meta = make_meta () in
+  (* 700.0 > 2 * 300.0 = 600.0 — secondary stuck-fiber timeout should fire *)
+  let agent_status = make_agent_status ~last_seen_ago_s:700.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "keepalive running but last_seen > 2x interval → stale (stuck fiber)" "stale" health
+
+let test_health_keepalive_below_secondary_timeout () =
+  let meta = make_meta () in
+  (* 599.0 < 2 * 300.0 = 600.0 — below stuck threshold; keepalive should still override *)
+  let agent_status = make_agent_status ~last_seen_ago_s:599.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check bool "keepalive running + last_seen just below 2x interval is NOT stale"
+    true (health <> "stale")
+
+let test_health_keepalive_stuck_respects_interval () =
+  let meta = make_meta () in
+  (* With a 30s interval, stuck threshold = 2 * 30 = 60s. 70s should be stale. *)
+  let agent_status = make_agent_status ~last_seen_ago_s:70.0 () in
+  let health =
+    ES.keeper_health_state ~keepalive_interval_s:30.0 ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts:(Time_compat.now ()) ()
+  in
+  check string "keepalive running + last_seen > 2x configured interval → stale" "stale" health
 
 let test_health_keepalive_not_running_respects_stale_last_seen () =
   let meta = make_meta () in
@@ -143,6 +175,12 @@ let () =
         [
           test_case "keepalive running overrides stale last_seen" `Quick
             test_health_keepalive_running_overrides_stale_last_seen;
+          test_case "keepalive stuck: secondary timeout fires" `Quick
+            test_health_keepalive_stuck_secondary_timeout;
+          test_case "keepalive stuck: below threshold not stale" `Quick
+            test_health_keepalive_below_secondary_timeout;
+          test_case "keepalive stuck: respects configured interval" `Quick
+            test_health_keepalive_stuck_respects_interval;
           test_case "no keepalive respects stale last_seen" `Quick
             test_health_keepalive_not_running_respects_stale_last_seen;
           test_case "zombie overrides keepalive" `Quick


### PR DESCRIPTION
## Summary

Adds a secondary timeout path to `keeper_health_state` so a keeper can be classified as `stale` even when `keepalive_running=true`, catching cases where the keepalive fiber exists but is stuck and not making forward progress.

- Added `?keepalive_interval_s` optional parameter (default `300.0`, the max allowed by `keeper.keepalive_interval_sec`) to `keeper_health_state` and its `.mli` signature.
- The stuck-fiber threshold is now `2.0 *. keepalive_interval_s` (600s by default) instead of a fixed multiple of `stale_threshold_s` (which was 240s), preventing false-positive `stale` classification for keepers with large heartbeat intervals (up to 300s).
- Callers that know the actual runtime interval can pass `~keepalive_interval_s` for a tighter threshold.
- Updated and expanded unit tests: existing boundary test at 600.0s remains valid; added three new cases covering the secondary timeout firing (700s), below-threshold not-stale (599s), and a custom configured interval (30s → stuck at 70s).

## Product impact

- Promise affected: `ops visibility`
- User-visible change: Keepers with long heartbeat intervals (up to 300s) are no longer incorrectly classified as `stale` while their keepalive fiber is healthy. Genuinely stuck fibers (no heartbeat for > 2× the configured interval) are still correctly flagged as `stale`.

## Evidence

- Added `test_health_keepalive_stuck_secondary_timeout`: verifies secondary timeout fires when `last_seen_ago_s > 2 × keepalive_interval_s`.
- Added `test_health_keepalive_below_secondary_timeout`: verifies values just below the threshold (599s) are not stale.
- Added `test_health_keepalive_stuck_respects_interval`: verifies a custom 30s interval triggers stuck detection at 70s.
- Existing `test_health_keepalive_running_overrides_stale_last_seen` remains passing (boundary: `600.0 > 600.0` is false with strict `>`).

## Review evidence

Addressed reviewer feedback: threshold now based on `keepalive_interval_s` rather than a hard-coded multiple of `stale_threshold_s`; tests updated to match new secondary-timeout behavior and prevent future regressions.

## Linked issue