### PR TITLE
fix(shell): treat rg exit code 1 (no match) as success

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -190,9 +190,12 @@ let handle_keeper_shell_readonly
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec:15.0 argv
         in
+        (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
+           Treat exit 1 as success with empty results — "no match" is a valid answer. *)
+        let is_ok = st = Unix.WEXITED 0 || st = Unix.WEXITED 1 in
         Yojson.Safe.to_string
           (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
+              [ "ok", `Bool is_ok
               ; "op", `String op
               ; "path", `String target
               ; "pattern", `String pattern


### PR DESCRIPTION
## Summary
- `rg` exit code 1 = no matches found (valid result, not error)
- 이전: exit 1 → `ok=false` → failure로 기록
- 수정: exit 0 OR 1 → `ok=true`, exit 2+ → `ok=false` (real error)

## Data
- 4/8 데이터: keeper_shell_readonly 43건 실패 중 14건이 rg no-match false positive
- 이 수정으로 **96.0% → 96.7%** 예상 (+0.7pp)

## Test plan
- [ ] dune build 통과
- [ ] rg 검색 결과 없을 때 ok=true 확인
- [ ] rg 실제 에러(exit 2) 시 ok=false 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)