### PR TITLE
fix(keeper): replace hardcoded 45s OAS timeout with configurable env var

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -260,6 +260,15 @@ module KeeperKeepalive = struct
     Float.max 60.0 (Float.min 3600.0
       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
+  (** Per-call timeout in seconds for a single OAS Agent.run execution.
+      Guards against indefinite LLM response waits within a turn.
+      Local LLMs with large context (200k+) can take 120-180s per call;
+      the previous hardcoded 45s was too short for local inference.
+      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: 300. Range: [30, 600]. *)
+  let oas_timeout_sec =
+    Float.max 30.0 (Float.min 600.0
+      (get_float ~default:300.0 "MASC_KEEPER_OAS_TIMEOUT_SEC"))
+
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.
       With tool_choice=Any, the model always calls tools, so idle

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1208,8 +1208,9 @@ let run_turn
       with
       | Error e -> Error (Oas.Error.Internal e)
       | Ok oas_allowed_paths ->
+        let timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_sec in
         (match
-        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:Env_config_keeper.KeeperKeepalive.oas_timeout_sec (fun () ->
+        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
           Oas_worker.run_named
             ~cascade_name
             ~goal:user_message

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1209,7 +1209,7 @@ let run_turn
       | Error e -> Error (Oas.Error.Internal e)
       | Ok oas_allowed_paths ->
         (match
-        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:45.0 (fun () ->
+        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:Env_config_keeper.KeeperKeepalive.oas_timeout_sec (fun () ->
           Oas_worker.run_named
             ~cascade_name
             ~goal:user_message


### PR DESCRIPTION
## Summary

- Keeper의 OAS Agent.run per-call timeout이 45초로 하드코딩되어 있어, 로컬 LLM(9B, 200k context)이 120-180초 걸리는 응답을 매번 타임아웃 처리함
- `MASC_KEEPER_OAS_TIMEOUT_SEC` 환경변수 추가 (default 300s, range 30-600s)
- 기존 `MASC_KEEPER_TURN_TIMEOUT_SEC` (전체 turn 타임아웃, 1200s)과 구분되는 per-call 타임아웃

## 변경 내역

| 파일 | 변경 |
|------|------|
| `lib/config/env_config_keeper.ml` | `oas_timeout_sec` 설정 추가 |
| `lib/keeper/keeper_agent_run.ml` | 하드코딩 `45.0` → `Env_config_keeper.KeeperKeepalive.oas_timeout_sec` |

## Test plan

- [ ] CI Build + Lint 통과
- [ ] 서버 재시작 후 keeper turn timeout 에러 해소 확인
- [ ] `MASC_KEEPER_OAS_TIMEOUT_SEC=60` 으로 설정 시 60초 타임아웃 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)