### PR TITLE
refactor(keeper): playground clone for pr_workflow

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -139,10 +139,6 @@ let handle_keeper_pr_workflow
         error_json "branch contains invalid chars. Use only a-z, A-Z, 0-9, hyphen, underscore, slash."
       else
       let root = Keeper_alerting_path.project_root_of_config config in
-      let task_id = Printf.sprintf "pr-%s"
-        (safe_task_id (String.sub branch 0 (min 20 (String.length branch)))) in
-      let agent_name = Printf.sprintf "keeper-%s"
-        (safe_task_id (strip_keeper_prefix meta.name)) in
       let steps = Buffer.create 512 in
       let step_ok = ref true in
       let step_error = ref "" in
@@ -161,31 +157,61 @@ let handle_keeper_pr_workflow
             None
         end else None
       in
-      (* Step 1: Create worktree *)
-      let worktree_path = ref "" in
-      let _s1 = run_step "worktree_create" (fun () ->
-        match Room.worktree_create_r config ~agent_name ~task_id ~base_branch with
-        | Ok msg ->
-          (* Derive worktree path from known naming convention, then verify it exists *)
-          let wt_dir = Filename.concat root
-            (Printf.sprintf ".worktrees/%s-%s" agent_name task_id) in
-          if Sys.file_exists wt_dir && Sys.is_directory wt_dir then begin
-            worktree_path := wt_dir;
-            Ok msg
-          end else
-            Error (Printf.sprintf "worktree created but path not found: %s" wt_dir)
-        | Error e -> Error (Types.masc_error_to_string e)
+      let run_sh ~cwd ~timeout_sec cmd =
+        let shell = Printf.sprintf "cd %s && %s 2>&1"
+          (Filename.quote cwd) cmd in
+        Process_eio.run_argv_with_status ~timeout_sec
+          [ "/bin/zsh"; "-lc"; shell ]
+      in
+      (* Step 1: Shallow clone into keeper playground.
+         Fully isolated from main repo — no shared git index. *)
+      let clone_dir = ref "" in
+      let _s1 = run_step "playground_clone" (fun () ->
+        let playground = Filename.concat root
+          (Keeper_alerting_path.playground_path_of_keeper meta.name) in
+        Fs_compat.mkdir_p playground;
+        let repo_name = Filename.basename root in
+        let clone_path = Filename.concat playground repo_name in
+        (* Clean up any previous clone *)
+        if Sys.file_exists clone_path then begin
+          let st, _ = run_sh ~cwd:playground ~timeout_sec:10.0
+            (Printf.sprintf "rm -rf %s" (Filename.quote repo_name)) in
+          if st <> Unix.WEXITED 0 then
+            Log.Keeper.warn "pr_workflow: failed to clean previous clone at %s" clone_path
+        end;
+        (* Shallow clone with single branch for speed *)
+        let origin_url =
+          let st, out = run_sh ~cwd:root ~timeout_sec:5.0
+            "git remote get-url origin" in
+          if st = Unix.WEXITED 0 then String.trim out
+          else root (* fallback to local path *)
+        in
+        let st, out = run_sh ~cwd:playground ~timeout_sec:120.0
+          (Printf.sprintf "git clone --depth 1 --branch %s %s %s"
+            (Filename.quote base_branch)
+            (Filename.quote origin_url)
+            (Filename.quote repo_name)) in
+        if st <> Unix.WEXITED 0 then
+          Error (Printf.sprintf "git clone: %s" out)
+        else begin
+          clone_dir := clone_path;
+          (* Create the feature branch *)
+          let st2, out2 = run_sh ~cwd:clone_path ~timeout_sec:5.0
+            (Printf.sprintf "git checkout -b %s" (Filename.quote branch)) in
+          if st2 <> Unix.WEXITED 0 then
+            Error (Printf.sprintf "git checkout -b: %s" out2)
+          else
+            Ok (Printf.sprintf "cloned to %s, branch %s" clone_path branch)
+        end
       ) in
       (* Step 2: Write file — with path traversal guard *)
       let _s2 = run_step "file_write" (fun () ->
-        if !worktree_path = "" then Error "no worktree path"
+        if !clone_dir = "" then Error "no clone path"
         else begin
-          let abs_path = Filename.concat !worktree_path file_path in
-          (* Resolve symlinks and normalize to catch ../.. traversal *)
+          let abs_path = Filename.concat !clone_dir file_path in
           let canonical =
             try Some (Unix.realpath abs_path)
             with Unix.Unix_error _ ->
-              (* File doesn't exist yet: check parent dir *)
               try
                 let parent = Unix.realpath (Filename.dirname abs_path) in
                 Some (Filename.concat parent (Filename.basename abs_path))
@@ -194,8 +220,8 @@ let handle_keeper_pr_workflow
           match canonical with
           | None -> Error (Printf.sprintf "cannot resolve path: %s" file_path)
           | Some resolved ->
-            if not (String.starts_with ~prefix:(!worktree_path ^ "/") resolved) then
-              Error (Printf.sprintf "path escapes worktree boundary: %s" file_path)
+            if not (String.starts_with ~prefix:(!clone_dir ^ "/") resolved) then
+              Error (Printf.sprintf "path escapes clone boundary: %s" file_path)
             else begin
               try
                 let dir = Filename.dirname resolved in
@@ -208,27 +234,25 @@ let handle_keeper_pr_workflow
       ) in
       (* Pre-commit: Version truth check guard *)
       let _s_ver = run_step "version_truth_check" (fun () ->
-        if !worktree_path = "" then Error "no worktree path"
+        if !clone_dir = "" then Error "no clone path"
         else begin
-          let check_cmd = Printf.sprintf "cd %s && ./scripts/check-version-truth.sh 2>&1" (Filename.quote !worktree_path) in
-          let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0 [ "/bin/zsh"; "-lc"; check_cmd ] in
+          let check_cmd = Printf.sprintf "cd %s && ./scripts/check-version-truth.sh 2>&1"
+            (Filename.quote !clone_dir) in
+          let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0
+            [ "/bin/zsh"; "-lc"; check_cmd ] in
           if st <> Unix.WEXITED 0 then
-            Error (Printf.sprintf "Version truth check failed (run scripts/bump-version.sh instead of editing dune-project manually): %s" out)
+            Error (Printf.sprintf "Version truth check failed: %s" out)
           else Ok "version truth OK"
         end
       ) in
-
       (* Step 3: Git add + commit + push *)
       let _s3 = run_step "git_commit_push" (fun () ->
-        if !worktree_path = "" then Error "no worktree path"
+        if !clone_dir = "" then Error "no clone path"
         else begin
-          let run_git cmd =
-            let shell = Printf.sprintf "cd %s && git %s 2>&1"
-              (Filename.quote !worktree_path) cmd in
-            Process_eio.run_argv_with_status ~timeout_sec:30.0
-              [ "/bin/zsh"; "-lc"; shell ]
-          in
-          let st_add, out_add = run_git (Printf.sprintf "add %s" (Filename.quote file_path)) in
+          let run_git cmd = run_sh ~cwd:(!clone_dir) ~timeout_sec:30.0
+            (Printf.sprintf "git %s" cmd) in
+          let st_add, out_add = run_git
+            (Printf.sprintf "add %s" (Filename.quote file_path)) in
           if st_add <> Unix.WEXITED 0 then
             Error (Printf.sprintf "git add: %s" out_add)
           else begin
@@ -237,10 +261,8 @@ let handle_keeper_pr_workflow
             if st_commit <> Unix.WEXITED 0 then
               Error (Printf.sprintf "git commit: %s" out_commit)
             else begin
-              (* Push using HEAD:<branch> because the worktree's local branch
-                 (agent_name/task_id) differs from the desired remote branch name *)
               let st_push, out_push = run_git
-                (Printf.sprintf "push -u origin HEAD:%s" (Filename.quote branch)) in
+                (Printf.sprintf "push -u origin %s" (Filename.quote branch)) in
               if st_push <> Unix.WEXITED 0 then
                 Error (Printf.sprintf "git push: %s" out_push)
               else
@@ -249,24 +271,34 @@ let handle_keeper_pr_workflow
           end
         end
       ) in
-      (* Step 4: Create draft PR — run from worktree for correct branch context *)
+      (* Step 4: Create draft PR *)
       let pr_url = ref "" in
       let _s4 = run_step "gh_pr_create" (fun () ->
-        let body = if pr_body = "" then pr_title else pr_body in
-        let gh_cmd = Printf.sprintf
-          "cd %s && gh pr create --draft --title %s --body %s --base %s 2>&1"
-          (Filename.quote !worktree_path) (Filename.quote pr_title) (Filename.quote body)
-          (Filename.quote base_branch) in
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:30.0
-            [ "/bin/zsh"; "-lc"; gh_cmd ] in
-        if st <> Unix.WEXITED 0 then
-          Error (Printf.sprintf "gh pr create: %s" out)
+        if !clone_dir = "" then Error "no clone path"
         else begin
-          pr_url := String.trim out;
-          Ok (Printf.sprintf "PR created: %s" (String.trim out))
+          let body = if pr_body = "" then pr_title else pr_body in
+          let gh_cmd = Printf.sprintf
+            "cd %s && gh pr create --draft --title %s --body %s --base %s 2>&1"
+            (Filename.quote !clone_dir) (Filename.quote pr_title) (Filename.quote body)
+            (Filename.quote base_branch) in
+          let st, out =
+            Process_eio.run_argv_with_status ~timeout_sec:30.0
+              [ "/bin/zsh"; "-lc"; gh_cmd ] in
+          if st <> Unix.WEXITED 0 then
+            Error (Printf.sprintf "gh pr create: %s" out)
+          else begin
+            pr_url := String.trim out;
+            Ok (Printf.sprintf "PR created: %s" (String.trim out))
+          end
         end
       ) in
+      (* Step 5: Clean up clone *)
+      (if !clone_dir <> "" && Sys.file_exists !clone_dir then begin
+        let st, _ = run_sh ~cwd:(Filename.dirname !clone_dir) ~timeout_sec:10.0
+          (Printf.sprintf "rm -rf %s" (Filename.quote (Filename.basename !clone_dir))) in
+        if st <> Unix.WEXITED 0 then
+          Log.Keeper.warn "pr_workflow: failed to clean clone at %s" !clone_dir
+      end);
       Yojson.Safe.to_string
         (`Assoc
           [ "ok", `Bool !step_ok

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -123,17 +123,6 @@ let handle_keeper_pr_workflow
           || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '/')
         |> String.of_seq
       in
-      (* Sanitize task_id: replace '/' with '-' because
-         worktree_create_r rejects path separators in task_id *)
-      let safe_task_id s =
-        String.to_seq s
-        |> Seq.filter_map (fun c ->
-          if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-             || (c >= '0' && c <= '9') || c = '-' || c = '_' then Some c
-          else if c = '/' then Some '-'
-          else None)
-        |> String.of_seq
-      in
       let branch_safe = safe_branch branch in
       if branch_safe <> branch then
         error_json "branch contains invalid chars. Use only a-z, A-Z, 0-9, hyphen, underscore, slash."

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -378,25 +378,25 @@ let test_branch_slash_converted_to_hyphen_in_task_id () =
     check bool "error does NOT mention path separators"
       false (String_util.contains_substring_ci error "path separator"))
 
-(* --- Worktree step failure propagation --- *)
+(* --- Clone step failure propagation --- *)
 
-let test_worktree_failure_propagates () =
+let test_clone_failure_propagates () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
     let result = call_tool config meta "keeper_pr_workflow" valid_pr_args in
     let json = parse_json result in
-    (* Test room is not a git repo, so worktree_create fails.
+    (* Test room is not a git repo, so playground_clone fails.
        The result should be ok=false with a meaningful error. *)
     check bool "ok is false" false (json_bool "ok" json);
     let steps = json_string "steps" json in
-    check bool "steps contains worktree_create"
+    check bool "steps contains playground_clone"
       true (try ignore (Str.search_forward
-        (Str.regexp_string "worktree_create") steps 0); true
+        (Str.regexp_string "playground_clone") steps 0); true
         with Not_found -> false);
     let error = json_string "error" json in
-    check bool "error mentions worktree"
+    check bool "error mentions clone"
       true (try ignore (Str.search_forward
-        (Str.regexp_string "worktree") (String.lowercase_ascii error) 0); true
+        (Str.regexp_string "clone") (String.lowercase_ascii error) 0); true
         with Not_found -> false))
 
 (* --- Task lifecycle: claim → done --- *)
