### PR TITLE
fix(keeper): set autonomous_turn_limit default to 1 for single-slot servers

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -38,11 +38,12 @@ let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
    keepers fire scheduled turns simultaneously on a shared LLM server.
    Reactive turns (explicit mentions, board events) bypass this gate
    so they are never starved by slow autonomous turns.
-   Default 3 = with 27B/8-slot each autonomous turn gets ~2-3 slots
-   of GPU throughput, completing in ~30-60s instead of 5min+. *)
+   Default 1 = with 1-slot llama-server, only one request can be in-flight
+   at a time. Higher values cause queue buildup and TCP keepalive timeouts.
+   For 8-slot servers, set MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4. *)
 let autonomous_turn_limit =
   Keeper_config.int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:12
+    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:1 ~min_v:1 ~max_v:8
 ;;
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit


### PR DESCRIPTION
## Summary
- Change `autonomous_turn_limit` default from 3 → 1 to match 1-slot llama-server capacity
- Reduce `max_v` from 12 → 8 (realistic ceiling for 8-slot servers)
- Root cause: with 1-slot Qwen3.5-9B on port 8085, concurrent autonomous requests queue up and trigger TCP keepalive timeouts

## Context
OAS companion PR: jeong-sik/oas#723 (retry malformed JSON InvalidRequest errors)

Two independent but related fixes for keeper reliability on single-slot servers:
1. **OAS side**: Retry transient InvalidRequest errors (malformed JSON from model output)
2. **MASC side**: Stop sending concurrent requests that a single-slot server cannot handle

## Test plan
- [x] `dune build --root .` passes
- [x] 168 tests all pass
- [ ] Deploy to dev and observe keeper turn queue behavior
- [ ] Verify reactive turns (mentions, board events) still bypass autonomous semaphore

🤖 Generated with [Claude Code](https://claude.com/claude-code)