### PR TITLE
fix(dashboard): replace orphan CSS variables with design system tokens

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -31,7 +31,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
 
   return html`
     <div
-      class="border-b border-[var(--border)] hover:bg-[var(--bg-hover)] transition-colors"
+      class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
     >
       <div
         class="flex items-center gap-2 px-3 py-2 text-xs cursor-pointer"
@@ -47,15 +47,15 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         }}
       >
         <span class="font-mono ${cat.color} w-4 text-center flex-shrink-0">${cat.icon}</span>
-        <span class="font-mono text-[var(--fg)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
-        <span class="font-mono font-medium text-[var(--fg)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
+        <span class="font-mono text-[var(--text-strong)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
+        <span class="font-mono font-medium text-[var(--text-strong)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
         <span class=${`font-mono flex-shrink-0 w-16 text-right ${durationColor(entry.duration_ms)}`}>
           ${formatDuration(entry.duration_ms)}
         </span>
         <span class=${`flex-shrink-0 w-5 text-center ${entry.success ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}`}>
           ${entry.success ? 'O' : 'X'}
         </span>
-        <span class="flex-shrink-0 w-4 text-[var(--fg-dim)] text-center">
+        <span class="flex-shrink-0 w-4 text-[var(--text-muted)] text-center">
           ${expanded.value ? '-' : '+'}
         </span>
       </div>
@@ -63,15 +63,15 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
       ${expanded.value ? html`
         <div class="px-3 pb-3 space-y-2">
           ${entry.model ? html`
-            <div class="text-[10px] text-[var(--fg-dim)]">model: <span class="text-[var(--fg)] font-mono">${entry.model}</span></div>
+            <div class="text-[10px] text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
           ` : null}
           <div>
-            <div class="text-[10px] text-[var(--fg-dim)] uppercase tracking-wider mb-1">Input</div>
-            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap text-[var(--fg)]">${formatInput(entry.input)}</pre>
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Input</div>
+            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap text-[var(--text-strong)]">${formatInput(entry.input)}</pre>
           </div>
           <div>
-            <div class="text-[10px] text-[var(--fg-dim)] uppercase tracking-wider mb-1">Output</div>
-            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--fg)]">${entry.output || '(empty)'}</pre>
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Output</div>
+            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--text-strong)]">${entry.output || '(empty)'}</pre>
           </div>
         </div>
       ` : null}
@@ -111,7 +111,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   const sorted = useMemo(() => [...filtered].reverse(), [filtered])
 
   if (loading.value) {
-    return html`<div class="text-xs text-[var(--fg-dim)] p-4">Loading tool calls...</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] p-4">Loading tool calls...</div>`
   }
 
   if (error.value) {
@@ -119,7 +119,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   }
 
   if (entries.value.length === 0) {
-    return html`<div class="text-xs text-[var(--fg-dim)] p-4">No tool call data yet. Data is recorded after server restart with this update.</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] p-4">No tool call data yet. Data is recorded after server restart with this update.</div>`
   }
 
   // Summary stats
@@ -132,7 +132,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   return html`
     <div class="space-y-3">
       <div class="flex items-center justify-between gap-3">
-        <div class="flex gap-4 text-xs text-[var(--fg-dim)]">
+        <div class="flex gap-4 text-xs text-[var(--text-muted)]">
           <span>${totalCalls} calls</span>
           <span>${uniqueTools} tools</span>
           <span class=${successRate < 80 ? 'text-[var(--warn)]' : ''}>${successRate}% ok</span>
@@ -140,14 +140,14 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
         <input
           type="text"
           placeholder="Filter tool..."
-          class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--border)] rounded px-2 py-1 w-40 text-[var(--fg)]"
+          class="text-xs font-mono bg-[var(--bg-deep)] border border-[var(--card-border)] rounded px-2 py-1 w-40 text-[var(--text-strong)]"
           value=${filterTool.value}
           onInput=${(e: Event) => { filterTool.value = (e.target as HTMLInputElement).value }}
         />
       </div>
 
-      <div class="border border-[var(--border)] rounded overflow-hidden max-h-[500px] overflow-y-auto">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] text-[10px] uppercase tracking-wider text-[var(--fg-dim)] border-b border-[var(--border)]">
+      <div class="border border-[var(--card-border)] rounded overflow-hidden max-h-[500px] overflow-y-auto">
+        <div class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] text-[10px] uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--card-border)]">
           <span class="w-4"></span>
           <span class="w-16">Time</span>
           <span class="flex-1">Tool</span>

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -57,7 +57,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
       : 'text-[var(--accent-primary)] font-medium'
 
   return html`
