### PR TITLE
feat(keeper): implement OAS bridge with Eio structured cancellation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -478,6 +478,7 @@
    keeper_tools_oas
    keeper_hooks_oas
    keeper_extend_turns
+   keeper_llm_bridge
    keeper_agent_run
    keeper_world_observation
    keeper_unified_prompt

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1209,44 +1209,46 @@ let run_turn
       | Error e -> Error (Oas.Error.Internal e)
       | Ok oas_allowed_paths ->
         (match
-        Oas_worker.run_named
-          ~cascade_name
-          ~goal:user_message
-          ~priority
-          ~session_id:meta.runtime.trace_id
-          ~system_prompt:turn_system_prompt
-          ~tools
-          ~compact_ratio:meta.compaction.ratio_gate
-          ~initial_messages:history_messages
-          ~hooks
-          ~context_reducer:reducer
-          ~memory
-          (* Keepers rely on turn-level retry (multi-turn loop) rather than
-             per-call retry. Ideally this would be Tool_retry_policy.none, but
-             OAS does not expose a zero-retry variant yet. default_internal
-             (max_retries=1) is acceptable as a minimal fallback. *)
-          ~tool_retry_policy:Oas.Tool_retry_policy.default_internal
-          ~max_turns
-          ~max_idle_turns
-          ~temperature
-          ~max_tokens
-          ?max_cost_usd
-          ?guardrails
-          ?on_event
-          ?on_yield
-          ?on_resume
-          ~agent_ref
-          ?contract
-          ~allowed_paths:oas_allowed_paths
-          ~cache_system_prompt:true
-          ~yield_on_tool
-          ~checkpoint_dir:session_dir
-          ~context_injector
-          ~context:shared_context
-          ?slot_id:(Keeper_config.keeper_slot_id meta.name)
-          ?oas_checkpoint:raw_oas_checkpoint
-          ?event_bus
-          ()
+        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:45.0 (fun () ->
+          Oas_worker.run_named
+            ~cascade_name
+            ~goal:user_message
+            ~priority
+            ~session_id:meta.runtime.trace_id
+            ~system_prompt:turn_system_prompt
+            ~tools
+            ~compact_ratio:meta.compaction.ratio_gate
+            ~initial_messages:history_messages
+            ~hooks
+            ~context_reducer:reducer
+            ~memory
+            (* Keepers rely on turn-level retry (multi-turn loop) rather than
+               per-call retry. Ideally this would be Tool_retry_policy.none, but
+               OAS does not expose a zero-retry variant yet. default_internal
+               (max_retries=1) is acceptable as a minimal fallback. *)
+            ~tool_retry_policy:Oas.Tool_retry_policy.default_internal
+            ~max_turns
+            ~max_idle_turns
+            ~temperature
+            ~max_tokens
+            ?max_cost_usd
+            ?guardrails
+            ?on_event
+            ?on_yield
+            ?on_resume
+            ~agent_ref
+            ?contract
+            ~allowed_paths:oas_allowed_paths
+            ~cache_system_prompt:true
+            ~yield_on_tool
+            ~checkpoint_dir:session_dir
+            ~context_injector
+            ~context:shared_context
+            ?slot_id:(Keeper_config.keeper_slot_id meta.name)
+            ?oas_checkpoint:raw_oas_checkpoint
+            ?event_bus
+            ()
+        )
       with
       | Error e -> Error e
       | Ok result ->

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -1,0 +1,31 @@
+(* lib/keeper/keeper_llm_bridge.ml *)
+(* OAS Adapter bridging Eio structured concurrency, multi-turn cascade rollbacks,
+   and strict global stop preemptions as formally verified in KeeperOASAdvanced.tla. *)
+
+(** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
+    structural timeout. If the execution is cancelled by a timeout or global stop,
+    the exception is caught, the context mutations are discarded (functional rollback),
+    and an OAS timeout error is returned. *)
+let run_with_timeout_and_fallback ~timeout_s fn =
+  let do_timeout fn =
+    match (Masc_eio_env.get ()).clock with
+    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
+    | None -> fn ()
+  in
+  try
+    do_timeout fn
+  with
+  | Eio.Time.Timeout ->
+    Log.Keeper.warn "keeper_llm_bridge: OAS execution timed out after %.1fs (structural rollback)" timeout_s;
+    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
+  | Eio.Cancel.Cancelled _ ->
+    (* TLA+: FiberHandlesCancellation -> Rollback context.
+       Since Oas_worker_exec returns the new context functionally inside the run_result,
+       we inherently discard intermediate state when cancelled here. *)
+    Log.Keeper.warn "keeper_llm_bridge: OAS execution cancelled (structural rollback)";
+    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
+  | exn ->
+    (* TLA+: HandleError -> Rollback context *)
+    let bt = Printexc.get_backtrace () in
+    Log.Keeper.error "keeper_llm_bridge: OAS execution error: %s\n%s" (Printexc.to_string exn) bt;
+    Error (Oas.Error.Internal (Printexc.to_string exn))

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -1,0 +1,10 @@
+(* lib/keeper/keeper_llm_bridge.mli *)
+
+(** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
+    structural timeout. If the execution is cancelled by a timeout or global stop,
+    the exception is caught, the context mutations are discarded (functional rollback),
+    and an OAS timeout error is returned. *)
+val run_with_timeout_and_fallback :
+  timeout_s:float ->
+  (unit -> ('a, Oas.Error.sdk_error) result) ->
+  ('a, Oas.Error.sdk_error) result


### PR DESCRIPTION
## Description

Implements Phase 1 & 2 of the Keeper OAS Migration plan.
This PR introduces the `Keeper_llm_bridge` adapter to encapsulate Eio structured concurrency timeouts and error fallback logic as mathematically verified by the recent TLA+ models.

- Adds `Keeper_llm_bridge.run_with_timeout_and_fallback` to catch `Eio.Time.Timeout`, `Eio.Cancel.Cancelled`, and `exn`.
- Uses `Masc_eio_env.get().clock` to cleanly perform `Eio.Time.with_timeout_exn`
- Wraps `Oas_worker.run_named` inside `keeper_agent_run.ml` with a 45.0s structural timeout.
- Modifies `lib/dune` to include the new bridge module.

Fixes the zombie fiber and cascade context pollution risks during LLM calls.