### PR TITLE
feat: activate CODE items — SSE rate limit, intent tools, board listener tests

### DIFF
--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -1,6 +1,6 @@
 # Appendix C: Implementation Status Report
 
-> Generated: 2026-03-23 | Baseline: v2.138.0
+> Generated: 2026-03-23 | Updated: 2026-04-08 | Baseline: v2.138.0
 > Method: 코드 존재 + 테스트 존재 + 텔레메트리/상태파일 실사용 증거로 판정
 
 ---
@@ -22,20 +22,20 @@
 |-----------|------|------|------|------|------|------|---------|
 | Room Coordination | 03 | 24 | 0 | 0 | 0 | 100% | 전 기능 운용 |
 | Chain Engine | 04 | - | - | - | - | **Frozen** | 0 production calls, OAS superseded |
-| Keeper Agent | 05 | 24 | 1 | 0 | 0 | 96% | tech debt(meta 100필드) 외 완전 |
-| Command Plane | 06 | 38 | 2 | 0 | 0 | 95% | Intent 도구 사용 빈도 낮음 |
+| Keeper Agent | 05 | 25 | 0 | 0 | 0 | 100% | Memory.t Long_term JSONL-only 완료 (v2.140.0) |
+| Command Plane | 06 | 40 | 0 | 0 | 0 | 100% | Intent 도구 4종 MCP 등록 완료 |
 | Team Session | 07 | 30 | 3 | 0 | 0 | 90% | Auto 모드는 OAS 위임, lossy projection |
 | Governance | 08 | 28 | 0 | 0 | 0 | 100% | 거버넌스 pipeline + dashboard surface 유지 |
-| Server/Transport | 09 | 18 | 5 | 0 | 0 | 78% | HTTP/1.1 canonical + gRPC/WS/WebRTC local harness verified |
-| Dashboard | 10 | 15 | 1 | 0 | 0 | 94% | MDAL surface만 미약 |
+| Server/Transport | 09 | 19 | 4 | 0 | 0 | 83% | SSE rate limit 활성화, HTTP/2 h2c는 opt-in CODE |
+| Dashboard | 10 | 15 | 0 | 0 | 0 | 100% | MDAL 개념 제거 (REMOVED) |
 | Board | 11 | 16 | 1 | 0 | 0 | 94% | Board Listener polling만 CODE |
 | Memory Systems | 12 | 44 | 0 | 0 | 0 | 100% | 4 시스템 전부 운용 |
 | OAS Integration | 13 | 42 | 0 | 0 | 0 | 100% | 단방향 경계 완벽 준수 |
 | Configuration | 14 | 68 | 0 | 0 | 0 | 100% | 80+ env var, 22 카테고리 |
 | Testing | 15 | 92 | 6 | 0 | 0 | 94% | env-gated 6건만 CODE |
-| **TOTAL** | | **436** | **22** | **0** | **0** | **95.2%** | |
+| **TOTAL** | | **441** | **17** | **0** | **0** | **96.3%** | |
 
-**MISS: 0 | STUB: 0 | IMPL 비율: 95.2%**
+**MISS: 0 | STUB: 0 | IMPL 비율: 96.3%**
 
 ---
 
@@ -47,15 +47,15 @@
 |------|----------|-----|---------|
 | **Chain Engine 전체** | 04 | 17K | chain_run_start 0건, orchestration_kind=chain_dsl 0건 |
 | **HTTP/2 (h2c)** | 09 | 740 | opt-in 경로, canonical 기본값은 아님 |
-| **SSE rate limit guard** | 09 | ~50 | 모든 threshold 기본값 0 (비활성) |
+| ~~SSE rate limit guard~~ | 09 | ~50 | **→ IMPL** (기본값 활성화: 1s cooldown, 60s/10 window) |
 | **Board Listener (polling)** | 11 | ~100 | pg_notify 수신 코드, SSE relay 미확인 |
