### PR TITLE
fix(tools): add ok:false to tool_not_allowed response

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -416,7 +416,7 @@ module Tools = struct
     if v < 1.0 then 1.0 else v
 
   let web_search_rate_limit_max_calls () =
-    let v = get_int ~default:10 "MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS" in
+    let v = get_int ~default:30 "MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS" in
     max 1 v
 end
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -789,6 +789,20 @@ let run_turn
      all_tool_names is constant for the session; building universe_set
      once here avoids O(n) Hashtbl allocation on every turn. *)
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
+  (* Precompute preset-executable set for AllowList pruning.
+     Prevents tools visible via core_discovery_tools but blocked by
+     preset (e.g. social keeper seeing keeper_fs_edit) from reaching
+     the LLM and triggering tool_not_allowed errors. *)
+  let allowed_exec_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let allowed_exec_set =
+    let set = Keeper_tool_policy.tool_name_set allowed_exec_names in
+    (* Core always-tools bypass candidate_set in can_execute, so they
+       may be absent from keeper_allowed_tool_names.  Add them back to
+       prevent the preset filter from dropping survival-critical tools. *)
+    List.iter (fun name -> Hashtbl.replace set name ())
+      Keeper_tool_registry.core_always_tools;
+    set
+  in
   let max_tools_per_turn =
     if is_retry then Keeper_config.keeper_retry_max_tools_per_turn ()
     else Keeper_config.keeper_max_tools_per_turn ()
@@ -960,7 +974,9 @@ let run_turn
              This can happen when core_discovery_tools includes tools
              not covered by the keeper's preset (e.g. minimal). *)
           let validated, dropped_names =
-            List.partition (fun n -> Hashtbl.mem universe_set n) raw
+            List.partition (fun n ->
+              Hashtbl.mem universe_set n
+              && Hashtbl.mem allowed_exec_set n) raw
           in
           let dropped = List.length dropped_names in
           if dropped > 0 then begin

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -73,6 +73,7 @@ let execute_keeper_tool_call
     in
     Yojson.Safe.to_string
       (`Assoc [
+        ("ok", `Bool false);
         ("error", `String "tool_not_allowed");
         ("tool", `String name);
         ("reason", `String reason);


### PR DESCRIPTION
## Summary
- Add missing `ok:false` to `tool_not_allowed` error response for JSON consistency
- Increase `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` default from 10→30 (8 keepers sharing 10/30s caused ~11% failures)
- **Preset-aware AllowList pruning**: prevents tools the keeper cannot execute from reaching the LLM, eliminating ~21 `tool_not_allowed` errors per 2-hour window

## Problem
`core_discovery_tools` exposes 26 tools to all keepers, including tools like `keeper_fs_edit`, `keeper_bash`, `keeper_pr_workflow` that social/minimal presets cannot execute. The AllowList validation only checked OAS dispatch membership (`universe_set`), not preset executability. This caused:

1. LLM sees `keeper_fs_edit` in its schema → calls it → `tool_not_allowed`
2. Social keepers waste turns on preset-blocked tools (~21 failures/2hr)

## Solution
AllowList validation now checks both:
- `universe_set` (OAS dispatch membership — tool exists)  
- `allowed_exec_set` (preset allows execution — tool is callable)

Core always-tools are explicitly included since they bypass `candidate_set` in `can_execute`.

## Files changed
- `lib/keeper/keeper_exec_tools.ml` — `ok:false` in `tool_not_allowed` response
- `lib/config/env_config_runtime.ml` — rate limit default 10→30
- `lib/keeper/keeper_agent_run.ml` — preset-aware AllowList validation + core_always safety

## Test plan
- [x] `dune build --root .` passes
- [x] Core always-tools preserved in AllowList (explicit inclusion)
- [ ] Manual verification: social keeper no longer sees `keeper_fs_edit` in schema
- [ ] Monitor logs for `tool_not_allowed` reduction after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)