### PR TITLE
refactor(keeper): DRY up allowed_providers empty fallback parsing

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1120,10 +1120,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; work_discovery_guidance = Safe_ops.json_string_opt "work_discovery_guidance" json
              ; telemetry_feedback_enabled = Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
              ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
-             ; allowed_providers =
-                 (match Safe_ops.json_string_list "allowed_providers" json with
-                  | [] -> None
-                  | xs -> Some (List.map String.lowercase_ascii xs))
+             ; allowed_providers = Keeper_types_profile.lower_string_list_opt (Safe_ops.json_string_list "allowed_providers" json)
              ; runtime = state.ps_runtime
              })
   with

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -61,6 +61,10 @@ let normalize_name_list_opt items =
   | [] -> None
   | xs -> Some xs
 
+let lower_string_list_opt = function
+  | [] -> None
+  | xs -> Some (List.map String.lowercase_ascii xs)
+
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
   match normalized with
@@ -444,10 +448,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
-                allowed_providers =
-                  (match Safe_ops.json_string_list "allowed_providers" keeper_json with
-                   | [] -> None
-                   | xs -> Some (List.map String.lowercase_ascii xs));
+                allowed_providers = lower_string_list_opt (Safe_ops.json_string_list "allowed_providers" keeper_json);
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 


### PR DESCRIPTION
## Description

Addresses GLM-5.1 cross-model review feedback from #5831.

> Nit: `[] -> None` mapping repeated 3 times, could DRY with a helper.

Extracts `lower_string_list_opt` helper in `Keeper_types_profile` to remove the duplicated pattern matching and lowercase mapping for `allowed_providers`.