### PR TITLE
refactor(core): apply OCaml best practices to excuse_patterns I/O

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -100,8 +100,9 @@ let load_excuse_patterns () : (string * string) list =
     let patterns =
       try
         let path = excuse_patterns_path () in
-        if Sys.file_exists path then
-          let json = Yojson.Safe.from_file path in
+        if Fs_compat.file_exists path then
+          let content = Fs_compat.load_file path in
+          let json = Yojson.Safe.from_string content in
           match parse_excuse_patterns_json json with
           | Ok p -> p
           | Error msg ->
@@ -126,13 +127,14 @@ let save_excuse_patterns (patterns : (string * string) list) : (unit, string) re
     let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
     let json = `List json_items in
     let tmp = path ^ ".tmp" in
-    Yojson.Safe.to_file tmp json;
+    let content = Yojson.Safe.pretty_to_string json in
+    Fs_compat.save_file tmp content;
     Sys.rename tmp path;
     cached_patterns := Some patterns;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _exn -> Error "Failed to save excuse patterns"
+  | exn -> Error (Printf.sprintf "Failed to save excuse patterns: %s" (Printexc.to_string exn))
 
 let min_notes_length = 10
 

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -44,7 +44,7 @@ let write_vcs_tools =
 (* ── Test 1: Core discovery tools respect preset ──────────────── *)
 
 let test_core_tools_filtered_by_research_preset () =
-  init_registry ();
+  ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-research" ()) with
       tool_access = Preset { preset = Research; also_allow = [] };
@@ -68,7 +68,7 @@ let test_core_tools_filtered_by_research_preset () =
   ) Keeper_tool_registry.core_always_tools
 
 let test_core_tools_filtered_by_social_preset () =
-  init_registry ();
+  ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-social" ()) with
       tool_access = Preset { preset = Social; also_allow = [] };
@@ -79,7 +79,7 @@ let test_core_tools_filtered_by_social_preset () =
     fail "keeper_fs_edit should be excluded for social preset"
 
 let test_core_tools_include_write_for_coding_preset () =
-  init_registry ();
+  ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-coding" ()) with
       tool_access = Preset { preset = Coding; also_allow = [] };


### PR DESCRIPTION
## Description

Addresses user feedback to follow OCaml and Eio best practices.
- Replaces blocking `Sys.file_exists`, `Yojson.Safe.from_file`, and `Yojson.Safe.to_file` with Eio-safe `Fs_compat` variants (`Fs_compat.file_exists`, `Fs_compat.load_file`, `Fs_compat.save_file`).
- Improves error handling in `save_excuse_patterns` to return a detailed `Result.Error` instead of swallowing exceptions.
- Fixes `init_registry` return type issue in tests introduced by previous PRs.