### PR TITLE
fix(keeper): trace_emit path missing .masc + crash on write failure

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -14,7 +14,7 @@ let enabled () = Lazy.force enabled_cache
 
 let trace_path ~base_path ~keeper_name =
   Filename.concat
-    (Filename.concat base_path "keepers")
+    (Filename.concat (Filename.concat base_path ".masc") "keepers")
     (keeper_name ^ ".tla-trace.jsonl")
 
 let emit_transition
@@ -39,4 +39,7 @@ let emit_transition
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in
-    Keeper_types_support.append_jsonl_line path json
+    try Keeper_types_support.append_jsonl_line path json
+    with exn ->
+      Printf.eprintf "trace_emit: %s: %s\n%!"
+        keeper_name (Printexc.to_string exn)


### PR DESCRIPTION
## Summary
Two bugs in keeper_trace_emit.ml found by actually running MASC_TLA_TRACE=1:

1. **Wrong path**: `base_path/keepers/` → `base_path/.masc/keepers/` (missing `.masc` prefix)
2. **Uncaught exception**: `append_jsonl_line` raises on missing directory, crashes keeper heartbeat loop

## Impact
With MASC_TLA_TRACE=1, **every keeper crashes on first heartbeat**. The trace emission code was never tested against a running server (only synthetic traces).

## Fix
- Add `.masc` to trace_path (matches all other keeper code paths)
- Wrap append in try/catch — trace failure logs to stderr, never kills keeper

## Test plan
- [x] `dune build` passes
- [ ] Restart server with MASC_TLA_TRACE=1, verify traces appear in `.masc/keepers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)