### PR TITLE
chore: bump OAS pin — accept_on_exhaustion + Ollama ctx fix

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.113.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="b7a26ae07fe924deca01dbb03ad96d92fdcc0f6b"
+readonly OAS_AGENT_SDK_SHA="58f7222f3aeff774168e8e71ccb419bf02d2f1b7"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.113.0"


### PR DESCRIPTION
## Summary
- OAS pin SHA bump: `b7a26ae` → `58f7222`
- Includes oas#715 (accept_on_exhaustion) and oas#707 (Ollama context key)

## Impact
- **8.4% keeper turn failures** (accept validator rejection) should drop to near 0%
- Ollama Discovery context now correctly reads model-specific keys

## Test plan
- [ ] CI pass
- [ ] Server restart with new OAS pin
- [ ] Verify "accepted on exhaustion" in cascade metrics
- [ ] Verify zero "All models failed: response rejected" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)