### PR TITLE
refactor: replace stringly-typed gate with variant type

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -28,12 +28,40 @@ type verdict =
   | Approve
   | Reject of string
 
+type gate =
+  | Length
+  | Excuse
+  | Contract
+  | Structured_tool
+  | Llm_text_fallback
+  | Format_reject
+  | Fallback
+
+let gate_to_string = function
+  | Length -> "length"
+  | Excuse -> "excuse"
+  | Contract -> "contract"
+  | Structured_tool -> "structured_tool"
+  | Llm_text_fallback -> "llm_text_fallback"
+  | Format_reject -> "format_reject"
+  | Fallback -> "fallback"
+
+let gate_of_string = function
+  | "length" -> Ok Length
+  | "excuse" -> Ok Excuse
+  | "contract" -> Ok Contract
+  | "structured_tool" -> Ok Structured_tool
+  | "llm_text_fallback" -> Ok Llm_text_fallback
+  | "format_reject" -> Ok Format_reject
+  | "fallback" -> Ok Fallback
+  | s -> Error (Printf.sprintf "unknown gate: %S" s)
+
 type review_result = {
   verdict : verdict;
   evaluator_cascade : string;
   generator_cascade : string option;
-  gate : string;  (** Which gate produced this verdict: "length", "excuse", "llm", "fallback" *)
-  fallback_reason : string option;  (** Error message when gate="fallback" — aids debugging *)
+  gate : gate;
+  fallback_reason : string option;
 }
 
 (* ================================================================ *)
@@ -340,7 +368,7 @@ let review
   if String.length notes_trimmed < min_notes_length then
     emit { verdict = Reject (sprintf "completion notes too short (%d chars, minimum %d)"
                           (String.length notes_trimmed) min_notes_length);
-      evaluator_cascade; generator_cascade; gate = "length"; fallback_reason = None }
+      evaluator_cascade; generator_cascade; gate = Length; fallback_reason = None }
   else
   (* Gate 2: local excuse pattern detection *)
   match find_excuse_pattern notes_trimmed with
@@ -349,7 +377,7 @@ let review
       req.agent_name req.task_title pattern;
     emit { verdict = Reject (sprintf "avoidance pattern detected: \"%s\" (%s). Revise your notes to describe actual completed work."
                           pattern reason);
-      evaluator_cascade; generator_cascade; gate = "excuse"; fallback_reason = None }
+      evaluator_cascade; generator_cascade; gate = Excuse; fallback_reason = None }
   | None ->
   (* Gate 2.5: contract verification (local, no LLM) *)
   let contract_rejection =
@@ -368,7 +396,7 @@ let review
   match contract_rejection with
   | Some reason ->
     emit { verdict = Reject reason;
-      evaluator_cascade; generator_cascade; gate = "contract"; fallback_reason = None }
+      evaluator_cascade; generator_cascade; gate = Contract; fallback_reason = None }
   | None ->
     (* Gate 3: LLM review via evaluator cascade (structured tool output, ADR D3) *)
     let prompt = build_prompt ~few_shot_block req in
@@ -405,19 +433,19 @@ let review
        let (v, gate, fallback_reason) = match !verdict_ref with
          | Some v ->
            Log.Task.info "[anti-rationalization] verdict via structured tool call";
-           (v, "structured_tool", None)
+           (v, Structured_tool, None)
          | None ->
            (* LLM responded with text — lenient fallback *)
            let text = Oas_response.text_of_response result.response in
            Log.Task.info "[anti-rationalization] verdict via text fallback";
            (match parse_verdict text with
-            | Ok v -> (v, "llm_text_fallback", None)
+            | Ok v -> (v, Llm_text_fallback, None)
             | Error parse_err ->
               (* ADR D3: parse failure is NOT silently approved.
                  Use Reject instead of Approve for unknown format. *)
               Log.Task.warn "[anti-rationalization] verdict parse failed: %s (rejecting)" parse_err;
               ( Reject (sprintf "review format unrecognized: %s" parse_err),
-                "format_reject",
+                Format_reject,
                 Some parse_err ))
        in
        (match v with
@@ -432,7 +460,7 @@ let review
        (* Liveness > correctness: if LLM is unavailable, approve *)
        let msg = Oas.Error.to_string err in
        Log.Task.warn "[anti-rationalization] LLM unavailable: %s (approving by default)" msg;
-       emit { verdict = Approve; evaluator_cascade; generator_cascade; gate = "fallback"; fallback_reason = Some msg })
+       emit { verdict = Approve; evaluator_cascade; generator_cascade; gate = Fallback; fallback_reason = Some msg })
 
 (** Backward-compatible wrapper that returns only the verdict.
     Use [review] directly for structured results with audit metadata. *)
