### PR TITLE
fix(dashboard): remove redundant keeper/config from sessions page

### DIFF
--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -2,7 +2,6 @@ import { html } from 'htm/preact'
 import { StatCell } from './common/stat-cell'
 import {
   toneClass,
-  relativeTime,
 } from './mission-utils'
 
 // Re-export from split files for consumers importing from './mission-cards'
@@ -10,29 +9,6 @@ export { SessionBriefCard, SessionDetailCard } from './mission-session-cards'
 export { AgentBriefCard, KeeperBriefCard, InternalSignalCard } from './mission-agent-cards'
 export { MissionBriefingCard } from './mission-briefing-card'
 export { AttentionCard } from './mission-attention-card'
-
-export function MissionContextBar({
-  cluster,
-  project,
-  namespace,
-  generatedAt,
-}: {
-  cluster?: string
-  project?: string
-  namespace?: string | null
-  generatedAt?: string
-}) {
-  return html`
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
-      <${StatCell} label="프로젝트" value=${project ?? '확인 없음'} />
-      <${StatCell} label="프로젝트 범위" value=${namespace ?? 'default'} />
-      <${StatCell} label="갱신 시각" value=${generatedAt ? relativeTime(generatedAt) : '기록 없음'} />
-      ${cluster && cluster !== 'unknown'
-        ? html`<${StatCell} label="배포 메타" value=${cluster} />`
-        : null}
-    </div>
-  `
-}
 
 export function SummaryStat({
   label,

--- a/dashboard/src/components/mission.test.ts
+++ b/dashboard/src/components/mission.test.ts
@@ -7,11 +7,9 @@ import {
 describe('hiddenMissionSectionLabels', () => {
   it('marks empty mission sections for hiding', () => {
     expect(hiddenMissionSectionLabels({
-      keeperCount: 0,
       activityCount: 0,
       attentionCount: 0,
     })).toEqual([
-      '키퍼 연속성',
       '최근 활동',
       '세션 우선순위',
     ])
@@ -19,7 +17,6 @@ describe('hiddenMissionSectionLabels', () => {
 
   it('keeps populated sections visible', () => {
     expect(hiddenMissionSectionLabels({
-      keeperCount: 2,
       activityCount: 3,
       attentionCount: 0,
     })).toEqual([
@@ -32,7 +29,6 @@ describe('missionJumpNavItems', () => {
   it('keeps the session anchor even when every secondary section is empty', () => {
     expect(missionJumpNavItems({
       sessionCount: 0,
-      keeperCount: 0,
       activityCount: 0,
       attentionCount: 0,
     })).toEqual([
@@ -43,12 +39,10 @@ describe('missionJumpNavItems', () => {
   it('adds only the populated secondary sections', () => {
     expect(missionJumpNavItems({
       sessionCount: 1,
-      keeperCount: 2,
       activityCount: 4,
       attentionCount: 0,
     })).toEqual([
       { id: 'mission-sessions', label: '세션', count: 1 },
-      { id: 'mission-keepers', label: '키퍼', count: 2 },
       { id: 'mission-output', label: '활동', count: 4 },
     ])
   })

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -4,7 +4,6 @@ import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { LoadingState } from './common/feedback-state'
 import { CountBadge } from './common/badge'
-import { navigate } from '../router'
 import {
   missionError,
   missionSessionDetail,
@@ -18,34 +17,28 @@ import {
   selectedAttentionId,
   selectedSessionId,
   sessionLookupById,
-  enrichedKeeperRow,
   clearMissionSelection,
   toneClass,
   relativeTime,
   statusLabel,
 } from './mission-utils'
 import {
-  MissionContextBar,
   SummaryStat,
   AttentionCard,
   SessionBriefCard,
   SessionDetailCard,
-  KeeperBriefCard,
   InternalSignalCard,
   MissionBriefingCard,
 } from './mission-cards'
 import { ProvenanceStrip } from './common/provenance-strip'
 export function hiddenMissionSectionLabels({
-  keeperCount,
   activityCount,
   attentionCount,
 }: {
-  keeperCount: number
   activityCount: number
   attentionCount: number
 }): string[] {
   return [
-    keeperCount > 0 ? null : '키퍼 연속성',
     activityCount > 0 ? null : '최근 활동',
     attentionCount > 0 ? null : '세션 우선순위',
   ].filter((label): label is string => label != null)
@@ -53,18 +46,15 @@ export function hiddenMissionSectionLabels({
 
 export function missionJumpNavItems({
   sessionCount,
-  keeperCount,
   activityCount,
   attentionCount,
 }: {
   sessionCount: number
-  keeperCount: number
   activityCount: number
   attentionCount: number
 }): Array<{ id: string, label: string, count: number }> {
   return [
     { id: 'mission-sessions', label: '세션', count: sessionCount, visible: true },
-    { id: 'mission-keepers', label: '키퍼', count: keeperCount, visible: keeperCount > 0 },
     { id: 'mission-output', label: '활동', count: activityCount, visible: activityCount > 0 },
     { id: 'mission-attention', label: '우선순위', count: attentionCount, visible: attentionCount > 0 },
   ]
@@ -109,7 +99,6 @@ export function Mission() {
   const activeSessionId = activeSelectedSessionId ?? attentionSessionId ?? sessionRows[0]?.session_id ?? null
   const sessionLookup = sessionLookupById()
   const focusSession = sessionRows.find(item => item.session_id === activeSessionId) ?? null
-  const keeperRows = mission.keeper_briefs.slice(0, 6).map(enrichedKeeperRow)
   const attentionQueue = mission.attention_queue
     .filter(item => item.related_session_ids.length > 0)
     .slice(0, 6)
@@ -118,29 +107,21 @@ export function Mission() {
     row.top_attention != null || row.related_attention_count > 0
   ).length
   const blockerSessions = sessionRows.filter(row => Boolean(row.blocker_summary)).length
-  const keeperStatusWarnings = keeperRows.filter(row => {
-    const status = (row.brief.status ?? '').trim().toLowerCase()
-    return status !== '' && status !== 'ok'
-  }).length
   const focusSessionOutputs = ((focusSession?.member_previews ?? []) as Array<{
     agent_name?: string | null
     role?: string | null
     recent_output_preview?: string | null
     status?: string | null
   }>).filter(row => row.recent_output_preview)
-  const keeperOutputRows = keeperRows.filter(row => row.recentOutput).slice(0, 4)
-  const activityCount = focusSessionOutputs.length + keeperOutputRows.length
-  const hasKeepers = keeperRows.length > 0
+  const activityCount = focusSessionOutputs.length
   const hasActivity = activityCount > 0
   const hasAttentionQueue = attentionQueue.length > 0
   const hiddenSectionLabels = hiddenMissionSectionLabels({
-    keeperCount: keeperRows.length,
     activityCount,
     attentionCount: attentionQueue.length,
   })
   const jumpNavItems = missionJumpNavItems({
     sessionCount: sessionRows.length,
-    keeperCount: keeperRows.length,
     activityCount,
     attentionCount: attentionQueue.length,
   })
@@ -158,13 +139,6 @@ export function Mission() {
         </span>
         <span class="text-[10px] text-[var(--text-muted)]">${mission.generated_at ? relativeTime(mission.generated_at) : ''}</span>
       </div>
-
-      <${MissionContextBar}
-        cluster=${mission.summary.cluster}
-        project=${mission.summary.project}
-        namespace=${mission.summary.namespace ?? mission.summary.namespace_id}
-        generatedAt=${mission.generated_at}
-      />
 
       <!-- Summary stats row -->
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
@@ -185,12 +159,6 @@ export function Mission() {
           value=${blockerSessions}
           detail="blocker"
           tone=${blockerSessions > 0 ? 'warn' : 'ok'}
-        />
-        <${SummaryStat}
-          label="키퍼 주의"
-          value=${keeperStatusWarnings}
-          detail=${`${keeperRows.length}명 중`}
-          tone=${keeperStatusWarnings > 0 ? 'warn' : 'ok'}
         />
       </div>
 
@@ -246,31 +214,6 @@ export function Mission() {
       />
 
       <!-- Keepers -->
-      ${hasKeepers
-        ? html`
-            <details open id="mission-keepers" class="rounded-lg border border-[var(--card-border)] overflow-hidden">
-              <summary class="mission-collapsible-summary flex items-center gap-2 px-4 py-3 cursor-pointer text-sm font-medium text-[var(--text-strong)]">
-                키퍼 연속성
-                <${CountBadge}>${keeperRows.length}<//>
-                ${keeperStatusWarnings > 0 ? html`<span class="text-[10px] px-1.5 py-px rounded bg-[var(--warn-12)] text-[var(--warn)] tabular-nums">${keeperStatusWarnings} 주의</span>` : null}
-              </summary>
-              <div class="p-4 pt-0">
-                <div class="mb-3">
-                  <p class="m-0 text-xs text-[var(--text-muted)]">키퍼는 세션과 별개로 보고, 연속성과 장기 행위자 상태를 관찰합니다.</p>
-                  <${ProvenanceStrip} items=${[{ kind: 'truth' }]} />
-                </div>
-                <div class="flex flex-col gap-3">
-                  ${keeperRows.map(row => html`<${KeeperBriefCard} key=${row.brief.name} row=${row} />`)}
-                </div>
-                <div class="flex gap-2 flex-wrap mt-3">
-                  <button type="button" class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('monitoring', { section: 'sessions' })}>세션 상세 보기</button>
-                  <button type="button" class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('command', { section: 'intervene' })}>운영 개입 열기</button>
-                </div>
-              </div>
-            </details>
-          `
-        : null}
-
       <!-- Activity -->
       ${hasActivity
         ? html`
@@ -285,26 +228,16 @@ export function Mission() {
                   <${ProvenanceStrip} items=${[{ kind: 'truth' }]} />
                 </div>
                 <div class="flex flex-col gap-3">
-                  ${focusSessionOutputs.length > 0
-                    ? focusSessionOutputs.slice(0, 4).map(row => html`
-                        <div class="flex flex-col gap-1 p-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)]">
-                          <div class="flex items-center gap-2">
-                            <span class="text-xs font-medium text-[var(--text-strong)]">${row.agent_name ?? 'unknown'}</span>
-                            ${row.role ? html`<span class="text-[10px] text-[var(--text-muted)]">${row.role}</span>` : null}
-                            ${row.status ? html`<span class="text-[10px] text-[var(--text-muted)]">${statusLabel(row.status)}</span>` : null}
-                          </div>
-                          <div class="text-xs text-[var(--text-body)] leading-relaxed">${row.recent_output_preview}</div>
-                        </div>
-                      `)
-                    : null}
-                  ${keeperOutputRows.length > 0
-                    ? keeperOutputRows.map(row => html`
-                        <div class="flex flex-col gap-1 p-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)]">
-                          <span class="text-xs font-medium text-[var(--text-strong)]">${row.brief.name}</span>
-                          <div class="text-xs text-[var(--text-body)] leading-relaxed">${row.recentOutput}</div>
-                        </div>
-                      `)
-                    : null}
+                  ${focusSessionOutputs.slice(0, 4).map(row => html`
+                    <div class="flex flex-col gap-1 p-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)]">
+                      <div class="flex items-center gap-2">
+                        <span class="text-xs font-medium text-[var(--text-strong)]">${row.agent_name ?? 'unknown'}</span>
+                        ${row.role ? html`<span class="text-[10px] text-[var(--text-muted)]">${row.role}</span>` : null}
+                        ${row.status ? html`<span class="text-[10px] text-[var(--text-muted)]">${statusLabel(row.status)}</span>` : null}
+                      </div>
+                      <div class="text-xs text-[var(--text-body)] leading-relaxed">${row.recent_output_preview}</div>
+                    </div>
+                  `)}
                 </div>
               </div>
             </details>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -59,7 +59,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: '모니터링',
     icon: '📡',
-    description: '세션, 프로젝트 범위, 에이전트/키퍼 현황 관찰',
+    description: '세션, 에이전트/키퍼 현황 관찰',
     defaultTab: 'monitoring',
     defaultParams: { section: 'sessions' },
     tabs: ['monitoring'],
@@ -113,8 +113,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   monitoring: [
     {
       id: 'sessions',
-      label: '세션 & 프로젝트 범위',
-      description: '세션 = SSE로 연결된 실시간 작업 단위. 프로젝트 범위 = 같은 .masc/ 폴더를 공유하는 에이전트 조정 공간.',
+      label: '세션',
+      description: '실시간 세션 상태와 주의 신호.',
       params: { section: 'sessions' },
     },
     {


### PR DESCRIPTION
## Summary
- 세션 페이지에서 agents 탭과 중복되는 키퍼 연속성 섹션 제거
- 운영 판단에 불필요한 MissionContextBar(static config) 제거
- "세션 & 프로젝트 범위" 라벨을 "세션"으로 단순화
- -97줄, 세션 페이지가 세션 상태와 주의 신호에만 집중

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — mission.test.ts 4/4 pass
- [ ] Dashboard에서 `monitoring?section=sessions` 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)