### PR TITLE
fix(github): surface detailed gh command errors to agents

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -74,12 +74,15 @@ let handle_keeper_github
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out
-              ])))
+        let is_ok = st = Unix.WEXITED 0 in
+        let fields =
+          [ "ok", `Bool is_ok
+          ; "status", Keeper_alerting_path.process_status_to_json st
+          ; "output", `String out
+          ]
+        in
+        let fields = if is_ok then fields else ("error", `String out) :: fields in
+        Yojson.Safe.to_string (`Assoc fields)))
 ;;
 
 let handle_keeper_pr_workflow


### PR DESCRIPTION
When a `gh` command fails (e.g. searching for a nonexistent issue), the `keeper_github` tool previously only populated the `output` field in its JSON result.

Because the `error` key was missing, the OAS bridge (`lib/keeper/keeper_tools_oas.ml`) fell back to returning a generic `"tool call failed"` error string to the agent, burying the actual CLI error in a nested JSON string inside the  object which makes it harder for the model to parse.

This fix explicitly adds the `"error"` key with the CLI output whenever `gh` returns a non-zero exit code, ensuring the agent sees the exact error (e.g., `GraphQL: Could not resolve to an issue...`) and can adapt accordingly.