### PR TITLE
feat(keeper): adaptive thinking — pipeline 신호 기반 per-turn thinking 제어 (#5650)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -844,11 +844,35 @@ let run_turn
     Agent_sdk.Hooks.empty with
     before_turn_params = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.BeforeTurnParams { turn; current_params; messages; _ } ->
+      | Agent_sdk.Hooks.BeforeTurnParams { turn; current_params; messages; last_tool_results; _ } ->
         let hook_t0 = Time_compat.now () in
         (* Update current_turn_ref so session-scoped callbacks
            (keeper_tool_search, on_tool_called) use the correct turn. *)
         current_turn_ref := turn;
+                (* Adaptive thinking override based on turn signals *)
+        let adaptive_thinking_budget =
+          if not (Keeper_config.keeper_adaptive_thinking_enabled ()) then
+            current_params.thinking_budget
+          else
+            (* 1) Error or Retry in last tools -> High thinking *)
+            let had_error = List.exists (fun (r : Agent_sdk.Types.tool_result) ->
+              match r with
+              | Error _ -> true
+              | Ok { content } -> String_util.contains_substring_ci content "error" || String_util.contains_substring_ci content "fail"
+            ) last_tool_results in
+            if had_error then Some 1500
+            else
+            (* 2) Task complexity keywords -> Max thinking *)
+            let complex_task = List.exists (fun needle -> String_util.contains_substring_ci (user_message ^ " " ^ dynamic_context) needle)
+              ["분석"; "설계"; "plan"; "architecture"; "complex"; "investigate"] in
+            if complex_task then Some 2000
+            else
+              (* Otherwise fallback to default or OFF (None) *)
+              current_params.thinking_budget
+        in
+
+        let current_params = { current_params with thinking_budget = adaptive_thinking_budget } in
+
         (* 1. Dynamic context injection *)
         let ctx =
           if String.trim dynamic_context = "" then

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -702,3 +702,12 @@ let keeper_slot_id (name : string) : int option =
   else
     let h = Hashtbl.hash name in
     Some (h mod num_slots)
+
+
+let keeper_adaptive_thinking_enabled_rp =
+  _rp_bool ~key:"keeper.turn.adaptive_thinking"
+    ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ADAPTIVE_THINKING" ~default:false)
+    ~description:"Enable pipeline signal-based per-turn adaptive thinking" ()
+
+let keeper_adaptive_thinking_enabled () : bool =
+  Runtime_params.get keeper_adaptive_thinking_enabled_rp


### PR DESCRIPTION
Resolves #5650.

### Overview
Introduces a signal-based `adaptive_thinking_enabled` mode that hooks into `before_turn_params` to dynamically override the `thinking_budget` on a per-turn basis. This is crucial for local `llama-server` environments that don't natively support provider-managed adaptive thinking (unlike Anthropic's API).

### Rules Implemented
- **High Thinking (1500 tokens)**: Triggered if any of the `last_tool_results` encountered an error or failed.
- **Max Thinking (2000 tokens)**: Triggered if the `user_message` or `dynamic_context` contains complex planning keywords (e.g., "분석", "설계", "plan", "architecture", "complex", "investigate").
- **Fallback**: Returns to the default budget (usually OFF) if no signals are triggered.
- **Toggle**: Gated behind `MASC_KEEPER_ADAPTIVE_THINKING=true` (default `false`).