### PR TITLE
refactor(keeper): config-driven workflow preset gate

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -90,6 +90,13 @@ tools = ["masc_status", "masc_heartbeat", "masc_tasks", "masc_claim_next", "masc
 [masc.coding]
 tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktree_create", "masc_worktree_remove", "masc_worktree_list"]
 
+# ── Permissions ─────────────────────────────────────────────────────
+# Presets allowed to execute workflow mutations (pr merge, pr close, etc.).
+# Keepers with presets not listed here have these operations blocked.
+
+[permissions]
+workflow_presets = ["coding", "delivery", "full"]
+
 # ── Git Clone Policy ────────────────────────────────────────────────
 # GitHub org names allowed for masc_code_git clone action.
 # URLs not matching any org here are rejected.

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -31,8 +31,8 @@ let handle_keeper_github
     | Ok () ->
       let preset_allows_workflow =
         match Keeper_types.tool_access_preset meta.tool_access with
-        | Some (Coding | Full) -> true
-        | _ -> false
+        | Some preset -> Keeper_tool_policy.allows_workflow_for_preset preset
+        | None -> false
       in
       if Worker_dev_tools.is_gh_dangerous_operation gh_raw
       then (

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -35,6 +35,15 @@ let preset_name_of_tool_preset = function
   | Delivery -> "delivery"
   | Full -> "full"
 
+(* ── Workflow permission (config-driven) ─────────────────────── *)
+
+let allows_workflow_for_preset (preset : tool_preset) : bool =
+  match !policy_config with
+  | None -> false
+  | Some cfg ->
+    Keeper_tool_policy_config.allows_workflow cfg
+      (preset_name_of_tool_preset preset)
+
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
 let keeper_denied_set : (string, unit) Hashtbl.t =

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -25,6 +25,7 @@ type t = {
   groups : (string, group_source) Hashtbl.t;
   masc_groups : (string, string list) Hashtbl.t;
   presets : (string, preset_def) Hashtbl.t;
+  workflow_presets : string list;
 }
 
 (* ── TOML parsing helpers ─────────────────────────────────────────── *)
@@ -173,6 +174,9 @@ let load ~base_path : (t, string) result =
       | Ok groups ->
         let masc_groups = parse_masc_groups doc in
         let presets = parse_presets doc in
+        let workflow_presets =
+          toml_string_list_at doc "permissions" "workflow_presets"
+        in
         (* Validate that each preset's group references are defined *)
         let ref_errors =
           Hashtbl.fold (fun preset_name (def : preset_def) acc ->
@@ -194,7 +198,7 @@ let load ~base_path : (t, string) result =
         | [] ->
           Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
             (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
-          Ok { groups; masc_groups; presets })
+          Ok { groups; masc_groups; presets; workflow_presets })
 
 (* ── Resolution ───────────────────────────────────────────────────── *)
 
@@ -257,3 +261,6 @@ let all_group_tools (config : t) : string list =
 
 let all_masc_tools (config : t) : string list =
   Hashtbl.fold (fun _ tools acc -> tools @ acc) config.masc_groups []
+
+let allows_workflow (config : t) (preset_name : string) : bool =
+  List.mem preset_name config.workflow_presets

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -47,4 +47,8 @@ val group_names : t -> string list
 
 (** Resolve a single group name to tool names.
     Returns [None] if the group is not defined. *)
+(** Check if a preset is allowed to execute workflow mutations
+    (pr merge, pr close, etc.) as configured in [permissions.workflow_presets]. *)
+val allows_workflow : t -> string -> bool
+
 val resolve_group : t -> string -> string list option


### PR DESCRIPTION
## Summary
- `keeper_exec_github.ml`의 하드코딩된 `Coding | Full` variant 매치를 제거
- `config/tool_policy.toml`에 `[permissions]` 섹션 추가 — `workflow_presets`로 선언적 관리
- preset 추가/변경 시 TOML만 수정하면 되고 코드 변경 불필요

## 변경 파일 (5개)
| 파일 | 변경 |
|------|------|
| `config/tool_policy.toml` | `[permissions]` 섹션 + `workflow_presets` 추가 |
| `keeper_tool_policy_config.ml` | `t` 타입에 `workflow_presets` 필드, 파싱, `allows_workflow` 함수 |
| `keeper_tool_policy_config.mli` | `allows_workflow` 인터페이스 노출 |
| `keeper_tool_policy.ml` | `allows_workflow_for_preset` 글로벌 ref 경유 래퍼 |
| `keeper_exec_github.ml` | 하드코딩 제거, `allows_workflow_for_preset` 호출 |

## 동작 변경
- **이전**: `Coding | Full`에서만 `pr merge`/`pr close` 허용 (하드코딩)
- **이후**: `["coding", "delivery", "full"]`에서 허용 (TOML 선언)
- `Delivery` preset이 새로 workflow operation 허용 대상에 포함됨

## Test plan
- [ ] CI 빌드 통과 확인 (로컬 ppx OOM으로 빌드 불가, CI 의존)
- [ ] 기존 `test_keeper_github_safety` 테스트 통과 확인
- [ ] delivery preset keeper에서 `gh pr merge` 실행 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)