### PR TITLE
fix: auto-create tool_usage and tool_metrics directories at init

### DIFF
--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -57,6 +57,7 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
   | Some (cached_path, s) when String.equal cached_path base_path -> s
   | _ ->
     let dir = Filename.concat base_path "data/tool-metrics" in
+    Fs_compat.mkdir_p dir;
     let s = Dated_jsonl.create ~base_dir:dir () in
     store_ref := Some (base_path, s);
     s

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -26,6 +26,7 @@ let store_ref : Dated_jsonl.t option ref = ref None
 let init ~base_path =
   let dir = Filename.concat base_path ".masc/tool_usage" in
   (try
+     Fs_compat.mkdir_p dir;
      let store = Dated_jsonl.create ~base_dir:dir () in
      store_ref := Some store
    with exn ->


### PR DESCRIPTION
Fixes #5771. Dashboard telemetry showed U=0, M=0 because directories did not exist until first write. Adds Fs_compat.mkdir_p at init time so Sys.file_exists checks succeed immediately.