### PR TITLE
fix(cascade): switch llama:auto to ollama:auto + OAS pin bump

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,5 @@
 {
-  "default_models": ["glm:auto", "llama:auto"],
+  "default_models": ["glm:auto", "ollama:auto"],
 
   "_comment": "Only default_models needed. OAS cascade_config falls back to default_models when a named cascade is absent. Per-cascade model overrides can be added as {name}_models when differentiation is needed.",
 

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.113.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="58f7222f3aeff774168e8e71ccb419bf02d2f1b7"
+readonly OAS_AGENT_SDK_SHA="44b0b742e8977302d12b9b44cf48081c645d0dd9"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.113.0"


### PR DESCRIPTION
## Summary
- `default_models`의 `llama:auto` → `ollama:auto`로 변경 (llama-server 미가동, Ollama 가동 중)
- OAS pin을 `58f7222` → `44b0b74` (oas#716: Ollama non-streaming `/api/chat` request_path 수정)

## Context
- `llama:auto` → llama-server(8085) → 프로세스 미가동 → keeper LLM 호출 실패
- `ollama:auto` → Ollama(11434) → 가동 중, Qwen3.5 9B/27B 로드됨
- OAS의 `ollama_defaults.request_path`가 `/v1/chat/completions`이었는데, non-streaming에서 native body format을 보내는 버그가 있었음 → oas#716에서 `/api/chat`로 수정

## Test plan
- [x] `dune runtest --root . --force` 전체 통과 (20 suites)
- [ ] 서버 재빌드/재시작 후 keeper가 Ollama native endpoint를 정상 호출하는지 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)