### PR TITLE
chore(oas): bump pin to bdfe965 (inline error feedback)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.113.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="44b0b742e8977302d12b9b44cf48081c645d0dd9"
+readonly OAS_AGENT_SDK_SHA="bdfe96534c3a409c62652a19cc76c13f1b09cc98"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.113.0"


### PR DESCRIPTION
## Summary
- OAS pin 업데이트: `44b0b74` → `bdfe965`
- oas#718 포함: Samchon-style inline error feedback for heal_tool_call
- validation 에러가 LLM 원본 JSON + 필드별 에러 표시로 변경

## OAS Changes Included
- `format_errors_inline`: 원본 JSON 위에 에러 마커 표시
- `validate_and_coerce`: inline 포맷 자동 사용
- 3개 테스트 추가 (20/20 통과)

## Test plan
- [ ] CI Build & Test 통과
- [ ] OAS pin ratchet check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)