### PR TITLE
fix(telemetry): cleanup JSON helpers, rename metric, bound file read, add data tests

### DIFF
--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -14,7 +14,7 @@ type behavioral_stats = {
   tool_use_turns : int;
   text_response_turns : int;
   unique_tools_used : string list;
-  tool_success_rate : float;
+  tool_utilization_rate : float;
   last_visible_action_age_sec : int;
   pr_workflow_attempts : int;
   work_discovery_count : int;
@@ -28,52 +28,11 @@ let empty_stats ~window_hours =
     tool_use_turns = 0;
     text_response_turns = 0;
     unique_tools_used = [];
-    tool_success_rate = 0.0;
+    tool_utilization_rate = 0.0;
     last_visible_action_age_sec = 0;
     pr_workflow_attempts = 0;
     work_discovery_count = 0;
   }
-
-(* ------------------------------------------------------------------ *)
-(* JSON field extraction helpers                                       *)
-(* ------------------------------------------------------------------ *)
-
-let json_float_opt key (json : Yojson.Safe.t) : float option =
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`Float f) -> Some f
-     | Some (`Int i) -> Some (float_of_int i)
-     | _ -> None)
-  | _ -> None
-
-let json_string_opt key (json : Yojson.Safe.t) : string option =
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String s) -> Some s
-     | _ -> None)
-  | _ -> None
-
-let json_int_opt key (json : Yojson.Safe.t) : int option =
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`Int i) -> Some i
-     | Some (`Float f) -> Some (int_of_float f)
-     | _ -> None)
-  | _ -> None
-
-let json_string_list key (json : Yojson.Safe.t) : string list =
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`List items) ->
-       List.filter_map (function
-         | `String s -> Some s
-         | _ -> None) items
-     | _ -> [])
-  | _ -> []
 
 (* ------------------------------------------------------------------ *)
 (* Decision log parsing                                                *)
@@ -90,24 +49,34 @@ let parse_decision_line (line : string) : parsed_decision option =
   match Yojson.Safe.from_string line with
   | json ->
     let timestamp_unix =
-      json_float_opt "timestamp_unix" json
+      Safe_ops.json_float_opt "timestamp_unix" json
       |> Option.value ~default:0.0
     in
     let outcome =
-      json_string_opt "outcome" json
+      Safe_ops.json_string_opt "outcome" json
       |> Option.value ~default:"unknown"
     in
     let tool_call_count =
-      json_int_opt "tool_call_count" json
+      Safe_ops.json_int_opt "tool_call_count" json
       |> Option.value ~default:0
     in
-    let tools_used = json_string_list "tools_used" json in
+    let tools_used = Safe_ops.json_string_list "tools_used" json in
     Some { timestamp_unix; outcome; tool_call_count; tools_used }
   | exception _ -> None
 
 (* ------------------------------------------------------------------ *)
 (* Stats computation                                                   *)
 (* ------------------------------------------------------------------ *)
+
+(* Bound file parsing to last N lines. Decision logs are append-only
+   so the most recent entries are at the end. 2000 lines covers ~16h
+   at 2 turns/min, well within any configured window. *)
+let max_decision_lines = 2000
+
+let take_last n lst =
+  let len = List.length lst in
+  if len <= n then lst
+  else List.filteri (fun i _ -> i >= len - n) lst
 
 let compute_stats ~decision_log_path ~window_hours =
   let now_ts = Unix.gettimeofday () in
@@ -117,6 +86,7 @@ let compute_stats ~decision_log_path ~window_hours =
       let content = Fs_compat.load_file decision_log_path in
       String.split_on_char '\n' content
       |> List.filter (fun s -> String.trim s <> "")
+      |> take_last max_decision_lines
     with _ -> []
   in
   let decisions =
@@ -173,7 +143,7 @@ let compute_stats ~decision_log_path ~window_hours =
     let silent_ratio =
       float_of_int silent_turns /. float_of_int total_turns
     in
-    let tool_success_rate =
+    let tool_utilization_rate =
       if total_tool_calls > 0 then
         float_of_int tool_use_turns /. float_of_int total_turns
       else 0.0
@@ -185,7 +155,7 @@ let compute_stats ~decision_log_path ~window_hours =
       tool_use_turns;
       text_response_turns;
       unique_tools_used = unique_tools;
-      tool_success_rate;
+      tool_utilization_rate;
       last_visible_action_age_sec;
       pr_workflow_attempts;
       work_discovery_count = 0;
@@ -219,7 +189,7 @@ let render_feedback_block ~(stats : behavioral_stats) =
       "### Behavioral Self-Assessment (last %dh)\n\
        - Turns: %d total (%d silent, %d active)\n\
        - Silent ratio: %.1f%%\n\
-       - Tool use turns: %d (success rate: %.1f%%)\n\
+       - Tool use turns: %d (utilization: %.1f%%)\n\
        - Text-only response turns: %d\n\
        - Last visible action: %s ago\n\
        - PR workflow attempts: %d\n\
@@ -228,7 +198,7 @@ let render_feedback_block ~(stats : behavioral_stats) =
       stats.total_turns stats.silent_turns
       (stats.total_turns - stats.silent_turns)
       (stats.silent_ratio *. 100.0)
-      stats.tool_use_turns (stats.tool_success_rate *. 100.0)
+      stats.tool_use_turns (stats.tool_utilization_rate *. 100.0)
       stats.text_response_turns
       (format_age_sec stats.last_visible_action_age_sec)
       stats.pr_workflow_attempts

