### PR TITLE
fix(fs_compat): re-raise Eio.Cancel.Cancelled in save_file_atomic

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -104,7 +104,11 @@ let save_file_atomic (path : string) (content : string) : (unit, string) result 
     save_file tmp content;
     Sys.rename tmp path;
     Ok ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    (try Sys.remove tmp with Sys_error _ -> ());
+    raise e
+  | exn ->
     (try Sys.remove tmp with Sys_error _ -> ());
     Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
 


### PR DESCRIPTION
save_file_atomic의 catch-all이 Eio.Cancel.Cancelled를 삼켜 fiber cancellation이 깨지는 버그. /simplify review에서 발견. Refs #5884