### PR TITLE
refactor(harness): remove dead gate_of_string, replace magic strings

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -46,16 +46,6 @@ let gate_to_string = function
   | Format_reject -> "format_reject"
   | Fallback -> "fallback"
 
-let gate_of_string = function
-  | "length" -> Ok Length
-  | "excuse" -> Ok Excuse
-  | "contract" -> Ok Contract
-  | "structured_tool" -> Ok Structured_tool
-  | "llm_text_fallback" -> Ok Llm_text_fallback
-  | "format_reject" -> Ok Format_reject
-  | "fallback" -> Ok Fallback
-  | s -> Error (Printf.sprintf "unknown gate: %S" s)
-
 type review_result = {
   verdict : verdict;
   evaluator_cascade : string;

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -40,7 +40,6 @@ type gate =
   | Fallback
 
 val gate_to_string : gate -> string
-val gate_of_string : string -> (gate, string) result
 
 (** Structured review result with audit metadata for cross-model tracking. *)
 type review_result = {

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -18,7 +18,7 @@ type verdict_record = {
   task_title : string;
   agent_name : string;
   verdict : string;               (** "approve" | "reject:<reason>" *)
-  gate : string;                  (** "length" | "excuse" | "contract" | "llm" | "fallback" *)
+  gate : string;                  (** Anti_rationalization.gate_to_string output *)
   evaluator_cascade : string;
   generator_cascade : string option;
   fallback_reason : string option; (** Error message when gate="fallback" *)
@@ -298,6 +298,7 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   let verdict_hashes : (string, string) Hashtbl.t = Hashtbl.create 64 in
   let recent_fallback_reasons : string list ref = ref [] in
   let max_fallback_reasons = 5 in
+  let fallback_tag = Anti_rationalization.gate_to_string Fallback in
   List.iter (fun json ->
     let rt = string_field json "record_type" in
     let hash = string_field json "notes_hash" in
@@ -310,7 +311,7 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
       let prev = try Hashtbl.find gate_counts gate with Not_found -> 0 in
       Hashtbl.replace gate_counts gate (prev + 1);
       Hashtbl.replace verdict_hashes hash v;
-      if gate = "fallback" && List.length !recent_fallback_reasons < max_fallback_reasons then
+      if gate = fallback_tag && List.length !recent_fallback_reasons < max_fallback_reasons then
         (let reason = string_field json "fallback_reason" in
          if reason <> "" then
            recent_fallback_reasons := reason :: !recent_fallback_reasons)
@@ -341,7 +342,8 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   let gate_json = Hashtbl.fold (fun k v acc ->
     (k, `Int v) :: acc) gate_counts [] in
   let fallback_count =
-    try Hashtbl.find gate_counts "fallback" with Not_found -> 0
+    try Hashtbl.find gate_counts (Anti_rationalization.gate_to_string Fallback)
+    with Not_found -> 0
   in
   `Assoc [
     ("total_verdicts", `Int !total_verdicts);


### PR DESCRIPTION
## Summary
- `gate_of_string` 제거 (anti_rationalization.ml/.mli) — caller 0개, dead code
- `eval_calibration.ml`의 `"fallback"` magic string을 `Anti_rationalization.gate_to_string Fallback`로 교체 — gate variant 변경 시 컴파일러가 잡아줌
- `fallback_tag` 상수를 루프 밖으로 호이스트

## Test plan
- [x] `test_eval_calibration.exe` 21 tests pass
- [x] `test_anti_rationalization_coverage.exe` all tests pass
- [x] `dune build` clean

Closes review item from #5881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)