### PR TITLE
fix(cascade): route keeper_unified to llama-server instead of dead Ollama

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -2,7 +2,7 @@
   "default_models": ["glm:auto"],
   "keeper_unified_models": ["llama:auto"],
 
-  "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
+  "_comment": "default_models is the fallback for unnamed cascades. Per-cascade overrides ({name}_models) route specific cascades to different providers — e.g. keeper_unified_models routes keeper turns to llama-server.",
 
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,6 @@
 {
   "default_models": ["glm:auto"],
-  "keeper_unified_models": ["ollama:auto", "glm:auto"],
+  "keeper_unified_models": ["llama:auto"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -295,9 +295,9 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 
 ```json
 {
-  "default_models": ["ollama:auto", "glm:auto"],
-  "keeper_turn_models": ["ollama:auto", "glm:auto"],
-  "briefing_models": ["ollama:auto", "glm:auto", "gemini:auto"],
+  "default_models": ["glm:auto"],
+  "keeper_unified_models": ["llama:auto"],
+  "briefing_models": ["llama:auto", "glm:auto", "gemini:auto"],
   "auto_responder_claude_models": ["claude:auto", "glm:auto"],
   "keeper_unified_temperature": 0.4,
   "keeper_unified_max_tokens": 2048
@@ -310,8 +310,8 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 
 | Provider | Env Config 모듈 | 기본 모델 |
 |----------|----------------|----------|
-| `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
-| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy llama-server, port 8085) |
+| `llama` | `Local_runtime` | `MASC_DEFAULT_MODEL` (llama-server, port 8085, 262k context) |
+| `ollama` | `Ollama` | `OLLAMA_DEFAULT_MODEL` (Ollama, port 11434 — currently unused) |
 | `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
 | `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |


### PR DESCRIPTION
## Summary

- `keeper_unified_models`가 `ollama:auto`를 사용하고 있어 port 11434(Ollama, 2026-03-18 이후 미운영)로 라우팅됨
- 실제 운영 중인 llama-server(port 8085)는 `llama` prefix로 접근해야 Discovery가 올바른 endpoint를 찾음
- `ollama:auto` → `llama:auto` 변경

## Root Cause

OAS에서 `llama`와 `ollama`는 다른 라우팅 경로를 가짐:
- `llama`: `Discovery.endpoint_for_model`로 실제 모델이 돌고 있는 endpoint를 찾음
- `ollama`: `defaults.base_url` = port 11434 하드코딩

cascade.json이 `ollama:auto`를 지정해서:
1. ollama 프로브 실패 (서버 없음)
2. GLM fallback → `tool_choice: required` 무시하고 텍스트만 반환
3. accept validator 거부 → "All models failed: response rejected by accept validator"
4. 매 사이클 206초 낭비, keeper 좀비 상태

## Test plan

- [ ] llama-server 기동 후 keeper 자율 턴 성공 확인
- [ ] `tool_choice=Any` 상태에서 tool call 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)