### PR TITLE
feat(dashboard): add excuse patterns editor UI and API

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -818,3 +818,15 @@ export function fetchTelemetry(opts?: {
 export function fetchTelemetrySummary(): Promise<TelemetrySummaryResponse> {
   return get<TelemetrySummaryResponse>('/api/v1/dashboard/telemetry/summary')
 }
+
+// --- Excuse Patterns ---
+
+export type ExcusePattern = [string, string]
+
+export function fetchExcusePatterns(): Promise<ExcusePattern[]> {
+  return get<ExcusePattern[]>('/api/v1/dashboard/config/excuse-patterns')
+}
+
+export function updateExcusePatterns(patterns: ExcusePattern[]): Promise<{ ok: boolean }> {
+  return post<{ ok: boolean }>('/api/v1/dashboard/config/excuse-patterns', patterns)
+}

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -1,0 +1,104 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { Card } from './common/card'
+import { fetchExcusePatterns, updateExcusePatterns } from '../api/dashboard'
+import type { ExcusePattern } from '../api/dashboard'
+import { createAsyncResource } from '../lib/async-state'
+
+const patternsResource = createAsyncResource<ExcusePattern[]>()
+const saving = signal(false)
+const saveMessage = signal('')
+
+export function refreshExcusePatterns(): Promise<void> {
+  patternsResource.reset()
+  return patternsResource.load(fetchExcusePatterns)
+}
+
+function handleSave(event: Event) {
+  event.preventDefault()
+  const formData = new FormData(event.target as HTMLFormElement)
+  const jsonStr = formData.get('patterns') as string
+  try {
+    const parsed = JSON.parse(jsonStr) as ExcusePattern[]
+    if (!Array.isArray(parsed)) throw new Error('Root must be an array')
+    for (const item of parsed) {
+      if (!Array.isArray(item) || item.length !== 2 || typeof item[0] !== 'string' || typeof item[1] !== 'string') {
+        throw new Error('Items must be an array of exactly two strings: [pattern, reason]')
+      }
+    }
+    saving.value = true
+    saveMessage.value = ''
+    updateExcusePatterns(parsed).then(() => {
+      saveMessage.value = 'Saved successfully.'
+      refreshExcusePatterns()
+    }).catch(err => {
+      saveMessage.value = `Failed to save: ${err.message}`
+    }).finally(() => {
+      saving.value = false
+    })
+  } catch (err: any) {
+    saveMessage.value = `Invalid format: ${err.message}`
+  }
+}
+
+export function ExcusePatterns() {
+  const s = patternsResource.state.value
+
+  if (s.status === 'idle') {
+    void refreshExcusePatterns()
+  }
+
+  if (s.status === 'loading') {
+    return html`
+      <${Card} title="Anti-Rationalization Excuse Patterns">
+        <div class="p-4 text-[var(--text-muted)]">Loading excuse patterns...</div>
+      </Card>
+    `
+  }
+
+  if (s.status === 'error') {
+    return html`
+      <${Card} title="Anti-Rationalization Excuse Patterns">
+        <div class="p-4 text-red-500">Failed to load patterns: ${s.message}</div>
+      </Card>
+    `
+  }
+
+  const data = s.status === 'loaded' ? s.data : undefined
+  const jsonStr = data ? JSON.stringify(data, null, 2) : '[]'
+
+  return html`
+    <${Card} title="Anti-Rationalization Excuse Patterns">
+      <div class="p-4">
+        <p class="text-sm text-[var(--text-muted)] mb-4">
+          These patterns are matched against agent completion notes. If matched, the task is rejected.
+          Changes here are saved to <code>config/excuse_patterns.json</code> and applied immediately without restarting.
+          The format must be a JSON array of arrays, each containing two strings: <code>["pattern", "reason"]</code>.
+        </p>
+
+        <form onSubmit=${handleSave}>
+          <textarea
+            name="patterns"
+            class="w-full h-96 p-3 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded font-mono text-sm mb-4 text-[var(--text-primary)]"
+            spellcheck="false"
+          >${jsonStr}</textarea>
+          
+          <div class="flex items-center gap-3">
+            <button
+              type="submit"
+              class="px-4 py-2 bg-[var(--accent-primary)] text-white rounded hover:opacity-90 disabled:opacity-50 text-sm font-medium"
+              disabled=${saving.value}
+            >
+              ${saving.value ? 'Saving...' : 'Save Patterns'}
+            </button>
+            ${saveMessage.value ? html`
+              <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-red-500' : 'text-green-500'}">
+                ${saveMessage.value}
+              </span>
+            ` : null}
+          </div>
+        </form>
+      </div>
+    </Card>
+  `
+}

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -3,6 +3,7 @@ import { signal } from '@preact/signals'
 import { Card } from './common/card'
 import { FeatureHealth } from './feature-health'
 import { ServerConfig } from './server-config'
+import { ExcusePatterns } from './excuse-patterns'
 import { navigate } from '../router'
 
 type InspectorSection = 'overview' | 'features' | 'config'
@@ -126,7 +127,12 @@ export function LabInspector() {
         ? html`<${InspectorOverview} />`
         : current === 'features'
           ? html`<${FeatureHealth} />`
-          : html`<${ServerConfig} />`}
+          : html`
+              <div class="flex flex-col gap-4">
+                <${ServerConfig} />
+                <${ExcusePatterns} />
+              </div>
+            `}
     </div>
   `
 }

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -40,50 +40,87 @@ type review_result = {
 (* Excuse pattern detection (local, no LLM)                         *)
 (* ================================================================ *)
 
-(** Load excuse patterns dynamically from config/excuse_patterns.json.
-    Returns the default hardcoded list if the file is missing or invalid. *)
-let load_excuse_patterns () : (string * string) list =
-  let default_patterns = [
-    ("pre-existing",        "claiming the problem already existed");
-    ("out of scope",        "declaring work out of scope");
-    ("beyond the scope",    "declaring work beyond scope");
-    ("will do later",       "deferring work to later");
-    ("will fix later",      "deferring fix to later");
-    ("will address later",  "deferring to later");
-    ("follow-up",           "deferring to a follow-up");
-    ("follow up",           "deferring to a follow-up");
-    ("works on my end",     "unverifiable claim");
-    ("works on my machine", "unverifiable claim");
-    ("not reproducible",    "dismissing without investigation");
-    ("not my responsibility", "responsibility deflection");
-    ("cannot reproduce",    "dismissing without investigation");
-  ] in
-  try
-    let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
-    let path = Filename.concat config_dir "excuse_patterns.json" in
-    if Sys.file_exists path then
-      let json = Yojson.Safe.from_file path in
-      match json with
-      | `List items ->
-          List.filter_map (function
-            | `List [`String pat; `String reason] -> Some (pat, reason)
-            | _ -> None
-          ) items
-      | _ -> default_patterns
-    else default_patterns
-  with _ -> default_patterns
+let default_excuse_patterns = [
+  ("pre-existing",        "claiming the problem already existed");
+  ("out of scope",        "declaring work out of scope");
+  ("beyond the scope",    "declaring work beyond scope");
+  ("will do later",       "deferring work to later");
+  ("will fix later",      "deferring fix to later");
+  ("will address later",  "deferring to later");
+  ("follow-up",           "deferring to a follow-up");
+  ("follow up",           "deferring to a follow-up");
+  ("works on my end",     "unverifiable claim");
+  ("works on my machine", "unverifiable claim");
+  ("not reproducible",    "dismissing without investigation");
+  ("not my responsibility", "responsibility deflection");
+  ("cannot reproduce",    "dismissing without investigation");
+]
 
-(** Save excuse patterns to config/excuse_patterns.json. *)
+(** Cached patterns. Loaded once from disk; invalidated by [save_excuse_patterns]. *)
+let cached_patterns : (string * string) list option ref = ref None
+
+let excuse_patterns_path () =
+  let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
+  Filename.concat config_dir "excuse_patterns.json"
+
+(** Parse a JSON value into a validated pattern list.
+    Returns [Error msg] if any item is malformed (no silent drops). *)
+let parse_excuse_patterns_json (json : Yojson.Safe.t) : ((string * string) list, string) result =
+  match json with
+  | `List items ->
+    let rec validate acc = function
+      | [] -> Ok (List.rev acc)
+      | `List [`String pat; `String reason] :: rest ->
+        validate ((pat, reason) :: acc) rest
+      | item :: _ ->
+        Error (Printf.sprintf "Invalid pattern entry: expected [string, string], got %s"
+          (Yojson.Safe.to_string item))
+    in
+    validate [] items
+  | _ -> Error "Expected JSON array of [pattern, reason] pairs"
+
+(** Load excuse patterns from config/excuse_patterns.json.
+    Returns cached value if available. Falls back to defaults on missing file. *)
+let load_excuse_patterns () : (string * string) list =
+  match !cached_patterns with
+  | Some p -> p
+  | None ->
+    let patterns =
+      try
+        let path = excuse_patterns_path () in
+        if Sys.file_exists path then
+          let json = Yojson.Safe.from_file path in
+          match parse_excuse_patterns_json json with
+          | Ok p -> p
+          | Error msg ->
+            Log.Misc.warn "excuse_patterns: parse error, using defaults: %s" msg;
+            default_excuse_patterns
+        else default_excuse_patterns
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Log.Misc.warn "excuse_patterns: load error, using defaults: %s" (Printexc.to_string exn);
+        default_excuse_patterns
+    in
+    cached_patterns := Some patterns;
+    patterns
+
+(** Save excuse patterns to config/excuse_patterns.json.
+    Uses atomic write (write-to-temp + rename) to prevent corruption.
+    Invalidates the in-memory cache on success. *)
 let save_excuse_patterns (patterns : (string * string) list) : (unit, string) result =
   try
-    let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
-    let path = Filename.concat config_dir "excuse_patterns.json" in
+    let path = excuse_patterns_path () in
     let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
     let json = `List json_items in
-    Yojson.Safe.to_file path json;
+    let tmp = path ^ ".tmp" in
+    Yojson.Safe.to_file tmp json;
+    Sys.rename tmp path;
+    cached_patterns := Some patterns;
     Ok ()
-  with exn ->
-    Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _exn -> Error "Failed to save excuse patterns"
 
 let min_notes_length = 10
 

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -65,18 +65,30 @@ let excuse_patterns_path () =
 
 (** Parse a JSON value into a validated pattern list.
     Returns [Error msg] if any item is malformed (no silent drops). *)
+let max_excuse_pattern_len = 500
+let max_excuse_entries = 100
+
 let parse_excuse_patterns_json (json : Yojson.Safe.t) : ((string * string) list, string) result =
   match json with
   | `List items ->
-    let rec validate acc = function
-      | [] -> Ok (List.rev acc)
-      | `List [`String pat; `String reason] :: rest ->
-        validate ((pat, reason) :: acc) rest
-      | item :: _ ->
-        Error (Printf.sprintf "Invalid pattern entry: expected [string, string], got %s"
-          (Yojson.Safe.to_string item))
-    in
-    validate [] items
+    if List.length items > max_excuse_entries then
+      Error (Printf.sprintf "Too many entries: %d (max %d)" (List.length items) max_excuse_entries)
+    else
+      let rec validate acc = function
+        | [] -> Ok (List.rev acc)
+        | `List [`String pat; `String reason] :: rest ->
+          if pat = "" || reason = "" then
+            Error "Pattern and reason must be non-empty strings"
+          else if String.length pat > max_excuse_pattern_len
+               || String.length reason > max_excuse_pattern_len then
+            Error (Printf.sprintf "String too long (max %d chars)" max_excuse_pattern_len)
+          else
+            validate ((pat, reason) :: acc) rest
+        | item :: _ ->
+          Error (Printf.sprintf "Invalid pattern entry: expected [string, string], got %s"
+            (Yojson.Safe.to_string item))
+      in
+      validate [] items
   | _ -> Error "Expected JSON array of [pattern, reason] pairs"
 
 (** Load excuse patterns from config/excuse_patterns.json.

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -40,28 +40,57 @@ type review_result = {
 (* Excuse pattern detection (local, no LLM)                         *)
 (* ================================================================ *)
 
-(** Known avoidance phrases. Matched case-insensitively as substrings. *)
-let excuse_patterns = [
-  ("pre-existing",        "claiming the problem already existed");
-  ("out of scope",        "declaring work out of scope");
-  ("beyond the scope",    "declaring work beyond scope");
-  ("will do later",       "deferring work to later");
-  ("will fix later",      "deferring fix to later");
-  ("will address later",  "deferring to later");
-  ("follow-up",           "deferring to a follow-up");
-  ("follow up",           "deferring to a follow-up");
-  ("works on my end",     "unverifiable claim");
-  ("works on my machine", "unverifiable claim");
-  ("not reproducible",    "dismissing without investigation");
-  ("not my responsibility", "responsibility deflection");
-  ("cannot reproduce",    "dismissing without investigation");
-]
+(** Load excuse patterns dynamically from config/excuse_patterns.json.
+    Returns the default hardcoded list if the file is missing or invalid. *)
+let load_excuse_patterns () : (string * string) list =
+  let default_patterns = [
+    ("pre-existing",        "claiming the problem already existed");
+    ("out of scope",        "declaring work out of scope");
+    ("beyond the scope",    "declaring work beyond scope");
+    ("will do later",       "deferring work to later");
+    ("will fix later",      "deferring fix to later");
+    ("will address later",  "deferring to later");
+    ("follow-up",           "deferring to a follow-up");
+    ("follow up",           "deferring to a follow-up");
+    ("works on my end",     "unverifiable claim");
+    ("works on my machine", "unverifiable claim");
+    ("not reproducible",    "dismissing without investigation");
+    ("not my responsibility", "responsibility deflection");
+    ("cannot reproduce",    "dismissing without investigation");
+  ] in
+  try
+    let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
+    let path = Filename.concat config_dir "excuse_patterns.json" in
+    if Sys.file_exists path then
+      let json = Yojson.Safe.from_file path in
+      match json with
+      | `List items ->
+          List.filter_map (function
+            | `List [`String pat; `String reason] -> Some (pat, reason)
+            | _ -> None
+          ) items
+      | _ -> default_patterns
+    else default_patterns
+  with _ -> default_patterns
+
+(** Save excuse patterns to config/excuse_patterns.json. *)
+let save_excuse_patterns (patterns : (string * string) list) : (unit, string) result =
+  try
+    let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
+    let path = Filename.concat config_dir "excuse_patterns.json" in
+    let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
+    let json = `List json_items in
+    Yojson.Safe.to_file path json;
+    Ok ()
+  with exn ->
+    Error (Printexc.to_string exn)
 
 let min_notes_length = 10
 
 (** Check if notes contain a known excuse pattern.
     Returns [Some (pattern, reason)] on match, [None] otherwise. *)
 let find_excuse_pattern (notes : string) : (string * string) option =
+  let patterns = load_excuse_patterns () in
   let lower = String.lowercase_ascii notes in
   List.find_opt (fun (pat, _reason) ->
     (* Simple substring search without Str module *)
@@ -75,7 +104,7 @@ let find_excuse_pattern (notes : string) : (string * string) option =
         else scan (i + 1)
       in
       scan 0
-  ) excuse_patterns
+  ) patterns
 
 (* ================================================================ *)
 (* LLM verification prompt                                          *)

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -75,7 +75,12 @@ val review_result_to_json : review_result -> Yojson.Safe.t
     Exposed for dashboard administration. *)
 val load_excuse_patterns : unit -> (string * string) list
 
+(** Parse and validate a JSON value into excuse patterns.
+    Rejects malformed entries with [Error msg] instead of silently dropping them. *)
+val parse_excuse_patterns_json : Yojson.Safe.t -> ((string * string) list, string) result
+
 (** Save excuse patterns to config/excuse_patterns.json.
+    Uses atomic write (temp + rename). Invalidates cache on success.
     Returns [Ok ()] on success or [Error msg] on failure.
     Exposed for dashboard administration. *)
 val save_excuse_patterns : (string * string) list -> (unit, string) result

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -70,6 +70,16 @@ val check_contract : notes:string -> contract:string list -> string list
 (** Serialize review result to JSON for logging/calibration. *)
 val review_result_to_json : review_result -> Yojson.Safe.t
 
+(** Load excuse patterns dynamically from config/excuse_patterns.json.
+    Returns the default hardcoded list if the file is missing or invalid.
+    Exposed for dashboard administration. *)
+val load_excuse_patterns : unit -> (string * string) list
+
+(** Save excuse patterns to config/excuse_patterns.json.
+    Returns [Ok ()] on success or [Error msg] on failure.
+    Exposed for dashboard administration. *)
+val save_excuse_patterns : (string * string) list -> (unit, string) result
+
 (** Check notes for known excuse patterns (local, no LLM).
     Returns [Some (pattern, reason)] if a match is found.
     Exposed for testing. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -501,6 +501,36 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let json = Env_config_introspect.to_json () in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/config/excuse-patterns" ->
+          let patterns = Anti_rationalization.load_excuse_patterns () in
+          let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
+          let json = `List json_items in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
+      | `POST, "/api/v1/dashboard/config/excuse-patterns" ->
+          h2_read_body h2_reqd (fun body_str ->
+            try
+               let json = Yojson.Safe.from_string body_str in
+               match json with
+               | `List items ->
+                   let patterns = List.filter_map (function
+                     | `List [`String pat; `String reason] -> Some (pat, reason)
+                     | _ -> None
+                   ) items in
+                   (match Anti_rationalization.save_excuse_patterns patterns with
+                   | Ok () ->
+                       h2_respond_json h2_reqd {|{"ok":true}|} ~extra_headers:cors
+                   | Error msg ->
+                       let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)]) in
+                       h2_respond_json h2_reqd err_json ~status:`Internal_server_error ~extra_headers:cors)
+               | _ ->
+                   let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "expected list of [pattern, reason]")]) in
+                   h2_respond_json h2_reqd err_json ~status:`Bad_request ~extra_headers:cors
+             with exn ->
+               let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String (Printexc.to_string exn))]) in
+               h2_respond_json h2_reqd err_json ~status:`Bad_request ~extra_headers:cors
+          )
+
       | `GET, "/api/v1/dashboard/namespace-truth"
       | `GET, "/api/v1/dashboard/room-truth" ->
           let state = get_server_state () in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -511,24 +511,23 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_read_body h2_reqd (fun body_str ->
             try
                let json = Yojson.Safe.from_string body_str in
-               match json with
-               | `List items ->
-                   let patterns = List.filter_map (function
-                     | `List [`String pat; `String reason] -> Some (pat, reason)
-                     | _ -> None
-                   ) items in
+               match Anti_rationalization.parse_excuse_patterns_json json with
+               | Error msg ->
+                   let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)]) in
+                   h2_respond_json h2_reqd err_json ~status:`Bad_request ~extra_headers:cors
+               | Ok patterns ->
                    (match Anti_rationalization.save_excuse_patterns patterns with
                    | Ok () ->
                        h2_respond_json h2_reqd {|{"ok":true}|} ~extra_headers:cors
                    | Error msg ->
                        let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)]) in
                        h2_respond_json h2_reqd err_json ~status:`Internal_server_error ~extra_headers:cors)
-               | _ ->
-                   let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "expected list of [pattern, reason]")]) in
-                   h2_respond_json h2_reqd err_json ~status:`Bad_request ~extra_headers:cors
-             with exn ->
-               let err_json = Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String (Printexc.to_string exn))]) in
-               h2_respond_json h2_reqd err_json ~status:`Bad_request ~extra_headers:cors
+             with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | _exn ->
+               h2_respond_json h2_reqd
+                 {|{"ok":false,"error":"Invalid JSON body"}|}
+                 ~status:`Bad_request ~extra_headers:cors
           )
 
       | `GET, "/api/v1/dashboard/namespace-truth"

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -139,30 +139,29 @@ let rec add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/config/excuse-patterns" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         Http.Request.read_body_async reqd (fun body_str ->
-           try
-             let json = Yojson.Safe.from_string body_str in
-             match json with
-             | `List items ->
-                 let patterns = List.filter_map (function
-                   | `List [`String pat; `String reason] -> Some (pat, reason)
-                   | _ -> None
-                 ) items in
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun _state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             try
+               let json = Yojson.Safe.from_string body_str in
+               match Anti_rationalization.parse_excuse_patterns_json json with
+               | Error msg ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)])) reqd
+               | Ok patterns ->
                  (match Anti_rationalization.save_excuse_patterns patterns with
                  | Ok () ->
                      Http.Response.json ~request:req {|{"ok":true}|} reqd
                  | Error msg ->
                      Http.Response.json ~status:`Internal_server_error ~request:req
                        (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)])) reqd)
