### PR TITLE
fix(keeper): replace '/' with '-' in pr_workflow task_id

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -115,23 +115,34 @@ let handle_keeper_pr_workflow
           ; "reason", `String "keeper_pr_workflow requires delivery, coding, or full preset"
           ])
     else
-      (* Sanitize branch/task_id: reject path traversal chars *)
-      let safe_name s =
+      (* Sanitize branch: allow a-z, A-Z, 0-9, hyphen, underscore, slash *)
+      let safe_branch s =
         String.to_seq s
         |> Seq.filter (fun c ->
           (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
           || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '/')
         |> String.of_seq
       in
-      let branch_safe = safe_name branch in
+      (* Sanitize task_id: replace '/' with '-' because
+         worktree_create_r rejects path separators in task_id *)
+      let safe_task_id s =
+        String.to_seq s
+        |> Seq.filter_map (fun c ->
+          if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+             || (c >= '0' && c <= '9') || c = '-' || c = '_' then Some c
+          else if c = '/' then Some '-'
+          else None)
+        |> String.of_seq
+      in
+      let branch_safe = safe_branch branch in
       if branch_safe <> branch then
         error_json "branch contains invalid chars. Use only a-z, A-Z, 0-9, hyphen, underscore, slash."
       else
       let root = Keeper_alerting_path.project_root_of_config config in
       let task_id = Printf.sprintf "pr-%s"
-        (safe_name (String.sub branch 0 (min 20 (String.length branch)))) in
+        (safe_task_id (String.sub branch 0 (min 20 (String.length branch)))) in
       let agent_name = Printf.sprintf "keeper-%s"
-        (safe_name (strip_keeper_prefix meta.name)) in
+        (safe_task_id (strip_keeper_prefix meta.name)) in
       let steps = Buffer.create 512 in
       let step_ok = ref true in
       let step_error = ref "" in

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -237,8 +237,10 @@ let handle_keeper_pr_workflow
             if st_commit <> Unix.WEXITED 0 then
               Error (Printf.sprintf "git commit: %s" out_commit)
             else begin
+              (* Push using HEAD:<branch> because the worktree's local branch
+                 (agent_name/task_id) differs from the desired remote branch name *)
               let st_push, out_push = run_git
-                (Printf.sprintf "push -u origin %s" (Filename.quote branch)) in
+                (Printf.sprintf "push -u origin HEAD:%s" (Filename.quote branch)) in
               if st_push <> Unix.WEXITED 0 then
                 Error (Printf.sprintf "git push: %s" out_push)
               else

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -357,6 +357,27 @@ let test_valid_branch_with_slash_accepted () =
     check bool "error is NOT branch_contains_invalid_chars"
       true (error <> "branch_contains_invalid_chars"))
 
+(* --- Branch slash → task_id hyphen conversion --- *)
+
+let test_branch_slash_converted_to_hyphen_in_task_id () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let args = `Assoc
+      [ "branch", `String "fix/cascade-glm-auto-model"
+      ; "file_path", `String "src/test.ml"
+      ; "file_content", `String "let x = 1"
+      ; "commit_message", `String "msg"
+      ; "pr_title", `String "title"
+      ] in
+    let result = call_tool config meta "keeper_pr_workflow" args in
+    let json = parse_json result in
+    (* Branch validation should pass (slash is valid in branch names).
+       The error should be at worktree_create step, NOT
+       "Invalid task ID: task_id cannot contain path separators". *)
+    let error = json_string "error" json in
+    check bool "error does NOT mention path separators"
+      false (String_util.contains_substring_ci error "path separator"))
+
 (* --- Worktree step failure propagation --- *)
 
 let test_worktree_failure_propagates () =
@@ -475,6 +496,9 @@ let () =
       ; test_case "dollar-paren rejected" `Quick test_branch_with_dollar_paren_rejected
       ; test_case "ampersand rejected" `Quick test_branch_with_ampersand_rejected
       ; test_case "slash accepted" `Quick test_valid_branch_with_slash_accepted
+      ]
+    ; "task_id_derivation",
+      [ test_case "slash to hyphen" `Quick test_branch_slash_converted_to_hyphen_in_task_id
       ]
     ; "step_propagation",
       [ test_case "worktree failure" `Quick test_worktree_failure_propagates


### PR DESCRIPTION
## Summary

`keeper_pr_workflow`의 두 가지 버그 수정:

1. **task_id `/` 버그**: branch name의 `/`가 task_id에 그대로 전달되어 `Validation.Task_id`가 path separator로 거부
2. **git push refspec 불일치**: worktree의 local branch(`agent_name/task_id`)와 push 대상(user-specified branch)이 달라 refspec mismatch

## Root Causes

**Bug 1** — `safe_name`이 branch 검증과 task_id 파생에 동일하게 사용되어 `/` 허용:
```
branch="fix/cascade-glm" → task_id="pr-fix/cascade-gl" → Validation rejects '/'
```

**Bug 2** — `git push -u origin <branch>` 시 현재 local branch가 다른 이름:
```
local branch: keeper-masc-improver/pr-flatten-repo-synthe
push target:  flatten-repo-synthesis-nesting
→ "src refspec does not match any"
```

## Fixes

| Commit | Fix |
|--------|-----|
| `539561f` | Split `safe_name` → `safe_branch` + `safe_task_id` (slash→hyphen) |
| `e0ef0f7` | `git push -u origin HEAD:<branch>` (refspec-safe) |

## Impact

04-07 keeper pr_workflow 실패 ~15건 모두 이 두 버그 조합:
- coder: 2건 task_id `/`
- masc-improver: 3건 (2건 task_id `/`, 1건 refspec mismatch)
- admin/janitor: preset gate에서 정상 차단 (별도 이슈 아님)

## Test plan

- [x] `dune build` passes
- [x] Existing 21 tests pass
- [ ] New `task_id_derivation` test (CI)
- [ ] Post-deploy: keeper pr_workflow with slash branches succeeds

Generated with [Claude Code](https://claude.com/claude-code)