### PR TITLE
fix(keeper): truncate large tool outputs to prevent OAS timeout

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -318,6 +318,15 @@ module KeeperToolExec = struct
       Default: 3. Range: [2, 20]. *)
   let max_consecutive_tool_failures =
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
+
+  (** Maximum characters in a single tool output before truncation.
+      Large tool outputs (e.g. board_list returning 15KB+) bloat the
+      LLM context and cause OAS timeout on local 9B models.
+      Truncated outputs include metadata (original size, truncation ratio)
+      so the LLM knows information was elided.
+      Env: [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS]. Default: 8000. Range: [1000, 32000]. *)
+  let max_tool_output_chars =
+    max 1000 (min 32000 (get_int ~default:8000 "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS"))
 end
 
 (** {1 Context Ratio Hard Cap}

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1,6 +1,17 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(** Shell operation timeout constants.
+    - [io_timeout_sec]: commands that may block on network/disk I/O
+      (git status, ls with large dirs, custom bash).
+    - [read_timeout_sec]: fast read-only commands on local files
+      (cat, rg, head, tail, find, git_log, tree).
+    - [user_timeout_max_sec]: upper bound for user-provided timeout_sec
+      in keeper_bash (prevents indefinite blocking). *)
+let io_timeout_sec = 30.0
+let read_timeout_sec = 15.0
+let user_timeout_max_sec = 180.0
+
 let handle_keeper_bash
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -13,7 +24,7 @@ let handle_keeper_bash
     |> Worker_dev_tools.truncate_for_log
   in
   let timeout_sec =
-    Safe_ops.json_float ~default:30.0 "timeout_sec" args |> fun n -> max 1.0 (min 180.0 n)
+    Safe_ops.json_float ~default:io_timeout_sec "timeout_sec" args |> fun n -> max 1.0 (min user_timeout_max_sec n)
   in
   (* Write access is config-driven via permissions.shell_write_presets *)
   let write_enabled =
@@ -118,7 +129,7 @@ let handle_keeper_shell_readonly
     resolve_keeper_read_path ~config ~raw_path
   in
   let render_process_result ~cmd argv =
-    let st, out = Process_eio.run_argv_with_status ~timeout_sec:30.0 argv in
+    let st, out = Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec argv in
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool (st = Unix.WEXITED 0)
@@ -139,7 +150,7 @@ let handle_keeper_shell_readonly
      | Error e -> error_json ~fields:[ "op", `String op ] e
      | Ok target ->
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:30.0 [ "/bin/ls"; "-la"; target ]
+         Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec [ "/bin/ls"; "-la"; target ]
        in
        let limit = shell_readonly_limit args in
        Yojson.Safe.to_string
@@ -156,7 +167,7 @@ let handle_keeper_shell_readonly
      | Ok target ->
        let max_bytes = shell_readonly_cat_max_bytes args in
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:15.0 [ "/bin/cat"; target ]
+         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec [ "/bin/cat"; target ]
        in
        let body =
          if String.length out > max_bytes then String.sub out 0 max_bytes else out
@@ -188,7 +199,7 @@ let handle_keeper_shell_readonly
         let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
         let argv = base_argv @ type_argv @ glob_argv @ [ pattern; target ] in
         let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:15.0 argv
+          Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
         in
         Yojson.Safe.to_string
           (`Assoc
@@ -209,7 +220,7 @@ let handle_keeper_shell_readonly
         Printf.sprintf "-%d" count ]
     in
     let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
-    let st, out = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+    let st, out = Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv in
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool (st = Unix.WEXITED 0)
@@ -228,7 +239,7 @@ let handle_keeper_shell_readonly
       | Ok target ->
         let limit = shell_readonly_limit args in
         let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:15.0
+          Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
             [ "find"; target; "-maxdepth"; "5"; "-name"; name_pattern;
               "-not"; "-path"; "*/.git/*";
               "-not"; "-path"; "*/_build/*";
@@ -249,7 +260,7 @@ let handle_keeper_shell_readonly
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:15.0
+         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
            [ "/usr/bin/head"; "-n"; string_of_int n; target ]
        in
        Yojson.Safe.to_string
@@ -267,7 +278,7 @@ let handle_keeper_shell_readonly
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:15.0
+         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
            [ "/usr/bin/tail"; "-n"; string_of_int n; target ]
        in
        Yojson.Safe.to_string
@@ -289,7 +300,7 @@ let handle_keeper_shell_readonly
      | Error e -> error_json ~fields:[ "op", `String op ] e
      | Ok target ->
        let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:15.0
+         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
            [ "find"; target; "-maxdepth"; "3"; "-print";
              "-not"; "-path"; "*/.git/*";
              "-not"; "-path"; "*/_build/*" ]
@@ -332,7 +343,7 @@ let handle_keeper_shell_readonly
               ])
       else
         let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:30.0
+          Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec
             [ "bash"; "-c"; cmd_str ]
         in
         Yojson.Safe.to_string

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -158,6 +158,29 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
         ("detail", `Null);
       ])
 
