### PR TITLE
fix(tools): align find param, block chaining ops, fix model label parser

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -203,14 +203,16 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
 
           let models_resolved =
             `List (List.filter_map (fun label ->
-              match String.split_on_char ':' label with
-              | [provider; model_id] ->
+              match String.index_opt label ':' with
+              | Some i ->
+                  let provider = String.sub label 0 i in
+                  let model_id = String.sub label (i + 1) (String.length label - i - 1) in
                   Some (`Assoc [
                     ("provider", `String provider);
                     ("model_id", `String model_id);
                     ("max_context", `Int 0);
                   ])
-              | _ -> None
+              | None -> None
             ) cascade_models)
           in
 

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -209,9 +209,9 @@ let handle_keeper_shell_readonly
           ; "entries", lines_to_json ~limit:50 out
           ])
   | "find" ->
-    let name_pattern = Safe_ops.json_string ~default:"" "name" args |> String.trim in
+    let name_pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
     if name_pattern = ""
-    then error_json ~fields:[ "op", `String op ] "name_required"
+    then error_json ~fields:[ "op", `String op ] "pattern_required"
     else (
       match read_target () with
       | Error e -> error_json ~fields:[ "op", `String op ] e
@@ -306,6 +306,7 @@ let handle_keeper_shell_readonly
         "chmod"; "chown"; "kill"; "pkill"; "dd "; "mkfs"; "wget "; "curl.*-o";
         "git push"; "git reset"; "git checkout"; "git rebase";
         "pip install"; "npm install"; "opam install";
+        "&&"; "||"; ";";
       ] in
       let has_dangerous = List.exists (fun pat ->
         String_util.contains_substring_ci cmd_str pat


### PR DESCRIPTION
## Summary
- find op: read `pattern` param to match schema (was reading `name`, causing silent failures)
- bash op: block `&&`, `||`, `;` chaining operators in readonly shell
- dashboard model parser: split on first `:` only to handle `ollama:qwen3.5:9b-nvfp4`

Fixes from review comments on #5737, #5741 that were merged before fixes landed.

## Test plan
- [ ] `dune exec test/test_mcp_server_eio.exe` passes
- [ ] Dashboard keeper detail shows ollama models correctly