### PR TITLE
fix(telemetry): cluster-aware read path

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -247,7 +247,9 @@ let rec add_routes ~sw ~clock router =
   (* ── Telemetry unified view ── *)
   |> Http.Router.get "/api/v1/dashboard/telemetry" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let config = state.Mcp_server.room_config in
+         let base_path = config.base_path in
+         let masc_root = Room.masc_root_dir config in
          let n =
            Server_utils.int_query_param req "n" ~default:100
            |> max 1 |> min 500
@@ -262,7 +264,7 @@ let rec add_routes ~sw ~clock router =
               | None -> Telemetry_unified.all_sources)
          in
          let entries =
-           Telemetry_unified.read_unified ~base_path ~sources
+           Telemetry_unified.read_unified ~base_path ~masc_root ~sources
              ?keeper_name ~n ()
          in
          let json = `Assoc [
@@ -275,8 +277,10 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/telemetry/summary" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
-         let json = Telemetry_unified.summary_json ~base_path () in
+         let config = state.Mcp_server.room_config in
+         let base_path = config.base_path in
+         let masc_root = Room.masc_root_dir config in
+         let json = Telemetry_unified.summary_json ~base_path ~masc_root () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -6,12 +6,12 @@
     No existing write paths are modified.  The module creates read-only
     {!Dated_jsonl} handles (no appends, no directory creation).
 
-    Sources:
-    - [.masc/keepers/<name>/metrics/]  — Per-keeper turn metrics (richest data)
-    - [.masc/telemetry/]               — Agent lifecycle + tool call events
-    - [.masc/tool_calls/]              — Full I/O for keeper tool calls
-    - [.masc/tool_usage/]              — System_internal surface tool calls
-    - [data/tool-metrics/]             — Tool duration/success metrics
+    Sources (paths are relative to the cluster-aware [masc_root]):
+    - [<masc_root>/keepers/<name>/metrics/]  — Per-keeper turn metrics
+    - [<masc_root>/telemetry/]               — Agent lifecycle + tool call events
+    - [<masc_root>/tool_calls/]              — Full I/O for keeper tool calls
+    - [<masc_root>/tool_usage/]              — System_internal surface tool calls
+    - [<base_path>/data/tool-metrics/]       — Tool duration/success metrics
 
     @since 2.251.0 *)
 
@@ -41,17 +41,21 @@ let all_sources = [Keeper_metric; Agent_event; Tool_call_io; Tool_usage; Tool_me
 
 (* ── Store paths ────────────────────────────────────── *)
 
-(** Fixed-path sources (single directory per source). *)
-let fixed_store_dir base_path = function
-  | Agent_event  -> Some (Filename.concat base_path ".masc/telemetry")
-  | Tool_call_io -> Some (Filename.concat base_path ".masc/tool_calls")
-  | Tool_usage   -> Some (Filename.concat base_path ".masc/tool_usage")
+(** Fixed-path sources (single directory per source).
+
+    [masc_root] is the cluster-aware .masc directory
+    (e.g. [base_path/.masc] or [base_path/.masc/clusters/<name>]).
+    [base_path] is the project root, used only for [data/] paths. *)
+let fixed_store_dir ~masc_root ~base_path = function
+  | Agent_event  -> Some (Filename.concat masc_root "telemetry")
+  | Tool_call_io -> Some (Filename.concat masc_root "tool_calls")
+  | Tool_usage   -> Some (Filename.concat masc_root "tool_usage")
   | Tool_metric  -> Some (Filename.concat base_path "data/tool-metrics")
   | Keeper_metric -> None  (* per-keeper, handled separately *)
 
-(** Discover all keeper metric directories under [.masc/keepers/]. *)
-let discover_keeper_metric_dirs base_path : (string * string) list =
-  let keepers_dir = Filename.concat base_path ".masc/keepers" in
+(** Discover all keeper metric directories under [masc_root/keepers/]. *)
+let discover_keeper_metric_dirs masc_root : (string * string) list =
+  let keepers_dir = Filename.concat masc_root "keepers" in
   if not (Sys.file_exists keepers_dir) then []
   else
     let entries =
@@ -123,8 +127,8 @@ let read_fixed_source dir source ~n : Yojson.Safe.t list =
 
 (* ── Read keeper metrics (per-keeper directories) ───── *)
 
-let read_keeper_metrics ~base_path ?keeper_name ~n () : Yojson.Safe.t list =
-  let dirs = discover_keeper_metric_dirs base_path in
+let read_keeper_metrics ~masc_root ?keeper_name ~n () : Yojson.Safe.t list =
+  let dirs = discover_keeper_metric_dirs masc_root in
   let dirs = match keeper_name with
     | None -> dirs
     | Some name -> List.filter (fun (k, _) -> String.equal k name) dirs
@@ -135,16 +139,16 @@ let read_keeper_metrics ~base_path ?keeper_name ~n () : Yojson.Safe.t list =
 
 (* ── Unified read ───────────────────────────────────── *)
 
-let read_unified ~base_path ?(sources = all_sources) ?keeper_name
+let read_unified ~base_path ~masc_root ?(sources = all_sources) ?keeper_name
     ?(n = 100) () : Yojson.Safe.t list =
   let per_source = max n (n * 2) in
   let all_entries =
     List.concat_map (fun source ->
       match source with
       | Keeper_metric ->
-        read_keeper_metrics ~base_path ?keeper_name ~n:per_source ()
+        read_keeper_metrics ~masc_root ?keeper_name ~n:per_source ()
       | _ ->
-        match fixed_store_dir base_path source with
+        match fixed_store_dir ~masc_root ~base_path source with
         | Some dir -> read_fixed_source dir source ~n:per_source
         | None -> []
     ) sources
@@ -171,8 +175,8 @@ let read_unified ~base_path ?(sources = all_sources) ?keeper_name
 
 (* ── Summary ────────────────────────────────────────── *)
 
-let count_fixed_source_entries ~base_path source : int =
-  match fixed_store_dir base_path source with
+let count_fixed_source_entries ~masc_root ~base_path source : int =
+  match fixed_store_dir ~masc_root ~base_path source with
   | None -> 0
   | Some dir ->
     if not (Sys.file_exists dir) then 0
@@ -181,8 +185,8 @@ let count_fixed_source_entries ~base_path source : int =
        | store -> List.length (Dated_jsonl.read_recent store 10_000)
        | exception _ -> 0)
 
-let summary_json ~base_path () : Yojson.Safe.t =
-  let keeper_dirs = discover_keeper_metric_dirs base_path in
+let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
+  let keeper_dirs = discover_keeper_metric_dirs masc_root in
   let keeper_total =
     List.fold_left (fun acc (_, dir) ->
       acc +
@@ -205,10 +209,10 @@ let summary_json ~base_path () : Yojson.Safe.t =
         ("entry_count", `Int keeper_total);
       ]
     | _ ->
