### PR TITLE
feat(dashboard): render output validation stats in tool quality table

### DIFF
--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -7,6 +7,8 @@ interface ToolStat {
   calls: number
   success_pct: number
   avg_ms: number
+  output_truncated_count: number
+  avg_output_chars: number
 }
 
 interface KeeperStat {
@@ -81,6 +83,7 @@ function ToolTable({ tools }: { tools: ToolStat[] }) {
             <th class="text-right py-1 font-normal">Calls</th>
             <th class="text-right py-1 font-normal">Success</th>
             <th class="text-right py-1 font-normal">Avg ms</th>
+            <th class="text-right py-1 font-normal">Output</th>
           </tr>
         </thead>
         <tbody>
@@ -93,6 +96,11 @@ function ToolTable({ tools }: { tools: ToolStat[] }) {
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
                 <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.avg_ms.toFixed(0)}</td>
+                <td class="text-right py-0.5 font-mono ${t.output_truncated_count > 0 ? 'text-amber-400' : 'text-[var(--text-dim)]'}">${
+                  t.output_truncated_count > 0
+                    ? `${(t.avg_output_chars / 1000).toFixed(1)}k ✂${t.output_truncated_count}`
+                    : `${(t.avg_output_chars / 1000).toFixed(1)}k`
+                }</td>
               </tr>
             `
           })}


### PR DESCRIPTION
## Summary
#5832에서 추가한 output_truncated_count, avg_output_chars API 필드를 tool-quality 테이블 UI에 렌더링.

## Changes
- `ToolStat` interface에 `output_truncated_count`, `avg_output_chars` 추가
- Tool 테이블에 **Output** 컬럼 추가
  - 평균 출력 크기 (e.g., "3.8k")
  - truncation 발생 시 amber + scissors 표시 (e.g., "3.8k ✂2")

## Test plan
- [x] `tsc --noEmit` 타입 체크 통과
- [x] `vite build` 통과
- [ ] 서버 재시작 후 dashboard에서 Output 컬럼 확인

Refs #5832, #5821

🤖 Generated with [Claude Code](https://claude.com/claude-code)