### PR TITLE
feat(task-routing): preset-aware task routing for keepers

### DIFF
--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -244,6 +244,7 @@ let row_to_task (((id, title, description), (priority, status, assignee),
     id; title; description; priority; files; created_at;
     worktree = None;  (* Worktree loaded separately if needed *)
     required_role;
+    required_preset = None;
     stage = None;
     contract = None;
     handoff_context = None;

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -53,9 +53,13 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
                  ~agent_name:meta.agent_name)
           then begin
             Room.ensure_room_bootstrap config room_id;
+            let preset_cap = match Keeper_types.tool_access_preset meta.tool_access with
+              | Some p -> ["preset:" ^ Keeper_types.tool_preset_to_string p]
+              | None -> []
+            in
             ignore
               (Room.join config ~agent_name:meta.agent_name
-                 ~capabilities:[ "keeper" ] ())
+                 ~capabilities:(["keeper"] @ preset_cap) ())
           end;
           ignore
             (Room.heartbeat config ~agent_name:meta.agent_name);

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -188,9 +188,13 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
                  ~agent_name:meta.agent_name)
           then begin
             Room.ensure_room_bootstrap config room_id;
+            let preset_cap = match Keeper_types.tool_access_preset meta.tool_access with
+              | Some p -> ["preset:" ^ Keeper_types.tool_preset_to_string p]
+              | None -> []
+            in
             ignore
               (Room.join config ~agent_name:meta.agent_name
-                 ~capabilities:[ "keeper" ] ())
+                 ~capabilities:(["keeper"] @ preset_cap) ())
           end;
           ignore
             (Room.heartbeat config ~agent_name:meta.agent_name);

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -92,7 +92,7 @@ let handle_keeper_task_tool
     let task_filter (task : Types.task) =
       match task.required_preset, preset_name with
       | None, _ -> true
