### PR TITLE
feat(keeper): per-keeper provider filter via allowed_providers

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -140,7 +140,10 @@ let keeper_action_kind_of_tool_names tool_names =
 
 
 let effective_model_labels_for_turn (m : keeper_meta) : string list =
-  let configured = Oas_model_resolve.models_of_cascade_name m.cascade_name in
+  let configured =
+    Oas_model_resolve.models_of_cascade_name m.cascade_name
+    |> Oas_model_resolve.filter_by_providers m.allowed_providers
+  in
   let configured_ids =
     try
       Llm_provider.Cascade_config.parse_model_strings configured

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -244,6 +244,7 @@ let write_heartbeat_snapshot
   let metrics_store = keeper_metrics_store ctx.config meta_current.name in
   let cascade_models =
     Oas_model_resolve.models_of_cascade_name meta_current.cascade_name
+    |> Oas_model_resolve.filter_by_providers meta_current.allowed_providers
   in
   let max_cascade_context =
     let min_keeper_context = 65_536 in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -32,7 +32,10 @@ let resolved_model_id_for_result ~(meta : keeper_meta)
     else s
   in
   let used = strip_latest result.model_used in
-  let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
+  let cascade_models =
+    Oas_model_resolve.models_of_cascade_name meta.cascade_name
+    |> Oas_model_resolve.filter_by_providers meta.allowed_providers
+  in
   let cfgs = Llm_provider.Cascade_config.parse_model_strings cascade_models in
   match
     List.find_opt
@@ -166,6 +169,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let effective_models =
         if direct_reply then
           Oas_model_resolve.models_of_cascade_name turn_cascade_name
+          |> Oas_model_resolve.filter_by_providers meta.allowed_providers
         else
           effective_model_labels_for_turn meta
       in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -189,7 +189,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ~fallback_message:env_message_gate
         ~fallback_token:env_token_gate
     in
-    let cascade_models = Oas_model_resolve.models_of_cascade_name Keeper_config.default_cascade_name in
+    let cascade_models =
+      Oas_model_resolve.models_of_cascade_name Keeper_config.default_cascade_name
+      |> Oas_model_resolve.filter_by_providers p.profile_defaults.allowed_providers
+    in
     ignore (Oas_model_resolve.refresh_local_discovery_if_possible cascade_models);
     let primary_max_context =
       match p.max_context_override_opt with
@@ -284,6 +287,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         work_discovery_guidance = p.profile_defaults.work_discovery_guidance;
         telemetry_feedback_enabled = p.profile_defaults.telemetry_feedback_enabled;
         telemetry_feedback_window_hours = p.profile_defaults.telemetry_feedback_window_hours;
