### PR TITLE
feat(dashboard): expose output validation stats in tool-quality endpoint

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -14,8 +14,8 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
   else
   let total = ref 0 in
   let success = ref 0 in
-  (* tool -> (calls, successes, total_ms) *)
-  let tool_stats : (string, int ref * int ref * float ref) Hashtbl.t =
+  (* tool -> (calls, successes, total_ms, truncated_count, total_output_chars) *)
+  let tool_stats : (string, int ref * int ref * float ref * int ref * int ref) Hashtbl.t =
     Hashtbl.create 64
   in
   (* keeper -> (calls, successes) *)
@@ -48,16 +48,33 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
          | _ -> 0.0)
       | _ -> 0.0
     in
+    let output_chars = match record with
+      | `Assoc fields ->
+        (match List.assoc_opt "result_bytes" fields with
+         | Some (`Int i) -> i
+         | _ ->
+           (* Fallback: use output string length for old entries *)
+           (match List.assoc_opt "output" fields with
+            | Some (`String s) -> String.length s
+            | _ -> 0))
+      | _ -> 0
+    in
+    let was_truncated = match record with
+      | `Assoc fields -> List.assoc_opt "truncated_to" fields <> None
+      | _ -> false
+    in
     if ok then incr success;
     (* tool stats *)
-    let (tc, ts, td) =
+    let (tc, ts, td, ttrunc, tochars) =
       match Hashtbl.find_opt tool_stats tool with
       | Some v -> v
       | None ->
-        let v = (ref 0, ref 0, ref 0.0) in
+        let v = (ref 0, ref 0, ref 0.0, ref 0, ref 0) in
         Hashtbl.replace tool_stats tool v; v
     in
     incr tc; if ok then incr ts; td := !td +. dur;
+    tochars := !tochars + output_chars;
+    if was_truncated then incr ttrunc;
     (* keeper stats *)
     let (kc, ks) =
       match Hashtbl.find_opt keeper_stats keeper with
@@ -109,7 +126,7 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
   in
   (* Sort by call count descending *)
   let by_tool =
-    Hashtbl.fold (fun name (c, s, d) acc ->
+    Hashtbl.fold (fun name (c, s, d, ttrunc, tochars) acc ->
       let calls = !c in
       let successes = !s in
       let avg_ms = if calls > 0 then !d /. Float.of_int calls else 0.0 in
@@ -117,11 +134,17 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
         then Float.of_int successes /. Float.of_int calls *. 100.0
         else 0.0
       in
+      let avg_output = if calls > 0
+        then Float.of_int !tochars /. Float.of_int calls
+        else 0.0
+      in
       (calls, `Assoc [
         ("name", `String name);
         ("calls", `Int calls);
         ("success_pct", `Float pct);
         ("avg_ms", `Float (Float.round (avg_ms *. 10.0) /. 10.0));
+        ("output_truncated_count", `Int !ttrunc);
+        ("avg_output_chars", `Float (Float.round (avg_output *. 10.0) /. 10.0));
       ]) :: acc
     ) tool_stats []
     |> List.sort (fun (a, _) (b, _) -> Int.compare b a)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -373,7 +373,8 @@ let make_hooks
              ~keeper_name:(!meta_ref).name
              ~tool_name ~input ~output_text
              ~success:(outcome = "ok") ~duration_ms
-             ~model:(!meta_ref).runtime.usage.last_model_used ()
+             ~model:(!meta_ref).runtime.usage.last_model_used
+             ~result_bytes:out_len ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (* Boring-tool gate: mark turn as productive only for genuinely
            productive tools. keeper_stay_silent is in the boring set. *)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -39,7 +39,7 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
-    ?(model : string = "") () =
+    ?(model : string = "") ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
@@ -47,6 +47,14 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     | Some store ->
       let model_field =
         if model = "" then [] else [("model", `String model)]
+      in
+      let result_bytes_field = match result_bytes with
+        | Some n -> [("result_bytes", `Int n)]
+        | None -> []
+      in
+      let truncated_to_field = match truncated_to with
+        | Some n -> [("truncated_to", `Int n)]
+        | None -> []
       in
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
@@ -59,7 +67,7 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           ; ("output", `String safe_output)
           ; ("success", `Bool success)
           ; ("duration_ms", `Float duration_ms)
-          ] @ model_field)
+          ] @ model_field @ result_bytes_field @ truncated_to_field)
       in
       (try Dated_jsonl.append store json
        with exn ->

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -16,11 +16,15 @@ val log_call :
   success:bool ->
   duration_ms:float ->
   ?model:string ->
+  ?result_bytes:int ->
+  ?truncated_to:int ->
   unit ->
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
     Output is truncated to 4000 bytes. [model] records which LLM generated
-    the tool call (for 9B vs GLM comparison). Best-effort (failures logged). *)
+    the tool call (for 9B vs GLM comparison). [result_bytes] is the original
+    output size before any truncation. [truncated_to] is present when
+    Tool_output_validation truncated the output. Best-effort (failures logged). *)
 
 val read_recent :
   ?keeper_name:string ->


### PR DESCRIPTION
## Summary
- Add `output_truncated_count` and `avg_output_chars` fields to per-tool stats in the `/api/tool-quality` dashboard endpoint
- Extend `Keeper_tool_call_log.log_call` with optional `result_bytes` and `truncated_to` params, written to JSONL entries when provided
- Wire `result_bytes` from the `post_tool_use` hook in `keeper_hooks_oas.ml`
- Dashboard falls back to `output` string length for older entries missing `result_bytes`

## Test plan
- [ ] Verify `dune build` passes (confirmed locally)
- [ ] Check `/api/tool-quality` endpoint returns new fields (`output_truncated_count`, `avg_output_chars`) per tool
- [ ] Confirm backward compatibility: old JSONL entries without `result_bytes`/`truncated_to` produce `output_truncated_count: 0` and `avg_output_chars` based on `output` string length

🤖 Generated with [Claude Code](https://claude.com/claude-code)