### PR TITLE
feat(keeper): add work discovery + telemetry feedback loops

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -45,3 +45,7 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "social"
+
+# Telemetry Feedback
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -53,3 +53,13 @@ tool_also_allow = [
   "keeper_shell_readonly",
   "masc_cleanup_zombies",
 ]
+
+# Work Discovery
+work_discovery_enabled = true
+work_discovery_sources = ["stale_tasks", "board_cleanup"]
+work_discovery_interval_sec = 1800
+work_discovery_guidance = "Look for zombie board posts, orphan tasks, and stale data to clean up."
+
+# Telemetry Feedback
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -44,3 +44,13 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "delivery"
+
+# Work Discovery
+work_discovery_enabled = true
+work_discovery_sources = ["github_issues", "lint_errors", "stale_tasks"]
+work_discovery_interval_sec = 600
+work_discovery_guidance = "Focus on code quality issues: lint warnings, TODO comments, failing tests. Create a task for each actionable item found, then claim and work on the highest priority one."
+
+# Telemetry Feedback
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -49,3 +49,7 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "social"
+
+# Telemetry Feedback
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24

--- a/lib/dune
+++ b/lib/dune
@@ -434,6 +434,7 @@
    labeling
    contract_risk
    contract_composer
+   keeper_telemetry_feedback
    keeper_deliberation
    keeper_types_profile
    keeper_types_support

