### PR TITLE
fix(cascade): defensive lowercase + warn log in filter_by_providers

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -282,6 +282,7 @@ let filter_by_providers (allowed : string list option) (models : string list)
   match allowed with
   | None | Some [] -> models
   | Some providers ->
+    let providers = List.map String.lowercase_ascii providers in
     let filtered =
       List.filter
         (fun label ->
@@ -290,4 +291,10 @@ let filter_by_providers (allowed : string list option) (models : string list)
           | None -> false)
         models
     in
-    if filtered = [] then models else filtered
+    if filtered = [] then (
+      Log.warn ~ctx:"OasModelResolve"
+        "filter_by_providers matched no models; falling back to unfiltered \
+         (allowed=[%s] models=[%s])"
+        (String.concat "," providers) (String.concat "," models);
+      models)
+    else filtered


### PR DESCRIPTION
## Summary
- Copilot review (#5831) 대응: `filter_by_providers`에 방어적 lowercase + fallback warn log 추가
- providers를 함수 내부에서 lowercase 처리 (호출자 실수 방지)
- 필터 결과가 빈 리스트일 때 warn log 출력 (설정 오류 조기 발견)

## Linked issue
Refs #5831 (Copilot review comments)

## Evidence
- `test_keeper_toml.exe` 56 tests 통과
- 기존 동작 변경 없음 (lowercase는 defense-in-depth, TOML 파싱에서 이미 처리)

## Test plan
- [x] `dune build` 통과
- [x] 56 tests 통과 (filter + profile 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)