### PR TITLE
fix(keeper): harden branch-switch guard and clone URL parsing

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -85,7 +85,9 @@ let handle_keeper_bash
               ; "error", `String "branch_switch_blocked"
               ; ( "reason"
                 , `String
-                    "git checkout/switch/branch is blocked in the main repo. \
+                    "git checkout, git switch, and git branch mutations \
+                     (create/rename/copy) are blocked in the main repo. \
+                     Plain git branch listing is allowed. \
                      Use keeper_pr_workflow to create changes in an isolated clone." )
               ; "cmd", `String cmd_for_log
               ; "hint", `String "keeper_pr_workflow"

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -130,7 +130,8 @@ let extract_github_org url =
       else
         Some org
 
-(** Extract "org/repo" from a GitHub clone URL (lowercase, .git stripped). *)
+(** Extract "org/repo" from a GitHub clone URL (lowercase, .git and trailing
+    slash stripped). Returns exactly two path segments or None. *)
 let extract_github_org_repo url =
   let lc = String.lowercase_ascii url in
   let prefixes = [
@@ -149,13 +150,22 @@ let extract_github_org_repo url =
   match after_prefix with
   | None -> None
   | Some rest ->
+    (* Strip trailing slash, then .git suffix *)
+    let rest =
+      if String.ends_with ~suffix:"/" rest
+      then String.sub rest 0 (String.length rest - 1)
+      else rest
+    in
     let stripped =
       if String.ends_with ~suffix:".git" rest
       then String.sub rest 0 (String.length rest - 4)
       else rest
     in
-    if String.contains stripped '/' then Some stripped
-    else None
+    (* Validate exactly "org/repo" — two segments, no deeper paths *)
+    match String.split_on_char '/' stripped with
+    | [org; repo] when org <> "" && repo <> "" ->
+      Some (org ^ "/" ^ repo)
+    | _ -> None
 
 let clone_denied_repos_cache : string list option ref = ref None
 

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -272,21 +272,77 @@ let is_write_operation cmd =
     List.mem cmd_name ["mv"; "cp"; "mkdir"; "touch"; "chmod"]
   | [] -> false
 
+(** Skip git global options (e.g. [-C dir], [--work-tree=...]) to find the
+    actual subcommand. Handles both [-C dir] (two-token) and [--work-tree=x]
+    (single-token) forms. *)
+let rec skip_git_global_options = function
+  | [] -> []
+  | "--" :: rest -> rest
+  | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace"
+    | "--super-prefix" | "--config-env" | "--exec-path") :: _ :: rest ->
+    skip_git_global_options rest
+  | opt :: rest when String.length opt > 1 && opt.[0] = '-' &&
+      (String.starts_with ~prefix:"--git-dir=" opt
+       || String.starts_with ~prefix:"--work-tree=" opt
+       || String.starts_with ~prefix:"--namespace=" opt
+       || String.starts_with ~prefix:"--exec-path=" opt
+       || String.starts_with ~prefix:"-c" opt) ->
+    skip_git_global_options rest
+  | parts -> parts
+
 (** Detect git branch-switch commands that would mutate the main repo's HEAD.
-    keeper_bash runs in the repo root, so checkout/switch/branch -b must be
-    redirected to keeper_pr_workflow (playground clone). *)
+    keeper_bash runs in the repo root, so checkout/switch/branch mutations must
+    be redirected to keeper_pr_workflow (playground clone).
+
+    Handles tab-separated tokens, global git options like [-C dir], and real
+    branch mutation forms (create, rename, copy). Allows read-only listing. *)
 let is_git_branch_switch cmd =
+  (* Tokenize on both space and tab *)
   let parts =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
+    let buf = Buffer.create 64 in
+    let tokens = ref [] in
+    String.iter (fun c ->
+      match c with
+      | ' ' | '\t' ->
+        if Buffer.length buf > 0 then begin
+          tokens := Buffer.contents buf :: !tokens;
+          Buffer.clear buf
+        end
+      | _ -> Buffer.add_char buf c
+    ) (String.trim cmd);
+    if Buffer.length buf > 0 then
+      tokens := Buffer.contents buf :: !tokens;
+    List.rev !tokens
+  in
+  let is_option arg = String.length arg > 0 && arg.[0] = '-' in
+  let has_any_flag flags args = List.exists (fun a -> List.mem a flags) args in
+  let rec first_non_option = function
+    | [] -> None
+    | a :: _ when not (is_option a) -> Some a
+    | _ :: rest -> first_non_option rest
   in
   match parts with
