### PR TITLE
test: add Eio.Fiber.yield() to concurrent atomicity test

### DIFF
--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -135,7 +135,8 @@ let test_concurrent_atomic_writes_never_empty () =
       let json =
         `Assoc [ ("name", `String (Printf.sprintf "v%d" i)) ]
       in
-      Room_utils.write_json_local path json
+      Room_utils.write_json_local path json;
+      Eio.Fiber.yield ()
     done);
   (* Reader fiber: read concurrently *)
   Eio.Fiber.fork ~sw (fun () ->
@@ -143,7 +144,8 @@ let test_concurrent_atomic_writes_never_empty () =
       (try
          let content = Fs_compat.load_file path in
          if String.trim content = "" then empty_seen := true
-       with _ -> ())
+       with _ -> ());
+      Eio.Fiber.yield ()
     done);
   check bool "concurrent reads never see empty file" false !empty_seen;
   (try Unix.unlink path with _ -> ());


### PR DESCRIPTION
## Description

Addresses GLM-5.1 cross-model review feedback from #5840.

> Nit: concurrent test uses cooperative scheduler with 2 sequential fibers — add Eio.Fiber.yield() to genuinely exercise atomicity.

Adds `Eio.Fiber.yield()` to both the reader and writer loops in `test_concurrent_atomic_writes_never_empty` so the Eio scheduler genuinely interleaves their execution, thoroughly exercising the atomic file write behavior.