-      | Some _, None -> true
+      | Some _required, None -> false  (* agent without preset cannot claim preset-required task *)
       | Some required, Some preset ->
         Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
     in

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -85,8 +85,28 @@ let handle_keeper_task_tool
       in
       Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "broadcast", `String message ]))
   | "keeper_task_claim" ->
-    let result = Room.claim_next config ~agent_name:meta.agent_name in
-    Yojson.Safe.to_string (`Assoc [ "result", `String result ])
+    let preset_name = match Keeper_types.tool_access_preset meta.tool_access with
+      | Some p -> Some (Keeper_types.tool_preset_to_string p)
+      | None -> None
+    in
+    let task_filter (task : Types.task) =
+      match task.required_preset, preset_name with
+      | None, _ -> true
+      | Some _, None -> true
+      | Some required, Some preset ->
+        Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
+    in
+    let result = Room.claim_next_r config ~agent_name:meta.agent_name ~task_filter () in
+    let message = match result with
+      | Room.Claim_next_claimed { message; _ } -> message
+      | Room.Claim_next_no_unclaimed -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+      | Room.Claim_next_no_eligible { preset_filtered; _ } when preset_filtered > 0 ->
+        Printf.sprintf "📋 No eligible tasks (preset mismatch: %d tasks require different preset, you have '%s')"
+          preset_filtered (Option.value ~default:"unknown" preset_name)
+      | Room.Claim_next_no_eligible _ -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+      | Room.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
+    in
+    Yojson.Safe.to_string (`Assoc [ "result", `String message ])
   | "keeper_task_done" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -51,6 +51,14 @@ let allows_shell_write_for_preset (preset : tool_preset) : bool =
     Keeper_tool_policy_config.allows_shell_write cfg
       (preset_name_of_tool_preset preset)
 
+(* ── Preset subsumption (config-driven) ──────────────────────── *)
+
+let preset_can_satisfy ~(agent_preset : string) ~(required_preset : string) : bool =
+  match !policy_config with
+  | None -> false
+  | Some cfg ->
+    Keeper_tool_policy_config.preset_can_satisfy cfg ~agent_preset ~required_preset
+
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
 let keeper_denied_set : (string, unit) Hashtbl.t =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -59,6 +59,14 @@ let preset_can_satisfy ~(agent_preset : string) ~(required_preset : string) : bo
   | Some cfg ->
     Keeper_tool_policy_config.preset_can_satisfy cfg ~agent_preset ~required_preset
 
+(** Return configured preset names (excluding "full") for schema enum generation. *)
+let configured_preset_names () : string list =
+  match !policy_config with
+  | None -> []
+  | Some cfg ->
+    Keeper_tool_policy_config.preset_names cfg
+    |> List.filter (fun n -> not (String.equal n "full"))
+
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
 let keeper_denied_set : (string, unit) Hashtbl.t =
@@ -205,8 +213,8 @@ let preset_allowlist preset =
       keeper_base_candidate_tool_names ()
     | Some (Keeper_tool_policy_config.Subset tools) -> dedupe_tool_names tools
     | None ->
-      invalid_arg
-        (Printf.sprintf "preset '%s' not defined in config/tool_policy.toml" name)
+      Log.Keeper.warn "preset '%s' not defined in config/tool_policy.toml, returning empty" name;
+      []
 
 let tool_policy_of_meta (meta : keeper_meta) =
   let allow =

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -266,6 +266,26 @@ let all_group_tools (config : t) : string list =
 let all_masc_tools (config : t) : string list =
   Hashtbl.fold (fun _ tools acc -> tools @ acc) config.masc_groups []
 
+(** Check if [agent_preset]'s resolved tool set covers [required_preset]'s.
+    Derived from config — adding a new preset to tool_policy.toml automatically
+    updates the subsumption graph.  No hardcoded hierarchy. *)
+let preset_can_satisfy (config : t) ~(agent_preset : string) ~(required_preset : string) : bool =
+  if String.equal agent_preset required_preset then true
+  else
+    let resolve name =
+      match resolve_preset config name ~masc_filter:(fun _ -> true) () with
+      | Some All_candidates -> None
+      | Some (Subset tools) -> Some (List.sort_uniq String.compare tools)
+      | None -> Some []
+    in
+    match resolve agent_preset with
+    | None -> true
+    | Some agent_tools ->
+      match resolve required_preset with
+      | None -> false
+      | Some req_tools ->
+        List.for_all (fun t -> List.mem t agent_tools) req_tools
+
 let allows_workflow (config : t) (preset_name : string) : bool =
   List.mem preset_name config.workflow_presets
 

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -213,8 +213,8 @@ let resolve_group_source = function
     | Some shard ->
       shard.tools |> List.map (fun (t : Types.tool_schema) -> t.name)
     | None ->
-      invalid_arg
-        (Printf.sprintf "tool_policy_config: shard '%s' not found" shard_name)
+      Log.Keeper.warn "tool_policy_config: shard '%s' not found, returning empty" shard_name;
+      []
 
 let resolve_group (config : t) (name : string) : string list option =
   match Hashtbl.find_opt config.groups name with
@@ -274,17 +274,16 @@ let preset_can_satisfy (config : t) ~(agent_preset : string) ~(required_preset :
   else
     let resolve name =
       match resolve_preset config name ~masc_filter:(fun _ -> true) () with
-      | Some All_candidates -> None
-      | Some (Subset tools) -> Some (List.sort_uniq String.compare tools)
-      | None -> Some []
+      | Some All_candidates -> `Full
+      | Some (Subset tools) -> `Tools (List.sort_uniq String.compare tools)
+      | None -> `Unknown
     in
-    match resolve agent_preset with
-    | None -> true
-    | Some agent_tools ->
-      match resolve required_preset with
-      | None -> false
-      | Some req_tools ->
-        List.for_all (fun t -> List.mem t agent_tools) req_tools
+    match resolve agent_preset, resolve required_preset with
+    | `Unknown, _ | _, `Unknown -> false  (* unknown preset — can't verify, reject *)
+    | `Full, _ -> true                     (* agent has full access *)
+    | _, `Full -> false                    (* required is full, agent isn't *)
+    | `Tools agent_tools, `Tools req_tools ->
+      List.for_all (fun t -> List.mem t agent_tools) req_tools
 
 let allows_workflow (config : t) (preset_name : string) : bool =
   List.mem preset_name config.workflow_presets

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -47,6 +47,10 @@ val group_names : t -> string list
 
 (** Resolve a single group name to tool names.
     Returns [None] if the group is not defined. *)
+(** Check if [agent_preset]'s tool set covers [required_preset]'s.
+    Config-derived — no hardcoded hierarchy. *)
+val preset_can_satisfy : t -> agent_preset:string -> required_preset:string -> bool
+
 (** Check if a preset is allowed to execute workflow mutations
     (pr merge, pr close, etc.) as configured in [permissions.workflow_presets]. *)
 val allows_workflow : t -> string -> bool

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -45,8 +45,6 @@ val preset_names : t -> string list
 (** List all defined group names. *)
 val group_names : t -> string list
 
-(** Resolve a single group name to tool names.
-    Returns [None] if the group is not defined. *)
 (** Check if [agent_preset]'s tool set covers [required_preset]'s.
     Config-derived — no hardcoded hierarchy. *)
 val preset_can_satisfy : t -> agent_preset:string -> required_preset:string -> bool

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -166,7 +166,7 @@ let find_duplicate_task (backlog : backlog) (title : string) : string option =
 (** Add task — file-locked to prevent task ID collision under concurrency.
     Rejects tasks with duplicate titles (exact match after normalization)
     to prevent the same work from being created multiple times. *)
-let add_task ?contract config ~title ~priority ~description =
+let add_task ?contract ?required_preset config ~title ~priority ~description =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
@@ -190,6 +190,7 @@ let add_task ?contract config ~title ~priority ~description =
       created_at = now_iso ();
       worktree = None;
       required_role = Types_core.Unassigned;
+      required_preset;
       stage = None;
       contract;
       handoff_context = None;
@@ -245,6 +246,7 @@ let add_task_with_role ?contract config ~title ~priority ~description
       created_at = now_iso ();
       worktree = None;
       required_role;
+      required_preset = None;
       stage = None;
       contract;
       handoff_context = None;
@@ -299,6 +301,7 @@ let batch_add_tasks_internal config tasks =
           created_at = now_iso ();
           worktree = None;
           required_role = Types_core.Unassigned;
+          required_preset = None;
           stage = None;
           contract;
           handoff_context = None;
@@ -1106,7 +1109,7 @@ type claim_next_result = Types.claim_next_result =
       message : string;
     }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of { excluded_count : int; preset_filtered : int }
   | Claim_next_error of string
 
 let link_task_execution_artifacts_r config ~task_id ?session_id ?operation_id

--- a/lib/room/room_task.mli
+++ b/lib/room/room_task.mli
@@ -33,6 +33,7 @@ val observe_task_transition :
 
 val add_task :
   ?contract:Types.task_contract ->
+  ?required_preset:string ->
   config -> title:string -> priority:int -> description:string -> string
 
 val add_task_with_role :
@@ -107,5 +108,5 @@ type claim_next_result = Types.claim_next_result =
       message : string;
     }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of { excluded_count : int; preset_filtered : int }
   | Claim_next_error of string

--- a/lib/room/room_task_schedule.ml
+++ b/lib/room/room_task_schedule.ml
@@ -14,7 +14,7 @@ include Room_state
     - Auto-releases any previous claim held by this agent (BUG-004)
     - Applies starvation prevention: tasks waiting >24h get priority boost
     - Within same effective priority, prefers older tasks (FIFO) *)
-let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
+let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:Types.task) -> true) () =
   ensure_initialized config;
 
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
@@ -92,6 +92,14 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
       in
       let eligible = List.filter (fun t -> not (List.mem t.id all_excluded)) unclaimed in
 
