### PR TITLE
fix(prompt): reduce redundant tool_search for already-visible tools

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -393,7 +393,9 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
      in instructions. *)
   let allowed_tools = Keeper_tool_policy.keeper_allowed_tool_names meta in
   if allowed_tools <> [] then (
-    Buffer.add_string ubuf "\n### Available Tools\n";
+    Buffer.add_string ubuf "\n### Available Tools\n\
+      These tools are already loaded. Call them directly — no keeper_tool_search needed.\n\
+      Use keeper_tool_search ONLY for tools NOT listed here.\n";
     List.iter (fun name ->
       match Keeper_tool_policy.tool_hint_of name with
       | Some hint ->


### PR DESCRIPTION
## Summary
데이터: 35/235 (15%) tool_search 호출이 이미 keeper에게 보이는 도구를 검색 (e.g. "board list recent posts" → keeper_board_list).

System prompt에 명시적 안내 추가:
> "These tools are already loaded. Call them directly — no keeper_tool_search needed."

## Root Cause
LLM이 Available Tools 목록을 tool_search 없이 직접 호출 가능하다는 것을 인식하지 못함.

## Expected Impact
tool_search 호출 ~15% 감소, ~100 calls/day BM25 오버헤드 절감.

## Test plan
- [ ] 24시간 후 tool_search 호출 수 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)