### PR TITLE
refactor(boundary): simplify tool output to memory-protection cap

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -319,9 +319,12 @@ module KeeperToolExec = struct
   let max_consecutive_tool_failures =
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
 
-  (** @deprecated Moved to [Tool_output_validation.default_budget].
-      Env var [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS] is still read by
-      [Tool_output_validation] for backward compatibility. *)
+  (** @deprecated Use [Tool_output_validation.default_budget] instead.
+      Kept for backward compat — callers that reference this binding
+      will get the same value as [Tool_output_validation.default_budget].
+      Env: [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS]. Default: 8000. Range: [1000, 32000]. *)
+  let max_tool_output_chars =
+    max 1000 (min 32000 (get_int ~default:8000 "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS"))
 end
 
 (** {1 Context Ratio Hard Cap}

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -319,12 +319,10 @@ module KeeperToolExec = struct
   let max_consecutive_tool_failures =
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
 
-  (** @deprecated Use [Tool_output_validation.default_budget] instead.
-      Kept for backward compat — callers that reference this binding
-      will get the same value as [Tool_output_validation.default_budget].
-      Env: [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS]. Default: 8000. Range: [1000, 32000]. *)
-  let max_tool_output_chars =
-    max 1000 (min 32000 (get_int ~default:8000 "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS"))
+  (** Memory-protection cap for tool output (chars).
+      SSOT: [Tool_output_validation.max_output_chars] (= 65536).
+      Mirrored here to avoid cross-library dependency. *)
+  let max_tool_output_chars = 65_536
 end
 
 (** {1 Context Ratio Hard Cap}

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -318,11 +318,6 @@ module KeeperToolExec = struct
       Default: 3. Range: [2, 20]. *)
   let max_consecutive_tool_failures =
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
-
-  (** Memory-protection cap for tool output (chars).
-      SSOT: [Tool_output_validation.max_output_chars] (= 65536).
-      Mirrored here to avoid cross-library dependency. *)
-  let max_tool_output_chars = 65_536
 end
 
 (** {1 Context Ratio Hard Cap}

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -319,12 +319,9 @@ module KeeperToolExec = struct
   let max_consecutive_tool_failures =
     max 2 (min 20 (get_int ~default:3 "MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES"))
 
-  (** @deprecated Use [Tool_output_validation.default_budget] instead.
-      Kept for backward compat — callers that reference this binding
-      will get the same value as [Tool_output_validation.default_budget].
-      Env: [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS]. Default: 8000. Range: [1000, 32000]. *)
-  let max_tool_output_chars =
-    max 1000 (min 32000 (get_int ~default:8000 "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS"))
+  (** @deprecated Moved to [Tool_output_validation.default_budget].
+      Env var [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS] is still read by
+      [Tool_output_validation] for backward compatibility. *)
 end
 
 (** {1 Context Ratio Hard Cap}

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -155,10 +155,6 @@ let resolve_keeper_read_path ~(config : Room.config) ~(raw_path : string)
         (Printf.sprintf "path_outside_project_root: %s (root=%s)"
            target_norm root_norm)
 
-let truncate_tool_output ?(max_len = 12000) (s : string) : string =
-  if String.length s <= max_len then s
-  else String.sub s 0 max_len ^ "\n...[truncated]"
-
 let process_status_to_json (st : Unix.process_status) : Yojson.Safe.t =
   match st with
   | Unix.WEXITED code ->

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -78,7 +78,7 @@ let handle_keeper_github
           (`Assoc
               [ "ok", `Bool (st = Unix.WEXITED 0)
               ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String (Keeper_alerting_path.truncate_tool_output out)
+              ; "output", `String out
               ])))
 ;;
 

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -118,7 +118,7 @@ let handle_keeper_bash
           (`Assoc
               [ "ok", `Bool (st = Unix.WEXITED 0)
               ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String (Keeper_alerting_path.truncate_tool_output out)
+              ; "output", `String out
               ]))
 ;;
 
@@ -156,7 +156,7 @@ let handle_keeper_shell_readonly
           ; "op", `String op
           ; "cmd", `String cmd
           ; "status", Keeper_alerting_path.process_status_to_json st
-          ; "output", `String (Keeper_alerting_path.truncate_tool_output out)
+          ; "output", `String out
           ])
   in
   match op with
