### PR TITLE
feat(team-session): resolve lossy projection (collaboration_context + Prompt_composer)

### DIFF
--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -24,7 +24,7 @@
 | Chain Engine | 04 | - | - | - | - | **Frozen** | 0 production calls, OAS superseded |
 | Keeper Agent | 05 | 25 | 0 | 0 | 0 | 100% | Memory.t Long_term JSONL-only 완료 (v2.140.0) |
 | Command Plane | 06 | 40 | 0 | 0 | 0 | 100% | Intent 도구 4종 MCP 등록 완료 |
-| Team Session | 07 | 30 | 3 | 0 | 0 | 90% | Auto 모드는 OAS 위임, lossy projection |
+| Team Session | 07 | 31 | 2 | 0 | 0 | 94% | Auto 모드는 OAS 위임, projection 해소 |
 | Governance | 08 | 28 | 0 | 0 | 0 | 100% | 거버넌스 pipeline + dashboard surface 유지 |
 | Server/Transport | 09 | 19 | 4 | 0 | 0 | 83% | SSE rate limit 활성화, HTTP/2 h2c는 opt-in CODE |
 | Dashboard | 10 | 15 | 0 | 0 | 0 | 100% | MDAL 개념 제거 (REMOVED) |
@@ -33,9 +33,9 @@
 | OAS Integration | 13 | 42 | 0 | 0 | 0 | 100% | 단방향 경계 완벽 준수 |
 | Configuration | 14 | 68 | 0 | 0 | 0 | 100% | 80+ env var, 22 카테고리 |
 | Testing | 15 | 92 | 6 | 0 | 0 | 94% | env-gated 6건만 CODE |
-| **TOTAL** | | **441** | **17** | **0** | **0** | **96.3%** | |
+| **TOTAL** | | **442** | **16** | **0** | **0** | **96.5%** | |
 
-**MISS: 0 | STUB: 0 | IMPL 비율: 96.3%**
+**MISS: 0 | STUB: 0 | IMPL 비율: 96.5%**
 
 ---
 
@@ -51,7 +51,7 @@
 | **Board Listener (polling)** | 11 | ~100 | pg_notify 수신 코드, SSE relay 미확인 |
 | ~~Intent 도구 4종~~ | 06 | ~200 | **→ IMPL** (MCP tool registry 등록 + dispatch 완료) |
 | ~~Keeper OAS Memory.t 일부~~ | 05 | ~100 | **→ IMPL** (v2.140.0 filesystem-first 전환으로 완료) |
