### PR TITLE
refactor: compact tool JSON + atomic file writes (#5857, #5860)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -120,12 +120,12 @@ let save_excuse_patterns (patterns : (string * string) list) : (unit, string) re
     let path = excuse_patterns_path () in
     let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
     let json = `List json_items in
-    let tmp = path ^ ".tmp" in
     let content = Yojson.Safe.pretty_to_string json in
-    Fs_compat.save_file tmp content;
-    Sys.rename tmp path;
-    cached_patterns := Some patterns;
-    Ok ()
+    match Fs_compat.save_file_atomic path content with
+    | Ok () ->
+      cached_patterns := Some patterns;
+      Ok ()
+    | Error msg -> Error msg
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Printf.sprintf "Failed to save excuse patterns: %s" (Printexc.to_string exn))

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -235,26 +235,26 @@ let rewrite_posts store =
   try
     ensure_masc_dir ();
     let path = persist_path () in
-    let tmp_path = path ^ ".tmp" in
     let buf = Buffer.create 4096 in
     Hashtbl.iter (fun _ (pst : post) ->
       Buffer.add_string buf (Yojson.Safe.to_string (post_to_yojson pst) ^ "\n")
     ) store.posts;
-    Fs_compat.save_file tmp_path (Buffer.contents buf);
-    Sys.rename tmp_path path
+    (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+     | Ok () -> ()
+     | Error msg -> Log.BoardLog.error "persist error (rewrite_posts): %s" msg)
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_posts): %s" msg
 
 let rewrite_comments store =
   try
     ensure_masc_dir ();
     let path = comments_path () in
-    let tmp_path = path ^ ".tmp" in
     let buf = Buffer.create 4096 in
     Hashtbl.iter (fun _ (cmt : comment) ->
       Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt) ^ "\n")
     ) store.comments;
-    Fs_compat.save_file tmp_path (Buffer.contents buf);
-    Sys.rename tmp_path path
+    (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+     | Ok () -> ()
+     | Error msg -> Log.BoardLog.error "persist error (rewrite_comments): %s" msg)
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_comments): %s" msg
 
 (** {1 Append Helpers} *)

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -24,7 +24,6 @@ let rewrite_vote_log store =
   try
     ensure_masc_dir ();
     let path = vote_log_path () in
-    let tmp_path = path ^ ".tmp" in
     let buf = Buffer.create 4096 in
     Hashtbl.iter
       (fun target direction ->
@@ -45,8 +44,9 @@ let rewrite_vote_log store =
         in
         Buffer.add_string buf (Yojson.Safe.to_string json ^ "\n"))
       store.vote_log;
-    Fs_compat.save_file tmp_path (Buffer.contents buf);
-    Sys.rename tmp_path path
+    (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+     | Ok () -> ()
+     | Error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg)
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg
 
 let vote store ~voter ~post_id ~direction : (int, board_error) result =

--- a/lib/cancellation.ml
+++ b/lib/cancellation.ml
@@ -198,7 +198,7 @@ let handle_cancellation_tool (arguments : Yojson.Safe.t) : (bool * string) =
   match get_string "action" with
   | Some "create" ->
     let token = TokenStore.create () in
-    (true, Yojson.Safe.pretty_to_string (token_to_json token))
+    (true, Yojson.Safe.to_string (token_to_json token))
 
   | Some "cancel" ->
     (match get_string "token_id" with
@@ -214,7 +214,7 @@ let handle_cancellation_tool (arguments : Yojson.Safe.t) : (bool * string) =
     (match get_string "token_id" with
      | Some id ->
        (match TokenStore.get id with
-        | Some token -> (true, Yojson.Safe.pretty_to_string (token_to_json token))
+        | Some token -> (true, Yojson.Safe.to_string (token_to_json token))
         | None -> (false, Printf.sprintf "Token '%s' not found" id))
      | None -> (false, "token_id required"))
 
@@ -224,7 +224,7 @@ let handle_cancellation_tool (arguments : Yojson.Safe.t) : (bool * string) =
       ("count", `Int (List.length tokens));
       ("tokens", `List (List.map token_to_json tokens));
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
 
   | Some "cleanup" ->
     let removed = TokenStore.cleanup ~max_age:Env_config.Cancellation.token_max_age_seconds in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -97,6 +97,17 @@ let save_file (path : string) (content : string) : unit =
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
 
+let save_file_atomic (path : string) (content : string) : (unit, string) result =
+  let dir = Filename.dirname path in
+  let tmp = Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp" in
+  try
+    save_file tmp content;
+    Sys.rename tmp path;
+    Ok ()
+  with exn ->
+    (try Sys.remove tmp with Sys_error _ -> ());
+    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+
 (** Append string to file.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -21,6 +21,10 @@ val load_file : string -> string
 val save_file : string -> string -> unit
 (** Save string to file (overwrite). *)
 
+val save_file_atomic : string -> string -> (unit, string) result
+(** Write content to path via temp file + rename.
+    Returns [Error msg] on I/O failure instead of raising. *)
+
 val append_file : string -> string -> unit
 (** Append string to file. *)
 

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -277,7 +277,6 @@ let memory_row_key (row : keeper_memory_row_raw) : string =
 let write_memory_bank_rows
     (path : string)
     (rows : keeper_memory_row_raw list) : (unit, string) result =
-  let tmp = path ^ ".tmp" in
   try
     let content =
       rows
@@ -286,11 +285,8 @@ let write_memory_bank_rows
       |> String.concat "\n"
     in
     let content = if content <> "" then content ^ "\n" else content in
-    Fs_compat.save_file tmp content;
-    Sys.rename tmp path;
-    Ok ()
+    Fs_compat.save_file_atomic path content
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Safe_ops.remove_file_logged ~context:"memory_compaction" tmp;
     Error (Printf.sprintf "failed to rewrite memory bank: %s" (Printexc.to_string exn))
 
 let compact_memory_bank_if_needed

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -23,7 +23,7 @@ let handle_persona_list _ctx args : tool_result =
         ("personas", payload);
       ]
   in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_keeper_create_from_persona ctx args : tool_result =
   match resolved_keeper_args_from_persona args with
@@ -41,7 +41,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
               ("resolved_args", resolved_args);
             ]
         in
-        (true, Yojson.Safe.pretty_to_string json)
+        (true, Yojson.Safe.to_string json)
       else if errors <> [] then
         ( false,
           Yojson.Safe.pretty_to_string
@@ -76,5 +76,5 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                 ("resolved_args", resolved_args);
               ]
           in
-          (true, Yojson.Safe.pretty_to_string json)
+          (true, Yojson.Safe.to_string json)
         end

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -35,7 +35,7 @@ let handle_keeper_list ctx args : tool_result =
         ("count", `Int (List.length keeper_names));
         ("keepers", `List (List.map (fun k -> `String k) keeper_names));
       ] in
