### PR TITLE
fix(compaction): lower gate defaults for local LLM short-turn pattern

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -20,7 +20,7 @@ let emergency_compact_ratio_threshold = 0.8
     ratio exceeds [tool_heavy_ratio_floor], trigger compaction to
     stub old tool results. Prevents slow inference on local LLMs
     when many tool calls accumulate without hitting other gates. *)
-let tool_heavy_msg_threshold = 40
+let tool_heavy_msg_threshold = 20
 let tool_heavy_ratio_floor = 0.15
 
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -442,7 +442,7 @@ let normalize_compaction_token_gate (v : int) : int =
 let normalize_continuity_compaction_cooldown_sec (v : int) : int =
   clamp_int v ~min_v:0 ~max_v:172800
 
-let default_compaction_profile = "custom"
+let default_compaction_profile = "balanced"
 
 let canonical_compaction_profile raw =
   match String.lowercase_ascii (String.trim raw) with


### PR DESCRIPTION
## Summary
- `default_compaction_profile`: `"custom"` → `"balanced"` (ratio=0.50, message=240, token=120K)
- `tool_heavy_msg_threshold`: 40 → 20

## Root Cause
Gate 기본값이 cloud model 세션 기준 (200K+ context, 긴 실행)으로 설정되어 있었음.
local 9B keeper는 ~7.5% ratio, 2-20 messages/turn으로 운영 → 어떤 gate도 trigger 안 됨.

| Gate | Before | After (balanced) |
|------|--------|-----------------|
| ratio_gate | 0.50 (env, but msg/token disabled) | 0.50 |
| message_gate | 0 (disabled) | **240** |
| token_gate | 196,608 | **120,000** |
| tool_heavy_msg | 40 | **20** |

## Test plan
- [ ] `dune build` 통과
- [ ] keeper 재시작 후 `compaction_ratio_gate`/`compaction_message_gate` 값 확인
- [ ] 장기 실행 keeper에서 compaction trigger 로그 확인
- [ ] env var override (`MASC_KEEPER_COMPACT_*`) 여전히 우선 적용되는지 확인

Closes #5895

🤖 Generated with [Claude Code](https://claude.com/claude-code)