### PR TITLE
fix(P0): remove auto model tokens from cascade.json

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,6 @@
 {
-  "default_models": ["glm:auto"],
-  "keeper_unified_models": ["ollama:auto", "glm:auto"],
+  "default_models": ["glm:glm-5.1"],
+  "keeper_unified_models": ["ollama:qwen3.5:9b-nvfp4", "glm:glm-5.1"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -203,14 +203,16 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
 
           let models_resolved =
             `List (List.filter_map (fun label ->
-              match String.split_on_char ':' label with
-              | [provider; model_id] ->
+              match String.index_opt label ':' with
+              | Some i ->
+                  let provider = String.sub label 0 i in
+                  let model_id = String.sub label (i + 1) (String.length label - i - 1) in
                   Some (`Assoc [
                     ("provider", `String provider);
                     ("model_id", `String model_id);
                     ("max_context", `Int 0);
                   ])
-              | _ -> None
+              | None -> None
             ) cascade_models)
           in
 


### PR DESCRIPTION
P0 Hotfix: Replace glm:auto with glm:glm-5.1 and ollama:auto with ollama:qwen3.5:9b-nvfp4 in cascade.json. The auto tokens caused 3371+ HTTP 429 errors across all keepers.