+        allowed_providers = p.profile_defaults.allowed_providers;
         runtime = {
           usage = {
             total_turns = 0;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -169,6 +169,7 @@ type keeper_meta =
   ; work_discovery_guidance : string option
   ; telemetry_feedback_enabled : bool option
   ; telemetry_feedback_window_hours : int option
+  ; allowed_providers : string list option
   ; (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
     runtime : agent_runtime_state
   }
@@ -633,6 +634,10 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "work_discovery_guidance", Json_util.string_opt_to_json m.work_discovery_guidance
     ; "telemetry_feedback_enabled", Json_util.bool_opt_to_json m.telemetry_feedback_enabled
     ; "telemetry_feedback_window_hours", Json_util.int_opt_to_json m.telemetry_feedback_window_hours
+    ; "allowed_providers"
+      , (match m.allowed_providers with
+         | Some xs -> `List (List.map (fun s -> `String s) xs)
+         | None -> `Null)
     ]
 ;;
 
@@ -1115,6 +1120,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; work_discovery_guidance = Safe_ops.json_string_opt "work_discovery_guidance" json
              ; telemetry_feedback_enabled = Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
              ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
+             ; allowed_providers =
+                 (match Safe_ops.json_string_list "allowed_providers" json with
+                  | [] -> None
+                  | xs -> Some (List.map String.lowercase_ascii xs))
              ; runtime = state.ps_runtime
              })
   with
@@ -1218,6 +1227,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "work_discovery_guidance"
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
+  ; "allowed_providers"
   ]
 ;;
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -167,6 +167,7 @@ type keeper_meta = {
   work_discovery_guidance : string option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  allowed_providers : string list option;
   runtime: agent_runtime_state;
 }
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -151,6 +151,7 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  allowed_providers : string list option;
 }
 
 type persona_summary = {
@@ -192,6 +193,7 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
+  allowed_providers = None;
 }
 
 let personas_root_opt () =
@@ -313,6 +315,10 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         work_discovery_guidance = str "work_discovery_guidance";
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
+        allowed_providers =
+          (match strs "allowed_providers" with
+           | [] -> None
+           | xs -> Some (List.map String.lowercase_ascii xs));
       })
     result
 
@@ -438,6 +444,10 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
+                allowed_providers =
+                  (match Safe_ops.json_string_list "allowed_providers" keeper_json with
+                   | [] -> None
+                   | xs -> Some (List.map String.lowercase_ascii xs));
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -265,7 +265,10 @@ let board_signal_match
 (** Read context ratio from checkpoint if available. *)
 let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
   try
-    let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
+    let cascade_models =
+      Oas_model_resolve.models_of_cascade_name meta.cascade_name
+      |> Oas_model_resolve.filter_by_providers meta.allowed_providers
+    in
     let primary_max_context =
       Oas_model_resolve.resolve_max_cascade_context cascade_models
     in
@@ -287,7 +290,10 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
 let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
     : string =
   try
-    let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
+    let cascade_models =
+      Oas_model_resolve.models_of_cascade_name meta.cascade_name
+      |> Oas_model_resolve.filter_by_providers meta.allowed_providers
+    in
     let primary_max_context =
       Oas_model_resolve.resolve_max_cascade_context cascade_models
     in

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -276,3 +276,18 @@ let models_of_cascade_name (cascade_name : string) : string list =
       "cascade config resolve failed for %s, using defaults: %s"
       cascade_name (Printexc.to_string exn);
     defaults
+
+let filter_by_providers (allowed : string list option) (models : string list)
+    : string list =
+  match allowed with
+  | None | Some [] -> models
+  | Some providers ->
+    let filtered =
+      List.filter
+        (fun label ->
+          match provider_name_of_label label with
+          | Some pname -> List.mem pname providers
+          | None -> false)
+        models
+    in
+    if filtered = [] then models else filtered

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -651,6 +651,65 @@ let with_personas_dir f =
       Masc_mcp.Config_dir_resolver.reset ();
       f personas_dir)
 
+let test_filter_by_providers_none () =
+  let models = [ "glm:auto"; "ollama:auto" ] in
+  let result = Masc_mcp.Oas_model_resolve.filter_by_providers None models in
+  check (list string) "None returns all" models result
+
+let test_filter_by_providers_empty () =
+  let models = [ "glm:auto"; "ollama:auto" ] in
+  let result = Masc_mcp.Oas_model_resolve.filter_by_providers (Some []) models in
+  check (list string) "empty list returns all" models result
+
+let test_filter_by_providers_single () =
+  let result =
+    Masc_mcp.Oas_model_resolve.filter_by_providers
+      (Some [ "ollama" ]) [ "glm:auto"; "ollama:auto" ]
+  in
+  check (list string) "single match" [ "ollama:auto" ] result
+
+let test_filter_by_providers_no_match () =
+  let models = [ "glm:auto"; "ollama:auto" ] in
+  let result =
+    Masc_mcp.Oas_model_resolve.filter_by_providers (Some [ "nonexistent" ]) models
+  in
+  check (list string) "no match falls back to all" models result
+
+let test_filter_by_providers_multi () =
+  let result =
+    Masc_mcp.Oas_model_resolve.filter_by_providers
+      (Some [ "glm"; "ollama" ]) [ "glm:auto"; "ollama:auto"; "claude:opus" ]
+  in
+  check (list string) "multi match" [ "glm:auto"; "ollama:auto" ] result
+
+let test_profile_allowed_providers () =
+  let input = {|
+[keeper]
+goal = "test"
+allowed_providers = ["Ollama", "GLM"]
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option (list string)) "lowercased"
+         (Some [ "ollama"; "glm" ]) d.allowed_providers)
+
+let test_profile_allowed_providers_absent () =
+  let input = {|
+[keeper]
+goal = "test"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option (list string)) "absent" None d.allowed_providers)
+
 let test_persona_resolver_defaults_to_research_tool_preset () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
@@ -745,6 +804,18 @@ let () =
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick
             test_profile_rejects_removed_initiative_keys;
+          test_case "allowed_providers parsed" `Quick
+            test_profile_allowed_providers;
+          test_case "allowed_providers absent" `Quick
+            test_profile_allowed_providers_absent;
+        ] );
+      ( "filter_by_providers",
+        [
+          test_case "None returns all" `Quick test_filter_by_providers_none;
+          test_case "empty returns all" `Quick test_filter_by_providers_empty;
+          test_case "single match" `Quick test_filter_by_providers_single;
+          test_case "no match falls back" `Quick test_filter_by_providers_no_match;
+          test_case "multi match" `Quick test_filter_by_providers_multi;
         ] );
       ( "file_loading",
         [


### PR DESCRIPTION
## Summary
- keeper TOML에 `allowed_providers = ["ollama"]` 추가로 해당 keeper가 cascade에서 특정 provider만 사용
- cascade.json (OAS) → 전체 inventory 유지, MASC 레이어에서 필터링
- `filter_by_providers`: empty-safe, no-match fallback to full list
- 실행 경로 7곳 필터 적용, 표시/진단 13곳은 의도적 미적용 (운영자 가시성)

## Product impact
- keeper별로 다른 LLM provider를 지정할 수 있어 Ollama/GLM 혼용 환경에서 특정 keeper만 Ollama 전용으로 운영 가능
- cascade.json 전체 inventory는 유지되므로 다른 keeper에 영향 없음

## Architecture
```
cascade.json ["glm:auto", "ollama:auto"]  ← OAS 소유
         ↓
models_of_cascade_name()  → full list
         ↓
filter_by_providers(meta.allowed_providers)  ← MASC 필터
         ↓
OAS cascade 실행
```

## Evidence
- `test_keeper_toml.exe` 56 tests 통과 (filter 5 + profile 2 새 테스트 포함)
- `dune build` 컴파일 성공
- 기존 test suite 전체 통과 (105 suites)

## Review evidence
- 실행 경로 vs 표시 경로 분리: 7곳만 필터, 13곳 미적용 (운영자 가시성 보존)
- safety fallback: filter 결과가 빈 리스트면 전체 cascade로 fallback

## Usage
```toml
# config/keepers/cheolsu.toml
[keeper]
allowed_providers = ["ollama"]  # only use Ollama, skip GLM
```

## Linked issue
Refs: cascade 정상화 Phase 10에서 파생된 per-keeper provider selection 요구

## Test plan
- [x] `dune build --root .` 통과
- [x] `test_keeper_toml.exe` 56 tests 통과
- [ ] cheolsu.toml에 `allowed_providers = ["ollama"]` 설정 후 Ollama 단독 실행 E2E 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)