### PR TITLE
fix(keeper): block git checkout/switch in keeper_bash

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -104,6 +104,8 @@ shell_write_presets = ["coding", "delivery", "full"]
 
 [git_clone]
 allowed_orgs = ["jeong-sik"]
+# Repos blocked even if org is allowed. Format: "org/repo" (lowercase).
+denied_repos = ["jeong-sik/me"]
 
 # ── Presets ─────────────────────────────────────────────────────────
 

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -62,6 +62,23 @@ let handle_keeper_bash
                      etc.) and is blocked for all presets." )
               ; "cmd", `String cmd_for_log
               ]))
+      (* Branch-switch guard: keeper_bash runs in the main repo root.
+         git checkout/switch/branch -b would mutate main's HEAD or create
+         branches in the shared repo. Use keeper_pr_workflow instead. *)
+      else if Worker_dev_tools.is_git_branch_switch cmd
+      then (
+        Log.Keeper.info "keeper_bash branch-switch blocked: %s (keeper=%s)" cmd_for_log meta.name;
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool false
+              ; "error", `String "branch_switch_blocked"
+              ; ( "reason"
+                , `String
+                    "git checkout/switch/branch is blocked in the main repo. \
+                     Use keeper_pr_workflow to create changes in an isolated clone." )
+              ; "cmd", `String cmd_for_log
+              ; "hint", `String "keeper_pr_workflow"
+              ]))
       (* Write gate: only for non-coding presets *)
       else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
       then (

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -130,6 +130,50 @@ let extract_github_org url =
       else
         Some org
 
+(** Extract "org/repo" from a GitHub clone URL (lowercase, .git stripped). *)
+let extract_github_org_repo url =
+  let lc = String.lowercase_ascii url in
+  let prefixes = [
+    "https://github.com/";
+    "git@github.com:";
+    "ssh://git@github.com/";
+  ] in
+  let after_prefix =
+    List.find_map (fun prefix ->
+      if String.starts_with ~prefix lc then
+        Some (String.sub lc (String.length prefix)
+                (String.length lc - String.length prefix))
+      else None
+    ) prefixes
+  in
+  match after_prefix with
+  | None -> None
+  | Some rest ->
+    let stripped =
+      if String.ends_with ~suffix:".git" rest
+      then String.sub rest 0 (String.length rest - 4)
+      else rest
+    in
+    if String.contains stripped '/' then Some stripped
+    else None
+
+let clone_denied_repos_cache : string list option ref = ref None
+
+let load_clone_denied_repos ~base_path =
+  match !clone_denied_repos_cache with
+  | Some repos -> repos
+  | None ->
+    let path = Filename.concat base_path "config/tool_policy.toml" in
+    let repos = match Safe_ops.read_file_safe path with
+      | Error _ -> []
+      | Ok content ->
+        match Keeper_toml_loader.parse_toml content with
+        | Error _ -> []
+        | Ok doc -> Keeper_toml_loader.toml_string_list doc "git_clone.denied_repos"
+    in
+    clone_denied_repos_cache := Some repos;
+    repos
+
 let validate_clone_url ~base_path url =
   let allowed = load_clone_allowed_orgs ~base_path in
   if allowed = [] then
@@ -139,11 +183,18 @@ let validate_clone_url ~base_path url =
     | None ->
       Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
     | Some org ->
-      (* Case-insensitive comparison: org is already lowercase from extract *)
       let allowed_lc = List.map String.lowercase_ascii allowed in
-      if List.mem org allowed_lc then Ok ()
-      else Error (Printf.sprintf
-        "GitHub org '%s' not in allowed list: %s" org (String.concat ", " allowed))
+      if not (List.mem org allowed_lc) then
+        Error (Printf.sprintf
+          "GitHub org '%s' not in allowed list: %s" org (String.concat ", " allowed))
+      else
+        (* Check repo-level deny list *)
+        let denied = load_clone_denied_repos ~base_path in
+        let denied_lc = List.map String.lowercase_ascii denied in
+        match extract_github_org_repo url with
+        | Some org_repo when List.mem org_repo denied_lc ->
+          Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
+        | _ -> Ok ()
 
 (** Validate cwd for clone: allows .worktrees/ itself (not just subdirs). *)
 let validate_clone_cwd config cwd =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -272,6 +272,23 @@ let is_write_operation cmd =
     List.mem cmd_name ["mv"; "cp"; "mkdir"; "touch"; "chmod"]
   | [] -> false
 
+(** Detect git branch-switch commands that would mutate the main repo's HEAD.
+    keeper_bash runs in the repo root, so checkout/switch/branch -b must be
+    redirected to keeper_pr_workflow (playground clone). *)
+let is_git_branch_switch cmd =
+  let parts =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  match parts with
+  | "git" :: "checkout" :: _ -> true
+  | "git" :: "switch" :: _ -> true
+  | "git" :: "branch" :: rest ->
+    (* git branch -b/-B/--create creates a new branch — block.
+       git branch (list) and git branch -d (delete) are safe to allow. *)
+    List.exists (fun a -> a = "-b" || a = "-B" || a = "--create") rest
+  | _ -> false
+
 (** Detect truly destructive commands that must be blocked even for
     Coding/Full preset keepers. Delegates to [Eval_gate.detect_destructive]
     for the full 19-pattern check as a fallback. *)

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -548,6 +548,38 @@ let test_playground_clone_creates_clone_and_commits () =
         (Printf.sprintf "cd %s && git push origin --delete %s 2>/dev/null"
           (Filename.quote repo_root) (Filename.quote test_branch))))
 
+(* --- keeper_bash branch-switch guard --- *)
+
+let test_bash_git_checkout_blocked () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let args = `Assoc [ "cmd", `String "git checkout refactor/some-branch" ] in
+    let result = call_tool config meta "keeper_bash" args in
+    let json = parse_json result in
+    let error = try json_string "error" json with _ -> "" in
+    check bool "checkout blocked"
+      true (error = "branch_switch_blocked"))
+
+let test_bash_git_switch_blocked () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let args = `Assoc [ "cmd", `String "git switch feature/x" ] in
+    let result = call_tool config meta "keeper_bash" args in
+    let json = parse_json result in
+    let error = try json_string "error" json with _ -> "" in
+    check bool "switch blocked"
+      true (error = "branch_switch_blocked"))
+
+let test_bash_git_status_allowed () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let args = `Assoc [ "cmd", `String "git status" ] in
+    let result = call_tool config meta "keeper_bash" args in
+    let json = parse_json result in
+    let error = try json_string "error" json with _ -> "" in
+    check bool "git status not blocked as branch_switch"
+      true (error <> "branch_switch_blocked"))
+
 let () =
   run "keeper_pr_workflow"
     [ "required_fields",
@@ -585,6 +617,11 @@ let () =
       ]
     ; "task_dedup",
       [ test_case "second claim no tasks" `Quick test_second_claim_on_single_task_returns_no_tasks
+      ]
+    ; "bash_branch_guard",
+      [ test_case "checkout blocked" `Quick test_bash_git_checkout_blocked
+      ; test_case "switch blocked" `Quick test_bash_git_switch_blocked
+      ; test_case "status allowed" `Quick test_bash_git_status_allowed
       ]
     ; "integration",
       [ test_case "playground clone e2e" `Slow test_playground_clone_creates_clone_and_commits


### PR DESCRIPTION
## Summary

`keeper_bash`가 main repo root에서 `git checkout`/`git switch`를 실행하는 것을 차단.

## Problem

keeper(masc-improver)가 `keeper_pr_workflow` 대신 `keeper_bash`로 직접 `git checkout refactor/...`를 실행 → main repo HEAD 변경 시도 → worktree 충돌 에러.

```json
{"tool":"keeper_bash","input":{"cmd":"git checkout refactor/masc-mcp-path-hardcoding"},
 "output":"fatal: '...' is already used by worktree"}
```

## Fix

`Worker_dev_tools.is_git_branch_switch`로 결정론적 차단:
- `git checkout <anything>` → blocked
- `git switch <anything>` → blocked
- `git branch -b/-B` → blocked
- `git status/log/diff/branch` (read-only) → allowed

에러 메시지가 `keeper_pr_workflow` 사용을 안내.

## Tests

- 26/26 통과 (3 new: checkout blocked, switch blocked, status allowed)
- 통합 테스트 포함 (playground clone e2e)

Generated with [Claude Code](https://claude.com/claude-code)