### PR TITLE
feat(autoresearch): add lower_is_better metric polarity

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -139,7 +139,7 @@ let generate_code_change = Autoresearch_codegen.generate_code_change
 (* Loop State Management                                             *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ~workdir () =
+let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ?(lower_is_better = false) ~workdir () =
   let now = Time_compat.now () in
   let patience = match patience with
     | Some p -> p
@@ -173,6 +173,7 @@ let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_tim
     patience;
     consecutive_discards = 0;
     build_verify_fn;
+    lower_is_better;
   }
 
 (** Append an insight, maintaining FIFO max 10 entries.
@@ -193,8 +194,13 @@ let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
     ~commit_hash ~elapsed_ms ~model_used =
   let delta = score_after -. score_before in
   (* Compare against the maintained baseline, not score_before which can dip
-     below baseline due to metric noise -- preventing ratchet-down regressions *)
-  let decision = if score_after > state.baseline then Keep else Discard in
+     below baseline due to metric noise -- preventing ratchet-down regressions.
+     Polarity: lower_is_better inverts the comparison direction. *)
+  let is_improvement =
+    if state.lower_is_better then score_after < state.baseline
+    else score_after > state.baseline
+  in
+  let decision = if is_improvement then Keep else Discard in
   let now = Time_compat.now () in
   let record = {
     cycle = state.current_cycle;
@@ -215,8 +221,12 @@ let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
       let state = { state with
         total_keeps = state.total_keeps + 1;
         baseline = score_after } in
+      let is_new_best =
+        if state.lower_is_better then score_after < state.best_score
+        else score_after > state.best_score
+      in
       let state =
-        if score_after > state.best_score then
+        if is_new_best then
           { state with best_score = score_after; best_cycle = state.current_cycle }
         else state
       in
@@ -282,6 +292,7 @@ let stop_loop ~base_path ?reason loop_id =
                 patience = persisted.patience;
                 consecutive_discards = persisted.consecutive_discards;
                 build_verify_fn = persisted.build_verify_fn;
+                lower_is_better = persisted.lower_is_better;
               }
             in
             Some (stop_state state)))

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -84,6 +84,7 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
     ("patience", `Int s.patience);
     ("consecutive_discards", `Int s.consecutive_discards);
     ("build_verify_fn", Json_util.string_opt_to_json s.build_verify_fn);
+    ("lower_is_better", `Bool s.lower_is_better);
     ("error", Json_util.string_opt_to_json s.error_message);
   ]
 
@@ -138,6 +139,7 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
     patience = int_ "patience" ~default:(max 3 (int_ "max_cycles" ~default:10 / 3));
     consecutive_discards = int_ "consecutive_discards" ~default:0;
     build_verify_fn = json |> member "build_verify_fn" |> to_string_option;
+    lower_is_better = Safe_ops.json_bool ~default:false "lower_is_better" json;
   }
 
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -47,6 +47,7 @@ type loop_state = {
   patience : int;  (** Max consecutive discards before early stop *)
   consecutive_discards : int;  (** Counter for consecutive discards without improvement *)
   build_verify_fn : string option;  (** Optional shell command that must exit 0 for a Keep to succeed *)
+  lower_is_better : bool;  (** When true, lower metric scores are better (e.g., val_bpb, loss) *)
 }
 
 type swarm_link = {
@@ -86,4 +87,5 @@ type persisted_summary = {
   patience : int;
   consecutive_discards : int;
   build_verify_fn : string option;
+  lower_is_better : bool;
 }

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -8,7 +8,7 @@
 include Autoresearch_types
 
 (** Build prompt for MODEL code change. Exported for testing. *)
-let build_code_change_prompt ~goal ~baseline ~history ~insights
+let build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file =
   let recent = List.filteri (fun i _ -> i < 5) history in
   let history_lines = List.map (fun (r : cycle_record) ->
@@ -16,10 +16,11 @@ let build_code_change_prompt ~goal ~baseline ~history ~insights
       r.cycle r.hypothesis r.delta (Autoresearch_serde.decision_to_string r.decision)
   ) recent in
   let insight_lines = List.map (fun s -> "  - " ^ s) insights in
+  let polarity = if lower_is_better then "lower is better" else "higher is better" in
   String.concat "\n" ([
     "You are an autonomous research assistant optimizing code.";
     Printf.sprintf "Goal: %s" goal;
-    Printf.sprintf "Current baseline score: %.4f (higher is better)" baseline;
+    Printf.sprintf "Current baseline score: %.4f (%s)" baseline polarity;
     Printf.sprintf "Target file: %s" target_file;
   ] @ (if history_lines <> [] then
     [""; "Recent experiment history:"] @ history_lines
@@ -130,13 +131,13 @@ let has_background_capacity () =
 
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)
-let generate_code_change ~goal ~baseline ~history ~insights
+let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
     ~target_file ~file_content =
   if not (has_background_capacity ()) then begin
     Eio.traceln "[autoresearch] backoff: local slots saturated, skipping cycle";
     Result.error "autoresearch: local slots saturated, skipping cycle"
   end else
-  let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
+  let prompt = build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file in
   match
     Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -333,6 +333,7 @@ let rehydrate_persisted_loop (persisted : Autoresearch_types.persisted_summary) 
     patience = persisted.patience;
     consecutive_discards = persisted.consecutive_discards;
     build_verify_fn = persisted.build_verify_fn;
+    lower_is_better = persisted.lower_is_better;
   }
 
 let load_loop_state ~base_path loop_id =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -47,6 +47,7 @@ let persisted_summary_json (summary : Autoresearch.persisted_summary) =
       ("patience", `Int summary.patience);
       ("consecutive_discards", `Int summary.consecutive_discards);
       ("build_verify_fn", Json_util.string_opt_to_json summary.build_verify_fn);
+      ("lower_is_better", `Bool summary.lower_is_better);
       ("error", Json_util.string_opt_to_json summary.error_message);
     ]
 
