### PR TITLE
refactor(keeper): config-driven shell write preset gate

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -96,6 +96,7 @@ tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktr
 
 [permissions]
 workflow_presets = ["coding", "delivery", "full"]
+shell_write_presets = ["coding", "delivery", "full"]
 
 # ── Git Clone Policy ────────────────────────────────────────────────
 # GitHub org names allowed for masc_code_git clone action.

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -15,11 +15,11 @@ let handle_keeper_bash
   let timeout_sec =
     Safe_ops.json_float ~default:30.0 "timeout_sec" args |> fun n -> max 1.0 (min 180.0 n)
   in
-  (* Coding/Full presets allow write operations and relaxed metachar rules *)
+  (* Write access is config-driven via permissions.shell_write_presets *)
   let write_enabled =
-    match meta.tool_access with
-    | Preset { preset = Coding; _ } | Preset { preset = Full; _ } -> true
-    | _ -> false
+    match Keeper_types.tool_access_preset meta.tool_access with
+    | Some preset -> Keeper_tool_policy.allows_shell_write_for_preset preset
+    | None -> false
   in
   if cmd = ""
   then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -44,6 +44,13 @@ let allows_workflow_for_preset (preset : tool_preset) : bool =
     Keeper_tool_policy_config.allows_workflow cfg
       (preset_name_of_tool_preset preset)
 
+let allows_shell_write_for_preset (preset : tool_preset) : bool =
+  match !policy_config with
+  | None -> false
+  | Some cfg ->
+    Keeper_tool_policy_config.allows_shell_write cfg
+      (preset_name_of_tool_preset preset)
+
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
 let keeper_denied_set : (string, unit) Hashtbl.t =

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -26,6 +26,7 @@ type t = {
   masc_groups : (string, string list) Hashtbl.t;
   presets : (string, preset_def) Hashtbl.t;
   workflow_presets : string list;
+  shell_write_presets : string list;
 }
 
 (* ── TOML parsing helpers ─────────────────────────────────────────── *)
@@ -177,6 +178,9 @@ let load ~base_path : (t, string) result =
         let workflow_presets =
           toml_string_list_at doc "permissions" "workflow_presets"
         in
+        let shell_write_presets =
+          toml_string_list_at doc "permissions" "shell_write_presets"
+        in
         (* Validate that each preset's group references are defined *)
         let ref_errors =
           Hashtbl.fold (fun preset_name (def : preset_def) acc ->
@@ -198,7 +202,7 @@ let load ~base_path : (t, string) result =
         | [] ->
           Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
             (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
-          Ok { groups; masc_groups; presets; workflow_presets })
+          Ok { groups; masc_groups; presets; workflow_presets; shell_write_presets })
 
 (* ── Resolution ───────────────────────────────────────────────────── *)
 
@@ -264,3 +268,6 @@ let all_masc_tools (config : t) : string list =
 
 let allows_workflow (config : t) (preset_name : string) : bool =
   List.mem preset_name config.workflow_presets
+
+let allows_shell_write (config : t) (preset_name : string) : bool =
+  List.mem preset_name config.shell_write_presets

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -51,4 +51,8 @@ val group_names : t -> string list
     (pr merge, pr close, etc.) as configured in [permissions.workflow_presets]. *)
 val allows_workflow : t -> string -> bool
 
+(** Check if a preset allows shell write operations
+    as configured in [permissions.shell_write_presets]. *)
+val allows_shell_write : t -> string -> bool
+
 val resolve_group : t -> string -> string list option


### PR DESCRIPTION
## Summary
- `keeper_exec_shell.ml`의 하드코딩된 `Coding | Full` variant 매치를 제거
- `permissions.shell_write_presets`로 선언적 관리 (#5777과 동일 패턴)
- preset 추가/변경 시 TOML만 수정, 코드 변경 불필요

## 동작 변경
- **이전**: `Coding | Full`에서만 shell write 허용 (하드코딩)
- **이후**: `["coding", "delivery", "full"]`에서 허용 (TOML 선언)
- `Delivery` preset이 새로 shell write 허용 대상에 포함됨

## Follow-up to #5777

🤖 Generated with [Claude Code](https://claude.com/claude-code)