@@ -444,7 +472,7 @@ let review_result_to_json (r : review_result) : Yojson.Safe.t =
     ("verdict", `String (match r.verdict with Approve -> "approve" | Reject s -> "reject:" ^ s));
     ("evaluator_cascade", `String r.evaluator_cascade);
     ("generator_cascade", Json_util.string_opt_to_json r.generator_cascade);
-    ("gate", `String r.gate);
+    ("gate", `String (gate_to_string r.gate));
   ] in
   let extra = match r.fallback_reason with
     | Some reason -> [("fallback_reason", `String reason)]

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -28,13 +28,27 @@ type verdict =
   | Approve
   | Reject of string
 
+(** Which gate produced the verdict. Variant type prevents typos that
+    would silently compile with a stringly-typed field. *)
+type gate =
+  | Length
+  | Excuse
+  | Contract
+  | Structured_tool
+  | Llm_text_fallback
+  | Format_reject
+  | Fallback
+
+val gate_to_string : gate -> string
+val gate_of_string : string -> (gate, string) result
+
 (** Structured review result with audit metadata for cross-model tracking. *)
 type review_result = {
   verdict : verdict;
   evaluator_cascade : string;
   generator_cascade : string option;
-  gate : string;
-  fallback_reason : string option;  (** Error message when gate="fallback" *)
+  gate : gate;
+  fallback_reason : string option;  (** Error message when gate=Fallback *)
 }
 
 (** Review a task completion claim with optional cross-model separation.

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -156,7 +156,7 @@ let record_verdict
     task_title = req.task_title;
     agent_name = req.agent_name;
     verdict = verdict_str;
-    gate = result.gate;
+    gate = Anti_rationalization.gate_to_string result.gate;
     evaluator_cascade = result.evaluator_cascade;
     generator_cascade = result.generator_cascade;
     fallback_reason = result.fallback_reason;

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -61,7 +61,7 @@ let review_completion_notes
                        ("task_id", `String task_id);
                        ("task_title", `String ar_req.task_title);
                        ("agent_name", `String ar_req.agent_name);
-                       ("gate", `String result.gate);
+                       ("gate", `String (Anti_rationalization.gate_to_string result.gate));
                        ("verdict", `String (verdict_to_string result));
                        ( "evaluator_cascade",
                          `String result.evaluator_cascade );

--- a/test/test_anti_rationalization_coverage.ml
+++ b/test/test_anti_rationalization_coverage.ml
@@ -146,11 +146,11 @@ let () = test "substantive_notes_no_pattern_match" (fun () ->
 
 let () = test "review_result_gate_field_length" (fun () ->
   let r = Anti_rationalization.review (make_request "") in
-  assert (r.gate = "length"))
+  assert (r.gate = Anti_rationalization.Length))
 
 let () = test "review_result_gate_field_excuse" (fun () ->
   let r = Anti_rationalization.review (make_request "This is out of scope entirely") in
-  assert (r.gate = "excuse"))
+  assert (r.gate = Anti_rationalization.Excuse))
 
 let () = test "review_result_evaluator_cascade_default" (fun () ->
   let r = Anti_rationalization.review (make_request "") in
@@ -175,7 +175,7 @@ let () = test "contract_unmet_rejects" (fun () ->
   let r = Anti_rationalization.review
     ~completion_contract:["test coverage"; "migration"]
     (make_request "Applied fix to the login flow.") in
-  assert (r.gate = "contract");
+  assert (r.gate = Anti_rationalization.Contract);
   assert_reject r)
 
 let () = test "contract_unmet_lists_items" (fun () ->

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -108,7 +108,7 @@ let make_req ?(title = "Task") ?(notes = "Detailed completion notes") () :
     agent_name = "codex";
   }
 
-let make_result ?(verdict = AR.Approve) ?(gate = "llm")
+let make_result ?(verdict = AR.Approve) ?(gate = AR.Structured_tool)
     ?fallback_reason () : AR.review_result =
   {
     verdict;
@@ -242,7 +242,7 @@ let test_overview_warns_when_evaluator_falls_back () =
   with_test_stores @@ fun config ->
   let req = make_req ~title:"Fallback task" () in
   let result =
-    make_result ~gate:"fallback" ~fallback_reason:"judge timeout" ()
+    make_result ~gate:AR.Fallback ~fallback_reason:"judge timeout" ()
   in
   Cal.record_verdict ~task_id:"task-1" ~req ~result ();
   let json =

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -37,7 +37,7 @@ let make_req ?(title = "Fix auth bug") ?(desc = "Fix the login issue")
     completion_notes = notes; agent_name = agent }
 
 let make_result ?(verdict = AR.Approve) ?(cascade = "verifier")
-    ?gen_cascade ?(gate = "llm") ?fallback_reason () : AR.review_result =
+    ?gen_cascade ?(gate = AR.Structured_tool) ?fallback_reason () : AR.review_result =
   { verdict; evaluator_cascade = cascade;
     generator_cascade = gen_cascade; gate; fallback_reason }
 
@@ -85,7 +85,7 @@ let test_record_verdict_reject () =
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
-  let result = make_result ~verdict:(AR.Reject "vague notes") ~gate:"excuse" () in
+  let result = make_result ~verdict:(AR.Reject "vague notes") ~gate:AR.Excuse () in
   Cal.record_verdict ~task_id:"task-2" ~req ~result ();
   let store = Cal.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
@@ -142,7 +142,7 @@ let test_find_divergences_false_positive () =
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FP task" ~notes:"looks ok but not" () in
-  let result = make_result ~verdict:AR.Approve ~gate:"llm" () in
+  let result = make_result ~verdict:AR.Approve ~gate:AR.Structured_tool () in
   Cal.record_verdict ~task_id:"t1" ~req ~result ();
   let hash = Cal.notes_hash ~task_title:"FP task" ~notes:"looks ok but not" in
   Cal.record_human_label
@@ -161,7 +161,7 @@ let test_find_divergences_false_negative () =
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FN task" ~notes:"actually good work" () in
-  let result = make_result ~verdict:(AR.Reject "unclear") ~gate:"excuse" () in
+  let result = make_result ~verdict:(AR.Reject "unclear") ~gate:AR.Excuse () in
   Cal.record_verdict ~task_id:"t2" ~req ~result ();
   let hash = Cal.notes_hash ~task_title:"FN task" ~notes:"actually good work" in
   Cal.record_human_label
@@ -263,13 +263,13 @@ let test_calibration_stats () =
   (* 2 approvals, 1 rejection *)
   let req1 = make_req ~title:"t1" ~notes:"n1" () in
   Cal.record_verdict ~task_id:"id1" ~req:req1
-    ~result:(make_result ~verdict:AR.Approve ~gate:"llm" ()) ();
+    ~result:(make_result ~verdict:AR.Approve ~gate:AR.Structured_tool ()) ();
   let req2 = make_req ~title:"t2" ~notes:"n2" () in
   Cal.record_verdict ~task_id:"id2" ~req:req2
-    ~result:(make_result ~verdict:AR.Approve ~gate:"length" ()) ();
+    ~result:(make_result ~verdict:AR.Approve ~gate:AR.Length ()) ();
   let req3 = make_req ~title:"t3" ~notes:"n3" () in
   Cal.record_verdict ~task_id:"id3" ~req:req3
-    ~result:(make_result ~verdict:(AR.Reject "bad") ~gate:"excuse" ()) ();
+    ~result:(make_result ~verdict:(AR.Reject "bad") ~gate:AR.Excuse ()) ();
   let stats = Cal.calibration_stats () in
   let total = Yojson.Safe.Util.(stats |> member "total_verdicts" |> to_int) in
   let approves = Yojson.Safe.Util.(stats |> member "approve_count" |> to_int) in


### PR DESCRIPTION
## Summary
- anti_rationalization의 `gate : string` → `type gate` variant 전환
- 7개 알려진 값을 variant로 정의하여 오타가 컴파일 에러로 잡힘
- `gate_to_string`/`gate_of_string : string -> (gate, string) result` 추가
- persistence DTO는 string 유지 — domain-persistence 경계에서 변환

## Evidence
- OCaml 빌드 성공
- test_anti_rationalization_coverage: all passed
- test_eval_calibration: 21/21 passed
- test_dashboard_harness_health: 6/6 passed

## Product impact
기능 변경 없음. JSONL 직렬화 형식 동일. 타입 안전성 향상.

## Linked issue
Closes #5856

## Review evidence
로컬 빌드+3개 테스트 스위트 통과.