### PR TITLE
fix(dashboard): catch Yojson.Json_error instead of wildcard

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -76,22 +76,22 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
       let cat =
         if String.length output > 0 then
           (* Extract error key from JSON output *)
-          try
-            let j = Yojson.Safe.from_string output in
-            Safe_ops.json_string_opt "error" j
-            |> Option.value ~default:"unknown_error"
-          with _ ->
-            (* Try after stripping "error: " prefix *)
-            let stripped =
-              if String.length output > 7 && String.sub output 0 7 = "error: "
-              then String.sub output 7 (String.length output - 7)
-              else output
-            in
-            (try
-               let j = Yojson.Safe.from_string stripped in
-               Safe_ops.json_string_opt "error" j
-               |> Option.value ~default:"parse_error"
-             with _ -> "parse_error")
+          (match Yojson.Safe.from_string output with
+           | j ->
+             Safe_ops.json_string_opt "error" j
+             |> Option.value ~default:"unknown_error"
+           | exception Yojson.Json_error _ ->
+             (* Try after stripping "error: " prefix *)
+             let stripped =
+               if String.length output > 7 && String.sub output 0 7 = "error: "
+               then String.sub output 7 (String.length output - 7)
+               else output
+             in
+             (match Yojson.Safe.from_string stripped with
+              | j ->
+                Safe_ops.json_string_opt "error" j
+                |> Option.value ~default:"parse_error"
+              | exception Yojson.Json_error _ -> "parse_error"))
         else "empty_output"
       in
       let r = match Hashtbl.find_opt failure_cats cat with


### PR DESCRIPTION
Copilot review on #5764: with _ catches Eio.Cancel. Fixed to Yojson.Json_error only.