--- a/lib/keeper/keeper_telemetry_feedback.mli
+++ b/lib/keeper/keeper_telemetry_feedback.mli
@@ -14,7 +14,7 @@ type behavioral_stats = {
   tool_use_turns : int;
   text_response_turns : int;
   unique_tools_used : string list;
-  tool_success_rate : float;
+  tool_utilization_rate : float;
   last_visible_action_age_sec : int;
   pr_workflow_attempts : int;
   work_discovery_count : int;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -535,6 +535,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
            else if has_substantive_tools then
              Printf.sprintf "(tools: %s)" (String.concat ", " result.tools_used)
            else rt.proactive_rt.last_preview);
+        (* Work discovery timestamp only advances when the keeper
+           actually used tools in response to the nudge. This is
+           intentional: the "Work Discovery Due" prompt block keeps
+           being injected until the keeper takes visible action,
+           preventing silent cycles from consuming the scan interval. *)
         last_work_discovery_ts =
           (if observation.work_discovery_due && has_substantive_tools then
              now_ts

--- a/test/test_keeper_telemetry_feedback.ml
+++ b/test/test_keeper_telemetry_feedback.ml
@@ -40,7 +40,7 @@ let () =
     ; tool_use_turns = 2
     ; text_response_turns = 1
     ; unique_tools_used = ["keeper_board_list"; "keeper_shell_readonly"]
-    ; tool_success_rate = 0.9
+    ; tool_utilization_rate = 0.9
     ; last_visible_action_age_sec = 3600
     ; pr_workflow_attempts = 0
     ; work_discovery_count = 0
@@ -58,5 +58,59 @@ let () =
   assert (contains block "PR workflow attempts: 0");
   assert (contains block "1h 0m");
   Printf.printf "PASS: render_feedback_block with data\n";
+
+  (* -- compute_stats with actual JSONL data -- *)
+  let now = Unix.gettimeofday () in
+  let tmp_path = Filename.temp_file "test_decisions_" ".jsonl" in
+  let oc = open_out tmp_path in
+  (* 3 entries in window: 1 silent, 1 with tools, 1 text-only *)
+  Printf.fprintf oc
+    {|{"timestamp_unix":%.1f,"outcome":"proactive_silent","tool_call_count":0,"tools_used":[]}|}
+    (now -. 100.0);
+  output_char oc '\n';
+  Printf.fprintf oc
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":2,"tools_used":["keeper_board_list","keeper_pr_workflow"]}|}
+    (now -. 50.0);
+  output_char oc '\n';
+  Printf.fprintf oc
+    {|{"timestamp_unix":%.1f,"outcome":"text_response","tool_call_count":0,"tools_used":[]}|}
+    (now -. 10.0);
+  output_char oc '\n';
+  (* 1 entry outside window (48h ago) — should be filtered out *)
+  Printf.fprintf oc
+    {|{"timestamp_unix":%.1f,"outcome":"proactive_silent","tool_call_count":0,"tools_used":[]}|}
+    (now -. 200000.0);
+  output_char oc '\n';
+  close_out oc;
+  let stats = TF.compute_stats ~decision_log_path:tmp_path ~window_hours:24 in
+  assert (stats.total_turns = 3);
+  assert (stats.silent_turns = 1);
+  assert (stats.tool_use_turns = 1);
+  assert (stats.text_response_turns = 1);
+  assert (stats.pr_workflow_attempts = 1);
+  assert (List.length stats.unique_tools_used = 2);
+  assert (List.mem "keeper_board_list" stats.unique_tools_used);
+  assert (List.mem "keeper_pr_workflow" stats.unique_tools_used);
+  (* silent_ratio = 1/3 ≈ 0.333 *)
+  assert (stats.silent_ratio > 0.33 && stats.silent_ratio < 0.34);
+  Sys.remove tmp_path;
+  Printf.printf "PASS: compute_stats with actual data\n";
+
+  (* -- window filtering: 1h window should exclude entries > 1h ago -- *)
+  let tmp_path2 = Filename.temp_file "test_decisions_window_" ".jsonl" in
+  let oc2 = open_out tmp_path2 in
+  Printf.fprintf oc2
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell_readonly"]}|}
+    (now -. 1800.0);  (* 30min ago — inside 1h window *)
+  output_char oc2 '\n';
+  Printf.fprintf oc2
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell_readonly"]}|}
+    (now -. 7200.0);  (* 2h ago — outside 1h window *)
+  output_char oc2 '\n';
+  close_out oc2;
+  let stats2 = TF.compute_stats ~decision_log_path:tmp_path2 ~window_hours:1 in
+  assert (stats2.total_turns = 1);
+  Sys.remove tmp_path2;
+  Printf.printf "PASS: compute_stats window filtering\n";
 
   Printf.printf "All telemetry feedback tests passed.\n"


### PR DESCRIPTION
## Summary

#5763 (work discovery + telemetry feedback) 리뷰에서 발견된 4개 이슈 수정.

- **JSON 헬퍼 중복 제거**: `keeper_telemetry_feedback.ml`의 커스텀 `json_float_opt` 등 4개 함수를 `Safe_ops` 모듈로 대체. -36줄.
- **메트릭 명칭 수정**: `tool_success_rate` → `tool_utilization_rate`. 실제로는 "도구 사용 비율"이지 "성공률"이 아님. LLM이 잘못된 판단을 하는 것을 방지.
- **파일 읽기 bound**: decision log 파싱을 최신 2000줄로 제한. 로그 증가에 따른 무한 비용 방지.
- **실제 데이터 테스트 추가**: 임시 JSONL 파일로 `compute_stats`의 outcome 분류, window 필터링, tool counting 검증.
- **nudge 동작 문서화**: work_discovery_due가 도구 사용 시에만 해제되는 의도적 동작에 주석 추가.

## Test plan

- [x] `test_keeper_telemetry_feedback.exe` 6개 테스트 통과 (기존 4 + 신규 2)
- [x] `test_keeper_unified.exe` 108개 테스트 통과
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)