### PR TITLE
refactor(keeper): replace hardcoded side-effect tools with deterministic boundary

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -918,14 +918,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          an independent observer, so concurrent keepers cannot interfere
          with each other's save/restore lifecycle. *)
       let side_effect_occurred = ref false in
-      let side_effect_tools =
-        [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote";
-          "keeper_board_delete";
-          "keeper_bash"; "keeper_fs_edit"; "keeper_github";
-          "keeper_pr_workflow" ]
-      in
       let side_effect_observer ~tool_name ~success =
-        if success && List.mem tool_name side_effect_tools then
+        if success && not (Tool_dispatch.is_read_only tool_name) then
           side_effect_occurred := true
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;


### PR DESCRIPTION
## Summary
When deciding whether to skip a transient retry to prevent duplicate side effects, `keeper_unified_turn.ml` relied on a hardcoded list of `side_effect_tools`. 
This PR replaces that brittle hardcoded list with a fundamental, deterministic boundary check using `not (Tool_dispatch.is_read_only tool_name)`.

## Product impact
Massive architectural improvement. Any new tools added to the MASC catalog in the future will automatically benefit from accurate transient-retry protection without requiring developers to remember to update a separate hardcoded list in the keeper execution loop.

## Evidence
Code cleanly uses existing `Tool_dispatch` metadata.

## Review evidence
Standard architecture cleanup.

## Linked issue
Fixes #0 (Implicit task-044)