-      let dir = match fixed_store_dir base_path source with
+      let dir = match fixed_store_dir ~masc_root ~base_path source with
         | Some d -> d | None -> "" in
       let exists = dir <> "" && Sys.file_exists dir in
-      let count = if exists then count_fixed_source_entries ~base_path source else 0 in
+      let count = if exists then count_fixed_source_entries ~masc_root ~base_path source else 0 in
       `Assoc [
         ("source", `String (source_to_string source));
         ("path", `String dir);
@@ -218,7 +222,7 @@ let summary_json ~base_path () : Yojson.Safe.t =
   in
   let fixed_total =
     List.fold_left (fun acc s ->
-      acc + count_fixed_source_entries ~base_path s
+      acc + count_fixed_source_entries ~masc_root ~base_path s
     ) 0 (List.filter (fun s -> s <> Keeper_metric) all_sources)
   in
   `Assoc [

--- a/lib/telemetry_unified.mli
+++ b/lib/telemetry_unified.mli
@@ -1,11 +1,13 @@
 (** Telemetry_unified — Read-only aggregation of scattered telemetry stores.
 
-    Provides a single, time-sorted view over five separate JSONL stores:
-    - [.masc/keepers/<name>/metrics/] — Per-keeper turn metrics (richest)
-    - [.masc/telemetry/]              — Agent lifecycle and tool call events
-    - [.masc/tool_calls/]             — Full I/O for keeper tool calls
-    - [.masc/tool_usage/]             — System_internal surface tool calls
-    - [data/tool-metrics/]            — Tool duration/success metrics
+    Provides a single, time-sorted view over five separate JSONL stores.
+    Paths under [.masc/] are resolved via the cluster-aware [masc_root]
+    (use [Room.masc_root_dir config]):
+    - [<masc_root>/keepers/<name>/metrics/] — Per-keeper turn metrics
+    - [<masc_root>/telemetry/]              — Agent lifecycle + tool call events
+    - [<masc_root>/tool_calls/]             — Full I/O for keeper tool calls
+    - [<masc_root>/tool_usage/]             — System_internal surface tool calls
+    - [<base_path>/data/tool-metrics/]      — Tool duration/success metrics
 
     Each returned entry is tagged with a ["source"] field for discrimination.
     No write paths are modified; this module is purely a read-side fan-in.
@@ -26,21 +28,28 @@ val all_sources : source list
 
 val read_unified :
   base_path:string ->
+  masc_root:string ->
   ?sources:source list ->
   ?keeper_name:string ->
   ?n:int ->
   unit ->
   Yojson.Safe.t list
-(** [read_unified ~base_path ?sources ?keeper_name ?n ()] reads entries
-    from [sources] (default: all five), optionally filtered by
-    [keeper_name], and returns at most [n] entries (default 100)
+(** [read_unified ~base_path ~masc_root ?sources ?keeper_name ?n ()]
+    reads entries from [sources] (default: all five), optionally filtered
+    by [keeper_name], and returns at most [n] entries (default 100)
     sorted by timestamp descending (newest first).
+
+    [masc_root] is the cluster-aware .masc directory (use
+    [Room.masc_root_dir config] to obtain it).  [base_path] is the
+    project root, used only for [data/] paths.
 
     Each entry is a JSON object with an added ["source"] field. *)
 
 val summary_json :
   base_path:string ->
+  masc_root:string ->
   unit ->
   Yojson.Safe.t
-(** [summary_json ~base_path ()] returns a JSON overview of each source:
-    path, entry count, and whether the store directory exists. *)
+(** [summary_json ~base_path ~masc_root ()] returns a JSON overview of
+    each source: path, entry count, and whether the store directory
+    exists.  [masc_root] is the cluster-aware .masc directory. *)

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -36,18 +36,20 @@ let test_source_of_string_unknown () =
 
 (* ── Empty base_path ─────────────────────────────── *)
 
+let masc_root dir = Filename.concat dir ".masc"
+
 let test_empty_returns_empty () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "telem_empty" in
-  let entries = Telemetry_unified.read_unified ~base_path:dir () in
+  let entries = Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir) () in
   Alcotest.(check int) "no entries" 0 (List.length entries)
 
 let test_summary_empty () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "telem_sum_empty" in
-  let json = Telemetry_unified.summary_json ~base_path:dir () in
+  let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:(masc_root dir) () in
   match json with
   | `Assoc fields ->
     let total = match List.assoc_opt "total_entries" fields with
@@ -68,7 +70,7 @@ let test_agent_event_source () =
     `Assoc [("timestamp", `Float 2000.0); ("event", `String "test2")];
   ];
   let entries =
-    Telemetry_unified.read_unified ~base_path:dir
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Agent_event] ()
   in
   Alcotest.(check int) "two entries" 2 (List.length entries);
@@ -99,11 +101,11 @@ let test_keeper_metrics_per_keeper () =
             ("channel", `String "turn")];
   ];
   (* All keepers *)
-  let all = Telemetry_unified.read_unified ~base_path:dir
+  let all = Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Keeper_metric] () in
   Alcotest.(check int) "two keeper entries" 2 (List.length all);
   (* Filter by keeper *)
-  let cheolsu_only = Telemetry_unified.read_unified ~base_path:dir
+  let cheolsu_only = Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Keeper_metric]
       ~keeper_name:"cheolsu" () in
   Alcotest.(check int) "one cheolsu entry" 1 (List.length cheolsu_only)
@@ -122,7 +124,7 @@ let test_sorted_newest_first () =
     `Assoc [("timestamp", `Float 2000.0); ("event", `String "mid")];
   ];
   let entries =
-    Telemetry_unified.read_unified ~base_path:dir
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Agent_event] ()
   in
   Alcotest.(check int) "three entries" 3 (List.length entries);
