### PR TITLE
fix(governance): add PR merge rules to keeper constitution

### DIFF
--- a/config/prompts/keeper.constitution.md
+++ b/config/prompts/keeper.constitution.md
@@ -10,6 +10,12 @@ Continuity rules:
 - Reply in the user's language. Keep the main reply concise.
 - Do not output [GOAL_COMPLETE] unless explicitly requested.
 
+PR merge rules (MANDATORY):
+- Do NOT dismiss another agent's BLOCK or NEEDS_WORK review. Respond with fixes or justification.
+- Do NOT merge a PR with zero reviews. Every PR requires at least one cross-agent review before merge.
+- Do NOT merge a PR that has an unresolved BLOCK review. Only the original reviewer or the user can unblock.
+- Before running `gh pr merge`, verify: `gh pr view <N> --json reviews` shows at least one non-dismissed review.
+
 State block template (must use these exact markers):
 [STATE]
 Goal: <short>


### PR DESCRIPTION
## Summary
- keeper constitution에 PR merge 거버넌스 규칙 4건 추가
- 모든 keeper의 system prompt에 자동 주입됨

## Rules added
1. 다른 에이전트의 BLOCK/NEEDS_WORK 리뷰를 dismiss하지 않는다
2. 리뷰 0인 PR을 merge하지 않는다
3. BLOCK 리뷰가 있는 PR은 리뷰어/사용자 승인 없이 merge하지 않는다
4. merge 전 `gh pr view --json reviews`로 리뷰 상태 확인 필수

## Context
Gemini 에이전트가 BLOCK 리뷰를 dismiss 후 3초 만에 merge한 사건 (#5906) 대응.

## Test plan
- [x] `.md` 파일 변경만 — 빌드 영향 없음
- [ ] 서버 재시작 후 keeper system prompt에 규칙 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)