### PR TITLE
fix(keeper): register masc_persona_list + tool-heavy compaction gate

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -15,6 +15,14 @@ open Keeper_context_core
     prevents context overflow regardless of cooldown state (#5634). *)
 let emergency_compact_ratio_threshold = 0.8
 
+(** Tool-heavy compaction thresholds.
+    When message count exceeds [tool_heavy_msg_threshold] AND context
+    ratio exceeds [tool_heavy_ratio_floor], trigger compaction to
+    stub old tool results. Prevents slow inference on local LLMs
+    when many tool calls accumulate without hitting other gates. *)
+let tool_heavy_msg_threshold = 40
+let tool_heavy_ratio_floor = 0.15
+
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
   (meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate)
 
@@ -50,13 +58,12 @@ let compact_if_needed
   (* Tool-heavy gate: when accumulated tool results bloat context
      without hitting ratio/message/token gates, stub old tool results
      to prevent slow inference on local LLMs (#5802).
-     Threshold: messages > 10 * turns_since_last_compaction.
-     This catches the pattern where each turn adds 2-4 messages
-     (user + assistant + tool_use + tool_result) without compaction. *)
+     Bypasses reflection cooldown like the emergency ratio gate —
+     tool bloat is an operational risk, not a content concern. *)
   let tool_heavy =
-    reflection_ready
-    && msg_count > 40
-    && ratio > 0.15
+    (reflection_ready || emergency)
+    && msg_count > tool_heavy_msg_threshold
+    && ratio > tool_heavy_ratio_floor
   in
   let trigger_reason =
     if not reflection_ready then

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -47,6 +47,17 @@ let compact_if_needed
         (Float.of_int meta.compaction.cooldown_sec
        -. (now_ts -. last_reflection_ts))
   in
+  (* Tool-heavy gate: when accumulated tool results bloat context
+     without hitting ratio/message/token gates, stub old tool results
+     to prevent slow inference on local LLMs (#5802).
+     Threshold: messages > 10 * turns_since_last_compaction.
+     This catches the pattern where each turn adds 2-4 messages
+     (user + assistant + tool_use + tool_result) without compaction. *)
+  let tool_heavy =
+    reflection_ready
+    && msg_count > 40
+    && ratio > 0.15
+  in
   let trigger_reason =
     if not reflection_ready then
       Some
@@ -59,6 +70,8 @@ let compact_if_needed
       Some (Printf.sprintf "messages(%d>=%d)" msg_count message_gate)
     else if token_gate > 0 && tok_count >= token_gate then
       Some (Printf.sprintf "tokens(%d>=%d)" tok_count token_gate)
+    else if tool_heavy then
+      Some (Printf.sprintf "tool_heavy(msgs=%d,ratio=%.4f)" msg_count ratio)
     else None
   in
   match trigger_reason with

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -48,6 +48,20 @@ let tool_access_schema description =
 
 let keeper_schemas : tool_schema list = [
   {
+    name = "masc_persona_list";
+    description = "List available persona profiles that can be used to create keepers via masc_keeper_create_from_persona.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("detailed", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool true);
+          ("description", `String "If true, return full persona summaries. If false, return names only.");
+        ]);
+      ]);
+    ];
+  };
+  {
     name = "masc_keeper_create_from_persona";
     description = "Create or dry-run a keeper configuration from a persona profile.json. Keepers are durable and auto-start on server boot.";
     input_schema = `Assoc [

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -125,6 +125,7 @@ let public_mcp_surface_tools =
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
+    "masc_persona_list";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_delete";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -497,7 +497,7 @@ let maybe_bootstrap_existing_keepalives ctx ~name ~args =
     Skipped for creation tools where the caller's base_path is authoritative. *)
 let resolve_ctx ctx ~name args =
   match name with
-  | "masc_keeper_up" | "masc_keeper_create_from_persona" -> ctx
+  | "masc_keeper_up" | "masc_keeper_create_from_persona" | "masc_persona_list" -> ctx
   | _ ->
     let keeper_name = get_string args "name" "" in
     let config = Keeper_registry.resolve_config ctx.config keeper_name in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -508,6 +508,7 @@ let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
+  | "masc_persona_list" -> Some (Persona.handle_persona_list ctx args)
   | "masc_keeper_create_from_persona" -> Some (handle_keeper_create_from_persona ctx args)
   | "masc_keeper_up" -> Some (handle_keeper_up ctx args)
   | "masc_keeper_status" -> Some (handle_keeper_status ctx args)

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -11,7 +11,9 @@ open Masc_mcp
 let init_registry () =
   Masc_test_deps.init_keeper_tool_registry ();
   let base_path = Masc_test_deps.find_project_root () in
-  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path))
+  match Keeper_tool_policy.init_policy_config ~base_path with
+  | Ok () -> ()
+  | Error e -> failwith (Printf.sprintf "init_policy_config failed: %s" e)
 
 let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json


### PR DESCRIPTION
## Summary
Keeper timeout(300s)과 tool hallucination의 근본 원인 2건 수정.

## Problem 1: masc_persona_list Unknown tool
LLM이 `masc_persona_list` 호출 → "Unknown tool" 에러. `Keeper_persona.handle_persona_list` handler는 존재하지만 schema/dispatch에 미등록 (dead code).

**Fix**: `keeper_schema.ml`에 schema 추가 + `tool_keeper.ml` dispatch에 등록.

## Problem 2: 300s timeout after 21 turns
`example` keeper가 turn 21에서 300s OAS timeout. 262K context에서 tool result가 누적되지만 ratio가 50% 미만이라 compaction gate 미작동.

**Fix**: `keeper_compact_policy.ml`에 tool-heavy gate 추가 — messages > 40 AND ratio > 15% 이면 PruneToolOutputs + StubToolResults 발동. 기존 gate(ratio/message/token)를 보완하는 4번째 gate.

## Test plan
- [x] `dune build` 통과
- [ ] keeper 재시작 후 `masc_persona_list` 호출 가능 확인
- [ ] 20+ 턴 keeper에서 tool-heavy compaction 발동 확인

Closes #5802
Refs #5807

🤖 Generated with [Claude Code](https://claude.com/claude-code)