-      (true, Yojson.Safe.pretty_to_string json)
+      (true, Yojson.Safe.to_string json)
     else
       let now_ts = Time_compat.now () in
       let keepers =
@@ -281,7 +281,7 @@ let handle_keeper_list ctx args : tool_result =
         ("count", `Int (List.length keepers));
         ("keepers", `List keepers);
       ] in
-      (true, Yojson.Safe.pretty_to_string json)
+      (true, Yojson.Safe.to_string json)
 
 let handle_keeper_trajectory ctx args : tool_result =
   let name = get_string args "name" "" in
@@ -317,7 +317,7 @@ let handle_keeper_trajectory ctx args : tool_result =
           ("showing", `Int (List.length recent));
           ("entries", `List json_list);
         ] in
-        (true, Yojson.Safe.pretty_to_string json)
+        (true, Yojson.Safe.to_string json)
 
 let handle_keeper_eval ctx args : tool_result =
   let name = get_string args "name" "" in
@@ -380,4 +380,4 @@ let handle_keeper_eval ctx args : tool_result =
           ("scenario_file", scenario_info);
           ("autonomous_action_count", `Int m.runtime.autonomous_action_count);
         ] in
-        (true, Yojson.Safe.pretty_to_string json)
+        (true, Yojson.Safe.to_string json)

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -76,4 +76,4 @@ let handle_keeper_down ctx args : tool_result =
         ("remove_meta", `Bool remove_meta);
         ("remove_session", `Bool remove_session);
       ] in
-      (true, Yojson.Safe.pretty_to_string json)
+      (true, Yojson.Safe.to_string json)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -424,4 +424,4 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("auto_handoff", `Bool meta.auto_handoff);
           ("handoff_threshold", `Float meta.handoff_threshold);
         ] in
-        (true, Yojson.Safe.pretty_to_string json)
+        (true, Yojson.Safe.to_string json)

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -209,4 +209,4 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
    | Ok () ->
      stop_keepalive updated.name;
      start_keepalive ctx updated;
-     (true, Yojson.Safe.pretty_to_string (meta_to_json updated)))
+     (true, Yojson.Safe.to_string (meta_to_json updated)))

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -107,9 +107,9 @@ let rewrite_procedures ~agent_name (procs : procedure list) =
     |> String.concat "\n"
     |> fun s -> if s = "" then "" else s ^ "\n"
   in
-  let tmp = path ^ ".tmp" in
-  Fs_compat.save_file tmp content;
-  Sys.rename tmp path
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> Log.Config.warn "procedural_memory save: %s" msg
 
 (* ================================================================ *)
 (* Procedure Operations                                             *)

--- a/lib/runtime_params.ml
+++ b/lib/runtime_params.ml
@@ -160,9 +160,9 @@ let persist ~base_path =
           registry_tbl [])
     in
     let json = `Assoc overrides in
-    let tmp = path ^ ".tmp" in
-    Fs_compat.save_file tmp (Yojson.Safe.pretty_to_string json);
-    Sys.rename tmp path
+    (match Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) with
+     | Ok () -> ()
+     | Error msg -> Log.Config.error "Runtime_params.persist atomic: %s" msg)
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Config.error "Runtime_params.persist: %s" (Printexc.to_string exn)
 

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -540,20 +540,20 @@ let handle_mcp_session_tool (arguments : Yojson.Safe.t) : (bool * string) =
     (match get_string "session_id" with
      | Some id ->
        (match McpSessionStore.get id with
-        | Some s -> (true, Yojson.Safe.pretty_to_string (McpSessionStore.to_json s))
+        | Some s -> (true, Yojson.Safe.to_string (McpSessionStore.to_json s))
         | None -> (false, Printf.sprintf "MCP session '%s' not found" id))
      | None -> (false, "session_id required"))
   | Some "create" ->
     let agent_name = get_string "agent_name" in
     let s = McpSessionStore.create ?agent_name () in
