### PR TITLE
fix(cascade): replace glm:auto and ollama:auto with concrete model IDs

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,6 @@
 {
-  "default_models": ["glm:auto"],
-  "keeper_unified_models": ["ollama:auto", "glm:auto"],
+  "default_models": ["glm:glm-5.1"],
+  "keeper_unified_models": ["ollama:qwen3.5:9b-nvfp4", "glm:glm-5.1"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,8 +1,8 @@
 {
   "default_models": ["glm:glm-5.1"],
-  "keeper_unified_models": ["ollama:qwen3.5:9b-nvfp4", "glm:glm-5.1"],
+  "keeper_unified_models": ["glm:glm-5.1"],
 
-  "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
+  "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed. Entries in *_models must remain in {provider}:{model_id} format; avoid model_id values containing additional ':' characters unless a parser-compatible alias is available.",
 
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,


### PR DESCRIPTION
## Summary

Fix critical model auto not found error affecting ALL keepers (2015+ errors on Apr 7).

Root Cause: `config/cascade.json` specified `glm:auto` as default model. GLM ZAI API does not recognize `auto` as a `model_id`.

Fix: `glm:auto` → `glm:glm-5.1` in `default_models`. `ollama:auto` was initially replaced with `ollama:qwen3.5:9b-nvfp4` in `keeper_unified_models`, but that label contains an extra `:` in the model_id which causes the dashboard's `models_resolved` parser (`String.split_on_char ':'`) to drop the entry (expects exactly two segments). `keeper_unified_models` is now set to `["glm:glm-5.1"]` to avoid the malformed label. The `_comment` field has been updated to document that `*_models` entries must follow strict `{provider}:{model_id}` format and avoid extra `:` characters in model_id.

## Product impact

- Promise affected: `repo coordination` | `delivery swarm` | `ops visibility` | `none/internal`
- User-visible change: Keepers that were failing with "model auto not found" errors will now route successfully to the GLM provider. Dashboard `models_resolved` list will no longer silently drop keeper model entries.

## Evidence

<!-- Tests, harness runs, screenshots, logs, or other proof. -->

## Review evidence

<!-- Cross-model review result, reviewer model, and fallback reason if any. -->

## Linked issue