### PR TITLE
fix(board): make vote idempotent for Already_voted

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -88,8 +88,19 @@ let handle_keeper_shell_readonly
       ~(args : Yojson.Safe.t)
   =
   ignore meta;
-  let op =
+  let raw_op =
     Safe_ops.json_string ~default:"" "op" args |> String.trim |> String.lowercase_ascii
+  in
+  (* Normalize common aliases so the model's naming variation doesn't cause
+     unsupported_op failures. *)
+  let op = match raw_op with
+    | "git status" | "status" -> "git_status"
+    | "git log" -> "git_log"
+    | "git diff" -> "git_diff"
+    | "read" | "file" | "type" -> "cat"
+    | "grep" | "search" -> "rg"
+    | "dir" | "list" -> "ls"
+    | _ -> raw_op
   in
   let root = Keeper_alerting_path.project_root_of_config config in
   let read_target () =

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -447,6 +447,16 @@ let handle_vote args =
             | Error _ -> ""
       in
       (true, Printf.sprintf "%s Vote recorded. New score: %+d%s" arrow new_score evolution_msg)
+  | Error (Board.Already_voted _) ->
+      (* Idempotent: same-direction duplicate vote is a no-op success.
+         The desired state already exists, so the tool call succeeds. *)
+      (match Board_dispatch.get_post ~post_id with
+       | Ok post ->
+           let score = post.votes_up - post.votes_down in
+           let arrow = if direction = Board.Up then "↑" else "↓" in
+           (true, Printf.sprintf "%s Already voted (idempotent). Score: %+d" arrow score)
+       | Error _ ->
+           (true, "Already voted (idempotent). Score unchanged."))
   | Error e ->
       (false, Printf.sprintf "❌ %s" (board_error_to_string e))
 
@@ -476,6 +486,8 @@ let handle_comment_vote args =
   else
     match Board_dispatch.vote_comment ~voter ~comment_id ~direction with
     | Ok score -> (true, Printf.sprintf "%s 코멘트 투표 완료! 점수: %+d" (if direction_str = "down" then "👎" else "👍") score)
+    | Error (Board.Already_voted _) ->
+        (true, Printf.sprintf "%s Already voted (idempotent)." (if direction_str = "down" then "👎" else "👍"))
     | Error e -> (false, Printf.sprintf "❌ %s" (board_error_to_string e))
 
 (** Agent profile *)


### PR DESCRIPTION
## Summary
두 가지 keeper tool 호출 실패 원인 해결:

### 1. board_vote Already_voted 멱등화 (27건 실패 → 0건)
- `handle_vote`와 `handle_comment_vote`에서 `Already_voted` 에러를 success(idempotent)로 처리
- Keeper가 이미 투표한 글에 재방문 시 실패가 아닌 성공으로 기록
- Board 레이어는 여전히 `Already_voted` 에러 반환 (economy abuse 방지), Tool 레이어에서만 success로 해석

### 2. shell_readonly op alias 정규화 (~23건 실패 중 일부 해결)
- 모델이 자주 틀리는 op 이름을 match 전에 정규화
- `git status`/`status` → `git_status`, `grep`/`search` → `rg`, `read`/`file`/`type` → `cat`, `dir`/`list` → `ls`

## Context
Cheolsu keeper 총 77건 tool 실패 중:
- board_vote: 27건 (35%) ← **이 PR으로 전면 해결**
- shell_readonly: 23건 (14%) ← **이 PR으로 일부 해결**

## Test plan
- [x] `dune build` 통과
- [x] `test_board_dispatch.exe` 25개 테스트 통과
- [ ] keeper cheolsu로 수동 확인 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)