### PR TITLE
refactor(transport): use bridge aggregate metrics in status endpoint

### DIFF
--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -193,5 +193,8 @@ let transport_status_json (ctx : http_context) =
               [ ("signaling_url", `String (ctx.base_url ^ "/webrtc")) ]
             else
               []) );
-      ("bridge", Transport_bridge.status_all_json ());
+      ("total_sessions", `Int (Transport_bridge.total_session_count ()));
+      ("enabled_protocols", `List (List.map
+        (fun p -> `String (Transport.protocol_to_string p))
+        (Transport_bridge.enabled_protocols ())));
     ]


### PR DESCRIPTION
## Summary
Replace the duplicate `bridge` dump with two useful aggregate fields from Transport_bridge:
- `total_sessions`: sum across all enabled transports  
- `enabled_protocols`: list of active protocol names (e.g. `["sse","ws","grpc"]`)

1 file, +4/-1 lines.

## Context
Follow-up to #5726. The bridge was appended as a parallel field without replacing anything. This PR removes the dump and adds the two fields that consumers (dashboard, Agent Card) actually need.

Per-transport detail sections are unchanged — they contain protocol-specific info that the generic bridge cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)