### PR TITLE
fix(dashboard): surface keeper_tool_skipped SSE + remove hardcoded thresholds

### DIFF
--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { navigate } from '../router'
 import type { Keeper, PipelineStage } from '../types/core'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_FLEET_WARN } from '../config/constants'
 
 // ── Pipeline stage styling ────────────────────────────
 
@@ -135,7 +136,7 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
       ` : null}
       <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
         <span class="text-[var(--text-dim)]">평균 컨텍스트</span>
-        <span class="font-mono font-medium ${avgCtx > 0.85 ? 'text-[var(--bad)]' : avgCtx > 0.6 ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${(avgCtx * 100).toFixed(0)}%</span>
+        <span class="font-mono font-medium ${avgCtx > CONTEXT_RATIO_CRITICAL ? 'text-[var(--bad)]' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${(avgCtx * 100).toFixed(0)}%</span>
       </span>
       ${totalTools > 0 ? html`
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -2,12 +2,12 @@
 
 import { html } from 'htm/preact'
 import { keeperHealthSummary, type KeeperPressure } from '../../live-store'
-import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from '../../config/constants'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from '../../config/constants'
 
 function pressureColor(ratio: number): string {
   if (ratio > CONTEXT_RATIO_CRITICAL) return 'bg-[var(--bad)]'
   if (ratio > CONTEXT_RATIO_WARN) return 'bg-[var(--warn)]'
-  if (ratio > 0.50) return 'bg-[var(--warn)]'
+  if (ratio > CONTEXT_RATIO_COMPACTING) return 'bg-[var(--warn)]'
   return 'bg-[var(--ok)]'
 }
 

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -34,9 +34,14 @@ export const SSE_RECONNECT_RETRY_MS = 3_000
 export const PERIODIC_REFRESH_DEV_MS = 180_000
 export const PERIODIC_REFRESH_PROD_MS = 120_000
 
-// --- Context ratio thresholds (SSOT: backend env_config_runtime.ml:496-499) ---
-export const CONTEXT_RATIO_CRITICAL = 0.85
-export const CONTEXT_RATIO_WARN = 0.70
+// --- Context ratio thresholds ---
+// Lifecycle state thresholds (SSOT: lib/config/env_config_runtime.ml Dashboard module)
+// Env vars: MASC_DASHBOARD_CTX_HANDOFF_IMMINENT, MASC_DASHBOARD_CTX_PREPARING, MASC_DASHBOARD_CTX_COMPACTING
+export const CONTEXT_RATIO_CRITICAL = 0.85  // handoff-imminent
+export const CONTEXT_RATIO_WARN = 0.70      // preparing
+export const CONTEXT_RATIO_COMPACTING = 0.50 // compacting
+// Fleet overview coloring (intermediate between warn and compacting)
+export const CONTEXT_RATIO_FLEET_WARN = 0.60
 
 // --- Trajectory timeline ---
 export const TRAJECTORY_HEARTBEAT_STALE_MS = 30_000

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -7,7 +7,7 @@ import type {
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
-import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from './config/constants'
+import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
@@ -43,7 +43,7 @@ export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
   const ratio = latest.context_ratio
   if (ratio > CONTEXT_RATIO_CRITICAL) return 'handoff-imminent'
   if (ratio > CONTEXT_RATIO_WARN) return 'preparing'
-  if (ratio > 0.50) return 'compacting'
+  if (ratio > CONTEXT_RATIO_COMPACTING) return 'compacting'
   return 'active'
 }
 

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -424,6 +424,31 @@ function handleEvent(event: SSEEvent): void {
       }
       break
     }
+    case 'keeper_tool_skipped': {
+      const toolName = event.tool_name ?? '?'
+      const reasonCode = event.reason_code ?? 'unknown'
+      addTypedJournalEntry(
+        event.name ?? agent,
+        `Tool skipped: ${toolName} (${reasonCode})`,
+        'keepers',
+        'keeper_tool_call',
+        {
+          severity: 'warn',
+          source: event.source,
+          narrativeText: `${actorLabel(event.name ?? agent)}의 ${toolName} 도구가 차단되었습니다 (${reasonCode})`,
+        },
+      )
+      if (event.name) {
+        appendLiveToolCall(event.name, {
+          toolName,
+          durationMs: 0,
+          success: false,
+          error: `skipped: ${reasonCode}`,
+          tsUnix: typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000,
+        })
+      }
+      break
+    }
     // OAS bridge events
     case 'oas:masc:autonomy:agent_selected': {
       const p = (event.payload ?? {}) as Record<string, unknown>

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -20,6 +20,7 @@ export type SSEEventType =
   | 'keeper_phase_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
+  | 'keeper_tool_skipped'
   | 'keeper_turn_complete'
   | 'masc/keeper_turn_complete'
   | 'client_input_approved'
@@ -81,11 +82,12 @@ export interface SSEEvent {
   prev_phase?: string
   new_phase?: string
   event?: string
-  // Keeper tool call fields
+  // Keeper tool call / tool skip fields
   tool_name?: string
   duration_ms?: number
   success?: boolean
   error_text?: string
+  reason_code?: string
   // OAS bridge payload (generic container for Event_bus events)
   payload?: Record<string, unknown>
 }

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -243,6 +243,16 @@ let dashboard_entries =
       "Execution refresh timeout";
     entry ~default:"8" "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S"
       "Transport health timeout";
+    entry ~default:"0.85" "MASC_DASHBOARD_CTX_HANDOFF_IMMINENT"
+      "Context ratio threshold: handoff-imminent";
+    entry ~default:"0.70" "MASC_DASHBOARD_CTX_PREPARING"
+      "Context ratio threshold: preparing";
+    entry ~default:"0.50" "MASC_DASHBOARD_CTX_COMPACTING"
+      "Context ratio threshold: compacting";
+    entry ~default:"0.9" "MASC_DASHBOARD_HEALTH_CTX_CRITICAL"
+      "Health scoring: context ratio critical threshold";
+    entry ~default:"0.8" "MASC_DASHBOARD_HEALTH_CTX_WARN"
+      "Health scoring: context ratio warning threshold";
   ]
 
 let all_categories () =