@@ -293,7 +293,7 @@ let handle_keeper_shell_readonly
              ; "path", `String target
              ; "lines", `Int n
              ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "content", `String (Keeper_alerting_path.truncate_tool_output out)
+             ; "content", `String out
              ]))
   | "tail" ->
     (match read_target () with
@@ -311,7 +311,7 @@ let handle_keeper_shell_readonly
              ; "path", `String target
              ; "lines", `Int n
              ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "content", `String (Keeper_alerting_path.truncate_tool_output out)
+             ; "content", `String out
              ]))
   | "wc" ->
     (match read_target () with
@@ -467,8 +467,8 @@ let handle_keeper_shell_readonly
               ; "op", `String op
               ; "command", `String cmd_str
               ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String (Keeper_alerting_path.truncate_tool_output out)
-              ]))
+              ; "output", `String out
+              ])
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -468,7 +468,7 @@ let handle_keeper_shell_readonly
               ; "command", `String cmd_str
               ; "status", Keeper_alerting_path.process_status_to_json st
               ; "output", `String out
-              ])
+              ]))
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -20,12 +20,13 @@ let handle_keeper_task_tool
     let include_done = Safe_ops.json_bool ~default:false "include_done" args in
     let limit = Safe_ops.json_int ~default:50 "limit" args |> max 1 |> min 100 in
     let result = Room.list_tasks ?status:status_filter ~include_done config in
-    (try
-       match Yojson.Safe.from_string result with
-       | `List items ->
-         Yojson.Safe.to_string (`List (List.filteri (fun i _ -> i < limit) items))
-       | _ -> result
-     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> result)
+    (match Yojson.Safe.from_string result with
+     | `List items ->
+       Yojson.Safe.to_string (`List (List.filteri (fun i _ -> i < limit) items))
+     | _ -> result
+     | exception Yojson.Json_error _ ->
+       let lines = String.split_on_char '\n' result in
+       String.concat "\n" (List.filteri (fun i _ -> i < limit + 2) lines))
   | "keeper_tasks_audit" ->
     let limit = Safe_ops.json_int ~default:20 "limit" args |> max 1 |> min 50 in
     let orphans = Room.audit_orphan_tasks config in

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -20,7 +20,6 @@ let handle_keeper_task_tool
     let include_done = Safe_ops.json_bool ~default:false "include_done" args in
     let limit = Safe_ops.json_int ~default:50 "limit" args |> max 1 |> min 100 in
     let result = Room.list_tasks ?status:status_filter ~include_done config in
-    (* Truncate JSON list output if it parses as a list *)
     (try
        match Yojson.Safe.from_string result with
        | `List items ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -158,12 +158,6 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
         ("detail", `Null);
       ])
 
-(** Memory-protection cap — delegates to [Tool_output_validation.cap].
-    Context budget management is OAS [context_reducer]'s responsibility.
-    Applied to ALL paths (success, error, exception) in [make_tools]. *)
-let validate_output ~tool_name:_ (result : string) : string =
-  Tool_output_validation.cap result
-
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
@@ -263,7 +257,7 @@ let make_tools
                 Keeper_tool_call_log.set_truncation_info
                   ~keeper_name:meta.name
                   ~original_bytes:(String.length normalized_error) ();
-                (false, validate_output ~tool_name:td.name normalized_error)
+                (false, Tool_output_validation.cap normalized_error)
               end else begin
                 Hashtbl.remove failure_counts key;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
@@ -311,7 +305,7 @@ let make_tools
                      with Yojson.Json_error _ -> normalized)
                 in
                 let original_len = String.length final_result in
-                let truncated_result = validate_output ~tool_name:td.name final_result in
+                let truncated_result = Tool_output_validation.cap final_result in
                 let was_truncated = original_len > Tool_output_validation.max_output_chars in
                 if was_truncated then
                   Log.Keeper.info "tool %s output truncated: %d -> %d chars"
@@ -382,6 +376,6 @@ let make_tools
               Keeper_tool_call_log.set_truncation_info
                 ~keeper_name:meta.name
                 ~original_bytes:(String.length normalized_exn) ();
-              (false, validate_output ~tool_name:td.name normalized_exn)))
+              (false, Tool_output_validation.cap normalized_exn)))
     else None
   ) tool_defs

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -158,13 +158,11 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
         ("detail", `Null);
       ])
 
-(** Deterministic output validation — delegates to [Tool_output_validation].
-
-    Replaces heuristic [truncate_tool_output] (blind char-cut) with
-    schema-aware validation: array-aware truncation + structured metadata.
+(** Memory-protection cap — delegates to [Tool_output_validation.cap].
+    Context budget management is OAS [context_reducer]'s responsibility.
     Applied to ALL paths (success, error, exception) in [make_tools]. *)
-let validate_output ~tool_name (result : string) : string =
-  Tool_output_validation.validate_and_truncate ~tool_name result
+let validate_output ~tool_name:_ (result : string) : string =
+  Tool_output_validation.cap result
 
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
@@ -314,7 +312,7 @@ let make_tools
                 in
                 let original_len = String.length final_result in
                 let truncated_result = validate_output ~tool_name:td.name final_result in
-                let was_truncated = String.length truncated_result < original_len in
+                let was_truncated = original_len > Tool_output_validation.max_output_chars in
                 if was_truncated then
                   Log.Keeper.info "tool %s output truncated: %d -> %d chars"
                     td.name original_len (String.length truncated_result);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -573,7 +573,7 @@ let tool_post_list : Types.tool_schema = {
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
-      ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max posts to return (default: 20)"); ("minimum", `Int 1); ("maximum", `Int 100)]);
+      ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max posts to return"); ("default", `Int 20); ("minimum", `Int 1); ("maximum", `Int 100)]);
       ("visibility", `Assoc [("type", `String "string"); ("enum", `List [`String "public"; `String "unlisted"; `String "internal"; `String "direct"]); ("description", `String "Filter by visibility")]);
       ("hearth", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter by hearth topic (e.g. webrtc, code-review)")]);
       ("random", `Assoc [("type", `String "boolean"); ("description", `String "Shuffle posts randomly (default: false)")]);
@@ -646,7 +646,7 @@ let tool_search : Types.tool_schema = {
     ("type", `String "object");
     ("properties", `Assoc [
       ("query", `Assoc [("type", `String "string"); ("maxLength", `Int 200); ("description", `String "Search keyword")]);
-      ("limit", `Assoc [("type", `String "integer"); ("minimum", `Int 1); ("maximum", `Int 100); ("description", `String "Max results (default: 20)")]);
+      ("limit", `Assoc [("type", `String "integer"); ("default", `Int 20); ("minimum", `Int 1); ("maximum", `Int 100); ("description", `String "Max results")]);
       ("compact", `Assoc [("type", `String "boolean"); ("default", `Bool true); ("description", `String "Compact one-line per post. Set false for full body")]);
     ]);
     ("required", `List [`String "query"]);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -583,7 +583,7 @@ let tool_post_list : Types.tool_schema = {
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);
       ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a 🔔 indicator")]);