+      (* Preset-aware filtering *)
+      let preset_ok = List.filter task_filter eligible in
+      let preset_filtered = List.length eligible - List.length preset_ok in
+      if preset_filtered > 0 then
+        log_event config (Printf.sprintf
+          "{\"type\":\"task_claim_preset_skip\",\"agent\":\"%s\",\"skipped\":%d,\"ts\":\"%s\"}"
+          agent_name preset_filtered (now_iso ()));
+
       (* Helper: clear agent current_task and reset status after auto-release
          when no replacement task can be claimed. *)
       let clear_agent_state_after_release () =
@@ -110,7 +118,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
         | None -> ()
       in
 
-      match unclaimed, eligible with
+      match unclaimed, preset_ok with
       | [], _ ->
           (* Even if we released a task, there may be nothing else to claim.
              Write the release if it happened. *)
@@ -138,7 +146,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
                observe_auto_release ()
            | None -> ());
           clear_agent_state_after_release ();
-          Claim_next_no_eligible { excluded_count = List.length exclude_task_ids }
+          Claim_next_no_eligible { excluded_count = List.length exclude_task_ids; preset_filtered }
       | _ :: _, task :: _ ->
           (* Claim this task *)
           let new_tasks = List.map (fun t ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -189,7 +189,11 @@ let handle_add_task ctx args =
   let title = get_string args "title" "" in
   let priority = get_int args "priority" 3 in
   let description = get_string args "description" "" in
-  let required_preset = Safe_ops.json_string_opt "required_preset" args in
+  let required_preset =
+    match Safe_ops.json_string_opt "required_preset" args with
+    | Some s when String.trim s <> "" -> Some (String.trim s)
+    | _ -> None
+  in
   let contract_result = parse_task_contract args in
   (* BUG-009/010: Validate title and priority *)
   let trimmed_title = String.trim title in
@@ -198,6 +202,17 @@ let handle_add_task ctx args =
   else if priority < 1 || priority > 5 then
     (false, Printf.sprintf "Priority must be between 1 and 5, got %d" priority)
   else
+    (* Validate required_preset against configured preset names *)
+    let preset_valid = match required_preset with
+      | None -> true
+      | Some name ->
+        let known = Keeper_tool_policy.configured_preset_names () in
+        known = [] (* config not loaded yet — accept *) || List.mem name known
+    in
+    if not preset_valid then
+      (false, Printf.sprintf "Unknown required_preset '%s'. Must match a preset in tool_policy.toml."
+        (Option.value ~default:"" required_preset))
+    else
     match contract_result with
     | Error error -> (false, error)
     | Ok contract ->
@@ -295,7 +310,7 @@ let resolve_agent_preset config agent_name =
 let preset_task_filter ~agent_preset (task : Types.task) =
   match task.required_preset, agent_preset with
   | None, _ -> true
-  | Some _, None -> true
+  | Some _required, None -> false  (* agent without preset cannot satisfy preset requirement *)
   | Some required, Some preset ->
     Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -189,6 +189,7 @@ let handle_add_task ctx args =
   let title = get_string args "title" "" in
   let priority = get_int args "priority" 3 in
   let description = get_string args "description" "" in
+  let required_preset = Safe_ops.json_string_opt "required_preset" args in
   let contract_result = parse_task_contract args in
   (* BUG-009/010: Validate title and priority *)
   let trimmed_title = String.trim title in
@@ -201,7 +202,7 @@ let handle_add_task ctx args =
     | Error error -> (false, error)
     | Ok contract ->
         ( true,
-          Room.add_task ?contract ctx.config ~title:trimmed_title ~priority
+          Room.add_task ?contract ?required_preset ctx.config ~title:trimmed_title ~priority
             ~description )
 
 let handle_batch_add_tasks ctx args =
@@ -273,17 +274,43 @@ let handle_claim ctx args =
    | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
   result_to_response result
 
+(** Extract agent's preset from capabilities list (e.g., ["keeper", "preset:delivery"] -> Some "delivery"). *)
+let resolve_agent_preset config agent_name =
+  let agent_file = Filename.concat (Room.agents_dir config) (Room.safe_filename agent_name ^ ".json") in
+  try
+    let json = Room.read_json config agent_file in
+    let caps = Yojson.Safe.Util.(json |> member "capabilities" |> to_list |> List.map to_string) in
+    List.find_map (fun c ->
+      let prefix = "preset:" in
+      let plen = String.length prefix in
+      if String.length c > plen && String.sub c 0 plen = prefix then
+        Some (String.sub c plen (String.length c - plen))
+      else None
+    ) caps
+  with _ -> None
+
+(** Build a task_filter closure that checks required_preset against the agent's preset. *)
+let preset_task_filter ~agent_preset (task : Types.task) =
+  match task.required_preset, agent_preset with
+  | None, _ -> true
+  | Some _, None -> true
+  | Some required, Some preset ->
+    Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
+
 let handle_claim_next ctx _args =
   if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
     (false, Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
   else
-  let result = Room.claim_next_r ctx.config ~agent_name:ctx.agent_name () in
+  let agent_preset = resolve_agent_preset ctx.config ctx.agent_name in
+  let task_filter = preset_task_filter ~agent_preset in
+  let result = Room.claim_next_r ctx.config ~agent_name:ctx.agent_name ~task_filter () in
   let message = match result with
     | Room.Claim_next_claimed { task_id; message; _ } ->
-        (* Auto-set current_task so planning tools pick it up immediately *)
         Planning_eio.set_current_task ctx.config ~task_id;
         message
     | Room.Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
+    | Room.Claim_next_no_eligible { preset_filtered; _ } when preset_filtered > 0 ->
+        Printf.sprintf "📋 No eligible tasks (preset mismatch: %d tasks require different preset)" preset_filtered
     | Room.Claim_next_no_eligible _ -> "📋 No unclaimed tasks available"
     | Room.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
   in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -287,7 +287,9 @@ let resolve_agent_preset config agent_name =
         Some (String.sub c plen (String.length c - plen))
       else None
     ) caps
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
 
 (** Build a task_filter closure that checks required_preset against the agent's preset. *)
 let preset_task_filter ~agent_preset (task : Types.task) =

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -28,6 +28,11 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
           ("type", `String "string");
           ("description", `String "Task description");
         ]);
+        ("required_preset", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Tool preset required to claim this task (e.g., 'delivery', 'coding'). Omit for any agent.");
+          ("enum", `List [`String "minimal"; `String "social"; `String "messaging"; `String "coding"; `String "research"; `String "delivery"]);
+        ]);
         ("contract", `Assoc [
           ("type", `String "object");
           ("description", `String "Optional persisted task contract for strict deterministic completion gating.");

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -30,8 +30,7 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
         ]);
         ("required_preset", `Assoc [
           ("type", `String "string");
-          ("description", `String "Tool preset required to claim this task (e.g., 'delivery', 'coding'). Omit for any agent.");
-          ("enum", `List [`String "minimal"; `String "social"; `String "messaging"; `String "coding"; `String "research"; `String "delivery"]);
+          ("description", `String "Tool preset required to claim this task. Must match a preset name from tool_policy.toml (e.g., 'delivery', 'coding'). Only keepers whose preset covers the required tools can claim. Omit for any agent.");
         ]);
         ("contract", `Assoc [
           ("type", `String "object");

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -508,6 +508,7 @@ type task = {
   created_at: string;
   worktree: worktree_info option; [@default None]  (* linked worktree info *)
   required_role: role; [@default Unassigned]  (** Role required to claim this task *)
+  required_preset: string option; [@default None]  (** Tool preset required to claim this task *)
   stage: Task_stage.t option; [@default None]  (** Coding task stage gate *)
   contract: task_contract option; [@default None]
   handoff_context: task_handoff_context option; [@default None]
@@ -534,10 +535,15 @@ let task_to_yojson t =
     | Unassigned -> with_worktree
     | role -> with_worktree @ [("required_role", role_to_yojson role)]
   in
+  (* Add required_preset if present *)
+  let with_preset = match t.required_preset with
+    | None -> with_role
+    | Some p -> with_role @ [("required_preset", `String p)]
+  in
   (* Add stage if present *)
   let with_stage = match t.stage with
-    | None -> with_role
-    | Some s -> with_role @ [("stage", Task_stage.to_yojson s)]
+    | None -> with_preset
+    | Some s -> with_preset @ [("stage", Task_stage.to_yojson s)]
   in
   let with_contract = match t.contract with
     | None -> with_stage
@@ -580,6 +586,7 @@ let task_of_yojson json =
       | Some s -> role_of_string s
       | None -> Unassigned
     in
+    let required_preset = json |> member "required_preset" |> to_string_option in
     (* Parse optional stage field *)
     let stage = match json |> member "stage" |> to_string_option with
       | Some s -> (match Task_stage.of_string s with Ok st -> Some st | Error _ -> None)
@@ -612,6 +619,7 @@ let task_of_yojson json =
             created_at;
             worktree;
             required_role;
+            required_preset;
             stage;
             contract;
             handoff_context;
@@ -913,5 +921,5 @@ type claim_next_result =
       message : string;
     }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of { excluded_count : int; preset_filtered : int }
   | Claim_next_error of string

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -16,6 +16,106 @@ let test_load_falls_back_to_resolved_config_dir () =
            "expected config load to succeed for base_path=%s: %s"
            base_path msg)
 
+(* ── preset_can_satisfy tests ───────────────────────────────── *)
+
+let load_config () =
+  let base_path = Masc_test_deps.find_project_root () in
+  match KTPC.load ~base_path with
+  | Ok cfg -> cfg
+  | Error msg -> fail (Printf.sprintf "config load failed: %s" msg)
+
+let test_same_preset_satisfies () =
+  let cfg = load_config () in
+  check bool "same preset satisfies itself" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"delivery" ~required_preset:"delivery");
+  check bool "social satisfies social" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"social" ~required_preset:"social")
+
+let test_social_cannot_satisfy_delivery () =
+  let cfg = load_config () in
+  check bool "social cannot satisfy delivery" false
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"social" ~required_preset:"delivery")
+
+let test_delivery_satisfies_coding () =
+  let cfg = load_config () in
+  (* delivery is a superset of coding — includes all coding tools plus autoresearch *)
+  check bool "delivery satisfies coding" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"delivery" ~required_preset:"coding")
+
+let test_full_satisfies_anything () =
+  let cfg = load_config () in
+  check bool "full satisfies delivery" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"full" ~required_preset:"delivery");
+  check bool "full satisfies social" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"full" ~required_preset:"social");
+  check bool "full satisfies coding" true
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"full" ~required_preset:"coding")
+
+let test_minimal_cannot_satisfy_social () =
+  let cfg = load_config () in
+  check bool "minimal cannot satisfy social" false
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"minimal" ~required_preset:"social")
+
+let test_unknown_preset_returns_false () =
+  let cfg = load_config () in
+  check bool "unknown agent preset cannot satisfy delivery" false
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"nonexistent" ~required_preset:"delivery");
+  check bool "any preset cannot satisfy unknown required" false
+    (KTPC.preset_can_satisfy cfg ~agent_preset:"delivery" ~required_preset:"nonexistent")
+
+(* ── task required_preset serialization round-trip ──────────── *)
+
+let test_task_required_preset_roundtrip () =
+  let task : Types.task = {
+    id = "test-001"; title = "Test"; description = "";
+    task_status = Todo; priority = 3; files = [];
+    created_at = "2026-01-01T00:00:00Z";
+    worktree = None;
+    required_role = Types_core.Unassigned;
+    required_preset = Some "delivery";
+    stage = None; contract = None; handoff_context = None;
+  } in
+  let json = Types.task_to_yojson task in
+  match Types.task_of_yojson json with
+  | Ok parsed ->
+    check (option string) "required_preset round-trips" (Some "delivery") parsed.required_preset
+  | Error e -> fail (Printf.sprintf "task parse failed: %s" e)
+
+let test_task_required_preset_none_compat () =
+  let task : Types.task = {
+    id = "test-002"; title = "Test"; description = "";
+    task_status = Todo; priority = 3; files = [];
+    created_at = "2026-01-01T00:00:00Z";
+    worktree = None;
+    required_role = Types_core.Unassigned;
+    required_preset = None;
+    stage = None; contract = None; handoff_context = None;
+  } in
+  let json = Types.task_to_yojson task in
+  let json_str = Yojson.Safe.to_string json in
+  check bool "None required_preset not in JSON" true
+    (not (String.contains json_str (Char.chr 114) && Re.execp (Re.Pcre.re "required_preset" |> Re.compile) json_str));
+  match Types.task_of_yojson json with
+  | Ok parsed ->
+    check (option string) "None round-trips" None parsed.required_preset
+  | Error e -> fail (Printf.sprintf "task parse failed: %s" e)
+
+let test_task_backward_compat_no_field () =
+  (* Simulate old JSON without required_preset field *)
+  let json = `Assoc [
+    ("id", `String "old-001");
+    ("title", `String "Old task");
+    ("description", `String "");
+    ("priority", `Int 3);
+    ("files", `List []);
+    ("created_at", `String "2026-01-01T00:00:00Z");
+    ("status", `String "todo");
+  ] in
+  match Types.task_of_yojson json with
+  | Ok parsed ->
+    check (option string) "missing field parses as None" None parsed.required_preset
+  | Error e -> fail (Printf.sprintf "backward compat failed: %s" e)
+
 let () =
   run "Keeper_tool_policy_config"
     [
@@ -23,5 +123,20 @@ let () =
         [
           test_case "falls back to resolved config dir" `Quick
             test_load_falls_back_to_resolved_config_dir;
+        ] );
+      ( "preset_can_satisfy",
+        [
+          test_case "same preset satisfies" `Quick test_same_preset_satisfies;
+          test_case "social cannot satisfy delivery" `Quick test_social_cannot_satisfy_delivery;
+          test_case "delivery satisfies coding" `Quick test_delivery_satisfies_coding;
+          test_case "full satisfies anything" `Quick test_full_satisfies_anything;
+          test_case "minimal cannot satisfy social" `Quick test_minimal_cannot_satisfy_social;
+          test_case "unknown preset returns false" `Quick test_unknown_preset_returns_false;
+        ] );
+      ( "task_required_preset",
+        [
+          test_case "round-trip with Some" `Quick test_task_required_preset_roundtrip;
+          test_case "round-trip with None" `Quick test_task_required_preset_none_compat;
+          test_case "backward compat no field" `Quick test_task_backward_compat_no_field;
         ] );
     ]

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -976,7 +976,7 @@ let test_append_archive_tasks () =
       files = [];
       created_at = "2026-01-01T00:00:00Z";
       worktree = None;