-    <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--bg-hover)] transition-colors">
+    <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--bg-panel-hover)] transition-colors">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
@@ -95,7 +95,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
   return html`
     <div class="border border-[var(--border-subtle)] rounded-lg overflow-hidden mb-3">
       <button
-        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)] transition-colors text-left"
+        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--bg-surface)] hover:bg-[var(--bg-panel-hover)] transition-colors text-left"
         onClick=${() => toggleCategory(name)}
       >
         <div class="flex items-center gap-2">
@@ -166,7 +166,7 @@ export function ServerConfig() {
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
         />
         <button
-          class="px-3 py-1.5 text-xs rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
+          class="px-3 py-1.5 text-xs rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-panel-hover)] transition-colors"
           onClick=${() => void refreshServerConfig()}
           disabled=${loading}
         >

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -56,19 +56,19 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const hasData = src.entry_count > 0
 
   return html`
-    <div class="rounded-lg border border-[var(--border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
+    <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
       <div class="flex items-center gap-2 mb-1">
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
-        <span class="text-xs font-medium text-[var(--fg)]">${meta.label}</span>
+        <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
       </div>
-      <div class="text-2xl font-bold ${hasData ? 'text-[var(--fg)]' : 'text-[var(--fg-dim)]'}">
+      <div class="text-2xl font-bold ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
         ${src.entry_count.toLocaleString()}
       </div>
       ${src.keeper_count != null ? html`
-        <div class="text-xs text-[var(--fg-dim)]">${src.keeper_count} keepers</div>
+        <div class="text-xs text-[var(--text-muted)]">${src.keeper_count} keepers</div>
       ` : null}
       ${src.exists === false ? html`
-        <div class="text-xs text-[var(--fg-dim)] italic">store not found</div>
+        <div class="text-xs text-[var(--text-muted)] italic">store not found</div>
       ` : null}
     </div>
   `
@@ -119,7 +119,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
   const success = entry.success as boolean | undefined
 
   return html`
-    <div class="border-b border-[var(--border)] hover:bg-[var(--bg-hover)] transition-colors">
+    <div class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors">
       <div
         class="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none"
         role="button"
@@ -133,7 +133,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         }}
       >
         <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-        <span class="font-mono text-[var(--fg-dim)] w-28 flex-shrink-0" title=${formatTs(ts)}>
+        <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
           ${timeAgo(ts)}
         </span>
         ${success != null ? html`
@@ -141,14 +141,14 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
             ${success ? 'O' : 'X'}
           </span>
         ` : html`<span class="w-4"></span>`}
-        <span class="font-mono text-[var(--fg)] truncate flex-1" title=${entryPreview(entry)}>
+        <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>
           ${entryPreview(entry)}
         </span>
-        <span class="flex-shrink-0 w-4 text-[var(--fg-dim)]">${expanded.value ? '-' : '+'}</span>
+        <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
       </div>
       ${expanded.value ? html`
         <div class="px-3 pb-2">
-          <pre class="text-[10px] font-mono text-[var(--fg-dim)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
+          <pre class="text-[10px] font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
 ${JSON.stringify(entry, null, 2)}</pre>
         </div>
       ` : null}