-      ("compact", `Assoc [("type", `String "boolean"); ("description", `String "Compact one-line per post (default: true). Set false for full body/TTL/visibility")]);
+      ("compact", `Assoc [("type", `String "boolean"); ("default", `Bool true); ("description", `String "Compact one-line per post. Set false for full body/TTL/visibility")]);
     ]);
   ];
 }
@@ -647,7 +647,7 @@ let tool_search : Types.tool_schema = {
     ("properties", `Assoc [
       ("query", `Assoc [("type", `String "string"); ("maxLength", `Int 200); ("description", `String "Search keyword")]);
       ("limit", `Assoc [("type", `String "integer"); ("minimum", `Int 1); ("maximum", `Int 100); ("description", `String "Max results (default: 20)")]);
-      ("compact", `Assoc [("type", `String "boolean"); ("description", `String "Compact one-line per post (default: true). Set false for full body")]);
+      ("compact", `Assoc [("type", `String "boolean"); ("default", `Bool true); ("description", `String "Compact one-line per post. Set false for full body")]);
     ]);
     ("required", `List [`String "query"]);
   ];

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -503,7 +503,7 @@ let handle_search args =
       let fmt = if compact then format_post_compact else format_post in
       let formatted = List.map fmt results in
       let separator = if compact then "\n" else "\n---\n" in
-      (true, Printf.sprintf "🔍 '%s' 검색 결과 (%d개):\n\n%s" query (List.length results) (String.concat separator formatted))
+      (true, Printf.sprintf "🔍 '%s' 검색 결과 (%d개):\n%s" query (List.length results) (String.concat separator formatted))
 
 (** Vote on comment *)
 let handle_comment_vote args =

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -503,7 +503,7 @@ let handle_search args =
       let fmt = if compact then format_post_compact else format_post in
       let formatted = List.map fmt results in
       let separator = if compact then "\n" else "\n---\n" in
-      (true, Printf.sprintf "🔍 '%s' 검색 결과 (%d개):\n%s" query (List.length results) (String.concat separator formatted))
+      (true, Printf.sprintf "🔍 '%s' 검색 결과 (%d개):\n\n%s" query (List.length results) (String.concat separator formatted))
 
 (** Vote on comment *)
 let handle_comment_vote args =

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -205,7 +205,8 @@ Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead age
       ("properties", `Assoc [
         ("limit", `Assoc [
           ("type", `String "integer");
-          ("description", `String "Max heartbeats to return (default: 20)");
+          ("description", `String "Max heartbeats to return");
+          ("default", `Int 20);
           ("minimum", `Int 1);
           ("maximum", `Int 100);
         ]);

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -33,12 +33,18 @@ let budget_for tool_name =
 
 (* ── Array-aware truncation ──────────────────────────────────── *)
 
+(** Estimate metadata JSON length for a given shown/total pair.
+    Avoids hardcoded byte constant — calculates from actual values. *)
+let metadata_json_len ~shown ~total =
+  (* {"_truncated":true,"_shown":NNN,"_total":NNN} + comma + safety margin *)
+  let digits n = if n = 0 then 1 else int_of_float (log10 (float_of_int (abs n))) + 1 in
+  50 + digits shown + digits total
+
 (** Truncate a JSON array to fit within [max_chars], preserving structure.
     Returns the truncated JSON string with a metadata element appended. *)
 let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
   let total = List.length items in
-  (* Binary-search-ish: serialize items one by one until budget exceeded *)
-  let buf = Buffer.create max_chars in
+  let buf = Buffer.create (min max_chars 16384) in
   Buffer.add_char buf '[';
   let shown = ref 0 in
   let first = ref true in
@@ -47,7 +53,8 @@ let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
     if not !done_ then begin
       let s = Yojson.Safe.to_string item in
       let sep = if !first then "" else "," in
-      let projected = Buffer.length buf + String.length sep + String.length s + 80 (* metadata *) in
+      let meta_reserve = metadata_json_len ~shown:(!shown + 1) ~total in
+      let projected = Buffer.length buf + String.length sep + String.length s + meta_reserve in
       if projected > max_chars then
         done_ := true
       else begin
@@ -58,7 +65,6 @@ let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
       end
     end
   ) items;
-  (* Append truncation metadata as last element *)
   if !shown < total then begin
     let meta = Printf.sprintf
       "%s{\"_truncated\":true,\"_shown\":%d,\"_total\":%d}"
@@ -132,17 +138,33 @@ let validate_and_truncate ~tool_name (output : string) : string =
 
 (* ── Post-hook for Tool_dispatch ─────────────────────────────── *)
 
