### PR TITLE
refactor: eradicate all remaining Hashtbl.find usages

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -46,7 +46,8 @@ let lookup_schemas_by_name_exn ~label all_schemas values =
     invalid_arg
       (Printf.sprintf "%s: unknown tool schema(s): %s" label
          (String.concat ", " missing));
-  requested |> List.filter_map (Hashtbl.find_opt by_name)
+  (* Guard above ensures all names exist — use List.map to preserve _exn contract *)
+  requested |> List.map (Hashtbl.find by_name)
 
 let spawned_agent_public_tool_names : string list =
   Tool_catalog.tools_for_surface Tool_catalog.Spawned_agent

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -46,7 +46,7 @@ let lookup_schemas_by_name_exn ~label all_schemas values =
     invalid_arg
       (Printf.sprintf "%s: unknown tool schema(s): %s" label
          (String.concat ", " missing));
-  requested |> List.map (Hashtbl.find by_name)
+  requested |> List.filter_map (Hashtbl.find_opt by_name)
 
 let spawned_agent_public_tool_names : string list =
   Tool_catalog.tools_for_surface Tool_catalog.Spawned_agent

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -92,7 +92,7 @@ let compute_tool_counts (groups : blocked_attempt_group list)
     : (string * int) list =
   let tbl = Hashtbl.create 8 in
   List.iter (fun g ->
-    let prev = try Hashtbl.find tbl g.key.tool_name with Not_found -> 0 in
+    let prev = Option.value ~default:0 (Hashtbl.find_opt tbl g.key.tool_name) in
     Hashtbl.replace tbl g.key.tool_name (prev + g.count)
   ) groups;
   Hashtbl.fold (fun name count acc -> (name, count) :: acc) tbl []

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -76,7 +76,7 @@ let group_violations (violations : Violation_record.t list)
   let tbl = H.create 16 in
   List.iter (fun v ->
     let k = key_of_violation v in
-    let prev = try H.find tbl k with Not_found -> 0 in
+    let prev = Option.value ~default:0 (H.find_opt tbl k) in
     H.replace tbl k (prev + 1)
   ) violations;
   H.fold (fun key count acc -> { key; count } :: acc) tbl []
@@ -223,7 +223,7 @@ let merge_groups (all_groups : blocked_attempt_group list list)
   let tbl = H.create 32 in
   List.iter (fun groups ->
     List.iter (fun (g : blocked_attempt_group) ->
-      let prev = try H.find tbl g.key with Not_found -> 0 in
+      let prev = Option.value ~default:0 (H.find_opt tbl g.key) in
       H.replace tbl g.key (prev + g.count)
     ) groups
   ) all_groups;

--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -85,13 +85,12 @@ let jaccard_similarity (a : string) (b : string) : float =
     let inter = ref 0 in
     let uniq_b = ref 0 in
     List.iter (fun w ->
-      if Hashtbl.mem h w then begin
-        if not (Hashtbl.find h w) then begin
+      match Hashtbl.find_opt h w with
+      | Some false ->
           incr inter;
           Hashtbl.replace h w true
-        end
-      end else
-        incr uniq_b
+      | Some true -> ()
+      | None -> incr uniq_b
     ) tb;
     let union = (List.length ta) + !uniq_b in
     if union = 0 then 0.0 else float_of_int !inter /. float_of_int union

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -308,7 +308,7 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
       if v = "approve" then incr approve_count
       else incr reject_count;
       let gate = string_field json "gate" in
-      let prev = try Hashtbl.find gate_counts gate with Not_found -> 0 in
+      let prev = Option.value ~default:0 (Hashtbl.find_opt gate_counts gate) in
       Hashtbl.replace gate_counts gate (prev + 1);
       Hashtbl.replace verdict_hashes hash v;
       if gate = fallback_tag && List.length !recent_fallback_reasons < max_fallback_reasons then
@@ -342,8 +342,8 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   let gate_json = Hashtbl.fold (fun k v acc ->
     (k, `Int v) :: acc) gate_counts [] in
   let fallback_count =
-    try Hashtbl.find gate_counts (Anti_rationalization.gate_to_string Fallback)
-    with Not_found -> 0
+    Option.value ~default:0
+      (Hashtbl.find_opt gate_counts (Anti_rationalization.gate_to_string Fallback))
   in
   `Assoc [
     ("total_verdicts", `Int !total_verdicts);

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -274,7 +274,7 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
     let cohorts = Hashtbl.create 4 in
     List.iter (fun ((entry : Keeper_registry.registry_entry), _msg) ->
       let key = cohort_key_of_reason entry.last_failure_reason in
-      let prev = try Hashtbl.find cohorts key with Not_found -> [] in
+      let prev = Option.value ~default:[] (Hashtbl.find_opt cohorts key) in
       Hashtbl.replace cohorts key ((entry, _msg) :: prev)
     ) to_restart;
     let dominant_key, dominant_entries =

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -105,7 +105,7 @@ let flush_pending () =
     match Eio.Stream.take_nonblocking write_queue with
     | None -> ()
     | Some entry ->
-        let prev = try Hashtbl.find batch entry.file with Not_found -> Buffer.create 256 in
+        let prev = Option.value ~default:(Buffer.create 256) (Hashtbl.find_opt batch entry.file) in
         Buffer.add_string prev entry.line;
         Hashtbl.replace batch entry.file prev;
         drain ()

--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -103,7 +103,7 @@ let is_repetitive_tokens s =
     let tbl = Hashtbl.create 16 in
     List.iter (fun t ->
       let lower = String.lowercase_ascii t in
-      let prev = try Hashtbl.find tbl lower with Not_found -> 0 in
+      let prev = Option.value ~default:0 (Hashtbl.find_opt tbl lower) in
       Hashtbl.replace tbl lower (prev + 1)
     ) tokens;
     let max_count = Hashtbl.fold (fun _ v acc -> max v acc) tbl 0 in


### PR DESCRIPTION
## Description

Follow-up to previous `Result` type enforcement and OCaml best practices (#5817, #5865, #5870, #5882).
This PR systematically eradicates all remaining occurrences of the unsafe `Hashtbl.find` function across the codebase, eliminating hidden `Not_found` exception risks.

- **`eval_calibration.ml` & `post_verifier.ml` & `cdal_friction_projection.ml` & `metrics_store_eio.ml` & `keeper_supervisor.ml`**: Replaced the `try Hashtbl.find ... with Not_found -> ...` anti-pattern with the much safer `Option.value ~default:X (Hashtbl.find_opt ...)`.
- **`agent_tool_surfaces.ml`**: Replaced `List.map (Hashtbl.find by_name)` with idiomatic `List.filter_map (Hashtbl.find_opt by_name)`.
- **`core/text_similarity.ml`**: Replaced the `Hashtbl.mem` + `Hashtbl.find` double lookup with a single `match Hashtbl.find_opt` pattern for improved safety and performance.