### PR TITLE
fix(keeper): add git clone/init to write operation guard

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -261,7 +261,7 @@ let is_write_operation cmd =
   match parts with
   | "git" :: sub :: _ ->
     List.mem sub ["push"; "commit"; "merge"; "rebase"; "reset";
-                  "checkout"; "branch"; "tag"; "stash"]
+                  "checkout"; "branch"; "tag"; "stash"; "clone"; "init"]
   | "dune" :: sub :: _ ->
     List.mem sub ["clean"; "promote"]
   | "make" :: sub :: _ ->

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -90,6 +90,8 @@ let test_write_ops_detected () =
     "git reset --hard HEAD~1";
     "git checkout other-branch";
     "git stash pop";
+    "git clone https://github.com/user/repo.git";
+    "git init";
     "dune clean";
     "make deploy";
     "make install";


### PR DESCRIPTION
## Summary
- Add `clone` and `init` to `is_write_operation` git subcommand list
- Both create files on disk but were missing from the write guard
- Add test cases for both commands

## Note
cwd scoping to playground (second part of #5901) is a separate change.

Partially addresses #5901