### PR TITLE
feat(dashboard): tool quality panel — observability-first

### DIFF
--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -5,12 +5,13 @@ import { Tools } from './tools'
 import { Autoresearch } from './autoresearch'
 import { HarnessHealth } from './harness-health'
 import { LabInspector } from './lab-inspector'
+import { ToolQualityPanel } from './tool-quality-panel'
 
-type LabSection = 'tools' | 'autoresearch' | 'harness' | 'inspector'
+type LabSection = 'tools' | 'autoresearch' | 'harness' | 'inspector' | 'tool-quality'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
-  if (section === 'autoresearch' || section === 'harness' || section === 'inspector') {
+  if (section === 'autoresearch' || section === 'harness' || section === 'inspector' || section === 'tool-quality') {
     return section
   }
   return 'tools'
@@ -37,6 +38,12 @@ export function Lab() {
 
       ${section === 'inspector' ? html`
         <${LabInspector} />
+      ` : null}
+
+      ${section === 'tool-quality' ? html`
+        <${Card} title="도구 품질" class="section mb-4">
+          <${ToolQualityPanel} />
+        <//>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,0 +1,189 @@
+import { html } from 'htm/preact'
+import { signal, computed, type Signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+
+interface ToolStat {
+  name: string
+  calls: number
+  success_pct: number
+  avg_ms: number
+}
+
+interface KeeperStat {
+  name: string
+  calls: number
+  success_pct: number
+}
+
+interface FailureCategory {
+  category: string
+  count: number
+}
+
+interface ToolQualityData {
+  total: number
+  success: number
+  failure: number
+  success_rate: number
+  by_tool: ToolStat[]
+  by_keeper: KeeperStat[]
+  failure_categories: FailureCategory[]
+}
+
+const data: Signal<ToolQualityData | null> = signal(null)
+const loading: Signal<boolean> = signal(false)
+const error: Signal<string | null> = signal(null)
+
+async function fetchToolQuality() {
+  loading.value = true
+  error.value = null
+  try {
+    const resp = await fetch('/api/v1/dashboard/tool-quality?n=5000')
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    data.value = await resp.json()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'fetch failed'
+  } finally {
+    loading.value = false
+  }
+}
+
+const successColor = computed(() => {
+  const rate = data.value?.success_rate ?? 0
+  if (rate >= 95) return 'text-emerald-400'
+  if (rate >= 90) return 'text-yellow-400'
+  return 'text-red-400'
+})
+
+function RateGauge({ rate, label }: { rate: number; label: string }) {
+  const color = rate >= 95 ? 'bg-emerald-500' : rate >= 90 ? 'bg-yellow-500' : 'bg-red-500'
+  return html`
+    <div class="flex flex-col gap-1">
+      <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider">${label}</div>
+      <div class="flex items-center gap-2">
+        <div class="flex-1 h-1.5 bg-[var(--bg-subtle)] rounded-full overflow-hidden">
+          <div class="${color} h-full rounded-full transition-all" style="width: ${Math.min(rate, 100)}%" />
+        </div>
+        <span class="text-xs font-mono ${rate >= 95 ? 'text-emerald-400' : rate >= 90 ? 'text-yellow-400' : 'text-red-400'}">${rate.toFixed(1)}%</span>
+      </div>
+    </div>
+  `
+}
+
+function ToolTable({ tools }: { tools: ToolStat[] }) {
+  const top = tools.slice(0, 15)
+  return html`
+    <div class="overflow-x-auto">
+      <table class="w-full text-[11px]">
+        <thead>
+          <tr class="text-[var(--text-dim)] border-b border-[var(--border)]">
+            <th class="text-left py-1 font-normal">Tool</th>
+            <th class="text-right py-1 font-normal">Calls</th>
+            <th class="text-right py-1 font-normal">Success</th>
+            <th class="text-right py-1 font-normal">Avg ms</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${top.map(t => {
+            const color = t.success_pct >= 95 ? 'text-emerald-400'
+              : t.success_pct >= 80 ? 'text-yellow-400' : 'text-red-400'
+            return html`
+              <tr class="border-b border-[var(--border)] border-opacity-30">
+                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}</td>
+                <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
+                <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>
+                <td class="text-right py-0.5 text-[var(--text-dim)]">${t.avg_ms.toFixed(0)}</td>
+              </tr>
+            `
+          })}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function KeeperGrid({ keepers }: { keepers: KeeperStat[] }) {
+  return html`
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      ${keepers.map(k => {
+        const color = k.success_pct >= 95 ? 'border-emerald-500/30'
+          : k.success_pct >= 90 ? 'border-yellow-500/30' : 'border-red-500/30'
+        return html`
+          <div class="px-2 py-1.5 rounded border ${color} bg-[var(--bg-subtle)]">
+            <div class="text-[10px] text-[var(--text-dim)] truncate">${k.name}</div>
+            <div class="text-xs font-mono">${k.success_pct.toFixed(1)}%</div>
+            <div class="text-[9px] text-[var(--text-dim)]">${k.calls} calls</div>
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+function FailureList({ categories }: { categories: FailureCategory[] }) {
+  const top = categories.slice(0, 8)
+  if (top.length === 0) return html`<div class="text-[11px] text-[var(--text-dim)]">No failures</div>`
+  return html`
+    <div class="flex flex-col gap-1">
+      ${top.map(c => html`
+        <div class="flex items-center justify-between text-[11px]">
+          <span class="font-mono text-red-400/80 truncate flex-1 mr-2">${c.category}</span>
+          <span class="text-[var(--text-dim)] shrink-0">${c.count}x</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+export function ToolQualityPanel() {
+  useEffect(() => { fetchToolQuality() }, [])
+
+  const d = data.value
+  if (loading.value && !d) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Loading tool quality...</div>`
+  if (error.value) return html`<div class="p-4 text-[11px] text-red-400">Error: ${error.value}</div>`
+  if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">No tool call data</div>`
+
+  return html`
+    <div class="flex flex-col gap-4 p-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-medium">Tool Call Quality</h2>
+        <button
+          class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
+          onClick=${fetchToolQuality}
+        >Refresh</button>
+      </div>
+
+      <div class="grid grid-cols-3 gap-3">
+        <div class="text-center">
+          <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
+          <div class="text-[9px] text-[var(--text-dim)] uppercase">Success Rate</div>
+        </div>
+        <div class="text-center">
+          <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
+          <div class="text-[9px] text-[var(--text-dim)] uppercase">Total Calls</div>
+        </div>
+        <div class="text-center">
+          <div class="text-lg font-mono text-red-400/80">${d.failure}</div>
+          <div class="text-[9px] text-[var(--text-dim)] uppercase">Failures</div>
+        </div>
+      </div>
+
+      <${RateGauge} rate=${d.success_rate} label="Overall" />
+
+      <div>
+        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Per Keeper</div>
+        <${KeeperGrid} keepers=${d.by_keeper} />
+      </div>
+
+      <div>
+        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Tool Success Rate</div>
+        <${ToolTable} tools=${d.by_tool} />
+      </div>
+
+      <div>
+        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Failure Categories</div>
+        <${FailureList} categories=${d.failure_categories} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -13,6 +13,7 @@ describe('lab navigation', () => {
       'autoresearch',
       'harness',
       'inspector',
+      'tool-quality',
     ])
 
     expect(labSections.map(item => item.label)).toEqual([
@@ -20,6 +21,7 @@ describe('lab navigation', () => {
       '오토리서치',
       '세이프티 하네스',
       '운영 인스펙터',
+      '도구 품질',
     ])
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -16,6 +16,7 @@ export type SurfaceSectionId =
   | 'harness'
   | 'inspector'
   | 'telemetry'
+  | 'tool-quality'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
@@ -199,6 +200,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '운영 인스펙터',
       description: '피처 플래그와 서버 설정을 한 화면으로 묶은 운영 진단/점검 화면.',
       params: { section: 'inspector' },
+    },
+    {
+      id: 'tool-quality',
+      label: '도구 품질',
+      description: 'Keeper tool call 성공률, 실패 카테고리, keeper별 품질 지표.',
+      params: { section: 'tool-quality' },
     },
   ],
 }

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -1,0 +1,162 @@
+(** Dashboard Tool Quality API — aggregate tool call quality metrics.
+
+    Reads [.masc/tool_calls/] JSONL via {!Keeper_tool_call_log.read_recent}
+    and produces summary statistics for dashboard consumption.
+
+    @since 2.260.0 *)
+
+let aggregate ?(n = 5000) () : Yojson.Safe.t =
+  let records = Keeper_tool_call_log.read_recent ~n () in
+  if records = [] then
+    `Assoc [("total", `Int 0); ("success_rate", `Float 0.0);
+            ("by_tool", `List []); ("by_keeper", `List []);
+            ("failure_categories", `List [])]
+  else
+  let total = ref 0 in
+  let success = ref 0 in
+  (* tool -> (calls, successes, total_ms) *)
+  let tool_stats : (string, int ref * int ref * float ref) Hashtbl.t =
+    Hashtbl.create 64
+  in
+  (* keeper -> (calls, successes) *)
+  let keeper_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  (* error category -> count *)
+  let failure_cats : (string, int ref) Hashtbl.t = Hashtbl.create 32 in
+  List.iter (fun record ->
+    incr total;
+    let tool =
+      Safe_ops.json_string_opt "tool" record
+      |> Option.value ~default:"unknown"
+    in
+    let keeper =
+      Safe_ops.json_string_opt "keeper" record
+      |> Option.value ~default:"unknown"
+    in
+    let ok = match record with
+      | `Assoc fields ->
+        (match List.assoc_opt "success" fields with
+         | Some (`Bool b) -> b | _ -> false)
+      | _ -> false
+    in
+    let dur = match record with
+      | `Assoc fields ->
+        (match List.assoc_opt "duration_ms" fields with
+         | Some (`Float f) -> f
+         | Some (`Int i) -> Float.of_int i
+         | _ -> 0.0)
+      | _ -> 0.0
+    in
+    if ok then incr success;
+    (* tool stats *)
+    let (tc, ts, td) =
+      match Hashtbl.find_opt tool_stats tool with
+      | Some v -> v
+      | None ->
+        let v = (ref 0, ref 0, ref 0.0) in
+        Hashtbl.replace tool_stats tool v; v
+    in
+    incr tc; if ok then incr ts; td := !td +. dur;
+    (* keeper stats *)
+    let (kc, ks) =
+      match Hashtbl.find_opt keeper_stats keeper with
+      | Some v -> v
+      | None ->
+        let v = (ref 0, ref 0) in
+        Hashtbl.replace keeper_stats keeper v; v
+    in
+    incr kc; if ok then incr ks;
+    (* failure category *)
+    if not ok then begin
+      let output =
+        Safe_ops.json_string_opt "output" record
+        |> Option.value ~default:""
+      in
+      let cat =
+        if String.length output > 0 then
+          (* Extract error key from JSON output *)
+          try
+            let j = Yojson.Safe.from_string output in
+            Safe_ops.json_string_opt "error" j
+            |> Option.value ~default:"unknown_error"
+          with _ ->
+            (* Try after stripping "error: " prefix *)
+            let stripped =
+              if String.length output > 7 && String.sub output 0 7 = "error: "
+              then String.sub output 7 (String.length output - 7)
+              else output
+            in
+            (try
+               let j = Yojson.Safe.from_string stripped in
+               Safe_ops.json_string_opt "error" j
+               |> Option.value ~default:"parse_error"
+             with _ -> "parse_error")
+        else "empty_output"
+      in
+      let r = match Hashtbl.find_opt failure_cats cat with
+        | Some r -> r
+        | None -> let r = ref 0 in Hashtbl.replace failure_cats cat r; r
+      in
+      incr r
+    end
+  ) records;
+  let total_n = !total in
+  let success_n = !success in
+  let rate =
+    if total_n = 0 then 0.0
+    else Float.of_int success_n /. Float.of_int total_n *. 100.0
+  in
+  (* Sort by call count descending *)
+  let by_tool =
+    Hashtbl.fold (fun name (c, s, d) acc ->
+      let calls = !c in
+      let successes = !s in
+      let avg_ms = if calls > 0 then !d /. Float.of_int calls else 0.0 in
+      let pct = if calls > 0
+        then Float.of_int successes /. Float.of_int calls *. 100.0
+        else 0.0
+      in
+      (calls, `Assoc [
+        ("name", `String name);
+        ("calls", `Int calls);
+        ("success_pct", `Float pct);
+        ("avg_ms", `Float (Float.round (avg_ms *. 10.0) /. 10.0));
+      ]) :: acc
+    ) tool_stats []
+    |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
+    |> List.map snd
+  in
+  let by_keeper =
+    Hashtbl.fold (fun name (c, s) acc ->
+      let calls = !c in
+      let successes = !s in
+      let pct = if calls > 0
+        then Float.of_int successes /. Float.of_int calls *. 100.0
+        else 0.0
+      in
+      (calls, `Assoc [
+        ("name", `String name);
+        ("calls", `Int calls);
+        ("success_pct", `Float pct);
+      ]) :: acc
+    ) keeper_stats []
+    |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
+    |> List.map snd
+  in
+  let failure_categories =
+    Hashtbl.fold (fun cat r acc ->
+      (!r, `Assoc [("category", `String cat); ("count", `Int !r)]) :: acc
+    ) failure_cats []
+    |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
+    |> List.map snd
+  in
+  `Assoc [
+    ("total", `Int total_n);
+    ("success", `Int success_n);
+    ("failure", `Int (total_n - success_n));
+    ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
+    ("by_tool", `List by_tool);
+    ("by_keeper", `List by_keeper);
+    ("failure_categories", `List failure_categories);
+  ]

--- a/lib/dune
+++ b/lib/dune
@@ -96,6 +96,7 @@
    dashboard_http_keeper_metrics
    dashboard_http_keeper_detail
    dashboard_http_keeper
+   dashboard_http_tool_quality
    dashboard_http_autoresearch
    dashboard_harness_health
    dashboard_goals
@@ -563,6 +564,7 @@
 (private_modules
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
+ dashboard_http_tool_quality
  board_core
  board_votes
  cp_snapshot_core

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -203,6 +203,16 @@ let rec add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/tool-quality" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let n = match Server_utils.query_param req "n" with
+           | Some s -> (try int_of_string s with _ -> 5000)
+           | None -> 5000
+         in
+         let json = Dashboard_http_tool_quality.aggregate ~n () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/transport-health" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_transport_health_http_json ~state in


### PR DESCRIPTION
## Summary
Composio observability 패턴 적용. 수동 스크립트(analyze-tool-call-quality.sh) → 실시간 dashboard panel.

**Backend**: `dashboard_http_tool_quality.ml`
- `.masc/tool_calls/` JSONL 집계 → JSON API
- `GET /api/v1/dashboard/tool-quality?n=5000`
- 응답: total, success_rate, by_tool, by_keeper, failure_categories

**Frontend**: `tool-quality-panel.ts`
- success rate gauge (95%+ green, 90%+ yellow, <90% red)
- per-keeper grid with color-coded success rates
- tool success rate table (top 15)
- failure category breakdown

**Navigation**: lab > 도구 품질 섹션 추가

## Data-driven
6498 tool calls 분석 결과 89.5% 성공률. 이 패널로 개선 효과를 실시간 모니터링.

## Test plan
- [ ] `dune build` pass
- [ ] Dashboard lab > 도구 품질 섹션 렌더링 확인
- [ ] API `curl localhost:8935/api/v1/dashboard/tool-quality` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)