### PR TITLE
fix(keeper): eliminate AllowList pruning WARN and agent JSON race condition

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -301,8 +301,12 @@ let handle_heartbeat
                   tm.tm_hour tm.tm_min tm.tm_sec
               in
               let updated = { agent with Types.last_seen = iso_now } in
-              Fs_compat.save_file agent_file
-                (Yojson.Safe.to_string (Types.agent_to_yojson updated))
+              let content =
+                Yojson.Safe.to_string (Types.agent_to_yojson updated)
+              in
+              let tmp_path = agent_file ^ ".tmp" in
+              Fs_compat.save_file tmp_path content;
+              Unix.rename tmp_path agent_file
             | Error e ->
                 Log.Transport.warn "gRPC heartbeat: invalid agent JSON for %s: %s"
                   ping.agent_name e

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1078,7 +1078,10 @@ let run_turn
            When LLM rerank is disabled, only tools explicitly discovered
            via keeper_tool_search appear alongside core. *)
               let effective_selected =
-                let core = Keeper_exec_tools.effective_core_tools () in
+                let core =
+                  Keeper_exec_tools.effective_core_tools ()
+                  |> List.filter (fun name -> Hashtbl.mem allowed_exec_set name)
+                in
                 let discovered =
                   Keeper_discovered_tools.active_names !discovered_ref ~turn
                 in

--- a/test/dune
+++ b/test/dune
@@ -98,7 +98,8 @@
         test_tool_prefilter
         test_keeper_state_machine
         test_telemetry_unified