-    (true, Yojson.Safe.pretty_to_string (McpSessionStore.to_json s))
+    (true, Yojson.Safe.to_string (McpSessionStore.to_json s))
   | Some "list" ->
     let sessions = McpSessionStore.list_all () in
     let json = `Assoc [
       ("count", `Int (List.length sessions));
       ("sessions", `List (List.map McpSessionStore.to_json sessions));
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
   | Some "cleanup" ->
     let removed = McpSessionStore.cleanup_stale () in
     (true, Printf.sprintf "Removed %d stale MCP sessions" removed)

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -233,7 +233,7 @@ let handle_subscription_tool (arguments : Yojson.Safe.t) : (bool * string) =
        let resource = resource_type_of_string resource_str in
        let filter = get_string "filter" in
        let sub = SubscriptionStore.subscribe ~subscriber ~resource ?filter () in
-       (true, Yojson.Safe.pretty_to_string (subscription_to_json sub))
+       (true, Yojson.Safe.to_string (subscription_to_json sub))
      | _ -> (false, "subscriber and resource required"))
 
   | Some "unsubscribe" ->
@@ -253,14 +253,14 @@ let handle_subscription_tool (arguments : Yojson.Safe.t) : (bool * string) =
          ("count", `Int (List.length subs));
          ("subscriptions", `List (List.map subscription_to_json subs));
        ] in
-       (true, Yojson.Safe.pretty_to_string json)
+       (true, Yojson.Safe.to_string json)
      | None ->
        let subs = SubscriptionStore.list_all () in
        let json = `Assoc [
          ("count", `Int (List.length subs));
          ("subscriptions", `List (List.map subscription_to_json subs));
        ] in
-       (true, Yojson.Safe.pretty_to_string json))
+       (true, Yojson.Safe.to_string json))
 
   | Some "poll" ->
     (match get_string "subscription_id" with
@@ -270,7 +270,7 @@ let handle_subscription_tool (arguments : Yojson.Safe.t) : (bool * string) =
          ("count", `Int (List.length notifs));
          ("notifications", `List (List.map notification_to_json notifs));
        ] in
-       (true, Yojson.Safe.pretty_to_string json)
+       (true, Yojson.Safe.to_string json)
      | None -> (false, "subscription_id required"))
 
   | Some other -> (false, Printf.sprintf "Unknown action: %s" other)

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -19,7 +19,7 @@ let handle_poll_events _ctx args =
   else
   let clear = get_bool args "clear" true in
   match A2a_tools.poll_events ~subscription_id ~clear () with
-  | Ok json -> (true, Yojson.Safe.pretty_to_string json)
+  | Ok json -> (true, Yojson.Safe.to_string json)
   | Error e -> (false, Printf.sprintf "Poll events failed: %s" e)
 
 (** A2A Worker submits heartbeat task result *)
@@ -47,7 +47,7 @@ let handle_heartbeat_result _ctx args =
         ~tool_call_count ~tool_names ~decision_reason ~decision_confidence
         ?failure_reason ()
     with
-    | Ok json -> (true, Yojson.Safe.pretty_to_string json)
+    | Ok json -> (true, Yojson.Safe.to_string json)
     | Error e -> (false, Printf.sprintf "Submit result failed: %s" e)
 
 (* Dispatch function - returns None if tool not handled *)

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -20,7 +20,7 @@ let handle_agents ctx args =
     | `List items -> `List (List.filteri (fun i _ -> i < limit) items)
     | other -> other
   in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (** Handle masc_register_capabilities *)
 let handle_register_capabilities ctx args =
