### PR TITLE
fix(compaction): lower tool_heavy gate for local LLM pattern

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -19,9 +19,13 @@ let emergency_compact_ratio_threshold = 0.8
     When message count exceeds [tool_heavy_msg_threshold] AND context
     ratio exceeds [tool_heavy_ratio_floor], trigger compaction to
     stub old tool results. Prevents slow inference on local LLMs
-    when many tool calls accumulate without hitting other gates. *)
-let tool_heavy_msg_threshold = 40
-let tool_heavy_ratio_floor = 0.15
+    when many tool calls accumulate without hitting other gates.
+
+    Lowered from 40/0.15 to 10/0.05 (#5895): local 9B keepers run
+    2-20 msgs/turn at ~7.5% context ratio — original cloud-calibrated
+    thresholds never fired. *)
+let tool_heavy_msg_threshold = 10
+let tool_heavy_ratio_floor = 0.05
 
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
   (meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate)


### PR DESCRIPTION
## Summary
- Lower `tool_heavy_msg_threshold` from 40 to 10
- Lower `tool_heavy_ratio_floor` from 0.15 to 0.05
- Original thresholds were cloud-model calibrated; local 9B keepers run 2-20 msgs/turn at ~7.5% ratio, so tool_heavy never triggered

## Evidence (from #5895)
- 8 keepers, ~6500 tool calls/day
- 0 compaction events recorded
- context_ratio consistently 7.5%

Closes #5895