### PR TITLE
fix(eio): close fd and run cleanup before re-raising Cancel

### DIFF
--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -88,7 +88,7 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
       end
   in
   try acquire max_attempts
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     (try Unix.close fd with Unix.Unix_error _ -> ());
     raise exn
 
@@ -124,7 +124,7 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
       end
   in
   try acquire max_attempts
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
     raise exn
 

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -231,7 +231,7 @@ let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv 
       close_fd_quietly stderr_fd;
       stderr_fd_opt := None;
       pid
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+    with exn ->
       cleanup_setup ();
       raise exn
   in


### PR DESCRIPTION
## Summary
- file_lock_eio.ml: fd leak on Cancel — 2곳 수정
- tool_command_plane_support.ml: cleanup_setup() skip on Cancel — 1곳 수정

Addresses Copilot review comments on #5842.

## Test plan
- [x] dune build
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)