### PR TITLE
fix(keeper): make truncate_tool_output a hard cap on total length

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -162,19 +162,30 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
 
     Large tool outputs (e.g. board_list returning 15KB) cause the LLM to
     time out on local models where generation speed drops with context size.
-    Truncation preserves the first [max_chars] of the result and appends
-    metadata so the LLM knows information was elided.
+
+    [max_chars] is a hard cap on total returned length. Space is reserved
+    for the metadata suffix; the preserved prefix is shortened accordingly.
 
     Only applies to success results — error messages are typically short
     and should always be visible in full for debugging. *)
 let truncate_tool_output ?(max_chars = Env_config_keeper.KeeperToolExec.max_tool_output_chars) (result : string) : string =
   let len = String.length result in
-  if len <= max_chars then result
+  if max_chars <= 0 then ""
+  else if len <= max_chars then result
   else begin
-    let truncated = String.sub result 0 max_chars in
     let pct = Float.of_int (len - max_chars) *. 100.0 /. Float.of_int len in
-    Printf.sprintf "%s\n[truncated: %d/%d chars shown (%.0f%% elided). Use more specific query params to reduce output.]"
-      truncated max_chars len pct
+    let suffix =
+      Printf.sprintf
+        "\n[truncated: showing %d/%d chars (%.0f%% elided). Use more specific query params to reduce output.]"
+        max_chars len pct
+    in
+    let suffix_len = String.length suffix in
+    if suffix_len >= max_chars then
+      String.sub suffix 0 max_chars
+    else
+      let prefix_len = max_chars - suffix_len in
+      let prefix = String.sub result 0 prefix_len in
+      prefix ^ suffix
   end
 
 (** Max chars for SSE error preview. Short enough for dashboard display,
@@ -320,9 +331,10 @@ let make_tools
                        | _ -> normalized
                      with Yojson.Json_error _ -> normalized)
                 in
+                let max_chars = Env_config_keeper.KeeperToolExec.max_tool_output_chars in
                 let original_len = String.length final_result in
-                let truncated_result = truncate_tool_output final_result in
-                let was_truncated = String.length truncated_result < original_len in
+                let truncated_result = truncate_tool_output ~max_chars final_result in
+                let was_truncated = original_len > max_chars in
                 if was_truncated then
                   Log.Keeper.info "tool %s output truncated: %d -> %d chars"
                     td.name original_len (String.length truncated_result);

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -474,17 +474,19 @@ let test_truncate_exact_limit_unchanged () =
   check string "exact limit unchanged" exact result
 
 let test_truncate_over_limit_is_truncated () =
-  let long = String.make 200 'a' in
-  let result = Keeper_tools_oas.truncate_tool_output ~max_chars:100 long in
-  check bool "result shorter than original" true (String.length result < 200);
-  check bool "starts with original prefix" true
-    (String.sub result 0 100 = String.make 100 'a');
+  let max_chars = 200 in
+  let long = String.make 400 'a' in
+  let result = Keeper_tools_oas.truncate_tool_output ~max_chars long in
+  (* Total output must be <= max_chars (hard cap) *)
+  check bool "result at most max_chars" true (String.length result <= max_chars);
   check bool "contains truncation marker" true
     (string_contains ~sub:"[truncated:" result)
 
 let test_truncate_metadata_shows_correct_stats () =
   let long = String.make 10000 'b' in
   let result = Keeper_tools_oas.truncate_tool_output ~max_chars:2000 long in
+  (* Total output is hard-capped at max_chars *)
+  check bool "result at most max_chars" true (String.length result <= 2000);
   check bool "mentions original size" true
     (string_contains ~sub:"10000" result);
   check bool "mentions kept size" true
@@ -493,10 +495,11 @@ let test_truncate_metadata_shows_correct_stats () =
     (string_contains ~sub:"80%" result)
 
 let test_truncate_default_uses_env_config () =
-  (* Default max_chars from env config (8000). A 16000-char string should be truncated. *)
-  let long = String.make 16000 'c' in
+  let max_chars = Env_config_keeper.KeeperToolExec.max_tool_output_chars in
+  let long = String.make (max_chars + 1) 'c' in
   let result = Keeper_tools_oas.truncate_tool_output long in
-  check bool "default truncates 16k" true (String.length result < 16000);
+  check bool "default truncates output longer than configured max" true
+    (String.length result <= max_chars);
   check bool "contains truncation marker" true
     (string_contains ~sub:"[truncated:" result)
 


### PR DESCRIPTION
## Summary
- Reserve space for metadata suffix so total output <= max_chars (was exceeding)
- Fix `was_truncated` detection: `original_len > max_chars` instead of post-truncation comparison
- Test derives limit from `Env_config` instead of hardcoding 8000

## Addresses review comments from
- #5794 (suffix exceeds max_chars, was_truncated detection, test hardcode)

## Test plan
- [x] `dune exec test/test_keeper_tools_oas.exe` — 26/26 pass
- [x] `dune build` — clean

Refs #5794

🤖 Generated with [Claude Code](https://claude.com/claude-code)