@@ -43,7 +43,7 @@ let handle_find_by_capability ctx args =
   let ( let*! ) = Tool_args.( let*! ) in
   let*! capability = get_string_required args "capability" in
   let json = Room.find_agents_by_capability ctx.config ~capability in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (** Handle masc_get_metrics *)
 let handle_get_metrics ctx args =
@@ -52,7 +52,7 @@ let handle_get_metrics ctx args =
   let days = get_int args "days" 7 in
   match Metrics_store_eio.calculate_agent_metrics ctx.config ~agent_id:target ~days with
   | Some metrics ->
-      (true, Yojson.Safe.pretty_to_string (Metrics_store_eio.agent_metrics_to_yojson metrics))
+      (true, Yojson.Safe.to_string (Metrics_store_eio.agent_metrics_to_yojson metrics))
   | None ->
       error_result_typed ~code:Not_found
         (Printf.sprintf "no metrics found for agent: %s" target)
@@ -182,7 +182,7 @@ let handle_agent_fitness ctx args =
       List.sort_uniq String.compare (metrics_agents @ room_agents)
   in
   if agents = [] then
-    (true, Yojson.Safe.pretty_to_string (`Assoc [("count", `Int 0); ("agents", `List [])]))
+    (true, Yojson.Safe.to_string (`Assoc [("count", `Int 0); ("agents", `List [])]))
   else
     let metrics_list = List.map (fun a -> (a, metrics_for ctx ~days a)) agents in
     let min_avg = min_avg_time metrics_list in
@@ -208,7 +208,7 @@ let handle_agent_fitness ctx args =
       ("count", `Int (List.length agents_json));
       ("agents", `List agents_json);
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
 
 (** Pick random from list *)
 let pick_random = function
