### PR TITLE
fix: fire post-hooks in dispatch so tool_usage and tool_metric record data

### DIFF
--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -37,22 +37,6 @@ let register_module ~(schemas : Types.tool_schema list) ~(handler : handler) =
         Hashtbl.replace registry schema.name handler)
       schemas)
 
-(** O(1) dispatch.  Returns [Some (success, message)] when a handler is
-    found, [None] when the tool name is unknown to the registry.
-    Handler exceptions are caught and returned as error tuples so the
-    caller gets a consistent result shape. *)
-let dispatch ~(token : Tool_token.t) ~args : (bool * string) option =
-  let name = token.name in
-  match Hashtbl.find_opt registry name with
-  | Some handler -> (
-      try handler ~name ~args
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        Some
-          ( false,
-            Printf.sprintf "dispatch_v2 handler error for %s: %s" name
-              (Printexc.to_string exn) ))
-  | None -> None
-
 (** {2 Dispatch Hooks}
 
     Pre-hooks run before the handler; post-hooks run after.
@@ -106,25 +90,52 @@ let run_pre_hooks ~name ~args =
 let run_post_hooks result =
   List.fold_left (fun r hook -> hook r) result !post_hooks
 
+(** O(1) dispatch.  Returns [Some (success, message)] when a handler is
+    found, [None] when the tool name is unknown to the registry.
+    Handler exceptions are caught and returned as error tuples so the
+    caller gets a consistent result shape.
+
+    Post-hooks fire as a side-effect after the handler completes,
+    enabling tool metrics and usage logging for all dispatch paths
+    (keeper, MCP, tag-dispatch). *)
+let dispatch ~(token : Tool_token.t) ~args : (bool * string) option =
+  let name = token.name in
+  match Hashtbl.find_opt registry name with
+  | Some handler ->
+    let start_time = Time_compat.now () in
+    let result =
+      try handler ~name ~args
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Some
+          ( false,
+            Printf.sprintf "dispatch_v2 handler error for %s: %s" name
+              (Printexc.to_string exn) )
+    in
+    (match result with
+     | Some (success, message) ->
+       let tr = Tool_result.wrap ~tool_name:name ~start_time (success, message) in
+       ignore (run_post_hooks tr)
+     | None -> ());
+    result
+  | None -> None
+
 (** Structured dispatch with hook support.
 
-    Execution order: pre-hooks → handler → post-hooks.
+    Execution order: pre-hooks → handler (with post-hooks) → result wrapping.
 
-    If a pre-hook short-circuits, the handler and post-hooks are skipped
-    and the pre-hook's result is returned directly.
+    Post-hooks are already fired inside [dispatch], so this function only
+    adds pre-hook gating and [Tool_result.t] wrapping.
 
     Returns [None] when the tool is unknown to the registry. *)
 let dispatch_structured ~(token : Tool_token.t) ~args : Tool_result.t option =
   let name = token.name in
-  (* Pre-hooks: may short-circuit or coerce args *)
   match run_pre_hooks ~name ~args with
   | (Some _ as blocked, _) -> blocked
   | (None, coerced_args) ->
     let start_time = Time_compat.now () in
     (match dispatch ~token ~args:coerced_args with
      | Some (success, message) ->
-       let result = Tool_result.wrap ~tool_name:name ~start_time (success, message) in
-       Some (run_post_hooks result)
+       Some (Tool_result.wrap ~tool_name:name ~start_time (success, message))
      | None -> None)
 
 (** Feature flag: use the new dispatch path.

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -114,9 +114,9 @@ let dispatch ~(token : Tool_token.t) ~args : (bool * string) option =
     (match result with
      | Some (success, message) ->
        let tr = Tool_result.wrap ~tool_name:name ~start_time (success, message) in
-       ignore (run_post_hooks tr)
-     | None -> ());
-    result
+       let tr' = run_post_hooks tr in
+       Some (Tool_result.to_legacy tr')
+     | None -> None)
   | None -> None
 
 (** Structured dispatch with hook support.


### PR DESCRIPTION
## Summary
- `dispatch()`가 handler만 호출하고 post-hook을 실행하지 않았음
- `dispatch_structured()`만 post-hook을 실행했으나 **caller가 0개** (dead code)
- 결과: `Tool_metrics_persist.enqueue`와 `Tool_usage_log`가 절대 실행되지 않아 대시보드에서 도구 사용=0, 도구 메트릭=0 표시

## 변경
- Hook 타입 정의와 `run_post_hooks`를 `dispatch()` 위로 이동 (OCaml forward ref 해결)
- `dispatch()`에서 handler 실행 후 `Tool_result.t`를 생성하여 post-hooks를 side-effect로 실행
- `dispatch_structured()`에서 post-hook 중복 실행 제거

## 영향
서버 재시작 후 keeper/MCP 도구 호출마다:
- `.masc/tool_usage/` 에 System_internal 호출 기록
- `data/tool-metrics/` 에 duration/success 메트릭 기록

## Test plan
- [ ] `dune build lib/` 성공
- [ ] 서버 재시작 후 keeper 도구 호출 발생 확인
- [ ] `.masc/tool_usage/` 에 JSONL 파일 생성 확인
- [ ] `data/tool-metrics/` 에 JSONL 파일 생성 확인
- [ ] 대시보드 텔레메트리에서 tool_usage, tool_metric 카운트 > 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)