+(** Truncate tool output that exceeds [max_chars] to prevent context bloat.
+
+    Large tool outputs (e.g. board_list returning 15KB) cause the LLM to
+    time out on local models where generation speed drops with context size.
+    Truncation preserves the first [max_chars] of the result and appends
+    metadata so the LLM knows information was elided.
+
+    Only applies to success results — error messages are typically short
+    and should always be visible in full for debugging. *)
+let truncate_tool_output ?(max_chars = Env_config_keeper.KeeperToolExec.max_tool_output_chars) (result : string) : string =
+  let len = String.length result in
+  if len <= max_chars then result
+  else begin
+    let truncated = String.sub result 0 max_chars in
+    let pct = Float.of_int (len - max_chars) *. 100.0 /. Float.of_int len in
+    Printf.sprintf "%s\n[truncated: %d/%d chars shown (%.0f%% elided). Use more specific query params to reduce output.]"
+      truncated max_chars len pct
+  end
+
+(** Max chars for SSE error preview. Short enough for dashboard display,
+    long enough to include the actionable portion of the error. *)
+let sse_error_preview_max_chars = 300
+
 let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -218,8 +241,8 @@ let make_tools
                 Keeper_exec_tools.notify_tool_call_observers ~tool_name:td.name ~success:false;
                 let detail =
                   let s = String.trim result in
-                  if String.length s <= 300 then s
-                  else String.sub s 0 300 ^ "..."
+                  if String.length s <= sse_error_preview_max_chars then s
+                  else String.sub s 0 sse_error_preview_max_chars ^ "..."
                 in
                 let ts = Time_compat.now () in
                 (try Sse.broadcast
@@ -297,20 +320,28 @@ let make_tools
                        | _ -> normalized
                      with Yojson.Json_error _ -> normalized)
                 in