@@ -501,7 +501,7 @@ let () =
       [ test_case "slash to hyphen" `Quick test_branch_slash_converted_to_hyphen_in_task_id
       ]
     ; "step_propagation",
-      [ test_case "worktree failure" `Quick test_worktree_failure_propagates
+      [ test_case "clone failure" `Quick test_clone_failure_propagates
       ]
     ; "task_lifecycle",
       [ test_case "claim then done" `Quick test_task_claim_then_done_lifecycle


### PR DESCRIPTION
## Summary

`keeper_pr_workflow`를 worktree 기반에서 **playground shallow clone** 기반으로 전환.

## Why

worktree는 main repo와 git index를 공유 → keeper 실수 시 main에 영향. 또한 worktree 생성 시 task_id 변환/branch name mismatch 등 복잡한 버그 발생 (PR #5766에서 2건 수정).

playground clone은 완전 격리된 환경에서 작업하므로 이런 문제가 구조적으로 발생하지 않음.

## Changes

| Before | After |
|--------|-------|
| `Room.worktree_create_r` → `.worktrees/` | `git clone --depth 1` → `.masc/playground/<keeper>/` |
| `agent_name/task_id` branch naming | user-specified branch name 직접 사용 |
| `HEAD:<branch>` push (workaround) | `push -u origin <branch>` (직접) |
| worktree 잔존 가능 | PR 후 자동 `rm -rf` |

## Flow

```
playground_clone → file_write → version_truth_check → git_commit_push → gh_pr_create → cleanup
```

## Test plan

- [x] `dune build` passes
- [x] 22 existing tests pass
- [ ] CI green
- [ ] Post-deploy: keeper pr_workflow creates PR via playground clone

Generated with [Claude Code](https://claude.com/claude-code)