### PR TITLE
fix(dashboard): add phase field to execution API keeper list

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -232,11 +232,17 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
              match Keeper_types.read_meta config name with
              | Error _ | Ok None -> None
              | Ok (Some meta) when lightweight && meta.paused ->
+                 let phase_str =
+                   match Keeper_registry.get_phase ~base_path:config.base_path meta.name with
+                   | Some p -> `String (Keeper_state_machine.phase_to_string p)
+                   | None -> `String "paused"
+                 in
                  Some
                    (`Assoc
                      [
                        ("runtime_class", `String "keeper");
                        ("pipeline_stage", `String "paused");
+                       ("phase", phase_str);
                        ("name", `String meta.name);
                        ("agent_name", `String meta.agent_name);
                        ("status", `String "paused");
@@ -279,16 +285,25 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    if not agent_exists then "offline"
                    else Keeper_exec_status.keeper_surface_status ~agent_status:agent_json ~diagnostic
                  in
+                 let registry_phase =
+                   Keeper_registry.get_phase ~base_path:config.base_path meta.name
+                 in
                  let pipeline_stage =
-                   match Keeper_registry.get_phase ~base_path:config.base_path meta.name with
+                   match registry_phase with
                    | Some phase -> Keeper_exec_status.pipeline_stage_of_phase phase
                    | None -> "offline"
+                 in
+                 let phase_str =
+                   match registry_phase with
+                   | Some p -> `String (Keeper_state_machine.phase_to_string p)
+                   | None -> `Null
                  in
                  Some
                    (`Assoc
                      [
                        ("runtime_class", `String "keeper");
                        ("pipeline_stage", `String pipeline_stage);
+                       ("phase", phase_str);
                        ("name", `String meta.name);
                        ("agent_name", `String meta.agent_name);
                        ("trace_id", `String meta.runtime.trace_id);


### PR DESCRIPTION
## Summary
- `operator_control_snapshot.ml`의 `keepers_json`에 `phase` 필드가 누락되어 대시보드에서 keeper phase가 항상 null로 표시되던 버그 수정
- `dashboard_http_keeper.ml` (keeper detail API)에는 phase가 있었지만, 대시보드 메인 뷰에서 사용하는 execution API에는 없었음
- lightweight (paused) 경로와 일반 경로 모두에 `phase` 필드 추가

## Root Cause
keeper 데이터를 생성하는 코드가 2곳에 분산:
1. `dashboard_http_keeper.ml` — keeper detail API (phase 포함)
2. `operator_control_snapshot.ml` — execution API (phase **누락**)

대시보드 프론트엔드는 execution API를 사용하므로 phase가 null.

## Test plan
- [x] `dune build` 성공
- [x] 서버 재시작 후 `curl /api/v1/dashboard/execution` 에서 모든 keeper에 phase 필드 확인
- [x] state-diagram 엔드포인트와 일치 확인

Generated with [Claude Code](https://claude.com/claude-code)