+(** Check if output already has truncation metadata (avoid double-truncation
+    when a keeper_* tool internally dispatches a masc_* tool). *)
+let is_already_truncated (data : Yojson.Safe.t) : bool =
+  match data with
+  | `Assoc fields -> List.mem_assoc "_output_budget_exceeded" fields
+  | `List items ->
+    List.exists (fun item ->
+      match item with
+      | `Assoc fields -> List.mem_assoc "_truncated" fields
+      | _ -> false
+    ) items
+  | _ -> false
+
 let post_hook (result : Tool_result.t) : Tool_result.t =
-  let budget = budget_for result.tool_name in
-  let serialized = Yojson.Safe.to_string result.data in
-  if String.length serialized <= budget then result
+  if is_already_truncated result.data then result
   else
-    let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
-    let new_data =
-      try Yojson.Safe.from_string truncated_str
-      with Yojson.Json_error _ -> `String truncated_str
-    in
-    { result with data = new_data }
+    (* Lazy serialize: only allocate the string if we need to check size *)
+    let serialized = Yojson.Safe.to_string result.data in
+    let budget = budget_for result.tool_name in
+    if String.length serialized <= budget then result
+    else
+      let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
+      let new_data =
+        try Yojson.Safe.from_string truncated_str
+        with Yojson.Json_error _ -> `String truncated_str
+      in
+      { result with data = new_data }
 
 (* ── Installation ────────────────────────────────────────────── *)
 

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -1,187 +1,45 @@
-(** Tool_output_validation — Deterministic output budget enforcement.
+(** Tool_output_validation — Memory-protection cap.
 
-    Replaces heuristic [truncate_tool_output] with schema-aware validation.
+    Context budget management belongs to OAS [context_reducer].
+    This module only prevents OOM from unbounded tool output
+    (e.g. a shell command that dumps a large file).
 
-    Two integration points:
-    1. [Tool_dispatch.register_post_hook] — catches [masc_*] tools
-    2. [validate_and_truncate] called from [keeper_tools_oas.ml] —
-       catches [keeper_*] tools that bypass [Tool_dispatch]
+    The cap is intentionally generous (64 KB): it guards against
+    runaway allocations, not against context window pressure.
+    OAS handles context-level truncation via its compression phases.
 
-    @since Samchon deterministic harness — #5807 *)
+    @since #5807 — originally JSON-aware; simplified to boundary-
+    respecting cap in #5821. *)
 
-(* ── Budget registry ─────────────────────────────────────────── *)
+(* ── Cap ────────────────────────────────────────────────────── *)
 
-let default_budget =
-  let env_val =
-    match Sys.getenv_opt "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS" with
-    | Some s -> (try int_of_string s with _ -> 8000)
-    | None -> 8000
-  in
-  max 1000 (min 32000 env_val)
+(** Hard cap: any tool output beyond this is an OOM risk, not a
+    context budget concern.  64 KB covers any reasonable structured
+    result while preventing multi-MB shell dumps from persisting
+    in the message list. *)
+let max_output_chars = 65_536
 
-(** Per-tool budget overrides.  No mutex: non-yielding Hashtbl ops,
-    single-domain writes during init, reads during dispatch. *)
-let budgets : (string, int) Hashtbl.t = Hashtbl.create 16
-
-let set_budget ~tool_name ~max_chars =
-  Hashtbl.replace budgets tool_name (max 100 (min 32000 max_chars))
-
-let budget_for tool_name =
-  match Hashtbl.find_opt budgets tool_name with
-  | Some b -> b
-  | None -> default_budget
-
-(* ── Array-aware truncation ──────────────────────────────────── *)
-
-(** Estimate metadata JSON length for a given shown/total pair.
-    Avoids hardcoded byte constant — calculates from actual values. *)
-let metadata_json_len ~shown ~total =
-  (* {"_truncated":true,"_shown":NNN,"_total":NNN} + comma + safety margin *)
-  let digits n = if n = 0 then 1 else int_of_float (log10 (float_of_int (abs n))) + 1 in
-  50 + digits shown + digits total
-
-(** Truncate a JSON array to fit within [max_chars], preserving structure.
-    Returns the truncated JSON string with a metadata element appended. *)
-let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
-  let total = List.length items in
-  let buf = Buffer.create (min max_chars 16384) in
-  Buffer.add_char buf '[';
-  let shown = ref 0 in
-  let first = ref true in
-  let done_ = ref false in
-  List.iter (fun item ->
-    if not !done_ then begin
-      let s = Yojson.Safe.to_string item in
-      let sep = if !first then "" else "," in
-      let meta_reserve = metadata_json_len ~shown:(!shown + 1) ~total in
-      let projected = Buffer.length buf + String.length sep + String.length s + meta_reserve in
-      if projected > max_chars then
-        done_ := true
-      else begin
-        Buffer.add_string buf sep;
-        Buffer.add_string buf s;
-        first := false;
-        incr shown
-      end
-    end
-  ) items;
-  if !shown < total then begin
-    let meta = Printf.sprintf
-      "%s{\"_truncated\":true,\"_shown\":%d,\"_total\":%d}"
-      (if !shown > 0 then "," else "") !shown total
-    in
-    Buffer.add_string buf meta
-  end;
-  Buffer.add_char buf ']';
-  Buffer.contents buf
-
-(** Truncate a JSON object by finding its largest string/array value
-    and shrinking it. Preserves the envelope structure.
-    Falls back to minimal metadata object if budget is too small. *)
-let truncate_json_object (fields : (string * Yojson.Safe.t) list) ~max_chars : string =
-  let sized_fields =
-    List.map (fun (k, v) ->
-      let s = Yojson.Safe.to_string v in
-      (k, v, String.length s)
-    ) fields
-  in
-  let sorted = List.sort (fun (_, _, a) (_, _, b) -> compare b a) sized_fields in
-  match sorted with
-  | [] -> "{}"
-  | (largest_key, largest_val, _) :: _ ->
-    let truncated_val = match largest_val with
-      | `List items ->
-        let item_budget = max_chars / 2 in
-        Yojson.Safe.from_string (truncate_json_array items ~max_chars:item_budget)
-      | `String s when String.length s > max_chars / 2 ->
-        let keep = max_chars / 2 in
-        `String (String.sub s 0 keep ^ "...")
-      | v -> v
-    in
-    let new_fields = List.map (fun (k, v) ->
-      if k = largest_key then (k, truncated_val) else (k, v)
-    ) fields in
-    let with_meta = new_fields @ [
-      ("_output_budget_exceeded", `Bool true);
-      ("_budget_chars", `Int max_chars);
-    ] in
-    let candidate = Yojson.Safe.to_string (`Assoc with_meta) in
-    (* Budget guarantee: if still over, fall back to minimal metadata *)
-    if String.length candidate <= max_chars then candidate
-    else
-      let minimal = `Assoc [
-        ("_output_budget_exceeded", `Bool true);
-        ("_budget_chars", `Int max_chars);
-        ("_original_fields", `Int (List.length fields));
-      ] in
-      Yojson.Safe.to_string minimal
-
-(* ── Core validation ─────────────────────────────────────────── *)
-
-(** Validate and truncate a tool output string.
-    - Within budget: return unchanged.
-    - Over budget + valid JSON array: array-aware truncation.
-    - Over budget + valid JSON object: object-aware truncation.
-    - Over budget + non-JSON: character truncation with metadata. *)
-let validate_and_truncate ~tool_name (output : string) : string =
-  let budget = budget_for tool_name in
+let cap (output : string) : string =
   let len = String.length output in
-  if len <= budget then output
+  if len <= max_output_chars then output
   else
-    (* Try JSON-aware truncation first *)
-    match
-      (try Some (Yojson.Safe.from_string output)
-       with Yojson.Json_error _ -> None)
-    with
-    | Some (`List items) ->
-      truncate_json_array items ~max_chars:budget
-    | Some (`Assoc fields) ->
-      truncate_json_object fields ~max_chars:budget
-    | _ ->
-      (* Fallback: character truncation with structured metadata *)
-      let kept = String.sub output 0 budget in
-      let pct = Float.of_int (len - budget) *. 100.0 /. Float.of_int len in
-      Printf.sprintf "%s\n{\"_output_budget_exceeded\":true,\"_shown_chars\":%d,\"_total_chars\":%d,\"_elided_pct\":%.0f}"
-        kept budget len pct
+    let kept = String.sub output 0 max_output_chars in
+    Printf.sprintf "%s\n[capped: %d/%d chars]" kept max_output_chars len
 
-(* ── Post-hook for Tool_dispatch ─────────────────────────────── *)
-
-(** Check if output already has truncation metadata (avoid double-truncation
-    when a keeper_* tool internally dispatches a masc_* tool). *)
-let is_already_truncated (data : Yojson.Safe.t) : bool =
-  match data with
-  | `Assoc fields -> List.mem_assoc "_output_budget_exceeded" fields
-  | `List items ->
-    List.exists (fun item ->
-      match item with
-      | `Assoc fields -> List.mem_assoc "_truncated" fields
-      | _ -> false
-    ) items
-  | _ -> false
+(* ── Post-hook for Tool_dispatch ────────────────────────────── *)
 
 let post_hook (result : Tool_result.t) : Tool_result.t =
-  if is_already_truncated result.data then result
-  else
-    let budget = budget_for result.tool_name in
-    (* For `String, operate on the raw string directly to avoid
-       JSON encoding overhead (quotes/escaping inflate length). *)
-    match result.data with
-    | `String s when String.length s > budget ->
-      let truncated = validate_and_truncate ~tool_name:result.tool_name s in
-      { result with data = `String truncated }
-    | `List _ | `Assoc _ ->
-      let serialized = Yojson.Safe.to_string result.data in
-      if String.length serialized <= budget then result
-      else
-        let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
-        let new_data =
-          try Yojson.Safe.from_string truncated_str
-          with Yojson.Json_error _ -> `String truncated_str
-        in
-        { result with data = new_data }
-    | _ -> result
+  match result.data with
+  | `String s when String.length s > max_output_chars ->
+    { result with data = `String (cap s) }
+  | `List _ | `Assoc _ ->
+    let serialized = Yojson.Safe.to_string result.data in
+    if String.length serialized <= max_output_chars then result
+    else
+      { result with data = `String (cap serialized) }
+  | _ -> result
 
-(* ── Installation ────────────────────────────────────────────── *)
+(* ── Installation ───────────────────────────────────────────── *)
 
 let installed = ref false
 

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -76,9 +76,9 @@ let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
   Buffer.contents buf
 
 (** Truncate a JSON object by finding its largest string/array value
-    and shrinking it. Preserves the envelope structure. *)
+    and shrinking it. Preserves the envelope structure.
+    Falls back to minimal metadata object if budget is too small. *)
 let truncate_json_object (fields : (string * Yojson.Safe.t) list) ~max_chars : string =
-  (* Find the largest field by serialized size *)
   let sized_fields =
     List.map (fun (k, v) ->
       let s = Yojson.Safe.to_string v in
@@ -89,7 +89,6 @@ let truncate_json_object (fields : (string * Yojson.Safe.t) list) ~max_chars : s
   match sorted with
   | [] -> "{}"
   | (largest_key, largest_val, _) :: _ ->
-    (* Truncate the largest field *)
     let truncated_val = match largest_val with
       | `List items ->
         let item_budget = max_chars / 2 in
@@ -106,7 +105,16 @@ let truncate_json_object (fields : (string * Yojson.Safe.t) list) ~max_chars : s
       ("_output_budget_exceeded", `Bool true);
       ("_budget_chars", `Int max_chars);
     ] in
-    Yojson.Safe.to_string (`Assoc with_meta)
+    let candidate = Yojson.Safe.to_string (`Assoc with_meta) in
+    (* Budget guarantee: if still over, fall back to minimal metadata *)
+    if String.length candidate <= max_chars then candidate
+    else
+      let minimal = `Assoc [
+        ("_output_budget_exceeded", `Bool true);
+        ("_budget_chars", `Int max_chars);
+        ("_original_fields", `Int (List.length fields));
+      ] in
+      Yojson.Safe.to_string minimal
 
 (* ── Core validation ─────────────────────────────────────────── *)
 
@@ -154,17 +162,24 @@ let is_already_truncated (data : Yojson.Safe.t) : bool =
 let post_hook (result : Tool_result.t) : Tool_result.t =
   if is_already_truncated result.data then result
   else
-    (* Lazy serialize: only allocate the string if we need to check size *)
-    let serialized = Yojson.Safe.to_string result.data in
     let budget = budget_for result.tool_name in
-    if String.length serialized <= budget then result
-    else
-      let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
-      let new_data =
-        try Yojson.Safe.from_string truncated_str
-        with Yojson.Json_error _ -> `String truncated_str
-      in
-      { result with data = new_data }
+    (* For `String, operate on the raw string directly to avoid
+       JSON encoding overhead (quotes/escaping inflate length). *)
+    match result.data with
+    | `String s when String.length s > budget ->
+      let truncated = validate_and_truncate ~tool_name:result.tool_name s in
+      { result with data = `String truncated }
+    | `List _ | `Assoc _ ->
+      let serialized = Yojson.Safe.to_string result.data in
+      if String.length serialized <= budget then result
+      else
+        let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
+        let new_data =
+          try Yojson.Safe.from_string truncated_str
+          with Yojson.Json_error _ -> `String truncated_str
+        in
+        { result with data = new_data }
+    | _ -> result
 
 (* ── Installation ────────────────────────────────────────────── *)
 

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -14,7 +14,7 @@
 let default_budget =
   let env_val =
     match Sys.getenv_opt "MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS" with
-    | Some s -> (try int_of_string s with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 8000)
+    | Some s -> (try int_of_string s with _ -> 8000)
     | None -> 8000
   in
   max 1000 (min 32000 env_val)
@@ -33,18 +33,12 @@ let budget_for tool_name =
 
 (* ── Array-aware truncation ──────────────────────────────────── *)
 
-(** Estimate metadata JSON length for a given shown/total pair.
-    Avoids hardcoded byte constant — calculates from actual values. *)
-let metadata_json_len ~shown ~total =
-  (* {"_truncated":true,"_shown":NNN,"_total":NNN} + comma + safety margin *)
-  let digits n = if n = 0 then 1 else int_of_float (log10 (float_of_int (abs n))) + 1 in
-  50 + digits shown + digits total
-
 (** Truncate a JSON array to fit within [max_chars], preserving structure.
     Returns the truncated JSON string with a metadata element appended. *)
 let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
   let total = List.length items in
-  let buf = Buffer.create (min max_chars 16384) in
+  (* Binary-search-ish: serialize items one by one until budget exceeded *)
+  let buf = Buffer.create max_chars in
   Buffer.add_char buf '[';
   let shown = ref 0 in
   let first = ref true in
@@ -53,8 +47,7 @@ let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
     if not !done_ then begin
       let s = Yojson.Safe.to_string item in
       let sep = if !first then "" else "," in
-      let meta_reserve = metadata_json_len ~shown:(!shown + 1) ~total in
-      let projected = Buffer.length buf + String.length sep + String.length s + meta_reserve in
+      let projected = Buffer.length buf + String.length sep + String.length s + 80 (* metadata *) in
       if projected > max_chars then
         done_ := true
       else begin
@@ -65,6 +58,7 @@ let truncate_json_array (items : Yojson.Safe.t list) ~max_chars : string =
       end
     end
   ) items;
+  (* Append truncation metadata as last element *)
   if !shown < total then begin
     let meta = Printf.sprintf
       "%s{\"_truncated\":true,\"_shown\":%d,\"_total\":%d}"
@@ -138,33 +132,17 @@ let validate_and_truncate ~tool_name (output : string) : string =
 
 (* ── Post-hook for Tool_dispatch ─────────────────────────────── *)
 
-(** Check if output already has truncation metadata (avoid double-truncation
-    when a keeper_* tool internally dispatches a masc_* tool). *)
-let is_already_truncated (data : Yojson.Safe.t) : bool =
-  match data with
-  | `Assoc fields -> List.mem_assoc "_output_budget_exceeded" fields
-  | `List items ->
-    List.exists (fun item ->
-      match item with
-      | `Assoc fields -> List.mem_assoc "_truncated" fields
-      | _ -> false
-    ) items
-  | _ -> false
-
 let post_hook (result : Tool_result.t) : Tool_result.t =