@@ -214,16 +214,16 @@ export function TelemetryUnified() {
       <!-- Summary cards -->
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded-lg border border-[var(--border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
-          <div class="text-xs font-medium text-[var(--fg-dim)] mb-1">Total</div>
-          <div class="text-2xl font-bold text-[var(--fg)]">${totalEntries.toLocaleString()}</div>
+        <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
+          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">Total</div>
+          <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
         </div>
       </div>
 
       <!-- Filters -->
       <div class="flex items-center gap-3 flex-wrap">
         <select
-          class="rounded border border-[var(--border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--fg)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${sourceFilter.value}
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
         >
@@ -235,12 +235,12 @@ export function TelemetryUnified() {
         <input
           type="text"
           placeholder="Keeper name..."
-          class="rounded border border-[var(--border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--fg)] w-32"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
           value=${keeperFilter.value}
           onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
         />
         <select
-          class="rounded border border-[var(--border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--fg)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${String(limit.value)}
           onChange=${(e: Event) => { limit.value = Number((e.target as HTMLSelectElement).value) }}
         >
@@ -250,12 +250,12 @@ export function TelemetryUnified() {
           <option value="500">500</option>
         </select>
         <button
-          class="rounded border border-[var(--border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--fg)] hover:bg-[var(--bg-hover)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void load()}
         >
           Refresh
         </button>
-        ${loading ? html`<span class="text-xs text-[var(--fg-dim)]">loading...</span>` : null}
+        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">loading...</span>` : null}
       </div>
 
       <!-- Error -->
@@ -266,15 +266,15 @@ export function TelemetryUnified() {
       ` : null}
 
       <!-- Entry list -->
-      <div class="rounded-lg border border-[var(--border)] bg-[rgba(255,255,255,0.02)] overflow-hidden">
-        <div class="flex items-center gap-2 px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--fg-dim)] border-b border-[var(--border)] bg-[rgba(0,0,0,0.2)]">
+      <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] overflow-hidden">
+        <div class="flex items-center gap-2 px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--card-border)] bg-[rgba(0,0,0,0.2)]">
           <span class="w-4">Src</span>
           <span class="w-28">Time</span>
           <span class="w-4">Ok</span>
           <span class="flex-1">Detail</span>
         </div>
         ${entries.length === 0 && !loading ? html`
-          <div class="px-3 py-8 text-center text-xs text-[var(--fg-dim)]">
+          <div class="px-3 py-8 text-center text-xs text-[var(--text-muted)]">
             No telemetry entries found
           </div>
         ` : null}

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -76,7 +76,7 @@ function ToolTable({ tools }: { tools: ToolStat[] }) {
     <div class="overflow-x-auto">
       <table class="w-full text-[11px]">
         <thead>
-          <tr class="text-[var(--text-dim)] border-b border-[var(--border)]">
+          <tr class="text-[var(--text-dim)] border-b border-[var(--card-border)]">
             <th class="text-left py-1 font-normal">Tool</th>
             <th class="text-right py-1 font-normal">Calls</th>
             <th class="text-right py-1 font-normal">Success</th>
@@ -88,7 +88,7 @@ function ToolTable({ tools }: { tools: ToolStat[] }) {
             const color = t.success_pct >= 95 ? 'text-emerald-400'
               : t.success_pct >= 80 ? 'text-yellow-400' : 'text-red-400'
             return html`
-              <tr class="border-b border-[var(--border)] border-opacity-30">
+              <tr class="border-b border-[var(--card-border)] border-opacity-30">
                 <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
                 <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>


### PR DESCRIPTION
## Summary

- `--fg`, `--fg-dim`, `--border`(bare), `--bg-hover`가 4개 컴포넌트에서 사용되지만 `variables.css`에 정의되지 않음
- CSS spec상 미정의 custom property는 inherited value로 폴백되어 우연히 동작하지만, 부모 스타일 변경 시 즉시 깨짐
- design system의 정식 변수로 교체: `--text-strong`, `--text-muted`, `--card-border`, `--bg-panel-hover`

| 파일 | 교체 수 |
|------|---------|
| `telemetry-unified.ts` | 21 |
| `keeper-tool-call-inspector.ts` | 15 |
| `tool-quality-panel.ts` | 2 |
| `server-config.ts` | 3 |

## Evidence

```bash
# variables.css에 --fg 정의 없음 확인
grep -E '^\s*--fg\b' dashboard/src/styles/variables.css  # (empty)

# 사용 분포 확인
grep -roh 'var(--[a-z_-]*)' dashboard/src/components/ | sort | uniq -c | sort -rn
# --text-muted: 702, --fg: 14, --fg-dim: 18 — 소수 파일만 orphan 변수 사용
```

## Product impact

시각적 변화 없음 (기존에 inherited value로 우연히 동작). design system 일관성 확보로 향후 테마 변경/리팩터링 시 안전.

## Test plan

- [x] `npx vitest run` — CSS-only 변경이므로 로직 테스트 영향 없음 (기존 실패만 존재)
- [ ] 브라우저에서 텔레메트리/도구 품질/서버 설정/키퍼 인스펙터 페이지 시각 확인

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)