### PR TITLE
feat(core): implement Masc_oas_bridge for global structured timeouts

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -334,16 +334,18 @@ let review
         (false, sprintf "Invalid verdict format: %s" msg)
     in
     (match
-       Oas_worker.run_named_with_masc_tools
-         ~cascade_name:evaluator_cascade
-         ~goal:prompt
-         ~masc_tools:[report_review_verdict_schema]
-         ~dispatch
-         ~max_turns:1
-         ~temperature:Oas_worker_cascade.deterministic_temperature
-         ~max_tokens:200
-         ?sw
-         ()
+       Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+         Oas_worker.run_named_with_masc_tools
+           ~cascade_name:evaluator_cascade
+           ~goal:prompt
+           ~masc_tools:[report_review_verdict_schema]
+           ~dispatch
+           ~max_turns:1
+           ~temperature:Oas_worker_cascade.deterministic_temperature
+           ~max_tokens:200
+           ?sw
+           ()
+       )
      with
      | Ok result ->
        let (v, gate, fallback_reason) = match !verdict_ref with

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -161,10 +161,12 @@ let call_model_direct_sync ~agent_type ~prompt =
   let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Oas_worker.run_named ~cascade_name
-        ~goal:prompt ~max_turns:1
-        ~accept:model_response_is_valid ~max_tokens:500
-        ()
+      Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+        Oas_worker.run_named ~cascade_name
+          ~goal:prompt ~max_turns:1
+          ~accept:model_response_is_valid ~max_tokens:500
+          ()
+      )
     with
     | Ok result ->
         let resp = result.Oas_worker.response in

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -139,13 +139,15 @@ let generate_code_change ~goal ~baseline ~history ~insights
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match
-    Oas_worker.run_named ~cascade_name:"autoresearch"
-      ~goal:prompt ~max_turns:1
-      ~temperature:(Cascade_inference.resolve_temperature
-        ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
-      ~max_tokens:(Cascade_inference.resolve_max_tokens
-        ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
-      ()
+    Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+      Oas_worker.run_named ~cascade_name:"autoresearch"
+        ~goal:prompt ~max_turns:1
+        ~temperature:(Cascade_inference.resolve_temperature
+          ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
+        ~max_tokens:(Cascade_inference.resolve_max_tokens
+          ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
+        ()
+    )
   with
   | Error e -> Result.error (Printf.sprintf "MODEL call failed: %s" (Oas.Error.to_string e))
   | Ok result -> parse_model_code_response (Oas_response.text_of_response result.Oas_worker.response)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -308,9 +308,11 @@ let compute_judgments
   let _timeout_sec = Env_config.Inference.dashboard_governance_judge_timeout_seconds in
   let prompt = prompt_for_facts factual_json in
   match
-    Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
-      ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-      ()
+    Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+      Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
+        ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ()
+    )
   with
   | Error err -> Error (Oas.Error.to_string err)
   | Ok result -> (

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -239,9 +239,11 @@ let compute_judgments
   let _timeout_sec = Env_config.Inference.operator_judge_timeout_seconds in
   let prompt = prompt_for_facts facts_json in
   match
-    Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
-      ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-      ()
+    Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+      Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
+        ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ()
+    )
   with
   | Error err -> Error (Oas.Error.to_string err)
   | Ok result -> (

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -344,15 +344,17 @@ let execute_single_agent_run ~sw ~net ~provider ~model ~prompt =
                provider)
         else (
           match
-            Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
-              ~system_prompt:(run_system_prompt provider)
-              ~max_turns:4
-              ~max_tokens:(Cascade_inference.resolve_max_tokens
-                ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 2048))
-              ~temperature:(Cascade_inference.resolve_temperature
-                ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 0.2))
-              ~sw ?net
-              ()
+            Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+              Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
+                ~system_prompt:(run_system_prompt provider)
+                ~max_turns:4
+                ~max_tokens:(Cascade_inference.resolve_max_tokens
+                  ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 2048))
+                ~temperature:(Cascade_inference.resolve_temperature
+                  ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 0.2))
+                ~sw ?net
+                ()
+            )
           with
           | Ok result ->
               Ok (response_text_of_api_response result.response)

--- a/lib/dune
+++ b/lib/dune
@@ -536,6 +536,7 @@
    oas_worker_cascade
    oas_worker_exec
    oas_worker_named
+   masc_oas_bridge
    oas_sse_bridge
    env_config_introspect
    runtime_params

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -1,0 +1,25 @@
+(* lib/masc_oas_bridge.ml *)
+(** Centralized boundary between MASC subsystems and the OAS Agent SDK.
+    Enforces strict structural timeouts, cancellation safety, and type isolation. *)
+
+(** Safe execution of a generic OAS operation with a mandatory timeout.
+    Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback. *)
+let run_safe ~timeout_s fn =
+  let do_timeout fn =
+    match (Masc_eio_env.get ()).clock with
+    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
+    | None -> fn ()
+  in
+  try
+    do_timeout fn
+  with
+  | Eio.Time.Timeout ->
+    Log.Misc.warn "masc_oas_bridge: OAS execution timed out after %.1fs" timeout_s;
+    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
+  | Eio.Cancel.Cancelled _ ->
+    Log.Misc.warn "masc_oas_bridge: OAS execution cancelled (structural rollback)";
+    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
+  | exn ->
+    let bt = Printexc.get_backtrace () in
+    Log.Misc.error "masc_oas_bridge: OAS execution error: %s\n%s" (Printexc.to_string exn) bt;
+    Error (Oas.Error.Internal (Printexc.to_string exn))

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -1,0 +1,11 @@
+(* lib/masc_oas_bridge.mli *)
+
+(** Centralized boundary between MASC subsystems and the OAS Agent SDK.
+    Enforces strict structural timeouts, cancellation safety, and type isolation. *)
+
+(** Safe execution of a generic OAS operation with a mandatory timeout.
+    Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback. *)
+val run_safe :
+  timeout_s:float ->
+  (unit -> ('a, Oas.Error.sdk_error) result) ->
+  ('a, Oas.Error.sdk_error) result

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -102,14 +102,16 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, string) result =
   match
-    Oas_worker.run_named
-      ~cascade_name:"default_models"
-      ~goal:message
-      ~system_prompt
-      ~max_turns:1
-      ~temperature
-      ~max_tokens
-      ()
+    Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+      Oas_worker.run_named
+        ~cascade_name:"default_models"
+        ~goal:message
+        ~system_prompt
+        ~max_turns:1
+        ~temperature
+        ~max_tokens
+        ()
+    )
   with
   | Ok result ->
     Ok (Oas_response.text_of_response result.response)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -645,17 +645,19 @@ let planned_worker_to_entry_with_state
         ~execution_scope:pw.execution_scope ~tool_names
     ) delivery_contract in
     match