-  if is_already_truncated result.data then result
+  let budget = budget_for result.tool_name in
+  let serialized = Yojson.Safe.to_string result.data in
+  if String.length serialized <= budget then result
   else
-    (* Lazy serialize: only allocate the string if we need to check size *)
-    let serialized = Yojson.Safe.to_string result.data in
-    let budget = budget_for result.tool_name in
-    if String.length serialized <= budget then result
-    else
-      let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
-      let new_data =
-        try Yojson.Safe.from_string truncated_str
-        with Yojson.Json_error _ -> `String truncated_str
-      in
-      { result with data = new_data }
+    let truncated_str = validate_and_truncate ~tool_name:result.tool_name serialized in
+    let new_data =
+      try Yojson.Safe.from_string truncated_str
+      with Yojson.Json_error _ -> `String truncated_str
+    in
+    { result with data = new_data }
 
 (* ── Installation ────────────────────────────────────────────── *)
 

--- a/lib/tool_output_validation.mli
+++ b/lib/tool_output_validation.mli
@@ -1,32 +1,22 @@
-(** Tool_output_validation — Deterministic output budget enforcement.
+(** Tool_output_validation — Memory-protection cap.
 
-    Replaces heuristic [truncate_tool_output] with schema-aware validation.
-    Each tool has a max output budget (in chars). Outputs exceeding the
-    budget are truncated with structured metadata so the LLM knows
-    information was elided.
+    Context budget management belongs to OAS [context_reducer].
+    This module only prevents OOM from unbounded tool output.
 
-    Array-aware: JSON arrays are truncated by removing items (preserving
-    structure) rather than blind character slicing.
+    @since #5807 — simplified to boundary-respecting cap in #5821. *)
 
-    @since Samchon deterministic harness — #5807 *)
+(** Hard cap in characters.  Any output beyond this is capped with
+    a trailing marker.  Intentionally generous (64 KB): guards against
+    runaway allocations, not against context window pressure. *)
+val max_output_chars : int
 
-(** Default output budget in chars.
-    Reads from [MASC_KEEPER_MAX_TOOL_OUTPUT_CHARS] for backward compat. *)
-val default_budget : int
-
-(** Register a per-tool output budget. Tools without explicit budgets
-    use [default_budget]. Call during server initialization. *)
-val set_budget : tool_name:string -> max_chars:int -> unit
-
-(** Validate and truncate a tool output string against its budget.
-    Returns the original if within budget, or a truncated version with
-    structured metadata appended.
-    Use this directly from [keeper_tools_oas.ml] for keeper_* tools
-    that bypass [Tool_dispatch]. *)
-val validate_and_truncate : tool_name:string -> string -> string
+(** Cap a tool output string.  Returns unchanged if within
+    [max_output_chars]; otherwise truncates and appends a marker. *)
+val cap : string -> string
 
 (** Post-hook for [Tool_dispatch.register_post_hook].
-    Catches [masc_*] tools that go through the dispatch pipeline. *)
+    Applies [cap] to [masc_*] tools that go through the dispatch
+    pipeline. *)
 val post_hook : Tool_result.t -> Tool_result.t
 
 (** Install the post-hook into [Tool_dispatch]. Idempotent. *)

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -495,9 +495,11 @@ let test_output_validation_array_aware_truncation () =
     (string_contains ~sub:"_shown" result)
 
 let test_output_validation_default_budget () =
-  let long = String.make 16000 'c' in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"unregistered_tool" long in
-  check bool "default truncates 16k" true (String.length result < 16000);
+  (* Use explicit budget to avoid env-var dependency in tests *)
+  Tool_output_validation.set_budget ~tool_name:"test_default" ~max_chars:5000;
+  let long = String.make 10000 'c' in
+  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test_default" long in
+  check bool "truncates over-budget output" true (String.length result < 10000);
   check bool "contains budget metadata" true
     (string_contains ~sub:"_output_budget_exceeded" result)
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -461,47 +461,33 @@ let test_normalize_failure_plain_text () =
   check bool "ok is false" false (json_bool "ok" json);
   check string "error is raw text" raw (json_string "error" json)
 
-(* ── Tool_output_validation tests ──────────────────────────── *)
+(* ── Tool_output_validation tests (memory cap) ──────────────── *)
 
-let test_output_validation_short_unchanged () =
+let test_cap_short_unchanged () =
   let short = "hello world" in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test" short in
+  let result = Tool_output_validation.cap short in
   check string "short output unchanged" short result
 
-let test_output_validation_exact_limit_unchanged () =
-  Tool_output_validation.set_budget ~tool_name:"test_exact" ~max_chars:100;
-  let exact = String.make 100 'x' in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test_exact" exact in
+let test_cap_exact_limit_unchanged () =
+  let exact = String.make Tool_output_validation.max_output_chars 'x' in
+  let result = Tool_output_validation.cap exact in
   check string "exact limit unchanged" exact result
 
-let test_output_validation_over_budget_truncates () =
-  Tool_output_validation.set_budget ~tool_name:"test_over" ~max_chars:200;
-  let long = String.make 500 'a' in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test_over" long in
-  check bool "result shorter than original" true (String.length result < 500);
-  check bool "contains budget metadata" true
-    (string_contains ~sub:"_output_budget_exceeded" result)
+let test_cap_over_limit () =
+  let long = String.make (Tool_output_validation.max_output_chars + 1000) 'a' in
+  let result = Tool_output_validation.cap long in
+  check bool "result shorter than original" true
+    (String.length result < String.length long);
+  check bool "contains capped marker" true
+    (string_contains ~sub:"[capped:" result)
 
-let test_output_validation_array_aware_truncation () =
-  Tool_output_validation.set_budget ~tool_name:"test_array" ~max_chars:200;
-  let items = List.init 50 (fun i -> `Assoc [("id", `Int i); ("name", `String (Printf.sprintf "item_%d" i))]) in
-  let json = Yojson.Safe.to_string (`List items) in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test_array" json in
-  check bool "result is valid JSON" true
-    (try ignore (Yojson.Safe.from_string result); true with _ -> false);
-  check bool "contains truncated marker" true
-    (string_contains ~sub:"_truncated" result);
-  check bool "contains shown count" true
-    (string_contains ~sub:"_shown" result)
-
-let test_output_validation_default_budget () =
-  (* Use explicit budget to avoid env-var dependency in tests *)
-  Tool_output_validation.set_budget ~tool_name:"test_default" ~max_chars:5000;
-  let long = String.make 10000 'c' in
-  let result = Tool_output_validation.validate_and_truncate ~tool_name:"test_default" long in
-  check bool "truncates over-budget output" true (String.length result < 10000);
-  check bool "contains budget metadata" true
-    (string_contains ~sub:"_output_budget_exceeded" result)
+let test_cap_preserves_prefix () =
+  let prefix = "HEADER:" in
+  let long = prefix ^ String.make (Tool_output_validation.max_output_chars + 1000) 'z' in
+  let result = Tool_output_validation.cap long in
+  check bool "prefix preserved" true
+    (String.length result >= String.length prefix
+     && String.sub result 0 (String.length prefix) = prefix)
 
 let () =
   let base_path = Masc_test_deps.find_project_root () in
@@ -538,11 +524,10 @@ let () =
       test_case "empty query fails" `Quick test_library_search_empty_query;
       test_case "missing topic fails" `Quick test_library_read_missing_topic;
     ];
