### PR TITLE
fix(shell): structured hint on command_blocked errors

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -32,11 +32,20 @@ let handle_keeper_bash
     match validate cmd with
     | Error reason ->
       Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
+      let hint =
+        if String.length reason > 0 &&
+           (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
+        then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
+        else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
+        then "Avoid shell metacharacters. Use keeper_shell_readonly with a specific op (rg, find, ls) instead."
+        else "Check the command for blocked patterns. Use keeper_shell_readonly for safe read-only ops."
+      in
       Yojson.Safe.to_string
         (`Assoc
             [ "ok", `Bool false
             ; "error", `String "command_blocked"
             ; "reason", `String reason
+            ; "hint", `String hint
             ])
     | Ok () ->
       (* Destructive guard: always active regardless of preset *)


### PR DESCRIPTION
## Summary
Samchon structured feedback 원칙 적용: command_blocked 에러에 "hint" 필드 추가.

**Before**: `{"error": "command_blocked", "reason": "Shell chaining detected"}`
**After**: `{"error": "command_blocked", "reason": "...", "hint": "Use separate tool calls instead of chaining."}`

## Hint Logic
- chaining/redirect/pipe → "Use separate tool calls"
- injection/symbol → "Use keeper_shell_readonly with specific op"
- fallback → "Use keeper_shell_readonly for safe read-only ops"

## Data
41 command_blocked errors/day, mostly from && chaining attempts.

## Test plan
- [ ] dune build pass
- [ ] keeper_bash command_blocked 응답에 hint 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)