### PR TITLE
fix(keeper): address adaptive thinking review comments (#5772)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -225,6 +225,26 @@ let log_keeper_memory_write
     @param is_retry When [true], replays the current user message into the
            working context without persisting it again, so transient retry
            attempts do not duplicate the user entry in session history *)
+let adaptive_thinking_budget ~enabled ~is_retry ~last_tool_results ~user_message ~dynamic_context ~current_budget =
+  if not enabled then
+    current_budget
+  else
+    (* 1) Structured tool errors in last tools -> High thinking *)
+    let had_error = List.exists (fun (r : Agent_sdk.Types.tool_result) ->
+      match r with
+      | Error _ -> true
+      | Ok _ -> false
+    ) last_tool_results in
+    if is_retry || had_error then Some 1500
+    else
+    (* 2) Task complexity keywords -> Max thinking *)
+    let complex_task = List.exists (fun needle -> String_util.contains_substring_ci (user_message ^ " " ^ dynamic_context) needle)
+      ["분석"; "설계"; "plan"; "architecture"; "complex"; "investigate"] in
+    if complex_task then Some 2000
+    else
+      (* Otherwise fallback to default or OFF (None) *)
+      current_budget
+
 let run_turn
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -869,26 +889,16 @@ let run_turn
         (* Update current_turn_ref so session-scoped callbacks
            (keeper_tool_search, on_tool_called) use the correct turn. *)
         current_turn_ref := turn;
-                (* Adaptive thinking override based on turn signals *)
+
+        (* Adaptive thinking override based on turn signals *)
         let adaptive_thinking_budget =
-          if not (Keeper_config.keeper_adaptive_thinking_enabled ()) then
-            current_params.thinking_budget
-          else
-            (* 1) Error or Retry in last tools -> High thinking *)
-            let had_error = List.exists (fun (r : Agent_sdk.Types.tool_result) ->
-              match r with
-              | Error _ -> true
-              | Ok { content } -> String_util.contains_substring_ci content "error" || String_util.contains_substring_ci content "fail"
-            ) last_tool_results in
-            if had_error then Some 1500
-            else
-            (* 2) Task complexity keywords -> Max thinking *)
-            let complex_task = List.exists (fun needle -> String_util.contains_substring_ci (user_message ^ " " ^ dynamic_context) needle)
-              ["분석"; "설계"; "plan"; "architecture"; "complex"; "investigate"] in
-            if complex_task then Some 2000
-            else
-              (* Otherwise fallback to default or OFF (None) *)
-              current_params.thinking_budget
+          adaptive_thinking_budget
+            ~enabled:(Keeper_config.keeper_adaptive_thinking_enabled ())
+            ~is_retry
+            ~last_tool_results
+            ~user_message
+            ~dynamic_context
+            ~current_budget:current_params.thinking_budget
         in
 
         let current_params = { current_params with thinking_budget = adaptive_thinking_budget } in

--- a/test/dune
+++ b/test/dune
@@ -48,6 +48,7 @@
         test_swarm_checkpoint test_swarm_goal_loop
         test_keeper_memory
         test_keeper_exec_status
+          test_keeper_adaptive_thinking
         test_keeper_lifecycle
         test_keeper_deliberation
         test_keeper_registry
@@ -113,6 +114,7 @@
           test_swarm_checkpoint test_swarm_goal_loop
           test_keeper_memory
           test_keeper_exec_status
+          test_keeper_adaptive_thinking
           test_keeper_lifecycle
           test_keeper_deliberation
           test_keeper_registry

--- a/test/test_keeper_adaptive_thinking.ml
+++ b/test/test_keeper_adaptive_thinking.ml
@@ -1,0 +1,71 @@
+open Alcotest
+
+let test_adaptive_thinking_disabled () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:false
+      ~is_retry:true
+      ~last_tool_results:[]
+      ~user_message:"분석"
+      ~dynamic_context:""
+      ~current_budget:(Some 100)
+  in
+  check (option int) "returns current budget when disabled" (Some 100) result
+
+let test_adaptive_thinking_error_or_retry () =
+  let err_res : Agent_sdk.Types.tool_result = Error { Agent_sdk.Types.message = "fail"; recoverable = true } in
+  let result1 =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[ err_res ]
+      ~user_message:"hello"
+      ~dynamic_context:""
+      ~current_budget:None
+  in
+  check (option int) "high thinking for error" (Some 1500) result1;
+  let result2 =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:true
+      ~last_tool_results:[]
+      ~user_message:"hello"
+      ~dynamic_context:""
+      ~current_budget:None
+  in
+  check (option int) "high thinking for retry" (Some 1500) result2
+
+let test_adaptive_thinking_complex_task () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[]
+      ~user_message:"please plan this"
+      ~dynamic_context:"some architecture"
+      ~current_budget:(Some 100)
+  in
+  check (option int) "max thinking for complex task keywords" (Some 2000) result
+
+let test_adaptive_thinking_fallback () =
+  let result =
+    Masc_mcp.Keeper_agent_run.adaptive_thinking_budget
+      ~enabled:true
+      ~is_retry:false
+      ~last_tool_results:[]
+      ~user_message:"simple hello"
+      ~dynamic_context:"nothing special"
+      ~current_budget:(Some 500)
+  in
+  check (option int) "fallback to current budget" (Some 500) result
+
+let () =
+  let tests =
+    [
+      "disabled", `Quick, test_adaptive_thinking_disabled;
+      "error_or_retry", `Quick, test_adaptive_thinking_error_or_retry;
+      "complex_task", `Quick, test_adaptive_thinking_complex_task;
+      "fallback", `Quick, test_adaptive_thinking_fallback;
+    ]
+  in
+  Alcotest.run "Keeper_adaptive_thinking" [ "budget_logic", tests ]


### PR DESCRIPTION
Follow-up to #5772 based on review feedback.

### Changes
- **Strict Error Matching:** `had_error` now exclusively flags  variants in  instead of performing brittle substring matches (e.g. "error", "fail") on free-form text.
- **Retry Signal Included:** Explicitly adds `is_retry` to the condition for granting the 1500-token budget (previously documented but omitted in implementation).
- **Testability & Coverage:** Extracted the budget calculation into the pure function `adaptive_thinking_budget` and added full unit tests (`test/test_keeper_adaptive_thinking.ml`) to verify disabled behavior, error/retry branches, keyword matches, and standard fallbacks.
- **Formatting:** Fixed indentation inconsistencies inside the `before_turn_params` hook body.