### PR TITLE
fix(test): handle result type in test_warn_root_causes

### DIFF
--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -11,7 +11,7 @@ open Masc_mcp
 let init_registry () =
   Masc_test_deps.init_keeper_tool_registry ();
   let base_path = Masc_test_deps.find_project_root () in
-  Keeper_tool_policy.init_policy_config ~base_path
+  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path))
 
 let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json


### PR DESCRIPTION
## Summary

- `init_policy_config`이 `(unit, string) result`를 반환하도록 변경됨에 따라 `test_warn_root_causes.ml`의 `init_registry`에서 빌드 에러 발생
- 다른 11개 테스트 파일에서 사용하는 `ignore (Result.get_ok (...))` 패턴 적용

## Test plan

- [x] `dune build --root .` 빌드 성공
- [x] `test/test_warn_root_causes.exe` 5/5 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)