--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -1,0 +1,235 @@
+(** Keeper_telemetry_feedback — compute behavioral statistics from
+    decision logs and render them as a prompt block for keeper
+    self-assessment.
+
+    Reads {keeper_name}.decisions.jsonl, filters entries within a
+    configurable time window, and produces aggregate stats.
+    The rendered block presents data only — the LLM decides how to act. *)
+
+type behavioral_stats = {
+  window_hours : int;
+  total_turns : int;
+  silent_turns : int;
+  silent_ratio : float;
+  tool_use_turns : int;
+  text_response_turns : int;
+  unique_tools_used : string list;
+  tool_success_rate : float;
+  last_visible_action_age_sec : int;
+  pr_workflow_attempts : int;
+  work_discovery_count : int;
+}
+
+let empty_stats ~window_hours =
+  { window_hours;
+    total_turns = 0;
+    silent_turns = 0;
+    silent_ratio = 0.0;
+    tool_use_turns = 0;
+    text_response_turns = 0;
+    unique_tools_used = [];
+    tool_success_rate = 0.0;
+    last_visible_action_age_sec = 0;
+    pr_workflow_attempts = 0;
+    work_discovery_count = 0;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* JSON field extraction helpers                                       *)
+(* ------------------------------------------------------------------ *)
+
+let json_float_opt key (json : Yojson.Safe.t) : float option =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Float f) -> Some f
+     | Some (`Int i) -> Some (float_of_int i)
+     | _ -> None)
+  | _ -> None
+
+let json_string_opt key (json : Yojson.Safe.t) : string option =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) -> Some s
+     | _ -> None)
+  | _ -> None
+
+let json_int_opt key (json : Yojson.Safe.t) : int option =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int i) -> Some i
+     | Some (`Float f) -> Some (int_of_float f)
+     | _ -> None)
+  | _ -> None
+
+let json_string_list key (json : Yojson.Safe.t) : string list =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`List items) ->
+       List.filter_map (function
+         | `String s -> Some s
+         | _ -> None) items
+     | _ -> [])
+  | _ -> []
+
+(* ------------------------------------------------------------------ *)
+(* Decision log parsing                                                *)
+(* ------------------------------------------------------------------ *)
+
+type parsed_decision = {
+  timestamp_unix : float;
+  outcome : string;
+  tool_call_count : int;
+  tools_used : string list;
+}
+
+let parse_decision_line (line : string) : parsed_decision option =
+  match Yojson.Safe.from_string line with
+  | json ->
+    let timestamp_unix =
+      json_float_opt "timestamp_unix" json
+      |> Option.value ~default:0.0
+    in
+    let outcome =
+      json_string_opt "outcome" json
+      |> Option.value ~default:"unknown"
+    in
+    let tool_call_count =
+      json_int_opt "tool_call_count" json
+      |> Option.value ~default:0
+    in
+    let tools_used = json_string_list "tools_used" json in
+    Some { timestamp_unix; outcome; tool_call_count; tools_used }
+  | exception _ -> None
+
+(* ------------------------------------------------------------------ *)
+(* Stats computation                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let compute_stats ~decision_log_path ~window_hours =
+  let now_ts = Unix.gettimeofday () in
+  let window_start = now_ts -. (float_of_int window_hours *. 3600.0) in
+  let lines =
+    try
+      let content = Fs_compat.load_file decision_log_path in
+      String.split_on_char '\n' content
+      |> List.filter (fun s -> String.trim s <> "")
+    with _ -> []
+  in
+  let decisions =
+    lines
+    |> List.filter_map parse_decision_line
+    |> List.filter (fun d -> d.timestamp_unix >= window_start)
+  in
+  let total_turns = List.length decisions in
+  if total_turns = 0 then
+    empty_stats ~window_hours
+  else
+    let is_silent d =
+      String.lowercase_ascii d.outcome = "proactive_silent"
+      || String.lowercase_ascii d.outcome = "noop"
+    in
+    let silent_turns =
+      List.length (List.filter is_silent decisions)
+    in
+    let tool_use_turns =
+      List.length (List.filter (fun d -> d.tool_call_count > 0) decisions)
+    in
+    let text_response_turns =
+      List.length (List.filter (fun d ->
+        (not (is_silent d)) && d.tool_call_count = 0) decisions)
+    in
+    let all_tools =
+      decisions
+      |> List.concat_map (fun d -> d.tools_used)
+    in
+    let unique_tools =
+      List.sort_uniq String.compare all_tools
+    in
+    let total_tool_calls =
+      List.fold_left (fun acc d -> acc + d.tool_call_count) 0 decisions
+    in
+    let pr_workflow_attempts =
+      List.length (List.filter (fun d ->
+        List.exists (fun t ->
+          String.lowercase_ascii t = "keeper_pr_workflow") d.tools_used
+      ) decisions)
+    in
+    let last_visible_ts =
+      decisions
+      |> List.filter (fun d -> not (is_silent d))
+      |> List.fold_left (fun acc d ->
+        max acc d.timestamp_unix) 0.0
+    in
+    let last_visible_action_age_sec =
+      if last_visible_ts <= 0.0 then
+        int_of_float (now_ts -. window_start)
+      else
+        int_of_float (max 0.0 (now_ts -. last_visible_ts))
+    in
+    let silent_ratio =
+      float_of_int silent_turns /. float_of_int total_turns
+    in
+    let tool_success_rate =
+      if total_tool_calls > 0 then
+        float_of_int tool_use_turns /. float_of_int total_turns
+      else 0.0
+    in
+    { window_hours;
+      total_turns;
+      silent_turns;
+      silent_ratio;
+      tool_use_turns;
+      text_response_turns;
+      unique_tools_used = unique_tools;
+      tool_success_rate;
+      last_visible_action_age_sec;
+      pr_workflow_attempts;
+      work_discovery_count = 0;
+    }
+
+(* ------------------------------------------------------------------ *)
+(* Prompt rendering                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let format_age_sec (sec : int) : string =
+  if sec < 60 then Printf.sprintf "%ds" sec
+  else if sec < 3600 then Printf.sprintf "%dm %ds" (sec / 60) (sec mod 60)
+  else
+    let h = sec / 3600 in
+    let m = (sec mod 3600) / 60 in
+    Printf.sprintf "%dh %dm" h m
+
+let render_feedback_block ~(stats : behavioral_stats) =
+  if stats.total_turns = 0 then
+    Printf.sprintf
+      "### Behavioral Self-Assessment (last %dh)\n\
+       - No turns recorded in this window.\n\n"
+      stats.window_hours
+  else
+    let tools_str =
+      match stats.unique_tools_used with
+      | [] -> "none"
+      | ts -> String.concat ", " ts
+    in
+    Printf.sprintf
+      "### Behavioral Self-Assessment (last %dh)\n\
+       - Turns: %d total (%d silent, %d active)\n\
+       - Silent ratio: %.1f%%\n\
+       - Tool use turns: %d (success rate: %.1f%%)\n\
+       - Text-only response turns: %d\n\
+       - Last visible action: %s ago\n\
+       - PR workflow attempts: %d\n\
+       - Unique tools used: %s\n\n"
+      stats.window_hours
+      stats.total_turns stats.silent_turns
+      (stats.total_turns - stats.silent_turns)
+      (stats.silent_ratio *. 100.0)
+      stats.tool_use_turns (stats.tool_success_rate *. 100.0)
+      stats.text_response_turns
+      (format_age_sec stats.last_visible_action_age_sec)
+      stats.pr_workflow_attempts
+      tools_str

--- a/lib/keeper/keeper_telemetry_feedback.mli
+++ b/lib/keeper/keeper_telemetry_feedback.mli
@@ -1,0 +1,35 @@
+(** Keeper_telemetry_feedback — compute behavioral statistics from
+    decision logs and render them as a prompt block for keeper
+    self-assessment.
+
+    Reads {keeper_name}.decisions.jsonl, filters entries within a
+    configurable time window, and produces aggregate stats.
+    The rendered block presents data only — the LLM decides how to act. *)
+
+type behavioral_stats = {
+  window_hours : int;
+  total_turns : int;
+  silent_turns : int;
+  silent_ratio : float;
+  tool_use_turns : int;
+  text_response_turns : int;
+  unique_tools_used : string list;
+  tool_success_rate : float;
+  last_visible_action_age_sec : int;
+  pr_workflow_attempts : int;
+  work_discovery_count : int;
+}
+
+val empty_stats : window_hours:int -> behavioral_stats
+(** Zero-valued stats for the given window. *)
+
+val compute_stats :
+  decision_log_path:string ->
+  window_hours:int ->
+  behavioral_stats
+(** Read decision log and compute stats for entries within the window.
+    Returns [empty_stats] on I/O errors or missing files. *)
+
+val render_feedback_block : stats:behavioral_stats -> string
+(** Render a "### Behavioral Self-Assessment" prompt block.
+    Presents data without judgment — the model interprets the numbers. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -105,6 +105,8 @@ let direct_turn_observation (meta : keeper_meta) :
     room_signal_digest_ref = None;
     last_turn_budget = None;
     last_tools_used = [];
+    work_discovery_due = false;
+    behavioral_stats = None;
   }
 
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -278,6 +278,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         team_session_start_count_total = 0;
         paused = false;
         current_task_id = None;
+        work_discovery_enabled = p.profile_defaults.work_discovery_enabled;
+        work_discovery_sources = p.profile_defaults.work_discovery_sources;
+        work_discovery_interval_sec = p.profile_defaults.work_discovery_interval_sec;
+        work_discovery_guidance = p.profile_defaults.work_discovery_guidance;
+        telemetry_feedback_enabled = p.profile_defaults.telemetry_feedback_enabled;
+        telemetry_feedback_window_hours = p.profile_defaults.telemetry_feedback_window_hours;
         runtime = {
           usage = {
             total_turns = 0;
@@ -308,6 +314,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_outcome = Proactive_never_started;
             last_reason = "";
             last_preview = "";
+            last_work_discovery_ts = 0.0;
+            work_discovery_count = 0;
           };
           generation = 0;
           trace_id;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -70,6 +70,8 @@ type proactive_runtime =
   ; last_outcome : proactive_cycle_outcome
   ; last_reason : string
   ; last_preview : string
+  ; last_work_discovery_ts : float
+  ; work_discovery_count : int
   }
 
 type scheduled_autonomous_runtime = proactive_runtime
@@ -161,6 +163,12 @@ type keeper_meta =
     (** Currently claimed task ID for cost attribution.
       Set when keeper claims a task; cleared on masc_done.
       Propagated to trajectory accumulator for per-task cost tracking. *)
+  ; work_discovery_enabled : bool option
+  ; work_discovery_sources : string list option
+  ; work_discovery_interval_sec : int option
+  ; work_discovery_guidance : string option
+  ; telemetry_feedback_enabled : bool option
+  ; telemetry_feedback_window_hours : int option
   ; (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
     runtime : agent_runtime_state
   }
@@ -589,6 +597,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       , `String (proactive_cycle_outcome_to_string rt.proactive_rt.last_outcome) )
     ; "last_proactive_reason", `String rt.proactive_rt.last_reason
     ; "last_proactive_preview", `String rt.proactive_rt.last_preview
+    ; "last_work_discovery_ts", `Float rt.proactive_rt.last_work_discovery_ts
+    ; "work_discovery_count", `Int rt.proactive_rt.work_discovery_count
     ; "last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts
     ; "last_compaction_decision", `String rt.compaction_rt.last_decision
     ; "last_continuity_update_ts", `Float rt.last_continuity_update_ts
@@ -614,6 +624,15 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "paused", `Bool m.paused
     ; "current_task_id", Json_util.string_opt_to_json m.current_task_id
     ; "max_context_override", Json_util.int_opt_to_json m.max_context_override
+    ; "work_discovery_enabled", Json_util.bool_opt_to_json m.work_discovery_enabled
+    ; "work_discovery_sources"
+      , (match m.work_discovery_sources with
+         | Some xs -> `List (List.map (fun s -> `String s) xs)
+         | None -> `Null)
+    ; "work_discovery_interval_sec", Json_util.int_opt_to_json m.work_discovery_interval_sec
+    ; "work_discovery_guidance", Json_util.string_opt_to_json m.work_discovery_guidance
+    ; "telemetry_feedback_enabled", Json_util.bool_opt_to_json m.telemetry_feedback_enabled
+    ; "telemetry_feedback_window_hours", Json_util.int_opt_to_json m.telemetry_feedback_window_hours
     ]
 ;;
 
@@ -911,6 +930,10 @@ let parse_proactive_runtime (json : Yojson.Safe.t) : proactive_runtime =
       |> proactive_cycle_outcome_of_string
   ; last_reason = Safe_ops.json_string ~default:"" "last_proactive_reason" json
   ; last_preview = Safe_ops.json_string ~default:"" "last_proactive_preview" json
+  ; last_work_discovery_ts =
+      Safe_ops.json_float ~default:0.0 "last_work_discovery_ts" json
+  ; work_discovery_count =
+      Safe_ops.json_int ~default:0 "work_discovery_count" json
   }
 ;;
 
@@ -1078,6 +1101,20 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; paused = state.ps_paused
              ; current_task_id = state.ps_current_task_id
              ; max_context_override = state.ps_max_context_override
+             ; work_discovery_enabled = Safe_ops.json_bool_opt "work_discovery_enabled" json
+             ; work_discovery_sources =
+                 (match json with
+                  | `Assoc fields ->
+                    (match List.assoc_opt "work_discovery_sources" fields with
+                     | Some (`List items) ->
+                       Some (List.filter_map (function
+                         | `String s -> Some s | _ -> None) items)
+                     | _ -> None)
+                  | _ -> None)
+             ; work_discovery_interval_sec = Safe_ops.json_int_opt "work_discovery_interval_sec" json
+             ; work_discovery_guidance = Safe_ops.json_string_opt "work_discovery_guidance" json
+             ; telemetry_feedback_enabled = Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
+             ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
              ; runtime = state.ps_runtime
              })
   with
