### PR TITLE
fix(eio): drain stdout/stderr pipes before reading buffers

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -273,12 +273,19 @@ let spawn_and_drain_stdout ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
       argv
   in
   Eio.Flow.close stdout_w;
-  Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
-  Eio.Flow.close stdout_r;
+  (* Drain to EOF before await — pipe close is switch-managed on cancel. *)
+  (try
+     Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
+     Eio.Flow.close stdout_r
+   with Eio.Cancel.Cancelled _ as e ->
+     (try Eio.Flow.close stdout_r with _ -> ());
+     raise e);
   ignore (Eio.Process.await proc : Eio.Process.exit_status)
 
 (** Like [spawn_and_drain_stdout] but captures both stdout and stderr into
-    separate buffers and returns the process exit status. *)
+    separate buffers and returns the process exit status.
+    Drain happens in parallel via [Fiber.both]; [await] is called after
+    both pipes reach EOF, so buffers are guaranteed complete. *)
 let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
     stderr_buf =
   let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
@@ -292,13 +299,18 @@ let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
   in
   Eio.Flow.close stdout_w;
   Eio.Flow.close stderr_w;
-  Eio.Fiber.both
-    (fun () ->
-      Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
-      Eio.Flow.close stdout_r)
-    (fun () ->
-      Eio.Flow.copy stderr_r (Eio.Flow.buffer_sink stderr_buf);
-      Eio.Flow.close stderr_r);
+  (try
+     Eio.Fiber.both
+       (fun () ->
+         Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
+         Eio.Flow.close stdout_r)
+       (fun () ->
+         Eio.Flow.copy stderr_r (Eio.Flow.buffer_sink stderr_buf);
+         Eio.Flow.close stderr_r)
+   with Eio.Cancel.Cancelled _ as e ->
+     (try Eio.Flow.close stdout_r with _ -> ());
+     (try Eio.Flow.close stderr_r with _ -> ());
+     raise e);
   let status = Eio.Process.await proc in
   match status with
   | `Exited n -> Unix.WEXITED n

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -257,6 +257,53 @@ let run_unix_argv_with_stdin_and_status_fallback
 
 (** ── Eio-native process execution (global refs) ─────────────────── *)
 
+(** Spawn a process with explicit pipes and drain stdout/stderr into buffers
+    before returning.  This avoids a race where [Eio.Process.await] returns
+    (process exited) but the internal copy-fiber that moves pipe data into
+    [buffer_sink] has not finished yet, resulting in truncated/empty output.
+
+    The fix mirrors [Eio.Process.parse_out]: create pipes, close write ends
+    after spawn, read to EOF in parallel fibers, then await the exit status. *)
+let spawn_and_drain_stdout ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
+  let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
+  let proc =
+    Eio.Process.spawn ~sw pm ~cwd ?env
+      ?stdin:stdin_source
+      ~stdout:stdout_w
+      argv
+  in
+  Eio.Flow.close stdout_w;
+  Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
+  Eio.Flow.close stdout_r;
+  ignore (Eio.Process.await proc : Eio.Process.exit_status)
+
+(** Like [spawn_and_drain_stdout] but captures both stdout and stderr into
+    separate buffers and returns the process exit status. *)
+let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
+    stderr_buf =
+  let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
+  let stderr_r, stderr_w = Eio.Process.pipe ~sw pm in
+  let proc =
+    Eio.Process.spawn ~sw pm ~cwd ?env
+      ?stdin:stdin_source
+      ~stdout:stdout_w
+      ~stderr:stderr_w
+      argv
+  in
+  Eio.Flow.close stdout_w;
+  Eio.Flow.close stderr_w;
+  Eio.Fiber.both
+    (fun () ->
+      Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
+      Eio.Flow.close stdout_r)
+    (fun () ->
+      Eio.Flow.copy stderr_r (Eio.Flow.buffer_sink stderr_buf);
+      Eio.Flow.close stderr_r);
+  let status = Eio.Process.await proc in
+  match status with
+  | `Exited n -> Unix.WEXITED n
+  | `Signaled n -> Unix.WSIGNALED n
+
 let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   if not (is_initialized ()) then run_unix_argv_fallback ?env argv
   else
@@ -268,8 +315,8 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
         let label = String.concat " " (List.map Filename.quote argv) in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Process.run pm ~cwd ?env ~stdout:(Eio.Flow.buffer_sink buf)
-                argv;
+              Eio.Switch.run (fun sw ->
+                  spawn_and_drain_stdout ~sw pm ~cwd ?env argv buf);
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
@@ -298,12 +345,11 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
     | Ok pm, Ok clk, Ok cwd ->
         let buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
+        let stdin_source = Eio.Flow.string_source stdin_content in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Process.run pm ~cwd ?env
-                ~stdin:(Eio.Flow.string_source stdin_content)
-                ~stdout:(Eio.Flow.buffer_sink buf)
-                argv;
+              Eio.Switch.run (fun sw ->
+                  spawn_and_drain_stdout ~sw pm ~cwd ?env ~stdin_source argv buf);
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
@@ -337,27 +383,19 @@ let run_argv_with_stdin_and_status
         let stdout_buf = Buffer.create 1024 in
         let stderr_buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
+        let stdin_source = Eio.Flow.string_source stdin_content in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Switch.run (fun sw ->
-                  let proc =
-                    Eio.Process.spawn ~sw pm ~cwd ?env
-                       ~stdin:(Eio.Flow.string_source stdin_content)
-                       ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-                       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-                       argv
-                   in
-                   let status = Eio.Process.await proc in
-                   let unix_status =
-                     match status with
-                     | `Exited n -> Unix.WEXITED n
-                     | `Signaled n -> Unix.WSIGNALED n
-                   in
-                   ( unix_status
-                   , output_for_status
-                       ~status:unix_status
-                       ~stdout:(Buffer.contents stdout_buf)
-                       ~stderr:(Buffer.contents stderr_buf) )))
+              let unix_status =
+                Eio.Switch.run (fun sw ->
+                    spawn_and_drain_both ~sw pm ~cwd ?env ~stdin_source argv
+                      stdout_buf stderr_buf)
+              in
+              ( unix_status
+              , output_for_status
+                  ~status:unix_status
+                  ~stdout:(Buffer.contents stdout_buf)
+                  ~stderr:(Buffer.contents stderr_buf) ))
         with
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
@@ -397,24 +435,16 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) : 
         let label = String.concat " " (List.map Filename.quote argv) in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Switch.run (fun sw ->
-                  let proc =
-                    Eio.Process.spawn ~sw pm ~cwd:effective_cwd ?env
-                      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-                      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-                      argv
-                  in
-                  let status = Eio.Process.await proc in
-                  let unix_status =
-                    match status with
-                    | `Exited n -> Unix.WEXITED n
-                    | `Signaled n -> Unix.WSIGNALED n
-                  in
-                  ( unix_status
-                  , output_for_status
-                      ~status:unix_status
-                      ~stdout:(Buffer.contents stdout_buf)
-                      ~stderr:(Buffer.contents stderr_buf) )))
+              let unix_status =
+                Eio.Switch.run (fun sw ->
+                    spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env argv
+                      stdout_buf stderr_buf)
+              in
+              ( unix_status
+              , output_for_status
+                  ~status:unix_status
+                  ~stdout:(Buffer.contents stdout_buf)
+                  ~stderr:(Buffer.contents stderr_buf) ))
         with
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -816,9 +816,17 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
                  let status, output =
                    Eio.Time.with_timeout_exn clock timeout (fun () ->
                      Eio.Switch.run @@ fun sw ->
+                     let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
                      let proc = Eio.Process.spawn ~sw proc_mgr
-                       ~stdout:(Eio.Flow.buffer_sink buf)
+                       ~stdout:stdout_w
                        ["sh"; "-c"; wrapped_command ^ " 2>&1"] in
+                     Eio.Flow.close stdout_w;
+                     (try
+                        Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
+                        Eio.Flow.close stdout_r
+                      with Eio.Cancel.Cancelled _ as e ->
+                        (try Eio.Flow.close stdout_r with _ -> ());
+                        raise e);
                      let status = Eio.Process.await proc in
                      (status, Buffer.contents buf))
                  in


### PR DESCRIPTION
## Summary
- `Eio.Process.await` 후 `buffer_sink`의 copy-fiber가 완료되지 않아 stdout이 빈 문자열로 반환되는 race condition 수정
- explicit pipe 생성 → write end close → `Eio.Fiber.both`로 병렬 drain → EOF 보장 → 그 다음 await
- `run_argv`, `run_argv_with_stdin`, `run_argv_with_stdin_and_status`, `run_argv_with_status` 4곳 모두 교체

## Product impact
- keeper_github `gh issue list` 등에서 간헐적으로 빈 출력이 반환되던 문제 해결
- 모든 Process_eio 기반 도구(keeper_bash, keeper_shell_readonly, keeper_github 등)에 영향

## Evidence
- 실측: `gh issue list --state open --limit 10` → exit 0, output="" (빈 출력) 간헐 발생
- 같은 세션에서 `gh issue view 594` → 정상 출력 (인증/디렉토리 문제 아님 확인)
- 외부 재현: `/bin/zsh -lc "cd ~/me && gh issue list --limit 3 2>&1"` → 282 bytes 정상

## Linked issue
Refs: keeper_github 빈 출력 이슈 (Eio buffer_sink race)

## Test plan
- [x] `dune build` 통과
- [ ] `dune runtest --force` 실행 중
- [ ] 서버 재시작 후 keeper_github 빈 출력 재발 여부 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)