-        test_keeper_topk_llm)
+        test_keeper_topk_llm
+        test_warn_root_causes)
  (modules test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -164,7 +165,8 @@
           test_tool_prefilter
           test_keeper_state_machine
           test_telemetry_unified
-          test_keeper_topk_llm)
+          test_keeper_topk_llm
+          test_warn_root_causes)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -1,0 +1,173 @@
+(** Harness tests for WARN root cause fixes.
+
+    1. AllowList pruning: core_discovery_tools filtered by preset
+    2. Atomic agent JSON writes: no empty-file race condition *)
+
+open Alcotest
+open Masc_mcp
+
+(* ── Helpers ──────────────────────────────────────────────────── *)
+
+let init_registry () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  let base_path = Masc_test_deps.find_project_root () in
+  Keeper_tool_policy.init_policy_config ~base_path
+
+let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+    (`Assoc [("name", `String name); ("agent_name", `String name);
+             ("trace_id", `String "test-trace-warn")]) with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
+
+(** Build the allowed_exec_set exactly as keeper_agent_run.ml does:
+    preset-allowed names + core_always_tools. *)
+let build_allowed_exec_set (meta : Keeper_types.keeper_meta) =
+  let allowed_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let set = Keeper_tool_policy.tool_name_set allowed_names in
+  List.iter
+    (fun name -> Hashtbl.replace set name ())
+    Keeper_tool_registry.core_always_tools;
+  set
+
+(** Filter core_discovery_tools by preset (the fix). *)
+let filter_core_by_preset (meta : Keeper_types.keeper_meta) =
+  let allowed_set = build_allowed_exec_set meta in
+  List.filter
+    (fun name -> Hashtbl.mem allowed_set name)
+    Keeper_tool_registry.core_discovery_tools
+
+(* Write/VCS tools that require coding/delivery/full presets *)
+let write_vcs_tools =
+  [ "keeper_fs_edit"; "keeper_pr_workflow"; "keeper_github" ]
+
+(* ── Test 1: Core discovery tools respect preset ──────────────── *)
+
+let test_core_tools_filtered_by_research_preset () =
+  init_registry ();
+  let meta =
+    { (make_meta ~name:"test-research" ()) with
+      tool_access = Preset { preset = Research; also_allow = [] };
+      tool_denylist = [] }
+  in
+  (* Precondition: write/VCS tools ARE in unfiltered core *)
+  List.iter (fun t ->
+    if not (List.mem t Keeper_tool_registry.core_discovery_tools) then
+      fail (Printf.sprintf "precondition: %s missing from core_discovery_tools" t)
+  ) write_vcs_tools;
+  let filtered = filter_core_by_preset meta in
+  (* Write/VCS tools must NOT survive preset filter *)
+  List.iter (fun t ->
+    if List.mem t filtered then
+      fail (Printf.sprintf "%s should be excluded for research preset" t)
+  ) write_vcs_tools;
+  (* Core always-tools must survive *)
+  List.iter (fun t ->
+    if not (List.mem t filtered) then
+      fail (Printf.sprintf "core_always %s must survive preset filter" t)
+  ) Keeper_tool_registry.core_always_tools
+
+let test_core_tools_filtered_by_social_preset () =
+  init_registry ();
+  let meta =
+    { (make_meta ~name:"test-social" ()) with
+      tool_access = Preset { preset = Social; also_allow = [] };
+      tool_denylist = [] }
+  in
+  let filtered = filter_core_by_preset meta in
+  if List.mem "keeper_fs_edit" filtered then
+    fail "keeper_fs_edit should be excluded for social preset"
+
+let test_core_tools_include_write_for_coding_preset () =
+  init_registry ();
+  let meta =
+    { (make_meta ~name:"test-coding" ()) with
+      tool_access = Preset { preset = Coding; also_allow = [] };
+      tool_denylist = [] }
+  in
+  let filtered = filter_core_by_preset meta in
+  List.iter (fun t ->
+    if not (List.mem t filtered) then
+      fail (Printf.sprintf "%s should be included for coding preset" t)
+  ) write_vcs_tools
+
+(* ── Test 2: Atomic agent JSON writes ─────────────────────────── *)
+
+let test_atomic_write_not_empty () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_atomic_%d" (Random.int 1_000_000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat dir "test_agent.json" in
+  let json =
+    `Assoc [ ("name", `String "test"); ("status", `String "ok") ]
+  in
+  Room_utils.write_json_local path json;
+  let content = Fs_compat.load_file path in
+  check bool "file not empty after atomic write" true
+    (String.length content > 0);
+  let parsed = Yojson.Safe.from_string content in
+  check string "name field" "test"
+    (Yojson.Safe.Util.member "name" parsed |> Yojson.Safe.Util.to_string);
+  (* Verify .tmp is cleaned up *)
+  check bool "no leftover .tmp" false (Sys.file_exists (path ^ ".tmp"));
+  (try Unix.unlink path with _ -> ());
+  (try Unix.rmdir dir with _ -> ())
+
+(** Concurrent writes via atomic pattern must never produce empty reads. *)
+let test_concurrent_atomic_writes_never_empty () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_concurrent_%d" (Random.int 1_000_000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat dir "agent.json" in
+  (* Seed with initial content *)
+  Room_utils.write_json_local path
+    (`Assoc [ ("name", `String "init") ]);
+  let empty_seen = ref false in
+  let iterations = 200 in
+  Eio.Switch.run @@ fun sw ->
+  (* Writer fiber: rapidly update the file *)
+  Eio.Fiber.fork ~sw (fun () ->
+    for i = 1 to iterations do
+      let json =
+        `Assoc [ ("name", `String (Printf.sprintf "v%d" i)) ]
+      in
+      Room_utils.write_json_local path json
+    done);
+  (* Reader fiber: read concurrently *)
+  Eio.Fiber.fork ~sw (fun () ->
+    for _ = 1 to iterations do
+      (try
+         let content = Fs_compat.load_file path in
+         if String.trim content = "" then empty_seen := true
+       with _ -> ())
+    done);
+  check bool "concurrent reads never see empty file" false !empty_seen;
+  (try Unix.unlink path with _ -> ());
+  (try Unix.rmdir dir with _ -> ())
+
+(* ── Runner ───────────────────────────────────────────────────── *)
+
+let () =
+  run "Warn_root_causes"
+    [
+      ( "allowlist_preset_filter",
+        [
+          test_case "research preset excludes write/VCS tools" `Quick
+            test_core_tools_filtered_by_research_preset;
+          test_case "social preset excludes write/VCS tools" `Quick
+            test_core_tools_filtered_by_social_preset;
+          test_case "coding preset includes write/VCS tools" `Quick
+            test_core_tools_include_write_for_coding_preset;
+        ] );
+      ( "atomic_agent_json",
+        [
+          test_case "atomic write produces non-empty file" `Quick
+            test_atomic_write_not_empty;
+          test_case "concurrent writes never produce empty reads" `Quick
+            test_concurrent_atomic_writes_never_empty;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- **AllowList pruning WARN 제거**: `core_discovery_tools`를 keeper preset으로 사전 필터링. research/social keeper가 실행할 수 없는 write/VCS 도구(keeper_fs_edit, keeper_pr_workflow, keeper_github)를 처음부터 보지 않도록 변경. 매턴 반복되던 WARN 제거.
- **Agent JSON race condition 수정**: gRPC heartbeat handler에서 `Fs_compat.save_file` 직접 호출(truncate-then-write) → tmp+rename 원자적 쓰기 패턴으로 교체. "Blank input data" WARN 제거.

## Root Cause Analysis
1. `keeper_agent_run.ml:1081`: `effective_core_tools()` 반환값에 preset 필터 없이 26개 도구 전체를 LLM에 노출 → AllowList 검증에서 매턴 3개 도구 제거 + WARN 로그
2. `masc_grpc_service.ml:304`: `Fs_compat.save_file`이 `open_out`(truncate) 후 write — Eio 취소 시 빈 파일 생성 → 다른 fiber가 빈 파일을 읽으면 JSON parse error

## Changes
| File | Change |
|------|--------|
| `lib/keeper/keeper_agent_run.ml` | core tools를 `allowed_exec_set`으로 사전 필터링 (+3 lines) |
| `lib/grpc/masc_grpc_service.ml` | heartbeat write를 tmp+rename atomic 패턴으로 교체 (+6/-2 lines) |
| `test/test_warn_root_causes.ml` | 하네스 5개: preset 필터링 3개 + atomic write 2개 (NEW) |
| `test/dune` | 테스트 등록 |

## Test plan
- [x] `test_warn_root_causes.exe` — 5/5 통과
- [x] `test_tool_access_policy.exe` — 53/53 통과 (기존 테스트 회귀 없음)
- [ ] `dune runtest` 전체 통과
- [ ] 서버 재시작 후 system log에서 AllowList WARN 미발생 확인
- [ ] "Blank input data" WARN 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)