### PR TITLE
fix(dashboard): phase case normalization and @keyframes spin

### DIFF
--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -7,14 +7,16 @@ import { useEffect, useState } from 'preact/hooks'
 import { fetchKeeperStateDiagram } from '../api/keeper'
 import { MermaidGraph } from './common/mermaid-graph'
 import { EmptyState } from './common/empty-state'
+import type { KeeperPhase } from '../types'
 
 interface KeeperStateDiagramProps {
   keeperName: string
-  currentPhase?: string | null
+  currentPhase?: KeeperPhase | string | null
 }
 
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
   const [mermaid, setMermaid] = useState<string | null>(null)
+  const [apiPhase, setApiPhase] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -27,6 +29,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       .then(resp => {
         if (cancelled) return
         setMermaid(resp.mermaid)
+        setApiPhase(resp.current_phase)
         setLoading(false)
       })
       .catch(err => {
@@ -38,10 +41,13 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
     return () => { cancelled = true }
   }, [keeperName])
 
+  // Prefer API response current_phase, fall back to prop
+  const displayPhase = apiPhase ?? currentPhase
+
   if (loading) {
     return html`
       <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
-        <span class="inline-block w-3 h-3 rounded-full border-2 border-[var(--accent)] border-t-transparent" style="animation: spin 0.8s linear infinite;"></span>
+        <span class="inline-block w-3 h-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
         상태 다이어그램 로딩중
       </div>
     `
@@ -53,9 +59,9 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
   return html`
     <div>
-      ${currentPhase ? html`
+      ${displayPhase ? html`
         <div class="mb-2 text-[10px] text-[var(--text-dim)]">
-          현재 phase: <span class="font-mono font-medium text-[var(--accent)]">${currentPhase}</span>
+          현재 phase: <span class="font-mono font-medium text-[var(--accent)]">${displayPhase}</span>
         </div>
       ` : null}
       <${MermaidGraph}

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -1,5 +1,65 @@
 import { describe, expect, it } from 'vitest'
-import { deriveLifecycleState, normalizeKeepers } from './keeper-store-normalize'
+import { deriveLifecycleState, normalizeKeepers, toKeeperPhase } from './keeper-store-normalize'
+
+describe('toKeeperPhase — backend lowercase to PascalCase normalization', () => {
+  it('maps lowercase backend phase strings to PascalCase KeeperPhase', () => {
+    expect(toKeeperPhase('offline')).toBe('Offline')
+    expect(toKeeperPhase('running')).toBe('Running')
+    expect(toKeeperPhase('failing')).toBe('Failing')
+    expect(toKeeperPhase('compacting')).toBe('Compacting')
+    expect(toKeeperPhase('handing_off')).toBe('HandingOff')
+    expect(toKeeperPhase('draining')).toBe('Draining')
+    expect(toKeeperPhase('paused')).toBe('Paused')
+    expect(toKeeperPhase('stopped')).toBe('Stopped')
+    expect(toKeeperPhase('crashed')).toBe('Crashed')
+    expect(toKeeperPhase('restarting')).toBe('Restarting')
+    expect(toKeeperPhase('dead')).toBe('Dead')
+  })
+
+  it('accepts PascalCase input for forward compatibility', () => {
+    expect(toKeeperPhase('Offline')).toBe('Offline')
+    expect(toKeeperPhase('Running')).toBe('Running')
+    expect(toKeeperPhase('HandingOff')).toBe('HandingOff')
+  })
+
+  it('returns null for unknown or empty values', () => {
+    expect(toKeeperPhase(null)).toBeNull()
+    expect(toKeeperPhase(undefined)).toBeNull()
+    expect(toKeeperPhase('')).toBeNull()
+    expect(toKeeperPhase('unknown_phase')).toBeNull()
+    expect(toKeeperPhase('RUNNING')).toBeNull()
+  })
+})
+
+describe('normalizeKeepers phase field', () => {
+  it('normalizes lowercase backend phase to PascalCase KeeperPhase', () => {
+    const [keeper] = normalizeKeepers([
+      { name: 'phase-test', status: 'active', phase: 'running' },
+    ])
+    expect(keeper?.phase).toBe('Running')
+  })
+
+  it('normalizes handing_off to HandingOff', () => {
+    const [keeper] = normalizeKeepers([
+      { name: 'handoff-test', status: 'active', phase: 'handing_off' },
+    ])
+    expect(keeper?.phase).toBe('HandingOff')
+  })
+
+  it('returns null for unknown phase', () => {
+    const [keeper] = normalizeKeepers([
+      { name: 'unknown-test', status: 'active', phase: 'bogus' },
+    ])
+    expect(keeper?.phase).toBeNull()
+  })
+
+  it('returns null when phase is absent', () => {
+    const [keeper] = normalizeKeepers([
+      { name: 'no-phase', status: 'active' },
+    ])
+    expect(keeper?.phase).toBeNull()
+  })
+})
 
 describe('normalizeKeepers lifecycle metrics', () => {
   it('accepts flat backend handoff fields', () => {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -10,14 +10,39 @@ import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 
-const VALID_PHASES = new Set<string>([
-  'Offline', 'Running', 'Failing', 'Compacting', 'HandingOff',
-  'Draining', 'Paused', 'Stopped', 'Crashed', 'Restarting', 'Dead',
-])
+/** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
+ *  Backend (keeper_state_machine.ml) emits lowercase: "offline", "running", "handing_off", etc.
+ *  Frontend KeeperPhase type uses PascalCase: "Offline", "Running", "HandingOff", etc.
+ */
+const BACKEND_PHASE_MAP: Record<string, KeeperPhase> = {
+  offline: 'Offline',
+  running: 'Running',
+  failing: 'Failing',
+  compacting: 'Compacting',
+  handing_off: 'HandingOff',
+  draining: 'Draining',
+  paused: 'Paused',
+  stopped: 'Stopped',
+  crashed: 'Crashed',
+  restarting: 'Restarting',
+  dead: 'Dead',
+  // Also accept PascalCase for forward-compat / test fixtures
+  Offline: 'Offline',
+  Running: 'Running',
+  Failing: 'Failing',
+  Compacting: 'Compacting',
+  HandingOff: 'HandingOff',
+  Draining: 'Draining',
+  Paused: 'Paused',
+  Stopped: 'Stopped',
+  Crashed: 'Crashed',
+  Restarting: 'Restarting',
+  Dead: 'Dead',
+}
 
-function toKeeperPhase(raw: string | null | undefined): KeeperPhase | null {
-  if (!raw || !VALID_PHASES.has(raw)) return null
-  return raw as KeeperPhase
+export function toKeeperPhase(raw: string | null | undefined): KeeperPhase | null {
+  if (!raw) return null
+  return BACKEND_PHASE_MAP[raw] ?? null
 }
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {

--- a/dashboard/src/styles/keyframes.css
+++ b/dashboard/src/styles/keyframes.css
@@ -108,6 +108,11 @@
   50% { opacity: 0.5; }
 }
 
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 @keyframes slideInRight {
   from { transform: translateX(100%); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }


### PR DESCRIPTION
## Summary
- `VALID_PHASES` Set → `BACKEND_PHASE_MAP` Record (lowercase→PascalCase)로 변환하여 backend lowercase phase를 정확히 매핑
- `@keyframes spin` 추가 (미정의로 spinner 미동작이었음)
- `KeeperStateDiagramPanel`에서 API `current_phase` 응답 우선 사용
- `toKeeperPhase` 62줄 테스트 추가

## Addresses
/simplify 리뷰에서 발견된 3개 이슈:
- `@keyframes spin` 미정의 (Efficiency review)
- PascalCase/lowercase 불일치 (Quality review)
- `VALID_PHASES` ↔ `PHASE_STYLES` 키 중복 (Reuse review)

Refs #5829

🤖 Generated with [Claude Code](https://claude.com/claude-code)