### PR TITLE
fix(telemetry): remove hardcoded error prefix from tool outcome logs

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -97,18 +97,7 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
            | j ->
              Safe_ops.json_string_opt "error" j
              |> Option.value ~default:"unknown_error"
-           | exception Yojson.Json_error _ ->
-             (* Try after stripping "error: " prefix *)
-             let stripped =
-               if String.length output >= 7 && String.sub output 0 7 = "error: "
-               then String.sub output 7 (String.length output - 7)
-               else output
-             in
-             (match Yojson.Safe.from_string stripped with
-              | j ->
-                Safe_ops.json_string_opt "error" j
-                |> Option.value ~default:"parse_error"
-              | exception Yojson.Json_error _ -> "parse_error"))
+           | exception Yojson.Json_error _ -> "parse_error")
         else "empty_output"
       in
       let r = match Hashtbl.find_opt failure_cats cat with

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -346,8 +346,7 @@ let make_hooks
       | Agent_sdk.Hooks.PostToolUse { tool_name; input; output; _ } ->
         let output_text = match output with
           | Ok { Agent_sdk.Types.content; _ } -> content
-          | Error { Agent_sdk.Types.message; _ } ->
-            Printf.sprintf "error: %s" message
+          | Error { Agent_sdk.Types.message; _ } -> message
         in
         let input_keys = match input with
           | `Assoc pairs -> String.concat "," (List.map fst pairs)


### PR DESCRIPTION
Resolves the issue where tool errors containing valid JSON were logged with a hardcoded `"error: "` prefix in the `output` field of the telemetry log (e.g. `tool_call_io`).

### Changes
- **Removed Hardcoding:** In `lib/keeper/keeper_hooks_oas.ml`, the `post_tool_use` hook no longer arbitrarily prepends `error: ` to the tool's failure message. If a tool returns a JSON string, it will be persisted as a valid JSON string.
- **Removed Dashboard Workaround:** The `lib/dashboard/dashboard_http_tool_quality.ml` metric parser no longer needs the hacky string-stripping logic (`String.sub output 7...`) to bypass the prefix, improving clarity and efficiency.