### PR TITLE
refactor: replace bare exceptions with Result types in worker and responder

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -215,12 +215,9 @@ let masc_call ~sw:_ ~tool_name ~(args : Yojson.Safe.t) : (string, string) result
           (* Extract MCP tool text: result.content[0].text *)
           try
             let json = Yojson.Safe.from_string body_str in
-            let txt =
-              match json |> member "result" |> member "content" |> to_list with
-              | item :: _ -> item |> member "text" |> to_string
-              | [] -> raise (Failure "empty content list")
-            in
-            Ok txt
+            match json |> member "result" |> member "content" |> to_list with
+            | item :: _ -> Ok (item |> member "text" |> to_string)
+            | [] -> Error "empty content list"
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -544,20 +544,18 @@ let rec run_worker_via_oas
         (Worker_container_types.leave_worker ~sw ~auth_token
            ~session_id ~worker_name))
     (fun () ->
-      let _ =
-        match
-          Worker_container_types.join_worker ~sw ~auth_token
-            ~session_id ~worker_name
-        with
-        | Ok _ -> ()
-        | Error e -> raise (Failure ("worker join failed: " ^ e))
-      in
-      let workspace_path =
-        if String.trim meta.workspace_path <> "" then meta.workspace_path
-        else base_path
-      in
-      run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
+      match
+        Worker_container_types.join_worker ~sw ~auth_token
+          ~session_id ~worker_name
+      with
+      | Error e -> Error ("worker join failed: " ^ e)
+      | Ok _ ->
+        let workspace_path =
+          if String.trim meta.workspace_path <> "" then meta.workspace_path
+          else base_path
+        in
+        run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
+          ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
 
 and resume_worker_via_oas
     ~(sw : Eio.Switch.t)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -617,24 +617,22 @@ and resume_worker_via_oas
         (Worker_container_types.leave_worker ~sw ~auth_token ~session_id
            ~worker_name))
     (fun () ->
-      let _ =
-        match
-          Worker_container_types.join_worker ~sw ~auth_token ~session_id
-            ~worker_name
-        with
-        | Ok _ -> ()
-        | Error e -> raise (Failure ("worker join failed: " ^ e))
-      in
-      let agent =
-        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config
-          ~context:shared_context ()
-      in
-      let workspace_path =
-        if String.trim meta.workspace_path <> "" then meta.workspace_path
-        else base_path
-      in
-      run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
-        ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
+      match
+        Worker_container_types.join_worker ~sw ~auth_token ~session_id
+          ~worker_name
+      with
+      | Error e -> Error ("worker join failed: " ^ e)
+      | Ok _ ->
+        let agent =
+          Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config
+            ~context:shared_context ()
+        in
+        let workspace_path =
+          if String.trim meta.workspace_path <> "" then meta.workspace_path
+          else base_path
+        in
+        run_existing_worker_agent ~sw ~base_path ~meta ~prompt
+          ~workspace_path ~raw_trace ?worker_run_id ?contract ~tool_names_ref agent)
 
 and run_existing_worker_agent
     ~(sw : Eio.Switch.t)


### PR DESCRIPTION
## Description

Addresses user feedback to repeatedly apply the `Result` type best practices and avoid bare exceptions that can crash fibers abruptly.
- Replaces `raise (Failure ...)` in `worker_oas.ml` (`start_worker_via_oas` and `resume_worker_via_oas`) with a proper `Result.Error`.
- Replaces `raise (Failure ...)` in `auto_responder.ml` with a proper `Result.Error` when the content list is empty.