@@ -1151,6 +1188,8 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_proactive_outcome"
   ; "last_proactive_reason"
   ; "last_proactive_preview"
+  ; "last_work_discovery_ts"
+  ; "work_discovery_count"
   ; "last_compaction_check_ts"
   ; "last_compaction_decision"
   ; "last_continuity_update_ts"
@@ -1173,6 +1212,12 @@ let fallback_canonical_keeper_meta_key_names =
   ; "paused"
   ; "current_task_id"
   ; "max_context_override"
+  ; "work_discovery_enabled"
+  ; "work_discovery_sources"
+  ; "work_discovery_interval_sec"
+  ; "work_discovery_guidance"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
   ]
 ;;
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -72,6 +72,8 @@ type proactive_runtime = {
   last_outcome: proactive_cycle_outcome;
   last_reason: string;
   last_preview: string;
+  last_work_discovery_ts : float;
+  work_discovery_count : int;
 }
 
 type scheduled_autonomous_runtime = proactive_runtime
@@ -159,6 +161,12 @@ type keeper_meta = {
   paused: bool;
   current_task_id: string option;
   (** Currently claimed task ID for cost attribution. *)
+  work_discovery_enabled : bool option;
+  work_discovery_sources : string list option;
+  work_discovery_interval_sec : int option;
+  work_discovery_guidance : string option;
+  telemetry_feedback_enabled : bool option;
+  telemetry_feedback_window_hours : int option;
   runtime: agent_runtime_state;
 }
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -143,6 +143,14 @@ type keeper_profile_defaults = {
   tool_preset : string option;
   tool_also_allow : string list option;
   tool_denylist : string list option;
+  (* Work Discovery — config-driven proactive work scanning *)
+  work_discovery_enabled : bool option;
+  work_discovery_sources : string list option;
+  work_discovery_interval_sec : int option;
+  work_discovery_guidance : string option;
+  (* Telemetry Feedback — inject behavioral stats into keeper context *)
+  telemetry_feedback_enabled : bool option;
+  telemetry_feedback_window_hours : int option;
 }
 
 type persona_summary = {
@@ -178,6 +186,12 @@ let empty_keeper_profile_defaults = {
   tool_preset = None;
   tool_also_allow = None;
   tool_denylist = None;
+  work_discovery_enabled = None;
+  work_discovery_sources = None;
+  work_discovery_interval_sec = None;
+  work_discovery_guidance = None;
+  telemetry_feedback_enabled = None;
+  telemetry_feedback_window_hours = None;
 }
 
 let personas_root_opt () =
@@ -290,6 +304,15 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
            | Some raw -> normalize_tool_preset_raw raw);
         tool_also_allow = normalize_name_list_opt (strs "tool_also_allow");
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
+        work_discovery_enabled = bool_ "work_discovery_enabled";
+        work_discovery_sources =
+          (match strs "work_discovery_sources" with
+           | [] -> None
+           | xs -> Some xs);
+        work_discovery_interval_sec = int_ "work_discovery_interval_sec";
+        work_discovery_guidance = str "work_discovery_guidance";
+        telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
+        telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
       })
     result
 
