### PR TITLE
refactor: eradicate unsafe Sys.getenv usages

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -89,7 +89,7 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
 
 let findings_dir () =
   let base = match Env_config_core.me_root_opt () with
-    | Some r -> r | None -> Sys.getenv "HOME" ^ "/me"
+    | Some r -> r | None -> (Option.value ~default:"/tmp" (Sys.getenv_opt "HOME")) ^ "/me"
   in
   Filename.concat base ".masc/autoresearch/findings"
 

--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -89,7 +89,7 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
 
 let findings_dir () =
   let base = match Env_config_core.me_root_opt () with
-    | Some r -> r | None -> (Option.value ~default:"/tmp" (Sys.getenv_opt "HOME")) ^ "/me"
+    | Some r -> r | None -> (Option.value ~default:"/tmp" (Env_config_core.home_dir_opt ())) ^ "/me"
   in
   Filename.concat base ".masc/autoresearch/findings"
 

--- a/lib/cdal/artifact_store.ml
+++ b/lib/cdal/artifact_store.ml
@@ -39,9 +39,7 @@ let kind_of_string = function
   | other -> Error (Printf.sprintf "unknown artifact kind: %s" other)
 
 let default_config ~session_id =
-  let home =
-    try Sys.getenv "HOME" with Not_found -> "/tmp"
-  in
+  let home = Option.value ~default:"/tmp" (Sys.getenv_opt "HOME") in
   { base_dir = Filename.concat home (Printf.sprintf ".masc/sessions/%s/artifacts" session_id) }
 
 (* --- Filesystem helpers --- *)

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -81,10 +81,13 @@ let friction_of_outcome = function
    be set before this module is loaded. Safe in practice because the
    server sets all env vars at process startup. *)
 let default_base_path =
-  let root = try Sys.getenv "MASC_DATA_DIR"
-    with Not_found ->
-      try Filename.concat (Sys.getenv "ME_ROOT") "data"
-      with Not_found -> "data"
+  let root =
+    match Sys.getenv_opt "MASC_DATA_DIR" with
+    | Some dir -> dir
+    | None ->
+      match Sys.getenv_opt "ME_ROOT" with
+      | Some root -> Filename.concat root "data"
+      | None -> "data"
   in
   Filename.concat root "cdal_verdicts"
 

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -56,9 +56,9 @@ let store_ref : Dated_jsonl.t option ref = ref None
 
 let base_path () =
   let me =
-    match Sys.getenv_opt "ME_ROOT" with
+    match Env_config_core.me_root_opt () with
     | Some p -> p
-    | None -> (Option.value ~default:"/tmp" (Sys.getenv_opt "HOME")) ^ "/me"
+    | None -> (Option.value ~default:"/tmp" (Env_config_core.home_dir_opt ())) ^ "/me"
   in
   Filename.concat me "data/verdicts"
 

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -55,7 +55,11 @@ type calibration_example = {
 let store_ref : Dated_jsonl.t option ref = ref None
 
 let base_path () =
-  let me = try Sys.getenv "ME_ROOT" with Not_found -> Sys.getenv "HOME" ^ "/me" in
+  let me =
+    match Sys.getenv_opt "ME_ROOT" with
+    | Some p -> p
+    | None -> (Option.value ~default:"/tmp" (Sys.getenv_opt "HOME")) ^ "/me"
+  in
   Filename.concat me "data/verdicts"
 
 let get_store () =


### PR DESCRIPTION
## Description

Addresses user feedback to apply OCaml best practices for Option types and remove implicit exceptions.
- Replaced all `try Sys.getenv ... with Not_found -> ...` patterns with the safer and idiomatic `Sys.getenv_opt` + `Option.value ~default`.
- Affected modules: `eval_calibration.ml`, `cdal_eval_v1.ml`, `artifact_store.ml`, `autoresearch_knowledge.ml`.