### PR TITLE
fix: keeper auto-bump misses version truth files (#5684)

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -192,6 +192,18 @@ let handle_keeper_pr_workflow
             end
         end
       ) in
+      (* Pre-commit: Version truth check guard *)
+      let _s_ver = run_step "version_truth_check" (fun () ->
+        if !worktree_path = "" then Error "no worktree path"
+        else begin
+          let check_cmd = Printf.sprintf "cd %s && ./scripts/check-version-truth.sh 2>&1" (Filename.quote !worktree_path) in
+          let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0 [ "/bin/zsh"; "-lc"; check_cmd ] in
+          if st <> Unix.WEXITED 0 then
+            Error (Printf.sprintf "Version truth check failed (run scripts/bump-version.sh instead of editing dune-project manually): %s" out)
+          else Ok "version truth OK"
+        end
+      ) in
+
       (* Step 3: Git add + commit + push *)
       let _s3 = run_step "git_commit_push" (fun () ->
         if !worktree_path = "" then Error "no worktree path"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -42,9 +42,8 @@ echo "  README.md badge updated"
 
 # 3) opam metadata (if tracked)
 if [ -f "$ROOT_DIR/masc_mcp.opam" ]; then
-  sedi -E "s/^version: \".*\"/version: \"$NEW_VERSION\"/" \
-    "$ROOT_DIR/masc_mcp.opam"
-  echo "  masc_mcp.opam updated"
+  dune build masc_mcp.opam --root "$ROOT_DIR"
+  echo "  masc_mcp.opam updated (via dune build)"
 fi
 
 # 4) CHANGELOG stub (prepend if missing)


### PR DESCRIPTION
Resolves #5684.

### Changes:
- Modified `scripts/bump-version.sh` to run `dune build masc_mcp.opam` directly instead of manually editing via `sed`.
- Added `scripts/check-version-truth.sh` as a pre-commit guard inside the `keeper_pr_workflow` tool (`lib/keeper/keeper_exec_github.ml`).
- If a keeper modifies `dune-project` but misses the `ROADMAP.md`, `SPEC-INDEX.md`, or `masc_mcp.opam` files, the `keeper_pr_workflow` will now explicitly fail with a descriptive error guiding the agent to use `scripts/bump-version.sh` instead of manually editing `dune-project`.