### PR TITLE
fix(telemetry): propagate truncation info to tool_call_log for dashboard

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -372,7 +372,8 @@ let make_hooks
            the (possibly truncated) result to OAS. Falls back to out_len
            when no truncation info was set (e.g. OAS-internal tool calls). *)
         let (original_bytes, truncated_to) =
-          Keeper_tool_call_log.consume_truncation_info ()
+          Keeper_tool_call_log.consume_truncation_info
+            ~keeper_name:(!meta_ref).name ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
         (try

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -368,13 +368,20 @@ let make_hooks
         let duration_ms =
           (Time_compat.now () -. !tool_start_time) *. 1000.0
         in
+        (* Consume truncation info set by keeper_tools_oas before returning
+           the (possibly truncated) result to OAS. Falls back to out_len
+           when no truncation info was set (e.g. OAS-internal tool calls). *)
+        let (original_bytes, truncated_to) =
+          Keeper_tool_call_log.consume_truncation_info ()
+        in
+        let result_bytes = if original_bytes > 0 then original_bytes else out_len in
         (try
            Keeper_tool_call_log.log_call
              ~keeper_name:(!meta_ref).name
              ~tool_name ~input ~output_text
              ~success:(outcome = "ok") ~duration_ms
              ~model:(!meta_ref).runtime.usage.last_model_used
-             ~result_bytes:out_len ()
+             ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (* Boring-tool gate: mark turn as productive only for genuinely
            productive tools. keeper_stay_silent is in the boring set. *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -263,6 +263,7 @@ let make_tools
                     ])
                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 Keeper_tool_call_log.set_truncation_info
+                  ~keeper_name:meta.name
                   ~original_bytes:(String.length normalized_error) ();
                 (false, validate_output ~tool_name:td.name normalized_error)
               end else begin
@@ -334,6 +335,7 @@ let make_tools
                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
                 (* Publish truncation info for OAS hook's tool_call_log *)
                 Keeper_tool_call_log.set_truncation_info
+                  ~keeper_name:meta.name
                   ~original_bytes:original_len
                   ?truncated_to:(if was_truncated
                     then Some (String.length truncated_result) else None) ();
@@ -380,6 +382,7 @@ let make_tools
                   ])
               with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
               Keeper_tool_call_log.set_truncation_info
