### PR TITLE
chore: add .mli for keeper_exec_* split modules

### DIFF
--- a/lib/keeper/keeper_exec_board.mli
+++ b/lib/keeper/keeper_exec_board.mli
@@ -1,0 +1,7 @@
+(** Keeper board tool handler — post, reply, vote, list, get. *)
+
+val handle_keeper_board_tool :
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -1,0 +1,13 @@
+(** Keeper filesystem tool handlers — read and edit. *)
+
+val handle_keeper_fs_read :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_fs_edit :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_github.mli
+++ b/lib/keeper/keeper_exec_github.mli
@@ -1,0 +1,13 @@
+(** Keeper GitHub tool handlers — git commands and PR workflow. *)
+
+val handle_keeper_github :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_pr_workflow :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_masc.mli
+++ b/lib/keeper/keeper_exec_masc.mli
@@ -1,0 +1,15 @@
+(** Keeper MASC coordination tool handlers — autoresearch and masc tools. *)
+
+val handle_keeper_autoresearch_tool :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_masc_tool :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_memory.mli
+++ b/lib/keeper/keeper_exec_memory.mli
@@ -1,0 +1,13 @@
+(** Keeper memory tool handlers — search, context status. *)
+
+val keeper_memory_search_json :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  ctx_work:Keeper_types.working_context ->
+  args:Yojson.Safe.t ->
+  string
+
+val keeper_context_status_json :
+  meta:Keeper_types.keeper_meta ->
+  ctx_work:Keeper_types.working_context ->
+  string

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -1,0 +1,19 @@
+(** Keeper shell tool handlers — bash execution and read-only ops.
+
+    Handles [keeper_bash] (write-capable) and [keeper_shell_readonly]
+    (ls, cat, find, grep, head, tail, wc, tree, git-log, git-diff, git-status).
+
+    Write-capable bash blocks dangerous commands (rm, mv, chmod, etc.)
+    and chaining operators (&&, ||, ;) via substring blocklist. *)
+
+val handle_keeper_bash :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_shell_readonly :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_task.mli
+++ b/lib/keeper/keeper_exec_task.mli
@@ -1,0 +1,8 @@
+(** Keeper task coordination tool handler — claim, transition, list. *)
+
+val handle_keeper_task_tool :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string

--- a/lib/keeper/keeper_exec_voice.mli
+++ b/lib/keeper/keeper_exec_voice.mli
@@ -1,0 +1,7 @@
+(** Keeper voice tool handler — TTS synthesis dispatch. *)
+
+val handle_keeper_voice_tool :
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string


### PR DESCRIPTION
## Summary
Add interface files for 8 keeper tool modules split from keeper_exec_tools.ml (#5708). Internal helpers become private; only public handler functions are exposed.

## Modules
| Module | Public API |
|--------|-----------|
| `keeper_exec_board` | `handle_keeper_board_tool` |
| `keeper_exec_fs` | `handle_keeper_fs_read`, `handle_keeper_fs_edit` |
| `keeper_exec_github` | `handle_keeper_github`, `handle_keeper_pr_workflow` |
| `keeper_exec_masc` | `handle_keeper_autoresearch_tool`, `handle_keeper_masc_tool` |
| `keeper_exec_memory` | `keeper_memory_search_json`, `keeper_context_status_json` |
| `keeper_exec_shell` | `handle_keeper_bash`, `handle_keeper_shell_readonly` |
| `keeper_exec_task` | `handle_keeper_task_tool` |
| `keeper_exec_voice` | `handle_keeper_voice_tool` |

## Test plan
- [x] `dune build` pass — no compilation errors

Closes #5750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)