-| **Team Session lossy projection** | 07 | ~50 | 47→12 필드 축소, 의도적 gap (Phase C-1, OAS 크로스 레포 작업 필요) |
+| ~~Team Session lossy projection~~ | 07 | ~50 | **→ IMPL** (collaboration_context JSON 채움 + Prompt_composer로 system_prompt 보강. OAS #698에서 Collaboration.t→opaque JSON 전환 완료) |
 | **env-gated 테스트** | 15 | ~300 | E2E 6종은 MASC_E2E_TESTS=true로 CI 활성화됨. PG 1종(test_board_pg)만 PostgreSQL service 미제공으로 CI 미실행 |
 | ~~MDAL dashboard surface~~ | 10 | ~50 | **→ REMOVED** (개념 폐기) |
 
@@ -108,7 +108,7 @@
 | Event Trace | Append-only events.jsonl | IMPL | 58KB, 1000+ entries |
 | Intent Tools | create/status/update/forecast | IMPL | MCP tool registry 등록 + dispatch 연결 완료 |
 
-### 07-Team Session (90% IMPL)
+### 07-Team Session (94% IMPL)
 
 | Section | Feature | Status | Evidence |
 |---------|---------|--------|----------|
@@ -118,7 +118,7 @@
 | Swarm Runner | Load→convert→callbacks→run→apply | IMPL | team_session_swarm_runner.ml |
 | Report/Proof | Markdown/JSON, Standard/Strong | IMPL | team_session_report_proof.ml 419 LOC |
 | Tool Surface | 9 handler modules, 4.5K LOC | IMPL | God file 분할 완료 |
-| Lossy Projection | 47→12 fields to OAS Collaboration.t | CODE | 의도적 gap |
+| Lossy Projection | collaboration_context JSON + Prompt_composer | IMPL | OAS #698 opaque JSON, system_prompt 보강 |
 
 ### 08-Governance (100% IMPL)
 
@@ -190,7 +190,7 @@ env-gated 6종(PG/network/viewer)만 CODE.
 ### 아키텍처 의사결정 필요
 1. Chain Engine 장기 방향 (현재 Frozen)
 2. live ICE/TURN/browser interop proof를 어떤 env-gated lane으로 운영할지
-3. Team Session lossy projection(47→12) 해소 방법
+3. ~~Team Session lossy projection(47→12) 해소 방법~~ → 해소됨 (OAS #698 + MASC projection 구현)
 
 ---
 
@@ -200,7 +200,7 @@ env-gated 6종(PG/network/viewer)만 CODE.
 |---------|------|------|
 | ~~1~~ | ~~Server: SSE rate limit 활성화~~ | **완료** (기본값 1s/60s-10 활성화) |
 | ~~2~~ | ~~Keeper: OAS Memory.t Long_term 백엔드 완성~~ | **완료** (v2.140.0 filesystem-first 전환) |
-| 1 | Team Session: lossy projection 해소 | 47→12 필드 축소가 OAS 측 정보 손실 유발. OAS Collaboration.t 확장 필요 (크로스 레포) |
+| ~~1~~ | ~~Team Session: lossy projection 해소~~ | **완료** (collaboration_context JSON + Prompt_composer system_prompt 보강) |
 | 2 | Board Listener: 테스트 + 활성화 검증 | pg_notify→SSE relay 경로 테스트 부재 |
 | 3 | Transport: HTTP/2 h2c 테스트 + 벤치마크 | opt-in 경로 검증, canonical 전환 판단 근거 |
 | 4 | Chain Engine: Adapter+Mermaid 유틸리티 추출 후 본체 archive | 17K LOC 유지비 제거 |

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -118,6 +118,23 @@ let build ~base_path ~team_session_id =
         task_tree;
       }
 
+let task_summary_to_json (t : task_summary) : Yojson.Safe.t =
+  `Assoc
+    ([ ("task_id", `String t.task_id);
+       ("title", `String t.title);
+       ("status", `String t.status) ]
+     @ (match t.assignee with
+        | Some a -> [ ("assignee", `String a) ]
+        | None -> []))
+
+let to_json (ctx : team_context) : Yojson.Safe.t =
+  `Assoc
+    [ ("team_goal", `String ctx.team_goal);
+      ("prior_decisions", `List (List.map (fun s -> `String s) ctx.prior_decisions));
+      ("shared_findings", `List (List.map (fun s -> `String s) ctx.shared_findings));
+      ("active_workers", `List (List.map (fun s -> `String s) ctx.active_workers));
+      ("task_tree", `List (List.map task_summary_to_json ctx.task_tree)) ]
+
 let truncate_list n lst =
   List.filteri (fun i _ -> i < n) lst
 

--- a/lib/team_context.mli
+++ b/lib/team_context.mli
@@ -37,6 +37,9 @@ val build :
     Output is capped to stay within ~500 tokens. *)
 val to_prompt_section : team_context -> string
 
+(** Serialize the team context to JSON for [collaboration_context]. *)
+val to_json : team_context -> Yojson.Safe.t
+
 (** Record a shared finding from a completed worker.
     [finding] should be 1-2 sentences summarizing the key result. *)
 val add_finding :

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -594,10 +594,20 @@ let planned_worker_to_entry_with_state
         List.mem tool.name scoped_tool_names)
       masc_tools
   in
+  let team_ctx =
+    Team_context.build ~base_path:config.base_path ~team_session_id:session_id
+  in
   let system_prompt =
-    Printf.sprintf "You are agent '%s' in a team session (room: %s). Your role: %s."
-      name config.base_path
-      (match pw.spawn_role with Some r -> r | None -> "execute")
+    Prompt_composer.compose [
+      Prompt_composer.Identity {
+        name;
+        role = (match pw.spawn_role with Some r -> r | None -> "execute");
+        model = cascade_name;
+      };
+      Prompt_composer.TeamContext team_ctx;
+      Prompt_composer.FreeText
+        (Printf.sprintf "Room: %s | Session: %s" config.base_path session_id);
+    ]
   in
   (* BM25 progressive tool disclosure: build once, reuse across turns.
      Synonym-enriched descriptions bridge user vocabulary to tool names.
@@ -755,13 +765,20 @@ let session_to_swarm_config
               (Printexc.to_string ex);
             entry_count)
   in
+  let collaboration_context =
+    let team_ctx =
+      Team_context.build ~base_path:config.base_path
+        ~team_session_id:session.session_id
+    in
+    Some (Team_context.to_json team_ctx)
+  in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;
     max_parallel = max 1 entry_count;
     prompt = session.goal; timeout_sec;
     budget = budget_of_session_timeout timeout_sec;
     max_agent_retries = 1;
-    collaboration_context = None;
+    collaboration_context;
     resource_check = Some (session_runtime_health_check ~config ~session);
     max_concurrent_agents = Some (max 1 (min entry_count slot_aware_cap));
     enable_streaming = false }

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -573,6 +573,7 @@ let planned_worker_to_entry_with_state
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~(success_by_agent : (string, bool) Hashtbl.t)
+    ~(team_ctx : Team_context.team_context)
     ?(delivery_contract : Team_session_types.delivery_contract option)
     (pw : Team_session_types.planned_worker)
   : Swarm.Swarm_types.agent_entry =
@@ -593,9 +594,6 @@ let planned_worker_to_entry_with_state
       (fun (tool : Types.tool_schema) ->
         List.mem tool.name scoped_tool_names)
       masc_tools
-  in
-  let team_ctx =
-    Team_context.build ~base_path:config.base_path ~team_session_id:session_id
   in
   let system_prompt =
     Prompt_composer.compose [
@@ -703,8 +701,12 @@ let planned_worker_to_entry
     (pw : Team_session_types.planned_worker)
   : Swarm.Swarm_types.agent_entry =
   let success_by_agent = Hashtbl.create 1 in
+  let team_ctx =
+    try Team_context.build ~base_path:config.base_path ~team_session_id:session_id
+    with _ -> Team_context.empty
+  in
   planned_worker_to_entry_with_state ~config ~session_id ~session_cascade ~masc_tools
-    ~dispatch ~success_by_agent ?delivery_contract:None pw
+    ~dispatch ~success_by_agent ~team_ctx ?delivery_contract:None pw
 
 (* ── session -> swarm_config ───────────────────────────────────── *)
 
@@ -717,11 +719,16 @@ let session_to_swarm_config
     (session : Team_session_types.session)
   : Swarm.Swarm_types.swarm_config =
   let success_by_agent = Hashtbl.create 8 in
+  let team_ctx =
+    try Team_context.build ~base_path:config.base_path
+          ~team_session_id:session.session_id
+    with _ -> Team_context.empty
+  in
   let entries =
     List.map
       (planned_worker_to_entry_with_state ~config ~session_id:session.session_id
          ~session_cascade:session.model_cascade ~masc_tools ~dispatch
-         ~success_by_agent ?delivery_contract:session.delivery_contract)
+         ~success_by_agent ~team_ctx ?delivery_contract:session.delivery_contract)
       session.planned_workers
   in
   List.iter
@@ -765,13 +772,7 @@ let session_to_swarm_config
               (Printexc.to_string ex);
             entry_count)
   in
-  let collaboration_context =
-    let team_ctx =
-      Team_context.build ~base_path:config.base_path
-        ~team_session_id:session.session_id
-    in
-    Some (Team_context.to_json team_ctx)
-  in
+  let collaboration_context = Some (Team_context.to_json team_ctx) in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;
     max_parallel = max 1 entry_count;

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -237,8 +237,15 @@ let test_session_to_swarm_config_health_contract () =
   Alcotest.(check int) "initial telemetry turn_count" 0 telemetry.turn_count;
   Alcotest.(check bool) "initial telemetry usage empty" true
     (Option.is_none telemetry.usage);
-  Alcotest.(check bool) "collaboration_context is None" true
-    (Option.is_none swarm_cfg.collaboration_context);
+  Alcotest.(check bool) "collaboration_context populated" true
+    (Option.is_some swarm_cfg.collaboration_context);
+  (match swarm_cfg.collaboration_context with
+   | Some (`Assoc fields) ->
+       Alcotest.(check bool) "has team_goal field" true
+         (List.mem_assoc "team_goal" fields);
+       Alcotest.(check bool) "has task_tree field" true
+         (List.mem_assoc "task_tree" fields)
+   | _ -> Alcotest.fail "collaboration_context should be JSON object");
   let resource_ok = Option.get swarm_cfg.resource_check () in
   Alcotest.(check bool) "resource check passes for initialized room" true
     resource_ok;


### PR DESCRIPTION
## Summary
- Team Session OAS Bridge의 lossy projection (47→12 fields) 해소
- `collaboration_context`에 `Team_context` JSON projection 채움
- Worker `system_prompt`를 `Prompt_composer`로 보강 (goal, findings, workers, tasks)
- OAS 크로스 레포 작업 불필요 (OAS #698에서 `Collaboration.t` → opaque JSON 전환 완료)

## Changes
- `lib/team_context.ml` — `to_json` 직렬화 추가
- `lib/team_context.mli` — API 시그니처 추가
- `lib/team_session/team_session_oas_bridge.ml` — system_prompt 보강 + collaboration_context 채움
- `test/test_team_session_oas_bridge.ml` — None→Some assertion + field 검증
- `docs/spec/C-implementation-status.md` — Team Session 90%→94%, 전체 96.5%

## Test plan
- [x] test_team_session_oas_bridge.exe — 32 tests pass
- [x] test_tool_surface_ssot.exe — 26 tests pass (no orphans)
- [ ] CI Build and Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)