@@ -66,6 +67,7 @@ type start_params = {
   baseline_override : float option;
   patience : int option;
   build_verify_fn : string option;
+  lower_is_better : bool;
 }
 
 let prepare_start_params (ctx : context) args =
@@ -116,6 +118,7 @@ let prepare_start_params (ctx : context) args =
           baseline_override = get_float_opt args "baseline";
           patience = get_int_opt args "patience";
           build_verify_fn;
+          lower_is_better = get_bool args "lower_is_better" false;
         }
 
 let register_loop (ctx : context) state =
@@ -157,6 +160,7 @@ let setup_running_loop (ctx : context) (params : start_params) =
       ~model_model:params.model_model ~target_file:params.target_file
       ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles
       ?patience:params.patience ?build_verify_fn:params.build_verify_fn
+      ~lower_is_better:params.lower_is_better
       ~workdir:params.source_workdir ()
   in
   match

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -312,6 +312,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
             generate
               ~goal:(Printf.sprintf "%s\n\nApply this hypothesis: %s" goal_with_feedback h)
               ~baseline:state.baseline
+              ~lower_is_better:state.lower_is_better
               ~history:state.history
               ~insights:state.insights
               ~target_file
@@ -321,6 +322,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
             generate
               ~goal:goal_with_feedback
               ~baseline:state.baseline
+              ~lower_is_better:state.lower_is_better
               ~history:state.history
               ~insights:state.insights
               ~target_file
@@ -568,7 +570,11 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                            check_patience_limit state
                          | Autoresearch.Keep ->
                            let state = { state with consecutive_discards = 0 } in
-                           if score_after >= state.best_score then
+                           let is_tag_worthy =
+                             if state.lower_is_better then score_after <= state.best_score
+                             else score_after >= state.best_score
+                           in
+                           if is_tag_worthy then
                              Autoresearch.git_tag_best ~workdir
                                ~cycle:state.current_cycle ~score:score_after;
                            state

--- a/lib/tool_autoresearch_registry.ml
+++ b/lib/tool_autoresearch_registry.ml
@@ -12,7 +12,7 @@ let pending_hypotheses : (string, string) Hashtbl.t =
 (** Code generator type for test injection.
     Returns Ok (hypothesis, new_code) or Error reason. *)
 type code_generator =
