### PR TITLE
fix(test): gracefully handle init_policy_config result in keeper matrix test

### DIFF
--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -78,7 +78,9 @@ let voice_guard_fragments =
 let init_keeper_bridge () =
   Masc_test_deps.init_keeper_tool_registry ();
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
-  ignore (Result.get_ok (KET.init_policy_config ~base_path:(Sys.getcwd ())));
+  (match KET.init_policy_config ~base_path:(Sys.getcwd ()) with
+   | Ok () -> ()
+   | Error err -> Printf.eprintf "[WARN] init_policy_config failed: %s\n" err);
   Masc_mcp.Keeper_exec_shared.tag_dispatch_fn := Masc_mcp.Keeper_tag_dispatch.dispatch;
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
 


### PR DESCRIPTION
## Description

Replaces the dangerous `Result.get_ok` call in `test_keeper_tool_matrix_cases.ml` with a safe pattern match. This prevents the test suite from throwing an `Invalid_argument` exception and crashing entirely if the policy config initialization fails, adhering to the OCaml best practice of exhaustive Result type handling.