### PR TITLE
chore: bump agent_sdk to 0.114.0

### DIFF
--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.113.0"}
+  "agent_sdk" {>= "0.114.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
Bumps `agent_sdk` (OAS) dependency to the latest `0.114.0` release.

## Product impact
Inherits critical fixes from OAS PRs #714 and #720:
- Prevents `Type_error` crashes when Ollama returns `message: null`.
- Wraps all provider JSON parsing in exception handlers to prevent hard crashes and enable graceful cascade failover.
- Logs unexpected API responses to stderr for observability.

## Evidence
`dune build` and `dune test` pass locally against the new SDK version.

## Review evidence
Standard dependency version bump.

## Linked issue
Refs #5788