@@ -297,7 +297,7 @@ let handle_select_agent ctx args =
       ("strategy", `String strategy);
       ("scores", scores_json);
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
 
 (** Handle masc_collaboration_graph *)
 let handle_collaboration_graph ctx args =
@@ -310,7 +310,7 @@ let handle_collaboration_graph ctx args =
       ("agents", `List (List.map (fun a -> `String a) agents));
       ("synapses", `List (List.map Hebbian_eio.synapse_to_json synapses));
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
   else
     let lines =
       synapses
@@ -352,7 +352,7 @@ let handle_agent_card _ctx args =
           ("legacy_endpoint", `String "/.well-known/agent-card.json");
         ]
   in
-  (true, Yojson.Safe.pretty_to_string response)
+  (true, Yojson.Safe.to_string response)
 
 (** Handle masc_agent_relations — proxy to Neo4j/GraphQL.
     MASC is a consumer: it queries the GraphQL API, which owns the data. *)
@@ -363,14 +363,14 @@ let handle_agent_relations ctx args =
     | _ -> ctx.agent_name
   in
   let json = Dashboard_agent_relations.json ~agent_name:target () in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (** Handle masc_meta_cognition_snapshot — deterministic room-level read model. *)
 let handle_meta_cognition_snapshot ctx args =
   let limit = get_int args "limit" 5 |> max 1 |> min 20 in
   let hearth = get_string_opt args "hearth" in
   let json = Meta_cognition.snapshot_json ?hearth ~limit ctx.config in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 let dispatch ctx ~name ~args =

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -442,7 +442,7 @@ let handle_agent_timeline (ctx : context) args : result =
       build_timeline ctx.config ~agent_name ~since_hours ~limit ~include_tasks
         ~include_board ~include_tool_calls
     in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
 
 (* Dispatch *)
 let dispatch (ctx : context) ~name ~args : result option =

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -170,14 +170,14 @@ let handle_code_search ctx args =
           ("count", `Int (List.length matches));
           ("results", `List matches);
         ] in
-        (true, Yojson.Safe.pretty_to_string response)
+        (true, Yojson.Safe.to_string response)
     | Unix.WEXITED 1, _ ->
         (* No matches *)
         let response = `Assoc [
           ("count", `Int 0);
           ("results", `List []);
         ] in
-        (true, Yojson.Safe.pretty_to_string response)
+        (true, Yojson.Safe.to_string response)
     | Unix.WEXITED 2, output ->
         (* rg error: invalid regex, missing file, etc. Provide actionable help. *)
         let hint =
@@ -273,7 +273,7 @@ let handle_code_symbols ctx args =
                 ("count", `Int (List.length symbols));
                 ("symbols", `List symbols_json);
               ] in
-              (true, Yojson.Safe.pretty_to_string response)
+              (true, Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               (false, Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn))
           end
@@ -328,7 +328,7 @@ let handle_code_read ctx args =
                 ("total_lines", `Int total_lines);
                 ("lines", `List (List.map (fun s -> `String s) result_lines));
               ] in
-              (true, Yojson.Safe.pretty_to_string response)
+              (true, Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               (false, Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn))
           end

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -252,7 +252,7 @@ let handle_code_write ctx args =
           ("bytes_written", `Int (String.length content));
           ("agent", `String ctx.agent_name);
         ] in
-        (true, Yojson.Safe.pretty_to_string response)
+        (true, Yojson.Safe.to_string response)
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         (false, Printf.sprintf "Write failed: %s" (Printexc.to_string exn))
   end
@@ -340,7 +340,7 @@ let handle_code_edit ctx args =
               ("replacements", `Int !count);
               ("agent", `String ctx.agent_name);
             ] in
-            (true, Yojson.Safe.pretty_to_string response)
+            (true, Yojson.Safe.to_string response)
           end
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           (false, Printf.sprintf "Edit failed: %s" (Printexc.to_string exn))
@@ -368,7 +368,7 @@ let handle_code_delete ctx args =
             ("path", `String path);
             ("agent", `String ctx.agent_name);
           ] in
-          (true, Yojson.Safe.pretty_to_string response)
+          (true, Yojson.Safe.to_string response)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           (false, Printf.sprintf "Delete failed: %s" (Printexc.to_string exn))
       end

--- a/lib/tool_handover.ml
+++ b/lib/tool_handover.ml
@@ -59,7 +59,7 @@ let handle_handover_list ctx args =
       in
       let handovers = List.filteri (fun i _ -> i < limit) handovers in
       let json = `List (List.map Handover_eio.handover_to_json handovers) in
-      (true, Yojson.Safe.pretty_to_string json)
+      (true, Yojson.Safe.to_string json)
   | None -> (false, "❌ Filesystem not available")
 
 let handle_handover_claim ctx args =

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -163,7 +163,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
             Error (Printf.sprintf "Unknown action: %s" other)
       in
       (match response with
-       | Ok json -> Some (true, Yojson.Safe.pretty_to_string json)
+       | Ok json -> Some (true, Yojson.Safe.to_string json)
        | Error e -> Some (false, e))
 
   (* ── Infrastructure tools ───────────────────────────────────── *)
@@ -196,7 +196,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
           ("anomaly_detection", `Bool g.anomaly_detection);
         ]);
       ] in
-      Some (true, Yojson.Safe.pretty_to_string json)
+      Some (true, Yojson.Safe.to_string json)
 
   | "masc_spawn" ->
       let spawn_agent_name = arg_get_string "agent_name" "" in

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -61,7 +61,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
 
       (match state.Mcp_server.env with
        | None ->
-           Some (true, Yojson.Safe.pretty_to_string (`Assoc [
+           Some (true, Yojson.Safe.to_string (`Assoc [
              ("success", `Bool false);
              ("error", `String "Database environment not available");
              ("suggestion", `String "Ensure runtime environment is initialized");
@@ -107,7 +107,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
                ("message", `String (Printf.sprintf "Found %d relevant items for query: %s"
                  (List.length result.items) query));
              ] in
-             Some (true, Yojson.Safe.pretty_to_string response))
+             Some (true, Yojson.Safe.to_string response))
 
   | "masc_board_post" ->
       let (success, message) as result = Tool_board.handle_tool name arguments in

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -152,7 +152,7 @@ let handle_lock (ctx : context) : result option =
                ("acquired_at", `Float now);
                ("expires_at", `Float expires_at);
              ] in
-             Some (true, Yojson.Safe.pretty_to_string payload)
+             Some (true, Yojson.Safe.to_string payload)
          | Ok false ->
              Some (false, Printf.sprintf "Lock busy: %s" expanded)
          | Error e ->
@@ -189,7 +189,7 @@ let handle_unlock (ctx : context) : result option =
                ("key", `String key);
                ("owner", `String agent_name);
              ] in
-             Some (true, Yojson.Safe.pretty_to_string payload)
+             Some (true, Yojson.Safe.to_string payload)
          | Ok false ->
              Some (false, Printf.sprintf "Lock not held by %s: %s" agent_name expanded)
          | Error e ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -222,7 +222,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
               ("resolved_args", resolved_args);
             ]
         in
-        (true, Yojson.Safe.pretty_to_string json)
+        (true, Yojson.Safe.to_string json)
       else
         let (ok, body) = with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args) in
         if not ok then
@@ -242,7 +242,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           in
           invalidate_keeper_list_cache ();
           invalidate_status_cache (get_string resolved_args "name" "");
-          (true, Yojson.Safe.pretty_to_string json)
+          (true, Yojson.Safe.to_string json)
 
 let handle_keeper_up ctx args : tool_result =
   with_keeper_startup_gate (fun () -> execute_keeper_up ctx args)
@@ -286,7 +286,7 @@ let handle_keeper_msg ctx args : tool_result =
         ("status", `String "queued");
         ("message", `String "Keeper turn submitted. Poll with keeper_msg_result.");
       ] in
-      (true, Yojson.Safe.pretty_to_string json)
+      (true, Yojson.Safe.to_string json)
 
 let handle_keeper_msg_result _ctx args : tool_result =
   let request_id = get_string args "request_id" "" in
@@ -297,7 +297,7 @@ let handle_keeper_msg_result _ctx args : tool_result =
     | None ->
       (false, Printf.sprintf {|{"error":"request_id not found","request_id":"%s"}|} request_id)
     | Some entry ->
-      (true, Yojson.Safe.pretty_to_string (Keeper_msg_async.entry_to_json entry))
+      (true, Yojson.Safe.to_string (Keeper_msg_async.entry_to_json entry))
 
 let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   match ensure_keeper_exists ctx args with

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -55,7 +55,7 @@ let handle_verify_handoff _ctx args =
       Drift_guard.verify_handoff ~original ~received ~threshold ()
       |> Drift_guard.result_to_json
     in
-    (true, Yojson.Safe.pretty_to_string result)
+    (true, Yojson.Safe.to_string result)
 
 let handle_gc ctx args =
   let days_raw = get_int args "days" 7 in
@@ -85,7 +85,7 @@ let handle_tool_stats _ctx args =
       Config.all_tool_schemas
   in
   let report = Tool_registry.stats_report ~top_n ~all_tool_names in
-  (true, Yojson.Safe.pretty_to_string report)
+  (true, Yojson.Safe.to_string report)
 
 let handle_tool_help _ctx args =
   let tool_name = String.trim (get_string args "tool_name" "") in
@@ -95,7 +95,7 @@ let handle_tool_help _ctx args =
     match Tool_help_registry.find_entry Config.raw_all_tool_schemas tool_name with
     | None -> (false, Printf.sprintf "❌ unknown tool: %s" tool_name)
     | Some entry ->
-        (true, Yojson.Safe.pretty_to_string (Tool_help_registry.entry_json entry))
+        (true, Yojson.Safe.to_string (Tool_help_registry.entry_json entry))
 
 let handle_web_search _ctx args =
   Tool_misc_web_search.handle args
@@ -167,7 +167,7 @@ let handle_keeper_tool_catalog _ctx args =
             Config.raw_all_tool_schemas );
       ]
   in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (* ================================================================ *)
 (* Public re-exports from sub-modules                               *)

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -228,12 +228,12 @@ let handle_feature_flags args : result =
     ("deprecated_tools", `Int (List.length deprecated_tools));
     ("deprecated_tool_names", `List (List.map (fun (name, _) -> `String name) deprecated_tools));
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_config args : result =
   let cat = get_string_opt args "category" in
   let json = Env_config_introspect.to_json_filtered ?cat () in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_tool_admin_snapshot ctx args =
   let include_hidden = get_bool args "include_hidden" true in
@@ -254,7 +254,7 @@ let handle_tool_admin_snapshot ctx args =
           tool_inventory_json ctx ~include_hidden ~include_deprecated );
       ]
   in
-  (true, Yojson.Safe.pretty_to_string payload)
+  (true, Yojson.Safe.to_string payload)
 
 let handle_tool_admin_update ctx args =
   let section =
@@ -319,7 +319,7 @@ let handle_tool_admin_update ctx args =
                 ("result", auth_snapshot_json ctx);
               ]
           in
-          (true, Yojson.Safe.pretty_to_string payload))
+          (true, Yojson.Safe.to_string payload))
   | "unit_policy" ->
       (match Command_plane_v2.policy_update_json ctx.config ~actor:ctx.agent_name args with
       | Error err -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String err) ]))
