### PR TITLE
fix(keeper): add also_allow for cheolsu + fix preset error messages

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -45,6 +45,7 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "social"
+also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell_readonly"]
 
 # Telemetry Feedback
 telemetry_feedback_enabled = true

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -136,7 +136,7 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
               | None ->
                   Error
                     (Printf.sprintf
-                       "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
+                       "invalid tool_preset '%s' (allowed: minimal, social, messaging, coding, research, delivery, full)"
                        raw))
           | Some `Null -> Error "tool_preset must not be null"
           | Some _ -> Error "tool_preset must be a string"

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -105,7 +105,7 @@ let handle_keeper_tools_post state req reqd =
                              | None ->
                                  Error
                                    (Printf.sprintf
-                                      "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
+                                      "invalid tool_preset '%s' (allowed: minimal, social, messaging, coding, research, delivery, full)"
                                       raw)
                              | Some preset ->
                                  Ok


### PR DESCRIPTION
## Summary
- Add `also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell_readonly"]` to cheolsu TOML
- Fix error messages in 2 files that listed "minimal, messaging, coding, research, full" — missing social and delivery variants
- Runtime JSON preset mismatch (social→delivery) is likely stale; next autoboot should pick up correct TOML value

## Root Cause
cheolsu instructions say "PR이나 이슈가 보이면 실제 상태를 확인" and "코드가 궁금하면 직접 읽고" but the social preset lacks those tools, causing 8x `not_in_allow_set` errors.

Closes #5913