### PR TITLE
fix: remove dead code from #5836 (3 unused cascade label parsers)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -69,37 +69,6 @@ let tokens_per_sec_json ~tokens ~latency_ms =
   if tokens <= 0 || latency_ms <= 0 then `Null
   else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
 
-let provider_name_of_label label =
-  match String.index_opt label ':' with
-  | Some idx when idx > 0 ->
-      String.sub label 0 idx |> String.trim |> String.lowercase_ascii
-  | _ -> "unknown"
-
-let raw_model_id_of_label label =
-  match String.index_opt label ':' with
-  | Some idx when idx + 1 < String.length label ->
-      String.sub label (idx + 1) (String.length label - idx - 1) |> String.trim
-  | _ -> String.trim label
-
-let resolved_model_json_of_label label =
-  match Llm_provider.Cascade_config.parse_model_string label with
-  | None ->
-      Some
-        (`Assoc
-          [
-            ("provider", `String (provider_name_of_label label));
-            ("model_id", `String (raw_model_id_of_label label));
-            ("max_context", `Int (Oas_model_resolve.max_context_of_label label));
-          ])
-  | Some cfg ->
-      Some
-        (`Assoc
-          [
-            ("provider", `String (provider_name_of_label label));
-            ("model_id", `String cfg.model_id);
-            ("max_context", `Int (Oas_model_resolve.max_context_of_label label));
-          ])
-
 let keeper_names (config : Room.config) =
   Keeper_types.keeper_names config
 


### PR DESCRIPTION
## Summary
- Remove 3 dead functions from `dashboard_http_keeper.ml` added by #5836
- `provider_name_of_label`, `raw_model_id_of_label`, `resolved_model_json_of_label` had zero callers
- Canonical `provider_name_of_label` already exists in `oas_model_resolve.ml`

## Context
PR #5836 was titled "Clarify cascade.json ownership in README and boundary docs" but snuck in 31 lines of production code + a cascade.json config change. The config change was reverted (#5871) but the dead code remained.

Found during 100-PR audit of main branch.

## Test plan
- [x] `dune build --root .` passes
- [x] `grep -rn` confirms zero callers outside definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)