@@ -146,7 +148,7 @@ let test_n_limits_output () =
       `Assoc [("timestamp", `Float (Float.of_int (i * 100))); ("i", `Int i)])
   );
   let entries =
-    Telemetry_unified.read_unified ~base_path:dir
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Agent_event] ~n:10 ()
   in
   Alcotest.(check int) "limited to 10" 10 (List.length entries)
@@ -162,7 +164,7 @@ let test_summary_with_data () =
   write_jsonl telemetry_dir [
     `Assoc [("timestamp", `Float 1000.0); ("event", `String "test")];
   ];
-  let json = Telemetry_unified.summary_json ~base_path:dir () in
+  let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:(masc_root dir) () in
   match json with
   | `Assoc fields ->
     let total = match List.assoc_opt "total_entries" fields with

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -172,6 +172,49 @@ let test_summary_with_data () =
     Alcotest.(check bool) "at least 1 entry" true (total >= 1)
   | _ -> Alcotest.fail "expected Assoc"
 
+(* ── Cluster-aware path ─────────────────────────── *)
+
+let test_cluster_aware_read () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_cluster" in
+  (* Simulate cluster layout: masc_root is NOT base_path/.masc but
+     base_path/.masc/clusters/my-cluster — the scenario that was broken. *)
+  let cluster_masc = Filename.concat dir ".masc/clusters/my-cluster" in
+  let telemetry_dir = Filename.concat cluster_masc "telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  write_jsonl telemetry_dir [
+    `Assoc [("timestamp", `Float 5000.0); ("event", `String "cluster_event")];
+  ];
+  (* Read with cluster-aware masc_root — should find the entry *)
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:cluster_masc
+      ~sources:[Telemetry_unified.Agent_event] ()
+  in
+  Alcotest.(check int) "cluster entry found" 1 (List.length entries);
+  (* Read with default masc_root — should NOT find it (old bug behavior) *)
+  let default_entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
+      ~sources:[Telemetry_unified.Agent_event] ()
+  in
+  Alcotest.(check int) "default masc_root misses cluster data" 0 (List.length default_entries)
+
+let test_cluster_keeper_metrics () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_cluster_keeper" in
+  let cluster_masc = Filename.concat dir ".masc/clusters/prod" in
+  let keeper_dir = Filename.concat cluster_masc "keepers/alpha/metrics" in
+  Fs_compat.mkdir_p keeper_dir;
+  write_jsonl keeper_dir [
+    `Assoc [("ts_unix", `Float 6000.0); ("name", `String "alpha"); ("channel", `String "turn")];
+  ];
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:cluster_masc
+      ~sources:[Telemetry_unified.Keeper_metric] ()
+  in
+  Alcotest.(check int) "cluster keeper metric found" 1 (List.length entries)
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -194,5 +237,10 @@ let () =
         [
           Alcotest.test_case "empty" `Quick test_summary_empty;
           Alcotest.test_case "with data" `Quick test_summary_with_data;
+        ] );
+      ( "cluster",
+        [
+          Alcotest.test_case "cluster-aware read" `Quick test_cluster_aware_read;
+          Alcotest.test_case "cluster keeper metrics" `Quick test_cluster_keeper_metrics;
         ] );
     ]


### PR DESCRIPTION
## Summary

- `Telemetry_unified.fixed_store_dir` used `base_path` directly, ignoring cluster namespacing via `Room.masc_root_dir`
- When `cluster_name != "default"`, writes went to `.masc/clusters/{name}/telemetry/` but reads went to `.masc/telemetry/` — the dashboard telemetry menu showed no data
- Changed `read_unified` and `summary_json` API to accept `~masc_root` (cluster-aware `.masc` root) alongside `~base_path` (project root for `data/` paths only)
- Updated dashboard route callers to pass `Room.masc_root_dir config`

## Test plan

- [x] `dune build` passes (exit 0)
- [x] Existing tests updated to pass `~masc_root` parameter
- [ ] Verify dashboard telemetry endpoint returns data for non-default cluster configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)