### PR TITLE
fix: /simplify review — dead pattern, missing helpers, lint robustness

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -37,6 +37,28 @@ let try_with_default ~default context f =
   | Some v -> v
   | None -> default
 
+(** Cancel-aware Result wrapper.
+    Re-raises [Eio.Cancel.Cancelled] with backtrace; captures other
+    exceptions as [Error exn]. *)
+let try_catch f =
+  try Ok (f ())
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace e bt
+  | exn -> Error exn
+
+(** Cancel-aware exception handler.
+    Re-raises [Eio.Cancel.Cancelled] with backtrace; delegates other
+    exceptions to [handler]. *)
+let handle f handler =
+  try f ()
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace e bt
+  | exn -> handler exn
+
 (** Parse JSON with detailed error reporting *)
 let parse_json_safe ~context str : (Yojson.Safe.t, string) result =
   try Ok (Yojson.Safe.from_string str)
@@ -155,7 +177,7 @@ let get_env_float_logged name ~default =
 (** {2 JSON Value Extraction Helpers}
 
     Safe extraction from Yojson.Safe.t values with proper error handling.
-    These replace `with Eio.Cancel.Cancelled _ as e -> raise e | _ -> default` patterns in JSON parsing code.
+    Safe extraction from Yojson.Safe.t values without exception handling.
 *)
 
 (** Safe member access: returns [`Null] for non-[`Assoc] inputs

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -16,6 +16,14 @@ val try_with_log : string -> (unit -> 'a) -> 'a option
 val try_with_default : default:'a -> string -> (unit -> 'a) -> 'a
 (** Execute with default value on failure. *)
 
+val try_catch : (unit -> 'a) -> ('a, exn) result
+(** Cancel-aware Result wrapper.
+    Re-raises [Eio.Cancel.Cancelled]; captures any other exception as [Error exn]. *)
+
+val handle : (unit -> 'a) -> (exn -> 'a) -> 'a
+(** Cancel-aware exception handler.
+    Re-raises [Eio.Cancel.Cancelled]; delegates other exceptions to the handler. *)
+
 (** {1 JSON Parsing} *)
 
 val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -210,7 +210,7 @@ let handle_keeper_shell_readonly
       | Error e -> error_json ~fields:[ "op", `String op ] e
       | Ok target ->
         let limit = shell_readonly_limit args in
-        (* Optional file-type filter (e.g. "ml", "py", "ts") *)
+        (* Optional file-type filter (e.g. "ml", "py") *)
         let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
         (* Optional glob filter (e.g. "*.ml", "lib/**/*.ml") *)
         let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
@@ -394,50 +394,59 @@ let handle_keeper_shell_readonly
     if cmd_str = "" then error_json ~fields:[ "op", `String op ] "command is required for bash op. Good: command='env'. Bad: command=''."
 
     else
-      (* Categorised dangerous-pattern table: (pattern, category, hint).
-         On match the first hit wins, so order matters — put specific
-         patterns before generic ones (e.g. "| tee " before "> "). *)
-      let categorised_patterns =
+      (* Non-overridable deny layer (runs after preset gate).
+         First match wins — specific patterns before generic. *)
+      let hint_of_category = function
+        | "chaining"        -> "Call the tool multiple times instead of chaining commands."
+        | "redirect"        -> "Redirects are not allowed. Use keeper_fs_edit to write files."
+        | "git_write"       -> "Use keeper_bash with coding preset for git write operations."
+        | "package_install" -> "Package installation requires keeper_bash with coding preset."
+        | "destructive"     -> "Use keeper_bash for write operations, not readonly shell."
+        | _                 -> "This operation is not allowed in readonly shell."
+      in
+      let deny_patterns =
         [ (* chaining *)
-          "&&",          "chaining",        "Call the tool multiple times instead of chaining commands."
-        ; "||",          "chaining",        "Call the tool multiple times instead of chaining commands."
-        ; ";",           "chaining",        "Call the tool multiple times instead of chaining commands."
+          "&&", "chaining"
+        ; "||", "chaining"
+        ; ";", "chaining"
         (* redirect *)
-        ; "| tee ",      "redirect",        "Redirects are not allowed. Use keeper_fs_edit to write files."
-        ; ">> ",         "redirect",        "Redirects are not allowed. Use keeper_fs_edit to write files."
-        ; "> ",          "redirect",        "Redirects are not allowed. Use keeper_fs_edit to write files."
+        ; "| tee ", "redirect"
+        ; ">> ", "redirect"
+        ; "> ", "redirect"
         (* git write *)
-        ; "git push",    "git_write",       "Use keeper_bash with coding preset for git write operations."
-        ; "git reset",   "git_write",       "Use keeper_bash with coding preset for git write operations."
-        ; "git checkout","git_write",       "Use keeper_bash with coding preset for git write operations."
-        ; "git rebase",  "git_write",       "Use keeper_bash with coding preset for git write operations."
+        ; "git push", "git_write"
+        ; "git reset", "git_write"
+        ; "git checkout", "git_write"
+        ; "git rebase", "git_write"
         (* package install *)
-        ; "pip install", "package_install", "Package installation requires keeper_bash with coding preset."
-        ; "npm install", "package_install", "Package installation requires keeper_bash with coding preset."
-        ; "opam install","package_install", "Package installation requires keeper_bash with coding preset."
+        ; "pip install", "package_install"
+        ; "npm install", "package_install"
+        ; "opam install", "package_install"
         (* destructive / write *)
-        ; "rm ",         "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "rm\t",        "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "rmdir",       "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "mv ",         "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "cp ",         "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "chmod",       "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "chown",       "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "kill",        "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "pkill",       "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "dd ",         "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "mkfs",        "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "wget ",       "destructive",     "Use keeper_bash for write operations, not readonly shell."
-        ; "curl.*-o",    "destructive",     "Use keeper_bash for write operations, not readonly shell."
+        ; "rm ", "destructive"
+        ; "rm\t", "destructive"
+        ; "rmdir", "destructive"
+        ; "mv ", "destructive"
+        ; "cp ", "destructive"
+        ; "chmod", "destructive"
+        ; "chown", "destructive"
+        ; "kill", "destructive"
+        ; "pkill", "destructive"
+        ; "dd ", "destructive"
+        ; "mkfs", "destructive"
+        ; "wget ", "destructive"
+        ; "curl -o", "destructive"
+        ; "curl --output", "destructive"
         ]
       in
       let matched =
-        List.find_opt (fun (pat, _cat, _hint) ->
+        List.find_opt (fun (pat, _cat) ->
           String_util.contains_substring_ci cmd_str pat
-        ) categorised_patterns
+        ) deny_patterns
       in
       (match matched with
-      | Some (pat, category, hint) ->
+      | Some (pat, category) ->
+        let hint = hint_of_category category in
         Yojson.Safe.to_string
           (`Assoc
               [ "ok", `Bool false

--- a/scripts/lint-cancel-guard.sh
+++ b/scripts/lint-cancel-guard.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
 NO_EIO_DIRS="dashboard_utils|masc_log|types|response|config|swarm_status|tool_schemas|mcp_session|ag_ui|compression|mcp_transport_protocol"
 VIOLATIONS=0
-find "$REPO_ROOT/lib" -name '*.ml' -type f | while IFS= read -r file; do
+while IFS= read -r file; do
   echo "$file" | grep -qE "/(${NO_EIO_DIRS})/" 2>/dev/null && continue
   while IFS=: read -r lineno line; do
     start=$((lineno > 3 ? lineno - 3 : 1))
@@ -15,7 +15,7 @@ find "$REPO_ROOT/lib" -name '*.ml' -type f | while IFS= read -r file; do
       VIOLATIONS=$((VIOLATIONS + 1))
     fi
   done < <(grep -n -E '(with\s+(_|exn)\s+->|\|\s*exception\s+_\s+->)' "$file" 2>/dev/null || true)
-done
+done < <(find "$REPO_ROOT/lib" -name '*.ml' -type f)
 if [ $VIOLATIONS -gt 0 ]; then
   echo "Found $VIOLATIONS wildcard catch(es) without Eio.Cancel guard."
   exit 1

--- a/scripts/lint-cancel-guard.sh
+++ b/scripts/lint-cancel-guard.sh
@@ -4,19 +4,18 @@
 set -euo pipefail
 REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
 NO_EIO_DIRS="dashboard_utils|masc_log|types|response|config|swarm_status|tool_schemas|mcp_session|ag_ui|compression|mcp_transport_protocol"
-FILES=$(find "$REPO_ROOT/lib" -name '*.ml' -type f)
 VIOLATIONS=0
-while IFS= read -r file; do
+find "$REPO_ROOT/lib" -name '*.ml' -type f | while IFS= read -r file; do
   echo "$file" | grep -qE "/(${NO_EIO_DIRS})/" 2>/dev/null && continue
   while IFS=: read -r lineno line; do
     start=$((lineno > 3 ? lineno - 3 : 1))
     context=$(sed -n "${start},${lineno}p" "$file")
-    if ! echo "$context" | grep -q 'Eio\.Cancel\.Cancelled'; then
+    if ! echo "$context" | grep -q 'Eio\.Cancel\.Cancelled' && ! sed -n "${lineno}p" "$file" | grep -q 'cancel-guard-ok'; then
       echo "VIOLATION: $file:$lineno: $line"
       VIOLATIONS=$((VIOLATIONS + 1))
     fi
   done < <(grep -n -E '(with\s+(_|exn)\s+->|\|\s*exception\s+_\s+->)' "$file" 2>/dev/null || true)
-done <<< "$FILES"
+done
 if [ $VIOLATIONS -gt 0 ]; then
   echo "Found $VIOLATIONS wildcard catch(es) without Eio.Cancel guard."
   exit 1


### PR DESCRIPTION
## Summary
- curl.*-o dead pattern fix (literal substring, not regex)
- Safe_ops.try_catch + handle 실제 구현 추가
- hint 문자열 중복 제거 (hint_of_category)
- lint-cancel-guard.sh: find pipe + suppression marker
- safe_ops.ml 주석 수정

Addresses 3-agent /simplify review findings.

## Test plan
- [x] dune build lib/ 성공
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)