### PR TITLE
refactor(core): decouple excuse_patterns into configurable json file

### DIFF
--- a/config/excuse_patterns.json
+++ b/config/excuse_patterns.json
@@ -1,0 +1,15 @@
+[
+  ["pre-existing", "claiming the problem already existed"],
+  ["out of scope", "declaring work out of scope"],
+  ["beyond the scope", "declaring work beyond scope"],
+  ["will do later", "deferring work to later"],
+  ["will fix later", "deferring fix to later"],
+  ["will address later", "deferring to later"],
+  ["follow-up", "deferring to a follow-up"],
+  ["follow up", "deferring to a follow-up"],
+  ["works on my end", "unverifiable claim"],
+  ["works on my machine", "unverifiable claim"],
+  ["not reproducible", "dismissing without investigation"],
+  ["not my responsibility", "responsibility deflection"],
+  ["cannot reproduce", "dismissing without investigation"]
+]


### PR DESCRIPTION
## Description

Removes the hardcoded  from .
Now, these excuse patterns are dynamically loaded from  via . If the configuration file is missing or invalid, it safely falls back to the original default patterns.

This allows developers to add or modify avoidance phrases (e.g. "it's a feature, not a bug") without requiring an OCaml compilation cycle.