### PR TITLE
refactor: consolidate Keeper_fs.save_atomic via Fs_compat.save_file_atomic

### DIFF
--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -44,35 +44,18 @@ let clear_dir_cache () : unit =
 (* ================================================================ *)
 
 (** Atomically save [content] to [path].
-    Writes to a temporary file first, then renames. On POSIX systems
-    rename(2) is atomic within the same filesystem, so readers never
-    see a partially-written file.
+    Delegates to {!Fs_compat.save_file_atomic} (Eio-aware, re-raises
+    [Eio.Cancel.Cancelled]).  Ensures the parent directory exists first.
 
     @raises Sys_error on I/O failure *)
 let save_atomic (path : string) (content : string) : unit =
   let dir = Filename.dirname path in
   ignore (ensure_dir dir);
-  let tmp_path, oc =
-    Filename.open_temp_file ~temp_dir:dir (Filename.basename path ^ ".") ".tmp"
-  in
-  let closed = ref false in
-  let renamed = ref false in
-  Fun.protect ~finally:(fun () ->
-    if not !closed then begin
-      close_out_noerr oc;
-      closed := true
-    end;
-    if not !renamed then begin
-      Log.Keeper.warn "keeper_fs: save_atomic failed path=%s tmp=%s"
-        path tmp_path;
-      try Sys.remove tmp_path with Sys_error _ -> ()
-    end)
-    (fun () ->
-      output_string oc content;
-      close_out oc;
-      closed := true;
-      Unix.rename tmp_path path;
-      renamed := true)
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg ->
+    Log.Keeper.warn "keeper_fs: save_atomic failed path=%s error=%s" path msg;
+    raise (Sys_error msg)
 
 (** Atomically save a Yojson value as pretty-printed JSON. *)
 let save_json_atomic (path : string) (json : Yojson.Safe.t) : unit =


### PR DESCRIPTION
## Summary
- `Keeper_fs.save_atomic`의 자체 temp-file + rename 구현 제거 (-24줄)
- `Fs_compat.save_file_atomic`에 위임 (+7줄)
- `ensure_dir` + `Sys_error` raise 동작 유지
- `Eio.Cancel.Cancelled` 전파는 `Fs_compat`에서 보장 (PR #5892)

## Motivation
두 개의 atomic write 구현이 미묘하게 달랐음:
- `Keeper_fs`: `Fun.protect` + `Unix.rename` + `output_string oc`
- `Fs_compat`: `try/with` + `Sys.rename` + `save_file` (Eio-aware)

`Fs_compat`가 Eio-aware하고 Cancel-safe하므로 SSOT로 통합.

## Test plan
- [ ] `dune build` 통과
- [ ] `dune test` 통과 (기존 keeper_tool_matrix 실패는 무관)
- [ ] keeper checkpoint save/load 동작 확인

Closes #5893

🤖 Generated with [Claude Code](https://claude.com/claude-code)