+                ~keeper_name:meta.name
                 ~original_bytes:(String.length normalized_exn) ();
               (false, validate_output ~tool_name:td.name normalized_exn)))
     else None

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -262,6 +262,8 @@ let make_tools
                       "ok", `Bool false;
                     ])
                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+                Keeper_tool_call_log.set_truncation_info
+                  ~original_bytes:(String.length normalized_error) ();
                 (false, validate_output ~tool_name:td.name normalized_error)
               end else begin
                 Hashtbl.remove failure_counts key;
@@ -330,6 +332,11 @@ let make_tools
                       ["truncated_to", `Int (String.length truncated_result)]
                     else [])))
                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+                (* Publish truncation info for OAS hook's tool_call_log *)
+                Keeper_tool_call_log.set_truncation_info
+                  ~original_bytes:original_len
+                  ?truncated_to:(if was_truncated
+                    then Some (String.length truncated_result) else None) ();
                 (true, truncated_result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -372,6 +379,8 @@ let make_tools
                     "error", `String error_text;
                   ])
               with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+              Keeper_tool_call_log.set_truncation_info
+                ~original_bytes:(String.length normalized_exn) ();
               (false, validate_output ~tool_name:td.name normalized_exn)))
     else None
   ) tool_defs

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,18 +14,21 @@
 
 let max_output_len = 4000
 
-(** Pre-truncation info, set by tool handler wrapper (keeper_tools_oas),
-    consumed by the OAS on_tool_result hook (keeper_hooks_oas).
-    Sequential tool execution within Agent.run guarantees no race. *)
-let pending_truncation : (int * int option) ref = ref (0, None)
+(** Pre-truncation info, keyed by keeper name.
+    Set by the tool handler wrapper (keeper_tools_oas), consumed by the
+    OAS on_tool_result hook (keeper_hooks_oas).  Per-keeper isolation
+    prevents cross-keeper corruption when multiple keepers call tools
+    concurrently. Within a single keeper's Agent.run, tool calls are
+    sequential so set→consume ordering is guaranteed. *)
+let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
 
-let set_truncation_info ~original_bytes ?truncated_to () =
-  pending_truncation := (original_bytes, truncated_to)
+let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
+  Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
 
-let consume_truncation_info () =
-  let info = !pending_truncation in
-  pending_truncation := (0, None);
-  info
+let consume_truncation_info ~keeper_name () =
+  match Hashtbl.find_opt pending_truncation keeper_name with
+  | Some info -> Hashtbl.remove pending_truncation keeper_name; info
+  | None -> (0, None)
 
 let store_ref : Dated_jsonl.t option ref = ref None
 

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,6 +14,19 @@
 
 let max_output_len = 4000
 
+(** Pre-truncation info, set by tool handler wrapper (keeper_tools_oas),
+    consumed by the OAS on_tool_result hook (keeper_hooks_oas).
+    Sequential tool execution within Agent.run guarantees no race. *)
+let pending_truncation : (int * int option) ref = ref (0, None)
+
+let set_truncation_info ~original_bytes ?truncated_to () =
+  pending_truncation := (original_bytes, truncated_to)
+
+let consume_truncation_info () =
+  let info = !pending_truncation in
+  pending_truncation := (0, None);
+  info
+
 let store_ref : Dated_jsonl.t option ref = ref None
 
 let init ~base_path =

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -6,19 +6,25 @@
     @since 2.249.0 *)
 
 val set_truncation_info :
+  keeper_name:string ->
   original_bytes:int ->
   ?truncated_to:int ->
   unit ->
   unit
-(** [set_truncation_info ~original_bytes ?truncated_to ()] records
-    pre-truncation output size. Called by the tool handler wrapper
-    before returning the (possibly truncated) result to OAS.
-    The OAS on_tool_result hook consumes this via {!consume_truncation_info}. *)
+(** [set_truncation_info ~keeper_name ~original_bytes ?truncated_to ()]
+    records pre-truncation output size for the given keeper. Called by
+    the tool handler wrapper before returning the (possibly truncated)
+    result to OAS. Per-keeper isolation prevents cross-keeper corruption
+    under concurrent tool execution. *)
 
-val consume_truncation_info : unit -> int * int option
-(** [consume_truncation_info ()] returns [(original_bytes, truncated_to)]
-    and resets the pending state. Returns [(0, None)] when no truncation
-    info was set (e.g. tool call didn't go through the handler wrapper). *)
+val consume_truncation_info :
+  keeper_name:string ->
+  unit ->
+  int * int option
+(** [consume_truncation_info ~keeper_name ()] returns
+    [(original_bytes, truncated_to)] for the given keeper and clears
+    the pending state. Returns [(0, None)] when no truncation info
+    was set (e.g. OAS-internal tool call that bypassed the wrapper). *)
 
 val init : base_path:string -> unit
 (** [init ~base_path] creates the Dated_jsonl store. Call once at startup. *)

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -5,6 +5,21 @@
 
     @since 2.249.0 *)
 
+val set_truncation_info :
+  original_bytes:int ->
+  ?truncated_to:int ->
+  unit ->
+  unit
+(** [set_truncation_info ~original_bytes ?truncated_to ()] records
+    pre-truncation output size. Called by the tool handler wrapper
+    before returning the (possibly truncated) result to OAS.
+    The OAS on_tool_result hook consumes this via {!consume_truncation_info}. *)
+
+val consume_truncation_info : unit -> int * int option
+(** [consume_truncation_info ()] returns [(original_bytes, truncated_to)]
+    and resets the pending state. Returns [(0, None)] when no truncation
+    info was set (e.g. tool call didn't go through the handler wrapper). *)
+
 val init : base_path:string -> unit
 (** [init ~base_path] creates the Dated_jsonl store. Call once at startup. *)
 


### PR DESCRIPTION
## Summary
- `truncated_to` field was never passed to `Keeper_tool_call_log.log_call` from the OAS hook, making dashboard truncation count always 0
- `result_bytes` was recording post-truncation length instead of pre-truncation original size
- Added `set_truncation_info`/`consume_truncation_info` handoff between handler wrapper and OAS hook

## Root Cause
Two independent recording paths exist:
1. **Decision log** (`keeper_tools_oas.ml`): had correct `result_bytes` + `truncated_to`
2. **Tool call log** (`keeper_hooks_oas.ml`): had only post-truncation length, no `truncated_to`

Dashboard reads tool_call_log, so truncation data was invisible.

## Design
Sequential ref handoff in `Keeper_tool_call_log`:
- Handler wrapper sets `(original_bytes, truncated_to)` before returning to OAS
- OAS hook consumes and resets, passing to `log_call`
- Falls back to `out_len` when no info set (OAS-internal calls)

No race: tool calls within Agent.run are sequential (per existing comment in hooks).

## Files Changed
| File | Change |
|------|--------|
| `lib/keeper_tool_call_log.ml` | Add `set_truncation_info` / `consume_truncation_info` |
| `lib/keeper_tool_call_log.mli` | Expose new API |
| `lib/keeper/keeper_tools_oas.ml` | Set truncation info in 3 paths (success/failure/exception) |
| `lib/keeper/keeper_hooks_oas.ml` | Consume truncation info, pass to `log_call` |

## Test plan
- [ ] `dune build --root .` passes
- [ ] Start keeper, trigger tool call exceeding budget → verify `truncated_to` in `.masc/tool_calls/` JSONL
- [ ] Dashboard tool quality panel shows non-zero truncation count

🤖 Generated with [Claude Code](https://claude.com/claude-code)