### PR TITLE
feat(dashboard): display 11-state phase per keeper with state diagram

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -41,11 +41,12 @@ import {
   resetKeeperConfig,
 } from './keeper-config-panel'
 import { PipelineStageBar } from './keeper-pipeline-stage'
+import { KeeperPhaseAndStage } from './keeper-phase-indicator'
+import { KeeperStateDiagramPanel } from './keeper-state-diagram'
 import { AgentJournalStream } from './agent-detail-journal'
 import { DialogOverlay } from './common/dialog'
 import { SessionTraceView } from './session-trace/session-trace-view'
 import { KeeperToolTelemetry } from './keeper-tool-telemetry'
-import { statusLabel } from '../lib/status-label'
 import { KeeperToolCallInspector } from './keeper-tool-call-inspector'
 import { SupervisorDiagnosticsPanel } from './keeper-supervisor-diagnostics'
 
@@ -87,47 +88,6 @@ async function runSocialSweep(): Promise<void> {
 async function refreshAfterRuntimeAction(): Promise<void> {
   invalidateDashboardCache()
   await refreshDashboard({ force: true })
-}
-
-// ── Status Badge (colored pill) ──────────────────────────
-
-function statusColor(status: string): { bg: string; text: string; dot: string } {
-  switch (status.trim().toLowerCase()) {
-    case 'active':
-    case 'running':
-    case 'busy':
-      return { bg: 'bg-[var(--ok-10)]', text: 'text-[var(--ok)]', dot: 'bg-[var(--ok)]' }
-    case 'working':
-      return { bg: 'bg-[var(--ok-10)]', text: 'text-[#7ae09a]', dot: 'bg-[#7ae09a]' }
-    case 'idle':
-    case 'quiet':
-      return { bg: 'bg-[rgba(251,191,36,0.12)]', text: 'text-[var(--warn)]', dot: 'bg-[#fbbf24]' }
-    case 'paused':
-    case 'blocked':
-      return { bg: 'bg-[rgba(251,191,36,0.12)]', text: 'text-[var(--warn)]', dot: 'bg-[#fbbf24]' }
-    case 'offline':
-    case 'inactive':
-      return { bg: 'bg-[rgba(148,163,184,0.12)]', text: 'text-[#94a3b8]', dot: 'bg-[#64748b]' }
-    case 'unbooted':
-      return { bg: 'bg-[rgba(148,163,184,0.08)]', text: 'text-[#64748b]', dot: 'bg-[#475569]' }
-    case 'stopped':
-      return { bg: 'bg-[rgba(148,163,184,0.12)]', text: 'text-[#94a3b8]', dot: 'bg-[#64748b]' }
-    case 'error':
-    case 'critical':
-      return { bg: 'bg-[rgba(239,68,68,0.12)]', text: 'text-[var(--bad)]', dot: 'bg-[var(--bad)]' }
-    default:
-      return { bg: 'bg-[rgba(138,163,211,0.1)]', text: 'text-[#86a0cf]', dot: 'bg-[#86a0cf]' }
-  }
-}
-
-function KeeperStatusPill({ status }: { status: string }) {
-  const c = statusColor(status)
-  return html`
-    <span class="inline-flex items-center gap-1.5 py-1 px-3 rounded-full text-xs font-medium ${c.bg} ${c.text}">
-      <span class="size-2 rounded-full ${c.dot}"></span>
-      ${statusLabel(status)}
-    </span>
-  `
 }
 
 function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
@@ -295,7 +255,7 @@ export function KeeperDetailOverlay() {
             <div class="flex flex-col gap-0.5">
               <div class="flex items-center gap-2.5">
                 <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
-                <${KeeperStatusPill} status=${effectiveStatus} />
+                <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} />
                 ${(() => {
                   const series = keeper.metrics_series ?? []
                   const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
@@ -334,8 +294,17 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Body ── */}
         <div class="p-6 flex flex-col gap-6">
 
-        ${'' /* ── Pipeline stage indicator ── */}
+        ${'' /* ── Pipeline stage + Phase state diagram ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
+        <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]">
+          <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-[var(--accent)]/50"></span>
+            Phase State Machine
+          </summary>
+          <div class="px-4 pb-4 pt-1">
+            <${KeeperStateDiagramPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
+          </div>
+        </details>
 
         ${'' /* ── KPIs ── */}
         <${KpiGrid} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -298,7 +298,7 @@ export function KeeperDetailOverlay() {
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
         <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]">
           <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
-            <span class="w-1.5 h-1.5 rounded-full bg-[var(--accent)]/50"></span>
+            <span class="w-1.5 h-1.5 rounded-full bg-[rgba(71,184,255,0.5)]"></span>
             Phase State Machine
           </summary>
           <div class="px-4 pb-4 pt-1">

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -81,7 +81,7 @@ function KeeperRow({ keeper }: { keeper: Keeper }) {
     >
       ${'' /* Phase badge (lifecycle) + Stage badge (activity) */}
       <div class="flex-shrink-0">
-        <${KeeperPhaseBadge} phase=${keeper.phase} />
+        <${KeeperPhaseBadge} phase=${keeper.phase} compact />
       </div>
       <div
         class="flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider text-center w-12"

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { navigate } from '../router'
 import type { Keeper, PipelineStage } from '../types/core'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_FLEET_WARN } from '../config/constants'
+import { KeeperPhaseBadge } from './keeper-phase-indicator'
 
 // ── Pipeline stage styling ────────────────────────────
 
@@ -78,7 +79,10 @@ function KeeperRow({ keeper }: { keeper: Keeper }) {
       class="flex items-center gap-3 py-2 px-3 rounded-lg cursor-pointer hover:bg-[var(--white-5)] transition-colors ${isActive ? 'ring-1 ring-[var(--accent-30)]' : ''}"
       onClick=${() => navigate('monitoring', { section: 'agents', agent: keeper.name })}
     >
-      ${'' /* Stage badge */}
+      ${'' /* Phase badge (lifecycle) + Stage badge (activity) */}
+      <div class="flex-shrink-0">
+        <${KeeperPhaseBadge} phase=${keeper.phase} />
+      </div>
       <div
         class="flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider text-center w-12"
         style="color: ${stage.color}; background: ${stage.bg}; ${stage.pulse ? 'animation: loadingPulse 2s ease-in-out infinite;' : ''}"

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -10,22 +10,25 @@ interface PhaseStyle {
   color: string
   bg: string
   border: string
+  glow: string
   icon: string
 }
 
 const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
-  Offline:    { label: '오프라인',  color: '#6b7280', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.20)', icon: '⭘' },
-  Running:    { label: '실행중',    color: '#34d399', bg: 'rgba(52,211,153,0.10)',  border: 'rgba(52,211,153,0.25)',  icon: '●' },
-  Failing:    { label: '오류중',    color: '#f97316', bg: 'rgba(249,115,22,0.10)',  border: 'rgba(249,115,22,0.25)',  icon: '▲' },
-  Compacting: { label: '압축중',    color: '#a855f7', bg: 'rgba(168,85,247,0.10)',  border: 'rgba(168,85,247,0.25)',  icon: '◆' },
-  HandingOff: { label: '승계중',    color: '#f472b6', bg: 'rgba(244,114,182,0.10)', border: 'rgba(244,114,182,0.25)', icon: '↻' },
-  Draining:   { label: '종료중',    color: '#fb923c', bg: 'rgba(251,146,60,0.10)',  border: 'rgba(251,146,60,0.25)',  icon: '▽' },
-  Paused:     { label: '일시정지',  color: '#a78bfa', bg: 'rgba(167,139,250,0.10)', border: 'rgba(167,139,250,0.25)', icon: '❚❚' },
-  Stopped:    { label: '정지',      color: '#6b7280', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.25)', icon: '■' },
-  Crashed:    { label: '비정상종료', color: '#ef4444', bg: 'rgba(239,68,68,0.10)',  border: 'rgba(239,68,68,0.30)',   icon: '✕' },
-  Restarting: { label: '재시작중',  color: '#38bdf8', bg: 'rgba(56,189,248,0.10)',  border: 'rgba(56,189,248,0.25)',  icon: '↺' },
-  Dead:       { label: '종료',      color: '#4b5563', bg: 'rgba(75,85,99,0.08)',    border: 'rgba(75,85,99,0.20)',    icon: '✦' },
+  Offline:    { label: '오프라인',   color: '#6b7280', bg: 'rgba(107,114,128,0.08)', border: 'rgba(107,114,128,0.18)', glow: 'none',                             icon: '○' },
+  Running:    { label: '실행중',     color: '#34d399', bg: 'rgba(52,211,153,0.08)',  border: 'rgba(52,211,153,0.22)',  glow: '0 0 8px rgba(52,211,153,0.25)',    icon: '●' },
+  Failing:    { label: '오류중',     color: '#f97316', bg: 'rgba(249,115,22,0.08)',  border: 'rgba(249,115,22,0.22)',  glow: '0 0 8px rgba(249,115,22,0.25)',    icon: '▲' },
+  Compacting: { label: '압축중',     color: '#a855f7', bg: 'rgba(168,85,247,0.08)',  border: 'rgba(168,85,247,0.22)',  glow: '0 0 8px rgba(168,85,247,0.20)',    icon: '◆' },
+  HandingOff: { label: '승계중',     color: '#f472b6', bg: 'rgba(244,114,182,0.08)', border: 'rgba(244,114,182,0.22)', glow: '0 0 8px rgba(244,114,182,0.20)',   icon: '⟳' },
+  Draining:   { label: '종료중',     color: '#fb923c', bg: 'rgba(251,146,60,0.08)',  border: 'rgba(251,146,60,0.22)',  glow: '0 0 8px rgba(251,146,60,0.20)',    icon: '▽' },
+  Paused:     { label: '일시정지',   color: '#a78bfa', bg: 'rgba(167,139,250,0.08)', border: 'rgba(167,139,250,0.22)', glow: 'none',                             icon: '⏸' },
+  Stopped:    { label: '정지',       color: '#6b7280', bg: 'rgba(107,114,128,0.08)', border: 'rgba(107,114,128,0.22)', glow: 'none',                             icon: '■' },
+  Crashed:    { label: '비정상종료', color: '#ef4444', bg: 'rgba(239,68,68,0.10)',   border: 'rgba(239,68,68,0.28)',   glow: '0 0 10px rgba(239,68,68,0.30)',    icon: '✕' },
+  Restarting: { label: '재시작중',   color: '#38bdf8', bg: 'rgba(56,189,248,0.08)',  border: 'rgba(56,189,248,0.22)',  glow: '0 0 8px rgba(56,189,248,0.20)',    icon: '↺' },
+  Dead:       { label: '종료',       color: '#4b5563', bg: 'rgba(75,85,99,0.06)',    border: 'rgba(75,85,99,0.18)',    glow: 'none',                             icon: '✦' },
 }
+
+const BUFFER_PHASES = new Set<string>(['Failing', 'Compacting', 'HandingOff', 'Draining', 'Restarting'])
 
 function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
   if (!phase) return PHASE_STYLES.Offline
@@ -33,18 +36,20 @@ function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseSty
 }
 
 /** Phase badge — color-coded pill showing 11-state lifecycle phase. */
-export function KeeperPhaseBadge({ phase }: { phase?: KeeperPhase | string | null }) {
+export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | string | null; compact?: boolean }) {
   const style = getPhaseStyle(phase)
-  const isBuffer = phase === 'Failing' || phase === 'Compacting' || phase === 'HandingOff'
-    || phase === 'Draining' || phase === 'Restarting'
+  const isBuffer = BUFFER_PHASES.has(phase ?? '')
+  const size = compact ? 'px-1.5 py-px text-[9px]' : 'px-2 py-0.5 text-[10px]'
 
   return html`
     <span
-      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-semibold tracking-wide select-none"
-      style="color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border}; ${isBuffer ? 'animation: loadingPulse 2.5s ease-in-out infinite;' : ''}"
+      class="inline-flex items-center gap-1 rounded-md font-semibold tracking-wide select-none transition-all duration-300 ${size}"
+      style="color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border}; box-shadow: ${style.glow}; ${isBuffer ? 'animation: loadingPulse 2.5s ease-in-out infinite;' : ''}"
       title="Phase: ${phase ?? 'unknown'} — ${style.label}"
+      role="status"
+      aria-label="${style.label}"
     >
-      <span class="text-[8px] leading-none">${style.icon}</span>
+      <span class="text-[8px] leading-none" aria-hidden="true">${style.icon}</span>
       ${style.label}
     </span>
   `
@@ -59,14 +64,14 @@ export function KeeperPhaseAndStage({
   pipelineStage?: string | null
 }) {
   const stageLabel = pipelineStage && pipelineStage !== 'idle' && pipelineStage !== 'offline'
-    ? pipelineStage
+    ? pipelineStage.replace('_', ' ')
     : null
 
   return html`
     <div class="flex items-center gap-2">
       <${KeeperPhaseBadge} phase=${phase} />
       ${stageLabel ? html`
-        <span class="text-[9px] text-[var(--text-dim)] font-mono">[${stageLabel}]</span>
+        <span class="text-[9px] text-[var(--text-dim)] font-mono tracking-tight opacity-70">${stageLabel}</span>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -1,0 +1,75 @@
+// Keeper phase indicator — shows the 11-state lifecycle phase
+// as a color-coded badge with Korean label.
+// Phase = lifecycle health (생명주기), complementary to pipeline_stage (활동).
+
+import { html } from 'htm/preact'
+import type { KeeperPhase } from '../types'
+
+interface PhaseStyle {
+  label: string
+  color: string
+  bg: string
+  border: string
+  icon: string
+}
+
+const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
+  Offline:    { label: '오프라인',  color: '#6b7280', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.20)', icon: '⭘' },
+  Running:    { label: '실행중',    color: '#34d399', bg: 'rgba(52,211,153,0.10)',  border: 'rgba(52,211,153,0.25)',  icon: '●' },
+  Failing:    { label: '오류중',    color: '#f97316', bg: 'rgba(249,115,22,0.10)',  border: 'rgba(249,115,22,0.25)',  icon: '▲' },
+  Compacting: { label: '압축중',    color: '#a855f7', bg: 'rgba(168,85,247,0.10)',  border: 'rgba(168,85,247,0.25)',  icon: '◆' },
+  HandingOff: { label: '승계중',    color: '#f472b6', bg: 'rgba(244,114,182,0.10)', border: 'rgba(244,114,182,0.25)', icon: '↻' },
+  Draining:   { label: '종료중',    color: '#fb923c', bg: 'rgba(251,146,60,0.10)',  border: 'rgba(251,146,60,0.25)',  icon: '▽' },
+  Paused:     { label: '일시정지',  color: '#a78bfa', bg: 'rgba(167,139,250,0.10)', border: 'rgba(167,139,250,0.25)', icon: '❚❚' },
+  Stopped:    { label: '정지',      color: '#6b7280', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.25)', icon: '■' },
+  Crashed:    { label: '비정상종료', color: '#ef4444', bg: 'rgba(239,68,68,0.10)',  border: 'rgba(239,68,68,0.30)',   icon: '✕' },
+  Restarting: { label: '재시작중',  color: '#38bdf8', bg: 'rgba(56,189,248,0.10)',  border: 'rgba(56,189,248,0.25)',  icon: '↺' },
+  Dead:       { label: '종료',      color: '#4b5563', bg: 'rgba(75,85,99,0.08)',    border: 'rgba(75,85,99,0.20)',    icon: '✦' },
+}
+
+function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
+  if (!phase) return PHASE_STYLES.Offline
+  return PHASE_STYLES[phase as KeeperPhase] ?? PHASE_STYLES.Offline
+}
+
+/** Phase badge — color-coded pill showing 11-state lifecycle phase. */
+export function KeeperPhaseBadge({ phase }: { phase?: KeeperPhase | string | null }) {
+  const style = getPhaseStyle(phase)
+  const isBuffer = phase === 'Failing' || phase === 'Compacting' || phase === 'HandingOff'
+    || phase === 'Draining' || phase === 'Restarting'
+
+  return html`
+    <span
+      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-semibold tracking-wide select-none"
+      style="color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border}; ${isBuffer ? 'animation: loadingPulse 2.5s ease-in-out infinite;' : ''}"
+      title="Phase: ${phase ?? 'unknown'} — ${style.label}"
+    >
+      <span class="text-[8px] leading-none">${style.icon}</span>
+      ${style.label}
+    </span>
+  `
+}
+
+/** Dual indicator showing both phase (lifecycle) and pipeline_stage (activity). */
+export function KeeperPhaseAndStage({
+  phase,
+  pipelineStage,
+}: {
+  phase?: KeeperPhase | string | null
+  pipelineStage?: string | null
+}) {
+  const stageLabel = pipelineStage && pipelineStage !== 'idle' && pipelineStage !== 'offline'
+    ? pipelineStage
+    : null
+
+  return html`
+    <div class="flex items-center gap-2">
+      <${KeeperPhaseBadge} phase=${phase} />
+      ${stageLabel ? html`
+        <span class="text-[9px] text-[var(--text-dim)] font-mono">[${stageLabel}]</span>
+      ` : null}
+    </div>
+  `
+}
+
+export { PHASE_STYLES, getPhaseStyle }

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -36,12 +36,13 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       })
 
     return () => { cancelled = true }