-  | "git" :: "checkout" :: _ -> true
-  | "git" :: "switch" :: _ -> true
-  | "git" :: "branch" :: rest ->
-    (* git branch -b/-B/--create creates a new branch — block.
-       git branch (list) and git branch -d (delete) are safe to allow. *)
-    List.exists (fun a -> a = "-b" || a = "-B" || a = "--create") rest
+  | "git" :: rest ->
+    (match skip_git_global_options rest with
+     | "checkout" :: _ -> true
+     | "switch" :: _ -> true
+     | "branch" :: branch_args ->
+       (* Block branch mutations:
+          - git branch <newname> [<start-point>]
+          - git branch -c/-C/--copy ...
+          - git branch -m/-M/--move ...
+          Allow: listing (-l/--list/-a/--all/-r/--remotes/-v/-vv/--show-current)
+                 and deletion (-d/-D/--delete). *)
+       if branch_args = [] then false
+       else if has_any_flag ["-d"; "-D"; "--delete"] branch_args then false
+       else if has_any_flag
+         ["-l"; "--list"; "-a"; "--all"; "-r"; "--remotes";
+          "--show-current"; "-v"; "-vv"] branch_args
+       then false
+       else if has_any_flag ["-c"; "-C"; "--copy"; "-m"; "-M"; "--move"] branch_args
+       then true
+       else Option.is_some (first_non_option branch_args)
+     | _ -> false)
   | _ -> false
 
 (** Detect truly destructive commands that must be blocked even for

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -550,25 +550,58 @@ let test_playground_clone_creates_clone_and_commits () =
 
 (* --- keeper_bash branch-switch guard --- *)
 
+let assert_branch_switch_blocked config cmd label =
+  let meta = make_meta_with_preset "delivery" in
+  let args = `Assoc [ "cmd", `String cmd ] in
+  let result = call_tool config meta "keeper_bash" args in
+  let json = parse_json result in
+  let error = try json_string "error" json with _ -> "" in
+  check bool (label ^ " blocked")
+    true (error = "branch_switch_blocked")
+
 let test_bash_git_checkout_blocked () =
   with_room (fun config ->
-    let meta = make_meta_with_preset "delivery" in
-    let args = `Assoc [ "cmd", `String "git checkout refactor/some-branch" ] in
-    let result = call_tool config meta "keeper_bash" args in
-    let json = parse_json result in
-    let error = try json_string "error" json with _ -> "" in
-    check bool "checkout blocked"
-      true (error = "branch_switch_blocked"))
+    assert_branch_switch_blocked config "git checkout refactor/some-branch" "checkout")
 
 let test_bash_git_switch_blocked () =
   with_room (fun config ->
+    assert_branch_switch_blocked config "git switch feature/x" "switch")
+
+let test_bash_git_checkout_with_global_opts_blocked () =
+  with_room (fun config ->
+    assert_branch_switch_blocked config "git -C . checkout refactor/x" "checkout -C")
+
+let test_bash_git_tab_separated_blocked () =
+  with_room (fun config ->
+    assert_branch_switch_blocked config "git\tcheckout feature/x" "tab checkout")
+
+let test_bash_git_branch_create_blocked () =
+  with_room (fun config ->
+    assert_branch_switch_blocked config "git branch new-feature" "branch create")
+
+let test_bash_git_branch_rename_blocked () =
+  with_room (fun config ->
+    assert_branch_switch_blocked config "git branch -m old-name new-name" "branch -m")
+
+let test_bash_git_branch_list_allowed () =
+  with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
-    let args = `Assoc [ "cmd", `String "git switch feature/x" ] in
+    let args = `Assoc [ "cmd", `String "git branch --list" ] in
     let result = call_tool config meta "keeper_bash" args in
     let json = parse_json result in
     let error = try json_string "error" json with _ -> "" in
-    check bool "switch blocked"
-      true (error = "branch_switch_blocked"))
+    check bool "git branch --list not blocked"
+      true (error <> "branch_switch_blocked"))
+
+let test_bash_git_branch_delete_allowed () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let args = `Assoc [ "cmd", `String "git branch -d old-branch" ] in
+    let result = call_tool config meta "keeper_bash" args in
+    let json = parse_json result in
+    let error = try json_string "error" json with _ -> "" in
+    check bool "git branch -d not blocked as branch_switch"
+      true (error <> "branch_switch_blocked"))
 
 let test_bash_git_status_allowed () =
   with_room (fun config ->
@@ -576,9 +609,12 @@ let test_bash_git_status_allowed () =
     let args = `Assoc [ "cmd", `String "git status" ] in
     let result = call_tool config meta "keeper_bash" args in
     let json = parse_json result in
-    let error = try json_string "error" json with _ -> "" in
-    check bool "git status not blocked as branch_switch"
-      true (error <> "branch_switch_blocked"))
+    let has_status = match json with
+      | `Assoc fields -> List.mem_assoc "status" fields
+      | _ -> false
+    in
+    check bool "git status returns normal execution shape"
+      true has_status)
 
 let () =
   run "keeper_pr_workflow"
@@ -621,6 +657,12 @@ let () =
     ; "bash_branch_guard",
       [ test_case "checkout blocked" `Quick test_bash_git_checkout_blocked
       ; test_case "switch blocked" `Quick test_bash_git_switch_blocked
+      ; test_case "checkout -C blocked" `Quick test_bash_git_checkout_with_global_opts_blocked
+      ; test_case "tab checkout blocked" `Quick test_bash_git_tab_separated_blocked
+      ; test_case "branch create blocked" `Quick test_bash_git_branch_create_blocked
+      ; test_case "branch rename blocked" `Quick test_bash_git_branch_rename_blocked
+      ; test_case "branch list allowed" `Quick test_bash_git_branch_list_allowed
+      ; test_case "branch delete allowed" `Quick test_bash_git_branch_delete_allowed
       ; test_case "status allowed" `Quick test_bash_git_status_allowed
       ]
     ; "integration",


### PR DESCRIPTION
## Summary
- `is_git_branch_switch`: tokenize on space+tab, skip git global options (-C etc), fix branch mutation detection (create/rename/copy blocked, list/delete allowed)
- `extract_github_org_repo`: strip trailing slash, validate exactly 2 segments
- Error message updated to reflect actual blocked/allowed operations
- 6 new test cases (32 total, all pass)

## Addresses review comments from
- #5795 (tab bypass, global options bypass, git branch detection wrong, error message misleading, trailing slash, test coverage)

## Test plan
- [x] `dune exec test/test_keeper_pr_workflow.exe` — 32/32 pass
- [x] `dune build` — clean

Refs #5795

🤖 Generated with [Claude Code](https://claude.com/claude-code)