### PR TITLE
refactor(keeper): remove hardcoded error mapping and enhance tool bridge logging

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -74,15 +74,12 @@ let handle_keeper_github
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
-        let is_ok = st = Unix.WEXITED 0 in
-        let fields =
-          [ "ok", `Bool is_ok
-          ; "status", Keeper_alerting_path.process_status_to_json st
-          ; "output", `String out
-          ]
-        in
-        let fields = if is_ok then fields else ("error", `String out) :: fields in
-        Yojson.Safe.to_string (`Assoc fields)))
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool (st = Unix.WEXITED 0)
+              ; "status", Keeper_alerting_path.process_status_to_json st
+              ; "output", `String out
+              ])))
 ;;
 
 let handle_keeper_pr_workflow

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -130,13 +130,16 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
         match Safe_ops.json_string_opt "error" json with
         | Some msg when String.trim msg <> "" -> msg
         | _ ->
-          match Safe_ops.json_string_opt "message" json with
+          match Safe_ops.json_string_opt "output" json with
           | Some msg when String.trim msg <> "" -> msg
           | _ ->
-            match Safe_ops.json_string_opt "status" json with
-            | Some s when String.lowercase_ascii (String.trim s) = "error" ->
-              "tool returned error status"
-            | _ -> "tool call failed"
+            match Safe_ops.json_string_opt "message" json with
+            | Some msg when String.trim msg <> "" -> msg
+            | _ ->
+              match Safe_ops.json_string_opt "status" json with
+              | Some s when String.lowercase_ascii (String.trim s) = "error" ->
+                "tool returned error status"
+              | _ -> "tool call failed"
       in
       Yojson.Safe.to_string (`Assoc [
         ("ok", `Bool false);


### PR DESCRIPTION
Reverts the hardcoding from #5888 and fixes the root cause at the central bridge layer.

### Changes
- **Centralized Fallback:** Instead of hardcoding `"error", `String out` directly inside `keeper_exec_github.ml`, the central OAS tool bridge (`lib/keeper/keeper_tools_oas.ml`) has been updated to check the `"output"` field if a tool call fails without an explicit `"error"` key.
- **Generic Support:** Now, any CLI/shell-based tool (e.g. `keeper_bash`, `keeper_shell_readonly`, `keeper_fs_*`) that returns a non-zero exit code will have its `output` (stdout/stderr) natively surfaced to the agent, eliminating the useless `"tool call failed"` fallback for all of them, not just `gh`.