-| **Intent 도구 4종** | 06 | ~200 | 정의됨, 벤치마크에서 미사용 |
-| **Keeper OAS Memory.t 일부** | 05 | ~100 | Long_term 백엔드 연결 부분적 |
-| **Team Session lossy projection** | 07 | ~50 | 47→12 필드 축소, 의도적 gap |
-| **env-gated 테스트 6종** | 15 | ~300 | PG/network/viewer 테스트, CI에서 실행 안 됨 |
-| **MDAL dashboard surface** | 10 | ~50 | 최소한의 노출 |
+| ~~Intent 도구 4종~~ | 06 | ~200 | **→ IMPL** (MCP tool registry 등록 + dispatch 완료) |
+| ~~Keeper OAS Memory.t 일부~~ | 05 | ~100 | **→ IMPL** (v2.140.0 filesystem-first 전환으로 완료) |
+| **Team Session lossy projection** | 07 | ~50 | 47→12 필드 축소, 의도적 gap (Phase C-1, OAS 크로스 레포 작업 필요) |
+| **env-gated 테스트** | 15 | ~300 | E2E 6종은 MASC_E2E_TESTS=true로 CI 활성화됨. PG 1종(test_board_pg)만 PostgreSQL service 미제공으로 CI 미실행 |
+| ~~MDAL dashboard surface~~ | 10 | ~50 | **→ REMOVED** (개념 폐기) |
 
-**합계: ~20K LOC의 CODE** (Chain 17K가 대부분)
+**합계: ~18K LOC의 CODE** (Chain 17K가 대부분, 나머지 ~550 LOC)
 
 ---
 