+                let original_len = String.length final_result in
+                let truncated_result = truncate_tool_output final_result in
+                let was_truncated = String.length truncated_result < original_len in
+                if was_truncated then
+                  Log.Keeper.info "tool %s output truncated: %d -> %d chars"
+                    td.name original_len (String.length truncated_result);
                 (try
                   Keeper_types_support.append_jsonl_line
                     (Keeper_types_support.keeper_decision_log_path config meta.name)
-                    (`Assoc [
+                    (`Assoc ([
                       "ts_unix", `Float ts;
                       "event", `String "tool_exec";
                       "keeper_name", `String meta.name;
                       "tool", `String td.name;
                       "duration_ms", `Int duration_ms;
-                      "result_bytes", `Int (String.length final_result);
+                      "result_bytes", `Int original_len;
                       "ok", `Bool true;
-                    ])
+                    ] @ (if was_truncated then
+                      ["truncated_to", `Int (String.length truncated_result)]
+                    else [])))
                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                (true, final_result)
+                (true, truncated_result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               let ts = Time_compat.now () in

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -140,6 +140,21 @@ let format_post (p : Board.post) =
     p.reply_count
     thread_str
 
+(** Compact one-line format for board_list: id, title, author, time, score.
+    Omits body, TTL, visibility, thread to minimize token usage. *)
+let format_post_compact (p : Board.post) =
+  let time_str = format_timestamp_relative p.created_at in
+  let score = p.votes_up - p.votes_down in
+  let hearth_str = match p.hearth with Some h -> Printf.sprintf " [%s]" h | None -> "" in
+  Printf.sprintf "%s · %s%s (by %s, %s, %+d, %d replies)"
+    (Board.Post_id.to_string p.id)
+    p.title
+    hearth_str
+    (Board.Agent_id.to_string p.author)
+    time_str
+    score
+    p.reply_count
+
 let format_comment ?(indent=0) (c : Board.comment) =
   let prefix = String.make indent ' ' in
   let tree_prefix = if indent > 0 then "└─ " else "" in
@@ -279,6 +294,7 @@ let dispatch_sort_of sort_by =
 
 let handle_post_list args =
   let limit = get_int args "limit" 20 |> max 1 |> min 100 in
+  let compact = get_bool args "compact" false in
   let visibility_str = get_string_opt args "visibility" in
   let hearth = get_string_opt args "hearth" in
   let random = get_bool args "random" false in
@@ -311,7 +327,9 @@ let handle_post_list args =
   match sort_by_result with
   | Error msg -> (false, Printf.sprintf "❌ %s" msg)
   | Ok sort_by ->
-      let fetch_limit = limit + offset + 100 in
+      (* Fetch exactly what we need: offset posts to skip + limit posts to show.
+         Board_dispatch.list_posts already applies visibility/hearth/author filters. *)
+      let fetch_limit = limit + offset in
       let sorted_posts =
         Board_dispatch.list_posts ~visibility_filter ?hearth ?author_filter
           ~exclude_system ~exclude_automation
@@ -344,7 +362,8 @@ let handle_post_list args =
         in
         let format_post_with_indicator p =
           let indicator = if has_new_activity p then " 🔔" else "" in
-          format_post p ^ indicator
+          let fmt = if compact then format_post_compact else format_post in
+          fmt p ^ indicator
         in
         let formatted = List.map format_post_with_indicator posts in
         let sort_label = match sort_by with
@@ -354,8 +373,10 @@ let handle_post_list args =
           | Updated -> "🔄 Recently Updated"
           | Discussed -> "💬 Most Discussed"
         in
-        let header = Printf.sprintf "📋 Posts (%d) — %s:" (List.length posts) sort_label in
-        (true, header ^ "\n\n" ^ String.concat "\n\n---\n\n" formatted)
+        let separator = if compact then "\n" else "\n\n---\n\n" in
+        let mode_label = if compact then " (compact)" else "" in
+        let header = Printf.sprintf "📋 Posts (%d) — %s%s:" (List.length posts) sort_label mode_label in
+        (true, header ^ "\n" ^ String.concat separator formatted)
 
 let handle_post_get args =
   let post_id = get_string args "post_id" "" in
@@ -559,6 +580,7 @@ let tool_post_list : Types.tool_schema = {
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);
       ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a 🔔 indicator")]);
+      ("compact", `Assoc [("type", `String "boolean"); ("description", `String "One-line per post (id, title, author, time, score). Omits body/TTL/visibility. Use for overview scans (default: false)")]);
     ]);
   ];
 }

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -461,6 +461,45 @@ let test_normalize_failure_plain_text () =
   check bool "ok is false" false (json_bool "ok" json);
   check string "error is raw text" raw (json_string "error" json)
 