-      required_role = Types_core.Unassigned; stage = None;
+      required_role = Types_core.Unassigned; required_preset = None; stage = None;
       contract = None; handoff_context = None;
     } in
     Room.append_archive_tasks config [task];

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -66,7 +66,7 @@ let test_task_with_stage () =
     id = "T-001"; title = "test"; description = "";
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
-    worktree = None; required_role = Unassigned;
+    worktree = None; required_role = Unassigned; required_preset = None;
     stage = Some Task_stage.Implement;
     contract = None; handoff_context = None;
   } in
@@ -82,7 +82,7 @@ let test_task_without_stage () =
     id = "T-002"; title = "no stage"; description = "";
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
-    worktree = None; required_role = Unassigned;
+    worktree = None; required_role = Unassigned; required_preset = None;
     stage = None;
     contract = None; handoff_context = None;
   } in

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -123,7 +123,7 @@ let make_task ~id ~status : Types.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
-  required_role = Types_core.Unassigned; stage = None;
+  required_role = Types_core.Unassigned; required_preset = None; stage = None;
   contract = None; handoff_context = None;
 }
 
@@ -160,7 +160,7 @@ let make_task_with_priority ~id ~priority : Types.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
-  required_role = Types_core.Unassigned; stage = None;
+  required_role = Types_core.Unassigned; required_preset = None; stage = None;
   contract = None; handoff_context = None;
 }
 

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -560,7 +560,7 @@ let test_backlog_to_yojson_with_tasks () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
-    required_role = Types_core.Unassigned; stage = None;
+    required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None;
   } in
   let b : Types.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