--- a/specs/keeper-state-machine/KeeperOASAdvanced-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperOASAdvanced-buggy.cfg
@@ -1,4 +1,4 @@
-SPECIFICATION Spec
+SPECIFICATION SpecBuggy
 
 CONSTANTS
     MaxTurns = 3

--- a/specs/keeper-state-machine/KeeperOASAdvanced.tla
+++ b/specs/keeper-state-machine/KeeperOASAdvanced.tla
@@ -95,10 +95,23 @@ FiberHandlesCancellation ==
     /\ context_polluted' = FALSE \* Rollback context via Switch.on_release or try/with
     /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
 
+\* 9. [BUG MODEL] Catch-all absorbs cancellation — fiber returns Error instead
+\*     of propagating Cancelled to the parent switch. This creates a zombie:
+\*     the parent believes the child completed, but the cancel signal is lost.
+CancelledAbsorbed ==
+    /\ fiber_state = "Cancelling"
+    /\ fiber_state' = "Terminated"
+    /\ oas_api_state' = "Idle"
+    \* BUG: keeper_decision becomes a normal result instead of fallback
+    /\ keeper_decision' = "ExecuteSelf"
+    /\ context_polluted' = TRUE  \* Context NOT rolled back — pollution persists
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
+
 TerminatedStutter ==
     /\ fiber_state = "Terminated"
     /\ UNCHANGED vars
 
+\* Correct Next: only well-formed transitions (production code).
 Next ==
     \/ GlobalStopPreempts
     \/ EioTimeoutTriggered
@@ -109,6 +122,13 @@ Next ==
     \/ FinishCascade
     \/ FiberHandlesCancellation
     \/ TerminatedStutter
+
+\* Buggy Next: includes CancelledAbsorbed to demonstrate that
+\* CancelledNeverAbsorbed catches the violation. Use NextBuggy in cfg
+\* to reproduce the bug scenario for regression testing.
+NextBuggy ==
+    \/ Next
+    \/ CancelledAbsorbed
 
 Fairness ==
     \* Weak Fairness for progress operations
@@ -121,6 +141,8 @@ Fairness ==
 
 Spec == Init /\ [][Next]_vars /\ Fairness
 
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ Fairness
+
 \* ── Safety Properties ─────────────────────────────────────
 
 \* 1. A terminated fiber cannot leave a zombie OAS fetch running in the background.
@@ -128,6 +150,14 @@ NoZombieFibers == ((fiber_state = "Terminated") => ~(oas_api_state = "Fetching")
 
 \* 2. If a cascade falls back (due to error or cancel), the context must be rolled back cleanly.
 AtomicCascadeFallback == []( (fiber_state = "Terminated" /\ keeper_decision = "AutonomyFallback") => (context_polluted = FALSE) )
+
+\* 3. Cancellation must never be absorbed — a terminated fiber with polluted
+\*    context must never hold a normal decision (ExecuteSelf/Delegate).
+\*    State predicate (no temporal ops) — usable as INVARIANT.
+\*    Violation means a catch-all swallowed Eio.Cancel.Cancelled.
+CancelledNeverAbsorbed ==
+    (fiber_state = "Terminated" /\ context_polluted = TRUE)
+      => (keeper_decision /= "ExecuteSelf" /\ keeper_decision /= "Delegate")
 
 \* ── Liveness Properties ───────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `keeper_tool_skipped` SSE event: add to type union, handle in dispatcher, route to journal + live trace. Tool skips (cost gate, deny list, destructive pattern) now visible.
- Context ratio thresholds: inline `0.6` and `0.50` extracted to named constants (`CONTEXT_RATIO_FLEET_WARN`, `CONTEXT_RATIO_COMPACTING`). SSOT comment fixed.
- Backend: 5 threshold env vars added to `Env_config_snapshot` → visible in `/api/v1/dashboard/config`.

## SSOT mapping

| Constant | Env Var | Default | Backend SSOT |
|----------|---------|---------|-------------|
| CONTEXT_RATIO_CRITICAL | MASC_DASHBOARD_CTX_HANDOFF_IMMINENT | 0.85 | env_config_runtime.ml |
| CONTEXT_RATIO_WARN | MASC_DASHBOARD_CTX_PREPARING | 0.70 | env_config_runtime.ml |
| CONTEXT_RATIO_COMPACTING | MASC_DASHBOARD_CTX_COMPACTING | 0.50 | env_config_runtime.ml |
| CONTEXT_RATIO_FLEET_WARN | (frontend-only) | 0.60 | constants.ts |

## Test plan
- [x] `dune build` — clean
- [x] `tsc --noEmit` — clean
- [ ] Dashboard shows tool skip events in journal
- [ ] Fleet overview uses constant instead of inline 0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)