@@ -401,6 +424,20 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 tool_denylist =
                   normalize_name_list_opt
                     (Safe_ops.json_string_list "tool_denylist" keeper_json);
+                work_discovery_enabled =
+                  Safe_ops.json_bool_opt "work_discovery_enabled" keeper_json;
+                work_discovery_sources =
+                  (match Safe_ops.json_string_list "work_discovery_sources" keeper_json with
+                   | [] -> None
+                   | xs -> Some xs);
+                work_discovery_interval_sec =
+                  Safe_ops.json_int_opt "work_discovery_interval_sec" keeper_json;
+                work_discovery_guidance =
+                  Safe_ops.json_string_opt "work_discovery_guidance" keeper_json;
+                telemetry_feedback_enabled =
+                  Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
+                telemetry_feedback_window_hours =
+                  Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -511,6 +511,32 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
        do something genuinely different this turn.\n";
     Buffer.add_string ubuf (String.concat "\n" own_recent_posts);
     Buffer.add_string ubuf "\n");
+  (* Work Discovery — nudge keeper to scan for actionable work *)
+  if observation.work_discovery_due then (
+    Buffer.add_string ubuf "\n### Work Discovery Due\n";
+    Buffer.add_string ubuf
+      "No work discovery scan in the configured interval. \
+       Use your available tools to scan for actionable work.\n";
+    (match meta.work_discovery_sources with
+     | Some sources ->
+       Buffer.add_string ubuf "Configured sources to check:\n";
+       List.iter (fun src ->
+         Buffer.add_string ubuf (Printf.sprintf "- %s\n" src)) sources
+     | None -> ());
+    (match meta.work_discovery_guidance with
+     | Some guide ->
+       Buffer.add_string ubuf (Printf.sprintf "Guidance: %s\n" guide)
+     | None -> ());
+    Buffer.add_string ubuf
+      "If you find actionable items, create tasks or claim existing ones. \
+       If nothing found, record what you checked.\n");
+  (* Behavioral Self-Assessment — telemetry feedback from decision log *)
+  (match observation.behavioral_stats with
+   | Some stats ->
+     Buffer.add_string ubuf "\n";
+     Buffer.add_string ubuf
+       (Keeper_telemetry_feedback.render_feedback_block ~stats)
+   | None -> ());
   let routes = actionable_routes ~allowed_tools observation in
   if routes <> [] then (
     Buffer.add_string ubuf "\n### Actionable Routes\n";

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -535,6 +535,14 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
            else if has_substantive_tools then
              Printf.sprintf "(tools: %s)" (String.concat ", " result.tools_used)
            else rt.proactive_rt.last_preview);
