### PR TITLE
fix(dashboard): reconcile heartbeat liveness with offline status display

### DIFF
--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -6,9 +6,11 @@ export function formatPct(value: number | null | undefined, fallback = '-'): str
   return `${Math.round(value * 100)}%`
 }
 
-/** Abbreviate large token counts: 1234567 → "1.2M", 4500 → "4.5K". */
-export function formatTokens(n: number | undefined): string {
-  if (!n) return '-'
+/** Abbreviate large token counts: 1234567 → "1.2M", 4500 → "4.5K".
+ *  Distinguishes 0 (valid data) from undefined (no data). */
+export function formatTokens(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return '-'
+  if (n === 0) return '0'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
   return String(n)

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -1,6 +1,9 @@
 import type { Keeper } from '../types'
 import { relativeTime } from './format-time'
 
+/** Max seconds since last heartbeat to consider the keeper process alive. */
+const HEARTBEAT_ALIVE_THRESHOLD_S = 120
+
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
   if (keeper?.paused) return 'paused'
   const status = keeper?.status ?? fallbackStatus
@@ -14,9 +17,19 @@ export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackS
   return status && status.trim() !== '' ? status : 'unknown'
 }
 
-/** Distinguish "never booted" from "was running but stopped" keepers. */
+/** Distinguish "never booted" from "was running but stopped" keepers.
+ *  Reconciles heartbeat liveness with agent registration status:
+ *  if heartbeat is recent but agent is offline, shows phase instead of "offline". */
 function refineOfflineStatus(keeper: Keeper | null | undefined): string {
   if (!keeper) return 'offline'
+
+  // Heartbeat alive but agent offline — keepalive fiber is running.
+  // Show actual phase instead of misleading "offline".
+  if (keeper.last_heartbeat && isHeartbeatAlive(keeper.last_heartbeat)) {
+    const phase = keeper.phase?.trim().toLowerCase()
+    if (phase && phase !== 'offline' && phase !== 'inactive') return phase
+    return 'idle'
+  }
 
   const generation = keeper.generation ?? 0
   const turnCount = keeper.turn_count ?? 0
@@ -33,6 +46,12 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): string {
   }
 
   return 'offline'
+}
+
+function isHeartbeatAlive(heartbeat: string): boolean {
+  const ts = new Date(heartbeat).getTime()
+  if (Number.isNaN(ts)) return false
+  return (Date.now() - ts) / 1000 < HEARTBEAT_ALIVE_THRESHOLD_S
 }
 
 export function keeperRecentHeartbeatLabel(keeper: Keeper | null | undefined): string {


### PR DESCRIPTION
## Summary
- `refineOfflineStatus`에 heartbeat recency 체크 추가 (120s threshold)
  - heartbeat가 살아있는데 agent가 offline이면 실제 phase를 표시
  - keepalive fiber가 돌고 있는데 "오프라인"으로 표시되던 모순 해결
- `formatTokens`에서 `!n` 대신 `n == null` 체크
  - `0`(유효 데이터)과 `undefined`(데이터 없음)을 구분
  - 토큰 0일 때 "-"가 아닌 "0"으로 표시

## Root cause
두 독립 데이터 경로의 reconcile 부재:
1. `status` = OAS agent registration 기반 (agent state machine)
2. `last_heartbeat` = keepalive loop 기반 (독립 fiber)

Agent 종료 후에도 keepalive fiber는 일정 시간 살아있을 수 있음. 이 두 신호를 reconcile하는 로직이 없었음.

## Test plan
- [ ] heartbeat가 최근인 keeper가 "offline" 대신 실제 phase(idle/listening 등)로 표시되는지 확인
- [ ] heartbeat가 120s 이상 오래된 keeper는 기존대로 stopped/unbooted/offline 표시
- [ ] context_tokens=0인 keeper가 "-" 대신 "0"으로 표시되는지 확인
- [ ] Dashboard tsc + vite build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)