### PR TITLE
fix(keeper): normalize providers + warn on empty filter fallback

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -282,7 +282,10 @@ let filter_by_providers (allowed : string list option) (models : string list)
   match allowed with
   | None | Some [] -> models
   | Some providers ->
-    let providers = List.map String.lowercase_ascii providers in
+    let providers =
+      List.sort_uniq String.compare
+        (List.map String.lowercase_ascii providers)
+    in
     let filtered =
       List.filter
         (fun label ->


### PR DESCRIPTION
## Summary
- Review followup for #5831 (per-keeper provider filter)
- `filter_by_providers`: lowercase + dedup `allowed_providers` before matching
- WARN log when no models match filter, falling back to full list

## Addresses
- copilot review: case-mismatch bypass risk
- copilot review: silent fallback hides typos/misconfig

Refs #5831

🤖 Generated with [Claude Code](https://claude.com/claude-code)