-  }, [keeperName, currentPhase])
+  }, [keeperName])
 
   if (loading) {
     return html`
-      <div class="flex items-center justify-center py-8 text-[11px] text-[var(--text-dim)]">
-        상태 다이어그램 로딩중...
+      <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
+        <span class="inline-block w-3 h-3 rounded-full border-2 border-[var(--accent)] border-t-transparent" style="animation: spin 0.8s linear infinite;"></span>
+        상태 다이어그램 로딩중
       </div>
     `
   }
@@ -51,19 +52,17 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
   }
 
   return html`
-    <div class="space-y-2">
-      <div class="flex items-center gap-2">
-        <span class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
-          Phase State Machine
-        </span>
-        ${currentPhase ? html`
-          <span class="text-[10px] font-mono text-[var(--accent)]">${currentPhase}</span>
-        ` : null}
-      </div>
+    <div>
+      ${currentPhase ? html`
+        <div class="mb-2 text-[10px] text-[var(--text-dim)]">
+          현재 phase: <span class="font-mono font-medium text-[var(--accent)]">${currentPhase}</span>
+        </div>
+      ` : null}
       <${MermaidGraph}
         source=${mermaid}
         prefix="keeper-state-diagram"
-        diagramClass="[&_svg]:max-w-full"
+        diagramClass="[&_svg]:max-w-full [&_svg]:mx-auto"
+        minHeightClass="min-h-[120px]"
       />
     </div>
   `

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -1,0 +1,70 @@
+// Keeper state diagram panel — fetches and renders per-keeper
+// Mermaid stateDiagram-v2 showing the 11-state lifecycle
+// with current phase highlighted.
+
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { fetchKeeperStateDiagram } from '../api/keeper'
+import { MermaidGraph } from './common/mermaid-graph'
+import { EmptyState } from './common/empty-state'
+
+interface KeeperStateDiagramProps {
+  keeperName: string
+  currentPhase?: string | null
+}
+
+export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
+  const [mermaid, setMermaid] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    fetchKeeperStateDiagram(keeperName)
+      .then(resp => {
+        if (cancelled) return
+        setMermaid(resp.mermaid)
+        setLoading(false)
+      })
+      .catch(err => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'state diagram fetch failed')
+        setLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [keeperName, currentPhase])
+
+  if (loading) {
+    return html`
+      <div class="flex items-center justify-center py-8 text-[11px] text-[var(--text-dim)]">
+        상태 다이어그램 로딩중...
+      </div>
+    `
+  }
+
+  if (error || !mermaid) {
+    return html`<${EmptyState} message=${error ?? '다이어그램 없음'} compact />`
+  }
+
+  return html`
+    <div class="space-y-2">
+      <div class="flex items-center gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+          Phase State Machine
+        </span>
+        ${currentPhase ? html`
+          <span class="text-[10px] font-mono text-[var(--accent)]">${currentPhase}</span>
+        ` : null}
+      </div>
+      <${MermaidGraph}
+        source=${mermaid}
+        prefix="keeper-state-diagram"
+        diagramClass="[&_svg]:max-w-full"
+      />
+    </div>
+  `
+}

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -10,6 +10,16 @@ import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 
+const VALID_PHASES = new Set<string>([
+  'Offline', 'Running', 'Failing', 'Compacting', 'HandingOff',
+  'Draining', 'Paused', 'Stopped', 'Crashed', 'Restarting', 'Dead',
+])
+
+function toKeeperPhase(raw: string | null | undefined): KeeperPhase | null {
+  if (!raw || !VALID_PHASES.has(raw)) return null
+  return raw as KeeperPhase
+}
+
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
   if (
@@ -229,7 +239,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         name,
         runtime_class: 'keeper' as const,
         pipeline_stage: (asString(row.pipeline_stage) ?? 'idle') as PipelineStage,
-        phase: (asString(row.phase) ?? null) as KeeperPhase | null,
+        phase: toKeeperPhase(asString(row.phase)),
         paused: asBoolean(row.paused),
         registered:
           typeof row.registered === 'boolean' ? row.registered : undefined,

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -2,6 +2,7 @@ import type {
   Keeper,
   KeeperLifecycleState,
   KeeperMetricPoint,
+  KeeperPhase,
   PipelineStage,
 } from './types'
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
@@ -228,6 +229,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         name,
         runtime_class: 'keeper' as const,
         pipeline_stage: (asString(row.pipeline_stage) ?? 'idle') as PipelineStage,
+        phase: (asString(row.phase) ?? null) as KeeperPhase | null,
         paused: asBoolean(row.paused),
         registered:
           typeof row.registered === 'boolean' ? row.registered : undefined,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -514,9 +514,23 @@ export interface MetricsWindow {
   [key: string]: unknown
 }
 
+export type KeeperPhase =
+  | 'Offline'
+  | 'Running'
+  | 'Failing'
+  | 'Compacting'
+  | 'HandingOff'
+  | 'Draining'
+  | 'Paused'
+  | 'Stopped'
+  | 'Crashed'
+  | 'Restarting'
+  | 'Dead'
+
 export interface Keeper {
   name: string
   pipeline_stage?: PipelineStage
+  phase?: KeeperPhase | null
   runtime_class?: 'keeper'
   paused?: boolean
   registered?: boolean


### PR DESCRIPTION
## Summary
- Keeper마다 11-state lifecycle phase를 색상 배지로 표시 (Running/Failing/Compacting/HandingOff/Draining 등)
- Keeper detail에서 Mermaid state machine 다이어그램을 접이식 패널로 렌더링 (기존 `/api/v1/keepers/{name}/state-diagram` endpoint 활용)
- Fleet overview에 phase 배지 추가 (pipeline_stage 배지와 나란히 표시)
- 기존 KeeperStatusPill (5-state 기반 heuristic) 제거 → KeeperPhaseAndStage (11-state + pipeline_stage dual) 로 교체

## 변경 파일
| 파일 | 변경 |
|------|------|
| `types/core.ts` | `KeeperPhase` 타입 + `Keeper.phase` 필드 추가 |
| `keeper-store-normalize.ts` | API 응답에서 `phase` 파싱 |
| `keeper-phase-indicator.ts` | Phase 배지 + dual indicator 컴포넌트 (NEW) |
| `keeper-state-diagram.ts` | Mermaid state diagram 패널 (NEW) |
| `keeper-detail.ts` | Phase 표시 + state diagram 패널 통합, StatusPill 제거 |
| `keeper-fleet-overview.ts` | Phase 배지 추가 |

## 설계 근거
Phase (lifecycle health)와 pipeline_stage (current activity)는 직교하는 두 축:
- **Phase**: 살아있나? (Offline → Running → Failing → Crashed → Dead)
- **Pipeline stage**: 뭘 하고 있나? (idle → thinking → tool_use → compacting)

둘 다 표시해야 keeper 상태를 정확히 파악할 수 있다.

## Test plan
- [ ] TypeScript type check 통과 (tsc --noEmit)
- [ ] Vite build 성공
- [ ] Keeper detail 열었을 때 Phase badge 표시 확인
- [ ] Phase State Machine details 열었을 때 Mermaid 렌더링 확인
- [ ] Fleet overview에서 각 keeper phase badge 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)