+(* ── truncate_tool_output tests ──────────────────────────── *)
+
+let test_truncate_short_output_unchanged () =
+  let short = "hello world" in
+  let result = Keeper_tools_oas.truncate_tool_output ~max_chars:100 short in
+  check string "short output unchanged" short result
+
+let test_truncate_exact_limit_unchanged () =
+  let exact = String.make 100 'x' in
+  let result = Keeper_tools_oas.truncate_tool_output ~max_chars:100 exact in
+  check string "exact limit unchanged" exact result
+
+let test_truncate_over_limit_is_truncated () =
+  let long = String.make 200 'a' in
+  let result = Keeper_tools_oas.truncate_tool_output ~max_chars:100 long in
+  check bool "result shorter than original" true (String.length result < 200);
+  check bool "starts with original prefix" true
+    (String.sub result 0 100 = String.make 100 'a');
+  check bool "contains truncation marker" true
+    (string_contains ~sub:"[truncated:" result)
+
+let test_truncate_metadata_shows_correct_stats () =
+  let long = String.make 10000 'b' in
+  let result = Keeper_tools_oas.truncate_tool_output ~max_chars:2000 long in
+  check bool "mentions original size" true
+    (string_contains ~sub:"10000" result);
+  check bool "mentions kept size" true
+    (string_contains ~sub:"2000" result);
+  check bool "mentions elided percentage" true
+    (string_contains ~sub:"80%" result)
+
+let test_truncate_default_uses_env_config () =
+  (* Default max_chars from env config (8000). A 16000-char string should be truncated. *)
+  let long = String.make 16000 'c' in
+  let result = Keeper_tools_oas.truncate_tool_output long in
+  check bool "default truncates 16k" true (String.length result < 16000);
+  check bool "contains truncation marker" true
+    (string_contains ~sub:"[truncated:" result)
+
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
@@ -495,5 +534,12 @@ let () =
       test_case "search returns results" `Quick test_library_search_returns_results;
       test_case "empty query fails" `Quick test_library_search_empty_query;
       test_case "missing topic fails" `Quick test_library_read_missing_topic;
+    ];
+    "truncate_tool_output", [
+      test_case "short output unchanged" `Quick test_truncate_short_output_unchanged;
+      test_case "exact limit unchanged" `Quick test_truncate_exact_limit_unchanged;
+      test_case "over limit is truncated" `Quick test_truncate_over_limit_is_truncated;
+      test_case "metadata shows correct stats" `Quick test_truncate_metadata_shows_correct_stats;
+      test_case "default uses env config" `Quick test_truncate_default_uses_env_config;
     ];
   ]


### PR DESCRIPTION
## Summary
- cheolsu keeper가 `board_list` 15.6KB 반환 후 9B 모델에서 300s OAS timeout 발생
- `MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS` (기본 8000) 환경변수로 tool output 크기 제한
- `keeper_tools_oas.ml`에서 OAS 반환 직전 범용 truncation 적용 (MASC 경계 내)
- `board_list`에 `compact` 모드 추가 (한 줄/포스트, ~80% 출력 감소)
- 하드코딩된 매직 넘버 제거 (`sse_error_preview_max_chars` 상수 추출, overfetch +100 제거)

## Root Cause
`board_list` → 15.6KB 반환 → context 비대화 → 9B 모델 KV cache 증가로 생성 속도 급감 → `oas_timeout_sec` (300s) 초과

## Changes
| 파일 | 변경 |
|------|------|
| `env_config_keeper.ml` | `max_tool_output_chars` 추가 (범위 1000-32000) |
| `keeper_tools_oas.ml` | `truncate_tool_output` + success path 적용 + `sse_error_preview_max_chars` 상수 |
| `tool_board.ml` | `format_post_compact` + `compact` param + overfetch 제거 |
| `test_keeper_tools_oas.ml` | truncation 테스트 5개 추가 |

## Test plan
- [x] `test_keeper_tools_oas.exe` 26/26 통과 (기존 21 + 신규 5)
- [ ] keeper 재시작 후 `board_list` compact 모드 동작 확인
- [ ] 대형 tool output (>8000 chars) 시 truncation 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)