+        last_work_discovery_ts =
+          (if observation.work_discovery_due && has_substantive_tools then
+             now_ts
+           else rt.proactive_rt.last_work_discovery_ts);
+        work_discovery_count =
+          rt.proactive_rt.work_discovery_count
+          + (if observation.work_discovery_due && has_substantive_tools then 1
+             else 0);
       };
       (* Autonomous action tracking from tool calls *)
       autonomous_action_count =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -45,6 +45,8 @@ type world_observation = {
   last_tools_used : string list;
     (** Tools used in the previous cycle. Empty on first cycle.
         Used by the unified prompt to generate data-driven anti-repetition hints. *)
+  work_discovery_due : bool;
+  behavioral_stats : Keeper_telemetry_feedback.behavioral_stats option;
 }
 
 type unified_turn_channel =
@@ -585,6 +587,35 @@ let observe ~(pending_board_events : pending_board_event list option)
         in
         events
   in
+  (* Work Discovery: check if scan interval has elapsed *)
+  let work_discovery_due =
+    match meta.work_discovery_enabled with
+    | Some true ->
+      let interval =
+        Option.value ~default:600 meta.work_discovery_interval_sec
+      in
+      let since_last =
+        Time_compat.now () -. meta.runtime.proactive_rt.last_work_discovery_ts
+      in
+      since_last >= float_of_int interval
+    | _ -> false
+  in
+  (* Telemetry Feedback: compute behavioral stats from decision log *)
+  let behavioral_stats =
+    match meta.telemetry_feedback_enabled with
+    | Some true ->
+      let window =
+        Option.value ~default:24 meta.telemetry_feedback_window_hours
+      in
+      let log_path =
+        Keeper_types_support.keeper_decision_log_path config meta.name
+      in
+      (try
+         Some (Keeper_telemetry_feedback.compute_stats
+                 ~decision_log_path:log_path ~window_hours:window)
+       with _ -> None)
+    | _ -> None
+  in
   {
     pending_mentions;
     pending_board_events;
@@ -603,6 +634,8 @@ let observe ~(pending_board_events : pending_board_event list option)
     room_signal_digest_ref;
     last_turn_budget = None;
     last_tools_used = [];
+    work_discovery_due;
+    behavioral_stats;
   }
 
 (** Compute effective scheduled autonomous cooldown with idle decay.

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -84,6 +84,9 @@ type world_observation = {
   last_tools_used : string list;
   (** Tools used in the previous cycle. Empty on first cycle or when unavailable.
       Used by the prompt builder to generate data-driven anti-repetition hints. *)
+
+  work_discovery_due : bool;
+  behavioral_stats : Keeper_telemetry_feedback.behavioral_stats option;
 }
 
 type unified_turn_channel =

--- a/test/dune
+++ b/test/dune
@@ -62,6 +62,7 @@
         test_tool_exposure
         test_autonomy_liberation
         test_keeper_unified
+        test_keeper_telemetry_feedback
         test_keeper_toml
         test_keeper_tool_policy_config
         test_keeper_toml_config_validation
@@ -126,6 +127,7 @@
           test_tool_exposure
           test_autonomy_liberation
           test_keeper_unified
+          test_keeper_telemetry_feedback
           test_keeper_toml
           test_keeper_tool_policy_config
           test_keeper_toml_config_validation

--- a/test/test_keeper_telemetry_feedback.ml
+++ b/test/test_keeper_telemetry_feedback.ml
@@ -1,0 +1,62 @@
+(** Tests for Keeper_telemetry_feedback — behavioral stats computation
+    and prompt block rendering. *)
+
+module TF = Masc_mcp.Keeper_telemetry_feedback
+
+let () =
+  (* -- empty_stats -- *)
+  let stats = TF.empty_stats ~window_hours:24 in
+  assert (stats.total_turns = 0);
+  assert (stats.silent_ratio = 0.0);
+  assert (stats.window_hours = 24);
+  assert (stats.unique_tools_used = []);
+  Printf.printf "PASS: empty_stats\n";
+
+  (* -- compute_stats on missing file -- *)
+  let stats =
+    TF.compute_stats
+      ~decision_log_path:"/nonexistent/path.jsonl"
+      ~window_hours:24
+  in
+  assert (stats.total_turns = 0);
+  assert (stats.silent_ratio = 0.0);
+  Printf.printf "PASS: compute_stats on missing file\n";
+
+  (* -- render_feedback_block with empty stats -- *)
+  let block = TF.render_feedback_block ~stats in
+  assert (String.length block > 0);
+  assert (
+    try
+      let _ = String.index block '#' in true
+    with Not_found -> false);
+  Printf.printf "PASS: render_feedback_block with empty stats\n";
+
+  (* -- render_feedback_block with non-zero stats -- *)
+  let stats =
+    { TF.window_hours = 24
+    ; total_turns = 10
+    ; silent_turns = 7
+    ; silent_ratio = 0.7
+    ; tool_use_turns = 2
+    ; text_response_turns = 1
+    ; unique_tools_used = ["keeper_board_list"; "keeper_shell_readonly"]
+    ; tool_success_rate = 0.9
+    ; last_visible_action_age_sec = 3600
+    ; pr_workflow_attempts = 0
+    ; work_discovery_count = 0
+    }
+  in
+  let block = TF.render_feedback_block ~stats in
+  assert (String.length block > 0);
+  let contains s sub =
+    try
+      let _ = Re.Str.search_forward (Re.Str.regexp_string sub) s 0 in
+      true
+    with Not_found -> false
+  in
+  assert (contains block "70.0%");
+  assert (contains block "PR workflow attempts: 0");
+  assert (contains block "1h 0m");
+  Printf.printf "PASS: render_feedback_block with data\n";
+
+  Printf.printf "All telemetry feedback tests passed.\n"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -101,6 +101,8 @@ let base_observation : WO.world_observation =
     room_signal_digest_ref = None;
     last_turn_budget = None;
     last_tools_used = [];
+    work_discovery_due = false;
+    behavioral_stats = None;
   }
 
 let sample_board_event : WO.pending_board_event =


