### PR TITLE
fix(keeper): add tasks_audit and shell_readonly to janitor

### DIFF
--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -49,5 +49,7 @@ tool_preset = "social"
 tool_also_allow = [
   "keeper_board_delete",
   "keeper_board_cleanup",
+  "keeper_tasks_audit",
+  "keeper_shell_readonly",
   "masc_cleanup_zombies",
 ]


### PR DESCRIPTION
## Summary
- Add `keeper_tasks_audit` and `keeper_shell_readonly` to janitor's `tool_also_allow`
- These tools are required for orphan task auditing and board status inspection but are not included in the social preset (`coordination_core` has no audit, `shell` group is not included)

## Problem
Janitor had 100% failure rate (16/16 calls) for `keeper_tasks_audit` (0/5) and `keeper_shell_readonly` (0/11) because the social preset's allow list excludes these tools. The 9B model discovers them via `core_discovery_tools` but execution is gated by `can_execute`, which returns `false` → `"error": "tool_not_allowed"` → classified as failure.

## Test plan
- [ ] Verify janitor can call `keeper_tasks_audit` without "tool_not_allowed" error
- [ ] Verify janitor can call `keeper_shell_readonly` without "tool_not_allowed" error
- [ ] Verify other social preset keepers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)