-  goal:string -> baseline:float ->
+  goal:string -> baseline:float -> lower_is_better:bool ->
   history:Autoresearch.cycle_record list ->
   insights:string list ->
   target_file:string -> file_content:string ->

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -11,7 +11,8 @@ let schemas : Types.tool_schema list = [
 a metric. Each cycle: read file -> LLM generates change -> measure -> keep if improved, \
 discard if not. Runs autonomously until max_cycles or stopped. Returns loop_id. \
 For team-coordinated research with multiple workers, use masc_autoresearch_swarm_start. \
-Requires: goal, metric_fn (shell command outputting a float), target_file.";
+Requires: goal, metric_fn (shell command outputting a float), target_file. \
+Set lower_is_better=true for metrics where lower values are better (e.g., loss, BPB).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -22,7 +23,7 @@ Requires: goal, metric_fn (shell command outputting a float), target_file.";
         ("metric_fn", `Assoc [
           ("type", `String "string");
           ("description", `String "Shell command that outputs a single float on its last line \
-(e.g. 'python eval.py --metric accuracy'). Higher is better.");
+(e.g. 'python eval.py --metric accuracy'). Higher is better by default; set lower_is_better=true to invert.");
         ]);
         ("workdir", `Assoc [
           ("type", `String "string");
@@ -44,6 +45,10 @@ Requires: goal, metric_fn (shell command outputting a float), target_file.";
         ("model_model", `Assoc [
           ("type", `String "string");
           ("description", `String "Model label for code change generation (uses cascade default)");
+        ]);
+        ("lower_is_better", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "When true, lower metric values are better (e.g., loss, BPB). Default: false (higher is better).");
         ]);
         ("target_file", `Assoc [
           ("type", `String "string");
@@ -104,6 +109,10 @@ session tools.";
         ("model_model", `Assoc [
           ("type", `String "string");
           ("description", `String "Model label for code change generation (uses cascade default)");
+        ]);
+        ("lower_is_better", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "When true, lower metric values are better (e.g., loss, BPB). Default: false.");
         ]);
       ]);
       ("required", `List [`String "goal"; `String "metric_fn"; `String "target_file"]);

--- a/test/test_autoresearch_codegen.ml
+++ b/test/test_autoresearch_codegen.ml
@@ -17,6 +17,7 @@ let test_prompt_requires_strict_json () =
     Lib.Autoresearch.build_code_change_prompt
       ~goal:"Improve throughput"
       ~baseline:1.25
+      ~lower_is_better:false
       ~history:[]
       ~insights:[]
       ~file_content:"let batch = 32\n"

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -161,7 +161,7 @@ let test_cycle_reinjects_diff_guard_lesson () =
     }
   in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id
-    (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
        Ok ("tighten main", "changed\n"));
   write_file (Filename.concat repo "notes.txt") "drifted\n";
   let first =
@@ -180,7 +180,7 @@ let test_cycle_reinjects_diff_guard_lesson () =
   write_file (Filename.concat repo "notes.txt") "notes\n";
   let captured_goal = ref None in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id
-    (fun ~goal ~baseline:_ ~history:_ ~insights:_ ~target_file:_ ~file_content ->
+    (fun ~goal ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_ ~target_file:_ ~file_content ->
        captured_goal := Some goal;
        Ok ("reuse lesson", file_content));
   let second =
@@ -238,7 +238,7 @@ let test_build_verify_downgrade_rewrites_history () =
     }
   in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id
-    (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
        Ok ("optimistic keep", "changed-once\n"));
   let first =
     Lib.Tool_autoresearch_cycle.handle_cycle ctx
@@ -270,7 +270,7 @@ let test_build_verify_downgrade_rewrites_history () =
     (Lib.Autoresearch.decision_to_string history_head.decision);
   let captured_history = ref None in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id
-    (fun ~goal:_ ~baseline:_ ~history ~insights:_ ~target_file:_ ~file_content:_ ->
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history ~insights:_ ~target_file:_ ~file_content:_ ->
        captured_history := Some history;
        Ok ("second pass", "changed-twice\n"));
   let second =
@@ -397,7 +397,7 @@ let test_cycle_restores_ignored_target_after_empty_diff () =
     }
   in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id
-    (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_ ~target_file:_ ~file_content:_ ->
        Ok ("ignored file edit", "changed\n"));
   let result =
     Lib.Tool_autoresearch_cycle.handle_cycle ctx


### PR DESCRIPTION
## Summary
- autoresearch 루프의 metric 비교가 "higher is better"로 하드코딩되어 있어 loss/BPB 같은 lower-is-better metric 최적화 불가
- `lower_is_better : bool` 필드 추가 (기본값 `false`, 하위 호환)
- keep/discard 결정, best_score 추적, git tag, LLM codegen 프롬프트 모두 polarity 반영

## Motivation
Karpathy autoresearch의 val_bpb (validation bits per byte) 최적화를 MASC keeper에서 실행하기 위한 선행 작업. autoresearch repo (`feature/mps-support`)에 Apple Silicon MPS 지원이 이미 구현되어 있음.

## Changes (11 files, +54/-17)
- `autoresearch_types.ml`: `lower_is_better` 필드 추가 (loop_state + persisted_summary)
- `autoresearch.ml`: `create_state` param, `record_cycle` 비교 로직 polarity 적용
- `autoresearch_codegen.ml`: LLM 프롬프트에 polarity text 반영
- `tool_autoresearch_cycle.ml`: git tag 비교 + codegen 호출 threading
- `tool_autoresearch_schemas.ml`: start + swarm_start schema에 필드 추가
- `tool_autoresearch.ml`: start_params 파싱 + persisted_summary_json
- `tool_autoresearch_registry.ml`: code_generator 타입 시그니처
- `dashboard_http_autoresearch.ml`: persist→state 변환
- 테스트 2개: mock closure 시그니처 + prompt 테스트

## Test plan
- [x] `dune build` 통과
- [x] `test_autoresearch_codegen` 5/5 통과
- [x] `test_autoresearch_oas_primitives` 13/13 통과
- [ ] E2E: `lower_is_better=true`로 autoresearch 루프 시작, score 감소 시 Keep 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)