### PR DESCRIPTION
## Summary

- Keeper들이 도구는 갖추고 있지만 실제 사용 0건인 근본 원인 해결
- 실측 데이터: tool call 성공률 91.8%, keeper_pr_workflow 호출 0건, cheolsu stay_silent 71%
- 모델 문제가 아니라 **컨텍스트 부재** — "할 일을 찾아라"는 신호와 행동 피드백이 없었음

### Changes

**Work Discovery** (TOML config-driven):
- `work_discovery_enabled`, `sources`, `interval_sec`, `guidance` 설정
- scan 주기 경과 시 "Work Discovery Due" 프롬프트 블록 주입
- 기존 도구(keeper_shell_readonly, keeper_github)로 스캔 — 새 도구 0개

**Telemetry Feedback Loop**:
- `keeper_telemetry_feedback.ml` — decision.jsonl에서 행동 통계 계산
- silent_ratio, tool_success_rate, last_action_age, pr_workflow_attempts
- "Behavioral Self-Assessment" 프롬프트 블록으로 keeper context에 주입

**설계 원칙**:
- unified_turn_decision 변경 없음 (턴은 이미 정상 발동)
- 하드코딩 절대 없음 — 모든 행동은 TOML에서 파생
- 판단은 LLM에 위임 — 데이터만 제시

### Keeper별 설정
| Keeper | work_discovery | telemetry_feedback |
|--------|---------------|-------------------|
| masc-improver | ON (github_issues, lint, stale_tasks, 10min) | ON (24h) |
| janitor | ON (stale_tasks, board_cleanup, 30min) | ON (24h) |
| cheolsu | OFF | ON (24h) |
| sangsu | OFF | ON (24h) |

## Test plan

- [x] `dune build` 성공
- [x] `test_keeper_telemetry_feedback.exe` 4개 테스트 통과
- [x] 기존 테스트 스위트 통과 (keeper_tool_matrix 환경 의존 실패는 기존 이슈)
- [ ] MASC 서버 재시작 후 masc-improver 프롬프트에 "Work Discovery Due" 블록 확인
- [ ] decision.jsonl에 work_discovery 관련 기록 확인

Closes #5739

🤖 Generated with [Claude Code](https://claude.com/claude-code)