### PR TITLE
fix: extract autoboot retry config + add Transport_bridge.seal test

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -381,6 +381,24 @@ let keeper_bootstrap_stagger_step_sec_rp =
 let keeper_bootstrap_stagger_step_sec () : int =
   Runtime_params.get keeper_bootstrap_stagger_step_sec_rp
 
+let keeper_bootstrap_retry_max_rp =
+  _rp_int ~key:"keeper.bootstrap.retry_max"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_RETRY_MAX"
+                          ~default:5 ~min_v:0 ~max_v:20)
+    ~min_v:0 ~max_v:20
+    ~description:"Maximum retry rounds for keepers that fail initial boot" ()
+let keeper_bootstrap_retry_max () : int =
+  Runtime_params.get keeper_bootstrap_retry_max_rp
+
+let keeper_bootstrap_retry_interval_sec_rp =
+  _rp_int ~key:"keeper.bootstrap.retry_interval_sec"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_RETRY_INTERVAL_SEC"
+                          ~default:30 ~min_v:5 ~max_v:300)
+    ~min_v:5 ~max_v:300
+    ~description:"Delay between autoboot retry rounds (seconds)" ()
+let keeper_bootstrap_retry_interval_sec () : int =
+  Runtime_params.get keeper_bootstrap_retry_interval_sec_rp
+
 let keeper_proactive_min_cooldown_sec_rp =
   _rp_int ~key:"keeper.proactive.min_cooldown_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_PROACTIVE_MIN_COOLDOWN_SEC"

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -291,8 +291,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Log.Keeper.info "autoboot: initial pass %d/%d keepers started" booted_count total;
       (* Retry loop for keepers that failed initial boot *)
       if booted_count < total then begin
-        let max_retries = 5 in
-        let retry_interval_s = 30.0 in
+        let max_retries = Keeper_config.keeper_bootstrap_retry_max () in
+        let retry_interval_s = Float.of_int (Keeper_config.keeper_bootstrap_retry_interval_sec ()) in
         let rec retry_loop round =
           if round > max_retries then
             Log.Keeper.warn

--- a/test/dune
+++ b/test/dune
@@ -844,6 +844,12 @@
  (modules test_keeper_context_isolation)
  (libraries masc_test_deps))
 
+; Transport_bridge.seal guard
+(test
+ (name test_transport_bridge_seal)
+ (modules test_transport_bridge_seal)
+ (libraries masc_test_deps))
+
 (executable
  (name keeper_tool_matrix_case_runner)
  (modules keeper_tool_matrix_case_runner test_keeper_tool_matrix_cases

--- a/test/test_transport_bridge_seal.ml
+++ b/test/test_transport_bridge_seal.ml
@@ -1,0 +1,31 @@
+(** Test that Transport_bridge.seal blocks post-bootstrap registration. *)
+
+open Alcotest
+
+module MockProvider : Masc_mcp.Transport_bridge.PROVIDER = struct
+  let name = "test-seal-mock"
+  let protocol = Masc_mcp.Transport.Sse
+  let is_enabled () = false
+  let session_count () = 0
+  let status_json () = `Null
+  let reap_stale () = 0
+end
+
+let test_seal_blocks_registration () =
+  (* seal may already be called by other tests or the server;
+     call it again — idempotent. *)
+  Masc_mcp.Transport_bridge.seal ();
+  let raised = ref false in
+  (try
+     Masc_mcp.Transport_bridge.register_provider (module MockProvider)
+   with Failure msg ->
+     if String.length msg > 0 then raised := true);
+  check bool "post-seal register raises Failure" true !raised
+
+let () =
+  run "Transport_bridge.seal" [
+    "seal", [
+      test_case "blocks post-seal registration" `Quick
+        test_seal_blocks_registration;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Extract hardcoded `max_retries=5` and `retry_interval_s=30.0` from autoboot loop to `Keeper_config` runtime params
- Add `test_transport_bridge_seal.ml` verifying post-seal `register_provider` raises `Failure`

## Details

### Autoboot Config (#5745)
| Param | Env Var | Default | Range |
|-------|---------|---------|-------|
| `keeper.bootstrap.retry_max` | `MASC_KEEPER_BOOTSTRAP_RETRY_MAX` | 5 | 0-20 |
| `keeper.bootstrap.retry_interval_sec` | `MASC_KEEPER_BOOTSTRAP_RETRY_INTERVAL_SEC` | 30 | 5-300 |

### Transport Seal Test (#5746)
Verifies the safety contract: `seal()` freezes the registry, post-seal `register_provider` raises `Failure`.

## Test plan
- [x] `dune build` pass
- [x] `test_transport_bridge_seal.exe` — 1/1 pass

Closes #5745, closes #5746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)