@@ -362,6 +362,6 @@ let handle_tool_admin_update ctx args =
                 ("result", json);
               ]
           in
-          (true, Yojson.Safe.pretty_to_string payload))
+          (true, Yojson.Safe.to_string payload))
   | _ ->
       (false, "section must be one of: auth | unit_policy")

--- a/lib/tool_misc_transport.ml
+++ b/lib/tool_misc_transport.ml
@@ -37,7 +37,7 @@ let handle_transport_status _args : result =
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
   in
   let json = Transport_read_model.transport_status_json ctx in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_websocket_discovery _args : result =
   let ctx =
@@ -45,7 +45,7 @@ let handle_websocket_discovery _args : result =
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
   in
   let json = Transport_read_model.websocket_discovery_json ctx in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_webrtc_offer args : result =
   if not (Server_webrtc_transport.is_enabled ()) then

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -27,7 +27,7 @@ let handle_plan_init ctx args : result =
         ("task_id", `String task_id);
         ("message", `String (Printf.sprintf "Planning context created for %s" task_id));
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to init planning: %s" e)
 
@@ -42,7 +42,7 @@ let handle_plan_update ctx args : result =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to update plan: %s" e)
 
@@ -57,7 +57,7 @@ let handle_note_add ctx args : result =
         ("task_id", `String task_id);
         ("note_count", `Int (List.length plan_ctx.Planning_eio.notes));
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to add note: %s" e)
 