@@ -1246,7 +1246,7 @@ let test_task_to_yojson () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
-    required_role = Types_core.Unassigned; stage = None;
+    required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None;
   } in
   let json = Types.task_to_yojson t in
@@ -1273,7 +1273,7 @@ let test_task_to_yojson_with_worktree () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     worktree = Some wt;
-    required_role = Types_core.Unassigned; stage = None;
+    required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None;
   } in
   let json = Types.task_to_yojson t in

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -442,7 +442,7 @@ let test_task_roundtrip () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-01T00:00:00Z";
     worktree = None;
-    required_role = Types_core.Unassigned; stage = None;
+    required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None;
   } in
   let json = Types.task_to_yojson task in
@@ -464,7 +464,7 @@ let test_task_with_worktree () =
       git_root = "/project";
       repo_name = "project";
     };
-    required_role = Types_core.Unassigned; stage = None;
+    required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None;
   } in
   let json = Types.task_to_yojson task in
@@ -481,12 +481,12 @@ let test_backlog_roundtrip () =
       { id = "t1"; title = "Task 1"; description = "Desc 1";
         task_status = Todo; priority = 1; files = [];
         created_at = "2024-01-01T00:00:00Z"; worktree = None;
-        required_role = Types_core.Unassigned; stage = None;
+        required_role = Types_core.Unassigned; required_preset = None; stage = None;
         contract = None; handoff_context = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z"; worktree = None;
-        required_role = Types_core.Unassigned; stage = None;
+        required_role = Types_core.Unassigned; required_preset = None; stage = None;
         contract = None; handoff_context = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";


### PR DESCRIPTION
## Summary

- Tasks can declare `required_preset` to restrict which keepers can claim them
- Matching is config-driven via `tool_policy.toml` preset subsumption — no hardcoded hierarchy
- Keepers persist their preset in agent capabilities at join time (`preset:delivery`)
- Scheduler filters via `?task_filter` callback, maintaining room/keeper layer separation

## Problem

`claim_next_r` selected tasks by priority+FIFO only. Any keeper could claim any task regardless of tool preset. With 3 social keepers vs 1 delivery keeper, social keepers claimed delivery-required tasks 75% of the time, wasting turns.

## Design

Inspired by Claude Code `requiredMcpServers`, Samchon harness schema-as-spec, me PR #814 auto-injection.

### Behavior

| `task.required_preset` | `agent.preset` | Result |
|---|---|---|
| `None` | any | claim allowed (no constraint) |
| `Some "delivery"` | `Some "delivery"` | allowed (same preset) |
| `Some "delivery"` | `Some "social"` | rejected (social tools not subset of delivery) |
| `Some "coding"` | `Some "delivery"` | allowed (delivery superset of coding) |
| `Some _` | `None` | rejected (no verifiable capability) |
| any | `Some "full"` | allowed (full covers everything) |

### Input validation

- `required_preset` is trimmed, empty-to-None normalized
- Validated against `configured_preset_names()` from tool_policy.toml at add-task time
- Unknown preset rejected with clear error

## Test plan

- [x] `dune build` passes
- [x] 10 unit tests pass (subsumption 6 + serialization 3 + load 1)
- [x] GLM-5.1 cross-model review: LGTM
- [x] Copilot review: 9 comments, all addressed
- [ ] E2E: create task with `required_preset: "delivery"`, verify social keeper skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)