### PR TITLE
chore(dashboard): remove dead exports and fix timeAgo locale

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -3,7 +3,6 @@
 import { showToast } from '../common/toast'
 import { prettyJson, displayStatus, statusLabel } from '../../lib/status-label'
 import type {
-  OperatorAttentionItem,
   OperatorDigest,
   OperatorGuidanceSummary,
   OperatorKeeperSnapshot,
@@ -177,16 +176,6 @@ export function sessionOutcomeLabel(session: OperatorSessionSnapshot): string {
   return `${session.done_delta_total ?? 0}건 완료`
 }
 
-export function sessionPriorityTone(session: OperatorSessionSnapshot): OpsPriorityTone {
-  const status = normalizeStatus(session.status)
-  if (status === 'paused') return 'bad'
-  if (status === '' || status === 'unknown') return 'warn'
-  const health = normalizeStatus(session.team_health?.status)
-  if (health && health !== 'ok' && health !== 'healthy' && health !== 'green') return 'warn'
-  if (status && status !== 'active' && status !== 'running' && status !== 'ended') return 'warn'
-  return 'ok'
-}
-
 export function keeperPriorityReasons(keeper: OperatorKeeperSnapshot): KeeperPriorityReason[] {
   const status = normalizeStatus(keeper.status)
   if (status === 'offline' || status === 'inactive' || status === 'error') return ['offline']
@@ -230,20 +219,6 @@ export function keeperPriorityTone(keeper: OperatorKeeperSnapshot): OpsPriorityT
 
 export function keeperPrioritySummary(keeper: OperatorKeeperSnapshot): string {
   return keeperPriorityInfo(keeper).summary
-}
-
-export function attentionTone(items: OperatorAttentionItem[]): OpsPriorityTone {
-  if (items.some(item => normalizeStatus(item.severity) === 'bad')) return 'bad'
-  if (items.length > 0) return 'warn'
-  return 'ok'
-}
-
-export function isSessionAttention(item: OperatorAttentionItem): boolean {
-  return item.target_type === 'team_session'
-}
-
-export function isKeeperAttention(item: OperatorAttentionItem): boolean {
-  return item.target_type === 'keeper'
 }
 
 export function actionTypeLabel(value?: string | null): string {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchTelemetry, fetchTelemetrySummary } from '../api/dashboard'
+import { formatTimeAgo } from '../lib/format-time'
 import type {
   TelemetryEntry,
   TelemetrySource,
@@ -42,11 +43,7 @@ function formatTs(ts: number): string {
 
 function timeAgo(ts: number): string {
   if (ts === 0) return ''
-  const diff = Date.now() / 1000 - ts
-  if (diff < 60) return `${Math.floor(diff)}s ago`
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
+  return formatTimeAgo(ts)
 }
 
 // ── Summary card ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- ops/helpers.ts에서 사용처 0인 export 4건 삭제 (-25줄)
  - `attentionTone`, `isKeeperAttention`, `isSessionAttention`, `sessionPriorityTone`
  - orphan import `OperatorAttentionItem` 함께 제거
- telemetry-unified.ts 로컬 `timeAgo` ("2m ago" 영어) → 공유 `formatTimeAgo` (한국어) 교체
  - 영한혼용 금지 규칙 준수

## Test plan
- [ ] tsc + vite build 통과 (CI)
- [ ] telemetry 페이지에서 시간 표시가 한국어로 나오는지 확인

Closes #5879

🤖 Generated with [Claude Code](https://claude.com/claude-code)