@@ -78,7 +78,7 @@ let handle_deliver ctx args : result =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to set deliverable: %s" e)
 
@@ -96,7 +96,7 @@ let handle_plan_get ctx args : result =
             ("context", Planning_eio.planning_context_to_yojson plan_ctx);
             ("markdown", `String markdown);
           ] in
-          (true, Yojson.Safe.pretty_to_string response)
+          (true, Yojson.Safe.to_string response)
       | Error e ->
           (false, Printf.sprintf "❌ Planning context not found: %s" e)
 
@@ -116,7 +116,7 @@ let handle_error_add ctx args : result =
         ("total_errors", `Int (List.length plan_ctx.errors));
         ("unresolved_count", `Int unresolved_count);
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to add error: %s" e)
 
@@ -133,7 +133,7 @@ let handle_error_resolve ctx args : result =
         ("error_index", `Int error_index);
         ("remaining_unresolved", `Int unresolved_count);
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | Error e ->
       (false, Printf.sprintf "❌ Failed to resolve error: %s" e)
 
@@ -147,7 +147,7 @@ let handle_plan_set_task ctx args : result =
       ("status", `String "set");
       ("current_task", `String task_id);
     ] in
-    (true, Yojson.Safe.pretty_to_string response)
+    (true, Yojson.Safe.to_string response)
   end
 
 let handle_plan_get_task ctx _args : result =
@@ -156,13 +156,13 @@ let handle_plan_get_task ctx _args : result =
       let response = `Assoc [
         ("current_task", `String task_id);
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
   | None ->
       let response = `Assoc [
         ("current_task", `Null);
         ("message", `String "No current task set. Use masc_plan_set_task first.");
       ] in
-      (true, Yojson.Safe.pretty_to_string response)
+      (true, Yojson.Safe.to_string response)
 
 let handle_plan_clear_task ctx _args : result =
   Planning_eio.clear_current_task ctx.config;
@@ -170,7 +170,7 @@ let handle_plan_clear_task ctx _args : result =
     ("status", `String "cleared");
     ("message", `String "Current task cleared");
   ] in
-  (true, Yojson.Safe.pretty_to_string response)
+  (true, Yojson.Safe.to_string response)
 
 (** {1 Dispatcher} *)
 

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -34,7 +34,7 @@ let handle_relay_status ctx args =
     ("should_relay", `Bool should_relay);
     ("calibration", Relay.get_calibration_info ());
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_relay_checkpoint ctx args =
   let*! summary = get_string_required args "summary" in
@@ -59,7 +59,7 @@ let handle_relay_checkpoint ctx args =
     ("estimated_tokens", `Int metrics.Relay.estimated_tokens);
     ("calibration", Relay.get_calibration_info ());
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_relay_now ctx args =
   let summary = get_string args "summary" "" in
@@ -111,7 +111,7 @@ let handle_relay_now ctx args =
     ("generation", `Int (generation + 1));
     ("output_preview", `String output_preview);
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let handle_relay_smart_check ctx args =
   let messages = get_int args "messages" 0 in
@@ -140,7 +140,7 @@ let handle_relay_smart_check ctx args =
     ("estimated_tokens", `Int metrics.Relay.estimated_tokens);
     ("max_tokens", `Int metrics.Relay.max_tokens);
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let schemas : Types.tool_schema list = [
   {

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -398,7 +398,7 @@ let handle_reset ctx args =
   end
 
 let handle_room_strategy_get ctx _args =
-  (true, Yojson.Safe.pretty_to_string (room_strategy_json ctx.config))
+  (true, Yojson.Safe.to_string (room_strategy_json ctx.config))
 
 let handle_room_strategy_set ctx args =
   let search_strategy_raw = get_string_opt args "search_strategy_default" in
@@ -511,7 +511,7 @@ let handle_workflow_guide ctx _args =
       ("guidance", Workflow_guide.guidance_to_json guidance);
     ]
   in
-  (true, Yojson.Safe.pretty_to_string result)
+  (true, Yojson.Safe.to_string result)
 
 (* ── State check (assertion-based verification) ────────────────── *)
 
@@ -574,7 +574,7 @@ let handle_check ctx args =
       ("fix_hint", fix_hint);
     ]
   in
-  (true, Yojson.Safe.pretty_to_string result)
+  (true, Yojson.Safe.to_string result)
 
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -24,7 +24,7 @@ let handle_run_init ctx args : result =
     let agent = get_string_opt args "agent_name" in
     match Run_eio.init ctx.config ~task_id ~agent_name:agent with
   | Ok run ->
-      (true, Yojson.Safe.pretty_to_string (Run_eio.run_record_to_json run))
+      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
       (false, Printf.sprintf "❌ Failed to init run: %s" e)
 
@@ -36,7 +36,7 @@ let handle_run_plan ctx args : result =
     let plan = get_string args "plan" "" in
     match Run_eio.update_plan ctx.config ~task_id ~content:plan with
   | Ok run ->
-      (true, Yojson.Safe.pretty_to_string (Run_eio.run_record_to_json run))
+      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
       (false, Printf.sprintf "❌ Failed to update run plan: %s" e)
 
@@ -48,7 +48,7 @@ let handle_run_log ctx args : result =
     let note = get_string args "note" "" in
     match Run_eio.append_log ctx.config ~task_id ~note with
   | Ok entry ->
-      (true, Yojson.Safe.pretty_to_string (Run_eio.log_entry_to_json entry))
+      (true, Yojson.Safe.to_string (Run_eio.log_entry_to_json entry))
   | Error e ->
       (false, Printf.sprintf "❌ Failed to append run log: %s" e)
 
@@ -60,7 +60,7 @@ let handle_run_deliverable ctx args : result =
     let deliverable = get_string args "deliverable" "" in
     match Run_eio.set_deliverable ctx.config ~task_id ~content:deliverable with
   | Ok run ->
-      (true, Yojson.Safe.pretty_to_string (Run_eio.run_record_to_json run))
+      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
       (false, Printf.sprintf "❌ Failed to set run deliverable: %s" e)
 
@@ -70,12 +70,12 @@ let handle_run_get ctx args : result =
     (false, "task_id is required")
   else
     match Run_eio.get ctx.config ~task_id with
-    | Ok json -> (true, Yojson.Safe.pretty_to_string json)
+    | Ok json -> (true, Yojson.Safe.to_string json)
     | Error e -> (false, Printf.sprintf "❌ Failed to get run: %s" e)
 
 let handle_run_list ctx _args : result =
   let json = Run_eio.list ctx.config in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (** {1 Dispatcher} *)
 

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -143,7 +143,7 @@ let handle_suspend ctx args =
       ("is_self_suspend", `Bool is_self);
       ("blacklisted_until", `Float until);
     ] in
-    (true, Yojson.Safe.pretty_to_string json)
+    (true, Yojson.Safe.to_string json)
 
 (** Handle masc_circuit_status *)
 let handle_circuit_status ctx args =
@@ -170,7 +170,7 @@ let handle_circuit_status ctx args =
     ("circuit_breaker", Circuit_breaker.status_to_json status);
     ("blacklist", blacklist_info);
   ] in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 let schemas : Types.tool_schema list = [
   {

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -733,13 +733,13 @@ let handle_task_history ctx args =
     | x :: rest -> x :: take (n - 1) rest
   in
   let events = parsed |> List.filter matches_task |> take limit in
-  (true, Yojson.Safe.pretty_to_string (`List events))
+  (true, Yojson.Safe.to_string (`List events))
 
 let handle_archive_view ctx args =
   let limit = get_int args "limit" 20 in
   let archive_path = Room_utils.archive_path ctx.config in
   if not (Room_utils.path_exists ctx.config archive_path) then
-    (true, Yojson.Safe.pretty_to_string (`Assoc [("count", `Int 0); ("tasks", `List [])]))
+    (true, Yojson.Safe.to_string (`Assoc [("count", `Int 0); ("tasks", `List [])]))
   else
     let json = Room_utils.read_json ctx.config archive_path in
     let tasks =
@@ -768,7 +768,7 @@ let handle_archive_view ctx args =
       ("total", `Int total);
       ("tasks", `List tasks);
     ] in
-    (true, Yojson.Safe.pretty_to_string response)
+    (true, Yojson.Safe.to_string response)
 
 include Tool_task_schemas
 (* Dispatch function *)

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -40,7 +40,7 @@ let handle_worktree_remove ctx args =
 
 let handle_worktree_list ctx _args =
   let json = Room.worktree_list ctx.config in
-  (true, Yojson.Safe.pretty_to_string json)
+  (true, Yojson.Safe.to_string json)
 
 (* Dispatch function - returns None if tool not handled *)
 let dispatch ctx ~name ~args : result option =


### PR DESCRIPTION
2개 이슈를 I/O 레이어 정비로 통합. Commit 1: tool output path의 pretty_to_string을 to_string으로 (92곳/28파일). Commit 2: Fs_compat.save_file_atomic 추출 + 7곳 인라인 교체. Result type 반환. Closes #5857 Closes #5860