### PR TITLE
fix(keeper): use actual API response model instead of stale cascade label

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -436,7 +436,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       c.model_id = result.model_used || c.model_id = used
     ) cfgs with
     | Some c -> c.model_id
-    | None -> (match cfgs with c :: _ -> c.model_id | [] -> result.model_used)
+    | None -> used  (* Use actual API response model, not stale cascade label *)
   in
   let turn_cost =
     let pricing = Llm_provider.Pricing.pricing_for_model used_model_id in


### PR DESCRIPTION
## Problem
keeper tool call 로그에 `qwen3.5-9b-local` (llama-server 시절 라벨)이 기록됨.
실제로는 Ollama가 `qwen3.5:9b-nvfp4`를 응답.

## Root cause
`keeper_unified_turn.ml:439` — cascade config에 매칭 실패 시 첫 번째 config의 stale model_id를 fallback으로 사용.

## Fix
매칭 실패 시 API 응답의 실제 model을 그대로 사용.

## Test plan
- [x] dune build
- [ ] CI
- [ ] 서버 재시작 후 tool call 로그에 올바른 모델명 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)