-    "output_validation", [
-      test_case "short output unchanged" `Quick test_output_validation_short_unchanged;
-      test_case "exact limit unchanged" `Quick test_output_validation_exact_limit_unchanged;
-      test_case "over budget truncates with metadata" `Quick test_output_validation_over_budget_truncates;
-      test_case "array-aware truncation" `Quick test_output_validation_array_aware_truncation;
-      test_case "default budget for unregistered tool" `Quick test_output_validation_default_budget;
+    "output_cap", [
+      test_case "short output unchanged" `Quick test_cap_short_unchanged;
+      test_case "exact limit unchanged" `Quick test_cap_exact_limit_unchanged;
+      test_case "over limit capped with marker" `Quick test_cap_over_limit;
+      test_case "prefix preserved after cap" `Quick test_cap_preserves_prefix;
     ];
   ]


### PR DESCRIPTION
## Summary

- `Tool_output_validation`을 178줄 JSON-aware truncation에서 50줄 64K memory cap으로 단순화
- MASC-OAS 경계 준수: context budget 관리는 OAS `context_reducer` 역할, MASC는 OOM 방지 cap만
- Legacy `truncate_tool_output` 완전 제거 (6 call sites + 함수 삭제)
- Tool schema에 `"default"` 필드 추가 (limit/compact params)

## 변경 내용

### 경계 준수 단순화
- 3중 truncation (legacy 12K → schema-aware 8K → OAS reducer) → 1중 cap (64K → OAS reducer)
- `truncate_json_array`, `truncate_json_object`, per-tool budget registry 삭제
- `validate_output` wrapper 삭제 → `Tool_output_validation.cap` 직접 호출
- `KeeperToolExec.max_tool_output_chars` dead code 삭제

### Schema 개선 (#5807 기반)
- 14개 P0 tool schema에 deterministic constraints 추가 (min/max/enum/pattern)
- `masc_board_list`, `masc_board_search`: limit에 `"default"` 필드 추가
- `keeper_tasks_list`: silent catch-all → explicit `Yojson.Json_error` 처리

## 근거

기존 `Tool_output_validation`은 OAS 영역(token budget/context management)을 MASC에서 재구현한 것:
- Per-tool budget registry = OAS context_reducer의 phase-based budget과 중복
- JSON-aware truncation = OAS가 이미 수행하는 context-level 축소와 중복
- 결과: 3중 truncation으로 정보 손실 극대화

단순 64K cap은 MASC 경계 내에서 OOM 보호만 담당. Context-level 축소는 OAS에 위임.

## Test plan

- [x] `dune build --root .` 빌드 성공
- [x] `test/test_keeper_tools_oas.exe` 25/25 통과
- [x] `rg "truncate_tool_output" lib/` → 0 matches
- [ ] Keeper 실행 시 tool output 정상 반환 확인
- [ ] 대용량 출력 (git log) 시 64K cap 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5821