### PR TITLE
refactor: name remaining inline magic number (#5797)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -265,7 +265,8 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     if success then None
     else
       let truncated =
-        if String.length message > 200 then String.sub message 0 200 ^ "..."
+        let error_preview_max = 200 in
+        if String.length message > error_preview_max then String.sub message 0 error_preview_max ^ "..."
         else message
       in
       Some (Printf.sprintf "timeout=%d|duration_ms=%d|detail=%s"


### PR DESCRIPTION
mcp_server_eio_call_tool.ml의 error preview 200을 named constant로 추출. #5797의 P1 항목 대부분은 이미 해결됨(#5794). 남은 P2(buffer sizes)는 표준 값이라 이점 미미. Refs #5797