-      Oas_worker.run_named_with_masc_tools
-        ~cascade_name ~goal:prompt ~system_prompt
-        ~masc_tools:scoped_masc_tools ~dispatch:dispatch_with_defaults
-        ~max_turns
-        ~hooks:progressive_hooks
-        ~temperature:(Cascade_inference.resolve_temperature
-          ~cascade_name ~fallback:(fun () -> 0.3))
-        ~max_tokens:(Cascade_inference.resolve_max_tokens
-          ~cascade_name ~fallback:(fun () -> 4096))
-        ?raw_trace ~proof_ref ?contract ~sw
-        ()
+      Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+        Oas_worker.run_named_with_masc_tools
+          ~cascade_name ~goal:prompt ~system_prompt
+          ~masc_tools:scoped_masc_tools ~dispatch:dispatch_with_defaults
+          ~max_turns
+          ~hooks:progressive_hooks
+          ~temperature:(Cascade_inference.resolve_temperature
+            ~cascade_name ~fallback:(fun () -> 0.3))
+          ~max_tokens:(Cascade_inference.resolve_max_tokens
+            ~cascade_name ~fallback:(fun () -> 4096))
+          ?raw_trace ~proof_ref ?contract ~sw
+          ()
+      )
     with
     | Ok result ->
         Hashtbl.replace success_by_agent name true;

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -104,13 +104,15 @@ let handle_deep_review (config : Room.config) args : bool * string =
         ]))
     | Ok prompt ->
         match
-          Oas_worker.run_named
-            ~cascade_name:"adversarial_reviewer"
-            ~goal:prompt
-            ~max_turns:1
-            ~temperature:0.5
-            ~max_tokens:500
-            ()
+          Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+            Oas_worker.run_named
+              ~cascade_name:"adversarial_reviewer"
+              ~goal:prompt
+              ~max_turns:1
+              ~temperature:0.5
+              ~max_tokens:500
+              ()
+          )
         with
         | Ok result ->
             let text = Oas_response.text_of_response result.response in

--- a/lib/tool_repair_loop.ml
+++ b/lib/tool_repair_loop.ml
@@ -167,10 +167,12 @@ let generate_or_repair_code (ctx : _ context) (state : state) :
           ~validator_output:(validator_output_of_attempt previous_attempt)
       in
       let result =
-        Oas_worker.run_model_by_label ~model_label:state.model_label
-          ~goal:prompt ~system_prompt:Ocaml.system_prompt ~max_turns:1
-          ~temperature:Oas_worker_cascade.deterministic_temperature ~max_tokens:1024 ~enable_thinking:false
-          ?sw:ctx.sw ()
+        Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+          Oas_worker.run_model_by_label ~model_label:state.model_label
+            ~goal:prompt ~system_prompt:Ocaml.system_prompt ~max_turns:1
+            ~temperature:Oas_worker_cascade.deterministic_temperature ~max_tokens:1024 ~enable_thinking:false
+            ?sw:ctx.sw ()
+        )
       in
       result
       |> Result.map_error Oas.Error.to_string

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -403,11 +403,13 @@ let model_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
           worker_class_text role_text spawn_prompt
       in
       (match
-        Oas_worker.run_named ~cascade_name:(Env_config.Model_defaults.routing_cascade ())
-          ~system_prompt:"You are a routing judge for a hybrid swarm. Output only JSON."
-          ~goal:prompt ~max_turns:1
-          ~temperature:Oas_worker_cascade.deterministic_temperature ~max_tokens:220
-          ()
+        Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+          Oas_worker.run_named ~cascade_name:(Env_config.Model_defaults.routing_cascade ())
+            ~system_prompt:"You are a routing judge for a hybrid swarm. Output only JSON."
+            ~goal:prompt ~max_turns:1
+            ~temperature:Oas_worker_cascade.deterministic_temperature ~max_tokens:220
+            ()
+        )
       with
       | Ok result -> (
           try


### PR DESCRIPTION
## Description

Enforces the OAS/MASC boundary across the entire ecosystem using Eio timeouts to prevent zombie fibers.

- Creates `Masc_oas_bridge` with `run_safe` to catch `Eio.Time.Timeout` and `Eio.Cancel.Cancelled`.
- Wraps direct `Oas_worker.run_*` calls in `dashboard/`, `autoresearch/`, `tools/`, and `server/` with strict structural timeouts (60s to 180s depending on the tool).
- Ensures no MASC subsystem can indefinitely hang due to OAS network or model issues.