-             | _ ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "expected list of [pattern, reason]")])) reqd
-           with exn ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String (Printexc.to_string exn))])) reqd
-         )
-       ) request reqd)
+             with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | _exn ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "Invalid JSON body")])) reqd
+           )
+         ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -131,6 +131,38 @@ let rec add_routes ~sw ~clock router =
          let json = Env_config_introspect.to_json () in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/config/excuse-patterns" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let patterns = Anti_rationalization.load_excuse_patterns () in
+         let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
+         let json = `List json_items in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.post "/api/v1/dashboard/config/excuse-patterns" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             match json with
+             | `List items ->
+                 let patterns = List.filter_map (function
+                   | `List [`String pat; `String reason] -> Some (pat, reason)
+                   | _ -> None
+                 ) items in
+                 (match Anti_rationalization.save_excuse_patterns patterns with
+                 | Ok () ->
+                     Http.Response.json ~request:req {|{"ok":true}|} reqd
+                 | Error msg ->
+                     Http.Response.json ~status:`Internal_server_error ~request:req
+                       (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)])) reqd)
+             | _ ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "expected list of [pattern, reason]")])) reqd
+           with exn ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String (Printexc.to_string exn))])) reqd
+         )
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in


### PR DESCRIPTION
## Description

Exposes  to the MASC Dashboard for live editing.

- Added  and  routes to  in both HTTP router and H2 gateway.
- Added  and  to  to allow reading/writing the JSON file dynamically.
- Implemented the  Preact component in the Dashboard's **운영 인스펙터 (Lab Inspector) -> 서버 설정 (Config)** tab.
- Enables operators to add or modify avoidance phrases (e.g. "it's a feature, not a bug") visually without backend restarts or file editing.