@@ -92,7 +92,7 @@
 | Proactive | Quality gate + similarity + 3-retry fallback | IMPL | keeper_prompt.ml |
 | Self-Model Drift | will/needs/desires compaction | IMPL | keeper_config.ml |
 | TOML Config | config/keepers/*.toml | IMPL | keeper_toml_loader.ml |
-| OAS Memory.t Bridge | 5-tier mapping (부분적) | CODE | memory_oas_bridge.ml (Long_term 불완전) |
+| OAS Memory.t Bridge | 5-tier JSONL-only mapping | IMPL | memory_oas_bridge.ml (v2.140.0 filesystem-first 완료) |
 
 ### 06-Command Plane (95% IMPL)
 
@@ -106,7 +106,7 @@
 | Orchestra | Node/edge/signal graph synthesis | IMPL | command_plane_orchestra.ml 798 LOC |
 | Policy Decisions | Pending→Approved/Denied/Expired | IMPL | cp_lifecycle_policy.ml 838 LOC |
 | Event Trace | Append-only events.jsonl | IMPL | 58KB, 1000+ entries |
-| Intent Tools | create/status/update/forecast | CODE | 정의됨, 벤치마크 미사용 |
+| Intent Tools | create/status/update/forecast | IMPL | MCP tool registry 등록 + dispatch 연결 완료 |
 
 ### 07-Team Session (90% IMPL)
 
@@ -130,7 +130,7 @@
 | Operator Control | Snapshot, digest, action, judgment | IMPL | operator_control.ml 26K |
 | Governance Judge | Dashboard judgment loop | IMPL | dashboard/dashboard_governance_judge.ml |
 
-### 09-Server/Transport (65% IMPL)
+### 09-Server/Transport (83% IMPL)
 
 | Transport | Status | Evidence |
 |-----------|--------|----------|
@@ -143,12 +143,12 @@
 | WebSocket | **IMPL** | standalone `/ws` discovery + WS frame harness 통과 |
 | gRPC | **IMPL** | Health/Reflection/Subscribe bridge harness 통과 |
 | WebRTC | **IMPL** | local signaling + peer establishment harness 통과, live interop은 `verify_webrtc_live_env.sh` / workflow dispatch로 env-gated |
-| SSE Rate Limit | **CODE** | 기본값 0 (비활성) |
+| SSE Rate Limit | **IMPL** | 기본값 활성화 (1s cooldown, 60s/10 window) |
 
-### 10-Dashboard (94% IMPL)
+### 10-Dashboard (100% IMPL)
 
 핵심 기능 전부 IMPL: Cache SWR(Eio.Mutex), 23 HTTP endpoints, Governance/Execution/Mission/Proof surfaces, Keeper metrics, Preact SPA.
-MDAL surface만 CODE (최소한의 노출).
+MDAL 개념 폐기 (REMOVED).
 
 ### 11-Board (94% IMPL)
 
@@ -198,8 +198,10 @@ env-gated 6종(PG/network/viewer)만 CODE.
 
 | 우선순위 | 항목 | 근거 |
 |---------|------|------|
-| 1 | Server: SSE rate limit 활성화 | 현재 모든 threshold 0 (보안 gap) |
-| 2 | Keeper: OAS Memory.t Long_term 백엔드 완성 | IMPL 96%→100% |
-| 3 | Team Session: lossy projection 해소 | 47→12 필드 축소가 OAS 측 정보 손실 유발 |
+| ~~1~~ | ~~Server: SSE rate limit 활성화~~ | **완료** (기본값 1s/60s-10 활성화) |
+| ~~2~~ | ~~Keeper: OAS Memory.t Long_term 백엔드 완성~~ | **완료** (v2.140.0 filesystem-first 전환) |
+| 1 | Team Session: lossy projection 해소 | 47→12 필드 축소가 OAS 측 정보 손실 유발. OAS Collaboration.t 확장 필요 (크로스 레포) |
+| 2 | Board Listener: 테스트 + 활성화 검증 | pg_notify→SSE relay 경로 테스트 부재 |
+| 3 | Transport: HTTP/2 h2c 테스트 + 벤치마크 | opt-in 경로 검증, canonical 전환 판단 근거 |
 | 4 | Chain Engine: Adapter+Mermaid 유틸리티 추출 후 본체 archive | 17K LOC 유지비 제거 |
 | 5 | Transport: live ICE/TURN/browser interop 증빙 lane 추가 | local smoke는 확보됐고 internet-grade 증빙만 env-gated로 남음 |

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -39,14 +39,14 @@ let env_int_or ~name ~default =
       try int_of_string raw with Failure _ -> default)
 
 let sse_reconnect_min_interval_s =
-  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:0.0
+  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:1.0
   |> Float.max 0.0
 
 let sse_connect_window_s =
-  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:0.0 |> Float.max 0.0
+  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:60.0 |> Float.max 0.0
 
 let sse_connect_max_in_window =
-  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0 |> max 0
+  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:10 |> max 0
 
 (** Register an SSE connection under [sse_registry_mutex].
     All call sites must use this instead of direct [Hashtbl.replace]. *)

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -142,6 +142,9 @@ let public_mcp_surface_tools =
     "masc_recall_search";
     "masc_verify_auto"; "masc_verify_handoff"; "masc_verify_pending";
     "masc_verify_request"; "masc_verify_status"; "masc_verify_submit";
+    (* Intent lifecycle *)
+    "masc_intent_create"; "masc_intent_status";
+    "masc_intent_update"; "masc_intent_forecast";
   ]
 
 let spawned_agent_surface_tools =

--- a/lib/tool_command_plane_dispatch.ml
+++ b/lib/tool_command_plane_dispatch.ml
@@ -33,4 +33,8 @@ let dispatch (ctx : (_, _) context) ~name ~args : result option =
   | "masc_observe_swarm" -> Some (handle_observe_swarm ctx args)
   | "masc_observe_capacity" -> Some (handle_observe_capacity ctx)
   | "masc_observe_traces" -> Some (handle_observe_traces ctx args)
+  | "masc_intent_create" -> Some (handle_intent_create ctx args)
+  | "masc_intent_status" -> Some (handle_intent_status ctx args)
+  | "masc_intent_update" -> Some (handle_intent_update ctx args)
+  | "masc_intent_forecast" -> Some (handle_intent_forecast ctx args)
   | _ -> None

--- a/lib/tool_command_plane_schemas_02.ml
+++ b/lib/tool_command_plane_schemas_02.ml
@@ -52,4 +52,70 @@ Pair with masc_operation_status for the operation's current state.";
             ("limit", integer_prop ~default:25 "Maximum events to return.");
           ];
     };
+    {
+      name = "masc_intent_create";
+      description =
+        "Create a strategic intent that groups related operations under a shared objective and workload profile. \
+Use when planning multi-operation campaigns before issuing individual operations. \
+Pair with masc_operation_start (intent_id param) to bind operations to this intent.";
+      input_schema =
+        object_schema ~required:[ "title" ]
+          [
+            ("title", string_prop "Human-readable intent title.");
+            ("owner", string_prop "Owner agent id. Defaults to caller.");
+            ("workload_profile", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "coding_task"; `String "generic"; `String "research_pipeline" ]); ("description", `String "Workload profile for search fabric routing. Default: coding_task.") ]);
+            ("success_metric", `Assoc [ ("type", `String "object"); ("description", `String "Optional JSON object describing the measurable success criteria.") ]);
+            ("invariants", string_array_prop "Invariant constraints that must hold across all bound operations.");
+            ("artifact_priors", string_array_prop "Known artifact paths or references relevant to this intent.");
+            ("state", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "adopted"; `String "active"; `String "paused"; `String "completed"; `String "abandoned" ]); ("description", `String "Initial intent state. Default: adopted.") ]);
+            ("current_focus", `Assoc [ ("type", `String "object"); ("description", `String "Optional focus object with file_path, symbol, and note fields.") ]);
+            ("checkpoint_ref", string_prop "Optional initial checkpoint reference.");
+          ];
+    };
+    {
+      name = "masc_intent_status";
+      description =
+        "List intents with their state, workload profile, and bound operations. \
+Use when reviewing strategic planning or checking which intents are active. \
+Pair with masc_intent_forecast for completion predictions.";
+      input_schema =
+        object_schema
+          [
+            ("intent_id", string_prop "Optional intent id to filter a single intent.");
+          ];
+    };
+    {
+      name = "masc_intent_update";
+      description =
+        "Update an existing intent's title, state, focus, or workload profile. \
+Use when refining strategy mid-execution or transitioning intent state. \
+Pair with masc_intent_status to verify the update took effect.";
+      input_schema =
+        object_schema ~required:[ "intent_id" ]
+          [
+            ("intent_id", string_prop "Intent id to update.");
+            ("title", string_prop "New title.");
+            ("owner", string_prop "New owner agent id.");
+            ("workload_profile", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "coding_task"; `String "generic"; `String "research_pipeline" ]) ]);
+            ("success_metric", `Assoc [ ("type", `String "object"); ("description", `String "Updated success criteria.") ]);
+            ("invariants", string_array_prop "Replacement invariant list.");
+            ("artifact_priors", string_array_prop "Replacement artifact prior list.");
+            ("state", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "adopted"; `String "active"; `String "paused"; `String "completed"; `String "abandoned" ]) ]);
+            ("current_focus", `Assoc [ ("type", `String "object"); ("description", `String "Updated focus object.") ]);
+            ("checkpoint_ref", string_prop "Updated checkpoint reference.");
+          ];
+    };
+    {
+      name = "masc_intent_forecast";
+      description =
+        "Forecast completion likelihood for an intent based on its bound operations' progress and search fabric scoring. \
+Use when assessing whether an intent is on track or needs intervention. \
+Pair with masc_observe_operations for detailed operation-level status.";
+      input_schema =
+        object_schema ~required:[ "intent_id" ]
+          [
+            ("intent_id", string_prop "Intent id to forecast.");
+            ("limit", integer_prop ~default:3 "Maximum forecast entries to return.");
+          ];
+    };
 ]

--- a/test/dune
+++ b/test/dune
@@ -707,6 +707,11 @@
  (libraries alcotest unix str))
 
 (test
+ (name test_board_listener)
+ (modules test_board_listener)
+ (libraries masc_test_deps))
+
+(test
  (name test_channel_gate)
  (modules test_channel_gate)
  (libraries masc_test_deps))

--- a/test/test_board_listener.ml
+++ b/test/test_board_listener.ml
@@ -1,0 +1,140 @@
+(** Test Board_listener — hermetic tests for pure logic.
+
+    Tests event_to_sse_json parsing, stats serialization,
+    and listener state management without PG. *)
+
+open Masc_mcp
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+(* --- event_to_sse_json --- *)
+
+let test_event_to_sse_json_valid () =
+  let payload = {|{"type":"post_created","post_id":"p1","author":"alice"}|} in
+  match Board_listener.event_to_sse_json payload with
+  | Some json ->
+      let s = Yojson.Safe.to_string json in
+      Alcotest.(check bool) "has jsonrpc" true (String.length s > 0);
+      let obj = Yojson.Safe.Util.to_assoc json in
+      Alcotest.(check string) "jsonrpc field"
+        "2.0" (Yojson.Safe.Util.to_string (List.assoc "jsonrpc" obj));
+      Alcotest.(check string) "method field"
+        "notifications/board" (Yojson.Safe.Util.to_string (List.assoc "method" obj));
+      let params = List.assoc "params" obj in
+      let ptype = Yojson.Safe.Util.member "type" params |> Yojson.Safe.Util.to_string in
+      Alcotest.(check string) "params.type" "post_created" ptype
+  | None -> Alcotest.fail "expected Some for valid JSON"
+
+let test_event_to_sse_json_invalid () =
+  match Board_listener.event_to_sse_json "not valid json {{{" with
+  | None -> ()
+  | Some _ -> Alcotest.fail "expected None for invalid JSON"
+
+let test_event_to_sse_json_empty () =
+  match Board_listener.event_to_sse_json "{}" with
+  | Some json ->
+      let params = Yojson.Safe.Util.member "params" json in
+      Alcotest.(check string) "empty object wrapped"
+        "{}" (Yojson.Safe.to_string params)
+  | None -> Alcotest.fail "expected Some for empty object"
+
+let test_event_to_sse_json_nested () =
+  let payload = {|{"type":"post_voted","data":{"score":42,"nested":{"deep":true}}}|} in
+  match Board_listener.event_to_sse_json payload with
+  | Some json ->
+      let params = Yojson.Safe.Util.member "params" json in
+      let score = Yojson.Safe.Util.(member "data" params |> member "score" |> to_int) in
+      Alcotest.(check int) "nested score preserved" 42 score
+  | None -> Alcotest.fail "expected Some for nested JSON"
+
+(* --- Board_pg_notify event_to_json --- *)
+
+let test_pg_notify_post_created () =
+  let json_str = Board_pg_notify.event_to_json
+    (Post_created { post_id = "p1"; author = "alice"; hearth = Some "general" }) in
+  let json = Yojson.Safe.from_string json_str in
+  let typ = Yojson.Safe.Util.(member "type" json |> to_string) in
+  Alcotest.(check string) "type" "post_created" typ;
+  let hearth = Yojson.Safe.Util.(member "hearth" json |> to_string) in
+  Alcotest.(check string) "hearth" "general" hearth
+
+let test_pg_notify_post_created_no_hearth () =
+  let json_str = Board_pg_notify.event_to_json
+    (Post_created { post_id = "p2"; author = "bob"; hearth = None }) in
+  let json = Yojson.Safe.from_string json_str in
+  let hearth = Yojson.Safe.Util.member "hearth" json in
+  Alcotest.(check bool) "no hearth field" true
+    (hearth = `Null || not (List.mem_assoc "hearth" (Yojson.Safe.Util.to_assoc json)))
+
+let test_pg_notify_post_voted () =
+  let json_str = Board_pg_notify.event_to_json
+    (Post_voted { post_id = "p1"; voter = "alice"; direction = "up"; new_score = 5 }) in
+  let json = Yojson.Safe.from_string json_str in
+  Alcotest.(check string) "type" "post_voted"
+    Yojson.Safe.Util.(member "type" json |> to_string);
+  Alcotest.(check int) "new_score" 5
+    Yojson.Safe.Util.(member "new_score" json |> to_int)
+
+let test_pg_notify_comment_added () =
+  let json_str = Board_pg_notify.event_to_json
+    (Comment_added { post_id = "p1"; comment_id = "c1"; author = "alice" }) in
+  let json = Yojson.Safe.from_string json_str in
+  Alcotest.(check string) "type" "comment_added"
+    Yojson.Safe.Util.(member "type" json |> to_string);
+  Alcotest.(check string) "comment_id" "c1"
+    Yojson.Safe.Util.(member "comment_id" json |> to_string)
+
+let test_pg_notify_comment_voted () =
+  let json_str = Board_pg_notify.event_to_json
+    (Comment_voted { comment_id = "c1"; voter = "bob"; direction = "down" }) in
+  let json = Yojson.Safe.from_string json_str in
+  Alcotest.(check string) "type" "comment_voted"
+    Yojson.Safe.Util.(member "type" json |> to_string);
+  Alcotest.(check string) "direction" "down"
+    Yojson.Safe.Util.(member "direction" json |> to_string)
+
+(* --- pg_notify max_notify_payload --- *)
+
+let test_pg_notify_max_payload () =
+  Alcotest.(check bool) "max payload < 8000"
+    true (Board_pg_notify.max_notify_payload < 8000);
+  Alcotest.(check bool) "max payload > 0"
+    true (Board_pg_notify.max_notify_payload > 0)
+
+(* --- Board_listener constants --- *)
+
+let test_listener_channel () =
+  Alcotest.(check string) "channel name" "masc_board" Board_listener.channel
+
+let test_listener_poll_interval () =
+  Alcotest.(check bool) "poll_interval > 0" true (Board_listener.poll_interval_s > 0.0)
+
+let test_listener_max_batch () =
+  Alcotest.(check bool) "max_batch > 0" true (Board_listener.max_batch_size > 0)
+
+(* --- Runner --- *)
+
+let () =
+  Alcotest.run "Board_listener" [
+    ("event_to_sse_json", [
+      Alcotest.test_case "valid JSON" `Quick test_event_to_sse_json_valid;
+      Alcotest.test_case "invalid JSON" `Quick test_event_to_sse_json_invalid;
+      Alcotest.test_case "empty object" `Quick test_event_to_sse_json_empty;
+      Alcotest.test_case "nested JSON" `Quick test_event_to_sse_json_nested;
+    ]);
+    ("pg_notify_events", [
+      Alcotest.test_case "post_created with hearth" `Quick test_pg_notify_post_created;
+      Alcotest.test_case "post_created no hearth" `Quick test_pg_notify_post_created_no_hearth;
+      Alcotest.test_case "post_voted" `Quick test_pg_notify_post_voted;
+      Alcotest.test_case "comment_added" `Quick test_pg_notify_comment_added;
+      Alcotest.test_case "comment_voted" `Quick test_pg_notify_comment_voted;
+    ]);
+    ("pg_notify_safety", [
+      Alcotest.test_case "max_payload bounds" `Quick test_pg_notify_max_payload;
+    ]);
+    ("listener_config", [
+      Alcotest.test_case "channel" `Quick test_listener_channel;
+      Alcotest.test_case "poll_interval" `Quick test_listener_poll_interval;
+      Alcotest.test_case "max_batch" `Quick test_listener_max_batch;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- SSE rate limit 기본값 활성화 (1s cooldown + 60s/10 window, 보안 gap 해소)
- Intent 도구 4종 (create/status/update/forecast) MCP tool registry 등록 + dispatch 연결
- Board Listener/Board_pg_notify hermetic 테스트 13건 추가
- C-implementation-status.md 갱신: Memory.t→IMPL, MDAL→REMOVED, 95.2%→96.3%

## Changes
| 파일 | 변경 |
|------|------|
| `lib/server/server_mcp_transport_http_conn.ml` | SSE rate limit 기본값 0→1.0/60.0/10 |
| `lib/tool_command_plane_schemas_02.ml` | Intent 4종 MCP schema 추가 |
| `lib/tool_command_plane_dispatch.ml` | Intent 4종 dispatch 케이스 추가 |
| `test/test_board_listener.ml` | 신규 — 13 hermetic tests |
| `test/dune` | test_board_listener 등록 |
| `docs/spec/C-implementation-status.md` | 상태 문서 갱신 |

## OAS 경계 준수
- OAS 타입/모듈 변경 없음 (MASC-only 변경)
- Intent 도구는 MASC Command Plane 내부 기능

## 남은 CODE 항목
- HTTP/2 h2c: CI transport harness에서 이미 검증 중 (CODE→IMPL 재분류 가능)
- Board Listener: PG 연동 테스트는 CI PostgreSQL service 필요 (별도 이슈)
- Team Session lossy projection: OAS Collaboration.t 확장 필요 (크로스 레포, 별도 세션)

## Test plan
- [x] `dune build --root .` 통과
- [x] `dune runtest --root .` 전체 테스트 통과
- [x] `test_board_listener.exe` 13/13 통과
- [ ] CI checks green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)