### PR TITLE
fix(worktree): normalize slash in task_id so keepers can create worktrees

### DIFF
--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -19,12 +19,18 @@ let handle_worktree_create ctx args =
     let from_args = get_string args "agent_name" "" in
     if from_args = "" then ctx.agent_name else from_args
   in
-  let task_id = get_string args "task_id" "" in
+  let raw_task_id = get_string args "task_id" "" in
   let base_branch = get_string args "base_branch" "develop" in
-  if task_id = "" then
-    (false, "task_id is required. Example: task_id='fix-login', task_id='feature/auth'. \
-             Use a short descriptive name for your task.")
+  if raw_task_id = "" then
+    (false, "task_id is required. Example: task_id='fix-login', task_id='add-auth'. \
+             Use a-z, 0-9, hyphen, underscore only. No slashes.")
   else
+  (* Normalize: replace / and \ with - so LLMs can use branch-style names *)
+  let task_id =
+    String.to_seq raw_task_id
+    |> Seq.map (fun c -> if c = '/' || c = '\\' then '-' else c)
+    |> String.of_seq
+  in
   match Room.worktree_create_r ctx.config ~agent_name ~task_id ~base_branch with
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)


### PR DESCRIPTION
## Summary
Keeper가 `masc_worktree_create`나 `keeper_pr_workflow`를 호출할 때 branch 스타일 이름(`feature/fix-auth`)을 task_id로 전달하면 `Task_id` 검증에서 path separator 거부로 실패.

로그: `worktree_create: FAILED — ❌ Invalid task ID: task_id cannot contain path separators`

## 변경
- `tool_worktree.ml`: task_id에서 `/`와 `\`를 `-`로 정규화 후 전달
- 도구 설명 예시에서 slash 포함 예시 제거

## Product impact
Keeper가 GitHub PR을 만들 수 있게 됨. 이전에는 모든 worktree 생성이 실패.

## Evidence
로그에서 masc-improver, coder, cheolsu 3개 keeper가 동일 에러로 실패 확인.

## Test plan
- [x] `dune build lib/` 성공
- [ ] 서버 재빌드 후 keeper worktree 생성 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)